### PR TITLE
Fix fastsim projection volume

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
@@ -9,7 +9,6 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4VPhysicalVolume.hh>          // for G4VPhysicalVolume
 #include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4String.hh>                   // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>              // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
@@ -19,8 +18,6 @@
 
 class PHCompositeNode;
 class PHG4Subsystem;
-
-using namespace std;
 
 PHG4BbcDetector::PHG4BbcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *params, const std::string &dnam)
   : PHG4Detector(subsys, Node, dnam)
@@ -36,9 +33,9 @@ PHG4BbcDetector::PHG4BbcDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, P
 //_______________________________________________________________
 int PHG4BbcDetector::IsInBbc(G4VPhysicalVolume *volume) const
 {
-  //cout << PHWHERE << " volume " << volume->GetName() << endl;
+  //std::cout << PHWHERE << " volume " << volume->GetName() << std::endl;
 
-  set<G4VPhysicalVolume *>::const_iterator iter = m_PhysicalVolumesSet.find(volume);
+  std::set<G4VPhysicalVolume *>::const_iterator iter = m_PhysicalVolumesSet.find(volume);
   if (iter != m_PhysicalVolumesSet.end())
   {
     return 1;
@@ -49,17 +46,17 @@ int PHG4BbcDetector::IsInBbc(G4VPhysicalVolume *volume) const
 
 void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
-  //cout << PHWHERE << " Constructing BBC" << endl;
+  //std::cout << PHWHERE << " Constructing BBC" << std::endl;
 
   // Logical Volume Info for a BBC PMT
   G4Material *Quartz = G4Material::GetMaterial("G4_SILICON_DIOXIDE");
 
-  const G4double z_bbcq[] = {-1.5, 1.5};
-  const G4double rInner_bbcq[] = {0.,0.};
-  const G4double rOuter_bbcq[] = {1.27*cm,1.27*cm};
+  const double z_bbcq[] = {-1.5, 1.5};
+  const double rInner_bbcq[] = {0.,0.};
+  const double rOuter_bbcq[] = {1.27*cm,1.27*cm};
   G4Polyhedra *bbcq = new G4Polyhedra("bbcq",0.,2.0*M_PI,6,2,z_bbcq,rInner_bbcq,rOuter_bbcq); // bbc quartz radiator
 
-  G4LogicalVolume *bbcq_lv = new G4LogicalVolume(bbcq, Quartz, G4String("Bbc_quartz"));
+  G4LogicalVolume *bbcq_lv = new G4LogicalVolume(bbcq, Quartz, "Bbc_quartz");
   G4VisAttributes *bbcqVisAtt = new G4VisAttributes();
   bbcqVisAtt->SetVisibility(true);
   bbcqVisAtt->SetForceSolid(true);
@@ -71,7 +68,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   // Locations of the 64 PMT tubes in an arm.
   // Should probably move this to a geometry object...
-  G4float xpos[] = {
+  float xpos[] = {
     2.45951, -2.45951, 4.91902, 0, -4.91902, 7.37854, 2.45951, -2.45951, 
     -7.37854, 9.83805, 4.91902, 0, -4.91902, -9.83805, 7.37854, 2.45951, 
     -2.45951, -7.37854, 9.83805, 4.91902, -4.91902, -9.83805, 12.2976, 7.37854, 
@@ -82,7 +79,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
     2.45951, -2.45951, -7.37854, 4.91902, 0, -4.91902, 2.45951, -2.45951, 
   };
 
-  G4float ypos[] = {
+  float ypos[] = {
     12.78, 12.78, 11.36, 11.36, 11.36, 9.94, 9.94, 9.94, 
     9.94, 8.52, 8.52, 8.52, 8.52, 8.52, 7.1, 7.1, 
     7.1, 7.1, 5.68, 5.68, 5.68, 5.68, 4.26, 4.26, 
@@ -96,7 +93,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   const int NPMT = 64;  // No. PMTs per arm
   for ( int iarm = 0; iarm<2; iarm ++ )
   {
-    G4float side = 1.0;
+    float side = 1.0;
     if ( iarm==0 ) side = -1.0;
 
     // Add BBC PMT's
@@ -118,7 +115,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   // BBC Outer and Inner Cylindrical Shells
   G4Material *Alum = G4Material::GetMaterial("G4_Al");
   G4Tubs *bbc_shell = new G4Tubs("bbc_shell",14.9*cm, 15*cm, 12.2*cm, 0, 2*M_PI);
-  G4LogicalVolume *bbc_shell_lv = new G4LogicalVolume(bbc_shell, Alum, G4String("Bbc_Shell"));
+  G4LogicalVolume *bbc_shell_lv = new G4LogicalVolume(bbc_shell, Alum, "Bbc_Shell");
   G4VisAttributes *bbc_shell_VisAtt = new G4VisAttributes();
   bbc_shell_VisAtt->SetVisibility(true);
   bbc_shell_VisAtt->SetForceSolid(true);
@@ -137,7 +134,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   // BBC Front Plate
   G4Tubs *bbc_fplate = new G4Tubs("bbc_fplate", 5*cm, 15*cm, 0.5*cm, 0, 2*M_PI);
-  G4LogicalVolume *bbc_fplate_lv = new G4LogicalVolume(bbc_fplate, Alum, G4String("Bbc_Front_Plate"));
+  G4LogicalVolume *bbc_fplate_lv = new G4LogicalVolume(bbc_fplate, Alum, "Bbc_Front_Plate");
   G4VisAttributes *bbc_fplate_VisAtt = new G4VisAttributes();
   bbc_fplate_VisAtt->SetVisibility(true);
   bbc_fplate_VisAtt->SetForceSolid(true);
@@ -159,10 +156,10 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
 void PHG4BbcDetector::Print(const std::string &what) const
 {
-  cout << "Bbc Detector:" << endl;
+  std::cout << "Bbc Detector:" << std::endl;
   if (what == "ALL" || what == "VOLUME")
   {
-    cout << "Version 0.1" << endl;
+    std::cout << "Version 0.1" << std::endl;
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
@@ -10,10 +10,9 @@
 #include <Geant4/G4VisAttributes.hh>
 
 #include <cmath>
+#include <string>
 
 class G4VPhysicalVolume;
-
-using namespace std;
 
 PHG4ConeDisplayAction::PHG4ConeDisplayAction(const std::string &name, PHParameters *pars)
   : PHG4DisplayAction(name)
@@ -66,7 +65,7 @@ void PHG4ConeDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 
 void PHG4ConeDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
 {
-  if (isfinite(red) && isfinite(green) && isfinite(blue) && isfinite(alpha))
+  if (std::isfinite(red) && std::isfinite(green) && std::isfinite(blue) && std::isfinite(alpha))
   {
     m_Colour = new G4Colour(red, green, blue, alpha);
   }

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -8,6 +8,7 @@
 
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4SteppingAction.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>    // for PHIODataNode

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -21,7 +21,6 @@
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4StepPoint.hh>   // for G4StepPoint
 #include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fPostSt...
-#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
@@ -42,7 +41,6 @@
 
 class PHCompositeNode;
 
-using namespace std;
 //____________________________________________________________________________..
 PHG4CylinderSteppingAction::PHG4CylinderSteppingAction(PHG4CylinderSubsystem* subsys, PHG4CylinderDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
@@ -103,7 +101,7 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   // if this cylinder stops everything, just put all kinetic energy into edep
   if (m_BlackHoleFlag)
   {
-    if ((!isfinite(m_Tmin) && !isfinite(m_Tmax)) ||
+    if ((!std::isfinite(m_Tmin) && !std::isfinite(m_Tmax)) ||
         aTrack->GetGlobalTime() < m_Tmin ||
         aTrack->GetGlobalTime() > m_Tmax)
     {
@@ -122,17 +120,17 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // an expensive string compare for every track when we know
     // geantino or chargedgeantino has pid=0
     if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != std::string::npos)
     {
       geantino = true;
     }
     G4StepPoint* prePoint = aStep->GetPreStepPoint();
     G4StepPoint* postPoint = aStep->GetPostStepPoint();
-    //        cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << endl;
-    //        cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << endl;
-    //        cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << endl;
+    //        std::cout << "time prepoint: " << prePoint->GetGlobalTime()/ns << std::endl;
+    //        std::cout << "time postpoint: " << postPoint->GetGlobalTime()/ns << std::endl;
+    //        std::cout << "kinetic energy: " <<  aTrack->GetKineticEnergy()/GeV << std::endl;
     //       G4ParticleDefinition* def = aTrack->GetDefinition();
-    //       cout << "Particle: " << def->GetParticleName() << endl;
+    //       std::cout << "Particle: " << def->GetParticleName() << std::endl;
     int prepointstatus = prePoint->GetStepStatus();
     if (prepointstatus == fGeomBoundary ||
         prepointstatus == fUndefined ||
@@ -141,17 +139,17 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       if (prepointstatus == fPostStepDoItProc && m_SavePostStepStatus == fGeomBoundary)
       {
-        cout << GetName() << ": New Hit for  " << endl;
-        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+        std::cout << GetName() << ": New Hit for  " << std::endl;
+        std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
              << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
              << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
-        cout << "last track: " << m_SaveTrackId
-             << ", current trackid: " << aTrack->GetTrackID() << endl;
-        cout << "phys pre vol: " << volume->GetName()
-             << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-        cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-             << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+        std::cout << "last track: " << m_SaveTrackId
+             << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+        std::cout << "phys pre vol: " << volume->GetName()
+             << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+        std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+             << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       }
 
       if (!m_Hit)
@@ -197,11 +195,11 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
       if (!hasMotherSubsystem() && (m_Hit->get_z(0) * cm > m_Zmax || m_Hit->get_z(0) * cm < m_Zmin))
       {
-        boost::io::ios_precision_saver ips(cout);
-        cout << m_Detector->SuperDetector() << std::setprecision(9)
+        boost::io::ios_precision_saver ips(std::cout);
+        std::cout << m_Detector->SuperDetector() << std::setprecision(9)
              << " PHG4CylinderSteppingAction: Entry hit z " << m_Hit->get_z(0) * cm
              << " outside acceptance,  zmin " << m_Zmin
-             << ", zmax " << m_Zmax << ", layer: " << layer_id << endl;
+             << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
       }
     }
     // here we just update the exit values, it will be overwritten
@@ -209,29 +207,29 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // ceases to exist
     // some sanity checks for inconsistencies
     // check if this hit was created, if not print out last post step status
-    if (!m_Hit || !isfinite(m_Hit->get_x(0)))
+    if (!m_Hit || !std::isfinite(m_Hit->get_x(0)))
     {
-      cout << GetName() << ": hit was not created" << endl;
-      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+      std::cout << GetName() << ": hit was not created" << std::endl;
+      std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
            << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
            << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
-      cout << "last track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-      cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-           << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+      std::cout << "last track: " << m_SaveTrackId
+           << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+      std::cout << "phys pre vol: " << volume->GetName()
+           << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+      std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+           << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       exit(1);
     }
     m_SavePostStepStatus = postPoint->GetStepStatus();
     // check if track id matches the initial one when the hit was created
     if (aTrack->GetTrackID() != m_SaveTrackId)
     {
-      cout << "hits do not belong to the same track" << endl;
-      cout << "saved track: " << m_SaveTrackId
+      std::cout << "hits do not belong to the same track" << std::endl;
+      std::cout << "saved track: " << m_SaveTrackId
            << ", current trackid: " << aTrack->GetTrackID()
-           << endl;
+           << std::endl;
       exit(1);
     }
     m_SavePreStepStatus = prePoint->GetStepStatus();
@@ -252,10 +250,10 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (!hasMotherSubsystem() && (m_Hit->get_z(1) * cm > m_Zmax || m_Hit->get_z(1) * cm < m_Zmin))
     {
-      cout << m_Detector->SuperDetector() << std::setprecision(9)
+      std::cout << m_Detector->SuperDetector() << std::setprecision(9)
            << " PHG4CylinderSteppingAction: Exit hit z " << m_Hit->get_z(1) * cm
            << " outside acceptance zmin " << m_Zmin
-           << ", zmax " << m_Zmax << ", layer: " << layer_id << endl;
+           << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
     }
     if (geantino)
     {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -274,7 +274,7 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       double light_yield = GetVisibleEnergyDeposition(aStep);
       m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
-    if (edep > 0)
+    if (edep > 0 || m_SaveAllHitsFlag)
     {
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -5,6 +5,8 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
+#include <string>
+
 class G4Step;
 class G4VPhysicalVolume;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -13,6 +13,7 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 
 #include <Geant4/G4Box.hh>
+#include <Geant4/G4Exception.hh>      // for G4Exception, G4ExceptionD
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -24,7 +25,6 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
-#include <Geant4/globals.hh>  // for G4Exception, G4ExceptionDe...
 
 #include <TSystem.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -15,6 +15,7 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>
+#include <Geant4/G4Exception.hh>  // for G4Exception
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -27,7 +28,6 @@
 #include <Geant4/G4Trap.hh>
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
-#include <Geant4/globals.hh>  // for G4Exception, G4ExceptionDe...
 
 #include <TSystem.h>
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -29,6 +29,7 @@
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#include <algorithm> // for max
 #include <cmath>     // for sin, cos, sqrt, M_PI, asin
 #include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, basic_ostream

--- a/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSteppingAction.cc
@@ -25,7 +25,6 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cmath>  // for sqrt, NAN
 #include <iostream>
 #include <string>  // for char_traits, operator<<
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
@@ -6,9 +6,9 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-using namespace std;
+#include <string>
 
-PHG4InnerHcalDisplayAction::PHG4InnerHcalDisplayAction(const string &name)
+PHG4InnerHcalDisplayAction::PHG4InnerHcalDisplayAction(const std::string &name)
   : PHG4DisplayAction(name)
   , m_MyTopVolume(nullptr)
   , m_SteelVol(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -14,6 +14,7 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>     // for G4DisplacedSolid
+#include <Geant4/G4Exception.hh>  // for G4Exception
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException, JustWarning
 #include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
@@ -27,7 +28,6 @@
 #include <Geant4/G4Transform3D.hh>    // for G4Transform3D, G4RotateX3D
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>              // for G4int
-#include <Geant4/globals.hh>  // for G4Exception
 
 #include <algorithm>  // for max
 #include <cassert>


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

zero energy hits were not saved in the truth for for projection volumes, leading to error messages. This PR sets the flag which saves those hits
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

