### PR TITLE
Add simple power law generation

### DIFF
--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -96,6 +96,11 @@ void PHG4SimpleEventGenerator::set_phi_range(const double min, const double max)
   return;
 }
 
+void PHG4SimpleEventGenerator::set_power_law_n(const double n)
+{
+  m_powerLawN = n;
+}
+
 void PHG4SimpleEventGenerator::set_pt_range(const double min, const double max, const double pt_gaus_width)
 {
   if (min > max)
@@ -352,16 +357,32 @@ int PHG4SimpleEventGenerator::process_event(PHCompositeNode *topNode)
         exit(-1);
       }
 
-      double phi = (m_PhiMax - m_PhiMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_PhiMin;
+      double phi = (m_PhiMax - m_PhiMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_PhiMin;      
 
       double pt;
+      
       if (!std::isnan(m_P_Min) && !std::isnan(m_P_Max) && !std::isnan(m_P_GausWidth))
       {
-        pt = ((m_P_Max - m_P_Min) * gsl_rng_uniform_pos(RandomGenerator()) + m_P_Min + gsl_ran_gaussian(RandomGenerator(), m_P_GausWidth)) / cosh(eta);
+	pt = ((m_P_Max - m_P_Min) * gsl_rng_uniform_pos(RandomGenerator()) + m_P_Min + gsl_ran_gaussian(RandomGenerator(), m_P_GausWidth)) / cosh(eta);
+	if(!std::isnan(m_powerLawN))
+	{
+	  double y = gsl_rng_uniform_pos(RandomGenerator());
+	  double x1 = pow(m_Pt_Max, m_powerLawN+1);
+	  double x0 = pow(m_Pt_Min, m_powerLawN+1);
+	  pt = pow((x1-x0)*y + x0,1./(m_powerLawN+1.));
+	}
       }
       else if (!std::isnan(m_Pt_Min) && !std::isnan(m_Pt_Max) && !std::isnan(m_Pt_GausWidth))
       {
         pt = (m_Pt_Max - m_Pt_Min) * gsl_rng_uniform_pos(RandomGenerator()) + m_Pt_Min + gsl_ran_gaussian(RandomGenerator(), m_Pt_GausWidth);
+	if(!std::isnan(m_powerLawN))
+	{
+	  double y = gsl_rng_uniform_pos(RandomGenerator());
+	  double x1 = pow(m_Pt_Max, m_powerLawN+1);
+	  double x0 = pow(m_Pt_Min, m_powerLawN+1);
+	  pt = pow((x1-x0)*y + x0,1./(m_powerLawN+1.));
+	}
+
       }
       else
       {

--- a/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4SimpleEventGenerator.h
@@ -45,6 +45,9 @@ class PHG4SimpleEventGenerator : public PHG4ParticleGeneratorBase
   //! range of randomized phi values
   void set_phi_range(const double phi_min, const double phi_max);
 
+  //! power law value of distribution to sample from for pt values
+  void set_power_law_n(const double n);
+
   //! range of randomized pt values (mutually exclusive with momentum range)
   //! \param[in] pt_gaus_width   if non-zero, further apply a Gauss smearing to the pt_min - pt_max flat distribution
   void set_pt_range(const double pt_min, const double pt_max, const double pt_gaus_width = 0);
@@ -110,6 +113,7 @@ class PHG4SimpleEventGenerator : public PHG4ParticleGeneratorBase
   double m_P_Min = NAN;
   double m_P_Max = NAN;
   double m_P_GausWidth = NAN;
+  double m_powerLawN = NAN;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a function to set a power law n value for the simple event generator to throw particles in (transverse) momentum. Nominally not used, unless user explicitly sets it. Gives a more realistic pT distribution from the simple event generator.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

