### PR TITLE
Modify track seed position

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -333,30 +333,10 @@ int PHSiliconTpcTrackMatching::Process()
 	      unsigned int vertexId = _tracklet_si->get_vertex_id();
 	      _tracklet_tpc->set_vertex_id(vertexId);
 
-	      // set the track position to the vertex position
-	      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	      if(svtxVertex)
-		{
-		  _tracklet_tpc->set_x(svtxVertex->get_x());
-		  _tracklet_tpc->set_y(svtxVertex->get_y());
-		  _tracklet_tpc->set_z(svtxVertex->get_z());
-		}
-	      else
-		{
-		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId 
-			    << " associated with TPC tracklet " << _tracklet_tpc->get_id() 
-			    << " si tracklet " << _tracklet_si->get_id()
-			    << " set vertex to (0,0,0)"
-			    << std::endl; 
-		  std::cout << " ---------- Silicon track --------------" << std::endl;
-		  _tracklet_si->identify();
-		  std::cout << " ---------- TPC track -----------------" << std::endl;
-		  _tracklet_tpc->identify();
+	      _tracklet_tpc->set_x(_tracklet_si->get_x());
+	      _tracklet_tpc->set_y(_tracklet_si->get_y());
+	      _tracklet_tpc->set_z(_tracklet_si->get_z());
 
-		  _tracklet_tpc->set_x(0.0);
-		  _tracklet_tpc->set_y(0.0);
-		  _tracklet_tpc->set_z(0.0);
-		}
 	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
 		{
 		  if(Verbosity() > 1) 
@@ -390,25 +370,9 @@ int PHSiliconTpcTrackMatching::Process()
 	      unsigned int vertexId = _tracklet_si->get_vertex_id();
 	      newTrack->set_vertex_id(vertexId);
 
-	      // set the track position to the vertex position
-	      const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	      if(svtxVertex)
-		{
-		  newTrack->set_x(svtxVertex->get_x());
-		  newTrack->set_y(svtxVertex->get_y());
-		  newTrack->set_z(svtxVertex->get_z());
-		}
-	      else
-		{
-		  std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId << " associated with TPC tracklet " << _tracklet_tpc->get_id() << std::endl; 
-		  std::cout << " ---------- Silicon track --------------" << std::endl;
-		  _tracklet_si->identify();
-		  std::cout << " ---------- TPC track -----------------" << std::endl;
-		  _tracklet_tpc->identify();
-		  newTrack->set_x(0.0);
-		  newTrack->set_y(0.0);
-		  newTrack->set_z(0.0);
-		}
+	      newTrack->set_x(_tracklet_si->get_x());
+	      newTrack->set_y(_tracklet_si->get_y());
+	      newTrack->set_z(_tracklet_si->get_z());
 		      
 	      newTrack->set_charge(_tracklet_tpc->get_charge());
 	      newTrack->set_px(_tracklet_tpc->get_px());

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -270,51 +270,21 @@ int PHSiliconTpcTrackMatching::Process()
 	      cout << PHWHERE << " Did NOT find a match for TPC track " << _tracklet_tpc->get_id()  << "  tpc_phi " << tpc_phi << " tpc_eta " << tpc_eta  << endl;
 	    }
 
-	  // we did not get a silicon track match, so set the track vertex arbitrarily to vertex 0 if one does not exist already
-	  unsigned int vertexId = _tracklet_tpc->get_vertex_id();
-	  if(vertexId == UINT_MAX)  vertexId = 0;
-	  _tracklet_tpc->set_vertex_id(vertexId);
-	  
-	  // set the track position to the vertex position
-	  const SvtxVertex *svtxVertex = _vertex_map->get(vertexId);      
-	  if(svtxVertex)
-	    {
-	      _tracklet_tpc->set_x(svtxVertex->get_x());
-	      _tracklet_tpc->set_y(svtxVertex->get_y());
-	      _tracklet_tpc->set_z(svtxVertex->get_z());
-
-	      if(Verbosity() > 1)
-		std::cout << " TPC seed track ID " << _tracklet_tpc->get_id() << " nclus " << _tracklet_tpc->size_cluster_keys() 
-			  << " no silicon match found " << std::endl;
-	    }
-	  else
-	    {
-	      std::cout << PHWHERE << "Failed to find vertex object for vertex ID " << vertexId 
-			<< " associated with TPC tracklet " << _tracklet_tpc->get_id() 
-			<< " si tracklet " << _tracklet_si->get_id()
-			<< " set vertex to (0,0,0)"
-			<< std::endl; 
-	      std::cout << " ---------- Silicon track --------------" << std::endl;
-	      _tracklet_si->identify();
-	      std::cout << " ---------- TPC track -----------------" << std::endl;
-	      _tracklet_tpc->identify();
-
-	      _tracklet_tpc->set_x(0.0);
-	      _tracklet_tpc->set_y(0.0);
-	      _tracklet_tpc->set_z(0.0);
-	    }
+	  // The TPC track seed vertex association is already done
+	  // The TPC track seed position has already been set in the vertex associator to the PCA from the helical fit to clusters
+	  // we do not need to change them here
 	}
