### PR TITLE
Direct laser reconstruction

### DIFF
--- a/offline/packages/tpccalib/Makefile.am
+++ b/offline/packages/tpccalib/Makefile.am
@@ -32,6 +32,7 @@ libtpccalib_la_LIBADD = \
   -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
+  TpcDirectLaserReconstruction.h \
   TpcSpaceChargeMatrixContainer.h \
   TpcSpaceChargeMatrixContainerv1.h \
   TpcSpaceChargeMatrixInversion.h \
@@ -53,6 +54,7 @@ libtpccalib_io_la_SOURCES = \
   TpcSpaceChargeMatrixContainerv1.cc 
 
 libtpccalib_la_SOURCES = \
+  TpcDirectLaserReconstruction.cc \
   TpcSpaceChargeMatrixInversion.cc \
   TpcSpaceChargeReconstruction.cc \
   TpcSpaceChargeReconstructionHelper.cc \

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -32,6 +32,8 @@
 #include <cmath>
 #include <TFile.h>
 #include <TTree.h>
+#include <TH1.h>
+#include <TH2.h>
 
 #include <iostream>
 #include <sstream>
@@ -45,7 +47,7 @@ namespace
   // radius
   template<class T> T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
 
-  template<class T> T deltaPhi(const T& phi)
+  template<class T> inline constexpr T deltaPhi(const T& phi)
   {
     if (phi > M_PI) 
       return phi - 2. * M_PI;
@@ -102,10 +104,8 @@ int PHTpcResiduals::process_event(PHCompositeNode *topNode)
 int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
 {
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
-
   if(Verbosity() > 0)
-    std::cout << "Number of bad SL propagations " 
-	      << m_nBadProps << std::endl;
+  { std::cout << "PHTpcResiduals::End - Number of bad SL propagations " << m_nBadProps << std::endl; }
       
   // save matrix container in output file
   if( m_matrix_container )
@@ -123,7 +123,6 @@ int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
     { if( o ) o->Write(); }
     m_histogramfile->Close();
   }
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -17,9 +17,9 @@
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
-class TrkrClusterContainer;
 class TpcSpaceChargeMatrixContainer;
 class TrkrCluster;
+class TrkrClusterContainer;
 
 namespace ActsExamples
 {
@@ -27,9 +27,10 @@ namespace ActsExamples
 }
 
 #include <memory>
-#include <TH1.h>
-#include <TH2.h>
-#include <TTree.h>
+class TFile;
+class TH1;
+class TH2;
+class TTree;
 
 using SourceLink = ActsExamples::TrkrClusterSourceLink;
 using BoundTrackParamPtr = 
@@ -66,8 +67,7 @@ class PHTpcResiduals : public SubsysReco
   void setMaxTrackResidualDz(float maxResidualDz)
     { m_maxResidualDz = maxResidualDz; }
   
-  void setGridDimensions(const int phiBins, const int rBins,
-			 const int zBins);
+  void setGridDimensions(const int phiBins, const int rBins, const int zBins);
 
   /// set to true to store evaluation histograms and ntuples
   void setSavehistograms( bool value ) { m_savehistograms = value; }

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -1,0 +1,195 @@
+/**
+ * \file TpcDirectLaserReconstruction.cc
+ * \brief performs the reconstruction of TPC direct laser tracks
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "TpcDirectLaserReconstruction.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackState_v1.h>
+
+#include <TVector3.h>
+
+#include <cassert>
+
+
+namespace
+{
+
+  //! range adaptor to be able to use range-based for loop
+  template<class T> class range_adaptor
+  {
+    public:
+    range_adaptor( const T& range ):m_range(range){}
+    inline const typename T::first_type& begin() {return m_range.first;}
+    inline const typename T::second_type& end() {return m_range.second;}
+    private:
+    T m_range;
+  };
+  
+  //! convenience square method
+  template<class T>
+    inline constexpr T square( const T& x ) { return x*x; }
+
+  //! get radius from x and y
+  template<class T>
+    inline constexpr T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
+    
+  //_____________________________________________________________
+  std::pair<TVector3,bool> cylinder_line_intersection(TVector3 s, TVector3 v, double radius)
+  {
+    
+    const double R2=square(radius);
+    
+    //Generalized Parameters for collision with cylinder of radius R:
+    //from quadratic formula solutions of when a vector intersects a circle:
+    const double a = square(v.x())+ square(v.y());
+    const double b = 2*(v.x()*s.x()+v.y()*s.y());
+    const double c = square(s.x()) + square(s.y())-R2;
+    const double rootterm=square(b)-4*a*c;
+    
+    //if a==0 then we are parallel and will have no solutions.
+    //if the rootterm is negative, we will have no real roots -- we are outside the cylinder and pointing skew to the cylinder such that we never cross.
+    if( rootterm <0 || a == 0 ) return std::make_pair( TVector3(), false );
+    
+    //Find the (up to) two points where we collide with the cylinder:
+    const double sqrtterm=std::sqrt(rootterm);
+    const double t1 = (-b+sqrtterm)/(2*a);
+    const double t2 = (-b-sqrtterm)/(2*a);
+    
+    // chose smaller value of t, in absolute value
+    const double& min_t = (t2<t1 && t2>0) ? t2:t1;
+    return std::make_pair( s+v*min_t, true );
+  }
+  
+  /// TVector3 stream
+  inline std::ostream& operator << (std::ostream& out, const TVector3& vector )
+  {
+    out << "( " << vector.x() << ", " << vector.y() << ", " << vector.z() << ")";
+    return out;
+  }
+
+}
+
+//_____________________________________________________________________
+TpcDirectLaserReconstruction::TpcDirectLaserReconstruction( const std::string& name ):
+  SubsysReco( name)
+  , PHParameterInterface(name)
+{ 
+  InitializeParameters(); 
+}
+
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::Init(PHCompositeNode* topNode )
+{ return Fun4AllReturnCodes::EVENT_OK; }
+
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::InitRun(PHCompositeNode* )
+{
+
+  // load parameters
+  UpdateParametersWithMacro(); 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::process_event(PHCompositeNode* topNode)
+{
+  // load nodes
+  const auto res = load_nodes(topNode);
+  if( res != Fun4AllReturnCodes::EVENT_OK ) return res;
+
+  process_tracks();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::End(PHCompositeNode* )
+{ return Fun4AllReturnCodes::EVENT_OK; }
+
+//___________________________________________________________________________
+void TpcDirectLaserReconstruction::SetDefaultParameters()
+{}
+
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
+{
+  // get necessary nodes
+  // tracks
+  m_track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  assert(m_track_map);
+
+  // hitset container
+  m_hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+
+  // clusters  
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  assert(m_cluster_map);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+void TpcDirectLaserReconstruction::process_tracks()
+{
+  if( !( m_track_map && m_cluster_map ) ) return;
+  for( auto iter = m_track_map->begin(); iter != m_track_map->end(); ++iter )
+  { process_track( iter->second ); }
+}
+
+
+//_____________________________________________________________________
+void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
+{
+    
+  // get track parameters
+  const TVector3 origin( track->get_x(), track->get_y(), track->get_z() );
+  const TVector3 direction( track->get_px(), track->get_py(), track->get_pz() );
+
+  if( Verbosity() )
+  { std::cout << "TpcDirectLaserReconstruction::process_track - position: " << origin << " direction: " << direction << std::endl; }
+  
+  // loop over hitsets
+  for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
+  {
+
+    // only check TPC hitsets
+    if( TrkrDefs::getTrkrId( hitsetkey ) != TrkrDefs::tpcId ) continue;
+    
+    // get corresponding clusters
+    for( const auto& [key,cluster]:range_adaptor(m_cluster_map->getClusters(hitsetkey)))
+    {
+      // get cluster radius
+      const auto cluster_r = get_r( cluster->getX(), cluster->getY() );      
+      const auto [intersection,valid] = cylinder_line_intersection( origin, direction, cluster_r );
+      if( !valid ) continue;
+      
+      // path length
+      const auto pathlength = (intersection - origin).Mag();
+    
+      // create relevant state vector
+      SvtxTrackState_v1 state( pathlength );
+      state.set_x( intersection.x() );
+      state.set_y( intersection.y() );
+      state.set_z( intersection.z() );
+      
+      state.set_px( direction.x());
+      state.set_py( direction.y());
+      state.set_pz( direction.z());
+      track->insert_state( &state );
+    
+      // associate cluster to track
+      track->insert_cluster_key( key );      
+    }
+  }
+  
+}

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -89,7 +89,7 @@ TpcDirectLaserReconstruction::TpcDirectLaserReconstruction( const std::string& n
 }
 
 //_____________________________________________________________________
-int TpcDirectLaserReconstruction::Init(PHCompositeNode* topNode )
+int TpcDirectLaserReconstruction::Init(PHCompositeNode*)
 { return Fun4AllReturnCodes::EVENT_OK; }
 
 //_____________________________________________________________________

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -6,10 +6,10 @@
 
 #include "TpcDirectLaserReconstruction.h"
 
+#include "TpcSpaceChargeMatrixContainerv1.h"
+
 #include <fun4all/Fun4AllReturnCodes.h>
-
 #include <phool/getClass.h>
-
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSetContainer.h>
@@ -17,10 +17,13 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
 
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
 #include <TVector3.h>
 
 #include <cassert>
-
 
 namespace
 {
@@ -35,7 +38,7 @@ namespace
     private:
     T m_range;
   };
-  
+
   //! convenience square method
   template<class T>
     inline constexpr T square( const T& x ) { return x*x; }
@@ -43,34 +46,7 @@ namespace
   //! get radius from x and y
   template<class T>
     inline constexpr T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
-    
-  //_____________________________________________________________
-  std::pair<TVector3,bool> cylinder_line_intersection(TVector3 s, TVector3 v, double radius)
-  {
-    
-    const double R2=square(radius);
-    
-    //Generalized Parameters for collision with cylinder of radius R:
-    //from quadratic formula solutions of when a vector intersects a circle:
-    const double a = square(v.x())+ square(v.y());
-    const double b = 2*(v.x()*s.x()+v.y()*s.y());
-    const double c = square(s.x()) + square(s.y())-R2;
-    const double rootterm=square(b)-4*a*c;
-    
-    //if a==0 then we are parallel and will have no solutions.
-    //if the rootterm is negative, we will have no real roots -- we are outside the cylinder and pointing skew to the cylinder such that we never cross.
-    if( rootterm <0 || a == 0 ) return std::make_pair( TVector3(), false );
-    
-    //Find the (up to) two points where we collide with the cylinder:
-    const double sqrtterm=std::sqrt(rootterm);
-    const double t1 = (-b+sqrtterm)/(2*a);
-    const double t2 = (-b-sqrtterm)/(2*a);
-    
-    // chose smaller value of t, in absolute value
-    const double& min_t = (t2<t1 && t2>0) ? t2:t1;
-    return std::make_pair( s+v*min_t, true );
-  }
-  
+
   /// TVector3 stream
   inline std::ostream& operator << (std::ostream& out, const TVector3& vector )
   {
@@ -78,29 +54,54 @@ namespace
     return out;
   }
 
+  /// calculate delta_phi between -pi and pi
+  template< class T>
+    inline constexpr T delta_phi( const T& phi )
+  {
+    if( phi >= M_PI ) return phi - 2*M_PI;
+    else if( phi < -M_PI ) return phi + 2*M_PI;
+    else return phi;
+  }
+
+  // phi range
+  static constexpr float m_phimin = 0;
+  static constexpr float m_phimax = 2.*M_PI;
+
+  // TODO: could try to get the r and z range from TPC geometry
+  // r range
+  static constexpr float m_rmin = 20;
+  static constexpr float m_rmax = 78;
+
+  // z range
+  static constexpr float m_zmin = -105.5;
+  static constexpr float m_zmax = 105.5;
+
 }
 
 //_____________________________________________________________________
 TpcDirectLaserReconstruction::TpcDirectLaserReconstruction( const std::string& name ):
   SubsysReco( name)
   , PHParameterInterface(name)
-{ 
-  InitializeParameters(); 
+  , m_matrix_container( new TpcSpaceChargeMatrixContainerv1 )
+{
+  InitializeParameters();
 }
 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::Init(PHCompositeNode*)
-{ return Fun4AllReturnCodes::EVENT_OK; }
+{
+  if( m_savehistograms ) create_histograms();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::InitRun(PHCompositeNode* )
 {
-
-  // load parameters
-  UpdateParametersWithMacro(); 
+  UpdateParametersWithMacro();
+  m_max_dca = get_double_param( "directlaser_max_dca" );
+  std::cout << "TpcDirectLaserReconstruction::InitRun - m_max_dca: " << m_max_dca << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::process_event(PHCompositeNode* topNode)
@@ -115,11 +116,35 @@ int TpcDirectLaserReconstruction::process_event(PHCompositeNode* topNode)
 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::End(PHCompositeNode* )
-{ return Fun4AllReturnCodes::EVENT_OK; }
+{
+  // save matrix container in output file
+  if( m_matrix_container )
+  {
+    std::unique_ptr<TFile> outputfile( TFile::Open( m_outputfile.c_str(), "RECREATE" ) );
+    outputfile->cd();
+    m_matrix_container->Write( "TpcSpaceChargeMatrixContainer" );
+  }
+
+  // write evaluation histograms to output
+  if( m_savehistograms && m_histogramfile )
+  {
+    m_histogramfile->cd();
+    for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer, h_deltaz_layer, h_entries }))
+    { if( o ) o->Write(); }
+    m_histogramfile->Close();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 
 //___________________________________________________________________________
 void TpcDirectLaserReconstruction::SetDefaultParameters()
-{}
+{
+  set_default_double_param( "directlaser_max_dca", 1.5 );
+}
+
+//_____________________________________________________________________
+void TpcDirectLaserReconstruction::set_grid_dimensions( int phibins, int rbins, int zbins )
+{ m_matrix_container->set_grid_dimensions( phibins, rbins, zbins ); }
 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
@@ -132,10 +157,34 @@ int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
   // hitset container
   m_hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
 
-  // clusters  
+  // clusters
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   assert(m_cluster_map);
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+void TpcDirectLaserReconstruction::create_histograms()
+{
+  std::cout << "TpcDirectLaserReconstruction::makeHistograms - writing evaluation histograms to: " << m_histogramfilename << std::endl;
+  m_histogramfile.reset( new TFile(m_histogramfilename.c_str(), "RECREATE") );
+  m_histogramfile->cd();
+
+  // residuals vs layers
+  h_dca_layer = new TH2F( "dca_layer", ";layer; DCA (cm)", 57, 0, 57, 500, 0, 2 );
+  h_deltarphi_layer = new TH2F( "deltarphi_layer", ";layer; r.#Delta#phi_{track-cluster} (cm)", 57, 0, 57, 500, -2, 2 );
+  h_deltaz_layer = new TH2F( "deltaz_layer", ";layer; #Deltaz_{track-cluster} (cm)", 57, 0, 57, 500, -2, 2 );
+
+  // entries vs cell grid
+  /* histogram dimension and axis limits must match that of TpcSpaceChargeMatrixContainer */
+  if( m_matrix_container )
+  {
+    int phibins = 0;
+    int rbins = 0;
+    int zbins = 0;
+    m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
+    h_entries = new TH3F( "entries", ";#phi;r (cm);z (cm)", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax );
+  }
 }
 
 //_____________________________________________________________________
