### PR TITLE
Do not depend on vertex to define track parameters

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -17,7 +17,6 @@
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
-class SvtxVertexMap;
 class TrkrClusterContainer;
 class TpcSpaceChargeMatrixContainer;
 class TrkrCluster;
@@ -110,11 +109,9 @@ class PHTpcResiduals : public SubsysReco
   Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey);
   Surface getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey);
   Surface getMMSurface(TrkrDefs::hitsetkey hitsetkey);
-  Acts::Vector3D getVertex(SvtxTrack *track);
 
   /// Node information for Acts tracking geometry and silicon+MM
   /// track fit
-  SvtxVertexMap *m_vertexMap = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
PHTpcResiduals was still using vertex position to get the track fit seed, used for calculating residuals. Changed the code to use the first track point instead, as done in PHActsTrkFit. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

