### PR TITLE
EventEvaluator: changed PDG IDs, mcpart IDs, and status variables from float to int

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -349,9 +349,9 @@ EventEvaluator::EventEvaluator(const string& name, const string& filename)
   _track_TLP_true_z = new float[_maxNProjections];
   _track_TLP_true_t = new float[_maxNProjections];
 
-  _mcpart_ID = new float[_maxNMCPart];
-  _mcpart_ID_parent = new float[_maxNMCPart];
-  _mcpart_PDG = new float[_maxNMCPart];
+  _mcpart_ID = new int[_maxNMCPart];
+  _mcpart_ID_parent = new int[_maxNMCPart];
+  _mcpart_PDG = new int[_maxNMCPart];
   _mcpart_E = new float[_maxNMCPart];
   _mcpart_px = new float[_maxNMCPart];
   _mcpart_py = new float[_maxNMCPart];
@@ -360,8 +360,8 @@ EventEvaluator::EventEvaluator(const string& name, const string& filename)
 
   _hepmcp_BCID = new int[_maxNHepmcp];
   //  _hepmcp_ID_parent = new float[_maxNHepmcp];
-  _hepmcp_status = new float[_maxNHepmcp];
-  _hepmcp_PDG = new float[_maxNHepmcp];
+  _hepmcp_status = new int[_maxNHepmcp];
+  _hepmcp_PDG = new int[_maxNHepmcp];
   _hepmcp_E = new float[_maxNHepmcp];
   _hepmcp_px = new float[_maxNHepmcp];
   _hepmcp_py = new float[_maxNHepmcp];
@@ -571,9 +571,9 @@ int EventEvaluator::Init(PHCompositeNode* topNode)
   {
     // MC particles
     _event_tree->Branch("nMCPart", &_nMCPart, "nMCPart/I");
-    _event_tree->Branch("mcpart_ID", _mcpart_ID, "mcpart_ID[nMCPart]/F");
-    _event_tree->Branch("mcpart_ID_parent", _mcpart_ID_parent, "mcpart_ID_parent[nMCPart]/F");
-    _event_tree->Branch("mcpart_PDG", _mcpart_PDG, "mcpart_PDG[nMCPart]/F");
+    _event_tree->Branch("mcpart_ID", _mcpart_ID, "mcpart_ID[nMCPart]/I");
+    _event_tree->Branch("mcpart_ID_parent", _mcpart_ID_parent, "mcpart_ID_parent[nMCPart]/I");
+    _event_tree->Branch("mcpart_PDG", _mcpart_PDG, "mcpart_PDG[nMCPart]/I");
     _event_tree->Branch("mcpart_E", _mcpart_E, "mcpart_E[nMCPart]/F");
     _event_tree->Branch("mcpart_px", _mcpart_px, "mcpart_px[nMCPart]/F");
     _event_tree->Branch("mcpart_py", _mcpart_py, "mcpart_py[nMCPart]/F");
@@ -589,8 +589,8 @@ int EventEvaluator::Init(PHCompositeNode* topNode)
     _event_tree->Branch("hepmcp_x2", &_hepmcp_x2, "hepmcp_x2/F");
 
     //    _event_tree->Branch("hepmcp_ID_parent", _hepmcp_ID_parent, "hepmcp_ID_parent[nHepmcp]/F");
-    _event_tree->Branch("hepmcp_status", _hepmcp_status, "hepmcp_status[nHepmcp]/F");
-    _event_tree->Branch("hepmcp_PDG", _hepmcp_PDG, "hepmcp_PDG[nHepmcp]/F");
+    _event_tree->Branch("hepmcp_status", _hepmcp_status, "hepmcp_status[nHepmcp]/I");
+    _event_tree->Branch("hepmcp_PDG", _hepmcp_PDG, "hepmcp_PDG[nHepmcp]/I");
     _event_tree->Branch("hepmcp_E", _hepmcp_E, "hepmcp_E[nHepmcp]/F");
     _event_tree->Branch("hepmcp_px", _hepmcp_px, "hepmcp_px[nHepmcp]/F");
     _event_tree->Branch("hepmcp_py", _hepmcp_py, "hepmcp_py[nHepmcp]/F");

--- a/simulation/g4simulation/g4eval/EventEvaluator.h
+++ b/simulation/g4simulation/g4eval/EventEvaluator.h
@@ -241,9 +241,9 @@ class EventEvaluator : public SubsysReco
 
   // MC particles
   int _nMCPart;
-  float* _mcpart_ID;
-  float* _mcpart_ID_parent;
-  float* _mcpart_PDG;
+  int* _mcpart_ID;
+  int* _mcpart_ID_parent;
+  int* _mcpart_PDG;
   float* _mcpart_E;
   float* _mcpart_px;
   float* _mcpart_py;
@@ -256,8 +256,8 @@ class EventEvaluator : public SubsysReco
   float _hepmcp_x1;
   float _hepmcp_x2;
   //  float* _hepmcp_ID_parent;
-  float* _hepmcp_status;
-  float* _hepmcp_PDG;
+  int* _hepmcp_status;
+  int* _hepmcp_PDG;
   float* _hepmcp_E;
   float* _hepmcp_px;
   float* _hepmcp_py;


### PR DESCRIPTION
Resubmitting https://github.com/ECCE-EIC/coresoftware/pull/2

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
In the EventEvaluator, there are several variables (HEPMC pdgID, mcpart ID's) that are added to the tree as floats, as opposed to ints (their natural representation).  I have changed this, although this will require some people to redo their macros when reading back the output files.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

