### PR TITLE
mods to allow for asymmetric iHCAL configurations (for ECCE)

### DIFF
--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -415,9 +415,15 @@ void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
   pars->FillFrom(saveparams, 0);
   set_int_param(PHG4HcalDefs::scipertwr, pars->get_int_param(PHG4HcalDefs::scipertwr));
   set_int_param(PHG4HcalDefs::n_towers, pars->get_int_param(PHG4HcalDefs::n_towers));
-  set_int_param("etabins", 2 * pars->get_int_param(PHG4HcalDefs::n_scinti_tiles));
   set_double_param(PHG4HcalDefs::innerrad, pars->get_double_param(PHG4HcalDefs::innerrad));
   set_double_param(PHG4HcalDefs::outerrad, pars->get_double_param(PHG4HcalDefs::outerrad));
+
+  int nTiles = 2 * pars->get_int_param(PHG4HcalDefs::n_scinti_tiles); 
+  if(nTiles <= 0){
+    nTiles = pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_pos) + pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_neg);    
+  }
+  set_int_param("etabins", nTiles);
+
   delete pars;
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
@@ -13,6 +13,8 @@ namespace PHG4HcalDefs
   static const std::string outerrad = "outer_radius";
   static const std::string n_towers = "n_towers";
   static const std::string n_scinti_tiles = "n_scinti_tiles";
+  static const std::string n_scinti_tiles_pos = "n_scinti_tiles_pos";
+  static const std::string n_scinti_tiles_neg = "n_scinti_tiles_neg";
 }
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -87,14 +87,30 @@ PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeN
   , m_VolumeSteel(NAN)
   , m_VolumeScintillator(NAN)
   , m_NumScintiPlates(m_Params->get_int_param(PHG4HcalDefs::scipertwr) * m_Params->get_int_param("n_towers"))
-  , m_NumScintiTiles(m_Params->get_int_param("n_scinti_tiles"))
+  , m_NumScintiTilesPos(m_Params->get_int_param("n_scinti_tiles_pos"))
+  , m_NumScintiTilesNeg(m_Params->get_int_param("n_scinti_tiles_neg"))
   , m_Active(m_Params->get_int_param("active"))
   , m_AbsorberActive(m_Params->get_int_param("absorberactive"))
   , m_Layer(0)
   , m_ScintiLogicNamePrefix("HcalInnerScinti")
 {
+  
+  // n_scinti_tiles takes precedence
+
+  int nTiles = 2 * m_Params->get_int_param(PHG4HcalDefs::n_scinti_tiles); 
+  if(nTiles <= 0){
+    nTiles =  m_NumScintiTilesPos +  m_NumScintiTilesNeg; 
+  }
+  else{
+    m_NumScintiTilesPos = nTiles/2; 
+    m_Params->set_int_param("n_scinti_tiles_pos", nTiles/2);
+    m_NumScintiTilesNeg = nTiles/2; 
+    m_Params->set_int_param("n_scinti_tiles_neg", nTiles/2);
+  }
+
   // allocate memory for scintillator plates
-  m_ScintiTilesVec.assign(2 * m_NumScintiTiles, static_cast<G4VSolid *>(nullptr));
+  m_ScintiTilesVec.assign(nTiles, static_cast<G4VSolid *>(nullptr));
+
 }
 
 PHG4InnerHcalDetector::~PHG4InnerHcalDetector()
@@ -559,8 +575,17 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
 void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hcalenvelope)
 {
   G4VSolid *bigtile = ConstructScintillatorBox(hcalenvelope);
+
   // eta->theta
-  G4double delta_eta = m_Params->get_double_param("scinti_eta_coverage") / m_NumScintiTiles;
+  // scinti_eta_coverage takes precedence
+  G4double eta_cov = m_Params->get_double_param("scinti_eta_coverage"); 
+  if(eta_cov>0){
+    m_Params->set_double_param("scinti_eta_coverage_pos", eta_cov);
+    m_Params->set_double_param("scinti_eta_coverage_neg", eta_cov);
+  }
+  G4double delta_eta_pos = m_Params->get_double_param("scinti_eta_coverage_pos") / m_NumScintiTilesPos;
+  G4double delta_eta_neg = m_Params->get_double_param("scinti_eta_coverage_neg") / m_NumScintiTilesNeg;
+
   G4double eta = 0;
   G4double theta;
   G4double x[4];
@@ -571,19 +596,22 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
   // is larger than the tile so we do not have
   // funny edge effects when overlapping vols
   double scinti_gap_neighbor = m_Params->get_double_param("scinti_gap_neighbor") * cm;
-  for (int i = 0; i < m_NumScintiTiles; i++)
+
+  // Positive first, then negative
+
+  for (int i = 0; i < m_NumScintiTilesPos; i++)
   {
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[0] = m_InnerRadius - overhang;
-    z[0] = tan(theta) * m_InnerRadius;
+    z[0] = tan(theta) * m_InnerRadius; 
     x[1] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[1] = tan(theta) * m_OuterRadius;
-    eta += delta_eta;
+    z[1] = tan(theta) * m_OuterRadius; 
+    eta += delta_eta_pos;
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[2] = m_InnerRadius - overhang;
-    z[2] = tan(theta) * m_InnerRadius;
+    z[2] = tan(theta) * m_InnerRadius; 
     x[3] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[3] = tan(theta) * m_OuterRadius;
+    z[3] = tan(theta) * m_OuterRadius; 
     // apply gap between scintillators
     z[0] += scinti_gap_neighbor / 2.;
     z[1] += scinti_gap_neighbor / 2.;
@@ -619,25 +647,74 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
     rotm->rotateX(-90 * deg);
     name.str("");
     name << "scintillator_" << i << "_left";
-    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, 0));
+    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, -m_Params->get_double_param("place_z") * cm));
     delete rotm;
