### PR TITLE
Added MVTX alignment capabilities. Currently global stave positioning…

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
@@ -12,7 +12,7 @@
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
-#include <g4main/PHG4Subsystem.h>                   // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -220,7 +220,7 @@ int PHG4EICMvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITS
   int N_staves = m_N_staves[layer];
   G4double layer_nominal_radius = m_nominal_radius[layer];
   G4double phitilt = m_nominal_phitilt[layer];
-  G4double phi0    = m_nominal_phi0[layer]; //YCM: azimuthal offset for the first stave
+  G4double phi0 = m_nominal_phi0[layer];  //YCM: azimuthal offset for the first stave
 
   if (N_staves < 0)
   {
@@ -373,7 +373,7 @@ void PHG4EICMvtxDetector::AddGeometryNode()
   {
     active |= isAct;
   }
-  if (active) // At least one layer is active
+  if (active)  // At least one layer is active
   {
     ostringstream geonode;
     geonode << "CYLINDERGEOM_" << ((m_SuperDetector != "NONE") ? m_SuperDetector : m_Detector);
@@ -395,8 +395,7 @@ void PHG4EICMvtxDetector::AddGeometryNode()
                                                         m_nominal_radius[ilayer] / cm,
                                                         get_phistep(ilayer) / rad,
                                                         m_nominal_phitilt[ilayer] / rad,
-                                                        m_nominal_phi0[ilayer] / rad
-                                                        );
+                                                        m_nominal_phi0[ilayer] / rad);
       geo->AddLayerGeom(ilayer, mygeom);
     }  // loop per layers
     if (Verbosity())

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
@@ -6,28 +6,28 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
@@ -43,10 +43,10 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
-#include <cmath>                              // for NAN
-#include <cstdlib>                            // for exit
+#include <cmath>    // for NAN
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                              // for operator<<, basic_string
+#include <string>  // for operator<<, basic_string
 
 class PHCompositeNode;
 
@@ -254,7 +254,7 @@ bool PHG4EICMvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         theTouchable = prePoint->GetTouchableHandle();
         cout << "entering: depth = " << theTouchable->GetHistory()->GetDepth() << endl;
-        G4VPhysicalVolume *vol1 = theTouchable->GetVolume();
+        G4VPhysicalVolume* vol1 = theTouchable->GetVolume();
         cout << "entering volume name = " << vol1->GetName() << endl;
       }
 

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.cc
@@ -1,34 +1,33 @@
 #include "PHG4EICMvtxSubsystem.h"
 
-#include "PHG4MvtxDefs.h"
 #include "PHG4EICMvtxDetector.h"
-#include "PHG4MvtxDisplayAction.h"
 #include "PHG4EICMvtxSteppingAction.h"
+#include "PHG4MvtxDefs.h"
+#include "PHG4MvtxDisplayAction.h"
 
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>  // for PHG4DetectorGrou...
 
-#include <g4main/PHG4DisplayAction.h>                // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>               // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
-#include <phool/PHIODataNode.h>                      // for PHIODataNode
-#include <phool/PHNode.h>                            // for PHNode
-#include <phool/PHNodeIterator.h>                    // for PHNodeIterator
-#include <phool/PHObject.h>                          // for PHObject
-#include <phool/phool.h>                             // for PHWHERE
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
-#include <mvtx/SegmentationAlpide.h>                 // for Alpide constants
+#include <mvtx/SegmentationAlpide.h>  // for Alpide constants
 
-#include <iostream>                                  // for operator<<, basi...
-#include <set>                                       // for _Rb_tree_const_i...
+#include <iostream>  // for operator<<, basi...
+#include <set>       // for _Rb_tree_const_i...
 #include <sstream>