-
-      // Add the silicon clusters to the track
+	  
+      // Add the silicon clusters to the track if there is one or more matches
       unsigned int isi = 0;
       for(auto si_it = si_matches.begin(); si_it != si_matches.end(); ++si_it)
 	{
 	  // get the si tracklet for this id
 	  _tracklet_si = _track_map_silicon->get(*si_it);
-
+	  
 	  if(Verbosity() > 1)
 	    cout << "   isi = " << isi << " si tracklet " << _tracklet_si->get_id() << " was matched to TPC tracklet " << _tracklet_tpc->get_id() << endl;
-
+	  
 	  // get the silicon clusters
 	  std::set<TrkrDefs::cluskey> si_clusters;
 	  for (SvtxTrack::ConstClusterKeyIter key_iter = _tracklet_si->begin_cluster_keys();
@@ -325,32 +295,32 @@ int PHSiliconTpcTrackMatching::Process()
 	      if(Verbosity() >1) cout << "   inserting cluster key " << cluster_key << " into list " << " for si tracklet " << _tracklet_si->get_id() << endl;
 	      si_clusters.insert(cluster_key);
 	    }
-
+	  
 	  if(isi == 0)
 	    {
 	      // update the original track on the node tree
-
+	      
 	      // the track takes its vertex from the si stub
 	      unsigned int vertexId = _tracklet_si->get_vertex_id();
 	      _tracklet_tpc->set_vertex_id(vertexId);
-
+	      
 	      _tracklet_tpc->set_x(_tracklet_si->get_x());
 	      _tracklet_tpc->set_y(_tracklet_si->get_y());
 	      _tracklet_tpc->set_z(_tracklet_si->get_z());
-
+	      
 	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
 		{
 		  if(Verbosity() > 1) 
 		    cout << "   inserting si cluster key " << *clus_iter << " into existing TPC track " << _tracklet_tpc->get_id() << endl;
-
+		  
 		  _tracklet_tpc->insert_cluster_key(*clus_iter);
 		  _assoc_container->SetClusterTrackAssoc(*clus_iter, _tracklet_tpc->get_id());
 		}
-
+	      
 	      if(Verbosity() > 1)
 		std::cout << " TPC seed track ID " << _tracklet_tpc->get_id() 
 			  << " new nclus " << _tracklet_tpc->size_cluster_keys() << std::endl;
-
+	      
 	      if(Verbosity() > 3)
 		_tracklet_tpc->identify();
 	    }
@@ -358,30 +328,28 @@ int PHSiliconTpcTrackMatching::Process()
 	    {
 	      // more than one si stub matches
 	      // make a copy of the TPC track, update it and add it to the end of the node tree 
-	      #if __cplusplus < 201402L
+#if __cplusplus < 201402L
 	      auto newTrack = boost::make_unique<SvtxTrack_v2>();
-	      #else
+#else
 	      auto newTrack = std::make_unique<SvtxTrack_v2>();
-	      #endif
+#endif
 	      const unsigned int lastTrackKey = _track_map->end()->first; 
 	      if(Verbosity() > 1) cout << "Extra match, add a new track to node tree with key " <<  lastTrackKey << endl;
 	      
 	      newTrack->set_id(lastTrackKey);
-
+	      
 	      unsigned int vertexId = _tracklet_si->get_vertex_id();
 	      newTrack->set_vertex_id(vertexId);
-
+	      
 	      newTrack->set_x(_tracklet_si->get_x());
 	      newTrack->set_y(_tracklet_si->get_y());
 	      newTrack->set_z(_tracklet_si->get_z());
-		      
+	      
 	      newTrack->set_charge(_tracklet_tpc->get_charge());
 	      newTrack->set_px(_tracklet_tpc->get_px());
 	      newTrack->set_py(_tracklet_tpc->get_py());
 	      newTrack->set_pz(_tracklet_tpc->get_pz());
-	      newTrack->set_x(_tracklet_tpc->get_x());
-	      newTrack->set_y(_tracklet_tpc->get_y());
-	      newTrack->set_z(_tracklet_tpc->get_z());
+	      
 	      for(int i = 0; i < 6; ++i)
 		{
 		  for(int j = 0; j < 6; ++j)
@@ -403,7 +371,7 @@ int PHSiliconTpcTrackMatching::Process()
 		      _assoc_container->SetClusterTrackAssoc(cluster_key, _tracklet_tpc->get_id());
 		    }
 		}
-		  
+	      
 	      // now add the new si clusters
 	      for(auto clus_iter=si_clusters.begin(); clus_iter != si_clusters.end(); ++clus_iter)
 		{
@@ -412,15 +380,15 @@ int PHSiliconTpcTrackMatching::Process()
 		  newTrack->insert_cluster_key(*clus_iter);
 		  _assoc_container->SetClusterTrackAssoc(*clus_iter, newTrack->get_id());
 		}
-
+	      
 	      if(Verbosity() > 3)
 		{
 		  cout << "  -- inserting new track with id " << newTrack->get_id() << " into trackmap " << endl;
 		  newTrack->identify();
 		}
-
+	      
 	      _track_map->insert(newTrack.get());
-
+	      
 	      if(Verbosity() > 1)
 		std::cout << " TPC seed track ID " << _tracklet_tpc->get_id() 
 			  << " new track ID " << newTrack->get_id() << " new nclus " << newTrack->size_cluster_keys() << std::endl;
@@ -430,7 +398,7 @@ int PHSiliconTpcTrackMatching::Process()
 	  isi++;
 	}
     }
