### PR TITLE
Don't erase cluster keys for iterative tracking

### DIFF
--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -418,10 +418,6 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory& traj,
         for (int j = 0; j < 6; ++j)
       { out.set_error(i, j, globalCov(i,j)); }
 
-      // add cluster key
-      const auto cluskey = state.uncalibrated().cluskey();
-      svtxTrack->insert_cluster_key(cluskey);
-
       // print
       if(m_verbosity > 20)
       {
@@ -431,7 +427,7 @@ void ActsTransformations::fillSvtxTrackStates(const Trajectory& traj,
           << " " << global.z() /  Acts::UnitConstants::cm 
           << " pathlength " << pathlength
           << " momentum px,py,pz = " <<  momentum.x() << "  " <<  momentum.y() << "  " << momentum.y()  
-          << " cluskey " << cluskey << std::endl
+		  << std::endl
           << "covariance " << globalCov << std::endl; 
       }
 	  

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -610,17 +610,14 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
       std::cout << " cluster keys size " << track->size_cluster_keys() << std::endl;  
     }
 
-  // The number of associated clusters may have changed - start over
+  
   if(!m_fitSiliconMMs)
-    {
-      track->clear_states();
-      track->clear_cluster_keys();
-    }
+    { track->clear_states(); }
 
   // create a state at pathlength = 0.0
   // This state holds the track parameters, which will be updated below
   float pathlength = 0.0;
-  SvtxTrackState_v1 out( pathlength);
+  SvtxTrackState_v1 out(pathlength);
   out.set_x(0.0);
   out.set_y(0.0);
   out.set_z(0.0);
@@ -651,8 +648,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   rotater.setVerbosity(Verbosity());
  
   if(params.covariance())
-    {
-     
+    {     
       Acts::BoundSymMatrix rotatedCov = 
 	rotater.rotateActsCovToSvtxTrack(params,
 					  m_tGeometry->geoContext);
@@ -665,8 +661,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 	      track->set_acts_covariance(i,j, 
 					 params.covariance().value()(i,j));
 	    }
-	}
-   
+	} 
     }
 
   // Also need to update the state list and cluster ID list for all measurements associated with the acts track  
@@ -688,7 +683,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 	      << stateTime << std::endl;
 
   if(m_timeAnalysis)
-    h_stateTime->Fill(stateTime);
+    { h_stateTime->Fill(stateTime); }
 
   if(Verbosity() > 2)
     {  


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR removes the cluster key erasing mechanism of the track fitter, so that all cluster keys determined by the seeding are associated to a track regardless of what Acts thinks about them (e.g. if the KF discards them during fitting). This is relevant for the iterative tracking scheme being implemented.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

