### PR TITLE
avoid to-be-deprecated GetPropertiesMap() and GetPropertiesCMap() in Geant4

### DIFF
--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteMaterials.cc
@@ -122,7 +122,7 @@ void PHG4GDMLWriteMaterials::ElementWrite(const G4Element* const elementPtr)
    if (NumberOfIsotopes>0)
    {
       const G4double* RelativeAbundanceVector =
-            elementPtr->GetRelativeAbundanceVector();             
+            elementPtr->GetRelativeAbundanceVector();
       for (size_t i=0;i<NumberOfIsotopes;i++)
       {
          G4String fractionref = GenerateName(elementPtr->GetIsotope(i)->GetName(),
@@ -173,9 +173,9 @@ void PHG4GDMLWriteMaterials::MaterialWrite(const G4Material* const materialPtr)
 
    // Write Ionisation potential (mean excitation energy)
    MEEWrite(materialElement,materialPtr->GetIonisation()->GetMeanExcitationEnergy());
-   
+
    DWrite(materialElement,materialPtr->GetDensity());
-  
+
    const size_t NumberOfElements = materialPtr->GetNumberOfElements();
 
    if ( (NumberOfElements>1)
@@ -229,47 +229,58 @@ void PHG4GDMLWriteMaterials::PropertyVectorWrite(const G4String& key,
 void PHG4GDMLWriteMaterials::PropertyWrite(xercesc::DOMElement* matElement,
                                          const G4Material* const mat)
 {
-   xercesc::DOMElement* propElement;
-   G4MaterialPropertiesTable* ptable = mat->GetMaterialPropertiesTable();
-   const std::map< G4String, G4PhysicsOrderedFreeVector*,
-                 std::less<G4String> >* pmap = ptable->GetPropertiesMap();
-   const std::map< G4String, G4double,
-                 std::less<G4String> >* cmap = ptable->GetPropertiesCMap();
-   std::map< G4String, G4PhysicsOrderedFreeVector*,
-                 std::less<G4String> >::const_iterator mpos;
-   std::map< G4String, G4double,
-                 std::less<G4String> >::const_iterator cpos;
-   for (mpos=pmap->begin(); mpos!=pmap->end(); ++mpos)
-   {
-      propElement = NewElement("property");
-      propElement->setAttributeNode(NewAttribute("name", mpos->first));
-      propElement->setAttributeNode(NewAttribute("ref",
-                                    GenerateName(mpos->first, mpos->second)));
-      if (mpos->second)
-      {
-         PropertyVectorWrite(mpos->first, mpos->second);
-         matElement->appendChild(propElement);
-      }
-      else
-      {
-         G4String warn_message = "Null pointer for material property -"
-                  + mpos->first + "- of material -" + mat->GetName() + "- !";
-         G4Exception("PHG4GDMLWriteMaterials::PropertyWrite()", "NullPointer",
-                     JustWarning, warn_message);
-         continue;
-      }
-   }
-   for (cpos=cmap->begin(); cpos!=cmap->end(); ++cpos)
-   {
-      propElement = NewElement("property");
-      propElement->setAttributeNode(NewAttribute("name", cpos->first));
-      propElement->setAttributeNode(NewAttribute("ref", cpos->first));
-      xercesc::DOMElement* constElement = NewElement("constant");
-      constElement->setAttributeNode(NewAttribute("name", cpos->first));
-      constElement->setAttributeNode(NewAttribute("value", cpos->second));
-      defineElement->appendChild(constElement);
-      matElement->appendChild(propElement);
-   }
+  xercesc::DOMElement* propElement;
+  G4MaterialPropertiesTable* ptable = mat->GetMaterialPropertiesTable();
+
+  const std::map< G4int, G4PhysicsOrderedFreeVector*,
+                std::less<G4int> >* pmap = ptable->GetPropertyMap();
+  const std::map< G4int, G4double,
+                std::less<G4int> >* cmap = ptable->GetConstPropertyMap();
+  std::map< G4int, G4PhysicsOrderedFreeVector*,
+                std::less<G4int> >::const_iterator mpos;
+  std::map< G4int, G4double,
+                std::less<G4int> >::const_iterator cpos;
+
+
+  for (mpos=pmap->begin(); mpos!=pmap->end(); mpos++)
+  {
+     propElement = NewElement("property");
+     propElement->setAttributeNode(NewAttribute("name",
+                           ptable->GetMaterialPropertyNames()[mpos->first]));
+     propElement->setAttributeNode(NewAttribute("ref",
+       GenerateName(ptable->GetMaterialPropertyNames()[mpos->first],
+                             mpos->second)));
+     if (mpos->second)
+     {
+        PropertyVectorWrite(ptable->GetMaterialPropertyNames()[mpos->first],
+                             mpos->second);
+        matElement->appendChild(propElement);
+     }
+     else
+     {
+        G4String warn_message = "Null pointer for material property -"
+         + ptable->GetMaterialPropertyNames()[mpos->first] + "- of material -"
+         + mat->GetName() + "- !";
+        G4Exception("G4GDMLWriteMaterials::PropertyWrite()", "NullPointer",
+                    JustWarning, warn_message);
+        continue;
+     }
+  }
+
+  for (cpos=cmap->begin(); cpos!=cmap->end(); cpos++)
+  {
+     propElement = NewElement("property");
+     propElement->setAttributeNode(NewAttribute("name",
+                  ptable->GetMaterialConstPropertyNames()[cpos->first]));
+     propElement->setAttributeNode(NewAttribute("ref",
+                  ptable->GetMaterialConstPropertyNames()[cpos->first]));
+     xercesc::DOMElement* constElement = NewElement("constant");
+     constElement->setAttributeNode(NewAttribute("name",
+                   ptable->GetMaterialConstPropertyNames()[cpos->first]));
+     constElement->setAttributeNode(NewAttribute("value", cpos->second));
+     defineElement->appendChild(constElement);
+     matElement->appendChild(propElement);
+  }
 }
 
 void PHG4GDMLWriteMaterials::MaterialsWrite(xercesc::DOMElement* element)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

In the G4->Reconstruction geometry transporter, avoids a to-be-deprecated function call to Geant4, i.e. `ptable->GetPropertiesMap()` and `ptable->GetPropertiesCMap()`

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