-    m_ScintiTilesVec[i + m_NumScintiTiles] = scinti_tile;
-    rotm = new G4RotationMatrix();
-    rotm->rotateX(90 * deg);
+    m_ScintiTilesVec[i + m_NumScintiTilesNeg] = scinti_tile;
 
+  }
+  
+  eta = 0.0; // reset
+  for (int i = 0; i < m_NumScintiTilesNeg; i++)
+  {
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[0] = m_InnerRadius - overhang;
+    z[0] = tan(theta) * m_InnerRadius; 
+    x[1] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[1] = tan(theta) * m_OuterRadius; 
+    eta += delta_eta_neg;
+    theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
+    x[2] = m_InnerRadius - overhang;
+    z[2] = tan(theta) * m_InnerRadius; 
+    x[3] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
+    z[3] = tan(theta) * m_OuterRadius; 
+    // apply gap between scintillators
+    z[0] += scinti_gap_neighbor / 2.;
+    z[1] += scinti_gap_neighbor / 2.;
+    z[2] -= scinti_gap_neighbor / 2.;
+    z[3] -= scinti_gap_neighbor / 2.;
+    Point_2 leftsidelow(z[0], x[0]);
+    Point_2 leftsidehigh(z[1], x[1]);
+    x[0] = m_InnerRadius - offset;
+    z[0] = x_at_y(leftsidelow, leftsidehigh, x[0]);
+    x[1] = m_OuterRadius + offset;
+    z[1] = x_at_y(leftsidelow, leftsidehigh, x[1]);
+    Point_2 rightsidelow(z[2], x[2]);
+    Point_2 rightsidehigh(z[3], x[3]);
+    x[2] = m_OuterRadius + offset;
+    z[2] = x_at_y(rightsidelow, rightsidehigh, x[2]);
+    x[3] = m_InnerRadius - offset;
+    z[3] = x_at_y(rightsidelow, rightsidehigh, x[3]);
+
+    vector<G4TwoVector> vertexes;
+    for (int j = 0; j < 4; j++)
+    {
+      G4TwoVector v(x[j], z[j]);
+      vertexes.push_back(v);
+    }
+    G4TwoVector zero(0, 0);
+
+    G4VSolid *scinti = new G4ExtrudedSolid("ScintillatorTile",
+                                           vertexes,
+                                           m_ScintiTileThickness + 0.2 * mm,
+                                           zero, 1.0,
+                                           zero, 1.0);
+
+    G4RotationMatrix *rotm = new G4RotationMatrix();
+    rotm->rotateX(90 * deg);
     name.str("");
     name << "scintillator_" << i << "_right";
-    scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, 0));
-    m_ScintiTilesVec[m_NumScintiTiles - i - 1] = scinti_tile;
+    G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, -m_Params->get_double_param("place_z") * cm));
+    m_ScintiTilesVec[m_NumScintiTilesNeg - i - 1] = scinti_tile;
     delete rotm;
+
   }
 
   // for (unsigned int i=0; i<m_ScintiTilesVec.size(); i++)
-  //    {
-  //      if (m_ScintiTilesVec[i])
-  //  	 {
-  //   	   DisplayVolume(m_ScintiTilesVec[i],hcalenvelope );
-  //   	 }
+  //     {
+  //       if (m_ScintiTilesVec[i])
+  //   	 {
+  //    	   DisplayVolume(m_ScintiTilesVec[i],hcalenvelope );
+  //    	 }
   //     }
 
   return;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -86,7 +86,6 @@ class PHG4InnerHcalDetector : public PHG4Detector
   double m_VolumeScintillator;
 
   int m_NumScintiPlates;