@@ -146,50 +195,91 @@ void TpcDirectLaserReconstruction::process_tracks()
   { process_track( iter->second ); }
 }
 
-
 //_____________________________________________________________________
 void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 {
-    
+
   // get track parameters
   const TVector3 origin( track->get_x(), track->get_y(), track->get_z() );
   const TVector3 direction( track->get_px(), track->get_py(), track->get_pz() );
 
   if( Verbosity() )
   { std::cout << "TpcDirectLaserReconstruction::process_track - position: " << origin << " direction: " << direction << std::endl; }
-  
+
   // loop over hitsets
   for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
   {
 
     // only check TPC hitsets
     if( TrkrDefs::getTrkrId( hitsetkey ) != TrkrDefs::tpcId ) continue;
-    
+
+    // store layer
+    const auto layer = TrkrDefs::getLayer( hitsetkey );
+
     // get corresponding clusters
     for( const auto& [key,cluster]:range_adaptor(m_cluster_map->getClusters(hitsetkey)))
     {
-      // get cluster radius
-      const auto cluster_r = get_r( cluster->getX(), cluster->getY() );      
-      const auto [intersection,valid] = cylinder_line_intersection( origin, direction, cluster_r );
-      if( !valid ) continue;
-      
+      const TVector3 oc( cluster->getX()-track->get_x(), cluster->getY()-track->get_y(), cluster->getZ()-track->get_z()  );
+      const auto t = direction.Dot( oc )/square( direction.Mag() );
+      const auto om = direction*t;
+      const auto dca = (oc-om).Mag();
+
+      // do not associate if dca is too large
+      if( dca > m_max_dca ) continue;
+
       // path length
-      const auto pathlength = (intersection - origin).Mag();
-    
-      // create relevant state vector
+      const auto pathlength = om.Mag();
+
+      // get projection to the track
+      const auto projection = origin + om;
+
+      // create relevant state vector and assign to track
       SvtxTrackState_v1 state( pathlength );
-      state.set_x( intersection.x() );
-      state.set_y( intersection.y() );
-      state.set_z( intersection.z() );
-      
+      state.set_x( projection.x() );
+      state.set_y( projection.y() );
+      state.set_z( projection.z() );
+
       state.set_px( direction.x());
       state.set_py( direction.y());
       state.set_pz( direction.z());
       track->insert_state( &state );
-    
-      // associate cluster to track
-      track->insert_cluster_key( key );      
+
+      // also associate cluster to track
+      track->insert_cluster_key( key );
+
+      // cluster r, phi and z
+      const auto cluster_r = get_r( cluster->getX(), cluster->getY() );
+      const auto cluster_phi = std::atan2( cluster->getY(), cluster->getX() );
+      const auto cluster_z = cluster->getZ();
+
+//       // cluster errors
+//       const auto cluster_rphi_error = cluster->getRPhiError();
+//       const auto cluster_z_error = cluster->getZError();
+
+      // track position
+      const auto track_phi = std::atan2( projection.y(), projection.x() );
+      const auto track_z = projection.z();
+
+      // residuals
+      const auto drp = cluster_r*delta_phi( cluster_phi - track_phi );
+      const auto dz = cluster_z - track_z;
+
+      if(m_savehistograms)
+      {
+        if(h_dca_layer) h_dca_layer->Fill(layer, dca);
+        if(h_deltarphi_layer) h_deltarphi_layer->Fill(layer, drp);
+        if(h_deltaz_layer) h_deltaz_layer->Fill(dz, drp);
+        if(h_entries)
+        {
+          auto phi = cluster_phi;
+          while( phi < m_phimin ) phi += 2.*M_PI;
+          while( phi >= m_phimax ) phi -= 2.*M_PI;
+          h_entries->Fill( phi, cluster_r, cluster_z );
+        }
+      }
+
     }
+
   }
-  
+
 }

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -10,19 +10,27 @@
 #include <fun4all/SubsysReco.h>
 #include <phparameter/PHParameterInterface.h>
 
