### PR TITLE
Return less aggressively on missing track sources

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -1875,11 +1875,13 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     std::vector<std::pair<std::string, TrackSource_t>> trackMapInfo = {
         {"TrackMap", TrackSource_t::all},
         {"TrackMapInner", TrackSource_t::inner}};
+    bool foundAtLeastOneTrackSource = false;
     for (const auto& trackMapInfo : trackMapInfo)
     {
       SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, trackMapInfo.first);
       if (trackmap)
       {
+        foundAtLeastOneTrackSource = true;
         int nTracksInASource = 0;
         if (Verbosity() > 0)
         {
@@ -1986,8 +1988,11 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         {
           cout << PHWHERE << "SvtxTrackMap node with name '" << trackMapInfo.first << "' not found on node tree" << endl;
         }
-        return;
       }
+    }
+    if (foundAtLeastOneTrackSource == false) {
+      cout << PHWHERE << "Requested tracks, but found no sources on node tree. Returning" << endl;
+      return;
     }
   }
   //------------------------


### PR DESCRIPTION
It's fine to have some missing track sources - there only has to be one
at minimum

Fixes an issue from #1174 causing the event evaluator tree not to be filled with only one track source

cc: @FriederikeBock 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

