### PR TITLE
store evaluation histogram to separate file, add flag to disable, turn off by default

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -70,10 +70,11 @@ class PHTpcResiduals : public SubsysReco
   void setGridDimensions(const int phiBins, const int rBins,
 			 const int zBins);
 
-  /// Option for outputting some basic cluster-track 
-  /// distortion histograms
-  void setOutputfile(std::string outputfile) 
-    {m_outputfile = outputfile;}
+  /// set to true to store evaluation histograms and ntuples
+  void setSavehistograms( bool value ) { m_savehistograms = value; }
+    
+  /// output file name for storing the space charge reconstruction matrices
+  void setOutputfile(std::string outputfile) {m_outputfile = outputfile;}
   
  private:
 
@@ -146,8 +147,10 @@ class PHTpcResiduals : public SubsysReco
   /// Counter for number of bad propagations from propagateTrackState()
   int m_nBadProps = 0;
 
-  /// Output root histograms
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
+
+  /// Output root histograms
+  bool m_savehistograms = false;
   TH2 *h_rphiResid = nullptr;
   TH2 *h_zResid = nullptr;
   TH2 *h_etaResidLayer = nullptr;
@@ -157,7 +160,8 @@ class PHTpcResiduals : public SubsysReco
   TH2 *h_alpha = nullptr;
   TH2 *h_beta = nullptr;
   TTree *residTup = nullptr;
-  TFile *m_outputFile = nullptr;
+  std::string m_histogramfilename = "PHTpcResiduals.root";
+  std::unique_ptr<TFile> m_histogramfile = nullptr;
 
   /// For diagnostics
   double tanAlpha = 0, tanBeta = 0, drphi = 0, dz = 0, clusR = 0, clusPhi = 0, 


### PR DESCRIPTION
This PR fixes a couple of issues introduced when writting space charge reconstruction matrices to output file. 
The evaluation histograms and ntuples, previously written to the same file, were erased when writing the matrices.
They are now written to a different file. Additionally, there is now a flag to turn these off, since they are only meant for debugging.
 
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

