### PR TITLE
Acts state vectors

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -426,14 +426,13 @@ BoundTrackParamPtrResult PHTpcResiduals::propagateTrackState(
 
 }
 void PHTpcResiduals::calculateTpcResiduals(
-		          const Acts::BoundTrackParameters &params,
-			  const TrkrCluster* cluster)
+  const Acts::BoundTrackParameters &params,
+  const TrkrCluster* cluster)
 {
   
   cluskey = cluster->getClusKey();
   // Get all the relevant information for residual calculation
-  clusR = sqrt(pow(cluster->getX(), 2) +
-	       pow(cluster->getY(), 2));
+  clusR = std::sqrt(square(cluster->getX()) + square(cluster->getY()));
   clusPhi = std::atan2(cluster->getY(), cluster->getX());
   clusZ = cluster->getZ();
 
@@ -470,8 +469,7 @@ void PHTpcResiduals::calculateTpcResiduals(
   const auto globStateY = globalStatePos.y() / Acts::UnitConstants::cm;
   const auto globStateZ = stateZ;
 
-  stateR = sqrt(pow(globStateX, 2) +
-		pow(globStateY, 2) );
+  stateR = std::sqrt(square(globStateX) + square(globStateY));
   
   const auto dr = clusR - stateR;
   const auto trackDrDt = (globStateX * globalStateMom(0) +
@@ -500,8 +498,8 @@ void PHTpcResiduals::calculateTpcResiduals(
 	      << "   " << statePhi << "+/-" << stateRPhiErr
 	      << " and " << stateZ << "+/-" << stateZErr << std::endl;
 
-  const auto erp = pow(clusRPhiErr, 2);
-  const auto ez = pow(clusZErr, 2);
+  const auto erp = square(clusRPhiErr);
+  const auto ez = square(clusZErr);
 
   const auto dPhi = clusPhi - statePhi;
 
@@ -514,9 +512,10 @@ void PHTpcResiduals::calculateTpcResiduals(
   
   const auto trackEta 
     = std::atanh(params.momentum().z() / params.absoluteMomentum());
-  const auto clusEta = std::atanh(clusZ / sqrt(pow(cluster->getX(), 2) +
-					       pow(cluster->getY(), 2) +
-					       pow(cluster->getZ(), 2)));
+  const auto clusEta = std::atanh(clusZ / std::sqrt(
+    square(cluster->getX()) +
+    square(cluster->getY()) +
+    square(cluster->getZ())));
 
   const auto trackPPhi = -params.momentum()(0) * std::sin(statePhi) +
     params.momentum()(1) * std::cos(statePhi);

--- a/offline/packages/trackreco/ActsTransformations.h
+++ b/offline/packages/trackreco/ActsTransformations.h
@@ -43,26 +43,23 @@ typedef boost::bimap<TrkrDefs::cluskey, unsigned int> CluskeyBimap;
 class ActsTransformations
 {
  public:
- ActsTransformations()
-   : m_verbosity(false)
-  {}
-  virtual ~ActsTransformations(){}
-  
+ ActsTransformations() = default;
+    
   /// Rotates an SvtxTrack covariance matrix from (x,y,z,px,py,pz) global
   /// cartesian coordinates to (d0, z0, phi, theta, q/p, time) coordinates for
   /// Acts. The track fitter performs the fitting with respect to the nominal
   /// origin of sPHENIX, so we rotate accordingly
   Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track,
-						Acts::GeometryContext geoCtxt);
+						Acts::GeometryContext geoCtxt) const;
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
   Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
                        const Acts::BoundTrackParameters params,
-		       Acts::GeometryContext geoCtxt);
+		       Acts::GeometryContext geoCtxt) const;
 
   void setVerbosity(int verbosity) {m_verbosity = verbosity;}
 
-  void printMatrix(const std::string &message, Acts::BoundSymMatrix matrix);
+  void printMatrix(const std::string &message, Acts::BoundSymMatrix matrix) const;
 
   /// Calculate the DCA for a given Acts fitted track parameters and 
   /// vertex
@@ -73,15 +70,15 @@ class ActsTransformations
 		    float &dca3Dxy,
 		    float &dca3Dz,
 		    float &dca3DxyCov,
-		    float &dca3DzCov);
+		    float &dca3DzCov) const;
 
