### PR TITLE
Vertexing Clustering Improvement

### DIFF
--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -670,7 +670,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
     }
 
   std::vector<SvtxTrack*> sortedTracks;
-  if(m_svtxTrackMapName.find("TrackMap") != std::string::npos)
+  if(m_svtxTrackMapName.find("Silicon") != std::string::npos)
     {
       sortedTracks = sortTracks();
     }
@@ -691,7 +691,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 	}
       
       /// Only vertex with stubs that have five clusters
-      if(m_svtxTrackMapName.find("TrackMap") != std::string::npos)
+      if(m_svtxTrackMapName.find("Silicon") != std::string::npos)
 	{
 	  if(track->size_cluster_keys() < 5)
 	    {

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -405,7 +405,7 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
   /// a centroid based on which they are closest to, and then iterate
   /// to update clusters and centroids
 
-  std::vector<float> centroids(m_nCentroids);
+  std::vector<Acts::Vector3D> centroids(m_nCentroids);
   std::uniform_int_distribution<int> indices(0,m_trackMap->size() - 1);
   std::vector<int> usedIndices;
 
@@ -418,11 +418,16 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
 	  index = indices(m_random_number_generator);
 
       usedIndices.push_back(index);
-      centroid = m_trackMap->get(index)->get_z();
+      
+      centroid = Acts::Vector3D(m_trackMap->get(index)->get_x(),
+				m_trackMap->get(index)->get_y(),
+				m_trackMap->get(index)->get_z());
       
       if(Verbosity() > 3)
 	{
-	  std::cout << "Centroid is " << centroid << std::endl;
+	  std::cout << "Centroid is (" << centroid(0) 
+		    << ", " << centroid(1) << ", " 
+		    << centroid(2) << ")" << std::endl;
 	}
     }
   
@@ -438,18 +443,19 @@ std::vector<SvtxTrack*> PHActsInitialVertexFinder::sortTracks()
 }
 
 std::vector<SvtxTrack*> PHActsInitialVertexFinder::getIVFTracks(
-CentroidMap& clusters, std::vector<float>& centroids)
+		        CentroidMap& clusters, 
+			std::vector<Acts::Vector3D>& centroids)
 {
   
   std::vector<SvtxTrack*> sortedTracks;
 
   /// Note the centroid that has the most tracks
   int maxTrackCentroid = 0;
-  std::vector<float> stddev(m_nCentroids);
+  std::vector<Acts::Vector3D> stddev(m_nCentroids);
 
   for(const auto& [centroidIndex, trackVec] : clusters)
     {
-      float sum = 0;
+      Acts::Vector3D sum = Acts::Vector3D::Zero();
       if(trackVec.size() > maxTrackCentroid)
 	{
 	  maxTrackCentroid = trackVec.size();
@@ -461,13 +467,18 @@ CentroidMap& clusters, std::vector<float>& centroids)
 	    {
 	      std::cout << "Checking track key " << track->get_id()
 			<< " with z " << track->get_z() << " and centroid " 
-			<< centroids.at(centroidIndex) << std::endl;
+			<< centroids.at(centroidIndex).transpose() << std::endl;
 	    }
-	  sum += pow(track->get_z() - centroids.at(centroidIndex), 2);
+	  for(int i = 0; i < sum.cols(); i++)
+	    {
+	      sum(i) += pow(track->get_pos(i) - centroids.at(centroidIndex)(i), 2);
+	    }
 	}
-
-      float stddevVal = sqrt(sum / trackVec.size());
-      stddev.at(centroidIndex) = stddevVal;
+      for(int i = 0; i < 3; i++)
+	{ 
+	  stddev.at(centroidIndex)(i) = sqrt(sum(i) / trackVec.size()); 
+	}
+      
     }
   
   for(const auto& [centroidIndex, trackVec] : clusters)
