### PR TITLE
Add machinery to determine vertex covariance

### DIFF
--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -60,9 +60,11 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
 
   // reset maps
   _vertex_track_map.clear();
+  _vertex_cov_map.clear();
   _track_pair_map.clear();
   _track_pair_pca_map.clear();
   _vertex_position_map.clear();
+  _vertex_covariance_map.clear();
   _vertex_set.clear();
   
   // define local scope objects
@@ -142,7 +144,14 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
       for(auto it : connected_tracks[ivtx])
 	{
 	  unsigned int id = it;
+	  matrix_t cov;
+	  auto track = _track_map->get(id);
+	  for(int i = 0; i < 3; ++i)
+	    for(int j = 0; j < 3; ++j)
+	      {cov(i,j) = track->get_error(i,j);}
+
 	  _vertex_track_map.insert(std::make_pair(ivtx, id));
+	  _vertex_cov_map.insert(std::make_pair(ivtx, cov));
 	  if(Verbosity() > 2)  std::cout << " adding track " << id << " to vertex " << ivtx << std::endl;	  
 
 	}      
@@ -187,12 +196,25 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
 					  << " pca2.x " << pca2.x() << " pca2.y " << pca2.y() << " pca2.z " << pca2.z()  << std::endl; 
 	  }
       }
+      
+      matrix_t avgCov = matrix_t::Zero();
+      auto covret = _vertex_cov_map.equal_range(vtxid);
+      double covWeight = 0.;
+      for(auto cit=covret.first; cit != covret.second; ++cit)
+	{
+	  auto cov = cit->second;
+	  avgCov += cov;
+	  covWeight++;
+	}
 
       pca_avge /= wt;
+      avgCov /= sqrt(covWeight);
+ 
       if(Verbosity() > 1) std::cout << "vertex " << vtxid << " average pca.x " << pca_avge.x() << " pca.y " << pca_avge.y() << " pca.z " << pca_avge.z() << std::endl;
 
       // capture the position
       _vertex_position_map.insert(std::make_pair(vtxid, pca_avge));
+      _vertex_covariance_map.insert(std::make_pair(vtxid, avgCov));
     }       
 
   // Write the vertices to the vertex map on the node tree
@@ -223,11 +245,12 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode */*topNode*/)
       svtxVertex->set_z(pos.z());
       if(Verbosity() > 1) std::cout << "   vertex " << it << " insert pos.x " << pos.x() << " pos.y " << pos.y() << " pos.z " << pos.z() << std::endl; 
 
+      auto vtxCov = _vertex_covariance_map.find(it)->second;
       for(int i = 0; i < 3; ++i) 
 	{
 	  for(int j = 0; j < 3; ++j)
 	    {
-	      svtxVertex->set_error(i, j, 0.0); 
+	      svtxVertex->set_error(i, j, vtxCov(i,j)); 
 	    }
 	}
       

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -61,11 +61,14 @@ class PHSimpleVertexFinder : public SubsysReco
   double beamline_xy_cut = 0.2;  // must be within 2 mm of beam line
   
   std::multimap<unsigned int, unsigned int> _vertex_track_map;
+  using matrix_t = Eigen::Matrix<float,3,3>;
+  std::multimap<unsigned int, matrix_t> _vertex_cov_map;
   std::multimap<unsigned int, std::pair<unsigned int, double>> _track_pair_map;
   //std::multimap<unsigned int, std::pair<unsigned int, Eigen::Vector3d>> _track_pca_map;
   std::multimap<unsigned int, std::pair<unsigned int, std::pair<Eigen::Vector3d,
 Eigen::Vector3d>>>  _track_pair_pca_map;
   std::map<unsigned int, Eigen::Vector3d> _vertex_position_map;
+  std::map<unsigned int, matrix_t> _vertex_covariance_map;
   std::set<unsigned int> _vertex_set;
   
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add code to propagate the track position covariances to the vertex covariance, and set the SvtxVertex covariance accordingly.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

