### PR TITLE
Ghost track rejector module

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -44,6 +44,7 @@ pkginclude_HEADERS = \
   PHActsVertexFitter.h \
   PHActsTrackProjection.h \
   PHGenFitTrkProp.h \
+  PHGhostRejection.h \
   PHHoughSeeding.h \
   PHTrackCleaner.h \
   PHRTreeSeeding.h \
@@ -168,6 +169,7 @@ libtrack_reco_la_SOURCES = \
   PHGenFitTrkProp.cc \
   PHGenFitTrkFitter.cc \
   PHGenFitTrackProjection.cc \
+  PHGhostRejection.cc \
   PHRaveVertexing.cc \
   PHTpcTrackSeedVertexAssoc.cc \
   ALICEKF.cc \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -223,11 +223,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 			      track->get_pz());
    
       auto actsVertex = getVertex(track);
-      /*
-      Acts::Vector3D actsVertex(track->get_x() * Acts::UnitConstants::cm, 
-      			track->get_y() * Acts::UnitConstants::cm, 
-      			track->get_z() * Acts::UnitConstants::cm);
-      */      
+
       auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
 					  actsVertex);
       auto actsFourPos = Acts::Vector4D(actsVertex(0), actsVertex(1),

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -222,11 +222,12 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 			      track->get_py(), 
 			      track->get_pz());
    
-      //      auto actsVertex = getVertex(track);
+      auto actsVertex = getVertex(track);
+      /*
       Acts::Vector3D actsVertex(track->get_x() * Acts::UnitConstants::cm, 
       			track->get_y() * Acts::UnitConstants::cm, 
       			track->get_z() * Acts::UnitConstants::cm);
-      
+      */      
       auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
 					  actsVertex);
       auto actsFourPos = Acts::Vector4D(actsVertex(0), actsVertex(1),

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -222,7 +222,11 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 			      track->get_py(), 
 			      track->get_pz());
    
-      auto actsVertex = getVertex(track);
+      //      auto actsVertex = getVertex(track);
+      Acts::Vector3D actsVertex(track->get_x() * Acts::UnitConstants::cm, 
+      			track->get_y() * Acts::UnitConstants::cm, 
+      			track->get_z() * Acts::UnitConstants::cm);
+      
       auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
 					  actsVertex);
       auto actsFourPos = Acts::Vector4D(actsVertex(0), actsVertex(1),
@@ -691,12 +695,13 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 	  std::cout << PHWHERE << " vertex ID " << vertexId << " not found!" << " for track " << track->get_id() << std::endl;
 	 return; 
 	}
-   
+
+
       Acts::Vector3D vertex(
 		  svtxVertex->get_x() * Acts::UnitConstants::cm, 
 		  svtxVertex->get_y() * Acts::UnitConstants::cm, 
 		  svtxVertex->get_z() * Acts::UnitConstants::cm);
-   
+      
       rotater.calculateDCA(params, vertex, rotatedCov,
 			    m_tGeometry->geoContext, 
 			    dca3Dxy, dca3Dz, 

--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -45,7 +45,7 @@ int PHGhostRejection::InitRun(PHCompositeNode *topNode)
 }
 
 //____________________________________________________________________________..