+#include <memory>
+
 class SvtxTrack;
 class SvtxTrackMap;
+class TpcSpaceChargeMatrixContainer;
 class TrkrClusterContainer;
 class TrkrHitSetContainer;
 
+class TFile;
+class TH1;
+class TH2;
+class TH3;
+
 class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterface
 {
-  
+
   public:
-  
+
   /// constructor
   TpcDirectLaserReconstruction( const std::string& = "TpcDirectLaserReconstruction" );
- 
+
   /// global initialization
   int Init(PHCompositeNode*) override;
 
@@ -37,25 +45,77 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// parameters
   void SetDefaultParameters() override;
-   
+
+  /// output file
+  /**
+   * this is the file where space charge matrix container is stored
+   */
+  void set_outputfile( const std::string& filename )
+  { m_outputfile = filename; }
+
+  /// set to true to store evaluation histograms and ntuples
+  void set_savehistograms( bool value ) { m_savehistograms = value; }
+
+  /// output file name for evaluation histograms
+  void set_histogram_outputfile(const std::string &outputfile)
+  {m_histogramfilename = outputfile;}
+
+  /// set grid dimensions
+  void set_grid_dimensions( int phibins, int rbins, int zbins );
+
   private:
 
   /// load nodes
   int load_nodes( PHCompositeNode* );
+
+  /// create evaluation histograms
+  void create_histograms();
 
   /// process tracks
   void process_tracks();
 
   /// process track
   void process_track( SvtxTrack* );
-    
+
+  /// output file
+  std::string m_outputfile = "TpcSpaceChargeMatrices.root";
+
   ///@name nodes
   //@{
   TrkrHitSetContainer* m_hitsetcontainer = nullptr;
   SvtxTrackMap* m_track_map = nullptr;
   TrkrClusterContainer* m_cluster_map = nullptr;
   //@}
-  
+
+  /// matrix container
+  std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
+
+  ///@name selection parameters
+  //@{
+  // residual cuts in r, phi plane
+  float m_max_dca = 1.5;
+  //@}
+
+  ///@name evaluation
+  //@{
+  bool m_savehistograms = false;
+  std::string m_histogramfilename = "TpcDirectLaserReconstruction.root";
+  std::unique_ptr<TFile> m_histogramfile = nullptr;
+
+  /// dca vs layer number
+  TH2* h_dca_layer = nullptr;
+
+  /// delta rphi vs layer number
+  TH2 *h_deltarphi_layer = nullptr;
+
+  /// delta z vs layer number
+  TH2 *h_deltaz_layer = nullptr;
+
+  /// number of entries per cell
+  TH3 *h_entries = nullptr;
+
+  //@}
+
 };
 
 #endif

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -1,0 +1,61 @@
+#ifndef TPCCALIB_TPCDIRECTLASERRECONSTRUCTION_H
+#define TPCCALIB_TPCDIRECTLASERRECONSTRUCTION_H
+
+/**
+ * \file TpcDirectLaserReconstruction.h
+ * \brief performs the reconstruction of TPC direct laser tracks
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <fun4all/SubsysReco.h>
+#include <phparameter/PHParameterInterface.h>
+
+class SvtxTrack;
+class SvtxTrackMap;
+class TrkrClusterContainer;
+class TrkrHitSetContainer;
+
+class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterface
+{
+  
+  public:
+  
+  /// constructor
+  TpcDirectLaserReconstruction( const std::string& = "TpcDirectLaserReconstruction" );
+ 
+  /// global initialization
+  int Init(PHCompositeNode*) override;
+
+  /// run initialization
+  int InitRun(PHCompositeNode*) override;
+
+  /// event processing
+  int process_event(PHCompositeNode*) override;
+
+  /// end of processing
+  int End(PHCompositeNode*) override;
+
+  /// parameters
+  void SetDefaultParameters() override;
+   
+  private:
+
+  /// load nodes
+  int load_nodes( PHCompositeNode* );
+
+  /// process tracks
+  void process_tracks();
+
+  /// process track
+  void process_track( SvtxTrack* );
+    
+  ///@name nodes
+  //@{
+  TrkrHitSetContainer* m_hitsetcontainer = nullptr;
+  SvtxTrackMap* m_track_map = nullptr;
+  TrkrClusterContainer* m_cluster_map = nullptr;
+  //@}
+  
+};
+
+#endif

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -32,7 +32,7 @@ namespace
 
   /// calculate delta_phi between -pi and pi
   template< class T>
-    T delta_phi( const T& phi )
+    inline constexpr T delta_phi( const T& phi )
   {
     if( phi >= M_PI ) return phi - 2*M_PI;
     else if( phi < -M_PI ) return phi + 2*M_PI;
@@ -77,10 +77,6 @@ TpcSpaceChargeReconstruction::TpcSpaceChargeReconstruction( const std::string& n
 //_____________________________________________________________________
 void TpcSpaceChargeReconstruction::set_grid_dimensions( int phibins, int rbins, int zbins )
 { m_matrix_container->set_grid_dimensions( phibins, rbins, zbins ); }
-
-//_____________________________________________________________________
-void TpcSpaceChargeReconstruction::set_outputfile( const std::string& filename )
-{ m_outputfile = filename; }
 
 //_____________________________________________________________________
 int TpcSpaceChargeReconstruction::Init(PHCompositeNode* /*topNode*/ )

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -59,7 +59,8 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   /**
    * this is the file where space charge matrix container is stored 
    */
-  void set_outputfile( const std::string& filename );
+  void set_outputfile( const std::string& filename )
+  { m_outputfile = filename; }
 
   //@}
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Adds a new module dedicated to Direct Lasers reconstruction. 
It gets the direct laser straight tracks generated by g4tpc/PHG4TpcDirectLaser, associate clusters to those tracks using a dca cut, calculate residuals that can then be used to 
1/ fill a bunch of evaluation histograms
2/ ultimately populate space charge reconstruction matrices. 
For now only 1/ is implemented. 2/ is still work in progress.  

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

