### PR TITLE
Fix High Occupancy vertexing

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -616,8 +616,9 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
     {
       m_nCentroids = 1;
     }
+
   std::vector<SvtxTrack*> sortedTracks;
-  if(m_svtxTrackMapName.find("silicon") != std::string::npos)
+  if(m_svtxTrackMapName.find("Silicon") != std::string::npos)
     {
       sortedTracks = sortTracks();
     }
@@ -626,6 +627,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
       for(const auto& [key, track] : *m_trackMap)
 	sortedTracks.push_back(track);
     }
+
   for(const auto& track : sortedTracks)
     {
       if(Verbosity() > 3)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR fixes the bug that was introduced by me that breaks the silicon seed sorting in the initial IVF. Vertexing and DCA QA in high occupancy should be fixed now.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