-#include <utility>                                   // for pair
+#include <utility>  // for pair
 
 class PHG4Detector;
 

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSubsystem.h
@@ -5,8 +5,8 @@
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <cmath>                                     // for asin
-#include <string>                                    // for string
+#include <cmath>   // for asin
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
@@ -5,17 +5,18 @@
 
 namespace PHG4MvtxDefs
 {
-
   static constexpr unsigned int kNLayers = 3;
 
-  enum {
+  enum
+  {
     kRmn,
     kRmd,
     kRmx,
     kNModPerStave,
     kPhi0,
     kNStave,
-    kNPar};
+    kNPar
+  };
 
   static const double mvtxdat[kNLayers][kNPar] = {
       {24.61, 25.23, 27.93, 9., 0.285, 12.},  // for each layer: rMin, rMid, rMax, NChip/Stave, phi0, nStaves
@@ -25,10 +26,11 @@ namespace PHG4MvtxDefs
   static const int GLOBAL = -1;
   static const int ALPIDE_SEGMENTATION = -2;
   static const int SUPPORTPARAMS = -3;
+  static const int ALIGNMENT = -4;
 
-// passive volume indices
+  // passive volume indices
 
-// detid of support structures
+  // detid of support structures
 
 };  // namespace PHG4MvtxDefs
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -12,7 +12,7 @@
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
-#include <g4main/PHG4Subsystem.h>                   // for PHG4Subsystem
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -26,15 +26,15 @@
 #include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
+#include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
 #include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
-#include <Geant4/G4Transform3D.hh>      // for G4Transform3D
+#include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
+#include <Geant4/G4Transform3D.hh>  // for G4Transform3D
+#include <Geant4/G4Tubs.hh>
 #include <Geant4/G4Types.hh>            // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
-#include <Geant4/G4PVPlacement.hh>
-#include <Geant4/G4Tubs.hh>
 
 #include <cmath>
 #include <cstdio>    // for sprintf
@@ -48,16 +48,16 @@ using namespace std;
 
 namespace mvtxGeomDef
 {
-  double mvtx_shell_inner_radius            =  4.8  * cm;
-  double skin_thickness                     =  0.01 * cm;
-  double foam_core_thickness                =  0.18 * cm;
-  double mvtx_shell_length                  = 50.   * cm;
-  double mvtx_shell_thickness =  skin_thickness + foam_core_thickness + skin_thickness;
+  double mvtx_shell_inner_radius = 4.8 * cm;
+  double skin_thickness = 0.01 * cm;
+  double foam_core_thickness = 0.18 * cm;
+  double mvtx_shell_length = 50. * cm;
+  double mvtx_shell_thickness = skin_thickness + foam_core_thickness + skin_thickness;
 
   double wrap_rmin = 2.1 * cm;
   double wrap_rmax = mvtx_shell_inner_radius + mvtx_shell_thickness;
   double wrap_zlen = mvtx_shell_length;
-};
+};  // namespace mvtxGeomDef
 
 PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)
@@ -66,6 +66,7 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
   , m_StaveGeometryFile(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("stave_geometry_file"))
   , m_EndWheelsSideS(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("end_wheels_sideS"))
   , m_EndWheelsSideN(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("end_wheels_sideN"))