-
+  
   if(Verbosity() > 0)  
     cout << " Final track map size " << _track_map->size() << " seed-track map size " << _seed_track_map->size() << endl;
   

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -51,9 +51,9 @@ PHTpcTrackSeedVertexAssoc::~PHTpcTrackSeedVertexAssoc()
 //____________________________________________________________________________..
 int PHTpcTrackSeedVertexAssoc::Setup(PHCompositeNode *topNode)
 {
-  std::cout << PHWHERE << " Parameters: _reject_xy_outliers " << _reject_xy_outliers << " _xy_residual_cut " << _xy_residual_cut
-	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut  << " _refit " << _refit
-	    << std::endl; 
+  //  std::cout << PHWHERE << " Parameters: _reject_xy_outliers " << _reject_xy_outliers << " _xy_residual_cut " << _xy_residual_cut
+  //	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut  << " _refit " << _refit
+  //	    << std::endl; 
 
   int ret = PHTrackPropagating::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
@@ -69,30 +69,17 @@ int PHTpcTrackSeedVertexAssoc::Process()
 {
   // _track_map contains the TPC seed track stubs
   // We want to associate these TPC track seeds with a collision vertex
-  // Then we add the collision vertex position as the track seed position
   // All we need is to project the TPC clusters in Z to the beam line.
-
-  double grand_circle_rms_squared = 0.0;
-  double grand_circle_wt = 0.0;
-  double grand_line_rms_squared = 0.0;
-  double grand_line_wt = 0.0;
-
-  double bad_clusters_per_track_xy = 0.0;
-  double bad_clusters_per_track_xy_wt = 0.0;
-  double bad_clusters_per_track_z = 0.0;
-  double bad_clusters_per_track_z_wt = 0.0;
+  // The TPC track seeds are given a position that is the PCA of the line and circle fit to the beam line
 
   if(Verbosity() > 0)
     cout << PHWHERE << " TPC track map size " << _track_map->size()  << endl;
 
   // loop over the TPC track seeds
-  std::set<unsigned int> bad_tracks;
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
        ++phtrk_iter)
     {
-      std::set<TrkrDefs::cluskey> bad_clusters;
-
       _tracklet_tpc = phtrk_iter->second;
       
       if (Verbosity() > 1)
@@ -167,124 +154,18 @@ int PHTpcTrackSeedVertexAssoc::Process()
       auto vertex = _vertex_map->find(trackVertexId)->second;
       vertex->insert_track(phtrk_iter->first);
 
-      // set the track position to the vertex position
-      _tracklet_tpc->set_x(vertex->get_x());
-      _tracklet_tpc->set_y(vertex->get_y());
-      _tracklet_tpc->set_z(vertex->get_z());
+      // set the track Z position to the Z dca
+      _tracklet_tpc->set_z(_z_proj);
 
       if(Verbosity() > 1)
 	  std::cout << "    TPC seed track " << phtrk_iter->first << " matched to vertex " << trackVertexId << endl; 
 
       // Finished association of track with vertex, now we modify the track parameters
 
-      // Repeat the z line fit including the vertex position, get theta, update pz
-      std::vector<std::pair<double, double>> points;
-      double r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
-      double z_vertex = vertex->get_z();
-      points.push_back(make_pair(r_vertex, z_vertex));
-      for (unsigned int i=0; i<clusters.size(); ++i)
-	{
-	  double z = clusters[i]->getZ();
-	  double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
-	  
-	  points.push_back(make_pair(r,z));
-	}
-      
-      line_fit(points, A, B);
-      if(Verbosity() > 2) 
-	std::cout << "       Fitted line including vertex has A " << A << " B " << B << std::endl;      
-
-      // optionally reject clusters with large residuals
-      if(_reject_z_outliers)
-	{
-	  std::vector<double> line_residuals = GetLineClusterResiduals(points, A, B);
-	  double line_rms_squared = 0.0;
-	  double line_wt = 0.0;
-	  for(unsigned int i = 1; i < points.size(); ++i)
-	    {
-	      double res_squared =  line_residuals[i]*line_residuals[i];
-	      //if(sqrt(res_squared) < 0.15)  // 1.5 mm, about 3 sigma
-	      if(sqrt(res_squared) < _z_residual_cut)  
-		{
-		  line_rms_squared += res_squared;
-		  line_wt += 1.0;
-		  //std::cout << " cluster " << i-1 << " r " << points[i].first << " z " << points[i].second << " residual " << line_residuals[i] << std::endl;
-		}
-	      else
-		{
-		  // flag this cluster for removal from the track
-		  bad_clusters.insert(clusters[i-1]->getClusKey());
-		  //std::cout << " bad cluster " << i << " r " << points[i].first << " z " << points[i].second << " line residual " << line_residuals[i] 
-		  //	<< " z from cluster " << clusters[i-1]->getZ() << std::endl;
-		}
-	    }
-	  double line_rms = sqrt(line_rms_squared / line_wt);
-	  if(Verbosity() > 5) 
-	    std::cout << " line_rms = " << line_rms << " line_rms_squared " << line_rms_squared << " line_wt " << line_wt << std::endl;
-	  
-	  grand_line_rms_squared += line_rms_squared;
-	  grand_line_wt += line_wt;
-
-	  // Remove the bad clusters from the track here, remake the clusters list,  and refit the line
-	  for(auto &key : bad_clusters)
-	    {
-	      if(Verbosity() > 5) std::cout << " TPC tracklet " << _tracklet_tpc->get_id() << " removing bad Z cluster " << key << std::endl;
-	      _tracklet_tpc->erase_cluster_key(key);
-	    }
-
-	  if(nlayers > 40)
-	    {
-	      bad_clusters_per_track_z += bad_clusters.size();
-	      bad_clusters_per_track_z_wt += 1.0;
-	    }
-
-	  // remake the cluster list for this track
-	  clusters.clear();
-	  clusters = getTrackClusters(_tracklet_tpc);
-
-	  if(Verbosity() > 2) 
-	    std::cout << "    z rejection: removed " << bad_clusters.size() << " bad clusters from track " << _tracklet_tpc->get_id() 
-		      << "    remaining clusters " << clusters.size() << " in track " << _tracklet_tpc->get_id() << std::endl;
-
-	  if(clusters.size() < 10)
-	    {
-	      if(Verbosity() > 2) std::cout << "    erasing tracklet " << _tracklet_tpc->get_id()  << std::endl;
-	      //_track_map->erase(_tracklet_tpc->get_id());	      
-	      bad_tracks.insert(_tracklet_tpc->get_id());
-	      continue;
-	    }
-
-	  //optionally refit the line
-	  if(_refit)
-	    {
-	      // refit the line
-	      points.clear();
-	      r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
-	      z_vertex = vertex->get_z();
-	      points.push_back(make_pair(r_vertex, z_vertex));
-	      for (unsigned int i=0; i<clusters.size(); ++i)
-		{
-		  double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
-		  double z = clusters[i]->getZ();	      
-		  points.push_back(make_pair(r,z));
-		}
-	      
-	      line_fit(points, A, B);
-	      if(Verbosity() > 2) 
-		std::cout << "       After bad cluster removal, re-fitted line including vertex has A " << A << " B " << B << std::endl;      	  
-	    }
-
-	  bad_clusters.clear();
-	}
-
       // extract the track theta
       double track_angle = atan(A);  // referenced to 90 degrees
 
-      // try dropping this fit including vertex, and adjusting further down 
-      std::vector<std::pair<double, double>> cpoints;
-      double x_vertex = vertex->get_x();
-      double y_vertex = vertex->get_y();
-      //cpoints.push_back(std::make_pair(x_vertex, y_vertex));
+       std::vector<std::pair<double, double>> cpoints;
       for (unsigned int i=0; i<clusters.size(); ++i)
 	{
 	  cpoints.push_back(make_pair(clusters[i]->getX(), clusters[i]->getY()));
@@ -296,91 +177,11 @@ int PHTpcTrackSeedVertexAssoc::Process()
       if(Verbosity() > 2) 
 	std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 
-      // optionally reject clusters with large residuals in (x,y)
-      if(_reject_xy_outliers)
-	{
-	  double circle_rms_squared = 0.0;
-	  double circle_wt = 0.0;
-	  std::vector<double> residuals = GetCircleClusterResiduals(cpoints, R, X0, Y0);
-	  for(unsigned int i = 1; i < cpoints.size(); ++i)
-	    {
-	      double res_squared =  residuals[i]*residuals[i];
-	      if(sqrt(res_squared) < _xy_residual_cut)  
-		{
-		  circle_rms_squared += res_squared;
-		  circle_wt += 1.0;
-		  //std::cout << " cluster " << i << " x " << cpoints[i].first << " y " << cpoints[i].second << " residual " << residuals[i] << std::endl;
-		}
-	      else
-		{
-		  // flag this cluster for removal from the track
-		  bad_clusters.insert(clusters[i-1]->getClusKey());
-		  //std::cout << " bad cluster " << i << " x " << cpoints[i].first << " y " << cpoints[i].second << " residual " << residuals[i]  << std::endl;
-		}
-	    }
-	  double circle_rms = sqrt(circle_rms_squared / circle_wt);
-	  if(Verbosity() > 5) std::cout << " circle_rms = " << circle_rms << " circle_rms_squared " << circle_rms_squared 
-					<< " circle_wt " << circle_wt << std::endl;
-	  
-	  grand_circle_rms_squared += circle_rms_squared;
-	  grand_circle_wt += circle_wt;
-
-	  if(nlayers > 40)
-	    {
-	      bad_clusters_per_track_xy += bad_clusters.size();
-	      bad_clusters_per_track_xy_wt += 1.0;
-	    }
-
-	  // Remove the bad clusters from the track here, remake the clusters list
-	  for(auto &key : bad_clusters)
-	    {
-	      if(Verbosity() > 5) std::cout << " TPC tracklet " << _tracklet_tpc->get_id() << " removing bad xy cluster " << key << std::endl;
-	      _tracklet_tpc->erase_cluster_key(key);
-	    }
-
-	  clusters.clear();
-	  clusters = getTrackClusters(_tracklet_tpc);
-
-	  if(Verbosity() > 2) 
-	    std::cout << "    xy rejection:  removed " << bad_clusters.size() << " bad clusters from track " << _tracklet_tpc->get_id() 
-		      << "    remaining clusters " << clusters.size() << " in track " << _tracklet_tpc->get_id() << std::endl;
-
-	  if(clusters.size() < 10)
-	    {
-	      if(Verbosity() > 2) std::cout << "   marking tracklet " << _tracklet_tpc->get_id()  << " to be erased" << std::endl;
-	      bad_tracks.insert(_tracklet_tpc->get_id());
-	      continue;
-	    }
-	  /*
-	  cpoints.clear();
-	  cpoints.push_back(std::make_pair(x_vertex, y_vertex));
-	  for (unsigned int i=0; i<clusters.size(); ++i)
-	    {
-	      double x = clusters[i]->getX();
-	      double y = clusters[i]->getY();	  
-	      cpoints.push_back(make_pair(x, y));
-	    }
-	  */
-	  bad_clusters.clear();
-	}
-
-      // Add vertex to cpoints
-      cpoints.clear();
-      cpoints.push_back(std::make_pair(x_vertex, y_vertex));
-      for (unsigned int i=0; i<clusters.size(); ++i)
-	{
-	  double x = clusters[i]->getX();
-	  double y = clusters[i]->getY();	  
-	  cpoints.push_back(make_pair(x, y));
-	}
-
-      // optionally refit the circle with vertex included
-      if(_refit)
-	{
-	  CircleFitByTaubin(cpoints, R, X0, Y0);
-	  if(Verbosity() > 2) 
-	    std::cout << " after bad xy cluster removal, re-fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
-	}
+      // set the track x and y positions to the circle PCA
+      double dcax, dcay;
+      findRoot(R, X0, Y0, dcax, dcay);
+      _tracklet_tpc->set_x(dcax);
+      _tracklet_tpc->set_y(dcay);
       
       double pt_track = _tracklet_tpc->get_pt();
       if(Verbosity() > 5)
@@ -393,6 +194,19 @@ int PHTpcTrackSeedVertexAssoc::Process()
       
       // We want the angle of the tangent relative to the positive x axis
       // start with the angle of the radial line from vertex to circle center
+
+      // Add vertex to cpoints
+      cpoints.clear();
+      double x_vertex = vertex->get_x();
+      double y_vertex = vertex->get_y();
+      cpoints.push_back(std::make_pair(x_vertex, y_vertex));
+      for (unsigned int i=0; i<clusters.size(); ++i)
+	{
+	  double x = clusters[i]->getX();
+	  double y = clusters[i]->getY();	  
+	  cpoints.push_back(make_pair(x, y));
+	}
+
       double dx = X0 - x_vertex;
       double dy = Y0 - y_vertex;
       double phi= atan2(dy,dx);
@@ -450,33 +264,7 @@ int PHTpcTrackSeedVertexAssoc::Process()
       
     }  // end loop over TPC track seeds
 
-  for(auto &key : bad_tracks)
-    {
-      std::cout << "Erase track " << key << " with too few clusters" << std::endl;
-      _track_map->erase(key);	      
-    }
-  bad_tracks.clear();
-
-  bad_clusters_per_track_z /= bad_clusters_per_track_z_wt;
-  bad_clusters_per_track_xy /= bad_clusters_per_track_xy_wt;
-  if(Verbosity() > 0)
-    std::cout << "Bad clusters per track:  z:  wt " << bad_clusters_per_track_z_wt << " bad clusters "  << bad_clusters_per_track_z 
-	      << " xy: wt " << bad_clusters_per_track_xy_wt << " bad clusters "  << bad_clusters_per_track_xy << std::endl;
-
-  if(_reject_z_outliers && Verbosity() > 5)
-    {
-      double grand_line_rms =  sqrt(grand_line_rms_squared / grand_line_wt);  
-      std::cout << "grand_line_rms = " << grand_line_rms << " grand_line_rms_squared " << grand_line_rms_squared 
-		<< " grand_line_wt " << grand_line_wt << std::endl;
-    }
-
-  if(_reject_xy_outliers && Verbosity() > 5)
-    {
-      double grand_circle_rms =  sqrt(grand_circle_rms_squared / grand_circle_wt);  
-      std::cout << "grand circle rms = " << grand_circle_rms << " grand_circle_rms_squared " << grand_circle_rms_squared << " grand_circle_wt " << grand_circle_wt << std::endl;
-    }
-  
-  if(Verbosity() > 0)  
+   if(Verbosity() > 0)  
     cout << " Final track map size " << _track_map->size() << endl;
   
   if (Verbosity() > 0)
@@ -704,4 +492,55 @@ std::vector<TrkrCluster*> PHTpcTrackSeedVertexAssoc::getTrackClusters(SvtxTrack 
 		  << "  " << tpc_clus->getY() << "  " << tpc_clus->getZ() << " clusters.size() " << clusters.size() << std::endl;
     }
   return clusters;
+}
+
+void PHTpcTrackSeedVertexAssoc::findRoot(const double R, const double X0,
+				    const double Y0, double& x,
+				    double& y)
+{
+  /**
+   * We need to determine the closest point on the circle to the origin
+   * since we can't assume that the track originates from the origin
+   * The eqn for the circle is (x-X0)^2+(y-Y0)^2=R^2 and we want to 
+   * minimize d = sqrt((0-x)^2+(0-y)^2), the distance between the 
+   * origin and some (currently, unknown) point on the circle x,y.
+   * 
+   * Solving the circle eqn for x and substituting into d gives an eqn for
+   * y. Taking the derivative and setting equal to 0 gives the following 
+   * two solutions. We take the smaller solution as the correct one, as 
+   * usually one solution is wildly incorrect (e.g. 1000 cm)
+   */
+  
+  double miny = (sqrt(pow(X0, 2) * pow(R, 2) * pow(Y0, 2) + pow(R, 2) 
+		      * pow(Y0,4)) + pow(X0,2) * Y0 + pow(Y0, 3)) 
+    / (pow(X0, 2) + pow(Y0, 2));
+
+  double miny2 = (-sqrt(pow(X0, 2) * pow(R, 2) * pow(Y0, 2) + pow(R, 2) 
+		      * pow(Y0,4)) + pow(X0,2) * Y0 + pow(Y0, 3)) 
+    / (pow(X0, 2) + pow(Y0, 2));
+
+  double minx = sqrt(pow(R, 2) - pow(miny - Y0, 2)) + X0;
+  double minx2 = -sqrt(pow(R, 2) - pow(miny2 - Y0, 2)) + X0;
+  
+  if(Verbosity() > 1)
+    std::cout << "minx1 and x2 : " << minx << ", " << minx2 << std::endl
+	      << "miny1 and y2 : " << miny << ", " << miny2 << std::endl;
+
+  /// Figure out which of the two roots is actually closer to the origin
+  if(fabs(minx) < fabs(minx2))
+    x = minx;
+  else
+    x = minx2;
+
+  if(fabs(miny) < fabs(miny2))
+    y = miny;
+  else
+    y = miny2;
+  
+  if(Verbosity() > 1)
+    {
+      std::cout << "Minimum x and y positions " << x << ",  " 
+		<< y << std::endl;
+    }
+
 }

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -23,13 +23,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   ~PHTpcTrackSeedVertexAssoc() override;
 
-  void reject_xy_outliers(const bool reject){_reject_xy_outliers = reject;}  
-  void reject_z_outliers(const bool reject){_reject_z_outliers = reject;}
-
-  void set_xy_residual_cut(const double cut){_xy_residual_cut = cut;}
-  void set_z_residual_cut(const double cut){_z_residual_cut = cut;}
-  void set_refit(const bool refit) {_refit = refit;}
-
  protected:
   int Setup(PHCompositeNode* topNode) override;
 
@@ -47,6 +40,7 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   std::vector<double> GetCircleClusterResiduals(std::vector<std::pair<double,double>> points, double R, double X0, double Y0);
   std::vector<double> GetLineClusterResiduals(std::vector<std::pair<double,double>> points, double A, double B);
   std::vector<TrkrCluster*> getTrackClusters(SvtxTrack *_tracklet_tpc);
+  void findRoot(const double R, const double X0, const double Y0, double& x, double& y);
 						    
   std::string _track_map_name_silicon;
 
@@ -57,13 +51,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   unsigned int _max_tpc_layer = 54;
 
   double _z_proj= 0;
-
-  bool _reject_xy_outliers = false;
-  bool _reject_z_outliers = false;
-  bool _refit  = false;
-
-  double _xy_residual_cut = 0.08;
-  double _z_residual_cut = 0.22;
 
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Modify tracking so that the silicon and TPC seeds are always given the position of the PCA (point of closest approach) of the helical fit to the clusters, rather than the nearest vertex associated with the track. This accomodates tracks that are not from a primary vertex. Tested with MB Hijing + 50 KHz events with 100 pions embedded. No detectable effect on the tracking performance was seen. See the slides at: the tracking meeting today:
https://indico.bnl.gov/event/12904/

The code changes are:

PHTpcTrackSeedVertexAssoc
Does not include the associated vertex in the helical fit.
Now sets track (x,y,z) from the PCA of the helix fitted to the clusters.
Removed a lot of unused cluster outlier rejection code.

PHSiliconTpcTrackMatching:
Unmatched TPC seeds: Retains the TPC seed helix PCA as the track position.
Matched TPC seeds: Assigns the silicon seed helix PCA as the track position.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

