### PR TITLE
std::prev can produce crashes when used on an empty container.

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -318,14 +318,14 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode*)
 
   if(Verbosity() > 0)
     std::cout << PHWHERE << " Event " << _event << " TPC track map size " << _track_map->size() << std::endl;
-
+  
   // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
+  const unsigned int original_track_map_lastkey = _track_map->empty() ? 0:std::prev(_track_map->end())->first;
 
   // loop over the original TPC tracks
   for (auto phtrk_iter = _track_map->begin(); phtrk_iter != _track_map->end(); ++phtrk_iter)
   {
-
+    
     // we may add tracks to the map, so we stop at the last original track
     if(phtrk_iter->first > original_track_map_lastkey)  break;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -117,7 +117,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
   
   
   // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
+  const unsigned int original_track_map_lastkey = _track_map->empty() ? 0:std::prev(_track_map->end())->first;
   if(Verbosity() > 1)
     std::cout << "Original track map has lastkey " << original_track_map_lastkey << std::endl;
 
@@ -349,7 +349,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
 #else
 	      auto newTrack = std::make_unique<SvtxTrack_v2>();
 #endif
-	      const unsigned int lastTrackKey = std::prev(_track_map->end())->first; 
+	      const unsigned int lastTrackKey =  _track_map->empty() ? 0:std::prev(_track_map->end())->first; 
 	      if(Verbosity() > 1) cout << "Extra match, add a new track to node tree with key " <<  lastTrackKey + 1 << endl;
 	      
 	      newTrack->set_id(lastTrackKey+1);

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -846,7 +846,7 @@ void PHSimpleKFProp::MoveToVertex()
     cout << PHWHERE << " TPC track map size " << _track_map->size()  << endl;
   /*
  // We remember the original size of the TPC track map here
-  const unsigned int original_track_map_lastkey = _track_map->end()->first;
+  const unsigned int original_track_map_lastkey = _track_map->empty() ? 0:std::prev(_track_map->end())->first;
   */
 
   // loop over the TPC track seeds

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -65,7 +65,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
   // Loop over all SvtxTracks from the CA seeder
   // These should contain all TPC clusters already
 
-  const unsigned int original_track_map_lastkey = std::prev(_track_map->end())->first;
+  const unsigned int original_track_map_lastkey = _track_map->empty() ? 0:std::prev(_track_map->end())->first;
   std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
 
   for (auto phtrk_iter = _track_map->begin();
@@ -133,7 +133,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 	{      
 	  SvtxTrack *newTrack = new SvtxTrack_v2();
 	  // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-	  const unsigned int lastTrackKey = std::prev(_track_map->end())->first + ig4;
+	  const unsigned int lastTrackKey = ( _track_map->empty() ? 0:std::prev(_track_map->end())->first ) + ig4;
 	  //std::cout << "   extra track key " << lastTrackKey + 1 << std::endl;
 	 	  
 	  newTrack->set_id(lastTrackKey + 1);
@@ -224,7 +224,7 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 	      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
 	      	
 	      // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-	      const unsigned int lastTrackKey = std::prev(_track_map->end())->first;
+	      const unsigned int lastTrackKey =  _track_map->empty() ? 0:std::prev(_track_map->end())->first;
 	      //std::cout << "   lastTrackKey " << lastTrackKey + 1 << std::endl;
 	      
 	      extraTrack[ig4]->set_id(lastTrackKey + 1);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
std::prev, when used on an empty container, can return an invalid iterator. When accessing the contained object, this can result in a crash
Check on track_map content before calling std::prev(track_map->end())

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

