### PR TITLE
Tpc lasers

### DIFF
--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -24,28 +24,32 @@ libg4tpc_la_LIBADD = \
   -ltpc_io
 
 pkginclude_HEADERS = \
+  PHG4TpcCentralMembrane.h \
+  PHG4TpcDigitizer.h \
+  PHG4TpcDirectLaser.h \
+  PHG4TpcDistortion.h \
   PHG4TpcElectronDrift.h \
+  PHG4TpcEndCapSubsystem.h \
   PHG4TpcPadPlane.h \
   PHG4TpcPadPlaneReadout.h \
-  PHG4TpcDigitizer.h \
-  PHG4TpcSubsystem.h \
-  PHG4TpcEndCapSubsystem.h \
-  PHG4TpcDistortion.h
+  PHG4TpcSubsystem.h 
 
 libg4tpc_la_SOURCES = \
+  PHG4TpcCentralMembrane.cc \
   PHG4TpcDetector.cc \
-  PHG4TpcEndCapDetector.cc \
   PHG4TpcDigitizer.cc \
+  PHG4TpcDirectLaser.cc \
   PHG4TpcDisplayAction.cc \
-  PHG4TpcEndCapDisplayAction.cc \
   PHG4TpcDistortion.cc \
   PHG4TpcElectronDrift.cc \
+  PHG4TpcEndCapDetector.cc \
+  PHG4TpcEndCapDisplayAction.cc \
+  PHG4TpcEndCapSteppingAction.cc \
+  PHG4TpcEndCapSubsystem.cc \
   PHG4TpcPadPlane.cc \
   PHG4TpcPadPlaneReadout.cc \
   PHG4TpcSteppingAction.cc \
