### PR TITLE
Automatic geometry export using unique file names

### DIFF
--- a/offline/packages/PHGeometry/Makefile.am
+++ b/offline/packages/PHGeometry/Makefile.am
@@ -38,7 +38,8 @@ AM_LDFLAGS = \
 
 libphgeom_la_LIBADD = \
   libphgeom_io.la \
-  -lSubsysReco
+  -lSubsysReco \
+  -luuid
 
 libphgeom_io_la_LIBADD = \
   -lphool \

--- a/offline/packages/PHGeometry/PHGeomUtility.cc
+++ b/offline/packages/PHGeometry/PHGeomUtility.cc
@@ -15,6 +15,7 @@
 
 #include <TGeoManager.h>
 
+#include <unistd.h>  // for generate unique local file
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -22,7 +23,6 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
-#include <unistd.h>  // for generate unique local file
 
 using namespace std;
 
@@ -168,7 +168,7 @@ std::string
 PHGeomUtility::GenerateGeometryFileName(const std::string &filename_extension)
 {
   ostringstream file;
-  file << "/tmp/"
+  file << mg_GenerateGeometryFileNameBase << "/"
        << "PHGeomUtility_geom_file_" << ::getpid() << "."
        << filename_extension;
 

--- a/offline/packages/PHGeometry/PHGeomUtility.cc
+++ b/offline/packages/PHGeometry/PHGeomUtility.cc
@@ -15,6 +15,8 @@
 
 #include <TGeoManager.h>
 
+#include <uuid/uuid.h>
+
 #include <unistd.h>  // for generate unique local file
 #include <cassert>
 #include <cstdio>
@@ -168,12 +170,20 @@ std::string
 PHGeomUtility::GenerateGeometryFileName(const std::string &filename_extension)
 {
   ostringstream file;
+
+  uuid_t uu;
+  uuid_generate(uu);
+  char uuid[50];
+  uuid_unparse(uu, uuid);
+
   file << mg_GenerateGeometryFileNameBase << "/"
-       << "PHGeomUtility_geom_file_" << ::getpid() << "."
+       << "PHGeomUtility_geom_file_" << uuid << "."
        << filename_extension;
 
   return file.str();
 }
+
+std::string PHGeomUtility::mg_GenerateGeometryFileNameBase = "/tmp";
 
 //! delete the geometry file after use
 bool PHGeomUtility::RemoveGeometryFile(const std::string &file_name)

--- a/offline/packages/PHGeometry/PHGeomUtility.h
+++ b/offline/packages/PHGeometry/PHGeomUtility.h
@@ -86,7 +86,7 @@ class PHGeomUtility
 
   //! Base path name for temp geometry GDML file used in GenerateGeometryFileName().
   //! User can overwrite it to e.g. local directory with  PHGeomUtility::SetGenerateGeometryFileNameBase('./');
-  static std::string mg_GenerateGeometryFileNameBase = "/tmp";
+  static std::string mg_GenerateGeometryFileNameBase;
 };
 
 #endif

--- a/offline/packages/PHGeometry/PHGeomUtility.h
+++ b/offline/packages/PHGeometry/PHGeomUtility.h
@@ -76,9 +76,17 @@ class PHGeomUtility
     return std::string("GEOMETRY_IO");
   }
 
+  //! Base path name for temp geometry GDML file used in GenerateGeometryFileName().
+  //! User can overwrite it to e.g. local directory with  PHGeomUtility::SetGenerateGeometryFileNameBase('./');
+  static void SetGenerateGeometryFileNameBase(const std::string &base) { mg_GenerateGeometryFileNameBase = base; }
+
  private:
   PHGeomUtility() = delete;
   ~PHGeomUtility() = delete;
+
+  //! Base path name for temp geometry GDML file used in GenerateGeometryFileName().
+  //! User can overwrite it to e.g. local directory with  PHGeomUtility::SetGenerateGeometryFileNameBase('./');
+  static std::string mg_GenerateGeometryFileNameBase = "/tmp";
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

The automatic G4->Reconstruction geometry export involves a GDML file write in the `/tmp` folder by default. Sometimes the file names are duplicated between [two processes of the same PID which causes file write error](https://chat.sdcc.bnl.gov/ecce/pl/kgbamwkgr7rkffsm9mhpkxxexr). 

This pull request resolve this problem by:
1. ensuring the GDML file name is unique with a UUID, such as in the new begin run STDOUT print of `PHG4Reco::InitRun - export geometry to DST via tmp file /tmp/PHGeomUtility_geom_file_e3ee9767-0cf5-43fd-8b31-a8a6afa8f8b1.gdml` 
2. allow user to override the folder for geometry export anywhere in the Fun4All macro with e.g. `PHGeomUtility::SetGenerateGeometryFileNameBase('./')`


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