-  void fillSvtxTrackStates(const Trajectory traj, 
+  void fillSvtxTrackStates(const Trajectory& traj, 
 			   const size_t &trackTip,
 			   SvtxTrack *svtxTrack,
-			   Acts::GeometryContext geoContext);
+			   Acts::GeometryContext geoContext) const;
 
  private:
-  int m_verbosity;
+  int m_verbosity = 0;
 
 
 };

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -91,9 +91,9 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
 
 int PHActsTrkFitter::process_event(PHCompositeNode *topNode)
 {
-  auto eventTimer = std::make_unique<PHTimer>("eventTimer");
-  eventTimer->stop();
-  eventTimer->restart();
+  PHTimer eventTimer("eventTimer");
+  eventTimer.stop();
+  eventTimer.restart();
   
   m_event++;
 
@@ -122,8 +122,8 @@ int PHActsTrkFitter::process_event(PHCompositeNode *topNode)
 
   loopTracks(logLevel);
 
-  eventTimer->stop();
-  auto eventTime = eventTimer->get_accumulated_time();
+  eventTimer.stop();
+  auto eventTime = eventTimer.get_accumulated_time();
 
   if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter total event time " 
@@ -203,9 +203,9 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	  continue;
 	}
 
-      auto trackTimer = std::make_unique<PHTimer>("TrackTimer");
-      trackTimer->stop();
-      trackTimer->restart();
+      PHTimer trackTimer("TrackTimer");
+      trackTimer.stop();
+      trackTimer.restart();
 
       auto sourceLinks = getSourceLinks(track);
       /// If using directed navigation, collect surface list to navigate
@@ -256,13 +256,13 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 			        ppPlainOptions,
 				&(*pSurface));
  
-      auto fitTimer = std::make_unique<PHTimer>("FitTimer");
-      fitTimer->stop();
-      fitTimer->restart();
+      PHTimer fitTimer("FitTimer");
+      fitTimer.stop();
+      fitTimer.restart();
       auto result = fitTrack(sourceLinks, seed, kfOptions,
 			     surfaces);
-      fitTimer->stop();
-      auto fitTime = fitTimer->get_accumulated_time();
+      fitTimer.stop();
+      auto fitTime = fitTimer.get_accumulated_time();
       
       if(Verbosity() > 1)
 	std::cout << "PHActsTrkFitter Acts fit time "
@@ -299,8 +299,8 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
 	}
 
-      trackTimer->stop();
-      auto trackTime = trackTimer->get_accumulated_time();
+      trackTimer.stop();
+      auto trackTime = trackTimer.get_accumulated_time();
       
       if(Verbosity() > 1)
 	std::cout << "PHActsTrkFitter total single track time "
@@ -489,14 +489,14 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
 
   /// Get position, momentum from the Acts output. Update the values of
   /// the proto track
-  auto updateTrackTimer = std::make_unique<PHTimer>("UpdateTrackTimer");
-  updateTrackTimer->stop();
-  updateTrackTimer->restart();
+  PHTimer updateTrackTimer("UpdateTrackTimer");
+  updateTrackTimer.stop();
+  updateTrackTimer.restart();
   if(fitOutput.fittedParameters)
     updateSvtxTrack(*trajectory, track);
   
-  updateTrackTimer->stop();
-  auto updateTime = updateTrackTimer->get_accumulated_time();
+  updateTrackTimer.stop();
+  auto updateTime = updateTrackTimer.get_accumulated_time();
   
   if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter update SvtxTrack time "
@@ -707,17 +707,17 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   // Also need to update the state list and cluster ID list for all measurements associated with the acts track  
   // loop over acts track states, copy over to SvtxTrackStates, and add to SvtxTrack
 
