### PR TITLE
Iterative vertex finder bug fix

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -418,7 +418,6 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
 	  index = indices(m_random_number_generator);
 
       usedIndices.push_back(index);
-
       centroid = m_trackMap->get(index)->get_z();
       
       if(Verbosity() > 3)
@@ -617,9 +616,16 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
     {
       m_nCentroids = 1;
     }
-  
-  auto sortedTracks = sortTracks();
-
+  std::vector<SvtxTrack*> sortedTracks;
+  if(m_svtxTrackMapName.find("silicon") != std::string::npos)
+    {
+      sortedTracks = sortTracks();
+    }
+  else
+    {
+      for(const auto& [key, track] : *m_trackMap)
+	sortedTracks.push_back(track);
+    }
   for(const auto& track : sortedTracks)
     {
       if(Verbosity() > 3)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a check to run the silicon seed selection only for the cases where the Acts iterative vertex finder is run with the silicon seeds. The HFTG uses this module for generic vertex finding, which pulled up a bug when testing with the MDC data.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

