### PR TITLE
Added MVTX alignment capabilities

### DIFF
--- a/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
+++ b/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
@@ -37,7 +37,7 @@ LiteCaloEval::LiteCaloEval(const std::string& name, const std::string& caloname,
 }
 
 //____________________________________________________________________________..
-int LiteCaloEval::InitRun(PHCompositeNode* /*topNode*/)
+int LiteCaloEval::InitRun(PHCompositeNode* topNode)
 {
   // just quit if we forgot to set the calorimeter type
   if (calotype == LiteCaloEval::NONE)
@@ -219,7 +219,7 @@ int LiteCaloEval::process_event(PHCompositeNode* topNode)
 }
 
 //____________________________________________________________________________..
-int LiteCaloEval::End(PHCompositeNode* /*topNode*/)
+int LiteCaloEval::End(PHCompositeNode* topNode)
 {
   cal_output->cd();
   if (calotype == LiteCaloEval::HCALIN)

--- a/calibrations/calorimeter/calo_tower_slope/configure.ac
+++ b/calibrations/calorimeter/calo_tower_slope/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -24,9 +24,9 @@ using namespace std;
 #define ALMOST_ZERO 0.00001
 
 AnnularFieldSim::AnnularFieldSim(float in_innerRadius, float in_outerRadius, float in_outerZ,
-				 int r, int roi_r0, int roi_r1, int /*in_rLowSpacing*/, int /*in_rHighSize*/,
-				 int phi, int roi_phi0, int roi_phi1, int /*in_phiLowSpacing*/, int /*in_phiHighSize*/,
-				 int z, int roi_z0, int roi_z1,int /*in_zLowSpacing*/, int /*in_zHighSize*/,
+				 int r, int roi_r0, int roi_r1, int in_rLowSpacing, int in_rHighSize,
+				 int phi, int roi_phi0, int roi_phi1, int in_phiLowSpacing, int in_phiHighSize,
+				 int z, int roi_z0, int roi_z1,int in_zLowSpacing, int in_zHighSize,
 				 float vdr,LookupCase in_lookupCase, ChargeCase in_chargeCase){
   //check well-ordering:
   if (roi_r0 >=r || roi_r1>r || roi_r0>=roi_r1){
@@ -2467,7 +2467,7 @@ void AnnularFieldSim::PlotFieldSlices(const std::string &filebase,TVector3 pos, 
 return;
 }
 
-void AnnularFieldSim::GenerateSeparateDistortionMaps(const char* filebase, int r_subsamples, int p_subsamples, int z_subsamples, int /*z_substeps*/, bool andCartesian){
+void AnnularFieldSim::GenerateSeparateDistortionMaps(const char* filebase, int r_subsamples, int p_subsamples, int z_subsamples, int z_substeps, bool andCartesian){
 //1) pick a map spacing ('s')  
   TVector3 s(step.Perp()/r_subsamples, 0,step.Z()/z_subsamples);
   s.SetPhi(step.Phi()/p_subsamples);
@@ -2952,7 +2952,7 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char* filebase, int r
 
 
 
-void AnnularFieldSim::GenerateDistortionMaps(const char* filebase, int r_subsamples, int p_subsamples, int z_subsamples, int /*z_substeps*/, bool andCartesian){
+void AnnularFieldSim::GenerateDistortionMaps(const char* filebase, int r_subsamples, int p_subsamples, int z_subsamples, int z_substeps, bool andCartesian){
 //1) pick a map spacing ('s')
   bool makeUnifiedMap=true; //if true, generate a single map across the whole TPC.  if false, save two maps, one for each side.
 

--- a/calibrations/tpc/generator/configure.ac
+++ b/calibrations/tpc/generator/configure.ac
@@ -10,14 +10,8 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-unused-parameter"
- ;;
-esac
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
+++ b/generators/FermiMotionAfterburner/FermimotionAfterburner.cc
@@ -39,7 +39,7 @@ FermimotionAfterburner::~FermimotionAfterburner()
 }
 
 //____________________________________________________________________________..
-int FermimotionAfterburner::Init(PHCompositeNode */*topNode*/)
+int FermimotionAfterburner::Init(PHCompositeNode *topNode)
 {
   unsigned int seed = PHRandomSeed();
   gsl_rng_set(RandomGenerator, seed);

--- a/generators/FermiMotionAfterburner/configure.ac
+++ b/generators/FermiMotionAfterburner/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/generators/JETSCAPE/configure.ac
+++ b/generators/JETSCAPE/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/generators/PHPythia6/PHPy6GenTrigger.h
+++ b/generators/PHPythia6/PHPy6GenTrigger.h
@@ -19,7 +19,7 @@ class PHPy6GenTrigger
  public:
   virtual ~PHPy6GenTrigger();
 
-  virtual bool Apply(const HepMC::GenEvent* /*evt*/)
+  virtual bool Apply(const HepMC::GenEvent* evt)
   {
     std::cout << "PHPy6GenTrigger::Apply - in virtual function" << std::endl;
     return false;

--- a/generators/PHPythia6/PHPythia6.cc
+++ b/generators/PHPythia6/PHPythia6.cc
@@ -90,7 +90,7 @@ int PHPythia6::Init(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHPythia6::End(PHCompositeNode */*topNode*/)
+int PHPythia6::End(PHCompositeNode *topNode)
 {
   //........................................TERMINATION
   // write out some information from Pythia to the screen
@@ -337,7 +337,7 @@ void PHPythia6::print_config() const
 {
 }
 
-int PHPythia6::process_event(PHCompositeNode */*topNode*/)
+int PHPythia6::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1) cout << "PHPythia6::process_event - event: " << _eventcount << endl;
 
@@ -467,7 +467,7 @@ void PHPythia6::IntegerTest(double number)
   return;
 }
 
-int PHPythia6::ResetEvent(PHCompositeNode */*topNode*/)
+int PHPythia6::ResetEvent(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/generators/PHPythia6/configure.ac
+++ b/generators/PHPythia6/configure.ac
@@ -11,9 +11,9 @@ dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic  -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic "
   else
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
   fi
 fi
 

--- a/generators/PHPythia8/PHPy8GenTrigger.h
+++ b/generators/PHPythia8/PHPy8GenTrigger.h
@@ -19,7 +19,7 @@ class PHPy8GenTrigger
  public:
   virtual ~PHPy8GenTrigger(){}
 
-  virtual bool Apply(Pythia8::Pythia */*pythia*/)
+  virtual bool Apply(Pythia8::Pythia *pythia)
   {
     std::cout << "PHPy8GenTrigger::Apply - in virtual function" << std::endl;
     return false;

--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -113,7 +113,7 @@ int PHPythia8::Init(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHPythia8::End(PHCompositeNode */*topNode*/)
+int PHPythia8::End(PHCompositeNode *topNode)
 {
   if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::End - I'm here!" << endl;
 
@@ -171,7 +171,7 @@ void PHPythia8::print_config() const
   m_Pythia8->info.list();
 }
 
-int PHPythia8::process_event(PHCompositeNode */*topNode*/)
+int PHPythia8::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() >= VERBOSITY_MORE) cout << "PHPythia8::process_event - event: " << m_EventCount << endl;
 

--- a/generators/PHPythia8/configure.ac
+++ b/generators/PHPythia8/configure.ac
@@ -12,10 +12,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
  case $CXX in
   clang++)
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions"
   ;;
   *g++)
-   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic -Wextra "
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -pedantic "
   ;;
  esac
 

--- a/generators/PHSartre/PHSartre.cc
+++ b/generators/PHSartre/PHSartre.cc
@@ -122,7 +122,7 @@ int PHSartre::Init(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHSartre::End(PHCompositeNode */*topNode*/)
+int PHSartre::End(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1) cout << "PHSartre::End - I'm here!" << endl;
 
@@ -151,7 +151,7 @@ void PHSartre::print_config() const
   settings->list();
 }
 
-int PHSartre::process_event(PHCompositeNode */*topNode*/)
+int PHSartre::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1) cout << "PHSartre::process_event - event: " << _eventcount << endl;
 
@@ -475,7 +475,7 @@ int PHSartre::process_event(PHCompositeNode */*topNode*/)
 
 
 
-int PHSartre::ResetEvent(PHCompositeNode */*topNode*/)
+int PHSartre::ResetEvent(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/generators/PHSartre/PHSartreGenTrigger.h
+++ b/generators/PHSartre/PHSartreGenTrigger.h
@@ -16,7 +16,7 @@ class PHSartreGenTrigger
  public:
   virtual ~PHSartreGenTrigger();
 
-  virtual bool Apply(Event */*event*/)
+  virtual bool Apply(Event *event)
   {
     std::cout << "PHSartreGenTrigger::Apply - in virtual function" << std::endl;
     return false;

--- a/generators/PHSartre/configure.ac
+++ b/generators/PHSartre/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/generators/flowAfterburner/configure.ac
+++ b/generators/flowAfterburner/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
 dnl test for root 6

--- a/generators/hijing/configure.ac
+++ b/generators/hijing/configure.ac
@@ -6,13 +6,7 @@ AC_PROG_CXX
 AC_PROG_F77(gfortran)
 LT_INIT([disable-static])
 
-dnl deprecated declaraion from fastjet header
-if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wextra"
-fi
-
-CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override -Wextra "
-
+CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
 
 AC_CONFIG_FILES([Makefile])

--- a/generators/hijing/src/hijfst.cc
+++ b/generators/hijing/src/hijfst.cc
@@ -49,7 +49,7 @@ hijfst_control(int enable, vector<string> valgorithm, vector<float> vR, vector<i
   enablep = (enable==1) ? true: false;
   
   algo_info_vec.clear();
-  for (unsigned int i = 0; i < valgorithm.size(); ++i)
+  for (int i = 0; i < valgorithm.size(); ++i)
     {
       string algorithmName = valgorithm[i];
       transform(algorithmName.begin(), algorithmName.end(), algorithmName.begin(), ::toupper);

--- a/generators/phhepmc/Fun4AllHepMCInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.cc
@@ -153,7 +153,7 @@ int Fun4AllHepMCInputManager::fileopen(const std::string &filenam)
   return 0;
 }
 
-int Fun4AllHepMCInputManager::run(const int /*nevents*/)
+int Fun4AllHepMCInputManager::run(const int nevents)
 {
   // attempt to retrieve a valid event from inputs
   while (true)

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.cc
@@ -58,7 +58,7 @@ int Fun4AllHepMCPileupInputManager::SkipForThisManager(const int nevents)
   return 0;
 }
 
-int Fun4AllHepMCPileupInputManager::run(const int /*nevents*/, const bool skip)
+int Fun4AllHepMCPileupInputManager::run(const int nevents, const bool skip)
 {
   if (_first_run)
   {

--- a/generators/phhepmc/HepMCFlowAfterBurner.cc
+++ b/generators/phhepmc/HepMCFlowAfterBurner.cc
@@ -49,7 +49,7 @@ HepMCFlowAfterBurner::HepMCFlowAfterBurner(const std::string &name)
 {
 }
 
-int HepMCFlowAfterBurner::Init(PHCompositeNode */*topNode*/)
+int HepMCFlowAfterBurner::Init(PHCompositeNode *topNode)
 {
   if (seedset)
   {
@@ -125,7 +125,7 @@ void HepMCFlowAfterBurner::RestoreRandomState(const string &savefile)
   cout << PHWHERE << " Random engine not started yet" << endl;
 }
 
-void HepMCFlowAfterBurner::Print(const string &/*what*/) const
+void HepMCFlowAfterBurner::Print(const string &what) const
 {
   cout << "FlowAfterBurner parameters:" << endl;
   cout << "algorithm: " << algorithmName << endl;

--- a/generators/phhepmc/PHGenIntegral.h
+++ b/generators/phhepmc/PHGenIntegral.h
@@ -31,7 +31,7 @@ class PHGenIntegral : public PHObject
   }
 
   //! Integrated luminosity in pb^-1
-  virtual void set_Integrated_Lumi(Double_t /*integratedLumi*/)
+  virtual void set_Integrated_Lumi(Double_t integratedLumi)
   {
   }
 
@@ -42,7 +42,7 @@ class PHGenIntegral : public PHObject
   }
 
   //! Number of accepted events in the event generator. This can be higher than fNProcessedEvent depending on trigger on the event generator
-  virtual void set_N_Generator_Accepted_Event(ULong64_t /*nGeneratorAcceptedEvent*/)
+  virtual void set_N_Generator_Accepted_Event(ULong64_t nGeneratorAcceptedEvent)
   {
   }
 
@@ -53,7 +53,7 @@ class PHGenIntegral : public PHObject
   }
 
   //! Number of processed events in the Fun4All cycles
-  virtual void set_N_Processed_Event(ULong64_t /*nProcessedEvent*/)
+  virtual void set_N_Processed_Event(ULong64_t nProcessedEvent)
   {
   }
 
@@ -68,7 +68,7 @@ class PHGenIntegral : public PHObject
   //! Sum of weight assigned to the events by the generators.
   //! Event weight is normally 1 and thus equal to number of the generated event and is uninteresting.
   //! However, there are several cases where one may have nontrivial event weights, e.g. using user hooks in Pythia8 generators to reweight the phase space
-  virtual void set_Sum_Of_Weight(Double_t /*sumOfWeight*/)
+  virtual void set_Sum_Of_Weight(Double_t sumOfWeight)
   {
   }
 
@@ -82,7 +82,7 @@ class PHGenIntegral : public PHObject
   virtual const std::string& get_Description() const;
 
   //! description on the source
-  virtual void set_Description(const std::string& /*description*/)
+  virtual void set_Description(const std::string& description)
   {
   }
 

--- a/generators/phhepmc/PHHepMCGenEvent.h
+++ b/generators/phhepmc/PHHepMCGenEvent.h
@@ -69,7 +69,7 @@ class PHHepMCGenEvent : public PHObject
   }
 
   //! boost beta vector for Lorentz Transform, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  virtual void set_boost_beta_vector(const HepMC::ThreeVector&) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_boost_beta_vector(const HepMC::ThreeVector& v) { PHOOL_VIRTUAL_WARNING; }
 
   //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
   virtual const HepMC::ThreeVector& get_rotation_vector() const
@@ -80,7 +80,7 @@ class PHHepMCGenEvent : public PHObject
   }
 
   //! rotation axis vector, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  virtual void set_rotation_vector(const HepMC::ThreeVector&) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_rotation_vector(const HepMC::ThreeVector& v) { PHOOL_VIRTUAL_WARNING; }
 
   //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
   virtual double get_rotation_angle() const
@@ -90,7 +90,7 @@ class PHHepMCGenEvent : public PHObject
   }
 
   //! rotation angle, part of composition of a LorentzRotation to translate from hepmc event frame to lab frame
-  virtual void set_rotation_angle(const double) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_rotation_angle(const double a) { PHOOL_VIRTUAL_WARNING; }
 
   //!LorentzRotation to translate from hepmc event frame to lab frame
   virtual CLHEP::HepLorentzRotation get_LorentzRotation_EvtGen2Lab() const { return CLHEP::HepLorentzRotation::IDENTITY; }

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -27,12 +27,11 @@
 
 #include <HepMC/SimpleVector.h>  // for FourVector
 
-#include <CLHEP/Units/PhysicalConstants.h>
-#include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Vector/Boost.h>
 #include <CLHEP/Vector/LorentzRotation.h>
 #include <CLHEP/Vector/LorentzVector.h>
 #include <CLHEP/Vector/Rotation.h>
+#include <CLHEP/Vector/ThreeVector.h>
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
@@ -129,127 +128,36 @@ void PHHepMCGenHelper::move_vertex(PHHepMCGenEvent *genevent)
   assert(_vertex_width_z >= 0);
   assert(_vertex_width_t >= 0);
 
-  assert(not _reuse_vertex);  // logic check
-
-  // not reusing vertex so smear with the vertex parameters
-  genevent->moveVertex(
-      (smear(_vertex_x, _vertex_width_x, _vertex_func_x)),
-      (smear(_vertex_y, _vertex_width_y, _vertex_func_y)),
-      (smear(_vertex_z, _vertex_width_z, _vertex_func_z)),
-      (smear(_vertex_t, _vertex_width_t, _vertex_func_t)));
-}
-
-//! use m_beam_bunch_width to calculate horizontal and vertical collision width
-//! \param[in] hv_index 0: horizontal. 1: vertical
-//! https://github.com/eic/documents/blob/d06b5597a0a89dcad215bab50fe3eefa17a097a5/reports/general/Note-Simulations-BeamEffects.pdf
-double PHHepMCGenHelper::get_collision_width(unsigned int hv_index)
-{
-  assert((hv_index == 0) or (hv_index == 1));
-
-  const double widthA = m_beam_bunch_width.first[hv_index];
-  const double widthB = m_beam_bunch_width.second[hv_index];
-
-  return widthA * widthB / sqrt(widthA * widthA + widthB * widthB);
-}
-
-//! generate vertx with bunch interaction according to
-//! https://github.com/eic/documents/blob/d06b5597a0a89dcad215bab50fe3eefa17a097a5/reports/general/Note-Simulations-BeamEffects.pdf
-//! \return pair of bunch local z position for beam A and beam B
-pair<double, double> PHHepMCGenHelper::generate_vertx_with_bunch_interaction(PHHepMCGenEvent *genevent)
-{
-  const pair<double, double> bunch_zs(
-      smear(
-          0,                            //  central vertical angle shift
-          m_beam_bunch_width.first[2],  // vertical angle smear
-          Gaus),
-      smear(
-          0,                             //  central vertical angle shift
-          m_beam_bunch_width.second[2],  // vertical angle smear
-          Gaus));
-
-  CLHEP::Hep3Vector beamA_center = pair2Hep3Vector(m_beam_direction_theta_phi.first);
-  CLHEP::Hep3Vector beamB_center = pair2Hep3Vector(m_beam_direction_theta_phi.second);
-  //  const static CLHEP::Hep3Vector z_axis(0, 0, 1);
-  const static CLHEP::Hep3Vector y_axis(0, 1, 0);
-
-  // the final longitudinal vertex smear axis
-  CLHEP::Hep3Vector beamCenterDiffAxis = (beamA_center - beamB_center);
-  assert(beamCenterDiffAxis.mag() > CLHEP::Hep3Vector::getTolerance());
-  beamCenterDiffAxis = beamCenterDiffAxis / beamCenterDiffAxis.mag();
-
-  CLHEP::Hep3Vector vec_crossing = beamA_center - 0.5 * (beamA_center - beamB_center);
-
-  CLHEP::Hep3Vector vec_longitudinal_collision = beamCenterDiffAxis * (bunch_zs.first + bunch_zs.second) / 2.;
-  double ct_collision = 0.5 * (-bunch_zs.first + bunch_zs.second) / beamCenterDiffAxis.dot(beamA_center);
-  double t_collision = ct_collision * CLHEP::cm / CLHEP::c_light / CLHEP::ns;
-  CLHEP::Hep3Vector vec_crossing_collision = ct_collision * vec_crossing;  // shift of collision to crossing dierction
-
-  CLHEP::Hep3Vector horizontal_axis = y_axis.cross(beamCenterDiffAxis);
-  assert(horizontal_axis.mag() > CLHEP::Hep3Vector::getTolerance());
-  horizontal_axis = horizontal_axis / horizontal_axis.mag();
-
-  CLHEP::Hep3Vector vertical_axis = beamCenterDiffAxis.cross(horizontal_axis);
-  assert(vertical_axis.mag() > CLHEP::Hep3Vector::getTolerance());
-  vertical_axis = vertical_axis / vertical_axis.mag();
-
-  CLHEP::Hep3Vector vec_horizontal_collision_vertex_smear = horizontal_axis *
-                                                            smear(
-                                                                0,
-                                                                get_collision_width(0),
-                                                                Gaus);
-  CLHEP::Hep3Vector vec_vertical_collision_vertex_smear = vertical_axis *
-                                                          smear(
-                                                              0,
-                                                              get_collision_width(1),
-                                                              Gaus);
-
-  CLHEP::Hep3Vector vec_collision_vertex =
-      vec_horizontal_collision_vertex_smear +
-      vec_vertical_collision_vertex_smear +  //
-      vec_crossing_collision + vec_longitudinal_collision;
-
-  genevent->set_collision_vertex(HepMC::FourVector(
-      vec_collision_vertex.x(),
-      vec_collision_vertex.y(),
-      vec_collision_vertex.z(),
-      t_collision));
-
-  if (m_verbosity)
+  if (_reuse_vertex)
   {
-    cout << __PRETTY_FUNCTION__
-         << ":"
-         << "bunch_zs.first  = " << bunch_zs.first << ", "
-         << "bunch_zs.second = " << bunch_zs.second << ", "
-         << "cos(theta/2) = " << beamCenterDiffAxis.dot(beamA_center) << ", " << endl
+    assert(_geneventmap);
 
-         << "beamCenterDiffAxis = " << beamCenterDiffAxis << ", "
-         << "vec_crossing = " << vec_crossing << ", "
-         << "horizontal_axis = " << horizontal_axis << ", "
-         << "vertical_axis = " << vertical_axis << ", " << endl
+    PHHepMCGenEvent *vtx_evt =
+        _geneventmap->get(_reuse_vertex_embedding_id);
 
-         << "vec_longitudinal_collision = " << vec_longitudinal_collision << ", "
-         << "vec_crossing_collision = " << vec_crossing_collision << ", "
-         << "vec_vertical_collision_vertex_smear = " << vec_vertical_collision_vertex_smear << ", "
-         << "vec_horizontal_collision_vertex_smear = " << vec_horizontal_collision_vertex_smear << ", " << endl
-         << "vec_collision_vertex = " << vec_collision_vertex << ", " << endl
+    if (!vtx_evt)
+    {
+      cout << "PHHepMCGenHelper::move_vertex - Fatal Error - the requested source subevent with embedding ID "
+           << _reuse_vertex_embedding_id << " does not exist. Current HepMCEventMap:";
+      _geneventmap->identify();
+      exit(11);
+    }
 
-         << "ct_collision = " << ct_collision << ", "
-         << "t_collision = " << t_collision << ", "
-         << endl;
+    genevent->moveVertex(
+        vtx_evt->get_collision_vertex().x(),
+        vtx_evt->get_collision_vertex().y(),
+        vtx_evt->get_collision_vertex().z(),
+        vtx_evt->get_collision_vertex().t());
   }
-
-  return bunch_zs;
-}
-
-CLHEP::Hep3Vector PHHepMCGenHelper::pair2Hep3Vector(const std::pair<double, double> &theta_phi)
-{
-  const double &theta = theta_phi.first;
-  const double &phi = theta_phi.second;
-
-  return CLHEP::Hep3Vector(
-      sin(theta) * cos(phi),
-      sin(theta) * sin(phi),
-      cos(theta));
+  else
+  {
+    // not reusing vertex so smear with the vertex parameters
+    genevent->moveVertex(
+        (smear(_vertex_x, _vertex_width_x, _vertex_func_x)),
+        (smear(_vertex_y, _vertex_width_y, _vertex_func_y)),
+        (smear(_vertex_z, _vertex_width_z, _vertex_func_z)),
+        (smear(_vertex_t, _vertex_width_t, _vertex_func_t)));
+  }
 }
 
 //! move vertex in translation,boost,rotation according to vertex settings
@@ -262,62 +170,25 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   assert(genevent);
 
-  if (_reuse_vertex)
-  {
-    // just copy over the vertex boost_rotation_translation
-
-    assert(_geneventmap);
-
-    PHHepMCGenEvent *vtx_evt =
-        _geneventmap->get(_reuse_vertex_embedding_id);
-
-    if (!vtx_evt)
-    {
-      cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal Error - the requested source subevent with embedding ID "
-           << _reuse_vertex_embedding_id << " does not exist. Current HepMCEventMap:";
-      _geneventmap->identify();
-      exit(1);
-    }
-
-    //copy boost_rotation_translation
-
-    genevent->moveVertex(
-        vtx_evt->get_collision_vertex().x(),
-        vtx_evt->get_collision_vertex().y(),
-        vtx_evt->get_collision_vertex().z(),
-        vtx_evt->get_collision_vertex().t());
-
-    genevent->set_boost_beta_vector(vtx_evt->get_boost_beta_vector());
-    genevent->set_rotation_vector(vtx_evt->get_rotation_vector());
-    genevent->set_rotation_angle(vtx_evt->get_rotation_angle());
-
-    if (m_verbosity)
-    {
-      cout << __PRETTY_FUNCTION__ << ": copied boost rotation shift of the collision" << endl;
-      genevent->identify();
-    }
-    return;
-  }  //!   if (_reuse_vertex)
-
   // now handle the collision vertex first, in the head-on collision frame
   // this is used as input to the Crab angle correction
-  pair<double, double> beam_bunch_zs;
-  if (m_use_beam_bunch_sim)
-  {
-    // bunch interaction simulation
-    beam_bunch_zs = generate_vertx_with_bunch_interaction(genevent);
-  }
-  else
-  {
-    // vertex distribution simulation
-    move_vertex(genevent);
-    const double init_vertex_longitudinal = genevent->get_collision_vertex().z();
-    beam_bunch_zs.first = beam_bunch_zs.second = init_vertex_longitudinal;
-  }
+  move_vertex(genevent);
+  const double init_vertex_longitudinal = genevent->get_collision_vertex().z();
 
   // boost-rotation from beam angles
 
   const static CLHEP::Hep3Vector z_axis(0, 0, 1);
+
+  // function to convert spherical coordinate to Hep3Vector in x-y-z
+  auto pair2Hep3Vector = [](const std::pair<double, double> &theta_phi) {
+    const double &theta = theta_phi.first;
+    const double &phi = theta_phi.second;
+
+    return CLHEP::Hep3Vector(
+        sin(theta) * cos(phi),
+        sin(theta) * sin(phi),
+        cos(theta));
+  };
 
   CLHEP::Hep3Vector beamA_center = pair2Hep3Vector(m_beam_direction_theta_phi.first);
   CLHEP::Hep3Vector beamB_center = pair2Hep3Vector(m_beam_direction_theta_phi.second);
@@ -359,14 +230,14 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     CLHEP::HepRotation x_smear_in_accelerator_plane(
         accelerator_plane,
         smear(
-            beam_bunch_zs.first * beam_angular_z_coefficient_hv.first,  //  central horizontal angle shift
-            x_divergence,                                               // horizontal angle smear
+            init_vertex_longitudinal * beam_angular_z_coefficient_hv.first,  //  central horizontal angle shift
+            x_divergence,                                                    // horizontal angle smear
             Gaus));
     CLHEP::HepRotation y_smear_out_accelerator_plane(
         accelerator_plane.cross(beam_center),
         smear(
-            beam_bunch_zs.second * beam_angular_z_coefficient_hv.second,  //  central vertical angle shift
-            y_divergence,                                                 // vertical angle smear
+            init_vertex_longitudinal * beam_angular_z_coefficient_hv.second,  //  central vertical angle shift
+            y_divergence,                                                     // vertical angle smear
             Gaus));
 
     return y_smear_out_accelerator_plane * x_smear_in_accelerator_plane * beam_center;
@@ -472,6 +343,61 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     }
   }  //  if (boost_axis.mag2() > CLHEP::Hep3Vector::getTolerance())
 
+  // rotate the collision vertex z direction to middle of the beam angles
+  if (not _reuse_vertex)
+  {
+    // the final longitudinal vertex smear axis
+    CLHEP::Hep3Vector beamCenterDiffAxis = (beamA_center - beamB_center);
+    beamCenterDiffAxis = beamCenterDiffAxis / beamCenterDiffAxis.mag();
+
+    double cos_rotation_center_angle_to_z = beamCenterDiffAxis.dot(z_axis);
+
+    if (1 - fabs(cos_rotation_center_angle_to_z) < CLHEP::Hep3Vector::getTolerance())
+    {
+      // new axis is basically beam axis
+
+      if (m_verbosity)
+      {
+        cout << __PRETTY_FUNCTION__
+             << ": collision longitudinal axis is very close to z-axis. No additional rotation of vertexes: "
+             << "cos_rotation_center_angle_to_z = " << cos_rotation_center_angle_to_z
+             << endl;
+      }
+    }
+    else
+    {
+      // need a rotation
+      CLHEP::Hep3Vector rotation_axis = beamCenterDiffAxis.cross(z_axis);
+      const double rotation_angle_to_z = -acos(cos_rotation_center_angle_to_z);
+      const CLHEP::HepRotation rotation(rotation_axis, rotation_angle_to_z);
+
+      const HepMC::FourVector init_4vertex = genevent->get_collision_vertex();
+      CLHEP::Hep3Vector init_3vertex(
+          init_4vertex.x(),
+          init_4vertex.y(),
+          init_4vertex.z());
+
+      CLHEP::Hep3Vector final_3vertex = rotation * init_3vertex;
+
+      genevent->set_collision_vertex(HepMC::FourVector(
+          final_3vertex.x(),
+          final_3vertex.y(),
+          final_3vertex.z(),
+          init_4vertex.t()));
+
+      if (m_verbosity)
+      {
+        cout << __PRETTY_FUNCTION__
+             << ": collision longitudinal axis is rotated: "
+             << "cos_rotation_center_angle_to_z = " << cos_rotation_center_angle_to_z << ", "
+             << "rotation_axis = " << rotation_axis << ", "
+             << "init_3vertex = " << init_3vertex << ", "
+             << "final_3vertex = " << final_3vertex << ", "
+             << endl;
+      }
+    }
+  }  //  if (not _reuse_vertex)
+
   if (m_verbosity)
   {
     cout << __PRETTY_FUNCTION__ << ": final boost rotation shift of the collision" << endl;
@@ -481,13 +407,6 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
 void PHHepMCGenHelper::set_vertex_distribution_function(VTXFUNC x, VTXFUNC y, VTXFUNC z, VTXFUNC t)
 {
-  if (m_use_beam_bunch_sim)
-  {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
-    exit(1);
-  }
   _vertex_func_x = x;
   _vertex_func_y = y;
   _vertex_func_z = z;
@@ -497,14 +416,6 @@ void PHHepMCGenHelper::set_vertex_distribution_function(VTXFUNC x, VTXFUNC y, VT
 
 void PHHepMCGenHelper::set_vertex_distribution_mean(const double x, const double y, const double z, const double t)
 {
-  if (m_use_beam_bunch_sim)
-  {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
-    exit(1);
-  }
-
   _vertex_x = x;
   _vertex_y = y;
   _vertex_z = z;
@@ -514,33 +425,11 @@ void PHHepMCGenHelper::set_vertex_distribution_mean(const double x, const double
 
 void PHHepMCGenHelper::set_vertex_distribution_width(const double x, const double y, const double z, const double t)
 {
-  if (m_use_beam_bunch_sim)
-  {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
-    exit(1);
-  }
-
   _vertex_width_x = x;
   _vertex_width_y = y;
   _vertex_width_z = z;
   _vertex_width_t = t;
   return;
-}
-
-void PHHepMCGenHelper::set_beam_bunch_width(const std::vector<double> &beamA, const std::vector<double> &beamB)
-{
-  if (not m_use_beam_bunch_sim)
-  {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect not to simulate bunch interaction but applying vertex distributions"
-         << endl;
-    exit(1);
-  }
-
-  m_beam_bunch_width.first = beamA;
-  m_beam_bunch_width.second = beamB;
 }
 
 double PHHepMCGenHelper::smear(const double position,
@@ -572,18 +461,9 @@ double PHHepMCGenHelper::smear(const double position,
 
 void PHHepMCGenHelper::CopySettings(PHHepMCGenHelper &helper_dest)
 {
-  //allow copy of vertex distributions
-  helper_dest.use_beam_bunch_sim(false);
   helper_dest.set_vertex_distribution_width(_vertex_width_x, _vertex_width_y, _vertex_width_z, _vertex_width_t);
   helper_dest.set_vertex_distribution_function(_vertex_func_x, _vertex_func_y, _vertex_func_z, _vertex_func_t);
   helper_dest.set_vertex_distribution_mean(_vertex_x, _vertex_y, _vertex_z, _vertex_t);
-
-  //allow copy of bunch distributions
-  helper_dest.use_beam_bunch_sim(true);
-  helper_dest.set_beam_bunch_width(m_beam_bunch_width.first, m_beam_bunch_width.second);
-
-  //final bunch settings
-  helper_dest.use_beam_bunch_sim(m_use_beam_bunch_sim);
 
   helper_dest.set_beam_direction_theta_phi(
       m_beam_direction_theta_phi.first.first,
@@ -595,12 +475,6 @@ void PHHepMCGenHelper::CopySettings(PHHepMCGenHelper &helper_dest)
       m_beam_angular_divergence_hv.first.second,
       m_beam_angular_divergence_hv.second.first,
       m_beam_angular_divergence_hv.second.second);
-  helper_dest.set_beam_angular_z_coefficient_hv(
-      m_beam_angular_z_coefficient_hv.first.first,
-      m_beam_angular_z_coefficient_hv.first.second,
-      m_beam_angular_z_coefficient_hv.second.first,
-      m_beam_angular_z_coefficient_hv.second.second);
-
   helper_dest.set_beam_angular_z_coefficient_hv(
       m_beam_angular_z_coefficient_hv.first.first,
       m_beam_angular_z_coefficient_hv.first.second,
@@ -632,7 +506,7 @@ void PHHepMCGenHelper::CopyHelperSettings(PHHepMCGenHelper *helper_src)
   }
 }
 
-void PHHepMCGenHelper::Print(const std::string &/*what*/) const
+void PHHepMCGenHelper::Print(const std::string &what) const
 {
   static map<VTXFUNC, string> vtxfunc = {{VTXFUNC::Uniform, "Uniform"}, {VTXFUNC::Gaus, "Gaus"}};
 
@@ -662,13 +536,6 @@ void PHHepMCGenHelper::Print(const std::string &/*what*/) const
        << ", " << m_beam_angular_z_coefficient_hv.first.second << endl;
   cout << "Beam angle shift as linear function of longitudinal vertex position: B X-Y = " << m_beam_angular_z_coefficient_hv.second.first
        << ", " << m_beam_angular_z_coefficient_hv.second.second << endl;
-
-  cout << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << endl;
-
-  cout << "Beam bunch A width = ["
-       << m_beam_bunch_width.first[0] << ", " << m_beam_bunch_width.first[1] << ", " << m_beam_bunch_width.first[2] << "] cm" << endl;
-  cout << "Beam bunch B width = ["
-       << m_beam_bunch_width.second[0] << ", " << m_beam_bunch_width.second[1] << ", " << m_beam_bunch_width.second[2] << "] cm" << endl;
 
   return;
 }

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -11,14 +11,11 @@
 #ifndef PHHEPMC_PHHEPMCGENHELPER_H
 #define PHHEPMC_PHHEPMCGENHELPER_H
 
-#include <CLHEP/Vector/ThreeVector.h>
-
 #include <gsl/gsl_rng.h>
 
 #include <cmath>
 #include <string>
 #include <utility>
-#include <vector>
 
 class PHCompositeNode;
 class PHHepMCGenEvent;
@@ -85,6 +82,12 @@ class PHHepMCGenHelper
   //! send HepMC::GenEvent to DST tree. This function takes ownership of evt
   PHHepMCGenEvent *insert_event(HepMC::GenEvent *evt);
 
+  //! Record the translation,boost,rotation for HepMC frame to lab frame according to collision settings
+  void HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *genevent);
+
+  //! move vertex in translation according to vertex settings
+  void move_vertex(PHHepMCGenEvent *genevent);
+
   const PHHepMCGenEventMap *get_geneventmap() const
   {
     return _geneventmap;
@@ -148,14 +151,6 @@ class PHHepMCGenHelper
     m_beam_angular_z_coefficient_hv = {{beamA_h, beamA_v}, {beamB_h, beamB_v}};
   }
 
-  //! simulate bunch interaction instead of applying vertex distributions
-  void use_beam_bunch_sim(bool b) { m_use_beam_bunch_sim = b; }
-
-  //! Beam bunch geometry as 3D Gauss width
-  //! First element is beamA, in vector of Gaussian Sigma H,V,Longitudinal
-  //! Second element is beamB, in vector of Gaussian Sigma H,V,Longitudinal
-  void set_beam_bunch_width(const std::vector<double> &beamA, const std::vector<double> &beamB);
-
   void CopySettings(PHHepMCGenHelper &helper);
 
   //! copy setting to helper_dest
@@ -170,25 +165,10 @@ class PHHepMCGenHelper
 
   int PHHepMCGenHelper_Verbosity() { return m_verbosity; }
 
- protected:
-  //! Record the translation,boost,rotation for HepMC frame to lab frame according to collision settings
-  void HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *genevent);
-
-  //! move vertex in translation according to vertex settings
-  void move_vertex(PHHepMCGenEvent *genevent);
-
-  //! generate vertx with bunch interaction according to
-  //! https://github.com/eic/documents/blob/d06b5597a0a89dcad215bab50fe3eefa17a097a5/reports/general/Note-Simulations-BeamEffects.pdf
-  //! \return pair of bunch local z position for beam A and beam B
-  std::pair<double, double> generate_vertx_with_bunch_interaction(PHHepMCGenEvent *genevent);
-
  private:
   gsl_rng *RandomGenerator;
 
   double smear(const double position, const double width, VTXFUNC dist) const;
-
-  //! function to convert spherical coordinate to Hep3Vector in x-y-z
-  static CLHEP::Hep3Vector pair2Hep3Vector(const std::pair<double, double> &theta_phi);
 
   VTXFUNC _vertex_func_x;
   VTXFUNC _vertex_func_y;
@@ -246,22 +226,6 @@ class PHHepMCGenHelper
 
   //!verbosity
   int m_verbosity = 0;
-
-  //! simulate bunch interaction instead of applying vertex distributions
-  bool m_use_beam_bunch_sim = false;
-
-  //! Beam bunch geometry as 3D Gauss width
-  //! First element is beamA, in vector of Gaussian Sigma H,V,Longitudinal
-  //! Second element is beamB, in vector of Gaussian Sigma H,V,Longitudinal
-  std::pair<std::vector<double>, std::vector<double>> m_beam_bunch_width = {
-      {0, 0, 0},  //+z beam
-      {0, 0, 0}   //-z beam
-  };
-
-  //! use m_beam_bunch_width to calculate horizontal and vertical collision width
-  //! \param[in] hv_index 0: horizontal. 1: vertical
-  double get_collision_width(unsigned int hv_index);
-
 };
 
 #endif /* PHHEPMC_PHHEPMCGENHELPER_H */

--- a/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.cc
+++ b/generators/phhepmc/PHHepMCParticleSelectorDecayProductChain.cc
@@ -30,12 +30,12 @@ PHHepMCParticleSelectorDecayProductChain::PHHepMCParticleSelectorDecayProductCha
   return;
 }
 
-int PHHepMCParticleSelectorDecayProductChain::InitRun(PHCompositeNode* /*topNode*/)
+int PHHepMCParticleSelectorDecayProductChain::InitRun(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-HepMC::GenParticle* PHHepMCParticleSelectorDecayProductChain::GetParent(HepMC::GenParticle* p, HepMC::GenEvent* /*event*/)
+HepMC::GenParticle* PHHepMCParticleSelectorDecayProductChain::GetParent(HepMC::GenParticle* p, HepMC::GenEvent* event)
 {
   HepMC::GenParticle* parent = nullptr;
   if (!p->production_vertex()) return parent;

--- a/generators/phhepmc/configure.ac
+++ b/generators/phhepmc/configure.ac
@@ -6,14 +6,8 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/generators/sHEPGen/configure.ac
+++ b/generators/sHEPGen/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/generators/sHijing/configure.ac
+++ b/generators/sHijing/configure.ac
@@ -12,7 +12,7 @@ dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
 dnl turn off warnings about unused functions in cfortran.h
-   CXXFLAGS="$CXXFLAGS -Wall  -Wno-unused-function -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall  -Wno-unused-function -Werror"
 fi
 
 dnl test for root 6

--- a/offline/QA/modules/QAG4SimulationCalorimeter.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.cc
@@ -200,7 +200,7 @@ QAG4SimulationCalorimeter::get_histo_prefix()
   return "h_QAG4Sim_" + string(_calo_name);
 }
 
-int QAG4SimulationCalorimeter::Init_G4Hit(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeter::Init_G4Hit(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -248,7 +248,7 @@ int QAG4SimulationCalorimeter::Init_G4Hit(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode *topNode)
 {
   if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeter::process_event_G4Hit() entered" << endl;
@@ -430,7 +430,7 @@ int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationCalorimeter::Init_Tower(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeter::Init_Tower(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -600,7 +600,7 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationCalorimeter::Init_Cluster(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeter::Init_Cluster(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
@@ -209,7 +209,7 @@ QAG4SimulationCalorimeterSum::get_truth_particle()
   return last_primary;
 }
 
-int QAG4SimulationCalorimeterSum::Init_TrackProj(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeterSum::Init_TrackProj(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -469,7 +469,7 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const string &detector, SvtxTra
 //  return Fun4AllReturnCodes::EVENT_OK;
 //}
 
-int QAG4SimulationCalorimeterSum::Init_Cluster(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeterSum::Init_Cluster(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -504,7 +504,7 @@ int QAG4SimulationCalorimeterSum::Init_Cluster(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationCalorimeterSum::process_event_Cluster(PHCompositeNode */*topNode*/)
+int QAG4SimulationCalorimeterSum::process_event_Cluster(PHCompositeNode *topNode)
 {
   if (Verbosity() > 2)
     cout << "QAG4SimulationCalorimeterSum::process_event_Cluster() entered"

--- a/offline/QA/modules/QAG4SimulationJet.cc
+++ b/offline/QA/modules/QAG4SimulationJet.cc
@@ -228,7 +228,7 @@ QAG4SimulationJet::get_histo_prefix(const std::string& src_jet_name,
   return histo_prefix;
 }
 
-int QAG4SimulationJet::Init_Spectrum(PHCompositeNode* /*topNode*/,
+int QAG4SimulationJet::Init_Spectrum(PHCompositeNode* topNode,
                                      const std::string& jet_name)
 {
   Fun4AllHistoManager* hm = QAHistManagerDef::getHistoManager();
@@ -553,7 +553,7 @@ int QAG4SimulationJet::process_Spectrum(PHCompositeNode* topNode,
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationJet::Init_TruthMatching(PHCompositeNode* /*topNode*/,
+int QAG4SimulationJet::Init_TruthMatching(PHCompositeNode* topNode,
                                           const std::string& reco_jet_name)
 {
   Fun4AllHistoManager* hm = QAHistManagerDef::getHistoManager();

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -61,7 +61,7 @@ int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationTracking::Init(PHCompositeNode */*topNode*/)
+int QAG4SimulationTracking::Init(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);

--- a/offline/QA/modules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/modules/QAG4SimulationUpsilon.cc
@@ -67,7 +67,7 @@ int QAG4SimulationUpsilon::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationUpsilon::Init(PHCompositeNode */*topNode*/)
+int QAG4SimulationUpsilon::Init(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -75,7 +75,7 @@ int QAG4SimulationVertex::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int QAG4SimulationVertex::Init(PHCompositeNode */*topNode*/)
+int QAG4SimulationVertex::Init(PHCompositeNode *topNode)
 {
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);

--- a/offline/QA/modules/configure.ac
+++ b/offline/QA/modules/configure.ac
@@ -10,10 +10,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/database/PHParameter/PHParameters.cc
+++ b/offline/database/PHParameter/PHParameters.cc
@@ -122,7 +122,7 @@ bool PHParameters::exist_double_param(const std::string &name) const
   return false;
 }
 
-void PHParameters::Print(Option_t */*option*/) const
+void PHParameters::Print(Option_t *option) const
 {
   std::cout << "Parameters for " << m_Detector << std::endl;
   printint();

--- a/offline/database/PHParameter/PHParametersContainer.cc
+++ b/offline/database/PHParameter/PHParametersContainer.cc
@@ -222,7 +222,7 @@ void PHParametersContainer::UpdatePdbParameterMapContainer(PdbParameterMapContai
   return;
 }
 
-void PHParametersContainer::Print(Option_t */*option*/) const
+void PHParametersContainer::Print(Option_t *option) const
 {
   cout << "Name: " << Name() << endl;
   map<int, PHParameters *>::const_iterator iter;

--- a/offline/database/PHParameter/configure.ac
+++ b/offline/database/PHParameter/configure.ac
@@ -6,7 +6,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/database/pdbcal/base/PHGenericFactoryT.h
+++ b/offline/database/pdbcal/base/PHGenericFactoryT.h
@@ -26,7 +26,7 @@ template
 class DefaultFactoryError
 {
 protected:
-  AbstractProduct* OnUnknownType(const std::string& /*id*/) { return 0; }
+  AbstractProduct* OnUnknownType(const std::string& id) { return 0; }
 };
 
 template

--- a/offline/database/pdbcal/base/PdbBankManager.h
+++ b/offline/database/pdbcal/base/PdbBankManager.h
@@ -103,9 +103,9 @@ public:
 			       const std::string &,
 			       PHTimeStamp &) = 0;
 
-  virtual void GetUsedBankRids(std::map<std::string,std::set<int> > &/*usedbanks*/) const {}
+  virtual void GetUsedBankRids(std::map<std::string,std::set<int> > &usedbanks) const {}
   virtual void ClearUsedBankRids() {}
-  virtual  void SetMaxInsertTime(const PHTimeStamp &/*tMax*/) {}
+  virtual  void SetMaxInsertTime(const PHTimeStamp &tMax) {}
 
 protected:
 

--- a/offline/database/pdbcal/base/configure.ac
+++ b/offline/database/pdbcal/base/configure.ac
@@ -9,7 +9,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/database/pdbcal/pg/PgPostApplication.cc
+++ b/offline/database/pdbcal/pg/PgPostApplication.cc
@@ -171,7 +171,7 @@ PgPostApplication::commit(PdbCalBank *b)
 }
 
 PdbStatus
-PgPostApplication::commit(PdbCalBank *b, int /*rid*/, long /*it*/, long /*st*/, long /*et*/)
+PgPostApplication::commit(PdbCalBank *b, int rid, long it, long st, long et)
 {
   PgPostBankWrapper *tb = dynamic_cast<PgPostBankWrapper *>(b);
   if (tb)

--- a/offline/database/pdbcal/pg/PgPostBankBackupStorage.cc
+++ b/offline/database/pdbcal/pg/PgPostBankBackupStorage.cc
@@ -149,7 +149,7 @@ PgPostBankBackupStorage::BankHeader::get_id_string() const
   return o.str();
 }
 
-void PgPostBankBackupStorage::BankHeader::Print(Option_t */*option*/) const
+void PgPostBankBackupStorage::BankHeader::Print(Option_t *option) const
 {
   //  TObject::Print(option);
   cout << "ID = " << get_id_string() << " from user " << userName

--- a/offline/database/pdbcal/pg/PgPostBankManager.cc
+++ b/offline/database/pdbcal/pg/PgPostBankManager.cc
@@ -234,7 +234,7 @@ PgPostBankManager::fetchClosestBank(const string &className, PdbBankID bankID, c
 // }
 
 //__________________________________________________________________________________
-PdbCalBank *PgPostBankManager::fetchBank(const string &/*className*/, PdbBankID bankID, const string &bankName, const PHTimeStamp &searchTime)
+PdbCalBank *PgPostBankManager::fetchBank(const string &className, PdbBankID bankID, const string &bankName, const PHTimeStamp &searchTime)
 {
 #ifdef DEBUG
   cout << "Fetching " << className << " from " << bankName << endl;
@@ -313,7 +313,7 @@ PdbCalBank *PgPostBankManager::fetchBank(const string &/*className*/, PdbBankID 
 
 //__________________________________________________________________________________
 PdbCalBank *
-PgPostBankManager::fetchClosestBank(const string &/*className*/, PdbBankID /*bankID*/, const string &/*bankName*/, PHTimeStamp &/*searchTime*/)
+PgPostBankManager::fetchClosestBank(const string &className, PdbBankID bankID, const string &bankName, PHTimeStamp &searchTime)
 {
   cout << PHWHERE << " PdbBankManager::fetchClosestBank: This method is not implemented" << endl;
   exit(1);

--- a/offline/database/pdbcal/pg/PgPostCalBank.h
+++ b/offline/database/pdbcal/pg/PgPostCalBank.h
@@ -36,13 +36,13 @@ class PgPostCalBank : public PdbCalBank
   virtual std::string getUserName() const { return 0; }
   virtual std::string getTableName() const { return 0; }
 
-  virtual void setBankID(const PdbBankID& /*val*/) {}
-  virtual void setInsertTime(const PHTimeStamp& /*val*/) {}
-  virtual void setStartValTime(const PHTimeStamp& /*val*/) {}
-  virtual void setEndValTime(const PHTimeStamp& /*val*/) {}
-  virtual void setDescription(const std::string& /*val*/) {}
-  virtual void setUserName(const std::string& /*val*/) {}
-  virtual void setTableName(const std::string& /*val*/) {}
+  virtual void setBankID(const PdbBankID& val) {}
+  virtual void setInsertTime(const PHTimeStamp& val) {}
+  virtual void setStartValTime(const PHTimeStamp& val) {}
+  virtual void setEndValTime(const PHTimeStamp& val) {}
+  virtual void setDescription(const std::string& val) {}
+  virtual void setUserName(const std::string& val) {}
+  virtual void setTableName(const std::string& val) {}
 
   virtual int isValid(const PHTimeStamp&) const { return 0; }
 

--- a/offline/database/pdbcal/pg/configure.ac
+++ b/offline/database/pdbcal/pg/configure.ac
@@ -13,10 +13,10 @@ dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
 dnl odbc++ has issues
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-inconsistent-missing-override -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-inconsistent-missing-override"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
 esac
 

--- a/offline/framework/ffamodules/HeadReco.cc
+++ b/offline/framework/ffamodules/HeadReco.cc
@@ -105,7 +105,7 @@ int HeadReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int HeadReco::EndRun(const int /*runno*/)
+int HeadReco::EndRun(const int runno)
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   FlagSave *flagsave = findNode::getClass<FlagSave>(se->topNode(), "Flags");

--- a/offline/framework/ffamodules/configure.ac
+++ b/offline/framework/ffamodules/configure.ac
@@ -10,7 +10,7 @@ AC_PROG_CXX(CC g++)
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/framework/ffaobjects/EventHeader.h
+++ b/offline/framework/ffaobjects/EventHeader.h
@@ -33,7 +33,7 @@ class EventHeader : public PHObject
   /// get Run Number
   virtual int get_RunNumber() const { return 0; }
   /// set Run Number
-  virtual void set_RunNumber(const int /*run*/) { return; }
+  virtual void set_RunNumber(const int run) { return; }
 
   /// get Event Number
   virtual int get_EvtSequence() const { return 0; }
@@ -46,11 +46,11 @@ class EventHeader : public PHObject
   //! bunch crossing
   virtual int64_t get_BunchCrossing() const { return get_intval("bcr"); }
 
-  virtual void set_floatval(const std::string &/*name*/, const float /*fval*/) { return; }
-  virtual float get_floatval(const std::string &/*name*/) const { return NAN; }
+  virtual void set_floatval(const std::string &name, const float fval) { return; }
+  virtual float get_floatval(const std::string &name) const { return NAN; }
 
-  virtual void set_intval(const std::string &/*name*/, const int64_t /*ival*/) { return; }
-  virtual int64_t get_intval(const std::string &/*name*/) const { return -999999; }
+  virtual void set_intval(const std::string &name, const int64_t ival) { return; }
+  virtual int64_t get_intval(const std::string &name) const { return -999999; }
 
   /// get Event Type (Data,rejected,EOR,BOR,...)
   int get_EvtType() const { return get_intval("type"); }

--- a/offline/framework/ffaobjects/RunHeader.h
+++ b/offline/framework/ffaobjects/RunHeader.h
@@ -34,11 +34,11 @@ class RunHeader : public PHObject
   /// set Run Number
   virtual void set_RunNumber(const int run);
 
-  virtual void set_floatval(const std::string &/*name*/, const float /*fval*/) { return; }
-  virtual float get_floatval(const std::string &/*name*/) const { return NAN; }
+  virtual void set_floatval(const std::string &name, const float fval) { return; }
+  virtual float get_floatval(const std::string &name) const { return NAN; }
 
-  virtual void set_intval(const std::string &/*name*/, const int /*ival*/) { return; }
-  virtual int get_intval(const std::string &/*name*/) const { return -999999; }
+  virtual void set_intval(const std::string &name, const int ival) { return; }
+  virtual int get_intval(const std::string &name) const { return -999999; }
 
   /// switches off the pesky virtual warning messages
   void NoWarning(const int i = 1);

--- a/offline/framework/ffaobjects/configure.ac
+++ b/offline/framework/ffaobjects/configure.ac
@@ -10,7 +10,7 @@ AC_PROG_CXX(CC g++)
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/framework/frog/configure.ac
+++ b/offline/framework/frog/configure.ac
@@ -12,10 +12,10 @@ dnl   treat warnings as errors: -Werror
 case $CXX in
  clang++)
 dnl odbc++ uses auto_ptr
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-deprecated-declarations"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wno-deprecated-declarations -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wno-deprecated-declarations"
  ;;
 esac
 

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -54,7 +54,7 @@ class Fun4AllInputManager : public Fun4AllBase
   std::string TopNodeName() const { return m_TopNodeName; }
   bool FileListEmpty() const { return m_FileList.empty(); }
   virtual int IsOpen() const { return m_IsOpen; }
-  virtual int SkipForThisManager(const int /*nevents*/) { return 0; }
+  virtual int SkipForThisManager(const int nevents) { return 0; }
   virtual int HasSyncObject() const { return 0; }
 
  protected:

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -46,7 +46,7 @@ class Fun4AllOutputManager : public Fun4AllBase
     return 0;
   }
 
-  virtual void SaveRunNode(const int) {return;}
+  virtual void SaveRunNode(const int i) {return;}
 
   /*! \brief
     add an event selector to the outputmanager.

--- a/offline/framework/fun4all/SubsysReco.h
+++ b/offline/framework/fun4all/SubsysReco.h
@@ -58,7 +58,7 @@ class SubsysReco : public Fun4AllBase
   /// Clean up after each event.
   virtual int ResetEvent(PHCompositeNode * /*topNode*/) { return 0; }
 
-  void Print(const std::string & /*what*/ = "ALL") const override {}
+  void Print(const std::string &what = "ALL") const override {}
 
  protected:
   /** ctor.

--- a/offline/framework/fun4all/configure.ac
+++ b/offline/framework/fun4all/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/framework/fun4allraw/configure.ac
+++ b/offline/framework/fun4allraw/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror -Wno-unused-parameter"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -23,9 +23,9 @@ PHObject::clone() const
   return nullptr;
 }
 
-void PHObject::identify(std::ostream& os) const
+void PHObject::identify(std::ostream& out) const
 {
-  os << "identify yourself: I am a PHObject object" << std::endl;
+  out << "identify yourself: I am a PHObject object" << std::endl;
 }
 
 void PHObject::Reset()
@@ -128,14 +128,14 @@ int PHObject::isImplemented(const unsigned int) const
 }
 
 
-void PHObject::CopyFrom(const PHObject */*obj*/)
+void PHObject::CopyFrom(const PHObject *obj)
 {
   std::cout << PHWHERE
             << " CopyFrom(const PHObject *obj) is not implemented" << std::endl;
   gSystem->Exit(1);
 }
 
-PHObject *PHObject::Clone(const char */*newname*/) const
+PHObject *PHObject::Clone(const char *newname) const
 {
 std::cout << PHWHERE
 	  << "You are overriding the TObject::Clone method which is not supported"  << std::endl;
@@ -143,7 +143,7 @@ std::cout << PHWHERE
   return nullptr;
 }
 
-void PHObject::Copy (TObject &/*object*/) const
+void PHObject::Copy (TObject &object) const
 {
 std::cout << PHWHERE
 	  << "You are overriding the TObject::Copy method which is not supported"  << std::endl;

--- a/offline/framework/phool/PHObject.h
+++ b/offline/framework/phool/PHObject.h
@@ -46,7 +46,7 @@ class PHObject : public TObject
   virtual int isImplemented(const unsigned int i) const;
 
   virtual int Integrate() const { return 0; }
-  virtual int Integrate(PHObject* /*obj*/) { return -1; }
+  virtual int Integrate(PHObject* obj) { return -1; }
   virtual void CopyFrom(const PHObject *obj);
 
  private:

--- a/offline/framework/phool/configure.ac
+++ b/offline/framework/phool/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   treat warnings as errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "

--- a/offline/framework/phoolraw/configure.ac
+++ b/offline/framework/phoolraw/configure.ac
@@ -5,9 +5,11 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-dnl   unused param warnings come from newbasic include
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+dnl   treat warnings as errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -37,7 +37,7 @@ class RawCluster : public PHObject
     PHOOL_VIRTUAL_WARNING;
     return 0;
   }
-  void identify(std::ostream& /*os*/ = std::cout) const override { PHOOL_VIRTUAL_WARNING; }
+  void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARNING; }
   /** @defgroup getters
    *  @{
    */
@@ -163,7 +163,7 @@ class RawCluster : public PHObject
     return NAN;
   }
   //! isolation ET the radius and hueristic can be specified
-  virtual float get_et_iso(const int /*radiusx10*/, bool /*subtracted*/, bool /*clusterTower*/) const
+  virtual float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) const
   {
     PHOOL_VIRTUAL_WARN("get_et_iso(const int radiusx10, bool subtracted, bool clusterTower)");
     return NAN;
@@ -188,31 +188,31 @@ class RawCluster : public PHObject
    *  @{
    */
   //! cluster ID
-  virtual void set_id(const RawClusterDefs::keytype) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_id(const RawClusterDefs::keytype id) { PHOOL_VIRTUAL_WARNING; }
   //! Tower operations
-  virtual void addTower(const RawClusterDefs::keytype /*twrid*/, const float /*etower*/) { PHOOL_VIRTUAL_WARNING; }
+  virtual void addTower(const RawClusterDefs::keytype twrid, const float etower) { PHOOL_VIRTUAL_WARNING; }
   //! total energy
-  virtual void set_energy(const float) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_energy(const float energy) { PHOOL_VIRTUAL_WARNING; }
   //
   //!  access to intrinsic cylindrical coordinate system
-  virtual void set_phi(const float) { PHOOL_VIRTUAL_WARNING; }
-  virtual void set_z(const float) { PHOOL_VIRTUAL_WARNING; }
-  virtual void set_r(const float) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_phi(const float phi) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_z(const float z) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_r(const float r) { PHOOL_VIRTUAL_WARNING; }
   //
   //! access additional optional properties
   //! cluster core energy for EM shower
-  virtual void set_ecore(const float) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_ecore(const float ecore) { PHOOL_VIRTUAL_WARNING; }
   //! reduced chi2 for EM shower
-  virtual void set_chi2(const float) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_chi2(const float chi2) { PHOOL_VIRTUAL_WARNING; }
   //! cluster template probability for EM shower
-  virtual void set_prob(const float) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_prob(const float prob) { PHOOL_VIRTUAL_WARNING; }
   //! isolation ET
-  virtual void set_et_iso(const float) { PHOOL_VIRTUAL_WARNING; }
-  virtual void set_et_iso(const float /*e*/, const int /*radiusx10*/, bool /*subtracted*/, bool /*clusterTower*/) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_et_iso(const float e) { PHOOL_VIRTUAL_WARNING; }
+  virtual void set_et_iso(const float e, const int radiusx10, bool subtracted, bool clusterTower) { PHOOL_VIRTUAL_WARNING; }
   //  //! truth cluster's PHG4Particle ID
-  //  virtual void set_truth_track_ID(const int) { PHOOL_VIRTUAL_WARNING; }
+  //  virtual void set_truth_track_ID(const int i) { PHOOL_VIRTUAL_WARNING; }
   //  //! truth cluster's PHG4Particle flavor
-  //  virtual void set_truth_flavor(const int) { PHOOL_VIRTUAL_WARNING; }
+  //  virtual void set_truth_flavor(const int f) { PHOOL_VIRTUAL_WARNING; }
   //
   /*
    *
@@ -273,14 +273,14 @@ class RawCluster : public PHObject
   };
 
   //! getters
-  virtual bool has_property(const PROPERTY /*prop_id*/) const { return false; }
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const { return NAN; }
-  virtual int get_property_int(const PROPERTY /*prop_id*/) const { return INT_MIN; }
-  virtual unsigned int get_property_uint(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
+  virtual bool has_property(const PROPERTY prop_id) const { return false; }
+  virtual float get_property_float(const PROPERTY prop_id) const { return NAN; }
+  virtual int get_property_int(const PROPERTY prop_id) const { return INT_MIN; }
+  virtual unsigned int get_property_uint(const PROPERTY prop_id) const { return UINT_MAX; }
   //! setters
-  virtual void set_property(const PROPERTY /*prop_id*/, const float /*value*/) { return; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const int /*value*/) { return; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) { return; }
+  virtual void set_property(const PROPERTY prop_id, const float value) { return; }
+  virtual void set_property(const PROPERTY prop_id, const int value) { return; }
+  virtual void set_property(const PROPERTY prop_id, const unsigned int value) { return; }
   //! type management
   static std::pair<const std::string, PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);

--- a/offline/packages/CaloBase/RawTower.cc
+++ b/offline/packages/CaloBase/RawTower.cc
@@ -7,12 +7,12 @@
 RawTower::CellMap DummyCellMap;
 RawTower::ShowerMap DummyShowerMap;
 
-RawTower::CellIterator RawTower::find_g4cell(CellKeyType /*id*/)
+RawTower::CellIterator RawTower::find_g4cell(CellKeyType id)
 {
   return DummyCellMap.end();
 }
 
-RawTower::CellConstIterator RawTower::find_g4cell(CellKeyType /*id*/) const
+RawTower::CellConstIterator RawTower::find_g4cell(CellKeyType id) const
 {
   return DummyCellMap.end();
 }
@@ -29,12 +29,12 @@ RawTower::ShowerConstRange RawTower::get_g4showers() const
   return ShowerConstRange(DummyShowerMap.begin(), DummyShowerMap.end());
 }
 
-RawTower::ShowerIterator RawTower::find_g4shower(int /*id*/)
+RawTower::ShowerIterator RawTower::find_g4shower(int id)
 {
   return DummyShowerMap.end();
 }
 
-RawTower::ShowerConstIterator RawTower::find_g4shower(int /*id*/) const
+RawTower::ShowerConstIterator RawTower::find_g4shower(int id) const
 {
   return DummyShowerMap.end();
 }

--- a/offline/packages/CaloBase/RawTower.h
+++ b/offline/packages/CaloBase/RawTower.h
@@ -40,9 +40,9 @@ class RawTower : public PHObject
     PHOOL_VIRTUAL_WARN("isValid()");
     return 0;
   }
-  void identify(std::ostream& /*os*/ = std::cout) const override { PHOOL_VIRTUAL_WARN("identify()"); }
+  void identify(std::ostream& os = std::cout) const override { PHOOL_VIRTUAL_WARN("identify()"); }
 
-  virtual void set_id(RawTowerDefs::keytype) { PHOOL_VIRTUAL_WARN("set_id()"); }
+  virtual void set_id(RawTowerDefs::keytype id) { PHOOL_VIRTUAL_WARN("set_id()"); }
   virtual RawTowerDefs::keytype get_id() const
   {
     PHOOL_VIRTUAL_WARN("get_id()");
@@ -143,7 +143,7 @@ class RawTower : public PHObject
   virtual CellConstRange get_g4cells() const;
   virtual CellIterator find_g4cell(CellKeyType id);
   virtual CellConstIterator find_g4cell(CellKeyType id) const;
-  virtual void add_ecell(const CellKeyType /*g4cellid*/, const float /*ecell*/)
+  virtual void add_ecell(const CellKeyType g4cellid, const float ecell)
   {
     PHOOL_VIRTUAL_WARN("add_ecell(const CellKeyType g4cellid, const float ecell)");
     return;
@@ -153,9 +153,9 @@ class RawTower : public PHObject
   virtual bool empty_g4showers() const { return true; }
   virtual size_t size_g4showers() const { return 0; }
   virtual ShowerConstRange get_g4showers() const;
-  virtual ShowerIterator find_g4shower(int /*id*/);
-  virtual ShowerConstIterator find_g4shower(int /*id*/) const;
-  virtual void add_eshower(const int /*g4showerid*/, const float /*eshower*/)
+  virtual ShowerIterator find_g4shower(int id);
+  virtual ShowerConstIterator find_g4shower(int id) const;
+  virtual void add_eshower(const int g4showerid, const float eshower)
   {
     PHOOL_VIRTUAL_WARN("add_eshower(const unsigned int g4showerid, const float eshower)");
     return;
@@ -178,16 +178,16 @@ class RawTower : public PHObject
     prop_MAX_NUMBER = UCHAR_MAX
   };
 
-  virtual bool has_property(const PROPERTY /*prop_id*/) const { return false; }
-  virtual double get_property(const PROPERTY /*prop_id*/) const { return NAN; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const double /*value*/) { return; }
+  virtual bool has_property(const PROPERTY prop_id) const { return false; }
+  virtual double get_property(const PROPERTY prop_id) const { return NAN; }
+  virtual void set_property(const PROPERTY prop_id, const double value) { return; }
   static const std::string get_property_info(PROPERTY prop_id);
 
  protected:
   RawTower() {}
 
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const { return UINT_MAX; }
+  virtual void set_property_nocheck(const PROPERTY prop_id, const unsigned int) { return; }
 
   ClassDefOverride(RawTower, 1)
 };

--- a/offline/packages/CaloBase/RawTowerDeadMap.cc
+++ b/offline/packages/CaloBase/RawTowerDeadMap.cc
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+using namespace std;
+
 const RawTowerDeadMap::Map&
 RawTowerDeadMap::getDeadTowers(void) const
 {
@@ -16,20 +18,20 @@ RawTowerDeadMap::getDeadTowers(void)
   return tmp_map;
 }
 
-void RawTowerDeadMap::addDeadTower(const unsigned int /*ieta*/, const int unsigned /*iphi*/)
+void RawTowerDeadMap::addDeadTower(const unsigned int ieta, const int unsigned iphi)
 {
 }
 
-void RawTowerDeadMap::addDeadTower(RawTowerDefs::keytype /*key*/)
+void RawTowerDeadMap::addDeadTower(RawTowerDefs::keytype key)
 {
 }
 
-bool RawTowerDeadMap::isDeadTower(RawTowerDefs::keytype /*key*/)
+bool RawTowerDeadMap::isDeadTower(RawTowerDefs::keytype key)
 {
   return false;
 }
 
-bool RawTowerDeadMap::isDeadTower(const unsigned int /*ieta*/, const unsigned int /*iphi*/)
+bool RawTowerDeadMap::isDeadTower(const unsigned int ieta, const unsigned int iphi)
 {
   return false;
 }

--- a/offline/packages/CaloBase/RawTowerDeadMap.h
+++ b/offline/packages/CaloBase/RawTowerDeadMap.h
@@ -20,7 +20,7 @@ class RawTowerDeadMap : public PHObject
 
   void identify(std::ostream &os = std::cout) const override;
 
-  virtual void setCalorimeterID(RawTowerDefs::CalorimeterId /*caloid*/) {}
+  virtual void setCalorimeterID(RawTowerDefs::CalorimeterId caloid) {}
   virtual RawTowerDefs::CalorimeterId getCalorimeterID() { return RawTowerDefs::NONE; }
   virtual void addDeadTower(const unsigned int ieta, const unsigned int iphi);
   virtual void addDeadTower(RawTowerDefs::keytype key);
@@ -34,7 +34,7 @@ class RawTowerDeadMap : public PHObject
   virtual unsigned int size() const { return 0; }
 
  protected:
-  RawTowerDeadMap(RawTowerDefs::CalorimeterId /*caloid*/ = RawTowerDefs::NONE)
+  RawTowerDeadMap(RawTowerDefs::CalorimeterId caloid = RawTowerDefs::NONE)
   {
   }
 

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -16,7 +16,7 @@ class RawTowerGeom : public PHObject
 
   void identify(std::ostream& os = std::cout) const override;
 
-  virtual void set_id(RawTowerDefs::keytype) { PHOOL_VIRTUAL_WARN("set_id()"); }
+  virtual void set_id(RawTowerDefs::keytype key) { PHOOL_VIRTUAL_WARN("set_id()"); }
 
   virtual RawTowerDefs::keytype get_id() const
   {

--- a/offline/packages/CaloBase/RawTowerGeomContainer.cc
+++ b/offline/packages/CaloBase/RawTowerGeomContainer.cc
@@ -11,7 +11,7 @@ void RawTowerGeomContainer::identify(std::ostream& os) const
   os << "Base class RawTowerGeomContainer." << std::endl;
 }
 
-RawTowerGeomContainer::ConstIterator RawTowerGeomContainer::add_tower_geometry(RawTowerGeom* /*geo*/)
+RawTowerGeomContainer::ConstIterator RawTowerGeomContainer::add_tower_geometry(RawTowerGeom* geo)
 {
   PHOOL_VIRTUAL_WARN("add_tower_geometry()");
   return DummyMap.end();

--- a/offline/packages/CaloBase/RawTowerGeomContainer.h
+++ b/offline/packages/CaloBase/RawTowerGeomContainer.h
@@ -43,7 +43,7 @@ class RawTowerGeomContainer : public PHObject
 
   //! go through all towers
   virtual ConstIterator add_tower_geometry(RawTowerGeom *geo);
-  virtual RawTowerGeom *get_tower_geometry(RawTowerDefs::keytype)
+  virtual RawTowerGeom *get_tower_geometry(RawTowerDefs::keytype key)
   {
     PHOOL_VIRTUAL_WARN("get_tower_geometry()");
     return NULL;
@@ -91,48 +91,48 @@ class RawTowerGeomContainer : public PHObject
   //  virtual double get_etastep() const {PHOOL_VIRTUAL_WARN("get_etastep()"); return NAN;}
   //  virtual double get_etamin() const {PHOOL_VIRTUAL_WARN("get_etamin()"); return NAN;}
 
-  virtual std::pair<double, double> get_phibounds(const int /*ibin*/) const
+  virtual std::pair<double, double> get_phibounds(const int ibin) const
   {
     PHOOL_VIRTUAL_WARN("get_phibounds(const int)");
     return std::make_pair(NAN, NAN);
   }
-  virtual std::pair<double, double> get_etabounds(const int /*ibin*/) const
+  virtual std::pair<double, double> get_etabounds(const int ibin) const
   {
     PHOOL_VIRTUAL_WARN("get_etabounds(const int)");
     return std::make_pair(NAN, NAN);
   }
-  virtual double get_etacenter(const int /*ibin*/) const
+  virtual double get_etacenter(const int ibin) const
   {
     PHOOL_VIRTUAL_WARN("get_etacenter(const int)");
     return NAN;
   }
-  virtual double get_phicenter(const int /*ibin*/) const
+  virtual double get_phicenter(const int ibin) const
   {
     PHOOL_VIRTUAL_WARN("get_phicenter(const int)");
     return NAN;
   }
 
-  virtual int get_etabin(const double /*eta*/) const
+  virtual int get_etabin(const double eta) const
   {
     PHOOL_VIRTUAL_WARN("get_etabin(const double)");
     return -1;
   }
-  virtual int get_phibin(const double /*phi*/) const
+  virtual int get_phibin(const double phi) const
   {
     PHOOL_VIRTUAL_WARN("get_phibin(const double)");
     return -1;
   }
 
-  virtual void set_radius(const double) { PHOOL_VIRTUAL_WARN("set_radius(const double)"); }
-  virtual void set_thickness(const double) { PHOOL_VIRTUAL_WARN("set_thickness(const double)"); }
-  virtual void set_phibins(const int) { PHOOL_VIRTUAL_WARN("set_phibins(const int)"); }
+  virtual void set_radius(const double r) { PHOOL_VIRTUAL_WARN("set_radius(const double)"); }
+  virtual void set_thickness(const double t) { PHOOL_VIRTUAL_WARN("set_thickness(const double)"); }
+  virtual void set_phibins(const int i) { PHOOL_VIRTUAL_WARN("set_phibins(const int)"); }
   //  virtual void set_phistep(const double phi) {PHOOL_VIRTUAL_WARN("set_phistep(const double)");}
   //  virtual void set_phimin(const double phi) {PHOOL_VIRTUAL_WARN("set_phimin(const double)");}
-  virtual void set_etabins(const int) { PHOOL_VIRTUAL_WARN("set_etabins(const int)"); }
+  virtual void set_etabins(const int i) { PHOOL_VIRTUAL_WARN("set_etabins(const int)"); }
   //  virtual void set_etamin(const double z) {PHOOL_VIRTUAL_WARN("set_etamin(const double)");}
   //  virtual void set_etastep(const double z) {PHOOL_VIRTUAL_WARN("set_etastep(const double)");}
-  virtual void set_etabounds(const int /*ibin*/, const std::pair<double, double> &/*bounds*/) { PHOOL_VIRTUAL_WARN("set_etabounds(const int ibin, const std::pair<double, double> & bounds)"); }
-  virtual void set_phibounds(const int /*ibin*/, const std::pair<double, double> &/*bounds*/) { PHOOL_VIRTUAL_WARN("set_etabounds(const int ibin, const std::pair<double, double> & bounds)"); }
+  virtual void set_etabounds(const int ibin, const std::pair<double, double> &bounds) { PHOOL_VIRTUAL_WARN("set_etabounds(const int ibin, const std::pair<double, double> & bounds)"); }
+  virtual void set_phibounds(const int ibin, const std::pair<double, double> &bounds) { PHOOL_VIRTUAL_WARN("set_etabounds(const int ibin, const std::pair<double, double> & bounds)"); }
 
   /**@}*/
 

--- a/offline/packages/CaloBase/configure.ac
+++ b/offline/packages/CaloBase/configure.ac
@@ -7,10 +7,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
  ;;
 esac
 

--- a/offline/packages/CaloReco/BEmcProfile.cc
+++ b/offline/packages/CaloReco/BEmcProfile.cc
@@ -361,7 +361,7 @@ float BEmcProfile::GetProbTest(std::vector<EmcModule>* plist, int NX, float en, 
 }
 */
 
-void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float /*phi*/, float ddz, float ddy, float& ep, float& err)
+void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float phi, float ddz, float ddy, float& ep, float& err)
 // ip changes from 0 to NP-1, meaning the profile index 1,2,..,NP
 {
   ep = err = -1;
@@ -511,7 +511,7 @@ void BEmcProfile::PredictEnergy(int ip, float energy, float theta, float /*phi*/
 }
 
 
-float BEmcProfile::PredictEnergyR(float energy, float theta, float /*phi*/, float rr)
+float BEmcProfile::PredictEnergyR(float energy, float theta, float phi, float rr)
 {
 
   if (!bloaded)

--- a/offline/packages/CaloReco/BEmcRec.cc
+++ b/offline/packages/CaloReco/BEmcRec.cc
@@ -48,7 +48,7 @@ BEmcRec::~BEmcRec()
 
 // ///////////////////////////////////////////////////////////////////////////
 
-void BEmcRec::LoadProfile(const std::string& /*fname*/)
+void BEmcRec::LoadProfile(const std::string& fname)
 {
   std::cout << "Warning from BEmcRec::LoadProfile(): No acton defined for shower profile evaluation; should be defined in a detector specific module " << Name() << std::endl;
 }
@@ -513,7 +513,7 @@ float BEmcRec::PredictEnergy(float en, float xcg, float ycg, int ix, int iy)
   return PredictEnergyParam(en, dx, dy);
 }
 
-float BEmcRec::PredictEnergyParam(float /*en*/, float xc, float yc)
+float BEmcRec::PredictEnergyParam(float en, float xc, float yc)
 {
   // Calculates the energy deposited in the tower, the distance between
   // its center and shower Center of Gravity being (xc,yc)

--- a/offline/packages/CaloReco/BEmcRec.h
+++ b/offline/packages/CaloReco/BEmcRec.h
@@ -89,21 +89,21 @@ class BEmcRec
   virtual float PredictEnergyParam(float, float, float);
 
   // Calorimeter specific functions to be specified in respective inherited object
-  virtual void CorrectEnergy(float energy, float /*x*/, float /*y*/, float &ecorr) { ecorr = energy; }
-  virtual void CorrectECore(float ecore, float /*x*/, float /*y*/, float &ecorecorr) { ecorecorr = ecore; }
-  virtual void CorrectPosition(float /*energy*/, float x, float y, float &xcorr, float &ycorr)
+  virtual void CorrectEnergy(float energy, float x, float y, float &ecorr) { ecorr = energy; }
+  virtual void CorrectECore(float ecore, float x, float y, float &ecorecorr) { ecorecorr = ecore; }
+  virtual void CorrectPosition(float energy, float x, float y, float &xcorr, float &ycorr)
   {
     xcorr = x;
     ycorr = y;
   }
-  virtual void CorrectShowerDepth(float /*energy*/, float x, float y, float z, float &xc, float &yc, float &zc)
+  virtual void CorrectShowerDepth(float energy, float x, float y, float z, float &xc, float &yc, float &zc)
   {
     xc = x;
     yc = y;
     zc = z;
   }
   virtual void LoadProfile(const std::string &fname);
-  virtual void GetImpactThetaPhi(float /*xg*/, float /*yg*/, float /*zg*/, float &theta, float &phi)
+  virtual void GetImpactThetaPhi(float xg, float yg, float zg, float &theta, float &phi)
   {
     theta = 0;
     phi = 0;

--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -235,7 +235,7 @@ float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float 
 }
 */
 
-void BEmcRecCEMC::CorrectShowerDepth(float /*E*/, float xA, float yA, float zA, float& xC, float& yC, float& zC)
+void BEmcRecCEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC)
 {
   xC = xA;
   yC = yA;
@@ -243,7 +243,7 @@ void BEmcRecCEMC::CorrectShowerDepth(float /*E*/, float xA, float yA, float zA, 
   return;
 }
 
-void BEmcRecCEMC::CorrectEnergy(float Energy, float /*x*/, float /*y*/,
+void BEmcRecCEMC::CorrectEnergy(float Energy, float x, float y,
                                 float& Ecorr)
 {
   // Corrects the EM Shower Energy for attenuation in fibers and
@@ -269,7 +269,7 @@ void BEmcRecCEMC::CorrectEnergy(float Energy, float /*x*/, float /*y*/,
   Ecorr = Energy;
 }
 
-void BEmcRecCEMC::CorrectECore(float Ecore, float /*x*/, float /*y*/, float& Ecorr)
+void BEmcRecCEMC::CorrectECore(float Ecore, float x, float y, float& Ecorr)
 {
   // Corrects the EM Shower Core Energy for attenuation in fibers,
   // long energy leakage and angle dependance

--- a/offline/packages/CaloReco/BEmcRecEEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecEEMC.cc
@@ -93,13 +93,13 @@ void BEmcRecEEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, floa
 
 }
 
-void BEmcRecEEMC::CorrectEnergy(float Energy, float /*x*/, float /*y*/,
+void BEmcRecEEMC::CorrectEnergy(float Energy, float x, float y,
                                 float& Ecorr)
 {
   Ecorr = Energy;
 }
 
-void BEmcRecEEMC::CorrectECore(float Ecore, float /*x*/, float /*y*/, float& Ecorr)
+void BEmcRecEEMC::CorrectECore(float Ecore, float x, float y, float& Ecorr)
 {
   // Corrects the EM Shower Core Energy for attenuation in fibers,
   // long energy leakage and angle dependance
@@ -109,7 +109,7 @@ void BEmcRecEEMC::CorrectECore(float Ecore, float /*x*/, float /*y*/, float& Eco
   Ecorr = Ecore;
 }
 
-float BEmcRecEEMC::GetImpactAngle(float /*e*/, float /*x*/, float /*y*/)
+float BEmcRecEEMC::GetImpactAngle(float e, float x, float y)
 // Get impact angle, (x,y) - position in Sector frame (cm)
 {
   /*

--- a/offline/packages/CaloReco/BEmcRecFEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecFEMC.cc
@@ -71,13 +71,13 @@ void BEmcRecFEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, floa
   yC = yA;
 }
 
-void BEmcRecFEMC::CorrectEnergy(float Energy, float /*x*/, float /*y*/,
+void BEmcRecFEMC::CorrectEnergy(float Energy, float x, float y,
                                 float& Ecorr)
 {
   Ecorr = Energy;
 }
 
-float BEmcRecFEMC::GetImpactAngle(float /*e*/, float /*x*/, float /*y*/)
+float BEmcRecFEMC::GetImpactAngle(float e, float x, float y)
 // Get impact angle, (x,y) - position in Sector frame (cm)
 {
   /*

--- a/offline/packages/CaloReco/RawClusterBuilderFwd.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderFwd.cc
@@ -306,7 +306,7 @@ bool RawClusterBuilderFwd::CorrectPhi(RawCluster *cluster, RawTowerContainer *to
   return true;  // mean phi was corrected
 }
 
-int RawClusterBuilderFwd::End(PHCompositeNode */*topNode*/)
+int RawClusterBuilderFwd::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawClusterBuilderGraph.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderGraph.cc
@@ -276,7 +276,7 @@ int RawClusterBuilderGraph::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawClusterBuilderGraph::End(PHCompositeNode */*topNode*/)
+int RawClusterBuilderGraph::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -257,7 +257,7 @@ void RawClusterBuilderTemplate::PrintCylGeom(RawTowerGeomContainer *towergeom, c
   outfile.close();
 }
 
-bool RawClusterBuilderTemplate::Cell2Abs(RawTowerGeomContainer */*towergeom*/, float /*phiC*/, float /*etaC*/, float &phi, float &eta)
+bool RawClusterBuilderTemplate::Cell2Abs(RawTowerGeomContainer *towergeom, float phiC, float etaC, float &phi, float &eta)
 {
   phi = eta = 0;
   return false;

--- a/offline/packages/CaloReco/RawClusterBuilderTopo.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.cc
@@ -1149,7 +1149,7 @@ int RawClusterBuilderTopo::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawClusterBuilderTopo::End(PHCompositeNode */*topNode*/)
+int RawClusterBuilderTopo::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
+++ b/offline/packages/CaloReco/RawClusterDeadAreaMask.cc
@@ -47,7 +47,7 @@ int RawClusterDeadAreaMask::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawClusterDeadAreaMask::process_event(PHCompositeNode */*topNode*/)
+int RawClusterDeadAreaMask::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() >= VERBOSITY_SOME)
   {
@@ -262,7 +262,7 @@ void RawClusterDeadAreaMask::CreateNodeTree(PHCompositeNode *topNode)
   }
 }
 
-int RawClusterDeadAreaMask::End(PHCompositeNode * /*topNode*/)
+int RawClusterDeadAreaMask::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.cc
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.cc
@@ -299,7 +299,7 @@ void RawClusterPositionCorrection::CreateNodeTree(PHCompositeNode *topNode)
   const string paramNodeName2 = string("ecore_Recalibration_" + _det_name);
   _ecore_calib_params.SaveToNodeTree(parNode, paramNodeName2);
 }
-int RawClusterPositionCorrection::End(PHCompositeNode */*topNode*/)
+int RawClusterPositionCorrection::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawTowerCalibration.cc
+++ b/offline/packages/CaloReco/RawTowerCalibration.cc
@@ -89,7 +89,7 @@ int RawTowerCalibration::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerCalibration::process_event(PHCompositeNode */*topNode*/)
+int RawTowerCalibration::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity())
   {
@@ -209,7 +209,7 @@ int RawTowerCalibration::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerCalibration::End(PHCompositeNode */*topNode*/)
+int RawTowerCalibration::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawTowerCombiner.cc
+++ b/offline/packages/CaloReco/RawTowerCombiner.cc
@@ -87,7 +87,7 @@ int RawTowerCombiner::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerCombiner::process_event(PHCompositeNode */*topNode*/)
+int RawTowerCombiner::process_event(PHCompositeNode *topNode)
 {
   assert(_towers);
 
@@ -195,7 +195,7 @@ int RawTowerCombiner::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerCombiner::End(PHCompositeNode */*topNode*/)
+int RawTowerCombiner::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
+++ b/offline/packages/CaloReco/RawTowerDeadTowerInterp.cc
@@ -65,7 +65,7 @@ int RawTowerDeadTowerInterp::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerDeadTowerInterp::process_event(PHCompositeNode */*topNode*/)
+int RawTowerDeadTowerInterp::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity())
   {
@@ -228,7 +228,7 @@ int RawTowerDeadTowerInterp::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerDeadTowerInterp::End(PHCompositeNode */*topNode*/)
+int RawTowerDeadTowerInterp::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/CaloReco/configure.ac
+++ b/offline/packages/CaloReco/configure.ac
@@ -7,10 +7,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-c11-extensions"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/ClusterIso/ClusterIso.cc
+++ b/offline/packages/ClusterIso/ClusterIso.cc
@@ -75,7 +75,7 @@ ClusterIso::ClusterIso(const std::string &kname, float eTCut = 0.0, int coneSize
   if (!do_subtracted && !do_unsubtracted && Verbosity() >= VERBOSITY_QUIET) std::cout << "WARNING in " << Name() << "ClusterIso:: all processes turned off doing nothing" << '\n';
 }
 
-int ClusterIso::Init(PHCompositeNode */*topNode*/)
+int ClusterIso::Init(PHCompositeNode *topNode)
 {
   return 0;
 }
@@ -99,7 +99,7 @@ void ClusterIso::setConeSize(int coneSize)
 /**
  * Returns the minimum transverse energy required for a cluster to have its isolation calculated
  */
-/*const*/ float ClusterIso::geteTCut()
+const float ClusterIso::geteTCut()
 {
   return m_eTCut;
 }
@@ -107,7 +107,7 @@ void ClusterIso::setConeSize(int coneSize)
 /**
  * Returns size of isolation cone as integer multiple of 0.1 (i.e. 3 is an R=0.3 cone)
  */
-/*const*/ int ClusterIso::getConeSize()
+const int ClusterIso::getConeSize()
 {
   return (int) m_coneSize * 10;
 }
@@ -115,7 +115,7 @@ void ClusterIso::setConeSize(int coneSize)
 /**
  * Must be called to set the new vertex for the cluster 
  */
-/*const*/ CLHEP::Hep3Vector ClusterIso::getVertex()
+const CLHEP::Hep3Vector ClusterIso::getVertex()
 {
   return CLHEP::Hep3Vector(m_vx, m_vy, m_vz);
 }
@@ -388,7 +388,7 @@ int ClusterIso::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int ClusterIso::End(PHCompositeNode */*topNode*/)
+int ClusterIso::End(PHCompositeNode *topNode)
 {
   return 0;
 }

--- a/offline/packages/ClusterIso/ClusterIso.h
+++ b/offline/packages/ClusterIso/ClusterIso.h
@@ -34,10 +34,10 @@ class ClusterIso : public SubsysReco
 
   void seteTCut(float x);
   void setConeSize(int x);
-  /*const*/ float geteTCut();
+  const float geteTCut();
   //! returns coneSize*10 as an int
-  /*const*/ int getConeSize();
-  /*const*/ CLHEP::Hep3Vector getVertex();
+  const int getConeSize();
+  const CLHEP::Hep3Vector getVertex();
 
  private:
   double getTowerEta(RawTowerGeom* tower_geom, double vx, double vy, double vz);
@@ -56,7 +56,7 @@ class ClusterIso : public SubsysReco
  * of the etas and phis added in quadrature. Used to find towers
  * inside a cone of delta R around a cluster.
  */
-inline /*const*/ float deltaR(float eta1, float eta2, float phi1, float phi2)
+inline const float deltaR(float eta1, float eta2, float phi1, float phi2)
 {
   float deta = eta1 - eta2;
   float dphi = phi1 - phi2;

--- a/offline/packages/ClusterIso/configure.ac
+++ b/offline/packages/ClusterIso/configure.ac
@@ -9,10 +9,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/Half/configure.ac
+++ b/offline/packages/Half/configure.ac
@@ -9,19 +9,14 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
-
+dnl test for root 6
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
-
 AC_SUBST(CINTDEFS)
-
+fi
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/HelixHough/FitNewton/FunctionGradHessian.h
+++ b/offline/packages/HelixHough/FitNewton/FunctionGradHessian.h
@@ -33,9 +33,9 @@ namespace FitNewton
       //create a new instance of this class from the current instance
       virtual FunctionGradHessian* Clone() const = 0;
       
-      virtual void computeCovariance(const double& /*val*/, const Eigen::MatrixXd& /*hessian*/){}
+      virtual void computeCovariance(const double& val, const Eigen::MatrixXd& hessian){}
       
-      virtual void rescaleMove(const Eigen::VectorXd& /*pars*/, Eigen::VectorXd& /*move*/){}
+      virtual void rescaleMove(const Eigen::VectorXd& pars, Eigen::VectorXd& move){}
       
       
       

--- a/offline/packages/HelixHough/FitNewton/NewtonMinimizerGradHessian.cpp
+++ b/offline/packages/HelixHough/FitNewton/NewtonMinimizerGradHessian.cpp
@@ -114,7 +114,7 @@ namespace FitNewton
   }
   
   
-  bool NewtonMinimizerGradHessian::lineSearch(double& alpha, const double& wolfe1, const double& wolfe2, VectorXd& try_grad, VectorXd& direction, double& grad0_dir, double& val0, VectorXd& init_params, VectorXd& try_params, const double& /*precision*/, const double& /*accuracy*/, unsigned int max_iter, double& result)
+  bool NewtonMinimizerGradHessian::lineSearch(double& alpha, const double& wolfe1, const double& wolfe2, VectorXd& try_grad, VectorXd& direction, double& grad0_dir, double& val0, VectorXd& init_params, VectorXd& try_params, const double& precision, const double& accuracy, unsigned int max_iter, double& result)
   {
     double tryval = val0;
     double prev_val = tryval;

--- a/offline/packages/HelixHough/FitNewton/SquareGradient.cpp
+++ b/offline/packages/HelixHough/FitNewton/SquareGradient.cpp
@@ -90,7 +90,7 @@ namespace FitNewton
   }
   
   
-  bool SquareGradient::calcValGradHessian(const VectorXd& x, double& val, VectorXd& grad, MatrixXd& /*hessian*/)
+  bool SquareGradient::calcValGradHessian(const VectorXd& x, double& val, VectorXd& grad, MatrixXd& hessian)
   {
 //     verbose = false;
 //     

--- a/offline/packages/HelixHough/Seamstress/Seamstress.cpp
+++ b/offline/packages/HelixHough/Seamstress/Seamstress.cpp
@@ -26,7 +26,7 @@ namespace SeamStress
   }
 
 
-  Seamstress::Seamstress(const Seamstress &/*ss*/)
+  Seamstress::Seamstress(const Seamstress &ss)
   {
     gotime = false;
     end = false;

--- a/offline/packages/HelixHough/configure.ac
+++ b/offline/packages/HelixHough/configure.ac
@@ -10,21 +10,18 @@ LT_INIT([disable-static])
 
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
-if test $ac_cv_prog_gxx = yes; then
-    CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
+dnl if test $ac_cv_prog_gxx = yes; then
+dnl    CXXFLAGS="$CXXFLAGS -Wall -Werror"
+dnl fi
 
 ROOTLIBS=`$ROOTSYS/bin/root-config --libs`
 AC_SUBST(ROOTLIBS)
 
+dnl test for root 6
+if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
+fi
 
 AC_CONFIG_FILES([
 	Makefile

--- a/offline/packages/HelixHough/helix_hough/HelixHough.h
+++ b/offline/packages/HelixHough/helix_hough/HelixHough.h
@@ -57,11 +57,11 @@ public:
     max_z0 = (((other.max_z0 > max_z0)-1)&max_z0) ^ (((other.max_z0 <= max_z0)-1)&other.max_z0);
   }
   
-  unsigned int min_k = UINT_MAX, max_k = UINT_MAX;
-  unsigned int min_phi = UINT_MAX, max_phi = UINT_MAX;
-  unsigned int min_d = UINT_MAX, max_d = UINT_MAX;
-  unsigned int min_dzdl = UINT_MAX, max_dzdl = UINT_MAX;
-  unsigned int min_z0 = UINT_MAX, max_z0 = UINT_MAX;
+  unsigned int min_k, max_k;
+  unsigned int min_phi, max_phi;
+  unsigned int min_d, max_d;
+  unsigned int min_dzdl, max_dzdl;
+  unsigned int min_z0, max_z0;
 };
 
 
@@ -142,21 +142,21 @@ class HelixHough
     
     void setPrintTimings(bool pt){print_timings=pt;}
     
-    virtual void finalize(std::vector<SimpleTrack3D>&, std::vector<SimpleTrack3D>&){}
-    virtual void findTracks(std::vector<SimpleHit3D>&, std::vector<SimpleTrack3D>&, const HelixRange&) = 0;
-    virtual void initEvent(std::vector<SimpleHit3D>&, unsigned int){}
-    virtual void findSeededTracks(std::vector<SimpleTrack3D>&, std::vector<SimpleHit3D>&, std::vector<SimpleTrack3D>&, const HelixRange&){}
+    virtual void finalize(std::vector<SimpleTrack3D>& input, std::vector<SimpleTrack3D>& output){}
+    virtual void findTracks(std::vector<SimpleHit3D>& hits, std::vector<SimpleTrack3D>& tracks, const HelixRange& range) = 0;
+    virtual void initEvent(std::vector<SimpleHit3D>& hits, unsigned int min_hits){}
+    virtual void findSeededTracks(std::vector<SimpleTrack3D>& seeds, std::vector<SimpleHit3D>& hits, std::vector<SimpleTrack3D>& tracks, const HelixRange& range){}
     
     // return true if we want to go straight into the user-written findTracks function instead of possibly continuing the Hough Transform
-    virtual bool breakRecursion(const std::vector<SimpleHit3D>&, const HelixRange&){return false;}
+    virtual bool breakRecursion(const std::vector<SimpleHit3D>& hits, const HelixRange& range){return false;}
     
     // additional phi error to add to a hit in the voting stage, given an bin with the k and dzdl parameters passed.  This is useful 
     // to take into account multiple scattering
-    virtual float phiError(SimpleHit3D&, float, float, float, float, float, float, float, float, bool = false){return 0.;}
+    virtual float phiError(SimpleHit3D& hit, float min_k, float max_k, float min_d, float max_d, float min_z0, float max_z0, float min_dzdl, float max_dzdl, bool pairvoting=false){return 0.;}
     // same as above, but for additional error on dzdl
-    virtual float dzdlError(SimpleHit3D&, float, float, float, float, float, float, float, float, bool = false){return 0.;}
+    virtual float dzdlError(SimpleHit3D& hit, float min_k, float max_k, float min_d, float max_d, float min_z0, float max_z0, float min_dzdl, float max_dzdl, bool pairvoting=false){return 0.;}
     
-    virtual void initSeeding(std::vector<SimpleTrack3D>&){}
+    virtual void initSeeding(std::vector<SimpleTrack3D>& seeds){}
     
     virtual void setSeparateByHelicity(bool sbh){separate_by_helicity=sbh;}
     virtual void setOnlyOneHelicity(bool ooh){only_one_helicity=ooh;}

--- a/offline/packages/HelixHough/helix_hough/HelixHough_allButKappaRange_sse.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_allButKappaRange_sse.cpp
@@ -20,7 +20,7 @@ static const __m128 SIGNMASK = _mm_castsi128_ps(_mm_set1_epi32(0x80000000));
 static const __m128 three_pi_over_two = {3.*0x1.921fb54442d1846ap0f, 3.*0x1.921fb54442d1846ap0f, 3.*0x1.921fb54442d1846ap0f, 3.*0x1.921fb54442d1846ap0f};
 
 
-static inline void __attribute__((always_inline)) calculate_phi_d(__m128& k, __m128& /*Delta*/, __m128& Delta2, __m128& /*Delta_inv*/, __m128& ux, __m128& uy, __m128& x3, __m128& y3, __m128& phi_1, __m128& phi_2, __m128& d_1, __m128& d_2)
+static inline void __attribute__((always_inline)) calculate_phi_d(__m128& k, __m128& Delta, __m128& Delta2, __m128& Delta_inv, __m128& ux, __m128& uy, __m128& x3, __m128& y3, __m128& phi_1, __m128& phi_2, __m128& d_1, __m128& d_2)
 {
   __m128 k_inv = _vec_rec_ps(k);
   __m128 k2 = _mm_mul_ps(k, k);

--- a/offline/packages/HelixHough/helix_hough/HelixHough_findHelices.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_findHelices.cpp
@@ -14,20 +14,20 @@
 
 using namespace std;
 
-// static inline void in_place_counting_sort_unique(vector<unsigned int>& A,
-//                                                  vector<unsigned int>& C,
-//                                                  unsigned int MAX) {
-//   unsigned int SIZE = A.size();
-//   for (unsigned int i = 0; i < SIZE; ++i) {
-//     ++C[A[i]];
-//   }
-//   unsigned int current = 0;
-//   for (unsigned int i = 0; i < MAX; ++i) {
-//     A[current] = ((((C[i] != 0) - 1) & (A[current])) ^ (((C[i] == 0) - 1) & i));
-//     current += (C[i] != 0);
-//   }
-//   A.resize(current);
-// }
+static inline void in_place_counting_sort_unique(vector<unsigned int>& A,
+                                                 vector<unsigned int>& C,
+                                                 unsigned int MAX) {
+  unsigned int SIZE = A.size();
+  for (unsigned int i = 0; i < SIZE; ++i) {
+    ++C[A[i]];
+  }
+  unsigned int current = 0;
+  for (unsigned int i = 0; i < MAX; ++i) {
+    A[current] = ((((C[i] != 0) - 1) & (A[current])) ^ (((C[i] == 0) - 1) & i));
+    current += (C[i] != 0);
+  }
+  A.resize(current);
+}
 
 static inline void in_place_counting_unique(vector<unsigned int>& A,
                                             vector<unsigned int>& C) {
@@ -224,7 +224,7 @@ bool HelixHough::attemptClusterMerge(
     float cluster_size_cut, float overlap_cut,
     vector<ParameterCluster>& clusters, unsigned int* bins_start,
     unsigned int* bins_end, vector<unsigned int>& map_clus,
-    vector<unsigned char>& too_big, vector<unsigned int>& /*temp_merged*/,
+    vector<unsigned char>& too_big, vector<unsigned int>& temp_merged,
     vector<unsigned int>& C) {
   if ((good_bins[newbin] == 1) && (map_clus[newbin] != 4294967295)) {
     if (too_big[map_clus[newbin]] == 0) {
@@ -269,10 +269,10 @@ void HelixHough::makeClusters(unsigned int zoomlevel, unsigned int MAX,
                               unsigned int n_k, unsigned int n_dzdl,
                               unsigned int n_z0, unsigned int min_hits,
                               vector<ParameterCluster>& clusters,
-                              bool& /*use_clusters*/, bool& is_super_bin) {
+                              bool& use_clusters, bool& is_super_bin) {
   unsigned int volume = n_phi * n_d * n_k * n_dzdl * n_z0;
   float cluster_size_cut = 1.0;
-//  float bin_size_cut = 0.75;
+  float bin_size_cut = 0.75;
   float overlap_cut = 0.1;
   is_super_bin = false;
 
@@ -668,15 +668,15 @@ void HelixHough::findSeededHelices(vector<SimpleTrack3D>& seeds,
   smooth_back = false;
   while (layers_left > 0) {
     unsigned int layers_iter = layers_at_a_time;
-    if ((cur_layer + layers_at_a_time - 1) > (unsigned int) max_layer) {
+    if ((cur_layer + layers_at_a_time - 1) > max_layer) {
       layers_iter = (max_layer - (cur_layer - 1));
     }
 
     cur_tracks.clear();
     cur_hits.clear();
     for (unsigned int i = 0; i < hits.size(); ++i) {
-      if ((hits[i].get_layer() >= (int) cur_layer) &&
-          (hits[i].get_layer() <= (int) (cur_layer + layers_at_a_time - 1))) {
+      if ((hits[i].get_layer() >= cur_layer) &&
+          (hits[i].get_layer() <= (cur_layer + layers_at_a_time - 1))) {
         cur_hits.push_back(hits[i]);
       }
     }
@@ -692,7 +692,7 @@ void HelixHough::findSeededHelices(vector<SimpleTrack3D>& seeds,
     clear();
     req_layers = nreq;
 
-    if (layers_left <= (int) layers_at_a_time) {
+    if (layers_left <= layers_at_a_time) {
       smooth_back = smooth_back_orig;
     }
 

--- a/offline/packages/HelixHough/helix_hough/HelixHough_findPairs.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_findPairs.cpp
@@ -36,34 +36,34 @@ static inline void setClusterRange(HelixRange& range1, HelixRange& range2,
   range2.max_z0 = range1.min_z0 + z0_size * ((float)(prange.max_z0 + 1));
 }
 
-// static inline void setRange(const BinEntryPair5D& bp, HelixRange& range1,
-//                             HelixRange& range2, unsigned int n_phi,
-//                             unsigned int n_d, unsigned int n_k,
-//                             unsigned int n_dzdl, unsigned int n_z0) {
-//   float dzdl_size = (range1.max_dzdl - range1.min_dzdl) / ((float)n_dzdl);
-//   float z0_size = (range1.max_z0 - range1.min_z0) / ((float)n_z0);
-//   float phi_size = (range1.max_phi - range1.min_phi) / ((float)n_phi);
-//   float d_size = (range1.max_d - range1.min_d) / ((float)n_d);
-//   float k_size = (range1.max_k - range1.min_k) / ((float)n_k);
+static inline void setRange(const BinEntryPair5D& bp, HelixRange& range1,
+                            HelixRange& range2, unsigned int n_phi,
+                            unsigned int n_d, unsigned int n_k,
+                            unsigned int n_dzdl, unsigned int n_z0) {
+  float dzdl_size = (range1.max_dzdl - range1.min_dzdl) / ((float)n_dzdl);
+  float z0_size = (range1.max_z0 - range1.min_z0) / ((float)n_z0);
+  float phi_size = (range1.max_phi - range1.min_phi) / ((float)n_phi);
+  float d_size = (range1.max_d - range1.min_d) / ((float)n_d);
+  float k_size = (range1.max_k - range1.min_k) / ((float)n_k);
 
-//   unsigned int z0_bin = 0;
-//   unsigned int dzdl_bin = 0;
-//   unsigned int k_bin = 0;
-//   unsigned int d_bin = 0;
-//   unsigned int phi_bin = 0;
+  unsigned int z0_bin = 0;
+  unsigned int dzdl_bin = 0;
+  unsigned int k_bin = 0;
+  unsigned int d_bin = 0;
+  unsigned int phi_bin = 0;
 
-//   bp.bin5D(n_d, n_k, n_dzdl, n_z0, phi_bin, d_bin, k_bin, dzdl_bin, z0_bin);
-//   range2.min_phi = range1.min_phi + phi_size * ((float)(phi_bin));
-//   range2.max_phi = range2.min_phi + phi_size;
-//   range2.min_d = range1.min_d + d_size * ((float)(d_bin));
-//   range2.max_d = range2.min_d + d_size;
-//   range2.min_k = range1.min_k + k_size * ((float)(k_bin));
-//   range2.max_k = range2.min_k + k_size;
-//   range2.min_dzdl = range1.min_dzdl + dzdl_size * ((float)(dzdl_bin));
-//   range2.max_dzdl = range2.min_dzdl + dzdl_size;
-//   range2.min_z0 = range1.min_z0 + z0_size * ((float)(z0_bin));
-//   range2.max_z0 = range2.min_z0 + z0_size;
-// }
+  bp.bin5D(n_d, n_k, n_dzdl, n_z0, phi_bin, d_bin, k_bin, dzdl_bin, z0_bin);
+  range2.min_phi = range1.min_phi + phi_size * ((float)(phi_bin));
+  range2.max_phi = range2.min_phi + phi_size;
+  range2.min_d = range1.min_d + d_size * ((float)(d_bin));
+  range2.max_d = range2.min_d + d_size;
+  range2.min_k = range1.min_k + k_size * ((float)(k_bin));
+  range2.max_k = range2.min_k + k_size;
+  range2.min_dzdl = range1.min_dzdl + dzdl_size * ((float)(dzdl_bin));
+  range2.max_dzdl = range2.min_dzdl + dzdl_size;
+  range2.min_z0 = range1.min_z0 + z0_size * ((float)(z0_bin));
+  range2.max_z0 = range2.min_z0 + z0_size;
+}
 
 void HelixHough::findHelicesByPairsBegin(unsigned int min_hits,
                                          unsigned int max_hits,
@@ -98,7 +98,7 @@ void HelixHough::findHelicesByPairs(unsigned int min_hits,
   if ((maxtracks != 0) && (tracks.size() >= max_tracks)) {
     return;
   }
-//  unsigned int tracks_at_start = tracks.size();
+  unsigned int tracks_at_start = tracks.size();
 
   timeval t1, t2;
   double time1 = 0.;

--- a/offline/packages/HelixHough/helix_hough/HelixHough_init.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_init.cpp
@@ -12,14 +12,14 @@
 using namespace std;
 
 
-HelixHough::HelixHough(unsigned int n_phi, unsigned int n_d, unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0, HelixResolution& min_resolution, HelixResolution& max_resolution, HelixRange& range) : remove_hits(false), vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), only_one_helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
+HelixHough::HelixHough(unsigned int n_phi, unsigned int n_d, unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0, HelixResolution& min_resolution, HelixResolution& max_resolution, HelixRange& range) : vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), remove_hits(false), only_one_helicity(false), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
 {
   initHelixHough(n_phi, n_d, n_k, n_dzdl, n_z0, min_resolution, max_resolution, range);
   hit_used = new vector<unsigned int>;
 }
 
 
-HelixHough::HelixHough(vector<vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range) : remove_hits(false), vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), only_one_helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), layer_start(-1), layer_end(-1), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
+HelixHough::HelixHough(vector<vector<unsigned int> >& zoom_profile, unsigned int minzoom, HelixRange& range) : vote_time(0.), xy_vote_time(0.), z_vote_time(0.), print_timings(false), separate_by_helicity(true), helicity(false), check_layers(false), req_layers(0), bin_scale(1.), z_bin_scale(1.), remove_hits(false), only_one_helicity(false), start_zoom(0), max_hits_pairs(0), cluster_start_bin(2), layers_at_a_time(4), n_layers(6), layer_start(-1), layer_end(-1), smooth_back(false), cull_input_hits(false), iterate_clustering(false)
 {
   for(unsigned int i=0;i<hits_vec.size();i++){delete hits_vec[i];}
   hits_vec.clear();

--- a/offline/packages/HelixHough/helix_hough/HelixHough_phiRange_sse.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_phiRange_sse.cpp
@@ -1374,7 +1374,7 @@ void HelixHough::phiRange_sse(float* hit_x, float* hit_y, float* min_d, float* m
 }
 
 
-void HelixHough::phiRange_sse(float* hit_x, float* hit_y, float* min_d, float* max_d, float* /*min_k*/, float* max_k, float* min_phi, float* max_phi, float* min_phi_2, float* max_phi_2, float hel, __m128& phi_3, __m128& phi_4, __m128& phi_3_out, __m128& phi_4_out, float* hit_x_2, float* hit_y_2, __m128& phi_3_2, __m128& phi_4_2, __m128& phi_3_out_2, __m128& phi_4_out_2)
+void HelixHough::phiRange_sse(float* hit_x, float* hit_y, float* min_d, float* max_d, float* min_k, float* max_k, float* min_phi, float* max_phi, float* min_phi_2, float* max_phi_2, float hel, __m128& phi_3, __m128& phi_4, __m128& phi_3_out, __m128& phi_4_out, float* hit_x_2, float* hit_y_2, __m128& phi_3_2, __m128& phi_4_2, __m128& phi_3_out_2, __m128& phi_4_out_2)
 {
   __m128 helicity_vec = _mm_load1_ps(&(hel));
   

--- a/offline/packages/HelixHough/helix_hough/HelixHough_split.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_split.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-void HelixHough::splitIntoBins(unsigned int /*min_hits*/, unsigned int /*max_hits*/,
+void HelixHough::splitIntoBins(unsigned int min_hits, unsigned int max_hits,
                                vector<HelixRange>& ranges,
                                vector<vector<SimpleHit3D> >& split_hits,
                                unsigned int zoomlevel) {

--- a/offline/packages/HelixHough/helix_hough/HelixHough_vote_pairs_sse.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_vote_pairs_sse.cpp
@@ -382,12 +382,12 @@ void HelixHough::vote_pairs(unsigned int zoomlevel) {
 }
 
 void HelixHough::fillBins(
-  unsigned int /*total_bins*/, unsigned int pair_counter,
+    unsigned int total_bins, unsigned int pair_counter,
     unsigned int* pair_index, float* min_phi, float* max_phi, float* min_d,
     float* max_d, float* min_dzdl, float* max_dzdl, float* min_z0,
-    float* max_z0, vector<vector<SimpleHit3D> >& /*four_pairs*/, unsigned int n_d,
+    float* max_z0, vector<vector<SimpleHit3D> >& four_pairs, unsigned int n_d,
     unsigned int n_k, unsigned int n_dzdl, unsigned int n_z0,
-    unsigned int k_bin, unsigned int n_phi, unsigned int /*zoomlevel*/,
+    unsigned int k_bin, unsigned int n_phi, unsigned int zoomlevel,
     float low_phi, float high_phi, float low_d, float high_d, float low_z0,
     float high_z0, float low_dzdl, float high_dzdl, float inv_phi_range,
     float inv_d_range, float inv_z0_range, float inv_dzdl_range,

--- a/offline/packages/HelixHough/helix_hough/HelixHough_vote_sse.cpp
+++ b/offline/packages/HelixHough/helix_hough/HelixHough_vote_sse.cpp
@@ -14,64 +14,64 @@
 
 using namespace std;
 
-//static const unsigned int digits = 2;
-//static const unsigned int r = 7;
-//static const unsigned int radix = 1 << r;
-//static const unsigned int mask = radix - 1;
+static const unsigned int digits = 2;
+static const unsigned int r = 7;
+static const unsigned int radix = 1 << r;
+static const unsigned int mask = radix - 1;
 
-// static void radix_sort(std::vector<BinEntryPair5D>& A) {
-//   unsigned int SIZE = A.size();
-//   std::vector<BinEntryPair5D> B(SIZE);
-//   std::vector<unsigned int> cnt(radix);
+static void radix_sort(std::vector<BinEntryPair5D>& A) {
+  unsigned int SIZE = A.size();
+  std::vector<BinEntryPair5D> B(SIZE);
+  std::vector<unsigned int> cnt(radix);
 
-//   for (unsigned int i = 0, shift = 0; i < digits; i++, shift += r) {
-//     for (unsigned int j = 0; j < radix; ++j) {
-//       cnt[j] = 0;
-//     }
+  for (unsigned int i = 0, shift = 0; i < digits; i++, shift += r) {
+    for (unsigned int j = 0; j < radix; ++j) {
+      cnt[j] = 0;
+    }
 
-//     for (unsigned int j = 0; j < SIZE; ++j) {
-//       ++cnt[(A[j].bin >> shift) & mask];
-//     }
+    for (unsigned int j = 0; j < SIZE; ++j) {
+      ++cnt[(A[j].bin >> shift) & mask];
+    }
 
-//     for (unsigned int j = 1; j < radix; ++j) {
-//       cnt[j] += cnt[j - 1];
-//     }
+    for (unsigned int j = 1; j < radix; ++j) {
+      cnt[j] += cnt[j - 1];
+    }
 
-//     for (long j = SIZE - 1; j >= 0; --j) {
-//       B[--cnt[(A[j].bin >> shift) & mask]] = A[j];
-//     }
+    for (long j = SIZE - 1; j >= 0; --j) {
+      B[--cnt[(A[j].bin >> shift) & mask]] = A[j];
+    }
 
-//     for (unsigned int j = 0; j < SIZE; ++j) {
-//       A[j] = B[j];
-//     }
-//   }
-// }
+    for (unsigned int j = 0; j < SIZE; ++j) {
+      A[j] = B[j];
+    }
+  }
+}
 
-// static void radix_sort(unsigned int* A, unsigned int* B, unsigned int SIZE) {
-//   unsigned int cnt[1 << 7];
+static void radix_sort(unsigned int* A, unsigned int* B, unsigned int SIZE) {
+  unsigned int cnt[1 << 7];
 
-//   for (unsigned int i = 0, shift = 0; i < digits; i++, shift += r) {
-//     for (unsigned int j = 0; j < radix; ++j) {
-//       cnt[j] = 0;
-//     }
+  for (unsigned int i = 0, shift = 0; i < digits; i++, shift += r) {
+    for (unsigned int j = 0; j < radix; ++j) {
+      cnt[j] = 0;
+    }
 
-//     for (unsigned int j = 0; j < SIZE; ++j) {
-//       ++cnt[((A[j] >> 20) >> shift) & mask];
-//     }
+    for (unsigned int j = 0; j < SIZE; ++j) {
+      ++cnt[((A[j] >> 20) >> shift) & mask];
+    }
 
-//     for (unsigned int j = 1; j < radix; ++j) {
-//       cnt[j] += cnt[j - 1];
-//     }
+    for (unsigned int j = 1; j < radix; ++j) {
+      cnt[j] += cnt[j - 1];
+    }
 
-//     for (long j = SIZE - 1; j >= 0; --j) {
-//       B[--cnt[((A[j] >> 20) >> shift) & mask]] = A[j];
-//     }
+    for (long j = SIZE - 1; j >= 0; --j) {
+      B[--cnt[((A[j] >> 20) >> shift) & mask]] = A[j];
+    }
 
-//     for (unsigned int j = 0; j < SIZE; ++j) {
-//       A[j] = B[j];
-//     }
-//   }
-// }
+    for (unsigned int j = 0; j < SIZE; ++j) {
+      A[j] = B[j];
+    }
+  }
+}
 
 static void counting_sort(unsigned int MAX, std::vector<BinEntryPair5D>& A,
                           unsigned int* C, unsigned int* bins_start,
@@ -236,13 +236,13 @@ void fillBins4_sse(float* min_phi_a, float* max_phi_a, float n_phi_val,
   _mm_store_si128((__m128i*)phihi2, highphi_sel_2);
 }
 
-void HelixHough::fillBins(unsigned int /*total_bins*/, unsigned int hit_counter,
+void HelixHough::fillBins(unsigned int total_bins, unsigned int hit_counter,
                           float* min_phi_a, float* max_phi_a,
                           vector<SimpleHit3D>& four_hits, fastvec2d& z_bins,
                           unsigned int n_d, unsigned int n_k,
                           unsigned int n_dzdl, unsigned int n_z0,
                           unsigned int d_bin, unsigned int k_bin,
-                          unsigned int n_phi, unsigned int /*zoomlevel*/,
+                          unsigned int n_phi, unsigned int zoomlevel,
                           float low_phi, float high_phi, float inv_phi_range,
                           fastvec& vote_array) {
   unsigned int buffer[(1 << 10)];
@@ -331,8 +331,8 @@ void HelixHough::fillBins(unsigned int /*total_bins*/, unsigned int hit_counter,
   vote_array.push_back(buffer, bufnum);
 }
 
-void HelixHough::vote_z(unsigned int zoomlevel, unsigned int /*n_phi*/,
-                        unsigned int /*n_d*/, unsigned int /*n_k*/, unsigned int n_dzdl,
+void HelixHough::vote_z(unsigned int zoomlevel, unsigned int n_phi,
+                        unsigned int n_d, unsigned int n_k, unsigned int n_dzdl,
                         unsigned int n_z0, fastvec2d& z_bins) {
   float z0_size =
       (zoomranges[zoomlevel].max_z0 - zoomranges[zoomlevel].min_z0) /

--- a/offline/packages/HelixHough/helix_hough/Kalman/HelixKalman.cpp
+++ b/offline/packages/HelixHough/helix_hough/Kalman/HelixKalman.cpp
@@ -313,7 +313,7 @@ void HelixKalman::calculate_dAdAp(HelixKalmanState& state,
 // dA'/dp , where p is the momentum vector
 void HelixKalman::calculate_dApdp(HelixKalmanState& state,
                                   Matrix<float, 3, 3>& dApdp, Vector3f& p,
-                                  float /*phi*/, float cosphi, float sinphi) {
+                                  float phi, float cosphi, float sinphi) {
   float k = state.kappa;
   float dzdl = state.dzdl;
 

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXSeedFinder.cpp
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXSeedFinder.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 void sPHENIXSeedFinder::tripletRejection(vector<SimpleTrack3D>& input,
-					 vector<SimpleTrack3D>& /*output*/, vector<bool>& usetrack,
+		vector<SimpleTrack3D>& output, vector<bool>& usetrack,
 		vector<float>& next_best_chi2) {
 
 	vector<hitTriplet> trips;
@@ -102,8 +102,8 @@ void sPHENIXSeedFinder::tripletRejection(vector<SimpleTrack3D>& input,
 	}
 	sort(trips.begin(), trips.end());
 	unsigned int pos = 0;
-	// unsigned int cur_h1 = trips[pos].hit1;
-	// unsigned int cur_h2 = trips[pos].hit2;
+	unsigned int cur_h1 = trips[pos].hit1;
+	unsigned int cur_h2 = trips[pos].hit2;
 	while (pos < trips.size()) {
 		unsigned int next_pos = pos + 1;
 		if (next_pos >= trips.size()) {
@@ -150,8 +150,8 @@ void sPHENIXSeedFinder::tripletRejection(vector<SimpleTrack3D>& input,
 			}
 		}
 		pos = next_pos;
-		// cur_h1 = trips[pos].hit1;
-		// cur_h2 = trips[pos].hit2;
+		cur_h1 = trips[pos].hit1;
+		cur_h2 = trips[pos].hit2;
 	}
 }
 
@@ -340,65 +340,65 @@ float sPHENIXSeedFinder::ptToKappa(float pt) {
 }
 
 // hel should be +- 1
-// static void xyTangent(SimpleHit3D& hit1, SimpleHit3D& hit2, float kappa,
-// 		float hel, float& ux_out, float& uy_out, float& ux_in, float& uy_in) {
-// 	float x = hit2.get_x() - hit1.get_x();
-// 	float y = hit2.get_y() - hit1.get_y();
-// 	float D = sqrt(x * x + y * y);
-// 	float ak = 0.5 * kappa * D;
-// 	float D_inv = 1. / D;
-// 	float hk = sqrt(1. - ak * ak);
+static void xyTangent(SimpleHit3D& hit1, SimpleHit3D& hit2, float kappa,
+		float hel, float& ux_out, float& uy_out, float& ux_in, float& uy_in) {
+	float x = hit2.get_x() - hit1.get_x();
+	float y = hit2.get_y() - hit1.get_y();
+	float D = sqrt(x * x + y * y);
+	float ak = 0.5 * kappa * D;
+	float D_inv = 1. / D;
+	float hk = sqrt(1. - ak * ak);
 
-// 	float kcx = (ak * x + hel * hk * y) * D_inv;
-// 	float kcy = (ak * y - hel * hk * x) * D_inv;
-// 	float ktx = -(kappa * y - kcy);
-// 	float kty = kappa * x - kcx;
-// 	float norm = 1. / sqrt(ktx * ktx + kty * kty);
-// 	ux_out = ktx * norm;
-// 	uy_out = kty * norm;
+	float kcx = (ak * x + hel * hk * y) * D_inv;
+	float kcy = (ak * y - hel * hk * x) * D_inv;
+	float ktx = -(kappa * y - kcy);
+	float kty = kappa * x - kcx;
+	float norm = 1. / sqrt(ktx * ktx + kty * kty);
+	ux_out = ktx * norm;
+	uy_out = kty * norm;
 
-// 	ktx = kcy;
-// 	kty = -kcx;
-// 	norm = 1. / sqrt(ktx * ktx + kty * kty);
-// 	ux_in = ktx * norm;
-// 	uy_in = kty * norm;
-// }
+	ktx = kcy;
+	kty = -kcx;
+	norm = 1. / sqrt(ktx * ktx + kty * kty);
+	ux_in = ktx * norm;
+	uy_in = kty * norm;
+}
 
 // hel should be +- 1
-// static float cosScatter(SimpleHit3D& hit1, SimpleHit3D& hit2, SimpleHit3D& hit3,
-// 		float kappa, float hel) {
-// 	float ux_in = 0.;
-// 	float uy_in = 0.;
-// 	float ux_out = 0.;
-// 	float uy_out = 0.;
+static float cosScatter(SimpleHit3D& hit1, SimpleHit3D& hit2, SimpleHit3D& hit3,
+		float kappa, float hel) {
+	float ux_in = 0.;
+	float uy_in = 0.;
+	float ux_out = 0.;
+	float uy_out = 0.;
 
-// 	float temp1 = 0.;
-// 	float temp2 = 0.;
+	float temp1 = 0.;
+	float temp2 = 0.;
 
-// 	xyTangent(hit1, hit2, kappa, hel, ux_in, uy_in, temp1, temp2);
-// 	xyTangent(hit2, hit3, kappa, hel, temp1, temp2, ux_out, uy_out);
+	xyTangent(hit1, hit2, kappa, hel, ux_in, uy_in, temp1, temp2);
+	xyTangent(hit2, hit3, kappa, hel, temp1, temp2, ux_out, uy_out);
 
-// 	return ux_in * ux_out + uy_in * uy_out;
-// }
+	return ux_in * ux_out + uy_in * uy_out;
+}
 
-// static float dzdsSimple(SimpleHit3D& hit1, SimpleHit3D& hit2, float k) {
-// 	float x = hit2.get_x() - hit1.get_x();
-// 	float y = hit2.get_y() - hit1.get_y();
-// 	float D = sqrt(x * x + y * y);
-// 	float s = 0.;
-// 	float temp1 = k * D * 0.5;
-// 	temp1 *= temp1;
-// 	float temp2 = D * 0.5;
-// 	s += 2. * temp2;
-// 	temp2 *= temp1;
-// 	s += temp2 / 3.;
-// 	temp2 *= temp1;
-// 	s += (3. / 20.) * temp2;
-// 	temp2 *= temp1;
-// 	s += (5. / 56.) * temp2;
+static float dzdsSimple(SimpleHit3D& hit1, SimpleHit3D& hit2, float k) {
+	float x = hit2.get_x() - hit1.get_x();
+	float y = hit2.get_y() - hit1.get_y();
+	float D = sqrt(x * x + y * y);
+	float s = 0.;
+	float temp1 = k * D * 0.5;
+	temp1 *= temp1;
+	float temp2 = D * 0.5;
+	s += 2. * temp2;
+	temp2 *= temp1;
+	s += temp2 / 3.;
+	temp2 *= temp1;
+	s += (3. / 20.) * temp2;
+	temp2 *= temp1;
+	s += (5. / 56.) * temp2;
 
-// 	return (hit2.get_z() - hit1.get_z()) / s;
-// }
+	return (hit2.get_z() - hit1.get_z()) / s;
+}
 
 float sPHENIXSeedFinder::dcaToVertexXY(SimpleTrack3D& track, float vx,
 		float vy) {
@@ -522,7 +522,7 @@ void sPHENIXSeedFinder::findTracks(vector<SimpleHit3D>& hits,
 }
 
 bool sPHENIXSeedFinder::breakRecursion(const vector<SimpleHit3D>& hits,
-				       const HelixRange& /*range*/) {
+		const HelixRange& range) {
 	if (seeding == true) {
 		return false;
 	}
@@ -546,8 +546,8 @@ bool sPHENIXSeedFinder::breakRecursion(const vector<SimpleHit3D>& hits,
 	return (nlayers < required_layers);
 }
 
-float sPHENIXSeedFinder::phiError(SimpleHit3D& hit, float  /*min_k*/, float max_k,
-				  float min_d, float max_d, float /*min_z0*/, float /*max_z0*/, float /*min_dzdl*/,
+float sPHENIXSeedFinder::phiError(SimpleHit3D& hit, float min_k, float max_k,
+		float min_d, float max_d, float min_z0, float max_z0, float min_dzdl,
 		float max_dzdl, bool pairvoting) {
 	float Bfield_inv = 1. / detector_B_field;
 	float p_inv = 0.;
@@ -585,8 +585,8 @@ float sPHENIXSeedFinder::phiError(SimpleHit3D& hit, float  /*min_k*/, float max_
 	return returnval;
 }
 
-float sPHENIXSeedFinder::dzdlError(SimpleHit3D& hit, float /*min_k*/, float max_k,
-				   float /*min_d*/, float /*max_d*/, float min_z0, float max_z0, float /*min_dzdl*/,
+float sPHENIXSeedFinder::dzdlError(SimpleHit3D& hit, float min_k, float max_k,
+		float min_d, float max_d, float min_z0, float max_z0, float min_dzdl,
 		float max_dzdl, bool pairvoting) {
 	float Bfield_inv = 1. / detector_B_field;
 	float p_inv = 0.;
@@ -1207,80 +1207,80 @@ void sPHENIXSeedFinder::initDummyHits(vector<SimpleHit3D>& dummies,
 	}
 }
 
-// static void triplet_rejection(vector<SimpleTrack3D>& input,
-// 		vector<float>& chi2s, vector<bool>& usetrack) {
-// 	vector<hit_triplet> trips;
-// 	for (unsigned int i = 0; i < input.size(); ++i) {
-// 		for (unsigned int h1 = 0; h1 < input[i].hits.size(); ++h1) {
-// 			for (unsigned int h2 = (h1 + 1); h2 < input[i].hits.size(); ++h2) {
-// 				for (unsigned int h3 = (h2 + 1); h3 < input[i].hits.size();
-// 						++h3) {
-// 					trips.push_back(
-// 							hit_triplet(input[i].hits[h1].get_id(),
-// 									input[i].hits[h2].get_id(),
-// 									input[i].hits[h3].get_id(), i, chi2s[i]));
-// 				}
-// 			}
-// 		}
-// 	}
-// 	if (trips.size() == 0) {
-// 		return;
-// 	}
-// 	sort(trips.begin(), trips.end());
-// 	unsigned int pos = 0;
-// 	unsigned int cur_h1 = trips[pos].hit1;
-// 	unsigned int cur_h2 = trips[pos].hit2;
-// 	while (pos < trips.size()) {
-// 		unsigned int next_pos = pos + 1;
-// 		if (next_pos >= trips.size()) {
-// 			break;
-// 		}
-// 		while (trips[pos] == trips[next_pos]) {
-// 			next_pos += 1;
-// 			if (next_pos >= trips.size()) {
-// 				break;
-// 			}
-// 		}
-// 		if ((next_pos - pos) > 1) {
-// 			float best_chi2 = trips[pos].chi2;
-// 			float next_chi2 = trips[pos + 1].chi2;
-// 			unsigned int best_pos = pos;
-// 			for (unsigned int i = (pos + 1); i < next_pos; ++i) {
-// 				if (input[trips[i].track].hits.size()
-// 						< input[trips[best_pos].track].hits.size()) {
-// 					continue;
-// 				} else if ((input[trips[i].track].hits.size()
-// 						> input[trips[best_pos].track].hits.size())
-// 						|| (input[trips[i].track].hits.back().get_layer()
-// 								> input[trips[best_pos].track].hits.back().get_layer())) {
-// 					next_chi2 = best_chi2;
-// 					best_chi2 = trips[i].chi2;
-// 					best_pos = i;
-// 					continue;
-// 				}
-// 				if ((trips[i].chi2 < best_chi2)
-// 						|| (usetrack[trips[best_pos].track] == false)) {
-// 					next_chi2 = best_chi2;
-// 					best_chi2 = trips[i].chi2;
-// 					best_pos = i;
-// 				} else if (trips[i].chi2 < next_chi2) {
-// 					next_chi2 = trips[i].chi2;
-// 				}
-// 			}
-// 			for (unsigned int i = pos; i < next_pos; ++i) {
-// 				if (i != best_pos) {
-// 					usetrack[trips[i].track] = false;
-// 				}
-// 			}
-// 		}
-// 		pos = next_pos;
-// 		cur_h1 = trips[pos].hit1;
-// 		cur_h2 = trips[pos].hit2;
-// 	}
-// }
+static void triplet_rejection(vector<SimpleTrack3D>& input,
+		vector<float>& chi2s, vector<bool>& usetrack) {
+	vector<hit_triplet> trips;
+	for (unsigned int i = 0; i < input.size(); ++i) {
+		for (unsigned int h1 = 0; h1 < input[i].hits.size(); ++h1) {
+			for (unsigned int h2 = (h1 + 1); h2 < input[i].hits.size(); ++h2) {
+				for (unsigned int h3 = (h2 + 1); h3 < input[i].hits.size();
+						++h3) {
+					trips.push_back(
+							hit_triplet(input[i].hits[h1].get_id(),
+									input[i].hits[h2].get_id(),
+									input[i].hits[h3].get_id(), i, chi2s[i]));
+				}
+			}
+		}
+	}
+	if (trips.size() == 0) {
+		return;
+	}
+	sort(trips.begin(), trips.end());
+	unsigned int pos = 0;
+	unsigned int cur_h1 = trips[pos].hit1;
+	unsigned int cur_h2 = trips[pos].hit2;
+	while (pos < trips.size()) {
+		unsigned int next_pos = pos + 1;
+		if (next_pos >= trips.size()) {
+			break;
+		}
+		while (trips[pos] == trips[next_pos]) {
+			next_pos += 1;
+			if (next_pos >= trips.size()) {
+				break;
+			}
+		}
+		if ((next_pos - pos) > 1) {
+			float best_chi2 = trips[pos].chi2;
+			float next_chi2 = trips[pos + 1].chi2;
+			unsigned int best_pos = pos;
+			for (unsigned int i = (pos + 1); i < next_pos; ++i) {
+				if (input[trips[i].track].hits.size()
+						< input[trips[best_pos].track].hits.size()) {
+					continue;
+				} else if ((input[trips[i].track].hits.size()
+						> input[trips[best_pos].track].hits.size())
+						|| (input[trips[i].track].hits.back().get_layer()
+								> input[trips[best_pos].track].hits.back().get_layer())) {
+					next_chi2 = best_chi2;
+					best_chi2 = trips[i].chi2;
+					best_pos = i;
+					continue;
+				}
+				if ((trips[i].chi2 < best_chi2)
+						|| (usetrack[trips[best_pos].track] == false)) {
+					next_chi2 = best_chi2;
+					best_chi2 = trips[i].chi2;
+					best_pos = i;
+				} else if (trips[i].chi2 < next_chi2) {
+					next_chi2 = trips[i].chi2;
+				}
+			}
+			for (unsigned int i = pos; i < next_pos; ++i) {
+				if (i != best_pos) {
+					usetrack[trips[i].track] = false;
+				}
+			}
+		}
+		pos = next_pos;
+		cur_h1 = trips[pos].hit1;
+		cur_h2 = trips[pos].hit2;
+	}
+}
 
 void sPHENIXSeedFinder::findTracksBySegments(vector<SimpleHit3D>& hits,
-					     vector<SimpleTrack3D>& tracks, const HelixRange& /*range*/) {
+		vector<SimpleTrack3D>& tracks, const HelixRange& range) {
 
 	vector<TrackSegment>* cur_seg = &segments1;
 	vector<TrackSegment>* next_seg = &segments2;
@@ -1295,10 +1295,10 @@ void sPHENIXSeedFinder::findTracksBySegments(vector<SimpleHit3D>& hits,
 	}
 	for (unsigned int i = 0; i < hits.size(); ++i) {
 		unsigned int min = (hits[i].get_layer() - allowed_missing);
-		if (allowed_missing > (unsigned int) hits[i].get_layer()) {
+		if (allowed_missing > hits[i].get_layer()) {
 			min = 0;
 		}
-		for (int l = min; l <= hits[i].get_layer(); l += 1) {
+		for (unsigned int l = min; l <= hits[i].get_layer(); l += 1) {
 			layer_sorted[l].push_back(hits[i]);
 		}
 	}
@@ -1889,11 +1889,11 @@ void sPHENIXSeedFinder::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
 	y = P2y + signk * uy * h;
 
 	double sign_dzdl = sign(dzdl);
-//	double onedzdl2_inv = 1. / (1. - dzdl * dzdl);
+	double onedzdl2_inv = 1. / (1. - dzdl * dzdl);
 	double startx = d * cosphi;
 	double starty = d * sinphi;
 	double D = sqrt((startx - x) * (startx - x) + (starty - y) * (starty - y));
-//	double D_inv = 1. / D;
+	double D_inv = 1. / D;
 	double v = 0.5 * k * D;
 	z = 0.;
 	if (v > 0.1) {
@@ -1901,8 +1901,8 @@ void sPHENIXSeedFinder::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
 			v = 0.999999;
 		}
 		double s = 2. * asin(v) / k;
-//		double s_inv = 1. / s;
-//		double sqrtvv = sqrt(1 - v * v);
+		double s_inv = 1. / s;
+		double sqrtvv = sqrt(1 - v * v);
 		double dz = sqrt(s * s * dzdl * dzdl / (1. - dzdl * dzdl));
 		z = z0 + sign_dzdl * dz;
 	} else {
@@ -1917,14 +1917,14 @@ void sPHENIXSeedFinder::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
 		s += (3. / 20.) * temp2;
 		temp2 *= temp1;
 		s += (5. / 56.) * temp2;
-//		double s_inv = 1. / s;
+		double s_inv = 1. / s;
 		double dz = sqrt(s * s * dzdl * dzdl / (1. - dzdl * dzdl));
 		z = z0 + sign_dzdl * dz;
 	}
 }
 
 void sPHENIXSeedFinder::initSplitting(vector<SimpleHit3D>& hits,
-				      unsigned int min_hits, unsigned int /*max_hits*/) {
+		unsigned int min_hits, unsigned int max_hits) {
 	initEvent(hits, min_hits);
 	(*(hits_vec[0])) = hits;
 	zoomranges.clear();
@@ -1934,8 +1934,8 @@ void sPHENIXSeedFinder::initSplitting(vector<SimpleHit3D>& hits,
 }
 
 void sPHENIXSeedFinder::findHelicesParallelOneHelicity(
-  vector<SimpleHit3D>& hits, unsigned int /*min_hits*/, unsigned int /*max_hits*/,
-		vector<SimpleTrack3D>& /*tracks*/) {
+		vector<SimpleHit3D>& hits, unsigned int min_hits, unsigned int max_hits,
+		vector<SimpleTrack3D>& tracks) {
 	unsigned int hits_per_thread = (hits.size() + 2 * nthreads) / nthreads;
 	unsigned int pos = 0;
 	while (pos < hits.size()) {

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXSeedFinder.h
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXSeedFinder.h
@@ -224,7 +224,7 @@ public:
 	void findTracksBySegments(std::vector<SimpleHit3D>& hits,
 			std::vector<SimpleTrack3D>& tracks, const HelixRange& range);
 
-	void initEvent(std::vector<SimpleHit3D>& hits, unsigned int) {
+	void initEvent(std::vector<SimpleHit3D>& hits, unsigned int min_hits) {
 		int min_layer = 999999;
 		int max_layer = 0;
 		for (unsigned int i = 0; i < hits.size(); ++i) {

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.cpp
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.cpp
@@ -70,7 +70,7 @@ class hitTriplet {
 };
 
 void sPHENIXTracker::tripletRejection(vector<SimpleTrack3D>& input,
-                                      vector<SimpleTrack3D>& /*output*/,
+                                      vector<SimpleTrack3D>& output,
                                       vector<bool>& usetrack,
                                       vector<float>& next_best_chi2) {
   vector<hitTriplet> trips;
@@ -92,8 +92,8 @@ void sPHENIXTracker::tripletRejection(vector<SimpleTrack3D>& input,
   }
   sort(trips.begin(), trips.end());
   unsigned int pos = 0;
-//  unsigned int cur_h1 = trips[pos].hit1;
-//  unsigned int cur_h2 = trips[pos].hit2;
+  unsigned int cur_h1 = trips[pos].hit1;
+  unsigned int cur_h2 = trips[pos].hit2;
   while (pos < trips.size()) {
     unsigned int next_pos = pos + 1;
     if (next_pos >= trips.size()) {
@@ -140,8 +140,8 @@ void sPHENIXTracker::tripletRejection(vector<SimpleTrack3D>& input,
       }
     }
     pos = next_pos;
-    // cur_h1 = trips[pos].hit1;
-    // cur_h2 = trips[pos].hit2;
+    cur_h1 = trips[pos].hit1;
+    cur_h2 = trips[pos].hit2;
   }
 }
 
@@ -326,66 +326,66 @@ float sPHENIXTracker::ptToKappa(float pt) {
 }
 
 // hel should be +- 1
-// static void xyTangent(SimpleHit3D& hit1, SimpleHit3D& hit2, float kappa,
-//                       float hel, float& ux_out, float& uy_out, float& ux_in,
-//                       float& uy_in) {
-//   float x = hit2.get_x() - hit1.get_x();
-//   float y = hit2.get_y() - hit1.get_y();
-//   float D = sqrt(x * x + y * y);
-//   float ak = 0.5 * kappa * D;
-//   float D_inv = 1. / D;
-//   float hk = sqrt(1. - ak * ak);
+static void xyTangent(SimpleHit3D& hit1, SimpleHit3D& hit2, float kappa,
+                      float hel, float& ux_out, float& uy_out, float& ux_in,
+                      float& uy_in) {
+  float x = hit2.get_x() - hit1.get_x();
+  float y = hit2.get_y() - hit1.get_y();
+  float D = sqrt(x * x + y * y);
+  float ak = 0.5 * kappa * D;
+  float D_inv = 1. / D;
+  float hk = sqrt(1. - ak * ak);
 
-//   float kcx = (ak * x + hel * hk * y) * D_inv;
-//   float kcy = (ak * y - hel * hk * x) * D_inv;
-//   float ktx = -(kappa * y - kcy);
-//   float kty = kappa * x - kcx;
-//   float norm = 1. / sqrt(ktx * ktx + kty * kty);
-//   ux_out = ktx * norm;
-//   uy_out = kty * norm;
+  float kcx = (ak * x + hel * hk * y) * D_inv;
+  float kcy = (ak * y - hel * hk * x) * D_inv;
+  float ktx = -(kappa * y - kcy);
+  float kty = kappa * x - kcx;
+  float norm = 1. / sqrt(ktx * ktx + kty * kty);
+  ux_out = ktx * norm;
+  uy_out = kty * norm;
 
-//   ktx = kcy;
-//   kty = -kcx;
-//   norm = 1. / sqrt(ktx * ktx + kty * kty);
-//   ux_in = ktx * norm;
-//   uy_in = kty * norm;
-// }
+  ktx = kcy;
+  kty = -kcx;
+  norm = 1. / sqrt(ktx * ktx + kty * kty);
+  ux_in = ktx * norm;
+  uy_in = kty * norm;
+}
 
 // hel should be +- 1
-// static float cosScatter(SimpleHit3D& hit1, SimpleHit3D& hit2, SimpleHit3D& hit3,
-//                         float kappa, float hel) {
-//   float ux_in = 0.;
-//   float uy_in = 0.;
-//   float ux_out = 0.;
-//   float uy_out = 0.;
+static float cosScatter(SimpleHit3D& hit1, SimpleHit3D& hit2, SimpleHit3D& hit3,
+                        float kappa, float hel) {
+  float ux_in = 0.;
+  float uy_in = 0.;
+  float ux_out = 0.;
+  float uy_out = 0.;
 
-//   float temp1 = 0.;
-//   float temp2 = 0.;
+  float temp1 = 0.;
+  float temp2 = 0.;
 
-//   xyTangent(hit1, hit2, kappa, hel, ux_in, uy_in, temp1, temp2);
-//   xyTangent(hit2, hit3, kappa, hel, temp1, temp2, ux_out, uy_out);
+  xyTangent(hit1, hit2, kappa, hel, ux_in, uy_in, temp1, temp2);
+  xyTangent(hit2, hit3, kappa, hel, temp1, temp2, ux_out, uy_out);
 
-//   return ux_in * ux_out + uy_in * uy_out;
-// }
+  return ux_in * ux_out + uy_in * uy_out;
+}
 
-// static float dzdsSimple(SimpleHit3D& hit1, SimpleHit3D& hit2, float k) {
-//   float x = hit2.get_x() - hit1.get_x();
-//   float y = hit2.get_y() - hit1.get_y();
-//   float D = sqrt(x * x + y * y);
-//   float s = 0.;
-//   float temp1 = k * D * 0.5;
-//   temp1 *= temp1;
-//   float temp2 = D * 0.5;
-//   s += 2. * temp2;
-//   temp2 *= temp1;
-//   s += temp2 / 3.;
-//   temp2 *= temp1;
-//   s += (3. / 20.) * temp2;
-//   temp2 *= temp1;
-//   s += (5. / 56.) * temp2;
+static float dzdsSimple(SimpleHit3D& hit1, SimpleHit3D& hit2, float k) {
+  float x = hit2.get_x() - hit1.get_x();
+  float y = hit2.get_y() - hit1.get_y();
+  float D = sqrt(x * x + y * y);
+  float s = 0.;
+  float temp1 = k * D * 0.5;
+  temp1 *= temp1;
+  float temp2 = D * 0.5;
+  s += 2. * temp2;
+  temp2 *= temp1;
+  s += temp2 / 3.;
+  temp2 *= temp1;
+  s += (3. / 20.) * temp2;
+  temp2 *= temp1;
+  s += (5. / 56.) * temp2;
 
-//   return (hit2.get_z() - hit1.get_z()) / s;
-// }
+  return (hit2.get_z() - hit1.get_z()) / s;
+}
 
 float sPHENIXTracker::dcaToVertexXY(SimpleTrack3D& track, float vx, float vy) {
   float d_out = 0.;
@@ -504,7 +504,7 @@ void sPHENIXTracker::findTracks(vector<SimpleHit3D>& hits,
 }
 
 bool sPHENIXTracker::breakRecursion(const vector<SimpleHit3D>& hits,
-                                    const HelixRange& /*range*/) {
+                                    const HelixRange& range) {
   if (seeding == true) {
     return false;
   }
@@ -527,9 +527,9 @@ bool sPHENIXTracker::breakRecursion(const vector<SimpleHit3D>& hits,
   return (nlayers < required_layers);
 }
 
-float sPHENIXTracker::phiError(SimpleHit3D& hit, float /*min_k*/, float max_k,
-                               float min_d, float max_d, float /*min_z0*/,
-                               float /*max_z0*/, float /*min_dzdl*/, float max_dzdl,
+float sPHENIXTracker::phiError(SimpleHit3D& hit, float min_k, float max_k,
+                               float min_d, float max_d, float min_z0,
+                               float max_z0, float min_dzdl, float max_dzdl,
                                bool pairvoting) {
   float Bfield_inv = 1. / detector_B_field;
   float p_inv = 0.;
@@ -567,9 +567,9 @@ float sPHENIXTracker::phiError(SimpleHit3D& hit, float /*min_k*/, float max_k,
   return returnval;
 }
 
-float sPHENIXTracker::dzdlError(SimpleHit3D& hit, float /*min_k*/, float max_k,
-                                float /*min_d*/, float /*max_d*/, float min_z0,
-                                float max_z0, float /*min_dzdl*/, float max_dzdl,
+float sPHENIXTracker::dzdlError(SimpleHit3D& hit, float min_k, float max_k,
+                                float min_d, float max_d, float min_z0,
+                                float max_z0, float min_dzdl, float max_dzdl,
                                 bool pairvoting) {
   float Bfield_inv = 1. / detector_B_field;
   float p_inv = 0.;
@@ -1180,79 +1180,79 @@ void sPHENIXTracker::initDummyHits(vector<SimpleHit3D>& dummies,
 
 
 
-// static void triplet_rejection(vector<SimpleTrack3D>& input,
-//                               vector<float>& chi2s, vector<bool>& usetrack) {
-//   vector<hit_triplet> trips;
-//   for (unsigned int i = 0; i < input.size(); ++i) {
-//     for (unsigned int h1 = 0; h1 < input[i].hits.size(); ++h1) {
-//       for (unsigned int h2 = (h1 + 1); h2 < input[i].hits.size(); ++h2) {
-//         for (unsigned int h3 = (h2 + 1); h3 < input[i].hits.size(); ++h3) {
-//           trips.push_back(hit_triplet(input[i].hits[h1].get_id(),
-//                                       input[i].hits[h2].get_id(),
-//                                       input[i].hits[h3].get_id(), i, chi2s[i]));
-//         }
-//       }
-//     }
-//   }
-//   if (trips.size() == 0) {
-//     return;
-//   }
-//   sort(trips.begin(), trips.end());
-//   unsigned int pos = 0;
-//   unsigned int cur_h1 = trips[pos].hit1;
-//   unsigned int cur_h2 = trips[pos].hit2;
-//   while (pos < trips.size()) {
-//     unsigned int next_pos = pos + 1;
-//     if (next_pos >= trips.size()) {
-//       break;
-//     }
-//     while (trips[pos] == trips[next_pos]) {
-//       next_pos += 1;
-//       if (next_pos >= trips.size()) {
-//         break;
-//       }
-//     }
-//     if ((next_pos - pos) > 1) {
-//       float best_chi2 = trips[pos].chi2;
-//       float next_chi2 = trips[pos + 1].chi2;
-//       unsigned int best_pos = pos;
-//       for (unsigned int i = (pos + 1); i < next_pos; ++i) {
-//         if (input[trips[i].track].hits.size() <
-//             input[trips[best_pos].track].hits.size()) {
-//           continue;
-//         } else if ((input[trips[i].track].hits.size() >
-//                     input[trips[best_pos].track].hits.size()) ||
-//                    (input[trips[i].track].hits.back().get_layer() >
-//                     input[trips[best_pos].track].hits.back().get_layer())) {
-//           next_chi2 = best_chi2;
-//           best_chi2 = trips[i].chi2;
-//           best_pos = i;
-//           continue;
-//         }
-//         if ((trips[i].chi2 < best_chi2) ||
-//             (usetrack[trips[best_pos].track] == false)) {
-//           next_chi2 = best_chi2;
-//           best_chi2 = trips[i].chi2;
-//           best_pos = i;
-//         } else if (trips[i].chi2 < next_chi2) {
-//           next_chi2 = trips[i].chi2;
-//         }
-//       }
-//       for (unsigned int i = pos; i < next_pos; ++i) {
-//         if (i != best_pos) {
-//           usetrack[trips[i].track] = false;
-//         }
-//       }
-//     }
-//     pos = next_pos;
-//     cur_h1 = trips[pos].hit1;
-//     cur_h2 = trips[pos].hit2;
-//   }
-// }
+static void triplet_rejection(vector<SimpleTrack3D>& input,
+                              vector<float>& chi2s, vector<bool>& usetrack) {
+  vector<hit_triplet> trips;
+  for (unsigned int i = 0; i < input.size(); ++i) {
+    for (unsigned int h1 = 0; h1 < input[i].hits.size(); ++h1) {
+      for (unsigned int h2 = (h1 + 1); h2 < input[i].hits.size(); ++h2) {
+        for (unsigned int h3 = (h2 + 1); h3 < input[i].hits.size(); ++h3) {
+          trips.push_back(hit_triplet(input[i].hits[h1].get_id(),
+                                      input[i].hits[h2].get_id(),
+                                      input[i].hits[h3].get_id(), i, chi2s[i]));
+        }
+      }
+    }
+  }
+  if (trips.size() == 0) {
+    return;
+  }
+  sort(trips.begin(), trips.end());
+  unsigned int pos = 0;
+  unsigned int cur_h1 = trips[pos].hit1;
+  unsigned int cur_h2 = trips[pos].hit2;
+  while (pos < trips.size()) {
+    unsigned int next_pos = pos + 1;
+    if (next_pos >= trips.size()) {
+      break;
+    }
+    while (trips[pos] == trips[next_pos]) {
+      next_pos += 1;
+      if (next_pos >= trips.size()) {
+        break;
+      }
+    }
+    if ((next_pos - pos) > 1) {
+      float best_chi2 = trips[pos].chi2;
+      float next_chi2 = trips[pos + 1].chi2;
+      unsigned int best_pos = pos;
+      for (unsigned int i = (pos + 1); i < next_pos; ++i) {
+        if (input[trips[i].track].hits.size() <
+            input[trips[best_pos].track].hits.size()) {
+          continue;
+        } else if ((input[trips[i].track].hits.size() >
+                    input[trips[best_pos].track].hits.size()) ||
+                   (input[trips[i].track].hits.back().get_layer() >
+                    input[trips[best_pos].track].hits.back().get_layer())) {
+          next_chi2 = best_chi2;
+          best_chi2 = trips[i].chi2;
+          best_pos = i;
+          continue;
+        }
+        if ((trips[i].chi2 < best_chi2) ||
+            (usetrack[trips[best_pos].track] == false)) {
+          next_chi2 = best_chi2;
+          best_chi2 = trips[i].chi2;
+          best_pos = i;
+        } else if (trips[i].chi2 < next_chi2) {
+          next_chi2 = trips[i].chi2;
+        }
+      }
+      for (unsigned int i = pos; i < next_pos; ++i) {
+        if (i != best_pos) {
+          usetrack[trips[i].track] = false;
+        }
+      }
+    }
+    pos = next_pos;
+    cur_h1 = trips[pos].hit1;
+    cur_h2 = trips[pos].hit2;
+  }
+}
 
 void sPHENIXTracker::findTracksBySegments(vector<SimpleHit3D>& hits,
                                           vector<SimpleTrack3D>& tracks,
-                                          const HelixRange& /*range*/) {
+                                          const HelixRange& range) {
 
   cout << "fidTracksBySegments " << endl;
   vector<TrackSegment>* cur_seg = &segments1;
@@ -1269,10 +1269,10 @@ void sPHENIXTracker::findTracksBySegments(vector<SimpleHit3D>& hits,
   }
   for (unsigned int i = 0; i < hits.size(); ++i) {
     unsigned int min = (hits[i].get_layer() - allowed_missing);
-    if (allowed_missing > (unsigned int) hits[i].get_layer()) {
+    if (allowed_missing > hits[i].get_layer()) {
       min = 0;
     }
-    for (int l = min; l <= hits[i].get_layer(); l += 1) {
+    for (unsigned int l = min; l <= hits[i].get_layer(); l += 1) {
       layer_sorted[l].push_back(hits[i]);
     }
   }
@@ -1801,11 +1801,11 @@ void sPHENIXTracker::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
   y = P2y + signk * uy * h;
 
   double sign_dzdl = sign(dzdl);
-//  double onedzdl2_inv = 1. / (1. - dzdl * dzdl);
+  double onedzdl2_inv = 1. / (1. - dzdl * dzdl);
   double startx = d * cosphi;
   double starty = d * sinphi;
   double D = sqrt((startx - x) * (startx - x) + (starty - y) * (starty - y));
-//  double D_inv = 1. / D;
+  double D_inv = 1. / D;
   double v = 0.5 * k * D;
   z = 0.;
   if (v > 0.1) {
@@ -1813,8 +1813,8 @@ void sPHENIXTracker::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
       v = 0.999999;
     }
     double s = 2. * asin(v) / k;
-//    double s_inv = 1. / s;
-//    double sqrtvv = sqrt(1 - v * v);
+    double s_inv = 1. / s;
+    double sqrtvv = sqrt(1 - v * v);
     double dz = sqrt(s * s * dzdl * dzdl / (1. - dzdl * dzdl));
     z = z0 + sign_dzdl * dz;
   } else {
@@ -1829,7 +1829,7 @@ void sPHENIXTracker::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
     s += (3. / 20.) * temp2;
     temp2 *= temp1;
     s += (5. / 56.) * temp2;
-//    double s_inv = 1. / s;
+    double s_inv = 1. / s;
     double dz = sqrt(s * s * dzdl * dzdl / (1. - dzdl * dzdl));
     z = z0 + sign_dzdl * dz;
   }
@@ -1837,7 +1837,7 @@ void sPHENIXTracker::projectToLayer(SimpleTrack3D& seed, unsigned int layer,
 
 void sPHENIXTracker::initSplitting(vector<SimpleHit3D>& hits,
                                    unsigned int min_hits,
-                                   unsigned int /*max_hits*/) {
+                                   unsigned int max_hits) {
   initEvent(hits, min_hits);
   (*(hits_vec[0])) = hits;
   zoomranges.clear();
@@ -1847,8 +1847,8 @@ void sPHENIXTracker::initSplitting(vector<SimpleHit3D>& hits,
 }
 
 void sPHENIXTracker::findHelicesParallelOneHelicity(
-  vector<SimpleHit3D>& hits, unsigned int /*min_hits*/, unsigned int /*max_hits*/,
-    vector<SimpleTrack3D>& /*tracks*/) {
+    vector<SimpleHit3D>& hits, unsigned int min_hits, unsigned int max_hits,
+    vector<SimpleTrack3D>& tracks) {
   unsigned int hits_per_thread = (hits.size() + 2 * nthreads) / nthreads;
   unsigned int pos = 0;
   while (pos < hits.size()) {

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.h
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTracker.h
@@ -220,7 +220,7 @@ class sPHENIXTracker : public HelixHough {
                             std::vector<SimpleTrack3D>& tracks,
                             const HelixRange& range);
 
-  void initEvent(std::vector<SimpleHit3D>& hits, unsigned int /*min_hits*/) {
+  void initEvent(std::vector<SimpleHit3D>& hits, unsigned int min_hits) {
     int min_layer = 999999;
     int max_layer = 0;
     for (unsigned int i = 0; i < hits.size(); ++i) {

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTpc.cpp
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTpc.cpp
@@ -47,7 +47,7 @@ public:
 };
 
 void sPHENIXTrackerTpc::tripletRejection(vector<SimpleTrack3D>& input,
-                                         vector<SimpleTrack3D>& /*output*/,
+                                         vector<SimpleTrack3D>& output,
                                          vector<bool>& usetrack,
                                          vector<float>& next_best_chi2) {
   vector<hitTriplet> trips;
@@ -69,8 +69,8 @@ void sPHENIXTrackerTpc::tripletRejection(vector<SimpleTrack3D>& input,
   }
   sort(trips.begin(), trips.end());
   unsigned int pos = 0;
-  // unsigned int cur_h1 = trips[pos].hit1;
-  // unsigned int cur_h2 = trips[pos].hit2;
+  unsigned int cur_h1 = trips[pos].hit1;
+  unsigned int cur_h2 = trips[pos].hit2;
   while (pos < trips.size()) {
     unsigned int next_pos = pos + 1;
     if (next_pos >= trips.size()) {
@@ -117,8 +117,8 @@ void sPHENIXTrackerTpc::tripletRejection(vector<SimpleTrack3D>& input,
       }
     }
     pos = next_pos;
-    // cur_h1 = trips[pos].hit1;
-    // cur_h2 = trips[pos].hit2;
+    cur_h1 = trips[pos].hit1;
+    cur_h2 = trips[pos].hit2;
   }
 }
 
@@ -424,7 +424,7 @@ void sPHENIXTrackerTpc::finalize(vector<SimpleTrack3D>& input,
 }
 
 bool sPHENIXTrackerTpc::breakRecursion(const vector<SimpleHit3D>& hits,
-                                       const HelixRange& /*range*/) {
+                                       const HelixRange& range) {
   if (seeding == true) {
     return false;
   }
@@ -453,9 +453,9 @@ bool sPHENIXTrackerTpc::breakRecursion(const vector<SimpleHit3D>& hits,
   return (nlayers < required_layers);
 }
 
-float sPHENIXTrackerTpc::phiError(SimpleHit3D& hit, float /*min_k*/, float max_k,
-                                  float min_d, float max_d, float /*min_z0*/,
-                                  float /*max_z0*/, float /*min_dzdl*/, float max_dzdl,
+float sPHENIXTrackerTpc::phiError(SimpleHit3D& hit, float min_k, float max_k,
+                                  float min_d, float max_d, float min_z0,
+                                  float max_z0, float min_dzdl, float max_dzdl,
                                   bool pairvoting) {
   float Bfield_inv = 1. / detector_B_field;
   float p_inv = 0.;
@@ -493,9 +493,9 @@ float sPHENIXTrackerTpc::phiError(SimpleHit3D& hit, float /*min_k*/, float max_k
   return returnval;
 }
 
-float sPHENIXTrackerTpc::dzdlError(SimpleHit3D& hit, float /*min_k*/, float max_k,
-                                   float /*min_d*/, float /*max_d*/, float min_z0,
-                                   float max_z0, float /*min_dzdl*/, float max_dzdl,
+float sPHENIXTrackerTpc::dzdlError(SimpleHit3D& hit, float min_k, float max_k,
+                                   float min_d, float max_d, float min_z0,
+                                   float max_z0, float min_dzdl, float max_dzdl,
                                    bool pairvoting) {
   float Bfield_inv = 1. / detector_B_field;
   float p_inv = 0.;
@@ -712,7 +712,7 @@ float sPHENIXTrackerTpc::fitTrack(SimpleTrack3D& track,
 
 void sPHENIXTrackerTpc::initSplitting(vector<SimpleHit3D>& hits,
                                       unsigned int min_hits,
-                                      unsigned int /*max_hits*/) {
+                                      unsigned int max_hits) {
   initEvent(hits, min_hits);
   (*(hits_vec[0])) = hits;
   zoomranges.clear();
@@ -723,14 +723,15 @@ void sPHENIXTrackerTpc::initSplitting(vector<SimpleHit3D>& hits,
 
 static bool remove_bad_hits(SimpleTrack3D& track, float cut, float scale = 1.0) {
   SimpleTrack3D temp_track = track;
+  float fit_chi2 = 0.;
   vector<float> chi2_hit;
   vector<float> temp_hits;
   while (true) {
     temp_track = track;
-    sPHENIXTrackerTpc::fitTrack(temp_track, chi2_hit, scale);
+    fit_chi2 = sPHENIXTrackerTpc::fitTrack(temp_track, chi2_hit, scale);
     bool all_good = true;
     track.hits.clear();
-    for (unsigned int h = 0; h < temp_track.hits.size(); h += 1) {
+    for (int h = 0; h < temp_track.hits.size(); h += 1) {
       if (chi2_hit[h] < cut) {
         track.hits.push_back(temp_track.hits[h]);
       } else {
@@ -749,7 +750,7 @@ static bool remove_bad_hits(SimpleTrack3D& track, float cut, float scale = 1.0) 
 static bool fit_all_update(vector<vector<int> >& layer_indexes,
                            SimpleTrack3D& temp_track, vector<int>& best_ind,
                            vector<float>& best_chi2, SimpleTrack3D& track,
-                           float& /*chi2*/, int iter = 0,
+                           float& chi2, int iter = 0,
 			   float tempscale = 1.0, float scale = 1.0) {
   if (iter != 0) {
     if (remove_bad_hits(track, 5., scale) == false) {
@@ -772,7 +773,7 @@ static bool fit_all_update(vector<vector<int> >& layer_indexes,
 
   best_ind.assign(layer_indexes.size(), -1);
   best_chi2.assign(layer_indexes.size(), -1.);
-  for (unsigned int i = 0; i < temp_track.hits.size(); i += 1) {
+  for (int i = 0; i < temp_track.hits.size(); i += 1) {
     float dx1 = temp_track.hits[i].get_x() - cx;
     float dy1 = temp_track.hits[i].get_y() - cy;
     float dx2 = temp_track.hits[i].get_x() + cx;
@@ -835,7 +836,7 @@ static bool fit_all_update(vector<vector<int> >& layer_indexes,
   }
 
   track.hits.clear();
-  for (unsigned int i = 0; i < layer_indexes.size(); i += 1) {
+  for (int i = 0; i < layer_indexes.size(); i += 1) {
     if (best_ind[i] < 0) {
       continue;
     }
@@ -855,7 +856,7 @@ static bool fit_all(vector<SimpleHit3D>& hits,
 
   SimpleTrack3D temp_track;
   vector<float> chi2_hit;
-  for (unsigned int i = 0; i < hits.size(); i += 1) {
+  for (int i = 0; i < hits.size(); i += 1) {
     if (hits[i].get_layer() < 3) {
       continue;
     }
@@ -865,7 +866,7 @@ static bool fit_all(vector<SimpleHit3D>& hits,
   vector<int> best_ind;
   vector<float> best_chi2;
   track.hits.clear();
-  for (unsigned int i = 0; i < hits.size(); i += 1) {
+  for (int i = 0; i < hits.size(); i += 1) {
     if (hits[i].get_layer() < 3) {
       continue;
     }
@@ -901,14 +902,14 @@ static bool fit_all(vector<SimpleHit3D>& hits,
 
 void sPHENIXTrackerTpc::findTracksByCombinatorialKalman(
     vector<SimpleHit3D>& hits, vector<SimpleTrack3D>& tracks,
-    const HelixRange& /*range*/) {
+    const HelixRange& range) {
 
   timeval t1, t2;
   double time1 = 0.;
   double time2 = 0.;
 
   gettimeofday(&t1, NULL);
-//  float CHI2_CUT = chi2_cut + 2.;
+  float CHI2_CUT = chi2_cut + 2.;
 
   vector<vector<int> > layer_indexes;
   layer_indexes.assign(n_layers, vector<int>());
@@ -984,9 +985,9 @@ void sPHENIXTrackerTpc::findTracksByCombinatorialKalman(
 
     vector<vector<int> > inner_combos;
     for (int l = 0; l < 2; ++l) {
-      for (unsigned int i0 = 0; i0 < layer_indexes[0].size(); ++i0) {
-        for (unsigned int i1 = 0; i1 < layer_indexes[1].size(); ++i1) {
-          for (unsigned int i2 = 0; i2 < layer_indexes[2].size(); ++i2) {
+      for (int i0 = 0; i0 < layer_indexes[0].size(); ++i0) {
+        for (int i1 = 0; i1 < layer_indexes[1].size(); ++i1) {
+          for (int i2 = 0; i2 < layer_indexes[2].size(); ++i2) {
             inner_combos.push_back(vector<int>(3, 0));
             inner_combos.back()[0] = layer_indexes[0][i0];
             inner_combos.back()[1] = layer_indexes[1][i1];
@@ -999,7 +1000,7 @@ void sPHENIXTrackerTpc::findTracksByCombinatorialKalman(
     float best_chi2_p[4] = {-1., -1., -1., -1.};
     int best_ind_p[4] = {-1, -1, -1, -1};
 
-    for (unsigned int c = 0; c < inner_combos.size(); ++c) {
+    for (int c = 0; c < inner_combos.size(); ++c) {
       HelixKalmanState temp_state(state);
       int n_p = 0;
       for (int l = 2; l >= 0; l -= 1) {
@@ -1077,7 +1078,7 @@ void sPHENIXTrackerTpc::findTracksByCombinatorialKalman(
 
 void sPHENIXTrackerTpc::findTracksBySegments(vector<SimpleHit3D>& hits,
                                              vector<SimpleTrack3D>& tracks,
-                                             const HelixRange& /*range*/) {
+                                             const HelixRange& range) {
 
   vector<TrackSegment>* cur_seg = &segments1;
   vector<TrackSegment>* next_seg = &segments2;
@@ -1092,10 +1093,10 @@ void sPHENIXTrackerTpc::findTracksBySegments(vector<SimpleHit3D>& hits,
   }
   for (unsigned int i = 0; i < hits.size(); ++i) {
     unsigned int min = (hits[i].get_layer() - allowed_missing);
-    if (allowed_missing > (unsigned int) hits[i].get_layer()) {
+    if (allowed_missing > hits[i].get_layer()) {
       min = 0;
     }
-    for (int l = min; l <= hits[i].get_layer(); l += 1) {
+    for (unsigned int l = min; l <= hits[i].get_layer(); l += 1) {
       layer_sorted[l].push_back(hits[i]);
     }
   }

--- a/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTpc.h
+++ b/offline/packages/HelixHough/helix_hough/sPHENIX/sPHENIXTrackerTpc.h
@@ -218,7 +218,7 @@ class sPHENIXTrackerTpc : public HelixHough {
   void findTracksBySegments(std::vector<SimpleHit3D>& hits,
                             std::vector<SimpleTrack3D>& tracks,
                             const HelixRange& range);  
-  void initEvent(std::vector<SimpleHit3D>& hits, unsigned int /*min_hits*/) {
+  void initEvent(std::vector<SimpleHit3D>& hits, unsigned int min_hits) {
 
     int min_layer = 999999;
     int max_layer = 0;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -82,7 +82,7 @@ KFParticle_Tools::KFParticle_Tools()
 {
 }
 
-KFParticle KFParticle_Tools::makeVertex(PHCompositeNode */*topNode*/)
+KFParticle KFParticle_Tools::makeVertex(PHCompositeNode *topNode)
 {
   float f_vertexParameters[6] = {m_dst_vertex->get_x(),
                                  m_dst_vertex->get_y(),
@@ -129,7 +129,7 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
   return primaryVertices;
 }
 
-KFParticle KFParticle_Tools::makeParticle(PHCompositeNode */*topNode*/)  ///Return a KFPTrack from track vector and covariance matrix. No mass or vertex constraints
+KFParticle KFParticle_Tools::makeParticle(PHCompositeNode *topNode)  ///Return a KFPTrack from track vector and covariance matrix. No mass or vertex constraints
 {
   float f_trackParameters[6] = {m_dst_track->get_x(),
                                 m_dst_track->get_y(),
@@ -189,7 +189,7 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, KFParticle v
   return associatedVertex->size_tracks();
 }
 
-/*const*/ bool KFParticle_Tools::isGoodTrack(KFParticle particle, const std::vector<KFParticle> primaryVertices)
+const bool KFParticle_Tools::isGoodTrack(KFParticle particle, const std::vector<KFParticle> primaryVertices)
 {
   bool goodTrack = false;
   

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -54,7 +54,7 @@ class KFParticle_Tools : public KFParticle_particleList, protected KFParticle_MV
 
   int getTracksFromVertex(PHCompositeNode *topNode, KFParticle vertex, std::string vertexMapName);
 
-  /*const*/ bool isGoodTrack(KFParticle particle, const std::vector<KFParticle> primaryVertices);
+  const bool isGoodTrack(KFParticle particle, const std::vector<KFParticle> primaryVertices);
 
   int calcMinIP(KFParticle track, std::vector<KFParticle> PVs, float& minimumIP, float& minimumIPchi2);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -146,7 +146,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int KFParticle_sPHENIX::End(PHCompositeNode */*topNode*/)
+int KFParticle_sPHENIX::End(PHCompositeNode *topNode)
 {
   std::cout << "KFParticle_sPHENIX object " << Name() << " finished. Number of canadidates: " << candidateCounter << std::endl;  
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -69,7 +69,7 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   ///Parameters for the user to vary
 
-  void setDecayDescriptor(const std::string &decayDescriptor) { m_decayDescriptor = decayDescriptor; }
+  void setDecayDescriptor(std::string decayDescriptor) { m_decayDescriptor = decayDescriptor; } 
 
   static const int max_particles = 99;
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -95,7 +95,7 @@ void KFParticle_truthAndDetTools::initializeTruthBranches(TTree *m_tree, int dau
   m_tree->Branch(TString(daughter_number) + "_true_track_history_pT", &m_true_daughter_track_history_pT[daughter_id]);
 }
 
-void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree */*m_tree*/, KFParticle daughter, int daughter_id, KFParticle vertex, bool m_constrain_to_vertex_truthMatch)
+void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id, KFParticle vertex, bool m_constrain_to_vertex_truthMatch)
 {
   float true_px, true_py, true_pz, true_p, true_pt;
 
@@ -212,7 +212,7 @@ void KFParticle_truthAndDetTools::fillHepMCBranch(HepMC::GenParticle *particle, 
   m_true_daughter_track_history_pT[daughter_id].push_back((Float_t) myFourVector.perp());
 }
 
-int KFParticle_truthAndDetTools::getHepMCInfo(PHCompositeNode *topNode, TTree */*m_tree*/, KFParticle daughter, int daughter_id)
+int KFParticle_truthAndDetTools::getHepMCInfo(PHCompositeNode *topNode, TTree *m_tree, KFParticle daughter, int daughter_id)
 {
   //Make dummy particle for null pointers and missing nodes
   HepMC::GenParticle* dummyParticle = new HepMC::GenParticle();
@@ -312,7 +312,7 @@ void KFParticle_truthAndDetTools::initializeCaloBranches(TTree *m_tree, int daug
 }
 
 void KFParticle_truthAndDetTools::fillCaloBranch(PHCompositeNode *topNode,
-                                                 TTree */*m_tree*/, KFParticle daughter, int daughter_id)
+                                                 TTree *m_tree, KFParticle daughter, int daughter_id)
 {
   PHNodeIterator nodeIter(topNode);
   PHNode *findNode = dynamic_cast<PHNode*>(nodeIter.findFirst(m_trk_map_node_name_nTuple));
@@ -379,7 +379,7 @@ void KFParticle_truthAndDetTools::initializeSubDetectorBranches(TTree *m_tree, s
 }
 
 void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
-                                                     TTree */*m_tree*/, KFParticle daughter, int daughter_id)
+                                                     TTree *m_tree, KFParticle daughter, int daughter_id)
 {
   PHNodeIterator nodeIter(topNode);
 
@@ -446,7 +446,7 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
 }
 
 void KFParticle_truthAndDetTools::allPVInfo(PHCompositeNode *topNode,
-                                            TTree */*m_tree*/, 
+                                            TTree *m_tree, 
                                             KFParticle motherParticle,
                                             std::vector<KFParticle> daughters,
                                             std::vector<KFParticle> intermediates)

--- a/offline/packages/KFParticle_sPHENIX/configure.ac
+++ b/offline/packages/KFParticle_sPHENIX/configure.ac
@@ -5,15 +5,14 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
 dnl KFParticle KFParticleDatabase.h includes Vc/Vc which collides with
 dnl clangs inbuild Vc by redefining a macro
 case $CXX in
   clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-macro-redefined -Wno-unused-parameter"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-macro-redefined"
+  ;;
+  *g++)
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
   ;;
 esac
 

--- a/offline/packages/NodeDump/DumpObject.cc
+++ b/offline/packages/NodeDump/DumpObject.cc
@@ -40,7 +40,7 @@ int DumpObject::OpenOutFile()
   return 0;
 }
 
-void DumpObject::Print(const char */*what*/) const
+void DumpObject::Print(const char *what) const
 {
   cout << ThisName << " did not implement Print method" << endl;
   return;
@@ -64,7 +64,7 @@ int DumpObject::process_event(PHNode *myNode)
   return 0;
 }
 
-int DumpObject::process_Node(PHNode */*myNode*/)
+int DumpObject::process_Node(PHNode *myNode)
 {
   //  cout << ThisName << " did not implement process_event method" << endl;
   return 0;

--- a/offline/packages/NodeDump/configure.ac
+++ b/offline/packages/NodeDump/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/PHField/PHFieldConfig.h
+++ b/offline/packages/PHField/PHFieldConfig.h
@@ -50,32 +50,32 @@ class PHFieldConfig : public PHObject
 
   std::string get_field_config_description() const;
 
-  virtual void set_field_config(FieldConfigTypes /*fieldConfig*/) { return; }
+  virtual void set_field_config(FieldConfigTypes fieldConfig) { return; }
 
   virtual const std::string& get_filename() const { return kInvalid_FileName; }
 
-  virtual void set_filename(const std::string& /*filename*/) { return; }
+  virtual void set_filename(const std::string& filename) { return; }
 
   virtual double get_magfield_rescale() const { return std::numeric_limits<double>::signaling_NaN(); }
 
-  virtual void set_magfield_rescale(double /*magfieldRescale*/) { return; }
+  virtual void set_magfield_rescale(double magfieldRescale) { return; }
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
   virtual double get_field_mag_x() const { return std::numeric_limits<double>::signaling_NaN(); }
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
-  virtual void set_field_mag_x(double /*fieldMagX*/) { return; }
+  virtual void set_field_mag_x(double fieldMagX) { return; }
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
   virtual double get_field_mag_y() const { return std::numeric_limits<double>::signaling_NaN(); }
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
-  virtual void set_field_mag_y(double /*fieldMagY*/) { return; }
+  virtual void set_field_mag_y(double fieldMagY) { return; }
 
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
   virtual double get_field_mag_z() const { return std::numeric_limits<double>::signaling_NaN(); }
   //! field value in Tesla for uniform field model ONLY for PHFieldConfig_v2
-  virtual void set_field_mag_z(double /*fieldMagZ*/) { return; }
+  virtual void set_field_mag_z(double fieldMagZ) { return; }
 
  protected:
   //! pure virtual interface class. not for direct use

--- a/offline/packages/PHField/PHFieldUniform.cc
+++ b/offline/packages/PHField/PHFieldUniform.cc
@@ -12,7 +12,7 @@ PHFieldUniform::PHFieldUniform(
 {
 }
 
-void PHFieldUniform::GetFieldValue(const double /*point*/ [4], double *Bfield) const
+void PHFieldUniform::GetFieldValue(const double point[4], double *Bfield) const
 {
   Bfield[0] = field_mag_x_;
   Bfield[1] = field_mag_y_;

--- a/offline/packages/PHField/configure.ac
+++ b/offline/packages/PHField/configure.ac
@@ -7,14 +7,8 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
+++ b/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -45,7 +45,7 @@ Fitter::Fitter(
     const std::string& tgeo_file_name,
     const PHField* field,
     const std::string& fitter_choice,
-    const std::string& /*track_rep_choice*/,
+    const std::string& track_rep_choice,
     const bool doEventDisplay)
   : verbosity(1000)
   , _doEventDisplay(doEventDisplay)
@@ -183,7 +183,7 @@ Fitter* Fitter::getInstance(const std::string& tgeo_file_name,
 
 Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
                const PHGenFit::Fitter::FitterType& fitter_choice,
-               const PHGenFit::Fitter::TrackRepType& /*track_rep_choice*/,
+               const PHGenFit::Fitter::TrackRepType& track_rep_choice,
                const bool doEventDisplay)
   : verbosity(0)
   , _tgeo_manager(tgeo_manager)
@@ -233,7 +233,7 @@ Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
 }
 
 Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
-               const std::string& fitter_choice, const std::string& /*track_rep_choice*/,
+               const std::string& fitter_choice, const std::string& track_rep_choice,
                const bool doEventDisplay)
   : verbosity(0)
   , _tgeo_manager(tgeo_manager)

--- a/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
+++ b/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/offline/packages/PHGeometry/configure.ac
+++ b/offline/packages/PHGeometry/configure.ac
@@ -6,7 +6,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 fi
 

--- a/offline/packages/PHTpcTracker/Fitter.cc
+++ b/offline/packages/PHTpcTracker/Fitter.cc
@@ -19,7 +19,7 @@
 
 namespace PHGenFit2
 {
-  Fitter::Fitter(TGeoManager* /*tgeo_manager*/, PHField* field)
+  Fitter::Fitter(TGeoManager* tgeo_manager, PHField* field)
   //    : _tgeo_manager(tgeo_manager)
   //    , _field(field)
   {

--- a/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTrackFollower.cc
@@ -57,7 +57,7 @@ PHTpcTrackFollower::PHTpcTrackFollower()
 {
 }
 
-std::vector<PHGenFit2::Track*> PHTpcTrackFollower::followTracks(std::vector<kdfinder::TrackCandidate<double>*>& candidates, PHField* /*B*/, PHTpcLookup* lookup, PHGenFit2::Fitter* fitter)
+std::vector<PHGenFit2::Track*> PHTpcTrackFollower::followTracks(std::vector<kdfinder::TrackCandidate<double>*>& candidates, PHField* B, PHTpcLookup* lookup, PHGenFit2::Fitter* fitter)
 {
   LOG_DEBUG("tracking.PHTpcTrackFollower.followTracks") << "start";
 

--- a/offline/packages/PHTpcTracker/configure.ac
+++ b/offline/packages/PHTpcTracker/configure.ac
@@ -6,13 +6,12 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-unused-parameter -Wno-deprecated-copy"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/compressor/compress_clu_res_float32.cc
+++ b/offline/packages/compressor/compress_clu_res_float32.cc
@@ -35,7 +35,7 @@ uint64_t timeSinceEpochMillisec()
    return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
-void compress_clu_res_float32(std::string &filename)
+void compress_clu_res_float32(std::string filename)
 {
  ofstream logFile;
  logFile.open ("log.csv");

--- a/offline/packages/compressor/configure.ac
+++ b/offline/packages/compressor/configure.ac
@@ -8,7 +8,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -73,8 +73,8 @@ bool InttClusterizer::ladder_are_adjacent( const std::pair<TrkrDefs::hitkey, Trk
 }
 
 InttClusterizer::InttClusterizer(const string& name,
-                                 unsigned int /*min_layer*/,
-                                 unsigned int /*max_layer*/)
+                                 unsigned int min_layer,
+                                 unsigned int max_layer)
   : SubsysReco(name)
   , m_hits(nullptr)
   , m_clusterlist(nullptr)

--- a/offline/packages/intt/InttClusterizer.h
+++ b/offline/packages/intt/InttClusterizer.h
@@ -25,7 +25,7 @@ class InttClusterizer : public SubsysReco
   ~InttClusterizer() override {}
 
   //! module initialization
-  int Init(PHCompositeNode */*topNode*/) override { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
   int InitRun(PHCompositeNode *topNode) override;
@@ -34,7 +34,7 @@ class InttClusterizer : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode */*topNode*/) override { return 0; }
+  int End(PHCompositeNode *topNode) override { return 0; }
 
   //! set an energy requirement relative to the thickness MIP expectation
   void set_threshold(const float fraction_of_mip)

--- a/offline/packages/intt/configure.ac
+++ b/offline/packages/intt/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/packages/jetbackground/CopyAndSubtractJets.cc
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.cc
@@ -196,7 +196,7 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int CopyAndSubtractJets::End(PHCompositeNode */*topNode*/)
+int CopyAndSubtractJets::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/jetbackground/TowerBackground.h
+++ b/offline/packages/jetbackground/TowerBackground.h
@@ -13,13 +13,13 @@ class TowerBackground : public PHObject
   void identify(std::ostream &os = std::cout) const override { os << "TowerBackground base class" << std::endl; };
   int isValid() const override { return 0; }
 
-  virtual void set_UE(int /*layer*/, const std::vector<float> &/*UE*/) {}
-  virtual void set_v2(float) {}
-  virtual void set_Psi2(float) {}
-  virtual void set_nStripsUsedForFlow(int) {}
-  virtual void set_nTowersUsedForBkg(int) {}
+  virtual void set_UE(int layer, const std::vector<float> &UE) {}
+  virtual void set_v2(float v2) {}
+  virtual void set_Psi2(float Psi2) {}
+  virtual void set_nStripsUsedForFlow(int nStrips) {}
+  virtual void set_nTowersUsedForBkg(int nTowers) {}
 
-  virtual std::vector<float> get_UE(int /*layer*/) { return std::vector<float>(); };
+  virtual std::vector<float> get_UE(int layer) { return std::vector<float>(); };
   virtual float get_v2() { return 0; }
   virtual float get_Psi2() { return 0; }
   virtual int get_nStripsUsedForFlow() { return 0; }

--- a/offline/packages/jetbackground/configure.ac
+++ b/offline/packages/jetbackground/configure.ac
@@ -10,13 +10,13 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
   fi
  ;;
 esac

--- a/offline/packages/micromegas/configure.ac
+++ b/offline/packages/micromegas/configure.ac
@@ -9,14 +9,8 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -71,7 +71,7 @@ CylinderGeom_Mvtx::CylinderGeom_Mvtx(
 }
 
 TVector3
-CylinderGeom_Mvtx::get_local_from_world_coords(int stave, int /*half_stave*/, int /*module*/, int chip, TVector3 world_location)
+CylinderGeom_Mvtx::get_local_from_world_coords(int stave, int half_stave, int module, int chip, TVector3 world_location)
 {
   double stave_phi = stave_phi_0 + stave_phi_step * (double) stave;
   double stave_phi_offset = M_PI / 2.0;  // stave initially points so that sensor faces upward in y
@@ -141,7 +141,7 @@ CylinderGeom_Mvtx::get_sensor_indices_from_world_coords(std::vector<double> &wor
 }
 
 TVector3
-CylinderGeom_Mvtx::get_world_from_local_coords(int stave, int /*half_stave*/, int /*module*/, int chip, TVector3 sensor_local)
+CylinderGeom_Mvtx::get_world_from_local_coords(int stave, int half_stave, int module, int chip, TVector3 sensor_local)
 {
   double stave_phi = stave_phi_0 + stave_phi_step * (double) stave;
   double stave_phi_offset = M_PI / 2.0;  // stave initially points so that sensor faces upward in y

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -78,8 +78,8 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   double get_stave_phi_tilt() const { return stave_phi_tilt; }
   double get_stave_phi_0() const { return stave_phi_0; }
 
-  int get_ladder_phi_index(int stave, int /*half_stave*/, int /*chip*/) {return stave; }
-  int get_ladder_z_index(int /*module*/, int chip) { return chip; }
+  int get_ladder_phi_index(int stave, int half_stave, int chip) {return stave; }
+  int get_ladder_z_index(int module, int chip) { return chip; }
 
   void find_sensor_center(int stave_number, int half_stave_number, int module_number, int chip_number, double location[]);
 

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -31,7 +31,7 @@ class MvtxClusterizer : public SubsysReco
   ~MvtxClusterizer() override {}
 
   //! module initialization
-  int Init(PHCompositeNode */*topNode*/) override { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
   int InitRun(PHCompositeNode *topNode) override;
@@ -40,7 +40,7 @@ class MvtxClusterizer : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode */*topNode*/) override { return 0; }
+  int End(PHCompositeNode *topNode) override { return 0; }
 
   //! option to turn off z-dimension clustering
   void SetZClustering(const bool make_z_clustering)

--- a/offline/packages/mvtx/configure.ac
+++ b/offline/packages/mvtx/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/packages/particleflow/ParticleFlowElement.h
+++ b/offline/packages/particleflow/ParticleFlowElement.h
@@ -34,22 +34,22 @@ class ParticleFlowElement : public PHObject
   int isValid() const override { return 0; }
 
   virtual unsigned int get_id() const { return 0xFFFFFFFF; }
-  virtual void set_id(unsigned int) { return; }
+  virtual void set_id(unsigned int id) { return; }
 
   virtual ParticleFlowElement::PFLOWTYPE get_type() const {return ParticleFlowElement::PFLOWTYPE::UNASSIGNED; }
   virtual void set_type( ParticleFlowElement::PFLOWTYPE ) { return; }
 
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) { return; }
+  virtual void set_px(float px) { return; }
 
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) { return; }
+  virtual void set_py(float py) { return; }
 
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) { return; }
+  virtual void set_pz(float pz) { return; }
 
   virtual float get_e() const { return NAN; }
-  virtual void set_e(float) { return; }
+  virtual void set_e(float e) { return; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }

--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -73,7 +73,7 @@ ParticleFlowReco::~ParticleFlowReco()
 }
 
 //____________________________________________________________________________..
-int ParticleFlowReco::Init(PHCompositeNode */*topNode*/)
+int ParticleFlowReco::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1053,7 +1053,7 @@ int ParticleFlowReco::CreateNode(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int ParticleFlowReco::ResetEvent(PHCompositeNode */*topNode*/)
+int ParticleFlowReco::ResetEvent(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
@@ -1073,7 +1073,7 @@ int ParticleFlowReco::EndRun(const int runnumber)
 }
 
 //____________________________________________________________________________..
-int ParticleFlowReco::End(PHCompositeNode */*topNode*/)
+int ParticleFlowReco::End(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
@@ -1083,7 +1083,7 @@ int ParticleFlowReco::End(PHCompositeNode */*topNode*/)
 }
 
 //____________________________________________________________________________..
-int ParticleFlowReco::Reset(PHCompositeNode */*topNode*/)
+int ParticleFlowReco::Reset(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {

--- a/offline/packages/particleflow/configure.ac
+++ b/offline/packages/particleflow/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/tpc/TpcClusterCleaner.cc
+++ b/offline/packages/tpc/TpcClusterCleaner.cc
@@ -193,12 +193,12 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int TpcClusterCleaner::End(PHCompositeNode */*topNode*/)
+int TpcClusterCleaner::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int  TpcClusterCleaner::GetNodes(PHCompositeNode* /*topNode*/)
+int  TpcClusterCleaner::GetNodes(PHCompositeNode* topNode)
 {
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -567,10 +567,10 @@ void *ProcessSector(void *threadarg) {
      if(fadc>0) 
        adc =  (unsigned short) fadc;
      
-//     if(phibin < 0) continue; // phibin is unsigned int, <0 cannot happen
+     if(phibin < 0) continue;
      if(phibin >= phibins) continue;
-//     if(zbin   < 0) continue;
-     if(zbin   >= zbins) continue; // zbin is unsigned int, <0 cannot happen
+     if(zbin   < 0) continue;
+     if(zbin   >= zbins) continue;
 
      if(adc>0){
        iphiz iCoord(std::make_pair(phibin,zbin));
@@ -878,7 +878,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int TpcClusterizer::End(PHCompositeNode */*topNode*/)
+int TpcClusterizer::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/configure.ac
+++ b/offline/packages/tpc/configure.ac
@@ -9,14 +9,8 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -62,7 +62,7 @@ PHTpcResiduals::PHTpcResiduals(const std::string &name)
   , m_matrix_container( new TpcSpaceChargeMatrixContainerv1 )
 {}
 
-int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::Init(PHCompositeNode *topNode)
 {
   if( m_savehistograms ) makeHistograms();
   return Fun4AllReturnCodes::EVENT_OK;
@@ -100,7 +100,7 @@ int PHTpcResiduals::process_event(PHCompositeNode *topNode)
   return returnVal;
 }
 
-int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::End(PHCompositeNode *topNode)
 {
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
 
@@ -120,7 +120,7 @@ int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
 }
 
 
-int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::processTracks(PHCompositeNode *topNode)
 {
 
   std::cout << "proto track size " << m_trackMap->size()
@@ -618,7 +618,7 @@ int PHTpcResiduals::getCell(const Acts::Vector3D& loc)
 
 }
 
-int PHTpcResiduals::createNodes(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::createNodes(PHCompositeNode *topNode)
 {
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -74,7 +74,7 @@ class PHTpcResiduals : public SubsysReco
   void setSavehistograms( bool value ) { m_savehistograms = value; }
     
   /// output file name for storing the space charge reconstruction matrices
-  void setOutputfile(const std::string &outputfile) {m_outputfile = outputfile;}
+  void setOutputfile(std::string outputfile) {m_outputfile = outputfile;}
   
  private:
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
@@ -30,11 +30,11 @@ class TpcSpaceChargeMatrixContainer : public PHObject
   //@{
 
   /// identify object
-  void identify(std::ostream &/*os*/ = std::cout) const override
+  void identify(std::ostream &os = std::cout) const override
   {}
 
   /// get grid dimensions
-  virtual void get_grid_dimensions( int& /*phibins*/, int& /*rbins*/, int& /*zbins*/ ) const
+  virtual void get_grid_dimensions( int& phibins, int& rbins, int& zbins ) const
   {}
 
   /// get total grid size
@@ -42,19 +42,19 @@ class TpcSpaceChargeMatrixContainer : public PHObject
   { return 0; }
 
   /// get grid index for given sub-indexes
-  virtual int get_cell_index( int /*iphibin*/, int /*irbin*/, int /*izbin*/ ) const
+  virtual int get_cell_index( int iphibin, int irbin, int izbin ) const
   { return -1; }
 
   /// get entries for a given cell
-  virtual int get_entries( int /*cell_index*/ ) const
+  virtual int get_entries( int cell_index ) const
   { return 0; }
 
   /// get left hand side
-  virtual float get_lhs( int /*cell_index*/, int /*i*/, int /*j*/ ) const
+  virtual float get_lhs( int cell_index, int i, int j ) const
   { return 0; }
 
   /// get right hand side
-  virtual float get_rhs( int /*cell_index*/, int /*i*/ ) const
+  virtual float get_rhs( int cell_index, int i ) const
   { return 0; }
 
   //@}
@@ -71,27 +71,27 @@ class TpcSpaceChargeMatrixContainer : public PHObject
   \param phibins the number of bins in the azimuth direction
   \param zbins the number of bins along z
   */
-  virtual void set_grid_dimensions( int /*phibins*/, int /*rbins*/, int /*zbins*/ )
+  virtual void set_grid_dimensions( int phibins, int rbins, int zbins )
   {}
 
   /// increment cell entries
-  virtual void add_to_entries( int /*cell_index*/ )
+  virtual void add_to_entries( int cell_index )
   {}
 
   /// increment cell entries
-  virtual void add_to_entries( int /*cell_index*/, int /*value*/ )
+  virtual void add_to_entries( int cell_index, int value )
   {}
 
   /// increment left hand side matrix
-  virtual void add_to_lhs( int /*cell_index*/, int /*i*/, int /*j*/, float /*value*/ )
+  virtual void add_to_lhs( int cell_index, int i, int j, float value )
   {}
 
   /// increment right hand side column
-  virtual void add_to_rhs( int /*cell_index*/, int /*i*/, float /*value*/ )
+  virtual void add_to_rhs( int cell_index, int i, float value )
   {}
 
   /// add content from other container, returns true on success
-  virtual bool add( const TpcSpaceChargeMatrixContainer& /*other*/ )
+  virtual bool add( const TpcSpaceChargeMatrixContainer& other )
   { return false; }
 
   //@}

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -83,7 +83,7 @@ void TpcSpaceChargeReconstruction::set_outputfile( const std::string& filename )
 { m_outputfile = filename; }
 
 //_____________________________________________________________________
-int TpcSpaceChargeReconstruction::Init(PHCompositeNode* /*topNode*/ )
+int TpcSpaceChargeReconstruction::Init(PHCompositeNode* topNode )
 {
   // reset counters
   m_total_tracks = 0;
@@ -138,7 +138,7 @@ int TpcSpaceChargeReconstruction::process_event(PHCompositeNode* topNode)
 }
 
 //_____________________________________________________________________
-int TpcSpaceChargeReconstruction::End(PHCompositeNode* /*topNode*/ )
+int TpcSpaceChargeReconstruction::End(PHCompositeNode* topNode )
 {
 
   // save matrix container in output file

--- a/offline/packages/tpccalib/configure.ac
+++ b/offline/packages/tpccalib/configure.ac
@@ -6,13 +6,12 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/tpcdaq/configure.ac
+++ b/offline/packages/tpcdaq/configure.ac
@@ -11,7 +11,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "

--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -38,35 +38,35 @@ class TrkrCluster : public PHObject
   // cluster id
   //
   virtual TrkrDefs::cluskey getClusKey() const { return TrkrDefs::CLUSKEYMAX; }
-  virtual void setClusKey(TrkrDefs::cluskey) {}
+  virtual void setClusKey(TrkrDefs::cluskey id) {}
  
   //
   // cluster position
   //
   virtual float getX() const { return NAN; }
-  virtual void setX(float) {}
+  virtual void setX(float x) {}
   virtual float getY() const { return NAN; }
-  virtual void setY(float) {}
+  virtual void setY(float y) {}
   virtual float getZ() const { return NAN; }
-  virtual void setZ(float) {}
-  virtual float getPosition(int /*coor*/) const { return NAN; }
-  virtual void setPosition(int /*coor*/, float /*xi*/) {}
+  virtual void setZ(float z) {}
+  virtual float getPosition(int coor) const { return NAN; }
+  virtual void setPosition(int coor, float xi) {}
   virtual void setGlobal() {}
   virtual void setLocal() {}
   virtual bool isGlobal() { return true; }
   virtual float getLocalX() const { return NAN; }
-  virtual void setLocalX(float) {}
+  virtual void setLocalX(float x) {}
   virtual float getLocalY() const { return NAN; }
-  virtual void setLocalY(float) {}
+  virtual void setLocalY(float y) {}
   //
   // cluster info
   //
-  virtual void setAdc(unsigned int) {}
+  virtual void setAdc(unsigned int adc) {}
   virtual unsigned int getAdc() const { return UINT_MAX; }
-  virtual float getSize(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void setSize(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
-  virtual float getError(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void setError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float getSize(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void setSize(unsigned int i, unsigned int j, float value) {}
+  virtual float getError(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void setError(unsigned int i, unsigned int j, float value) {}
   //
   // convenience interface
   //
@@ -77,10 +77,10 @@ class TrkrCluster : public PHObject
   virtual float getZError() const { return NAN; }
 
   /// Acts functions, for Acts modules use only
-  virtual void setActsLocalError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/){}
-  virtual float getActsLocalError(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual void setActsLocalError(unsigned int i, unsigned int j, float value){}
+  virtual float getActsLocalError(unsigned int i, unsigned int j) const { return NAN; }
   virtual TrkrDefs::subsurfkey getSubSurfKey() const { return TrkrDefs::SUBSURFKEYMAX; }
-  virtual void setSubSurfKey(TrkrDefs::subsurfkey /*id*/) {}
+  virtual void setSubSurfKey(TrkrDefs::subsurfkey id) {}
 
  protected:
   TrkrCluster() = default;

--- a/offline/packages/trackbase/TrkrClusterContainer.cc
+++ b/offline/packages/trackbase/TrkrClusterContainer.cc
@@ -27,5 +27,5 @@ TrkrClusterContainer::ConstRange TrkrClusterContainer::getClusters() const
 { return std::make_pair( dummy_map.cbegin(), dummy_map.cend() ); }
 
 //__________________________________________________________
-TrkrClusterContainer::ConstRange TrkrClusterContainer::getClusters(TrkrDefs::hitsetkey /*hitsetkey*/) const
+TrkrClusterContainer::ConstRange TrkrClusterContainer::getClusters(TrkrDefs::hitsetkey hitsetkey) const
 { return std::make_pair( dummy_map.cbegin(), dummy_map.cend() ); }

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -38,7 +38,7 @@ class TrkrClusterContainer : public PHObject
   void Reset() override {}
 
   //! identify object
-  void identify(std::ostream &/*os*/ = std::cout) const override {}
+  void identify(std::ostream &os = std::cout) const override {}
 
   //! add a cluster
   virtual ConstIterator addCluster(TrkrCluster*);

--- a/offline/packages/trackbase/TrkrClusterv1.cc
+++ b/offline/packages/trackbase/TrkrClusterv1.cc
@@ -47,7 +47,7 @@ TrkrClusterv1::TrkrClusterv1()
 
   for (int j = 0; j < 3; ++j)
   {
-    for (int i = 0; i < 3; ++i)
+    for (int i = j; i < 3; ++i)
     {
       setSize(i, j, NAN);
       setError(i, j, NAN);

--- a/offline/packages/trackbase/TrkrHit.h
+++ b/offline/packages/trackbase/TrkrHit.h
@@ -37,11 +37,11 @@ class TrkrHit : public PHObject
   int isValid() const override { return 0; }
 
   // these set and get the energy before digitization
-  virtual void addEnergy(const double){}
+  virtual void addEnergy(const double edep){}
   virtual double getEnergy() {return 0;}
 
   // after digitization, these are the adc values
-  virtual void setAdc(const unsigned int) {}
+  virtual void setAdc(const unsigned int adc) {}
   virtual unsigned int getAdc() { return 0;}
 
  protected:

--- a/offline/packages/trackbase/TrkrHitSet.h
+++ b/offline/packages/trackbase/TrkrHitSet.h
@@ -35,7 +35,7 @@ class TrkrHitSet : public PHObject
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
 
   //! TObject functions
-  void identify(std::ostream& /*os*/ = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
   }
 

--- a/offline/packages/trackbase/TrkrHitSetContainer.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainer.cc
@@ -24,19 +24,19 @@ void TrkrHitSetContainer::Reset()
 }
 
 TrkrHitSetContainer::ConstIterator
-TrkrHitSetContainer::addHitSet(TrkrHitSet* /*newhit*/)
+TrkrHitSetContainer::addHitSet(TrkrHitSet* newhit)
 { return dummy_map.cbegin(); }
 
 TrkrHitSetContainer::ConstIterator
-TrkrHitSetContainer::addHitSetSpecifyKey(const TrkrDefs::hitsetkey /*key*/, TrkrHitSet* /*newhit*/)
+TrkrHitSetContainer::addHitSetSpecifyKey(const TrkrDefs::hitsetkey key, TrkrHitSet* newhit)
 { return dummy_map.cbegin(); }
  
 TrkrHitSetContainer::Iterator
-TrkrHitSetContainer::findOrAddHitSet(TrkrDefs::hitsetkey /*key*/)
+TrkrHitSetContainer::findOrAddHitSet(TrkrDefs::hitsetkey key)
 { return dummy_map.begin(); }
 
 TrkrHitSetContainer::ConstRange
-TrkrHitSetContainer::getHitSets(const TrkrDefs::TrkrId /*trackerid*/) const
+TrkrHitSetContainer::getHitSets(const TrkrDefs::TrkrId trackerid) const
 { return std::make_pair( dummy_map.cbegin(), dummy_map.cend() ); }
 
 TrkrHitSetContainer::ConstRange

--- a/offline/packages/trackbase/TrkrHitSetContainer.h
+++ b/offline/packages/trackbase/TrkrHitSetContainer.h
@@ -42,7 +42,7 @@ class TrkrHitSetContainer : public PHObject
   virtual ConstIterator addHitSetSpecifyKey(const TrkrDefs::hitsetkey, TrkrHitSet*);
 
   //! preferred removal method, key is currently the hit id
-  virtual void removeHitSet(TrkrDefs::hitsetkey)
+  virtual void removeHitSet(TrkrDefs::hitsetkey key)
   {}
 
   //! inefficent, use key where possible instead

--- a/offline/packages/trackbase/TrkrHitTruthAssoc.h
+++ b/offline/packages/trackbase/TrkrHitTruthAssoc.h
@@ -37,7 +37,7 @@ class TrkrHitTruthAssoc : public PHObject
   void Reset() override
   {}
 
-  void identify(std::ostream &/*os*/ = std::cout) const override
+  void identify(std::ostream &os = std::cout) const override
   {}
 
   /**
@@ -46,7 +46,7 @@ class TrkrHitTruthAssoc : public PHObject
    * @param[in] hidx TrkrHit index in TrkrHitSet
    * @param[in] ckey Key for assocuated g4hit
    */
-  virtual void addAssoc(const TrkrDefs::hitsetkey /*hitsetkey*/, const TrkrDefs::hitkey /*hitkey*/, const PHG4HitDefs::keytype  /*g4hitkey*/) 
+  virtual void addAssoc(const TrkrDefs::hitsetkey hitsetkey, const TrkrDefs::hitkey hitkey, const PHG4HitDefs::keytype  g4hitkey) 
   {}
 
   /**
@@ -55,10 +55,10 @@ class TrkrHitTruthAssoc : public PHObject
    * @param[in] hidx TrkrHit index in TrkrHitSet
    * @param[in] ckey Key for assocuated g4hit
    */
-  virtual void findOrAddAssoc(const TrkrDefs::hitsetkey /*hitsetkey*/, const TrkrDefs::hitkey /*hitkey*/, const PHG4HitDefs::keytype  /*g4hitkey*/)
+  virtual void findOrAddAssoc(const TrkrDefs::hitsetkey hitsetkey, const TrkrDefs::hitkey hitkey, const PHG4HitDefs::keytype  g4hitkey)
   {}
 
-  virtual void removeAssoc(const TrkrDefs::hitsetkey /*hitsetkey*/, const TrkrDefs::hitkey /*hitkey*/)
+  virtual void removeAssoc(const TrkrDefs::hitsetkey hitsetkey, const TrkrDefs::hitkey hitkey)
   {}
 
   /**
@@ -66,7 +66,7 @@ class TrkrHitTruthAssoc : public PHObject
    * @param[in] hset TrkrHitSet key
    * @param[in] hidx TrkrHit index in TrkrHitSet
    */
-  virtual void getG4Hits(const TrkrDefs::hitsetkey /*hitsetkey*/, const unsigned int /*hidx*/, MMap &/*temp_map*/) const
+  virtual void getG4Hits(const TrkrDefs::hitsetkey hitsetkey, const unsigned int hidx, MMap &temp_map) const
   {}
 
   protected:

--- a/offline/packages/trackbase/configure.ac
+++ b/offline/packages/trackbase/configure.ac
@@ -9,14 +9,8 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -pedantic -Wextra -Werror"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -pedantic"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/offline/packages/trackbase_historic/SvtxTrack.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack.cc
@@ -10,7 +10,7 @@ SvtxTrack::HitIdConstIter SvtxTrack::begin_g4hit_id() const
   return DummyHitIdMap.end();
 }
 
-SvtxTrack::HitIdConstIter SvtxTrack::find_g4hit_id(int /*volume*/) const
+SvtxTrack::HitIdConstIter SvtxTrack::find_g4hit_id(int volume) const
 {
   return DummyHitIdMap.end();
 }
@@ -26,7 +26,7 @@ SvtxTrack::HitIdIter SvtxTrack::begin_g4hit_id()
   return DummyHitIdMap.end();
 }
 
-SvtxTrack::HitIdIter SvtxTrack::find_g4hit_id(int /*volume*/)
+SvtxTrack::HitIdIter SvtxTrack::find_g4hit_id(int volume)
 {
   return DummyHitIdMap.end();
 }
@@ -42,7 +42,7 @@ SvtxTrack::ConstStateIter SvtxTrack::begin_states() const
   return DummyStateMap.end();
 }
 
-SvtxTrack::ConstStateIter SvtxTrack::find_state(float /*pathlength*/)  const
+SvtxTrack::ConstStateIter SvtxTrack::find_state(float pathlength)  const
 {
   return DummyStateMap.end();
 }
@@ -57,7 +57,7 @@ SvtxTrack::StateIter SvtxTrack::begin_states()
 return DummyStateMap.end();
 }
 
-SvtxTrack::StateIter SvtxTrack::find_state(float /*pathlength*/)
+SvtxTrack::StateIter SvtxTrack::find_state(float pathlength)
 {
 return DummyStateMap.end();
 }
@@ -72,7 +72,7 @@ SvtxTrack::ConstClusterIter SvtxTrack::begin_clusters() const
   return DummyClusterSet.end();
 }
 
-SvtxTrack::ConstClusterIter SvtxTrack::find_cluster(unsigned int /*clusterid*/) const
+SvtxTrack::ConstClusterIter SvtxTrack::find_cluster(unsigned int clusterid) const
 {
   return DummyClusterSet.end();
 }
@@ -87,7 +87,7 @@ SvtxTrack::ClusterIter SvtxTrack::begin_clusters()
   return DummyClusterSet.end();
 }
 
-SvtxTrack::ClusterIter SvtxTrack::find_cluster(unsigned int /*clusterid*/)
+SvtxTrack::ClusterIter SvtxTrack::find_cluster(unsigned int clusterid)
 {
   return DummyClusterSet.end();
 }
@@ -97,7 +97,7 @@ SvtxTrack::ClusterIter SvtxTrack::end_clusters()
   return DummyClusterSet.end();
 }
 
-SvtxTrack::ConstClusterKeyIter SvtxTrack::find_cluster_key(TrkrDefs::cluskey /*clusterid*/) const
+SvtxTrack::ConstClusterKeyIter SvtxTrack::find_cluster_key(TrkrDefs::cluskey clusterid) const
 {
   return DummyClusterKeySet.end();
 }
@@ -118,7 +118,7 @@ SvtxTrack::ClusterKeyIter SvtxTrack::begin_cluster_keys()
   return DummyClusterKeySet.end();
 }
 
-SvtxTrack::ClusterKeyIter SvtxTrack::find_cluster_keys(unsigned int /*clusterid*/)
+SvtxTrack::ClusterKeyIter SvtxTrack::find_cluster_keys(unsigned int clusterid)
 {
   return DummyClusterKeySet.end();
 }

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -64,91 +64,91 @@ class SvtxTrack : public PHObject
   //
 
   virtual unsigned int get_id() const { return UINT_MAX; }
-  virtual void set_id(unsigned int) {}
+  virtual void set_id(unsigned int id) {}
 
   virtual unsigned int get_vertex_id() const { return UINT_MAX; }
-  virtual void set_vertex_id(unsigned int) {}
+  virtual void set_vertex_id(unsigned int vertex_id) {}
 
   virtual bool get_positive_charge() const { return false; }
-  virtual void set_positive_charge(bool) {}
+  virtual void set_positive_charge(bool ispos) {}
 
   virtual int get_charge() const { return -1; }
-  virtual void set_charge(int) {}
+  virtual void set_charge(int charge) {}
 
   virtual float get_chisq() const { return NAN; }
-  virtual void set_chisq(float) {}
+  virtual void set_chisq(float chisq) {}
 
   virtual unsigned int get_ndf() const { return UINT_MAX; }
-  virtual void set_ndf(int) {}
+  virtual void set_ndf(int ndf) {}
 
   virtual float get_quality() const { return NAN; }
 
   virtual float get_dca() const { return NAN; }
-  virtual void set_dca(float) {}
+  virtual void set_dca(float dca) {}
 
   virtual float get_dca_error() const { return NAN; }
-  virtual void set_dca_error(float) {}
+  virtual void set_dca_error(float dca) {}
 
   virtual float get_dca2d() const { return NAN; }
-  virtual void set_dca2d(float) {}
+  virtual void set_dca2d(float dca2d) {}
 
   virtual float get_dca2d_error() const { return NAN; }
-  virtual void set_dca2d_error(float) {}
+  virtual void set_dca2d_error(float error) {}
 
   virtual float get_dca3d_xy() const { return NAN; }
-  virtual void set_dca3d_xy(float) {}
+  virtual void set_dca3d_xy(float dcaxy) {}
 
   virtual float get_dca3d_xy_error() const { return NAN; }
-  virtual void set_dca3d_xy_error(float) {}
+  virtual void set_dca3d_xy_error(float error) {}
 
   virtual float get_dca3d_z() const { return NAN; }
-  virtual void set_dca3d_z(float) {}
+  virtual void set_dca3d_z(float dcaz) {}
 
   virtual float get_dca3d_z_error() const { return NAN; }
-  virtual void set_dca3d_z_error(float) {}
+  virtual void set_dca3d_z_error(float error) {}
 
   virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual void set_x(float x) {}
 
   virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual void set_y(float y) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float z) {}
 
-  virtual float get_pos(unsigned int) const { return NAN; }
+  virtual float get_pos(unsigned int i) const { return NAN; }
 
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) {}
+  virtual void set_px(float px) {}
 
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) {}
+  virtual void set_py(float py) {}
 
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) {}
+  virtual void set_pz(float pz) {}
 
-  virtual float get_mom(unsigned int) const { return NAN; }
+  virtual float get_mom(unsigned int i) const { return NAN; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }
   virtual float get_eta() const { return NAN; }
   virtual float get_phi() const { return NAN; }
 
-  virtual float get_error(int /*i*/, int /*j*/) const { return NAN; }
-  virtual void set_error(int /*i*/, int /*j*/, float /*value*/) {}
+  virtual float get_error(int i, int j) const { return NAN; }
+  virtual void set_error(int i, int j, float value) {}
 
   //
   // state methods -------------------------------------------------------------
   //
   virtual bool empty_states() const { return false; }
   virtual size_t size_states() const { return 0; }
-  virtual size_t count_states(float /*pathlength*/) const { return 0; }
+  virtual size_t count_states(float pathlength) const { return 0; }
   virtual void clear_states() {}
 
-  virtual const SvtxTrackState* get_state(float /*pathlength*/) const { return nullptr; }
-  virtual SvtxTrackState* get_state(float /*pathlength*/) { return nullptr; }
-  virtual SvtxTrackState* insert_state(const SvtxTrackState*) { return nullptr; }
-  virtual size_t erase_state(float /*pathlength*/) { return 0; }
+  virtual const SvtxTrackState* get_state(float pathlength) const { return nullptr; }
+  virtual SvtxTrackState* get_state(float pathlength) { return nullptr; }
+  virtual SvtxTrackState* insert_state(const SvtxTrackState* state) { return nullptr; }
+  virtual size_t erase_state(float pathlength) { return 0; }
 
   virtual ConstStateIter begin_states() const;
   virtual ConstStateIter find_state(float pathlength)  const;
@@ -172,13 +172,13 @@ class SvtxTrack : public PHObject
   virtual size_t size_clusters() const { return 0; }
 
   //! deprecated - please use cluster keys instead
-  virtual void insert_cluster(unsigned int /*clusterid*/) {}
+  virtual void insert_cluster(unsigned int clusterid) {}
   //! deprecated - please use cluster keys instead
-  virtual size_t erase_cluster(unsigned int /*clusterid*/) { return 0; }
+  virtual size_t erase_cluster(unsigned int clusterid) { return 0; }
   //! deprecated - please use cluster keys instead
   virtual ConstClusterIter begin_clusters() const;
   //! deprecated - please use cluster keys instead
-  virtual ConstClusterIter find_cluster(unsigned int /*clusterid*/) const;
+  virtual ConstClusterIter find_cluster(unsigned int clusterid) const;
   //! deprecated - please use cluster keys instead
   virtual ConstClusterIter end_clusters() const;
   //! deprecated - please use cluster keys instead
@@ -193,8 +193,8 @@ class SvtxTrack : public PHObject
   virtual bool empty_cluster_keys() const { return false; }
   virtual size_t size_cluster_keys() const { return 0; }
 
-  virtual void insert_cluster_key(TrkrDefs::cluskey /*clusterid*/) {}
-  virtual size_t erase_cluster_key(TrkrDefs::cluskey /*clusterid*/) { return 0; }
+  virtual void insert_cluster_key(TrkrDefs::cluskey clusterid) {}
+  virtual size_t erase_cluster_key(TrkrDefs::cluskey clusterid) { return 0; }
   virtual ConstClusterKeyIter find_cluster_key(TrkrDefs::cluskey clusterid) const;
   virtual ConstClusterKeyIter begin_cluster_keys() const;
   virtual ConstClusterKeyIter end_cluster_keys() const;
@@ -205,30 +205,30 @@ class SvtxTrack : public PHObject
   //
   // calo projection methods ---------------------------------------------------
   //
-  virtual float get_cal_dphi(CAL_LAYER /*layer*/) const { return 0.; }
-  virtual void set_cal_dphi(CAL_LAYER /*layer*/, float /*dphi*/) {}
+  virtual float get_cal_dphi(CAL_LAYER layer) const { return 0.; }
+  virtual void set_cal_dphi(CAL_LAYER layer, float dphi) {}
 
-  virtual float get_cal_deta(CAL_LAYER /*layer*/) const { return 0.; }
-  virtual void set_cal_deta(CAL_LAYER /*layer*/, float /*deta*/) {}
+  virtual float get_cal_deta(CAL_LAYER layer) const { return 0.; }
+  virtual void set_cal_deta(CAL_LAYER layer, float deta) {}
 
-  virtual float get_cal_energy_3x3(CAL_LAYER /*layer*/) const { return 0.; }
-  virtual void set_cal_energy_3x3(CAL_LAYER /*layer*/, float /*energy_3x3*/) {}
+  virtual float get_cal_energy_3x3(CAL_LAYER layer) const { return 0.; }
+  virtual void set_cal_energy_3x3(CAL_LAYER layer, float energy_3x3) {}
 
-  virtual float get_cal_energy_5x5(CAL_LAYER /*layer*/) const { return 0.; }
-  virtual void set_cal_energy_5x5(CAL_LAYER /*layer*/, float /*energy_5x5*/) {}
+  virtual float get_cal_energy_5x5(CAL_LAYER layer) const { return 0.; }
+  virtual void set_cal_energy_5x5(CAL_LAYER layer, float energy_5x5) {}
 
-  virtual unsigned int get_cal_cluster_id(CAL_LAYER /*layer*/) const { return 0; }
-  virtual void set_cal_cluster_id(CAL_LAYER /*layer*/, unsigned int /*id*/) {}
+  virtual unsigned int get_cal_cluster_id(CAL_LAYER layer) const { return 0; }
+  virtual void set_cal_cluster_id(CAL_LAYER layer, unsigned int id) {}
 
-  virtual TrkrDefs::cluskey get_cal_cluster_key(CAL_LAYER /*layer*/) const { return 0; }
-  virtual void set_cal_cluster_key(CAL_LAYER /*layer*/, TrkrDefs::cluskey /*key*/) {}
+  virtual TrkrDefs::cluskey get_cal_cluster_key(CAL_LAYER layer) const { return 0; }
+  virtual void set_cal_cluster_key(CAL_LAYER layer, TrkrDefs::cluskey key) {}
 
-  virtual float get_cal_cluster_e(CAL_LAYER /*layer*/) const { return 0.; }
-  virtual void set_cal_cluster_e(CAL_LAYER /*layer*/, float /*e*/) {}
+  virtual float get_cal_cluster_e(CAL_LAYER layer) const { return 0.; }
+  virtual void set_cal_cluster_e(CAL_LAYER layer, float e) {}
 
   // Acts methods for use by Acts modules only
-  virtual float get_acts_covariance(unsigned int /*i*/, unsigned int /*j*/) const { return NAN;}
-  virtual void set_acts_covariance(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float get_acts_covariance(unsigned int i, unsigned int j) const { return NAN;}
+  virtual void set_acts_covariance(unsigned int i, unsigned int j, float value) {}
  
   
 
@@ -238,8 +238,8 @@ class SvtxTrack : public PHObject
 
   //SvtxTrack_FastSim
   virtual unsigned int get_truth_track_id() const { return UINT_MAX; }
-  virtual void set_truth_track_id(unsigned int) {}
-  virtual void set_num_measurements(int) {}
+  virtual void set_truth_track_id(unsigned int truthTrackId) {}
+  virtual void set_num_measurements(int nmeas) {}
   virtual unsigned int get_num_measurements() const { return 0; }
 
   //SvtxTrack_FastSim_v1
@@ -249,15 +249,15 @@ class SvtxTrack : public PHObject
 
   virtual bool empty_g4hit_id() const { return true; }
   virtual size_t size_g4hit_id() const { return 0; }
-  virtual void add_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) {}
+  virtual void add_g4hit_id(int volume, PHG4HitDefs::keytype id) {}
   virtual HitIdIter begin_g4hit_id();
   virtual HitIdConstIter begin_g4hit_id() const;
-  virtual HitIdIter find_g4hit_id(int /*volume*/);
-  virtual HitIdConstIter find_g4hit_id(int /*volume*/) const;
+  virtual HitIdIter find_g4hit_id(int volume);
+  virtual HitIdConstIter find_g4hit_id(int volume) const;
   virtual HitIdIter end_g4hit_id();
   virtual HitIdConstIter end_g4hit_id() const;
-  virtual size_t remove_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) { return 0; }
-  virtual size_t remove_g4hit_volume(int /*volume*/) { return 0; }
+  virtual size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return 0; }
+  virtual size_t remove_g4hit_volume(int volume) { return 0; }
   virtual void clear_g4hit_id() {}
   virtual const HitIdMap& g4hit_ids() const;
 

--- a/offline/packages/trackbase_historic/SvtxTrackMap.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackMap.cc
@@ -10,7 +10,7 @@ SvtxTrackMap::ConstIter SvtxTrackMap::begin() const
   return DummyTrackMap.end();
 }
 
-SvtxTrackMap::ConstIter SvtxTrackMap::find(unsigned int /*idkey*/) const
+SvtxTrackMap::ConstIter SvtxTrackMap::find(unsigned int idkey) const
 {
   return DummyTrackMap.end();
 }
@@ -26,7 +26,7 @@ SvtxTrackMap::Iter SvtxTrackMap::begin()
   return DummyTrackMap.end();
 }
 
-SvtxTrackMap::Iter SvtxTrackMap::find(unsigned int /*idkey*/)
+SvtxTrackMap::Iter SvtxTrackMap::find(unsigned int idkey)
 {
   return DummyTrackMap.end();
 }

--- a/offline/packages/trackbase_historic/SvtxTrackMap.h
+++ b/offline/packages/trackbase_historic/SvtxTrackMap.h
@@ -26,13 +26,13 @@ class SvtxTrackMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }
-  virtual size_t count(unsigned int /*idkey*/) const { return 0; }
+  virtual size_t count(unsigned int idkey) const { return 0; }
   virtual void clear() {}
 
-  virtual const SvtxTrack* get(unsigned int /*idkey*/) const { return nullptr; }
-  virtual SvtxTrack* get(unsigned int /*idkey*/) { return nullptr; }
-  virtual SvtxTrack* insert(const SvtxTrack* /*cluster*/) { return nullptr; }
-  virtual size_t erase(unsigned int /*idkey*/) { return 0; }
+  virtual const SvtxTrack* get(unsigned int idkey) const { return nullptr; }
+  virtual SvtxTrack* get(unsigned int idkey) { return nullptr; }
+  virtual SvtxTrack* insert(const SvtxTrack* cluster) { return nullptr; }
+  virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -20,37 +20,37 @@ class SvtxTrackState : public PHObject
   virtual float get_pathlength() const { return NAN; }
 
   virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual void set_x(float x) {}
 
   virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual void set_y(float y) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float z) {}
 
-  virtual float get_pos(unsigned int /*i*/) const { return NAN; }
+  virtual float get_pos(unsigned int i) const { return NAN; }
 
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) {}
+  virtual void set_px(float px) {}
 
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) {}
+  virtual void set_py(float py) {}
 
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) {}
+  virtual void set_pz(float pz) {}
 
-  virtual float get_mom(unsigned int /*i*/) const { return NAN; }
+  virtual float get_mom(unsigned int i) const { return NAN; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }
   virtual float get_eta() const { return NAN; }
   virtual float get_phi() const { return NAN; }
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float get_error(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void set_error(unsigned int i, unsigned int j, float value) {}
 
   virtual std::string get_name() const { return ""; }
-  virtual void set_name(const std::string &/*name*/) {}
+  virtual void set_name(const std::string &name) {}
 
   ///@name convenience interface, also found in Trkrcluster
   //@{
@@ -76,7 +76,7 @@ class SvtxTrackState : public PHObject
   //@}
 
  protected:
-  SvtxTrackState(float /*pathlength*/ = 0.0) {}
+  SvtxTrackState(float pathlength = 0.0) {}
 
   ClassDefOverride(SvtxTrackState, 1);
 };

--- a/offline/packages/trackbase_historic/SvtxVertex.cc
+++ b/offline/packages/trackbase_historic/SvtxVertex.cc
@@ -7,7 +7,7 @@ SvtxVertex::ConstTrackIter SvtxVertex::begin_tracks() const
   return DummyTrackSet.end();
 }
 
-SvtxVertex::ConstTrackIter SvtxVertex::find_track(unsigned int /*trackid*/) const
+SvtxVertex::ConstTrackIter SvtxVertex::find_track(unsigned int trackid) const
 {
   return DummyTrackSet.end();
 }
@@ -22,7 +22,7 @@ SvtxVertex::TrackIter SvtxVertex::begin_tracks()
   return DummyTrackSet.end();
 }
 
-SvtxVertex::TrackIter SvtxVertex::find_track(unsigned int /*trackid*/)
+SvtxVertex::TrackIter SvtxVertex::find_track(unsigned int trackid)
 {
   return DummyTrackSet.end();
 }

--- a/offline/packages/trackbase_historic/SvtxVertex.h
+++ b/offline/packages/trackbase_historic/SvtxVertex.h
@@ -31,31 +31,31 @@ class SvtxVertex : public PHObject
   // vertex info
 
   virtual unsigned int get_id() const { return UINT_MAX; }
-  virtual void set_id(unsigned int) {}
+  virtual void set_id(unsigned int id) {}
 
   virtual float get_t0() const { return NAN; }
-  virtual void set_t0(float) {}
+  virtual void set_t0(float t0) {}
 
   virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual void set_x(float x) {}
 
   virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual void set_y(float y) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float z) {}
 
   virtual float get_chisq() const { return NAN; }
-  virtual void set_chisq(float) {}
+  virtual void set_chisq(float chisq) {}
 
   virtual unsigned int get_ndof() const { return UINT_MAX; }
-  virtual void set_ndof(unsigned int) {}
+  virtual void set_ndof(unsigned int ndof) {}
 
-  virtual float get_position(unsigned int) const { return NAN; }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
+  virtual float get_position(unsigned int coor) const { return NAN; }
+  virtual void set_position(unsigned int coor, float xi) {}
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float get_error(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void set_error(unsigned int i, unsigned int j, float value) {}
 
   //
   // associated track ids methods
@@ -63,8 +63,8 @@ class SvtxVertex : public PHObject
   virtual void clear_tracks() {}
   virtual bool empty_tracks() { return true; }
   virtual size_t size_tracks() const { return 0; }
-  virtual void insert_track(unsigned int /*trackid*/) {}
-  virtual size_t erase_track(unsigned int /*trackid*/) { return 0; }
+  virtual void insert_track(unsigned int trackid) {}
+  virtual size_t erase_track(unsigned int trackid) { return 0; }
   virtual ConstTrackIter begin_tracks() const;
   virtual ConstTrackIter find_track(unsigned int trackid) const;
   virtual ConstTrackIter end_tracks() const;

--- a/offline/packages/trackbase_historic/SvtxVertexMap.cc
+++ b/offline/packages/trackbase_historic/SvtxVertexMap.cc
@@ -7,7 +7,7 @@ SvtxVertexMap::ConstIter SvtxVertexMap::begin() const
   return DummyVertexMap.end();
 }
 
-SvtxVertexMap::ConstIter SvtxVertexMap::find(unsigned int /*idkey*/) const
+SvtxVertexMap::ConstIter SvtxVertexMap::find(unsigned int idkey) const
 {
   return DummyVertexMap.end();
 }
@@ -23,7 +23,7 @@ SvtxVertexMap::Iter SvtxVertexMap::begin()
   return DummyVertexMap.end();
 }
 
-SvtxVertexMap::Iter SvtxVertexMap::find(unsigned int /*idkey*/)
+SvtxVertexMap::Iter SvtxVertexMap::find(unsigned int idkey)
 {
   return DummyVertexMap.end();
 }

--- a/offline/packages/trackbase_historic/SvtxVertexMap.h
+++ b/offline/packages/trackbase_historic/SvtxVertexMap.h
@@ -25,18 +25,18 @@ class SvtxVertexMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }
-  virtual size_t count(unsigned int /*idkey*/) const { return 0; }
+  virtual size_t count(unsigned int idkey) const { return 0; }
   virtual void clear() {}
 
-  virtual const SvtxVertex* get(unsigned int /*idkey*/) const { return nullptr; }
-  virtual SvtxVertex* get(unsigned int /*idkey*/) { return nullptr; }
+  virtual const SvtxVertex* get(unsigned int idkey) const { return nullptr; }
+  virtual SvtxVertex* get(unsigned int idkey) { return nullptr; }
 
   //! Add vertex to container. Note the container take to ownership
-  virtual SvtxVertex* insert(SvtxVertex* /*cluster*/) { return nullptr; }
+  virtual SvtxVertex* insert(SvtxVertex* cluster) { return nullptr; }
   //! legacy interface. Add vertex to container. Note the container does not take ownership
-  virtual SvtxVertex* insert_clone(const SvtxVertex* /*vertex*/) { return nullptr; }
+  virtual SvtxVertex* insert_clone(const SvtxVertex* vertex) { return nullptr; }
 
-  virtual size_t erase(unsigned int /*idkey*/) { return 0; }
+  virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -50,7 +50,7 @@ ActsEvaluator::~ActsEvaluator()
 {
 }
 
-int ActsEvaluator::Init(PHCompositeNode */*topNode*/)
+int ActsEvaluator::Init(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
   {
@@ -250,7 +250,7 @@ void ActsEvaluator::evaluateTrackFits(PHCompositeNode *topNode)
 }
 
 
-int ActsEvaluator::End(PHCompositeNode */*topNode*/)
+int ActsEvaluator::End(PHCompositeNode *topNode)
 {
   m_trackFile->cd();
   m_trackTree->Write();
@@ -259,7 +259,7 @@ int ActsEvaluator::End(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int ActsEvaluator::ResetEvent(PHCompositeNode */*topNode*/)
+int ActsEvaluator::ResetEvent(PHCompositeNode *topNode)
 {
   m_trajNr = 0;
   return Fun4AllReturnCodes::EVENT_OK;
@@ -776,7 +776,7 @@ void ActsEvaluator::visitTrackStates(const Trajectory traj,
 
 
 
-Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode */*topNode*/,
+Acts::Vector3D ActsEvaluator::getGlobalTruthHit(PHCompositeNode *topNode, 
 						TrkrDefs::cluskey cluskey,
 						float &_gt)
 {

--- a/offline/packages/trackreco/ActsTransformations.cc
+++ b/offline/packages/trackreco/ActsTransformations.cc
@@ -6,7 +6,7 @@ using namespace std::chrono;
 
 Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 			        const SvtxTrack *track,
-				Acts::GeometryContext /*geoCtxt*/) const
+				Acts::GeometryContext geoCtxt) const
 {
   Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
 
@@ -94,7 +94,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 
 Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
 			        const Acts::BoundTrackParameters params,
-				Acts::GeometryContext /*geoCtxt*/) const
+				Acts::GeometryContext geoCtxt) const
 {
 
   auto covarianceMatrix = *params.covariance();

--- a/offline/packages/trackreco/AssocInfoContainer.h
+++ b/offline/packages/trackreco/AssocInfoContainer.h
@@ -19,9 +19,9 @@ class AssocInfoContainer : public PHObject
 
   void identify(std::ostream& os = std::cout) const override;
 
-  virtual void SetClusterTrackAssoc(const TrkrDefs::cluskey& /*cluster_id*/, const unsigned int& /*track_id*/) {return;}
+  virtual void SetClusterTrackAssoc(const TrkrDefs::cluskey& cluster_id, const unsigned int& track_id) {return;}
 
-  virtual std::vector<unsigned int> GetTracksFromCluster(const TrkrDefs::cluskey& /*cluster_id*/) const { std::vector<unsigned int> emptyvec; return emptyvec;}
+  virtual std::vector<unsigned int> GetTracksFromCluster(const TrkrDefs::cluskey& cluster_id) const { std::vector<unsigned int> emptyvec; return emptyvec;}
 
  protected:
   AssocInfoContainer(){};

--- a/offline/packages/trackreco/CellularAutomaton.h
+++ b/offline/packages/trackreco/CellularAutomaton.h
@@ -6,6 +6,9 @@
 #include <HelixHough/SimpleTrack3D.h>
 #include <HelixHough/HelixKalmanState.h>
 
+//#include <phool/PHObject.h>
+//#include <phool/phool.h>
+
 #include <climits>
 #include <cmath>
 #include <map>
@@ -27,66 +30,67 @@ class CellularAutomaton  {
   virtual int  isValid() const {return 0;}
   virtual CellularAutomaton* Clone() const {return nullptr;}
 
-  virtual void set_hough_space(HelixHoughSpace*) {}
-  virtual void set_mag_field(float) {}
-  virtual void set_pt_rescale(float) {}
-  virtual void set_n_layers(unsigned int) {}
-  virtual void set_required_layers(unsigned int) {}
-  virtual void set_ca_chi2(float) {}
-  virtual void set_ca_chi2_layer(float) {}
-  virtual void set_ca_phi_cut(float) {}
-  virtual void set_ca_z_cut(float) {}
-  virtual void set_ca_dcaxy_cut(float) {}
-  virtual void set_propagate_forward(bool) {}
-  virtual void set_remove_hits(bool) {}
-  virtual void set_remove_inner_hits(bool) {}
-  virtual void set_require_inner_hits(bool) {}
-  virtual void set_triplet_mode(bool) {}
-  virtual void set_seeding_mode(bool) {}
-  virtual void set_hits_map(std::map<unsigned int, SimpleHit3D>&) {}
+  virtual void set_hough_space(HelixHoughSpace* hough_space) {}
+  virtual void set_mag_field(float mag_field) {}
+  virtual void set_pt_rescale(float pt_rescale) {}
+  virtual void set_n_layers(unsigned int n_layers) {}
+  virtual void set_required_layers(unsigned int req_layers) {}
+  virtual void set_ca_chi2(float ca_chi2) {}
+  virtual void set_ca_chi2_layer(float chi2_layer_cut) {}
+  virtual void set_ca_phi_cut(float phi_cut) {}
+  virtual void set_ca_z_cut(float z_cut) {}
+  virtual void set_ca_dcaxy_cut(float dcaxy_cut) {}
+  virtual void set_propagate_forward(bool fwd) {}
+  virtual void set_remove_hits(bool remove) {}
+  virtual void set_remove_inner_hits(bool remove_inner) {}
+  virtual void set_require_inner_hits(bool require_inner) {}
+  virtual void set_triplet_mode(bool mod) {}
+  virtual void set_seeding_mode(bool mod) {}
+  virtual void set_hits_map(std::map<unsigned int, SimpleHit3D>& hits_map) {}
 
-  virtual int run(std::vector<SimpleTrack3D>&, std::vector<HelixKalmanState>&, std::map<unsigned int, bool>&) {return 0;}
+  virtual int run(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states, std::map<unsigned int, bool>& hits_used) {return 0;}
 
  private:
 
-  virtual void set_detector_radii(std::vector<float>&) {}
-  virtual void set_detector_material(std::vector<float>&) {}
-  virtual void set_input_tracks(std::vector<SimpleTrack3D>&) {}
+  virtual void set_detector_radii(std::vector<float>& radius) {}
+  virtual void set_detector_material(std::vector<float>& material) {}
+  virtual void set_input_tracks(std::vector<SimpleTrack3D>& input_tracks) {}
   virtual void set_cylinder_kalman() {}
 
   virtual int init() {return 0;}
   virtual int process_tracks() {return 0;}
-  virtual int process_single_track(SimpleTrack3D&) {return 0;}
-  virtual int process_single_triplet(SimpleTrack3D&) {return 0;}
-  virtual int get_ca_tracks(std::vector<SimpleTrack3D>&, std::vector<HelixKalmanState>&) {return 0;}
+  virtual int process_single_track(SimpleTrack3D& track) {return 0;}
+  virtual int process_single_triplet(SimpleTrack3D& track) {return 0;}
+  virtual int get_ca_tracks(std::vector<SimpleTrack3D>& output_tracks, std::vector<HelixKalmanState>& output_track_states) {return 0;}
 
   virtual int calculate_kappa_tangents(
-                        float, float, float, float, float, float,
-                        float, float, float,
-                        float, float, float, float, float, float,
-                        float, float, float,
-                        float&, float&,
-                        float&, float&, float&, float&,
-                        float&, float&, float&, float&) {return 0;}
+                        float x1, float y1, float z1, float x2, float y2, float z2,
+                        float x3, float y3, float z3,
+                        float dx1, float dy1, float dz1, float dx2, float dy2, float dz2,
+                        float dx3, float dy3, float dz3,
+                        float& kappa, float& dkappa,
+                        float& ux_mid, float& uy_mid, float& ux_end, float&uy_end,
+                        float& dzdl_1, float& dzdl_2, float& ddzdl_1, float& ddzdl_2) {return 0;}
 
   virtual int calculate_kappa_tangents(
-                        float, float, float, float, float, float,
-                        float, float, float,
-                        float, float, float, float, float, float,
-                        float, float, float,
-                        float&, float&,
-                        float&, float&, float&, float&,
-                        float&, float&, float&, float&,
-                        float, float,
-                        float, float, float, float,
-                        float, float&) {return 0;}
+                        float x1, float y1, float z1, float x2, float y2, float z2,
+                        float x3, float y3, float z3,
+                        float dx1, float dy1, float dz1, float dx2, float dy2, float dz2,
+                        float dx3, float dy3, float dz3,
+                        float& kappa, float& dkappa,
+                        float& ux_mid, float& uy_mid, float& ux_end, float& uy_end,
+                        float& dzdl_1, float& dzdl_2, float& ddzdl_1, float& ddzdl_2,
+                        float ca_sin_ang_cut, float inv_cos_ang_diff,
+                        float cur_kappa, float cur_dkappa, float cur_ux, float cur_uy,
+                        float cur_chi2, float& chi2) {return 0;}
 
-  virtual float shift_phi_range(float){return 0;};
+  virtual float shift_phi_range(float phi){return 0;};
 
 
  protected:
   CellularAutomaton(){}
 
+//  ClassDefOverride(CellularAutomaton,1);
 };
 
 #endif

--- a/offline/packages/trackreco/CellularAutomaton_v1.cc
+++ b/offline/packages/trackreco/CellularAutomaton_v1.cc
@@ -521,7 +521,7 @@ int CellularAutomaton_v1::process_single_triplet(SimpleTrack3D& track){ // track
     		}
     		combos.insert(temp_combo);
 
-    		for (int j = i-1; j>=0; --j){
+    		for (unsigned int j = i-1; j>=0; --j){
       			comp2.clear();
       			for (unsigned int m = 0; m < (*cur_seg)[j].n_hits; ++m){
       				comp2.insert(layer_sorted[m][(*cur_seg)[j].hits[m]].get_id());
@@ -1365,7 +1365,7 @@ int CellularAutomaton_v1::process_single_track(SimpleTrack3D& track)
     }
     combos.insert(temp_combo);
 
-    for (int j = i-1; j>=0; --j){
+    for (unsigned int j = i-1; j>=0; --j){
       comp2.clear();
       for (unsigned int m = 0; m < (*cur_seg)[j].n_hits; ++m){
       comp2.insert(layer_sorted[m][(*cur_seg)[j].hits[m]].get_id());

--- a/offline/packages/trackreco/CellularAutomaton_v1.h
+++ b/offline/packages/trackreco/CellularAutomaton_v1.h
@@ -44,7 +44,7 @@ class CellularAutomaton_v1 : public CellularAutomaton {
 	~CellularAutomaton_v1() override {};
 
 	// The "standard PHObject response" functions...
-	void identify(std::ostream& = std::cout) const override {};
+	void identify(std::ostream &os=std::cout) const override {};
 	void Reset() override;
 	int  isValid() const override {return 1;}
 	CellularAutomaton* Clone() const override {return new CellularAutomaton_v1(*this);}

--- a/offline/packages/trackreco/HelixHoughBin.cc
+++ b/offline/packages/trackreco/HelixHoughBin.cc
@@ -7,7 +7,7 @@ HelixHoughBin::ConstClusterIter HelixHoughBin::begin_clusters() const
   return HelixHoughBinClusterSet.end();
 }
 
-HelixHoughBin::ConstClusterIter HelixHoughBin::find_cluster(unsigned int /*cluster_id*/) const
+HelixHoughBin::ConstClusterIter HelixHoughBin::find_cluster(unsigned int cluster_id) const
 {
   return HelixHoughBinClusterSet.end();
 }
@@ -21,7 +21,7 @@ HelixHoughBin::ClusterIter HelixHoughBin::begin_clusters()
   return HelixHoughBinClusterSet.end();
 }
 
-HelixHoughBin::ClusterIter HelixHoughBin::find_cluster(unsigned int /*cluster_id*/)
+HelixHoughBin::ClusterIter HelixHoughBin::find_cluster(unsigned int cluster_id)
 {
   return HelixHoughBinClusterSet.end();
 }

--- a/offline/packages/trackreco/HelixHoughBin.h
+++ b/offline/packages/trackreco/HelixHoughBin.h
@@ -36,11 +36,11 @@ class HelixHoughBin : public PHObject
   virtual void init() {}
 
   //     get_cluster_IDs() {}
-  virtual void add_cluster_ID(unsigned int /*cluster_ID*/) {}
+  virtual void add_cluster_ID(unsigned int cluster_ID) {}
   virtual unsigned int get_count() const { return UINT_MAX; }
   virtual void clear_clusters() {}
   virtual bool empty_clusters() { return true; }
-  virtual size_t erase_cluster(unsigned int /*cluster_id*/) { return 0; }
+  virtual size_t erase_cluster(unsigned int cluster_id) { return 0; }
   virtual ConstClusterIter begin_clusters() const;
   virtual ConstClusterIter find_cluster(unsigned int cluster_id) const;
   virtual ConstClusterIter end_clusters() const;
@@ -48,48 +48,48 @@ class HelixHoughBin : public PHObject
   virtual ClusterIter find_cluster(unsigned int cluster_id);
   virtual ClusterIter end_clusters();
 
-  virtual unsigned int get_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_bin(unsigned int /*zoomlevel*/, unsigned int /*bin*/) {}
+  virtual unsigned int get_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_bin(unsigned int zoomlevel, unsigned int bin) {}
 
   virtual unsigned int get_zoomlevel() const { return UINT_MAX; }
-  virtual void set_zoomlevel(unsigned int /*zoomlevel*/) {}
+  virtual void set_zoomlevel(unsigned int zoomlevel) {}
 
-  virtual unsigned int get_kappa_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_kappa_bin(unsigned int /*zoomlevel*/, unsigned int /*kappa_bin*/) {}
-  virtual unsigned int get_phi_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_phi_bin(unsigned int /*zoomlevel*/, unsigned int /*phi_bin*/) {}
-  virtual unsigned int get_phi_high_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_phi_high_bin(unsigned int /*zoomlevel*/) {}
-  virtual void set_phi_high_bin(unsigned int /*zoomlevel*/, unsigned int /*phi_high_bin*/) {}
-  virtual unsigned int get_phi_low_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_phi_low_bin(unsigned int /*zoomlevel*/) {}
-  virtual void set_phi_low_bin(unsigned int /*zoomlevel*/, unsigned int /*phi_low_bin*/) {}
-  virtual unsigned int get_d_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_d_bin(unsigned int /*zoomlevel*/, unsigned int /*d_bin*/) {}
-  virtual unsigned int get_dzdl_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_dzdl_bin(unsigned int /*zoomlevel*/, unsigned int /*dzdl_bin*/) {}
-  virtual unsigned int get_dzdl_high_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_dzdl_high_bin(unsigned int /*zoomlevel*/) {}
-  virtual void set_dzdl_high_bin(unsigned int /*zoomlevel*/, unsigned int /*dzdl_high_bin*/) {}
-  virtual unsigned int get_dzdl_low_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_dzdl_low_bin(unsigned int /*zoomlevel*/) {}
-  virtual void set_dzdl_low_bin(unsigned int /*zoomlevel*/, unsigned int /*dzdl_low_bin*/) {}
-  virtual unsigned int get_z0_bin(unsigned int /*zoomlevel*/) const { return UINT_MAX; }
-  virtual void set_z0_bin(unsigned int /*zoomlevel*/, unsigned int /*z0_bin*/) {}
+  virtual unsigned int get_kappa_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_kappa_bin(unsigned int zoomlevel, unsigned int kappa_bin) {}
+  virtual unsigned int get_phi_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_phi_bin(unsigned int zoomlevel, unsigned int phi_bin) {}
+  virtual unsigned int get_phi_high_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_phi_high_bin(unsigned int zoomlevel) {}
+  virtual void set_phi_high_bin(unsigned int zoomlevel, unsigned int phi_high_bin) {}
+  virtual unsigned int get_phi_low_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_phi_low_bin(unsigned int zoomlevel) {}
+  virtual void set_phi_low_bin(unsigned int zoomlevel, unsigned int phi_low_bin) {}
+  virtual unsigned int get_d_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_d_bin(unsigned int zoomlevel, unsigned int d_bin) {}
+  virtual unsigned int get_dzdl_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_dzdl_bin(unsigned int zoomlevel, unsigned int dzdl_bin) {}
+  virtual unsigned int get_dzdl_high_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_dzdl_high_bin(unsigned int zoomlevel) {}
+  virtual void set_dzdl_high_bin(unsigned int zoomlevel, unsigned int dzdl_high_bin) {}
+  virtual unsigned int get_dzdl_low_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_dzdl_low_bin(unsigned int zoomlevel) {}
+  virtual void set_dzdl_low_bin(unsigned int zoomlevel, unsigned int dzdl_low_bin) {}
+  virtual unsigned int get_z0_bin(unsigned int zoomlevel) const { return UINT_MAX; }
+  virtual void set_z0_bin(unsigned int zoomlevel, unsigned int z0_bin) {}
 
-  virtual void set_hough_space(HelixHoughSpace* /*hough_space*/){};
-  virtual void set_bins(unsigned int /*zoomlevel*/, unsigned int /*bin*/){};
+  virtual void set_hough_space(HelixHoughSpace* hough_space){};
+  virtual void set_bins(unsigned int zoomlevel, unsigned int bin){};
 
-  virtual unsigned int get_global_bin(unsigned int /*zoomlevel*/) { return UINT_MAX; }
-  virtual void set_global_bin(unsigned int /*zoomlevel*/) {}
+  virtual unsigned int get_global_bin(unsigned int zoomlevel) { return UINT_MAX; }
+  virtual void set_global_bin(unsigned int zoomlevel) {}
 
-  virtual unsigned int get_neighbors_global_bin(unsigned int /*zoomlevel*/, unsigned int /*var*/, unsigned int /*bit_sign*/) { return UINT_MAX; }
+  virtual unsigned int get_neighbors_global_bin(unsigned int zoomlevel, unsigned int var, unsigned int bit_sign) { return UINT_MAX; }
 
-  virtual float get_kappa_center(unsigned int /*zoomlevel*/) { return 999.; }
-  virtual float get_phi_center(unsigned int /*zoomlevel*/) { return 999.; }
-  virtual float get_d_center(unsigned int /*zoomlevel*/) { return 999.; }
-  virtual float get_dzdl_center(unsigned int /*zoomlevel*/) { return 999.; }
-  virtual float get_z0_center(unsigned int /*zoomlevel*/) { return 999.; }
+  virtual float get_kappa_center(unsigned int zoomlevel) { return 999.; }
+  virtual float get_phi_center(unsigned int zoomlevel) { return 999.; }
+  virtual float get_d_center(unsigned int zoomlevel) { return 999.; }
+  virtual float get_dzdl_center(unsigned int zoomlevel) { return 999.; }
+  virtual float get_z0_center(unsigned int zoomlevel) { return 999.; }
 
  protected:
   HelixHoughBin() {}

--- a/offline/packages/trackreco/HelixHoughBin_v1.cc
+++ b/offline/packages/trackreco/HelixHoughBin_v1.cc
@@ -101,7 +101,7 @@ void HelixHoughBin_v1::set_bins(unsigned int zoomlevel, unsigned int bin) {
 // bin = kappabin + nkappabin* (phibin + nphibin* (dbin + ndbin *( dzdlbin + ndzdlbin*z0bin) ) )
 } 
 
-unsigned int HelixHoughBin_v1::get_global_bin(unsigned int /*zoomlevel*/)
+unsigned int HelixHoughBin_v1::get_global_bin(unsigned int zoomlevel)
 {
 	return _global_bin;
 }

--- a/offline/packages/trackreco/HelixHoughFuncs.h
+++ b/offline/packages/trackreco/HelixHoughFuncs.h
@@ -24,12 +24,12 @@ class HelixHoughFuncs : public PHObject
   PHObject* CloneMe() const override { return nullptr; }
 
   // Define Hough space for helical tracks
-  virtual void set_current_zoom(unsigned int /*cur_zoom*/) {}
-  virtual void set_hough_space(HelixHoughSpace* /*hough_space*/) {}
-  virtual void calculate_dzdl_range(float* /*hitpos3d*/, std::vector<float>& /*z0_range*/, std::vector<float>& /*kappa_phi_d_ranges*/, float* /*dzdl_range*/){};
-  virtual void calculate_phi_range(float* /*hitpos2d*/, std::vector<float>& /*kappa_d_ranges*/, float* /*phi_r_range*/, float* /*phi_l_range*/){};
-  virtual void calculate_phi_range(float* /*hitpos2d*/, std::vector<float>& /*kappa_d_ranges*/, int /*helicity*/, float* /*phi_range*/, float* /*phi_next_range*/){};
-  virtual void calculate_phi_range(float* /*hitpos2d*/, std::vector<float>& /*kappa_d_ranges*/, int /*helicity*/, float* /*phi_range*/, float* /*phi_prev_range*/, float* /*phi_next_range*/){};
+  virtual void set_current_zoom(unsigned int cur_zoom) {}
+  virtual void set_hough_space(HelixHoughSpace* hough_space) {}
+  virtual void calculate_dzdl_range(float* hitpos3d, std::vector<float>& z0_range, std::vector<float>& kappa_phi_d_ranges, float* dzdl_range){};
+  virtual void calculate_phi_range(float* hitpos2d, std::vector<float>& kappa_d_ranges, float* phi_r_range, float* phi_l_range){};
+  virtual void calculate_phi_range(float* hitpos2d, std::vector<float>& kappa_d_ranges, int helicity, float* phi_range, float* phi_next_range){};
+  virtual void calculate_phi_range(float* hitpos2d, std::vector<float>& kappa_d_ranges, int helicity, float* phi_range, float* phi_prev_range, float* phi_next_range){};
 
   /*
   virtual void set_z0_max(float z0_max)         {}

--- a/offline/packages/trackreco/HelixHoughFuncs_v1.h
+++ b/offline/packages/trackreco/HelixHoughFuncs_v1.h
@@ -17,7 +17,7 @@ class HelixHoughFuncs_v1 : public HelixHoughFuncs
   ~HelixHoughFuncs_v1() override{};
 
   // The "standard PHObject response" functions...
-  void identify(std::ostream& /*os*/ = std::cout) const override{};
+  void identify(std::ostream& os = std::cout) const override{};
   void Reset() override {}
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new HelixHoughFuncs_v1(*this); }

--- a/offline/packages/trackreco/HelixHoughSpace.h
+++ b/offline/packages/trackreco/HelixHoughSpace.h
@@ -24,44 +24,44 @@ public :
   PHObject* CloneMe() const  override {return nullptr;}
 
   // Define Hough space for helical tracks 
-  virtual void add_one_zoom(std::vector<unsigned int>& /*one_zoom*/) {};
+  virtual void add_one_zoom(std::vector<unsigned int>& one_zoom) {};
   virtual unsigned int get_max_zoom() 		{return UINT_MAX;}
   virtual void print_zoom_profile()		{}
   virtual void print_para_range()		{}
 
-  virtual void set_kappa_min(float /*kappa_min*/)   {}
+  virtual void set_kappa_min(float kappa_min)   {}
   virtual float get_kappa_min() const    	{return NAN;}
-  virtual void set_kappa_max(float /*kappa_max*/)   {}
+  virtual void set_kappa_max(float kappa_max)   {}
   virtual float get_kappa_max() const    	{return NAN;}
-  virtual void set_phi_min(float /*phi_min*/)       {}
+  virtual void set_phi_min(float phi_min)       {}
   virtual float get_phi_min() const      	{return NAN;} 
-  virtual void set_phi_max(float /*phi_max*/)       {}
+  virtual void set_phi_max(float phi_max)       {}
   virtual float get_phi_max() const      	{return NAN;}
-  virtual void set_d_min(float /*d_min*/)           {}
+  virtual void set_d_min(float d_min)           {}
   virtual float get_d_min() const        	{return NAN;}
-  virtual void set_d_max(float /*d_max*/)           {}
+  virtual void set_d_max(float d_max)           {}
   virtual float get_d_max() const        	{return NAN;}
-  virtual void set_dzdl_min(float /*dzdl_min*/)     {}
+  virtual void set_dzdl_min(float dzdl_min)     {}
   virtual float get_dzdl_min() const     	{return NAN;}
-  virtual void set_dzdl_max(float /*dzdl_max*/)     {}
+  virtual void set_dzdl_max(float dzdl_max)     {}
   virtual float get_dzdl_max() const     	{return NAN;}
-  virtual void set_z0_min(float /*z0_min*/)         {}
+  virtual void set_z0_min(float z0_min)         {}
   virtual float get_z0_min() const       	{return NAN;}
-  virtual void set_z0_max(float /*z0_max*/)         {}
+  virtual void set_z0_max(float z0_max)         {}
   virtual float get_z0_max() const       	{return NAN;}
 
 
-  virtual unsigned int get_n_kappa_bins(unsigned int /*zoomlevel*/) const {return UINT_MAX;}
-  virtual unsigned int get_n_phi_bins(unsigned int /*zoomlevel*/) const   {return UINT_MAX;}
-  virtual unsigned int get_n_d_bins(unsigned int /*zoomlevel*/) const     {return UINT_MAX;}
-  virtual unsigned int get_n_dzdl_bins(unsigned int /*zoomlevel*/) const  {return UINT_MAX;}
-  virtual unsigned int get_n_z0_bins(unsigned int /*zoomlevel*/) const    {return UINT_MAX;}
+  virtual unsigned int get_n_kappa_bins(unsigned int zoomlevel) const {return UINT_MAX;}
+  virtual unsigned int get_n_phi_bins(unsigned int zoomlevel) const   {return UINT_MAX;}
+  virtual unsigned int get_n_d_bins(unsigned int zoomlevel) const     {return UINT_MAX;}
+  virtual unsigned int get_n_dzdl_bins(unsigned int zoomlevel) const  {return UINT_MAX;}
+  virtual unsigned int get_n_z0_bins(unsigned int zoomlevel) const    {return UINT_MAX;}
 
-  virtual float get_kappa_bin_size(unsigned int /*zoomlevel*/) const      {return NAN;}
-  virtual float get_phi_bin_size(unsigned int /*zoomlevel*/) const      {return NAN;}
-  virtual float get_d_bin_size(unsigned int /*zoomlevel*/) const      {return NAN;}
-  virtual float get_dzdl_bin_size(unsigned int /*zoomlevel*/) const      {return NAN;}
-  virtual float get_z0_bin_size(unsigned int /*zoomlevel*/) const      {return NAN;}
+  virtual float get_kappa_bin_size(unsigned int zoomlevel) const      {return NAN;}
+  virtual float get_phi_bin_size(unsigned int zoomlevel) const      {return NAN;}
+  virtual float get_d_bin_size(unsigned int zoomlevel) const      {return NAN;}
+  virtual float get_dzdl_bin_size(unsigned int zoomlevel) const      {return NAN;}
+  virtual float get_z0_bin_size(unsigned int zoomlevel) const      {return NAN;}
 
 /*
   virtual float get_kappa_center(unsigned int zoomlevel, std::vector<unsigned int>& v_ik) const {return NAN;}
@@ -70,14 +70,14 @@ public :
   virtual float get_dzdl_center(unsigned int zoomlevel, std::vector<unsigned int>& v_il) const  {return NAN;}
   virtual float get_z0_center(unsigned int zoomlevel, std::vector<unsigned int>& v_iz) const    {return NAN;}
 */
-  virtual unsigned int get_kappa_bin(unsigned int /*zoomlevel*/, float /*kappa*/) const {return UINT_MAX;} 
-  virtual unsigned int get_phi_bin(unsigned int /*zoomlevel*/, float /*phi*/) const   {return UINT_MAX;}
-  virtual unsigned int get_d_bin(unsigned int /*zoomlevel*/, float /*d*/) const     {return UINT_MAX;} 
-  virtual unsigned int get_dzdl_bin(unsigned int /*zoomlevel*/, float /*dzdl*/) const  {return UINT_MAX;}
-  virtual unsigned int get_z0_bin(unsigned int /*zoomlevel*/, float /*z0*/) const    {return UINT_MAX;}
+  virtual unsigned int get_kappa_bin(unsigned int zoomlevel, float kappa) const {return UINT_MAX;} 
+  virtual unsigned int get_phi_bin(unsigned int zoomlevel, float phi) const   {return UINT_MAX;}
+  virtual unsigned int get_d_bin(unsigned int zoomlevel, float d) const     {return UINT_MAX;} 
+  virtual unsigned int get_dzdl_bin(unsigned int zoomlevel, float dzdl) const  {return UINT_MAX;}
+  virtual unsigned int get_z0_bin(unsigned int zoomlevel, float z0) const    {return UINT_MAX;}
 
 
-  virtual unsigned int get_bin(unsigned int /*zoomlevel*/, unsigned int* /*bins*/) const {return UINT_MAX;}
+  virtual unsigned int get_bin(unsigned int zoomlevel, unsigned int* bins) const {return UINT_MAX;}
 
 protected:
   HelixHoughSpace() = default;

--- a/offline/packages/trackreco/HelixHoughSpace_v1.cc
+++ b/offline/packages/trackreco/HelixHoughSpace_v1.cc
@@ -212,7 +212,7 @@ unsigned int HelixHoughSpace_v1::get_dzdl_bin(unsigned int zoomlevel, float dzdl
 //	cout<<"dzdl-prevzoom "<<dzdl<<endl;
 // 	if (zoomlevel==1) cout<<"i "<<i<<" lbin "<<lbin<<endl;
 	if (lbin >= get_n_dzdl_bins(i)) return 999;
-//	if (lbin<0) return 9999; // lbin is unsigned - test for <0 is non sensical
+	if (lbin<0) return 9999;
 	}	
 //	cout<<"lbin "<<lbin<<endl;
 	return lbin;

--- a/offline/packages/trackreco/HelixHoughSpace_v1.h
+++ b/offline/packages/trackreco/HelixHoughSpace_v1.h
@@ -18,7 +18,7 @@ public:
 
 
   // The "standard PHObject response" functions...
-  void identify(std::ostream &/*os*/=std::cout) const override {};
+  void identify(std::ostream &os=std::cout) const override {};
   void Reset() override {}
   int  isValid() const override {return 1;}
   PHObject* CloneMe() const override {return new HelixHoughSpace_v1(*this);}

--- a/offline/packages/trackreco/HelixKalmanFilter.cc
+++ b/offline/packages/trackreco/HelixKalmanFilter.cc
@@ -513,7 +513,7 @@ void HelixKalmanFilter::calculate_dAdAp(HelixKalmanState& state,
 // dA'/dp , where p is the momentum vector
 void HelixKalmanFilter::calculate_dApdp(HelixKalmanState& state,
                                   Matrix<float, 3, 3>& dApdp, Vector3f& p,
-					float /*phi*/, float cosphi, float sinphi) {
+                                  float phi, float cosphi, float sinphi) {
   float k = state.kappa;
   float dzdl = state.dzdl;
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -97,7 +97,7 @@ MakeActsGeometry::MakeActsGeometry(const std::string &name)
 : SubsysReco(name)
 { setPlanarSurfaceDivisions(); }
 
-int MakeActsGeometry::Init(PHCompositeNode */*topNode*/)
+int MakeActsGeometry::Init(PHCompositeNode *topNode)
 {  
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -147,11 +147,11 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int MakeActsGeometry::process_event(PHCompositeNode */*topNode*/)
+int MakeActsGeometry::process_event(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
-int MakeActsGeometry::End(PHCompositeNode */*topNode*/)
+int MakeActsGeometry::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -1119,7 +1119,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getInttHitSetKeyFromCoords(unsigned int la
   return intt_hitsetkey;
 }
 
-void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode * /*topNode*/)
+void MakeActsGeometry::makeTGeoNodeMap(PHCompositeNode *topNode)
 {
   // This is just a diagnostic method
   // it lets you list all of the nodes by setting print_sensors = true
@@ -1282,7 +1282,7 @@ void MakeActsGeometry::getInttKeyFromNode(TGeoNode *gnode)
 
   return;
 }
-void MakeActsGeometry::getTpcKeyFromNode(TGeoNode * /*gnode*/)
+void MakeActsGeometry::getTpcKeyFromNode(TGeoNode *gnode)
 {
 
 }

--- a/offline/packages/trackreco/PH3DVertexing.cc
+++ b/offline/packages/trackreco/PH3DVertexing.cc
@@ -31,7 +31,7 @@ int PH3DVertexing::InitRun(PHCompositeNode* topNode)
   return Setup(topNode);
 }
 
-int PH3DVertexing::process_event(PHCompositeNode* /*topNode*/)
+int PH3DVertexing::process_event(PHCompositeNode* topNode)
 {
   return Process();
 }

--- a/offline/packages/trackreco/PHActsInitialVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsInitialVertexFinder.cc
@@ -66,7 +66,7 @@ int PHActsInitialVertexFinder::Setup(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsInitialVertexFinder::Process(PHCompositeNode */*topNode*/)
+int PHActsInitialVertexFinder::Process(PHCompositeNode *topNode)
 {
   if(Verbosity() > 0)
     std::cout << "PHActsInitialVertexFinder processing event " 
@@ -114,12 +114,12 @@ int PHActsInitialVertexFinder::Process(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsInitialVertexFinder::ResetEvent(PHCompositeNode */*topNode*/)
+int PHActsInitialVertexFinder::ResetEvent(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsInitialVertexFinder::End(PHCompositeNode */*topNode*/)
+int PHActsInitialVertexFinder::End(PHCompositeNode *topNode)
 {
 
   std::cout << "Acts IVF succeeded " << m_successFits 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -40,7 +40,7 @@ PHActsSiliconSeeding::PHActsSiliconSeeding(const std::string& name)
   : SubsysReco(name)
 {}
 
-int PHActsSiliconSeeding::Init(PHCompositeNode */*topNode*/)
+int PHActsSiliconSeeding::Init(PHCompositeNode *topNode)
 {
   m_seedFinderCfg = configureSeeder();
   m_gridCfg = configureSPGrid();
@@ -77,7 +77,7 @@ int PHActsSiliconSeeding::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsSiliconSeeding::process_event(PHCompositeNode */*topNode*/)
+int PHActsSiliconSeeding::process_event(PHCompositeNode *topNode)
 {
 
   auto eventTimer = std::make_unique<PHTimer>("eventTimer");
@@ -123,7 +123,7 @@ int PHActsSiliconSeeding::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsSiliconSeeding::End(PHCompositeNode */*topNode*/)
+int PHActsSiliconSeeding::End(PHCompositeNode *topNode)
 {
   if(m_seedAnalysis)
     {
@@ -1208,9 +1208,9 @@ Acts::SeedfinderConfig<SpacePoint> PHActsSiliconSeeding::configureSeeder()
   config.deltaRMax = m_deltaRMax;
 
   /// Limiting collision region in z
-  config.collisionRegionMin = -210.;
-  config.collisionRegionMax = 210.;
-  config.sigmaScattering = 5.;
+  config.collisionRegionMin = -100.;
+  config.collisionRegionMax = 100.;
+  config.sigmaScattering = 50.;
   config.maxSeedsPerSpM = m_maxSeedsPerSpM;
   config.cotThetaMax = m_cotThetaMax;
   config.minPt = m_minSeedPt;
@@ -1362,17 +1362,4 @@ double PHActsSiliconSeeding::normPhi2Pi(const double phi)
   if(returnPhi < 0)
     returnPhi += 2 * M_PI;
   return returnPhi;
-}
-
-
-void PHActsSiliconSeeding::largeGridSpacing(const bool spacing)
-{
-  if(!spacing)
-    {
-      m_gridFactor = 1.;
-      m_rMax = 50.;
-      m_cotThetaMax = 1.335647;
-      m_maxSeedPCA = 0.1;
-    }
-
 }

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -114,10 +114,6 @@ class PHActsSiliconSeeding : public SubsysReco
   void gridFactor(const float gridFactor)
   {m_gridFactor = gridFactor;}
 
-  /// A function to run the seeder with large (true)
-  /// or small (false) grid spacing
-  void largeGridSpacing(const bool spacing);
-
  private:
 
   int getNodes(PHCompositeNode *topNode);

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -89,12 +89,12 @@ int PHActsTrackProjection::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrackProjection::Init(PHCompositeNode */*topNode*/)
+int PHActsTrackProjection::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrackProjection::End(PHCompositeNode */*topNode*/)
+int PHActsTrackProjection::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -90,7 +90,7 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrkFitter::process_event(PHCompositeNode */*topNode*/)
+int PHActsTrkFitter::process_event(PHCompositeNode *topNode)
 {
   PHTimer eventTimer("eventTimer");
   eventTimer.stop();
@@ -146,7 +146,7 @@ int PHActsTrkFitter::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrkFitter::ResetEvent(PHCompositeNode */*topNode*/)
+int PHActsTrkFitter::ResetEvent(PHCompositeNode *topNode)
 {
   
   if(Verbosity() > 1)
@@ -163,7 +163,7 @@ int PHActsTrkFitter::ResetEvent(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrkFitter::End(PHCompositeNode */*topNode*/)
+int PHActsTrkFitter::End(PHCompositeNode *topNode)
 {
   if(m_timeAnalysis)
     {

--- a/offline/packages/trackreco/PHActsVertexFinder.cc
+++ b/offline/packages/trackreco/PHActsVertexFinder.cc
@@ -107,7 +107,7 @@ int PHActsVertexFinder::Process(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsVertexFinder::ResetEvent(PHCompositeNode */*topNode*/)
+int PHActsVertexFinder::ResetEvent(PHCompositeNode *topNode)
 {
   m_actsVertexMap->clear();
   m_svtxVertexMap->clear();
@@ -116,7 +116,7 @@ int PHActsVertexFinder::ResetEvent(PHCompositeNode */*topNode*/)
 
 }
 
-  int PHActsVertexFinder::End(PHCompositeNode */*topNode*/)
+int PHActsVertexFinder::End(PHCompositeNode *topNode)
 {
   std::cout << "Acts Final vertex finder succeeeded " << m_goodFits
 	    << " out of " << m_totalFits << " events processed"

--- a/offline/packages/trackreco/PHActsVertexFitter.cc
+++ b/offline/packages/trackreco/PHActsVertexFitter.cc
@@ -46,7 +46,7 @@ PHActsVertexFitter::PHActsVertexFitter(const std::string &name)
 {
 }
 
-int PHActsVertexFitter::Init(PHCompositeNode */*topNode*/)
+int PHActsVertexFitter::Init(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
     std::cout << "PHActsVertexFitter::Init" << std::endl;
@@ -54,14 +54,14 @@ int PHActsVertexFitter::Init(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsVertexFitter::End(PHCompositeNode */*topNode*/)
+int PHActsVertexFitter::End(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
     std::cout << "PHActsVertexFitter::End " << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsVertexFitter::ResetEvent(PHCompositeNode */*topNode*/)
+int PHActsVertexFitter::ResetEvent(PHCompositeNode *topNode)
 {
   m_actsVertexMap->clear();
 
@@ -79,7 +79,7 @@ int PHActsVertexFitter::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsVertexFitter::process_event(PHCompositeNode */*topNode*/)
+int PHActsVertexFitter::process_event(PHCompositeNode *topNode)
 {
   auto logLevel = Acts::Logging::FATAL;
   if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -456,7 +456,7 @@ vector<coordKey> PHCASeeding::fromPointKey(vector<pointKey> p)
   return output;
 }
 
-int PHCASeeding::Process(PHCompositeNode */*topNode*/)
+int PHCASeeding::Process(PHCompositeNode *topNode)
 {
 //  TFile fpara("CA_para.root", "RECREATE");
 //  _vertex = _vertex_map->get(0);

--- a/offline/packages/trackreco/PHGenFitTrackProjection.cc
+++ b/offline/packages/trackreco/PHGenFitTrackProjection.cc
@@ -85,7 +85,7 @@ PHGenFitTrackProjection::PHGenFitTrackProjection(const string &name, const int p
 	_cal_types.push_back(SvtxTrack::HCALOUT);
 }
 
-int PHGenFitTrackProjection::Init(PHCompositeNode */*topNode*/) {
+int PHGenFitTrackProjection::Init(PHCompositeNode *topNode) {
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -471,6 +471,6 @@ int PHGenFitTrackProjection::process_event(PHCompositeNode *topNode) {
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHGenFitTrackProjection::End(PHCompositeNode */*topNode*/) {
+int PHGenFitTrackProjection::End(PHCompositeNode *topNode) {
 	return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -164,7 +164,7 @@ PHGenFitTrkFitter::PHGenFitTrkFitter(const string& name)
 /*
  * Init
  */
-int PHGenFitTrkFitter::Init(PHCompositeNode* /*topNode*/)
+int PHGenFitTrkFitter::Init(PHCompositeNode* topNode)
 {
   //	CreateNodes(topNode);
 
@@ -500,7 +500,7 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
 /*
  * End
  */
-int PHGenFitTrkFitter::End(PHCompositeNode* /*topNode*/)
+int PHGenFitTrkFitter::End(PHCompositeNode* topNode)
 {
   if (_do_eval)
   {
@@ -520,7 +520,7 @@ int PHGenFitTrkFitter::End(PHCompositeNode* /*topNode*/)
 /*
  * fill_eval_tree():
  */
-void PHGenFitTrkFitter::fill_eval_tree(PHCompositeNode* /*topNode*/)
+void PHGenFitTrkFitter::fill_eval_tree(PHCompositeNode* topNode)
 {
   //! Make sure to reset all the TTree variables before trying to set them.
   reset_eval_variables();

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -360,7 +360,7 @@ int PHGenFitTrkProp::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHGenFitTrkProp::check_track_exists(MapPHGenFitTrack::iterator iter, SvtxTrackMap::Iter /*phtrk_iter*/)
+int PHGenFitTrkProp::check_track_exists(MapPHGenFitTrack::iterator iter, SvtxTrackMap::Iter phtrk_iter)
 {
   //Loop over hitIDs on current track and check if they have been used
   unsigned int n_clu = iter->second->get_cluster_keys().size();

--- a/offline/packages/trackreco/PHHoughSeeding.cc
+++ b/offline/packages/trackreco/PHHoughSeeding.cc
@@ -362,7 +362,7 @@ int PHHoughSeeding::Setup(PHCompositeNode* topNode)
   return ret;
 }
 
-int PHHoughSeeding::Process(PHCompositeNode */*topNode*/)
+int PHHoughSeeding::Process(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
   {
@@ -1814,7 +1814,7 @@ float PHHoughSeeding::ptToKappa(float pt)
 }
 
 void PHHoughSeeding::convertHelixCovarianceToEuclideanCovariance(float B,
-                                                                 float phi, float d, float kappa, float /*z0*/, float dzdl,
+                                                                 float phi, float d, float kappa, float z0, float dzdl,
                                                                  Eigen::Matrix<float, 5, 5> const& input,
                                                                  Eigen::Matrix<float, 6, 6>& output)
 {

--- a/offline/packages/trackreco/PHHoughSeeding.h
+++ b/offline/packages/trackreco/PHHoughSeeding.h
@@ -218,34 +218,34 @@ class PHHoughSeeding : public PHTrackSeeding
   //---deprecated---------------------------------------------------------------
 
   /// set option to produce initial vertex for further tracking
-  void set_use_vertex(bool /*b*/)
+  void set_use_vertex(bool b)
   {
   }
 
-  void setInitialResMultiplier(int /*beta*/)
+  void setInitialResMultiplier(int beta)
   {
   }
-  void setFullResMultiplier(int /*lambda*/)
+  void setFullResMultiplier(int lambda)
   {
   }
 
   /// set the minimum pT to try to find during initial vertex finding tracking
-  void set_min_pT_init(float /*PT*/)
+  void set_min_pT_init(float PT)
   {
   }
 
   /// limit the maximum error reported by cluster (in number of cell units)
-  void setMaxClusterError(float /*max_cluster_error*/)
+  void setMaxClusterError(float max_cluster_error)
   {
   }
 
   /// use the cell size as cluster size instead of value stored on cluster
-  void setUseCellSize(bool /*use_cell_size*/)
+  void setUseCellSize(bool use_cell_size)
   {
   }
 
   /// set the tracking chi2 for initial vertex finding
-  void set_chi2_cut_init(double /*chi2_cut*/)
+  void set_chi2_cut_init(double chi2_cut)
   {
   }
 

--- a/offline/packages/trackreco/PHHybridSeeding.cc
+++ b/offline/packages/trackreco/PHHybridSeeding.cc
@@ -230,7 +230,7 @@ int PHHybridSeeding::InitializeGeometry(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHHybridSeeding::Process(PHCompositeNode */*topNode*/)
+int PHHybridSeeding::Process(PHCompositeNode *topNode)
 {
   // wipe previous vertex coordinates
   _vertex_x.clear();

--- a/offline/packages/trackreco/PHInitZVertexing.cc
+++ b/offline/packages/trackreco/PHInitZVertexing.cc
@@ -719,7 +719,7 @@ int PHInitZVertexing::initialize_geometry(PHCompositeNode *topNode) {
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHInitZVertexing::translate_input(PHCompositeNode* /*topNode*/) {
+int PHInitZVertexing::translate_input(PHCompositeNode* topNode) {
 
   unsigned int clusid = 0;
   unsigned int ilayer = 0;
@@ -2333,7 +2333,7 @@ int PHInitZVertexing::fit_vertex(){
 } 
 
 void PHInitZVertexing::convertHelixCovarianceToEuclideanCovariance(float B,
-								   float phi, float d, float kappa, float /*z0*/, float dzdl,
+		float phi, float d, float kappa, float z0, float dzdl,
 		Eigen::Matrix<float, 5, 5> const& input,
 		Eigen::Matrix<float, 6, 6>& output) {
 

--- a/offline/packages/trackreco/PHRTreeSeeding.cc
+++ b/offline/packages/trackreco/PHRTreeSeeding.cc
@@ -482,7 +482,7 @@ void PHRTreeSeeding::FillTree()
   std::cout << "number of duplicates : " << n_dupli << std::endl;
 }
 
-int PHRTreeSeeding::Process(PHCompositeNode */*topNode*/)
+int PHRTreeSeeding::Process(PHCompositeNode *topNode)
 {
   TFile fpara("rtree_para.root", "RECREATE");
   TNtuple *NT = new TNtuple("NT", "NT", "pt:dpt:z:dz:phi:dphi:c:dc:nhit");

--- a/offline/packages/trackreco/PHRaveVertexing.cc
+++ b/offline/packages/trackreco/PHRaveVertexing.cc
@@ -95,7 +95,7 @@ PHRaveVertexing::PHRaveVertexing(const string& name)
 /*
  * Init
  */
-int PHRaveVertexing::Init(PHCompositeNode* /*topNode*/)
+int PHRaveVertexing::Init(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -214,7 +214,7 @@ int PHRaveVertexing::process_event(PHCompositeNode* topNode)
 /*
  * End
  */
-int PHRaveVertexing::End(PHCompositeNode* /*topNode*/)
+int PHRaveVertexing::End(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -25,9 +25,6 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   void set_track_map_name_silicon(const std::string &map_name) { _track_map_name_silicon = map_name; }
   void set_phi_search_window(const double win){_phi_search_win = win;}
   void set_eta_search_window(const double win){_eta_search_win = win;}
-  void set_x_search_window(const double win){_x_search_win = win;}
-  void set_y_search_window(const double win){_y_search_win = win;}
-  void set_z_search_window(const double win){_z_search_win = win;}
   void set_search_par_values(const double p0, const double p1, const double p2){_par0 = p0; _par1 = p1; _par2 = p2; }
   void set_seeder(const bool is_ca_seeder){_is_ca_seeder = is_ca_seeder;}
 
@@ -59,9 +56,6 @@ class PHSiliconTpcTrackMatching : public PHTrackPropagating
   // default values, can be replaced from the macro
   double _phi_search_win = 0.01;
   double _eta_search_win = 0.004;
-  double _x_search_win = 0.3;
-  double _y_search_win = 0.3;
-  double _z_search_win = 0.4;
   
   SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -73,7 +73,7 @@ int PHSiliconTruthTrackSeeding::Setup(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* /*topNode*/)
+int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* topNode)
 {
   // We start with all reco clusters in the silicon layers
   // get the associated truth g4hits and from that the g4particle

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -66,7 +66,7 @@ int PHTpcClusterMover::InitRun(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
+int PHTpcClusterMover::process_event(PHCompositeNode *topNode)
 {
 
   if(Verbosity() > 0)
@@ -185,7 +185,7 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHTpcClusterMover::End(PHCompositeNode */*topNode*/)
+int PHTpcClusterMover::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.cc
@@ -51,9 +51,9 @@ PHTpcTrackSeedVertexAssoc::~PHTpcTrackSeedVertexAssoc()
 //____________________________________________________________________________..
 int PHTpcTrackSeedVertexAssoc::Setup(PHCompositeNode *topNode)
 {
-  //  std::cout << PHWHERE << " Parameters: _reject_xy_outliers " << _reject_xy_outliers << " _xy_residual_cut " << _xy_residual_cut
-  //	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut  << " _refit " << _refit
-  //	    << std::endl; 
+  std::cout << PHWHERE << " Parameters: _reject_xy_outliers " << _reject_xy_outliers << " _xy_residual_cut " << _xy_residual_cut
+	    << " _reject_z_outliers " << _reject_z_outliers << " _z_residual_cut " << _z_residual_cut  << " _refit " << _refit
+	    << std::endl; 
 
   int ret = PHTrackPropagating::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
@@ -69,17 +69,30 @@ int PHTpcTrackSeedVertexAssoc::Process()
 {
   // _track_map contains the TPC seed track stubs
   // We want to associate these TPC track seeds with a collision vertex
+  // Then we add the collision vertex position as the track seed position
   // All we need is to project the TPC clusters in Z to the beam line.
-  // The TPC track seeds are given a position that is the PCA of the line and circle fit to the beam line
+
+  double grand_circle_rms_squared = 0.0;
+  double grand_circle_wt = 0.0;
+  double grand_line_rms_squared = 0.0;
+  double grand_line_wt = 0.0;
+
+  double bad_clusters_per_track_xy = 0.0;
+  double bad_clusters_per_track_xy_wt = 0.0;
+  double bad_clusters_per_track_z = 0.0;
+  double bad_clusters_per_track_z_wt = 0.0;
 
   if(Verbosity() > 0)
     cout << PHWHERE << " TPC track map size " << _track_map->size()  << endl;
 
   // loop over the TPC track seeds
+  std::set<unsigned int> bad_tracks;
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
        ++phtrk_iter)
     {
+      std::set<TrkrDefs::cluskey> bad_clusters;
+
       _tracklet_tpc = phtrk_iter->second;
       
       if (Verbosity() > 1)
@@ -154,18 +167,124 @@ int PHTpcTrackSeedVertexAssoc::Process()
       auto vertex = _vertex_map->find(trackVertexId)->second;
       vertex->insert_track(phtrk_iter->first);
 
-      // set the track Z position to the Z dca
-      _tracklet_tpc->set_z(_z_proj);
+      // set the track position to the vertex position
+      _tracklet_tpc->set_x(vertex->get_x());
+      _tracklet_tpc->set_y(vertex->get_y());
+      _tracklet_tpc->set_z(vertex->get_z());
 
       if(Verbosity() > 1)
 	  std::cout << "    TPC seed track " << phtrk_iter->first << " matched to vertex " << trackVertexId << endl; 
 
       // Finished association of track with vertex, now we modify the track parameters
 
+      // Repeat the z line fit including the vertex position, get theta, update pz
+      std::vector<std::pair<double, double>> points;
+      double r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
+      double z_vertex = vertex->get_z();
+      points.push_back(make_pair(r_vertex, z_vertex));
+      for (unsigned int i=0; i<clusters.size(); ++i)
+	{
+	  double z = clusters[i]->getZ();
+	  double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
+	  
+	  points.push_back(make_pair(r,z));
+	}
+      
+      line_fit(points, A, B);
+      if(Verbosity() > 2) 
+	std::cout << "       Fitted line including vertex has A " << A << " B " << B << std::endl;      
+
+      // optionally reject clusters with large residuals
+      if(_reject_z_outliers)
+	{
+	  std::vector<double> line_residuals = GetLineClusterResiduals(points, A, B);
+	  double line_rms_squared = 0.0;
+	  double line_wt = 0.0;
+	  for(unsigned int i = 1; i < points.size(); ++i)
+	    {
+	      double res_squared =  line_residuals[i]*line_residuals[i];
+	      //if(sqrt(res_squared) < 0.15)  // 1.5 mm, about 3 sigma
+	      if(sqrt(res_squared) < _z_residual_cut)  
+		{
+		  line_rms_squared += res_squared;
+		  line_wt += 1.0;
+		  //std::cout << " cluster " << i-1 << " r " << points[i].first << " z " << points[i].second << " residual " << line_residuals[i] << std::endl;
+		}
+	      else
+		{
+		  // flag this cluster for removal from the track
+		  bad_clusters.insert(clusters[i-1]->getClusKey());
+		  //std::cout << " bad cluster " << i << " r " << points[i].first << " z " << points[i].second << " line residual " << line_residuals[i] 
+		  //	<< " z from cluster " << clusters[i-1]->getZ() << std::endl;
+		}
+	    }
+	  double line_rms = sqrt(line_rms_squared / line_wt);
+	  if(Verbosity() > 5) 
+	    std::cout << " line_rms = " << line_rms << " line_rms_squared " << line_rms_squared << " line_wt " << line_wt << std::endl;
+	  
+	  grand_line_rms_squared += line_rms_squared;
+	  grand_line_wt += line_wt;
+
+	  // Remove the bad clusters from the track here, remake the clusters list,  and refit the line
+	  for(auto &key : bad_clusters)
+	    {
+	      if(Verbosity() > 5) std::cout << " TPC tracklet " << _tracklet_tpc->get_id() << " removing bad Z cluster " << key << std::endl;
+	      _tracklet_tpc->erase_cluster_key(key);
+	    }
+
+	  if(nlayers > 40)
+	    {
+	      bad_clusters_per_track_z += bad_clusters.size();
+	      bad_clusters_per_track_z_wt += 1.0;
+	    }
+
+	  // remake the cluster list for this track
+	  clusters.clear();
+	  clusters = getTrackClusters(_tracklet_tpc);
+
+	  if(Verbosity() > 2) 
+	    std::cout << "    z rejection: removed " << bad_clusters.size() << " bad clusters from track " << _tracklet_tpc->get_id() 
+		      << "    remaining clusters " << clusters.size() << " in track " << _tracklet_tpc->get_id() << std::endl;
+
+	  if(clusters.size() < 10)
+	    {
+	      if(Verbosity() > 2) std::cout << "    erasing tracklet " << _tracklet_tpc->get_id()  << std::endl;
+	      //_track_map->erase(_tracklet_tpc->get_id());	      
+	      bad_tracks.insert(_tracklet_tpc->get_id());
+	      continue;
+	    }
+
+	  //optionally refit the line
+	  if(_refit)
+	    {
+	      // refit the line
+	      points.clear();
+	      r_vertex = sqrt(vertex->get_x()*vertex->get_x() + vertex->get_y()*vertex->get_y());
+	      z_vertex = vertex->get_z();
+	      points.push_back(make_pair(r_vertex, z_vertex));
+	      for (unsigned int i=0; i<clusters.size(); ++i)
+		{
+		  double r = sqrt(pow(clusters[i]->getX(),2) + pow(clusters[i]->getY(), 2));
+		  double z = clusters[i]->getZ();	      
+		  points.push_back(make_pair(r,z));
+		}
+	      
+	      line_fit(points, A, B);
+	      if(Verbosity() > 2) 
+		std::cout << "       After bad cluster removal, re-fitted line including vertex has A " << A << " B " << B << std::endl;      	  
+	    }
+
+	  bad_clusters.clear();
+	}
+
       // extract the track theta
       double track_angle = atan(A);  // referenced to 90 degrees
 
-       std::vector<std::pair<double, double>> cpoints;
+      // try dropping this fit including vertex, and adjusting further down 
+      std::vector<std::pair<double, double>> cpoints;
+      double x_vertex = vertex->get_x();
+      double y_vertex = vertex->get_y();
+      //cpoints.push_back(std::make_pair(x_vertex, y_vertex));
       for (unsigned int i=0; i<clusters.size(); ++i)
 	{
 	  cpoints.push_back(make_pair(clusters[i]->getX(), clusters[i]->getY()));
@@ -177,11 +296,91 @@ int PHTpcTrackSeedVertexAssoc::Process()
       if(Verbosity() > 2) 
 	std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 
-      // set the track x and y positions to the circle PCA
-      double dcax, dcay;
-      findRoot(R, X0, Y0, dcax, dcay);
-      _tracklet_tpc->set_x(dcax);
-      _tracklet_tpc->set_y(dcay);
+      // optionally reject clusters with large residuals in (x,y)
+      if(_reject_xy_outliers)
+	{
+	  double circle_rms_squared = 0.0;
+	  double circle_wt = 0.0;
+	  std::vector<double> residuals = GetCircleClusterResiduals(cpoints, R, X0, Y0);
+	  for(unsigned int i = 1; i < cpoints.size(); ++i)
+	    {
+	      double res_squared =  residuals[i]*residuals[i];
+	      if(sqrt(res_squared) < _xy_residual_cut)  
+		{
+		  circle_rms_squared += res_squared;
+		  circle_wt += 1.0;
+		  //std::cout << " cluster " << i << " x " << cpoints[i].first << " y " << cpoints[i].second << " residual " << residuals[i] << std::endl;
+		}
+	      else
+		{
+		  // flag this cluster for removal from the track
+		  bad_clusters.insert(clusters[i-1]->getClusKey());
+		  //std::cout << " bad cluster " << i << " x " << cpoints[i].first << " y " << cpoints[i].second << " residual " << residuals[i]  << std::endl;
+		}
+	    }
+	  double circle_rms = sqrt(circle_rms_squared / circle_wt);
+	  if(Verbosity() > 5) std::cout << " circle_rms = " << circle_rms << " circle_rms_squared " << circle_rms_squared 
+					<< " circle_wt " << circle_wt << std::endl;
+	  
+	  grand_circle_rms_squared += circle_rms_squared;
+	  grand_circle_wt += circle_wt;
+
+	  if(nlayers > 40)
+	    {
+	      bad_clusters_per_track_xy += bad_clusters.size();
+	      bad_clusters_per_track_xy_wt += 1.0;
+	    }
+
+	  // Remove the bad clusters from the track here, remake the clusters list
+	  for(auto &key : bad_clusters)
+	    {
+	      if(Verbosity() > 5) std::cout << " TPC tracklet " << _tracklet_tpc->get_id() << " removing bad xy cluster " << key << std::endl;
+	      _tracklet_tpc->erase_cluster_key(key);
+	    }
+
+	  clusters.clear();
+	  clusters = getTrackClusters(_tracklet_tpc);
+
+	  if(Verbosity() > 2) 
+	    std::cout << "    xy rejection:  removed " << bad_clusters.size() << " bad clusters from track " << _tracklet_tpc->get_id() 
+		      << "    remaining clusters " << clusters.size() << " in track " << _tracklet_tpc->get_id() << std::endl;
+
+	  if(clusters.size() < 10)
+	    {
+	      if(Verbosity() > 2) std::cout << "   marking tracklet " << _tracklet_tpc->get_id()  << " to be erased" << std::endl;
+	      bad_tracks.insert(_tracklet_tpc->get_id());
+	      continue;
+	    }
+	  /*
+	  cpoints.clear();
+	  cpoints.push_back(std::make_pair(x_vertex, y_vertex));
+	  for (unsigned int i=0; i<clusters.size(); ++i)
+	    {
+	      double x = clusters[i]->getX();
+	      double y = clusters[i]->getY();	  
+	      cpoints.push_back(make_pair(x, y));
+	    }
+	  */
+	  bad_clusters.clear();
+	}
+
+      // Add vertex to cpoints
+      cpoints.clear();
+      cpoints.push_back(std::make_pair(x_vertex, y_vertex));
+      for (unsigned int i=0; i<clusters.size(); ++i)
+	{
+	  double x = clusters[i]->getX();
+	  double y = clusters[i]->getY();	  
+	  cpoints.push_back(make_pair(x, y));
+	}
+
+      // optionally refit the circle with vertex included
+      if(_refit)
+	{
+	  CircleFitByTaubin(cpoints, R, X0, Y0);
+	  if(Verbosity() > 2) 
+	    std::cout << " after bad xy cluster removal, re-fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+	}
       
       double pt_track = _tracklet_tpc->get_pt();
       if(Verbosity() > 5)
@@ -194,19 +393,6 @@ int PHTpcTrackSeedVertexAssoc::Process()
       
       // We want the angle of the tangent relative to the positive x axis
       // start with the angle of the radial line from vertex to circle center
-
-      // Add vertex to cpoints
-      cpoints.clear();
-      double x_vertex = vertex->get_x();
-      double y_vertex = vertex->get_y();
-      cpoints.push_back(std::make_pair(x_vertex, y_vertex));
-      for (unsigned int i=0; i<clusters.size(); ++i)
-	{
-	  double x = clusters[i]->getX();
-	  double y = clusters[i]->getY();	  
-	  cpoints.push_back(make_pair(x, y));
-	}
-
       double dx = X0 - x_vertex;
       double dy = Y0 - y_vertex;
       double phi= atan2(dy,dx);
@@ -264,7 +450,33 @@ int PHTpcTrackSeedVertexAssoc::Process()
       
     }  // end loop over TPC track seeds
 
-   if(Verbosity() > 0)  
+  for(auto &key : bad_tracks)
+    {
+      std::cout << "Erase track " << key << " with too few clusters" << std::endl;
+      _track_map->erase(key);	      
+    }
+  bad_tracks.clear();
+
+  bad_clusters_per_track_z /= bad_clusters_per_track_z_wt;
+  bad_clusters_per_track_xy /= bad_clusters_per_track_xy_wt;
+  if(Verbosity() > 0)
+    std::cout << "Bad clusters per track:  z:  wt " << bad_clusters_per_track_z_wt << " bad clusters "  << bad_clusters_per_track_z 
+	      << " xy: wt " << bad_clusters_per_track_xy_wt << " bad clusters "  << bad_clusters_per_track_xy << std::endl;
+
+  if(_reject_z_outliers && Verbosity() > 5)
+    {
+      double grand_line_rms =  sqrt(grand_line_rms_squared / grand_line_wt);  
+      std::cout << "grand_line_rms = " << grand_line_rms << " grand_line_rms_squared " << grand_line_rms_squared 
+		<< " grand_line_wt " << grand_line_wt << std::endl;
+    }
+
+  if(_reject_xy_outliers && Verbosity() > 5)
+    {
+      double grand_circle_rms =  sqrt(grand_circle_rms_squared / grand_circle_wt);  
+      std::cout << "grand circle rms = " << grand_circle_rms << " grand_circle_rms_squared " << grand_circle_rms_squared << " grand_circle_wt " << grand_circle_wt << std::endl;
+    }
+  
+  if(Verbosity() > 0)  
     cout << " Final track map size " << _track_map->size() << endl;
   
   if (Verbosity() > 0)
@@ -278,7 +490,7 @@ int PHTpcTrackSeedVertexAssoc::End()
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int  PHTpcTrackSeedVertexAssoc::GetNodes(PHCompositeNode* /*topNode*/)
+int  PHTpcTrackSeedVertexAssoc::GetNodes(PHCompositeNode* topNode)
 {
   //---------------------------------
   // Get additional objects off the Node Tree
@@ -492,55 +704,4 @@ std::vector<TrkrCluster*> PHTpcTrackSeedVertexAssoc::getTrackClusters(SvtxTrack 
 		  << "  " << tpc_clus->getY() << "  " << tpc_clus->getZ() << " clusters.size() " << clusters.size() << std::endl;
     }
   return clusters;
-}
-
-void PHTpcTrackSeedVertexAssoc::findRoot(const double R, const double X0,
-				    const double Y0, double& x,
-				    double& y)
-{
-  /**
-   * We need to determine the closest point on the circle to the origin
-   * since we can't assume that the track originates from the origin
-   * The eqn for the circle is (x-X0)^2+(y-Y0)^2=R^2 and we want to 
-   * minimize d = sqrt((0-x)^2+(0-y)^2), the distance between the 
-   * origin and some (currently, unknown) point on the circle x,y.
-   * 
-   * Solving the circle eqn for x and substituting into d gives an eqn for
-   * y. Taking the derivative and setting equal to 0 gives the following 
-   * two solutions. We take the smaller solution as the correct one, as 
-   * usually one solution is wildly incorrect (e.g. 1000 cm)
-   */
-  
-  double miny = (sqrt(pow(X0, 2) * pow(R, 2) * pow(Y0, 2) + pow(R, 2) 
-		      * pow(Y0,4)) + pow(X0,2) * Y0 + pow(Y0, 3)) 
-    / (pow(X0, 2) + pow(Y0, 2));
-
-  double miny2 = (-sqrt(pow(X0, 2) * pow(R, 2) * pow(Y0, 2) + pow(R, 2) 
-		      * pow(Y0,4)) + pow(X0,2) * Y0 + pow(Y0, 3)) 
-    / (pow(X0, 2) + pow(Y0, 2));
-
-  double minx = sqrt(pow(R, 2) - pow(miny - Y0, 2)) + X0;
-  double minx2 = -sqrt(pow(R, 2) - pow(miny2 - Y0, 2)) + X0;
-  
-  if(Verbosity() > 1)
-    std::cout << "minx1 and x2 : " << minx << ", " << minx2 << std::endl
-	      << "miny1 and y2 : " << miny << ", " << miny2 << std::endl;
-
-  /// Figure out which of the two roots is actually closer to the origin
-  if(fabs(minx) < fabs(minx2))
-    x = minx;
-  else
-    x = minx2;
-
-  if(fabs(miny) < fabs(miny2))
-    y = miny;
-  else
-    y = miny2;
-  
-  if(Verbosity() > 1)
-    {
-      std::cout << "Minimum x and y positions " << x << ",  " 
-		<< y << std::endl;
-    }
-
 }

--- a/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedVertexAssoc.h
@@ -23,6 +23,13 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
 
   ~PHTpcTrackSeedVertexAssoc() override;
 
+  void reject_xy_outliers(const bool reject){_reject_xy_outliers = reject;}  
+  void reject_z_outliers(const bool reject){_reject_z_outliers = reject;}
+
+  void set_xy_residual_cut(const double cut){_xy_residual_cut = cut;}
+  void set_z_residual_cut(const double cut){_z_residual_cut = cut;}
+  void set_refit(const bool refit) {_refit = refit;}
+
  protected:
   int Setup(PHCompositeNode* topNode) override;
 
@@ -40,7 +47,6 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   std::vector<double> GetCircleClusterResiduals(std::vector<std::pair<double,double>> points, double R, double X0, double Y0);
   std::vector<double> GetLineClusterResiduals(std::vector<std::pair<double,double>> points, double A, double B);
   std::vector<TrkrCluster*> getTrackClusters(SvtxTrack *_tracklet_tpc);
-  void findRoot(const double R, const double X0, const double Y0, double& x, double& y);
 						    
   std::string _track_map_name_silicon;
 
@@ -51,6 +57,13 @@ class PHTpcTrackSeedVertexAssoc : public PHTrackPropagating
   unsigned int _max_tpc_layer = 54;
 
   double _z_proj= 0;
+
+  bool _reject_xy_outliers = false;
+  bool _reject_z_outliers = false;
+  bool _refit  = false;
+
+  double _xy_residual_cut = 0.08;
+  double _z_residual_cut = 0.22;
 
 };
 

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -45,7 +45,7 @@ int PHTrackCleaner::InitRun(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
+int PHTrackCleaner::process_event(PHCompositeNode *topNode)
 {
 
   if(Verbosity() > 0)
@@ -160,7 +160,7 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHTrackCleaner::End(PHCompositeNode */*topNode*/)
+int PHTrackCleaner::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTrackFitting.cc
+++ b/offline/packages/trackreco/PHTrackFitting.cc
@@ -31,7 +31,7 @@ PHTrackFitting::PHTrackFitting(const std::string& name)
 {
 }
 
-int PHTrackFitting::Init(PHCompositeNode* /*topNode*/)
+int PHTrackFitting::Init(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -41,7 +41,7 @@ int PHTrackFitting::InitRun(PHCompositeNode* topNode)
   return Setup(topNode);
 }
 
-int PHTrackFitting::process_event(PHCompositeNode* /*topNode*/)
+int PHTrackFitting::process_event(PHCompositeNode* topNode)
 {
   return Process();
 }

--- a/offline/packages/trackreco/PHTrackPropagating.cc
+++ b/offline/packages/trackreco/PHTrackPropagating.cc
@@ -36,12 +36,12 @@ int PHTrackPropagating::InitRun(PHCompositeNode* topNode)
   return Setup(topNode);
 }
 
-int PHTrackPropagating::process_event(PHCompositeNode* /*topNode*/)
+int PHTrackPropagating::process_event(PHCompositeNode* topNode)
 {
   return Process();
 }
 
-int PHTrackPropagating::End(PHCompositeNode* /*topNode*/)
+int PHTrackPropagating::End(PHCompositeNode* topNode)
 {
   End();
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTrackSeeding.cc
@@ -40,7 +40,7 @@ int PHTrackSeeding::process_event(PHCompositeNode* topNode)
   return Process(topNode);
 }
 
-int PHTrackSeeding::End(PHCompositeNode* /*topNode*/)
+int PHTrackSeeding::End(PHCompositeNode* topNode)
 {
   return End();
 }

--- a/offline/packages/trackreco/PHTrackSetMerging.cc
+++ b/offline/packages/trackreco/PHTrackSetMerging.cc
@@ -28,7 +28,7 @@ PHTrackSetMerging::PHTrackSetMerging(const std::string& name)
 {
 }
 
-int PHTrackSetMerging::Init(PHCompositeNode* /*topNode*/)
+int PHTrackSetMerging::Init(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -38,12 +38,12 @@ int PHTrackSetMerging::InitRun(PHCompositeNode* topNode)
   return Setup(topNode);
 }
 
-int PHTrackSetMerging::process_event(PHCompositeNode* /*topNode*/)
+int PHTrackSetMerging::process_event(PHCompositeNode* topNode)
 {
   return Process();
 }
 
-int PHTrackSetMerging::End(PHCompositeNode* /*topNode*/)
+int PHTrackSetMerging::End(PHCompositeNode* topNode)
 {
   return End();
 }

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -42,7 +42,7 @@ PHTruthSiliconAssociation::~PHTruthSiliconAssociation()
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::Init(PHCompositeNode */*topNode*/)
+int PHTruthSiliconAssociation::Init(PHCompositeNode *topNode)
 {
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -57,7 +57,7 @@ int PHTruthSiliconAssociation::InitRun(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
+int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() >= 1) 
     cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
@@ -273,32 +273,32 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode */*topNode*/)
+int PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode)
 {
   //cout << "PHTruthSiliconAssociation::ResetEvent(PHCompositeNode *topNode) Resetting internal structures, prepare for next event" << endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::EndRun(const int /*runnumber*/)
+int PHTruthSiliconAssociation::EndRun(const int runnumber)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::End(PHCompositeNode */*topNode*/)
+int PHTruthSiliconAssociation::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int PHTruthSiliconAssociation::Reset(PHCompositeNode */*topNode*/)
+int PHTruthSiliconAssociation::Reset(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-void PHTruthSiliconAssociation::Print(const std::string &/*what*/) const
+void PHTruthSiliconAssociation::Print(const std::string &what) const
 {
   //cout << "PHTruthSiliconAssociation::Print(const std::string &what) const Printing info for " << what << endl;
 }

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -17,7 +17,7 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
-     CXXFLAGS="$CXXFLAGS -Wall -Wextra"
+     CXXFLAGS="$CXXFLAGS -Wall"
 fi
 
 AM_CONDITIONAL([MAKE_ACTS],false)
@@ -25,7 +25,7 @@ dnl gcc 8.3 creates warning in boost header, needs -Wno-class-memaccess
 dnl need to check for *g++ since $CXX contains full path to g++
 case $CXX in
  clang++)
-   CXXFLAGS="$CXXFLAGS -Werror -Wno-undefined-var-template -Wno-unused-private-field -Wno-range-loop-construct -Wno-unused-local-typedef -Wno-deprecated-copy -Wno-sign-compare -Wno-unused-parameter"
+   CXXFLAGS="$CXXFLAGS -Werror -Wno-undefined-var-template -Wno-unused-private-field -Wno-range-loop-construct -Wno-unused-local-typedef"
    AM_CONDITIONAL([MAKE_ACTS],test `clang++ -dumpversion | awk '{print $1>=10.0?"1":"0"}'` = 1)
  ;;
  *analyzer)

--- a/offline/packages/trigger/CaloTriggerInfo.h
+++ b/offline/packages/trigger/CaloTriggerInfo.h
@@ -12,72 +12,72 @@ class CaloTriggerInfo : public PHObject
   int isValid() const override { return 0; }
 
   // EMCal 2x2
-  virtual void set_best_EMCal_2x2_E(const float /*E*/) {}
-  virtual void set_best_EMCal_2x2_eta(const float /*eta*/) {}
-  virtual void set_best_EMCal_2x2_phi(const float /*phi*/) {}
+  virtual void set_best_EMCal_2x2_E(const float E) {}
+  virtual void set_best_EMCal_2x2_eta(const float eta) {}
+  virtual void set_best_EMCal_2x2_phi(const float phi) {}
 
   virtual float get_best_EMCal_2x2_E() const { return 0; }
   virtual float get_best_EMCal_2x2_eta() const { return 0; }
   virtual float get_best_EMCal_2x2_phi() const { return 0; }
 
   // EMCal 4x4
-  virtual void set_best_EMCal_4x4_E(const float /*E*/) {}
-  virtual void set_best_EMCal_4x4_eta(const float /*eta*/) {}
-  virtual void set_best_EMCal_4x4_phi(const float /*phi*/) {}
+  virtual void set_best_EMCal_4x4_E(const float E) {}
+  virtual void set_best_EMCal_4x4_eta(const float eta) {}
+  virtual void set_best_EMCal_4x4_phi(const float phi) {}
 
   virtual float get_best_EMCal_4x4_E() const { return 0; }
   virtual float get_best_EMCal_4x4_eta() const { return 0; }
   virtual float get_best_EMCal_4x4_phi() const { return 0; }
 
   // 2nd best
-  virtual void set_best2_EMCal_4x4_E(const float /*E*/) {}
-  virtual void set_best2_EMCal_4x4_eta(const float /*eta*/) {}
-  virtual void set_best2_EMCal_4x4_phi(const float /*phi*/) {}
+  virtual void set_best2_EMCal_4x4_E(const float E) {}
+  virtual void set_best2_EMCal_4x4_eta(const float eta) {}
+  virtual void set_best2_EMCal_4x4_phi(const float phi) {}
 
   virtual float get_best2_EMCal_4x4_E() const { return 0; }
   virtual float get_best2_EMCal_4x4_eta() const { return 0; }
   virtual float get_best2_EMCal_4x4_phi() const { return 0; }
 
   // FullCalo 0.2x0.2
-  virtual void set_best_FullCalo_0p2x0p2_E(const float /*E*/) {}
-  virtual void set_best_FullCalo_0p2x0p2_eta(const float /*eta*/) {}
-  virtual void set_best_FullCalo_0p2x0p2_phi(const float /*phi*/) {}
+  virtual void set_best_FullCalo_0p2x0p2_E(const float E) {}
+  virtual void set_best_FullCalo_0p2x0p2_eta(const float eta) {}
+  virtual void set_best_FullCalo_0p2x0p2_phi(const float phi) {}
 
   virtual float get_best_FullCalo_0p2x0p2_E() const { return 0; }
   virtual float get_best_FullCalo_0p2x0p2_eta() const { return 0; }
   virtual float get_best_FullCalo_0p2x0p2_phi() const { return 0; }
 
   // FullCalo 0.4x0.4
-  virtual void set_best_FullCalo_0p4x0p4_E(const float /*E*/) {}
-  virtual void set_best_FullCalo_0p4x0p4_eta(const float /*eta*/) {}
-  virtual void set_best_FullCalo_0p4x0p4_phi(const float /*phi*/) {}
+  virtual void set_best_FullCalo_0p4x0p4_E(const float E) {}
+  virtual void set_best_FullCalo_0p4x0p4_eta(const float eta) {}
+  virtual void set_best_FullCalo_0p4x0p4_phi(const float phi) {}
 
   virtual float get_best_FullCalo_0p4x0p4_E() const { return 0; }
   virtual float get_best_FullCalo_0p4x0p4_eta() const { return 0; }
   virtual float get_best_FullCalo_0p4x0p4_phi() const { return 0; }
 
   // FullCalo 0.6x0.6
-  virtual void set_best_FullCalo_0p6x0p6_E(const float /*E*/) {}
-  virtual void set_best_FullCalo_0p6x0p6_eta(const float /*eta*/) {}
-  virtual void set_best_FullCalo_0p6x0p6_phi(const float /*phi*/) {}
+  virtual void set_best_FullCalo_0p6x0p6_E(const float E) {}
+  virtual void set_best_FullCalo_0p6x0p6_eta(const float eta) {}
+  virtual void set_best_FullCalo_0p6x0p6_phi(const float phi) {}
 
   virtual float get_best_FullCalo_0p6x0p6_E() const { return 0; }
   virtual float get_best_FullCalo_0p6x0p6_eta() const { return 0; }
   virtual float get_best_FullCalo_0p6x0p6_phi() const { return 0; }
 
   // FullCalo 0.8x0.8
-  virtual void set_best_FullCalo_0p8x0p8_E(const float /*E*/) {}
-  virtual void set_best_FullCalo_0p8x0p8_eta(const float /*eta*/) {}
-  virtual void set_best_FullCalo_0p8x0p8_phi(const float /*phi*/) {}
+  virtual void set_best_FullCalo_0p8x0p8_E(const float E) {}
+  virtual void set_best_FullCalo_0p8x0p8_eta(const float eta) {}
+  virtual void set_best_FullCalo_0p8x0p8_phi(const float phi) {}
 
   virtual float get_best_FullCalo_0p8x0p8_E() const { return 0; }
   virtual float get_best_FullCalo_0p8x0p8_eta() const { return 0; }
   virtual float get_best_FullCalo_0p8x0p8_phi() const { return 0; }
 
   // FullCalo 1.0x1.0
-  virtual void set_best_FullCalo_1p0x1p0_E(const float /*E*/) {}
-  virtual void set_best_FullCalo_1p0x1p0_eta(const float /*eta*/) {}
-  virtual void set_best_FullCalo_1p0x1p0_phi(const float /*phi*/) {}
+  virtual void set_best_FullCalo_1p0x1p0_E(const float E) {}
+  virtual void set_best_FullCalo_1p0x1p0_eta(const float eta) {}
+  virtual void set_best_FullCalo_1p0x1p0_phi(const float phi) {}
 
   virtual float get_best_FullCalo_1p0x1p0_E() const { return 0; }
   virtual float get_best_FullCalo_1p0x1p0_eta() const { return 0; }

--- a/offline/packages/trigger/configure.ac
+++ b/offline/packages/trigger/configure.ac
@@ -10,10 +10,10 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/offline/packages/vararray/configure.ac
+++ b/offline/packages/vararray/configure.ac
@@ -8,14 +8,8 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
-
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/simulation/g4simulation/EICPhysicsList/configure.ac
+++ b/simulation/g4simulation/EICPhysicsList/configure.ac
@@ -10,10 +10,10 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-final-dtor-non-final-class -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-final-dtor-non-final-class"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4bbc/BbcVertex.h
+++ b/simulation/g4simulation/g4bbc/BbcVertex.h
@@ -20,19 +20,19 @@ class BbcVertex : public PHObject
   // vertex info
 
   virtual unsigned int get_id() const { return 0xFFFFFFFF; }
-  virtual void set_id(unsigned int) {}
+  virtual void set_id(unsigned int id) {}
 
   virtual float get_t() const { return NAN; }
-  virtual void set_t(float) {}
+  virtual void set_t(float t) {}
 
   virtual float get_t_err() const { return NAN; }
-  virtual void set_t_err(float) {}
+  virtual void set_t_err(float t_err) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float z) {}
 
   virtual float get_z_err() const { return NAN; }
-  virtual void set_z_err(float) {}
+  virtual void set_z_err(float z_err) {}
 
  protected:
   BbcVertex() {}

--- a/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.cc
+++ b/simulation/g4simulation/g4bbc/BbcVertexFastSimReco.cc
@@ -43,7 +43,7 @@ BbcVertexFastSimReco::~BbcVertexFastSimReco()
   gsl_rng_free(RandomGenerator);
 }
 
-int BbcVertexFastSimReco::Init(PHCompositeNode */*topNode*/)
+int BbcVertexFastSimReco::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -128,7 +128,7 @@ int BbcVertexFastSimReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int BbcVertexFastSimReco::End(PHCompositeNode */*topNode*/)
+int BbcVertexFastSimReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4bbc/BbcVertexMap.cc
+++ b/simulation/g4simulation/g4bbc/BbcVertexMap.cc
@@ -7,7 +7,7 @@ BbcVertexMap::ConstIter BbcVertexMap::begin() const
   return DummyBbcVertexMap.end();
 }
 
-BbcVertexMap::ConstIter BbcVertexMap::find(unsigned int /*idkey*/) const
+BbcVertexMap::ConstIter BbcVertexMap::find(unsigned int idkey) const
 {
   return DummyBbcVertexMap.end();
 }
@@ -23,7 +23,7 @@ BbcVertexMap::Iter BbcVertexMap:: begin()
   return DummyBbcVertexMap.end();
 }
 
-BbcVertexMap::Iter BbcVertexMap::find(unsigned int /*idkey*/)
+BbcVertexMap::Iter BbcVertexMap::find(unsigned int idkey)
 {
   return DummyBbcVertexMap.end();
 }

--- a/simulation/g4simulation/g4bbc/BbcVertexMap.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexMap.h
@@ -20,13 +20,13 @@ class BbcVertexMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }
-  virtual size_t count(unsigned int /*idkey*/) const { return 0; }
+  virtual size_t count(unsigned int idkey) const { return 0; }
   virtual void clear() {}
 
-  virtual const BbcVertex* get(unsigned int /*idkey*/) const { return nullptr; }
-  virtual BbcVertex* get(unsigned int /*idkey*/) { return nullptr; }
-  virtual BbcVertex* insert(BbcVertex* /*vertex*/) { return nullptr; }
-  virtual size_t erase(unsigned int /*idkey*/) { return 0; }
+  virtual const BbcVertex* get(unsigned int idkey) const { return nullptr; }
+  virtual BbcVertex* get(unsigned int idkey) { return nullptr; }
+  virtual BbcVertex* insert(BbcVertex* vertex) { return nullptr; }
+  virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;

--- a/simulation/g4simulation/g4bbc/configure.ac
+++ b/simulation/g4simulation/g4bbc/configure.ac
@@ -9,10 +9,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.cc
+++ b/simulation/g4simulation/g4calo/RawTowerBuilderByHitIndex.cc
@@ -157,7 +157,7 @@ int RawTowerBuilderByHitIndex::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerBuilderByHitIndex::End(PHCompositeNode */*topNode*/)
+int RawTowerBuilderByHitIndex::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -102,7 +102,7 @@ int RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RawTowerDigitizer::process_event(PHCompositeNode */*topNode*/)
+int RawTowerDigitizer::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity())
   {

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -9,10 +9,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4decayer/configure.ac
+++ b/simulation/g4simulation/g4decayer/configure.ac
@@ -20,14 +20,14 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template -Wno-shadow"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-shadow"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
@@ -29,7 +29,7 @@ BeamLineMagnetDisplayAction::~BeamLineMagnetDisplayAction()
   m_VisAttVec.clear();
 }
 
-void BeamLineMagnetDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void BeamLineMagnetDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
@@ -58,7 +58,7 @@ BeamLineMagnetSteppingAction::~BeamLineMagnetSteppingAction()
 }
 
 //____________________________________________________________________________..
-bool BeamLineMagnetSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_used*/)
+bool BeamLineMagnetSteppingAction::UserSteppingAction(const G4Step* aStep, bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
@@ -127,7 +127,6 @@ bool BeamLineMagnetSteppingAction::UserSteppingAction(const G4Step* aStep, bool 
       std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
                 << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
     }
-    [[fallthrough]];
   case fGeomBoundary:
   case fUndefined:
     if (!m_Hit)

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
@@ -173,7 +173,7 @@ void BeamLineMagnetSubsystem::SetDefaultParameters()
   set_default_double_param("outer_radius", 100);
 }
 
-void BeamLineMagnetSubsystem::Print(const string &/*what*/) const
+void BeamLineMagnetSubsystem::Print(const string &what) const
 {
   cout << Name() << " Parameters: " << endl;
   if (!BeginRunExecuted())

--- a/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
@@ -36,7 +36,7 @@
 class PHCompositeNode;
 
 //____________________________________________________________________________..
-PHG4BbcSteppingAction::PHG4BbcSteppingAction(PHG4BbcDetector* detector, const PHParameters* /*parameters*/)
+PHG4BbcSteppingAction::PHG4BbcSteppingAction(PHG4BbcDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
   , m_HitContainer(nullptr)
@@ -62,7 +62,7 @@ PHG4BbcSteppingAction::~PHG4BbcSteppingAction()
 }
 
 //____________________________________________________________________________..
-bool PHG4BbcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_used*/)
+bool PHG4BbcSteppingAction::UserSteppingAction(const G4Step* aStep, bool was_used)
 {
   //std::cout << PHWHERE << " In PHG4BbcSteppingAction::UserSteppingAction()" << std::endl;
 
@@ -149,7 +149,6 @@ bool PHG4BbcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
       std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
                 << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
     }
-    [[fallthrough]];
   // These are the normal cases
   case fGeomBoundary:
   case fUndefined:

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -29,7 +29,7 @@ int PHG4BeamlineMagnetSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-int PHG4BeamlineMagnetSubsystem::process_event(PHCompositeNode* /*topNode*/)
+int PHG4BeamlineMagnetSubsystem::process_event(PHCompositeNode* topNode)
 {
   return 0;
 }
@@ -64,7 +64,7 @@ void PHG4BeamlineMagnetSubsystem::SetDefaultParameters()
   set_default_string_param("material", "G4_Galactic");
 }
 
-void PHG4BeamlineMagnetSubsystem::Print(const string& /*what*/) const
+void PHG4BeamlineMagnetSubsystem::Print(const string& what) const
 {
   cout << Name() << " Parameters: " << endl;
   if (!BeginRunExecuted())

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -46,7 +46,7 @@ PHG4BlockCellReco::PHG4BlockCellReco(const string &name)
   SetDefaultParameters();
 }
 
-int PHG4BlockCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+int PHG4BlockCellReco::ResetEvent(PHCompositeNode *topNode)
 {
   sum_energy_g4hit = 0.;
   return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
@@ -26,7 +26,7 @@ PHG4BlockDisplayAction::~PHG4BlockDisplayAction()
   delete m_Colour;
 }
 
-void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   if (m_MyVolume->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
@@ -34,12 +34,12 @@ class PHG4BlockGeom: public PHObject
 
   virtual double get_rot_matrix(const int, const int) const {PHOOL_VIRTUAL_WARN("get_rot_matrix(const int, const int)"); return NAN;}
 
-  virtual void set_layer(const int) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
-  virtual void set_size(const double /*sizex*/, const double /*sizey*/, const double /*sizez*/)
+  virtual void set_layer(const int i) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
+  virtual void set_size(const double sizex, const double sizey, const double sizez)
     {PHOOL_VIRTUAL_WARN("set_size(const double, const double, const double)");}
-  virtual void set_place(const double /*placex*/, const double /*placey*/, const double /*placez*/)
+  virtual void set_place(const double placex, const double placey, const double placez)
     {PHOOL_VIRTUAL_WARN("set_place(const double, const double, const double)");}
-  virtual void set_z_rot(const double) {PHOOL_VIRTUAL_WARN("set_z_rot(const double)");}
+  virtual void set_z_rot(const double z) {PHOOL_VIRTUAL_WARN("set_z_rot(const double)");}
 
   virtual void convert_local_to_global(const double, const double, const double,
                                        double &, double &, double &) const

--- a/simulation/g4simulation/g4detectors/PHG4Cell.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.cc
@@ -29,11 +29,11 @@ PHG4Cell::CopyFrom(const PHObject *phobj)
 void
 PHG4Cell::identify(ostream& os) const
 {
-  os << "Class " << this->ClassName() << endl;
+  cout << "Class " << this->ClassName() << endl;
   return;
 }
 
-ostream& operator<<(ostream& stream, const PHG4Cell * /*cell*/){
+ostream& operator<<(ostream& stream, const PHG4Cell * cell){
   stream << "PHG4Cell"  << endl;
   return stream;
 }

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -41,17 +41,17 @@ class PHG4Cell: public PHObject
   friend std::ostream &operator<<(std::ostream & stream, const PHG4Cell * cell);
 
   // all methods connected to the cell id (encoding/decoding
-  virtual void set_cellid(const PHG4CellDefs::keytype) {return;}
+  virtual void set_cellid(const PHG4CellDefs::keytype i) {return;}
 
   virtual PHG4CellDefs::keytype get_cellid() const {return ~0x0;}
   virtual bool has_binning(const PHG4CellDefs::CellBinning) const {return false;}
 
   // this adds hits to the g4 hit list map
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/) {return;}
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/, const float /*light_yield*/) {return;}
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const int /*tbin*/, const float /*edep*/) {return;}
+  virtual void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) {return;}
+  virtual void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep, const float light_yield) {return;}
+  virtual void add_edep(const PHG4HitDefs::keytype g4hitid, const int tbin, const float edep) {return;}
   // this adds showers to the shower map
-  virtual void add_shower_edep(const int /*g4showerid*/, const float /*edep*/) {return;}
+  virtual void add_shower_edep(const int g4showerid, const float edep) {return;}
 
   virtual EdepConstRange get_g4hits();
 
@@ -61,44 +61,44 @@ class PHG4Cell: public PHObject
   // for backward compatibility, layers and detector ids are identical
   short int get_layer() const {return get_detid();}
 
-  virtual void add_edep(const float) {return;}
+  virtual void add_edep(const float f) {return;}
   virtual double get_edep() const {return NAN;}
 
-  virtual void add_eion(const float) {return;}
+  virtual void add_eion(const float f) {return;}
   virtual double get_eion() const {return NAN;}
 
-  virtual void add_light_yield(const float){return;}
+  virtual void add_light_yield(const float lightYield){return;}
   virtual float get_light_yield() const {return NAN;}
 
   // get/set methodes - PLEASE add those ALPHABETICALLY
 
-  virtual void set_chip_index(const int) {return;}
+  virtual void set_chip_index(const int i) {return;}
   virtual int get_chip_index() const {return ~0x0;}
 
-  virtual void set_half_stave_index(const int) {return;}
+  virtual void set_half_stave_index(const int i) {return;}
   virtual int get_half_stave_index() const {return ~0x0;}
 
-  virtual void set_ladder_phi_index(const int) {return;}
+  virtual void set_ladder_phi_index(const int i) {return;}
   virtual int get_ladder_phi_index() const {return ~0x0;}
 
-  virtual void set_ladder_z_index(const int) {return;}
+  virtual void set_ladder_z_index(const int i) {return;}
   virtual int get_ladder_z_index() const {return ~0x0;}
 
-  virtual void set_module_index(const int) {return;}
+  virtual void set_module_index(const int i) {return;}
   virtual int get_module_index() const {return ~0x0;}
 
-  virtual void set_phibin(const int) {return;}
+  virtual void set_phibin(const int i) {return;}
   virtual int get_phibin() const {return ~0x0;}
 
-  virtual void set_pixel_index(const int) {return;}
+  virtual void set_pixel_index(const int i) {return;}
   virtual int get_pixel_index() const {return ~0x0;}
 
-  virtual void set_stave_index(const int) {return;}
+  virtual void set_stave_index(const int i) {return;}
   virtual int get_stave_index() const {return ~0x0;}
 
 //  virtual tpctod* get_train_of_digits() {return 0;}
 
-  virtual void set_zbin(const int) {return;}
+  virtual void set_zbin(const int i) {return;}
   virtual int get_zbin() const {return ~0x0;}
 
 
@@ -141,21 +141,21 @@ class PHG4Cell: public PHObject
     type_unknown = -1
   };
 
-  virtual bool  has_property(const PROPERTY /*prop_id*/) const {return false;}
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const {return NAN;}
-  virtual int   get_property_int(const PROPERTY /*prop_id*/) const {return INT_MIN;}
-  virtual unsigned int   get_property_uint(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const float /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const int /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) {return;}
+  virtual bool  has_property(const PROPERTY prop_id) const {return false;}
+  virtual float get_property_float(const PROPERTY prop_id) const {return NAN;}
+  virtual int   get_property_int(const PROPERTY prop_id) const {return INT_MIN;}
+  virtual unsigned int   get_property_uint(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void  set_property(const PROPERTY prop_id, const float value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const int value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const unsigned int value) {return;}
   static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
   PHG4Cell() {}
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/,const unsigned int) {return;}
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void set_property_nocheck(const PROPERTY prop_id,const unsigned int) {return;}
   ClassDefOverride(PHG4Cell,2)
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
@@ -29,7 +29,7 @@ PHG4ConeDisplayAction::~PHG4ConeDisplayAction()
   delete m_Colour;
 }
 
-void PHG4ConeDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4ConeDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   if (m_MyVolume->GetVisAttributes())
   {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
@@ -26,15 +26,15 @@ class PHG4CylinderCell : public PHG4Cell
     os << "PHG4CylinderCell base class" << std::endl;
   }
   
-    void set_ladder_phi_index(const int) override {return;}
+    void set_ladder_phi_index(const int i) override {return;}
   int get_ladder_phi_index() const override {return -9999;}
 
-  void set_ladder_z_index(const int) override {return;}
+  void set_ladder_z_index(const int i) override {return;}
   int get_ladder_z_index() const override {return -9999;}
 
 // our own - not inherited  
-  virtual void set_cell_id(const PHG4CylinderCellDefs::keytype) {return;}
-  virtual void set_layer(const unsigned int) {return;}
+  virtual void set_cell_id(const PHG4CylinderCellDefs::keytype id) {return;}
+  virtual void set_layer(const unsigned int i) {return;}
 
   virtual unsigned int get_layer() const {return 0xFFFFFFFF;}
   virtual PHG4CylinderCellDefs::keytype get_cell_id() const {return 0xFFFFFFFF;}
@@ -42,21 +42,21 @@ class PHG4CylinderCell : public PHG4Cell
   virtual int get_binphi() const {return -1;}
   virtual int get_bineta() const {return -1;}
 
-  virtual void set_etabin(const int) {return;}
-  virtual void set_light_yield(float)  {   return;  }
+  virtual void set_etabin(const int i) {return;}
+  virtual void set_light_yield(float lightYield)  {   return;  }
 
-  virtual void set_fiber_ID(int) {   return;  }
+  virtual void set_fiber_ID(int fiberId) {   return;  }
   virtual int get_fiber_ID() const {return -1;}
 
-  virtual void set_sensor_index(const std::string &) {return;}
+  virtual void set_sensor_index(const std::string &si) {return;}
   virtual std::string get_sensor_index() const {return "";}
 
   virtual int get_j_index() const {return -9999;}
-  virtual void set_j_index(const int) {return;}
+  virtual void set_j_index(const int i) {return;}
   virtual int get_k_index() const {return -9999;}
-  virtual void set_k_index(const int) {return;}
+  virtual void set_k_index(const int i) {return;}
   virtual int get_l_index() const {return -9999;}
-  virtual void set_l_index(const int) {return;}
+  virtual void set_l_index(const int i) {return;}
 
    protected:
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
@@ -142,7 +142,7 @@ PHG4CylinderCellGeom_Spacalv1::get_etabounds(const int ibin) const
 }
 
 int
-PHG4CylinderCellGeom_Spacalv1::get_zbin(const double /*z*/) const
+PHG4CylinderCellGeom_Spacalv1::get_zbin(const double z) const
 {
   cout << "PHG4CylinderCellGeom_Spacalv1::get_zbin is invalid" << endl;
   exit(1);
@@ -150,7 +150,7 @@ PHG4CylinderCellGeom_Spacalv1::get_zbin(const double /*z*/) const
 }
 
 int
-PHG4CylinderCellGeom_Spacalv1::get_etabin(const double /*eta*/) const
+PHG4CylinderCellGeom_Spacalv1::get_etabin(const double eta) const
 {
   cout << "PHG4CylinderCellGeom_Spacalv1::get_etabin is invalid" << endl;
   exit(1);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -48,7 +48,7 @@ PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name)
   memset(nbins, 0, sizeof(nbins));
 }
 
-int PHG4CylinderCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+int PHG4CylinderCellReco::ResetEvent(PHCompositeNode *topNode)
 {
   sum_energy_before_cuts = 0.;
   sum_energy_g4hit = 0.;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -28,7 +28,7 @@ PHG4CylinderDisplayAction::~PHG4CylinderDisplayAction()
   delete m_Colour;
 }
 
-void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   if (m_MyVolume->GetVisAttributes())
   {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
@@ -30,19 +30,19 @@ class PHG4CylinderGeom: public PHObject
   virtual double get_tiltangle() const {PHOOL_VIRTUAL_WARN("get_tiltangle()");return NAN;}
   virtual double get_phi_slat_zero() const {PHOOL_VIRTUAL_WARN("get_phi_slat_zero()"); return NAN;}
 
-  virtual void set_layer(const int) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
-  virtual void set_radius(const double) {PHOOL_VIRTUAL_WARN("set_radius(const double)");}
-  virtual void set_thickness(const double) {PHOOL_VIRTUAL_WARN("set_thickness(const double)");}
-  virtual void set_zmin(const double) {PHOOL_VIRTUAL_WARN("set_zmin(const double)");}
-  virtual void set_zmax(const double) {PHOOL_VIRTUAL_WARN("set_zmax(const double)");}
-  virtual void set_nscint(const int) {PHOOL_VIRTUAL_WARN("set_nscint(const int)"); return;}
-  virtual void set_tiltangle(const double) {PHOOL_VIRTUAL_WARN("set_tiltangle(const double)"); return;}
-  virtual void set_phi_slat_zero (const double) {PHOOL_VIRTUAL_WARN("set_phi_slat_zero (const double)"); return;}
+  virtual void set_layer(const int i) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
+  virtual void set_radius(const double r) {PHOOL_VIRTUAL_WARN("set_radius(const double)");}
+  virtual void set_thickness(const double t) {PHOOL_VIRTUAL_WARN("set_thickness(const double)");}
+  virtual void set_zmin(const double z) {PHOOL_VIRTUAL_WARN("set_zmin(const double)");}
+  virtual void set_zmax(const double z) {PHOOL_VIRTUAL_WARN("set_zmax(const double)");}
+  virtual void set_nscint(const int i) {PHOOL_VIRTUAL_WARN("set_nscint(const int)"); return;}
+  virtual void set_tiltangle(const double i) {PHOOL_VIRTUAL_WARN("set_tiltangle(const double)"); return;}
+  virtual void set_phi_slat_zero (const double phi) {PHOOL_VIRTUAL_WARN("set_phi_slat_zero (const double)"); return;}
 
-  virtual void find_segment_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_sensor_center"); return;}
-  virtual void find_strip_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, const int /*strip_column*/, const int /*strip_index*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_strip_center"); return;}
- virtual void find_strip_index_values(const int /*segment_z_bin*/, const double /*ypos*/, const double /*zpos*/, int &/*strip_y_index*/, int &/*strip_z_index*/){PHOOL_VIRTUAL_WARN("find_strip_index_values"); return;}
-  virtual void find_strip_center_local_coords(const int /*segment_z_bin*/, const int /*strip_y_index*/, const int /*strip_z_index*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_strip_center_localcoords"); return;}
+  virtual void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]){PHOOL_VIRTUAL_WARN("find_sensor_center"); return;}
+  virtual void find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]){PHOOL_VIRTUAL_WARN("find_strip_center"); return;}
+ virtual void find_strip_index_values(const int segment_z_bin, const double ypos, const double zpos, int &strip_y_index, int &strip_z_index){PHOOL_VIRTUAL_WARN("find_strip_index_values"); return;}
+  virtual void find_strip_center_local_coords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]){PHOOL_VIRTUAL_WARN("find_strip_center_localcoords"); return;}
 
   virtual double get_strip_y_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_y_spacing"); return NAN;}
   virtual double get_strip_z_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_z_spacing"); return NAN;}
@@ -57,7 +57,7 @@ class PHG4CylinderGeom: public PHObject
   virtual double get_pixel_thickness() const {PHOOL_VIRTUAL_WARN("get_pixel_thickness"); return NAN;}
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & /*param*/) {return ;}
+  virtual void ImportParameters(const PHParameters & param) {return ;}
 
  protected:
   PHG4CylinderGeom() {}

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -498,7 +498,7 @@ int PHG4DetectorGroupSubsystem::SaveParamsToDB()
   return iret;
 }
 
-int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &/*name*/, const int /*issuper*/)
+int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &name, const int issuper)
 {
   int iret = 1;
   // if (issuper)
@@ -546,7 +546,7 @@ int PHG4DetectorGroupSubsystem::SaveParamsToFile(const PHG4DetectorGroupSubsyste
   return iret;
 }
 
-int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &/*name*/, const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp, const int /*issuper*/)
+int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &name, const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp, const int issuper)
 {
   string extension;
   switch (ftyp)

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-PHG4EnvelopeSubsystem::PHG4EnvelopeSubsystem(const std::string& name, const int /*lyr*/)
+PHG4EnvelopeSubsystem::PHG4EnvelopeSubsystem(const std::string& name, const int lyr)
   : PHG4Subsystem(name)
   , detector_(nullptr)
   , steppingAction_(nullptr)

--- a/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.cc
@@ -20,7 +20,7 @@ PHG4EventActionClearZeroEdep::AddNode(const std::string &name)
 }
 
 //___________________________________________________
-void PHG4EventActionClearZeroEdep::EndOfEventAction(const G4Event* /*evt*/)
+void PHG4EventActionClearZeroEdep::EndOfEventAction(const G4Event* evt)
 {
   BOOST_FOREACH(std::string node, nodename_set)
     {

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -63,7 +63,7 @@ PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
 }
 
 int
-PHG4FullProjSpacalCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+PHG4FullProjSpacalCellReco::ResetEvent(PHCompositeNode *topNode)
 {
   sum_energy_g4hit = 0.;
   return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -552,7 +552,7 @@ PHG4FullProjSpacalDetector::Construct_Tower(
   return block_logic;
 }
 
-void PHG4FullProjSpacalDetector::Print(const std::string& /*what*/) const
+void PHG4FullProjSpacalDetector::Print(const std::string& what) const
 {
   cout << "PHG4FullProjSpacalDetector::Print::" << GetName()
        << " - Print Geometry:" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -914,7 +914,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_LightGuide(
   return block_logic;
 }
 
-void PHG4FullProjTiltedSpacalDetector::Print(const std::string& /*what*/) const
+void PHG4FullProjTiltedSpacalDetector::Print(const std::string& what) const
 {
   cout << "PHG4FullProjTiltedSpacalDetector::Print::" << GetName()
        << " - Print Geometry:" << endl;

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -67,7 +67,7 @@ PHG4GDMLDetector::~PHG4GDMLDetector()
 
 void
 
-PHG4GDMLDetector::Print(const std::string& /*what*/) const
+PHG4GDMLDetector::Print(const std::string& what) const
 {
   cout << "PHG4GDMLDetector::" << GetName() << " - import " << m_TopVolName << " from " << m_GDMPath << " with shift "
        << m_placeX << ","

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -101,7 +101,7 @@ int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 }
 
 //_______________________________________________________________________
-int PHG4GDMLSubsystem::process_event(PHCompositeNode */*topNode*/)
+int PHG4GDMLSubsystem::process_event(PHCompositeNode *topNode)
 {
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -188,7 +188,7 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4HcalCellReco::End(PHCompositeNode */*topNode*/)
+int PHG4HcalCellReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -275,7 +275,7 @@ PHG4HcalDetector::GetLength(const double phi) const
   return a;
 }
 
-void PHG4HcalDetector::Print(const std::string& /*what*/) const
+void PHG4HcalDetector::Print(const std::string& what) const
 {
   cout << "radius: " << radius << endl;
   return;

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -140,7 +140,7 @@ int PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume *volume) const
 }
 
 G4VSolid *
-PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*/)
+PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
 {
   double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   Point_2 p_in_1(mid_radius, 0);  // center of scintillator
@@ -217,7 +217,7 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*
 }
 
 G4VSolid *
-PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
+PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
@@ -25,7 +25,7 @@ PHG4InnerHcalDisplayAction::~PHG4InnerHcalDisplayAction()
   m_ScintiLogVolSet.clear();
 }
 
-void PHG4InnerHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4InnerHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   for (auto &it : m_ScintiLogVolSet)
   {

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -160,7 +160,6 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
              << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
       }
-      [[fallthrough]];
     case fGeomBoundary:
     case fUndefined:
       // if previous hit was saved, hit pointer was set to nullptr

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -129,7 +129,7 @@ int PHG4OuterHcalDetector::IsInOuterHcal(G4VPhysicalVolume *volume) const
 }
 
 G4VSolid *
-PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*/)
+PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume *hcalenvelope)
 {
   double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   PHG4OuterHcalDetector::Point_2 p_in_1(mid_radius, 0);  // center of scintillator
@@ -206,7 +206,7 @@ PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*
 }
 
 G4VSolid *
-PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
+PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume *hcalenvelope)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.cc
@@ -23,7 +23,7 @@ PHG4OuterHcalDisplayAction::~PHG4OuterHcalDisplayAction()
   m_ScintiLogVolSet.clear();
 }
 
-void PHG4OuterHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4OuterHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   for (auto &it:m_ScintiLogVolSet)
   {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -196,7 +196,6 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
         cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
              << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
       }
-      [[fallthrough]];
     case fGeomBoundary:
     case fUndefined:
       if (!m_Hit)

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -38,7 +38,7 @@ class PHCompositeNode;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4PSTOFSteppingAction::PHG4PSTOFSteppingAction(PHG4PSTOFDetector* detector, const PHParametersContainer* /*parameters*/)
+PHG4PSTOFSteppingAction::PHG4PSTOFSteppingAction(PHG4PSTOFDetector* detector, const PHParametersContainer* parameters)
   : PHG4SteppingAction(detector->GetName())
   , detector_(detector)
   , hits_(nullptr)
@@ -63,7 +63,7 @@ PHG4PSTOFSteppingAction::~PHG4PSTOFSteppingAction()
 }
 
 //____________________________________________________________________________..
-bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_used*/)
+bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
@@ -130,7 +130,6 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       cout << " previous phys pre vol: " << savevolpre->GetName()
            << " previous phys post vol: " << savevolpost->GetName() << endl;
       }
-    [[fallthrough]];
   case fGeomBoundary:
   case fUndefined:
     if (!hit)

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
@@ -22,7 +22,7 @@ class PHG4ScintillatorSlat : public PHObject
     os << "PHG4ScintillatorSlat base class" << std::endl;
   }
   
-  virtual void add_edep(const double /*edep*/, const double /*e*/, const double /*light_yield*/) {return;}
+  virtual void add_edep(const double edep, const double e, const double light_yield) {return;}
 
   virtual void set_key(const PHG4ScintillatorSlatDefs::keytype) {return;}
   virtual void add_hit_key(PHG4HitDefs::keytype) {return;}

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
@@ -30,7 +30,7 @@ PHG4SectorDisplayAction::~PHG4SectorDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4SectorDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4SectorDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -384,7 +384,7 @@ PHG4SpacalDetector::Construct_Fiber(const G4double length, const string &id)
   return fiber_logic;
 }
 
-void PHG4SpacalDetector::Print(const std::string &/*what*/) const
+void PHG4SpacalDetector::Print(const std::string &what) const
 {
   cout << "PHG4SpacalDetector::Print::" << GetName() << " - Print Geometry:"
        << endl;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
@@ -31,7 +31,7 @@ PHG4SpacalDisplayAction::~PHG4SpacalDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -5,13 +5,12 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template -Wno-tautological-overlap-compare -Wno-deprecated-copy"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-tautological-overlap-compare"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4dst/configure.ac
+++ b/simulation/g4simulation/g4dst/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 dnl test for root 6

--- a/simulation/g4simulation/g4epd/configure.ac
+++ b/simulation/g4simulation/g4epd/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4eval/CaloEvaluator.cc
+++ b/simulation/g4simulation/g4eval/CaloEvaluator.cc
@@ -75,7 +75,7 @@ CaloEvaluator::CaloEvaluator(const string& name, const string& caloname, const s
 {
 }
 
-int CaloEvaluator::Init(PHCompositeNode* /*topNode*/)
+int CaloEvaluator::Init(PHCompositeNode* topNode)
 {
   _ievent = 0;
 
@@ -161,7 +161,7 @@ int CaloEvaluator::process_event(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int CaloEvaluator::End(PHCompositeNode* /*topNode*/)
+int CaloEvaluator::End(PHCompositeNode* topNode)
 {
   _tfile->cd();
 

--- a/simulation/g4simulation/g4eval/EventEvaluator.cc
+++ b/simulation/g4simulation/g4eval/EventEvaluator.cc
@@ -291,7 +291,7 @@ EventEvaluator::EventEvaluator(const string& name, const string& filename)
 
 }
 
-int EventEvaluator::Init(PHCompositeNode* /*topNode*/)
+int EventEvaluator::Init(PHCompositeNode* topNode)
 {
   _ievent = 0;
 
@@ -1512,7 +1512,7 @@ void EventEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   return;
 }
 
-int EventEvaluator::End(PHCompositeNode* /*topNode*/)
+int EventEvaluator::End(PHCompositeNode* topNode)
 {
   _tfile->cd();
 

--- a/simulation/g4simulation/g4eval/JetEvaluator.cc
+++ b/simulation/g4simulation/g4eval/JetEvaluator.cc
@@ -42,7 +42,7 @@ JetEvaluator::JetEvaluator(const string &name,
 {
 }
 
-int JetEvaluator::Init(PHCompositeNode */*topNode*/)
+int JetEvaluator::Init(PHCompositeNode *topNode)
 {
   _ievent = 0;
 
@@ -97,7 +97,7 @@ int JetEvaluator::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int JetEvaluator::End(PHCompositeNode */*topNode*/)
+int JetEvaluator::End(PHCompositeNode *topNode)
 {
   _tfile->cd();
 
@@ -120,13 +120,13 @@ int JetEvaluator::End(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void JetEvaluator::printInputInfo(PHCompositeNode */*topNode*/)
+void JetEvaluator::printInputInfo(PHCompositeNode *topNode)
 {
   // to be implemented later if needed
   return;
 }
 
-void JetEvaluator::printOutputInfo(PHCompositeNode */*topNode*/)
+void JetEvaluator::printOutputInfo(PHCompositeNode *topNode)
 {
   // to be implemented later if needed
   return;

--- a/simulation/g4simulation/g4eval/MomentumEvaluator.cc
+++ b/simulation/g4simulation/g4eval/MomentumEvaluator.cc
@@ -356,7 +356,7 @@ bool RecursiveMomentumContainer::insert(TrivialTrack& track)
   return containers[x_ind][y_ind][z_ind]->insert(track);
 }
 
-MomentumEvaluator::MomentumEvaluator(const std::string& fname, float pt_s, float pz_s, unsigned int /*n_l*/, unsigned int n_i, unsigned int n_r, float i_z, float o_z)
+MomentumEvaluator::MomentumEvaluator(const std::string& fname, float pt_s, float pz_s, unsigned int n_l, unsigned int n_i, unsigned int n_r, float i_z, float o_z)
   : ntp_true(nullptr)
   , ntp_reco(nullptr)
   , pt_search_scale(pt_s)
@@ -381,7 +381,7 @@ MomentumEvaluator::~MomentumEvaluator()
   }
 }
 
-int MomentumEvaluator::Init(PHCompositeNode* /*topNode*/)
+int MomentumEvaluator::Init(PHCompositeNode* topNode)
 {
   if (ntp_true != nullptr)
   {
@@ -595,7 +595,7 @@ int MomentumEvaluator::process_event(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int MomentumEvaluator::End(PHCompositeNode* /*topNode*/)
+int MomentumEvaluator::End(PHCompositeNode* topNode)
 {
   TFile outfile(file_name.c_str(), "recreate");
   outfile.cd();

--- a/simulation/g4simulation/g4eval/PHG4DstCompressReco.cc
+++ b/simulation/g4simulation/g4eval/PHG4DstCompressReco.cc
@@ -75,7 +75,7 @@ int PHG4DstCompressReco::InitRun(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4DstCompressReco::process_event(PHCompositeNode* /*topNode*/)
+int PHG4DstCompressReco::process_event(PHCompositeNode* topNode)
 {
   if (_g4hits.empty() && _g4cells.empty() && _towers.empty()) return Fun4AllReturnCodes::EVENT_OK;
 

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -940,7 +940,7 @@ void SvtxClusterEval::FillRecoClusterFromG4HitCache(){
     std::multimap<PHG4Particle*, TrkrDefs::cluskey>::const_iterator lower_bound = temp_clusters_from_particles.lower_bound(g4particle);
     std::multimap<PHG4Particle*, TrkrDefs::cluskey>::const_iterator upper_bound = temp_clusters_from_particles.upper_bound(g4particle);
     std::multimap<PHG4Particle*, TrkrDefs::cluskey>::const_iterator cfp_iter;
-    for(cfp_iter = lower_bound;cfp_iter != upper_bound;++cfp_iter){
+    for(cfp_iter = lower_bound;cfp_iter != upper_bound;cfp_iter++){
       TrkrDefs::cluskey cluster_key = cfp_iter->second;
       clusters.insert(cluster_key);
     }

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -56,7 +56,7 @@
 
 using namespace std;
 
-SvtxEvaluator::SvtxEvaluator(const string& /*name*/, const string& filename, const string& trackmapname,
+SvtxEvaluator::SvtxEvaluator(const string& name, const string& filename, const string& trackmapname,
                              unsigned int nlayers_maps,
                              unsigned int nlayers_intt,
                              unsigned int nlayers_tpc,
@@ -80,7 +80,6 @@ SvtxEvaluator::SvtxEvaluator(const string& /*name*/, const string& filename, con
   , _do_gseed_eval(false)
   , _do_track_match(true)
   , _do_eval_light(true)
-  , _do_vtx_eval_light(true)
   , _scan_for_embedded(false)
   , _scan_for_primaries(false)
   , _nlayers_maps(nlayers_maps)
@@ -109,7 +108,7 @@ SvtxEvaluator::~SvtxEvaluator()
   delete _timer;
 }
 
-int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
+int SvtxEvaluator::Init(PHCompositeNode* topNode)
 {
   _ievent = 0;
 
@@ -122,13 +121,11 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex", "vertex => max truth",
-						 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
-						 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
-						 "gnembed:nfromtruth:"
-						 "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
+                                                 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
+                                                 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
+                                                 "gnembed:nfromtruth:"
+                                                 "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
-    
-    
   if (_do_gpoint_eval) _ntp_gpoint = new TNtuple("ntp_gpoint", "g4point => best vertex",
                                                  "event:seed:gvx:gvy:gvz:gvt:gntracks:gembed:"
                                                  "vx:vy:vz:ntracks:"
@@ -215,7 +212,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int SvtxEvaluator::InitRun(PHCompositeNode* /*topNode*/)
+int SvtxEvaluator::InitRun(PHCompositeNode* topNode)
 {
   //clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
@@ -282,7 +279,7 @@ int SvtxEvaluator::process_event(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int SvtxEvaluator::End(PHCompositeNode* /*topNode*/)
+int SvtxEvaluator::End(PHCompositeNode* topNode)
 {
   _tfile->cd();
 
@@ -932,7 +929,6 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         _ntp_info->Fill(info_data);
     }
 
-
   //-----------------------
   // fill the Vertex NTuple
   //-----------------------
@@ -963,7 +959,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       map<int, unsigned int> embedvtxid_maps_particle_count;
       map<int, unsigned int> vertex_particle_count;
 
-      if (_do_vtx_eval_light == false)
+      if (_do_eval_light == false)
       {
         for (auto iter = prange.first; iter != prange.second; ++iter)  // process all primary paricle
         {
@@ -1029,7 +1025,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       {
         const int point_id = iter->first;
         int gembed = truthinfo->isEmbededVtx(point_id);
-	
+
         if (_scan_for_embedded && gembed <= 0) continue;
 
         auto search = embedvtxid_found.find(gembed);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -60,7 +60,6 @@ class SvtxEvaluator : public SubsysReco
 
   void do_track_match(bool b) { _do_track_match = b; }
   void do_eval_light(bool b) { _do_eval_light = b; }
-  void do_vtx_eval_light(bool b) { _do_vtx_eval_light = b;}
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
   void scan_for_primaries(bool b) { _scan_for_primaries = b; }
 
@@ -95,7 +94,6 @@ class SvtxEvaluator : public SubsysReco
 
   bool _do_track_match;
   bool _do_eval_light;
-  bool _do_vtx_eval_light;
   bool _scan_for_embedded;
   bool _scan_for_primaries;
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -255,7 +255,7 @@ void  SvtxTruthEval::FillTruthHitsFromParticleCache(){
     std::multimap<const int, PHG4Hit*>::const_iterator lower_bound = temp_clusters_from_particles.lower_bound(g4particle->get_track_id());
     std::multimap<const int, PHG4Hit*>::const_iterator upper_bound = temp_clusters_from_particles.upper_bound(g4particle->get_track_id());
     std::multimap<const int, PHG4Hit*>::const_iterator cfp_iter;
-    for(cfp_iter = lower_bound;cfp_iter != upper_bound;++cfp_iter){
+    for(cfp_iter = lower_bound;cfp_iter != upper_bound;cfp_iter++){
       PHG4Hit* g4hit = cfp_iter->second;
       truth_hits.insert(g4hit);
     }

--- a/simulation/g4simulation/g4eval/configure.ac
+++ b/simulation/g4simulation/g4eval/configure.ac
@@ -6,13 +6,12 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
-fi
-
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+ *g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4gdml/PHG4GDMLConfig.hh
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLConfig.hh
@@ -36,7 +36,7 @@ class PHG4GDMLConfig : public PHObject
   virtual int isValid() const { return 1; }
   virtual void identify(std::ostream &os = std::cout) const
   {
-    os << "PHG4GDMLConfig with " << excluded_physical_vol.size() << "excluded physical volume and "
+    std::cout << "PHG4GDMLConfig with " << excluded_physical_vol.size() << "excluded physical volume and "
               << excluded_logical_vol.size() << " excluded logical volume" << std::endl;
   }
 

--- a/simulation/g4simulation/g4gdml/configure.ac
+++ b/simulation/g4simulation/g4gdml/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 fi
 

--- a/simulation/g4simulation/g4histos/G4CellNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4CellNtuple.cc
@@ -131,7 +131,7 @@ int G4CellNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4CellNtuple::End(PHCompositeNode */*topNode*/)
+int G4CellNtuple::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   ntup->Write();

--- a/simulation/g4simulation/g4histos/G4EdepNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4EdepNtuple.cc
@@ -74,7 +74,7 @@ int G4EdepNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4EdepNtuple::End(PHCompositeNode */*topNode*/)
+int G4EdepNtuple::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   ntup->Write();

--- a/simulation/g4simulation/g4histos/G4HitNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4HitNtuple.cc
@@ -87,7 +87,7 @@ int G4HitNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4HitNtuple::End(PHCompositeNode */*topNode*/)
+int G4HitNtuple::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   ntup->Write();

--- a/simulation/g4simulation/g4histos/G4HitTTree.cc
+++ b/simulation/g4simulation/g4histos/G4HitTTree.cc
@@ -120,7 +120,7 @@ int G4HitTTree::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4HitTTree::End(PHCompositeNode */*topNode*/)
+int G4HitTTree::End(PHCompositeNode *topNode)
 {
   hm->dumpHistos("HitHistos.root");
   delete hm;

--- a/simulation/g4simulation/g4histos/G4RawTowerTTree.cc
+++ b/simulation/g4simulation/g4histos/G4RawTowerTTree.cc
@@ -86,7 +86,7 @@ int G4RawTowerTTree::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4RawTowerTTree::End(PHCompositeNode */*topNode*/)
+int G4RawTowerTTree::End(PHCompositeNode *topNode)
 {
   hm->dumpHistos(_histofilename);
   delete hm;

--- a/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.cc
+++ b/simulation/g4simulation/g4histos/G4ScintillatorSlatTTree.cc
@@ -83,7 +83,7 @@ int G4ScintillatorSlatTTree::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4ScintillatorSlatTTree::End(PHCompositeNode */*topNode*/)
+int G4ScintillatorSlatTTree::End(PHCompositeNode *topNode)
 {
   hm->dumpHistos(_histofilename);
   delete hm;

--- a/simulation/g4simulation/g4histos/G4ScintillatorTowerTTree.cc
+++ b/simulation/g4simulation/g4histos/G4ScintillatorTowerTTree.cc
@@ -83,7 +83,7 @@ int G4ScintillatorTowerTTree::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4ScintillatorTowerTTree::End(PHCompositeNode */*topNode*/)
+int G4ScintillatorTowerTTree::End(PHCompositeNode *topNode)
 {
   hm->dumpHistos(_histofilename);
   delete hm;

--- a/simulation/g4simulation/g4histos/G4SnglNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4SnglNtuple.cc
@@ -120,7 +120,7 @@ int G4SnglNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4SnglNtuple::End(PHCompositeNode */*topNode*/)
+int G4SnglNtuple::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   ntup->Write();

--- a/simulation/g4simulation/g4histos/G4SnglTree.cc
+++ b/simulation/g4simulation/g4histos/G4SnglTree.cc
@@ -129,7 +129,7 @@ int G4SnglTree::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4SnglTree::End(PHCompositeNode */*topNode*/)
+int G4SnglTree::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   g4tree->Write();

--- a/simulation/g4simulation/g4histos/G4TowerNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4TowerNtuple.cc
@@ -104,7 +104,7 @@ int G4TowerNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4TowerNtuple::End(PHCompositeNode */*topNode*/)
+int G4TowerNtuple::End(PHCompositeNode *topNode)
 {
   outfile->cd();
   ntup->Write();

--- a/simulation/g4simulation/g4histos/G4VtxNtuple.cc
+++ b/simulation/g4simulation/g4histos/G4VtxNtuple.cc
@@ -44,7 +44,7 @@ int G4VtxNtuple::process_event(PHCompositeNode *topNode)
   return 0;
 }
 
-int G4VtxNtuple::End(PHCompositeNode */*topNode*/)
+int G4VtxNtuple::End(PHCompositeNode *topNode)
 {
   hm->dumpHistos(m_FileName, "RECREATE");
   return 0;

--- a/simulation/g4simulation/g4histos/configure.ac
+++ b/simulation/g4simulation/g4histos/configure.ac
@@ -10,10 +10,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4intt/InttDeadMap.h
+++ b/simulation/g4simulation/g4intt/InttDeadMap.h
@@ -21,9 +21,9 @@ class InttDeadMap : public PHObject
   void addDeadChannelIntt(const int layer,
                           const int ladder_phi, const int ladder_z,
                           const int strip_z, const int strip_phi);
-  virtual void addDeadChannel(PHG4CellDefs::keytype) {return;}
+  virtual void addDeadChannel(PHG4CellDefs::keytype key) {return;}
 
-  virtual bool isDeadChannel(PHG4CellDefs::keytype) const {return false;}
+  virtual bool isDeadChannel(PHG4CellDefs::keytype key) const {return false;}
   bool isDeadChannelIntt(const int layer,
                          const int ladder_phi, const int ladder_z,
                          const int strip_z, const int strip_phi) const;

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
@@ -282,7 +282,7 @@ void PHG4InttDigitizer::DigitizeLadderCells(PHCompositeNode *topNode)
 }
 
 //! end of process
-int PHG4InttDigitizer::End(PHCompositeNode */*topNode*/)
+int PHG4InttDigitizer::End(PHCompositeNode *topNode)
 {
   if (Verbosity() >= VERBOSITY_SOME)
   {

--- a/simulation/g4simulation/g4intt/PHG4InttDisplayAction.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDisplayAction.cc
@@ -28,7 +28,7 @@ PHG4InttDisplayAction::~PHG4InttDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4InttDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4InttDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
 

--- a/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttSubsystem.cc
@@ -361,7 +361,7 @@ void PHG4InttSubsystem::SetDefaultParameters()
   return;
 }
 
-void PHG4InttSubsystem::Print(const string &/*what*/) const
+void PHG4InttSubsystem::Print(const string &what) const
 {
   PrintDefaultParams();
   cout << endl

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -7,10 +7,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-range-loop-construct -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-range-loop-construct"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4jets/Jet.cc
+++ b/simulation/g4simulation/g4jets/Jet.cc
@@ -15,17 +15,17 @@ Jet::ConstIter Jet::begin_comp() const
   return DummyJetMap.end();
 }
 
-Jet::ConstIter Jet::lower_bound_comp(Jet::SRC /*source*/) const
+Jet::ConstIter Jet::lower_bound_comp(Jet::SRC source) const
 {
   return DummyJetMap.end();
 }
 
-Jet::ConstIter Jet::upper_bound_comp(Jet::SRC /*source*/) const
+Jet::ConstIter Jet::upper_bound_comp(Jet::SRC source) const
 {
   return DummyJetMap.end();
 }
 
-Jet::ConstIter Jet::find(Jet::SRC /*source*/) const
+Jet::ConstIter Jet::find(Jet::SRC source) const
 {
   return DummyJetMap.end();
 }
@@ -40,17 +40,17 @@ Jet::Iter Jet::begin_comp()
   return DummyJetMap.end();
 }
 
-Jet::Iter Jet::lower_bound_comp(Jet::SRC /*source*/)
+Jet::Iter Jet::lower_bound_comp(Jet::SRC source)
 {
   return DummyJetMap.end();
 }
 
-Jet::Iter Jet::upper_bound_comp(Jet::SRC /*source*/)
+Jet::Iter Jet::upper_bound_comp(Jet::SRC source)
 {
   return DummyJetMap.end();
 }
 
-Jet::Iter Jet::find(Jet::SRC /*source*/)
+Jet::Iter Jet::find(Jet::SRC source)
 {
   return DummyJetMap.end();
 }

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -84,19 +84,19 @@ class Jet : public PHObject
   // jet info ------------------------------------------------------------------
 
   virtual unsigned int get_id() const { return 0xFFFFFFFF; }
-  virtual void set_id(unsigned int) { return; }
+  virtual void set_id(unsigned int id) { return; }
 
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) { return; }
+  virtual void set_px(float px) { return; }
 
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) { return; }
+  virtual void set_py(float py) { return; }
 
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) { return; }
+  virtual void set_pz(float pz) { return; }
 
   virtual float get_e() const { return NAN; }
-  virtual void set_e(float) { return; }
+  virtual void set_e(float e) { return; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }
@@ -108,10 +108,10 @@ class Jet : public PHObject
 
   // extended jet info ---------------------------------------------------------
 
-  virtual bool has_property(Jet::PROPERTY /*prop_id*/) const { return false; }
-  virtual float get_property(Jet::PROPERTY /*prop_id*/) const { return NAN; }
-  virtual void set_property(Jet::PROPERTY /*prop_id*/, float /*value*/) { return; }
-  virtual void print_property(std::ostream& /*os*/) const { return; }
+  virtual bool has_property(Jet::PROPERTY prop_id) const { return false; }
+  virtual float get_property(Jet::PROPERTY prop_id) const { return NAN; }
+  virtual void set_property(Jet::PROPERTY prop_id, float value) { return; }
+  virtual void print_property(std::ostream& os) const { return; }
 
   // component id storage ------------------------------------------------------
 
@@ -127,13 +127,13 @@ class Jet : public PHObject
 
   virtual bool empty_comp() const { return true; }
   virtual size_t size_comp() const { return 0; }
-  virtual size_t count_comp(Jet::SRC /*source*/) const { return 0; }
+  virtual size_t count_comp(Jet::SRC source) const { return 0; }
 
   virtual void clear_comp() { return; }
-  virtual void insert_comp(Jet::SRC /*source*/, unsigned int /*compid*/) { return; }
-  virtual size_t erase_comp(Jet::SRC /*source*/) { return 0; }
-  virtual void erase_comp(Iter /*iter*/) { return; }
-  virtual void erase_comp(Iter /*first*/, Iter /*last*/) { return; }
+  virtual void insert_comp(Jet::SRC source, unsigned int compid) { return; }
+  virtual size_t erase_comp(Jet::SRC source) { return 0; }
+  virtual void erase_comp(Iter iter) { return; }
+  virtual void erase_comp(Iter first, Iter last) { return; }
 
   virtual ConstIter begin_comp() const;
   virtual ConstIter lower_bound_comp(Jet::SRC source) const;

--- a/simulation/g4simulation/g4jets/JetAlgo.h
+++ b/simulation/g4simulation/g4jets/JetAlgo.h
@@ -18,7 +18,7 @@ class JetAlgo
   virtual Jet::ALGO get_algo() { return Jet::NONE; }
   virtual float get_par() { return NAN; }
 
-  virtual std::vector<Jet*> get_jets(std::vector<Jet*>/* particles*/)
+  virtual std::vector<Jet*> get_jets(std::vector<Jet*> particles)
   {
     return std::vector<Jet*>();
   }

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.cc
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.cc
@@ -57,7 +57,7 @@ JetHepMCLoader::~JetHepMCLoader()
 {
 }
 
-int JetHepMCLoader::Init(PHCompositeNode */*topNode*/)
+int JetHepMCLoader::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -198,7 +198,7 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int JetHepMCLoader::End(PHCompositeNode */*topNode*/)
+int JetHepMCLoader::End(PHCompositeNode *topNode)
 {
   if (m_saveQAPlots)
   {

--- a/simulation/g4simulation/g4jets/JetInput.h
+++ b/simulation/g4simulation/g4jets/JetInput.h
@@ -20,7 +20,7 @@ class JetInput
 
   virtual Jet::SRC get_src() { return Jet::VOID; }
 
-  virtual std::vector<Jet*> get_input(PHCompositeNode* /*topNode*/)
+  virtual std::vector<Jet*> get_input(PHCompositeNode* topNode)
   {
     return std::vector<Jet*>();
   }

--- a/simulation/g4simulation/g4jets/JetMap.cc
+++ b/simulation/g4simulation/g4jets/JetMap.cc
@@ -16,7 +16,7 @@ JetMap::ConstSrcIter JetMap::begin_src() const
   return DummyJetSourceSet.end();
 }
 
-JetMap::ConstSrcIter JetMap::find_src(Jet::SRC /*src*/) const
+JetMap::ConstSrcIter JetMap::find_src(Jet::SRC src) const
 {
   return DummyJetSourceSet.end();
 }
@@ -31,7 +31,7 @@ JetMap::SrcIter JetMap::begin_src()
   return DummyJetSourceSet.end();
 }
 
-JetMap::SrcIter JetMap::find_src(Jet::SRC /*src*/)
+JetMap::SrcIter JetMap::find_src(Jet::SRC src)
 {
   return DummyJetSourceSet.end();
 }
@@ -46,7 +46,7 @@ JetMap::ConstIter JetMap::begin() const
   return DummyJetMapMap.end();
 }
 
-JetMap::ConstIter JetMap::find(unsigned int /*idkey*/) const
+JetMap::ConstIter JetMap::find(unsigned int idkey) const
 {
   return DummyJetMapMap.end();
 }
@@ -61,7 +61,7 @@ JetMap::Iter JetMap::begin()
   return DummyJetMapMap.end();
 }
 
-JetMap::Iter JetMap::find(unsigned int /*idkey*/)
+JetMap::Iter JetMap::find(unsigned int idkey)
 {
   return DummyJetMapMap.end();
 }

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -32,16 +32,16 @@ class JetMap : public PHObject
 
   // map content info ----------------------------------------------------------
 
-  virtual void set_algo(Jet::ALGO /*algo*/) { return; }
+  virtual void set_algo(Jet::ALGO algo) { return; }
   virtual Jet::ALGO get_algo() const { return Jet::NONE; }
 
-  virtual void set_par(float) { return; }
+  virtual void set_par(float par) { return; }
   virtual float get_par() const { return NAN; }
 
   // set access to list of source identifiers ----------------------------------
 
   virtual bool empty_src() const { return true; }
-  virtual void insert_src(Jet::SRC /*src*/) { return; }
+  virtual void insert_src(Jet::SRC src) { return; }
 
   virtual ConstSrcIter begin_src() const;
   virtual ConstSrcIter find_src(Jet::SRC src) const;
@@ -55,14 +55,14 @@ class JetMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }
-  virtual size_t count(unsigned int /*idkey*/) const { return 0; }
+  virtual size_t count(unsigned int idkey) const { return 0; }
   virtual void clear() { return; }
 
-  virtual const Jet* get(unsigned int /*idkey*/) const { return nullptr; }
-  virtual Jet* get(unsigned int /*idkey*/) { return nullptr; }
+  virtual const Jet* get(unsigned int idkey) const { return nullptr; }
+  virtual Jet* get(unsigned int idkey) { return nullptr; }
 
-  virtual Jet* insert(Jet* /*jet*/) { return nullptr; }
-  virtual size_t erase(unsigned int /*idkey*/) { return 0; }
+  virtual Jet* insert(Jet* jet) { return nullptr; }
+  virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;

--- a/simulation/g4simulation/g4jets/JetReco.cc
+++ b/simulation/g4simulation/g4jets/JetReco.cc
@@ -47,7 +47,7 @@ JetReco::~JetReco()
   _outputs.clear();
 }
 
-int JetReco::Init(PHCompositeNode */*topNode*/)
+int JetReco::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -106,7 +106,7 @@ int JetReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int JetReco::End(PHCompositeNode */*topNode*/)
+int JetReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4jets/Jetv1.cc
+++ b/simulation/g4simulation/g4jets/Jetv1.cc
@@ -137,21 +137,21 @@ void Jetv1::print_property(ostream& os) const
   for (typ_property_map::const_iterator citer = _property_map.begin();
        citer != _property_map.end(); ++citer)
   {
-    os << " ";  //indent
+    cout << " ";  //indent
 
     switch (citer->first)
     {
     case prop_JetCharge:
-      os << "Jet Charge";
+      cout << "Jet Charge";
       break;
     case prop_BFrac:
-      os << "Jet B-quark fraction";
+      cout << "Jet B-quark fraction";
       break;
     default:
-      os << "Property[" << citer->first << "]";
+      cout << "Property[" << citer->first << "]";
       break;
     }
 
-    os << "\t= " << citer->second << endl;
+    cout << "\t= " << citer->second << endl;
   }
 }

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -10,13 +10,13 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
   if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations"
+   CXXFLAGS="$CXXFLAGS -Wall -Wno-deprecated-declarations -Werror"
   else
-   CXXFLAGS="$CXXFLAGS"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
   fi
  ;;
 esac

--- a/simulation/g4simulation/g4main/EicEventHeader.h
+++ b/simulation/g4simulation/g4main/EicEventHeader.h
@@ -23,16 +23,16 @@ class EicEventHeader : public PHObject
 
   void Reset() override;
 
-  virtual void set_eventgenerator_type(const int) { return; }
+  virtual void set_eventgenerator_type(const int i) { return; }
   virtual int get_eventgenerator_type() const { return -99999; }
 
   // Milou
 
-  virtual void set_milou_weight(const float) { return; }
+  virtual void set_milou_weight(const float val) { return; }
   virtual float get_milou_weight() const { return NAN; }
-  virtual void set_milou_trueX(const float) { return; }
+  virtual void set_milou_trueX(const float val) { return; }
   virtual float get_milou_trueX() const { return NAN; }
-  virtual void set_milou_trueQ2(const float) { return; }
+  virtual void set_milou_trueQ2(const float val) { return; }
   virtual float get_milou_trueQ2() const { return NAN; }
 
 
@@ -40,7 +40,7 @@ class EicEventHeader : public PHObject
 //  float get_milou_weight() const override { return get_property_float(prop_milou_weight); }
 
   // DEMP
-  virtual void set_demp_weight(const float) { return; }
+  virtual void set_demp_weight(const float val) { return; }
   virtual float get_demp_weight() const { return NAN; }
 
   //! Procedure to add a new PROPERTY tag:
@@ -73,20 +73,20 @@ class EicEventHeader : public PHObject
     DEMP = 2
   };
 
-  virtual bool has_property(const PROPERTY /*prop_id*/) const { return false; }
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const { return NAN; }
-  virtual int get_property_int(const PROPERTY /*prop_id*/) const { return INT_MIN; }
-  virtual unsigned int get_property_uint(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const float /*value*/) { return; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const int /*value*/) { return; }
-  virtual void set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) { return; }
+  virtual bool has_property(const PROPERTY prop_id) const { return false; }
+  virtual float get_property_float(const PROPERTY prop_id) const { return NAN; }
+  virtual int get_property_int(const PROPERTY prop_id) const { return INT_MIN; }
+  virtual unsigned int get_property_uint(const PROPERTY prop_id) const { return UINT_MAX; }
+  virtual void set_property(const PROPERTY prop_id, const float value) { return; }
+  virtual void set_property(const PROPERTY prop_id, const int value) { return; }
+  virtual void set_property(const PROPERTY prop_id, const unsigned int value) { return; }
   static std::pair<const std::string, PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const { return UINT_MAX; }
+  virtual void set_property_nocheck(const PROPERTY prop_id, const unsigned int) { return; }
 
   std::map<std::string, double> evInfo;
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -66,7 +66,6 @@ static IsStateFinal isfinal;
 
 HepMCNodeReader::HepMCNodeReader(const std::string &name)
   : SubsysReco(name)
-  , is_pythia(false)
   , use_seed(0)
   , seed(0)
   , vertex_pos_x(0.0)
@@ -189,8 +188,6 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       genevt->identify();
     }
 
-    const auto collisionVertex = genevt->get_collision_vertex();
-
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
@@ -285,20 +282,6 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
                                           (*v)->position().y(),
                                           (*v)->position().z(),
                                           (*v)->position().t());
-	if(is_pythia)
-	  {
-	    lv_vertex.setX(collisionVertex.x());
-	    lv_vertex.setY(collisionVertex.y());
-	    lv_vertex.setZ(collisionVertex.z());
-	    lv_vertex.setT(collisionVertex.t());
-	    if (Verbosity() > 1)
-	      {
-		std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ 
-			  << std::endl;
-		std::cout << "\t vertex reset to collision vertex: " 
-			  << lv_vertex << std::endl;
-	      }
-	  }
 
         // event gen frame to lab frame
         lv_vertex = lortentz_rotation(lv_vertex);
@@ -436,7 +419,7 @@ void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
   return;
 }
 
-void HepMCNodeReader::Embed(const int)
+void HepMCNodeReader::Embed(const int i)
 {
   cout << "HepMCNodeReader::Embed - WARNING - this function is depreciated. "
        << "Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -23,9 +23,6 @@ class HepMCNodeReader : public SubsysReco
   int Init(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
 
-  void pythia(const bool pythia)
-  { is_pythia = pythia; }
-
   //! this function is depreciated.
   //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
   void Embed(const int i = 1);
@@ -57,7 +54,7 @@ class HepMCNodeReader : public SubsysReco
   double smearflat(const double width);
 
   gsl_rng *RandomGenerator;
-  bool is_pythia;
+
   int use_seed;
   unsigned int seed;
   double vertex_pos_x;

--- a/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
+++ b/simulation/g4simulation/g4main/PHG4ConsistencyCheck.cc
@@ -22,7 +22,7 @@ PHG4ConsistencyCheck::PHG4ConsistencyCheck(const std::string &name):
 {}
 
 int
-PHG4ConsistencyCheck::InitRun(PHCompositeNode */*topNode*/)
+PHG4ConsistencyCheck::InitRun(PHCompositeNode *topNode)
 {
 
   return 0;

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -49,7 +49,7 @@ class PHG4Detector
   virtual std::string GetName() const { return m_Name; }
   virtual void OverlapCheck(const bool chk) { m_OverlapCheck = chk; }
   virtual bool OverlapCheck() const { return m_OverlapCheck; }
-  virtual void Print(const std::string &/*what*/ = "ALL") const
+  virtual void Print(const std::string &what = "ALL") const
   {
     std::cout << GetName() << ": Print method not implemented" << std::endl;
   }

--- a/simulation/g4simulation/g4main/PHG4DisplayAction.h
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.h
@@ -35,7 +35,7 @@ class PHG4DisplayAction
 
   virtual std::string GetName() const { return m_Detector; }
 
-  virtual void Print(const std::string &/*what*/="ALL") {}
+  virtual void Print(const std::string &what="ALL") {}
 
   enum CheckReturnCodes
   {
@@ -55,13 +55,13 @@ class PHG4DisplayAction
   /*
  * @param[in] physical volume to be checked
  */
-  virtual int CheckVolume(G4VPhysicalVolume */*physvol*/) { return 0; }
+  virtual int CheckVolume(G4VPhysicalVolume *physvol) { return 0; }
 
   //! ApplyVisAttributes method
   /**
  *@param[in] physvol selected physical volume
  */
-  virtual void ApplyVisAttributes(G4VPhysicalVolume */*physvol*/) { return; }
+  virtual void ApplyVisAttributes(G4VPhysicalVolume *physvol) { return; }
 
  private:
   std::string m_Detector;

--- a/simulation/g4simulation/g4main/PHG4Hit.cc
+++ b/simulation/g4simulation/g4main/PHG4Hit.cc
@@ -41,22 +41,22 @@ PHG4Hit::CopyFrom(const PHObject *phobj)
 void
 PHG4Hit::identify(ostream& os) const
 {
-  os << "Class " << this->ClassName() << endl;
-  os << "x0: " << get_x(0)
+  cout << "Class " << this->ClassName() << endl;
+  cout << "x0: " << get_x(0)
        << ", y0: " << get_y(0)
        << ", z0: " << get_z(0)
        << ", t0: " << get_t(0) << endl;
-  os << "x1: " << get_x(1)
+  cout << "x1: " << get_x(1)
        << ", y1: " << get_y(1)
        << ", z1: " << get_z(1)
        << ", t1: " << get_t(1) << endl;
-  os     << "trackid: " << get_trkid() << ", edep: " << get_edep() << endl;
-  os     << "strip_z_index: " << get_strip_z_index() << ", strip_y_index: " << get_strip_y_index() << endl;
-  os     << "ladder_z_index: " << get_ladder_z_index() << ", ladder_phi_index: " << get_ladder_phi_index() << endl;
-  os     << "stave_index: " << get_property_int(prop_stave_index) << " half_stave_index " << get_property_int(prop_half_stave_index) << endl;
-  os     << "module_index: " << get_property_int(prop_module_index) << " chip_index " << get_property_int(prop_chip_index) << endl;
-  os << "layer id: " << get_layer() << ", scint_id: " << get_scint_id() << endl;
-  os << "hit type: " << get_hit_type() << endl; 
+  cout     << "trackid: " << get_trkid() << ", edep: " << get_edep() << endl;
+  cout     << "strip_z_index: " << get_strip_z_index() << ", strip_y_index: " << get_strip_y_index() << endl;
+  cout     << "ladder_z_index: " << get_ladder_z_index() << ", ladder_phi_index: " << get_ladder_phi_index() << endl;
+  cout     << "stave_index: " << get_property_int(prop_stave_index) << " half_stave_index " << get_property_int(prop_half_stave_index) << endl;
+  cout     << "module_index: " << get_property_int(prop_module_index) << " chip_index " << get_property_int(prop_chip_index) << endl;
+  cout << "layer id: " << get_layer() << ", scint_id: " << get_scint_id() << endl;
+  cout << "hit type: " << get_hit_type() << endl; 
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Hit.h
+++ b/simulation/g4simulation/g4main/PHG4Hit.h
@@ -25,16 +25,16 @@ class PHG4Hit: public PHObject
   void Reset() override;
 
   // The indices here represent the entry and exit points of the particle
-  virtual float get_x(const int) const {return NAN;}
-  virtual float get_y(const int) const {return NAN;}
-  virtual float get_z(const int) const {return NAN;}
-  virtual float get_px(const int) const {return NAN;}
-  virtual float get_py(const int) const {return NAN;}
-  virtual float get_pz(const int) const {return NAN;}
-  virtual float get_local_x(const int) const {return NAN;}
-  virtual float get_local_y(const int) const {return NAN;}
-  virtual float get_local_z(const int) const {return NAN;}
-  virtual float get_t(const int) const {return NAN;}
+  virtual float get_x(const int i) const {return NAN;}
+  virtual float get_y(const int i) const {return NAN;}
+  virtual float get_z(const int i) const {return NAN;}
+  virtual float get_px(const int i) const {return NAN;}
+  virtual float get_py(const int i) const {return NAN;}
+  virtual float get_pz(const int i) const {return NAN;}
+  virtual float get_local_x(const int i) const {return NAN;}
+  virtual float get_local_y(const int i) const {return NAN;}
+  virtual float get_local_z(const int i) const {return NAN;}
+  virtual float get_t(const int i) const {return NAN;}
   virtual float get_edep() const {return NAN;}
   virtual float get_eion() const {return NAN;}
   virtual float get_light_yield() const {return NAN;}
@@ -56,35 +56,35 @@ class PHG4Hit: public PHObject
   virtual int get_index_l() const {return INT_MIN;}
   virtual int get_hit_type() const {return INT_MIN;}
 
-  virtual void set_x(const int, const float) {return;}
-  virtual void set_y(const int, const float) {return;}
-  virtual void set_z(const int, const float) {return;}
-  virtual void set_px(const int, const float) {return;}
-  virtual void set_py(const int, const float) {return;}
-  virtual void set_pz(const int, const float) {return;}
-  virtual void set_local_x(const int, const float) {return;}
-  virtual void set_local_y(const int, const float) {return;}
-  virtual void set_local_z(const int, const float) {return;}
-  virtual void set_t(const int, const float) {return;}
-  virtual void set_edep(const float) {return;}
-  virtual void set_eion(const float) {return;}
-  virtual void set_light_yield(const float){return;}
-  virtual void set_path_length(const float){return;}
-  virtual void set_layer(const unsigned int) {return;}
-  virtual void set_hit_id(const PHG4HitDefs::keytype) {return;}
-  virtual void set_shower_id(const int) {return;}
-  virtual void set_scint_id(const int) {return;}
-  virtual void set_row(const int) {return;}
-  virtual void set_trkid(const int) {return;}
-  virtual void set_strip_z_index(const int) {return;}
-  virtual void set_strip_y_index(const int) {return;}
-  virtual void set_ladder_z_index(const int) {return;}
-  virtual void set_ladder_phi_index(const int) {return;}
-  virtual void set_index_i(const int) {return;}
-  virtual void set_index_j(const int) {return;}
-  virtual void set_index_k(const int) {return;}
-  virtual void set_index_l(const int) {return;}
-  virtual void set_hit_type(const int) {return;}
+  virtual void set_x(const int i, const float f) {return;}
+  virtual void set_y(const int i, const float f) {return;}
+  virtual void set_z(const int i, const float f) {return;}
+  virtual void set_px(const int i, const float f) {return;}
+  virtual void set_py(const int i, const float f) {return;}
+  virtual void set_pz(const int i, const float f) {return;}
+  virtual void set_local_x(const int i, const float f) {return;}
+  virtual void set_local_y(const int i, const float f) {return;}
+  virtual void set_local_z(const int i, const float f) {return;}
+  virtual void set_t(const int i, const float f) {return;}
+  virtual void set_edep(const float f) {return;}
+  virtual void set_eion(const float f) {return;}
+  virtual void set_light_yield(const float lightYield){return;}
+  virtual void set_path_length(const float pathLength){return;}
+  virtual void set_layer(const unsigned int i) {return;}
+  virtual void set_hit_id(const PHG4HitDefs::keytype i) {return;}
+  virtual void set_shower_id(const int i) {return;}
+  virtual void set_scint_id(const int i) {return;}
+  virtual void set_row(const int i) {return;}
+  virtual void set_trkid(const int i) {return;}
+  virtual void set_strip_z_index(const int i) {return;}
+  virtual void set_strip_y_index(const int i) {return;}
+  virtual void set_ladder_z_index(const int i) {return;}
+  virtual void set_ladder_phi_index(const int i) {return;}
+  virtual void set_index_i(const int i) {return;}
+  virtual void set_index_j(const int i) {return;}
+  virtual void set_index_k(const int i) {return;}
+  virtual void set_index_l(const int i) {return;}
+  virtual void set_hit_type(const int i) {return;}
 
   virtual float get_avg_x() const;
   virtual float get_avg_y() const;
@@ -180,20 +180,20 @@ class PHG4Hit: public PHObject
     type_unknown = -1
   };
 
-  virtual bool  has_property(const PROPERTY /*prop_id*/) const {return false;}
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const {return NAN;}
-  virtual int   get_property_int(const PROPERTY /*prop_id*/) const {return INT_MIN;}
-  virtual unsigned int   get_property_uint(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const float /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const int /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) {return;}
+  virtual bool  has_property(const PROPERTY prop_id) const {return false;}
+  virtual float get_property_float(const PROPERTY prop_id) const {return NAN;}
+  virtual int   get_property_int(const PROPERTY prop_id) const {return INT_MIN;}
+  virtual unsigned int   get_property_uint(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void  set_property(const PROPERTY prop_id, const float value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const int value) {return;}
+  virtual void  set_property(const PROPERTY prop_id, const unsigned int value) {return;}
   static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/,const unsigned int) {return;}
+  virtual unsigned int get_property_nocheck(const PROPERTY prop_id) const {return UINT_MAX;}
+  virtual void set_property_nocheck(const PROPERTY prop_id,const unsigned int) {return;}
   ClassDefOverride(PHG4Hit,1)
 };
 

--- a/simulation/g4simulation/g4main/PHG4HitReadBack.cc
+++ b/simulation/g4simulation/g4main/PHG4HitReadBack.cc
@@ -21,7 +21,7 @@ PHG4HitReadBack::PHG4HitReadBack(const string &name): SubsysReco(name)
 }
 
 int
-PHG4HitReadBack::InitRun(PHCompositeNode */*topNode*/)
+PHG4HitReadBack::InitRun(PHCompositeNode *topNode)
 {
   return 0;
 }

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -382,37 +382,37 @@ PHG4Hitv1::set_local_z(const int i, const float f)
 void
 PHG4Hitv1::identify(ostream& os) const
 {
-  os << "Class " << this->ClassName() << endl;
-  os << "hitid: 0x" << hex << hitid << dec << endl; 
-  os << "x0: " << get_x(0)
+  cout << "Class " << this->ClassName() << endl;
+  cout << "hitid: 0x" << hex << hitid << dec << endl; 
+  cout << "x0: " << get_x(0)
        << ", y0: " << get_y(0)
        << ", z0: " << get_z(0)
        << ", t0: " << get_t(0) << endl;
-  os << "x1: " << get_x(1)
+  cout << "x1: " << get_x(1)
        << ", y1: " << get_y(1)
        << ", z1: " << get_z(1)
        << ", t1: " << get_t(1) << endl;
-  os << "trackid: " << trackid << ", showerid: " << showerid
+  cout << "trackid: " << trackid << ", showerid: " << showerid
        << ", edep: " << edep << endl;
   for (prop_map_t::const_iterator i = prop_map.begin(); i!= prop_map.end(); ++i)
     {
       PROPERTY prop_id = static_cast<PROPERTY>(i->first);
       pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-      os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+      cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
       switch(property_info.second)
 	{
 	case type_int:
-	  os << get_property_int(prop_id);
+	  cout << get_property_int(prop_id);
 	  break;
 	case type_uint:
-	  os << get_property_uint(prop_id);
+	  cout << get_property_uint(prop_id);
 	  break;
 	case type_float:
-	  os << get_property_float(prop_id);
+	  cout << get_property_float(prop_id);
 	  break;
 	default:
-	  os << " unknown type ";
+	  cout << " unknown type ";
 	}
-      os <<endl;
+      cout <<endl;
     }
 }

--- a/simulation/g4simulation/g4main/PHG4InEvent.cc
+++ b/simulation/g4simulation/g4main/PHG4InEvent.cc
@@ -6,7 +6,7 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <algorithm>
+
 using namespace std;
 
 PHG4InEvent::~PHG4InEvent()
@@ -18,7 +18,7 @@ PHG4InEvent::~PHG4InEvent()
 }
 
 int
-PHG4InEvent::AddVtx(const int /*id*/, const PHG4VtxPoint &vtx)
+PHG4InEvent::AddVtx(const int id, const PHG4VtxPoint &vtx)
 {
   PHG4VtxPoint *newvtx = new PHG4VtxPoint(vtx);
   int iret = AddVtxCommon(newvtx);
@@ -46,28 +46,8 @@ PHG4InEvent::AddVtxCommon(PHG4VtxPoint *newvtx)
 {
   std::pair< std::map<int, PHG4VtxPoint *>::const_iterator, std::map<int, PHG4VtxPoint *>::const_iterator > vtxbegin_end =  GetVertices();
   for (map<int, PHG4VtxPoint *>::const_iterator viter = vtxbegin_end.first; viter != vtxbegin_end.second; ++viter)
-    {        
-      /// Do a simultaneous relative + absolute floating point comparison for 
-      /// the vertex four vectors
-      /// make the distance comparison 1 micron, time comparison 0.1 ps
-      const auto distepsilon = 0.0001;
-      const auto timeepsilon = 0.0001;
-      auto xlist = {1.0, std::abs(newvtx->get_x()), std::abs(viter->second->get_x())};
-      auto ylist = {1.0, std::abs(newvtx->get_y()), std::abs(viter->second->get_y())};
-      auto zlist = {1.0, std::abs(newvtx->get_z()), std::abs(viter->second->get_z())};
-      auto tlist = {1.0, std::abs(newvtx->get_t()), std::abs(viter->second->get_t())};
-     
-      bool xcomp = std::abs(newvtx->get_x() - viter->second->get_x())
-	<= distepsilon * (*std::max_element(xlist.begin(), xlist.end()));
-      bool ycomp = std::abs(newvtx->get_y() - viter->second->get_y())
-	<= distepsilon * (*std::max_element(ylist.begin(), ylist.end()));
-      bool zcomp = std::abs(newvtx->get_z() - viter->second->get_z())
-	<= distepsilon * (*std::max_element(zlist.begin(), zlist.end()));
-      bool tcomp = std::abs(newvtx->get_t() - viter->second->get_t())
-	<= timeepsilon * (*std::max_element(tlist.begin(), tlist.end()));
-      
-      if (*newvtx == *(viter->second) or
-	  (xcomp and ycomp and zcomp and tcomp) )
+    {
+      if (*newvtx == *(viter->second))
 	{
 	  delete newvtx;
 	  return viter->first;

--- a/simulation/g4simulation/g4main/PHG4InEventCompress.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventCompress.cc
@@ -107,7 +107,7 @@ PHG4InEventCompress::process_event(PHCompositeNode *topNode)
 }
 
 int
-PHG4InEventCompress::End(PHCompositeNode */*topNode*/)
+PHG4InEventCompress::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4main/PHG4InEventReadBack.cc
+++ b/simulation/g4simulation/g4main/PHG4InEventReadBack.cc
@@ -104,7 +104,7 @@ PHG4InEventReadBack::process_event(PHCompositeNode *topNode)
 }
 
 int
-PHG4InEventReadBack::End(PHCompositeNode */*topNode*/)
+PHG4InEventReadBack::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4main/PHG4IonGun.cc
+++ b/simulation/g4simulation/g4main/PHG4IonGun.cc
@@ -69,7 +69,7 @@ void PHG4IonGun::UpdateParticle()
   return;
 }
 
-void PHG4IonGun::Print(const string &/*what*/) const
+void PHG4IonGun::Print(const string &what) const
 {
   cout << "PHG4IonGun, using ions of" << endl;
   cout << "A: " << A << ", Z: " << Z << ", charge: " << ioncharge

--- a/simulation/g4simulation/g4main/PHG4Particle.cc
+++ b/simulation/g4simulation/g4main/PHG4Particle.cc
@@ -1,8 +1,10 @@
 #include "PHG4Particle.h"
 
-void PHG4Particle::identify(std::ostream& os) const
+using namespace std;
+
+void PHG4Particle::identify(ostream& os) const
 {
-  os << "calling virtual PHG4Particle base class" << std::endl;
+  cout << "calling virtual PHG4Particle base class" << endl;
   return;
 }
 

--- a/simulation/g4simulation/g4main/PHG4Particle.h
+++ b/simulation/g4simulation/g4main/PHG4Particle.h
@@ -38,24 +38,24 @@ class PHG4Particle : public PHObject
   virtual double get_IonCharge() const { return NAN; }
   virtual double get_ExcitEnergy() const { return NAN; }
 
-  virtual void set_track_id(const int) { return; }
-  virtual void set_vtx_id(const int) { return; }
-  virtual void set_parent_id(const int) { return; }
-  virtual void set_primary_id(const int) { return; }
-  virtual void set_name(const std::string &) { return; }
-  virtual void set_pid(const int) { return; }
-  virtual void set_px(const double) { return; }
-  virtual void set_py(const double) { return; }
-  virtual void set_pz(const double) { return; }
-  virtual void set_e(const double) { return; }
+  virtual void set_track_id(const int i) { return; }
+  virtual void set_vtx_id(const int i) { return; }
+  virtual void set_parent_id(const int i) { return; }
+  virtual void set_primary_id(const int i) { return; }
+  virtual void set_name(const std::string &name) { return; }
+  virtual void set_pid(const int i) { return; }
+  virtual void set_px(const double x) { return; }
+  virtual void set_py(const double x) { return; }
+  virtual void set_pz(const double x) { return; }
+  virtual void set_e(const double e) { return; }
 
-  virtual void set_barcode(const int) { return; }
+  virtual void set_barcode(const int barcode) { return; }
 
-  virtual void set_A(const int) { return; }
-  virtual void set_Z(const int) { return; }
-  virtual void set_NumCharge(const int) { return; }
-  virtual void set_IonCharge(const double) { return; }
-  virtual void set_ExcitEnergy(const double) { return; }
+  virtual void set_A(const int a) { return; }
+  virtual void set_Z(const int z) { return; }
+  virtual void set_NumCharge(const int c) { return; }
+  virtual void set_IonCharge(const double e) { return; }
+  virtual void set_ExcitEnergy(const double e) { return; }
 
   bool operator==(const PHG4Particle &p) const;
 

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -141,13 +141,13 @@ int PHG4ParticleGeneratorBase::InitRun(PHCompositeNode *topNode)
   return 0;
 }
 
-int PHG4ParticleGeneratorBase::process_event(PHCompositeNode */*topNode*/)
+int PHG4ParticleGeneratorBase::process_event(PHCompositeNode *topNode)
 {
   std::cout << PHWHERE << " " << Name() << " using empty process_event" << std::endl;
   return 0;
 }
 
-void PHG4ParticleGeneratorBase::PrintParticles(const std::string &/*what*/) const
+void PHG4ParticleGeneratorBase::PrintParticles(const std::string &what) const
 {
   std::vector<PHG4Particle *>::const_iterator iter;
   int i = 0;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -70,7 +70,7 @@ void PHG4ParticleGeneratorD0::set_mass(const double mass_in)
   return;
 }
 
-int PHG4ParticleGeneratorD0::InitRun(PHCompositeNode */*topNode*/)
+int PHG4ParticleGeneratorD0::InitRun(PHCompositeNode *topNode)
 {
   unsigned int iseed = PHRandomSeed();  // fixed seed handled in PHRandomSeed()
   std::cout << Name() << " random seed: " << iseed << std::endl;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -472,7 +472,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
 }
 
 double
-PHG4ParticleGeneratorVectorMeson::smearvtx(const double position, const double /*width*/, FUNCTION dist) const
+PHG4ParticleGeneratorVectorMeson::smearvtx(const double position, const double width, FUNCTION dist) const
 {
   double res = position;
   if (dist == Uniform)

--- a/simulation/g4simulation/g4main/PHG4PhenixDisplayAction.cc
+++ b/simulation/g4simulation/g4main/PHG4PhenixDisplayAction.cc
@@ -24,7 +24,7 @@ PHG4PhenixDisplayAction::~PHG4PhenixDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4PhenixDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4PhenixDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4main/PHG4ScoringManager.cc
+++ b/simulation/g4simulation/g4main/PHG4ScoringManager.cc
@@ -61,7 +61,7 @@ PHG4ScoringManager::PHG4ScoringManager()
 {
 }
 
-int PHG4ScoringManager::InitRun(PHCompositeNode */*topNode*/)
+int PHG4ScoringManager::InitRun(PHCompositeNode *topNode)
 {
   //1. check G4RunManager
   G4RunManager *runManager = G4RunManager::GetRunManager();

--- a/simulation/g4simulation/g4main/PHG4Shower.cc
+++ b/simulation/g4simulation/g4main/PHG4Shower.cc
@@ -49,7 +49,7 @@ PHG4Shower::HitIdConstIter PHG4Shower::begin_g4hit_id() const
   return DummyHitIdMap.end();
 }
 
-PHG4Shower::HitIdConstIter PHG4Shower::find_g4hit_id(int /*volume*/) const
+PHG4Shower::HitIdConstIter PHG4Shower::find_g4hit_id(int volume) const
 {
   return DummyHitIdMap.end();
 }
@@ -64,7 +64,7 @@ PHG4Shower::HitIdIter PHG4Shower::begin_g4hit_id()
   return DummyHitIdMap.end();
 }
 
-PHG4Shower::HitIdIter PHG4Shower::find_g4hit_id(int /*volume*/)
+PHG4Shower::HitIdIter PHG4Shower::find_g4hit_id(int volume)
 {
   return DummyHitIdMap.end();
 }

--- a/simulation/g4simulation/g4main/PHG4Shower.h
+++ b/simulation/g4simulation/g4main/PHG4Shower.h
@@ -39,79 +39,79 @@ class PHG4Shower : public PHObject
   // shower info
 
   virtual int get_id() const { return 0; }
-  virtual void set_id(int /*id*/) {}
+  virtual void set_id(int id) {}
 
   virtual int get_parent_particle_id() const { return 0; }
-  virtual void set_parent_particle_id(int /*parent_particle_id*/) {}
+  virtual void set_parent_particle_id(int parent_particle_id) {}
 
   virtual int get_parent_shower_id() const { return 0; }
-  virtual void set_parent_shower_id(int /*parent_shower_id*/) {}
+  virtual void set_parent_shower_id(int parent_shower_id) {}
 
   virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual void set_x(float x) {}
 
   virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual void set_y(float y) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float x) {}
 
-  virtual float get_position(unsigned int /*coor*/) const { return NAN; }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
+  virtual float get_position(unsigned int coor) const { return NAN; }
+  virtual void set_position(unsigned int coor, float xi) {}
 
-  virtual float get_covar(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void set_covar(unsigned int /*i*/, unsigned int /*j*/, float /*entry*/) {}
+  virtual float get_covar(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void set_covar(unsigned int i, unsigned int j, float entry) {}
 
-  virtual unsigned int get_nhits(int /*volume*/) const { return 0; }
-  virtual void set_nhits(int /*volume*/, unsigned int /*nhits*/) {}
+  virtual unsigned int get_nhits(int volume) const { return 0; }
+  virtual void set_nhits(int volume, unsigned int nhits) {}
 
   virtual double get_edep() const { return NAN; }
-  virtual float get_edep(int /*volume*/) const { return NAN; }
-  virtual void set_edep(int /*volume*/, float /*edep*/) {}
+  virtual float get_edep(int volume) const { return NAN; }
+  virtual void set_edep(int volume, float edep) {}
 
   virtual double get_eion() const { return NAN; }
-  virtual float get_eion(int /*volume*/) const { return NAN; }
-  virtual void set_eion(int /*volume*/, float /*eion*/) {}
+  virtual float get_eion(int volume) const { return NAN; }
+  virtual void set_eion(int volume, float eion) {}
 
-  virtual float get_light_yield(int /*volume*/) const { return NAN; }
-  virtual void set_light_yield(int /*volume*/, float /*light_yield*/) {}
+  virtual float get_light_yield(int volume) const { return NAN; }
+  virtual void set_light_yield(int volume, float light_yield) {}
 
-  virtual float get_eh_ratio(int /*volume*/) const { return NAN; }
-  virtual void set_eh_ratio(int /*volume*/, float /*eh_ratio*/) {}
+  virtual float get_eh_ratio(int volume) const { return NAN; }
+  virtual void set_eh_ratio(int volume, float eh_ratio) {}
 
   virtual bool empty_g4particle_id() const { return true; }
   virtual size_t size_g4particle_id() const { return 0; }
-  virtual void add_g4particle_id(int /*id*/) {}
+  virtual void add_g4particle_id(int id) {}
   virtual ParticleIdIter begin_g4particle_id();
   virtual ParticleIdConstIter begin_g4particle_id() const;
   virtual ParticleIdIter end_g4particle_id();
   virtual ParticleIdConstIter end_g4particle_id() const;
-  virtual size_t remove_g4particle_id(int /*id*/) { return 0; }
+  virtual size_t remove_g4particle_id(int id) { return 0; }
   virtual void clear_g4particle_id() {}
   virtual const ParticleIdSet& g4particle_ids() const = 0;
 
   virtual bool empty_g4vertex_id() const { return true; }
   virtual size_t size_g4vertex_id() const { return 0; }
-  virtual void add_g4vertex_id(int /*id*/) {}
+  virtual void add_g4vertex_id(int id) {}
   virtual VertexIdIter begin_g4vertex_id();
   virtual VertexIdConstIter begin_g4vertex_id() const;
   virtual VertexIdIter end_g4vertex_id();
   virtual VertexIdConstIter end_g4vertex_id() const;
-  virtual size_t remove_g4vertex_id(int /*id*/) { return 0; }
+  virtual size_t remove_g4vertex_id(int id) { return 0; }
   virtual void clear_g4vertex_id() {}
   virtual const VertexIdSet& g4vertex_ids() const = 0;
 
   virtual bool empty_g4hit_id() const { return true; }
   virtual size_t size_g4hit_id() const { return 0; }
-  virtual void add_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) {}
+  virtual void add_g4hit_id(int volume, PHG4HitDefs::keytype id) {}
   virtual HitIdIter begin_g4hit_id();
   virtual HitIdConstIter begin_g4hit_id() const;
-  virtual HitIdIter find_g4hit_id(int /*volume*/);
-  virtual HitIdConstIter find_g4hit_id(int /*volume*/) const;
+  virtual HitIdIter find_g4hit_id(int volume);
+  virtual HitIdConstIter find_g4hit_id(int volume) const;
   virtual HitIdIter end_g4hit_id();
   virtual HitIdConstIter end_g4hit_id() const;
-  virtual size_t remove_g4hit_id(int /*volume*/, PHG4HitDefs::keytype /*id*/) { return 0; }
-  virtual size_t remove_g4hit_volume(int /*volume*/) { return 0; }
+  virtual size_t remove_g4hit_id(int volume, PHG4HitDefs::keytype id) { return 0; }
+  virtual size_t remove_g4hit_volume(int volume) { return 0; }
   virtual void clear_g4hit_id() {}
   virtual const HitIdMap& g4hit_ids() const = 0;
 

--- a/simulation/g4simulation/g4main/PHG4StackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4StackingAction.h
@@ -24,14 +24,14 @@ class PHG4StackingAction
   //! stacking action. This gets called by the stacking action when a new track is generated
   // It can classify those tracks (urgent, wait, kill, postpone to next event)
   // default return in G4 is fUrgent
-  virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track* /*aTrack*/) {return fUrgent;}
+  virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track* aTrack) {return fUrgent;}
   virtual void PrepareNewEvent() {}
   virtual void Verbosity(const int i) { m_Verbosity = i; }
   virtual int Verbosity() const { return m_Verbosity; }
   virtual int Init() { return 0; }
 
   virtual void SetInterfacePointers(PHCompositeNode*) { return; }
-  virtual void Print(const std::string& /*what*/) const { return; }
+  virtual void Print(const std::string& what) const { return; }
   std::string GetName() const { return m_Name; }
   void SetName(const std::string& name) { m_Name = name; }
 

--- a/simulation/g4simulation/g4main/PHG4SteppingAction.h
+++ b/simulation/g4simulation/g4main/PHG4SteppingAction.h
@@ -39,7 +39,7 @@ class PHG4SteppingAction
   virtual void StoreLocalCoordinate(PHG4Hit* hit, const G4Step* step, const bool do_prepoint, const bool do_postpoint);
 
   virtual void SetInterfacePointers(PHCompositeNode*) { return; }
-  virtual void Print(const std::string& /*what*/) const { return; }
+  virtual void Print(const std::string& what) const { return; }
   std::string GetName() const { return m_Name; }
   void SetName(const std::string& name) { m_Name = name; }
   virtual void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);

--- a/simulation/g4simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4simulation/g4main/PHG4Subsystem.h
@@ -85,7 +85,7 @@ class PHG4Subsystem : public SubsysReco
   virtual bool CanBeMotherSubsystem() const {return false;}
 
 //
-  virtual void AddProcesses(G4ParticleDefinition */*particle*/) {}
+  virtual void AddProcesses(G4ParticleDefinition *particle) {}
 
  private:
   PHG4Subsystem *m_MyMotherSubsystem = nullptr;

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -45,7 +45,7 @@ PHG4TruthEventAction::PHG4TruthEventAction()
 }
 
 //___________________________________________________
-void PHG4TruthEventAction::BeginOfEventAction(const G4Event* /*evt*/)
+void PHG4TruthEventAction::BeginOfEventAction(const G4Event* evt)
 {
   // if we do not find the node we need to make it.
   if (!m_TruthInfoContainer)

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -49,47 +49,47 @@ void PHG4TruthInfoContainer::Reset()
 
 void PHG4TruthInfoContainer::identify(ostream& os) const
 {
-  os << "---particlemap--------------------------" << endl;
+  cout << "---particlemap--------------------------" << endl;
   for (ConstIterator iter = particlemap.begin(); iter != particlemap.end(); ++iter)
   {
-    os << "particle id " << iter->first << endl;
+    cout << "particle id " << iter->first << endl;
     (iter->second)->identify();
   }
 
-  os << "---vtxmap-------------------------------" << endl;
+  cout << "---vtxmap-------------------------------" << endl;
   for (ConstVtxIterator vter = vtxmap.begin(); vter != vtxmap.end(); ++vter)
   {
-    os << "vtx id: " << vter->first << endl;
+    cout << "vtx id: " << vter->first << endl;
     (vter->second)->identify();
   }
 
-  os << "---showermap-------------------------------" << endl;
+  cout << "---showermap-------------------------------" << endl;
   for (ConstShowerIterator ster = showermap.begin(); ster != showermap.end(); ++ster)
   {
-    os << "shower id: " << ster->first << endl;
+    cout << "shower id: " << ster->first << endl;
     (ster->second)->identify();
   }
 
-  os << "---list of embeded track flags-------------------" << endl;
+  cout << "---list of embeded track flags-------------------" << endl;
   for (std::map<int, int>::const_iterator eter = particle_embed_flags.begin();
        eter != particle_embed_flags.end();
        ++eter)
   {
-    os << "embeded track id: " << eter->first
+    cout << "embeded track id: " << eter->first
          << " flag: " << eter->second << endl;
   }
 
-  os << "---list of embeded vtx flags-------------------" << endl;
+  cout << "---list of embeded vtx flags-------------------" << endl;
   for (std::map<int, int>::const_iterator eter = vertex_embed_flags.begin();
        eter != vertex_embed_flags.end();
        ++eter)
   {
-    os << "embeded vertex id: " << eter->first
+    cout << "embeded vertex id: " << eter->first
          << " flag: " << eter->second << endl;
   }
 
-  os << "---primary vertex-------------------" << endl;
-  os << "Vertex " << GetPrimaryVertexIndex() << " is identified as the primary vertex" << endl;
+  cout << "---primary vertex-------------------" << endl;
+  cout << "Vertex " << GetPrimaryVertexIndex() << " is identified as the primary vertex" << endl;
 
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4VertexSelection.cc
+++ b/simulation/g4simulation/g4main/PHG4VertexSelection.cc
@@ -25,7 +25,7 @@ PHG4VertexSelection::PHG4VertexSelection(const std::string &name)
 }
 
 //____________________________________________________________________________
-int PHG4VertexSelection::InitRun(PHCompositeNode */*topNode*/)
+int PHG4VertexSelection::InitRun(PHCompositeNode *topNode)
 {
   UpdateParametersWithMacro();
 

--- a/simulation/g4simulation/g4main/PHG4VtxPoint.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPoint.h
@@ -16,11 +16,11 @@ class PHG4VtxPoint: public PHObject
 
   void identify(std::ostream& os = std::cout) const override;
 
-  virtual void set_x(const double) {}
-  virtual void set_y(const double) {}
-  virtual void set_z(const double) {}
-  virtual void set_t(const double) {}
-  virtual void set_id(const int) {}
+  virtual void set_x(const double r) {}
+  virtual void set_y(const double r) {}
+  virtual void set_z(const double r) {}
+  virtual void set_t(const double r) {}
+  virtual void set_id(const int i) {}
 
   virtual double get_x() const {return NAN;}
   virtual double get_y() const {return NAN;}

--- a/simulation/g4simulation/g4main/ReadEICFiles.cc
+++ b/simulation/g4simulation/g4main/ReadEICFiles.cc
@@ -137,12 +137,17 @@ int ReadEICFiles::process_event(PHCompositeNode *topNode)
     evthead->set_milou_trueX(gen->trueX);
     evthead->set_milou_trueQ2(gen->trueQ2);
   }
-  break;
   case EvtGen::DEMP:
   {
     erhic::EventDEMP *gen = dynamic_cast<erhic::EventDEMP *>(GenEvent);
+
+//    cout << gen->weight << endl;
     evthead->set_eventgenerator_type(EicEventHeader::EvtGen::DEMP);
     evthead->set_demp_weight(gen->weight);
+
+//    cout << "DEMP: " <<  gen->weight << "     " << " aAAAAAAAAA:  " << evthead->get_demp_weight() << endl;
+//    exit(0);
+
   }
   break;
   case EvtGen::Unknown:
@@ -152,6 +157,11 @@ int ReadEICFiles::process_event(PHCompositeNode *topNode)
     cout << "what is this " << m_EvtGenId << " ????" << endl;
     break;
   }
+
+
+//  cout << "what is this " << m_EvtGenId << " ????" << endl;
+//  exit(0);
+
 
   /* Create GenEvent */
   HepMC::GenEvent *evt = new HepMC::GenEvent();

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -10,10 +10,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDigitizer.cc
@@ -51,7 +51,7 @@ PHG4MicromegasDigitizer::PHG4MicromegasDigitizer(const std::string &name)
 }
 
 //____________________________________________________________________________
-int PHG4MicromegasDigitizer::InitRun(PHCompositeNode */*topNode*/)
+int PHG4MicromegasDigitizer::InitRun(PHCompositeNode *topNode)
 {
 
   UpdateParametersWithMacro();

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSteppingAction.cc
@@ -55,7 +55,7 @@ PHG4MicromegasSteppingAction::PHG4MicromegasSteppingAction(PHG4MicromegasDetecto
 
 //____________________________________________________________________________..
 // This is the implementation of the G4 UserSteppingAction
-bool PHG4MicromegasSteppingAction::UserSteppingAction(const G4Step *aStep,bool /*was_used*/)
+bool PHG4MicromegasSteppingAction::UserSteppingAction(const G4Step *aStep,bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();

--- a/simulation/g4simulation/g4micromegas/configure.ac
+++ b/simulation/g4simulation/g4micromegas/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
@@ -12,7 +12,7 @@
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
-#include <g4main/PHG4Subsystem.h>                   // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -220,7 +220,7 @@ int PHG4EICMvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITS
   int N_staves = m_N_staves[layer];
   G4double layer_nominal_radius = m_nominal_radius[layer];
   G4double phitilt = m_nominal_phitilt[layer];
-  G4double phi0    = m_nominal_phi0[layer]; //YCM: azimuthal offset for the first stave
+  G4double phi0 = m_nominal_phi0[layer];  //YCM: azimuthal offset for the first stave
 
   if (N_staves < 0)
   {
@@ -373,7 +373,7 @@ void PHG4EICMvtxDetector::AddGeometryNode()
   {
     active |= isAct;
   }
-  if (active) // At least one layer is active
+  if (active)  // At least one layer is active
   {
     ostringstream geonode;
     geonode << "CYLINDERGEOM_" << ((m_SuperDetector != "NONE") ? m_SuperDetector : m_Detector);
@@ -395,8 +395,7 @@ void PHG4EICMvtxDetector::AddGeometryNode()
                                                         m_nominal_radius[ilayer] / cm,
                                                         get_phistep(ilayer) / rad,
                                                         m_nominal_phitilt[ilayer] / rad,
-                                                        m_nominal_phi0[ilayer] / rad
-                                                        );
+                                                        m_nominal_phi0[ilayer] / rad);
       geo->AddLayerGeom(ilayer, mygeom);
     }  // loop per layers
     if (Verbosity())

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
@@ -6,28 +6,28 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
@@ -43,10 +43,10 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
-#include <cmath>                              // for NAN
-#include <cstdlib>                            // for exit
+#include <cmath>    // for NAN
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                              // for operator<<, basic_string
+#include <string>  // for operator<<, basic_string
 
 class PHCompositeNode;
 
@@ -254,7 +254,7 @@ bool PHG4EICMvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         theTouchable = prePoint->GetTouchableHandle();
         cout << "entering: depth = " << theTouchable->GetHistory()->GetDepth() << endl;
-        G4VPhysicalVolume *vol1 = theTouchable->GetVolume();
+        G4VPhysicalVolume* vol1 = theTouchable->GetVolume();
         cout << "entering volume name = " << vol1->GetName() << endl;
       }
 

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.cc
@@ -1,34 +1,33 @@
 #include "PHG4EICMvtxSubsystem.h"
 
-#include "PHG4MvtxDefs.h"
 #include "PHG4EICMvtxDetector.h"
-#include "PHG4MvtxDisplayAction.h"
 #include "PHG4EICMvtxSteppingAction.h"
+#include "PHG4MvtxDefs.h"
+#include "PHG4MvtxDisplayAction.h"
 
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>  // for PHG4DetectorGrou...
 
-#include <g4main/PHG4DisplayAction.h>                // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>               // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
-#include <phool/PHIODataNode.h>                      // for PHIODataNode
-#include <phool/PHNode.h>                            // for PHNode
-#include <phool/PHNodeIterator.h>                    // for PHNodeIterator
-#include <phool/PHObject.h>                          // for PHObject
-#include <phool/phool.h>                             // for PHWHERE
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
-#include <mvtx/SegmentationAlpide.h>                 // for Alpide constants
+#include <mvtx/SegmentationAlpide.h>  // for Alpide constants
 
-#include <iostream>                                  // for operator<<, basi...
-#include <set>                                       // for _Rb_tree_const_i...
+#include <iostream>  // for operator<<, basi...
+#include <set>       // for _Rb_tree_const_i...
 #include <sstream>
-#include <utility>                                   // for pair
+#include <utility>  // for pair
 
 class PHG4Detector;
 

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
@@ -5,8 +5,8 @@
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <cmath>                                     // for asin
-#include <string>                                    // for string
+#include <cmath>   // for asin
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
@@ -5,17 +5,18 @@
 
 namespace PHG4MvtxDefs
 {
-
   static constexpr unsigned int kNLayers = 3;
 
-  enum {
+  enum
+  {
     kRmn,
     kRmd,
     kRmx,
     kNModPerStave,
     kPhi0,
     kNStave,
-    kNPar};
+    kNPar
+  };
 
   static const double mvtxdat[kNLayers][kNPar] = {
       {24.61, 25.23, 27.93, 9., 0.285, 12.},  // for each layer: rMin, rMid, rMax, NChip/Stave, phi0, nStaves
@@ -25,10 +26,11 @@ namespace PHG4MvtxDefs
   static const int GLOBAL = -1;
   static const int ALPIDE_SEGMENTATION = -2;
   static const int SUPPORTPARAMS = -3;
+  static const int ALIGNMENT = -4;
 
-// passive volume indices
+  // passive volume indices
 
-// detid of support structures
+  // detid of support structures
 
 };  // namespace PHG4MvtxDefs
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -12,7 +12,7 @@
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
-#include <g4main/PHG4Subsystem.h>                   // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -26,15 +26,15 @@
 #include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>            // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
-#include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4Tubs.hh>
 
 #include <cmath>
 #include <cstdio>    // for sprintf
@@ -48,16 +48,16 @@ using namespace std;
 
 namespace mvtxGeomDef
 {
-  double mvtx_shell_inner_radius            =  4.8  * cm;
-  double skin_thickness                     =  0.01 * cm;
-  double foam_core_thickness                =  0.18 * cm;
-  double mvtx_shell_length                  = 50.   * cm;
-  double mvtx_shell_thickness =  skin_thickness + foam_core_thickness + skin_thickness;
+  double mvtx_shell_inner_radius = 4.8 * cm;
+  double skin_thickness = 0.01 * cm;
+  double foam_core_thickness = 0.18 * cm;
+  double mvtx_shell_length = 50. * cm;
+  double mvtx_shell_thickness = skin_thickness + foam_core_thickness + skin_thickness;
 
   double wrap_rmin = 2.1 * cm;
   double wrap_rmax = mvtx_shell_inner_radius + mvtx_shell_thickness;
   double wrap_zlen = mvtx_shell_length;
-};
+};  // namespace mvtxGeomDef
 
 PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
@@ -66,6 +66,7 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
   , m_StaveGeometryFile(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("stave_geometry_file"))
   , m_EndWheelsSideS(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("end_wheels_sideS"))
   , m_EndWheelsSideN(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("end_wheels_sideN"))
+  , m_alignmentPath(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("alignment_path"))
 {
   //  Verbosity(2);
 
@@ -74,6 +75,11 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
 
   if (Verbosity() > 10)
     cout << " cm " << cm << " mm " << mm << endl;
+
+  const PHParameters* defualt_align_params = m_ParamsContainer->GetParameters(PHG4MvtxDefs::ALIGNMENT);
+  PHParameters* align_params = new PHParameters(*defualt_align_params, "defaultMVTXalignment");
+  align_params->ReadFromFile("mvtx", "xml", PHG4MvtxDefs::ALIGNMENT, true, m_alignmentPath);
+
   for (int ilayer = 0; ilayer < n_Layers; ++ilayer)
   {
     const PHParameters* params = m_ParamsContainer->GetParameters(ilayer);
@@ -84,7 +90,20 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
     m_nominal_radius[ilayer] = params->get_double_param("layer_nominal_radius");
     m_nominal_phitilt[ilayer] = params->get_double_param("phitilt");
     m_nominal_phi0[ilayer] = params->get_double_param("phi0");
+    m_layer_z_offset[ilayer] = params->get_double_param("layer_z_offset");
+
+    for (int iStave = 0; iStave < m_N_staves[ilayer]; ++iStave)
+    {
+      pair<int, int> stave_coord = make_pair(ilayer, iStave);
+      std::string stave_location = Form("layer_%i_stave_%i", ilayer, iStave);
+      m_stave_name[stave_coord] = align_params->get_string_param(stave_location + "_name");
+      m_stave_x_offset[stave_coord] = align_params->get_double_param(stave_location + "_x_offset");
+      m_stave_y_offset[stave_coord] = align_params->get_double_param(stave_location + "_y_offset");
+      m_stave_z_offset[stave_coord] = align_params->get_double_param(stave_location + "_z_offset");
+      m_stave_tilt[stave_coord] = align_params->get_double_param(stave_location + "_tilt");
+    }
   }
+
   /*
   const PHParameters* alpide_params = m_ParamsContainer->GetParameters(PHG4MvtxDefs::ALPIDE_SEGMENTATION);
   m_PixelX = alpide_params->get_double_param("pixel_x");
@@ -245,7 +264,7 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
   int N_staves = m_N_staves[layer];
   G4double layer_nominal_radius = m_nominal_radius[layer];
   G4double phitilt = m_nominal_phitilt[layer];
-  G4double phi0    = m_nominal_phi0[layer]; //YCM: azimuthal offset for the first stave
+  G4double phi0 = m_nominal_phi0[layer];  //YCM: azimuthal offset for the first stave
 
   if (N_staves < 0)
   {
@@ -271,7 +290,6 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
   }
 
   G4double phistep = get_phistep(layer);  // this produces even stave spacing
-  double z_location = 0.0;
 
   if (Verbosity() > 0)
   {
@@ -306,19 +324,48 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
     // It  is first rotated in phi by the azimuthal angle phi_rotation, plus the 90 degrees needed to point the face of the sensor  at the origin,  plus the tilt (if a tilt is appropriate)
 
     // note - if this is layer 0-2, phitilt is the additional tilt for clearance. Otherwise it is zero
+    Ra.rotateX(0);
+    Ra.rotateY(0);
     Ra.rotateZ(phi_rotation + phi_offset + phitilt);
     // Then translated as follows
 
-    Ta.setX(layer_nominal_radius * cos(phi_rotation));
-    Ta.setY(layer_nominal_radius * sin(phi_rotation));
-    Ta.setZ(z_location);
+    double x_offset = 0.0;
+    double y_offset = 0.0;
+    double z_offset = 0.0;
+    z_offset = m_layer_z_offset[layer];
+
+    //Now add stave specific tilts and offsets
+    std::pair<int, int> thisStave{layer, iphi};
+    if (m_stave_tilt.find(thisStave)->second != 0.0)
+    {
+      double tiltAngle = m_stave_tilt.find(thisStave)->second;
+      Ra.rotateX(cos(tiltAngle));
+      Ra.rotateY(sin(tiltAngle));
+    }
+    if (m_stave_x_offset.find(thisStave)->second != 0.0)
+    {
+      x_offset = m_stave_x_offset.find(thisStave)->second;
+    }
+    if (m_stave_y_offset.find(thisStave)->second != 0.0)
+    {
+      y_offset = m_stave_y_offset.find(thisStave)->second;
+    }
+    if (m_stave_z_offset.find(thisStave)->second != 0.0)
+    {
+      z_offset = m_stave_z_offset.find(thisStave)->second;
+    }
+
+    Ta.setX(layer_nominal_radius * cos(phi_rotation) + x_offset);
+    Ta.setY(layer_nominal_radius * sin(phi_rotation) + y_offset);
+    Ta.setZ(z_offset);
 
     if (Verbosity() > 0)
     {
-      cout << " iphi " << iphi << " phi_rotation " << phi_rotation
+      cout << "Stave: " << m_stave_name.find(thisStave)->second
+           << " iphi " << iphi << " phi_rotation " << phi_rotation
            << " x " << layer_nominal_radius * cos(phi_rotation)
            << " y " << layer_nominal_radius * sin(phi_rotation)
-           << " z " << z_location
+           << " z " << z_offset
            << endl;
     }
     G4Transform3D Tr(Ra, Ta);
@@ -344,14 +391,14 @@ int PHG4MvtxDetector::ConstructMvtxPassiveVol(G4LogicalVolume*& lv)
   //=======================================================
   // Add an outer shell for the MVTX - moved it from INTT PHG4InttDetector.cc
   //=======================================================
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
+  G4LogicalVolume* mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
                     "mvtx_shell_outer_skin_volume", lv, false, 0, OverlapCheck());
 
   //===================================
   // Construct Services geometry
   //===================================
-  if ( (! m_EndWheelsSideN.empty()) && (!m_EndWheelsSideS.empty()) )
+  if ((!m_EndWheelsSideN.empty()) && (!m_EndWheelsSideS.empty()))
   {
     // import the end_wheels from the geometry file
     std::unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
@@ -383,25 +430,24 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
   // A Rohacell foam sandwich made of 0.1 mm thick CFRP skin and 1.8 mm Rohacell 110 foam core, it has a density of 110 kg/m**3.
   //mvtx_outer_shell
   G4Tubs* mvtx_outer_shell_tube = new G4Tubs("mvtx_outer_shell",
-                                              mvtxGeomDef::mvtx_shell_inner_radius,
-                                              mvtxGeomDef::mvtx_shell_inner_radius + mvtxGeomDef::mvtx_shell_thickness,
-                                              mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
+                                             mvtxGeomDef::mvtx_shell_inner_radius,
+                                             mvtxGeomDef::mvtx_shell_inner_radius + mvtxGeomDef::mvtx_shell_thickness,
+                                             mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_outer_shell_volume = new G4LogicalVolume(mvtx_outer_shell_tube,
+  G4LogicalVolume* mvtx_outer_shell_volume = new G4LogicalVolume(mvtx_outer_shell_tube,
                                                                  trackerenvelope->GetMaterial(),
                                                                  "mvtx_outer_shell_volume", 0, 0, 0);
 
-
   double mvtx_shell_inner_skin_inner_radius = mvtxGeomDef::mvtx_shell_inner_radius;
-  double mvtx_shell_foam_core_inner_radius  = mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness;
-  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius  + mvtxGeomDef::foam_core_thickness;
+  double mvtx_shell_foam_core_inner_radius = mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness;
+  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius + mvtxGeomDef::foam_core_thickness;
 
-  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs("mvtx_shell_inner_skin",
+  G4Tubs* mvtx_shell_inner_skin_tube = new G4Tubs("mvtx_shell_inner_skin",
                                                   mvtx_shell_inner_skin_inner_radius,
                                                   mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness,
                                                   mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube,
+  G4LogicalVolume* mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube,
                                                                       G4Material::GetMaterial("CFRP_INTT"),
                                                                       "mvtx_shell_inner_skin_volume", 0, 0, 0);
 
@@ -409,12 +455,12 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
                     "mvtx_shell_inner_skin", mvtx_outer_shell_volume, false, 0, OverlapCheck());
   //m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume, "Rail");
 
-  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
+  G4Tubs* mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
                                                  mvtx_shell_foam_core_inner_radius,
                                                  mvtx_shell_foam_core_inner_radius + mvtxGeomDef::foam_core_thickness,
                                                  mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube,
+  G4LogicalVolume* mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube,
                                                                      G4Material::GetMaterial("ROHACELL_FOAM_110"),
                                                                      "mvtx_shell_foam_core_volume", 0, 0, 0);
 
@@ -422,12 +468,12 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
                     "mvtx_shell_foam_core", mvtx_outer_shell_volume, false, 0, OverlapCheck());
   //m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume, "Rail");
 
-  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
+  G4Tubs* mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
                                                   mvtx_shell_outer_skin_inner_radius,
                                                   mvtx_shell_outer_skin_inner_radius + mvtxGeomDef::skin_thickness,
                                                   mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube,
+  G4LogicalVolume* mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube,
                                                                       G4Material::GetMaterial("CFRP_INTT"),
                                                                       "mvtx_shell_outer_skin_volume", 0, 0, 0);
 
@@ -437,7 +483,6 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
 
   return mvtx_outer_shell_volume;
 }
-
 
 void PHG4MvtxDetector::SetDisplayProperty(G4AssemblyVolume* av)
 {
@@ -504,7 +549,7 @@ void PHG4MvtxDetector::AddGeometryNode()
   {
     active |= isAct;
   }
-  if (active) // At least one layer is active
+  if (active)  // At least one layer is active
   {
     ostringstream geonode;
     geonode << "CYLINDERGEOM_" << ((m_SuperDetector != "NONE") ? m_SuperDetector : m_Detector);
@@ -526,8 +571,7 @@ void PHG4MvtxDetector::AddGeometryNode()
                                                         m_nominal_radius[ilayer] / cm,
                                                         get_phistep(ilayer) / rad,
                                                         m_nominal_phitilt[ilayer] / rad,
-                                                        m_nominal_phi0[ilayer] / rad
-                                                        );
+                                                        m_nominal_phi0[ilayer] / rad);
       geo->AddLayerGeom(ilayer, mygeom);
     }  // loop per layers
     if (Verbosity())

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -80,12 +80,19 @@ class PHG4MvtxDetector : public PHG4Detector
   std::array<double, n_Layers> m_nominal_radius;
   std::array<double, n_Layers> m_nominal_phitilt;
   std::array<double, n_Layers> m_nominal_phi0;
+  std::array<double, n_Layers> m_layer_z_offset;
+  std::map<std::pair<int, int>, std::string> m_stave_name;
+  std::map<std::pair<int, int>, double> m_stave_x_offset;
+  std::map<std::pair<int, int>, double> m_stave_y_offset;
+  std::map<std::pair<int, int>, double> m_stave_z_offset;
+  std::map<std::pair<int, int>, double> m_stave_tilt;
 
   std::string m_Detector;
   std::string m_SuperDetector;
   std::string m_StaveGeometryFile;
   std::string m_EndWheelsSideS;
   std::string m_EndWheelsSideN;
+  std::string m_alignmentPath;
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -4,27 +4,27 @@
 
 // Move to new storage containers
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHitv2.h>                      // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                     // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHNode.h>                           // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
-#include <phool/phool.h>                            // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <gsl/gsl_rng.h>                            // for gsl_rng_alloc
+#include <gsl/gsl_rng.h>  // for gsl_rng_alloc
 
-#include <cstdlib>                                 // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
 #include <set>
 
@@ -152,7 +152,7 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
     cout << "Could not locate TRKR_HITSET node, quit! " << endl;
     exit(1);
   }
-  
+
   // Get the TrkrHitTruthAssoc node
   auto hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
 
@@ -182,26 +182,25 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
 
       // Convert the signal value to an ADC value and write that to the hit
       //unsigned int adc = hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup *_energy_scale[layer]);
-      if (Verbosity() > 0) 
-	cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup << " in layer " << layer << std::endl;
+      if (Verbosity() > 0)
+        cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup << " in layer " << layer << std::endl;
       // Remove the hits with energy under threshold
       bool rm_hit = false;
-      if ( (hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup) < _energy_threshold) rm_hit = true;
+      if ((hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup) < _energy_threshold) rm_hit = true;
 
-      unsigned short adc = (unsigned short) (hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup *_energy_scale[layer]));
+      unsigned short adc = (unsigned short) (hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup * _energy_scale[layer]));
       if (adc > _max_adc[layer]) adc = _max_adc[layer];
       hit->setAdc(adc);
 
       if (rm_hit) hits_rm.insert(hit_iter->first);
     }
 
-    for( const auto& key:hits_rm )
-    { 
+    for (const auto &key : hits_rm)
+    {
       if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: remove hit with key: " << key << endl;
       hitset->removeHit(key);
-      if( hittruthassoc ) hittruthassoc->removeAssoc(hitsetkey, key);
-   }
-
+      if (hittruthassoc) hittruthassoc->removeAssoc(hitsetkey, key);
+    }
   }
 
   // end new containers

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
@@ -9,10 +9,9 @@
 #include <gsl/gsl_rng.h>
 
 #include <map>
-#include <string>                // for string
-#include <utility>               // for pair, make_pair
+#include <string>   // for string
+#include <utility>  // for pair, make_pair
 #include <vector>
-
 
 class PHCompositeNode;
 
@@ -23,7 +22,7 @@ class PHG4MvtxDigitizer : public SubsysReco
   ~PHG4MvtxDigitizer() override;
 
   //! module initialization
-  int Init(PHCompositeNode */*topNode*/) override { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
   int InitRun(PHCompositeNode *topNode) override;
@@ -32,7 +31,7 @@ class PHG4MvtxDigitizer : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode */*topNode*/) override { return 0; };
+  int End(PHCompositeNode *topNode) override { return 0; };
 
   void set_adc_scale(const int layer, const unsigned short max_adc, const float energy_per_adc)
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
@@ -1,12 +1,12 @@
 #include "PHG4MvtxDisplayAction.h"
 
-#include "g4main/PHG4DisplayAction.h"  // for PHG4DisplayAction
 #include <g4main/PHG4Utils.h>
+#include "g4main/PHG4DisplayAction.h"  // for PHG4DisplayAction
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -24,7 +24,7 @@ PHG4MvtxDisplayAction::~PHG4MvtxDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4MvtxDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4MvtxDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -6,10 +6,10 @@
 #include <mvtx/MvtxDefs.h>
 
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitTruthAssocv1.h>
+#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 
 #include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
@@ -27,7 +27,7 @@
 #include <phool/PHIODataNode.h>
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>      // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
@@ -376,8 +376,8 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       // YCM: Fix pixel range: Xbin (row) 0 to 511, Zbin (col) 0 to 1023
       if (xbin_min < 0) xbin_min = 0;
       if (zbin_min < 0) zbin_min = 0;
-      if (xbin_max >= maxNX) xbin_max = maxNX-1;
-      if (zbin_max >= maxNZ) xbin_max = maxNZ-1;
+      if (xbin_max >= maxNX) xbin_max = maxNX - 1;
+      if (zbin_max >= maxNZ) xbin_max = maxNZ - 1;
 
       if (Verbosity() > 1)
       {
@@ -518,7 +518,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         if (!hit)
         {
           // Otherwise, create a new one
-	  hit = new TrkrHitv2();
+          hit = new TrkrHitv2();
           hitsetit->second->addHitSpecificKey(hitkey, hit);
         }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
@@ -6,28 +6,28 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
@@ -43,10 +43,10 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
-#include <cmath>                              // for NAN
-#include <cstdlib>                            // for exit
+#include <cmath>    // for NAN
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                              // for operator<<, basic_string
+#include <string>  // for operator<<, basic_string
 
 class PHCompositeNode;
 
@@ -254,7 +254,7 @@ bool PHG4MvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         theTouchable = prePoint->GetTouchableHandle();
         cout << "entering: depth = " << theTouchable->GetHistory()->GetDepth() << endl;
-        G4VPhysicalVolume *vol1 = theTouchable->GetVolume();
+        G4VPhysicalVolume* vol1 = theTouchable->GetVolume();
         cout << "entering volume name = " << vol1->GetName() << endl;
       }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -8,27 +8,26 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>  // for PHG4DetectorGrou...
 
-#include <g4main/PHG4DisplayAction.h>                // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>               // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
-#include <phool/PHIODataNode.h>                      // for PHIODataNode
-#include <phool/PHNode.h>                            // for PHNode
-#include <phool/PHNodeIterator.h>                    // for PHNodeIterator
-#include <phool/PHObject.h>                          // for PHObject
-#include <phool/phool.h>                             // for PHWHERE
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
-#include <mvtx/SegmentationAlpide.h>                 // for Alpide constants
+#include <mvtx/SegmentationAlpide.h>  // for Alpide constants
 
-#include <iostream>                                  // for operator<<, basi...
-#include <set>                                       // for _Rb_tree_const_i...
+#include <iostream>  // for operator<<, basi...
+#include <set>       // for _Rb_tree_const_i...
 #include <sstream>
-#include <utility>                                   // for pair
+#include <utility>  // for pair
 
 class PHG4Detector;
 
@@ -210,6 +209,18 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
     set_default_double_param(ilyr, "phitilt", turbo);
     set_default_double_param(ilyr, "phi0", mvtxdat[ilyr][kPhi0]);
     set_default_string_param(ilyr, "material", "G4_AIR");  // default - almost nothing
+
+    set_default_double_param(ilyr, "layer_z_offset", 0.0);
+
+    for (int iStave = 0; iStave < mvtxdat[ilyr][kNStave]; ++iStave)
+    {
+      std::string stave_location = Form("layer_%i_stave_%i", ilyr, iStave);
+      set_default_string_param(ALIGNMENT, stave_location + "_name", "X000");
+      set_default_double_param(ALIGNMENT, stave_location + "_x_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_y_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_z_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_tilt", 0.0);
+    }
   }
 
   set_default_string_param(GLOBAL, "stave_geometry_file", "ITS.gdml");  // default - almost nothing
@@ -217,6 +228,8 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
                            string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideA_mod_PEEK.gdml"));
   set_default_string_param(GLOBAL, "end_wheels_sideN",
                            string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideC_PEEK.gdml"));
+  set_default_string_param(GLOBAL, "alignment_path",
+                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry"));
   /*
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", NAN);
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", NAN);

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
@@ -5,8 +5,8 @@
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <cmath>                                     // for asin
-#include <string>                                    // for string
+#include <cmath>   // for asin
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -8,10 +8,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
@@ -386,7 +386,7 @@ PHG4Hitv1* PHG4TpcCentralMembrane::GetTopVerticesFromStripe(int moduleID, int ra
     return topvert;
 }
 
-int PHG4TpcCentralMembrane::SearchModule(int /*nStripes*/, 
+int PHG4TpcCentralMembrane::SearchModule(int nStripes, 
   const double x1a[][nRadii], const double x1b[][nRadii], 
   const double x2a[][nRadii], const double x2b[][nRadii], 
   const double y1a[][nRadii], const double y1b[][nRadii], 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -24,7 +24,7 @@ class PHG4TpcDigitizer : public SubsysReco
   ~PHG4TpcDigitizer() override;
 
   //! module initialization
-  int Init(PHCompositeNode */*topNode*/) override { return 0; }
+  int Init(PHCompositeNode *topNode) override { return 0; }
 
   //! run initialization
   int InitRun(PHCompositeNode *topNode) override;
@@ -33,7 +33,7 @@ class PHG4TpcDigitizer : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
 
   //! end of process
-  int End(PHCompositeNode */*topNode*/) override { return 0; };
+  int End(PHCompositeNode *topNode) override { return 0; };
 
   void set_adc_scale(const int layer, const unsigned int max_adc, const float energy_per_adc)
   {

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -17,7 +17,6 @@
 #include <trackbase_historic/SvtxTrackMap_v1.h>
 
 #include <cassert>
-#include <optional>
 
 namespace
 {
@@ -45,40 +44,40 @@ namespace
   //half the thickness of the CM;
   static constexpr double halfwidth_CM = 0.5*cm;
 
-  //_____________________________________________________________
-  std::optional<TVector3> central_membrane_intersection(TVector3 start, TVector3 direction)
+  //_____________________________________________________________  
+  std::pair<TVector3,bool> central_membrane_intersection(TVector3 start, TVector3 direction)
   {
     const double end = start.z() > 0 ? halfwidth_CM:-halfwidth_CM;
     const double dist=end-start.z();
     
     // if line is vertical, it will never intercept the endcap
-    if( direction.z() == 0 ) return std::nullopt;
+    if( direction.z() == 0 ) return std::make_pair( TVector3(), false );
 
     // check that distance and direction have the same sign
-    if( dist*direction.z() < 0 ) return std::nullopt;
+    if( dist*direction.z() < 0 ) return std::make_pair( TVector3(), false );
 
     const double direction_scale=dist/direction.z();
-    return start + direction * direction_scale;
+    return std::make_pair(start + direction * direction_scale, true );
   }
-
-  //_____________________________________________________________
-  std::optional<TVector3> endcap_intersection(TVector3 start, TVector3 direction)
+   
+  //_____________________________________________________________  
+  std::pair<TVector3,bool> endcap_intersection(TVector3 start, TVector3 direction)
   {
     const double end = start.z() > 0 ? halflength_tpc:-halflength_tpc;
     const double dist=end-start.z();
     
     // if line is vertical, it will never intercept the endcap
-    if( direction.z() == 0 ) return std::nullopt;
-
+    if( direction.z() == 0 ) return std::make_pair( TVector3(), false );
+    
     // check that distance and direction have the same sign
-    if( dist*direction.z() < 0 ) return std::nullopt;
+    if( dist*direction.z() < 0 ) return std::make_pair( TVector3(), false );
 
     const double direction_scale=dist/direction.z();
-    return start + direction * direction_scale;
+    return std::make_pair(start + direction * direction_scale, true );
   }
 
   //_____________________________________________________________
-  std::optional<TVector3>  cylinder_line_intersection(TVector3 s, TVector3 v, double radius)
+  std::pair<TVector3,bool>  cylinder_line_intersection(TVector3 s, TVector3 v, double radius)
   {
     
     const double R2=square(radius);
@@ -96,8 +95,8 @@ namespace
      * if the rootterm is negative, we will have no real roots,
      * we are outside the cylinder and pointing skew to the cylinder such that we never cross.
      */
-    if( rootterm < 0 || a == 0 ) return std::nullopt;
-
+    if( rootterm < 0 || a == 0 ) return std::make_pair(TVector3(), false);
+    
     //Find the (up to) two points where we collide with the cylinder:
     const double sqrtterm=std::sqrt(rootterm);
     const double t1 = (-b+sqrtterm)/(2*a);
@@ -108,27 +107,27 @@ namespace
     * the collision closest to the start (hence with the smallest t that is greater than zero) is the one that happens.
     */
     const double& min_t = (t2<t1 && t2>0) ? t2:t1;
-    return s+v*min_t;
+    return std::make_pair(s+v*min_t, true );
   }
   
   //_____________________________________________________________
-  std::optional<TVector3> field_cage_intersection(TVector3 start, TVector3 direction)
+  std::pair<TVector3,bool> field_cage_intersection(TVector3 start, TVector3 direction)
   {
     const auto ofc_strike=cylinder_line_intersection(start,direction,end_CM);
     const auto ifc_strike=cylinder_line_intersection(start,direction,begin_CM);
     
     // if either of the two intersection is invalid, return the other
-    if( !ifc_strike ) return ofc_strike;
-    if( !ofc_strike ) return ifc_strike;
-
+    if( !ifc_strike.second ) return ofc_strike;
+    if( !ofc_strike.second ) return ifc_strike;
+    
     // both intersection are valid, calculate signed distance to start z
-    const auto ifc_dist=(ifc_strike->Z()-start.Z())/direction.Z();
-    const auto ofc_dist=(ofc_strike->Z()-start.Z())/direction.Z();
-
-    if(ifc_dist<0) return (ofc_dist > 0) ? ofc_strike : std::nullopt;
+    const auto ifc_dist=(ifc_strike.first.Z()-start.Z())/direction.Z();
+    const auto ofc_dist=(ofc_strike.first.Z()-start.Z())/direction.Z();
+   
+    if(ifc_dist<0) return (ofc_dist > 0) ? ofc_strike:std::make_pair( TVector3(), false );
     else if( ofc_dist<0 ) return ifc_strike;
-    else return (ifc_dist<ofc_dist) ? ifc_strike : ofc_strike;
-
+    else return (ifc_dist<ofc_dist) ? ifc_strike:ofc_strike;
+    
   }
   
   /// TVector3 stream
@@ -438,14 +437,14 @@ void PHG4TpcDirectLaser::AppendLaserTrack(double theta, double phi, const PHG4Tp
   // field cage intersection
   const auto fc_strike=field_cage_intersection(pos,dir);
 
-  // if none of the strikes is valid, there is no valid information found.
-  if( !(plane_strike || fc_strike ) ) return;
-
+  // if none of the strikes is valid, there is no valid information found. 
+  if( !(plane_strike.second || fc_strike.second ) ) return;
+  
   // decide relevant end of laser
   /* chose field cage intersection if valid, and if either plane intersection is invalid or happens on a larger z along the laser direction) */
-  const auto& strike = ( fc_strike && (!plane_strike || fc_strike->z()/dir.z() < plane_strike->z()/dir.z()) ) ?
-    *fc_strike:
-    *plane_strike;
+  const auto& strike = ( fc_strike.second && (!plane_strike.second || fc_strike.first.z()/dir.z()<plane_strike.first.z()/dir.z()) ) ?
+    fc_strike.first:
+    plane_strike.first;
 
   //find length
   TVector3 delta=(strike-pos);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.cc
@@ -29,7 +29,7 @@ PHG4TpcDisplayAction::~PHG4TpcDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4TpcDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4TpcDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   static const G4Colour color[] = {PHG4TpcColorDefs::tpc_cu_color,
                                    PHG4TpcColorDefs::tpc_pcb_color,

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -593,7 +593,7 @@ void PHG4TpcElectronDrift::MapToPadPlane(const double x_gem, const double y_gem,
   padplane->MapToPadPlane(single_hitsetcontainer.get(), temp_hitsetcontainer.get(), hittruthassoc, x_gem, y_gem, t_gem, hiter, ntpad, nthit);
 }
 
-int PHG4TpcElectronDrift::End(PHCompositeNode */*topNode*/)
+int PHG4TpcElectronDrift::End(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -191,11 +191,11 @@ G4AssemblyVolume *PHG4TpcEndCapDetector::ConstructEndCapAssembly()
   return assmeblyvol;
 }
 
-void PHG4TpcEndCapDetector::AddLayer(  //
+void PHG4TpcEndCapDetector ::AddLayer(  //
     G4AssemblyVolume *assmeblyvol,
     G4double &z_start,
-    const std::string &_name,         //! name base for this layer
-    const std::string &_material,     //! material name in G4
+    std::string _name,         //! name base for this layer
+    std::string _material,     //! material name in G4
     G4double _depth,           //! depth in G4 units
     double _percentage_filled  //! percentage filled//
 )

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4TPC_PHG4TPCENDCAPDETECTOR_H
-#define G4TPC_PHG4TPCENDCAPDETECTOR_H
+#ifndef PHG4TPCENDCAPDETECTOR_H
+#define PHG4TPCENDCAPDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 #include <Geant4/G4Types.hh>
@@ -63,11 +63,11 @@ class PHG4TpcEndCapDetector : public PHG4Detector
   AddLayer(  //
       G4AssemblyVolume *assmeblyvol,
       G4double &z_start,
-      const std::string &_name,               //! name base for this layer
-      const std::string &_material,           //! material name in G4
+      std::string _name,               //! name base for this layer
+      std::string _material,           //! material name in G4
       G4double _depth,                 //! depth in G4 units
       double _percentage_filled = 100  //! percentage filled//
   );
 };
 
-#endif  // G4TPC_PHG4TPCENDCAPDETECTOR_H
+#endif  // PHG4TPCENDCAPDETECTOR_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDisplayAction.cc
@@ -30,7 +30,7 @@ PHG4TpcEndCapDisplayAction::~PHG4TpcEndCapDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4TpcEndCapDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapSteppingAction.cc
@@ -91,7 +91,7 @@ PHG4TpcEndCapSteppingAction::~PHG4TpcEndCapSteppingAction()
 
 //____________________________________________________________________________..
 // This is the implementation of the G4 UserSteppingAction
-bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep,bool /*was_used*/)
+bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep,bool was_used)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
@@ -176,8 +176,7 @@ bool PHG4TpcEndCapSteppingAction::UserSteppingAction(const G4Step *aStep,bool /*
       cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
            << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
     }
-    [[fallthrough]];
- // These are the normal cases
+// These are the normal cases
   case fGeomBoundary:
   case fUndefined:
     if (!m_Hit)

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -29,10 +29,10 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
     return 0;
   }
   int InitRun(PHCompositeNode *topNode) override;
-  virtual int CreateReadoutGeometry(PHCompositeNode */*topNode*/, PHG4CylinderCellGeomContainer */*seggeo*/) { return 0; }
+  virtual int CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo) { return 0; }
   virtual void UpdateInternalParameters() { return; }
-  virtual void MapToPadPlane(PHG4CellContainer */*g4cells*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple */*ntpad*/, TNtuple */*nthit*/) {}
-  virtual void MapToPadPlane(TrkrHitSetContainer */*single_hitsetcontainer*/, TrkrHitSetContainer */*hitsetcontainer*/, TrkrHitTruthAssoc * /*hittruthassoc*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple */*ntpad*/, TNtuple */*nthit*/) {}
+  virtual void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) {}
+  virtual void MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc * hittruthassoc, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) {}
   void Detector(const std::string &name) { detector = name; }
 
  protected:

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -69,7 +69,7 @@ PHG4TpcPadPlaneReadout::~PHG4TpcPadPlaneReadout()
   gsl_rng_free(RandomGenerator);
 }
 
-int PHG4TpcPadPlaneReadout::CreateReadoutGeometry(PHCompositeNode */*topNode*/, PHG4CylinderCellGeomContainer *seggeo)
+int PHG4TpcPadPlaneReadout::CreateReadoutGeometry(PHCompositeNode *topNode, PHG4CylinderCellGeomContainer *seggeo)
 {
   if (Verbosity()) cout << "PHG4TpcPadPlaneReadout: CreateReadoutGeometry: " << endl;
 
@@ -115,7 +115,7 @@ int PHG4TpcPadPlaneReadout::CreateReadoutGeometry(PHCompositeNode */*topNode*/, 
 }
 
 // This is obsolete, it uses the old PHG4Cell containers
-void PHG4TpcPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double z_gem, PHG4HitContainer::ConstIterator hiter, TNtuple */*ntpad*/, TNtuple */*nthit*/)
+void PHG4TpcPadPlaneReadout::MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double z_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit)
 {
   // One electron per call of this method
   // The x_gem and y_gem values have already been randomized within the transverse drift diffusion width
@@ -318,7 +318,7 @@ double PHG4TpcPadPlaneReadout::getSingleEGEMAmplification()
   return nelec;
 }
 
-void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc * /*hittruthassoc*/, const double x_gem, const double y_gem, const double z_gem, PHG4HitContainer::ConstIterator hiter, TNtuple */*ntpad*/, TNtuple */*nthit*/)
+void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc *hittruthassoc, const double x_gem, const double y_gem, const double z_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit)
 {
   // One electron per call of this method
   // The x_gem and y_gem values have already been randomized within the transverse drift diffusion width
@@ -547,7 +547,7 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *single_hitsetcon
   return;
 }
 
-void PHG4TpcPadPlaneReadout::populate_rectangular_phibins(const unsigned int /*layernum*/, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share)
+void PHG4TpcPadPlaneReadout::populate_rectangular_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share)
 {
   double cloud_sig_rp_inv = 1. / cloud_sig_rp;
 

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -7,10 +7,10 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSim.cc
@@ -98,8 +98,8 @@ using namespace std;
 // names of our implemented calorimeters where the projections are done
 // at 1/2 of their depth, not at the surface
 // this is used to avoid user added projections with identical names
-set<string> reserved_cylinder_projection_names{"CEMC", "HCALIN", "HCALOUT", "BECAL"};
-set<string> reserved_zplane_projection_names{"FEMC", "FHCAL", "EEMC", "EHCAL", "LFHCAL"};
+set<string> reserved_cylinder_projection_names{"CEMC", "HCALIN", "HCALOUT"};
+set<string> reserved_zplane_projection_names{"FEMC", "FHCAL", "EEMC", "EHCAL"};
 
 PHG4TrackFastSim::PHG4TrackFastSim(const std::string& name)
   : SubsysReco(name)
@@ -232,7 +232,7 @@ int PHG4TrackFastSim::InitRun(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4TrackFastSim::End(PHCompositeNode* /*topNode*/)
+int PHG4TrackFastSim::End(PHCompositeNode* topNode)
 {
   if (m_DoEvtDisplayFlag && m_Fitter)
   {
@@ -242,7 +242,7 @@ int PHG4TrackFastSim::End(PHCompositeNode* /*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4TrackFastSim::process_event(PHCompositeNode* /*topNode*/)
+int PHG4TrackFastSim::process_event(PHCompositeNode* topNode)
 {
   m_EventCnt++;
 

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -72,7 +72,7 @@ PHG4TrackFastSimEval::PHG4TrackFastSimEval(const string &name, const string &fil
 //-- Init():
 //--   Intialize all histograms, trees, and ntuples
 //----------------------------------------------------------------------------//
-int PHG4TrackFastSimEval::Init(PHCompositeNode */*topNode*/)
+int PHG4TrackFastSimEval::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -246,7 +246,7 @@ int PHG4TrackFastSimEval::process_event(PHCompositeNode *topNode)
 //-- End():
 //--   End method, wrap everything up
 //----------------------------------------------------------------------------//
-int PHG4TrackFastSimEval::End(PHCompositeNode */*topNode*/)
+int PHG4TrackFastSimEval::End(PHCompositeNode *topNode)
 {
   PHTFileServer::get().cd(m_OutFileName);
 
@@ -440,7 +440,7 @@ void PHG4TrackFastSimEval::fill_track_tree(PHCompositeNode *topNode)
 //-- fill_tree():
 //--   Fill the trees with truth, track fit, and cluster information
 //----------------------------------------------------------------------------//
-void PHG4TrackFastSimEval::fill_vertex_tree(PHCompositeNode */*topNode*/)
+void PHG4TrackFastSimEval::fill_vertex_tree(PHCompositeNode *topNode)
 {
   if (!m_TruthInfoContainer)
   {

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -10,10 +10,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/g4vertex/GlobalVertex.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.cc
@@ -7,7 +7,7 @@ GlobalVertex::ConstVtxIter GlobalVertex::begin_vtxids() const
   return DummyGlobalVertex.end();
 }
 
-GlobalVertex::ConstVtxIter GlobalVertex::find_vtxids(VTXTYPE /*type*/) const
+GlobalVertex::ConstVtxIter GlobalVertex::find_vtxids(VTXTYPE type) const
 {
   return DummyGlobalVertex.end();
 }
@@ -22,7 +22,7 @@ GlobalVertex::VtxIter GlobalVertex::begin_vtxids()
   return DummyGlobalVertex.end();
 }
 
-GlobalVertex::VtxIter GlobalVertex::find_vtxids(VTXTYPE /*type*/)
+GlobalVertex::VtxIter GlobalVertex::find_vtxids(VTXTYPE type)
 {
   return DummyGlobalVertex.end();
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertex.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.h
@@ -36,47 +36,47 @@ class GlobalVertex : public PHObject
   // vertex info
 
   virtual unsigned int get_id() const { return 0xFFFFFFFF; }
-  virtual void set_id(unsigned int) {}
+  virtual void set_id(unsigned int id) {}
 
   virtual float get_t() const { return NAN; }
-  virtual void set_t(float) {}
+  virtual void set_t(float t) {}
 
   virtual float get_t_err() const { return NAN; }
-  virtual void set_t_err(float) {}
+  virtual void set_t_err(float t_err) {}
 
   virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual void set_x(float x) {}
 
   virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual void set_y(float y) {}
 
   virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual void set_z(float z) {}
 
   virtual float get_chisq() const { return NAN; }
-  virtual void set_chisq(float) {}
+  virtual void set_chisq(float chisq) {}
 
   virtual unsigned int get_ndof() const { return 0xFFFFFFFF; }
-  virtual void set_ndof(unsigned int) {}
+  virtual void set_ndof(unsigned int ndof) {}
 
-  virtual float get_position(unsigned int /*coor*/) const { return NAN; }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
+  virtual float get_position(unsigned int coor) const { return NAN; }
+  virtual void set_position(unsigned int coor, float xi) {}
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float get_error(unsigned int i, unsigned int j) const { return NAN; }
+  virtual void set_error(unsigned int i, unsigned int j, float value) {}
 
   //
   // associated vertex ids methods
   //
   virtual bool empty_vtxids() const { return true; }
   virtual size_t size_vtxids() const { return 0; }
-  virtual size_t count_vtxids(VTXTYPE /*type*/) const { return 0; }
+  virtual size_t count_vtxids(VTXTYPE type) const { return 0; }
 
   virtual void clear_vtxids() {}
-  virtual void insert_vtxids(VTXTYPE /*type*/, unsigned int /*vtxid*/) {}
-  virtual size_t erase_vtxids(VTXTYPE /*type*/) { return 0; }
-  virtual void erase_vtxids(VtxIter /*iter*/) {}
-  virtual void erase_vtxids(VtxIter /*first*/, VtxIter /*last*/) {}
+  virtual void insert_vtxids(VTXTYPE type, unsigned int vtxid) {}
+  virtual size_t erase_vtxids(VTXTYPE type) { return 0; }
+  virtual void erase_vtxids(VtxIter iter) {}
+  virtual void erase_vtxids(VtxIter first, VtxIter last) {}
 
   virtual ConstVtxIter begin_vtxids() const;
   virtual ConstVtxIter find_vtxids(VTXTYPE type) const;

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
@@ -44,7 +44,7 @@ GlobalVertexFastSimReco::~GlobalVertexFastSimReco()
   gsl_rng_free(RandomGenerator);
 }
 
-int GlobalVertexFastSimReco::Init(PHCompositeNode */*topNode*/)
+int GlobalVertexFastSimReco::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -130,7 +130,7 @@ int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int GlobalVertexFastSimReco::End(PHCompositeNode */*topNode*/)
+int GlobalVertexFastSimReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertexMap.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMap.cc
@@ -7,7 +7,7 @@ GlobalVertexMap::ConstIter GlobalVertexMap::begin() const
   return DummyGlobalVertexMap.end();
 }
 
-GlobalVertexMap::ConstIter GlobalVertexMap::find(unsigned int /*idkey*/) const
+GlobalVertexMap::ConstIter GlobalVertexMap::find(unsigned int idkey) const
 {
   return DummyGlobalVertexMap.end();
 }
@@ -22,7 +22,7 @@ GlobalVertexMap::Iter GlobalVertexMap::begin()
   return DummyGlobalVertexMap.end();
 }
 
-GlobalVertexMap::Iter GlobalVertexMap::find(unsigned int /*idkey*/)
+GlobalVertexMap::Iter GlobalVertexMap::find(unsigned int idkey)
 {
   return DummyGlobalVertexMap.end();
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertexMap.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMap.h
@@ -23,13 +23,13 @@ class GlobalVertexMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }
-  virtual size_t count(unsigned int /*idkey*/) const { return 0; }
+  virtual size_t count(unsigned int idkey) const { return 0; }
   virtual void clear() {}
 
-  virtual const GlobalVertex* get(unsigned int /*idkey*/) const { return nullptr; }
-  virtual GlobalVertex* get(unsigned int /*idkey*/) { return nullptr; }
-  virtual GlobalVertex* insert(GlobalVertex* /*vertex*/) { return nullptr; }
-  virtual size_t erase(unsigned int /*idkey*/) { return 0; }
+  virtual const GlobalVertex* get(unsigned int idkey) const { return nullptr; }
+  virtual GlobalVertex* get(unsigned int idkey) { return nullptr; }
+  virtual GlobalVertex* insert(GlobalVertex* vertex) { return nullptr; }
+  virtual size_t erase(unsigned int idkey) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
@@ -44,7 +44,7 @@ GlobalVertexReco::GlobalVertexReco(const string &name)
 
 GlobalVertexReco::~GlobalVertexReco() {}
 
-int GlobalVertexReco::Init(PHCompositeNode */*topNode*/)
+int GlobalVertexReco::Init(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -245,7 +245,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int GlobalVertexReco::End(PHCompositeNode */*topNode*/)
+int GlobalVertexReco::End(PHCompositeNode *topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4vertex/configure.ac
+++ b/simulation/g4simulation/g4vertex/configure.ac
@@ -10,10 +10,10 @@ dnl leaving this here in case we want to play with different compiler
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
  ;;
 esac
 

--- a/simulation/g4simulation/tpcresponse/configure.ac
+++ b/simulation/g4simulation/tpcresponse/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
 fi
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This adds some MVTX alignment capabilities. We can move any stave independently in x, y and/or z and give it a tilt in z around the origin. There are corresponding PRs in calibrations to generate the XML file with the positions and in macros to read in the alignment

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

The next step is to add the ability to read in a different GDML file for each stave to allow for calibration of the individual ASICs. We have surveys on each stave from CERN so we also need to generate a GDML file for each stave they produced and put it in our calibrations

## Links to other PRs in macros and calibration repositories (if applicable)

Macros PR: https://github.com/sPHENIX-Collaboration/macros/pull/432 
Calibrations PR: https://github.com/sPHENIX-Collaboration/calibrations/pull/82