-int PHGhostRejection::process_event(PHCompositeNode *topNode)
+int PHGhostRejection::process_event(PHCompositeNode * /*topNode*/)
 {
 
   if(Verbosity() > 0)
@@ -62,7 +62,7 @@ int PHGhostRejection::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHGhostRejection::End(PHCompositeNode *topNode)
+int PHGhostRejection::End(PHCompositeNode * /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -1,0 +1,181 @@
+#include "PHGhostRejection.h"
+
+#include "PHGhostRejection.h"   
+
+/// Tracking includes
+
+#include <trackbase/TrkrCluster.h>            // for TrkrCluster
+#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TpcSeedTrackMap.h>
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <cmath>                              // for sqrt, fabs, atan2, cos
+#include <iostream>                           // for operator<<, basic_ostream
+#include <map>                                // for map
+#include <set>                                // for _Rb_tree_const_iterator
+#include <utility>                            // for pair, make_pair
+
+//____________________________________________________________________________..
+PHGhostRejection::PHGhostRejection(const std::string &name)
+  : SubsysReco(name)
+{
+
+}
+
+//____________________________________________________________________________..
+PHGhostRejection::~PHGhostRejection()
+{
+
+}
+
+//____________________________________________________________________________..
+int PHGhostRejection::InitRun(PHCompositeNode *topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHGhostRejection::process_event(PHCompositeNode *topNode)
+{
+
+  if(Verbosity() > 0)
+    std::cout << PHWHERE << " Beginning track map size " << _track_map->size() << std::endl;
+
+  // Try to eliminate repeated tracks
+
+  findGhostTracks();
+
+  if(Verbosity() > 0)
+    std::cout << "Track map size after deleting ghost tracks: " << _track_map->size() << std::endl;
+
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHGhostRejection::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int  PHGhostRejection::GetNodes(PHCompositeNode* topNode)
+{
+
+  _track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!_track_map)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find SvtxTrackMap: " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void PHGhostRejection::findGhostTracks()
+{
+  std::set<unsigned int> matches_set;
+  std::multimap<unsigned int, unsigned int>  matches;
+  for (auto tr1_iter = _track_map->begin();
+       tr1_iter != _track_map->end(); 
+       ++tr1_iter)
+    {
+      auto track1 = (tr1_iter)->second;
+      
+      for (auto tr2_iter = tr1_iter;
+	   tr2_iter != _track_map->end(); 
+	   ++tr2_iter)
+	{
+	  if((tr2_iter)->first  ==  (tr1_iter)->first) continue;
+	  
+	  auto track2 = (tr2_iter)->second;
+	  if( 
+	     fabs( track1->get_phi() - track2->get_phi() ) < _phi_cut &&
+	     fabs( track1->get_eta() - track2->get_eta() ) < _eta_cut &&
+	     fabs( track1->get_x() - track2->get_x() ) < _x_cut &&
+	     fabs( track1->get_y() - track2->get_y() ) < _y_cut &&
+	     fabs( track1->get_z() - track2->get_z() ) < _z_cut
+	      )
+	    {
+	      matches_set.insert(tr1_iter->first);
+	      matches.insert( std::pair( (tr1_iter)->first, (tr2_iter)->first) );
+
+	      if(Verbosity() > 1)
+		std::cout << "Found match for tracks " << (tr1_iter)->first << " and " << (tr2_iter)->first << std::endl;
+	    }
+	}
+    }
+
+  std::set<unsigned int> ghost_reject_list;
+
+  for(auto set_it : matches_set)
+    {
+      if(ghost_reject_list.find(set_it) != ghost_reject_list.end()) continue;  // already rejected  
+
+      auto match_list = matches.equal_range(set_it);
+
+      auto tr1 = _track_map->get(set_it);
+      double best_qual = tr1->get_chisq() / tr1->get_ndf();
+      unsigned int best_track = set_it;
+
+      if(Verbosity() > 1)  
+	std::cout << " ****** start checking track " << set_it << " with best quality " << best_qual << " best_track " << best_track << std::endl;
+
+      for (auto it=match_list.first; it!=match_list.second; ++it)
+	{
+	  if(Verbosity() > 1)
+	    std::cout << "    match of track " << it->first << " to track " << it->second << std::endl;
+	  
+	  // which one has best quality?
+	  auto tr2 = _track_map->get(it->second);	  
+	  double tr2_qual = tr2->get_chisq() / tr2->get_ndf();
+	  if(Verbosity() > 1)
+	    {
+	      std::cout << "       Compare: best quality " << best_qual << " track 2 quality " << tr2_qual << std::endl;
+	      std::cout << "       tr1: phi " << tr1->get_phi() << " eta " << tr1->get_eta() 
+			<<  " x " << tr1->get_x() << " y " << tr1->get_y() << " z " << tr1->get_z() << std::endl;
+	      std::cout << "       tr2: phi " << tr2->get_phi() << " eta " << tr2->get_eta() 
+			<<  " x " << tr2->get_x() << " y " << tr2->get_y() << " z " << tr2->get_z() << std::endl;
+	    }
+
+	  if(tr2_qual < best_qual)
+	    {
+	      if(Verbosity() > 1)
+		std::cout << "       --------- Track " << it->second << " has better quality, erase track " << best_track << std::endl;
+	      ghost_reject_list.insert(best_track);
+	      best_qual = tr2_qual;
+	      best_track = it->second;
+	    }
+	  else
+	    {
+	      if(Verbosity() > 1)
+		std::cout << "       --------- Track " << best_track << " has better quality, erase track " << it->second << std::endl;
+	      ghost_reject_list.insert(it->second);
+	    }
+
+	}
+      if(Verbosity() > 1)
+	std::cout << " best track " << best_track << " best_qual " << best_qual << std::endl;      
+
+    }
+
+  // delete ghost tracks
+  for(auto it : ghost_reject_list)
+    {
+      if(Verbosity() > 1)
+	std::cout << " erasing track ID " << it << std::endl;
+
+      _track_map->erase(it);
+    }
+  
+  return;
+}
+

--- a/offline/packages/trackreco/PHGhostRejection.h
+++ b/offline/packages/trackreco/PHGhostRejection.h
@@ -38,6 +38,7 @@ class PHGhostRejection : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
   void findGhostTracks();
+  bool checkClusterSharing(SvtxTrack *tr1, SvtxTrack *tr2);
 
 SvtxTrackMap *_track_map{nullptr};
 
@@ -46,7 +47,6 @@ SvtxTrackMap *_track_map{nullptr};
   double _x_cut = 0.3;
   double _y_cut = 0.3;
   double _z_cut = 0.4;
-  bool _reject_ghosts = true;
 
 };
 

--- a/offline/packages/trackreco/PHGhostRejection.h
+++ b/offline/packages/trackreco/PHGhostRejection.h
@@ -1,0 +1,53 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+
+/*!
+ *  \file		  PHGhostRejection
+ *  \brief		Class for deciding which track based on a given TPC seed is the best one
+ *  \author	 Tony Frawley <afrawley@fsu.edu>
+ */
+
+#ifndef PHGHOSTREJECTION_H
+#define PHGHOSTREJECTION_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+#include <map>
+
+class PHCompositeNode;
+class SvtxTrack;
+class SvtxTrackMap;
+class TrkrCluster;
+class TpcSeedTrackMap;
+
+class PHGhostRejection : public SubsysReco
+{
+ public:
+
+  PHGhostRejection(const std::string &name = "PHGhostRejection");
+
+  ~PHGhostRejection() override;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+ private:
+
+  int GetNodes(PHCompositeNode* topNode);
+  void findGhostTracks();
+
+SvtxTrackMap *_track_map{nullptr};
+
+  double _phi_cut = 0.01;
+  double _eta_cut = 0.004;
+  double _x_cut = 0.3;
+  double _y_cut = 0.3;
+  double _z_cut = 0.4;
+  bool _reject_ghosts = true;
+
+};
+
+#endif // PHGHOSTREJECTION_H

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -322,14 +322,14 @@ int PHMicromegasTpcTrackMatching::Process()
     std::cout << PHWHERE << " Event " << _event << " TPC track map size " << _track_map->size() << std::endl;
 
   // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
 
   // loop over the original TPC tracks
   for (auto phtrk_iter = _track_map->begin(); phtrk_iter != _track_map->end(); ++phtrk_iter)
   {
 
     // we may add tracks to the map, so we stop at the last original track
-    if(phtrk_iter->first >= original_track_map_lastkey)  break;
+    if(phtrk_iter->first > original_track_map_lastkey)  break;
 
     auto tracklet_tpc = phtrk_iter->second;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -115,15 +115,17 @@ int PHSiliconTpcTrackMatching::Process()
   
   
   // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = _track_map->end()->first;
-  
+  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
+  if(Verbosity() > 1)
+    std::cout << "Original track map has lastkey " << original_track_map_lastkey << std::endl;
+
   // loop over the original TPC tracks
   for (auto phtrk_iter = _track_map->begin();
        phtrk_iter != _track_map->end(); 
        ++phtrk_iter)
     {
       // we may add tracks to the map, so we stop at the last original track
-      if(phtrk_iter->first >= original_track_map_lastkey)  break;
+      if(phtrk_iter->first > original_track_map_lastkey)  break;
       
       _tracklet_tpc = phtrk_iter->second;
       
@@ -350,10 +352,10 @@ int PHSiliconTpcTrackMatching::Process()
 #else
 	      auto newTrack = std::make_unique<SvtxTrack_v2>();
 #endif
-	      const unsigned int lastTrackKey = _track_map->end()->first; 
-	      if(Verbosity() > 1) cout << "Extra match, add a new track to node tree with key " <<  lastTrackKey << endl;
+	      const unsigned int lastTrackKey = std::prev(_track_map->end())->first; 
+	      if(Verbosity() > 1) cout << "Extra match, add a new track to node tree with key " <<  lastTrackKey + 1 << endl;
 	      
-	      newTrack->set_id(lastTrackKey);
+	      newTrack->set_id(lastTrackKey+1);
 	      
 	      unsigned int vertexId = _tracklet_si->get_vertex_id();
 	      newTrack->set_vertex_id(vertexId);

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -160,7 +160,8 @@ int PHTrackCleaner::process_event(PHCompositeNode *topNode)
   // now we have a single silicon match per TPC seed
   // Try to eliminate tracks based on repeated TPC seeds
 
-  findGhostTracks();
+  if(_reject_ghosts)
+    findGhostTracks();
 
   if(Verbosity() > 0)
     std::cout << "Track map size after deleting ghost tracks: " << _track_map->size() << std::endl;

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -157,17 +157,6 @@ int PHTrackCleaner::process_event(PHCompositeNode *topNode)
   if(Verbosity() > 0)
     std::cout << "Track map size after choosing best silicon match: " << _track_map->size() << std::endl;
 
-  // now we have a single silicon match per TPC seed
-  // Try to eliminate tracks based on repeated TPC seeds
-
-  if(_reject_ghosts)
-    {
-      findGhostTracks();
-
-      if(Verbosity() > 0)
-	std::cout << "Track map size after deleting ghost tracks: " << _track_map->size() << std::endl;
-    }
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -195,90 +184,3 @@ int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
-void PHTrackCleaner::findGhostTracks()
-{
-  std::set<unsigned int> matches_set;
-  std::multimap<unsigned int, unsigned int>  matches;
-  for (auto tr1_iter = _track_map->begin();
-       tr1_iter != _track_map->end(); 
-       ++tr1_iter)
-    {
-      auto track1 = (tr1_iter)->second;
-      
-      for (auto tr2_iter = tr1_iter;
-	   tr2_iter != _track_map->end(); 
-	   ++tr2_iter)
-	{
-	  if((tr2_iter)->first  ==  (tr1_iter)->first) continue;
-	  
-	  auto track2 = (tr2_iter)->second;
-	  if( 
-	     fabs( track1->get_phi() - track2->get_phi() ) < _phi_cut &&
-	     fabs( track1->get_eta() - track2->get_eta() ) < _eta_cut &&
-	     fabs( track1->get_x() - track2->get_x() ) < _x_cut &&
-	     fabs( track1->get_y() - track2->get_y() ) < _y_cut &&
-	     fabs( track1->get_z() - track2->get_z() ) < _z_cut
-	      )
-	    {
-	      matches_set.insert(tr1_iter->first);
-	      matches.insert( std::pair( (tr1_iter)->first, (tr2_iter)->first) );
-
-	      if(Verbosity() > 0)
-		std::cout << "Found match for tracks " << (tr1_iter)->first << " and " << (tr2_iter)->first << std::endl;
-	    }
-	}
-    }
-
-  std::set<unsigned int> ghost_reject_list;
-
-  for(auto set_it : matches_set)
-    {
-      auto match_list = matches.equal_range(set_it);
-
-      auto tr1 = _track_map->get(set_it);
-      double best_qual = tr1->get_chisq() / tr1->get_ndf();
-      unsigned int best_track = set_it;
-
-      if(Verbosity() > 0)  
-	std::cout << " start checking track " << set_it << " with best quality " << best_qual << " best_track " << best_track << std::endl;
-
-      for (auto it=match_list.first; it!=match_list.second; ++it)
-	{
-	  if(Verbosity() > 0)
-	    std::cout << "    match of track " << it->first << " to track " << it->second << std::endl;
-	  
-	  // which one has best quality?
-	  auto tr2 = _track_map->get(it->second);	  
-	  double tr2_qual = tr2->get_chisq() / tr2->get_ndf();
-	  if(Verbosity() > 0)
-	    std::cout << "       best quality " << best_qual << " track 2 quality " << tr2_qual << std::endl;
-
-	  if(tr2_qual < best_qual)
-	    {
-	      ghost_reject_list.insert(best_track);
-	      best_qual = tr2_qual;
-	      best_track = it->second;
-	    }
-	  else
-	    ghost_reject_list.insert(it->second);
-
-	}
-      if(Verbosity() > 0)
-	std::cout << " best track " << best_track << " best_qual " << best_qual << std::endl;      
-
-    }
-
-  // delete ghost tracks
-  //for(auto it = ghost_reject_list.begin(); it != ghost_reject_list.end(); ++it)
-  for(auto it : ghost_reject_list)
-    {
-      if(Verbosity() > 1)
-	std::cout << " erasing track ID " << it << std::endl;
-
-      _track_map->erase(it);
-    }
-  
-  return;
-}
-

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -161,11 +161,12 @@ int PHTrackCleaner::process_event(PHCompositeNode *topNode)
   // Try to eliminate tracks based on repeated TPC seeds
 
   if(_reject_ghosts)
-    findGhostTracks();
+    {
+      findGhostTracks();
 
-  if(Verbosity() > 0)
-    std::cout << "Track map size after deleting ghost tracks: " << _track_map->size() << std::endl;
-
+      if(Verbosity() > 0)
+	std::cout << "Track map size after deleting ghost tracks: " << _track_map->size() << std::endl;
+    }
   
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -34,6 +34,7 @@ class PHTrackCleaner : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
+  void enableGhostRejection(bool enable){_reject_ghosts = enable;}
 
  private:
 
@@ -52,7 +53,8 @@ SvtxTrack *_track{nullptr};
   double _x_cut = 0.3;
   double _y_cut = 0.3;
   double _z_cut = 0.4;
-  
+  bool _reject_ghosts = true;
+
 };
 
 #endif // PHTRACKCLEANER_H

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -34,8 +34,6 @@ class PHTrackCleaner : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
-  void enableGhostRejection(bool enable){_reject_ghosts = enable;}
-
  private:
 
   int GetNodes(PHCompositeNode* topNode);
@@ -47,13 +45,6 @@ SvtxTrack *_track{nullptr};
  TpcSeedTrackMap *_seed_track_map{nullptr};
 
  unsigned int min_clusters = 20;
-
-  double _phi_cut = 0.01;
-  double _eta_cut = 0.004;
-  double _x_cut = 0.3;
-  double _y_cut = 0.3;
-  double _z_cut = 0.4;
-  bool _reject_ghosts = true;
 
 };
 

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -38,6 +38,7 @@ class PHTrackCleaner : public SubsysReco
  private:
 
   int GetNodes(PHCompositeNode* topNode);
+  void findGhostTracks();
 
 SvtxTrackMap *_track_map{nullptr};
 SvtxTrack *_track{nullptr};
@@ -46,6 +47,12 @@ SvtxTrack *_track{nullptr};
 
  unsigned int min_clusters = 20;
 
+  double _phi_cut = 0.01;
+  double _eta_cut = 0.004;
+  double _x_cut = 0.3;
+  double _y_cut = 0.3;
+  double _z_cut = 0.4;
+  
 };
 
 #endif // PHTRACKCLEANER_H

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -65,7 +65,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
   // Loop over all SvtxTracks from the CA seeder
   // These should contain all TPC clusters already
 
-  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
   std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
 
   for (auto phtrk_iter = _track_map->begin();
@@ -73,7 +73,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
        ++phtrk_iter)
     {
       // we may add tracks to the map, so we stop at the last original track
-      if(phtrk_iter->first >= original_track_map_lastkey)  break;
+      if(phtrk_iter->first > original_track_map_lastkey)  break;
 
       _tracklet = phtrk_iter->second;
       if (Verbosity() >= 1)
@@ -133,10 +133,10 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	{      
 	  SvtxTrack *newTrack = new SvtxTrack_v2();
 	  // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-	  const unsigned int lastTrackKey = _track_map->end()->first + ig4;
-	  //std::cout << "   extra track key " << lastTrackKey << std::endl;
+	  const unsigned int lastTrackKey = std::prev(_track_map->end())->first + ig4;
+	  //std::cout << "   extra track key " << lastTrackKey + 1 << std::endl;
 	 	  
-	  newTrack->set_id(lastTrackKey);
+	  newTrack->set_id(lastTrackKey + 1);
 	  newTrack->set_vertex_id(vertexId);
 
 	  newTrack->set_charge(_tracklet->get_charge());
@@ -164,7 +164,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	    }
 	  
 	  extraTrack.push_back(newTrack);
-	  //std::cout << "  added new copy of track " << lastTrackKey << " g4particle_vec.zize " << g4particle_vec.size() << std::endl;
+	  //std::cout << "  added new copy of track " << lastTrackKey + 1 << " g4particle_vec.zize " << g4particle_vec.size() << std::endl;
 	  //extraTrack[ig4]->identify();
 	}
 
@@ -224,10 +224,10 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode)
 	      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
 	      	
 	      // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-	      const unsigned int lastTrackKey = _track_map->end()->first;
-	      //std::cout << "   lastTrackKey " << lastTrackKey << std::endl;
+	      const unsigned int lastTrackKey = std::prev(_track_map->end())->first;
+	      //std::cout << "   lastTrackKey " << lastTrackKey + 1 << std::endl;
 	      
-	      extraTrack[ig4]->set_id(lastTrackKey);
+	      extraTrack[ig4]->set_id(lastTrackKey + 1);
 	      
 	      if (Verbosity() >= 1) 
 		{

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1995,7 +1995,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	      PHG4Hit* g4hit = clustereval->max_truth_hit_by_energy(cluster_key);
 	      PHG4Particle* g4particle = trutheval->get_particle(g4hit);
 	      
-	      float hitID = cluster_key;
+	      //float hitID = cluster_key;
+	      float hitID = (float) TrkrDefs::getClusIndex(cluster_key);
 	      float x = cluster->getX();
 	      float y = cluster->getY();
 	      float z = cluster->getZ();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a module to reject duplicate ("ghost") tracks. It can be run on the TPC track seeds after vertex association, or on the full tracks after the first track fitter is run. Because of the way the CA seeder works, it is very efficient but produces roughly two (usually identical) seeds per truth track. This module compares (x,y,z), phi and eta for every pair of tracks. When it finds matches, it keeps the track having the best chisq/ndf and deletes the others. Tests with MB + 50 KHz pileup events show that tracking efficiency (defined as fraction of truth tracks reconstructed) is not affected.
Because this module deletes tracks from the track map, it was necessary to modify any code that finds the last key in the track map. The last key is no longer the track map size - 1. The last key is now std::prev(_track_map->end())->first. 
An unrelated change to the evaluator makes the cluster ntuple "hitID" the cluster index (rather than a cast of the cluster key to float, which is gibberish). For a given hitset (phi element and z element), the cluster index is unique.
Running the ghost rejection module on the TPC seeds reduces the time taken for all subsequent steps by about a factor of two, so that is the preferred use.
I will make a macros PR later. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

