### PR TITLE
Fix TPC volume id detection in ActsTrkFitter

### DIFF
--- a/offline/packages/trackbase/ActsSurfaceMaps.cc
+++ b/offline/packages/trackbase/ActsSurfaceMaps.cc
@@ -1,0 +1,15 @@
+/*!
+ *  \file		ActsSurfaceMaps.cc
+ *  \brief		maps hitsetids to Acts Surfaces
+ *  \author Tony Frawley <afrawley@fsu.edu>, Joe Osborn <osbornjd@ornl.gov>, Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "ActsSurfaceMaps.h"
+
+#include <Acts/Surfaces/Surface.hpp>
+
+bool ActsSurfaceMaps::isTpcSurface( const Acts::Surface& surface ) const
+{ return tpcVolumeIds.find( surface.geometryId().volume() ) != tpcVolumeIds.end(); }
+  
+bool ActsSurfaceMaps::isMicromegasSurface( const Acts::Surface& surface ) const
+{ return micromegasVolumeIds.find( surface.geometryId().volume() ) != micromegasVolumeIds.end(); }

--- a/offline/packages/trackbase/ActsSurfaceMaps.h
+++ b/offline/packages/trackbase/ActsSurfaceMaps.h
@@ -1,5 +1,10 @@
 #ifndef TRACKRECO_ACTSSURFACEMAPS_H
 #define TRACKRECO_ACTSSURFACEMAPS_H
+/*!
+ *  \file		ActsSurfaceMaps.h
+ *  \brief		maps hitsetids to Acts Surfaces
+ *  \author Tony Frawley <afrawley@fsu.edu>, Joe Osborn <osbornjd@ornl.gov>, Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
 
 #include <trackbase/TrkrDefs.h>
 
@@ -7,8 +12,9 @@ namespace Acts{ class Surface; }
 class TGeoNode;
 
 #include <map>
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 using Surface = std::shared_ptr<const Acts::Surface>;
 using SurfaceVec = std::vector<Surface>;
@@ -16,12 +22,34 @@ using SurfaceVec = std::vector<Surface>;
 struct ActsSurfaceMaps
 {
 
-  ActsSurfaceMaps(){};
+  ActsSurfaceMaps() = default;
+ 
+  //! true if given surface corresponds to TPC
+  bool isTpcSurface( const Acts::Surface& surface ) const;
+    
+  //! true if given surface corresponds to Micromegas
+  bool isMicromegasSurface( const Acts::Surface& surface ) const;
+  
+  //! map hitset to Surface for the silicon detectors (MVTX and INTT)
   std::map<TrkrDefs::hitsetkey, Surface> siliconSurfaceMap;
+
+  //! map hitset to surface vector for the TPC
   std::map<TrkrDefs::hitsetkey, SurfaceVec> tpcSurfaceMap;
+
+  //! map hitset to surface vector for the micromegas
   std::map<TrkrDefs::hitsetkey, Surface> mmSurfaceMap;
+  
+  //! map TGeoNode to hitset
   std::map<TrkrDefs::hitsetkey, TGeoNode*> tGeoNodeMap;
  
+  //! stores all acts volume ids relevant to the TPC
+  /** it is used to quickly tell if a given Acts Surface belongs to the TPC */
+  std::set<int> tpcVolumeIds;
+
+  //! stores all acts volume ids relevant to the micromegas
+  /** it is used to quickly tell if a given Acts Surface belongs to micromegas */
+  std::set<int> micromegasVolumeIds;
+
 };
 
 #endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -19,9 +19,9 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   ActsSurfaceMaps.h \
+  ActsTrackingGeometry.h \
   TpcSeedTrackMap.h \
   TpcSeedTrackMapv1.h \
-  ActsTrackingGeometry.h \
   TrkrCluster.h \
   TrkrClusterv1.h \
   TrkrClusterv2.h \
@@ -97,6 +97,7 @@ nobase_dist_pcm_DATA = \
 # sources for io library
 libtrack_io_la_SOURCES = \
   $(ROOTDICTS) \
