### PR TITLE
Circle Fit Truth Seed Option

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -8,14 +8,16 @@
 #define TRACKRECO_PHTRUTHTRACKSEEDING_H
 
 #include "PHTrackSeeding.h"
-
+#include <trackbase/TrkrDefs.h>
 #include <string>  // for string
+#include <vector>
 
 // forward declarations
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 class TrkrHitTruthAssoc;
+class TrkrClusterContainer;
 class SvtxClusterEval;
 
 //class SvtxHitMap;
@@ -62,7 +64,8 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   {
     _min_momentum = m;
   }
-
+void helicalTrackFit(const bool helicalTrackFit)
+{m_helicalTrackFit = helicalTrackFit; }
  protected:
   int Setup(PHCompositeNode* topNode) override;
 
@@ -74,8 +77,17 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   /// fetch node pointers
   int GetNodes(PHCompositeNode* topNode);
 
+  void circleFitSeed(std::vector<TrkrDefs::cluskey> clusters,
+		     double& x, double& y, double&z,
+		       double& px, double& py, double& pz, int charge);
+void circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
+			 double& R, double& X0, double& Y0);
+  void findRoot(const double& R, const double& X0, const double& Y0,
+		double& x, double& y);
+  void lineFit(std::vector<TrkrDefs::cluskey>& clusters,
+	       double& A, double& B);
   PHG4TruthInfoContainer* _g4truth_container = nullptr;
-
+  TrkrClusterContainer *m_clusterMap = nullptr;
   PHG4HitContainer* phg4hits_tpc = nullptr;
   PHG4HitContainer* phg4hits_intt = nullptr;
   PHG4HitContainer* phg4hits_mvtx = nullptr;
@@ -87,6 +99,10 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   unsigned int _min_clusters_per_track = 3;
   unsigned int _min_layer = 0;
   unsigned int _max_layer = 60;
+
+  /// Option to perform a helical track fit to get track parameters for
+  /// truth seeded track
+  bool m_helicalTrackFit = false;
 
   //! minimal truth momentum cut (GeV)
   double _min_momentum = 50e-3;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a circle fit option to the truth seeding algorithm. The option is off by default. When turned on, the clusters that are accumulated by the truth seeding are used for a circle fit to determine the track seed parameters. This gives a more realistic set of track seed parameters rather than the default of smearing the truth track parameters by 5%. This option can be useful for track fit debugging.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