-  auto trackStateTimer = std::make_unique<PHTimer>("TrackStateTimer");
-  trackStateTimer->stop();
-  trackStateTimer->restart();
+  PHTimer trackStateTimer("TrackStateTimer");
+  trackStateTimer.stop();
+  trackStateTimer.restart();
 
 
   if(m_fillSvtxTrackStates)
     rotater.fillSvtxTrackStates(traj, trackTip, track,
 				 m_tGeometry->geoContext);  
 
-  trackStateTimer->stop();
-  auto stateTime = trackStateTimer->get_accumulated_time();
+  trackStateTimer.stop();
+  auto stateTime = trackStateTimer.get_accumulated_time();
   
   if(Verbosity() > 1)
     std::cout << "PHActsTrkFitter update SvtxTrackStates time "

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -337,7 +337,7 @@ Acts::Vector3D PHActsTrkFitter::getVertex(SvtxTrack *track)
 }
 
 //___________________________________________________________________________________
-Surface PHActsTrkFitter::getSurface(TrkrDefs::cluskey cluskey, TrkrDefs::subsurfkey surfkey)
+Surface PHActsTrkFitter::getSurface(TrkrDefs::cluskey cluskey, TrkrDefs::subsurfkey surfkey) const
 {
   const auto trkrid = TrkrDefs::getTrkrId(cluskey);
   const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
@@ -359,7 +359,7 @@ Surface PHActsTrkFitter::getSurface(TrkrDefs::cluskey cluskey, TrkrDefs::subsurf
 }
 
 //___________________________________________________________________________________
-Surface PHActsTrkFitter::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey)
+Surface PHActsTrkFitter::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const
 {
   auto surfMap = m_surfMaps->siliconSurfaceMap;
   auto iter = surfMap.find(hitsetkey);
@@ -374,7 +374,7 @@ Surface PHActsTrkFitter::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey)
 }
 
 //___________________________________________________________________________________
-Surface PHActsTrkFitter::getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey)
+Surface PHActsTrkFitter::getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey) const
 {
   const auto iter = m_surfMaps->tpcSurfaceMap.find(hitsetkey);
   if(iter != m_surfMaps->tpcSurfaceMap.end())
@@ -388,7 +388,7 @@ Surface PHActsTrkFitter::getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::
 }
 
 //___________________________________________________________________________________
-Surface PHActsTrkFitter::getMMSurface(TrkrDefs::hitsetkey hitsetkey)
+Surface PHActsTrkFitter::getMMSurface(TrkrDefs::hitsetkey hitsetkey) const
 {
   const auto iter = m_surfMaps->mmSurfaceMap.find( hitsetkey );
   return (iter == m_surfMaps->mmSurfaceMap.end()) ? nullptr:iter->second;
@@ -522,7 +522,7 @@ ActsExamples::TrkrClusterFittingAlgorithm::FitterResult PHActsTrkFitter::fitTrac
 }
 
 SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks,
-						SurfacePtrVec& surfaces)
+						SurfacePtrVec& surfaces) const
 {
    SourceLinkVec siliconMMSls;
 
@@ -559,7 +559,7 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 
 }
 