@@ -480,15 +491,17 @@ CentroidMap& clusters, std::vector<float>& centroids)
 
       for(const auto& track : trackVec)
 	{
-	  float z = track->get_z();
-	  float pull = fabs(z-centroids.at(centroidIndex)) / stddev.at(centroidIndex);
+	  Acts::Vector3D pulls = Acts::Vector3D::Zero();
+	  for(int i = 0; i < 3; i++)
+	    pulls(i) = fabs(track->get_pos(i) - centroids.at(centroidIndex)(i)) / stddev.at(centroidIndex)(i);
+	 
 	  if(Verbosity() > 3)
 	    {
-	      std::cout << "z is " << z << " with Pull : " 
-			<< pull
-			<< std::endl;
+	      std::cout << "Track pos is (" << track->get_x() << ", " 
+			<< track->get_y() << ", " << track->get_z() 
+			<< ") and pull is " << pulls.transpose() << std::endl;
 	    }
-	  if(pull < 2)
+	  if(pulls(0) < 3 and pulls(1) < 3 and pulls(2) < 3)
 	    {
 	      sortedTracks.push_back(track);
 	    }
@@ -501,11 +514,12 @@ CentroidMap& clusters, std::vector<float>& centroids)
 
 	      if(Verbosity() > 3)
 		{
-		  std::cout << "Not adding track with z " << z 
-			    << " as it is incompatible with centroid " 
-			    << centroids.at(centroidIndex) 
+		  std::cout << "Not adding track with pos (" << track->get_x()
+			    << ", " << track->get_y() << ", " << track->get_z() 
+			    << ") as it is incompatible with centroid " 
+			    << centroids.at(centroidIndex).transpose() 
 			    << " with std dev " 
-			    << stddev.at(centroidIndex) << std::endl;
+			    << stddev.at(centroidIndex).transpose() << std::endl;
 		}
 	    }
 	}
@@ -515,7 +529,7 @@ CentroidMap& clusters, std::vector<float>& centroids)
 
 }
 
