### PR TITLE
Fixing a fast tracking initialization bug introduced in #1115

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -83,52 +83,6 @@ int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
 //----------------------------------------------------------------------------//
 int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
 {
-  for (map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.begin(); iter != m_ProjectionNameMap.end(); ++iter)
-  {
-    for (int i = 0; i < 4; i++)
-    {
-      string bname = iter->first + "_proj_" + xyzt[i];
-      string bdef = bname + "/F";
-
-      // fourth element is the path length
-      if (i == 3)
-      {
-        bdef = iter->first + "_proj_path_length" + "/F";
-      }
-
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_vec[iter->second][i], bdef.c_str());
-    }
-
-    for (int i = 0; i < 3; i++)
-    {
-      string bname = iter->first + "_proj_p" + xyzt[i];
-      string bdef = bname + "/F";
-      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p_vec[iter->second][i], bdef.c_str());
-    }
-    string nodename = "G4HIT_" + iter->first;
-    PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
-    if (hits)
-    {
-      for (int i = 0; i < 4; i++)
-      {
-        string bname = iter->first + "_" + xyzt[i];
-        string bdef = bname + "/F";
-        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
-      }
-      for (int i = 0; i < 3; i++)
-      {
-        string bname = iter->first + "_p" + xyzt[i];
-        string bdef = bname + "/F";
-
-        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
-      }
-    }
-    if (!hits && Verbosity() > 0)
-    {
-      cout << "InitRun: could not find " << nodename << endl;
-    }
-  }
-
   if (Verbosity())
     cout << PHWHERE << " Openning file " << m_OutFileName << endl;
   PHTFileServer::get().open(m_OutFileName, "RECREATE");
@@ -216,6 +170,52 @@ int PHG4TrackFastSimEval::InitRun(PHCompositeNode *topNode)
   m_VertexEvalTree->Branch("ID", &m_TTree_TrackID, "ID/I");
   m_VertexEvalTree->Branch("ntracks", &m_TTree_nTracks, "ntracks/I");
   m_VertexEvalTree->Branch("n_from_truth", &m_TTree_nFromTruth, "n_from_truth/I");
+
+  for (map<string, unsigned int>::const_iterator iter = m_ProjectionNameMap.begin(); iter != m_ProjectionNameMap.end(); ++iter)
+  {
+    for (int i = 0; i < 4; i++)
+    {
+      string bname = iter->first + "_proj_" + xyzt[i];
+      string bdef = bname + "/F";
+
+      // fourth element is the path length
+      if (i == 3)
+      {
+        bdef = iter->first + "_proj_path_length" + "/F";
+      }
+
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_vec[iter->second][i], bdef.c_str());
+    }
+
+    for (int i = 0; i < 3; i++)
+    {
+      string bname = iter->first + "_proj_p" + xyzt[i];
+      string bdef = bname + "/F";
+      m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_proj_p_vec[iter->second][i], bdef.c_str());
+    }
+    string nodename = "G4HIT_" + iter->first;
+    PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
+    if (hits)
+    {
+      for (int i = 0; i < 4; i++)
+      {
+        string bname = iter->first + "_" + xyzt[i];
+        string bdef = bname + "/F";
+        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_vec[iter->second][i], bdef.c_str());
+      }
+      for (int i = 0; i < 3; i++)
+      {
+        string bname = iter->first + "_p" + xyzt[i];
+        string bdef = bname + "/F";
+
+        m_TracksEvalTree->Branch(bname.c_str(), &m_TTree_ref_p_vec[iter->second][i], bdef.c_str());
+      }
+    }
+    if (!hits && Verbosity() > 0)
+    {
+      cout << "InitRun: could not find " << nodename << endl;
+    }
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
…-Collaboration/coresoftware/pull/1115

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

The initialization order for `m_TracksEvalTree` was reversed during the reorganization of `PHG4TrackFastSimEval` as in #1115. This pull request correct for that.

## Links to other PRs in macros and calibration repositories (if applicable)

#1115