### PR TITLE
added SDM, ZDC is now able to be built one at a time

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4ZDCDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDetector.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4DETECTORS_PHG4FORWARDECALDETECTOR_H
-#define G4DETECTORS_PHG4FORWARDECALDETECTOR_H
+#ifndef G4DETECTORS_PHG4ZDCDETECTOR_H
+#define G4DETECTORS_PHG4ZDCDETECTOR_H
 
 #include <g4main/PHG4Detector.h>
 
@@ -20,9 +20,6 @@ class PHG4GDMLConfig;
 class PHParameters;
 
 /**
- * \file ${file_name}
- * \brief Module to build forward sampling Hadron calorimeterr (endcap) in Geant4
- * \author Nils Feege <nils.feege@stonybrook.edu>
  */
 
 class PHG4ZDCDetector : public PHG4Detector
@@ -55,7 +52,8 @@ class PHG4ZDCDetector : public PHG4Detector
   PHParameters *m_Params;
   //! registry for volumes that should not be exported, i.e. fibers
   PHG4GDMLConfig *m_GdmlConfig;
-
+  
+  bool m_Window;
   /* ZDC geometry */
   double m_Angle;
 
@@ -82,6 +80,20 @@ class PHG4ZDCDetector : public PHG4Detector
   double m_PlaceY;
   double m_PlaceZ;
 
+  double m_TSMD;
+  double m_HSMD;
+  double m_WSMD;
+
+  double m_RHole;
+  double m_TWin;
+  double m_RWin;
+  
+  double m_PlaceHole;
+  double m_Pxwin;
+  double m_Pywin;
+  double m_Pzwin;
+  
+
   int m_NMod;
   int m_NLay;
 
@@ -94,6 +106,7 @@ class PHG4ZDCDetector : public PHG4Detector
 
   std::set<G4LogicalVolume *> m_AbsorberLogicalVolSet;
   std::set<G4LogicalVolume *> m_ScintiLogicalVolSet;
+  std::set<G4LogicalVolume *> m_FiberLogicalVolSet;
 
  protected:
  

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
@@ -59,6 +59,14 @@ void PHG4ZDCDisplayAction::ApplyDisplayAction(G4VPhysicalVolume *physvol)
     {
       visatt->SetColour(G4Colour::Red());
     }
+    else if (it.second == "Window")
+    {
+      visatt->SetColour(G4Colour::Blue());
+    }
+    else if (it.second == "SMD")
+    {
+      visatt->SetColour(G4Colour::Yellow());
+    }
     else if (it.second == "FiberPlate")
     {
       visatt->SetColour(G4Colour::Cyan());

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.h
@@ -34,7 +34,9 @@ class PHG4ZDCSteppingAction : public PHG4SteppingAction
   virtual void SetInterfacePointers(PHCompositeNode*);
 
  private:
-  int FindIndex(G4TouchableHandle& touch, int& j, int& k);
+  int FindIndexZDC(G4TouchableHandle& touch, int& j, int& k);
+
+  int FindIndexSMD(G4TouchableHandle& touch, int& j, int& k);
   
   double ZDCResponce(double beta, double angle);
   

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.cc
@@ -54,16 +54,13 @@ int PHG4ZDCSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   // create display settings before detector
   m_DisplayAction = new PHG4ZDCDisplayAction(Name());
   // create detector
- 
-  m_Detector = new PHG4ZDCDetector(this, topNode, GetParams(), Name());
+   m_Detector = new PHG4ZDCDetector(this, topNode, GetParams(), Name());
 
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->OverlapCheck(CheckOverlap());
   m_Detector->Verbosity(Verbosity());
   set<string> nodes;
-  // GetParams()->set_int_param("active",1);
-  // std::cout<<"active?"<<GetParams()->get_int_param("active")<<std::endl;
-  
+   
   if (GetParams()->get_int_param("active"))
    {
    
@@ -137,7 +134,9 @@ PHG4Detector* PHG4ZDCSubsystem::GetDetector(void) const
 
 void PHG4ZDCSubsystem::SetDefaultParameters()
 {
-  
+  set_default_int_param("fzdc", 0);
+  set_default_int_param("bzdc", 0);
+  set_default_double_param("z", 1843.0);
   return;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Added SMD(7*8 scintillator blocks) in between the first and second modules of ZDC. Modified the stepping, energy loss when particles in SMD, Cherenkov if in the PMMA fiber. idx_j from 10 to 23, idx_k from 10 to 17 are for the SMD.

Modified the ZDC subsystem, added two int parameters: fzdc, bzdc. We can now build ZDC in the forward or backward region by setting fzdc or bzdc to 1(or do both).



[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

sPHENIX-Collaboration/macros/pull/435