-CentroidMap PHActsInitialVertexFinder::createCentroidMap(std::vector<float>& centroids)
+CentroidMap PHActsInitialVertexFinder::createCentroidMap(std::vector<Acts::Vector3D>& centroids)
 {
   CentroidMap clusters;
   
@@ -523,7 +537,7 @@ CentroidMap PHActsInitialVertexFinder::createCentroidMap(std::vector<float>& cen
     {
       /// reset the centroid-track map
       clusters.clear();
-      for(unsigned int i =0; i<m_nCentroids; i++)
+      for(unsigned int i = 0; i<m_nCentroids; i++)
 	{
 	  std::vector<SvtxTrack*> vec;
 	  clusters.insert(std::make_pair(i, vec));
@@ -533,15 +547,21 @@ CentroidMap PHActsInitialVertexFinder::createCentroidMap(std::vector<float>& cen
 	{
 	  for(int i =0; i< m_nCentroids; i++)
 	    std::cout << "Starting centroid is : " 
-		      << centroids.at(i) << std::endl;
+		      << centroids.at(i).transpose() << std::endl;
 	}
       for(const auto& [key, track] : *m_trackMap)
 	{
-	  double minDist = 9999.;
-	  unsigned int centKey = 9999.;
+	  Acts::Vector3D trackPos(track->get_x(),
+				  track->get_y(),
+				  track->get_z());
+	      
+	  double minDist = std::numeric_limits<double>::max();
+	  unsigned int centKey = std::numeric_limits<unsigned int>::max();
 	  for(int i = 0; i < centroids.size(); i++)
 	    {
-	      double dist = fabs(track->get_z() - centroids.at(i));
+	      double dist = sqrt(pow(trackPos(0) - centroids.at(i)(0), 2) +
+				 pow(trackPos(1) - centroids.at(i)(1), 2) +
+				 pow(trackPos(2) - centroids.at(i)(2), 2));
 	      if(dist < minDist)
 		{
 		  minDist = dist;
@@ -558,32 +578,36 @@ CentroidMap PHActsInitialVertexFinder::createCentroidMap(std::vector<float>& cen
 	  /// Add this track to the map that associates centroids with tracks
 	  if(Verbosity() > 3)
 	    {
-	      std::cout << "adding track with " << track->get_z() 
+	      std::cout << "adding track with " << trackPos.transpose() 
 			<< " to centroid " 
-			<< centroids.at(centKey) << std::endl;
+			<< centroids.at(centKey).transpose() << std::endl;
 	    }
-	  clusters.find(centKey)->second.push_back(track);
-	  
+
+	  clusters.find(centKey)->second.push_back(track);	  
 	}
       
-      /// Update z pos centroids
-      std::vector<float> newCentroids(m_nCentroids);
+      /// Update pos centroids
+      std::vector<Acts::Vector3D> newCentroids(m_nCentroids);
+      for(auto& centroid : newCentroids)
+	centroid = Acts::Vector3D(0,0,0);
+
       for(const auto& [centroidVal, trackVec] : clusters)
 	{
 	  for(const auto& track : trackVec)
 	    {
-	      newCentroids.at(centroidVal) += track->get_z();
+	      for(int i = 0; i < 3; i++)
+		newCentroids.at(centroidVal)(i) += track->get_pos(i);
 	    }
 
-	  /// Sets the centroid as the average z value
+	  /// Sets the centroid as the average value
 	  centroids.at(centroidVal) = 
 	    newCentroids.at(centroidVal) / trackVec.size();
 	}
       
       if(Verbosity() > 3)
 	{
-	  for(int i=0; i< m_nCentroids; i++)
-	    std::cout << "new centroids " << centroids.at(i) 
+	  for(int i = 0; i < m_nCentroids; i++)
+	    std::cout << "new centroids " << centroids.at(i).transpose() 
 		      << std::endl;
    
 	  for(const auto& [centKey, trackVec] : clusters)
@@ -618,7 +642,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
     }
 
   std::vector<SvtxTrack*> sortedTracks;
-  if(m_svtxTrackMapName.find("Silicon") != std::string::npos)
+  if(m_svtxTrackMapName.find("TrackMap") != std::string::npos)
     {
       sortedTracks = sortTracks();
     }
@@ -638,7 +662,7 @@ TrackParamVec PHActsInitialVertexFinder::getTrackPointers(InitKeyMap& keyMap)
 	}
       
       /// Only vertex with stubs that have five clusters
-      if(m_svtxTrackMapName.find("SiliconTrackMap") != std::string::npos)
+      if(m_svtxTrackMapName.find("TrackMap") != std::string::npos)
 	{
 	  if(track->size_cluster_keys() < 5)
 	    {

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -103,7 +103,7 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   /// Max number of vertices allowed by the Acts IVF
   int m_maxVertices = 5;
   /// Maximum centroid transverse PCA cut
-  float m_pcaCut = 0.05; // cm
+  float m_pcaCut = 0.03; // cm
   /// Event num
   int m_event = 0;
   /// Diagnostic vertex numbers

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -86,9 +86,10 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   std::vector<SvtxTrack*> sortTracks();
   
   /// Helper functions for the k-means cluster algorithm
-  CentroidMap createCentroidMap(std::vector<float>& centroids);
+  CentroidMap createCentroidMap(std::vector<Acts::Vector3D>& centroids);
+
   std::vector<SvtxTrack*> getIVFTracks(CentroidMap& clusters, 
-				       std::vector<float>& centroids);
+				       std::vector<Acts::Vector3D>& centroids);
   
   /// Number of centroids for k-means clustering algorithm
   int m_nCentroids = 5;

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.h
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.h
@@ -51,10 +51,15 @@ class PHActsInitialVertexFinder: public PHInitVertexing
 
   void setCentroids(const int centroids)
   { m_nCentroids = centroids;}
+
   void setIterations(const int iterations)
   {m_nIterations = iterations;}
+
   void removeSiliconSeeds(const bool removeSeeds)
   {m_removeSeeds = removeSeeds;}
+
+  void setPCACut(const float pcaCut)
+  {m_pcaCut = pcaCut;}
 
  protected:
   int Setup(PHCompositeNode *topNode) override;
@@ -97,6 +102,8 @@ class PHActsInitialVertexFinder: public PHInitVertexing
   int m_nIterations = 15;
   /// Max number of vertices allowed by the Acts IVF
   int m_maxVertices = 5;
+  /// Maximum centroid transverse PCA cut
+  float m_pcaCut = 0.05; // cm
   /// Event num
   int m_event = 0;
   /// Diagnostic vertex numbers

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -1206,12 +1206,12 @@ int PHActsSiliconSeeding::createNodes(PHCompositeNode *topNode)
     dstNode->addNode(svtxNode);
   }
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxSiliconTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
   if(!m_trackMap)
     {
       m_trackMap = new SvtxTrackMap_v1;
       PHIODataNode<PHObject> *trackNode = 
-	new PHIODataNode<PHObject>(m_trackMap,"SvtxSiliconTrackMap","PHObject");
+	new PHIODataNode<PHObject>(m_trackMap,"SvtxTrackMap","PHObject");
       svtxNode->addNode(trackNode);
 
     }

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -1296,12 +1296,12 @@ int PHActsSiliconSeeding::createNodes(PHCompositeNode *topNode)
     dstNode->addNode(svtxNode);
   }
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxSiliconTrackMap");
   if(!m_trackMap)
     {
       m_trackMap = new SvtxTrackMap_v1;
       PHIODataNode<PHObject> *trackNode = 
-	new PHIODataNode<PHObject>(m_trackMap,"SvtxTrackMap","PHObject");
+	new PHIODataNode<PHObject>(m_trackMap,"SvtxSiliconTrackMap","PHObject");
       svtxNode->addNode(trackNode);
 
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR expands the initial silicon seed clustering algorithm to include the transverse direction. The clustering is performed based on a 3D radial distance now instead of just along the z axis, which helps remove tracks in the transverse direction that are inconsistent with the vertex cluster.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

