### PR TITLE
Bug fix on fast tracking eval's variable reset

### DIFF
--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -577,6 +577,7 @@ void PHG4TrackFastSimEval::reset_variables()
   for (auto &elem : m_TTree_proj_p_vec) std::fill(elem.begin(), elem.end(), -9999);
   for (auto &elem : m_TTree_ref_vec) std::fill(elem.begin(), elem.end(), -9999);
   for (auto &elem : m_TTree_ref_p_vec) std::fill(elem.begin(), elem.end(), -9999);
+  for (auto &pair : m_TTree_HitContainerID_nHits_map) pair.second=0;
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Bug fix for the evaluator output reset for truth tracking (used in EIC studies)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

