### PR TITLE
Master override

### DIFF
--- a/generators/PHPythia6/PHPy6ForwardElectronTrig.h
+++ b/generators/PHPythia6/PHPy6ForwardElectronTrig.h
@@ -17,9 +17,9 @@ class PHPy6ForwardElectronTrig : public PHPy6GenTrigger
   PHPy6ForwardElectronTrig(const std::string& name = "PHPy6ForwardElectronTrigger");
 
   //! destructor
-  ~PHPy6ForwardElectronTrig(void) {}
+  ~PHPy6ForwardElectronTrig(void) override {}
 
-  bool Apply(const HepMC::GenEvent* evt);
+  bool Apply(const HepMC::GenEvent* evt) override;
 
   void set_electrons_required(int n)
   {

--- a/generators/PHPythia6/PHPy6JetTrigger.h
+++ b/generators/PHPythia6/PHPy6JetTrigger.h
@@ -14,9 +14,9 @@ class PHPy6JetTrigger : public PHPy6GenTrigger
 {
  public:
   PHPy6JetTrigger(const std::string& name = "PHPy6JetTrigger");
-  virtual ~PHPy6JetTrigger();
+  ~PHPy6JetTrigger() override;
 
-  bool Apply(const HepMC::GenEvent* evt);
+  bool Apply(const HepMC::GenEvent* evt) override;
 
   void SetEtaHighLow(double etaHigh, double etaLow);
   void SetMinJetPt(double minPt) { m_minPt = minPt; }

--- a/generators/PHPythia6/PHPy6ParticleTrigger.h
+++ b/generators/PHPythia6/PHPy6ParticleTrigger.h
@@ -26,9 +26,9 @@ class PHPy6ParticleTrigger : public PHPy6GenTrigger
   PHPy6ParticleTrigger(const std::string &name = "PHPy6ParticleTriggerger");
 
   //! destructor
-  ~PHPy6ParticleTrigger(void) {}
+  ~PHPy6ParticleTrigger(void) override {}
 
-  bool Apply(const HepMC::GenEvent *evt);
+  bool Apply(const HepMC::GenEvent *evt) override;
 
   void AddParticles(const std::string &particles);
   void AddParticles(int particle);

--- a/generators/PHPythia6/PHPythia6.h
+++ b/generators/PHPythia6/PHPythia6.h
@@ -15,15 +15,15 @@ class PHPythia6 : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   PHPythia6(const std::string &name = "PHPythia6");
-  virtual ~PHPythia6() {}
+  ~PHPythia6() override {}
 
-  int Init(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int ResetEvent(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode) override;
 
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
 
   void set_config_file(const std::string &cfg_file) { _configFile = cfg_file; }
 

--- a/generators/PHPythia8/PHPy8JetTrigger.h
+++ b/generators/PHPythia8/PHPy8JetTrigger.h
@@ -14,9 +14,9 @@ class PHPy8JetTrigger : public PHPy8GenTrigger
 {
  public:
   PHPy8JetTrigger(const std::string &name = "PHPy8JetTrigger");
-  virtual ~PHPy8JetTrigger();
+  ~PHPy8JetTrigger() override;
 
-  bool Apply(Pythia8::Pythia *pythia);
+  bool Apply(Pythia8::Pythia *pythia) override;
 
   void SetEtaHighLow(double etaHigh, double etaLow);
   void SetMinJetPt(double minPt);

--- a/generators/PHPythia8/PHPy8ParticleTrigger.h
+++ b/generators/PHPythia8/PHPy8ParticleTrigger.h
@@ -15,9 +15,9 @@ class PHPy8ParticleTrigger : public PHPy8GenTrigger
 {
  public:
   PHPy8ParticleTrigger(const std::string &name = "PHPy8ParticleTrigger");
-  virtual ~PHPy8ParticleTrigger();
+  ~PHPy8ParticleTrigger() override;
 
-  bool Apply(Pythia8::Pythia *pythia);
+  bool Apply(Pythia8::Pythia *pythia) override;
 
   void AddParticles(const std::string &particles);
   void AddParticles(int particle);

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -28,11 +28,11 @@ class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   PHPythia8(const std::string &name = "PHPythia8");
-  virtual ~PHPythia8();
+  ~PHPythia8() override;
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_config_file(const std::string &cfg_file)
   {

--- a/generators/phhepmc/Fun4AllHepMCInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.h
@@ -27,24 +27,24 @@ class Fun4AllHepMCInputManager : public Fun4AllInputManager, public PHHepMCGenHe
 {
  public:
   Fun4AllHepMCInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
-  virtual ~Fun4AllHepMCInputManager();
-  virtual int fileopen(const std::string &filenam);
-  int fileclose();
-  virtual int run(const int nevents = 0);
-  virtual int ResetEvent();
+  ~Fun4AllHepMCInputManager() override;
+  int fileopen(const std::string &filenam) override;
+  int fileclose() override;
+  int run(const int nevents = 0) override;
+  int ResetEvent() override;
   void ReadOscar(const int i) { m_ReadOscarFlag = i; }
   int ReadOscar() const { return m_ReadOscarFlag; }
-  virtual void Print(const std::string &what = "ALL") const;
-  virtual int PushBackEvents(const int i);
+  void Print(const std::string &what = "ALL") const override;
+  int PushBackEvents(const int i) override;
 
   // Effectivly turn off the synchronization checking
   //
-  int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_OK; }
-  int GetSyncObject(SyncObject ** /*mastersync*/) { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
-  int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
+  int SyncIt(const SyncObject * /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject ** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
   HepMC::GenEvent *ConvertFromOscar();
 
-  virtual int SkipForThisManager(const int nevents) { return PushBackEvents(-nevents); }
+  int SkipForThisManager(const int nevents) override { return PushBackEvents(-nevents); }
   int MyCurrentEvent(const unsigned int index = 0) const;
 
  protected:

--- a/generators/phhepmc/Fun4AllHepMCOutputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCOutputManager.h
@@ -19,13 +19,13 @@ class Fun4AllHepMCOutputManager : public Fun4AllOutputManager
   Fun4AllHepMCOutputManager(const std::string &myname = "HEPMCOUT",
                             const std::string &filename = "hepmcout.txt");
 
-  virtual ~Fun4AllHepMCOutputManager();
+  ~Fun4AllHepMCOutputManager() override;
 
-  int outfileopen(const std::string & /*fname*/) { return 0; }
+  int outfileopen(const std::string & /*fname*/) override { return 0; }
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
-  int Write(PHCompositeNode *startNode);
+  int Write(PHCompositeNode *startNode) override;
 
   int AddComment(const std::string &text);
 

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
@@ -17,7 +17,7 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
   Fun4AllHepMCPileupInputManager(const std::string &name = "DUMMY",
                                  const std::string &nodename = "DST",
                                  const std::string &topnodename = "TOP");
-  virtual ~Fun4AllHepMCPileupInputManager();
+  ~Fun4AllHepMCPileupInputManager() override;
 
   int run(const int nevents = 0) override { return run(nevents, false); }
 

--- a/generators/phhepmc/Fun4AllOscarInputManager.h
+++ b/generators/phhepmc/Fun4AllOscarInputManager.h
@@ -22,20 +22,20 @@ class Fun4AllOscarInputManager : public Fun4AllInputManager, public PHHepMCGenHe
 {
  public:
   Fun4AllOscarInputManager(const std::string &name = "DUMMY", const std::string &topnodename = "TOP");
-  virtual ~Fun4AllOscarInputManager();
-  int fileopen(const std::string &filenam);
-  int fileclose();
-  int run(const int nevents = 0);
-  void Print(const std::string &what = "ALL") const;
-  int ResetEvent();
-  int PushBackEvents(const int i);
-  int skip(const int i) { return PushBackEvents(i); }
+  ~Fun4AllOscarInputManager() override;
+  int fileopen(const std::string &filenam) override;
+  int fileclose() override;
+  int run(const int nevents = 0) override;
+  void Print(const std::string &what = "ALL") const override;
+  int ResetEvent() override;
+  int PushBackEvents(const int i) override;
+  int skip(const int i) override { return PushBackEvents(i); }
 
   // Effectivly turn off the synchronization checking
   //
-  int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_OK; }
-  int GetSyncObject(SyncObject ** /*mastersync*/) { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
-  int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
+  int SyncIt(const SyncObject * /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject ** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
   int ConvertFromOscar();
 
  protected:

--- a/generators/phhepmc/HepMCFlowAfterBurner.h
+++ b/generators/phhepmc/HepMCFlowAfterBurner.h
@@ -14,12 +14,12 @@ class HepMCFlowAfterBurner : public SubsysReco
 {
  public:
   HepMCFlowAfterBurner(const std::string &name = "HEPMCFLOWAFTERBURNER");
-  virtual ~HepMCFlowAfterBurner() {}
+  ~HepMCFlowAfterBurner() override {}
 
-  int Init(PHCompositeNode *);
-  int process_event(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
+  int process_event(PHCompositeNode *) override;
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   void setAlgorithmName(const std::string &name);
 

--- a/generators/phhepmc/PHGenIntegral.h
+++ b/generators/phhepmc/PHGenIntegral.h
@@ -22,7 +22,7 @@ class PHGenIntegral : public PHObject
 {
  public:
   PHGenIntegral(){}
-  virtual ~PHGenIntegral(){}
+  ~PHGenIntegral() override{}
 
   //! Integrated luminosity in pb^-1
   virtual Double_t get_Integrated_Lumi() const

--- a/generators/phhepmc/PHGenIntegralv1.h
+++ b/generators/phhepmc/PHGenIntegralv1.h
@@ -26,17 +26,17 @@ class PHGenIntegralv1 : public PHGenIntegral
  public:
   PHGenIntegralv1();
   explicit PHGenIntegralv1(const std::string& description);
-  virtual ~PHGenIntegralv1(){}
+  ~PHGenIntegralv1() override{}
 
-  virtual PHObject* CloneMe() const override {return new PHGenIntegralv1(*this);}
-  virtual int isValid() const override { return 1; }
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override;
+  PHObject* CloneMe() const override {return new PHGenIntegralv1(*this);}
+  int isValid() const override { return 1; }
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
 
-  virtual int Integrate() const override { return 1; }
+  int Integrate() const override { return 1; }
   /// For integral objects, e.g. integrated luminosity counter, integrate with another object from another run
-  virtual int Integrate(PHObject*) override;
-  virtual void CopyFrom(const PHObject* obj) override;
+  int Integrate(PHObject*) override;
+  void CopyFrom(const PHObject* obj) override;
 
   //! Integrated luminosity in pb^-1
   Double_t get_Integrated_Lumi() const override

--- a/generators/phhepmc/PHHepMCGenEvent.h
+++ b/generators/phhepmc/PHHepMCGenEvent.h
@@ -23,15 +23,15 @@ class PHHepMCGenEvent : public PHObject
 
   PHHepMCGenEvent(const PHHepMCGenEvent& event);
   PHHepMCGenEvent& operator=(const PHHepMCGenEvent& event);
-  virtual ~PHHepMCGenEvent();
+  ~PHHepMCGenEvent() override;
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override;
-  virtual int isValid() const override
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override
   {
     return (getEvent() != nullptr) ? 1 : 0;
   }
-  virtual PHObject* CloneMe() const override { return new PHHepMCGenEvent(*this); }
+  PHObject* CloneMe() const override { return new PHHepMCGenEvent(*this); }
 
   HepMC::GenEvent* getEvent();
   const HepMC::GenEvent* getEvent() const;

--- a/generators/phhepmc/PHHepMCGenEventMap.h
+++ b/generators/phhepmc/PHHepMCGenEventMap.h
@@ -31,7 +31,7 @@ class PHHepMCGenEventMap : public PHObject
   PHHepMCGenEventMap(const PHHepMCGenEventMap& eventmap);
   PHHepMCGenEventMap& operator=(const PHHepMCGenEventMap& eventmap);
 
-  virtual ~PHHepMCGenEventMap();
+  ~PHHepMCGenEventMap() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;

--- a/generators/phhepmc/PHHepMCGenEventv1.h
+++ b/generators/phhepmc/PHHepMCGenEventv1.h
@@ -10,11 +10,11 @@ class PHHepMCGenEventv1 : public PHHepMCGenEvent
 
   PHHepMCGenEventv1(const PHHepMCGenEventv1& event);
   PHHepMCGenEventv1& operator=(const PHHepMCGenEventv1& event);
-  virtual ~PHHepMCGenEventv1();
+  ~PHHepMCGenEventv1() override;
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override;
-  virtual int isValid() const override
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override
   {
     PHOOL_VIRTUAL_WARNING;
     return 0;

--- a/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.h
+++ b/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.h
@@ -21,10 +21,10 @@ class PHHepMCParticleSelectorDecayProductChain : public SubsysReco
 {
  public:
   PHHepMCParticleSelectorDecayProductChain(const std::string& name = "PARTICLESELECTOR");
-  virtual ~PHHepMCParticleSelectorDecayProductChain() {}
+  ~PHHepMCParticleSelectorDecayProductChain() override {}
 
-  int InitRun(PHCompositeNode* topNode);
-  int process_event(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode) override;
+  int process_event(PHCompositeNode* topNode) override;
 
   /// Set the ID of the particle you want in your output.
   virtual void SetParticle(const int pid);

--- a/offline/database/PHParameter/PHParameters.h
+++ b/offline/database/PHParameter/PHParameters.h
@@ -33,7 +33,7 @@ class PHParameters : public PHObject
   }
   PHParameters(const PHParameters &params, const std::string &name);
 
-  virtual ~PHParameters();
+  ~PHParameters() override;
 
   void Print(Option_t *option = "") const override;
 

--- a/offline/database/PHParameter/PHParametersContainer.h
+++ b/offline/database/PHParameter/PHParametersContainer.h
@@ -23,7 +23,7 @@ class PHParametersContainer : public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   explicit PHParametersContainer(const std::string &name = "NONE");
-  virtual ~PHParametersContainer();
+  ~PHParametersContainer() override;
 
   void AddPHParameters(const int detid, PHParameters *params);
   const PHParameters *GetParameters(const int detid) const;
@@ -35,7 +35,7 @@ class PHParametersContainer : public PHObject
   std::string Name() const { return superdetectorname; }
   //  std::pair<std::map<int, PHParameters *>::const_iterator,  std::map<int, PHParameters *>::const_iterator> GetAllParameters() {return std::make_pair(parametermap.begin(),parametermap.end());}
   ConstRange GetAllParameters() const { return std::make_pair(parametermap.begin(), parametermap.end()); }
-  void Print(Option_t *option = "") const;
+  void Print(Option_t *option = "") const override;
   void SaveToNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   void UpdateNodeTree(PHCompositeNode *topNode, const std::string &nodename);
   int ExistDetid(const int detid) const;

--- a/offline/database/pdbcal/base/PdbBankID.h
+++ b/offline/database/pdbcal/base/PdbBankID.h
@@ -19,7 +19,7 @@
 class PdbBankID : public PHObject {
 public:
    PdbBankID(const int val = 0);
-   virtual ~PdbBankID(){}
+   ~PdbBankID() override{}
 
    void print() const;
 

--- a/offline/database/pdbcal/base/PdbBankList.h
+++ b/offline/database/pdbcal/base/PdbBankList.h
@@ -9,7 +9,7 @@ class PdbBankList : public PHPointerList<PdbCalBank>
 {
 public:
   PdbBankList() {}
-  virtual ~PdbBankList() {}
+  ~PdbBankList() override {}
 };
 
 #endif /* PDBCAL_BASE_PDBBANKLIST_H */

--- a/offline/database/pdbcal/base/PdbBankListIterator.h
+++ b/offline/database/pdbcal/base/PdbBankListIterator.h
@@ -26,7 +26,7 @@ class PdbBankListIterator : public PHPointerListIterator<PdbCalBank>
   {
   }
 
-  ~PdbBankListIterator() {}
+  ~PdbBankListIterator() override {}
  private: 
   PdbBankListIterator() = delete;
 };

--- a/offline/database/pdbcal/base/PdbCalBank.h
+++ b/offline/database/pdbcal/base/PdbCalBank.h
@@ -21,8 +21,8 @@ class PdbCalBank : public  PHObject
 {
 public:
   PdbCalBank() {}
-  virtual ~PdbCalBank() {}
-   virtual PHObject* CloneMe() const override;
+  ~PdbCalBank() override {}
+   PHObject* CloneMe() const override;
 
    virtual void printHeader() const = 0;
    virtual void print() = 0;

--- a/offline/database/pdbcal/base/PdbCalChan.h
+++ b/offline/database/pdbcal/base/PdbCalChan.h
@@ -19,7 +19,7 @@ class PdbCalChan : public PHObject{
 
 public:
   PdbCalChan() {}
-  virtual ~PdbCalChan() {}
+  ~PdbCalChan() override {}
   
   virtual void print() const = 0;
 

--- a/offline/database/pdbcal/base/PdbParameter.h
+++ b/offline/database/pdbcal/base/PdbParameter.h
@@ -16,7 +16,7 @@ public:
                   // default ctor when reading from file
 
   PdbParameter(const double, const std::string &name); 
-  virtual ~PdbParameter() {}
+  ~PdbParameter() override {}
 
   double getParameter() const  { return thePar;  }
   const std::string getName() const { return theName; }
@@ -24,7 +24,7 @@ public:
   void  setParameter(const double val) { thePar = val; }
   void  setName(const std::string &name) {theName = name;}
 
-  virtual void print() const override;
+  void print() const override;
 
 protected:
 

--- a/offline/database/pdbcal/base/PdbParameterError.h
+++ b/offline/database/pdbcal/base/PdbParameterError.h
@@ -14,13 +14,13 @@ class PdbParameterError : public PdbParameter
  public:
   PdbParameterError();
   PdbParameterError(const double, const double, const std::string &name); 
-  virtual ~PdbParameterError() {}
+  ~PdbParameterError() override {}
 
   double getParameterError() const { return theParError; }
 
   void  setParameterError(const double val) { theParError = val; }
 
-  virtual void print() const override;
+  void print() const override;
 
  protected:
 

--- a/offline/database/pdbcal/base/PdbParameterMap.h
+++ b/offline/database/pdbcal/base/PdbParameterMap.h
@@ -22,7 +22,7 @@ class PdbParameterMap: public PdbCalChan
   typedef std::pair<strIter, strIter> strConstRange;
 
   PdbParameterMap() {}
-  virtual ~PdbParameterMap() {}
+  ~PdbParameterMap() override {}
 
   void print() const override;
   void Reset() override; // from PHObject - clear content

--- a/offline/database/pdbcal/base/PdbParameterMapContainer.h
+++ b/offline/database/pdbcal/base/PdbParameterMapContainer.h
@@ -17,7 +17,7 @@ class PdbParameterMapContainer : public PdbCalChan
   typedef std::pair<parIter, parIter> parConstRange;
 
   PdbParameterMapContainer() {}
-  virtual ~PdbParameterMapContainer();
+  ~PdbParameterMapContainer() override;
 
   void print() const override;
 

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -16,19 +16,19 @@ class EventHeader : public PHObject
 {
  public:
   /// dtor
-  virtual ~EventHeader() = default;
+  ~EventHeader() override = default;
 
   /// Clear Event
-  virtual void Reset() override;
+  void Reset() override;
 
   /*
    * identify Function from PHObject
    * @param os Output Stream 
    */
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
-  virtual int isValid() const override;
+  int isValid() const override;
 
   /// get Run Number
   virtual int get_RunNumber() const { return 0; }

--- a/offline/framework/ffaobjects/EventHeaderv1.h
+++ b/offline/framework/ffaobjects/EventHeaderv1.h
@@ -19,7 +19,7 @@ class EventHeaderv1 : public EventHeader
   /// ctor
   EventHeaderv1() = default;
   /// dtor
-  virtual ~EventHeaderv1() = default;
+  ~EventHeaderv1() override = default;
 
   PHObject *CloneMe() const override { return new EventHeaderv1(*this); }
 

--- a/offline/framework/ffaobjects/EventHeaderv2.h
+++ b/offline/framework/ffaobjects/EventHeaderv2.h
@@ -23,7 +23,7 @@ class EventHeaderv2 : public EventHeaderv1
   EventHeaderv2() = default;
 
   //! dtor
-  virtual ~EventHeaderv2() = default;
+  ~EventHeaderv2() override = default;
 
   //! clone
   PHObject* CloneMe() const override
@@ -38,7 +38,7 @@ class EventHeaderv2 : public EventHeaderv1
    * identify Function from PHObject
    * @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   //! bunch crossing
   void set_BunchCrossing(int64_t value) override

--- a/offline/framework/ffaobjects/FlagSave.h
+++ b/offline/framework/ffaobjects/FlagSave.h
@@ -13,10 +13,10 @@ class FlagSave : public PHObject
 {
  public:
   /// dtor
-  virtual ~FlagSave() {}
+  ~FlagSave() override {}
 
   /// Clear Flag
-  virtual void Reset() override
+  void Reset() override
   {
     std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
     return;
@@ -25,14 +25,14 @@ class FlagSave : public PHObject
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "identify yourself: virtual FlagSave Object" << std::endl;
     return;
   }
 
   /// isValid returns non zero if object contains valid data
-  virtual int isValid() const override
+  int isValid() const override
   {
     std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
     return 0;

--- a/offline/framework/ffaobjects/FlagSavev1.h
+++ b/offline/framework/ffaobjects/FlagSavev1.h
@@ -19,7 +19,7 @@ class FlagSavev1 : public FlagSave
   /// ctor
   FlagSavev1() = default;
   /// dtor
-  virtual ~FlagSavev1() = default;
+  ~FlagSavev1() override = default;
 
   PHObject *CloneMe() const override;
 

--- a/offline/framework/ffaobjects/RunHeader.h
+++ b/offline/framework/ffaobjects/RunHeader.h
@@ -14,20 +14,20 @@ class RunHeader : public PHObject
 {
  public:
   /// dtor
-  virtual ~RunHeader() {}
+  ~RunHeader() override {}
 
-  virtual PHObject *CloneMe() const override;
+  PHObject *CloneMe() const override;
 
   /// Clear Event
-  virtual void Reset() override;
+  void Reset() override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
-  virtual int isValid() const override;
+  int isValid() const override;
 
   /// get Run Number
   virtual int get_RunNumber() const;

--- a/offline/framework/ffaobjects/RunHeaderv1.h
+++ b/offline/framework/ffaobjects/RunHeaderv1.h
@@ -13,7 +13,7 @@ class RunHeaderv1 : public RunHeader
 {
  public:
   RunHeaderv1() = default;
-  virtual ~RunHeaderv1() = default;
+  ~RunHeaderv1() override = default;
 
   void Reset() override {return;}
   void identify(std::ostream &os = std::cout) const override;

--- a/offline/framework/ffaobjects/SyncObject.h
+++ b/offline/framework/ffaobjects/SyncObject.h
@@ -12,20 +12,20 @@ class SyncObject : public PHObject
 {
  public:
   /// dtor
-  virtual ~SyncObject() {}
+  ~SyncObject() override {}
 
   /// Clear Sync
-  virtual void Reset() override;
+  void Reset() override;
 
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   /// isValid returns non zero if object contains valid data
-  virtual int isValid() const override;
+  int isValid() const override;
 
-  virtual PHObject* CloneMe() const override;
+  PHObject* CloneMe() const override;
   virtual SyncObject& operator=(const SyncObject& source);
   virtual int Different(const SyncObject* other) const;
 

--- a/offline/framework/ffaobjects/SyncObjectv1.h
+++ b/offline/framework/ffaobjects/SyncObjectv1.h
@@ -18,7 +18,7 @@ class SyncObjectv1 : public SyncObject
 
   PHObject* CloneMe() const override { return new SyncObjectv1(*this); }
   /// dtor
-  virtual ~SyncObjectv1() = default;
+  ~SyncObjectv1() override = default;
 
   ///  Clear Event
   void Reset() override;

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -16,18 +16,18 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
 {
  public:
   Fun4AllDstInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");
-  virtual ~Fun4AllDstInputManager();
-  int fileopen(const std::string &filenam);
-  int fileclose();
-  int run(const int nevents = 0);
-  int GetSyncObject(SyncObject **mastersync);
-  int SyncIt(const SyncObject *mastersync);
-  int BranchSelect(const std::string &branch, const int iflag);
-  int setBranches();
+  ~Fun4AllDstInputManager() override;
+  int fileopen(const std::string &filenam) override;
+  int fileclose() override;
+  int run(const int nevents = 0) override;
+  int GetSyncObject(SyncObject **mastersync) override;
+  int SyncIt(const SyncObject *mastersync) override;
+  int BranchSelect(const std::string &branch, const int iflag) override;
+  int setBranches() override;
   virtual int setSyncBranches(PHNodeIOManager *IManager);
-  void Print(const std::string &what = "ALL") const;
-  int PushBackEvents(const int i);
-  virtual int HasSyncObject() const;
+  void Print(const std::string &what = "ALL") const override;
+  int PushBackEvents(const int i) override;
+  int HasSyncObject() const override;
 
  protected:
   int ReadNextEventSyncObject();

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -15,19 +15,19 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
 {
  public:
   Fun4AllDstOutputManager(const std::string &myname = "DSTOUT", const std::string &filename = "dstout.root");
-  virtual ~Fun4AllDstOutputManager();
+  ~Fun4AllDstOutputManager() override;
 
-  int AddNode(const std::string &nodename);
-  int AddRunNode(const std::string &nodename);
-  int StripNode(const std::string &nodename);
-  int StripRunNode(const std::string &nodename);
-  void SaveRunNode(const int i) {m_SaveRunNodeFlag = i;}
-  int outfileopen(const std::string &fname);
+  int AddNode(const std::string &nodename) override;
+  int AddRunNode(const std::string &nodename) override;
+  int StripNode(const std::string &nodename) override;
+  int StripRunNode(const std::string &nodename) override;
+  void SaveRunNode(const int i) override {m_SaveRunNodeFlag = i;}
+  int outfileopen(const std::string &fname) override;
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
-  int Write(PHCompositeNode *startNode);
-  int WriteNode(PHCompositeNode *thisNode);
+  int Write(PHCompositeNode *startNode) override;
+  int WriteNode(PHCompositeNode *thisNode) override;
 
  private:
   PHNodeIOManager *dstOut = nullptr;

--- a/offline/framework/fun4all/Fun4AllDummyInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDummyInputManager.h
@@ -16,17 +16,17 @@ class Fun4AllDummyInputManager : public Fun4AllInputManager
 {
  public:
   Fun4AllDummyInputManager(const std::string& name = "DUMMY", const std::string& nodename = "DST");
-  virtual ~Fun4AllDummyInputManager() {}
-  int fileopen(const std::string&) { return 0; }
-  int fileclose() { return 0; }
-  int IsOpen() const { return 1; }
-  int run(const int /*nevents=0*/);
-  int GetSyncObject(SyncObject** /*mastersync*/) { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
-  int SyncIt(const SyncObject* /*mastersync*/) { return Fun4AllReturnCodes::SYNC_OK; }
-  void setSyncManager(Fun4AllSyncManager* master);
-  int PushBackEvents(const int nevt);
-  int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
-  int ResetFileList();
+  ~Fun4AllDummyInputManager() override {}
+  int fileopen(const std::string&) override { return 0; }
+  int fileclose() override { return 0; }
+  int IsOpen() const override { return 1; }
+  int run(const int /*nevents=0*/) override;
+  int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  void setSyncManager(Fun4AllSyncManager* master) override;
+  int PushBackEvents(const int nevt) override;
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
+  int ResetFileList() override;
 
  private:
   int m_NumEvents = 0;

--- a/offline/framework/fun4all/Fun4AllHistoManager.h
+++ b/offline/framework/fun4all/Fun4AllHistoManager.h
@@ -14,9 +14,9 @@ class Fun4AllHistoManager : public Fun4AllBase
 {
  public:
   Fun4AllHistoManager(const std::string &name);
-  virtual ~Fun4AllHistoManager();
+  ~Fun4AllHistoManager() override;
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //! Register histogram or TTree object
   //! For histograms, enforce error calculation and propagation

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -20,7 +20,7 @@ class Fun4AllSyncManager;
 class Fun4AllInputManager : public Fun4AllBase
 {
  public:
-  virtual ~Fun4AllInputManager();
+  ~Fun4AllInputManager() override;
   virtual int fileopen(const std::string & /*filename*/) { return -1; }
   virtual int fileclose() { return -1; }
   virtual int run(const int /*nevents=0*/) { return -1; }
@@ -31,7 +31,7 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int SyncIt(const SyncObject * /*mastersync*/) { return Fun4AllReturnCodes::SYNC_FAIL; }
   virtual int BranchSelect(const std::string & /*branch*/, const int /*iflag*/) { return -1; }
   virtual int setBranches() { return -1; }  // publich bc needed by the sync manager
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
   virtual int PushBackEvents(const int /*nevt*/) { return -1; }
   // so people can use the skip they are used to instead of PushBackEvents
   // with negative arg

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.h
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.h
@@ -18,7 +18,7 @@ class Fun4AllMemoryTracker : public Fun4AllBase
     mInstance = new Fun4AllMemoryTracker();
     return mInstance;
   }
-  ~Fun4AllMemoryTracker();
+  ~Fun4AllMemoryTracker() override;
   void Snapshot(const std::string &trackername, const std::string &group = "");
   void Start(const std::string &trackername, const std::string &group = "");
   void Stop(const std::string &trackername, const std::string &group = "");

--- a/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllNoSyncDstInputManager.h
@@ -17,21 +17,21 @@ class Fun4AllNoSyncDstInputManager : public Fun4AllDstInputManager
  public:
   Fun4AllNoSyncDstInputManager(const std::string& name = "DUMMY", const std::string& nodename = "DST", const std::string& topnodename = "TOP");
 
-  virtual ~Fun4AllNoSyncDstInputManager() {}
+  ~Fun4AllNoSyncDstInputManager() override {}
 
   // Effectivly turn off the synchronization checking
   //
-  int SyncIt(const SyncObject* /*mastersync*/) { return Fun4AllReturnCodes::SYNC_OK; }
-  int GetSyncObject(SyncObject** /*mastersync*/) { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
-  int NoSyncPushBackEvents(const int nevt) { return PushBackEvents(nevt); }
+  int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
   // no sync object we don't need to enable the sync variables
-  int setSyncBranches(PHNodeIOManager* /*IManager*/) { return 0; }
+  int setSyncBranches(PHNodeIOManager* /*IManager*/) override { return 0; }
 
   // turn off reading of the runwise TTree to make run mixing for embedding possible
   int NoRunTTree();
 
-  int SkipForThisManager(const int nevents) { return PushBackEvents(nevents); }
-  int HasSyncObject() const { return 0; }
+  int SkipForThisManager(const int nevents) override { return PushBackEvents(nevents); }
+  int HasSyncObject() const override { return 0; }
 };
 
 #endif  // FUN4ALL_FUN4ALLNOSYNCDSTINPUTMANAGER_H

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -15,12 +15,12 @@ class Fun4AllOutputManager : public Fun4AllBase
 {
  public:
   //! destructor
-  virtual ~Fun4AllOutputManager()
+  ~Fun4AllOutputManager() override
   {
   }
 
   //! print method (dump event selector)
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //! add a node in outputmanager
   virtual int AddNode(const std::string & /*nodename*/)

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -30,7 +30,7 @@ class Fun4AllServer : public Fun4AllBase
 {
  public:
   static Fun4AllServer *instance();
-  virtual ~Fun4AllServer();
+  ~Fun4AllServer() override;
 
   virtual bool registerHisto(const std::string &hname, TNamed *h1d, const int replace = 0);
   virtual bool registerHisto(TNamed *h1d, const int replace = 0);
@@ -51,7 +51,7 @@ class Fun4AllServer : public Fun4AllBase
   TNamed *getHisto(const std::string &hname) const;
   TNamed *getHisto(const unsigned int ihisto) const;
   std::string getHistoName(const unsigned int ihisto) const;
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   void InitAll();
   int BeginRunTimeStamp(PHTimeStamp &TimeStp);

--- a/offline/framework/fun4all/Fun4AllSyncManager.h
+++ b/offline/framework/fun4all/Fun4AllSyncManager.h
@@ -19,7 +19,7 @@ class Fun4AllSyncManager : public Fun4AllBase
 {
  public:
   Fun4AllSyncManager(const std::string &name = "SYNCMANAGERNONAME");
-  virtual ~Fun4AllSyncManager();
+  ~Fun4AllSyncManager() override;
   int registerInputManager(Fun4AllInputManager *InManager);
   Fun4AllInputManager *getInputManager(const std::string &name);
 
@@ -37,7 +37,7 @@ class Fun4AllSyncManager : public Fun4AllBase
   int CurrentRun() { return m_CurrentRun; }
   void CurrentRun(const int ival) { m_CurrentRun = ival; }
   void CurrentEvent(const int evt);
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
   void SegmentNumber(const int iseg) { m_PrdfSegment = iseg; }
   int SegmentNumber() const { return m_PrdfSegment; }
   int BranchSelect(const std::string &managername, const std::string &branch, int iflag);

--- a/offline/framework/fun4all/PHTFileServer.h
+++ b/offline/framework/fun4all/PHTFileServer.h
@@ -78,7 +78,7 @@ class PHTFileServer
     }
 
     //! destructor
-    virtual ~SafeTFile(void);
+    ~SafeTFile(void) override;
 
     //! get reference to counter
     int& counter()

--- a/offline/framework/fun4all/SubsysReco.h
+++ b/offline/framework/fun4all/SubsysReco.h
@@ -26,7 +26,7 @@ class SubsysReco : public Fun4AllBase
   /** dtor. 
       Does nothing as this is a base class only.
   */
-  virtual ~SubsysReco() {}
+  ~SubsysReco() override {}
 
   /// Called at the end of all processing.
   virtual int End(PHCompositeNode * /*topNode*/) { return 0; }
@@ -58,7 +58,7 @@ class SubsysReco : public Fun4AllBase
   /// Clean up after each event.
   virtual int ResetEvent(PHCompositeNode * /*topNode*/) { return 0; }
 
-  virtual void Print(const std::string &what = "ALL") const {}
+  void Print(const std::string &what = "ALL") const override {}
 
  protected:
   /** ctor.

--- a/offline/framework/phool/PHCompositeNode.h
+++ b/offline/framework/phool/PHCompositeNode.h
@@ -17,7 +17,7 @@ class PHCompositeNode : public PHNode
 
  public:
   explicit PHCompositeNode(const std::string &);
-  virtual ~PHCompositeNode();
+  ~PHCompositeNode() override;
 
   //
   // The user is only allowed to add new nodes, not to delete existing ones.
@@ -29,16 +29,16 @@ class PHCompositeNode : public PHNode
   // If a subnode is found to be marked as transient (non persistent)
   // the entire sub-tree is deleted.
   //
-  virtual void prune();
+  void prune() override;
 
   //
   // I/O functions
   //
-  void print(const std::string & = "");
-  virtual bool write(PHIOManager *, const std::string & = "");
+  void print(const std::string & = "") override;
+  bool write(PHIOManager *, const std::string & = "") override;
 
  protected:
-  virtual void forgetMe(PHNode *);
+  void forgetMe(PHNode *) override;
   PHPointerList<PHNode> subNodes;
   int deleteMe;
 

--- a/offline/framework/phool/PHDataNode.h
+++ b/offline/framework/phool/PHDataNode.h
@@ -15,15 +15,15 @@ class PHDataNode : public PHNode
  public:
   PHDataNode(T*, const std::string&);
   PHDataNode(T*, const std::string&, const std::string&);
-  virtual ~PHDataNode();
+  ~PHDataNode() override;
 
  public:
   T* getData() { return data.data; }
   void setData(T* d) { data.data = d; }
-  virtual void prune() {}
-  virtual void forgetMe(PHNode*) {}
-  virtual void print(const std::string&);
-  virtual bool write(PHIOManager*, const std::string& = "")
+  void prune() override {}
+  void forgetMe(PHNode*) override {}
+  void print(const std::string&) override;
+  bool write(PHIOManager*, const std::string& = "") override
   {
     return true;
   }

--- a/offline/framework/phool/PHDataNodeIterator.h
+++ b/offline/framework/phool/PHDataNodeIterator.h
@@ -23,7 +23,7 @@ class PHDataNodeIterator : public PHNodeIterator
   PHDataNodeIterator(PHCompositeNode* node);
 
   /// Destructor
-  virtual ~PHDataNodeIterator() {}
+  ~PHDataNodeIterator() override {}
   /**
    * Finds an IODataNode of name "name" containing data of type "T".
    * A null pointer will be returned if the node is not found, or if
@@ -77,7 +77,7 @@ PHDataNodeIterator::AddIODataNode(T* data, const char* name)
   // TODO:  also check that "name" is not a null string!
   if (!name)
   {
-    return False;
+    return false;
   }
   // For IODataNode, ought to check (if possible) that T derives
   // from TObject.  Will typeid() give us this info?
@@ -85,7 +85,7 @@ PHDataNodeIterator::AddIODataNode(T* data, const char* name)
   PHIODataNode<T>* n = new PHIODataNode<T>(data, name);
   if (!n)
   {
-    return False;  // problem creating node?
+    return false;  // problem creating node?
   }
   return addNode(n);
 }

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -26,11 +26,11 @@ class PHNodeIOManager : public PHIOManager
   PHNodeIOManager(const std::string &, const PHAccessType = PHReadOnly);
   PHNodeIOManager(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
   PHNodeIOManager(const std::string &, const PHAccessType, const PHTreeType);
-  virtual ~PHNodeIOManager();
+  ~PHNodeIOManager() override;
 
-  virtual void closeFile();
-  virtual bool write(PHCompositeNode *);
-  virtual void print() const;
+  void closeFile() override;
+  bool write(PHCompositeNode *) override;
+  void print() const override;
 
   bool setFile(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
   PHCompositeNode *read(PHCompositeNode * = nullptr, size_t = 0);

--- a/offline/framework/phool/PHNodeIntegrate.h
+++ b/offline/framework/phool/PHNodeIntegrate.h
@@ -18,7 +18,7 @@ class PHNodeIntegrate : public PHNodeOperation
     , runsumnode(nullptr)
   {
   }
-  virtual ~PHNodeIntegrate() {}
+  ~PHNodeIntegrate() override {}
   void RunNode(PHCompositeNode *node)
   {
     runnode = node;
@@ -29,7 +29,7 @@ class PHNodeIntegrate : public PHNodeOperation
   }
 
  protected:
-  virtual void perform(PHNode *);
+  void perform(PHNode *) override;
 
  private:
   PHCompositeNode *runnode;

--- a/offline/framework/phool/PHNodeReset.h
+++ b/offline/framework/phool/PHNodeReset.h
@@ -13,10 +13,10 @@ class PHNodeReset : public PHNodeOperation
 {
  public:
   PHNodeReset() {}
-  virtual ~PHNodeReset() {}
+  ~PHNodeReset() override {}
 
  protected:
-  virtual void perform(PHNode*);
+  void perform(PHNode*) override;
 };
 
 #endif

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -17,13 +17,13 @@ class PHObject : public TObject
   PHObject() {}
 
   /// dtor
-  virtual ~PHObject() {}
+  ~PHObject() override {}
   /// Virtual copy constructor.
   virtual PHObject* CloneMe() const;
 
   virtual PHObject* clone() const final;
-  virtual PHObject *Clone(const char *newname = "") const final;
-  virtual void 	Copy(TObject &object) const final;
+  PHObject *Clone(const char *newname = "") const final;
+  void 	Copy(TObject &object) const final;
 
   /** identify Function from PHObject
       @param os Output Stream 

--- a/offline/framework/phool/PHTimeStamp.h
+++ b/offline/framework/phool/PHTimeStamp.h
@@ -28,7 +28,7 @@ class PHTimeStamp : public PHObject
   PHTimeStamp(const time_t);
   void setBinTics(const phtime_t t);
 
-  virtual ~PHTimeStamp() {}
+  ~PHTimeStamp() override {}
 
  public:
   void set(const int, const int, const int, const int, const int, const int, const int = 0);

--- a/offline/framework/phool/PHTypedNodeIterator.h
+++ b/offline/framework/phool/PHTypedNodeIterator.h
@@ -37,7 +37,7 @@ class PHTypedNodeIterator : public PHNodeIterator
 
   /// Destructor
   //  virtual ~PHTypedNodeIterator();  // Need a virtual ~PHNodeIterator() !
-  ~PHTypedNodeIterator() {}
+  ~PHTypedNodeIterator() override {}
   /**
    * Finds an IODataNode of name "name" containing data of type "T".
    * A null pointer will be returned if the node is not found, or if

--- a/offline/framework/phool/recoConsts.h
+++ b/offline/framework/phool/recoConsts.h
@@ -16,7 +16,7 @@ class recoConsts : public PHFlag
     return __instance;
   }
 
-  void Print() const;
+  void Print() const override;
 
  private:
   recoConsts() {}

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -27,17 +27,17 @@ class RawCluster : public PHObject
   typedef std::pair<TowerIterator, TowerIterator> TowerRange;
   typedef std::pair<TowerConstIterator, TowerConstIterator> TowerConstRange;
 
-  virtual ~RawCluster() {}
-  virtual void Reset() override { PHOOL_VIRTUAL_WARNING; }
+  ~RawCluster() override {}
+  void Reset() override { PHOOL_VIRTUAL_WARNING; }
 
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  PHObject* CloneMe() const override { return nullptr; }
 
-  virtual int isValid() const override
+  int isValid() const override
   {
     PHOOL_VIRTUAL_WARNING;
     return 0;
   }
-  virtual void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARNING; }
+  void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARNING; }
   /** @defgroup getters
    *  @{
    */

--- a/offline/packages/CaloBase/RawClusterContainer.h
+++ b/offline/packages/CaloBase/RawClusterContainer.h
@@ -21,7 +21,7 @@ class RawClusterContainer : public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   RawClusterContainer() {}
-  virtual ~RawClusterContainer() {}
+  ~RawClusterContainer() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -18,12 +18,12 @@ class RawClusterv1 : public RawCluster
 {
  public:
   RawClusterv1();
-  virtual ~RawClusterv1() {}
+  ~RawClusterv1() override {}
 
-  virtual void Reset() override;
-  virtual PHObject* CloneMe() const override { return new RawClusterv1(*this); }
-  virtual int isValid() const override { return towermap.size() > 0; }
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  PHObject* CloneMe() const override { return new RawClusterv1(*this); }
+  int isValid() const override { return towermap.size() > 0; }
+  void identify(std::ostream& os = std::cout) const override;
 
   /** @defgroup getters
    *  @{
@@ -39,7 +39,7 @@ class RawClusterv1 : public RawCluster
   const TowerMap& get_towermap() const override { return towermap; }
   //
   //! cluster position in 3D
-  virtual CLHEP::Hep3Vector get_position() const override
+  CLHEP::Hep3Vector get_position() const override
   {
     return CLHEP::Hep3Vector(get_x(), get_y(), get_z());
   }
@@ -54,20 +54,20 @@ class RawClusterv1 : public RawCluster
   //  virtual float get_et(const float z) const;
   //
   //! access Cartesian coordinate system
-  virtual float get_x() const override { return get_r() * std::cos(get_phi()); }
-  virtual float get_y() const override { return get_r() * std::sin(get_phi()); }
+  float get_x() const override { return get_r() * std::cos(get_phi()); }
+  float get_y() const override { return get_r() * std::sin(get_phi()); }
   //
   //! access additional optional properties
   //! cluster core energy for EM shower
-  virtual float get_ecore() const override { return get_property_float(prop_ecore); }
+  float get_ecore() const override { return get_property_float(prop_ecore); }
   //! reduced chi2 for EM shower
-  virtual float get_chi2() const override { return get_property_float(prop_chi2); }
+  float get_chi2() const override { return get_property_float(prop_chi2); }
   //! cluster template probability for EM shower
-  virtual float get_prob() const override { return get_property_float(prop_prob); }
+  float get_prob() const override { return get_property_float(prop_prob); }
   //! isolation ET default
-  virtual float get_et_iso() const override { return get_property_float(prop_et_iso_calotower_R03); }
+  float get_et_iso() const override { return get_property_float(prop_et_iso_calotower_R03); }
   //! isolation ET the radius and hueristic can be specified
-  virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) const override;
+  float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) const override;
   //  //! truth cluster's PHG4Particle ID
   //  virtual int get_truth_track_ID() const override { return get_property_int(prop_truth_track_ID); }
   //  //! truth cluster's PHG4Particle flavor
@@ -91,15 +91,15 @@ class RawClusterv1 : public RawCluster
   //
   //! access additional optional properties
   //! cluster core energy for EM shower
-  virtual void set_ecore(const float ecore) override { set_property(prop_ecore, ecore); }
+  void set_ecore(const float ecore) override { set_property(prop_ecore, ecore); }
   //! reduced chi2 for EM shower
-  virtual void set_chi2(const float chi2) override { set_property(prop_chi2, chi2); }
+  void set_chi2(const float chi2) override { set_property(prop_chi2, chi2); }
   //! cluster template probability for EM shower
-  virtual void set_prob(const float prob) override { set_property(prop_prob, prob); }
+  void set_prob(const float prob) override { set_property(prop_prob, prob); }
   //! isolation ET default
-  virtual void set_et_iso(const float e) override { set_property(prop_et_iso_calotower_R03, e); }
+  void set_et_iso(const float e) override { set_property(prop_et_iso_calotower_R03, e); }
   //! isolation ET the radius and hueristic can be specified
-  virtual void set_et_iso(const float et_iso, const int radiusx10, bool subtracted, bool clusterTower) override;
+  void set_et_iso(const float et_iso, const int radiusx10, bool subtracted, bool clusterTower) override;
   //  //! truth cluster's PHG4Particle ID
   //  virtual void set_truth_track_ID(const int i) override { set_property(prop_truth_track_ID, i); }
   //  //! truth cluster's PHG4Particle flavor

--- a/offline/packages/CaloBase/RawTower.h
+++ b/offline/packages/CaloBase/RawTower.h
@@ -32,15 +32,15 @@ class RawTower : public PHObject
   typedef std::pair<ShowerIterator, ShowerIterator> ShowerRange;
   typedef std::pair<ShowerConstIterator, ShowerConstIterator> ShowerConstRange;
 
-  virtual ~RawTower() {}
+  ~RawTower() override {}
 
-  virtual void Reset() override { PHOOL_VIRTUAL_WARNING; }
-  virtual int isValid() const override
+  void Reset() override { PHOOL_VIRTUAL_WARNING; }
+  int isValid() const override
   {
     PHOOL_VIRTUAL_WARN("isValid()");
     return 0;
   }
-  virtual void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARN("identify()"); }
+  void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARN("identify()"); }
 
   virtual void set_id(RawTowerDefs::keytype id) { PHOOL_VIRTUAL_WARN("set_id()"); }
   virtual RawTowerDefs::keytype get_id() const

--- a/offline/packages/CaloBase/RawTowerContainer.h
+++ b/offline/packages/CaloBase/RawTowerContainer.h
@@ -25,7 +25,7 @@ class RawTowerContainer : public PHObject
   {
   }
 
-  virtual ~RawTowerContainer() {}
+  ~RawTowerContainer() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/offline/packages/CaloBase/RawTowerDeadMap.h
+++ b/offline/packages/CaloBase/RawTowerDeadMap.h
@@ -13,12 +13,12 @@ class RawTowerDeadMap : public PHObject
  public:
   typedef std::set<RawTowerDefs::keytype> Map;
 
-  virtual ~RawTowerDeadMap() {}
+  ~RawTowerDeadMap() override {}
 
-  virtual void Reset() override;
-  virtual int isValid() const override;
+  void Reset() override;
+  int isValid() const override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   virtual void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) {}
   virtual RawTowerDefs::CalorimeterId getCalorimeterID() { return RawTowerDefs::NONE; }

--- a/offline/packages/CaloBase/RawTowerDeadMapv1.h
+++ b/offline/packages/CaloBase/RawTowerDeadMapv1.h
@@ -13,24 +13,24 @@ class RawTowerDeadMapv1 : public RawTowerDeadMap
     : _caloid(caloid)
   {
   }
-  virtual ~RawTowerDeadMapv1() {}
+  ~RawTowerDeadMapv1() override {}
 
-  virtual void Reset() override;
-  virtual int isValid() const override;
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) override { _caloid = caloid; }
-  virtual RawTowerDefs::CalorimeterId getCalorimeterID() override { return _caloid; }
-  virtual void addDeadTower(const unsigned int ieta, const unsigned int iphi) override;
-  virtual void addDeadTower(RawTowerDefs::keytype key) override;
+  void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) override { _caloid = caloid; }
+  RawTowerDefs::CalorimeterId getCalorimeterID() override { return _caloid; }
+  void addDeadTower(const unsigned int ieta, const unsigned int iphi) override;
+  void addDeadTower(RawTowerDefs::keytype key) override;
 
-  virtual bool isDeadTower(RawTowerDefs::keytype key) override;
-  virtual bool isDeadTower(const unsigned int ieta, const unsigned int iphi) override;
+  bool isDeadTower(RawTowerDefs::keytype key) override;
+  bool isDeadTower(const unsigned int ieta, const unsigned int iphi) override;
   //! return all towers
-  virtual const Map &getDeadTowers(void) const override;
-  virtual Map &getDeadTowers(void) override;
+  const Map &getDeadTowers(void) const override;
+  Map &getDeadTowers(void) override;
 
-  virtual unsigned int size() const override { return m_DeadTowers.size(); }
+  unsigned int size() const override { return m_DeadTowers.size(); }
 
  private:
   RawTowerDefs::CalorimeterId _caloid;

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -12,9 +12,9 @@
 class RawTowerGeom : public PHObject
 {
  public:
-  virtual ~RawTowerGeom() {}
+  ~RawTowerGeom() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   virtual void set_id(RawTowerDefs::keytype key) { PHOOL_VIRTUAL_WARN("set_id()"); }
 

--- a/offline/packages/CaloBase/RawTowerGeomContainer.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainer.h
@@ -29,9 +29,9 @@ class RawTowerGeomContainer : public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   //! default constructor for ROOT IO
-  virtual ~RawTowerGeomContainer() {}
+  ~RawTowerGeomContainer() override {}
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   //! 8-bit calorimeter ID
   virtual void set_calorimeter_id(RawTowerDefs::CalorimeterId) { PHOOL_VIRTUAL_WARN("set_calorimeter_id()"); }

--- a/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainer_Cylinderv1.h
@@ -17,12 +17,12 @@ class RawTowerGeomContainer_Cylinderv1 : public RawTowerGeomContainerv1
  public:
   RawTowerGeomContainer_Cylinderv1(
       RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE);
-  virtual ~RawTowerGeomContainer_Cylinderv1() { Reset(); }
+  ~RawTowerGeomContainer_Cylinderv1() override { Reset(); }
 
-  virtual void
+  void
   identify(std::ostream& os = std::cout) const override;
 
-  virtual void Reset() override;
+  void Reset() override;
 
   double
   get_radius() const override

--- a/offline/packages/CaloBase/RawTowerGeomContainerv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainerv1.h
@@ -16,11 +16,11 @@ class RawTowerGeomContainerv1 : public RawTowerGeomContainer
 {
  public:
   RawTowerGeomContainerv1(RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE);
-  virtual ~RawTowerGeomContainerv1();
+  ~RawTowerGeomContainerv1() override;
 
-  virtual void Reset() override;
-  virtual int isValid() const override;
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   void set_calorimeter_id(RawTowerDefs::CalorimeterId caloid) override { _caloid = caloid; }
   RawTowerDefs::CalorimeterId get_calorimeter_id() const override { return _caloid; }

--- a/offline/packages/CaloBase/RawTowerGeomv1.h
+++ b/offline/packages/CaloBase/RawTowerGeomv1.h
@@ -13,7 +13,7 @@ class RawTowerGeomv1 : public RawTowerGeom
  public:
   RawTowerGeomv1() {}
   RawTowerGeomv1(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv1() {}
+  ~RawTowerGeomv1() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/offline/packages/CaloBase/RawTowerGeomv2.h
+++ b/offline/packages/CaloBase/RawTowerGeomv2.h
@@ -12,7 +12,7 @@ class RawTowerGeomv2 : public RawTowerGeom
  public:
   RawTowerGeomv2();
   RawTowerGeomv2(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv2() {}
+  ~RawTowerGeomv2() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/offline/packages/CaloBase/RawTowerGeomv3.h
+++ b/offline/packages/CaloBase/RawTowerGeomv3.h
@@ -13,7 +13,7 @@ class RawTowerGeomv3 : public RawTowerGeom
  public:
   RawTowerGeomv3() {}
   RawTowerGeomv3(RawTowerDefs::keytype id);
-  virtual ~RawTowerGeomv3() {}
+  ~RawTowerGeomv3() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/offline/packages/CaloBase/RawTowerv1.h
+++ b/offline/packages/CaloBase/RawTowerv1.h
@@ -19,7 +19,7 @@ class RawTowerv1 : public RawTower
   RawTowerv1(const unsigned int ieta, const unsigned int iphi);
   RawTowerv1(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
              const unsigned int iphi);
-  virtual ~RawTowerv1() {}
+  ~RawTowerv1() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/offline/packages/CaloBase/RawTowerv2.h
+++ b/offline/packages/CaloBase/RawTowerv2.h
@@ -20,7 +20,7 @@ class RawTowerv2 : public RawTowerv1
   RawTowerv2(const unsigned int ieta, const unsigned int iphi);
   RawTowerv2(const RawTowerDefs::CalorimeterId caloid, const unsigned int ieta,
              const unsigned int iphi);
-  virtual ~RawTowerv2() {}
+  ~RawTowerv2() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/offline/packages/CaloReco/BEmcCluster.h
+++ b/offline/packages/CaloReco/BEmcCluster.h
@@ -64,7 +64,7 @@ class EmcCluster : public TObject
   }
 
   ///
-  virtual ~EmcCluster()
+  ~EmcCluster() override
   {
   }
 

--- a/offline/packages/CaloReco/BEmcRecCEMC.h
+++ b/offline/packages/CaloReco/BEmcRecCEMC.h
@@ -13,7 +13,7 @@ class BEmcRecCEMC : public BEmcRec
 {
  public:
   BEmcRecCEMC();
-  virtual ~BEmcRecCEMC();
+  ~BEmcRecCEMC() override;
   void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
   void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;

--- a/offline/packages/CaloReco/BEmcRecEEMC.h
+++ b/offline/packages/CaloReco/BEmcRecEEMC.h
@@ -13,7 +13,7 @@ class BEmcRecEEMC : public BEmcRec
 {
  public:
   BEmcRecEEMC();
-  virtual ~BEmcRecEEMC();
+  ~BEmcRecEEMC() override;
   void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
   void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;

--- a/offline/packages/CaloReco/BEmcRecFEMC.h
+++ b/offline/packages/CaloReco/BEmcRecFEMC.h
@@ -13,7 +13,7 @@ class BEmcRecFEMC : public BEmcRec
 {
  public:
   BEmcRecFEMC();
-  virtual ~BEmcRecFEMC();
+  ~BEmcRecFEMC() override;
   void CorrectEnergy(float energy, float x, float y, float &ecorr) override;
   void CorrectECore(float ecore, float x, float y, float &ecorecorr) override;
   void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr) override;

--- a/offline/packages/CaloReco/RawClusterBuilderFwd.h
+++ b/offline/packages/CaloReco/RawClusterBuilderFwd.h
@@ -15,11 +15,11 @@ class RawClusterBuilderFwd : public SubsysReco
 {
  public:
   RawClusterBuilderFwd(const std::string &name = "RawClusterBuilder");
-  virtual ~RawClusterBuilderFwd() {}
+  ~RawClusterBuilderFwd() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void Detector(const std::string &d) { detector = d; }
 
   void set_threshold_energy(const float e) { _min_tower_e = e; }

--- a/offline/packages/CaloReco/RawClusterBuilderGraph.h
+++ b/offline/packages/CaloReco/RawClusterBuilderGraph.h
@@ -12,11 +12,11 @@ class RawClusterBuilderGraph : public SubsysReco
 {
  public:
   RawClusterBuilderGraph(const std::string &name = "RawClusterBuilderGraph");
-  virtual ~RawClusterBuilderGraph() {}
+  ~RawClusterBuilderGraph() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void Detector(const std::string &d) { detector = d; }
 
   void set_threshold_energy(const float e) { _min_tower_e = e; }

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -14,10 +14,10 @@ class RawClusterBuilderTemplate : public SubsysReco
 {
  public:
   RawClusterBuilderTemplate(const std::string& name = "RawClusterBuilderTemplate");
-  virtual ~RawClusterBuilderTemplate();
+  ~RawClusterBuilderTemplate() override;
 
-  int InitRun(PHCompositeNode* topNode);
-  int process_event(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode) override;
+  int process_event(PHCompositeNode* topNode) override;
   void Detector(const std::string& d);
 
   void SetCylindricalGeometry();

--- a/offline/packages/CaloReco/RawClusterBuilderTopo.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.h
@@ -22,11 +22,11 @@ class RawClusterBuilderTopo : public SubsysReco
 {
  public:
   RawClusterBuilderTopo(const std::string &name = "RawClusterBuilderTopo");
-  virtual ~RawClusterBuilderTopo() {}
+  ~RawClusterBuilderTopo() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_nodename( const std::string &nodename ) {
 

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.h
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.h
@@ -16,9 +16,9 @@ class RawClusterDeadAreaMask : public SubsysReco
  public:
   explicit RawClusterDeadAreaMask(const std::string &name = "RawClusterDeadAreaMask");
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   //! half width of the dead area around the center of a dead tower, if cluster center fall into this region it is rejected.
   void deadTowerMaskHalfWidth(double deadTowerMaskHalfWidth)

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.h
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.h
@@ -16,9 +16,9 @@ class RawClusterPositionCorrection : public SubsysReco
  public:
   explicit RawClusterPositionCorrection(const std::string &name);
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void CreateNodeTree(PHCompositeNode *topNode);
 

--- a/offline/packages/CaloReco/RawTowerCalibration.h
+++ b/offline/packages/CaloReco/RawTowerCalibration.h
@@ -19,13 +19,13 @@ class RawTowerCalibration : public SubsysReco
 {
  public:
   RawTowerCalibration(const std::string &name = "RawTowerCalibration");
-  virtual ~RawTowerCalibration()
+  ~RawTowerCalibration() override
   {
   }
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void
   Detector(const std::string &d)
   {

--- a/offline/packages/CaloReco/RawTowerCombiner.h
+++ b/offline/packages/CaloReco/RawTowerCombiner.h
@@ -67,13 +67,13 @@ class RawTowerCombiner : public SubsysReco
  public:
   RawTowerCombiner(const std::string &name = "RawTowerCombiner");
 
-  virtual ~RawTowerCombiner()
+  ~RawTowerCombiner() override
   {
   }
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void
   Detector(const std::string &d)

--- a/offline/packages/CaloReco/RawTowerDeadMapLoader.h
+++ b/offline/packages/CaloReco/RawTowerDeadMapLoader.h
@@ -25,9 +25,9 @@ class RawTowerDeadMapLoader : public SubsysReco
  public:
   RawTowerDeadMapLoader(const std::string& detector);
 
-  virtual ~RawTowerDeadMapLoader() {}
+  ~RawTowerDeadMapLoader() override {}
 
-  virtual int InitRun(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode) override;
 
   const std::string& deadMapPath() const
   {

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.h
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.h
@@ -15,13 +15,13 @@ class RawTowerDeadTowerInterp : public SubsysReco
 {
  public:
   RawTowerDeadTowerInterp(const std::string &name = "RawTowerDeadTowerInterp");
-  virtual ~RawTowerDeadTowerInterp()
+  ~RawTowerDeadTowerInterp() override
   {
   }
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void
   detector(const std::string &d)

--- a/offline/packages/ClusterIso/ClusterIso.h
+++ b/offline/packages/ClusterIso/ClusterIso.h
@@ -28,9 +28,9 @@ class ClusterIso : public SubsysReco
    */
   ClusterIso(const std::string&, float eTCut, int coneSize, bool do_subtracted, bool do_unsubtracted);
 
-  virtual int Init(PHCompositeNode*);
-  virtual int process_event(PHCompositeNode*);
-  virtual int End(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
+  int process_event(PHCompositeNode*) override;
+  int End(PHCompositeNode*) override;
 
   void seteTCut(float x);
   void setConeSize(int x);

--- a/offline/packages/NodeDump/DumpAssocInfoContainer.h
+++ b/offline/packages/NodeDump/DumpAssocInfoContainer.h
@@ -11,10 +11,10 @@ class DumpAssocInfoContainer : public DumpObject
 {
  public:
   DumpAssocInfoContainer(const std::string &NodeName);
-  virtual ~DumpAssocInfoContainer() {}
+  ~DumpAssocInfoContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpBbcVertexMap.h
+++ b/offline/packages/NodeDump/DumpBbcVertexMap.h
@@ -11,10 +11,10 @@ class DumpBbcVertexMap : public DumpObject
 {
  public:
   DumpBbcVertexMap(const std::string &NodeName);
-  virtual ~DumpBbcVertexMap() {}
+  ~DumpBbcVertexMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpCaloTriggerInfo.h
+++ b/offline/packages/NodeDump/DumpCaloTriggerInfo.h
@@ -10,8 +10,8 @@ class DumpCaloTriggerInfo : public DumpObject
 {
  public:
   DumpCaloTriggerInfo(const std::string &NodeName);
-  virtual ~DumpCaloTriggerInfo() {}
+  ~DumpCaloTriggerInfo() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };

--- a/offline/packages/NodeDump/DumpEventHeader.h
+++ b/offline/packages/NodeDump/DumpEventHeader.h
@@ -11,10 +11,10 @@ class DumpEventHeader : public DumpObject
 {
  public:
   DumpEventHeader(const std::string &NodeName);
-  virtual ~DumpEventHeader() {}
+  ~DumpEventHeader() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpGlobalVertexMap.h
+++ b/offline/packages/NodeDump/DumpGlobalVertexMap.h
@@ -11,10 +11,10 @@ class DumpGlobalVertexMap : public DumpObject
 {
  public:
   DumpGlobalVertexMap(const std::string &NodeName);
-  virtual ~DumpGlobalVertexMap() {}
+  ~DumpGlobalVertexMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpJetMap.h
+++ b/offline/packages/NodeDump/DumpJetMap.h
@@ -11,10 +11,10 @@ class DumpJetMap : public DumpObject
 {
  public:
   DumpJetMap(const std::string &NodeName);
-  virtual ~DumpJetMap() {}
+  ~DumpJetMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4BlockCellGeomContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4BlockCellGeomContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4BlockCellGeomContainer : public DumpObject
 {
  public:
   DumpPHG4BlockCellGeomContainer(const std::string &NodeName);
-  virtual ~DumpPHG4BlockCellGeomContainer() {}
+  ~DumpPHG4BlockCellGeomContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4BlockGeomContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4BlockGeomContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4BlockGeomContainer : public DumpObject
 {
  public:
   DumpPHG4BlockGeomContainer(const std::string &NodeName);
-  virtual ~DumpPHG4BlockGeomContainer() {}
+  ~DumpPHG4BlockGeomContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4CellContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4CellContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4CellContainer : public DumpObject
 {
  public:
   DumpPHG4CellContainer(const std::string &NodeName);
-  virtual ~DumpPHG4CellContainer() {}
+  ~DumpPHG4CellContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4CylinderCellContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4CylinderCellContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4CylinderCellContainer : public DumpObject
 {
  public:
   DumpPHG4CylinderCellContainer(const std::string &NodeName);
-  virtual ~DumpPHG4CylinderCellContainer() {}
+  ~DumpPHG4CylinderCellContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4CylinderCellGeomContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4CylinderCellGeomContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4CylinderCellGeomContainer : public DumpObject
 {
  public:
   DumpPHG4CylinderCellGeomContainer(const std::string &NodeName);
-  virtual ~DumpPHG4CylinderCellGeomContainer() {}
+  ~DumpPHG4CylinderCellGeomContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4CylinderGeomContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4CylinderGeomContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4CylinderGeomContainer : public DumpObject
 {
  public:
   DumpPHG4CylinderGeomContainer(const std::string &NodeName);
-  virtual ~DumpPHG4CylinderGeomContainer() {}
+  ~DumpPHG4CylinderGeomContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4HitContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4HitContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4HitContainer : public DumpObject
 {
  public:
   DumpPHG4HitContainer(const std::string &NodeName);
-  virtual ~DumpPHG4HitContainer() {}
+  ~DumpPHG4HitContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4InEvent.h
+++ b/offline/packages/NodeDump/DumpPHG4InEvent.h
@@ -11,10 +11,10 @@ class DumpPHG4InEvent : public DumpObject
 {
  public:
   DumpPHG4InEvent(const std::string &NodeName);
-  virtual ~DumpPHG4InEvent() {}
+  ~DumpPHG4InEvent() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4ScintillatorSlatContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4ScintillatorSlatContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4ScintillatorSlatContainer : public DumpObject
 {
  public:
   DumpPHG4ScintillatorSlatContainer(const std::string &NodeName);
-  virtual ~DumpPHG4ScintillatorSlatContainer() {}
+  ~DumpPHG4ScintillatorSlatContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.h
+++ b/offline/packages/NodeDump/DumpPHG4TruthInfoContainer.h
@@ -11,10 +11,10 @@ class DumpPHG4TruthInfoContainer : public DumpObject
 {
  public:
   DumpPHG4TruthInfoContainer(const std::string &NodeName);
-  virtual ~DumpPHG4TruthInfoContainer() {}
+  ~DumpPHG4TruthInfoContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPHHepMCGenEventMap.h
+++ b/offline/packages/NodeDump/DumpPHHepMCGenEventMap.h
@@ -11,10 +11,10 @@ class DumpPHHepMCGenEventMap : public DumpObject
 {
  public:
   DumpPHHepMCGenEventMap(const std::string &NodeName);
-  virtual ~DumpPHHepMCGenEventMap() {}
+  ~DumpPHHepMCGenEventMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpParticleFlowElementContainer.h
+++ b/offline/packages/NodeDump/DumpParticleFlowElementContainer.h
@@ -11,10 +11,10 @@ class DumpParticleFlowElementContainer : public DumpObject
 {
  public:
   DumpParticleFlowElementContainer(const std::string &NodeName);
-  virtual ~DumpParticleFlowElementContainer() {}
+  ~DumpParticleFlowElementContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPdbParameterMap.h
+++ b/offline/packages/NodeDump/DumpPdbParameterMap.h
@@ -11,10 +11,10 @@ class DumpPdbParameterMap : public DumpObject
 {
  public:
   DumpPdbParameterMap(const std::string &NodeName);
-  virtual ~DumpPdbParameterMap() {}
+  ~DumpPdbParameterMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpPdbParameterMapContainer.h
+++ b/offline/packages/NodeDump/DumpPdbParameterMapContainer.h
@@ -11,10 +11,10 @@ class DumpPdbParameterMapContainer : public DumpObject
 {
  public:
   DumpPdbParameterMapContainer(const std::string &NodeName);
-  virtual ~DumpPdbParameterMapContainer() {}
+  ~DumpPdbParameterMapContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRawClusterContainer.h
+++ b/offline/packages/NodeDump/DumpRawClusterContainer.h
@@ -11,10 +11,10 @@ class DumpRawClusterContainer : public DumpObject
 {
  public:
   DumpRawClusterContainer(const std::string &NodeName);
-  virtual ~DumpRawClusterContainer() {}
+  ~DumpRawClusterContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRawTowerContainer.h
+++ b/offline/packages/NodeDump/DumpRawTowerContainer.h
@@ -11,10 +11,10 @@ class DumpRawTowerContainer : public DumpObject
 {
  public:
   DumpRawTowerContainer(const std::string &NodeName);
-  virtual ~DumpRawTowerContainer() {}
+  ~DumpRawTowerContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRawTowerGeom.h
+++ b/offline/packages/NodeDump/DumpRawTowerGeom.h
@@ -11,10 +11,10 @@ class DumpRawTowerGeom : public DumpObject
 {
  public:
   DumpRawTowerGeom(const std::string &NodeName);
-  virtual ~DumpRawTowerGeom() {}
+  ~DumpRawTowerGeom() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRawTowerGeomContainer.h
+++ b/offline/packages/NodeDump/DumpRawTowerGeomContainer.h
@@ -11,10 +11,10 @@ class DumpRawTowerGeomContainer : public DumpObject
 {
  public:
   DumpRawTowerGeomContainer(const std::string &NodeName);
-  virtual ~DumpRawTowerGeomContainer() {}
+  ~DumpRawTowerGeomContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpRunHeader.h
+++ b/offline/packages/NodeDump/DumpRunHeader.h
@@ -11,10 +11,10 @@ class DumpRunHeader : public DumpObject
 {
  public:
   DumpRunHeader(const std::string &NodeName);
-  virtual ~DumpRunHeader() {}
+  ~DumpRunHeader() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
   int node_written = 0;
 };
 

--- a/offline/packages/NodeDump/DumpSvtxTrackMap.h
+++ b/offline/packages/NodeDump/DumpSvtxTrackMap.h
@@ -11,10 +11,10 @@ class DumpSvtxTrackMap : public DumpObject
 {
  public:
   DumpSvtxTrackMap(const std::string &NodeName);
-  virtual ~DumpSvtxTrackMap() {}
+  ~DumpSvtxTrackMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpSvtxVertexMap.h
+++ b/offline/packages/NodeDump/DumpSvtxVertexMap.h
@@ -11,10 +11,10 @@ class DumpSvtxVertexMap : public DumpObject
 {
  public:
   DumpSvtxVertexMap(const std::string &NodeName);
-  virtual ~DumpSvtxVertexMap() {}
+  ~DumpSvtxVertexMap() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpSyncObject.h
+++ b/offline/packages/NodeDump/DumpSyncObject.h
@@ -11,10 +11,10 @@ class DumpSyncObject : public DumpObject
 {
  public:
   DumpSyncObject(const std::string &NodeName);
-  virtual ~DumpSyncObject() {}
+  ~DumpSyncObject() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpTowerBackground.h
+++ b/offline/packages/NodeDump/DumpTowerBackground.h
@@ -10,8 +10,8 @@ class DumpTowerBackground : public DumpObject
 {
  public:
   DumpTowerBackground(const std::string &NodeName);
-  virtual ~DumpTowerBackground() {}
+  ~DumpTowerBackground() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };

--- a/offline/packages/NodeDump/DumpTrkrClusterContainer.h
+++ b/offline/packages/NodeDump/DumpTrkrClusterContainer.h
@@ -11,10 +11,10 @@ class DumpTrkrClusterContainer : public DumpObject
 {
  public:
   DumpTrkrClusterContainer(const std::string &NodeName);
-  virtual ~DumpTrkrClusterContainer() {}
+  ~DumpTrkrClusterContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpTrkrClusterHitAssoc.h
+++ b/offline/packages/NodeDump/DumpTrkrClusterHitAssoc.h
@@ -11,10 +11,10 @@ class DumpTrkrClusterHitAssoc : public DumpObject
 {
  public:
   DumpTrkrClusterHitAssoc(const std::string &NodeName);
-  virtual ~DumpTrkrClusterHitAssoc() {}
+  ~DumpTrkrClusterHitAssoc() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpTrkrHitSetContainer.h
+++ b/offline/packages/NodeDump/DumpTrkrHitSetContainer.h
@@ -11,10 +11,10 @@ class DumpTrkrHitSetContainer : public DumpObject
 {
  public:
   DumpTrkrHitSetContainer(const std::string &NodeName);
-  virtual ~DumpTrkrHitSetContainer() {}
+  ~DumpTrkrHitSetContainer() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpTrkrHitTruthAssoc.h
+++ b/offline/packages/NodeDump/DumpTrkrHitTruthAssoc.h
@@ -11,10 +11,10 @@ class DumpTrkrHitTruthAssoc : public DumpObject
 {
  public:
   DumpTrkrHitTruthAssoc(const std::string &NodeName);
-  virtual ~DumpTrkrHitTruthAssoc() {}
+  ~DumpTrkrHitTruthAssoc() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/DumpVariableArray.h
+++ b/offline/packages/NodeDump/DumpVariableArray.h
@@ -11,10 +11,10 @@ class DumpVariableArray : public DumpObject
 {
  public:
   DumpVariableArray(const std::string &NodeName);
-  virtual ~DumpVariableArray() {}
+  ~DumpVariableArray() override {}
 
  protected:
-  int process_Node(PHNode *mynode);
+  int process_Node(PHNode *mynode) override;
 };
 
 #endif

--- a/offline/packages/NodeDump/Dumper.h
+++ b/offline/packages/NodeDump/Dumper.h
@@ -12,9 +12,9 @@ class Dumper : public SubsysReco
 {
  public:
   Dumper(const std::string &name = "DUMPER");
-  virtual ~Dumper();
-  int End(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  ~Dumper() override;
+  int End(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
   void SetOutDir(const std::string &outdir);
   void SetPrecision(const int digits);
   int AddIgnore(const std::string &name);

--- a/offline/packages/NodeDump/PHNodeDump.h
+++ b/offline/packages/NodeDump/PHNodeDump.h
@@ -15,7 +15,7 @@ class PHNodeDump : public PHNodeOperation
 {
  public:
   PHNodeDump();
-  virtual ~PHNodeDump();
+  ~PHNodeDump() override;
   int CloseOutputFiles();
   int GetGlobalVars(PHCompositeNode *topNode);
 
@@ -28,7 +28,7 @@ class PHNodeDump : public PHNodeOperation
   void SetPrecision(const int digits) { fp_precision = digits; }
 
  protected:
-  virtual void perform(PHNode *);
+  void perform(PHNode *) override;
   int AddDumpObject(const std::string &NodeName, PHNode *node);
   std::map<std::string, DumpObject *> dumpthis;
   std::set<std::string> ignore;

--- a/offline/packages/PHField/PHField2D.h
+++ b/offline/packages/PHField/PHField2D.h
@@ -16,12 +16,12 @@ class PHField2D : public PHField
 
  public:
   PHField2D(const std::string &filename, const int verb = 0, const float magfield_rescale = 1.0);
-  virtual ~PHField2D() {}
+  ~PHField2D() override {}
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
-  void GetFieldValue(const double Point[4], double *Bfield) const;
+  void GetFieldValue(const double Point[4], double *Bfield) const override;
 
   void GetFieldCyl(const double CylPoint[4], double *Bfield) const;
 

--- a/offline/packages/PHField/PHField3DCartesian.h
+++ b/offline/packages/PHField/PHField3DCartesian.h
@@ -10,13 +10,13 @@ class PHField3DCartesian : public PHField
 {
  public:
   PHField3DCartesian(const std::string &fname, const float magfield_rescale = 1.0);
-  virtual ~PHField3DCartesian();
+  ~PHField3DCartesian() override;
 
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
-  void GetFieldValue(const double Point[4], double *Bfield) const;
+  void GetFieldValue(const double Point[4], double *Bfield) const override;
 
  protected:
   std::string filename;

--- a/offline/packages/PHField/PHField3DCylindrical.h
+++ b/offline/packages/PHField/PHField3DCylindrical.h
@@ -34,8 +34,8 @@ class PHField3DCylindrical : public PHField
 
  public:
   PHField3DCylindrical(const std::string& filename, int verb = 0, const float magfield_rescale = 1.0);
-  virtual ~PHField3DCylindrical() {}
-  void GetFieldValue(const double Point[4], double* Bfield) const;
+  ~PHField3DCylindrical() override {}
+  void GetFieldValue(const double Point[4], double* Bfield) const override;
   void GetFieldCyl(const double CylPoint[4], double* Bfield) const;
 
  protected:

--- a/offline/packages/PHField/PHFieldBeast.h
+++ b/offline/packages/PHField/PHFieldBeast.h
@@ -11,12 +11,12 @@ class PHFieldBeast : public PHField
 {
  public:
   PHFieldBeast(const std::string &filename, const int verb = 0, const float magfield_rescale = 1.0);
-  virtual ~PHFieldBeast() {}
+  ~PHFieldBeast() override {}
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
-  void GetFieldValue(const double Point[4], double *Bfield) const;
+  void GetFieldValue(const double Point[4], double *Bfield) const override;
 
  private:
   BeastMagneticField *m_BeastMagneticField;

--- a/offline/packages/PHField/PHFieldCleo.h
+++ b/offline/packages/PHField/PHFieldCleo.h
@@ -10,12 +10,12 @@ class PHFieldCleo : public PHField
 {
  public:
   PHFieldCleo(const std::string &filename, const int verb = 0, const float magfield_rescale = 1.0);
-  virtual ~PHFieldCleo() {}
+  ~PHFieldCleo() override {}
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
-  void GetFieldValue(const double Point[4], double *Bfield) const;
+  void GetFieldValue(const double Point[4], double *Bfield) const override;
 
  private:
   std::vector<std::vector<std::vector<double> > > xField;

--- a/offline/packages/PHField/PHFieldConfig.h
+++ b/offline/packages/PHField/PHFieldConfig.h
@@ -20,12 +20,12 @@
 class PHFieldConfig : public PHObject
 {
  public:
-  virtual ~PHFieldConfig() {}
+  ~PHFieldConfig() override {}
 
   /** identify Function from PHObject
    @param os Output Stream
    */
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   enum FieldConfigTypes
   {

--- a/offline/packages/PHField/PHFieldConfigv1.h
+++ b/offline/packages/PHField/PHFieldConfigv1.h
@@ -34,22 +34,22 @@ class PHFieldConfigv1 : public PHFieldConfig
   {
   }
 
-  virtual ~PHFieldConfigv1() {}
+  ~PHFieldConfigv1() override {}
 
   /// Virtual copy constructor.
-  virtual PHObject* CloneMe() const override { return new PHFieldConfigv1(*this); }
+  PHObject* CloneMe() const override { return new PHFieldConfigv1(*this); }
 
   /** identify Function from PHObject
    @param os Output Stream
    */
-  virtual void
+  void
   identify(std::ostream& os = std::cout) const override;
 
   /// Clear Content
-  virtual void Reset() override {}
+  void Reset() override {}
 
   /// isValid returns non zero if object contains vailid data
-  virtual int
+  int
   isValid() const override;
 
   FieldConfigTypes get_field_config() const override

--- a/offline/packages/PHField/PHFieldConfigv2.h
+++ b/offline/packages/PHField/PHFieldConfigv2.h
@@ -34,22 +34,22 @@ class PHFieldConfigv2 : public PHFieldConfig
   {
   }
 
-  virtual ~PHFieldConfigv2() {}
+  ~PHFieldConfigv2() override {}
 
   /// Virtual copy constructor.
-  virtual PHObject* CloneMe() const override { return new PHFieldConfigv2(*this); }
+  PHObject* CloneMe() const override { return new PHFieldConfigv2(*this); }
 
   /** identify Function from PHObject
    @param os Output Stream
    */
-  virtual void
+  void
   identify(std::ostream& os = std::cout) const override;
 
   /// Clear Content
-  virtual void Reset() override {}
+  void Reset() override {}
 
   /// isValid returns non zero if object contains vailid data
-  virtual int
+  int
   isValid() const override { return 3; }
 
   FieldConfigTypes get_field_config() const override

--- a/offline/packages/PHField/PHFieldUniform.h
+++ b/offline/packages/PHField/PHFieldUniform.h
@@ -11,12 +11,12 @@ class PHFieldUniform : public PHField
       double field_mag_x,
       double field_mag_y,
       double field_mag_z);
-  virtual ~PHFieldUniform() {}
+  ~PHFieldUniform() override {}
   //! access field value
   //! Follow the convention of G4ElectroMagneticField
   //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
-  void GetFieldValue(const double Point[4], double *Bfield) const;
+  void GetFieldValue(const double Point[4], double *Bfield) const override;
 
   double get_field_mag_x() const
   {

--- a/offline/packages/PHGenFitPkg/GenFitExp/Field.h
+++ b/offline/packages/PHGenFitPkg/GenFitExp/Field.h
@@ -26,13 +26,13 @@ class Field : public AbsBField
  public:
   Field(const PHField* field);
 
-  virtual ~Field() {}
+  ~Field() override {}
 
   //  void plot(std::string option = "");
 
   //! return value at position
-  TVector3 get(const TVector3& pos) const;
-  void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const;
+  TVector3 get(const TVector3& pos) const override;
+  void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const override;
 
   const PHField* get_field() const
   {

--- a/offline/packages/PHGeometry/PHGeomFileImport.h
+++ b/offline/packages/PHGeometry/PHGeomFileImport.h
@@ -12,9 +12,9 @@ class PHGeomFileImport : public SubsysReco
 {
  public:
   explicit PHGeomFileImport(const std::string &geometry_file);
-  virtual ~PHGeomFileImport() {}
+  ~PHGeomFileImport() override {}
 
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
  protected:
   std::string m_GeometryFile;

--- a/offline/packages/PHGeometry/PHGeomIOTGeo.h
+++ b/offline/packages/PHGeometry/PHGeomIOTGeo.h
@@ -28,22 +28,22 @@ class PHGeomIOTGeo : public PHObject
 {
  public:
   PHGeomIOTGeo();
-  virtual ~PHGeomIOTGeo();
+  ~PHGeomIOTGeo() override;
 
-  virtual PHObject* CloneMe() const override {return new PHGeomIOTGeo(*this);}
+  PHObject* CloneMe() const override {return new PHGeomIOTGeo(*this);}
 
   /** identify Function from PHObject
    @param os Output Stream
    */
-  virtual void
+  void
   identify(std::ostream& os = std::cout) const override;
 
   /// Clear Event
-  virtual void
+  void
   Reset() override;
 
   /// isValid returns non zero if object contains vailid data
-  virtual int
+  int
   isValid() const override;
 
   //! PHGeomIOTGeo do NOT own this TGeoVolume * g. Internally, it will use g to make a copy which PHGeomIOTGeo fully owns

--- a/offline/packages/PHGeometry/PHGeomTGeo.h
+++ b/offline/packages/PHGeometry/PHGeomTGeo.h
@@ -27,18 +27,18 @@ class PHGeomTGeo : public PHObject
 {
  public:
   PHGeomTGeo();
-  virtual ~PHGeomTGeo();
+  ~PHGeomTGeo() override;
 
   /** identify Function from PHObject
       @param os Output Stream
    */
-  virtual void identify(std::ostream& os = std::cout) const;
+  void identify(std::ostream& os = std::cout) const override;
 
   /// Clear Event
-  virtual void Reset();
+  void Reset() override;
 
   /// isValid returns non zero if object contains vailid data
-  virtual int isValid() const;
+  int isValid() const override;
 
   //! Assign TGeoManager object.
   //! Once assigned, the TGeoManager will be locked to avoid a second TGeoManager override gGeoManager and lead to an invalid PHGeomTGeo

--- a/offline/packages/PHTpcTracker/PHTpcTracker.h
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.h
@@ -37,7 +37,7 @@ class PHTpcTracker : public PHTrackSeeding
 {
  public:
   PHTpcTracker(const std::string& name = "PHTpcTracker");
-  ~PHTpcTracker();
+  ~PHTpcTracker() override;
 
   void set_seed_finder_options(double maxdistance1 = 3.0, double tripletangle1 = M_PI / 8, size_t minhits1 = 10,
                                double maxdistance2 = 6.0, double tripletangle2 = M_PI / 8, size_t minhits2 = 5, size_t nthreads = 1);
@@ -54,11 +54,11 @@ class PHTpcTracker : public PHTrackSeeding
   void enable_json_export(bool opt = false) { mEnableJsonExport = opt; }
 
  protected:
-  int Setup(PHCompositeNode* topNode);
+  int Setup(PHCompositeNode* topNode) override;
 
-  int Process(PHCompositeNode* topNode);
+  int Process(PHCompositeNode* topNode) override;
 
-  int End() {return 0;}
+  int End() override {return 0;}
 
   PHField* getMagField(PHCompositeNode* topNode, double& B);
 

--- a/offline/packages/PHTpcTracker/externals/kdfinder.hpp
+++ b/offline/packages/PHTpcTracker/externals/kdfinder.hpp
@@ -1280,7 +1280,7 @@ namespace kdfinder
 
     bool is_good()
     {
-      return !std::isnan(a) && !isnan(b) && !isnan(r) &&
+      return !std::isnan(a) && !std::isnan(b) && !std::isnan(r) &&
              std::isfinite(a) && std::isfinite(b) && std::isfinite(r) &&
              std::isfinite(j) && j > 0;
     }
@@ -1320,7 +1320,7 @@ namespace kdfinder
 
     bool is_good()
     {
-      return !std::isnan(a) && !isnan(b) && !isnan(chi2) &&
+      return !std::isnan(a) && !std::isnan(b) && !std::isnan(chi2) &&
              std::isfinite(a) && std::isfinite(b) && std::isfinite(chi2);
     }
     T a;     // a + b * x

--- a/offline/packages/intt/InttClusterizer.h
+++ b/offline/packages/intt/InttClusterizer.h
@@ -22,19 +22,19 @@ class InttClusterizer : public SubsysReco
  public:
   InttClusterizer(const std::string &name = "InttClusterizer",
                   unsigned int min_layer = 0, unsigned int max_layer = UINT_MAX);
-  virtual ~InttClusterizer() {}
+  ~InttClusterizer() override {}
 
   //! module initialization
-  int Init(PHCompositeNode *topNode) { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode *topNode) { return 0; }
+  int End(PHCompositeNode *topNode) override { return 0; }
 
   //! set an energy requirement relative to the thickness MIP expectation
   void set_threshold(const float fraction_of_mip)

--- a/offline/packages/jetbackground/CopyAndSubtractJets.h
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.h
@@ -27,11 +27,11 @@ class CopyAndSubtractJets : public SubsysReco
 {
  public:
   CopyAndSubtractJets(const std::string &name = "CopyAndSubtractJets");
-  virtual ~CopyAndSubtractJets() {}
+  ~CopyAndSubtractJets() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void SetFlowModulation(bool use_flow_modulation) { _use_flow_modulation = use_flow_modulation; }
 

--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -28,10 +28,10 @@ class DetermineTowerBackground : public SubsysReco
 {
  public:
   DetermineTowerBackground(const std::string &name = "DetermineTowerBackground");
-  virtual ~DetermineTowerBackground() {}
+  ~DetermineTowerBackground() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void SetBackgroundOutputName(const std::string &name) { _backgroundName = name; }
   void SetSeedType(int seed_type) { _seed_type = seed_type; }

--- a/offline/packages/jetbackground/FastJetAlgoSub.h
+++ b/offline/packages/jetbackground/FastJetAlgoSub.h
@@ -12,13 +12,13 @@ class FastJetAlgoSub : public JetAlgo
 {
  public:
   FastJetAlgoSub(Jet::ALGO algo, float par, float verbosity = 0);
-  virtual ~FastJetAlgoSub() {}
+  ~FastJetAlgoSub() override {}
 
-  void identify(std::ostream& os = std::cout);
-  Jet::ALGO get_algo() { return _algo; }
-  float get_par() { return _par; }
+  void identify(std::ostream& os = std::cout) override;
+  Jet::ALGO get_algo() override { return _algo; }
+  float get_par() override { return _par; }
 
-  std::vector<Jet*> get_jets(std::vector<Jet*> particles);
+  std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
 
  private:
   int _verbosity;

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -27,10 +27,10 @@ class RetowerCEMC : public SubsysReco
 {
  public:
   RetowerCEMC(const std::string &name = "RetowerCEMC");
-  virtual ~RetowerCEMC() {}
+  ~RetowerCEMC() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
  private:
   int CreateNode(PHCompositeNode *topNode);

--- a/offline/packages/jetbackground/SubtractTowers.h
+++ b/offline/packages/jetbackground/SubtractTowers.h
@@ -26,10 +26,10 @@ class SubtractTowers : public SubsysReco
 {
  public:
   SubtractTowers(const std::string &name = "SubtractTowers");
-  virtual ~SubtractTowers() {}
+  ~SubtractTowers() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void SetFlowModulation(bool use_flow_modulation) { _use_flow_modulation = use_flow_modulation; }
 

--- a/offline/packages/jetbackground/SubtractTowersCS.h
+++ b/offline/packages/jetbackground/SubtractTowersCS.h
@@ -26,10 +26,10 @@ class SubtractTowersCS : public SubsysReco
 {
  public:
   SubtractTowersCS(const std::string &name = "SubtractTowersCS");
-  virtual ~SubtractTowersCS() {}
+  ~SubtractTowersCS() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void SetFlowModulation(bool use_flow_modulation) { _use_flow_modulation = use_flow_modulation; }
   void SetAlpha(float alpha) { _alpha = alpha; }

--- a/offline/packages/jetbackground/TowerBackground.h
+++ b/offline/packages/jetbackground/TowerBackground.h
@@ -8,10 +8,10 @@
 class TowerBackground : public PHObject
 {
  public:
-  virtual ~TowerBackground(){};
+  ~TowerBackground() override{};
 
-  virtual void identify(std::ostream &os = std::cout) const override { os << "TowerBackground base class" << std::endl; };
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream &os = std::cout) const override { os << "TowerBackground base class" << std::endl; };
+  int isValid() const override { return 0; }
 
   virtual void set_UE(int layer, const std::vector<float> &UE) {}
   virtual void set_v2(float v2) {}

--- a/offline/packages/jetbackground/TowerBackgroundv1.h
+++ b/offline/packages/jetbackground/TowerBackgroundv1.h
@@ -10,22 +10,22 @@ class TowerBackgroundv1 : public TowerBackground
 {
  public:
   TowerBackgroundv1();
-  virtual ~TowerBackgroundv1() {}
+  ~TowerBackgroundv1() override {}
 
   void identify(std::ostream &os = std::cout) const override;
   void Reset() override {}
   int isValid() const override { return 1; }
 
-  virtual void set_UE(int layer, const std::vector<float> &UE) override { _UE[layer] = UE; }
-  virtual void set_v2(float v2) override { _v2 = v2; }
-  virtual void set_Psi2(float Psi2) override { _Psi2 = Psi2; }
-  virtual void set_nStripsUsedForFlow(int nStrips) override { _nStrips = nStrips; }
-  virtual void set_nTowersUsedForBkg(int nTowers) override { _nTowers = nTowers; }
+  void set_UE(int layer, const std::vector<float> &UE) override { _UE[layer] = UE; }
+  void set_v2(float v2) override { _v2 = v2; }
+  void set_Psi2(float Psi2) override { _Psi2 = Psi2; }
+  void set_nStripsUsedForFlow(int nStrips) override { _nStrips = nStrips; }
+  void set_nTowersUsedForBkg(int nTowers) override { _nTowers = nTowers; }
 
-  virtual std::vector<float> get_UE(int layer) override { return _UE[layer]; }
-  virtual float get_v2() override { return _v2; }
-  virtual float get_Psi2() override { return _Psi2; }
-  virtual int get_nStripsUsedForFlow() override { return _nStrips; }
+  std::vector<float> get_UE(int layer) override { return _UE[layer]; }
+  float get_v2() override { return _v2; }
+  float get_Psi2() override { return _Psi2; }
+  int get_nStripsUsedForFlow() override { return _nStrips; }
 
 // our own - not from parent class
   virtual int get_nTowersUsedForFlow() { return _nTowers; }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -36,15 +36,15 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   {}
 
   //! print information about this layer
-  virtual void identify(std::ostream&) const override;
+  void identify(std::ostream&) const override;
 
   //!@name accessors
   //@{
-  virtual int get_layer() const override {return m_layer;}
-  virtual double get_radius() const override {return m_radius;}
-  virtual double get_thickness() const override { return m_thickness;}
-  virtual double get_zmin() const override {return m_zmin;}
-  virtual double get_zmax() const override {return m_zmax;}
+  int get_layer() const override {return m_layer;}
+  double get_radius() const override {return m_radius;}
+  double get_thickness() const override { return m_thickness;}
+  double get_zmin() const override {return m_zmin;}
+  double get_zmax() const override {return m_zmax;}
   double get_pitch() const { return m_pitch; }
 
   //! segmentation type
@@ -137,11 +137,11 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
 
   //!@name modifiers
   //@{
-  virtual void set_layer(const int i) override {m_layer = i;}
-  virtual void set_radius(const double value) override {m_radius = value;}
-  virtual void set_thickness(const double value) override {m_thickness = value;}
-  virtual void set_zmin(const double value) override {m_zmin = value;}
-  virtual void set_zmax(const double value) override {m_zmax = value;}
+  void set_layer(const int i) override {m_layer = i;}
+  void set_radius(const double value) override {m_radius = value;}
+  void set_thickness(const double value) override {m_thickness = value;}
+  void set_zmin(const double value) override {m_zmin = value;}
+  void set_zmax(const double value) override {m_zmax = value;}
   void set_pitch( double value ) { m_pitch = value; }
 
   //! tiles

--- a/offline/packages/micromegas/MicromegasTile.h
+++ b/offline/packages/micromegas/MicromegasTile.h
@@ -27,7 +27,7 @@ class MicromegasTile: public PHObject
   MicromegasTile() = default;
 
   //! destructor
-  virtual ~MicromegasTile() = default;
+  ~MicromegasTile() override = default;
 
   //! constructor
   MicromegasTile( std::array<double, 4> values )

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -31,7 +31,7 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   {
   }
 
-  virtual ~CylinderGeom_Mvtx() {}
+  ~CylinderGeom_Mvtx() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -28,19 +28,19 @@ class MvtxClusterizer : public SubsysReco
   typedef std::pair<unsigned int, unsigned int> pixel;
 
   MvtxClusterizer(const std::string &name = "MvtxClusterizer");
-  virtual ~MvtxClusterizer() {}
+  ~MvtxClusterizer() override {}
 
   //! module initialization
-  int Init(PHCompositeNode *topNode) { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode *topNode) { return 0; }
+  int End(PHCompositeNode *topNode) override { return 0; }
 
   //! option to turn off z-dimension clustering
   void SetZClustering(const bool make_z_clustering)

--- a/offline/packages/particleflow/ParticleFlowElement.h
+++ b/offline/packages/particleflow/ParticleFlowElement.h
@@ -28,10 +28,10 @@ class ParticleFlowElement : public PHObject
   };
 
   ParticleFlowElement() {}
-  virtual ~ParticleFlowElement() {}
+  ~ParticleFlowElement() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override { return 0; }
 
   virtual unsigned int get_id() const { return 0xFFFFFFFF; }
   virtual void set_id(unsigned int id) { return; }

--- a/offline/packages/particleflow/ParticleFlowElementContainer.h
+++ b/offline/packages/particleflow/ParticleFlowElementContainer.h
@@ -28,7 +28,7 @@ class ParticleFlowElementContainer : public PHObject
       
     }
   
-  virtual ~ParticleFlowElementContainer() {}
+  ~ParticleFlowElementContainer() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/offline/packages/particleflow/ParticleFlowElementv1.cc
+++ b/offline/packages/particleflow/ParticleFlowElementv1.cc
@@ -33,9 +33,9 @@ int ParticleFlowElementv1::isValid() const
 {
   for (int i = 0; i < 3; ++i)
     {
-      if (isnan(_mom[i])) return 0;
+      if (std::isnan(_mom[i])) return 0;
     }
-  if (isnan(_e)) return 0;
+  if (std::isnan(_e)) return 0;
   
   return 1;
 }

--- a/offline/packages/particleflow/ParticleFlowElementv1.h
+++ b/offline/packages/particleflow/ParticleFlowElementv1.h
@@ -18,7 +18,7 @@ class ParticleFlowElementv1 : public ParticleFlowElement
 {
  public:
   ParticleFlowElementv1();
-  virtual ~ParticleFlowElementv1() {}
+  ~ParticleFlowElementv1() override {}
   
   // PHObject virtual overloads
   

--- a/offline/packages/particleflow/ParticleFlowJetInput.h
+++ b/offline/packages/particleflow/ParticleFlowJetInput.h
@@ -20,10 +20,10 @@ class ParticleFlowJetInput : public JetInput
 {
  public:
   ParticleFlowJetInput();
-  virtual ~ParticleFlowJetInput() {}
+  ~ParticleFlowJetInput() override {}
 
-  std::vector<Jet*> get_input(PHCompositeNode* topNode);
-  void identify(std::ostream& os = std::cout);
+  std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
+  void identify(std::ostream& os = std::cout) override;
 
  private:
   int _verbosity;

--- a/offline/packages/particleflow/ParticleFlowReco.h
+++ b/offline/packages/particleflow/ParticleFlowReco.h
@@ -22,7 +22,7 @@ class ParticleFlowReco : public SubsysReco
 
   ParticleFlowReco(const std::string &name = "ParticleFlowReco");
 
-  virtual ~ParticleFlowReco();
+  ~ParticleFlowReco() override;
 
   int Init(PHCompositeNode *topNode) override;
 

--- a/offline/packages/tpc/TpcClusterCleaner.h
+++ b/offline/packages/tpc/TpcClusterCleaner.h
@@ -26,11 +26,11 @@ class TpcClusterCleaner : public SubsysReco
 
   TpcClusterCleaner(const std::string &name = "TpcClusterCleaner");
 
-  virtual ~TpcClusterCleaner();
+  ~TpcClusterCleaner() override;
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_rphi_error_low_cut(double cut){_rphi_error_low_cut = cut;}
   void set_rphi_error_high_cut(double cut){_rphi_error_high_cut = cut;}

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -27,11 +27,11 @@ class TpcClusterizer : public SubsysReco
 {
  public:
   TpcClusterizer(const std::string &name = "TpcClusterizer");
-  virtual ~TpcClusterizer(){}
+  ~TpcClusterizer() override{}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_sector_fiducial_cut(const double cut){SectorFiducialCut = cut; }
   void set_search_bins(const int bins){NSearch = bins;}

--- a/offline/packages/tpc/TpcSpaceChargeCorrection.h
+++ b/offline/packages/tpc/TpcSpaceChargeCorrection.h
@@ -20,10 +20,10 @@ class TpcSpaceChargeCorrection : public SubsysReco
   TpcSpaceChargeCorrection(  const std::string& = "TpcSpaceChargeCorrection" );
 
   //! global initialization
-  virtual int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //! event processing
-  virtual int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! distortion filename
   void set_distortion_filename( const std::string& value )

--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -26,14 +26,14 @@ class TrkrCluster : public PHObject
 {
  public:
   //! dtor
-  virtual ~TrkrCluster() {}
+  ~TrkrCluster() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "TrkrCluster base class" << std::endl;
   }
-  virtual void Reset() override {}
-  virtual int isValid() const override { return 0; }
+  void Reset() override {}
+  int isValid() const override { return 0; }
   //
   // cluster id
   //

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -35,10 +35,10 @@ class TrkrClusterContainer : public PHObject
   //@}
 
   //! reset method
-  virtual void Reset() override {}
+  void Reset() override {}
 
   //! identify object
-  virtual void identify(std::ostream &os = std::cout) const override {}
+  void identify(std::ostream &os = std::cout) const override {}
 
   //! add a cluster
   virtual ConstIterator addCluster(TrkrCluster*);

--- a/offline/packages/trackbase/TrkrClusterContainerv1.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv1.h
@@ -34,25 +34,25 @@ class TrkrClusterContainerv1 : public TrkrClusterContainer
 
   TrkrClusterContainerv1() = default;
   
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual ConstIterator addCluster(TrkrCluster *newClus) override;
+  ConstIterator addCluster(TrkrCluster *newClus) override;
 
-  virtual ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster *newClus) override;
+  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster *newClus) override;
 
-  virtual void removeCluster(TrkrDefs::cluskey) override;
+  void removeCluster(TrkrDefs::cluskey) override;
 
-  virtual void removeCluster(TrkrCluster*) override;
+  void removeCluster(TrkrCluster*) override;
 
-  virtual Iterator findOrAddCluster(TrkrDefs::cluskey key) override;
+  Iterator findOrAddCluster(TrkrDefs::cluskey key) override;
   
-  virtual ConstRange getClusters() const override;
+  ConstRange getClusters() const override;
 
-  virtual TrkrCluster *findCluster(TrkrDefs::cluskey key) const override;
+  TrkrCluster *findCluster(TrkrDefs::cluskey key) const override;
 
-  virtual unsigned int size() const override;
+  unsigned int size() const override;
 
   private:
   Map m_clusmap;

--- a/offline/packages/trackbase/TrkrClusterContainerv2.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.h
@@ -23,27 +23,27 @@ class TrkrClusterContainerv2 : public TrkrClusterContainer
 
   TrkrClusterContainerv2() = default;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual ConstIterator addCluster(TrkrCluster*) override;
+  ConstIterator addCluster(TrkrCluster*) override;
 
-  virtual ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
+  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
 
-  virtual void removeCluster(TrkrDefs::cluskey) override;
+  void removeCluster(TrkrDefs::cluskey) override;
 
-  virtual void removeCluster(TrkrCluster*) override;
+  void removeCluster(TrkrCluster*) override;
 
-  virtual Iterator findOrAddCluster(TrkrDefs::cluskey) override;
+  Iterator findOrAddCluster(TrkrDefs::cluskey) override;
 
-  virtual ConstRange getClusters(TrkrDefs::hitsetkey) const override;
+  ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 
-  virtual Map* getClusterMap(TrkrDefs::hitsetkey) override;
+  Map* getClusterMap(TrkrDefs::hitsetkey) override;
 
-  virtual TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
+  TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
-  virtual unsigned int size() const override;
+  unsigned int size() const override;
 
   private:
   

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -23,27 +23,27 @@ class TrkrClusterContainerv3 : public TrkrClusterContainer
 
   TrkrClusterContainerv3() = default;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual ConstIterator addCluster(TrkrCluster*) override;
+  ConstIterator addCluster(TrkrCluster*) override;
 
-  virtual ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
+  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
 
-  virtual void removeCluster(TrkrDefs::cluskey) override;
+  void removeCluster(TrkrDefs::cluskey) override;
 
-  virtual void removeCluster(TrkrCluster*) override;
+  void removeCluster(TrkrCluster*) override;
 
-  virtual Iterator findOrAddCluster(TrkrDefs::cluskey) override;
+  Iterator findOrAddCluster(TrkrDefs::cluskey) override;
 
-  virtual ConstRange getClusters(TrkrDefs::hitsetkey) const override;
+  ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 
-  virtual Map* getClusterMap(TrkrDefs::hitsetkey) override;
+  Map* getClusterMap(TrkrDefs::hitsetkey) override;
 
-  virtual TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
+  TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
-  virtual unsigned int size(void) const override;
+  unsigned int size(void) const override;
 
   private:
   

--- a/offline/packages/trackbase/TrkrClusterHitAssoc.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssoc.h
@@ -29,7 +29,7 @@ public:
   using ConstIterator = Map::const_iterator;
   using ConstRange = std::pair<Map::const_iterator, Map::const_iterator>;
   
-  virtual void Reset() override;
+  void Reset() override;
 
   /**
    * @brief Add association between cluster and hit

--- a/offline/packages/trackbase/TrkrClusterHitAssocv1.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv1.h
@@ -28,23 +28,23 @@ public:
   //! ctor
   TrkrClusterHitAssocv1() = default;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   /**
    * @brief Add association between cluster and hit
    * @param[in] ckey Cluster key
    * @param[in] hidx Index of the hit in TrkrHitSet
    */
-  virtual void addAssoc(TrkrDefs::cluskey ckey, unsigned int hidx) override;
+  void addAssoc(TrkrDefs::cluskey ckey, unsigned int hidx) override;
 
   /**
    * @brief Get all the hits associated with a cluster by key
    * @param[in] ckey Cluster key
    * @param[out] Range over hits associated with @c ckey
    */
-  virtual ConstRange getHits(TrkrDefs::cluskey) override;
+  ConstRange getHits(TrkrDefs::cluskey) override;
   
 private:
 

--- a/offline/packages/trackbase/TrkrClusterHitAssocv2.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv2.h
@@ -27,17 +27,17 @@ class TrkrClusterHitAssocv2 : public TrkrClusterHitAssoc
 
   TrkrClusterHitAssocv2() = default;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual void addAssoc(TrkrDefs::cluskey, unsigned int) override;
+  void addAssoc(TrkrDefs::cluskey, unsigned int) override;
 
-  virtual Map* getClusterMap(TrkrDefs::hitsetkey) override;
+  Map* getClusterMap(TrkrDefs::hitsetkey) override;
 
-  virtual ConstRange getHits(TrkrDefs::cluskey) override;
+  ConstRange getHits(TrkrDefs::cluskey) override;
 
-  virtual unsigned int size() const override;
+  unsigned int size() const override;
 
 private:
   unsigned int max_layer = 57;

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.h
@@ -28,17 +28,17 @@ class TrkrClusterHitAssocv3 : public TrkrClusterHitAssoc
 
   TrkrClusterHitAssocv3() = default;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual void addAssoc(TrkrDefs::cluskey, unsigned int) override;
+  void addAssoc(TrkrDefs::cluskey, unsigned int) override;
 
-  virtual Map* getClusterMap(TrkrDefs::hitsetkey) override;
+  Map* getClusterMap(TrkrDefs::hitsetkey) override;
 
-  virtual ConstRange getHits(TrkrDefs::cluskey) override;
+  ConstRange getHits(TrkrDefs::cluskey) override;
 
-  virtual unsigned int size(void) const override;
+  unsigned int size(void) const override;
 
 private:
 

--- a/offline/packages/trackbase/TrkrClusterv1.cc
+++ b/offline/packages/trackbase/TrkrClusterv1.cc
@@ -110,15 +110,15 @@ int TrkrClusterv1::isValid() const
   if (m_cluskey == TrkrDefs::CLUSKEYMAX) return 0;
   for (int i = 0; i < 3; ++i)
   {
-    if (isnan(getPosition(i))) return 0;
+    if (std::isnan(getPosition(i))) return 0;
   }
   if (m_adc == 0xFFFFFFFF) return 0;
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (isnan(getSize(i, j))) return 0;
-      if (isnan(getError(i, j))) return 0;
+      if (std::isnan(getSize(i, j))) return 0;
+      if (std::isnan(getError(i, j))) return 0;
     }
   }
 

--- a/offline/packages/trackbase/TrkrClusterv1.h
+++ b/offline/packages/trackbase/TrkrClusterv1.h
@@ -29,49 +29,49 @@ class TrkrClusterv1 : public TrkrCluster
   TrkrClusterv1();
 
   //!dtor
-  virtual ~TrkrClusterv1() {}
+  ~TrkrClusterv1() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override {}
-  virtual int isValid() const override;
-  virtual PHObject* CloneMe() const override { return new TrkrClusterv1(*this); }
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new TrkrClusterv1(*this); }
 
-  virtual void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
-  virtual TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
+  void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
+  TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
   //
   // cluster position
   //
-  virtual float getX() const override { return m_pos[0]; }
-  virtual void setX(float x) override { m_pos[0] = x; }
-  virtual float getY() const override { return m_pos[1]; }
-  virtual void setY(float y) override { m_pos[1] = y; }
-  virtual float getZ() const override { return m_pos[2]; }
-  virtual void setZ(float z) override { m_pos[2] = z; }
-  virtual float getPosition(int coor) const override { return m_pos[coor]; }
-  virtual void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
-  virtual void setGlobal() override { m_isGlobal = true; }
-  virtual void setLocal() override { m_isGlobal = false; }
-  virtual bool isGlobal() override { return m_isGlobal; }
+  float getX() const override { return m_pos[0]; }
+  void setX(float x) override { m_pos[0] = x; }
+  float getY() const override { return m_pos[1]; }
+  void setY(float y) override { m_pos[1] = y; }
+  float getZ() const override { return m_pos[2]; }
+  void setZ(float z) override { m_pos[2] = z; }
+  float getPosition(int coor) const override { return m_pos[coor]; }
+  void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
+  void setGlobal() override { m_isGlobal = true; }
+  void setLocal() override { m_isGlobal = false; }
+  bool isGlobal() override { return m_isGlobal; }
   //
   // cluster info
   //
-  virtual unsigned int getAdc() const override { return m_adc; }
-  virtual void setAdc(unsigned int adc) override { m_adc = adc; }
-  virtual float getSize(unsigned int i, unsigned int j) const override;        //< get cluster dimension covar
-  virtual void setSize(unsigned int i, unsigned int j, float value) override;  //< set cluster dimension covar
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+  float getSize(unsigned int i, unsigned int j) const override;        //< get cluster dimension covar
+  void setSize(unsigned int i, unsigned int j, float value) override;  //< set cluster dimension covar
 
-  virtual float getError(unsigned int i, unsigned int j) const override;        //< get cluster error covar
-  virtual void setError(unsigned int i, unsigned int j, float value) override;  //< set cluster error covar
+  float getError(unsigned int i, unsigned int j) const override;        //< get cluster error covar
+  void setError(unsigned int i, unsigned int j, float value) override;  //< set cluster error covar
 
   //
   // convenience interface
   //
-  virtual float getPhiSize() const override;
-  virtual float getZSize() const override;
+  float getPhiSize() const override;
+  float getZSize() const override;
 
-  virtual float getRPhiError() const override;
-  virtual float getPhiError() const override;
-  virtual float getZError() const override;
+  float getRPhiError() const override;
+  float getPhiError() const override;
+  float getZError() const override;
 
  protected:
 

--- a/offline/packages/trackbase/TrkrClusterv2.cc
+++ b/offline/packages/trackbase/TrkrClusterv2.cc
@@ -116,15 +116,15 @@ int TrkrClusterv2::isValid() const
   if (m_cluskey == TrkrDefs::CLUSKEYMAX) return 0;
   for (int i = 0; i < 3; ++i)
   {
-    if (isnan(getPosition(i))) return 0;
+    if (std::isnan(getPosition(i))) return 0;
   }
   if (m_adc == 0xFFFFFFFF) return 0;
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (isnan(getSize(i, j))) return 0;
-      if (isnan(getError(i, j))) return 0;
+      if (std::isnan(getSize(i, j))) return 0;
+      if (std::isnan(getError(i, j))) return 0;
     }
   }
 

--- a/offline/packages/trackbase/TrkrClusterv2.h
+++ b/offline/packages/trackbase/TrkrClusterv2.h
@@ -27,63 +27,63 @@ class TrkrClusterv2 : public TrkrCluster
   TrkrClusterv2();
 
   //!dtor
-  virtual ~TrkrClusterv2() {}
+  ~TrkrClusterv2() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override {}
-  virtual int isValid() const override;
-  virtual PHObject* CloneMe() const override { return new TrkrClusterv2(*this); }
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new TrkrClusterv2(*this); }
 
-  virtual void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
-  virtual TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
+  void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
+  TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
   
   
   //
   // cluster position
   //
-  virtual float getX() const override { return m_pos[0]; }
-  virtual void setX(float x) override { m_pos[0] = x; }
-  virtual float getY() const override { return m_pos[1]; }
-  virtual void setY(float y) override { m_pos[1] = y; }
-  virtual float getZ() const override { return m_pos[2]; }
-  virtual void setZ(float z) override { m_pos[2] = z; }
-  virtual float getPosition(int coor) const override { return m_pos[coor]; }
-  virtual void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
-  virtual void setGlobal() override { m_isGlobal = true; }
-  virtual void setLocal() override { m_isGlobal = false; }
-  virtual bool isGlobal() override { return m_isGlobal; }
+  float getX() const override { return m_pos[0]; }
+  void setX(float x) override { m_pos[0] = x; }
+  float getY() const override { return m_pos[1]; }
+  void setY(float y) override { m_pos[1] = y; }
+  float getZ() const override { return m_pos[2]; }
+  void setZ(float z) override { m_pos[2] = z; }
+  float getPosition(int coor) const override { return m_pos[coor]; }
+  void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
+  void setGlobal() override { m_isGlobal = true; }
+  void setLocal() override { m_isGlobal = false; }
+  bool isGlobal() override { return m_isGlobal; }
 
-  virtual float getLocalX() const override { return m_local[0]; }
-  virtual void setLocalX(float loc0) override { m_local[0] = loc0; }
-  virtual float getLocalY() const override { return m_local[1]; }
-  virtual void setLocalY(float loc1) override { m_local[1] = loc1; }
+  float getLocalX() const override { return m_local[0]; }
+  void setLocalX(float loc0) override { m_local[0] = loc0; }
+  float getLocalY() const override { return m_local[1]; }
+  void setLocalY(float loc1) override { m_local[1] = loc1; }
 
   /// Acts functions, for Acts module use only
-  virtual void setActsLocalError(unsigned int i, unsigned int j, float value) override;
-  virtual float getActsLocalError(unsigned int i, unsigned int j) const override { return m_actsLocalErr[i][j]; }
-  virtual TrkrDefs::subsurfkey getSubSurfKey() const override { return m_subsurfkey; }
-  virtual void setSubSurfKey(TrkrDefs::subsurfkey id) override { m_subsurfkey = id; }
+  void setActsLocalError(unsigned int i, unsigned int j, float value) override;
+  float getActsLocalError(unsigned int i, unsigned int j) const override { return m_actsLocalErr[i][j]; }
+  TrkrDefs::subsurfkey getSubSurfKey() const override { return m_subsurfkey; }
+  void setSubSurfKey(TrkrDefs::subsurfkey id) override { m_subsurfkey = id; }
 
   //
   // cluster info
   //
-  virtual unsigned int getAdc() const override { return m_adc; }
-  virtual void setAdc(unsigned int adc) override { m_adc = adc; }
-  virtual float getSize(unsigned int i, unsigned int j) const override;        //< get cluster dimension covar
-  virtual void setSize(unsigned int i, unsigned int j, float value) override;  //< set cluster dimension covar
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+  float getSize(unsigned int i, unsigned int j) const override;        //< get cluster dimension covar
+  void setSize(unsigned int i, unsigned int j, float value) override;  //< set cluster dimension covar
 
-  virtual float getError(unsigned int i, unsigned int j) const override;        //< get cluster error covar
-  virtual void setError(unsigned int i, unsigned int j, float value) override;  //< set cluster error covar
+  float getError(unsigned int i, unsigned int j) const override;        //< get cluster error covar
+  void setError(unsigned int i, unsigned int j, float value) override;  //< set cluster error covar
   
   //
   // convenience interface
   //
-  virtual float getPhiSize() const override;
-  virtual float getZSize() const override;
+  float getPhiSize() const override;
+  float getZSize() const override;
 
-  virtual float getRPhiError() const override;
-  virtual float getPhiError() const override;
-  virtual float getZError() const override;
+  float getRPhiError() const override;
+  float getPhiError() const override;
+  float getZError() const override;
 
  protected:
 

--- a/offline/packages/trackbase/TrkrHit.h
+++ b/offline/packages/trackbase/TrkrHit.h
@@ -27,14 +27,14 @@ class TrkrHit : public PHObject
  public:
 
   //! dtor
-  virtual ~TrkrHit() {}
+  ~TrkrHit() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "TrkrHit base class" << std::endl;
   }
-  virtual void Reset() override {}
-  virtual int isValid() const override { return 0; }
+  void Reset() override {}
+  int isValid() const override { return 0; }
 
   // these set and get the energy before digitization
   virtual void addEnergy(const double edep){}

--- a/offline/packages/trackbase/TrkrHitSet.h
+++ b/offline/packages/trackbase/TrkrHitSet.h
@@ -35,11 +35,11 @@ class TrkrHitSet : public PHObject
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
   //! TObject functions
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
   }
 
-  virtual void Reset() override
+  void Reset() override
   {
   }
 

--- a/offline/packages/trackbase/TrkrHitSetContainer.h
+++ b/offline/packages/trackbase/TrkrHitSetContainer.h
@@ -31,10 +31,10 @@ class TrkrHitSetContainer : public PHObject
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
   //! dtir
-  virtual ~TrkrHitSetContainer() = default;
+  ~TrkrHitSetContainer() override = default;
 
   //! PHObject functions
-  virtual void Reset()  override;
+  void Reset()  override;
   
   //! Add a TrkrHitSet to the container
   virtual ConstIterator addHitSet(TrkrHitSet*);

--- a/offline/packages/trackbase/TrkrHitSetContainerv1.h
+++ b/offline/packages/trackbase/TrkrHitSetContainerv1.h
@@ -25,32 +25,32 @@ class TrkrHitSetContainerv1 : public TrkrHitSetContainer
 
   TrkrHitSetContainerv1() = default;
 
-  virtual ~TrkrHitSetContainerv1()
+  ~TrkrHitSetContainerv1() override
   { TrkrHitSetContainerv1::Reset(); }
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream& = std::cout) const override;
+  void identify(std::ostream& = std::cout) const override;
 
-  virtual ConstIterator addHitSet(TrkrHitSet*) override;
+  ConstIterator addHitSet(TrkrHitSet*) override;
 
-  virtual ConstIterator addHitSetSpecifyKey(const TrkrDefs::hitsetkey, TrkrHitSet*) override;
+  ConstIterator addHitSetSpecifyKey(const TrkrDefs::hitsetkey, TrkrHitSet*) override;
 
-  virtual void removeHitSet(TrkrDefs::hitsetkey ) override;
+  void removeHitSet(TrkrDefs::hitsetkey ) override;
 
-  virtual void removeHitSet(TrkrHitSet* ) override;
+  void removeHitSet(TrkrHitSet* ) override;
 
-  virtual Iterator findOrAddHitSet(TrkrDefs::hitsetkey key) override;
+  Iterator findOrAddHitSet(TrkrDefs::hitsetkey key) override;
 
-  virtual ConstRange getHitSets(const TrkrDefs::TrkrId trackerid) const override;
+  ConstRange getHitSets(const TrkrDefs::TrkrId trackerid) const override;
 
-  virtual ConstRange getHitSets(const TrkrDefs::TrkrId trackerid, const uint8_t layer) const override;
+  ConstRange getHitSets(const TrkrDefs::TrkrId trackerid, const uint8_t layer) const override;
 
-  virtual ConstRange getHitSets() const override;
+  ConstRange getHitSets() const override;
 
-  virtual TrkrHitSet *findHitSet(TrkrDefs::hitsetkey key) override;
+  TrkrHitSet *findHitSet(TrkrDefs::hitsetkey key) override;
 
-  virtual unsigned int size() const override
+  unsigned int size() const override
   { return m_hitmap.size(); }
 
   private: 

--- a/offline/packages/trackbase/TrkrHitSetv1.h
+++ b/offline/packages/trackbase/TrkrHitSetv1.h
@@ -22,34 +22,34 @@ class TrkrHitSetv1 : public TrkrHitSet
  public:
   TrkrHitSetv1() = default;
 
-  virtual ~TrkrHitSetv1()
+  ~TrkrHitSetv1() override
   {
     TrkrHitSetv1::Reset();
   }
 
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void setHitSetKey(const TrkrDefs::hitsetkey key) override
+  void setHitSetKey(const TrkrDefs::hitsetkey key) override
   {
     m_hitSetKey = key;
   }
 
-  virtual TrkrDefs::hitsetkey getHitSetKey() const override
+  TrkrDefs::hitsetkey getHitSetKey() const override
   {
     return m_hitSetKey;
   }
 
-  virtual ConstIterator addHitSpecificKey(const TrkrDefs::hitkey, TrkrHit*) override;
+  ConstIterator addHitSpecificKey(const TrkrDefs::hitkey, TrkrHit*) override;
 
-  virtual void removeHit(TrkrDefs::hitkey) override;
+  void removeHit(TrkrDefs::hitkey) override;
 
-  virtual TrkrHit* getHit(const TrkrDefs::hitkey) const override;
+  TrkrHit* getHit(const TrkrDefs::hitkey) const override;
 
-  virtual ConstRange getHits() const override;
+  ConstRange getHits() const override;
 
-  virtual unsigned int size() const override
+  unsigned int size() const override
   {
     return m_hits.size();
   }

--- a/offline/packages/trackbase/TrkrHitTruthAssoc.h
+++ b/offline/packages/trackbase/TrkrHitTruthAssoc.h
@@ -34,10 +34,10 @@ class TrkrHitTruthAssoc : public PHObject
   using Range = std::pair<Iterator, Iterator>;
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
-  virtual void Reset() override
+  void Reset() override
   {}
 
-  virtual void identify(std::ostream &os = std::cout) const override
+  void identify(std::ostream &os = std::cout) const override
   {}
 
   /**

--- a/offline/packages/trackbase/TrkrHitTruthAssocv1.h
+++ b/offline/packages/trackbase/TrkrHitTruthAssocv1.h
@@ -27,17 +27,17 @@ class TrkrHitTruthAssocv1 : public TrkrHitTruthAssoc
 
   TrkrHitTruthAssocv1() = default;
  
-  virtual void Reset() override;
+  void Reset() override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual void addAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey, const PHG4HitDefs::keytype) override;
+  void addAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey, const PHG4HitDefs::keytype) override;
 
-  virtual void findOrAddAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey, const PHG4HitDefs::keytype) override;
+  void findOrAddAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey, const PHG4HitDefs::keytype) override;
 
-  virtual void removeAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey) override;
+  void removeAssoc(const TrkrDefs::hitsetkey, const TrkrDefs::hitkey) override;
   
-  virtual void getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap &temp_map) const override;
+  void getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap &temp_map) const override;
 
   private:
   

--- a/offline/packages/trackbase/TrkrHitv1.h
+++ b/offline/packages/trackbase/TrkrHitv1.h
@@ -23,19 +23,19 @@ class TrkrHitv1 : public TrkrHit
   TrkrHitv1(); 
 
   //! dtor
-  virtual ~TrkrHitv1() {}
+  ~TrkrHitv1() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "TrkrHitV1 class with adc = " << m_adc  << std::endl;
   }
-  virtual void Reset() override {}
-  virtual int isValid() const override { return 0; }
+  void Reset() override {}
+  int isValid() const override { return 0; }
 
-  virtual void addEnergy(const double edep) override {m_edep += edep;}
-  virtual double getEnergy() override {return m_edep;}
-  virtual void setAdc(const unsigned int adc) override {m_adc = adc;}
-  virtual unsigned int getAdc() override;
+  void addEnergy(const double edep) override {m_edep += edep;}
+  double getEnergy() override {return m_edep;}
+  void setAdc(const unsigned int adc) override {m_adc = adc;}
+  unsigned int getAdc() override;
 
  protected:
   double m_edep = 0;

--- a/offline/packages/trackbase/TrkrHitv2.h
+++ b/offline/packages/trackbase/TrkrHitv2.h
@@ -28,22 +28,22 @@ class TrkrHitv2 : public TrkrHit
   TrkrHitv2(); 
 
   //! dtor
-  virtual ~TrkrHitv2() {}
+  ~TrkrHitv2() override {}
   // PHObject virtual overloads
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "TrkrHitv2 class with adc = " << m_adc << std::endl;
   }
-  virtual void Reset() override {}
-  virtual int isValid() const override { return 0; }
+  void Reset() override {}
+  int isValid() const override { return 0; }
 
   // these set and get the energy before digitization
-  virtual void addEnergy(const double edep) override;
-  virtual double getEnergy() override;
+  void addEnergy(const double edep) override;
+  double getEnergy() override;
 
   // after digitization, these are the adc values
-  virtual void setAdc(const unsigned int adc) override;
-  virtual unsigned int getAdc() override ;
+  void setAdc(const unsigned int adc) override;
+  unsigned int getAdc() override ;
 
  protected:
 

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -37,16 +37,16 @@ class SvtxTrack : public PHObject
     HCALOUT = 3
   };
 
-  virtual ~SvtxTrack() = default;
+  ~SvtxTrack() override = default;
 
   // The "standard PHObject response" functions...
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxTrack base class" << std::endl;
   }
 
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   //! import PHObject CopyFrom, in order to avoid clang warning
   using PHObject::CopyFrom;

--- a/offline/packages/trackbase_historic/SvtxTrackMap.h
+++ b/offline/packages/trackbase_historic/SvtxTrackMap.h
@@ -15,14 +15,14 @@ class SvtxTrackMap : public PHObject
   typedef std::map<unsigned int, SvtxTrack*>::const_iterator ConstIter;
   typedef std::map<unsigned int, SvtxTrack*>::iterator Iter;
 
-  virtual ~SvtxTrackMap() {}
+  ~SvtxTrackMap() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxTrackMap base class" << std::endl;
   }
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }

--- a/offline/packages/trackbase_historic/SvtxTrackMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackMap_v1.h
@@ -15,7 +15,7 @@ class SvtxTrackMap_v1 : public SvtxTrackMap
   SvtxTrackMap_v1();
   SvtxTrackMap_v1(const SvtxTrackMap_v1& trackmap);
   SvtxTrackMap_v1& operator=(const SvtxTrackMap_v1& trackmap);
-  virtual ~SvtxTrackMap_v1();
+  ~SvtxTrackMap_v1() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -7,15 +7,15 @@
 class SvtxTrackState : public PHObject
 {
  public:
-  virtual ~SvtxTrackState() {}
+  ~SvtxTrackState() override {}
     
-  virtual void identify(std::ostream &os = std::cout) const override
+  void identify(std::ostream &os = std::cout) const override
   {
     os << "SvtxTrackState base class" << std::endl;
   }
 
-  virtual int isValid() const override { return 0; }
-  virtual PHObject *CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject *CloneMe() const override { return nullptr; }
 
   virtual float get_pathlength() const { return NAN; }
 

--- a/offline/packages/trackbase_historic/SvtxTrackState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v1.h
@@ -13,7 +13,7 @@ class SvtxTrackState_v1 : public SvtxTrackState
 {
  public:
   SvtxTrackState_v1(float pathlength = 0.0);
-  virtual ~SvtxTrackState_v1() {}
+  ~SvtxTrackState_v1() override {}
 
   // The "standard PHObject response" functions...
   void identify(std::ostream &os = std::cout) const override;
@@ -56,9 +56,9 @@ class SvtxTrackState_v1 : public SvtxTrackState
   std::string get_name() const override { return state_name; }
   void set_name(const std::string &name) override { state_name = name; }
 
-  virtual float get_rphi_error() const override;
-  virtual float get_phi_error() const override;
-  virtual float get_z_error() const override;
+  float get_rphi_error() const override;
+  float get_phi_error() const override;
+  float get_z_error() const override;
 
   //@}
 

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
@@ -20,14 +20,14 @@ class SvtxTrack_FastSim: public SvtxTrack_v1
   SvtxTrack_FastSim() = default;
 
   //* destructor
-  virtual ~SvtxTrack_FastSim() = default;
+  ~SvtxTrack_FastSim() override = default;
 
   //* base class copy constructor
   SvtxTrack_FastSim( const SvtxTrack& );
 
   // copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) override;
-  virtual void CopyFrom( SvtxTrack* source ) override
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }
 
   // The "standard PHObject response" functions...

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
@@ -19,11 +19,11 @@ class SvtxTrack_FastSim_v1 final: public SvtxTrack_FastSim
   SvtxTrack_FastSim_v1( const SvtxTrack& );
 
   //* destructor
-  virtual ~SvtxTrack_FastSim_v1() = default;
+  ~SvtxTrack_FastSim_v1() override = default;
 
   // copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) override;
-  virtual void CopyFrom( SvtxTrack* source ) override
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }
 
   // The "standard PHObject response" functions...

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.h
@@ -19,11 +19,11 @@ class SvtxTrack_FastSim_v2 final: public SvtxTrack_v2
   SvtxTrack_FastSim_v2( const SvtxTrack& );
 
   //* destructor
-  virtual ~SvtxTrack_FastSim_v2() = default;
+  ~SvtxTrack_FastSim_v2() override = default;
 
   // copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) override;
-  virtual void CopyFrom( SvtxTrack* source ) override
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }
 
   // The "standard PHObject response" functions...

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.cc
@@ -76,13 +76,13 @@ void SvtxTrack_v1::CopyFrom( const SvtxTrack& source )
 
   for( const auto& type: { SvtxTrack::PRES, SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT } )
   {
-    if(!isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
-    if(!isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
-    if(!isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
-    if(!isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
+    if(!std::isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
+    if(!std::isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
+    if(!std::isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
+    if(!std::isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
     if(source.get_cal_cluster_id(type) != UINT_MAX) set_cal_cluster_id(type, source.get_cal_cluster_id(type));
     if(source.get_cal_cluster_key(type) != UINT_MAX) set_cal_cluster_key(type, source.get_cal_cluster_key(type));
-    if(!isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
+    if(!std::isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
   }
 
 }

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.h
@@ -28,7 +28,7 @@ class SvtxTrack_v1 : public SvtxTrack
   //* assignment operator
   SvtxTrack_v1& operator=(const SvtxTrack_v1& track);
   
-  virtual ~SvtxTrack_v1();
+  ~SvtxTrack_v1() override;
 
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const override;
@@ -37,8 +37,8 @@ class SvtxTrack_v1 : public SvtxTrack
   PHObject* CloneMe() const override { return new SvtxTrack_v1(*this); }
   
   // copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) override;
-  virtual void CopyFrom( SvtxTrack* source ) override
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }
 
   //

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -84,13 +84,13 @@ void SvtxTrack_v2::CopyFrom( const SvtxTrack& source )
 
   for( const auto& type: { SvtxTrack::PRES, SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT } )
   {
-    if(!isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
-    if(!isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
-    if(!isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
-    if(!isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
+    if(!std::isnan(source.get_cal_dphi(type))) set_cal_dphi(type, source.get_cal_dphi(type));
+    if(!std::isnan(source.get_cal_deta(type))) set_cal_deta(type, source.get_cal_deta(type));
+    if(!std::isnan(source.get_cal_energy_3x3(type))) set_cal_energy_3x3(type, source.get_cal_energy_3x3(type));
+    if(!std::isnan(source.get_cal_energy_5x5(type))) set_cal_energy_5x5(type, source.get_cal_energy_5x5(type));
     if(source.get_cal_cluster_id(type) != UINT_MAX) set_cal_cluster_id(type, source.get_cal_cluster_id(type));
     if(source.get_cal_cluster_key(type) != UINT_MAX) set_cal_cluster_key(type, source.get_cal_cluster_key(type));
-    if(!isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
+    if(!std::isnan(source.get_cal_cluster_e(type))) set_cal_cluster_e(type, source.get_cal_cluster_e(type));
   }
 
 }

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -29,7 +29,7 @@ class SvtxTrack_v2: public SvtxTrack
   SvtxTrack_v2& operator=(const SvtxTrack_v2& track);
 
   //* destructor
-  virtual ~SvtxTrack_v2(); 
+  ~SvtxTrack_v2() override; 
 
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const override;
@@ -38,8 +38,8 @@ class SvtxTrack_v2: public SvtxTrack
   PHObject* CloneMe() const override { return new SvtxTrack_v2(*this); }
 
   // copy content from base class
-  virtual void CopyFrom( const SvtxTrack& ) override;
-  virtual void CopyFrom( SvtxTrack* source ) override
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }
 
   //

--- a/offline/packages/trackbase_historic/SvtxVertex.h
+++ b/offline/packages/trackbase_historic/SvtxVertex.h
@@ -16,17 +16,17 @@ class SvtxVertex : public PHObject
   typedef std::set<unsigned int>::const_iterator ConstTrackIter;
   typedef std::set<unsigned int>::iterator TrackIter;
 
-  virtual ~SvtxVertex() {}
+  ~SvtxVertex() override {}
 
   // PHObject virtual overloads
 
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxVertex base class" << std::endl;
   }
 
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   // vertex info
 

--- a/offline/packages/trackbase_historic/SvtxVertexMap.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap.h
@@ -14,14 +14,14 @@ class SvtxVertexMap : public PHObject
   typedef std::map<unsigned int, SvtxVertex*>::const_iterator ConstIter;
   typedef std::map<unsigned int, SvtxVertex*>::iterator Iter;
 
-  virtual ~SvtxVertexMap() {}
+  ~SvtxVertexMap() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxVertexMap base class" << std::endl;
   }
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }

--- a/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap_v1.h
@@ -16,7 +16,7 @@ class SvtxVertexMap_v1 : public SvtxVertexMap
   SvtxVertexMap_v1();
   SvtxVertexMap_v1(const SvtxVertexMap_v1& vertexmap);
   SvtxVertexMap_v1& operator=(const SvtxVertexMap_v1& vertexmap);
-  virtual ~SvtxVertexMap_v1();
+  ~SvtxVertexMap_v1() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;

--- a/offline/packages/trackbase_historic/SvtxVertex_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxVertex_v1.cc
@@ -65,19 +65,19 @@ void SvtxVertex_v1::identify(ostream& os) const
 int SvtxVertex_v1::isValid() const
 {
   if (_id == 0xFFFFFFFF) return 0;
-  if (isnan(_t0)) return 0;
-  if (isnan(_chisq)) return 0;
+  if (std::isnan(_t0)) return 0;
+  if (std::isnan(_chisq)) return 0;
   if (_ndof == 0xFFFFFFFF) return 0;
 
   for (int i = 0; i < 3; ++i)
   {
-    if (isnan(_pos[i])) return 0;
+    if (std::isnan(_pos[i])) return 0;
   }
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (isnan(get_error(i, j))) return 0;
+      if (std::isnan(get_error(i, j))) return 0;
     }
   }
   if (_track_ids.empty()) return 0;

--- a/offline/packages/trackbase_historic/SvtxVertex_v1.h
+++ b/offline/packages/trackbase_historic/SvtxVertex_v1.h
@@ -13,7 +13,7 @@ class SvtxVertex_v1 : public SvtxVertex
 {
  public:
   SvtxVertex_v1();
-  virtual ~SvtxVertex_v1() {}
+  ~SvtxVertex_v1() override {}
 
   // PHObject virtual overloads
 

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -57,12 +57,12 @@ class ActsEvaluator : public SubsysReco
  public:
   ActsEvaluator(const std::string &name = "ActsEvaluator.root",
                      SvtxEvaluator *svtxEvaluator = nullptr);
-  ~ActsEvaluator();
+  ~ActsEvaluator() override;
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int ResetEvent(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void setEvalCKF(bool evalCKF) {m_evalCKF = evalCKF;}
 
  private:

--- a/offline/packages/trackreco/AssocInfoContainer.h
+++ b/offline/packages/trackreco/AssocInfoContainer.h
@@ -15,9 +15,9 @@ class AssocInfoContainer : public PHObject
  public:
   typedef std::multimap<TrkrDefs::cluskey, unsigned int> ClusterTrackMap;
 
-  virtual ~AssocInfoContainer(){}
+  ~AssocInfoContainer() override{}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   virtual void SetClusterTrackAssoc(const TrkrDefs::cluskey& cluster_id, const unsigned int& track_id) {return;}
 

--- a/offline/packages/trackreco/AssocInfoContainerv1.h
+++ b/offline/packages/trackreco/AssocInfoContainerv1.h
@@ -16,7 +16,7 @@ class AssocInfoContainerv1 : public AssocInfoContainer
   typedef std::multimap<TrkrDefs::cluskey, unsigned int> ClusterTrackMap;
 
   AssocInfoContainerv1();
-  virtual ~AssocInfoContainerv1();
+  ~AssocInfoContainerv1() override;
 
   void Reset() override;
   void identify(std::ostream& os = std::cout) const override;

--- a/offline/packages/trackreco/CellularAutomaton_v1.h
+++ b/offline/packages/trackreco/CellularAutomaton_v1.h
@@ -41,48 +41,48 @@ class CellularAutomaton_v1 : public CellularAutomaton {
 
 	CellularAutomaton_v1(std::vector<SimpleTrack3D>& input_tracks, std::vector<float>& radius, std::vector<float>& material);
 //	CellularAutomaton_v1(const CellularAutomaton_v1& cellular_automaton);
-	virtual ~CellularAutomaton_v1() {};
+	~CellularAutomaton_v1() override {};
 
 	// The "standard PHObject response" functions...
-	void identify(std::ostream &os=std::cout) const {};
-	void Reset();
-	int  isValid() const {return 1;}
-	CellularAutomaton* Clone() const {return new CellularAutomaton_v1(*this);}
+	void identify(std::ostream &os=std::cout) const override {};
+	void Reset() override;
+	int  isValid() const override {return 1;}
+	CellularAutomaton* Clone() const override {return new CellularAutomaton_v1(*this);}
 
-	void set_hough_space(HelixHoughSpace* hough_space);
-	void set_mag_field(float mag_field);
-	void set_pt_rescale(float pt_rescale);
-        void set_n_layers(unsigned int n_layers) {nlayers = n_layers;}
-        void set_required_layers(unsigned int req_layers) {rlayers = req_layers;}
-	void set_ca_chi2(float chi2_cut){ ca_chi2_cut = chi2_cut;}
-	void set_ca_chi2_layer(float chi2_layer_cut){ca_chi2_layer_cut = chi2_layer_cut;}
-	void set_ca_phi_cut(float phi_cut){ca_phi_cut = phi_cut;}
-	void set_ca_z_cut(float z_cut) {ca_z_cut = z_cut;}
-	void set_ca_dcaxy_cut(float dcaxy_cut){ca_dcaxy_cut = dcaxy_cut;}
-	void set_propagate_forward(bool fwd) {forward = fwd;}
-	void set_remove_hits(bool remove){remove_hits = remove;}
-	void set_remove_inner_hits(bool remove_inner){remove_inner_hits = remove_inner;}
-	void set_require_inner_hits(bool require_inner){require_inner_hits = require_inner;}
-	void set_triplet_mode(bool mod) {triplet_mode = mod;}
-	void set_seeding_mode(bool mod) {seeding_mode = mod;}
-	void set_hits_map(std::map<unsigned int, SimpleHit3D>& hits_map){_hits_map = hits_map;}
+	void set_hough_space(HelixHoughSpace* hough_space) override;
+	void set_mag_field(float mag_field) override;
+	void set_pt_rescale(float pt_rescale) override;
+        void set_n_layers(unsigned int n_layers) override {nlayers = n_layers;}
+        void set_required_layers(unsigned int req_layers) override {rlayers = req_layers;}
+	void set_ca_chi2(float chi2_cut) override{ ca_chi2_cut = chi2_cut;}
+	void set_ca_chi2_layer(float chi2_layer_cut) override{ca_chi2_layer_cut = chi2_layer_cut;}
+	void set_ca_phi_cut(float phi_cut) override{ca_phi_cut = phi_cut;}
+	void set_ca_z_cut(float z_cut) override {ca_z_cut = z_cut;}
+	void set_ca_dcaxy_cut(float dcaxy_cut) override{ca_dcaxy_cut = dcaxy_cut;}
+	void set_propagate_forward(bool fwd) override {forward = fwd;}
+	void set_remove_hits(bool remove) override{remove_hits = remove;}
+	void set_remove_inner_hits(bool remove_inner) override{remove_inner_hits = remove_inner;}
+	void set_require_inner_hits(bool require_inner) override{require_inner_hits = require_inner;}
+	void set_triplet_mode(bool mod) override {triplet_mode = mod;}
+	void set_seeding_mode(bool mod) override {seeding_mode = mod;}
+	void set_hits_map(std::map<unsigned int, SimpleHit3D>& hits_map) override{_hits_map = hits_map;}
 	void set_verbose(int v) {verbose = v;}
 
-	int run(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states, std::map<unsigned int, bool>& hits_used);	
+	int run(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states, std::map<unsigned int, bool>& hits_used) override;	
 
 
  private:
 
-	void set_detector_radii(std::vector<float>& radii);
+	void set_detector_radii(std::vector<float>& radii) override;
 	void set_detector_materials(std::vector<float>& materials);
-	void set_input_tracks(std::vector<SimpleTrack3D>& input_tracks);
-	void set_cylinder_kalman();
+	void set_input_tracks(std::vector<SimpleTrack3D>& input_tracks) override;
+	void set_cylinder_kalman() override;
 
-	int init();
-	int process_tracks();
-	int process_single_track(SimpleTrack3D& track);
-	int process_single_triplet(SimpleTrack3D& track);
-	int get_ca_tracks(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states);	
+	int init() override;
+	int process_tracks() override;
+	int process_single_track(SimpleTrack3D& track) override;
+	int process_single_triplet(SimpleTrack3D& track) override;
+	int get_ca_tracks(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states) override;	
 
 	int calculate_kappa_tangents(                        
 			float x1, float y1, float z1, float x2, float y2, float z2, 
@@ -91,7 +91,7 @@ class CellularAutomaton_v1 : public CellularAutomaton {
                         float dx3, float dy3, float dz3, 
                         float& kappa, float& dkappa,
                         float& ux_mid, float& uy_mid, float& ux_end, float& uy_end,
-                        float& dzdl_1, float& dzdl_2, float& ddzdl_1, float& ddzdl_2);
+                        float& dzdl_1, float& dzdl_2, float& ddzdl_1, float& ddzdl_2) override;
 	int calculate_kappa_tangents(
                         float x1, float y1, float z1, float x2, float y2, float z2,
                         float x3, float y3, float z3,
@@ -102,10 +102,10 @@ class CellularAutomaton_v1 : public CellularAutomaton {
                         float& dzdl_1, float& dzdl_2, float& ddzdl_1, float& ddzdl_2,
                         float ca_sin_ang_cut, float inv_cos_ang_diff,
                         float cur_kappa, float cur_dkappa, float cur_ux, float cur_uy, 
-                        float cur_chi2, float& chi2);	
+                        float cur_chi2, float& chi2) override;	
 
 	float kappa_to_pt(float kappa);
-	float shift_phi_range(float phi);
+	float shift_phi_range(float phi) override;
 
 	HelixHoughSpace* _hough_space;
 	HelixKalmanFilter* _kalman;

--- a/offline/packages/trackreco/HelixHoughBin.h
+++ b/offline/packages/trackreco/HelixHoughBin.h
@@ -23,15 +23,15 @@ class HelixHoughBin : public PHObject
   typedef std::set<unsigned int>::const_iterator ConstClusterIter;
   typedef std::set<unsigned int>::iterator ClusterIter;
 
-  virtual ~HelixHoughBin() {}
+  ~HelixHoughBin() override {}
 
   // The "standard PHObject response" functions...
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "HelixHoughBin base class" << std::endl;
   }
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   virtual void init() {}
 

--- a/offline/packages/trackreco/HelixHoughBin_v1.h
+++ b/offline/packages/trackreco/HelixHoughBin_v1.h
@@ -13,7 +13,7 @@ class HelixHoughBin_v1 : public HelixHoughBin
 {
  public:
   HelixHoughBin_v1(unsigned int bin);
-  virtual ~HelixHoughBin_v1() {}
+  ~HelixHoughBin_v1() override {}
 
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const override;

--- a/offline/packages/trackreco/HelixHoughFuncs.h
+++ b/offline/packages/trackreco/HelixHoughFuncs.h
@@ -13,15 +13,15 @@ class HelixHoughSpace;
 class HelixHoughFuncs : public PHObject
 {
  public:
-  virtual ~HelixHoughFuncs() {}
+  ~HelixHoughFuncs() override {}
 
   // The "standard PHObject response" functions...
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "HelixHoughFuncs base class" << std::endl;
   }
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   // Define Hough space for helical tracks
   virtual void set_current_zoom(unsigned int cur_zoom) {}

--- a/offline/packages/trackreco/HelixHoughFuncs_v1.h
+++ b/offline/packages/trackreco/HelixHoughFuncs_v1.h
@@ -14,7 +14,7 @@ class HelixHoughFuncs_v1 : public HelixHoughFuncs
  public:
   HelixHoughFuncs_v1();
   HelixHoughFuncs_v1(const HelixHoughFuncs_v1& hough_funcs);
-  virtual ~HelixHoughFuncs_v1(){};
+  ~HelixHoughFuncs_v1() override{};
 
   // The "standard PHObject response" functions...
   void identify(std::ostream& os = std::cout) const override{};

--- a/offline/packages/trackreco/HelixHoughSpace.h
+++ b/offline/packages/trackreco/HelixHoughSpace.h
@@ -13,15 +13,15 @@
 class HelixHoughSpace : public PHObject {
 
 public :
-  virtual ~HelixHoughSpace() {}
+  ~HelixHoughSpace() override {}
 
 
   // The "standard PHObject response" functions...
-  virtual void identify(std::ostream &os=std::cout) const override {
+  void identify(std::ostream &os=std::cout) const override {
     os << "HelixHough base class" << std::endl;
   }
-  virtual int  isValid() const override {return 0;}
-  virtual PHObject* CloneMe() const  override {return nullptr;}
+  int  isValid() const override {return 0;}
+  PHObject* CloneMe() const  override {return nullptr;}
 
   // Define Hough space for helical tracks 
   virtual void add_one_zoom(std::vector<unsigned int>& one_zoom) {};

--- a/offline/packages/trackreco/HelixHoughSpace_v1.h
+++ b/offline/packages/trackreco/HelixHoughSpace_v1.h
@@ -14,7 +14,7 @@ public:
 
   HelixHoughSpace_v1();
   HelixHoughSpace_v1(const HelixHoughSpace_v1& hough_space);
-  virtual ~HelixHoughSpace_v1() {};
+  ~HelixHoughSpace_v1() override {};
 
 
   // The "standard PHObject response" functions...

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -68,12 +68,12 @@ class MakeActsGeometry : public SubsysReco
   MakeActsGeometry(const std::string& name = "MakeActsGeometry");
 
   //! Destructor
-  ~MakeActsGeometry() = default;
+  ~MakeActsGeometry() override = default;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator>> getContextDecorators()
     { return m_contextDecorators; }

--- a/offline/packages/trackreco/PH3DVertexing.h
+++ b/offline/packages/trackreco/PH3DVertexing.h
@@ -32,10 +32,10 @@ class PH3DVertexing : public SubsysReco
 {
  public:
   PH3DVertexing(const std::string &name = "PH3DVertexing");
-  virtual ~PH3DVertexing() {}
+  ~PH3DVertexing() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   virtual const std::set<unsigned int> &get_seeding_layers() const = 0;
 

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -210,7 +210,7 @@ void PHActsInitialVertexFinder::fillVertexMap(VertexVector& vertices,
       svtxVertex->set_t0(vertex.time());
       svtxVertex->set_id(vertexId);
           
-      for(const auto track : vertex.tracks())
+      for(const auto& track : vertex.tracks())
 	{
 	  const auto originalParams = track.originalParams;
 

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -32,7 +32,7 @@ class PHActsInitialVertexFinder: public PHInitVertexing
 {
  public: 
   PHActsInitialVertexFinder(const std::string& name="PHActsInitialVertexFinder");
-  virtual ~PHActsInitialVertexFinder() {}
+  ~PHActsInitialVertexFinder() override {}
 
   void setMaxVertices(const int maxVertices)
   { m_maxVertices = maxVertices;}

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -77,10 +77,10 @@ class PHActsSiliconSeeding : public SubsysReco
 {
  public:
   PHActsSiliconSeeding(const std::string& name = "PHActsSiliconSeeding");
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   /// Set seeding with truth clusters
   void useTruthClusters(bool useTruthClusters)

--- a/offline/packages/trackreco/PHActsToSvtxTracks.h
+++ b/offline/packages/trackreco/PHActsToSvtxTracks.h
@@ -37,14 +37,14 @@ class PHActsToSvtxTracks : public SubsysReco
  public:
   /// Default constructor and destructor
   PHActsToSvtxTracks(const std::string &name = "PHActsToSvtxTracks");
-  virtual ~PHActsToSvtxTracks() {}
+  ~PHActsToSvtxTracks() override {}
 
   /// Inherited SubsysReco functions
-  int End(PHCompositeNode *topNode);
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int ResetEvent(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
   
   void setSvtxTrackMapName(std::string &name)
   { m_svtxMapName = name;}

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -45,10 +45,10 @@ class PHActsTrackProjection : public SubsysReco
   PHActsTrackProjection(const std::string& name 
 			= "PHActsTrackProjection");
   
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   
  private:
   

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -62,18 +62,18 @@ class PHActsTrkFitter : public SubsysReco
   PHActsTrkFitter(const std::string& name = "PHActsTrkFitter");
 
   /// Destructor
-  ~PHActsTrkFitter();
+  ~PHActsTrkFitter() override;
 
   /// End, write and close files
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
 
   /// Get and create nodes
-  int InitRun(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode) override;
 
   /// Process each event by calling the fitter
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int ResetEvent(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode) override;
 
   /// Do some internal time benchmarking analysis
   void doTimeAnalysis(bool timeAnalysis){m_timeAnalysis = timeAnalysis;}

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -330,7 +330,7 @@ void PHActsVertexFinder::fillVertexMap(VertexVector& vertices,
 	    }
 	}
 
-      for(const auto track : vertex.tracks())
+      for(const auto& track : vertex.tracks())
 	{
 	  const auto originalParams = track.originalParams;
 	  const auto trackKey = keyMap.find(originalParams)->second;

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -40,7 +40,7 @@ class PHActsVertexFinder: public PHInitVertexing
  public:
   PHActsVertexFinder(const std::string &name = "PHActsVertexFinder");
 
-  virtual ~PHActsVertexFinder() {}
+  ~PHActsVertexFinder() override {}
 
   void setMaxVertices(int maxVertices)
     { m_maxVertices = maxVertices; }

--- a/offline/packages/trackreco/PHActsVertexFitter.h
+++ b/offline/packages/trackreco/PHActsVertexFitter.h
@@ -36,12 +36,12 @@ class PHActsVertexFitter : public SubsysReco
 {
  public:
   PHActsVertexFitter(const std::string &name = "PHActsVertexFitter");
-  virtual ~PHActsVertexFitter() {}
-  int process_event(PHCompositeNode *topNode);
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int ResetEvent(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  ~PHActsVertexFitter() override {}
+  int process_event(PHCompositeNode *topNode) override;
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void updateSvtxVertexMap(bool updateSvtxVertexMap)
   {

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -89,7 +89,7 @@ class PHCASeeding : public PHTrackSeeding
       float Bz = 14*0.000299792458f,
       float cosTheta_limit = -0.8);
 
-  virtual ~PHCASeeding()
+  ~PHCASeeding() override
   {
   }
   void SetLayerRange(unsigned int layer_low, unsigned int layer_up) {_start_layer = layer_low; _end_layer = layer_up;}
@@ -106,11 +106,11 @@ class PHCASeeding : public PHTrackSeeding
   }
 
  protected:
-  virtual int Setup(PHCompositeNode *topNode);
-  virtual int Process(PHCompositeNode *topNode);
+  int Setup(PHCompositeNode *topNode) override;
+  int Process(PHCompositeNode *topNode) override;
   int InitializeGeometry(PHCompositeNode *topNode);
   int FindSeedsLayerSkip(double cosTheta_limit);
-  virtual int End();
+  int End() override;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trackreco/PHGenFitTrackProjection.h
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.h
@@ -32,12 +32,12 @@ class PHGenFitTrackProjection : public SubsysReco
  public:
  
   PHGenFitTrackProjection(const std::string &name = "PHGenFitTrackProjection", const int pid_guess = 211);
-  virtual ~PHGenFitTrackProjection() {}
+  ~PHGenFitTrackProjection() override {}
 		
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   int get_pid_guess() const {
     return _pid_guess;

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -84,16 +84,16 @@ class PHGenFitTrkFitter : public SubsysReco
   PHGenFitTrkFitter(const std::string& name = "PHGenFitTrkFitter");
 
   //!Initialization, called for initialization
-  virtual int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   //!Initialization Run, called for initialization of a run
-  virtual int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //!Process Event, called for each event
-  virtual int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //!End, write and close files
-  virtual int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
 
   //! For evalution
   //! Change eval output filename

--- a/offline/packages/trackreco/PHHoughSeeding.h
+++ b/offline/packages/trackreco/PHHoughSeeding.h
@@ -53,16 +53,16 @@ class PHHoughSeeding : public PHTrackSeeding
       unsigned int min_seeding_nlayer = 4
 );
 
-  virtual ~PHHoughSeeding()
+  ~PHHoughSeeding() override
   {
   }
 
  protected:
-  int Setup(PHCompositeNode *topNode);
+  int Setup(PHCompositeNode *topNode) override;
 
-  int Process(PHCompositeNode *topNode);
+  int Process(PHCompositeNode *topNode) override;
 
-  int End();
+  int End() override;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trackreco/PHHybridSeeding.h
+++ b/offline/packages/trackreco/PHHybridSeeding.h
@@ -53,7 +53,7 @@ class PHHybridSeeding : public PHTrackSeeding
       size_t nthreads = 1
       );
 
-  virtual ~PHHybridSeeding()
+  ~PHHybridSeeding() override
   {
   }
   
@@ -76,10 +76,10 @@ class PHHybridSeeding : public PHTrackSeeding
   void setMinFitTrackSize(size_t s) {_min_fit_track_size = s;}
 
  protected:
-  virtual int Setup(PHCompositeNode *topNode);
-  virtual int Process(PHCompositeNode *topNode);
+  int Setup(PHCompositeNode *topNode) override;
+  int Process(PHCompositeNode *topNode) override;
   int InitializeGeometry(PHCompositeNode *topNode);
-  virtual int End();
+  int End() override;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trackreco/PHInitVertexing.h
+++ b/offline/packages/trackreco/PHInitVertexing.h
@@ -28,10 +28,10 @@ class PHInitVertexing : public SubsysReco
 {
  public:
   PHInitVertexing(const std::string &name = "PHInitVertexing");
-  virtual ~PHInitVertexing() {}
+  ~PHInitVertexing() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
  protected:
 

--- a/offline/packages/trackreco/PHInitZVertexing.h
+++ b/offline/packages/trackreco/PHInitZVertexing.h
@@ -44,7 +44,7 @@ public:
 
 	PHInitZVertexing(unsigned int nlayers = 7, unsigned int min_nlayers = 7,
 			const std::string &name = "PHInitZVertexing");
-	virtual ~PHInitZVertexing() ;
+	~PHInitZVertexing() override ;
 
 	void set_file_name(const std::string &fname){_fname = fname;}
 	void set_mag_field(float mag_field) {
@@ -138,9 +138,9 @@ public:
 
  protected:
 
-  int Setup(PHCompositeNode *topNode);
-  int Process(PHCompositeNode *topNode);
-  int End(PHCompositeNode * /*topNode*/);
+  int Setup(PHCompositeNode *topNode) override;
+  int Process(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode * /*topNode*/) override;
 
 private:
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -22,7 +22,7 @@ class PHMicromegasTpcTrackMatching : public PHTrackPropagating
   
   public:
   PHMicromegasTpcTrackMatching(const std::string &name = "PHMicromegasTpcTrackMatching");
-  virtual ~PHMicromegasTpcTrackMatching() = default;
+  ~PHMicromegasTpcTrackMatching() override = default;
 
   void set_rphi_search_window_lyr1(const double win){_rphi_search_win[0] = win;}
   void set_z_search_window_lyr1(const double win){_z_search_win[0] = win;}

--- a/offline/packages/trackreco/PHPatternReco.cc
+++ b/offline/packages/trackreco/PHPatternReco.cc
@@ -756,11 +756,11 @@ int PHPatternReco::translate_input(PHCompositeNode* topNode) {
   unsigned int clusid = 0;
   unsigned int ilayer = 0;
 
-  auto hitsetrange = m_hitsets->getHitSets();
+  auto hitsetrange = _hitsets->getHitSets();
   for (auto hitsetitr = hitsetrange.first;
        hitsetitr != hitsetrange.second;
        ++hitsetitr){
-    auto range = m_clusterMap->getClusters(hitsetitr->first);
+    auto range = _clustermap->getClusters(hitsetitr->first);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       TrkrCluster *cluster = clusIter->second;
       TrkrDefs::cluskey cluskey = clusIter->first;

--- a/offline/packages/trackreco/PHPatternReco.h
+++ b/offline/packages/trackreco/PHPatternReco.h
@@ -44,12 +44,12 @@ public:
 
 	PHPatternReco(unsigned int nlayers = 7, unsigned int min_nlayers = 7,
 			const std::string &name = "PHPatternReco");
-	virtual ~PHPatternReco() ;
+	~PHPatternReco() override ;
 
-	int Init(PHCompositeNode *topNode);
-	int InitRun(PHCompositeNode *topNode);
-	int process_event(PHCompositeNode *topNode);
-	int End(PHCompositeNode *topNode);
+	int Init(PHCompositeNode *topNode) override;
+	int InitRun(PHCompositeNode *topNode) override;
+	int process_event(PHCompositeNode *topNode) override;
+	int End(PHCompositeNode *topNode) override;
 
 
 	void set_file_name(const std::string &fname){_fname = fname;}

--- a/offline/packages/trackreco/PHRTreeSeeding.h
+++ b/offline/packages/trackreco/PHRTreeSeeding.h
@@ -71,18 +71,18 @@ class PHRTreeSeeding : public PHTrackSeeding
   void set_phi_scale(float scale) { _phi_scale = scale; }
   void set_z_scale(float scale) { _z_scale = scale; }
 
-  virtual ~PHRTreeSeeding()
+  ~PHRTreeSeeding() override
   {
   }
 
  protected:
-  int Setup(PHCompositeNode *topNode);
+  int Setup(PHCompositeNode *topNode) override;
   int GetNodes(PHCompositeNode *topNode);
   int Process();
-  int Process(PHCompositeNode *topNode);
+  int Process(PHCompositeNode *topNode) override;
   int InitializeGeometry(PHCompositeNode *topNode);
 
-  int End();
+  int End() override;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trackreco/PHRaveVertexing.h
+++ b/offline/packages/trackreco/PHRaveVertexing.h
@@ -43,19 +43,19 @@ class PHRaveVertexing : public SubsysReco
   PHRaveVertexing(const std::string& name = "PHRaveVertexing");
 
   //! dtor
-  ~PHRaveVertexing();
+  ~PHRaveVertexing() override;
 
   //!Initialization, called for initialization
-  int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   //!Initialization Run, called for initialization of a run
-  int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //!Process Event, called for each event
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //!End, write and close files
-  int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
 
   const std::string& get_vertexing_method() const
   {

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -19,7 +19,7 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
 
   PHSiliconTpcTrackMatching(const std::string &name = "PHSiliconTpcTrackMatching");
 
-  virtual ~PHSiliconTpcTrackMatching();
+  ~PHSiliconTpcTrackMatching() override;
 
   void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
   void set_phi_search_window(const double win){_phi_search_win = win;}

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -38,7 +38,7 @@ class PHSimpleKFProp : public PHTrackPropagating
 {
  public:
   PHSimpleKFProp(const std::string &name = "PHSimpleKFProp");
-  virtual ~PHSimpleKFProp() {}
+  ~PHSimpleKFProp() override {}
 
   //int InitRun(PHCompositeNode *topNode) override;
   //int process_event(PHCompositeNode *topNode) override;

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -27,11 +27,11 @@ class PHTpcClusterMover : public SubsysReco
 
   PHTpcClusterMover(const std::string &name = "PHTpcClusterMover");
 
-  virtual ~PHTpcClusterMover();
+  ~PHTpcClusterMover() override;
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
 
  private:

--- a/offline/packages/trackreco/PHTpcResiduals.h
+++ b/offline/packages/trackreco/PHTpcResiduals.h
@@ -50,12 +50,12 @@ class PHTpcResiduals : public SubsysReco
  public:
 
   PHTpcResiduals(const std::string &name = "PHTpcResiduals");
-  ~PHTpcResiduals();
+  ~PHTpcResiduals() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   /// Option for setting distortion correction calculation limits
   void setMaxTrackAlpha(float maxTAlpha) 

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -21,7 +21,7 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   PHTpcTrackSeedVertexAssoc(const std::string &name = "PHTpcTrackSeedVertexAssoc");
 
-  virtual ~PHTpcTrackSeedVertexAssoc();
+  ~PHTpcTrackSeedVertexAssoc() override;
 
   void reject_xy_outliers(const bool reject){_reject_xy_outliers = reject;}  
   void reject_z_outliers(const bool reject){_reject_z_outliers = reject;}

--- a/offline/packages/trackreco/PHTrackFitting.h
+++ b/offline/packages/trackreco/PHTrackFitting.h
@@ -31,11 +31,11 @@ class PHTrackFitting : public SubsysReco
 {
  public:
   PHTrackFitting(const std::string &name = "PHTrackFitting");
-  virtual ~PHTrackFitting() {}
+  ~PHTrackFitting() override {}
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   //virtual const std::set<unsigned int> &get_seeding_layers() const = 0;
 

--- a/offline/packages/trackreco/PHTrackPropagating.h
+++ b/offline/packages/trackreco/PHTrackPropagating.h
@@ -30,11 +30,11 @@ class PHTrackPropagating : public SubsysReco
 {
  public:
   PHTrackPropagating(const std::string &name = "PHTrackPropagating");
-  virtual ~PHTrackPropagating() {}
+  ~PHTrackPropagating() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   void SetUseTruthClusters(bool setit){_use_truth_clusters = setit;}
 

--- a/offline/packages/trackreco/PHTrackSeeding.h
+++ b/offline/packages/trackreco/PHTrackSeeding.h
@@ -32,11 +32,11 @@ class PHTrackSeeding : public SubsysReco
 {
  public:
   PHTrackSeeding(const std::string &name = "PHTrackSeeding");
-  virtual ~PHTrackSeeding() {}
+  ~PHTrackSeeding() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   void SetUseTruthClusters(bool setit){_use_truth_clusters = setit;}
 

--- a/offline/packages/trackreco/PHTrackSetMerging.h
+++ b/offline/packages/trackreco/PHTrackSetMerging.h
@@ -30,12 +30,12 @@ class PHTrackSetMerging : public SubsysReco
 {
  public:
   PHTrackSetMerging(const std::string &name = "PHTrackSetMerging");
-  virtual ~PHTrackSetMerging() {}
+  ~PHTrackSetMerging() override {}
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_track_map_name_in1(const std::string &map_name) { _track_map_name_in1 = map_name; }
   void set_track_map_name_in2(const std::string &map_name) { _track_map_name_in2 = map_name; }

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -36,11 +36,11 @@ class PHTruthClustering  : public SubsysReco
 {
 public:
   PHTruthClustering(const std::string &name = "PHTruthClustering");
-  virtual ~PHTruthClustering();
+  ~PHTruthClustering() override;
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void UsePrimaryTrackClustersOnly(bool flag) {_primary_clusters_only = flag;}
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -30,7 +30,7 @@ class PHTruthSiliconAssociation : public SubsysReco
 
   PHTruthSiliconAssociation(const std::string &name = "PHTruthSiliconAssociation");
 
-  virtual ~PHTruthSiliconAssociation();
+  ~PHTruthSiliconAssociation() override;
 
   /** Called during initialization.
       Typically this is where you can book histograms, and e.g.

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -29,7 +29,7 @@ class PHTruthVertexing : public PHInitVertexing
 {
  public:
   PHTruthVertexing(const std::string &name = "PHTruthVertexing");
-  virtual ~PHTruthVertexing();
+  ~PHTruthVertexing() override;
 
   void set_vertex_error(const float &x_err, const float &y_err, const float &z_err)
   {
@@ -54,11 +54,11 @@ class PHTruthVertexing : public PHInitVertexing
 
  protected:
 
-  int Setup(PHCompositeNode *topNode);
+  int Setup(PHCompositeNode *topNode) override;
 
-  int Process(PHCompositeNode *topNode);
+  int Process(PHCompositeNode *topNode) override;
 
-  int End(PHCompositeNode * /*topNode*/);
+  int End(PHCompositeNode * /*topNode*/) override;
 
  private:
   /// fetch node pointers

--- a/offline/packages/trigger/CaloTriggerInfo.h
+++ b/offline/packages/trigger/CaloTriggerInfo.h
@@ -6,10 +6,10 @@
 class CaloTriggerInfo : public PHObject
 {
  public:
-  virtual ~CaloTriggerInfo(){};
+  ~CaloTriggerInfo() override{};
 
-  virtual void identify(std::ostream &os = std::cout) const override { os << "CaloTriggerInfo base class" << std::endl; };
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream &os = std::cout) const override { os << "CaloTriggerInfo base class" << std::endl; };
+  int isValid() const override { return 0; }
 
   // EMCal 2x2
   virtual void set_best_EMCal_2x2_E(const float E) {}

--- a/offline/packages/trigger/CaloTriggerInfov1.h
+++ b/offline/packages/trigger/CaloTriggerInfov1.h
@@ -9,7 +9,7 @@ class CaloTriggerInfov1 : public CaloTriggerInfo
 {
  public:
   CaloTriggerInfov1();
-  virtual ~CaloTriggerInfov1() {}
+  ~CaloTriggerInfov1() override {}
 
   void identify(std::ostream &os = std::cout) const override;
   void Reset() override {}

--- a/offline/packages/trigger/CaloTriggerSim.h
+++ b/offline/packages/trigger/CaloTriggerSim.h
@@ -27,10 +27,10 @@ class CaloTriggerSim : public SubsysReco
 {
  public:
   CaloTriggerSim(const std::string &name = "CaloTriggerSim");
-  virtual ~CaloTriggerSim() {}
+  ~CaloTriggerSim() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void set_truncation(const int emulate_truncation) { m_EmulateTruncationFlag = emulate_truncation; }
   double truncate_8bit(const double raw_E) const;

--- a/offline/packages/vararray/VariableArray.h
+++ b/offline/packages/vararray/VariableArray.h
@@ -10,7 +10,7 @@ class VariableArray : public PHObject
 {
  public:
   VariableArray(const unsigned int idval = 0);
-  virtual ~VariableArray();
+  ~VariableArray() override;
 
   void identify(std::ostream &os = std::cout) const override;
 

--- a/offline/packages/vararray/VariableArrayContainer.h
+++ b/offline/packages/vararray/VariableArrayContainer.h
@@ -12,7 +12,7 @@ class VariableArrayContainer : public PHObject
 {
  public:
   VariableArrayContainer();
-  virtual ~VariableArrayContainer();
+  ~VariableArrayContainer() override;
 
   void identify(std::ostream &os = std::cout) const override;
   void AddVarArray(VariableArray *var);

--- a/simulation/g4simulation/g4bbc/BbcVertex.h
+++ b/simulation/g4simulation/g4bbc/BbcVertex.h
@@ -9,13 +9,13 @@
 class BbcVertex : public PHObject
 {
  public:
-  virtual ~BbcVertex() {}
+  ~BbcVertex() override {}
 
   // PHObject virtual overloads
 
-  virtual void identify(std::ostream& os = std::cout) const override { os << "BbcVertex base class" << std::endl; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
-  virtual int isValid() const  override{ return 0; }
+  void identify(std::ostream& os = std::cout) const override { os << "BbcVertex base class" << std::endl; }
+  PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const  override{ return 0; }
 
   // vertex info
 

--- a/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.h
@@ -23,12 +23,12 @@ class BbcVertexFastSimReco : public SubsysReco
 {
  public:
   BbcVertexFastSimReco(const std::string &name = "BbcVertexFastSimReco");
-  virtual ~BbcVertexFastSimReco();
+  ~BbcVertexFastSimReco() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_t_smearing(const float t_smear) { m_T_Smear = t_smear; }
   void set_z_smearing(const float z_smear) { m_Z_Smear = z_smear; }

--- a/simulation/g4simulation/g4bbc/BbcVertexMap.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexMap.h
@@ -13,10 +13,10 @@ class BbcVertexMap : public PHObject
   typedef std::map<unsigned int, BbcVertex*>::const_iterator ConstIter;
   typedef std::map<unsigned int, BbcVertex*>::iterator Iter;
 
-  virtual ~BbcVertexMap() {}
+  ~BbcVertexMap() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override { os << "BbcVertexMap base class" << std::endl; }
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream& os = std::cout) const override { os << "BbcVertexMap base class" << std::endl; }
+  int isValid() const override { return 0; }
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }

--- a/simulation/g4simulation/g4bbc/BbcVertexMapv1.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexMapv1.h
@@ -13,7 +13,7 @@ class BbcVertexMapv1 : public BbcVertexMap
 {
  public:
   BbcVertexMapv1();
-  virtual ~BbcVertexMapv1();
+  ~BbcVertexMapv1() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override { clear(); }

--- a/simulation/g4simulation/g4bbc/BbcVertexv1.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexv1.h
@@ -9,7 +9,7 @@ class BbcVertexv1 : public BbcVertex
 {
  public:
   BbcVertexv1();
-  virtual ~BbcVertexv1();
+  ~BbcVertexv1() override;
 
   // PHObject virtual overloads
 

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
@@ -15,10 +15,10 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
 {
  public:
   HcalRawTowerBuilder(const std::string &name = "HcalRawTowerBuilder");
-  virtual ~HcalRawTowerBuilder() {}
+  ~HcalRawTowerBuilder() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
   void Detector(const std::string &d) { m_Detector = d; }
   void EminCut(const double e) { m_Emin = e; }
   void checkenergy(const int i = 1) { m_ChkEnergyConservationFlag = i; }
@@ -56,7 +56,7 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
 
   short get_tower_row(const short cellrow) const;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
  private:
   void CreateNodes(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4calo/RawTowerBuilder.h
+++ b/simulation/g4simulation/g4calo/RawTowerBuilder.h
@@ -13,9 +13,9 @@ class RawTowerBuilder : public SubsysReco
 {
  public:
   RawTowerBuilder(const std::string &name = "RawTowerBuilder");
-  virtual ~RawTowerBuilder() {}
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  ~RawTowerBuilder() override {}
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
   void Detector(const std::string &d) { m_Detector = d; }
   void EminCut(const double e) { m_Emin = e; }
   void checkenergy(const int i = 1) { m_ChkEnergyConservationFlag = i; }

--- a/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.h
+++ b/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.h
@@ -21,13 +21,13 @@ class RawTowerBuilderByHitIndex : public SubsysReco
 {
  public:
   RawTowerBuilderByHitIndex(const std::string &name = "RawTowerBuilderByHitIndex");
-  virtual ~RawTowerBuilderByHitIndex() {}
+  ~RawTowerBuilderByHitIndex() override {}
 
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
 
   /** Name of the detector node the G4Hits should be taken from.
    */

--- a/simulation/g4simulation/g4calo/RawTowerBuilderDRCALO.h
+++ b/simulation/g4simulation/g4calo/RawTowerBuilderDRCALO.h
@@ -21,13 +21,13 @@ class RawTowerBuilderDRCALO : public SubsysReco
 {
  public:
   RawTowerBuilderDRCALO(const std::string &name = "RawTowerBuilderDRCALO");
-  virtual ~RawTowerBuilderDRCALO() {}
+  ~RawTowerBuilderDRCALO() override {}
 
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
 
   /** Name of the detector node the G4Hits should be taken from.
    */

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.h
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.h
@@ -23,10 +23,10 @@ class RawTowerDigitizer : public SubsysReco
 {
  public:
   RawTowerDigitizer(const std::string &name = "RawTowerDigitizer");
-  virtual ~RawTowerDigitizer();
+  ~RawTowerDigitizer() override;
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
   void Detector(const std::string &d) { m_Detector = d; _tower_params.set_name(d);}
   void TowerType(const int type) { m_TowerType = type; }
   void set_seed(const unsigned int iseed);

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.h
@@ -21,12 +21,12 @@ class BeamLineMagnetDetector : public PHG4Detector
   BeamLineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int magnetid = 0);
 
   //! destructor
-  virtual ~BeamLineMagnetDetector(void)
+  ~BeamLineMagnetDetector(void) override
   {
   }
 
   //! construct
-  void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   int IsInBeamLineMagnet(const G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { superdetector = name; }

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.h
@@ -18,9 +18,9 @@ class BeamLineMagnetDisplayAction : public PHG4DisplayAction
  public:
   BeamLineMagnetDisplayAction(const std::string &name);
 
-  virtual ~BeamLineMagnetDisplayAction();
+  ~BeamLineMagnetDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.h
@@ -20,13 +20,13 @@ class BeamLineMagnetSteppingAction : public PHG4SteppingAction
   BeamLineMagnetSteppingAction(BeamLineMagnetDetector*, const PHParameters* parameters);
 
   //! destructor
-  virtual ~BeamLineMagnetSteppingAction();
+  ~BeamLineMagnetSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.h
@@ -20,7 +20,7 @@ class BeamLineMagnetSubsystem : public PHG4DetectorSubsystem
   BeamLineMagnetSubsystem(const std::string& name = "CYLINDER", const int layer = 0);
 
   //! destructor
-  virtual ~BeamLineMagnetSubsystem();
+  ~BeamLineMagnetSubsystem() override;
 
   //! init runwise stuff
   /*!
@@ -28,25 +28,25 @@ class BeamLineMagnetSubsystem : public PHG4DetectorSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override { return m_SteppingAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4BbcDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDetector.h
@@ -22,7 +22,7 @@ class PHG4BbcDetector : public PHG4Detector
   PHG4BbcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *params, const std::string &dnam = "BBC");
 
   //! destructor
-  virtual ~PHG4BbcDetector()
+  ~PHG4BbcDetector() override
   {
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.h
@@ -21,13 +21,13 @@ class PHG4BbcSteppingAction : public PHG4SteppingAction
   PHG4BbcSteppingAction(PHG4BbcDetector*, const PHParameters*);
 
   //! destructor
-  virtual ~PHG4BbcSteppingAction();
+  ~PHG4BbcSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4BbcSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSubsystem.h
@@ -40,7 +40,7 @@ class PHG4BbcSubsystem : public PHG4DetectorSubsystem
   PHG4BbcSubsystem(const std::string& name = "BBC");
 
   //! destructor
-  virtual ~PHG4BbcSubsystem(void)
+  ~PHG4BbcSubsystem(void) override
   {
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.h
@@ -20,12 +20,12 @@ class PHG4BeamlineMagnetDetector : public PHG4Detector
   PHG4BeamlineMagnetDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4BeamlineMagnetDetector(void)
+  ~PHG4BeamlineMagnetDetector(void) override
   {
   }
 
   //! construct
-  void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   bool IsInBeamlineMagnet(const G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { superdetector = name; }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
@@ -20,7 +20,7 @@ class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
   PHG4BeamlineMagnetSubsystem( const std::string &name = "CYLINDER", const int layer = 0 );
 
   //! destructor
-  virtual ~PHG4BeamlineMagnetSubsystem( void )
+  ~PHG4BeamlineMagnetSubsystem( void ) override
   {}
 
   //! init runwise stuff
@@ -29,23 +29,23 @@ class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const;
+  PHG4Detector* GetDetector( void ) const override;
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.h
@@ -14,7 +14,7 @@ class PHG4BlockCellGeom: public PHObject
  public:
   PHG4BlockCellGeom();
 
-  virtual ~PHG4BlockCellGeom() {}
+  ~PHG4BlockCellGeom() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.h
@@ -21,7 +21,7 @@ class PHG4BlockCellGeomContainer: public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   PHG4BlockCellGeomContainer(){}
-  virtual ~PHG4BlockCellGeomContainer();
+  ~PHG4BlockCellGeomContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.h
@@ -19,17 +19,17 @@ class PHG4BlockCellReco : public SubsysReco, public PHParameterContainerInterfac
  public:
   PHG4BlockCellReco(const std::string &name = "BLOCKRECO");
 
-  virtual ~PHG4BlockCellReco() {}
+  ~PHG4BlockCellReco() override {}
 
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int ResetEvent(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode) override;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d) { detector = d; }
   void etaxsize(const int i, const double deltaeta, const double deltax);

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.h
@@ -21,12 +21,12 @@ class PHG4BlockDetector : public PHG4Detector
   PHG4BlockDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4BlockDetector(void)
+  ~PHG4BlockDetector(void) override
   {
   }
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4BlockDisplayAction : public PHG4DisplayAction
  public:
   PHG4BlockDisplayAction(const std::string &name, PHParameters *parameters);
 
-  virtual ~PHG4BlockDisplayAction();
+  ~PHG4BlockDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
   void SetColor(const double red, const double green, const double blue, const double alpha = 1.);
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
@@ -14,10 +14,10 @@ class PHG4BlockGeom: public PHObject
 {
  public:
 
-  virtual ~PHG4BlockGeom() {}
+  ~PHG4BlockGeom() override {}
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   virtual int get_layer() const {PHOOL_VIRTUAL_WARN("get_layer()"); return -99999;}
   virtual double get_size_x() const {PHOOL_VIRTUAL_WARN("get_size_x()");return NAN;}

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.h
@@ -21,7 +21,7 @@ class PHG4BlockGeomContainer: public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   PHG4BlockGeomContainer();
-  virtual ~PHG4BlockGeomContainer();
+  ~PHG4BlockGeomContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.h
@@ -16,7 +16,7 @@ class PHG4BlockGeomv1: public PHG4BlockGeom
                    const double centerx, const double centery, const double centerz,
                    const double zrot );
 
-  virtual ~PHG4BlockGeomv1() {}
+  ~PHG4BlockGeomv1() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.h
@@ -21,13 +21,13 @@ class PHG4BlockSteppingAction : public PHG4SteppingAction
   PHG4BlockSteppingAction(PHG4BlockDetector *, const PHParameters *parameters);
 
   //! destructor
-  virtual ~PHG4BlockSteppingAction();
+  ~PHG4BlockSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -21,7 +21,7 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
   PHG4BlockSubsystem(const std::string& name = "BLOCK", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4BlockSubsystem();
+  ~PHG4BlockSubsystem() override;
 
   //! InitRunSubsystem
   /*!
@@ -29,21 +29,21 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector() const;
+  PHG4Detector* GetDetector() const override;
 
-  PHG4SteppingAction* GetSteppingAction() const { return m_SteppingAction; }
+  PHG4SteppingAction* GetSteppingAction() const override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
   void set_color(const double red, const double green, const double blue, const double alpha = 1.)
   {
@@ -55,10 +55,10 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
 // this method is used to check if it can be used as mothervolume
 // Subsystems which can be mothervolume need to implement this 
 // and return true
-  virtual bool CanBeMotherSubsystem() const {return true;}
+  bool CanBeMotherSubsystem() const override {return true;}
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defines from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.h
@@ -22,12 +22,12 @@ class PHG4CEmcTestBeamDetector : public PHG4Detector
   PHG4CEmcTestBeamDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4CEmcTestBeamDetector(void)
+  ~PHG4CEmcTestBeamDetector(void) override
   {
   }
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.h
@@ -20,14 +20,14 @@ class PHG4CEmcTestBeamSteppingAction : public PHG4SteppingAction
   PHG4CEmcTestBeamSteppingAction( PHG4CEmcTestBeamDetector* );
 
   //! destroctor
-  virtual ~PHG4CEmcTestBeamSteppingAction()
+  ~PHG4CEmcTestBeamSteppingAction() override
   {}
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers( PHCompositeNode* );
+  void SetInterfacePointers( PHCompositeNode* ) override;
 
   private:
 

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.h
@@ -25,7 +25,7 @@ class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
   PHG4CEmcTestBeamSubsystem( const std::string &name = "BLOCK", const int layer = 0 );
 
   //! destructor
-  virtual ~PHG4CEmcTestBeamSubsystem( void )
+  ~PHG4CEmcTestBeamSubsystem( void ) override
   {}
 
   //! init
@@ -34,18 +34,18 @@ class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4Detector* GetDetector( void ) const override;
+  PHG4SteppingAction* GetSteppingAction( void ) const override;
 
   void SetSize(const G4double sizex, const G4double sizey, const G4double sizez)
      {dimension[0] = sizex; dimension[1] = sizey; dimension[2] = sizez;}
@@ -54,7 +54,7 @@ class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
   void SetXRot(const G4double dbl);
   void SetYRot(const G4double dbl);
   void SetZRot(const G4double dbl);
-  PHG4EventAction* GetEventAction() const {return eventAction_;}
+  PHG4EventAction* GetEventAction() const override {return eventAction_;}
   void SetActive(const int i = 1) {active = i;}
   void SetAbsorberActive(const int i = 1) {absorberactive = i;}
   void SuperDetector(const std::string &name) {superdetector = name;}

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -31,12 +31,12 @@ class PHG4Cell: public PHObject
   typedef std::pair<ShowerEdepIterator, ShowerEdepIterator> ShowerEdepRange;
   typedef std::pair<ShowerEdepConstIterator, ShowerEdepConstIterator> ShowerEdepConstRange;
 
-  virtual ~PHG4Cell() {}
+  ~PHG4Cell() override {}
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void CopyFrom(const PHObject *phobj) override;
-  virtual void Reset() override;
+  void identify(std::ostream& os = std::cout) const override;
+  void CopyFrom(const PHObject *phobj) override;
+  void Reset() override;
 
   friend std::ostream &operator<<(std::ostream & stream, const PHG4Cell * cell);
 

--- a/simulation/g4simulation/g4detectors/PHG4CellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CellContainer.h
@@ -25,7 +25,7 @@ class PHG4CellContainer: public PHObject
 
   PHG4CellContainer();
 
-  virtual ~PHG4CellContainer() {}
+  ~PHG4CellContainer() override {}
 
 // from PHObject
   void Reset() override;

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -20,10 +20,10 @@ class PHG4Cellv1: public PHG4Cell
  public:
   PHG4Cellv1();
   PHG4Cellv1(const PHG4CellDefs::keytype g4cellid);
-  virtual ~PHG4Cellv1();
+  ~PHG4Cellv1() override;
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void Reset() override;
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
 
   void set_cellid(const PHG4CellDefs::keytype i) override {cellid = i;}
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.h
@@ -21,12 +21,12 @@ class PHG4ConeDetector : public PHG4Detector
   PHG4ConeDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, PHParameters* parameters, const std::string& dnam, const int lyr = 0);
 
   //! destructor
-  virtual ~PHG4ConeDetector(void)
+  ~PHG4ConeDetector(void) override
   {
   }
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4ConeDisplayAction : public PHG4DisplayAction
  public:
   PHG4ConeDisplayAction(const std::string &name, PHParameters *parameters);
 
-  virtual ~PHG4ConeDisplayAction();
+  ~PHG4ConeDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
   void SetColor(const double red, const double green, const double blue, const double alpha = 1.);
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSteppingAction.h
@@ -19,13 +19,13 @@ class PHG4ConeSteppingAction : public PHG4SteppingAction
   PHG4ConeSteppingAction(PHG4ConeDetector*);
 
   //! destructor
-  virtual ~PHG4ConeSteppingAction();
+  ~PHG4ConeSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.h
@@ -21,7 +21,7 @@ class PHG4ConeSubsystem : public PHG4DetectorSubsystem
   PHG4ConeSubsystem(const std::string& name = "CONE", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4ConeSubsystem(void);
+  ~PHG4ConeSubsystem(void) override;
 
   //! init runwise stuff
   /*!
@@ -75,7 +75,7 @@ class PHG4ConeSubsystem : public PHG4DetectorSubsystem
   // this method is used to check if it can be used as mothervolume
   // Subsystems which can be mothervolume need to implement this
   // and return true
-  virtual bool CanBeMotherSubsystem() const override { return true; }
+  bool CanBeMotherSubsystem() const override { return true; }
 
  private:
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
@@ -18,19 +18,19 @@ class PHG4CylinderCell : public PHG4Cell
 {
  public:
   
-  virtual ~PHG4CylinderCell(){}
+  ~PHG4CylinderCell() override{}
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override 
+  void identify(std::ostream& os = std::cout) const override 
   {
     os << "PHG4CylinderCell base class" << std::endl;
   }
   
-    virtual void set_ladder_phi_index(const int i) override {return;}
-  virtual int get_ladder_phi_index() const override {return -9999;}
+    void set_ladder_phi_index(const int i) override {return;}
+  int get_ladder_phi_index() const override {return -9999;}
 
-  virtual void set_ladder_z_index(const int i) override {return;}
-  virtual int get_ladder_z_index() const override {return -9999;}
+  void set_ladder_z_index(const int i) override {return;}
+  int get_ladder_z_index() const override {return -9999;}
 
 // our own - not inherited  
   virtual void set_cell_id(const PHG4CylinderCellDefs::keytype id) {return;}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
@@ -28,7 +28,7 @@ class PHG4CylinderCellContainer: public PHObject
 
   PHG4CylinderCellContainer(){}
 
-  virtual ~PHG4CylinderCellContainer() {}
+  ~PHG4CylinderCellContainer() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.h
@@ -14,7 +14,7 @@ class PHG4CylinderCellGeom: public PHObject
  public:
   PHG4CylinderCellGeom();
 
-  virtual ~PHG4CylinderCellGeom() {}
+  ~PHG4CylinderCellGeom() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.h
@@ -21,7 +21,7 @@ class PHG4CylinderCellGeomContainer: public PHObject
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
   PHG4CylinderCellGeomContainer(){}
-  virtual ~PHG4CylinderCellGeomContainer();
+  ~PHG4CylinderCellGeomContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.h
@@ -26,23 +26,23 @@ class PHG4CylinderCellGeom_Spacalv1 : public PHG4CylinderCellGeom
 {
 public:
   PHG4CylinderCellGeom_Spacalv1();
-  virtual ~PHG4CylinderCellGeom_Spacalv1();
+  ~PHG4CylinderCellGeom_Spacalv1() override;
 
   void identify(std::ostream& os = std::cout) const override;
 
-  virtual std::pair<double, double>
+  std::pair<double, double>
   get_zbounds(const int ibin) const override;
-  virtual std::pair<double, double>
+  std::pair<double, double>
   get_etabounds(const int ibin) const override;
 
-  virtual double
+  double
   get_etacenter(const int ibin) const override;
-  virtual double
+  double
   get_zcenter(const int ibin) const override;
 
-  virtual int
+  int
   get_etabin(const double eta) const override;
-  virtual int
+  int
   get_zbin(const double z) const override;
 
   void

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -20,17 +20,17 @@ class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInter
  public:
   explicit PHG4CylinderCellReco(const std::string &name = "CYLINDERRECO");
 
-  virtual ~PHG4CylinderCellReco() {}
+  ~PHG4CylinderCellReco() override {}
 
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
-  int ResetEvent(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode) override;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d);
   void cellsize(const int i, const double sr, const double sz);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
@@ -19,7 +19,7 @@ class PHG4CylinderCellv1 : public PHG4CylinderCell
  public:
 
   PHG4CylinderCellv1();
-  virtual ~PHG4CylinderCellv1(){}
+  ~PHG4CylinderCellv1() override{}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
@@ -13,7 +13,7 @@ class PHG4CylinderCellv2 : public PHG4CylinderCellv1
  public:
 
   PHG4CylinderCellv2();
-  virtual ~PHG4CylinderCellv2(){}
+  ~PHG4CylinderCellv2() override{}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.h
@@ -12,7 +12,7 @@ class PHG4CylinderCellv3 : public PHG4CylinderCellv1
  public:
 
   PHG4CylinderCellv3();
-  virtual ~PHG4CylinderCellv3(){}
+  ~PHG4CylinderCellv3() override{}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.h
@@ -21,12 +21,12 @@ class PHG4CylinderDetector : public PHG4Detector
   PHG4CylinderDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderDetector()
+  ~PHG4CylinderDetector() override
   {
   }
 
   //! construct
-  void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   bool IsInCylinder(const G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { m_SuperDetector = name; }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4CylinderDisplayAction : public PHG4DisplayAction
  public:
   PHG4CylinderDisplayAction(const std::string &name, PHParameters *parameters);
 
-  virtual ~PHG4CylinderDisplayAction();
+  ~PHG4CylinderDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
   void SetColor(const double red, const double green, const double blue, const double alpha=1.);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
@@ -16,10 +16,10 @@ class PHG4CylinderGeom: public PHObject
 {
  public:
 
-  virtual ~PHG4CylinderGeom() {}
+  ~PHG4CylinderGeom() override {}
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   virtual int get_layer() const {PHOOL_VIRTUAL_WARN("get_layer()"); return -99999;}
   virtual double get_radius() const {PHOOL_VIRTUAL_WARN("get_radius()");return NAN;}

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.h
@@ -21,7 +21,7 @@ class PHG4CylinderGeomContainer: public PHObject
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
   PHG4CylinderGeomContainer();
-  virtual ~PHG4CylinderGeomContainer();
+  ~PHG4CylinderGeomContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -28,21 +28,21 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
   ///@{
   PHG4CylinderGeom_Spacalv1();
 
-  virtual ~PHG4CylinderGeom_Spacalv1()
+  ~PHG4CylinderGeom_Spacalv1() override
   {
     sector_map.clear();
   }
 
 // from PHObject
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
 // from TObject
-  virtual void Print(Option_t *option = "") const override;
+  void Print(Option_t *option = "") const override;
 
   virtual void SetDefault();
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters &param) override;
+  void ImportParameters(const PHParameters &param) override;
 
   ///@}
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
@@ -24,24 +24,24 @@ class PHG4CylinderGeom_Spacalv2 : public PHG4CylinderGeom_Spacalv1
 public:
   PHG4CylinderGeom_Spacalv2();
 
-  virtual
-  ~PHG4CylinderGeom_Spacalv2()
+  
+  ~PHG4CylinderGeom_Spacalv2() override
   {
   }
 
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
 // from TObject
-  virtual void Print(Option_t* option = "") const override;
+  void Print(Option_t* option = "") const override;
 
-  virtual void SetDefault() override;
+  void SetDefault() override;
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & param) override;
+  void ImportParameters(const PHParameters & param) override;
 
-  virtual int get_azimuthal_n_sec() const override;
+  int get_azimuthal_n_sec() const override;
 
   virtual void set_azimuthal_n_sec(int azimuthalNSec);
 
@@ -59,7 +59,7 @@ public:
     azimuthal_tilt = azimuthalTilt;
   }
 
-  virtual
+  
   bool is_azimuthal_seg_visible() const override;
 
   virtual

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -26,18 +26,18 @@ class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
  public:
   PHG4CylinderGeom_Spacalv3();
 
-  virtual ~PHG4CylinderGeom_Spacalv3();
+  ~PHG4CylinderGeom_Spacalv3() override;
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
 // from TObject
-  virtual void Print(Option_t* option = "") const override;
+  void Print(Option_t* option = "") const override;
 
-  virtual void SetDefault() override;
+  void SetDefault() override;
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters& param) override;
+  void ImportParameters(const PHParameters& param) override;
 
   double
   get_sidewall_outer_torr() const

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
@@ -22,7 +22,7 @@ class PHG4CylinderGeomv1 : public PHG4CylinderGeom
   {
   }
 
-  virtual ~PHG4CylinderGeomv1() {}
+  ~PHG4CylinderGeomv1() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;
@@ -40,7 +40,7 @@ class PHG4CylinderGeomv1 : public PHG4CylinderGeom
   void set_zmax(const double z) override { zmax = z; }
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters& param) override;
+  void ImportParameters(const PHParameters& param) override;
 
  protected:
   int layer;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
@@ -18,7 +18,7 @@ class PHG4CylinderGeomv2: public PHG4CylinderGeomv1
     nscint(n_scint)
       {}
 
-  virtual ~PHG4CylinderGeomv2() {}
+  ~PHG4CylinderGeomv2() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;
@@ -27,7 +27,7 @@ class PHG4CylinderGeomv2: public PHG4CylinderGeomv1
   int get_nscint() const override {return nscint;}
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & param) override;
+  void ImportParameters(const PHParameters & param) override;
 
  protected:
   int nscint;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.h
@@ -18,7 +18,7 @@ class PHG4CylinderGeomv3: public PHG4CylinderGeomv2
     phi_slat_zero(phi_slat_null)
       {}
 
-  virtual ~PHG4CylinderGeomv3() {}
+  ~PHG4CylinderGeomv3() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.h
@@ -44,7 +44,7 @@ class PHG4CylinderGeomv4: public PHG4CylinderGeom
     strip_tilt(st)
   {}
 
-  virtual ~PHG4CylinderGeomv4() {}
+  ~PHG4CylinderGeomv4() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -22,13 +22,13 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   PHG4CylinderSteppingAction(PHG4CylinderSubsystem *subsys, PHG4CylinderDetector *detector, const PHParameters *parameters);
 
   //! destructor
-  virtual ~PHG4CylinderSteppingAction();
+  ~PHG4CylinderSteppingAction() override;
 
   //! stepping action
-  bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
   void SaveLightYield(const int i = 1) { m_SaveLightYieldFlag = i; }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.h
@@ -21,7 +21,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   PHG4CylinderSubsystem(const std::string& name = "CYLINDER", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4CylinderSubsystem(void);
+  ~PHG4CylinderSubsystem(void) override;
 
   //! init runwise stuff
   /*!
@@ -56,7 +56,7 @@ class PHG4CylinderSubsystem : public PHG4DetectorSubsystem
   // this method is used to check if it can be used as mothervolume
   // Subsystems which can be mothervolume need to implement this
   // and return true
-  virtual bool CanBeMotherSubsystem() const override { return true; }
+  bool CanBeMotherSubsystem() const override { return true; }
 
   // this is just needed for use as reference plane for projections
   // this is the only detector using this - there is no need to add

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.h
@@ -23,7 +23,7 @@ class PHG4DetectorGroupSubsystem : public PHG4Subsystem
     root = 2
   };
 
-  virtual ~PHG4DetectorGroupSubsystem() {}
+  ~PHG4DetectorGroupSubsystem() override {}
   int Init(PHCompositeNode *) final;
   int InitRun(PHCompositeNode *) final;
 

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -22,7 +22,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
     root = 2
   };
 
-  virtual ~PHG4DetectorSubsystem() {}
+  ~PHG4DetectorSubsystem() override {}
 
   int Init(PHCompositeNode *) final;
   int InitRun(PHCompositeNode *) final;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
@@ -22,10 +22,10 @@ class PHG4EnvelopeDetector : public PHG4Detector
   PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //Destructor
-  virtual ~PHG4EnvelopeDetector(){}
+  ~PHG4EnvelopeDetector() override{}
 
   //Construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   //Volume accessors
   bool IsInEnvelope(G4VPhysicalVolume *) const;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.h
@@ -18,14 +18,14 @@ class PHG4EnvelopeSteppingAction: public PHG4SteppingAction
 		PHG4EnvelopeSteppingAction( PHG4EnvelopeDetector* );
 	
 		//Destructor
-		virtual ~PHG4EnvelopeSteppingAction()
+		~PHG4EnvelopeSteppingAction() override
 		{}
 	
 		//Stepping Action
-		virtual bool UserSteppingAction( const G4Step*, bool);
+		bool UserSteppingAction( const G4Step*, bool) override;
 	
 		//reimplemented from base class
-		virtual void SetInterfacePointers( PHCompositeNode* );
+		void SetInterfacePointers( PHCompositeNode* ) override;
 	
 	private:
 		

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.h
@@ -22,7 +22,7 @@ class PHG4EnvelopeSubsystem: public PHG4Subsystem
 		PHG4EnvelopeSubsystem ( const std::string &name = "ENVELOPE_DEFAULT", const int layer = 0 );
 		
 		//Destructor
-		virtual ~PHG4EnvelopeSubsystem ( void )
+		~PHG4EnvelopeSubsystem ( void ) override
 		{}
 			
 		/*
@@ -31,14 +31,14 @@ class PHG4EnvelopeSubsystem: public PHG4Subsystem
 			Creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
 		*/
 	
-		int Init(PHCompositeNode *);
+		int Init(PHCompositeNode *) override;
 	
 		//Event Processing
-		int process_event(PHCompositeNode *);
+		int process_event(PHCompositeNode *) override;
 	
 		//Accessors (reimplemented)
-		virtual PHG4Detector* GetDetector( void ) const;
-		virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+		PHG4Detector* GetDetector( void ) const override;
+		PHG4SteppingAction* GetSteppingAction( void ) const override;
 	
 	private:
 		//Pointer to Geant4 implementation of detector

--- a/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.h
+++ b/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.h
@@ -22,10 +22,10 @@ public:
   void AddNode(const std::string &name);
 
   //! destuctor
-  virtual ~PHG4EventActionClearZeroEdep()
+  ~PHG4EventActionClearZeroEdep() override
   {}
 
-  void EndOfEventAction(const G4Event*);
+  void EndOfEventAction(const G4Event*) override;
   
  private:
   

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -21,18 +21,18 @@ class PHG4FullProjSpacalCellReco : public SubsysReco,  public PHParameterInterfa
 
   PHG4FullProjSpacalCellReco(const std::string &name = "HCALCELLRECO");
 
-  virtual ~PHG4FullProjSpacalCellReco(){}
+  ~PHG4FullProjSpacalCellReco() override{}
   
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
   
     //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! reset after event processing  
-  int ResetEvent(PHCompositeNode *topNode);
+  int ResetEvent(PHCompositeNode *topNode) override;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d) {detector = d;}
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.h
@@ -40,12 +40,12 @@ class PHG4FullProjSpacalDetector : public PHG4SpacalDetector
                              PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
-  virtual ~PHG4FullProjSpacalDetector(void) {}
-  virtual void
-  ConstructMe(G4LogicalVolume* world);
+  ~PHG4FullProjSpacalDetector(void) override {}
+  void
+  ConstructMe(G4LogicalVolume* world) override;
 
-  virtual std::pair<G4LogicalVolume*, G4Transform3D>
-  Construct_AzimuthalSeg();
+  std::pair<G4LogicalVolume*, G4Transform3D>
+  Construct_AzimuthalSeg() override;
 
   //! a block along z axis built with G4Trd that is slightly tapered in x dimension
   virtual G4LogicalVolume*
@@ -59,10 +59,10 @@ class PHG4FullProjSpacalDetector : public PHG4SpacalDetector
   virtual int
   Construct_Fibers_SameLengthFiberPerTower(const SpacalGeom_t::geom_tower& tower, G4LogicalVolume* LV_tower);
 
-  virtual void
-  Print(const std::string& what = "ALL") const;
+  void
+  Print(const std::string& what = "ALL") const override;
 
-  virtual PHG4CylinderGeom* clone_geom() const
+  PHG4CylinderGeom* clone_geom() const override
   {
     return new SpacalGeom_t(*get_geom_v3());
   }

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -37,13 +37,13 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
                                    PHParameters* parameters, const int layer = 0);
 
   // empty dtor, step limits are deleted in base class
-  virtual ~PHG4FullProjTiltedSpacalDetector(void) {}
+  ~PHG4FullProjTiltedSpacalDetector(void) override {}
 
-  virtual void
-  ConstructMe(G4LogicalVolume* world);
+  void
+  ConstructMe(G4LogicalVolume* world) override;
 
-  virtual std::pair<G4LogicalVolume*, G4Transform3D>
-  Construct_AzimuthalSeg();
+  std::pair<G4LogicalVolume*, G4Transform3D>
+  Construct_AzimuthalSeg() override;
 
   //! a block along z axis built with G4Trd that is slightly tapered in x dimension
   virtual G4LogicalVolume*
@@ -60,10 +60,10 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
   virtual int
   Construct_Fibers_SameLengthFiberPerTower(const SpacalGeom_t::geom_tower& tower, G4LogicalVolume* LV_tower);
 
-  virtual void
-  Print(const std::string& what = "ALL") const;
+  void
+  Print(const std::string& what = "ALL") const override;
 
-  virtual PHG4CylinderGeom* clone_geom() const
+  PHG4CylinderGeom* clone_geom() const override
   {
     return new SpacalGeom_t(*get_geom_v3());
   }

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.h
@@ -35,17 +35,17 @@ class PHG4GDMLDetector : public PHG4Detector
  public:
   PHG4GDMLDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, PHParameters* parameters);
 
-  virtual ~PHG4GDMLDetector();
+  ~PHG4GDMLDetector() override;
 
   //! construct
-  void ConstructMe(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world) override;
 
-  G4UserSteppingAction* GetSteppingAction()
+  G4UserSteppingAction* GetSteppingAction() override
   {
     return nullptr;
   }
 
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
  private:
   void SetDisplayProperty(G4AssemblyVolume* av);

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
@@ -30,7 +30,7 @@ class PHG4GDMLSubsystem : public PHG4DetectorSubsystem
  public:
 
   PHG4GDMLSubsystem(const std::string &name);
-  virtual ~PHG4GDMLSubsystem();
+  ~PHG4GDMLSubsystem() override;
 
 
   /*!
@@ -38,24 +38,24 @@ class PHG4GDMLSubsystem : public PHG4DetectorSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return nullptr; }
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override { return nullptr; }
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! derives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4GenHit.h
+++ b/simulation/g4simulation/g4detectors/PHG4GenHit.h
@@ -13,9 +13,9 @@ class PHG4GenHit: public SubsysReco
 {
  public:
   PHG4GenHit(const std::string &name = "PHG4GenHit");
-  virtual ~PHG4GenHit() {}
+  ~PHG4GenHit() override {}
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   void set_phi(const double d) {phi = d;}
   void set_theta(const double d) {theta = d;}

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -17,18 +17,18 @@ class PHG4HcalCellReco : public SubsysReco, public PHParameterInterface
 
   PHG4HcalCellReco(const std::string &name = "HcalCellReco");
 
-  virtual ~PHG4HcalCellReco(){}
+  ~PHG4HcalCellReco() override{}
   
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
   
     //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
   
   //! end of process
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
   
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d) {detector = d;}
   void checkenergy(const int i=1) {chkenergyconservation = i;}

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.h
@@ -26,12 +26,12 @@ class PHG4HcalDetector : public PHG4Detector
   PHG4HcalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam, const int layer = 0);
 
   //! destructor
-  virtual ~PHG4HcalDetector(void)
+  ~PHG4HcalDetector(void) override
   {
   }
 
   //! construct
-  void ConstructMe(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world) override;
 
   void SetRadius(const G4double dbl) { radius = dbl * cm; }
   void SetLength(const G4double dbl) { length = dbl * cm; }
@@ -56,7 +56,7 @@ class PHG4HcalDetector : public PHG4Detector
   void SuperDetector(const std::string& name) { superdetector = name; }
   const std::string SuperDetector() const { return superdetector; }
   int get_Layer() const { return layer; }
-  G4UserSteppingAction* GetSteppingAction()
+  G4UserSteppingAction* GetSteppingAction() override
   {
     if (_region)
       return _region->GetRegionalSteppingAction();
@@ -64,7 +64,7 @@ class PHG4HcalDetector : public PHG4Detector
       return 0;
   }
 
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
   static int INACTIVE;
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.h
@@ -21,13 +21,13 @@ class PHG4HcalSteppingAction : public PHG4SteppingAction
   PHG4HcalSteppingAction(PHG4HcalDetector*);
 
   //! destroctor
-  virtual ~PHG4HcalSteppingAction();
+  ~PHG4HcalSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
   void set_zmin(const float z) { zmin = z; }
   void set_zmax(const float z) { zmax = z; }

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.h
@@ -23,7 +23,7 @@ class PHG4HcalSubsystem : public PHG4Subsystem
   PHG4HcalSubsystem(const std::string &name = "HCALCYLINDER", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4HcalSubsystem(void)
+  ~PHG4HcalSubsystem(void) override
   {
   }
 
@@ -33,18 +33,18 @@ class PHG4HcalSubsystem : public PHG4Subsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRun(PHCompositeNode *);
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector *GetDetector(void) const;
-  virtual PHG4SteppingAction *GetSteppingAction(void) const;
+  PHG4Detector *GetDetector(void) const override;
+  PHG4SteppingAction *GetSteppingAction(void) const override;
 
   void SetRadius(const G4double dbl) { radius = dbl; }
   void SetLength(const G4double dbl) { length = dbl; }
@@ -81,7 +81,7 @@ class PHG4HcalSubsystem : public PHG4Subsystem
     light_scint_model_ = b;
   }
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
  private:
   //! detector geometry

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -34,12 +34,12 @@ class PHG4InnerHcalDetector : public PHG4Detector
   PHG4InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4InnerHcalDetector();
+  ~PHG4InnerHcalDetector() override;
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4InnerHcalDisplayAction : public PHG4DisplayAction
  public:
   PHG4InnerHcalDisplayAction(const std::string &name);
 
-  virtual ~PHG4InnerHcalDisplayAction();
+  ~PHG4InnerHcalDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyTopVolume(G4VPhysicalVolume *vol) { m_MyTopVolume = vol; }
   void AddScintiVolume(G4LogicalVolume *vol) { m_ScintiLogVolSet.insert(vol); }
   void AddSteelVolume(G4LogicalVolume *vol) { m_SteelVol = vol; }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -21,13 +21,13 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector *, const PHParameters *parameters);
 
   //! destructor
-  virtual ~PHG4InnerHcalSteppingAction();
+  ~PHG4InnerHcalSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -20,34 +20,34 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
   PHG4InnerHcalSubsystem(const std::string& name = "HCALIN", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4InnerHcalSubsystem();
+  ~PHG4InnerHcalSubsystem() override;
 
   /*!
   creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector(void) const;
-  PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override { return m_SteppingAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
   void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! derives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -35,12 +35,12 @@ class PHG4OuterHcalDetector : public PHG4Detector
   PHG4OuterHcalDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *params, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4OuterHcalDetector();
+  ~PHG4OuterHcalDetector() override;
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4OuterHcalDisplayAction : public PHG4DisplayAction
  public:
   PHG4OuterHcalDisplayAction(const std::string &name);
 
-  virtual ~PHG4OuterHcalDisplayAction();
+  ~PHG4OuterHcalDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyTopVolume(G4VPhysicalVolume *vol) { m_MyTopVolume = vol; }
   void AddScintiVolume(G4LogicalVolume *vol) { m_ScintiLogVolSet.insert(vol);}
   void AddSteelVolume(G4LogicalVolume *vol) {m_SteelVol = vol;}

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalField.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalField.h
@@ -33,11 +33,11 @@ class PHG4OuterHcalField : public G4MagneticField
 public:
   PHG4OuterHcalField( bool isInIron, G4int steelPlates,
       G4double scintiGap, G4double tiltAngle );
-  virtual
-  ~PHG4OuterHcalField();
+  
+  ~PHG4OuterHcalField() override;
 
   void
-  GetFieldValue(const double Point[4], double *Bfield) const;
+  GetFieldValue(const double Point[4], double *Bfield) const override;
 
   bool
   is_is_in_iron() const

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -21,15 +21,15 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
   PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector *, const PHParameters *parameters);
 
   //! destructor
-  virtual ~PHG4OuterHcalSteppingAction();
+  ~PHG4OuterHcalSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
-  virtual int Init();
+  int Init() override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
   void FieldChecker(const G4Step *);
   void EnableFieldChecker(const int i = 1) { m_EnableFieldCheckerFlag = i; }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -22,34 +22,34 @@ class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
   PHG4OuterHcalSubsystem( const std::string &name = "HCALOUT", const int layer = 0 );
 
   //! destructor
-  virtual ~PHG4OuterHcalSubsystem();
+  ~PHG4OuterHcalSubsystem() override;
 
   /*!
   creates the Detector object. Creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const;
-  PHG4SteppingAction* GetSteppingAction( ) const { return m_SteppingAction; }
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4Detector* GetDetector( void ) const override;
+  PHG4SteppingAction* GetSteppingAction( ) const override { return m_SteppingAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
   void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
 
   private:
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.h
@@ -21,12 +21,12 @@ class PHG4PSTOFDetector : public PHG4Detector
   PHG4PSTOFDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *params_array, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4PSTOFDetector() {}
+  ~PHG4PSTOFDetector() override {}
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
-  virtual void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.h
@@ -20,13 +20,13 @@ class PHG4PSTOFSteppingAction : public PHG4SteppingAction
   PHG4PSTOFSteppingAction(PHG4PSTOFDetector*, const PHParametersContainer*);
 
   //! destructor
-  virtual ~PHG4PSTOFSteppingAction();
+  ~PHG4PSTOFSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.h
@@ -40,7 +40,7 @@ class PHG4PSTOFSubsystem : public PHG4DetectorGroupSubsystem
   PHG4PSTOFSubsystem(const std::string& name = "PSTOF");
 
   //! destructor
-  virtual ~PHG4PSTOFSubsystem(void)
+  ~PHG4PSTOFSubsystem(void) override
   {
   }
 
@@ -49,23 +49,23 @@ class PHG4PSTOFSubsystem : public PHG4DetectorGroupSubsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  virtual int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  virtual int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const;
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override;
   //! Print info (from SubsysReco)
-  virtual void Print(const std::string& what = "ALL") const;
+  void Print(const std::string& what = "ALL") const override;
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
@@ -15,10 +15,10 @@ class PHG4ScintillatorSlat : public PHObject
 {
  public:
   
-  virtual ~PHG4ScintillatorSlat(){}
+  ~PHG4ScintillatorSlat() override{}
 
 // from PHObject
-  virtual void identify(std::ostream& os = std::cout) const override {
+  void identify(std::ostream& os = std::cout) const override {
     os << "PHG4ScintillatorSlat base class" << std::endl;
   }
   

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.h
@@ -28,7 +28,7 @@ class PHG4ScintillatorSlatContainer: public PHObject
 
   PHG4ScintillatorSlatContainer();
 
-  virtual ~PHG4ScintillatorSlatContainer() {}
+  ~PHG4ScintillatorSlatContainer() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
@@ -18,7 +18,7 @@ class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
  public:
 
   PHG4ScintillatorSlatv1();
-  virtual ~PHG4ScintillatorSlatv1(){}
+  ~PHG4ScintillatorSlatv1() override{}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
@@ -22,12 +22,12 @@ class PHG4SectorDetector : public PHG4Detector, public PHG4Sector::PHG4SectorCon
   PHG4SectorDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4SectorDetector(void)
+  ~PHG4SectorDetector(void) override
   {
   }
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   //!@name volume accessors
   //@{
@@ -37,7 +37,7 @@ class PHG4SectorDetector : public PHG4Detector, public PHG4Sector::PHG4SectorCon
   void SuperDetector(const std::string &name) { superdetector = name; }
   const std::string SuperDetector() const { return superdetector; }
 
-  virtual void OverlapCheck(const bool chk = true)
+  void OverlapCheck(const bool chk = true) override
   {
     PHG4Detector::OverlapCheck(chk);
     PHG4SectorConstructor::OverlapCheck(chk);

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4SectorDisplayAction : public PHG4DisplayAction
  public:
   PHG4SectorDisplayAction(const std::string &name);
 
-  virtual ~PHG4SectorDisplayAction();
+  ~PHG4SectorDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.h
@@ -19,13 +19,13 @@ class PHG4SectorSteppingAction : public PHG4SteppingAction
   PHG4SectorSteppingAction(PHG4SectorDetector*);
 
   //! destructor
-  virtual ~PHG4SectorSteppingAction();
+  ~PHG4SectorSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
@@ -22,7 +22,7 @@ class PHG4SectorSubsystem : public PHG4Subsystem
   PHG4SectorSubsystem(const std::string& name = "Sector");
 
   //! destructor
-  virtual ~PHG4SectorSubsystem();
+  ~PHG4SectorSubsystem() override;
 
   //! init
   /*!
@@ -30,21 +30,21 @@ class PHG4SectorSubsystem : public PHG4Subsystem
    reates the stepping action and place it on the node tree, under "ACTIONS" node
    creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
    */
-  int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   //! event processing
   /*!
    get all relevant nodes from top nodes (namely hit list)
    and pass that to the stepping action
    */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector*
-  GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const { return m_SteppingAction; }
+  PHG4Detector*
+  GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
   void
   SuperDetector(const std::string& name)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -42,10 +42,10 @@ class PHG4SpacalDetector : public PHG4Detector
   PHG4SpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const std::string& dnam,
                      PHParameters* parameters, const int layer = 0, bool init_geom = true);
 
-  virtual ~PHG4SpacalDetector(void);
+  ~PHG4SpacalDetector(void) override;
 
-  virtual void
-  ConstructMe(G4LogicalVolume* world);
+  void
+  ConstructMe(G4LogicalVolume* world) override;
 
   virtual std::pair<G4LogicalVolume*, G4Transform3D>
   Construct_AzimuthalSeg();
@@ -90,8 +90,8 @@ class PHG4SpacalDetector : public PHG4Detector
     return layer;
   }
 
-  virtual void
-  Print(const std::string& what = "ALL") const;
+  void
+  Print(const std::string& what = "ALL") const override;
 
   const SpacalGeom_t*
   get_geom() const

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.h
@@ -19,9 +19,9 @@ class PHG4SpacalDisplayAction : public PHG4DisplayAction
  public:
   PHG4SpacalDisplayAction(const std::string &name);
 
-  virtual ~PHG4SpacalDisplayAction();
+  ~PHG4SpacalDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
   void SetGeom(const PHG4CylinderGeom_Spacalv1 *geo) { m_Geom = geo; }
   void AddMaterial(const std::string &name, const std::string &mat) { m_MaterialMap[name] = mat; }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -27,15 +27,15 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction
   explicit PHG4SpacalSteppingAction(PHG4SpacalDetector *);
 
   //! destroctor
-  virtual ~PHG4SpacalSteppingAction();
+  ~PHG4SpacalSteppingAction() override;
 
   //! stepping action
-  virtual bool
-  UserSteppingAction(const G4Step *, bool);
+  bool
+  UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void
-  SetInterfacePointers(PHCompositeNode *);
+  void
+  SetInterfacePointers(PHCompositeNode *) override;
 
   double
   get_zmin();

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
@@ -29,7 +29,7 @@ class PHG4SpacalSubsystem : public PHG4DetectorSubsystem
                       const int layer = 0);
 
   //! destructor
-  virtual ~PHG4SpacalSubsystem();
+  ~PHG4SpacalSubsystem() override;
 
   //! init
   /*!
@@ -38,26 +38,26 @@ class PHG4SpacalSubsystem : public PHG4DetectorSubsystem
   ceates the stepping action 
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
    */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   //! event processing
   /*!
    get all relevant nodes from top nodes (namely hit list)
    and pass that to the stepping action
    */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector *GetDetector() const;
-  virtual PHG4SteppingAction *GetSteppingAction() const { return steppingAction_; }
+  PHG4Detector *GetDetector() const override;
+  PHG4SteppingAction *GetSteppingAction() const override { return steppingAction_; }
 
-  PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction *GetDisplayAction() const override { return m_DisplayAction; }
 
   void
-  Print(const std::string &what = "ALL") const;
+  Print(const std::string &what = "ALL") const override;
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
   //  SpacalGeom_t _geom;
 
   //! detector geometry

--- a/simulation/g4simulation/g4eval/CaloEvaluator.h
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.h
@@ -32,11 +32,11 @@ class CaloEvaluator : public SubsysReco
   CaloEvaluator(const std::string &name = "CALOEVALUATOR",
                 const std::string &caloname = "CEMC",
                 const std::string &filename = "g4eval_cemc.root");
-  virtual ~CaloEvaluator(){};
+  ~CaloEvaluator() override{};
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_strict(bool b) { _strict = b; }
   // funtions to limit the tracing to only part of the event ---------

--- a/simulation/g4simulation/g4eval/EventEvaluator.h
+++ b/simulation/g4simulation/g4eval/EventEvaluator.h
@@ -36,11 +36,11 @@ class EventEvaluator : public SubsysReco
 
   EventEvaluator(const std::string& name = "EventEvaluator",
                  const std::string& filename = "g4eval_cemc.root");
-  virtual ~EventEvaluator(){};
+  ~EventEvaluator() override{};
 
-  int Init(PHCompositeNode* topNode);
-  int process_event(PHCompositeNode* topNode);
-  int End(PHCompositeNode* topNode);
+  int Init(PHCompositeNode* topNode) override;
+  int process_event(PHCompositeNode* topNode) override;
+  int End(PHCompositeNode* topNode) override;
 
   void set_strict(bool b) { _strict = b; }
 

--- a/simulation/g4simulation/g4eval/JetEvaluator.h
+++ b/simulation/g4simulation/g4eval/JetEvaluator.h
@@ -31,11 +31,11 @@ class JetEvaluator : public SubsysReco
                const std::string &recojetname = "AntiKt_Tower_r0.3",
                const std::string &truthjetname = "AntiKt_Truth_r0.3",
                const std::string &filename = "g4eval_jets.root");
-  virtual ~JetEvaluator(){};
+  ~JetEvaluator() override{};
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_strict(bool b) { _strict = b; }
 

--- a/simulation/g4simulation/g4eval/MomentumEvaluator.cc
+++ b/simulation/g4simulation/g4eval/MomentumEvaluator.cc
@@ -265,23 +265,23 @@ class RecursiveMomentumContainerEnd : public RecursiveMomentumContainer
   {
   }
 
-  virtual ~RecursiveMomentumContainerEnd()
+  ~RecursiveMomentumContainerEnd() override
   {
   }
 
-  virtual bool insert(TrivialTrack& track)
+  bool insert(TrivialTrack& track) override
   {
     tracks.push_back(track);
     return true;
   }
 
-  virtual TrivialTrack* begin()
+  TrivialTrack* begin() override
   {
     x_pos = 0;
     return (&(tracks.at(0)));
   }
 
-  virtual TrivialTrack* next()
+  TrivialTrack* next() override
   {
     if (x_pos >= (tracks.size() - 1))
     {
@@ -294,7 +294,7 @@ class RecursiveMomentumContainerEnd : public RecursiveMomentumContainer
     }
   }
 
-  virtual void append_list(vector<TrivialTrack*>& track_list, float PX_LO, float PX_HI, float PY_LO, float PY_HI, float PZ_LO, float PZ_HI)
+  void append_list(vector<TrivialTrack*>& track_list, float PX_LO, float PX_HI, float PY_LO, float PY_HI, float PZ_LO, float PZ_HI) override
   {
     for (unsigned int i = 0; i < tracks.size(); ++i)
     {

--- a/simulation/g4simulation/g4eval/MomentumEvaluator.h
+++ b/simulation/g4simulation/g4eval/MomentumEvaluator.h
@@ -12,11 +12,11 @@ class MomentumEvaluator : public SubsysReco
 {
  public:
   MomentumEvaluator(const std::string &fname, float pt_s = 0.1, float pz_s = 0.2, unsigned int n_l = 62, unsigned int n_i = 2, unsigned int n_r = 50, float i_z = 10., float o_z = 80.);
-  ~MomentumEvaluator();
+  ~MomentumEvaluator() override;
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
  private:
   TNtuple *ntp_true;

--- a/simulation/g4simulation/g4eval/PHG4DSTReader.h
+++ b/simulation/g4simulation/g4eval/PHG4DSTReader.h
@@ -33,16 +33,16 @@ class PHG4DSTReader : public SubsysReco
 {
  public:
   PHG4DSTReader(const std::string &filename);
-  virtual ~PHG4DSTReader();
+  ~PHG4DSTReader() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void
   AddNode(const std::string &name)

--- a/simulation/g4simulation/g4eval/PHG4DstCompressReco.h
+++ b/simulation/g4simulation/g4eval/PHG4DstCompressReco.h
@@ -18,13 +18,13 @@ class PHG4DstCompressReco : public SubsysReco
 {
  public:
   PHG4DstCompressReco(const std::string &name = "PHG4DstCompressReco");
-  virtual ~PHG4DstCompressReco() {}
+  ~PHG4DstCompressReco() override {}
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   void AddHitContainer(const std::string &name) { _compress_g4hit_names.insert(name); }
   void AddCellContainer(const std::string &name) { _compress_g4cell_names.insert(name); }

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -36,12 +36,12 @@ class SvtxEvaluator : public SubsysReco
                 unsigned int nlayers_intt = 8,
                 unsigned int nlayers_tpc = 48,
                 unsigned int nlayers_mms = 2);
-  virtual ~SvtxEvaluator();
+  ~SvtxEvaluator() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_strict(bool b) { _strict = b; }
   void set_use_initial_vertex(bool use_init_vtx) {_use_initial_vertex = use_init_vtx;}

--- a/simulation/g4simulation/g4eval/TrackEvaluation.h
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.h
@@ -35,16 +35,16 @@ class TrackEvaluation : public SubsysReco
   TrackEvaluation( const std::string& = "TrackEvaluation" );
 
   //! global initialization
-  virtual int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   //! run initialization
-  virtual int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //! event processing
-  virtual int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! end of processing
-  virtual int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
 
   enum Flags
   {

--- a/simulation/g4simulation/g4eval/TrackEvaluationContainerv1.h
+++ b/simulation/g4simulation/g4eval/TrackEvaluationContainerv1.h
@@ -39,7 +39,7 @@ class TrackEvaluationContainerv1: public TrackEvaluationContainer
   }
    
   //! reset
-  virtual void Reset() override;
+  void Reset() override;
 
   //! event information
   /*! do not modify and commit: this will break reading past DSTs */

--- a/simulation/g4simulation/g4histos/G4CellNtuple.h
+++ b/simulation/g4simulation/g4histos/G4CellNtuple.h
@@ -22,16 +22,16 @@ class G4CellNtuple : public SubsysReco
   G4CellNtuple(const std::string &name = "G4CellNtuple", const std::string &filename = "G4CellNtuple.root");
 
   //! destructor
-  virtual ~G4CellNtuple();
+  ~G4CellNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const int detid = 0);
 

--- a/simulation/g4simulation/g4histos/G4EdepNtuple.h
+++ b/simulation/g4simulation/g4histos/G4EdepNtuple.h
@@ -20,16 +20,16 @@ class G4EdepNtuple : public SubsysReco
   G4EdepNtuple(const std::string &name = "G4EdepNtuple", const std::string &filename = "G4EdepNtuple.root");
 
   //! destructor
-  virtual ~G4EdepNtuple();
+  ~G4EdepNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const int detid = 0);
 

--- a/simulation/g4simulation/g4histos/G4HitNtuple.h
+++ b/simulation/g4simulation/g4histos/G4HitNtuple.h
@@ -22,16 +22,16 @@ class G4HitNtuple : public SubsysReco
   G4HitNtuple(const std::string &name = "G4HitNtuple", const std::string &filename = "G4HitNtuple.root");
 
   //! destructor
-  virtual ~G4HitNtuple();
+  ~G4HitNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const int detid = 0);
 

--- a/simulation/g4simulation/g4histos/G4HitTTree.h
+++ b/simulation/g4simulation/g4histos/G4HitTTree.h
@@ -14,15 +14,15 @@ class G4HitTTree : public SubsysReco
 {
  public:
   G4HitTTree(const std::string &name = "HITTTREE");
-  virtual ~G4HitTTree() {}
+  ~G4HitTTree() override {}
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void Detector(const std::string &det);
   void BlackHoleName(const std::string &bh);

--- a/simulation/g4simulation/g4histos/G4RawTowerTTree.h
+++ b/simulation/g4simulation/g4histos/G4RawTowerTTree.h
@@ -13,15 +13,15 @@ class G4RawTowerTTree : public SubsysReco
 {
  public:
   G4RawTowerTTree(const std::string &name = "RAWTOWERTTREE");
-  virtual ~G4RawTowerTTree() {}
+  ~G4RawTowerTTree() override {}
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void Detector(const std::string &det);
 

--- a/simulation/g4simulation/g4histos/G4RootHitContainer.h
+++ b/simulation/g4simulation/g4histos/G4RootHitContainer.h
@@ -12,7 +12,7 @@ class G4RootHitContainer : public PHObject
 {
  public:
   G4RootHitContainer();
-  virtual ~G4RootHitContainer();
+  ~G4RootHitContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4histos/G4RootRawTower.h
+++ b/simulation/g4simulation/g4histos/G4RootRawTower.h
@@ -10,7 +10,7 @@ class G4RootRawTower : public PHObject
  public:
   G4RootRawTower();
   G4RootRawTower(const float ieta, const float iphi, const float e);
-  virtual ~G4RootRawTower() {}
+  ~G4RootRawTower() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/simulation/g4simulation/g4histos/G4RootRawTowerContainer.h
+++ b/simulation/g4simulation/g4histos/G4RootRawTowerContainer.h
@@ -12,7 +12,7 @@ class G4RootRawTowerContainer : public PHObject
 {
  public:
   G4RootRawTowerContainer();
-  virtual ~G4RootRawTowerContainer();
+  ~G4RootRawTowerContainer() override;
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4histos/G4RootScintillatorSlat.h
+++ b/simulation/g4simulation/g4histos/G4RootScintillatorSlat.h
@@ -12,7 +12,7 @@ class G4RootScintillatorSlat : public PHObject
  public:
   G4RootScintillatorSlat();
   G4RootScintillatorSlat(const PHG4ScintillatorSlat& slat);
-  virtual ~G4RootScintillatorSlat() {}
+  ~G4RootScintillatorSlat() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/simulation/g4simulation/g4histos/G4RootScintillatorSlatContainer.h
+++ b/simulation/g4simulation/g4histos/G4RootScintillatorSlatContainer.h
@@ -13,7 +13,7 @@ class G4RootScintillatorSlatContainer : public PHObject
 {
  public:
   G4RootScintillatorSlatContainer();
-  virtual ~G4RootScintillatorSlatContainer();
+  ~G4RootScintillatorSlatContainer() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;

--- a/simulation/g4simulation/g4histos/G4RootScintillatorTower.h
+++ b/simulation/g4simulation/g4histos/G4RootScintillatorTower.h
@@ -14,7 +14,7 @@ class G4RootScintillatorTower : public PHObject
  public:
   G4RootScintillatorTower();
   G4RootScintillatorTower(const RawTower& tower);
-  virtual ~G4RootScintillatorTower() {}
+  ~G4RootScintillatorTower() override {}
 
   void Reset() override;
   int isValid() const override;

--- a/simulation/g4simulation/g4histos/G4RootScintillatorTowerContainer.h
+++ b/simulation/g4simulation/g4histos/G4RootScintillatorTowerContainer.h
@@ -13,7 +13,7 @@ class G4RootScintillatorTowerContainer : public PHObject
 {
  public:
   G4RootScintillatorTowerContainer();
-  virtual ~G4RootScintillatorTowerContainer();
+  ~G4RootScintillatorTowerContainer() override;
 
   void Reset() override;
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.h
+++ b/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.h
@@ -13,15 +13,15 @@ class G4ScintillatorSlatTTree : public SubsysReco
 {
  public:
   G4ScintillatorSlatTTree(const std::string &name = "SCINTILLATORSLATTTREE");
-  virtual ~G4ScintillatorSlatTTree() {}
+  ~G4ScintillatorSlatTTree() override {}
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void Detector(const std::string &det);
 

--- a/simulation/g4simulation/g4histos/G4ScintillatorTowerTTree.h
+++ b/simulation/g4simulation/g4histos/G4ScintillatorTowerTTree.h
@@ -13,15 +13,15 @@ class G4ScintillatorTowerTTree : public SubsysReco
 {
  public:
   G4ScintillatorTowerTTree(const std::string &name = "SCINTILLATORTOWERTTREE");
-  virtual ~G4ScintillatorTowerTTree() {}
+  ~G4ScintillatorTowerTTree() override {}
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void Detector(const std::string &det);
 

--- a/simulation/g4simulation/g4histos/G4SnglNtuple.h
+++ b/simulation/g4simulation/g4histos/G4SnglNtuple.h
@@ -22,16 +22,16 @@ class G4SnglNtuple : public SubsysReco
   G4SnglNtuple(const std::string &name = "G4SnglNtuple", const std::string &filename = "G4SnglNtuple.root");
 
   //! destructor
-  virtual ~G4SnglNtuple();
+  ~G4SnglNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const int detid = 0);
 

--- a/simulation/g4simulation/g4histos/G4SnglTree.h
+++ b/simulation/g4simulation/g4histos/G4SnglTree.h
@@ -22,19 +22,19 @@ class G4SnglTree : public SubsysReco
   G4SnglTree(const std::string &name = "G4SnglTree", const std::string &filename = "G4SnglTree.root");
 
   //! destructor
-  virtual ~G4SnglTree() {}
+  ~G4SnglTree() override {}
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! hit processing method
   int process_hit(PHG4HitContainer *hits, const std::string &dName, int detid, int &nhits);
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const int detid = 0);
 

--- a/simulation/g4simulation/g4histos/G4TowerNtuple.h
+++ b/simulation/g4simulation/g4histos/G4TowerNtuple.h
@@ -22,16 +22,16 @@ class G4TowerNtuple : public SubsysReco
   G4TowerNtuple(const std::string &name = "G4TowerNtuple", const std::string &filename = "G4TowerNtuple.root");
 
   //! destructor
-  virtual ~G4TowerNtuple();
+  ~G4TowerNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   void AddNode(const std::string &name, const std::string &twrtype, const int detid);
 

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.h
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.h
@@ -17,16 +17,16 @@ class G4VtxNtuple : public SubsysReco
   G4VtxNtuple(const std::string &name = "G4VtxNtuple", const std::string &filename = "G4VtxNtuple.root");
 
   //! destructor
-  virtual ~G4VtxNtuple();
+  ~G4VtxNtuple() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
  protected:
   std::string m_FileName;

--- a/simulation/g4simulation/g4intt/InttDeadMap.h
+++ b/simulation/g4simulation/g4intt/InttDeadMap.h
@@ -13,10 +13,10 @@ class InttDeadMap : public PHObject
  public:
   typedef std::set<PHG4CellDefs::keytype> Map;
 
-  virtual ~InttDeadMap() {}
+  ~InttDeadMap() override {}
 
-  virtual int isValid() const override;
-  virtual void identify(std::ostream &os = std::cout) const override;
+  int isValid() const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   void addDeadChannelIntt(const int layer,
                           const int ladder_phi, const int ladder_z,

--- a/simulation/g4simulation/g4intt/InttDeadMapv1.h
+++ b/simulation/g4simulation/g4intt/InttDeadMapv1.h
@@ -13,21 +13,21 @@ class InttDeadMapv1 : public InttDeadMap
   InttDeadMapv1()
   {
   }
-  virtual ~InttDeadMapv1() {}
+  ~InttDeadMapv1() override {}
 
-  virtual void Reset() override;
-  virtual int isValid() const override;
+  void Reset() override;
+  int isValid() const override;
 
-  virtual void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   void addDeadChannel(PHG4CellDefs::keytype key) override;
 
   bool isDeadChannel(PHG4CellDefs::keytype key) const override;
   //! return all towers
-  virtual const Map &getDeadChannels(void) const override;
-  virtual Map &getDeadChannels(void) override;
+  const Map &getDeadChannels(void) const override;
+  Map &getDeadChannels(void) override;
 
-  virtual unsigned int size() const override { return m_DeadChannels.size(); }
+  unsigned int size() const override { return m_DeadChannels.size(); }
 
  private:
   Map m_DeadChannels;

--- a/simulation/g4simulation/g4intt/PHG4InttDeadMapLoader.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDeadMapLoader.cc
@@ -91,7 +91,7 @@ int PHG4InttDeadMapLoader::InitRun(PHCompositeNode *topNode)
 
   assert(deadmap);
 
-  for (const auto pathiter : m_deadMapPathMap)
+  for (const auto& pathiter : m_deadMapPathMap)
   {
     const unsigned int ilayer = pathiter.first;
     const string &deadMapPath = pathiter.second;

--- a/simulation/g4simulation/g4intt/PHG4InttDeadMapLoader.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDeadMapLoader.h
@@ -26,9 +26,9 @@ class PHG4InttDeadMapLoader : public SubsysReco
  public:
   explicit PHG4InttDeadMapLoader(const std::string& detector = "SILICON_TRACKER");
 
-  virtual ~PHG4InttDeadMapLoader();
+  ~PHG4InttDeadMapLoader() override;
 
-  virtual int InitRun(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode) override;
 
   void deadMapPath(unsigned int layer, const std::string& deadMapPath)
   {

--- a/simulation/g4simulation/g4intt/PHG4InttDetector.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDetector.h
@@ -26,9 +26,9 @@ class PHG4InttDetector : public PHG4Detector
   PHG4InttDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParametersContainer *parameters, const std::string &dnam, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_b_e);
 
   //! destructor
-  virtual ~PHG4InttDetector() {}
+  ~PHG4InttDetector() override {}
   //! construct
-  virtual void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
@@ -18,18 +18,18 @@ class PHG4InttDigitizer : public SubsysReco, public PHParameterInterface
 {
  public:
   PHG4InttDigitizer(const std::string &name = "PHG4InttDigitizer");
-  virtual ~PHG4InttDigitizer();
+  ~PHG4InttDigitizer() override;
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode) override;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d) { detector = d; }
 

--- a/simulation/g4simulation/g4intt/PHG4InttDisplayAction.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4InttDisplayAction : public PHG4DisplayAction
  public:
   PHG4InttDisplayAction(const std::string &name);
 
-  virtual ~PHG4InttDisplayAction();
+  ~PHG4InttDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4intt/PHG4InttFPHXParameterisation.h
+++ b/simulation/g4simulation/g4intt/PHG4InttFPHXParameterisation.h
@@ -15,8 +15,8 @@ class PHG4InttFPHXParameterisation : public G4VPVParameterisation
 {
  public:
   PHG4InttFPHXParameterisation(const double offsetx, const double offsety, const double offsetz, const double dz, const int ncopy);
-  virtual ~PHG4InttFPHXParameterisation() {}
-  virtual void ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const;
+  ~PHG4InttFPHXParameterisation() override {}
+  void ComputeTransformation(const G4int icopy, G4VPhysicalVolume *physVol) const override;
 
  private:
   G4double fXFPHX[20];

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -18,15 +18,15 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
  public:
   PHG4InttHitReco(const std::string &name = "PHG4InttHitReco");
 
-  virtual ~PHG4InttHitReco();
+  ~PHG4InttHitReco() override;
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! set default parameter values
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   void Detector(const std::string &d) { m_Detector = d; }
 

--- a/simulation/g4simulation/g4intt/PHG4InttSteppingAction.h
+++ b/simulation/g4simulation/g4intt/PHG4InttSteppingAction.h
@@ -22,11 +22,11 @@ class PHG4InttSteppingAction : public PHG4SteppingAction
  public:
   PHG4InttSteppingAction(PHG4InttDetector *, const PHParametersContainer *parameters, const std::pair<std::vector<std::pair<int, int>>::const_iterator, std::vector<std::pair<int, int>>::const_iterator> &layer_begin_end);
 
-  virtual ~PHG4InttSteppingAction();
+  ~PHG4InttSteppingAction() override;
 
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4intt/PHG4InttSubsystem.h
+++ b/simulation/g4simulation/g4intt/PHG4InttSubsystem.h
@@ -24,7 +24,7 @@ class PHG4InttSubsystem : public PHG4DetectorGroupSubsystem
   PHG4InttSubsystem(const std::string &name = "PHG4InttSubsystem", const vpair &layerconfig = vpair(0));
 
   //! destructor
-  virtual ~PHG4InttSubsystem();
+  ~PHG4InttSubsystem() override;
 
   //! init
   /*!
@@ -33,26 +33,26 @@ class PHG4InttSubsystem : public PHG4DetectorGroupSubsystem
   ceates the stepping action 
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! accessors (reimplemented)
-  PHG4Detector *GetDetector(void) const;
+  PHG4Detector *GetDetector(void) const override;
 
-  PHG4SteppingAction *GetSteppingAction(void) const { return m_SteppingAction; }
+  PHG4SteppingAction *GetSteppingAction(void) const override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */

--- a/simulation/g4simulation/g4jets/ClusterJetInput.h
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.h
@@ -18,13 +18,13 @@ class ClusterJetInput : public JetInput
 {
  public:
   ClusterJetInput(Jet::SRC input);
-  virtual ~ClusterJetInput() {}
+  ~ClusterJetInput() override {}
 
-  void identify(std::ostream& os = std::cout);
+  void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() { return _input; }
+  Jet::SRC get_src() override { return _input; }
 
-  std::vector<Jet*> get_input(PHCompositeNode* topNode);
+  std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
  private:
   int _verbosity;

--- a/simulation/g4simulation/g4jets/FastJetAlgo.h
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.h
@@ -11,11 +11,11 @@ class FastJetAlgo : public JetAlgo
 {
  public:
   FastJetAlgo(Jet::ALGO algo, float par, int verbosity = 0);
-  virtual ~FastJetAlgo() {}
+  ~FastJetAlgo() override {}
 
-  void identify(std::ostream& os = std::cout);
-  Jet::ALGO get_algo() { return _algo; }
-  float get_par() { return _par; }
+  void identify(std::ostream& os = std::cout) override;
+  Jet::ALGO get_algo() override { return _algo; }
+  float get_par() override { return _par; }
 
   void set_do_SoftDrop( bool do_SD ) {
     _do_SD = do_SD;
@@ -29,7 +29,7 @@ class FastJetAlgo : public JetAlgo
     _SD_zcut = zcut;
   }
 
-  std::vector<Jet*> get_jets(std::vector<Jet*> particles);
+  std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
 
  private:
   int _verbosity;

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -75,11 +75,11 @@ class Jet : public PHObject
   };
 
   Jet() {}
-  virtual ~Jet() {}
+  ~Jet() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   // jet info ------------------------------------------------------------------
 

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -44,12 +44,12 @@ class JetHepMCLoader : public SubsysReco
  public:
   //! \param[in] jetInputCategory is the DST PHCompositeNode name that list the output jet maps, e.g. sHijing_HIJFRG for sHijing HIJFRG truth jets
   JetHepMCLoader(const std::string &jetInputCategory);
-  virtual ~JetHepMCLoader();
+  ~JetHepMCLoader() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   //! \brief addJet add HepMC entries for a particular type of jets
   //! Example of adding sHijing HIJFRG truth jets with R=0.4:

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -24,11 +24,11 @@ class JetMap : public PHObject
   typedef std::set<Jet::SRC>::iterator SrcIter;
 
   JetMap(){}
-  virtual ~JetMap() {}
+  ~JetMap() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   // map content info ----------------------------------------------------------
 

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -17,7 +17,7 @@ class JetMapv1 : public JetMap
   JetMapv1();
   JetMapv1(const JetMap *jets);
   JetMapv1& operator=(const JetMapv1& jets);
-  virtual ~JetMapv1();
+  ~JetMapv1() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;

--- a/simulation/g4simulation/g4jets/JetReco.h
+++ b/simulation/g4simulation/g4jets/JetReco.h
@@ -32,12 +32,12 @@ class JetReco : public SubsysReco
 {
  public:
   JetReco(const std::string &name = "JetReco");
-  virtual ~JetReco();
+  ~JetReco() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void add_input(JetInput *input) { _inputs.push_back(input); }
   void add_algo(JetAlgo *algo, std::string output)

--- a/simulation/g4simulation/g4jets/Jetv1.h
+++ b/simulation/g4simulation/g4jets/Jetv1.h
@@ -25,7 +25,7 @@ class Jetv1 : public Jet
 {
  public:
   Jetv1();
-  virtual ~Jetv1() {}
+  ~Jetv1() override {}
 
   // PHObject virtual overloads
 

--- a/simulation/g4simulation/g4jets/TowerJetInput.h
+++ b/simulation/g4simulation/g4jets/TowerJetInput.h
@@ -15,13 +15,13 @@ class TowerJetInput : public JetInput
 {
  public:
   TowerJetInput(Jet::SRC input);
-  virtual ~TowerJetInput() {}
+  ~TowerJetInput() override {}
 
-  void identify(std::ostream& os = std::cout);
+  void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() { return _input; }
+  Jet::SRC get_src() override { return _input; }
 
-  std::vector<Jet*> get_input(PHCompositeNode* topNode);
+  std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
  private:
   Jet::SRC _input;

--- a/simulation/g4simulation/g4jets/TrackJetInput.h
+++ b/simulation/g4simulation/g4jets/TrackJetInput.h
@@ -15,13 +15,13 @@ class TrackJetInput : public JetInput
 {
  public:
   TrackJetInput(Jet::SRC input, const std::string &name = "SvtxTrackMap");
-  virtual ~TrackJetInput() {}
+  ~TrackJetInput() override {}
 
-  void identify(std::ostream& os = std::cout);
+  void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() { return _input; }
+  Jet::SRC get_src() override { return _input; }
 
-  std::vector<Jet*> get_input(PHCompositeNode* topNode);
+  std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
  private:
   std::string m_NodeName;

--- a/simulation/g4simulation/g4jets/TruthJetInput.h
+++ b/simulation/g4simulation/g4jets/TruthJetInput.h
@@ -14,7 +14,7 @@ class TruthJetInput : public JetInput
 {
  public:
   TruthJetInput(Jet::SRC input);
-  virtual ~TruthJetInput() {}
+  ~TruthJetInput() override {}
 
   //! by default, TruthJetInput process all truth primary particle.
   //! However, it can be configured to read only one or more embedded stream via add_embedding_flag()
@@ -25,11 +25,11 @@ class TruthJetInput : public JetInput
     _embed_id.push_back(embed_stream_id);
   }
 
-  void identify(std::ostream& os = std::cout);
+  void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() { return _input; }
+  Jet::SRC get_src() override { return _input; }
 
-  std::vector<Jet*> get_input(PHCompositeNode* topNode);
+  std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
   void set_eta_range(float eta_min, float eta_max)
   {

--- a/simulation/g4simulation/g4main/EicEventHeader.h
+++ b/simulation/g4simulation/g4main/EicEventHeader.h
@@ -16,12 +16,12 @@ class EicEventHeader : public PHObject
 {
  public:
   EicEventHeader() {}
-  virtual ~EicEventHeader();
+  ~EicEventHeader() override;
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void CopyFrom(const PHObject* phobj) override;
+  void identify(std::ostream& os = std::cout) const override;
+  void CopyFrom(const PHObject* phobj) override;
 
-  virtual void Reset() override;
+  void Reset() override;
 
   virtual void set_eventgenerator_type(const int i) { return; }
   virtual int get_eventgenerator_type() const { return -99999; }

--- a/simulation/g4simulation/g4main/EicEventHeaderv1.h
+++ b/simulation/g4simulation/g4main/EicEventHeaderv1.h
@@ -14,7 +14,7 @@ class EicEventHeaderv1 : public EicEventHeader
  public:
   EicEventHeaderv1() {}
   explicit EicEventHeaderv1(const EicEventHeader *eicevt);
-  virtual ~EicEventHeaderv1() {}
+  ~EicEventHeaderv1() override {}
 
   //  void identify(std::ostream& os  = std::cout) const;
   void Reset() override;

--- a/simulation/g4simulation/g4main/Fun4AllMessenger.h
+++ b/simulation/g4simulation/g4main/Fun4AllMessenger.h
@@ -14,9 +14,9 @@ class Fun4AllMessenger: public G4UImessenger
 {
 public:
   Fun4AllMessenger(Fun4AllServer *ffa);
-  virtual ~Fun4AllMessenger();
+  ~Fun4AllMessenger() override;
 
-void SetNewValue(G4UIcommand*, G4String);
+void SetNewValue(G4UIcommand*, G4String) override;
 
 private:
 

--- a/simulation/g4simulation/g4main/HepMCCompress.h
+++ b/simulation/g4simulation/g4main/HepMCCompress.h
@@ -14,10 +14,10 @@ class HepMCCompress : public SubsysReco
 {
  public:
   HepMCCompress(const std::string &name = "HEPMCREADER");
-  virtual ~HepMCCompress() {}
+  ~HepMCCompress() override {}
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
  protected:
   short int FloatToInt(const float rval) const;
   std::set<int> exclude_pid;

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -18,10 +18,10 @@ class HepMCNodeReader : public SubsysReco
 {
  public:
   HepMCNodeReader(const std::string &name = "HEPMCREADER");
-  virtual ~HepMCNodeReader();
+  ~HepMCNodeReader() override;
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   //! this function is depreciated.
   //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.

--- a/simulation/g4simulation/g4main/PHG4ConsistencyCheck.h
+++ b/simulation/g4simulation/g4main/PHG4ConsistencyCheck.h
@@ -13,12 +13,12 @@ class PHG4ConsistencyCheck: public SubsysReco
 {
  public:
 PHG4ConsistencyCheck( const std::string &name = "CONSISTENCYCHECK" );
- virtual ~PHG4ConsistencyCheck() {}
+ ~PHG4ConsistencyCheck() override {}
   //! init
-  int InitRun(PHCompositeNode *);
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
  protected:
   unsigned int errorcnt;

--- a/simulation/g4simulation/g4main/PHG4EtaParameterization.h
+++ b/simulation/g4simulation/g4main/PHG4EtaParameterization.h
@@ -30,15 +30,15 @@ public:
 			  double centerZ  // overall Z of center of rings
 			  );
   
-  virtual ~PHG4EtaParameterization();
+  ~PHG4EtaParameterization() override;
   
   virtual void Print(std::ostream& os = std::cout) const;
 
   void ComputeTransformation(const G4int copyNo,
-			     G4VPhysicalVolume* physVol) const;
+			     G4VPhysicalVolume* physVol) const override;
   
   void ComputeDimensions(G4Tubs& ring, const G4int copyNo,
-			 const G4VPhysicalVolume* physVol) const;
+			 const G4VPhysicalVolume* physVol) const override;
 
   int GetIEta(int copyNo) const { return _ieta.at(copyNo); }
 

--- a/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
+++ b/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.cc
@@ -78,7 +78,7 @@ PHG4EtaPhiParameterization::PHG4EtaPhiParameterization(
   //
   for (unsigned int i = 0; i < _neta * _nphi; i++)
   {
-    div_t q = div(i, _nphi);
+    div_t q = div((int)i, (int)_nphi);
     int ieta = q.quot;
     int iphi = q.rem;
     _ieta.push_back(ieta);

--- a/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.h
+++ b/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.h
@@ -31,15 +31,15 @@ public:
 			  double centerZ  // overall Z of center of rings
 			  );
   
-  virtual ~PHG4EtaPhiParameterization();
+  ~PHG4EtaPhiParameterization() override;
   
   virtual void Print(std::ostream& os = std::cout) const;
 
   void ComputeTransformation(const G4int copyNo,
-			     G4VPhysicalVolume* physVol) const;
+			     G4VPhysicalVolume* physVol) const override;
   
   void ComputeDimensions(G4Tubs& ring, const G4int copyNo,
-			 const G4VPhysicalVolume* physVol) const;
+			 const G4VPhysicalVolume* physVol) const override;
 
   int GetIEta(int copyNo) const { return _ieta.at(copyNo); }
   int GetIPhi(int copyNo) const { return _iphi.at(copyNo); }

--- a/simulation/g4simulation/g4main/PHG4EventHeader.h
+++ b/simulation/g4simulation/g4main/PHG4EventHeader.h
@@ -15,10 +15,10 @@ class PHG4EventHeader: public PHObject
  public:
 
   /// dtor
-  virtual ~PHG4EventHeader() {}
+  ~PHG4EventHeader() override {}
 
   /// Clear Event
-  virtual void Reset() override
+  void Reset() override
     {
       std::cout << PHWHERE << "ERROR Reset() not implemented by daughter class" << std::endl;
       return;
@@ -27,14 +27,14 @@ class PHG4EventHeader: public PHObject
   /** identify Function from PHObject
       @param os Output Stream 
    */
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
     {
       os << "identify yourself: virtual PHG4EventHeader Object" << std::endl;
       return;
     }
 
   /// isValid returns non zero if object contains valid data
-  virtual int isValid() const override
+  int isValid() const override
     {
       std::cout << PHWHERE << "isValid not implemented by daughter class" << std::endl;
       return 0;

--- a/simulation/g4simulation/g4main/PHG4EventHeaderv1.h
+++ b/simulation/g4simulation/g4main/PHG4EventHeaderv1.h
@@ -15,10 +15,10 @@ class PHG4EventHeaderv1: public PHG4EventHeader
   PHG4EventHeaderv1();
 
   /// dtor
-  virtual ~PHG4EventHeaderv1() {}
+  ~PHG4EventHeaderv1() override {}
 
   /// Clear Event
-  virtual void Reset() override;
+  void Reset() override;
 
   /** identify Function from PHObject
       @param os Output Stream 

--- a/simulation/g4simulation/g4main/PHG4HeadReco.h
+++ b/simulation/g4simulation/g4main/PHG4HeadReco.h
@@ -13,9 +13,9 @@ class PHG4HeadReco: public SubsysReco
 {
  public:
   PHG4HeadReco(const std::string &name="PHG4HeadReco");
-  virtual ~PHG4HeadReco(){}
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  ~PHG4HeadReco() override{}
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
  protected:
 

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -17,12 +17,12 @@ class PHG4Hit: public PHObject
 {
  public:
   PHG4Hit() {}
-  virtual ~PHG4Hit() {}
+  ~PHG4Hit() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
-  virtual void CopyFrom(const PHObject *phobj) override;
+  void identify(std::ostream& os = std::cout) const override;
+  void CopyFrom(const PHObject *phobj) override;
   friend std::ostream &operator<<(std::ostream & stream, const PHG4Hit * hit);
-  virtual void Reset() override;
+  void Reset() override;
 
   // The indices here represent the entry and exit points of the particle
   virtual float get_x(const int i) const {return NAN;}

--- a/simulation/g4simulation/g4main/PHG4HitContainer.h
+++ b/simulation/g4simulation/g4main/PHG4HitContainer.h
@@ -29,7 +29,7 @@ class PHG4HitContainer: public PHObject
   PHG4HitContainer(); //< used only by ROOT for DST readback
   PHG4HitContainer(const std::string &nodename);
 
-  virtual ~PHG4HitContainer() {}
+  ~PHG4HitContainer() override {}
 
   void Reset() override;
 

--- a/simulation/g4simulation/g4main/PHG4HitEval.h
+++ b/simulation/g4simulation/g4main/PHG4HitEval.h
@@ -28,9 +28,9 @@ class PHG4HitEval : public PHG4Hitv1
 
   PHG4HitEval(const PHG4Hit *g4hit);
 
-  virtual ~PHG4HitEval() {}
+  ~PHG4HitEval() override {}
 
-  virtual void CopyFrom(const PHObject *phobj) override;
+  void CopyFrom(const PHObject *phobj) override;
 
   float
   get_eion() const override

--- a/simulation/g4simulation/g4main/PHG4HitReadBack.h
+++ b/simulation/g4simulation/g4main/PHG4HitReadBack.h
@@ -13,8 +13,8 @@ class PHG4HitReadBack : public SubsysReco
 {
  public:
   PHG4HitReadBack(const std::string &name="PHG4HITREADBACK");
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
  protected:
 };
 

--- a/simulation/g4simulation/g4main/PHG4Hitv1.h
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.h
@@ -17,7 +17,7 @@ class PHG4Hitv1 : public PHG4Hit
  public:
   PHG4Hitv1() = default;
   explicit PHG4Hitv1(const PHG4Hit* g4hit);
-  virtual ~PHG4Hitv1() = default;
+  ~PHG4Hitv1() override = default;
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;
 
@@ -41,7 +41,7 @@ class PHG4Hitv1 : public PHG4Hit
   void set_shower_id(const int i) override { showerid = i; }
   void set_trkid(const int i) override { trackid = i; }
 
-  virtual void print() const override;
+  void print() const override;
 
   bool has_property(const PROPERTY prop_id) const override;
   float get_property_float(const PROPERTY prop_id) const override;
@@ -51,49 +51,49 @@ class PHG4Hitv1 : public PHG4Hit
   void set_property(const PROPERTY prop_id, const int value) override;
   void set_property(const PROPERTY prop_id, const unsigned int value) override;
 
-  virtual float get_px(const int i) const override;
-  virtual float get_py(const int i) const override;
-  virtual float get_pz(const int i) const override;
-  virtual float get_local_x(const int i) const override;
-  virtual float get_local_y(const int i) const override;
-  virtual float get_local_z(const int i) const override;
-  virtual float get_eion() const override { return get_property_float(prop_eion); }
-  virtual float get_light_yield() const override { return get_property_float(prop_light_yield); }
-  virtual float get_path_length() const override { return get_property_float(prop_path_length); }
-  virtual unsigned int get_layer() const override { return get_property_uint(prop_layer); }
-  virtual int get_scint_id() const override { return get_property_int(prop_scint_id); }
-  virtual int get_row() const override { return get_property_int(prop_row); }
-  virtual int get_strip_z_index() const override { return get_property_int(prop_strip_z_index); }
-  virtual int get_strip_y_index() const override { return get_property_int(prop_strip_y_index); }
-  virtual int get_ladder_z_index() const override { return get_property_int(prop_ladder_z_index); }
-  virtual int get_ladder_phi_index() const override { return get_property_int(prop_ladder_phi_index); }
-  virtual int get_index_i() const override { return get_property_int(prop_index_i); }
-  virtual int get_index_j() const override { return get_property_int(prop_index_j); }
-  virtual int get_index_k() const override { return get_property_int(prop_index_k); }
-  virtual int get_index_l() const override { return get_property_int(prop_index_l); }
-  virtual int get_hit_type() const override { return get_property_int(prop_hit_type); }
+  float get_px(const int i) const override;
+  float get_py(const int i) const override;
+  float get_pz(const int i) const override;
+  float get_local_x(const int i) const override;
+  float get_local_y(const int i) const override;
+  float get_local_z(const int i) const override;
+  float get_eion() const override { return get_property_float(prop_eion); }
+  float get_light_yield() const override { return get_property_float(prop_light_yield); }
+  float get_path_length() const override { return get_property_float(prop_path_length); }
+  unsigned int get_layer() const override { return get_property_uint(prop_layer); }
+  int get_scint_id() const override { return get_property_int(prop_scint_id); }
+  int get_row() const override { return get_property_int(prop_row); }
+  int get_strip_z_index() const override { return get_property_int(prop_strip_z_index); }
+  int get_strip_y_index() const override { return get_property_int(prop_strip_y_index); }
+  int get_ladder_z_index() const override { return get_property_int(prop_ladder_z_index); }
+  int get_ladder_phi_index() const override { return get_property_int(prop_ladder_phi_index); }
+  int get_index_i() const override { return get_property_int(prop_index_i); }
+  int get_index_j() const override { return get_property_int(prop_index_j); }
+  int get_index_k() const override { return get_property_int(prop_index_k); }
+  int get_index_l() const override { return get_property_int(prop_index_l); }
+  int get_hit_type() const override { return get_property_int(prop_hit_type); }
 
-  virtual void set_px(const int i, const float f) override;
-  virtual void set_py(const int i, const float f) override;
-  virtual void set_pz(const int i, const float f) override;
-  virtual void set_local_x(const int i, const float f) override;
-  virtual void set_local_y(const int i, const float f) override;
-  virtual void set_local_z(const int i, const float f) override;
-  virtual void set_eion(const float f) override { set_property(prop_eion, f); }
-  virtual void set_light_yield(const float f) override { set_property(prop_light_yield, f); }
-  virtual void set_path_length(const float f) override { set_property(prop_path_length, f); }
-  virtual void set_layer(const unsigned int i) override { set_property(prop_layer, i); }
-  virtual void set_scint_id(const int i) override { set_property(prop_scint_id, i); }
-  virtual void set_row(const int i) override { set_property(prop_row, i); }
-  virtual void set_strip_z_index(const int i) override { set_property(prop_strip_z_index, i); }
-  virtual void set_strip_y_index(const int i) override { set_property(prop_strip_y_index, i); }
-  virtual void set_ladder_z_index(const int i) override { set_property(prop_ladder_z_index, i); }
-  virtual void set_ladder_phi_index(const int i) override { set_property(prop_ladder_phi_index, i); }
-  virtual void set_index_i(const int i) override { set_property(prop_index_i, i); }
-  virtual void set_index_j(const int i) override { set_property(prop_index_j, i); }
-  virtual void set_index_k(const int i) override { set_property(prop_index_k, i); }
-  virtual void set_index_l(const int i) override { set_property(prop_index_l, i); }
-  virtual void set_hit_type(const int i) override { set_property(prop_hit_type, i); }
+  void set_px(const int i, const float f) override;
+  void set_py(const int i, const float f) override;
+  void set_pz(const int i, const float f) override;
+  void set_local_x(const int i, const float f) override;
+  void set_local_y(const int i, const float f) override;
+  void set_local_z(const int i, const float f) override;
+  void set_eion(const float f) override { set_property(prop_eion, f); }
+  void set_light_yield(const float f) override { set_property(prop_light_yield, f); }
+  void set_path_length(const float f) override { set_property(prop_path_length, f); }
+  void set_layer(const unsigned int i) override { set_property(prop_layer, i); }
+  void set_scint_id(const int i) override { set_property(prop_scint_id, i); }
+  void set_row(const int i) override { set_property(prop_row, i); }
+  void set_strip_z_index(const int i) override { set_property(prop_strip_z_index, i); }
+  void set_strip_y_index(const int i) override { set_property(prop_strip_y_index, i); }
+  void set_ladder_z_index(const int i) override { set_property(prop_ladder_z_index, i); }
+  void set_ladder_phi_index(const int i) override { set_property(prop_ladder_phi_index, i); }
+  void set_index_i(const int i) override { set_property(prop_index_i, i); }
+  void set_index_j(const int i) override { set_property(prop_index_j, i); }
+  void set_index_k(const int i) override { set_property(prop_index_k, i); }
+  void set_index_l(const int i) override { set_property(prop_index_l, i); }
+  void set_hit_type(const int i) override { set_property(prop_hit_type, i); }
 
  protected:
   unsigned int get_property_nocheck(const PROPERTY prop_id) const override;

--- a/simulation/g4simulation/g4main/PHG4InEvent.h
+++ b/simulation/g4simulation/g4main/PHG4InEvent.h
@@ -16,9 +16,9 @@ class PHG4InEvent: public PHObject
 {
  public:
   PHG4InEvent() {}
-  virtual ~PHG4InEvent();
+  ~PHG4InEvent() override;
 
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
   void Reset() override;
   // this one is for HepMC records where we want to keep the HepMC vertex numbering
   int AddVtxHepMC(const int id, const double x, const double y, const double z, const double t);

--- a/simulation/g4simulation/g4main/PHG4InEventCompress.h
+++ b/simulation/g4simulation/g4main/PHG4InEventCompress.h
@@ -14,10 +14,10 @@ class PHG4InEventCompress: public SubsysReco
 {
  public:
   PHG4InEventCompress(const std::string &name = "PHG4InEventCompress");
-  virtual ~PHG4InEventCompress() {}
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  ~PHG4InEventCompress() override {}
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
  protected:
   VariableArray *vtxarray;

--- a/simulation/g4simulation/g4main/PHG4InEventReadBack.h
+++ b/simulation/g4simulation/g4main/PHG4InEventReadBack.h
@@ -13,10 +13,10 @@ class PHG4InEventReadBack: public SubsysReco
 {
  public:
   PHG4InEventReadBack(const std::string &name = "PHG4InEventReadBack");
-  virtual ~PHG4InEventReadBack() {}
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  ~PHG4InEventReadBack() override {}
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
  protected:
   

--- a/simulation/g4simulation/g4main/PHG4InputFilter.h
+++ b/simulation/g4simulation/g4main/PHG4InputFilter.h
@@ -13,9 +13,9 @@ class PHG4InputFilter : public SubsysReco
 {
  public:
   PHG4InputFilter(const std::string &name = "G4INPUTFILTER");
-  virtual ~PHG4InputFilter() {}
+  ~PHG4InputFilter() override {}
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   void set_eta_range(const double min, const double max) {etamin = min; etamax = max;}
   void set_etamin(const double min) {etamin = min;}

--- a/simulation/g4simulation/g4main/PHG4IonGun.h
+++ b/simulation/g4simulation/g4main/PHG4IonGun.h
@@ -15,14 +15,14 @@ class PHG4IonGun : public PHG4ParticleGeneratorBase
 {
  public:
   PHG4IonGun(const std::string &name = "PHG4IONGUN");
-  virtual ~PHG4IonGun() {}
-  int process_event(PHCompositeNode *topNode);
+  ~PHG4IonGun() override {}
+  int process_event(PHCompositeNode *topNode) override;
   void SetA(const int a) { A = a; }
   void SetZ(const int z) { Z = z; }
   void SetCharge(const int c);
   void ExcitEnergy(const double e) { excitEnergy = e; }
   void SetMom(const double px, const double py, const double pz);
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
  private:
   void UpdateParticle();

--- a/simulation/g4simulation/g4main/PHG4MagneticField.h
+++ b/simulation/g4simulation/g4main/PHG4MagneticField.h
@@ -24,7 +24,7 @@ class PHG4MagneticField : public G4MagneticField
 {
  public:
   PHG4MagneticField(const PHField* field);
-  virtual ~PHG4MagneticField();
+  ~PHG4MagneticField() override;
 
   const PHField* get_field() const
   {
@@ -36,7 +36,7 @@ class PHG4MagneticField : public G4MagneticField
     field_ = field;
   }
 
-  void GetFieldValue( const double Point[4],    double *Bfield ) const;
+  void GetFieldValue( const double Point[4],    double *Bfield ) const override;
 
  protected:
   const PHField* field_;

--- a/simulation/g4simulation/g4main/PHG4Particle.h
+++ b/simulation/g4simulation/g4main/PHG4Particle.h
@@ -13,7 +13,7 @@ class PHG4Particle : public PHObject
 {
  public:
   PHG4Particle() {}
-  virtual ~PHG4Particle() {}
+  ~PHG4Particle() override {}
 
   void identify(std::ostream &os = std::cout) const override;
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGenerator.h
@@ -14,14 +14,14 @@ class PHG4ParticleGenerator : public PHG4ParticleGeneratorBase
 {
  public:
   PHG4ParticleGenerator(const std::string &name = "PGENERATOR");
-  virtual ~PHG4ParticleGenerator() {}
+  ~PHG4ParticleGenerator() override {}
 
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
   void set_z_range(const double z_min, const double z_max);
   void set_eta_range(const double eta_min, const double eta_max);
   void set_phi_range(const double phi_min, const double phi_max);
   void set_mom_range(const double mom_min, const double mom_max);
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
  protected:
   double m_ZMin = -10.;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -17,10 +17,10 @@ class PHG4Particle;
 class PHG4ParticleGeneratorBase : public SubsysReco
 {
  public:
-  virtual ~PHG4ParticleGeneratorBase();
+  ~PHG4ParticleGeneratorBase() override;
 
-  virtual int InitRun(PHCompositeNode *topNode);
-  virtual int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   virtual void set_name(const std::string &particle = "proton");
   virtual void set_pid(const int pid);
@@ -34,7 +34,7 @@ class PHG4ParticleGeneratorBase : public SubsysReco
   virtual double get_vtx_z() const { return m_Vtx_z; }
   virtual double get_t0() const { return m_TZero; }
 
-  virtual void Print(const std::string &what = "ALL") const { PrintParticles(what); }
+  void Print(const std::string &what = "ALL") const override { PrintParticles(what); }
   virtual void PrintParticles(const std::string &what = "ALL") const;
   virtual void AddParticle(const std::string &particle, const double x, const double y, const double z);
   virtual void AddParticle(const int pid, const double x, const double y, const double z);

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.h
@@ -14,10 +14,10 @@ class PHG4ParticleGeneratorD0 : public PHG4ParticleGeneratorBase
 {
  public:
   PHG4ParticleGeneratorD0(const std::string &name = "D0GEN");
-  virtual ~PHG4ParticleGeneratorD0() {}
+  ~PHG4ParticleGeneratorD0() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   void set_eta_range(const double eta_min, const double eta_max);
   void set_rapidity_range(const double y_min, const double y_max);

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -25,7 +25,7 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
   };
 
   explicit PHG4ParticleGeneratorVectorMeson(const std::string &name = "VMESON");
-  virtual ~PHG4ParticleGeneratorVectorMeson();
+  ~PHG4ParticleGeneratorVectorMeson() override;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;

--- a/simulation/g4simulation/g4main/PHG4ParticleGun.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGun.h
@@ -13,8 +13,8 @@ class PHG4ParticleGun : public PHG4ParticleGeneratorBase
 {
  public:
   PHG4ParticleGun(const std::string &name = "PGUN");
-  virtual ~PHG4ParticleGun() {}
-  int process_event(PHCompositeNode *topNode);
+  ~PHG4ParticleGun() override {}
+  int process_event(PHCompositeNode *topNode) override;
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Particlev1.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.h
@@ -15,7 +15,7 @@ class PHG4Particlev1 : public PHG4Particle
   PHG4Particlev1(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev1(const PHG4Particle *in);
 
-  virtual ~PHG4Particlev1() {}
+  ~PHG4Particlev1() override {}
 
   void identify(std::ostream &os = std::cout) const override;
 

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -17,7 +17,7 @@ class PHG4Particlev2 : public PHG4Particlev1
   PHG4Particlev2(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev2(const PHG4Particle *in);
 
-  virtual ~PHG4Particlev2() {}
+  ~PHG4Particlev2() override {}
 
   void identify(std::ostream &os = std::cout) const override;
 

--- a/simulation/g4simulation/g4main/PHG4Particlev3.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.h
@@ -16,7 +16,7 @@ class PHG4Particlev3 : public PHG4Particlev2
   //  PHG4Particlev3(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev3(const PHG4Particle* in);
 
-  virtual ~PHG4Particlev3() {}
+  ~PHG4Particlev3() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 

--- a/simulation/g4simulation/g4main/PHG4PhenixDetector.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixDetector.h
@@ -23,7 +23,7 @@ class PHG4PhenixDetector : public G4VUserDetectorConstruction
   PHG4PhenixDetector(PHG4Reco* subsys);
 
   //! destructor
-  virtual ~PHG4PhenixDetector();
+  ~PHG4PhenixDetector() override;
 
   void Verbosity(const int verb) { m_Verbosity = verb; }
   int Verbosity() const { return m_Verbosity; }
@@ -35,7 +35,7 @@ class PHG4PhenixDetector : public G4VUserDetectorConstruction
   }
 
   //! this is called by geant to actually construct all detectors
-  virtual G4VPhysicalVolume* Construct();
+  G4VPhysicalVolume* Construct() override;
 
   G4double GetWorldSizeX() const { return WorldSizeX; }
 

--- a/simulation/g4simulation/g4main/PHG4PhenixDisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4PhenixDisplayAction : public PHG4DisplayAction
  public:
   PHG4PhenixDisplayAction(const std::string &name);
 
-  virtual ~PHG4PhenixDisplayAction();
+  ~PHG4PhenixDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4main/PHG4PhenixEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixEventAction.h
@@ -19,15 +19,15 @@ class PHG4PhenixEventAction : public G4UserEventAction
   public:
   PHG4PhenixEventAction( void );
 
-  virtual ~PHG4PhenixEventAction();
+  ~PHG4PhenixEventAction() override;
 
   //! register an action. This is called in PHG4Reco::Init based on which actions are found on the tree
   void AddAction( PHG4EventAction* action )
   { actions_.push_back( action ); }
 
-  void BeginOfEventAction(const G4Event*);
+  void BeginOfEventAction(const G4Event*) override;
 
-  void EndOfEventAction(const G4Event*);
+  void EndOfEventAction(const G4Event*) override;
 
   private:
 

--- a/simulation/g4simulation/g4main/PHG4PhenixSteppingAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixSteppingAction.h
@@ -16,7 +16,7 @@ class PHG4PhenixSteppingAction : public G4UserSteppingAction
   PHG4PhenixSteppingAction( void )
   {}
 
-  virtual ~PHG4PhenixSteppingAction();
+  ~PHG4PhenixSteppingAction() override;
   
 
   //! register an action. This is called in PHG4Reco::Init based on which actions are found on the tree
@@ -28,7 +28,7 @@ class PHG4PhenixSteppingAction : public G4UserSteppingAction
       }
   }
 
-  virtual void UserSteppingAction(const G4Step*);
+  void UserSteppingAction(const G4Step*) override;
 
   private:
 

--- a/simulation/g4simulation/g4main/PHG4PhenixTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixTrackingAction.h
@@ -17,14 +17,14 @@ class PHG4PhenixTrackingAction : public G4UserTrackingAction
 public:
   PHG4PhenixTrackingAction( void ) : verbosity_(0) {}
 
-  virtual ~PHG4PhenixTrackingAction();
+  ~PHG4PhenixTrackingAction() override;
 
   //! register an action. This is called in PHG4Reco::Init based on which actions are found on the tree
   void AddAction( PHG4TrackingAction* action ) { actions_.push_back( action ); }
 
-  virtual void PreUserTrackingAction(const G4Track*);
+  void PreUserTrackingAction(const G4Track*) override;
 
-  virtual void PostUserTrackingAction(const G4Track*);
+  void PostUserTrackingAction(const G4Track*) override;
 
   //! Get/Set verbosity level
   void Verbosity(int val) { verbosity_ = val; }

--- a/simulation/g4simulation/g4main/PHG4PileupGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4PileupGenerator.h
@@ -13,15 +13,15 @@ class PHG4PileupGenerator : public PHG4ParticleGeneratorBase
 {
  public:
   PHG4PileupGenerator(const std::string &name = "PILEUPGENERATOR");
-  virtual ~PHG4PileupGenerator();
+  ~PHG4PileupGenerator() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int Reset(PHCompositeNode *topNode);
-  int ResetEvent(PHCompositeNode *topNode);
-  int EndRun(const int runnumber);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int Reset(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
+  int EndRun(const int runnumber) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_generator(PHG4ParticleGeneratorBase *generator) { _generator = generator; }
 

--- a/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.h
+++ b/simulation/g4simulation/g4main/PHG4PrimaryGeneratorAction.h
@@ -17,11 +17,11 @@ class PHG4PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
   {
   }
 
-  virtual ~PHG4PrimaryGeneratorAction()
+  ~PHG4PrimaryGeneratorAction() override
   {
   }
 
-  virtual void GeneratePrimaries(G4Event* anEvent);
+  void GeneratePrimaries(G4Event* anEvent) override;
 
   //! set top node (from where particle list is retrieved for passing to geant
   void SetInEvent(PHG4InEvent* const inevt)

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -40,21 +40,21 @@ class PHG4Reco : public SubsysReco
   PHG4Reco(const std::string &name = "PHG4RECO");
 
   //! destructor
-  virtual ~PHG4Reco();
+  ~PHG4Reco() override;
 
   //! full initialization
-  int Init(PHCompositeNode *);
+  int Init(PHCompositeNode *) override;
 
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! Clean up after each event.
-  int ResetEvent(PHCompositeNode *);
+  int ResetEvent(PHCompositeNode *) override;
 
   //! print info
-  void Print(const std::string &what = std::string()) const;
+  void Print(const std::string &what = std::string()) const override;
 
   //! register subsystem
   void registerSubsystem(PHG4Subsystem *subsystem)

--- a/simulation/g4simulation/g4main/PHG4RegionInformation.h
+++ b/simulation/g4simulation/g4main/PHG4RegionInformation.h
@@ -44,8 +44,8 @@ class PHG4RegionInformation : public G4VUserRegionInformation
 {
   public:
     PHG4RegionInformation(); 
-    ~PHG4RegionInformation(){}
-    void Print() const;
+    ~PHG4RegionInformation() override{}
+    void Print() const override;
 
   private:
     G4bool isWorld;

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.h
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.h
@@ -33,16 +33,16 @@ class PHG4ScoringManager : public SubsysReco
  public:
   PHG4ScoringManager();
 
-  virtual ~PHG4ScoringManager() {}
+  ~PHG4ScoringManager() override {}
 
   //! full initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing method
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! end of run method
-  int End(PHCompositeNode *);
+  int End(PHCompositeNode *) override;
 
   //! Output result to a ROOT file with this name
   void setOutputFileName(const std::string &outputfilename) { m_outputFileName = outputfilename; };

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -27,14 +27,14 @@ class PHG4Shower : public PHObject
   typedef HitIdMap::iterator HitIdIter;
   typedef HitIdMap::const_iterator HitIdConstIter;
 
-  virtual ~PHG4Shower() {}
+  ~PHG4Shower() override {}
 
   // PHObject virtual overloads
 
-  virtual void identify(std::ostream& os = std::cout) const override { os << "PHG4Shower base class" << std::endl; }
-  virtual PHG4Shower* CloneMe() const override { return nullptr; }
-  virtual void Reset() override {}
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream& os = std::cout) const override { os << "PHG4Shower base class" << std::endl; }
+  PHG4Shower* CloneMe() const override { return nullptr; }
+  void Reset() override {}
+  int isValid() const override { return 0; }
 
   // shower info
 

--- a/simulation/g4simulation/g4main/PHG4Showerv1.h
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.h
@@ -16,7 +16,7 @@ class PHG4Showerv1 : public PHG4Shower
 {
  public:
   PHG4Showerv1();
-  virtual ~PHG4Showerv1() {}
+  ~PHG4Showerv1() override {}
 
   // PHObject virtual overloads
 

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
@@ -25,10 +25,10 @@ class PHG4SimpleEventGenerator : public PHG4ParticleGeneratorBase
   };
 
   PHG4SimpleEventGenerator(const std::string &name = "EVTGENERATOR");
-  virtual ~PHG4SimpleEventGenerator() {}
+  ~PHG4SimpleEventGenerator() override {}
 
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   //! interface for adding particles by name
   void add_particles(const std::string &name, const unsigned int count);

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -30,7 +30,7 @@ class PHG4Subsystem : public SubsysReco
   }
 
   //! destructor
-  virtual ~PHG4Subsystem(void) {}
+  ~PHG4Subsystem(void) override {}
 
   //! event processing
   virtual int process_after_geant(PHCompositeNode *)

--- a/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
+++ b/simulation/g4simulation/g4main/PHG4TrackUserInfoV1.h
@@ -30,9 +30,9 @@ class PHG4TrackUserInfoV1 : public G4VUserTrackInformation
     , shower(nullptr)
   {
   }
-  virtual ~PHG4TrackUserInfoV1() {}
+  ~PHG4TrackUserInfoV1() override {}
 
-  void Print() const
+  void Print() const override
   {
     std::cout << "PHG4TrackUserInfoV1: " << std::endl;
     std::cout << "   UserTrackId = " << usertrackid << std::endl;

--- a/simulation/g4simulation/g4main/PHG4TrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TrackingAction.h
@@ -13,12 +13,12 @@ class PHG4TrackingAction : public G4UserTrackingAction
 public:
   PHG4TrackingAction( void ) {}
 
-  virtual ~PHG4TrackingAction() {}
+  ~PHG4TrackingAction() override {}
 
 //   //! tracking action. This defines pre/post processing of a single track in an event
-  virtual void PreUserTrackingAction(const G4Track*) {}
+  void PreUserTrackingAction(const G4Track*) override {}
 
-   virtual void PostUserTrackingAction(const G4Track*) {}
+   void PostUserTrackingAction(const G4Track*) override {}
 
   //! Set the node pointers
   virtual void SetInterfacePointers( PHCompositeNode* ) {return;}

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.h
@@ -20,16 +20,16 @@ class PHG4TruthEventAction : public PHG4EventAction
   PHG4TruthEventAction();
 
   //! destuctor
-  virtual ~PHG4TruthEventAction() {}
+  ~PHG4TruthEventAction() override {}
 
-  void BeginOfEventAction(const G4Event*);
+  void BeginOfEventAction(const G4Event*) override;
 
-  void EndOfEventAction(const G4Event*);
+  void EndOfEventAction(const G4Event*) override;
 
-  int ResetEvent(PHCompositeNode*);
+  int ResetEvent(PHCompositeNode*) override;
 
   //! get relevant nodes from top node passed as argument
-  void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
   //! add id into track list
   void AddTrackidToWritelist(const int trackid);

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -36,7 +36,7 @@ class PHG4TruthInfoContainer : public PHObject
   typedef std::pair<ConstShowerIterator, ConstShowerIterator> ConstShowerRange;
 
   PHG4TruthInfoContainer();
-  virtual ~PHG4TruthInfoContainer();
+  ~PHG4TruthInfoContainer() override;
 
 // from PHObject
   void Reset() override;

--- a/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
+++ b/simulation/g4simulation/g4main/PHG4TruthSubsystem.h
@@ -20,25 +20,25 @@ class PHG4TruthSubsystem : public PHG4Subsystem
   PHG4TruthSubsystem(const std::string &name = "TRUTH");
 
   //! destructor
-  virtual ~PHG4TruthSubsystem(void)
+  ~PHG4TruthSubsystem(void) override
   {
   }
 
   //! init
-  int InitRun(PHCompositeNode *);
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! event processing
-  virtual int process_after_geant(PHCompositeNode *);
+  int process_after_geant(PHCompositeNode *) override;
 
   //! Clean up after each event.
-  int ResetEvent(PHCompositeNode *);
+  int ResetEvent(PHCompositeNode *) override;
 
   //! accessors (reimplemented)
-  virtual PHG4EventAction *GetEventAction(void) const;
-  virtual PHG4TrackingAction *GetTrackingAction(void) const;
+  PHG4EventAction *GetEventAction(void) const override;
+  PHG4TrackingAction *GetTrackingAction(void) const override;
 
   //! only save the G4 truth information that is associated with the embedded particle
   void SetSaveOnlyEmbeded(bool b = true) { m_SaveOnlyEmbededFlag = b; };

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.h
@@ -24,17 +24,17 @@ class PHG4TruthTrackingAction : public PHG4TrackingAction
   PHG4TruthTrackingAction(PHG4TruthEventAction*);
 
   //! destructor
-  virtual ~PHG4TruthTrackingAction() {}
+  ~PHG4TruthTrackingAction() override {}
 
   //! tracking action
-  virtual void PreUserTrackingAction(const G4Track*);
+  void PreUserTrackingAction(const G4Track*) override;
 
-  virtual void PostUserTrackingAction(const G4Track*);
+  void PostUserTrackingAction(const G4Track*) override;
 
   //! Set pointers to the i/o nodes
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
-  int ResetEvent(PHCompositeNode*);
+  int ResetEvent(PHCompositeNode*) override;
 
  private:
   std::map<G4ThreeVector, int> m_VertexMap;

--- a/simulation/g4simulation/g4main/PHG4UIsession.h
+++ b/simulation/g4simulation/g4main/PHG4UIsession.h
@@ -11,14 +11,14 @@ class PHG4UIsession : public G4UIsession {
 
 public:
   PHG4UIsession();
-  virtual ~PHG4UIsession() {}
+  ~PHG4UIsession() override {}
 
   void Verbosity(int verb) {verbosity = verb;}
   
-  G4UIsession * SessionStart();
-  void PauseSessionStart(const G4String& Prompt);
-  G4int ReceiveG4cout(const G4String& coutString);
-  G4int ReceiveG4cerr(const G4String& cerrString);
+  G4UIsession * SessionStart() override;
+  void PauseSessionStart(const G4String& Prompt) override;
+  G4int ReceiveG4cout(const G4String& coutString) override;
+  G4int ReceiveG4cerr(const G4String& cerrString) override;
 
 private:
   int verbosity;

--- a/simulation/g4simulation/g4main/PHG4Units.h
+++ b/simulation/g4simulation/g4main/PHG4Units.h
@@ -7,6 +7,6 @@
 // so we cannot use G4UnitDefinition for these
 #include <Geant4/G4SystemOfUnits.hh>
 
-static const G4double inch = 2.54*cm;
+static const double inch = 2.54*cm;
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
+++ b/simulation/g4simulation/g4main/PHG4UserPrimaryParticleInformation.h
@@ -15,7 +15,7 @@ public:
     uservtxid(0),
     barcode(-1)   {}
 
-  void Print() const 
+  void Print() const override 
   {
     std::cout << "Embedding = " << embed << std::endl;
     std::cout << "User Track ID = " << usertrackid << std::endl;

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.h
@@ -12,9 +12,9 @@
 class PHG4VtxPoint: public PHObject
 {
  public:
-  virtual ~PHG4VtxPoint() {}
+  ~PHG4VtxPoint() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
   virtual void set_x(const double r) {}
   virtual void set_y(const double r) {}

--- a/simulation/g4simulation/g4main/PHG4VtxPointv1.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv1.h
@@ -36,7 +36,7 @@ class PHG4VtxPointv1: public PHG4VtxPoint
     id(id_value)
       {}
 
-  virtual ~PHG4VtxPointv1() {}
+  ~PHG4VtxPointv1() override {}
 
 // from PHObject
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4main/ReadEICFiles.h
+++ b/simulation/g4simulation/g4main/ReadEICFiles.h
@@ -21,10 +21,10 @@ class ReadEICFiles : public SubsysReco, public PHHepMCGenHelper
 {
  public:
   ReadEICFiles(const std::string &name = "EICReader");
-  virtual ~ReadEICFiles();
+  ~ReadEICFiles() override;
 
-  int Init(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
   /** Specify name of input file to open */
   bool OpenInputFile(const std::string &name);

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.h
@@ -27,10 +27,10 @@ class PHG4EICMvtxDetector : public PHG4Detector
   PHG4EICMvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam);
 
   //! destructor
-  virtual ~PHG4EICMvtxDetector() {}
+  ~PHG4EICMvtxDetector() override {}
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.h
@@ -19,13 +19,13 @@ class PHG4EICMvtxSteppingAction : public PHG4SteppingAction
   PHG4EICMvtxSteppingAction(PHG4EICMvtxDetector *);
 
   //! destroctor
-  virtual ~PHG4EICMvtxSteppingAction();
+  ~PHG4EICMvtxSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
@@ -21,7 +21,7 @@ class PHG4EICMvtxSubsystem : public PHG4DetectorGroupSubsystem
   PHG4EICMvtxSubsystem(const std::string& name = "PHG4EICMvtxSubsystem", const int _n_layers = 3);
 
   //! destructor
-  virtual ~PHG4EICMvtxSubsystem();
+  ~PHG4EICMvtxSubsystem() override;
 
   //! InitRunSubsystem
   /*!
@@ -30,23 +30,23 @@ class PHG4EICMvtxSubsystem : public PHG4DetectorGroupSubsystem
   creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const;
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override;
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
   static double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
   {
     // compute turbo angle from radii and sensor width

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -27,10 +27,10 @@ class PHG4MvtxDetector : public PHG4Detector
   PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam);
 
   //! destructor
-  virtual ~PHG4MvtxDetector() {}
+  ~PHG4MvtxDetector() override {}
 
   //! construct
-  virtual void ConstructMe(G4LogicalVolume* world);
+  void ConstructMe(G4LogicalVolume* world) override;
 
   //!@name volume accessors
   //@{

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
@@ -20,19 +20,19 @@ class PHG4MvtxDigitizer : public SubsysReco
 {
  public:
   PHG4MvtxDigitizer(const std::string &name = "PHG4MvtxDigitizer");
-  virtual ~PHG4MvtxDigitizer();
+  ~PHG4MvtxDigitizer() override;
 
   //! module initialization
-  int Init(PHCompositeNode *topNode) { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode *topNode) { return 0; };
+  int End(PHCompositeNode *topNode) override { return 0; };
 
   void set_adc_scale(const int layer, const unsigned short max_adc, const float energy_per_adc)
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4MvtxDisplayAction : public PHG4DisplayAction
  public:
   PHG4MvtxDisplayAction(const std::string &name);
 
-  virtual ~PHG4MvtxDisplayAction();
+  ~PHG4MvtxDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -16,13 +16,13 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
  public:
   explicit PHG4MvtxHitReco(const std::string &name = "PHG4MvtxRECO");
 
-  virtual ~PHG4MvtxHitReco() {}
+  ~PHG4MvtxHitReco() override {}
 
   //! module initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   void Detector(const std::string &d) { detector = d; }
 
@@ -30,7 +30,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   double get_timing_window_max(const int i) { return tmin_max[i].second; }
   void set_timing_window(const int detid, const double tmin, const double tmax);
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
  protected:
   std::string detector;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.h
@@ -19,13 +19,13 @@ class PHG4MvtxSteppingAction : public PHG4SteppingAction
   PHG4MvtxSteppingAction(PHG4MvtxDetector *);
 
   //! destroctor
-  virtual ~PHG4MvtxSteppingAction();
+  ~PHG4MvtxSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
@@ -21,7 +21,7 @@ class PHG4MvtxSubsystem : public PHG4DetectorGroupSubsystem
   PHG4MvtxSubsystem(const std::string& name = "PHG4MvtxSubsystem", const int _n_layers = 3);
 
   //! destructor
-  virtual ~PHG4MvtxSubsystem();
+  ~PHG4MvtxSubsystem() override;
 
   //! InitRunSubsystem
   /*!
@@ -30,23 +30,23 @@ class PHG4MvtxSubsystem : public PHG4DetectorGroupSubsystem
   creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode*);
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  virtual PHG4Detector* GetDetector(void) const;
-  virtual PHG4SteppingAction* GetSteppingAction(void) const;
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override;
 
-  PHG4DisplayAction* GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
   static double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
   {
     // compute turbo angle from radii and sensor width

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -23,12 +23,12 @@ class PHG4TpcDetector : public PHG4Detector
   PHG4TpcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4TpcDetector(void)
+  ~PHG4TpcDetector(void) override
   {
   }
 
   //! construct
-  void ConstructMe(G4LogicalVolume *world);
+  void ConstructMe(G4LogicalVolume *world) override;
 
   int IsInTpc(G4VPhysicalVolume *) const;
   void SuperDetector(const std::string &name) { superdetector = name; }

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -21,19 +21,19 @@ class PHG4TpcDigitizer : public SubsysReco
 {
  public:
   PHG4TpcDigitizer(const std::string &name = "PHG4TpcDigitizer");
-  virtual ~PHG4TpcDigitizer();
+  ~PHG4TpcDigitizer() override;
 
   //! module initialization
-  int Init(PHCompositeNode *topNode) { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
 
   //! event processing
-  int process_event(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode *topNode) { return 0; };
+  int End(PHCompositeNode *topNode) override { return 0; };
 
   void set_adc_scale(const int layer, const unsigned int max_adc, const float energy_per_adc)
   {

--- a/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4TpcDisplayAction : public PHG4DisplayAction
  public:
   PHG4TpcDisplayAction(const std::string &name);
 
-  virtual ~PHG4TpcDisplayAction();
+  ~PHG4TpcDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
   void AddTpcInnerLayer(G4LogicalVolume *logvol) { m_TpcInnerLayersVec.push_back(logvol); }
   void AddTpcOuterLayer(G4LogicalVolume *logvol) { m_TpcOuterLayersVec.push_back(logvol); }

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -30,13 +30,13 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
 {
  public:
   PHG4TpcElectronDrift(const std::string &name = "PHG4TpcElectronDrift");
-  virtual ~PHG4TpcElectronDrift() = default;
-  virtual int Init(PHCompositeNode *);
-  virtual int InitRun(PHCompositeNode *);
-  virtual int process_event(PHCompositeNode *);
-  virtual int End(PHCompositeNode *);
+  ~PHG4TpcElectronDrift() override = default;
+  int Init(PHCompositeNode *) override;
+  int InitRun(PHCompositeNode *) override;
+  int process_event(PHCompositeNode *) override;
+  int End(PHCompositeNode *) override;
 
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector name
   void Detector(const std::string &d)

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -25,7 +25,7 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   PHG4TpcEndCapDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam);
 
   //! destructor
-  virtual ~PHG4TpcEndCapDetector();
+  ~PHG4TpcEndCapDetector() override;
 
   //! construct
   void ConstructMe(G4LogicalVolume *world) override;

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.h
@@ -18,9 +18,9 @@ class PHG4TpcEndCapDisplayAction : public PHG4DisplayAction
  public:
   PHG4TpcEndCapDisplayAction(const std::string &name);
 
-  virtual ~PHG4TpcEndCapDisplayAction();
+  ~PHG4TpcEndCapDisplayAction() override;
 
-  void ApplyDisplayAction(G4VPhysicalVolume *physvol);
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void AddVolume(G4LogicalVolume *logvol, const std::string &mat) { m_LogicalVolumeMap[logvol] = mat; }
 
  private:

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.h
@@ -21,13 +21,13 @@ class PHG4TpcEndCapSteppingAction : public PHG4SteppingAction
   PHG4TpcEndCapSteppingAction(PHG4TpcEndCapDetector*, const PHParameters* parameters);
 
   //! destructor
-  virtual ~PHG4TpcEndCapSteppingAction();
+  ~PHG4TpcEndCapSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step*, bool);
+  bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode*);
+  void SetInterfacePointers(PHCompositeNode*) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSubsystem.h
@@ -28,7 +28,7 @@ class PHG4TpcEndCapSubsystem : public PHG4DetectorSubsystem
   PHG4TpcEndCapSubsystem(const std::string& name = "PHG4TpcEndCap");
 
   //! destructor
-  virtual ~PHG4TpcEndCapSubsystem() ;
+  ~PHG4TpcEndCapSubsystem() override ;
 
   /*!
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -22,13 +22,13 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
  public:
   PHG4TpcPadPlane(const std::string &name = "PHG4TpcPadPlane");
 
-  virtual ~PHG4TpcPadPlane() {}
+  ~PHG4TpcPadPlane() override {}
 
   int process_event(PHCompositeNode *) final
   {
     return 0;
   }
-  int InitRun(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode) override;
   virtual int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo) { return 0; }
   virtual void UpdateInternalParameters() { return; }
   virtual void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) {}

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -27,16 +27,16 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
  public:
   PHG4TpcPadPlaneReadout(const std::string &name = "PHG4TpcPadPlaneReadout");
 
-  virtual ~PHG4TpcPadPlaneReadout();
+  ~PHG4TpcPadPlaneReadout() override;
 
-  int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo);
+  int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo) override;
 
-  void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit);
+  void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) override;
 
-  void MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc *hittruthassoc, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit);
+  void MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc *hittruthassoc, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) override;
 
-  void SetDefaultParameters();
-  void UpdateInternalParameters();
+  void SetDefaultParameters() override;
+  void UpdateInternalParameters() override;
 
   private:
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneSimple.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneSimple.h
@@ -9,12 +9,12 @@ class PHG4TpcPadPlaneSimple : public PHG4TpcPadPlane
 {
  public:
   PHG4TpcPadPlaneSimple(const std::string& name = "PHG4TpcPadPlaneSimple");
-  virtual ~PHG4TpcPadPlaneSimple() {}
+  ~PHG4TpcPadPlaneSimple() override {}
 
   void MapToPadPlane(PHG4CellContainer* g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter);
 
-  void SetDefaultParameters();
-  void UpdateInternalParameters();
+  void SetDefaultParameters() override;
+  void UpdateInternalParameters() override;
 
  protected:
   double max_active_radius;

--- a/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSteppingAction.h
@@ -19,13 +19,13 @@ class PHG4TpcSteppingAction : public PHG4SteppingAction
   PHG4TpcSteppingAction(PHG4TpcDetector *, const PHParameters *parameters);
 
   //! destructor
-  virtual ~PHG4TpcSteppingAction();
+  ~PHG4TpcSteppingAction() override;
 
   //! stepping action
-  virtual bool UserSteppingAction(const G4Step *, bool);
+  bool UserSteppingAction(const G4Step *, bool) override;
 
   //! reimplemented from base class
-  virtual void SetInterfacePointers(PHCompositeNode *);
+  void SetInterfacePointers(PHCompositeNode *) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.h
@@ -20,7 +20,7 @@ class PHG4TpcSubsystem : public PHG4DetectorSubsystem
   PHG4TpcSubsystem(const std::string &name = "TPC", const int layer = 0);
 
   //! destructor
-  virtual ~PHG4TpcSubsystem();
+  ~PHG4TpcSubsystem() override;
 
   /*!
   called during InitRun (the original InitRun does common setup and calls this one)
@@ -28,27 +28,27 @@ class PHG4TpcSubsystem : public PHG4DetectorSubsystem
   ceates the stepping action 
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *);
+  int InitRunSubsystem(PHCompositeNode *) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *);
+  int process_event(PHCompositeNode *) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const;
+  void Print(const std::string &what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector *GetDetector(void) const;
+  PHG4Detector *GetDetector(void) const override;
 
-  PHG4SteppingAction *GetSteppingAction(void) const { return steppingAction_; }
+  PHG4SteppingAction *GetSteppingAction(void) const override { return steppingAction_; }
 
-  PHG4DisplayAction *GetDisplayAction() const { return m_DisplayAction; }
+  PHG4DisplayAction *GetDisplayAction() const override { return m_DisplayAction; }
 
  private:
-  void SetDefaultParameters();
+  void SetDefaultParameters() override;
 
   //! detector geometry
   /*! derives from PHG4Detector */

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.h
@@ -64,16 +64,16 @@ class PHG4TrackFastSim : public SubsysReco
   explicit PHG4TrackFastSim(const std::string& name = "PHG4TrackFastSim");
 
   //! dtor
-  virtual ~PHG4TrackFastSim();
+  ~PHG4TrackFastSim() override;
 
   //!Initialization Run, called for initialization of a run
-  int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //!Process Event, called for each event
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //!End, write and close files
-  int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
 
   bool is_do_evt_display() const
   {

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.h
@@ -34,16 +34,16 @@ class PHG4TrackFastSimEval : public SubsysReco
                        const std::string& trackmapname = "SvtxTrackMap");
 
   //Initialization, called for initialization
-  int Init(PHCompositeNode*);
+  int Init(PHCompositeNode*) override;
 
   //Initialization, called for initialization
-  int InitRun(PHCompositeNode*);
+  int InitRun(PHCompositeNode*) override;
 
   //Process Event, called for each event
-  int process_event(PHCompositeNode*);
+  int process_event(PHCompositeNode*) override;
 
   //End, write and close files
-  int End(PHCompositeNode*);
+  int End(PHCompositeNode*) override;
 
   //Change output filename
   void set_filename(const std::string& file)

--- a/simulation/g4simulation/g4vertex/GlobalVertex.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.h
@@ -22,16 +22,16 @@ class GlobalVertex : public PHObject
   typedef std::map<GlobalVertex::VTXTYPE, unsigned int>::const_iterator ConstVtxIter;
   typedef std::map<GlobalVertex::VTXTYPE, unsigned int>::iterator VtxIter;
 
-  virtual ~GlobalVertex() {}
+  ~GlobalVertex() override {}
 
   // PHObject virtual overloads
 
-  virtual void identify(std::ostream& os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "GlobalVertex base class" << std::endl;
   }
-  virtual int isValid() const override { return 0; }
-  virtual PHObject* CloneMe() const override { return nullptr; }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   // vertex info
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
@@ -25,12 +25,12 @@ class GlobalVertexFastSimReco : public SubsysReco
 {
  public:
   GlobalVertexFastSimReco(const std::string &name = "GlobalVertexFastSimReco");
-  virtual ~GlobalVertexFastSimReco();
+  ~GlobalVertexFastSimReco() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_x_smearing(const float x_smear) { _x_smear = x_smear; }
   void set_y_smearing(const float y_smear) { _y_smear = y_smear; }

--- a/simulation/g4simulation/g4vertex/GlobalVertexMap.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMap.h
@@ -16,10 +16,10 @@ class GlobalVertexMap : public PHObject
   typedef std::map<unsigned int, GlobalVertex*>::const_iterator ConstIter;
   typedef std::map<unsigned int, GlobalVertex*>::iterator Iter;
 
-  virtual ~GlobalVertexMap() {}
+  ~GlobalVertexMap() override {}
 
-  virtual void identify(std::ostream& os = std::cout) const override { os << "GlobalVertexMap base class" << std::endl; }
-  virtual int isValid() const override { return 0; }
+  void identify(std::ostream& os = std::cout) const override { os << "GlobalVertexMap base class" << std::endl; }
+  int isValid() const override { return 0; }
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
@@ -15,7 +15,7 @@ class GlobalVertexMapv1 : public GlobalVertexMap
 {
  public:
   GlobalVertexMapv1();
-  virtual ~GlobalVertexMapv1();
+  ~GlobalVertexMapv1() override;
 
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override { clear(); }

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.h
@@ -24,12 +24,12 @@ class GlobalVertexReco : public SubsysReco
 {
  public:
   GlobalVertexReco(const std::string &name = "GlobalVertexReco");
-  virtual ~GlobalVertexReco();
+  ~GlobalVertexReco() override;
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
 
   void set_x_defaults(float xdefault, float xerr)
   {

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.h
@@ -16,7 +16,7 @@ class GlobalVertexv1 : public GlobalVertex
 {
  public:
   GlobalVertexv1();
-  virtual ~GlobalVertexv1();
+  ~GlobalVertexv1() override;
 
   // PHObject virtual overloads
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR uses clang-tidy to add "override" after all reimplemented virtual functions
This will be more robust for future changes than using "virtual" only.

I have found nothing obviously wrong by looking at the diff, could compile and run the whole changeset at RCF with no problem

@pinkenburg unfortunately clang-tidy also replaces all "virtual void myFunction() override", by "void myFunction() override", on the basis that virtual+override are redundant. I hope it is ok. I have not found a way to change this behavior. 
Also, for some of the packages (eg "phool"), I could remove the Wno-inconsistent-missing-override check from configure.ac without getting any inconsistent override warning. So maybe we should try that in a separate PR, once this one goes through.

I have also added a few other unrelated fixes, e.g. isnan -> std::isnan, because that was making my local compiler (gcc11) unhappy. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people) (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

