### PR TITLE
Quality cut and MVTX match for PHSimpleVertexFinder  

### DIFF
--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -99,7 +99,7 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
 	    {
 	      connected_tracks.push_back(connected);
 	      connected.clear();
-	      std::cout << "           closing out set " << std::endl;
+	      if(Verbosity() > 2) std::cout << "           closing out set " << std::endl;
 	    }
 	}
 
@@ -143,7 +143,7 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
 	{
 	  unsigned int id = it;
 	  _vertex_track_map.insert(std::make_pair(ivtx, id));
-	  if(Verbosity() > 2)  std::cout << " adding track " << id << " to vertex " << ivtx << std::endl;	  
+	  if(Verbosity() > 1)  std::cout << " adding track " << id << " to vertex " << ivtx << std::endl;	  
 
 	}      
     }
@@ -329,17 +329,46 @@ void PHSimpleVertexFinder::checkDCAs()
   for(auto tr1_it = _track_map->begin(); tr1_it != _track_map->end(); ++tr1_it)
     {
       auto id1 = tr1_it->first;
-
+      auto tr1 = tr1_it->second;
+      if(tr1->get_quality() > qual_cut) continue;
+      if(require_mvtx)
+	{
+	  unsigned int nmvtx = 0;
+	  for(auto clusit = tr1->begin_cluster_keys(); clusit != tr1->end_cluster_keys(); ++clusit)
+	    {
+	      if(TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId )
+		{
+		  nmvtx++;
+		}
+	      if(nmvtx > 2) break;
+	    }
+	  if(nmvtx <3) continue;
+	  if(Verbosity() > 1) std::cout << " tr1 has nmvtx " << nmvtx << std::endl;
+	}
+      
       // look for close DCA matches with all other such tracks
       for(auto tr2_it = std::next(tr1_it); tr2_it != _track_map->end(); ++tr2_it)
 	{
 	  auto id2 = tr2_it->first;
-
-	  auto tr1 = tr1_it->second;
 	  auto tr2 = tr2_it->second;
-
+	  if(tr2->get_quality() > qual_cut) continue;
+	  if(require_mvtx)
+	    {
+	      unsigned int nmvtx = 0;
+	      for(auto clusit = tr2->begin_cluster_keys(); clusit != tr2->end_cluster_keys(); ++clusit)
+		{
+		  if(TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
+		    {
+		      nmvtx++;
+		    }
+		  if(nmvtx > 2) break;
+		}
+	      if(nmvtx <3) continue;
+	      if(Verbosity() > 1)  std::cout << " tr2 has nmvtx " << nmvtx << std::endl;
+	    }
+	  
 	  // find DCA of these two tracks
-	  if(Verbosity() > 1) std::cout << "Check DCA for tracks " << id1 << "and " << id2 << std::endl;
+	  if(Verbosity() > 2) std::cout << "Check DCA for tracks " << id1 << " and  " << id2 << std::endl;
 	  
 	  findDcaTwoTracks(tr1, tr2);
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -61,7 +61,7 @@ class PHSimpleVertexFinder : public SubsysReco
   
   double dcacut = 0.0080;  // 80 microns 
   double beamline_xy_cut = 0.2;  // must be within 2 mm of beam line
-  double qual_cut = 10.0;
+  double qual_cut = 6.0;
   bool require_mvtx = true;
   
   std::multimap<unsigned int, unsigned int> _vertex_track_map;

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -39,6 +39,8 @@ class PHSimpleVertexFinder : public SubsysReco
   int End(PHCompositeNode *topNode) override;
  void setBeamLineCut(const double cut) {beamline_xy_cut = cut;}
  void setDcaCut(const double cut) {dcacut = cut;}
+ void setTrackQualityCut(double cut) {qual_cut = cut;}
+ void setRequireMVTX(bool set) {require_mvtx = set;}
 
  private:
 
@@ -59,12 +61,14 @@ class PHSimpleVertexFinder : public SubsysReco
   
   double dcacut = 0.0080;  // 80 microns 
   double beamline_xy_cut = 0.2;  // must be within 2 mm of beam line
+  double qual_cut = 10.0;
+  bool require_mvtx = true;
   
   std::multimap<unsigned int, unsigned int> _vertex_track_map;
   std::multimap<unsigned int, std::pair<unsigned int, double>> _track_pair_map;
   //std::multimap<unsigned int, std::pair<unsigned int, Eigen::Vector3d>> _track_pca_map;
   std::multimap<unsigned int, std::pair<unsigned int, std::pair<Eigen::Vector3d,
-Eigen::Vector3d>>>  _track_pair_pca_map;
+  Eigen::Vector3d>>>  _track_pair_pca_map;
   std::map<unsigned int, Eigen::Vector3d> _vertex_position_map;
   std::set<unsigned int> _vertex_set;
   


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds both a track quality cut and a requirement for a match to the MVTX for tracks used in the primary vertex determination. The vertex resolution is significantly improved.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

