### PR TITLE
X-Y-Z rotations in simple subsystems

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -82,7 +82,33 @@ void PHG4BlockDetector::ConstructMe(G4LogicalVolume *logicWorld)
   mysys->SetLogicalVolume(block_logic);
 
   G4RotationMatrix *rotm = new G4RotationMatrix();
-  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  int nRotation(0);
+  if (m_Params->get_double_param("rot_x") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
+  }
+  if (m_Params->get_double_param("rot_y") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  }
+  if (m_Params->get_double_param("rot_z") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  }
+
+  if (nRotation>=2)
+  {
+    cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
+        <<"("<<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<") degrees. "
+        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    rotm->print(cout);
+  }
+
   m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm),
                                    block_logic,
                                    G4String(GetName()),

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -71,8 +71,33 @@ void PHG4ConeDetector::ConstructMe(G4LogicalVolume *logicWorld)
   mysys->SetLogicalVolume(cone_logic);
 
   G4RotationMatrix *rotm = new G4RotationMatrix();
-  rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
-  rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+
+  int nRotation(0);
+  if (m_Params->get_double_param("rot_x") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
+  }
+  if (m_Params->get_double_param("rot_y") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  }
+  if (m_Params->get_double_param("rot_z") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  }
+
+  if (nRotation>=2)
+  {
+    std::cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
+        <<"("<<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<") degrees. "
+        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    rotm->print(std::cout);
+  }
 
   m_ConePhysVol = new G4PVPlacement(rotm,
                                     G4ThreeVector(m_Params->get_double_param("place_x") * cm,

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -145,8 +145,9 @@ void PHG4ConeSubsystem::SetDefaultParameters()
   set_default_double_param("rmax2", NAN);
   set_default_double_param("sphi", 0.);
   set_default_double_param("dphi", 360.);  // degrees
-  set_default_double_param("rot_z", 0);
+  set_default_double_param("rot_x", 0);
   set_default_double_param("rot_y", 0);
+  set_default_double_param("rot_z", 0);
 
   set_default_string_param("material", "WorldMaterial");
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -92,7 +92,32 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
   mysys->SetLogicalVolume(cylinder_logic);
 
   G4RotationMatrix *rotm = new G4RotationMatrix();
-  rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  int nRotation(0);
+  if (m_Params->get_double_param("rot_x") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
+  }
+  if (m_Params->get_double_param("rot_y") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
+  }
+  if (m_Params->get_double_param("rot_z") !=0 )
+  {
+    ++ nRotation;
+    rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
+  }
+
+  if (nRotation>=2)
+  {
+    cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
+        <<"("<<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<", "
+        <<m_Params->get_double_param("rot_x")<<") degrees. "
+        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    rotm->print(cout);
+  }
 
   m_CylinderPhysicalVolume = new G4PVPlacement(rotm,
 					       G4ThreeVector(m_Params->get_double_param("place_x") * cm,

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -168,8 +168,9 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_double_param("thickness", NAN);
   set_default_double_param("tmin", NAN);
   set_default_double_param("tmax", NAN);
+  set_default_double_param("rot_x", 0.);
   set_default_double_param("rot_y", 0.);
-
+  set_default_double_param("rot_z", 0.);
   set_default_int_param("lengthviarapidity", 1);
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Following bug report at https://discourse.sdcc.bnl.gov/t/zdcsurrogate-rotation-in-y-not-being-performed/207 , implementing X-Y-Z rotations in simple subsystems. 

If more than one rotation is given, the input is ambiguous, and the rotation will be executed in the order of X->Y->Z with a warning message explicitly printing out the rotation matrix. 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

