### PR TITLE
Check vertex association

### DIFF
--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -19,6 +19,7 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   ActsSurfaceMaps.h \
+  TpcSeedTrackMap.h \
   ActsTrackingGeometry.h \
   TrkrCluster.h \
   TrkrClusterv1.h \

--- a/offline/packages/trackbase/TpcSeedTrackMap.h
+++ b/offline/packages/trackbase/TpcSeedTrackMap.h
@@ -1,0 +1,21 @@
+#ifndef TRACKRECO_TPCSEEDTRACKMAP_H
+#define TRACKRECO_TPCSEEDTRACKMAP_H
+
+#include <trackbase/TrkrDefs.h>
+
+
+#include <map>
+#include <vector>
+#include <memory>
+
+class TpcSeedTrackMap
+{
+ public:
+
+  TpcSeedTrackMap(){};
+
+  std::multimap<unsigned int, unsigned int> SeedTrackMap;
+
+};
+
+#endif

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -44,6 +44,7 @@ pkginclude_HEADERS = \
   PHActsTrackProjection.h \
   PHGenFitTrkProp.h \
   PHHoughSeeding.h \
+  PHTrackCleaner.h \
   PHRTreeSeeding.h \
   PHCASeeding.h \
   PHHybridSeeding.h \
@@ -159,6 +160,7 @@ libtrack_reco_la_SOURCES = \
   PHSiliconTruthTrackSeeding.cc \
   PHTruthSiliconAssociation.cc \
   PHHoughSeeding.cc \
+  PHTrackCleaner.cc \
   PHRTreeSeeding.cc \
   ../PHTpcTracker/PHTpcTrackerUtil.cc \
   PHHybridSeeding.cc \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -135,7 +135,7 @@ int PHActsTrkFitter::process_event(PHCompositeNode *topNode)
   eventTimer->stop();
   auto eventTime = eventTimer->get_accumulated_time();
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter total event time " 
 	      << eventTime << std::endl;
 
@@ -270,7 +270,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       fitTimer->stop();
       auto fitTime = fitTimer->get_accumulated_time();
       
-      if(Verbosity() > 0)
+      if(Verbosity() > 1)
 	std::cout << "PHActsTrkFitter Acts fit time "
 		  << fitTime << std::endl;
 
@@ -308,7 +308,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       trackTimer->stop();
       auto trackTime = trackTimer->get_accumulated_time();
       
-      if(Verbosity() > 0)
+      if(Verbosity() > 1)
 	std::cout << "PHActsTrkFitter total single track time "
 		  << trackTime << std::endl;
     
@@ -508,7 +508,7 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
   updateTrackTimer->stop();
   auto updateTime = updateTrackTimer->get_accumulated_time();
   
-  if(Verbosity() > 0)
+  if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter update SvtxTrack time "
 	      << updateTime << std::endl;
 
@@ -732,7 +732,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   trackStateTimer->stop();
   auto stateTime = trackStateTimer->get_accumulated_time();
   
-  if(Verbosity() > 0)
+  if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter update SvtxTrackStates time "
 	      << stateTime << std::endl;
 

--- a/offline/packages/trackreco/PHActsVertexFinder.h
+++ b/offline/packages/trackreco/PHActsVertexFinder.h
@@ -69,6 +69,8 @@ class PHActsVertexFinder: public PHInitVertexing
   void updateTrackDCA(const unsigned int trackKey,
 		      const Acts::Vector3D vertex);
 
+  void checkTrackVertexAssociation();
+
   /// An Acts vertex object map
   VertexMap *m_actsVertexMap;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -6,12 +6,13 @@
 #include <trackreco/PHTrackPropagating.h>
 
 #include <string>
+#include <map>
 
 class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
 class TF1;