-void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces)
+void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces) const
 {
   for(int i = 0; i < surfaces.size() - 1; i++)
     {
@@ -739,7 +739,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   
 }
 
-Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance()
+Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance() const
 {
   Acts::BoundSymMatrix cov;
    

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -46,6 +46,7 @@
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
+  , m_trajectories(nullptr)
 {}
 
 int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
@@ -193,8 +194,6 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
   /// Store a vector of track fits that fail to erase, so that the
   /// track map iterator doesn't crash
   std::vector<unsigned int> badTracks;
-
-  ActsTransformations transformer;
 
   for(const auto& [trackKey, track] : *m_trackMap)
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -655,8 +655,8 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   track->set_chisq(trajState.chi2Sum);
   track->set_ndf(trajState.NDF);
 
-  auto rotater = std::make_unique<ActsTransformations>();
-  rotater->setVerbosity(Verbosity());
+  ActsTransformations rotater;
+  rotater.setVerbosity(Verbosity());
   
   float dca3Dxy = NAN;
   float dca3Dz = NAN;
@@ -667,7 +667,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
     {
      
       Acts::BoundSymMatrix rotatedCov = 
-	rotater->rotateActsCovToSvtxTrack(params,
+	rotater.rotateActsCovToSvtxTrack(params,
 					  m_tGeometry->geoContext);
       
       for(int i = 0; i < 6; i++)
@@ -688,7 +688,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 		  svtxVertex->get_y() * Acts::UnitConstants::cm, 
 		  svtxVertex->get_z() * Acts::UnitConstants::cm);
    
-      rotater->calculateDCA(params, vertex, rotatedCov,
+      rotater.calculateDCA(params, vertex, rotatedCov,
 			    m_tGeometry->geoContext, 
 			    dca3Dxy, dca3Dz, 
 			    dca3DxyCov, dca3DzCov);
@@ -713,7 +713,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 
 
   if(m_fillSvtxTrackStates)
-    rotater->fillSvtxTrackStates(traj, trackTip, track,
+    rotater.fillSvtxTrackStates(traj, trackTip, track,
 				 m_tGeometry->geoContext);  
 
   trackStateTimer->stop();

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -46,33 +46,7 @@
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
-  , m_event(0)
-  , m_tGeometry(nullptr)
-  , m_trackMap(nullptr)
-  , m_directedTrackMap(nullptr)
-  , m_vertexMap(nullptr)
-  , m_clusterContainer(nullptr)
-  , m_surfMaps(nullptr)
-  , m_nBadFits(0)
-  , m_fitSiliconMMs(false)
-  , m_fillSvtxTrackStates(true)
-  , m_actsEvaluator(false)
-  , m_trajectories(nullptr)
-  , m_seedTracks(nullptr)
-  , m_timeAnalysis(false)
-  , m_timeFile(nullptr)
-  , h_eventTime(nullptr)
-  , h_fitTime(nullptr)
-  , h_updateTime(nullptr)
-  , h_stateTime(nullptr)
-  , h_rotTime(nullptr)
-{
-  Verbosity(0);
-}
-
-PHActsTrkFitter::~PHActsTrkFitter()
-{
-}
+{}
 
 int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
 {
@@ -140,7 +114,7 @@ int PHActsTrkFitter::process_event(PHCompositeNode *topNode)
       /// wipe at the beginning of every new fit pass, so that the seeds 
       /// are whatever is currently in SvtxTrackMap
       m_seedTracks->clear();
-      for(const auto [key, track] : *m_trackMap)
+      for(const auto& [key, track] : *m_trackMap)
 	{
 	  m_seedTracks->insert(track);
 	}
@@ -222,7 +196,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
   ActsTransformations transformer;
 
-  for(auto& [trackKey, track] : *m_trackMap)
+  for(const auto& [trackKey, track] : *m_trackMap)
     {
       if(!track)
 	{
@@ -335,26 +309,13 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
   /// Now erase bad tracks from the track map
-  for(auto key : badTracks)
+  for(const auto& key : badTracks)
     {
       m_trackMap->erase(key);
     }
 
   return;
 
-}
-void PHActsTrkFitter::printTrackSeed(ActsExamples::TrackParameters seed)
-{
-  std::cout << PHWHERE << " Processing proto track with position:" 
-	    << seed.position(m_tGeometry->geoContext) 
-	    << std::endl 
-	    << "momentum: " << seed.momentum() 
-	    << std::endl
-	    << "charge : " << seed.charge() 
-	    << std::endl;
-  std::cout << "proto track covariance " << std::endl
-	    << seed.covariance().value() << std::endl;
-  
 }
 
 Acts::Vector3D PHActsTrkFitter::getVertex(SvtxTrack *track)
@@ -560,7 +521,7 @@ ActsExamples::TrkrClusterFittingAlgorithm::FitterResult PHActsTrkFitter::fitTrac
     return m_fitCfg.fit(sourceLinks, seed, kfOptions);
 }
 
-SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
+SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks,
 						SurfacePtrVec& surfaces)
 {
    SourceLinkVec siliconMMSls;
@@ -568,7 +529,7 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
   if(Verbosity() > 1)
     std::cout << "Sorting " << sourceLinks.size() << " SLs" << std::endl;
   
-  for(auto sl : sourceLinks)
+  for(const auto& sl : sourceLinks)
     {
       if(Verbosity() > 1)
       { std::cout<<"SL available on : " << sl.referenceSurface().geometryId()<<std::endl; } 
@@ -588,7 +549,7 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(SourceLinkVec sourceLinks,
 
   if(Verbosity() > 1)
     {
-      for(auto surf : surfaces)
+      for(const auto& surf : surfaces)
 	{
 	  std::cout << "Surface vector : " << surf->geometryId() << std::endl;
 	}
@@ -809,8 +770,21 @@ Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance()
 
   return cov;
 }
-    
 
+void PHActsTrkFitter::printTrackSeed(const ActsExamples::TrackParameters& seed) const
+{
+  std::cout << PHWHERE << " Processing proto track with position:" 
+    << seed.position(m_tGeometry->geoContext) 
+    << std::endl 
+    << "momentum: " << seed.momentum() 
+    << std::endl
+    << "charge : " << seed.charge() 
+    << std::endl;
+  std::cout << "proto track covariance " << std::endl
+    << seed.covariance().value() << std::endl;
+  
+}
+    
 int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
 {
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -115,17 +115,17 @@ class PHActsTrkFitter : public SubsysReco
   /// Functions to get list of sorted surfaces for direct navigation, if
   /// applicable
   SourceLinkVec getSurfaceVector(const SourceLinkVec& sourceLinks, 
-				 SurfacePtrVec& surfaces);
-  void checkSurfaceVec(SurfacePtrVec& surfaces);
+				 SurfacePtrVec& surfaces) const;
+  void checkSurfaceVec(SurfacePtrVec& surfaces) const;
   void getTrackFitResult(const FitResult& fitOutput, 
 			 SvtxTrack* track);
 
-  Surface getSurface(TrkrDefs::cluskey cluskey,TrkrDefs::subsurfkey surfkey);
-  Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey);
-  Surface getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey);
-  Surface getMMSurface(TrkrDefs::hitsetkey hitsetkey);
+  Surface getSurface(TrkrDefs::cluskey cluskey,TrkrDefs::subsurfkey surfkey) const;
+  Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const;
+  Surface getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey) const;
+  Surface getMMSurface(TrkrDefs::hitsetkey hitsetkey) const;
 
-  Acts::BoundSymMatrix setDefaultCovariance();
+  Acts::BoundSymMatrix setDefaultCovariance() const;
   void printTrackSeed(const ActsExamples::TrackParameters& seed) const;
 
   /// Event counter

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -62,7 +62,7 @@ class PHActsTrkFitter : public SubsysReco
   PHActsTrkFitter(const std::string& name = "PHActsTrkFitter");
 
   /// Destructor
-  ~PHActsTrkFitter() override;
+  ~PHActsTrkFitter() override = default;
 
   /// End, write and close files
   int End(PHCompositeNode *topNode) override;
@@ -90,9 +90,6 @@ class PHActsTrkFitter : public SubsysReco
 
  private:
 
-  /// Event counter
-  int m_event;
-
   /// Get all the nodes
   int getNodes(PHCompositeNode *topNode);
 
@@ -117,7 +114,7 @@ class PHActsTrkFitter : public SubsysReco
 
   /// Functions to get list of sorted surfaces for direct navigation, if
   /// applicable
-  SourceLinkVec getSurfaceVector(SourceLinkVec sourceLinks, 
+  SourceLinkVec getSurfaceVector(const SourceLinkVec& sourceLinks, 
 				 SurfacePtrVec& surfaces);
   void checkSurfaceVec(SurfacePtrVec& surfaces);
   void getTrackFitResult(const FitResult& fitOutput, 
@@ -129,42 +126,46 @@ class PHActsTrkFitter : public SubsysReco
   Surface getMMSurface(TrkrDefs::hitsetkey hitsetkey);
 
   Acts::BoundSymMatrix setDefaultCovariance();
-  void printTrackSeed(ActsExamples::TrackParameters seed);
+  void printTrackSeed(const ActsExamples::TrackParameters& seed) const;
+
+  /// Event counter
+  int m_event = 0;
 
   /// Options that Acts::Fitter needs to run from MakeActsGeometry
-  ActsTrackingGeometry *m_tGeometry;
+  ActsTrackingGeometry *m_tGeometry = nullptr;
 
   /// Configuration containing the fitting function instance
   ActsExamples::TrkrClusterFittingAlgorithm::Config m_fitCfg;
 
   /// TrackMap containing SvtxTracks
-  SvtxTrackMap *m_trackMap, *m_directedTrackMap;
-  SvtxVertexMap *m_vertexMap;
-  TrkrClusterContainer *m_clusterContainer;
-  ActsSurfaceMaps *m_surfMaps;
+  SvtxTrackMap *m_trackMap = nullptr;
+  SvtxTrackMap *m_directedTrackMap = nullptr;
+  SvtxVertexMap *m_vertexMap = nullptr;
+  TrkrClusterContainer *m_clusterContainer = nullptr;
+  ActsSurfaceMaps *m_surfMaps = nullptr;
   
   /// Number of acts fits that returned an error
-  int m_nBadFits;
+  int m_nBadFits = 0;
 
   /// Boolean to use normal tracking geometry navigator or the
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
-  bool m_fitSiliconMMs;
+  bool m_fitSiliconMMs = false;
 
   /// A bool to update the SvtxTrackState information (or not)
-  bool m_fillSvtxTrackStates;
+  bool m_fillSvtxTrackStates = true;
 
-  bool m_actsEvaluator;
-  std::map<const unsigned int, Trajectory> *m_trajectories;
-  SvtxTrackMap *m_seedTracks;
+  bool m_actsEvaluator = false;
+  std::map<const unsigned int, Trajectory> *m_trajectories = nullptr;
+  SvtxTrackMap *m_seedTracks = nullptr;
 
   /// Variables for doing event time execution analysis
-  bool m_timeAnalysis;
-  TFile *m_timeFile;
-  TH1 *h_eventTime;
-  TH2 *h_fitTime;
-  TH1 *h_updateTime;
-  TH1 *h_stateTime;
-  TH1 *h_rotTime;
+  bool m_timeAnalysis = false;
+  TFile *m_timeFile = nullptr;
+  TH1 *h_eventTime = nullptr;
+  TH2 *h_fitTime = nullptr;
+  TH1 *h_updateTime = nullptr;
+  TH1 *h_stateTime = nullptr;
+  TH1 *h_rotTime = nullptr;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
In this PR, one uses the fit parameters position, instead of the measurement position to fill the track's Svx StateVector
This 
- is consistent with what is done in GenFit
- fixes discrepancies between GenFit and ACTS when looking at residuals (track - truth or track-clusters) as disscussed there: https://phenix-intra.sdcc.bnl.gov/WWW/p/draft/hpereira/sphenix/Tracking_meeting_2021_03_29/talk.pdf
- is needed to be able to compare track and cluster position in a given layer (whith TPC included in the fit), when running e.g. millepede to perform track-based alignment.

Also added some tiny optimizations and c++ cosmetics 

I'll prepare some slides about this for the next tracking meeting, on Monday July 19. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

