### PR TITLE
Enable extrapolation in the TPC without TPOT

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -179,8 +179,14 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track)
 	      << nMMHits << std::endl;
 
   // Require at least 2 hits in each detector
-  if(nMvtxHits < 2 or nInttHits < 2 or nMMHits < 2)
+  if( m_useMicromegas )
+  {
+    if(nMvtxHits<2 || nInttHits<2 || nMMHits<2)
     return false;
+  } else {
+    if(nMvtxHits<2 || nInttHits<2 )
+    return false;
+  }
 
   return true;
 

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -523,26 +523,20 @@ void PHTpcResiduals::calculateTpcResiduals(
     std::cout << "Track angles " << trackPPhi << ", " << trackPR
 	      << ", " << trackPZ << ", " << trackAlpha << ", " << trackBeta
 	      << std::endl;
-
-  if(std::abs(trackAlpha) > m_maxTAlpha
-     or std::abs(drphi) > m_maxResidualDrphi)
-    return;
-
-  if(std::abs(trackBeta) > m_maxTBeta
-     or std::abs(dz) > m_maxResidualDz)
-    return;
     
   tanBeta = trackBeta;
   tanAlpha = trackAlpha;
   
+  // cluster global position
   Acts::Vector3D globClus(cluster->getX(), 
 			  cluster->getY(), 
 			  cluster->getZ());
+      
+  // get cell index
   const auto index = getCell(globClus);
-  
   if(Verbosity() > 3)
-    std::cout << "Bin index found is " << index << std::endl;
-
+  { std::cout << "Bin index found is " << index << std::endl; }
+  
   if(index < 0 ) return;
 
   if( m_savehistograms )
@@ -562,6 +556,15 @@ void PHTpcResiduals::calculateTpcResiduals(
 
     residTup->Fill();
   }
+  
+  // check track angles and residuals agains cuts
+  if(std::abs(trackAlpha) > m_maxTAlpha
+     or std::abs(drphi) > m_maxResidualDrphi)
+    return;
+
+  if(std::abs(trackBeta) > m_maxTBeta
+     or std::abs(dz) > m_maxResidualDz)
+    return;
   
   // Fill distortion matrices
   m_matrix_container->add_to_lhs(index, 0, 0, 1./erp );

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -77,6 +77,10 @@ class PHTpcResiduals : public SubsysReco
 
   /// output file name for storing the space charge reconstruction matrices
   void setOutputfile(const std::string &outputfile) {m_outputfile = outputfile;}
+
+  /// require micromegas to be present when extrapolating tracks to the TPC
+  void setUseMicromegas( bool value )
+  { m_useMicromegas = value; }
   
  private:
 
@@ -146,6 +150,9 @@ class PHTpcResiduals : public SubsysReco
   
   /// Counter for number of bad propagations from propagateTrackState()
   int m_nBadProps = 0;
+
+  /// require micromegas to be present when extrapolating tracks to the TPC
+  bool m_useMicromegas = true;
 
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
 

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -72,6 +72,9 @@ class PHTpcResiduals : public SubsysReco
   /// set to true to store evaluation histograms and ntuples
   void setSavehistograms( bool value ) { m_savehistograms = value; }
     
+  /// output file name for evaluation histograms
+  void setHistogramOutputfile(const std::string &outputfile) {m_histogramfilename = outputfile;}
+
   /// output file name for storing the space charge reconstruction matrices
   void setOutputfile(const std::string &outputfile) {m_outputfile = outputfile;}
   
@@ -157,15 +160,33 @@ class PHTpcResiduals : public SubsysReco
   TH2 *h_alpha = nullptr;
   TH2 *h_beta = nullptr;
   TTree *residTup = nullptr;
+
+  /// delta rphi vs layer number
+  TH2 *h_deltarphi_layer = nullptr;
+
+  /// delta z vs layer number
+  TH2 *h_deltaz_layer = nullptr;
+
   std::string m_histogramfilename = "PHTpcResiduals.root";
   std::unique_ptr<TFile> m_histogramfile = nullptr;
 
   /// For diagnostics
-  double tanAlpha = 0, tanBeta = 0, drphi = 0, dz = 0, clusR = 0, clusPhi = 0, 
-    clusZ = 0, statePhi = 0, stateZ = 0, stateRPhiErr = 0, stateZErr = 0, 
-    clusRPhiErr = 0, clusZErr = 0, stateR = 0;
-  // int cell = 0, ir = 0, iz = 0, iphi = 0;
-  unsigned int cluskey = 0;
+  double tanAlpha = 0;
+  double tanBeta = 0;
+  double drphi = 0;
+  double dz = 0;
+  double clusR = 0;
+  double clusPhi = 0;
+  double clusZ = 0;
+  double statePhi = 0;
+  double stateZ = 0;
+  double stateRPhiErr = 0;
+  double stateZErr = 0;
+  double clusRPhiErr = 0;
+  double clusZErr = 0;
+  double stateR = 0;
+  TrkrDefs::cluskey cluskey = 0;
+
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -81,6 +81,10 @@ class PHActsTrkFitter : public SubsysReco
   void fitSiliconMMs(bool fitSiliconMMs)
        {m_fitSiliconMMs = fitSiliconMMs;}
 
+  /// require micromegas in SiliconMM fits
+  void setUseMicromegas( bool value )
+  { m_useMicromegas = value; }
+
   void setUpdateSvtxTrackStates(bool fillSvtxTrackStates)
        { m_fillSvtxTrackStates = fillSvtxTrackStates; }   
 
@@ -150,6 +154,9 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs = false;
 
+  /// requires micromegas present when fitting silicon-MM surfaces
+  bool m_useMicromegas = true;
+  
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR allows to extrapolate tracks to the TPC using Silicon detector only, and without TPOT. 
Resulting extrapolation accuracy is similar to that achieved with GenFit: 

![image](https://user-images.githubusercontent.com/22907496/135373694-50661c3c-3e77-4471-a2f0-f0ba6fba4237.png)

A PR to the macros repository will follow to enable this feature when TPOT is not enabled. 

Also fixed a couple of minor issues with evaluation histograms, and introduced two residuals vs layer number evaluation histograms.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

