### PR TITLE
Add floating point precision comparison to truth vertex parsing

### DIFF
--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -6,7 +6,7 @@
 
 #include <cmath>
 #include <cstdlib>
-
+#include <algorithm>
 using namespace std;
 
 PHG4InEvent::~PHG4InEvent()
@@ -46,8 +46,28 @@ PHG4InEvent::AddVtxCommon(PHG4VtxPoint *newvtx)
 {
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end =  GetVertices();
   for (map<int, PHG4VtxPoint *>::const_iterator viter = vtxbegin_end.first; viter != vtxbegin_end.second; ++viter)
-    {
-      if (*newvtx == *(viter->second))
+    {        
+      /// Do a simultaneous relative + absolute floating point comparison for 
+      /// the vertex four vectors
+      /// make the distance comparison 1 micron, time comparison 0.1 ps
+      const auto distepsilon = 0.0001;
+      const auto timeepsilon = 0.0001;
+      auto xlist = {1.0, std::abs(newvtx->get_x()), std::abs(viter->second->get_x())};
+      auto ylist = {1.0, std::abs(newvtx->get_y()), std::abs(viter->second->get_y())};
+      auto zlist = {1.0, std::abs(newvtx->get_z()), std::abs(viter->second->get_z())};
+      auto tlist = {1.0, std::abs(newvtx->get_t()), std::abs(viter->second->get_t())};
+     
+      bool xcomp = std::abs(newvtx->get_x() - viter->second->get_x())
+	<= distepsilon * (*std::max_element(xlist.begin(), xlist.end()));
+      bool ycomp = std::abs(newvtx->get_y() - viter->second->get_y())
+	<= distepsilon * (*std::max_element(ylist.begin(), ylist.end()));
+      bool zcomp = std::abs(newvtx->get_z() - viter->second->get_z())
+	<= distepsilon * (*std::max_element(zlist.begin(), zlist.end()));
+      bool tcomp = std::abs(newvtx->get_t() - viter->second->get_t())
+	<= timeepsilon * (*std::max_element(tlist.begin(), tlist.end()));
+      
+      if (*newvtx == *(viter->second) or
+	  (xcomp and ycomp and zcomp and tcomp) )
 	{
 	  delete newvtx;
 	  return viter->first;


### PR DESCRIPTION
vertices to implicitly merge PYTHIA particles that have
sub micron precision similar vertices

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a floating point precision comparison to the (x,y,z,t) four vectors of the truth vertices  in addition to the usual check. In PYTHIA, truth vertices are assigned to every particle and these can vary on the order of less than 0.1 micron based on what time PYTHIA assigns to the track. This PR "overrides" this by grouping particles together based on 1 micron precision in (x,y,z) and 1 ps in time. This allows all truth vertices to be propagated through the G4 routine for evaluation (e.g. all primary and secondary vertices that PYTHIA produces that are actually separate from one another on the order of 1 micron).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