-
+class TpcSeedTrackMap;
 
 class PHSiliconTpcTrackMatching : public PHTrackPropagating
 {
@@ -60,6 +61,9 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   SvtxTrack *_tracklet_tpc{nullptr};
   SvtxTrack *_tracklet_si{nullptr};
 
+  TpcSeedTrackMap *_seed_track_map_class{nullptr};
+  //std::multimap<unsigned int, unsigned int> _seed_track_map;
+ 
   // correction function for PHTpcTracker track phi bias
   TF1 *fdphi{nullptr};
   // default values, can be replaced from the macro

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -94,7 +94,7 @@ int PHTpcTrackSeedVertexAssoc::Process()
 
       _tracklet_tpc = phtrk_iter->second;
       
-      if (Verbosity() >= 1)
+      if (Verbosity() > 1)
 	{
 	  std::cout
 	    << __LINE__
@@ -452,7 +452,7 @@ int PHTpcTrackSeedVertexAssoc::Process()
   if(Verbosity() > 0)  
     cout << " Final track map size " << _track_map->size() << endl;
   
-  if (Verbosity() >= 1)
+  if (Verbosity() > 0)
     cout << "PHTpcTrackSeedVertexAssoc::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
   
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -1,0 +1,187 @@
+#include "PHTrackCleaner.h"
+
+#include "PHTrackCleaner.h"   
+
+/// Tracking includes
+
+#include <trackbase/TrkrCluster.h>            // for TrkrCluster
+#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TpcSeedTrackMap.h>
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cmath>                              // for sqrt, fabs, atan2, cos
+#include <iostream>                           // for operator<<, basic_ostream
+#include <map>                                // for map
+#include <set>                                // for _Rb_tree_const_iterator
+#include <utility>                            // for pair, make_pair
+
+//____________________________________________________________________________..
+PHTrackCleaner::PHTrackCleaner(const std::string &name)
+  : SubsysReco(name)
+{
+
+}
+
+//____________________________________________________________________________..
+PHTrackCleaner::~PHTrackCleaner()
+{
+
+}
+
+//____________________________________________________________________________..
+int PHTrackCleaner::InitRun(PHCompositeNode *topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHTrackCleaner::process_event(PHCompositeNode *topNode)
+{
+
+  if(Verbosity() > 0)
+    std::cout << PHWHERE << " track map size " << _track_map->size() 
+	      << " _seed_track_map size " << _seed_track_map_class->SeedTrackMap.size() << std::endl;
+
+  std::set<unsigned int> track_keep_list;
+  std::set<unsigned int> track_delete_list;
+
+  unsigned int good_track = 0;  // for diagnostic output only
+  unsigned int ok_track = 0;   // tracks to keep
+
+  // loop over the TPC seed - track map and make a set containing all TPC seed ID's
+  std::set<unsigned int> seed_id_list;
+  std::multimap<unsigned int, unsigned int>::iterator it;
+  for(it = _seed_track_map_class->SeedTrackMap.begin(); it != _seed_track_map_class->SeedTrackMap.end(); ++it)
+    {
+      seed_id_list.insert( (*it).first );
+    }
+
+  if(Verbosity() > 0)
+    std::cout << " seed_id_list size " << seed_id_list.size() << std::endl;
+
+  // loop over the TPC seed ID's
+
+  for(auto seed_iter = seed_id_list.begin(); seed_iter != seed_id_list.end(); ++seed_iter)
+    {
+      unsigned int tpc_id = *seed_iter;
+
+      if(Verbosity() > 1)
+	std::cout << " TPC ID " << tpc_id << std::endl;
+
+      auto tpc_range =   _seed_track_map_class->SeedTrackMap.equal_range(tpc_id);
+
+      unsigned int best_id = 99999;
+      double min_chisq = 99999.0;
+      unsigned int best_ndf = 1;
+      for (auto it = tpc_range.first; it !=tpc_range.second; ++it)
+	{
+	  unsigned int track_id = it->second;
+	  
+	  // note that the track no longer exists if it failed in the Acts fitter
+	  _track = _track_map->get(track_id);
+	  if(_track)
+	    {
+	      if(Verbosity() > 1)	      
+		std::cout << "        track ID " << track_id << " chisq " << _track->get_chisq() << " ndf " << _track->get_ndf() << "min_chisq " << min_chisq << std::endl;
+
+	      // only accept tracks with nclus > min_clusters
+	      if(_track->get_chisq() < min_chisq && _track->size_cluster_keys() > min_clusters)
+		{
+		  min_chisq = _track->get_chisq();
+		  best_id = track_id;
+		  best_ndf = _track->get_ndf();
+		}
+	    }
+	}
+
+      if(best_id != 99999)
+	{
+	  double qual = min_chisq / best_ndf;
+
+	  if(Verbosity() > 1)
+	    std::cout << "        best track for tpc_id " << tpc_id << " has track_id " << best_id << " chisq " << min_chisq << " chisq/ndf " << qual << std::endl;
+
+	  if(qual < 30)
+	    {
+	      track_keep_list.insert(best_id);
+	      ok_track++;
+	      if(qual < 10.0)
+		good_track++;
+	    }
+	}
+      else
+	{
+	  if(Verbosity() > 1)
+	    std::cout << "        no track exists  for tpc_id " << tpc_id << std::endl;
+	}
+    }
+
+  if(Verbosity() > 0)
+    std::cout << " Number of good tracks with qual < 10  is " << good_track << " OK tracks " << ok_track << std::endl; 
+
+  // make a list of tracks that did not make the keep list
+  for(auto track_it = _track_map->begin(); track_it != _track_map->end(); ++track_it)
+    {
+      auto id = track_it->first;
+
+      auto set_it = track_keep_list.find(id);
+      if(set_it == track_keep_list.end())
+	{
+	  if(Verbosity() > 1)
+	    std::cout << "    add id " << id << " to track_delete_list " << std::endl;
+	  track_delete_list.insert(id);
+	}
+    }
+
+  if(Verbosity() > 0)
+    std::cout << " track_delete_list size " << track_delete_list.size() << std::endl;
+
+  // delete failed tracks
+  for(auto it = track_delete_list.begin(); it != track_delete_list.end(); ++it)
+    {
+      if(Verbosity() > 1)
+	std::cout << " erasing track ID " << *it << std::endl;
+      _track_map->erase(*it);
+    }
+
+  if(Verbosity() > 0)
+    std::cout << "Final  track map size " << _track_map->size() << std::endl;
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHTrackCleaner::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
+{
+
+  _track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!_track_map)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find SvtxTrackMap: " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _seed_track_map_class = findNode::getClass<TpcSeedTrackMap>(topNode, "TpcSeedTrackMap");
+  if (!_seed_track_map_class)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find node TpcSeedTrackMap: " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -1,0 +1,51 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+
+/*!
+ *  \file		  PHTrackCleaner
+ *  \brief		Class for deciding which track based on a given TPC seed is the best one
+ *  \author	 Tony Frawley <afrawley@fsu.edu>
+ */
+
+#ifndef PHTRACKCLEANER_H
+#define PHTRACKCLEANER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+#include <map>
+
+class PHCompositeNode;
+class SvtxTrack;
+class SvtxTrackMap;
+class TrkrCluster;
+class TpcSeedTrackMap;
+
+class PHTrackCleaner : public SubsysReco
+{
+ public:
+
+  PHTrackCleaner(const std::string &name = "PHTrackCleaner");
+
+  ~PHTrackCleaner() override;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+
+ private:
+
+  int GetNodes(PHCompositeNode* topNode);
+
+SvtxTrackMap *_track_map{nullptr};
+SvtxTrack *_track{nullptr};
+
+ TpcSeedTrackMap *_seed_track_map_class{nullptr};
+
+ unsigned int min_clusters = 20;
+
+};
+
+#endif // PHTRACKCLEANER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a check for vertex association to tracks in the final vertex finding/fitting. For tracks that are incompatible with a primary vertex, the Acts::IterativeVertexFinder appears to reject them and not associate them to a particular found vertex. This PR associates those tracks to the closest vertex in z, since typically the secondaries have large transverse DCA but are associated to a PV in z.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

