### PR TITLE
remove printout, add PrepareNewEvent() to PHG4StackingAction, remove shadowed vars

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -143,13 +143,13 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
   ConversionMap vtxid_map;
   ConversionMap trkid_map;
 
-  const auto container = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
-  if (container && m_g4truthinfo)
+  const auto container_truth = findNode::getClass<PHG4TruthInfoContainer>(dstNode, "G4TruthInfo");
+  if (container_truth && m_g4truthinfo)
   {
     {
       // primary vertices
       auto key = m_g4truthinfo->maxvtxindex();
-      const auto range = container->GetPrimaryVtxRange();
+      const auto range = container_truth->GetPrimaryVtxRange();
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         // clone vertex, insert in map, and add index conversion
@@ -164,7 +164,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
     {
       // secondary vertices
       auto key = m_g4truthinfo->minvtxindex();
-      const auto range = container->GetSecondaryVtxRange();
+      const auto range = container_truth->GetSecondaryVtxRange();
 
       // loop from last to first to preserve order with respect to the original event
       for (
@@ -184,7 +184,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
     {
       // primary particles
       auto key = m_g4truthinfo->maxtrkindex();
-      const auto range = container->GetPrimaryParticleRange();
+      const auto range = container_truth->GetPrimaryParticleRange();
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         const auto &source = iter->second;
@@ -213,7 +213,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
     {
       // secondary particles
       auto key = m_g4truthinfo->mintrkindex();
-      const auto range = container->GetSecondaryParticleRange();
+      const auto range = container_truth->GetSecondaryParticleRange();
 
       /*
        * loop from last to first to preserve order with respect to the original event
@@ -282,8 +282,8 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
     }
 
     // find source node
-    auto container = findNode::getClass<PHG4HitContainer>(dstNode, pair.first);
-    if (!container)
+    auto container_hit = findNode::getClass<PHG4HitContainer>(dstNode, pair.first);
+    if (!container_hit)
     {
       std::cout << "Fun4AllDstPileupMerger::copy_background_event - invalid source container " << pair.first << std::endl;
       continue;
@@ -291,7 +291,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
 
     {
       // hits
-      const auto range = container->getHits();
+      const auto range = container_hit->getHits();
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         // clone hit
@@ -326,7 +326,7 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
 
     {
       // layers
-      const auto range = container->getLayers();
+      const auto range = container_hit->getLayers();
       for (auto iter = range.first; iter != range.second; ++iter)
       {
         pair.second->AddLayer(*iter);

--- a/simulation/g4simulation/g4main/PHG4PhenixStackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixStackingAction.h
@@ -30,7 +30,7 @@ class PHG4PhenixStackingAction : public G4UserStackingAction
   }
 
   G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track* aTrack) override;
-
+  void PrepareNewEvent() override {}
 
   private:
 

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -414,15 +414,13 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   m_StackingAction = new PHG4PhenixStackingAction();
   BOOST_FOREACH (PHG4Subsystem *g4sub, m_SubsystemList)
   {
-    cout << "checking stacking action for " << g4sub->Name() << endl;
     PHG4StackingAction *action = g4sub->GetStackingAction();
     if (action)
     {
-//      if (Verbosity() > 1)
+      if (Verbosity() > 1)
       {
         cout << "Adding steppingaction for " << g4sub->Name() << endl;
       }
-
       m_StackingAction->AddAction(g4sub->GetStackingAction());
     }
   }

--- a/simulation/g4simulation/g4main/PHG4StackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4StackingAction.h
@@ -25,6 +25,7 @@ class PHG4StackingAction
   // It can classify those tracks (urgent, wait, kill, postpone to next event)
   // default return in G4 is fUrgent
   virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track* aTrack) {return fUrgent;}
+  virtual void PrepareNewEvent() {}
   virtual void Verbosity(const int i) { m_Verbosity = i; }
   virtual int Verbosity() const { return m_Verbosity; }
   virtual int Init() { return 0; }


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The stacking action left an annoying printout. This PR adds a hook to PrepareNewEvent() for the stacking action
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

