### PR TITLE
Add event level info to event evaluator

### DIFF
--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -45,7 +45,7 @@ PHPythia8::PHPythia8(const std::string &name)
   , m_Pythia8(nullptr)
   , m_ConfigFileName("phpythia8.cfg")
   , m_Pythia8ToHepMC(nullptr)
-  , m_SaveEventWeightFlag(false)
+  , m_SaveEventWeightFlag(true)
   , m_SaveIntegratedLuminosityFlag(true)
   , m_IntegralNode(nullptr)
 {

--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -45,6 +45,7 @@ PHPythia8::PHPythia8(const std::string &name)
   , m_Pythia8(nullptr)
   , m_ConfigFileName("phpythia8.cfg")
   , m_Pythia8ToHepMC(nullptr)
+  , m_SaveEventWeightFlag(false)
   , m_SaveIntegratedLuminosityFlag(true)
   , m_IntegralNode(nullptr)
 {
@@ -236,6 +237,11 @@ int PHPythia8::process_event(PHCompositeNode *topNode)
 
   HepMC::GenEvent *genevent = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
   m_Pythia8ToHepMC->fill_next_event(*m_Pythia8, genevent, m_EventCount);
+  // Enable continuous reweighting by storing additional reweighting factor
+  if (m_SaveEventWeightFlag)
+  {
+    genevent->weights().push_back(m_Pythia8->info.weight());
+  }
 
   /* pass HepMC to PHNode*/
   PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(genevent);

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -67,6 +67,7 @@ class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
     set_vertex_distribution_width(beamXsigma, beamYsigma, beamZsigma, 0);
   }
 
+  void save_event_weight(const bool b) { m_SaveEventWeightFlag = b; }
   void save_integrated_luminosity(const bool b) { m_SaveIntegratedLuminosityFlag = b; }
 
  private:
@@ -88,6 +89,9 @@ class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
 
   // HepMC
   HepMC::Pythia8ToHepMC *m_Pythia8ToHepMC;
+
+  //! whether to store the overall event weight into the HepMC weights
+  bool m_SaveEventWeightFlag;
 
   //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
   bool m_SaveIntegratedLuminosityFlag;

--- a/simulation/g4simulation/g4eval/EventEvaluator.h
+++ b/simulation/g4simulation/g4eval/EventEvaluator.h
@@ -47,6 +47,7 @@ class EventEvaluator : public SubsysReco
 
   void set_strict(bool b) { _strict = b; }
 
+  void set_do_store_event_level_info(bool b) { _do_store_event_info = b; }
   void set_do_FHCAL(bool b) { _do_FHCAL = b; }
   void set_do_HCALIN(bool b) { _do_HCALIN = b; }
   void set_do_HCALOUT(bool b) { _do_HCALOUT = b; }
@@ -81,6 +82,7 @@ class EventEvaluator : public SubsysReco
   }
 
  private:
+  bool _do_store_event_info;
   bool _do_FHCAL;
   bool _do_HCALIN;
   bool _do_HCALOUT;
@@ -98,6 +100,11 @@ class EventEvaluator : public SubsysReco
   bool _do_HEPMC;
   bool _do_GEOMETRY;
   unsigned int _ievent;
+
+  // Event level info
+  float _cross_section;
+  float _event_weight;
+  int _n_generator_accepted;
 
   // track hits
   int _nHitsLayers;
@@ -226,6 +233,8 @@ class EventEvaluator : public SubsysReco
   float* _track_px;
   float* _track_py;
   float* _track_pz;
+  float* _track_dca;
+  float* _track_dca_2d;
   float* _track_trueID;
   unsigned short* _track_source;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Add event level info to the event evaluator (xsec, event weight, etc). To do so, the Pythia8 event weight is now stored in the HepMC event. Based on how these weights are used, I don't think this is used, but to be safe, the option is off by default.

Also add some track DCA values

@FriederikeBock 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

