### PR TITLE
Make track projections work without calos

### DIFF
--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -7,7 +7,7 @@
 #include <CLHEP/Vector/LorentzRotation.h>
 #include <CLHEP/Vector/LorentzVector.h>
 #include <CLHEP/Vector/Rotation.h>
-#include <CLHEP/Vector/ThreeVector.h>        // for Hep3Vector
+#include <CLHEP/Vector/ThreeVector.h>  // for Hep3Vector
 
 #include <sstream>
 
@@ -64,10 +64,10 @@ void PHHepMCGenEventv1::identify(std::ostream& os) const
   static const CLHEP::HepLorentzVector zp_lightcone(0, 0, 1, 1);
   static const CLHEP::HepLorentzVector zm_lightcone(0, 0, -1, 1);
 
-  os << " HepMC Frame unit light cone vector along +z axis "<<zp_lightcone<<" translate to lab at : "
+  os << " HepMC Frame unit light cone vector along +z axis " << zp_lightcone << " translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zp_lightcone)
      << std::endl;
-  os << " HepMC Frame unit light cone vector along -z axis  "<<zm_lightcone<<" translate to lab at : "
+  os << " HepMC Frame unit light cone vector along -z axis  " << zm_lightcone << " translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zm_lightcone)
      << std::endl;
 

--- a/generators/phhepmc/PHHepMCGenEventv1.cc
+++ b/generators/phhepmc/PHHepMCGenEventv1.cc
@@ -7,11 +7,9 @@
 #include <CLHEP/Vector/LorentzRotation.h>
 #include <CLHEP/Vector/LorentzVector.h>
 #include <CLHEP/Vector/Rotation.h>
+#include <CLHEP/Vector/ThreeVector.h>        // for Hep3Vector
 
 #include <sstream>
-#include <utility>  // for swap
-
-using namespace std;
 
 PHHepMCGenEventv1::PHHepMCGenEventv1()
   : m_boost_beta_vector(0, 0, 0)
@@ -60,18 +58,18 @@ void PHHepMCGenEventv1::identify(std::ostream& os) const
 {
   PHHepMCGenEvent::identify(os);
 
-  os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << endl;
-  os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << endl;
+  os << " m_boost_beta_vector = (" << m_boost_beta_vector.x() << "," << m_boost_beta_vector.y() << "," << m_boost_beta_vector.z() << ") " << std::endl;
+  os << " m_rotation_vector = (" << m_rotation_vector.x() << "," << m_rotation_vector.y() << "," << m_rotation_vector.z() << ") by " << m_rotation_angle << " rad" << std::endl;
 
   static const CLHEP::HepLorentzVector zp_lightcone(0, 0, 1, 1);
   static const CLHEP::HepLorentzVector zm_lightcone(0, 0, -1, 1);
 
   os << " HepMC Frame unit light cone vector along +z axis "<<zp_lightcone<<" translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zp_lightcone)
-     << endl;
+     << std::endl;
   os << " HepMC Frame unit light cone vector along -z axis  "<<zm_lightcone<<" translate to lab at : "
      << (get_LorentzRotation_EvtGen2Lab() * zm_lightcone)
-     << endl;
+     << std::endl;
 
   return;
 }

--- a/generators/phhepmc/PHHepMCGenEventv1.h
+++ b/generators/phhepmc/PHHepMCGenEventv1.h
@@ -3,6 +3,16 @@
 
 #include "PHHepMCGenEvent.h"
 