+  , m_alignmentPath(_paramsContainer->GetParameters(PHG4MvtxDefs::GLOBAL)->get_string_param("alignment_path"))
 {
   //  Verbosity(2);
 
@@ -74,6 +75,11 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
 
   if (Verbosity() > 10)
     cout << " cm " << cm << " mm " << mm << endl;
+
+  const PHParameters* defualt_align_params = m_ParamsContainer->GetParameters(PHG4MvtxDefs::ALIGNMENT);
+  PHParameters* align_params = new PHParameters(*defualt_align_params, "defaultMVTXalignment");
+  align_params->ReadFromFile("mvtx", "xml", PHG4MvtxDefs::ALIGNMENT, true, m_alignmentPath);
+
   for (int ilayer = 0; ilayer < n_Layers; ++ilayer)
   {
     const PHParameters* params = m_ParamsContainer->GetParameters(ilayer);
@@ -84,7 +90,20 @@ PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
     m_nominal_radius[ilayer] = params->get_double_param("layer_nominal_radius");
     m_nominal_phitilt[ilayer] = params->get_double_param("phitilt");
     m_nominal_phi0[ilayer] = params->get_double_param("phi0");
+    m_layer_z_offset[ilayer] = params->get_double_param("layer_z_offset");
+
+    for (int iStave = 0; iStave < m_N_staves[ilayer]; ++iStave)
+    {
+      pair<int, int> stave_coord = make_pair(ilayer, iStave);
+      std::string stave_location = Form("layer_%i_stave_%i", ilayer, iStave);
+      m_stave_name[stave_coord] = align_params->get_string_param(stave_location + "_name");
+      m_stave_x_offset[stave_coord] = align_params->get_double_param(stave_location + "_x_offset");
+      m_stave_y_offset[stave_coord] = align_params->get_double_param(stave_location + "_y_offset");
+      m_stave_z_offset[stave_coord] = align_params->get_double_param(stave_location + "_z_offset");
+      m_stave_tilt[stave_coord] = align_params->get_double_param(stave_location + "_tilt");
+    }
   }
+
   /*
   const PHParameters* alpide_params = m_ParamsContainer->GetParameters(PHG4MvtxDefs::ALPIDE_SEGMENTATION);
   m_PixelX = alpide_params->get_double_param("pixel_x");
@@ -245,7 +264,7 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
   int N_staves = m_N_staves[layer];
   G4double layer_nominal_radius = m_nominal_radius[layer];
   G4double phitilt = m_nominal_phitilt[layer];
-  G4double phi0    = m_nominal_phi0[layer]; //YCM: azimuthal offset for the first stave
+  G4double phi0 = m_nominal_phi0[layer];  //YCM: azimuthal offset for the first stave
 
   if (N_staves < 0)
   {
@@ -271,7 +290,6 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
   }
 
   G4double phistep = get_phistep(layer);  // this produces even stave spacing
-  double z_location = 0.0;
 
   if (Verbosity() > 0)
   {
@@ -306,19 +324,48 @@ int PHG4MvtxDetector::ConstructMvtx_Layer(int layer, G4AssemblyVolume* av_ITSUSt
     // It  is first rotated in phi by the azimuthal angle phi_rotation, plus the 90 degrees needed to point the face of the sensor  at the origin,  plus the tilt (if a tilt is appropriate)
 
     // note - if this is layer 0-2, phitilt is the additional tilt for clearance. Otherwise it is zero
+    Ra.rotateX(0);
+    Ra.rotateY(0);
     Ra.rotateZ(phi_rotation + phi_offset + phitilt);
     // Then translated as follows
 
-    Ta.setX(layer_nominal_radius * cos(phi_rotation));
-    Ta.setY(layer_nominal_radius * sin(phi_rotation));
-    Ta.setZ(z_location);
+    double x_offset = 0.0;
+    double y_offset = 0.0;
+    double z_offset = 0.0;
+    z_offset = m_layer_z_offset[layer];
+
+    //Now add stave specific tilts and offsets
+    std::pair<int, int> thisStave{layer, iphi};
+    if (m_stave_tilt.find(thisStave)->second != 0.0)
+    {
+      double tiltAngle = m_stave_tilt.find(thisStave)->second;
+      Ra.rotateX(cos(tiltAngle));
+      Ra.rotateY(sin(tiltAngle));
+    }
+    if (m_stave_x_offset.find(thisStave)->second != 0.0)
+    {
+      x_offset = m_stave_x_offset.find(thisStave)->second;
+    }
+    if (m_stave_y_offset.find(thisStave)->second != 0.0)
+    {
+      y_offset = m_stave_y_offset.find(thisStave)->second;
+    }
+    if (m_stave_z_offset.find(thisStave)->second != 0.0)
+    {
+      z_offset = m_stave_z_offset.find(thisStave)->second;
+    }
+
+    Ta.setX(layer_nominal_radius * cos(phi_rotation) + x_offset);
+    Ta.setY(layer_nominal_radius * sin(phi_rotation) + y_offset);
+    Ta.setZ(z_offset);
 
     if (Verbosity() > 0)
     {
-      cout << " iphi " << iphi << " phi_rotation " << phi_rotation
+      cout << "Stave: " << m_stave_name.find(thisStave)->second
+           << " iphi " << iphi << " phi_rotation " << phi_rotation
            << " x " << layer_nominal_radius * cos(phi_rotation)
            << " y " << layer_nominal_radius * sin(phi_rotation)
-           << " z " << z_location
+           << " z " << z_offset
            << endl;
     }
     G4Transform3D Tr(Ra, Ta);
@@ -344,14 +391,14 @@ int PHG4MvtxDetector::ConstructMvtxPassiveVol(G4LogicalVolume*& lv)
   //=======================================================
   // Add an outer shell for the MVTX - moved it from INTT PHG4InttDetector.cc
   //=======================================================
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
+  G4LogicalVolume* mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
   new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
                     "mvtx_shell_outer_skin_volume", lv, false, 0, OverlapCheck());
 
   //===================================
   // Construct Services geometry
   //===================================
-  if ( (! m_EndWheelsSideN.empty()) && (!m_EndWheelsSideS.empty()) )
+  if ((!m_EndWheelsSideN.empty()) && (!m_EndWheelsSideS.empty()))
   {
     // import the end_wheels from the geometry file
     std::unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
@@ -383,25 +430,24 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
   // A Rohacell foam sandwich made of 0.1 mm thick CFRP skin and 1.8 mm Rohacell 110 foam core, it has a density of 110 kg/m**3.
   //mvtx_outer_shell
   G4Tubs* mvtx_outer_shell_tube = new G4Tubs("mvtx_outer_shell",
-                                              mvtxGeomDef::mvtx_shell_inner_radius,
-                                              mvtxGeomDef::mvtx_shell_inner_radius + mvtxGeomDef::mvtx_shell_thickness,
-                                              mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
+                                             mvtxGeomDef::mvtx_shell_inner_radius,
+                                             mvtxGeomDef::mvtx_shell_inner_radius + mvtxGeomDef::mvtx_shell_thickness,
+                                             mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_outer_shell_volume = new G4LogicalVolume(mvtx_outer_shell_tube,
+  G4LogicalVolume* mvtx_outer_shell_volume = new G4LogicalVolume(mvtx_outer_shell_tube,
                                                                  trackerenvelope->GetMaterial(),
                                                                  "mvtx_outer_shell_volume", 0, 0, 0);
 
-
   double mvtx_shell_inner_skin_inner_radius = mvtxGeomDef::mvtx_shell_inner_radius;
-  double mvtx_shell_foam_core_inner_radius  = mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness;
-  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius  + mvtxGeomDef::foam_core_thickness;
+  double mvtx_shell_foam_core_inner_radius = mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness;
+  double mvtx_shell_outer_skin_inner_radius = mvtx_shell_foam_core_inner_radius + mvtxGeomDef::foam_core_thickness;
 
-  G4Tubs *mvtx_shell_inner_skin_tube = new G4Tubs("mvtx_shell_inner_skin",
+  G4Tubs* mvtx_shell_inner_skin_tube = new G4Tubs("mvtx_shell_inner_skin",
                                                   mvtx_shell_inner_skin_inner_radius,
                                                   mvtx_shell_inner_skin_inner_radius + mvtxGeomDef::skin_thickness,
                                                   mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube,
+  G4LogicalVolume* mvtx_shell_inner_skin_volume = new G4LogicalVolume(mvtx_shell_inner_skin_tube,
                                                                       G4Material::GetMaterial("CFRP_INTT"),
                                                                       "mvtx_shell_inner_skin_volume", 0, 0, 0);
 
@@ -409,12 +455,12 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
                     "mvtx_shell_inner_skin", mvtx_outer_shell_volume, false, 0, OverlapCheck());
   //m_DisplayAction->AddVolume(mvtx_shell_inner_skin_volume, "Rail");
 
-  G4Tubs *mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
+  G4Tubs* mvtx_shell_foam_core_tube = new G4Tubs("mvtx_shell_foam_core",
                                                  mvtx_shell_foam_core_inner_radius,
                                                  mvtx_shell_foam_core_inner_radius + mvtxGeomDef::foam_core_thickness,
                                                  mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube,
+  G4LogicalVolume* mvtx_shell_foam_core_volume = new G4LogicalVolume(mvtx_shell_foam_core_tube,
                                                                      G4Material::GetMaterial("ROHACELL_FOAM_110"),
                                                                      "mvtx_shell_foam_core_volume", 0, 0, 0);
 
@@ -422,12 +468,12 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
                     "mvtx_shell_foam_core", mvtx_outer_shell_volume, false, 0, OverlapCheck());
   //m_DisplayAction->AddVolume(mvtx_shell_foam_core_volume, "Rail");
 
-  G4Tubs *mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
+  G4Tubs* mvtx_shell_outer_skin_tube = new G4Tubs("mvtx_shell_outer_skin",
                                                   mvtx_shell_outer_skin_inner_radius,
                                                   mvtx_shell_outer_skin_inner_radius + mvtxGeomDef::skin_thickness,
                                                   mvtxGeomDef::mvtx_shell_length / 2.0, -M_PI, 2.0 * M_PI);
 
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube,
+  G4LogicalVolume* mvtx_shell_outer_skin_volume = new G4LogicalVolume(mvtx_shell_outer_skin_tube,
                                                                       G4Material::GetMaterial("CFRP_INTT"),
                                                                       "mvtx_shell_outer_skin_volume", 0, 0, 0);
 
@@ -437,7 +483,6 @@ G4LogicalVolume* PHG4MvtxDetector::GetMvtxOuterShell(G4LogicalVolume*& trackeren
 
   return mvtx_outer_shell_volume;
 }
-
 
 void PHG4MvtxDetector::SetDisplayProperty(G4AssemblyVolume* av)
 {
@@ -504,7 +549,7 @@ void PHG4MvtxDetector::AddGeometryNode()
   {
     active |= isAct;
   }
-  if (active) // At least one layer is active
+  if (active)  // At least one layer is active
   {
     ostringstream geonode;
     geonode << "CYLINDERGEOM_" << ((m_SuperDetector != "NONE") ? m_SuperDetector : m_Detector);
@@ -526,8 +571,7 @@ void PHG4MvtxDetector::AddGeometryNode()
                                                         m_nominal_radius[ilayer] / cm,
                                                         get_phistep(ilayer) / rad,
                                                         m_nominal_phitilt[ilayer] / rad,
-                                                        m_nominal_phi0[ilayer] / rad
-                                                        );
+                                                        m_nominal_phi0[ilayer] / rad);
       geo->AddLayerGeom(ilayer, mygeom);
     }  // loop per layers
     if (Verbosity())

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -80,12 +80,19 @@ class PHG4MvtxDetector : public PHG4Detector
   std::array<double, n_Layers> m_nominal_radius;
   std::array<double, n_Layers> m_nominal_phitilt;
   std::array<double, n_Layers> m_nominal_phi0;
+  std::array<double, n_Layers> m_layer_z_offset;
+  std::map<std::pair<int, int>, std::string> m_stave_name;
+  std::map<std::pair<int, int>, double> m_stave_x_offset;
+  std::map<std::pair<int, int>, double> m_stave_y_offset;
+  std::map<std::pair<int, int>, double> m_stave_z_offset;
+  std::map<std::pair<int, int>, double> m_stave_tilt;
 
   std::string m_Detector;
   std::string m_SuperDetector;
   std::string m_StaveGeometryFile;
   std::string m_EndWheelsSideS;
   std::string m_EndWheelsSideN;
+  std::string m_alignmentPath;
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -4,27 +4,27 @@
 
 // Move to new storage containers
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHitv2.h>                      // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                     // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHNode.h>                           // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
-#include <phool/phool.h>                            // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <gsl/gsl_rng.h>                            // for gsl_rng_alloc
+#include <gsl/gsl_rng.h>  // for gsl_rng_alloc
 
-#include <cstdlib>                                 // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
 #include <set>
 
@@ -152,7 +152,7 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
     cout << "Could not locate TRKR_HITSET node, quit! " << endl;
     exit(1);
   }
-  
+
   // Get the TrkrHitTruthAssoc node
   auto hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
 
@@ -182,26 +182,25 @@ void PHG4MvtxDigitizer::DigitizeMvtxLadderCells(PHCompositeNode *topNode)
 
       // Convert the signal value to an ADC value and write that to the hit
       //unsigned int adc = hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup *_energy_scale[layer]);
-      if (Verbosity() > 0) 
-	cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup << " in layer " << layer << std::endl;
+      if (Verbosity() > 0)
+        cout << "    PHG4MvtxDigitizer: found hit with key: " << hit_iter->first << " and signal " << hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup << " in layer " << layer << std::endl;
       // Remove the hits with energy under threshold
       bool rm_hit = false;
-      if ( (hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup) < _energy_threshold) rm_hit = true;
+      if ((hit->getEnergy() / TrkrDefs::MvtxEnergyScaleup) < _energy_threshold) rm_hit = true;
 
-      unsigned short adc = (unsigned short) (hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup *_energy_scale[layer]));
+      unsigned short adc = (unsigned short) (hit->getEnergy() / (TrkrDefs::MvtxEnergyScaleup * _energy_scale[layer]));
       if (adc > _max_adc[layer]) adc = _max_adc[layer];
       hit->setAdc(adc);
 
       if (rm_hit) hits_rm.insert(hit_iter->first);
     }
 
-    for( const auto& key:hits_rm )
-    { 
+    for (const auto &key : hits_rm)
+    {
       if (Verbosity() > 0) cout << "    PHG4MvtxDigitizer: remove hit with key: " << key << endl;
       hitset->removeHit(key);
-      if( hittruthassoc ) hittruthassoc->removeAssoc(hitsetkey, key);
-   }
-
+      if (hittruthassoc) hittruthassoc->removeAssoc(hitsetkey, key);
+    }
   }
 
   // end new containers

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.h
@@ -9,10 +9,9 @@
 #include <gsl/gsl_rng.h>
 
 #include <map>
-#include <string>                // for string
-#include <utility>               // for pair, make_pair
+#include <string>   // for string
+#include <utility>  // for pair, make_pair
 #include <vector>
-
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDisplayAction.cc
@@ -1,12 +1,12 @@
 #include "PHG4MvtxDisplayAction.h"
 
-#include "g4main/PHG4DisplayAction.h"  // for PHG4DisplayAction
 #include <g4main/PHG4Utils.h>
+#include "g4main/PHG4DisplayAction.h"  // for PHG4DisplayAction
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 using namespace std;
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -6,10 +6,10 @@
 #include <mvtx/MvtxDefs.h>
 
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitTruthAssocv1.h>
+#include <trackbase/TrkrHitv2.h>  // for TrkrHit
 
 #include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
@@ -27,7 +27,7 @@
 #include <phool/PHIODataNode.h>
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>      // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
@@ -376,8 +376,8 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       // YCM: Fix pixel range: Xbin (row) 0 to 511, Zbin (col) 0 to 1023
       if (xbin_min < 0) xbin_min = 0;
       if (zbin_min < 0) zbin_min = 0;
-      if (xbin_max >= maxNX) xbin_max = maxNX-1;
-      if (zbin_max >= maxNZ) xbin_max = maxNZ-1;
+      if (xbin_max >= maxNX) xbin_max = maxNX - 1;
+      if (zbin_max >= maxNZ) xbin_max = maxNZ - 1;
 
       if (Verbosity() > 1)
       {
@@ -518,7 +518,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         if (!hit)
         {
           // Otherwise, create a new one
-	  hit = new TrkrHitv2();
+          hit = new TrkrHitv2();
           hitsetit->second->addHitSpecificKey(hitkey, hit);
         }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
@@ -6,28 +6,28 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <boost/tokenizer.hpp>
 // this is an ugly hack, the gcc optimizer has a bug which
@@ -43,10 +43,10 @@
 #include <boost/lexical_cast.hpp>
 #endif
 
-#include <cmath>                              // for NAN
-#include <cstdlib>                            // for exit
+#include <cmath>    // for NAN
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                              // for operator<<, basic_string
+#include <string>  // for operator<<, basic_string
 
 class PHCompositeNode;
 
@@ -254,7 +254,7 @@ bool PHG4MvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         theTouchable = prePoint->GetTouchableHandle();
         cout << "entering: depth = " << theTouchable->GetHistory()->GetDepth() << endl;
-        G4VPhysicalVolume *vol1 = theTouchable->GetVolume();
+        G4VPhysicalVolume* vol1 = theTouchable->GetVolume();
         cout << "entering volume name = " << vol1->GetName() << endl;
       }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -229,7 +229,7 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
   set_default_string_param(GLOBAL, "end_wheels_sideN",
                            string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideC_PEEK.gdml"));
   set_default_string_param(GLOBAL, "alignment_path",
-                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry"));
+                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/MVTX/alignment"));
   /*
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", NAN);
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", NAN);

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -8,27 +8,26 @@
 #include <phparameter/PHParameters.h>
 #include <phparameter/PHParametersContainer.h>
 
-
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>  // for PHG4DetectorGrou...
 
-#include <g4main/PHG4DisplayAction.h>                // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>               // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
-#include <phool/PHIODataNode.h>                      // for PHIODataNode
-#include <phool/PHNode.h>                            // for PHNode
-#include <phool/PHNodeIterator.h>                    // for PHNodeIterator
-#include <phool/PHObject.h>                          // for PHObject
-#include <phool/phool.h>                             // for PHWHERE
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
-#include <mvtx/SegmentationAlpide.h>                 // for Alpide constants
+#include <mvtx/SegmentationAlpide.h>  // for Alpide constants
 
-#include <iostream>                                  // for operator<<, basi...
-#include <set>                                       // for _Rb_tree_const_i...
+#include <iostream>  // for operator<<, basi...
+#include <set>       // for _Rb_tree_const_i...
 #include <sstream>
-#include <utility>                                   // for pair
+#include <utility>  // for pair
 
 class PHG4Detector;
 
@@ -210,6 +209,18 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
     set_default_double_param(ilyr, "phitilt", turbo);
     set_default_double_param(ilyr, "phi0", mvtxdat[ilyr][kPhi0]);
     set_default_string_param(ilyr, "material", "G4_AIR");  // default - almost nothing
+
+    set_default_double_param(ilyr, "layer_z_offset", 0.0);
+
+    for (int iStave = 0; iStave < mvtxdat[ilyr][kNStave]; ++iStave)
+    {
+      std::string stave_location = Form("layer_%i_stave_%i", ilyr, iStave);
+      set_default_string_param(ALIGNMENT, stave_location + "_name", "X000");
+      set_default_double_param(ALIGNMENT, stave_location + "_x_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_y_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_z_offset", 0.0);
+      set_default_double_param(ALIGNMENT, stave_location + "_tilt", 0.0);
+    }
   }
 
   set_default_string_param(GLOBAL, "stave_geometry_file", "ITS.gdml");  // default - almost nothing
@@ -217,6 +228,8 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
                            string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideA_mod_PEEK.gdml"));
   set_default_string_param(GLOBAL, "end_wheels_sideN",
                            string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/ITS_ibEndWheelSideC_PEEK.gdml"));
+  set_default_string_param(GLOBAL, "alignment_path",
+                           string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry"));
   /*
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", NAN);
   set_default_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", NAN);

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
@@ -5,8 +5,8 @@
 
 #include <g4detectors/PHG4DetectorGroupSubsystem.h>
 
-#include <cmath>                                     // for asin
-#include <string>                                    // for string
+#include <cmath>   // for asin
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This adds some MVTX alignment capabilities. We can move any stave independently in x, y and/or z and give it a tilt in z around the origin. There are corresponding PRs in calibrations to generate the XML file with the positions and in macros to read in the alignment

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

The next step is to add the ability to read in a different GDML file for each stave to allow for calibration of the individual ASICs. We have surveys on each stave from CERN so we also need to generate a GDML file for each stave they produced and put it in our calibrations

## Links to other PRs in macros and calibration repositories (if applicable)

Macros PR: https://github.com/sPHENIX-Collaboration/macros/pull/432 
Calibrations PR: https://github.com/sPHENIX-Collaboration/calibrations/pull/82