### PR TITLE
Fix mm volume id detection in ActsTrkFitter

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -147,6 +147,13 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs;
 
+  /// micromegas volume id(s). 
+  /** 
+   * this is needed to check whether a given track has micromegas hits or not
+   * it is set in InitRun, by looping over registered micromegas surfaces 
+   */
+  std::set<int> m_mmVolumeIds;
+  
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates;
 


### PR DESCRIPTION
hard coded volume id for Micomegas surface was incorrect since the new micromegas geometry was implemented.
This result in all tracks to be discarded in the SCCalibMode fit (Silicium+MM track fits)

rather than hard code the new volume, store all possible volumes in a std::set when calling GetNodes, and use that to identify MM surfaces. this should be more robust to future changes

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

