### PR TITLE
PHSimpleKFProp valgrind fix

### DIFF
--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -556,6 +556,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(SvtxTrack* track)
          fabs(tz-ccZ)<_max_dist*sqrt(tzerr*tzerr+czerr*czerr))
       {
         propagated_track.push_back(closest_ckey);
+        layers.push_back(TrkrDefs::getLayer(closest_ckey));
 /*        TrkrCluster* cc = _cluster_map->findCluster(closest_ckey);
         double ccX = cc->getX();
         cout << "cluster X: " << ccX << endl;
@@ -693,6 +694,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(SvtxTrack* track)
          fabs(tz-ccZ)<_max_dist*sqrt(tzerr*tzerr+czerr*czerr))
       {
         propagated_track.push_back(closest_ckey);
+        layers.push_back(TrkrDefs::getLayer(closest_ckey));
 /*        TrkrCluster* cc = _cluster_map->findCluster(closest_ckey);
         double ccX = cc->getX();
         cout << "cluster X: " << ccX << endl;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -424,7 +424,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(SvtxTrack* track)
     // choosing the last one first (clusters organized from inside out)
     bool layer_filled = false;
     TrkrDefs::cluskey next_ckey = 0;
-    for(int k=ckeys.size()-1; k>=0; k--)
+    for(int k=layers.size()-1; k>=0; k--)
     {
       if(layer_filled) continue;
       if(layers[k]==l)
@@ -493,7 +493,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(SvtxTrack* track)
           cout << "z: " << fabs(tz-cz) << " vs. " << _max_dist*sqrt(tzerr*tzerr+czerr*czerr) << endl;
         }
         kftrack.SetNDF(kftrack.GetNDF()-2);
-        ckeys.erase(std::remove(ckeys.begin(),ckeys.end(),next_ckey),ckeys.end());
+        //ckeys.erase(std::remove(ckeys.begin(),ckeys.end(),next_ckey),ckeys.end());
       }
       old_phi = cphi;
     }
@@ -601,7 +601,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(SvtxTrack* track)
     // choosing the first one first (clusters organized from outside in)
     bool layer_filled = false;
     TrkrDefs::cluskey next_ckey = 0;
-    for(size_t k=0; k<propagated_track.size(); k++)
+    for(size_t k=0; k<layers.size(); k++)
     {
       if(layer_filled) continue;
       if(layers[k]==l)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fixes issue where invalid read occurred when browsing a list of layers of a lengthened track. The list of layers was not updated at the same time as the track itself, so under certain conditions the list of layers could be read out of bounds.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Updates layer list when clusters are added to track, iterates over length of layer list when checking if layer is already occupied, and no longer removes cluster keys from the original cluster key list when a cluster is rejected as an outlier, instead simply not adding it to the propagated track.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