+#include <phool/phool.h>                   // for PHOOL_VIRTUAL_WARNING
+
+#include <HepMC/SimpleVector.h>            // for ThreeVector
+
+#include <CLHEP/Vector/LorentzRotation.h>  // for HepLorentzRotation
+
+#include <iostream>                        // for cout, ostream
+
+class PHObject;
+
 class PHHepMCGenEventv1 : public PHHepMCGenEvent
 {
  public:

--- a/generators/phhepmc/PHHepMCGenEventv1.h
+++ b/generators/phhepmc/PHHepMCGenEventv1.h
@@ -3,13 +3,13 @@
 
 #include "PHHepMCGenEvent.h"
 
-#include <phool/phool.h>                   // for PHOOL_VIRTUAL_WARNING
+#include <phool/phool.h>  // for PHOOL_VIRTUAL_WARNING
 
-#include <HepMC/SimpleVector.h>            // for ThreeVector
+#include <HepMC/SimpleVector.h>  // for ThreeVector
 
 #include <CLHEP/Vector/LorentzRotation.h>  // for HepLorentzRotation
 
-#include <iostream>                        // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 class PHObject;
 

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -28,11 +28,9 @@
 #include <HepMC/SimpleVector.h>  // for FourVector
 
 #include <CLHEP/Units/PhysicalConstants.h>
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Vector/Boost.h>
-#include <CLHEP/Vector/LorentzRotation.h>
-#include <CLHEP/Vector/LorentzVector.h>
 #include <CLHEP/Vector/Rotation.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <CLHEP/Vector/ThreeVector.h>
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
@@ -42,8 +40,7 @@
 #include <cstdlib>  // for exit
 #include <iostream>
 #include <limits>
-
-using namespace std;
+#include <map>
 
 PHHepMCGenHelper::PHHepMCGenHelper()
   : _vertex_func_x(Gaus)
@@ -60,7 +57,7 @@ PHHepMCGenHelper::PHHepMCGenHelper()
   , _vertex_width_t(0)
   , _embedding_id(0)
   , _reuse_vertex(false)
-  , _reuse_vertex_embedding_id(numeric_limits<int>::min())
+  , _reuse_vertex_embedding_id(std::numeric_limits<int>::min())
   , _geneventmap(nullptr)
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
@@ -80,7 +77,7 @@ int PHHepMCGenHelper::create_node_tree(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing doing nothing" << endl;
+    std::cout << PHWHERE << "DST Node missing doing nothing" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -155,9 +152,9 @@ double PHHepMCGenHelper::get_collision_width(unsigned int hv_index)
 //! generate vertx with bunch interaction according to
 //! https://github.com/eic/documents/blob/d06b5597a0a89dcad215bab50fe3eefa17a097a5/reports/general/Note-Simulations-BeamEffects.pdf
 //! \return pair of bunch local z position for beam A and beam B
-pair<double, double> PHHepMCGenHelper::generate_vertx_with_bunch_interaction(PHHepMCGenEvent *genevent)
+std::pair<double, double> PHHepMCGenHelper::generate_vertx_with_bunch_interaction(PHHepMCGenEvent *genevent)
 {
-  const pair<double, double> bunch_zs(
+  const std::pair<double, double> bunch_zs(
       smear(
           0,                            //  central vertical angle shift
           m_beam_bunch_width.first[2],  // vertical angle smear
@@ -216,26 +213,26 @@ pair<double, double> PHHepMCGenHelper::generate_vertx_with_bunch_interaction(PHH
 
   if (m_verbosity)
   {
-    cout << __PRETTY_FUNCTION__
+    std::cout << __PRETTY_FUNCTION__
          << ":"
          << "bunch_zs.first  = " << bunch_zs.first << ", "
          << "bunch_zs.second = " << bunch_zs.second << ", "
-         << "cos(theta/2) = " << beamCenterDiffAxis.dot(beamA_center) << ", " << endl
+         << "cos(theta/2) = " << beamCenterDiffAxis.dot(beamA_center) << ", " << std::endl
 
          << "beamCenterDiffAxis = " << beamCenterDiffAxis << ", "
          << "vec_crossing = " << vec_crossing << ", "
          << "horizontal_axis = " << horizontal_axis << ", "
-         << "vertical_axis = " << vertical_axis << ", " << endl
+         << "vertical_axis = " << vertical_axis << ", " << std::endl
 
          << "vec_longitudinal_collision = " << vec_longitudinal_collision << ", "
          << "vec_crossing_collision = " << vec_crossing_collision << ", "
          << "vec_vertical_collision_vertex_smear = " << vec_vertical_collision_vertex_smear << ", "
-         << "vec_horizontal_collision_vertex_smear = " << vec_horizontal_collision_vertex_smear << ", " << endl
-         << "vec_collision_vertex = " << vec_collision_vertex << ", " << endl
+         << "vec_horizontal_collision_vertex_smear = " << vec_horizontal_collision_vertex_smear << ", " << std::endl
+         << "vec_collision_vertex = " << vec_collision_vertex << ", " << std::endl
 
          << "ct_collision = " << ct_collision << ", "
          << "t_collision = " << t_collision << ", "
-         << endl;
+         << std::endl;
   }
 
   return bunch_zs;
@@ -273,7 +270,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
     if (!vtx_evt)
     {
-      cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal Error - the requested source subevent with embedding ID "
+      std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal Error - the requested source subevent with embedding ID "
            << _reuse_vertex_embedding_id << " does not exist. Current HepMCEventMap:";
       _geneventmap->identify();
       exit(1);
@@ -293,7 +290,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": copied boost rotation shift of the collision" << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": copied boost rotation shift of the collision" << std::endl;
       genevent->identify();
     }
     return;
@@ -301,7 +298,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   // now handle the collision vertex first, in the head-on collision frame
   // this is used as input to the Crab angle correction
-  pair<double, double> beam_bunch_zs;
+  std::pair<double, double> beam_bunch_zs;
   if (m_use_beam_bunch_sim)
   {
     // bunch interaction simulation
@@ -324,9 +321,9 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   if (m_verbosity)
   {
-    cout << __PRETTY_FUNCTION__ << ": " << endl;
-    cout << "beamA_center = " << beamA_center << endl;
-    cout << "beamB_center = " << beamB_center << endl;
+    std::cout << __PRETTY_FUNCTION__ << ": " << std::endl;
+    std::cout << "beamA_center = " << beamA_center << std::endl;
+    std::cout << "beamB_center = " << beamB_center << std::endl;
   }
 
   assert(fabs(beamB_center.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
@@ -334,7 +331,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   if (beamA_center.dot(beamB_center) > -0.5)
   {
-    cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - WARNING -"
+    std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - WARNING -"
          << "Beam A and Beam B are not near back to back. "
          << "Please double check beam direction setting at set_beam_direction_theta_phi()."
          << "beamA_center = " << beamA_center << ","
@@ -381,9 +378,9 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
   if (m_verbosity)
   {
-    cout << __PRETTY_FUNCTION__ << ": " << endl;
-    cout << "beamA_vec = " << beamA_vec << endl;
-    cout << "beamB_vec = " << beamB_vec << endl;
+    std::cout << __PRETTY_FUNCTION__ << ": " << std::endl;
+    std::cout << "beamA_vec = " << beamA_vec << std::endl;
+    std::cout << "beamB_vec = " << beamB_vec << std::endl;
   }
 
   assert(fabs(beamA_vec.mag2() - 1) < CLHEP::Hep3Vector::getTolerance());
@@ -400,7 +397,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": non-zero boost " << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": non-zero boost " << std::endl;
     }
   }  //    if (cos_rotation_angle> CLHEP::Hep3Vector::getTolerance())
   else
@@ -408,7 +405,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     genevent->set_boost_beta_vector(CLHEP::Hep3Vector(0, 0, 0));
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": zero boost " << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": zero boost " << std::endl;
     }
   }
 
@@ -416,7 +413,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   CLHEP::Hep3Vector beamDiffAxis = (beamA_vec - beamB_vec);
   if (beamDiffAxis.mag2() < CLHEP::Hep3Vector::getTolerance())
   {
-    cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal error -"
+    std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal error -"
          << "Beam A and Beam B are too close to each other in direction "
          << "Please double check beam direction and divergence setting. "
          << "beamA_vec = " << beamA_vec << ","
@@ -432,8 +429,8 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   double cos_rotation_angle_to_z = beamDiffAxis.dot(z_axis);
   if (m_verbosity)
   {
-    cout << __PRETTY_FUNCTION__ << ": check rotation ";
-    cout << "cos_rotation_angle_to_z= " << cos_rotation_angle_to_z << endl;
+    std::cout << __PRETTY_FUNCTION__ << ": check rotation ";
+    std::cout << "cos_rotation_angle_to_z= " << cos_rotation_angle_to_z << std::endl;
   }
 
   if (1 - cos_rotation_angle_to_z < CLHEP::Hep3Vector::getTolerance())
@@ -444,7 +441,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": no rotation " << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": no rotation " << std::endl;
     }
   }
   else if (cos_rotation_angle_to_z + 1 < CLHEP::Hep3Vector::getTolerance())
@@ -454,7 +451,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     genevent->set_rotation_angle(M_PI);
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": reverse beam direction " << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": reverse beam direction " << std::endl;
     }
   }
   else
@@ -468,13 +465,13 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
 
     if (m_verbosity)
     {
-      cout << __PRETTY_FUNCTION__ << ": has rotation " << endl;
+      std::cout << __PRETTY_FUNCTION__ << ": has rotation " << std::endl;
     }
   }  //  if (boost_axis.mag2() > CLHEP::Hep3Vector::getTolerance())
 
   if (m_verbosity)
   {
-    cout << __PRETTY_FUNCTION__ << ": final boost rotation shift of the collision" << endl;
+    std::cout << __PRETTY_FUNCTION__ << ": final boost rotation shift of the collision" << std::endl;
     genevent->identify();
   }
 }
@@ -483,9 +480,9 @@ void PHHepMCGenHelper::set_vertex_distribution_function(VTXFUNC x, VTXFUNC y, VT
 {
   if (m_use_beam_bunch_sim)
   {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
+    std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
          << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
+         << std::endl;
     exit(1);
   }
   _vertex_func_x = x;
@@ -499,9 +496,9 @@ void PHHepMCGenHelper::set_vertex_distribution_mean(const double x, const double
 {
   if (m_use_beam_bunch_sim)
   {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
+    std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
          << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
+         << std::endl;
     exit(1);
   }
 
@@ -516,9 +513,9 @@ void PHHepMCGenHelper::set_vertex_distribution_width(const double x, const doubl
 {
   if (m_use_beam_bunch_sim)
   {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
+    std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
          << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << endl;
+         << std::endl;
     exit(1);
   }
 
@@ -533,9 +530,9 @@ void PHHepMCGenHelper::set_beam_bunch_width(const std::vector<double> &beamA, co
 {
   if (not m_use_beam_bunch_sim)
   {
-    cout << __PRETTY_FUNCTION__ << " Fatal Error: "
+    std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
          << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect not to simulate bunch interaction but applying vertex distributions"
-         << endl;
+         << std::endl;
     exit(1);
   }
 
@@ -564,7 +561,7 @@ double PHHepMCGenHelper::smear(const double position,
   }
   else
   {
-    cout << "PHHepMCGenHelper::smear - FATAL Error - unknown vertex function " << dist << endl;
+    std::cout << "PHHepMCGenHelper::smear - FATAL Error - unknown vertex function " << dist << std::endl;
     exit(10);
   }
   return res;
@@ -616,7 +613,7 @@ void PHHepMCGenHelper::CopySettings(PHHepMCGenHelper *helper_dest)
     CopySettings(*helper_dest);
   else
   {
-    cout << "PHHepMCGenHelper::CopySettings - fatal error - invalid input class helper_dest which is nullptr!" << endl;
+    std::cout << "PHHepMCGenHelper::CopySettings - fatal error - invalid input class helper_dest which is nullptr!" << std::endl;
     exit(1);
   }
 }
@@ -627,48 +624,48 @@ void PHHepMCGenHelper::CopyHelperSettings(PHHepMCGenHelper *helper_src)
     helper_src->CopySettings(this);
   else
   {
-    cout << "PHHepMCGenHelper::CopyHelperSettings - fatal error - invalid input class helper_src which is nullptr!" << endl;
+    std::cout << "PHHepMCGenHelper::CopyHelperSettings - fatal error - invalid input class helper_src which is nullptr!" << std::endl;
     exit(1);
   }
 }
 
 void PHHepMCGenHelper::Print(const std::string &/*what*/) const
 {
-  static map<VTXFUNC, string> vtxfunc = {{VTXFUNC::Uniform, "Uniform"}, {VTXFUNC::Gaus, "Gaus"}};
+  static std::map<VTXFUNC, std::string> vtxfunc = {{VTXFUNC::Uniform, "Uniform"}, {VTXFUNC::Gaus, "Gaus"}};
 
-  cout << "Vertex distribution width x: " << _vertex_width_x
+  std::cout << "Vertex distribution width x: " << _vertex_width_x
        << ", y: " << _vertex_width_y
        << ", z: " << _vertex_width_z
        << ", t: " << _vertex_width_t
-       << endl;
+       << std::endl;
 
-  cout << "Vertex distribution function x: " << vtxfunc[_vertex_func_x]
+  std::cout << "Vertex distribution function x: " << vtxfunc[_vertex_func_x]
        << ", y: " << vtxfunc[_vertex_func_y]
        << ", z: " << vtxfunc[_vertex_func_z]
        << ", t: " << vtxfunc[_vertex_func_t]
-       << endl;
+       << std::endl;
 
-  cout << "Beam direction: A  theta-phi = " << m_beam_direction_theta_phi.first.first
-       << ", " << m_beam_direction_theta_phi.first.second << endl;
-  cout << "Beam direction: B  theta-phi = " << m_beam_direction_theta_phi.second.first
-       << ", " << m_beam_direction_theta_phi.second.second << endl;
+  std::cout << "Beam direction: A  theta-phi = " << m_beam_direction_theta_phi.first.first
+       << ", " << m_beam_direction_theta_phi.first.second << std::endl;
+  std::cout << "Beam direction: B  theta-phi = " << m_beam_direction_theta_phi.second.first
+       << ", " << m_beam_direction_theta_phi.second.second << std::endl;
 
-  cout << "Beam divergence: A X-Y = " << m_beam_angular_divergence_hv.first.first
-       << ", " << m_beam_angular_divergence_hv.first.second << endl;
-  cout << "Beam divergence: B X-Y = " << m_beam_angular_divergence_hv.second.first
-       << ", " << m_beam_angular_divergence_hv.second.second << endl;
+  std::cout << "Beam divergence: A X-Y = " << m_beam_angular_divergence_hv.first.first
+       << ", " << m_beam_angular_divergence_hv.first.second << std::endl;
+  std::cout << "Beam divergence: B X-Y = " << m_beam_angular_divergence_hv.second.first
+       << ", " << m_beam_angular_divergence_hv.second.second << std::endl;
 
-  cout << "Beam angle shift as linear function of longitudinal vertex position : A X-Y = " << m_beam_angular_z_coefficient_hv.first.first
-       << ", " << m_beam_angular_z_coefficient_hv.first.second << endl;
-  cout << "Beam angle shift as linear function of longitudinal vertex position: B X-Y = " << m_beam_angular_z_coefficient_hv.second.first
-       << ", " << m_beam_angular_z_coefficient_hv.second.second << endl;
+  std::cout << "Beam angle shift as linear function of longitudinal vertex position : A X-Y = " << m_beam_angular_z_coefficient_hv.first.first
+       << ", " << m_beam_angular_z_coefficient_hv.first.second << std::endl;
+  std::cout << "Beam angle shift as linear function of longitudinal vertex position: B X-Y = " << m_beam_angular_z_coefficient_hv.second.first
+       << ", " << m_beam_angular_z_coefficient_hv.second.second << std::endl;
 
-  cout << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << endl;
+  std::cout << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << std::endl;
 
-  cout << "Beam bunch A width = ["
-       << m_beam_bunch_width.first[0] << ", " << m_beam_bunch_width.first[1] << ", " << m_beam_bunch_width.first[2] << "] cm" << endl;
-  cout << "Beam bunch B width = ["
-       << m_beam_bunch_width.second[0] << ", " << m_beam_bunch_width.second[1] << ", " << m_beam_bunch_width.second[2] << "] cm" << endl;
+  std::cout << "Beam bunch A width = ["
+       << m_beam_bunch_width.first[0] << ", " << m_beam_bunch_width.first[1] << ", " << m_beam_bunch_width.first[2] << "] cm" << std::endl;
+  std::cout << "Beam bunch B width = ["
+       << m_beam_bunch_width.second[0] << ", " << m_beam_bunch_width.second[1] << ", " << m_beam_bunch_width.second[2] << "] cm" << std::endl;
 
   return;
 }

--- a/generators/phhepmc/PHHepMCGenHelper.cc
+++ b/generators/phhepmc/PHHepMCGenHelper.cc
@@ -28,8 +28,8 @@
 #include <HepMC/SimpleVector.h>  // for FourVector
 
 #include <CLHEP/Units/PhysicalConstants.h>
-#include <CLHEP/Vector/Rotation.h>
 #include <CLHEP/Units/SystemOfUnits.h>
+#include <CLHEP/Vector/Rotation.h>
 #include <CLHEP/Vector/ThreeVector.h>
 
 #include <gsl/gsl_randist.h>
@@ -214,25 +214,25 @@ std::pair<double, double> PHHepMCGenHelper::generate_vertx_with_bunch_interactio
   if (m_verbosity)
   {
     std::cout << __PRETTY_FUNCTION__
-         << ":"
-         << "bunch_zs.first  = " << bunch_zs.first << ", "
-         << "bunch_zs.second = " << bunch_zs.second << ", "
-         << "cos(theta/2) = " << beamCenterDiffAxis.dot(beamA_center) << ", " << std::endl
+              << ":"
+              << "bunch_zs.first  = " << bunch_zs.first << ", "
+              << "bunch_zs.second = " << bunch_zs.second << ", "
+              << "cos(theta/2) = " << beamCenterDiffAxis.dot(beamA_center) << ", " << std::endl
 
-         << "beamCenterDiffAxis = " << beamCenterDiffAxis << ", "
-         << "vec_crossing = " << vec_crossing << ", "
-         << "horizontal_axis = " << horizontal_axis << ", "
-         << "vertical_axis = " << vertical_axis << ", " << std::endl
+              << "beamCenterDiffAxis = " << beamCenterDiffAxis << ", "
+              << "vec_crossing = " << vec_crossing << ", "
+              << "horizontal_axis = " << horizontal_axis << ", "
+              << "vertical_axis = " << vertical_axis << ", " << std::endl
 
-         << "vec_longitudinal_collision = " << vec_longitudinal_collision << ", "
-         << "vec_crossing_collision = " << vec_crossing_collision << ", "
-         << "vec_vertical_collision_vertex_smear = " << vec_vertical_collision_vertex_smear << ", "
-         << "vec_horizontal_collision_vertex_smear = " << vec_horizontal_collision_vertex_smear << ", " << std::endl
-         << "vec_collision_vertex = " << vec_collision_vertex << ", " << std::endl
+              << "vec_longitudinal_collision = " << vec_longitudinal_collision << ", "
+              << "vec_crossing_collision = " << vec_crossing_collision << ", "
+              << "vec_vertical_collision_vertex_smear = " << vec_vertical_collision_vertex_smear << ", "
+              << "vec_horizontal_collision_vertex_smear = " << vec_horizontal_collision_vertex_smear << ", " << std::endl
+              << "vec_collision_vertex = " << vec_collision_vertex << ", " << std::endl
 
-         << "ct_collision = " << ct_collision << ", "
-         << "t_collision = " << t_collision << ", "
-         << std::endl;
+              << "ct_collision = " << ct_collision << ", "
+              << "t_collision = " << t_collision << ", "
+              << std::endl;
   }
 
   return bunch_zs;
@@ -271,7 +271,7 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
     if (!vtx_evt)
     {
       std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal Error - the requested source subevent with embedding ID "
-           << _reuse_vertex_embedding_id << " does not exist. Current HepMCEventMap:";
+                << _reuse_vertex_embedding_id << " does not exist. Current HepMCEventMap:";
       _geneventmap->identify();
       exit(1);
     }
@@ -332,11 +332,11 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   if (beamA_center.dot(beamB_center) > -0.5)
   {
     std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - WARNING -"
-         << "Beam A and Beam B are not near back to back. "
-         << "Please double check beam direction setting at set_beam_direction_theta_phi()."
-         << "beamA_center = " << beamA_center << ","
-         << "beamB_center = " << beamB_center << ","
-         << " Current setting:";
+              << "Beam A and Beam B are not near back to back. "
+              << "Please double check beam direction setting at set_beam_direction_theta_phi()."
+              << "beamA_center = " << beamA_center << ","
+              << "beamB_center = " << beamB_center << ","
+              << " Current setting:";
 
     Print();
   }
@@ -414,11 +414,11 @@ void PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation(PHHepMCGenEvent *gen
   if (beamDiffAxis.mag2() < CLHEP::Hep3Vector::getTolerance())
   {
     std::cout << "PHHepMCGenHelper::HepMC2Lab_boost_rotation_translation - Fatal error -"
-         << "Beam A and Beam B are too close to each other in direction "
-         << "Please double check beam direction and divergence setting. "
-         << "beamA_vec = " << beamA_vec << ","
-         << "beamB_vec = " << beamB_vec << ","
-         << " Current setting:";
+              << "Beam A and Beam B are too close to each other in direction "
+              << "Please double check beam direction and divergence setting. "
+              << "beamA_vec = " << beamA_vec << ","
+              << "beamB_vec = " << beamB_vec << ","
+              << " Current setting:";
 
     Print();
 
@@ -481,8 +481,8 @@ void PHHepMCGenHelper::set_vertex_distribution_function(VTXFUNC x, VTXFUNC y, VT
   if (m_use_beam_bunch_sim)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << std::endl;
+              << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
+              << std::endl;
     exit(1);
   }
   _vertex_func_x = x;
@@ -497,8 +497,8 @@ void PHHepMCGenHelper::set_vertex_distribution_mean(const double x, const double
   if (m_use_beam_bunch_sim)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << std::endl;
+              << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
+              << std::endl;
     exit(1);
   }
 
@@ -514,8 +514,8 @@ void PHHepMCGenHelper::set_vertex_distribution_width(const double x, const doubl
   if (m_use_beam_bunch_sim)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
-         << std::endl;
+              << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect to simulate bunch interaction instead of applying vertex distributions"
+              << std::endl;
     exit(1);
   }
 
@@ -531,8 +531,8 @@ void PHHepMCGenHelper::set_beam_bunch_width(const std::vector<double> &beamA, co
   if (not m_use_beam_bunch_sim)
   {
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error: "
-         << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect not to simulate bunch interaction but applying vertex distributions"
-         << std::endl;
+              << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << ". Expect not to simulate bunch interaction but applying vertex distributions"
+              << std::endl;
     exit(1);
   }
 
@@ -629,43 +629,43 @@ void PHHepMCGenHelper::CopyHelperSettings(PHHepMCGenHelper *helper_src)
   }
 }
 
-void PHHepMCGenHelper::Print(const std::string &/*what*/) const
+void PHHepMCGenHelper::Print(const std::string & /*what*/) const
 {
   static std::map<VTXFUNC, std::string> vtxfunc = {{VTXFUNC::Uniform, "Uniform"}, {VTXFUNC::Gaus, "Gaus"}};
 
   std::cout << "Vertex distribution width x: " << _vertex_width_x
-       << ", y: " << _vertex_width_y
-       << ", z: " << _vertex_width_z
-       << ", t: " << _vertex_width_t
-       << std::endl;
+            << ", y: " << _vertex_width_y
+            << ", z: " << _vertex_width_z
+            << ", t: " << _vertex_width_t
+            << std::endl;
 
   std::cout << "Vertex distribution function x: " << vtxfunc[_vertex_func_x]
-       << ", y: " << vtxfunc[_vertex_func_y]
-       << ", z: " << vtxfunc[_vertex_func_z]
-       << ", t: " << vtxfunc[_vertex_func_t]
-       << std::endl;
+            << ", y: " << vtxfunc[_vertex_func_y]
+            << ", z: " << vtxfunc[_vertex_func_z]
+            << ", t: " << vtxfunc[_vertex_func_t]
+            << std::endl;
 
   std::cout << "Beam direction: A  theta-phi = " << m_beam_direction_theta_phi.first.first
-       << ", " << m_beam_direction_theta_phi.first.second << std::endl;
+            << ", " << m_beam_direction_theta_phi.first.second << std::endl;
   std::cout << "Beam direction: B  theta-phi = " << m_beam_direction_theta_phi.second.first
-       << ", " << m_beam_direction_theta_phi.second.second << std::endl;
+            << ", " << m_beam_direction_theta_phi.second.second << std::endl;
 
   std::cout << "Beam divergence: A X-Y = " << m_beam_angular_divergence_hv.first.first
-       << ", " << m_beam_angular_divergence_hv.first.second << std::endl;
+            << ", " << m_beam_angular_divergence_hv.first.second << std::endl;
   std::cout << "Beam divergence: B X-Y = " << m_beam_angular_divergence_hv.second.first
-       << ", " << m_beam_angular_divergence_hv.second.second << std::endl;
+            << ", " << m_beam_angular_divergence_hv.second.second << std::endl;
 
   std::cout << "Beam angle shift as linear function of longitudinal vertex position : A X-Y = " << m_beam_angular_z_coefficient_hv.first.first
-       << ", " << m_beam_angular_z_coefficient_hv.first.second << std::endl;
+            << ", " << m_beam_angular_z_coefficient_hv.first.second << std::endl;
   std::cout << "Beam angle shift as linear function of longitudinal vertex position: B X-Y = " << m_beam_angular_z_coefficient_hv.second.first
-       << ", " << m_beam_angular_z_coefficient_hv.second.second << std::endl;
+            << ", " << m_beam_angular_z_coefficient_hv.second.second << std::endl;
 
   std::cout << "m_use_beam_bunch_sim = " << m_use_beam_bunch_sim << std::endl;
 
   std::cout << "Beam bunch A width = ["
-       << m_beam_bunch_width.first[0] << ", " << m_beam_bunch_width.first[1] << ", " << m_beam_bunch_width.first[2] << "] cm" << std::endl;
+            << m_beam_bunch_width.first[0] << ", " << m_beam_bunch_width.first[1] << ", " << m_beam_bunch_width.first[2] << "] cm" << std::endl;
   std::cout << "Beam bunch B width = ["
-       << m_beam_bunch_width.second[0] << ", " << m_beam_bunch_width.second[1] << ", " << m_beam_bunch_width.second[2] << "] cm" << std::endl;
+            << m_beam_bunch_width.second[0] << ", " << m_beam_bunch_width.second[1] << ", " << m_beam_bunch_width.second[2] << "] cm" << std::endl;
 
   return;
 }

--- a/generators/phhepmc/PHHepMCGenHelper.h
+++ b/generators/phhepmc/PHHepMCGenHelper.h
@@ -261,7 +261,6 @@ class PHHepMCGenHelper
   //! use m_beam_bunch_width to calculate horizontal and vertical collision width
   //! \param[in] hv_index 0: horizontal. 1: vertical
   double get_collision_width(unsigned int hv_index);
-
 };
 
 #endif /* PHHEPMC_PHHEPMCGENHELPER_H */

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -38,11 +38,8 @@ pkginclude_HEADERS = \
   PHGenFitTrackProjection.h \
   PHGenFitTrkFitter.h \
   PHActsSiliconSeeding.h \
-  PHActsInitialVertexFinder.h \
-  PHActsVertexFinder.h \
   PHActsVertexPropagator.h \
   PHActsTrkFitter.h \
-  PHActsVertexFitter.h \
   PHActsTrackProjection.h \
   PHGenFitTrkProp.h \
   PHGhostRejection.h \
@@ -119,9 +116,6 @@ ACTS_SOURCES = \
   MakeActsGeometry.cc \
   PHActsSiliconSeeding.cc \
   PHActsTrkFitter.cc \
-  PHActsInitialVertexFinder.cc \
-  PHActsVertexFinder.cc \
-  PHActsVertexFitter.cc \
   PHActsVertexPropagator.cc \
   PHActsTrackProjection.cc
 

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -69,6 +69,8 @@ int PHActsTrackProjection::process_event(PHCompositeNode *topNode)
   if(Verbosity() > 1)
     std::cout << "PHActsTrackProjection : Starting process_event event "
 	      << m_event << std::endl;
+  if(m_skipCalos)
+    { return Fun4AllReturnCodes::EVENT_OK; }
 
   for(int layer = 0; layer < m_nCaloLayers; layer++)
     {
@@ -409,7 +411,12 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode *topNode)
   for(int caloLayer = 0; caloLayer < m_nCaloLayers; caloLayer++)
     {
       if(setCaloContainerNodes(topNode, caloLayer) != Fun4AllReturnCodes::EVENT_OK)
-	return Fun4AllReturnCodes::ABORTEVENT;
+	{
+	  std::cerr << "Calo nodes not available, track projection to calo values won't be added."
+		    << std::endl;
+	  m_skipCalos = true;
+	  return Fun4AllReturnCodes::EVENT_OK;
+	}
       
       const auto caloRadius = m_towerGeomContainer->get_radius() 
 	* Acts::UnitConstants::cm;

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -106,6 +106,7 @@ class PHActsTrackProjection : public SubsysReco
   RawTowerContainer *m_towerContainer = nullptr;
   RawClusterContainer *m_clusterContainer = nullptr;
 
+  bool m_skipCalos = false;
   bool m_useCemcPosRecalib = false;
 
   int m_event = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a catch when running without the calos so that the track projection code doesn't call `Fun4AllReturnCodes::ABORTRUN`. This is useful for tracking development, so that the module can still run but it doesn't abort the macro.

This PR also removes some files from the `trackreco` makefile to improve default compilation time.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