-  PHG4TpcEndCapSteppingAction.cc \
-  PHG4TpcSubsystem.cc \
-  PHG4TpcEndCapSubsystem.cc
+  PHG4TpcSubsystem.cc 
 
 ################################################
 # linking tests

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
@@ -1,0 +1,606 @@
+#include "PHG4TpcCentralMembrane.h"
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include "TMath.h"
+#include "TVector3.h"
+#include "TH2F.h"
+
+
+//from phg4tpcsteppingaction.cc
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
+//R__LOAD_LIBRARY(libphg4hit.so)
+
+// all distances in mm, all angles in rad
+// class that generates stripes and dummy hit coordinates
+// stripes have width of one mm, length of one pad width, and are centered in middle of sector gaps
+
+using namespace std;
+
+//PHG4TpcCentralMembrane::
+
+PHG4TpcCentralMembrane::PHG4TpcCentralMembrane()
+  : R1_e {227.0902789 * mm, 238.4100043 * mm, 249.7297296 * mm, 261.049455 * mm, 272.3691804 * mm, 283.6889058 * mm, 295.0086312 * mm, 306.3283566 * mm},
+    R1 {317.648082 * mm, 328.9678074 * mm, 340.2875328 * mm, 351.6072582 * mm, 362.9269836 * mm, 374.246709 * mm,  385.5664344 * mm, 396.8861597 * mm},
+    R2 {421.705532 * mm, 442.119258 * mm, 462.532984 * mm, 482.9467608 * mm, 503.36069 * mm, 523.774416 * mm, 544.188015 * mm, 564.601868 * mm},
+    R3 {594.6048725 * mm, 616.545823 * mm, 638.4867738 * mm, 660.4277246 * mm, 682.3686754 * mm, 704.3096262 * mm, 726.250577 * mm, 748.1915277 * mm},
+    widthmod_R1_e {1.493, 1.398, 1.334, 1.284, 1.243, 1.208, 1.178, 1.152},
+    widthmod_R1 {1.129, 1.109, 1.091, 1.076, 1.062, 1.050, 1.040, 1.030},
+    widthmod_R2 {1.015, 1.007, 1.002, 1.000, 1.001, 1.006, 1.013, 1.023},
+    widthmod_R3 {1.044, 1.064, 1.087, 1.115, 1.147, 1.186, 1.232, 1.288},
+    keepThisAndAfter {1,0,1,0,1,0,1,0},
+    keepUntil_R1_e {4,4,5,4,5,5,5,5},
+    keepUntil_R1 {5,5,6,5,6,5,6,5},
+    keepUntil_R2 {7,7,8,7,8,8,8,8},
+    keepUntil_R3 {11,10,11,11,11,11,12,11}
+{
+  begin_CM = 221.4019814 * mm; // inner radius of CM
+  end_CM = 759.2138 * mm; // outer radius of CM
+  
+  nPads_R1 = 6*16;
+  nPads_R2 = 8*16;
+  nPads_R3 = 12*16;
+  
+  padfrac_R1 = 0.5*5.59106385 * mm;
+  padfrac_R2 = 0.5*10.13836283 * mm;
+  padfrac_R3 = 0.5*10.90189537 * mm;
+  
+  //str_width = 1.0 * mm;
+  arc_r = 0.5 * mm;
+
+
+  // set to 1.0 mm for all else
+  for (int j=0; j<nRadii; j++){
+    for (int i=0; i<nStripes_R1; i++){
+      str_width_R1_e[i][j] = 1.0 * mm;
+      str_width_R1[i][j] = 1.0 * mm;
+    }
+    for (int i=0; i<nStripes_R2; i++){
+      str_width_R2[i][j] = 1.0 * mm;
+    }
+    for (int i=0; i<nStripes_R3; i++){
+      str_width_R3[i][j] = 1.0 * mm;
+    }
+  }
+  
+  
+  nStripesPerPetal = 213;
+  nPetals = 18;
+
+  nTotStripes = nStripesPerPetal * nPetals;
+  
+  nElectrons = 100;
+
+    
+  CalculateVertices(nStripes_R1, nPads_R1, R1_e, spacing_R1_e, x1a_R1_e, y1a_R1_e, x1b_R1_e, y1b_R1_e, x2a_R1_e, y2a_R1_e, x2b_R1_e, y2b_R1_e, x3a_R1_e, y3a_R1_e, x3b_R1_e, y3b_R1_e, padfrac_R1, str_width_R1_e, widthmod_R1_e, nGoodStripes_R1_e, keepUntil_R1_e, nStripesIn_R1_e, nStripesBefore_R1_e);
+  CalculateVertices(nStripes_R1, nPads_R1, R1, spacing_R1, x1a_R1, y1a_R1, x1b_R1, y1b_R1, x2a_R1, y2a_R1, x2b_R1, y2b_R1, x3a_R1, y3a_R1, x3b_R1, y3b_R1, padfrac_R1, str_width_R1, widthmod_R1, nGoodStripes_R1, keepUntil_R1, nStripesIn_R1, nStripesBefore_R1);
+  CalculateVertices(nStripes_R2, nPads_R2, R2, spacing_R2, x1a_R2, y1a_R2, x1b_R2, y1b_R2, x2a_R2, y2a_R2, x2b_R2, y2b_R2, x3a_R2, y3a_R2, x3b_R2, y3b_R2, padfrac_R2, str_width_R2, widthmod_R2, nGoodStripes_R2, keepUntil_R2, nStripesIn_R2, nStripesBefore_R2);
+  CalculateVertices(nStripes_R3, nPads_R3, R3, spacing_R3, x1a_R3, y1a_R3, x1b_R3, y1b_R3, x2a_R3, y2a_R3, x2b_R3, y2b_R3, x3a_R3, y3a_R3, x3b_R3, y3b_R3, padfrac_R3, str_width_R3, widthmod_R3, nGoodStripes_R3, keepUntil_R3, nStripesIn_R3, nStripesBefore_R3);
+
+  
+  
+  for (int i = 0; i < 18; i++){ // loop over petalID
+    for (int j = 0; j < 8; j++){ // loop over radiusID
+      for (int k = 0; k < nGoodStripes_R1_e[j]; k++){ // loop over stripeID
+	PHG4Hits.push_back(GetPHG4HitFromStripe(i, 0, j, k, nElectrons));
+	BotVertices.push_back(GetBotVerticesFromStripe(0, j, k));
+	TopVertices.push_back(GetTopVerticesFromStripe(0, j, k));
+      }
+      for (int k = 0; k < nGoodStripes_R1[j]; k++){ // loop over stripeID
+	PHG4Hits.push_back(GetPHG4HitFromStripe(i, 1, j, k, nElectrons));
+	BotVertices.push_back(GetBotVerticesFromStripe(1, j, k));
+	TopVertices.push_back(GetTopVerticesFromStripe(1, j, k));
+      }
+      for (int k = 0; k < nGoodStripes_R2[j]; k++){ // loop over stripeID
+	PHG4Hits.push_back(GetPHG4HitFromStripe(i, 2, j, k, nElectrons));
+	BotVertices.push_back(GetBotVerticesFromStripe(2, j, k));
+	TopVertices.push_back(GetTopVerticesFromStripe(2, j, k));
+      }
+      for (int k = 0; k < nGoodStripes_R3[j]; k++){ // loop over stripeID
+	PHG4Hits.push_back(GetPHG4HitFromStripe(i, 3, j, k, nElectrons));
+	BotVertices.push_back(GetBotVerticesFromStripe(3, j, k));
+	TopVertices.push_back(GetTopVerticesFromStripe(3, j, k));
+      }
+    }
+  }
+  
+ return;
+}
+
+
+void PHG4TpcCentralMembrane::CalculateVertices(int nStripes, int nPads, double R[], double spacing[], double x1a[][nRadii], double y1a[][nRadii], double x1b[][nRadii], double y1b[][nRadii], double x2a[][nRadii], double y2a[][nRadii], double x2b[][nRadii], double y2b[][nRadii], double x3a[][nRadii], double y3a[][nRadii], double x3b[][nRadii], double y3b[][nRadii], double padfrac, double str_width[][nRadii], double widthmod[], int nGoodStripes[],  int keepUntil[], int nStripesIn[], int nStripesBefore[]) {
+  const double phi_module = TMath::Pi()/6.0; // angle span of a module
+  const int pr_mult = 3; // multiples of intrinsic resolution of pads
+  const int dw_mult = 8; // multiples of diffusion width
+  const double diffwidth = 0.6 * mm; // diffusion width
+  const double adjust = 0.015; //arbitrary angle to center the pattern in a petal
+
+  double theta = 0.0;
+  //center coords
+  double cx[nStripes][nRadii], cy[nStripes][nRadii];
+  //corner coords
+  /* double tempX1a[nStripes][nRadii], tempY1a[nStripes][nRadii];
+  double tempX1b[nStripes][nRadii], tempY1b[nStripes][nRadii];
+  double tempX2a[nStripes][nRadii], tempY2a[nStripes][nRadii];
+  double tempX2b[nStripes][nRadii], tempY2b[nStripes][nRadii];
+  double rotatedX1a[nStripes][nRadii], rotatedY1a[nStripes][nRadii];
+  double rotatedX1b[nStripes][nRadii], rotatedY1b[nStripes][nRadii];
+  double rotatedX2a[nStripes][nRadii], rotatedY2a[nStripes][nRadii];
+  double rotatedX2b[nStripes][nRadii], rotatedY2b[nStripes][nRadii]; */
+
+  //calculate spacing first:
+  for (int i=0; i<nRadii; i++){
+    spacing[i] = 2.0*((dw_mult*diffwidth/R[i]) + (pr_mult*phi_module/nPads));
+  }
+  
+  //vertex calculation
+  for (int j=0; j<nRadii; j++){
+    int i_out = 0;
+    for (int i=keepThisAndAfter[j]; i<keepUntil[j]; i++){
+      if (j % 2 == 0){
+	theta = i*spacing[j] + (spacing[j]/2) - adjust;
+	cx[i_out][j] = R[j]*cos(theta);
+	cy[i_out][j] = R[j]*sin(theta);
+      } else {
+	theta = (i+1)*spacing[j] - adjust;
+	cx[i_out][j] = R[j]*cos(theta);
+	cy[i_out][j] = R[j]*sin(theta);
+      }
+
+      TVector3 corner[4];
+      corner[0].SetXYZ(-padfrac+arc_r,-(widthmod[j]*str_width[i][j])/2,0);//"1a" = length of the pad, but not including the arc piece
+      corner[1].SetXYZ(padfrac-arc_r,-(widthmod[j]*str_width[i][j])/2,0);//"1b" = length of the pad, but not including the arc piece
+      corner[2].SetXYZ(-padfrac+arc_r,(widthmod[j]*str_width[i][j])/2,0);//"2a" = length of the pad, but not including the arc piece
+      corner[3].SetXYZ(padfrac-arc_r,(widthmod[j]*str_width[i][j])/2,0);//"2b" = length of the pad, but not including the arc piece
+     
+      TVector3 rotatedcorner[4];
+      for (int i=0;i<4;i++){
+	rotatedcorner[i]=corner[i];
+	rotatedcorner[i].RotateZ(theta);
+      }
+
+      x1a[i_out][j]=rotatedcorner[0].X()+cx[i_out][j];
+      x1b[i_out][j]=rotatedcorner[1].X()+cx[i_out][j];
+      x2a[i_out][j]=rotatedcorner[2].X()+cx[i_out][j];
+      x2b[i_out][j]=rotatedcorner[3].X()+cx[i_out][j];
+
+      y1a[i_out][j]=rotatedcorner[0].Y()+cy[i_out][j];
+      y1b[i_out][j]=rotatedcorner[1].Y()+cy[i_out][j];
+      y2a[i_out][j]=rotatedcorner[2].Y()+cy[i_out][j];
+      y2b[i_out][j]=rotatedcorner[3].Y()+cy[i_out][j];
+
+      /* x1a[i_out][j] = cx[i_out][j] - padfrac + arc_r;
+      y1a[i_out][j] = cy[i_out][j] - str_width/2;
+      x1b[i_out][j] = cx[i_out][j] + padfrac - arc_r;
+      y1b[i_out][j] = cy[i_out][j] - str_width/2;
+      x2a[i_out][j] = cx[i_out][j] - padfrac + arc_r;
+      y2a[i_out][j] = cy[i_out][j] + str_width/2;
+      x2b[i_out][j] = cx[i_out][j] + padfrac - arc_r;
+      y2b[i_out][j] = cy[i_out][j] + str_width/2;
+      
+      tempX1a[i_out][j] = x1a[i_out][j] - cx[i_out][j];
+      tempY1a[i_out][j] = y1a[i_out][j] - cy[i_out][j];
+      tempX1b[i_out][j] = x1b[i_out][j] - cx[i_out][j];
+      tempY1b[i_out][j] = y1b[i_out][j] - cy[i_out][j];
+      tempX2a[i_out][j] = x2a[i_out][j] - cx[i_out][j];
+      tempY2a[i_out][j] = y2a[i_out][j] - cy[i_out][j];
+      tempX2b[i_out][j] = x2b[i_out][j] - cx[i_out][j];
+      tempY2b[i_out][j] = y2b[i_out][j] - cy[i_out][j];
+
+      rotatedX1a[i_out][j] = tempX1a[i_out][j]*cos(theta) - tempY1a[i_out][j]*sin(theta);
+      rotatedY1a[i_out][j] = tempX1a[i_out][j]*sin(theta) + tempY1a[i_out][j]*cos(theta);
+      rotatedX1b[i_out][j] = tempX1b[i_out][j]*cos(theta) - tempY1b[i_out][j]*sin(theta);
+      rotatedY1b[i_out][j] = tempX1b[i_out][j]*sin(theta) + tempY1b[i_out][j]*cos(theta);
+      rotatedX2a[i_out][j] = tempX2a[i_out][j]*cos(theta) - tempY2a[i_out][j]*sin(theta);
+      rotatedY2a[i_out][j] = tempX2a[i_out][j]*sin(theta) + tempY2a[i_out][j]*cos(theta);
+      rotatedX2b[i_out][j] = tempX2b[i_out][j]*cos(theta) - tempY2b[i_out][j]*sin(theta);
+      rotatedY2b[i_out][j] = tempX2b[i_out][j]*sin(theta) + tempY2b[i_out][j]*cos(theta);*/
+
+      /* x1a[i_out][j] = rotatedX1a[i_out][j] + cx[i_out][j];
+      y1a[i_out][j] = rotatedY1a[i_out][j] + cy[i_out][j];
+      x1b[i_out][j] = rotatedX1b[i_out][j] + cx[i_out][j];
+      y1b[i_out][j] = rotatedY1b[i_out][j] + cy[i_out][j];
+      x2a[i_out][j] = rotatedX2a[i_out][j] + cx[i_out][j];
+      y2a[i_out][j] = rotatedY2a[i_out][j] + cy[i_out][j];
+      x2b[i_out][j] = rotatedX2b[i_out][j] + cx[i_out][j];
+      y2b[i_out][j] = rotatedY2b[i_out][j] + cy[i_out][j]; */
+
+      x3a[i_out][j] = (x1a[i_out][j] +  x2a[i_out][j])/ 2.0;
+      y3a[i_out][j] = (y1a[i_out][j] +  y2a[i_out][j])/ 2.0;
+      x3b[i_out][j] = (x1b[i_out][j] +  x2b[i_out][j])/ 2.0;
+      y3b[i_out][j] = (y1b[i_out][j] +  y2b[i_out][j])/ 2.0;
+
+      i_out++;
+
+      nStripesBefore_R1_e[0] = 0;
+
+      nStripesIn[j] = keepUntil[j] - keepThisAndAfter[j];
+      
+      nStripesBefore[j] = nStripesIn[j-1] + nStripesBefore[j-1];
+      nStripesBefore_R1_e[0] = 0;
+    }
+    nGoodStripes[j]=i_out;
+  }
+}
+
+PHG4Hitv1* PHG4TpcCentralMembrane::GetBotVerticesFromStripe(int moduleID, int radiusID, int stripeID){
+  PHG4Hitv1 *botvert;
+  TVector3 dummyPos0, dummyPos1;
+    
+  //0 - left, 1 - right
+  
+  botvert = new PHG4Hitv1();
+  botvert->set_layer(-2);
+  if (moduleID == 0){
+    botvert->set_x(0, x1a_R1_e[stripeID][radiusID]);
+    botvert->set_y(0, y1a_R1_e[stripeID][radiusID]);
+    botvert->set_x(1, x1b_R1_e[stripeID][radiusID]);
+    botvert->set_y(1, y1b_R1_e[stripeID][radiusID]);
+    
+  } else if (moduleID == 1){
+    botvert->set_x(0, x1a_R1[stripeID][radiusID]);
+    botvert->set_y(0, y1a_R1[stripeID][radiusID]);
+    botvert->set_x(1, x1b_R1[stripeID][radiusID]);
+    botvert->set_y(1, y1b_R1[stripeID][radiusID]);
+    
+  } else if (moduleID == 2){
+    botvert->set_x(0, x1a_R2[stripeID][radiusID]);
+    botvert->set_y(0, y1a_R2[stripeID][radiusID]);
+    botvert->set_x(1, x1b_R2[stripeID][radiusID]);
+    botvert->set_y(1, y1b_R2[stripeID][radiusID]);
+    
+  } else if (moduleID == 3){
+    botvert->set_x(0, x1a_R3[stripeID][radiusID]);
+    botvert->set_y(0, y1a_R3[stripeID][radiusID]);
+    botvert->set_x(1, x1b_R3[stripeID][radiusID]);
+    botvert->set_y(1, y1b_R3[stripeID][radiusID]);
+  }
+  botvert->set_z(0, 0.0);
+  
+ 
+  return botvert;
+}
+
+PHG4Hitv1* PHG4TpcCentralMembrane::GetTopVerticesFromStripe(int moduleID, int radiusID, int stripeID){
+  PHG4Hitv1 *topvert;
+  TVector3 dummyPos0, dummyPos1;
+    
+  //0 - left, 1 - right
+  
+  topvert = new PHG4Hitv1();
+  topvert->set_layer(-3);
+  if (moduleID == 0){
+    topvert->set_x(0, x2a_R1_e[stripeID][radiusID]);
+    topvert->set_y(0, y2a_R1_e[stripeID][radiusID]);
+    topvert->set_x(1, x2b_R1_e[stripeID][radiusID]);
+    topvert->set_y(1, y2b_R1_e[stripeID][radiusID]);
+    
+  } else if (moduleID == 1){
+    topvert->set_x(0, x2a_R1[stripeID][radiusID]);
+    topvert->set_y(0, y2a_R1[stripeID][radiusID]);
+    topvert->set_x(1, x2b_R1[stripeID][radiusID]);
+    topvert->set_y(1, y2b_R1[stripeID][radiusID]);
+    
+  } else if (moduleID == 2){
+    topvert->set_x(0, x2a_R2[stripeID][radiusID]);
+    topvert->set_y(0, y2a_R2[stripeID][radiusID]);
+    topvert->set_x(1, x2b_R2[stripeID][radiusID]);
+    topvert->set_y(1, y2b_R2[stripeID][radiusID]);
+    
+  } else if (moduleID == 3){
+    topvert->set_x(0, x2a_R3[stripeID][radiusID]);
+    topvert->set_y(0, y2a_R3[stripeID][radiusID]);
+    topvert->set_x(1, x2b_R3[stripeID][radiusID]);
+    topvert->set_y(1, y2b_R3[stripeID][radiusID]);
+  }
+  topvert->set_z(0, 0.0);
+  
+ 
+    return topvert;
+}
+
+int PHG4TpcCentralMembrane::SearchModule(int nStripes, double x1a[][nRadii], double x1b[][nRadii], double x2a[][nRadii], double x2b[][nRadii], double y1a[][nRadii], double y1b[][nRadii], double y2a[][nRadii], double y2b[][nRadii], double x3a[][nRadii], double y3a[][nRadii], double x3b[][nRadii], double y3b[][nRadii], double x, double y, int nGoodStripes[]){
+  int c = 0;
+  
+  for(int j=0; j<nRadii; j++){
+    for (int i=0; i<nGoodStripes[j]; i++){
+      if( ((y1a[i][j]>y) != (y2a[i][j]>y) && (x<(x2a[i][j]-x1a[i][j])*(y-y1a[i][j])/(y2a[i][j]-y1a[i][j])+x1a[i][j])))
+	c = !c;
+      if( ((y1b[i][j]>y) != (y1a[i][j]>y) && (x<(x1a[i][j]-x1b[i][j])*(y-y1b[i][j])/(y1a[i][j]-y1b[i][j])+x1b[i][j])))
+	c = !c;
+      if( ((y2b[i][j]>y) != (y1b[i][j]>y) && (x<(x1b[i][j]-x2b[i][j])*(y-y2b[i][j])/(y1b[i][j]-y2b[i][j])+x2b[i][j])))
+	c = !c;
+      if( ((y2a[i][j]>y) != (y2b[i][j]>y) && (x<(x2b[i][j]-x2a[i][j])*(y-y2a[i][j])/(y2b[i][j]-y2a[i][j])+x2a[i][j])))
+	c = !c;
+      
+      //check inside arcs
+      if (c==0){
+	if (((x - x3a[i][j])*(x-x3a[i][j]) + (y-y3a[i][j])*(y-y3a[i][j])) <= arc_r*arc_r){
+	  c =!c;
+	} else if (((x - x3b[i][j])*(x-x3b[i][j]) + (y-y3b[i][j])*(y-y3b[i][j])) <= arc_r*arc_r){
+	  c =!c;
+	}
+      }
+    }
+  }
+  return c;
+}
+
+int PHG4TpcCentralMembrane::getSearchResult(double xcheck, double ycheck){
+  const double phi_petal = TMath::Pi()/9.0; // angle span of one petal
+  const double end_R1_e = 312.0 * mm; // arbitrary radius between R1_e and R1
+  const double end_R1 = 408.0 * mm; // arbitrary radius between R1 and R2
+  const double end_R2 = 580.0 * mm; // arbitrary radius between R2 and R3
+
+  double r, phi, phimod, xmod, ymod;
+  
+  r = sqrt(xcheck*xcheck + ycheck*ycheck);
+  phi = atan(ycheck/xcheck);
+  if((xcheck < 0.0) && (ycheck > 0.0)){
+    phi = phi + TMath::Pi();
+  } else if ((xcheck > 0.0) && (ycheck < 0.0)){
+    phi = phi + 2.0*TMath::Pi();
+  }
+  
+  phimod = fmod(phi,phi_petal);
+  xmod = r*cos(phimod);
+  ymod = r*sin(phimod); 
+  
+  if (r <= end_R1_e){ 
+    result = SearchModule(nStripes_R1, x1a_R1_e, x1b_R1_e, x2a_R1_e, x2b_R1_e, y1a_R1_e, y1b_R1_e, y2a_R1_e, y2b_R1_e, x3a_R1_e, y3a_R1_e, x3b_R1_e, y3b_R1_e, xmod, ymod, nGoodStripes_R1_e);
+  } else if ((r > end_R1_e) && (r <= end_R1)){
+    result = SearchModule(nStripes_R1, x1a_R1, x1b_R1, x2a_R1, x2b_R1, y1a_R1, y1b_R1, y2a_R1, y2b_R1, x3a_R1, y3a_R1, x3b_R1, y3b_R1, xmod, ymod, nGoodStripes_R1);
+  } else if ((r > end_R1) && (r <= end_R2)){
+    result = SearchModule(nStripes_R2, x1a_R2, x1b_R2, x2a_R2, x2b_R2, y1a_R2, y1b_R2, y2a_R2, y2b_R2, x3a_R2, y3a_R2, x3b_R2, y3b_R2, xmod, ymod, nGoodStripes_R2);
+  } else if ((r > end_R2) && (r <= end_CM)){
+    result = SearchModule(nStripes_R3, x1a_R3, x1b_R3, x2a_R3, x2b_R3, y1a_R3, y1b_R3, y2a_R3, y2b_R3, x3a_R3, y3a_R3, x3b_R3, y3b_R3, xmod, ymod, nGoodStripes_R3);
+  }
+  
+  return result;
+}
+
+PHG4Hitv1* PHG4TpcCentralMembrane::GetPHG4HitFromStripe(int petalID, int moduleID, int radiusID, int stripeID, int nElectrons)
+{ //this function generates a PHG4 hit using coordinates from a stripe
+  const double phi_petal = TMath::Pi()/9.0; // angle span of one petal
+  PHG4Hitv1 *hit;
+  TVector3 dummyPos0, dummyPos1;
+  
+  //could put in some sanity checks here but probably not necessary since this is only really used within the class
+  //petalID ranges 0-17, module ID 0-3, stripeID varies - nGoodStripes for each module
+  //radiusID ranges 0-7
+
+  //from phg4tpcsteppingaction.cc
+  hit = new PHG4Hitv1();
+  hit->set_layer(-1); // dummy number 
+  //here we set the entrance values in cm
+  if (moduleID == 0){
+    hit->set_x(0, x3a_R1_e[stripeID][radiusID] / cm);
+    hit->set_y(0, y3a_R1_e[stripeID][radiusID] / cm);
+  } else if (moduleID == 1){
+    hit->set_x(0, x3a_R1[stripeID][radiusID] / cm);
+    hit->set_y(0, y3a_R1[stripeID][radiusID] / cm);
+  } else if (moduleID == 2){
+    hit->set_x(0, x3a_R2[stripeID][radiusID] / cm);
+    hit->set_y(0, y3a_R2[stripeID][radiusID] / cm);
+  } else if (moduleID == 3){
+    hit->set_x(0, x3a_R3[stripeID][radiusID] / cm);
+    hit->set_y(0, y3a_R3[stripeID][radiusID] / cm);
+  }
+  hit->set_z(0, 0.0 / cm);
+
+  // check if you need to rotate coords to another petal
+  if(petalID > 0){
+    dummyPos0.SetXYZ(hit->get_x(0), hit->get_y(0), hit->get_z(0));
+    dummyPos0.RotateZ(petalID * phi_petal);
+    hit->set_x(0, dummyPos0.X());
+    hit->set_y(0, dummyPos0.Y());
+  }
+  
+  // momentum
+  hit->set_px(0, 0.0); // GeV
+  hit->set_py(0, 0.0);
+  hit->set_pz(0, 0.0);
+  
+  // time in ns
+  hit->set_t(0, 0.0); // nanosecond
+  //set and save the track ID
+  hit->set_trkid(-1); // dummy number
+
+  // here we just update the exit values, it will be overwritten
+  // for every step until we leave the volume or the particle
+  // ceases to exist
+  if (moduleID == 0){
+    hit->set_x(1, x3b_R1_e[stripeID][radiusID] / cm);
+    hit->set_y(1, y3b_R1_e[stripeID][radiusID] / cm);
+  } else if (moduleID == 1){
+    hit->set_x(1, x3b_R1[stripeID][radiusID] / cm);
+    hit->set_y(1, y3b_R1[stripeID][radiusID] / cm);
+  } else if (moduleID == 2){
+    hit->set_x(1, x3b_R2[stripeID][radiusID] / cm);
+    hit->set_y(1, y3b_R2[stripeID][radiusID] / cm);
+  } else if (moduleID == 3){
+    hit->set_x(1, x3b_R3[stripeID][radiusID] / cm);
+    hit->set_y(1, y3b_R3[stripeID][radiusID] / cm);
+  }
+  hit->set_z(1, 0.0 / cm);
+
+  // check if you need to rotate coords to another petal
+  if(petalID > 0){
+    dummyPos1.SetXYZ(hit->get_x(1), hit->get_y(1), hit->get_z(1));
+    dummyPos1.RotateZ(petalID * phi_petal);
+    hit->set_x(1, dummyPos1.X());
+    hit->set_y(1, dummyPos1.Y());
+  }
+  
+  hit->set_px(1, 500.0); // dummy large number, in GeV
+  hit->set_py(1, 500.0);
+  hit->set_pz(1, 500.0);
+  
+  hit->set_t(1, 1.0); // dummy number, nanosecond
+
+  //calculate the total energy deposited
+  
+  double Ne_dEdx = 1.56;   // keV/cm
+  double CF4_dEdx = 7.00;  // keV/cm
+
+  //double Ne_NTotal = 43;    // Number/cm
+  //double CF4_NTotal = 100;  // Number/cm
+  //double Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+
+  double Tpc_NTot = nElectrons;
+  double Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+
+  //double Tpc_ElectronsPerKeV = Tpc_NTot / Tpc_dEdx;
+  //double Tpc_ElectronsPerGeV = Tpc_NTot / Tpc_dEdx*1e6; //electrons per gev.
+
+  double edep = Tpc_dEdx*1e6 / Tpc_NTot; // GeV dep per electron
+  hit->set_edep(edep); // dont need get edep
+  //calculate eion - make same as edep
+  hit->set_eion(edep);// dont need get eion
+
+  /*
+  if (hit->get_edep()){ //print out hits
+    double rin = sqrt(hit->get_x(0) * hit->get_x(0) + hit->get_y(0) * hit->get_y(0));
+    double rout = sqrt(hit->get_x(1) * hit->get_x(1) + hit->get_y(1) * hit->get_y(1));
+    cout << "Added Tpc g4hit with rin, rout = " << rin << "  " << rout
+	 << " g4hitid " << hit->get_hit_id() << endl;
+    cout << " xin " << hit->get_x(0)
+	 << " yin " << hit->get_y(0)
+	 << " zin " << hit->get_z(0)
+	 << " rin " << rin
+	 << endl;
+    cout << " xout " << hit->get_x(1)
+	 << " yout " << hit->get_y(1)
+	 << " zout " << hit->get_z(1)
+	 << " rout " << rout
+	 << endl;
+    cout << " xav " << (hit->get_x(1) + hit->get_x(0)) / 2.0
+	 << " yav " << (hit->get_y(1) + hit->get_y(0)) / 2.0
+	 << " zav " << (hit->get_z(1) + hit->get_z(0)) / 2.0
+	 << " rav " << (rout + rin) / 2.0
+	 << endl;
+  }
+  */
+  
+  return hit;
+}
+
+int PHG4TpcCentralMembrane::getStripeID(double xcheck, double ycheck){
+  //check if point came from stripe then see which stripe it is
+  //213 stripes in a petal, 18 petals, ntotstripes = 3834
+  int result, rID, petalID;
+  int phiID = 0;
+  int fullID = -1;
+  //double theta, spacing[nRadii], angle, m, dist;
+  double m, dist;
+  //const double adjust = 0.015; //arbitrary angle to center the pattern in a petal
+  const double phi_petal = TMath::Pi()/9.0; // angle span of one petal
+
+  double r, phi, phimod, xmod, ymod;
+
+  // check if in a stripe
+  result = getSearchResult(xcheck, ycheck);
+  
+  // find which stripe
+  if(result == 1){
+    //cout << "on a stripe" << endl;
+    //convert coords to radius n angle
+    r = sqrt(xcheck*xcheck + ycheck*ycheck);
+    phi = atan(ycheck/xcheck);
+    if((xcheck < 0.0) && (ycheck > 0.0)){
+      phi = phi + TMath::Pi();
+    } else if ((xcheck > 0.0) && (ycheck < 0.0)){
+      phi = phi + 2.0*TMath::Pi();
+    }
+    //get angle within first petal
+    phimod = fmod(phi,phi_petal);
+    xmod = r*cos(phimod);
+    ymod = r*sin(phimod);
+
+    petalID = phi/phi_petal; 
+    
+    for(int j=0; j<nRadii; j++){
+      if(((R1_e[j] - padfrac_R1) < r) && (r < (R1_e[j] + padfrac_R1))){ // check if radius is in stripe 
+	rID = j; 
+	cout << "rID: " << rID << endl;
+	//'angle' is to the center of a stripe
+	for (int i=0; i<nGoodStripes_R1_e[j]; i++){
+	  //if (j % 2 == 0){
+	  //theta = i*spacing[j];
+	  //angle = theta + (spacing[j]/2) - adjust;
+	  // look at distance from center line of stripe
+	  // if distance from x,y to center line < str_width
+	  // calculate slope n then do dist
+	  
+	  m = (y3b_R1_e[i][j] - y3a_R1_e[i][j])/(x3b_R1_e[i][j] - x3a_R1_e[i][j]);
+	  /*cout << "y2: " << y3b_R1_e[i][j] << endl;
+	  cout << "y1: " << y3a_R1_e[i][j] << endl;
+	  cout << "x2: " << x3b_R1_e[i][j] << endl;
+	  cout << "x1: " << x3a_R1_e[i][j] << endl;
+	  cout << "xc: " << xcheck << endl;
+	  cout << "yc: " << ycheck << endl;
+	  cout << "m: " << m << endl;  */
+	  //cout << fabs((-m)*xcheck + ycheck) << endl;
+	  dist = fabs((-m)*xmod + ymod)/sqrt(1 + m*m);
+	  //cout << "dist:" << dist << endl;
+       	  if(dist < ((widthmod_R1_e[j]*str_width_R1_e[i][j])/2.0)){ 
+	    phiID = i;
+	    //cout << "phiID: " << phiID << endl;
+	  }
+	}
+
+	cout << "nStripesBefore: " << nStripesBefore_R1_e[j] << endl;
+	fullID = petalID*nStripesPerPetal + nStripesBefore_R1_e[j] + phiID;
+	//cout << "fullID: " << fullID << endl;
+      } else if (((R1[j]- padfrac_R1) < r) && (r < (R1[j]+ padfrac_R1))){
+	rID = j+nRadii;
+	//cout << "R1" << endl;
+	for (int i=0; i<nGoodStripes_R1[j]; i++){
+	  // look at distance from center line of stripe
+	  m = (y3b_R1[i][j] - y3a_R1[i][j])/(x3b_R1[i][j] - x3a_R1[i][j]);
+	  dist = fabs(m*xmod - ymod)/sqrt(1 + m*m);
+	  if(dist < ((widthmod_R1[j]*str_width_R1[i][j])/2.0)){ 
+	    phiID = i;
+	  }
+	}
+	
+	fullID = petalID*nStripesPerPetal + nStripesBefore_R1[j] + phiID;
+	
+      } else if (((R2[j]- padfrac_R2) < r) && (r < (R2[j]+ padfrac_R2))){
+	rID = j+(2*nRadii);
+	//cout << "R2" << endl;
+	for (int i=0; i<nGoodStripes_R2[j]; i++){
+	  // look at distance from center line of stripe
+	  m = (y3b_R2[i][j] - y3a_R2[i][j])/(x3b_R2[i][j] - x3a_R2[i][j]);
+	  dist = fabs(m*xmod - ymod)/sqrt(1 + m*m);
+	  if(dist < ((widthmod_R2[j]*str_width_R2[i][j])/2.0)){ 
+	    phiID = i;
+	  }
+	}	  
+	
+       	fullID = petalID*nStripesPerPetal + nStripesBefore_R2[j] + phiID;
+	
+      } else if (((R3[j]- padfrac_R3) < r) && (r < (R3[j]+ padfrac_R3))){
+	rID = j+(3*nRadii);
+	//cout << "R3" << endl;
+	for (int i=0; i<nGoodStripes_R3[j]; i++){
+	  // look at distance from center line of stripe
+	  m = (y3b_R3[i][j] - y3a_R3[i][j])/(x3b_R3[i][j] - x3a_R3[i][j]);
+	  dist = fabs(m*xmod - ymod)/sqrt(1 + m*m);
+	  if(dist < ((widthmod_R3[j]*str_width_R3[i][j])/2.0)){ 
+	    phiID = i;
+	  }
+	}
+	
+	fullID = petalID*nStripesPerPetal + nStripesBefore_R3[j] + phiID;
+      } 
+    }
+  } else {
+    fullID = -1;
+  }
+  
+  return fullID;
+      
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
@@ -1,0 +1,142 @@
+#ifndef PHG4TPCCENTRALMEMBRANE_H
+#define PHG4TPCCENTRALMEMBRANE_H
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include "TMath.h"
+#include "TVector3.h"
+
+//from phg4tpcsteppingaction.cc
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
+//R__LOAD_LIBRARY(libphg4hit.so)
+
+
+// all distances in mm, all angles in rad
+// class that generates stripes and dummy hit coordinates
+// stripes have width of one mm, length of one pad width, and are centered in middle of sector gaps
+
+using namespace std;
+
+class PHG4TpcCentralMembrane {
+public:
+  PHG4TpcCentralMembrane(); //default constructor
+  int getSearchResult(double xcheck, double ycheck); // check if coords are in a stripe
+  int getStripeID(double xcheck, double ycheck);
+ 
+  int fullID;
+  double begin_CM, end_CM; // inner and outer radii of central membrane
+  
+  vector<PHG4Hitv1*> PHG4Hits;
+  vector<PHG4Hitv1*> BotVertices;
+  vector<PHG4Hitv1*> TopVertices;
+  
+private:
+  static const int nRadii = 8;
+  static const int nStripes_R1 = 6;
+  static const int nStripes_R2 = 8;
+  static const int nStripes_R3 = 12;
+
+  const double mm = 1.0;
+  const double cm = 10.0;
+  
+  int nPads_R1;
+  int nPads_R2;
+  int nPads_R3;
+  
+  double padfrac_R1;
+  double padfrac_R2;
+  double padfrac_R3;
+  //double str_width; // width of a stripe
+  double arc_r; // radius of arc on end of a stripe
+  double R1_e[nRadii], R1[nRadii], R2[nRadii], R3[nRadii];
+  
+  double str_width_R1_e[nStripes_R1][nRadii];
+  double str_width_R1[nStripes_R1][nRadii];
+  double str_width_R2[nStripes_R2][nRadii];
+  double str_width_R3[nStripes_R3][nRadii];
+  double widthmod_R1_e[nRadii];
+  double widthmod_R1[nRadii];
+  double widthmod_R2[nRadii];
+  double widthmod_R3[nRadii];
+ 
+  double spacing_R1_e[nRadii], spacing_R1[nRadii], spacing_R2[nRadii], spacing_R3[nRadii];
+  
+  //bottom left - 1a
+  double x1a_R1_e[nStripes_R1][nRadii], y1a_R1_e[nStripes_R1][nRadii];
+  double x1a_R1[nStripes_R1][nRadii], y1a_R1[nStripes_R1][nRadii];
+  double x1a_R2[nStripes_R2][nRadii], y1a_R2[nStripes_R2][nRadii];
+  double x1a_R3[nStripes_R3][nRadii], y1a_R3[nStripes_R3][nRadii];
+  
+  //bottom right - 1b
+  double x1b_R1_e[nStripes_R1][nRadii], y1b_R1_e[nStripes_R1][nRadii];
+  double x1b_R1[nStripes_R1][nRadii], y1b_R1[nStripes_R1][nRadii];
+  double x1b_R2[nStripes_R2][nRadii], y1b_R2[nStripes_R2][nRadii];
+  double x1b_R3[nStripes_R3][nRadii], y1b_R3[nStripes_R3][nRadii];
+  
+  //top left - 2a
+  double x2a_R1_e[nStripes_R1][nRadii], y2a_R1_e[nStripes_R1][nRadii];
+  double x2a_R1[nStripes_R1][nRadii], y2a_R1[nStripes_R1][nRadii];
+  double x2a_R2[nStripes_R2][nRadii], y2a_R2[nStripes_R2][nRadii];
+  double x2a_R3[nStripes_R3][nRadii], y2a_R3[nStripes_R3][nRadii];
+  
+  //top right - 2b
+  double x2b_R1_e[nStripes_R1][nRadii], y2b_R1_e[nStripes_R1][nRadii];
+  double x2b_R1[nStripes_R1][nRadii], y2b_R1[nStripes_R1][nRadii];
+  double x2b_R2[nStripes_R2][nRadii], y2b_R2[nStripes_R2][nRadii];
+  double x2b_R3[nStripes_R3][nRadii], y2b_R3[nStripes_R3][nRadii];
+  
+  //left midpoint - 3a
+  double x3a_R1_e[nStripes_R1][nRadii], y3a_R1_e[nStripes_R1][nRadii];
+  double x3a_R1[nStripes_R1][nRadii], y3a_R1[nStripes_R1][nRadii];
+  double x3a_R2[nStripes_R2][nRadii], y3a_R2[nStripes_R2][nRadii];
+  double x3a_R3[nStripes_R3][nRadii], y3a_R3[nStripes_R3][nRadii];
+  
+  //right midpoint - 3b
+  double x3b_R1_e[nStripes_R1][nRadii], y3b_R1_e[nStripes_R1][nRadii];
+  double x3b_R1[nStripes_R1][nRadii], y3b_R1[nStripes_R1][nRadii];
+  double x3b_R2[nStripes_R2][nRadii], y3b_R2[nStripes_R2][nRadii];
+  double x3b_R3[nStripes_R3][nRadii], y3b_R3[nStripes_R3][nRadii];
+  
+  //Check which stripes get removed
+  int nGoodStripes_R1_e[nRadii];
+  int nGoodStripes_R1[nRadii];
+  int nGoodStripes_R2[nRadii];
+  int nGoodStripes_R3[nRadii];
+  int keepThisAndAfter[nRadii]; //min stripe index
+  int keepUntil_R1_e[nRadii]; //max stripe index
+  int keepUntil_R1[nRadii];
+  int keepUntil_R2[nRadii];
+  int keepUntil_R3[nRadii];
+  int nStripesIn_R1_e[nRadii];
+  int nStripesIn_R1[nRadii];
+  int nStripesIn_R2[nRadii];
+  int nStripesIn_R3[nRadii];
+  int nStripesBefore_R1_e[nRadii];
+  int nStripesBefore_R1[nRadii];
+  int nStripesBefore_R2[nRadii];
+  int nStripesBefore_R3[nRadii];
+  int result;
+
+  double botvert, topvert;
+  
+  int nStripesPerPetal;
+  int nPetals;
+  int nTotStripes;
+  int stripeID;
+  
+  int nElectrons;
+  
+  void CalculateVertices(int nStripes, int nPads, double R[], double spacing[], double x1a[][nRadii], double y1a[][nRadii], double x1b[][nRadii], double y1b[][nRadii], double x2a[][nRadii], double y2a[][nRadii], double x2b[][nRadii], double y2b[][nRadii], double x3a[][nRadii], double y3a[][nRadii], double x3b[][nRadii], double y3b[][nRadii], double padfrac, double str_width[][nRadii], double widthmod[], int nGoodStripes[], int keepUntil[], int nStripesIn[], int nStripesBefore[]);
+
+  PHG4Hitv1* GetBotVerticesFromStripe(int moduleID, int radiusID, int stripeID);
+  PHG4Hitv1* GetTopVerticesFromStripe(int moduleID, int radiusID, int stripeID);
+  
+  int SearchModule(int nStripes, double x1a[][nRadii], double x1b[][nRadii], double x2a[][nRadii], double x2b[][nRadii], double y1a[][nRadii], double y1b[][nRadii], double y2a[][nRadii], double y2b[][nRadii], double x3a[][nRadii], double y3a[][nRadii], double x3b[][nRadii], double y3b[][nRadii], double x, double y, int nGoodStripes[]);
+  
+  PHG4Hitv1* GetPHG4HitFromStripe(int petalID, int moduleID, int radiusID, int stripeID, int nElectrons);
+};
+
+
+#endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
@@ -118,13 +118,10 @@ private:
   int nStripesBefore_R2[nRadii];
   int nStripesBefore_R3[nRadii];
   int result;
-
-  double botvert, topvert;
   
   int nStripesPerPetal;
   int nPetals;
   int nTotStripes;
-  int stripeID;
   
   int nElectrons;
   

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -23,9 +23,20 @@ using namespace std;
 
 PHG4TpcDirectLaser::PHG4TpcDirectLaser()
 {
-  begin_CM = 20. *cm; // outer radius of IFC
-  end_CM = 78. * cm; // inner radius of OFC
-  halfwidth_CM=0.5*cm;
+  ifc = 20. *cm; // outer radius of IFC
+  ofc = 78. * cm; // inner radius of OFC
+  halfwidth_CM=0.5*cm; //thickness of CM
+
+  double electrons_per_cm=300;
+  //these should be synched to another source
+    double Ne_dEdx = 1.56;   // keV/cm
+  double CF4_dEdx = 7.00;  // keV/cm
+  double Ne_NTotal = 43;    // Number/cm
+  double CF4_NTotal = 100;  // Number/cm
+  double Tpc_NTot = 0.50 * Ne_NTotal + 0.50 * CF4_NTotal;
+  double Tpc_dEdx = 0.50 * Ne_dEdx + 0.50 * CF4_dEdx;
+  double electrons_per_gev = Tpc_dEdx*1e6 / Tpc_NTot; // GeV dep per electron
+  gev_per_electron=1./electrons_per_gev;
 
   for (int i=0;i<4*2;i++){
     //PHG4Hits.push_back(new PHG4Hitv1());//instantiate it
@@ -97,8 +108,8 @@ TVector3 PHG4TpcDirectLaser::GetCmStrike(TVector3 start, TVector3 direction){
   return ret;
 }
 TVector3 PHG4TpcDirectLaser::GetFieldcageStrike(TVector3 start, TVector3 direction){
-  TVector3 ofc_strike=GetCylinderStrike(start,direction,end_CM);
-  TVector3 ifc_strike=GetCylinderStrike(start,direction,begin_CM);
+  TVector3 ofc_strike=GetCylinderStrike(start,direction,ofc);
+  TVector3 ifc_strike=GetCylinderStrike(start,direction,ifc);
   TVector3 no_strike(999,999,999);
 
   //measure which one occurs 'first' along the track, by dividing by the trajectory z.
@@ -242,24 +253,7 @@ void PHG4TpcDirectLaser::AppendLaserTrack(float theta, float phi, int laser)
 
   //calculate the total energy deposited
 
-  //should calc this stuff in advance!
-  double Ne_dEdx = 1.56;   // keV/cm
-  double CF4_dEdx = 7.00;  // keV/cm
-
-  //double Ne_NTotal = 43;    // Number/cm
-  //double CF4_NTotal = 100;  // Number/cm
-  //double Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
-
-  double Tpc_NTot = nElectrons;
-  double Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-
-  //double Tpc_ElectronsPerKeV = Tpc_NTot / Tpc_dEdx;
-  //double Tpc_ElectronsPerGeV = Tpc_NTot / Tpc_dEdx*1e6; //electrons per gev.
-
-  double electrons_per_gev = Tpc_dEdx*1e6 / Tpc_NTot; // GeV dep per electron
-
-  float electrons_per_length=300./cm;//hardcoded
-  float totalE=electrons_per_length*stepLength/electrons_per_gev;//rcc dummy hardcoded 300 electrons per cm!
+  float totalE=electrons_per_cm*stepLength/electrons_per_gev;//rcc dummy hardcoded 300 electrons per cm!
 
   hit->set_eion(totalE);
   hit->set_edep(totalE);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -253,7 +253,7 @@ void PHG4TpcDirectLaser::AppendLaserTrack(float theta, float phi, int laser)
 
   //calculate the total energy deposited
 
-  float totalE=electrons_per_cm*stepLength/electrons_per_gev;//rcc dummy hardcoded 300 electrons per cm!
+  float totalE=electrons_per_cm*stepLength*gev_per_electron;//rcc dummy hardcoded 300 electrons per cm!
 
   hit->set_eion(totalE);
   hit->set_edep(totalE);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -174,11 +174,11 @@ void PHG4TpcDirectLaser::AppendLaserTrack(float theta, float phi, int laser)
   TVector3 cm_strike=GetCmStrike(pos,dir);
   TVector3 fc_strike=GetFieldcageStrike(pos,dir);
   TVector3 strike=cm_strike;
-  char strikeChar='c';
+  //char strikeChar='c';
   if( fc_strike.Z()!=999){
     if ((fc_strike.Z()-pos.Z())/dir.Z()<(cm_strike.Z()-pos.Z())/dir.Z()){
       strike=fc_strike;
-    strikeChar='f';
+      //strikeChar='f';
     }
   }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -27,7 +27,7 @@ PHG4TpcDirectLaser::PHG4TpcDirectLaser()
   ofc = 78. * cm; // inner radius of OFC
   halfwidth_CM=0.5*cm; //thickness of CM
 
-  double electrons_per_cm=300;
+  electrons_per_cm=300;
   //these should be synched to another source
     double Ne_dEdx = 1.56;   // keV/cm
   double CF4_dEdx = 7.00;  // keV/cm

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -1,0 +1,271 @@
+#include "PHG4TpcDirectLaser.h"
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include "TMath.h"
+#include "TVector3.h"
+#include "TH2F.h"
+
+
+//from phg4tpcsteppingaction.cc
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
+//R__LOAD_LIBRARY(libphg4hit.so)
+
+// all distances in mm, all angles in rad
+// class that generates stripes and dummy hit coordinates
+// stripes have width of one mm, length of one pad width, and are centered in middle of sector gaps
+
+using namespace std;
+
+//PHG4TpcDirectLaser::
+
+PHG4TpcDirectLaser::PHG4TpcDirectLaser()
+{
+  begin_CM = 20. *cm; // outer radius of IFC
+  end_CM = 78. * cm; // inner radius of OFC
+  halfwidth_CM=0.5*cm;
+
+  for (int i=0;i<4*2;i++){
+    //PHG4Hits.push_back(new PHG4Hitv1());//instantiate it
+    AppendLaserTrack(TMath::Pi()/180.*10.,TMath::Pi()/180.*90,i); //add random starting laser tracks...
+  }
+  
+  
+ return;
+}
+
+
+void PHG4TpcDirectLaser::SetPhiStepping(int n, float min,float max){
+  if (n<0 || max<min){
+    printf("SetPhiStepping values weird.  not setting.\n");
+    return;
+  }
+  nPhiSteps=n;
+  minPhi=min;
+  maxPhi=max;
+  nTotalSteps=nThetaSteps*nPhiSteps;
+  return;
+}
+void PHG4TpcDirectLaser::SetThetaStepping(int n, float min,float max){
+  if (n<0 || max<min){
+    printf("SetThetaStepping values weird.  not setting.\n");
+    return;
+  }
+  nThetaSteps=n;
+  minTheta=min;
+  maxTheta=max;
+  nTotalSteps=nThetaSteps*nPhiSteps;
+
+  return;
+}
+void PHG4TpcDirectLaser::AimToThetaPhi(float theta, float phi){
+  ClearHits();
+  for (int i=0;i<4*2;i++){
+    AppendLaserTrack(theta,phi,i);
+  }
+return;
+}
+void PHG4TpcDirectLaser::AimToPatternStep(int n){
+  n=n%nTotalSteps;//trim against overflows
+  currentPatternStep=n;
+  int phiStep=n%nThetaSteps;
+  int thetaStep=n/nPhiSteps;
+  AimToThetaPhi((maxTheta-minTheta)/(nThetaSteps*1.)*thetaStep,(maxPhi-minPhi)/(nPhiSteps*1.)*phiStep);
+  return;
+}
+
+void PHG4TpcDirectLaser::ClearHits(){
+  for (int i =0; i< (int)(PHG4Hits.size());i++)
+   {
+     delete (PHG4Hits[i]);
+   } 
+   PHG4Hits.clear();
+   return;
+}
+
+TVector3 PHG4TpcDirectLaser::GetCmStrike(TVector3 start, TVector3 direction){
+  TVector3 ret;
+  float end=halfwidth_CM;
+  if (start.Z()<0) end=-halfwidth_CM;
+  float dist=end-start.Z();
+  float direction_scale=dist/direction.Z();
+  ret=start+direction*direction_scale;
+  
+  
+  return ret;
+}
+TVector3 PHG4TpcDirectLaser::GetFieldcageStrike(TVector3 start, TVector3 direction){
+  TVector3 ofc_strike=GetCylinderStrike(start,direction,end_CM);
+  TVector3 ifc_strike=GetCylinderStrike(start,direction,begin_CM);
+  TVector3 no_strike(999,999,999);
+
+  //measure which one occurs 'first' along the track, by dividing by the trajectory z.
+
+  float ifc_dist=(ifc_strike.Z()-start.Z())/direction.Z();
+  float ofc_dist=(ofc_strike.Z()-start.Z())/direction.Z();
+
+  if (ifc_dist<0){
+    if (ofc_dist>0) return ofc_strike;
+    return no_strike;
+  }
+  //now ifc strike is guaranteed to be positive or zero
+  if (ofc_dist<0){
+    return ifc_strike;
+  }
+  //now they're both positive
+  if (ifc_dist<ofc_dist){
+    return ifc_strike;
+  } else return ofc_strike;
+  
+}
+
+TVector3  PHG4TpcDirectLaser::GetCylinderStrike(TVector3 s, TVector3 v, float radius){
+
+
+  float R2=radius*radius;
+		
+  //Generalized Parameters for collision with cylinder of radius R:
+  //from quadratic formula solutions of when a vector intersects a circle:
+  float a = v.x()*v.x()+v.y()*v.y();
+  float b = 2*(v.x()*s.x()+v.y()*s.y());
+  float c = s.x()*s.x()+s.y()*s.y()-R2;
+
+  float rootterm=b*b-4*a*c;
+
+  //if a==0 then we are parallel and will have no solutions.
+  //if the rootterm is negative, we will have no real roots -- we are outside the cylinder and pointing skew to the cylinder such that we never cross.
+  float t1=-1,t2=-1; //this is the distance, in units of v, we must travel to find a collision
+  if (rootterm >= 0 && a > 0) {
+    //Find the (up to) two points where we collide with the cylinder:
+    float sqrtterm=sqrt(rootterm);
+     t1 = (-b+sqrtterm)/(2*a);
+     t2 = (-b-sqrtterm)/(2*a);
+  }
+
+  //if either of the t's are nonzero, we have a collision.  the collision closest to the start (hence with the smallest t that is greater than zero) is the one that happens.
+  float min_t=t1;
+  if (t2>t1 && t2>0) min_t=t2;
+  TVector3 ret=s+v*min_t;
+  return ret;
+}
+  
+
+void PHG4TpcDirectLaser::AppendLaserTrack(float theta, float phi, int laser)
+{ //this function generates a series of PHG4 hits from the specified laser, in the specified direction.
+  PHG4Hitv1 *hit;
+  float direction=1;
+  if (laser>3) direction=-1;
+  TVector3 pos(60.*cm,0.*cm,105.5*cm*direction);
+  TVector3 dir(0.,0.,-1.*direction);
+
+
+
+  //adjust direction:
+  dir.RotateY(theta*direction);
+  dir.RotateZ(phi*direction);
+
+  //rotate to the correct laser spot:
+  pos.RotateZ(TMath::TwoPi()/4.*laser);
+  dir.RotateZ(TMath::TwoPi()/4.*laser);
+
+  //find collision point
+  TVector3 cm_strike=GetCmStrike(pos,dir);
+  TVector3 fc_strike=GetFieldcageStrike(pos,dir);
+  TVector3 strike=cm_strike;
+  char strikeChar='c';
+  if( fc_strike.Z()!=999){
+    if ((fc_strike.Z()-pos.Z())/dir.Z()<(cm_strike.Z()-pos.Z())/dir.Z()){
+      strike=fc_strike;
+    strikeChar='f';
+    }
+  }
+
+  //find length
+  TVector3 delta=(strike-pos);
+  float fullLength=delta.Mag();
+  int nHitSteps=fullLength/maxHitLength+1;
+
+  TVector3 start=pos;
+  TVector3 end=start;
+  TVector3 step=dir*(maxHitLength/(dir.Mag()));
+  float stepLength=0;
+  for (int i=0;i<nHitSteps;i++){
+    start=end;//new starting point is the previous ending point.
+    if (i+1==nHitSteps){
+      //last step is the remainder size
+      end=strike;
+      delta=start-end;
+      stepLength=delta.Mag();
+    } else {
+      //all other steps are uniform length
+      end=start+step;
+      stepLength=step.Mag();
+    }
+    
+  //now compute the laser hit:
+  //printf("PHG4TpcDirectLaser::Adding New Hit(%1.2f,%1.2f,%d): (%1.2f,%1.2f,%1.2f) to (%1.2f,%1.2f,%1.2f)\n",theta,phi,laser,start.X()/cm,start.Y()/cm,start.Z()/cm,end.X()/cm,end.Y()/cm,end.Z()/cm);
+      if (i+1==nHitSteps){
+	//printf("PHG4TpcDirectLaser::Strike %c\n",strikeChar);
+      }
+
+  //from phg4tpcsteppingaction.cc
+  hit = new PHG4Hitv1();
+  hit->set_layer(99); // dummy number
+  //here we set the entrance values in cm
+  hit->set_x(0, start.X() / cm);
+  hit->set_y(0, start.Y() / cm);
+  hit->set_z(0, start.Z() / cm);
+  //and the exist values
+  hit->set_x(1, end.X() / cm);
+  hit->set_y(1, end.Y() / cm);
+  hit->set_z(1, end.Z() / cm);
+
+
+  // momentum
+  hit->set_px(0, 700.0); // GeV
+  hit->set_py(0, 700.0);
+  hit->set_pz(0, 700.0);
+  
+  // time in ns
+  hit->set_t(0, 0.0); // nanosecond
+  //set and save the track ID
+  hit->set_trkid(-1); // dummy number
+
+  
+  hit->set_px(1, 700.0); // dummy large number, in GeV
+  hit->set_py(1, 700.0);
+  hit->set_pz(1, 700.0);
+  
+  hit->set_t(1, 0.0); // dummy number, nanosecond
+
+  //calculate the total energy deposited
+
+  //should calc this stuff in advance!
+  double Ne_dEdx = 1.56;   // keV/cm
+  double CF4_dEdx = 7.00;  // keV/cm
+
+  //double Ne_NTotal = 43;    // Number/cm
+  //double CF4_NTotal = 100;  // Number/cm
+  //double Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+
+  double Tpc_NTot = nElectrons;
+  double Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+
+  //double Tpc_ElectronsPerKeV = Tpc_NTot / Tpc_dEdx;
+  //double Tpc_ElectronsPerGeV = Tpc_NTot / Tpc_dEdx*1e6; //electrons per gev.
+
+  double electrons_per_gev = Tpc_dEdx*1e6 / Tpc_NTot; // GeV dep per electron
+
+  float electrons_per_length=300./cm;//hardcoded
+  float totalE=electrons_per_length*stepLength/electrons_per_gev;//rcc dummy hardcoded 300 electrons per cm!
+
+  hit->set_eion(totalE);
+  hit->set_edep(totalE);
+
+  PHG4Hits.push_back(hit);
+  }
+  
+  return;
+}

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.h
@@ -1,0 +1,65 @@
+#ifndef PHG4TPCDIRECTLASER_H
+#define PHG4TPCDIRECTLASER_H
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include "TMath.h"
+#include "TVector3.h"
+
+//from phg4tpcsteppingaction.cc
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
+//R__LOAD_LIBRARY(libphg4hit.so)
+
+
+// all distances in mm, all angles in rad
+// class that generates stripes and dummy hit coordinates
+// stripes have width of one mm, length of one pad width, and are centered in middle of sector gaps
+
+using namespace std;
+
+class PHG4TpcDirectLaser {
+public:
+  PHG4TpcDirectLaser(); //default constructor
+
+  double begin_CM, end_CM; // inner and outer radii of field cages/TPC
+  double halfwidth_CM; //half the thickness of the CM;
+  double ifc,ofc;
+  
+  vector<PHG4Hitv1*> PHG4Hits;
+
+  void SetPhiStepping(int n, float min,float max);
+  void SetThetaStepping(int n, float min,float max);
+  int GetNpatternSteps(){return nPhiSteps*nThetaSteps;};
+  void AimToThetaPhi(float theta, float phi);
+  void AimToPatternStep(int n);
+  void AimToNextPatternStep(){if (nTotalSteps>1)AimToPatternStep(currentPatternStep+1);};
+  
+private:
+  static const int nLasers = 4; //per side
+  const double mm = 0.10;
+  const double cm = 1.0;
+  const float maxHitLength=1.0;//1cm.
+
+  int nPhiSteps=1;
+  int nThetaSteps=1;
+  int nTotalSteps=1;
+  int currentPatternStep=0;
+  float minPhi=0;
+  float maxPhi=0;
+  float minTheta=0;
+  float maxTheta=0;
+
+  TVector3 GetCmStrike(TVector3 start, TVector3 direction);
+  TVector3 GetFieldcageStrike(TVector3 start, TVector3 direction);
+  TVector3 GetCylinderStrike(TVector3 s, TVector3 v, float radius);
+  
+  int nElectrons;
+ 
+  void AppendLaserTrack(float theta, float phi, int laser);
+  void ClearHits();
+};
+
+
+#endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.h
@@ -23,9 +23,8 @@ class PHG4TpcDirectLaser {
 public:
   PHG4TpcDirectLaser(); //default constructor
 
-  double begin_CM, end_CM; // inner and outer radii of field cages/TPC
   double halfwidth_CM; //half the thickness of the CM;
-  double ifc,ofc;
+  double ifc,ofc;// inner and outer radii of field cages/TPC
   
   vector<PHG4Hitv1*> PHG4Hits;
 
@@ -38,7 +37,6 @@ public:
   
 private:
   static const int nLasers = 4; //per side
-  const double mm = 0.10;
   const double cm = 1.0;
   const float maxHitLength=1.0;//1cm.
 
@@ -55,7 +53,8 @@ private:
   TVector3 GetFieldcageStrike(TVector3 start, TVector3 direction);
   TVector3 GetCylinderStrike(TVector3 s, TVector3 v, float radius);
   
-  int nElectrons;
+  int electrons_per_cm;
+  float gev_per_electron;
  
   void AppendLaserTrack(float theta, float phi, int laser);
   void ClearHits();

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -236,6 +236,24 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
     deltarnodist = new TH2F("deltarnodist", "Delta r (no SC distortion, only diffusion); r (cm);#Delta r (cm)", 580, 20, 78, 1000, -2, 5);
   }
 
+
+ //add CM hits if requested
+  
+  if (do_addCmHits)
+    {//todo:  put in the real spacing.
+      for (int i=0;i<(int)(membrane->PHG4Hits.size());i++){
+	membrane->PHG4Hits[i]->set_eion(300./electrons_per_gev);//rcc hardcoded 300 electrons per stripe!
+	membrane->PHG4Hits[i]->set_hit_id(1e8+i); //dummy hit id
+	membrane->PHG4Hits[i]->set_t(0,1.*centralMembraneDelay);//real hit delay
+	membrane->PHG4Hits[i]->set_t(1,1.*centralMembraneDelay);//real hit delay.
+	membrane->PHG4Hits[i]->set_z(0,1.);
+	membrane->PHG4Hits[i]->set_z(1,1.);
+	laserHits->AddHit(membrane->PHG4Hits[i]);
+      }
+    }
+
+
+  
   if (Verbosity())
   {
     // eval tree only when verbosity is on
@@ -272,7 +290,47 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     gSystem->Exit(1);
   }
 
+  
   PHG4HitContainer::ConstIterator hiter;
+
+
+ if (do_addCmHits || do_addDirectLaserHits){//add in the laser hit set, if we have it.
+
+    int newkey=g4hit->getmaxkey(g4hit->GetID());
+    //printf("first Laser hitID is %d\n",newkey);
+    //add in the diffuse laser hits, which do not change event to event.
+    PHG4HitContainer::ConstRange laserHit_begin_end=laserHits->getHits();
+    for (hiter = laserHit_begin_end.first; hiter != laserHit_begin_end.second; ++hiter){
+      hiter->second->set_hit_id(newkey);
+      PHG4Hitv1* tempHit=new PHG4Hitv1(hiter->second);
+      g4hit->AddHit(tempHit);
+      newkey++;
+    }
+
+    //handle the directed laser hits, which can, if we are auto-advancing:
+    if ( do_addDirectLaserHits)
+      {
+	if (do_autoAdvanceDirectLaser){
+	  directLaser->AimToNextPatternStep();
+	}
+  	//we link the laser hits from the directLaser into the overall laserHits collection,
+	// note that these are COPIES,of the originals.
+	for (int i=0;i<(int)(directLaser->PHG4Hits.size());i++){
+	  directLaser->PHG4Hits[i]->set_hit_id(newkey); //dummy hit id
+	  PHG4Hitv1* tempHit=new PHG4Hitv1(directLaser->PHG4Hits[i]);
+	  g4hit->AddHit(tempHit);
+	  newkey++;
+	}
+      }
+
+    
+ //printf("last Laser hitID is %d\n",newkey);
+
+  }
+
+
+
+  
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   //std::cout << "g4hits size " << g4hit->size() << std::endl;
   unsigned int count_g4hits = 0;

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -3,6 +3,8 @@
 
 #include "PHG4TpcElectronDrift.h"
 #include "PHG4TpcDistortion.h"
+#include "PHG4TpcCentralMembrane.h"
+#include "PHG4TpcDirectLaser.h"
 #include "PHG4TpcPadPlane.h"  // for PHG4TpcPadPlane
 
 #include <g4main/PHG4Hit.h>

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -76,6 +76,12 @@ PHG4TpcElectronDrift::PHG4TpcElectronDrift(const std::string &name)
   InitializeParameters();
   RandomGenerator.reset(gsl_rng_alloc(gsl_rng_mt19937));
   set_seed(PHRandomSeed());
+
+  membrane=new PHG4TpcCentralMembrane();//eventually make this an external PHG4TpcLaser module that we pass in?
+  directLaser=new PHG4TpcDirectLaser();//eventually make this an external PHG4TpcLaser module that we pass in?
+  laserHits=new PHG4HitContainer();
+  centralMembraneDelay=0;//ns, set nonzero for testing.  -15000<x<100 should fit okay.
+
   return;
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -16,6 +16,8 @@
 
 class PHG4TpcPadPlane;
 class PHG4TpcDistortion;
+class PHG4TpcCentralMembrane;
+class PHG4TpcDirectLaser;
 class PHCompositeNode;
 class TH1;
 class TH2;

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -59,6 +59,16 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   //! setup readout plane
   void registerPadPlane(PHG4TpcPadPlane *padplane);
 
+  //!setup Central Membrane
+   void setCentralMembrane(bool addCMHits){do_addCmHits=addCMHits; return;};
+   void setCentralMembraneDelay(int ns){centralMembraneDelay=ns; return;};
+
+   //! setup Direct Lasers
+   void setDirectLaser(bool x){do_addDirectLaserHits=x; return;};
+   void setDirectLaserAuto(bool x){do_autoAdvanceDirectLaser=x; return;};//make it advance through its pattern automatically
+   PHG4TpcDirectLaser * directLaser=nullptr; //cheap way to expose the direct laser so we can adjust it
+  
+
  private:
   //! map a given x,y,z coordinates to plane hits
   void MapToPadPlane(const double x, const double y, const double z, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit);
@@ -73,6 +83,16 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   int event_num = 0;
   bool do_ElectronDriftQAHistos = false;
 
+
+
+  //laser booleans etc.
+  bool do_addCmHits=false;
+  bool do_addDirectLaserHits=false;
+  bool do_autoAdvanceDirectLaser=false;
+  PHG4TpcCentralMembrane * membrane=nullptr;
+  PHG4HitContainer *laserHits=nullptr; //holds the cm and direct laser hits
+  int centralMembraneDelay=0; //ns
+  
   TH1 *dlong = nullptr;
   TH1 *dtrans = nullptr;
   TH2 *hitmapstart = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR introduces central membrane flashes and steerable directed lasers to the TPC data by generating g4hit sets representing the laser tracks and central membrane stripes and adding these into the g4hit set that is drifted in PHG4TpcElectronDrift.  These features are disabled by default.   A modified G4_TPC.C macro is needed to interact with them properly.  The associated pull request will be generated shortly.


## TODOs (if applicable)

A complete version of this ought to interact with the g4hits independently, rather than adding to the record directly in the drift code.  Methods for controlling the lasers are currently exposed by providing direct access to the pointer owned by the PHG4TpcElectronDrift object. 


## Links to other PRs in macros and calibration repositories (if applicable)

