### PR TITLE
Patched missing null check for EventEvaluator

### DIFF
--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -565,7 +565,10 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           }
 
           auto xsec = truthevent->cross_section();
-          _cross_section = xsec->cross_section();
+          if (xsec)
+          {
+            _cross_section = xsec->cross_section();
+          }
           // Only fill the event weight if available.
           // The overall event weight will be stored in the last entry in the vector.
           auto weights = truthevent->weights();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

In the event evaluator, there was an addition of the cross section as an output branch. This is only available in certain generators such as pythia8. When the object was created it could return a null pointer which would crash Fun4All on the next access. Simple fix:

```c++
          auto xsec = truthevent->cross_section();
          if (xsec)
          {
            _cross_section = xsec->cross_section();
          }
```

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

