### PR TITLE
add function to take best intt hits

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -89,7 +89,9 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Output some diagnostic histograms
   void seedAnalysis(bool seedAnalysis)
     { m_seedAnalysis = seedAnalysis; }
-  
+  void cleanSeeds(bool cleanSeeds)
+    { m_cleanSeeds = cleanSeeds;}
+ 
  private:
 
   int getNodes(PHCompositeNode *topNode);
@@ -160,6 +162,9 @@ class PHActsSiliconSeeding : public SubsysReco
 
   Surface getSurface(TrkrDefs::hitsetkey hitsetkey);
 
+  std::map<const unsigned int, std::vector<TrkrCluster*>>
+    identifyBestSeed(std::map<const unsigned int, std::vector<TrkrCluster*>>);
+
   void createHistograms();
   void writeHistograms();
   double normPhi2Pi(const double phi);
@@ -217,6 +222,8 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Whether or not to use truth clusters in hit lookup
   bool m_useTruthClusters = false;
+
+  bool m_cleanSeeds = false;
 
   int m_nBadUpdates = 0;
   int m_nBadInitialFits = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a function to the silicon seeder that takes duplicate seeds, most frequently with different combinations of INTT hits, and selects the best INTT hits to create one silicon track seed. Silicon seeder efficiency stays the same in low occupancy and reduces the number of duplicate tracks. It is turned off by default but can be switched on in the macro (for now).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