+  ActsSurfaceMaps.cc \
   TrkrClusterv1.cc \
   TrkrClusterv2.cc \
   TrkrClusterContainer.cc \

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -1,5 +1,5 @@
 /*!
- *  \file		MakeActsGeometry.C
+ *  \file		MakeActsGeometry.cc
  *  \brief		Refit SvtxTracks with PHActs.
  *  \details	Refit SvtxTracks with PHActs.
  *  \author	        Tony Frawley <afrawley@fsu.edu>
@@ -119,12 +119,31 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->mmSurfStepPhi = m_surfStepPhi;
   m_actsGeometry->mmSurfStepZ = m_surfStepZ;
 
-  /// Same for the surface maps
+  // fill ActsSurfaceMap content
   m_surfMaps->siliconSurfaceMap = m_clusterSurfaceMapSilicon;
   m_surfMaps->tpcSurfaceMap = m_clusterSurfaceMapTpcEdit;
-  m_surfMaps->tGeoNodeMap = m_clusterNodeMap;
   m_surfMaps->mmSurfaceMap = m_clusterSurfaceMapMmEdit;
+  m_surfMaps->tGeoNodeMap = m_clusterNodeMap;
 
+  // fill TPC volume ids
+  for( const auto& [hitsetid, surfaceVector]:m_clusterSurfaceMapTpcEdit )
+    for( const auto& surface:surfaceVector )
+  { m_surfMaps->tpcVolumeIds.insert( surface->geometryId().volume() ); }
+  
+  // fill Micromegas volume ids
+  for( const auto& [hitsetid, surface]:m_clusterSurfaceMapMmEdit )
+  { m_surfMaps->micromegasVolumeIds.insert( surface->geometryId().volume() ); } 
+
+  // print
+  if( Verbosity() )
+  {
+    for( const auto& id:m_surfMaps->tpcVolumeIds )
+    { std::cout << "MakeActsGeometry::InitRun - TPC volume id: " << id << std::endl; }
+  
+    for( const auto& id:m_surfMaps->micromegasVolumeIds )
+    { std::cout << "MakeActsGeometry::InitRun - Micromegas volume id: " << id << std::endl; }
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -547,11 +547,11 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
 	std::cout<<"SL available on : " << sl.referenceSurface().geometryId()<<std::endl;
     
       /// If volume is not the TPC add the SL to the list
-      if(volume != 14)
-	{
-	  siliconMMSls.push_back(sl);	
-	  surfaces.push_back(&sl.referenceSurface());
-	}
+      if( m_tpcVolumeIds.find( volume ) == m_tpcVolumeIds.end() )
+      {
+        siliconMMSls.push_back(sl);
+        surfaces.push_back(&sl.referenceSurface());
+      }
     }
 
   /// Surfaces need to be sorted in order, i.e. from smallest to
@@ -834,9 +834,24 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-    // dump micromegas surfaces
+    // save micromegas surface volume ids
     for( const auto& [hitsetid, surface]:m_surfMaps->mmSurfaceMap )
     { m_mmVolumeIds.insert( surface->geometryId().volume() ); }
+
+    // save tpc surface volume ids
+    for( const auto& [hitsetid, surfacevect]:m_surfMaps->tpcSurfaceMap )
+      for( const auto& surface:surfacevect )
+    { m_tpcVolumeIds.insert( surface->geometryId().volume() ); }
+
+    // and dump
+    if( Verbosity() )
+    {
+      for( const auto& id:m_mmVolumeIds )
+      { std::cout << "PHActsTrkFitter::getNodes - found Micromegas volume id: " << id << std::endl; }
+
+      for( const auto& id:m_tpcVolumeIds )
+      { std::cout << "PHActsTrkFitter::getNodes - found TPC volume id: " << id << std::endl; }
+    }
 
   m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"TRKR_CLUSTER");
   if(!m_clusterContainer)

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -147,16 +147,6 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs;
 
-  /// micromegas volume id(s). 
-  /** 
-   * this is needed to check whether a given track has micromegas hits or not
-   * it is set in InitRun, by looping over registered micromegas surfaces 
-   */
-  std::set<int> m_mmVolumeIds;
-
-  /// tpc volume ids
-  std::set<int> m_tpcVolumeIds;
-
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates;
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -153,7 +153,10 @@ class PHActsTrkFitter : public SubsysReco
    * it is set in InitRun, by looping over registered micromegas surfaces 
    */
   std::set<int> m_mmVolumeIds;
-  
+
+  /// tpc volume ids
+  std::set<int> m_tpcVolumeIds;
+
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates;
 


### PR DESCRIPTION
Since the micromegas geometry reimplementation in ACTS, the main TPC volume ID has changed from 14 to 12, likely  because of how ACTS handles Geant volumes internally when converting to ACTS geometry. 

This breaks the volume-id based identification of TPC surfaces in ActsTrkFitter.

Rather than updating the hard-coded volume id used for this identifiation, an std::set is used to store TPC relevant volume IDs. It is filled from TPC surfaces when calling GetNodes and is used for TPC surfaces identifiaction.

This is essentially the same change as in https://github.com/sPHENIX-Collaboration/coresoftware/pull/1194, but for the TPC

Following suggestion from Joe, the std::sets for Micromegas and TPC are moved to ActsSurfaceMap, and filled in MakeActsGeom.
Two convenience functions are added to ActsSurfaceMaps, namely isTpcSurface and isMicromegasSurface. 
They are used in PHActsTrkFitter to identified the relevant surfaces.


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

