### PR TITLE
Improve Vertex Evaluation

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -80,6 +80,7 @@ SvtxEvaluator::SvtxEvaluator(const string& name, const string& filename, const s
   , _do_gseed_eval(false)
   , _do_track_match(true)
   , _do_eval_light(true)
+  , _do_vtx_eval_light(true)
   , _scan_for_embedded(false)
   , _scan_for_primaries(false)
   , _nlayers_maps(nlayers_maps)
@@ -121,11 +122,13 @@ int SvtxEvaluator::Init(PHCompositeNode* topNode)
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex", "vertex => max truth",
-                                                 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
-                                                 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
-                                                 "gnembed:nfromtruth:"
-                                                 "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
+						 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
+						 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
+						 "gnembed:nfromtruth:"
+						 "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
+    
+    
   if (_do_gpoint_eval) _ntp_gpoint = new TNtuple("ntp_gpoint", "g4point => best vertex",
                                                  "event:seed:gvx:gvy:gvz:gvt:gntracks:gembed:"
                                                  "vx:vy:vz:ntracks:"
@@ -929,6 +932,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         _ntp_info->Fill(info_data);
     }
 
+
   //-----------------------
   // fill the Vertex NTuple
   //-----------------------
@@ -959,7 +963,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       map<int, unsigned int> embedvtxid_maps_particle_count;
       map<int, unsigned int> vertex_particle_count;
 
-      if (_do_eval_light == false)
+      if (_do_vtx_eval_light == false)
       {
         for (auto iter = prange.first; iter != prange.second; ++iter)  // process all primary paricle
         {
@@ -1025,7 +1029,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       {
         const int point_id = iter->first;
         int gembed = truthinfo->isEmbededVtx(point_id);
-
+	
         if (_scan_for_embedded && gembed <= 0) continue;
 
         auto search = embedvtxid_found.find(gembed);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -60,6 +60,7 @@ class SvtxEvaluator : public SubsysReco
 
   void do_track_match(bool b) { _do_track_match = b; }
   void do_eval_light(bool b) { _do_eval_light = b; }
+  void do_vtx_eval_light(bool b) { _do_vtx_eval_light = b;}
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
   void scan_for_primaries(bool b) { _scan_for_primaries = b; }
 
@@ -94,6 +95,7 @@ class SvtxEvaluator : public SubsysReco
 
   bool _do_track_match;
   bool _do_eval_light;
+  bool _do_vtx_eval_light;
   bool _scan_for_embedded;
   bool _scan_for_primaries;
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -66,6 +66,7 @@ static IsStateFinal isfinal;
 
 HepMCNodeReader::HepMCNodeReader(const std::string &name)
   : SubsysReco(name)
+  , is_pythia(false)
   , use_seed(0)
   , seed(0)
   , vertex_pos_x(0.0)
@@ -188,6 +189,8 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       genevt->identify();
     }
 
+    const auto collisionVertex = genevt->get_collision_vertex();
+
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
@@ -282,6 +285,20 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
                                           (*v)->position().y(),
                                           (*v)->position().z(),
                                           (*v)->position().t());
+	if(is_pythia)
+	  {
+	    lv_vertex.setX(collisionVertex.x());
+	    lv_vertex.setY(collisionVertex.y());
+	    lv_vertex.setZ(collisionVertex.z());
+	    lv_vertex.setT(collisionVertex.t());
+	    if (Verbosity() > 1)
+	      {
+		std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ 
+			  << std::endl;
+		std::cout << "\t vertex reset to collision vertex: " 
+			  << lv_vertex << std::endl;
+	      }
+	  }
 
         // event gen frame to lab frame
         lv_vertex = lortentz_rotation(lv_vertex);

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -23,6 +23,9 @@ class HepMCNodeReader : public SubsysReco
   int Init(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
 
+  void pythia(const bool pythia)
+  { is_pythia = pythia; }
+
   //! this function is depreciated.
   //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
   void Embed(const int i = 1);
@@ -54,7 +57,7 @@ class HepMCNodeReader : public SubsysReco
   double smearflat(const double width);
 
   gsl_rng *RandomGenerator;
-
+  bool is_pythia;
   int use_seed;
   unsigned int seed;
   double vertex_pos_x;


### PR DESCRIPTION
Add switch to HepMCNodeReader to override PYTHIA's
assignment of a single vertex to each particle
with the collision vertex

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds two switches to the `SvtxEvaluator` and the `HepMCNodeReader`. Both are off by default.

For the `SvtxEvaluator`, a separate switch is added for performing the light vertex evaluation. This way one can perform the light g4hit evaluation while doing heavy g4vertex evaluation, rather than having to do light or heavy evaluation for both at the same time.

For the `HepMCNodeReader`, a switch is added that overrides PYTHIA's default assigning of a single vertex to every particle. When the switch is turned on, the individual particle's vertex is given as the collision vertex such that there is only one vertex per HEPMC event. This makes vertex performance evaluation with PYTHIA events meaningful.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