-  int m_NumScintiTiles;
   int m_NumScintiTilesPos;
   int m_NumScintiTilesNeg;
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -87,6 +87,8 @@ class PHG4InnerHcalDetector : public PHG4Detector
 
   int m_NumScintiPlates;
   int m_NumScintiTiles;
+  int m_NumScintiTilesPos;
+  int m_NumScintiTilesNeg;
 
   int m_Active;
   int m_AbsorberActive;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -165,6 +165,8 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
   set_default_double_param("scinti_eta_coverage", 1.1);
+  set_default_double_param("scinti_eta_coverage_pos", 1.1);
+  set_default_double_param("scinti_eta_coverage_neg", 1.1);
   set_default_double_param("scinti_gap_neighbor", 0.1);
   set_default_double_param("scinti_inner_gap", 0.85);
   set_default_double_param("scinti_outer_gap", 1.22 * (5.0 / 4.0));
@@ -185,6 +187,8 @@ void PHG4InnerHcalSubsystem::SetDefaultParameters()
   set_default_int_param(PHG4HcalDefs::n_towers, 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 4);
   set_default_int_param(PHG4HcalDefs::n_scinti_tiles, 12);
+  set_default_int_param(PHG4HcalDefs::n_scinti_tiles_pos, 12);
+  set_default_int_param(PHG4HcalDefs::n_scinti_tiles_neg, 12);
 
   set_default_string_param("material", "G4_Al");
 }


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? 
This set of modifications enables asymmetric configurations of the inner HCAL both in terms of the location and length along the z-axis as well as the eta coverage and number of scintillating tiles.  In ECCE this is needed because the iHCAL frame needs to extend further on the electron going side to support the barrel EMCal. 

Conceptually there are two changes:
 
(1) Previously, if the module was shifted in z to account for a longer size on one side than the other, the scintillation tiles would no longer be projective with respect to the center of the experiment, but would be projective with respect to the center of the iHCAL.

(2) The new parameters n_scinti_tiles_pos, n_scinti_tiles_neg and scinti_eta_coverage_pos, scinti_coverage_eta_neg  allow for varying scintillator configurations on the electron-going (negative) and hadron-going (positive) sides.  

NOTE: the old parameters n_scinit_tiles and scinti_coverage_eta with the sPHENIX iHCAL defaults still exist *and take precedence over the new parameters*.  In order to set up and asymmetric configuration you must first set n_scinti_tiles and scinti_eta_coverage to 0 as well as setting the pos, neg parameters.  In this was *no macro changes* are required for the sPHENIX detector simulations.  The current ECCE frame configuration modifies the parameters in the macro as: 

  double z_end = G4HCALIN::support_ring_z_ring2 - 13.5 + (G4HCALIN::dz/2.0);
  double z_start = -287; // DIRC prizm end
  double length = z_end - z_start;
  double z_shift = 0.5 * (z_end + z_start);

  hcal->set_double_param("outer_radius", 138.5);
  hcal->set_double_param("scinti_outer_radius", 138.0);
  hcal->set_double_param("inner_radius", 134.0);
  hcal->set_double_param("tilt_angle", 36.15);
  hcal->set_double_param("size_z", length);
  hcal->set_int_param("n_scinti_tiles", 0);
  hcal->set_int_param("n_scinti_tiles_pos", 12);
  hcal->set_int_param("n_scinti_tiles_neg", 15);
  hcal->set_double_param("place_z", z_shift);
  hcal->set_double_param("scinti_eta_coverage", 0.0);
  hcal->set_double_param("scinti_eta_coverage_pos", 1.15);
  hcal->set_double_param("scinti_eta_coverage_neg", 1.45);

While produces the following image (the iHCAL steel is hidden so you can see the scintillators): 

![newIHCAL](https://user-images.githubusercontent.com/3042746/124181574-4ba6fe80-da7b-11eb-992d-27912cc749b1.png)

If instead you set 

  hcal->set_int_param("n_scinti_tiles", 12);
  hcal->set_double_param("scinti_eta_coverage", 1.1);

you will get the standard sPHENIX scintillator coverage (although in this image using the smaller ECCE radial size): 

![def](https://user-images.githubusercontent.com/3042746/124181808-9cb6f280-da7b-11eb-83f3-3c1d026068a6.png)
 
There was a small corresponding change to HCalRawTowerBuilder.cc to ensure that an asymmetric configuration calculates the correct number of eta bins. 

## TODOs (if applicable)

This pull request is made as a draft to allow Jenkins checking. 

## Links to other PRs in macros and calibration repositories (if applicable)

Once this pull request is merged, there will be a corresponding pull request for the ECCE macros repository to implement the new scintillator geometry. 
