### PR TITLE
fixed naming of projection layers in EventEvaluator

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -3136,21 +3136,21 @@ int EventEvaluator::GetProjectionIndex(std::string projname)
   else if (projname.find("FST_5") != std::string::npos)
     return 55;
 
-  else if (projname.find("EHCAL_0") != std::string::npos)
+  else if (projname.find("EHCAL") != std::string::npos)
     return 60;
-  else if (projname.find("EEMC_0") != std::string::npos)
+  else if (projname.find("EEMC") != std::string::npos)
     return 61;
-  else if (projname.find("HCALIN_0") != std::string::npos)
+  else if (projname.find("HCALIN") != std::string::npos)
     return 62;
-  else if (projname.find("HCALOUT_0") != std::string::npos)
+  else if (projname.find("HCALOUT") != std::string::npos)
     return 63;
-  else if (projname.find("CEMC_0") != std::string::npos)
+  else if (projname.find("CEMC") != std::string::npos)
     return 64;
   else if (projname.find("EEMC_glass_0") != std::string::npos)
     return 65;
-  else if (projname.find("BECAL_0") != std::string::npos)
+  else if (projname.find("BECAL") != std::string::npos)
     return 66;
-  else if (projname.find("LFHCAL_0") != std::string::npos)
+  else if (projname.find("LFHCAL") != std::string::npos)
     return 67;
 
   else


### PR DESCRIPTION
[comment]: Just a small fix to obtain the correct projection layers in the EventEvaluator, since the projections are named without "_0".

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

