### PR TITLE
Fix cluster cleaner

### DIFF
--- a/offline/packages/tpc/TpcClusterCleaner.cc
+++ b/offline/packages/tpc/TpcClusterCleaner.cc
@@ -89,7 +89,7 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 	
 	if (Verbosity() >= 1)
 	  {
-	  std::cout << " cluster : " << cluskey << " layer " << layer
+	  std::cout << " layer " << layer << " cluster : " << cluskey 
 		    << " position x,y,z " << cluster->getX() << "  " << cluster->getY() << "  " << cluster->getZ()
 		    << " ADC " << cluster->getAdc()
 		    << std::endl;
@@ -109,8 +109,8 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 	
 	// errors too large
 	// associated with very small ADC values
-	if(cluster->getRPhiError() > _rphi_error_high_cut)
-	  discard_cluster = true;
+	//if(cluster->getRPhiError() > _rphi_error_high_cut)
+	//discard_cluster = true;
 	
 	if(discard_cluster)
 	  {
@@ -118,7 +118,7 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 	    // mark it for modification
 	    discard_set.insert(cluskey);
 	    if(Verbosity() > 0) 
-	      std::cout << " found cluster " << cluskey << " with ephi " << cluster->getRPhiError() << " adc " << cluster->getAdc() 
+	      std::cout << "                       found cluster " << cluskey << " with ephi " << cluster->getRPhiError() << " adc " << cluster->getAdc() 
 			<< " phisize " << cluster->getPhiSize() << " Z size " << cluster->getZSize() << std::endl;
 	  }
       }
@@ -126,11 +126,11 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 
   for(auto iter = discard_set.begin(); iter != discard_set.end(); ++iter)
     {
-      /*
+
       // remove bad clusters from the node tree map
       _cluster_map->removeCluster(*iter);
-      */
-      
+
+      /*      
       // increase the errors on the bad clusters to _new_rphi_error in r-phi and _new_z_error in z
       TrkrCluster *clus = _cluster_map->findCluster(*iter);
       double clusphi = atan2(clus->getY() , clus->getX());
@@ -139,14 +139,25 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
       for(int i = 0; i < 3; ++i)
 	for(int j = 0; j < 3; ++j)
 	  clus->setError(i,j,error[i][j]);
+
+      // set the local coordinates used by Acts
+      double ERR[3][3] = {0,0,0,0,0,0,0,0,0};
+      ERR[1][1] = _new_rphi_error * _new_rphi_error;  //cluster_v1 expects rad, arc, z as elementsof covariance
+      ERR[2][2] = _new_z_error * _new_z_error;
+
+      clus->setActsLocalError(0,0, ERR[1][1]);
+      clus->setActsLocalError(1,0, ERR[2][1]);
+      clus->setActsLocalError(0,1, ERR[1][2]);
+      clus->setActsLocalError(1,1, ERR[2][2]);
       
       if(Verbosity() > 1)
 	{
 	  TrkrDefs::cluskey ckey = clus->getClusKey();
 	  std::cout << " changed cluster " << ckey << " error to erphi " << clus->getRPhiError() << " ez " << clus->getZError() << std::endl;
 	}
+      */
     }
-
+      
   if(Verbosity() > 0)
     std::cout << "Clusters updated this event: " << count_discards << std::endl;
 

--- a/offline/packages/tpc/TpcClusterCleaner.h
+++ b/offline/packages/tpc/TpcClusterCleaner.h
@@ -50,8 +50,7 @@ class TpcClusterCleaner : public SubsysReco
   double _rphi_error_high_cut = 0.1;  // made large enough to not matter for now
 
   double _new_rphi_error = 0.05;
-  double _new_z_error = 0.10;
-
+  double _new_z_error = 0.1;
 };
 
 #endif // TPCCLUSTERCLEANER_H

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -681,6 +681,12 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
       unsigned int vertexId = track->get_vertex_id();
 
       const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
+
+      if(!svtxVertex) 
+	{
+	  std::cout << PHWHERE << " vertex ID " << vertexId << " not found!" << " for track " << track->get_id() << std::endl;
+	 return; 
+	}
    
       Acts::Vector3D vertex(
 		  svtxVertex->get_x() * Acts::UnitConstants::cm, 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR primarily fixes a bug in "packages/tpc/TpcClusterCleaner". The cluster cleaner previously increased the covariance on the 3D cluster position for any cluster for which the XY covariance was too small - which occurs because the cluster contains a large signal from delta electrons, and the cluster position is therefore bad. The cluster was kept with an increased error to help the track seeder connect the layers. When the cluster container was modified to store the local cluster coordinates for Acts to use, the cluster cleaner was not modified to update the local coordinates, so the change made by the cluster cleaner was ignored by Acts, resulting in poor performance. Because the CA seeder now handles missing layers very well, this PR modifies the cluster cleaner to just drop clusters with too small covariances. It improves the momentum resolution very significantly, restoring it to S&C Review levels. See the slides at:
https://indico.bnl.gov/event/12751/

Minor additional changes:

in PHTpcTrackSeedVertexAssociation:
Remove the vertex point from the circle fit 
Move the track deletion (sometimes required when XY cluster rejection is implemented) outside the track loop!

In PHActsTrkFitter:
Protected against a rare segfault when a vertex for a non-existent vertex ID is requested. Just skips the track.
 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

