### PR TITLE
Add option to remove silicon seeds

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -72,7 +72,6 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
     std::cout << "PHActsInitialVertexFinder processing event " 
 	      << m_event << std::endl;
 
-
   if(m_trackMap->size() == 0)
     {
       std::cout << PHWHERE 
@@ -98,8 +97,7 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
 	  delete track;
 	}
     }
-
-  if(Verbosity() > 0)
+ if(Verbosity() > 0)
     std::cout << "PHActsInitialVertexFinder processed event "
 	      << m_event << std::endl;
 
@@ -496,12 +494,21 @@ CentroidMap& clusters, std::vector<float>& centroids)
 	      sortedTracks.push_back(track);
 	    }
 	  else
-	    if(Verbosity() > 3)
-	      std::cout << "Not adding track with z " << z 
-			<< " as it is incompatible with centroid " 
-			<< centroids.at(centroidIndex) 
-			<< " with std dev " 
-			<< stddev.at(centroidIndex) << std::endl;
+	    {
+	      if(m_removeSeeds)
+		{
+		  m_trackMap->erase(track->get_id());
+		}
+
+	      if(Verbosity() > 3)
+		{
+		  std::cout << "Not adding track with z " << z 
+			    << " as it is incompatible with centroid " 
+			    << centroids.at(centroidIndex) 
+			    << " with std dev " 
+			    << stddev.at(centroidIndex) << std::endl;
+		}
+	    }
 	}
     }
 

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -53,6 +53,8 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   { m_nCentroids = centroids;}
   void setIterations(const int iterations)
   {m_nIterations = iterations;}
+  void removeSiliconSeeds(const bool removeSeeds)
+  {m_removeSeeds = removeSeeds;}
 
  protected:
   int Setup(PHCompositeNode *topNode) override;
@@ -108,6 +110,7 @@ class PHActsInitialVertexFinder: public PHInitVertexing
 
   bool m_resetTrackCovariance = true;
   bool m_disableWeights = true;
+  bool m_removeSeeds = false;
 
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This adds an option to remove the silicon seeds from the track map that are not used in the initial vertexing. Note that is turned off by default, and there is an accessor function to set it in the macro with e.g.
```
init_vtx->removeSiliconSeeds(true);
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

