### PR TITLE
add scan for primaries

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -81,6 +81,7 @@ SvtxEvaluator::SvtxEvaluator(const string& name, const string& filename, const s
   , _do_track_match(true)
   , _do_eval_light(true)
   , _scan_for_embedded(false)
+  , _scan_for_primaries(false)
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
   , _nlayers_tpc(nlayers_tpc)
@@ -2369,6 +2370,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
     {
 
       PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
+      if(_scan_for_primaries){
+	range = truthinfo->GetPrimaryParticleRange();
+      }
+
       Float_t gntracks = (Float_t) truthinfo->GetNumPrimaryVertexParticles();
       for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
            iter != range.second;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -42,6 +42,7 @@ class SvtxEvaluator : public SubsysReco
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
+  //  void do_primaries(bool b);
 
   void set_strict(bool b) { _strict = b; }
   void set_use_initial_vertex(bool use_init_vtx) {_use_initial_vertex = use_init_vtx;}
@@ -60,6 +61,8 @@ class SvtxEvaluator : public SubsysReco
   void do_track_match(bool b) { _do_track_match = b; }
   void do_eval_light(bool b) { _do_eval_light = b; }
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
+  void scan_for_primaries(bool b) { _scan_for_primaries = b; }
+
 
  private:
   unsigned int _ievent;
@@ -92,6 +95,7 @@ class SvtxEvaluator : public SubsysReco
   bool _do_track_match;
   bool _do_eval_light;
   bool _scan_for_embedded;
+  bool _scan_for_primaries;
 
   unsigned int _nlayers_maps = 3;
   unsigned int _nlayers_intt = 4;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Added switch to turn on and off scanning for only primary particles in the ntp_gtrack ntuple
scan_for_primaries(true) -> output contains only primary particles [default]
scan_for_primaries(false) -> output contains primaries and all secondaries

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

