### PR TITLE
Removed deprecated cluster get commands from cluster cleaner

### DIFF
--- a/offline/packages/tpc/TpcClusterCleaner.cc
+++ b/offline/packages/tpc/TpcClusterCleaner.cc
@@ -87,14 +87,10 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 	
 	if(trkrId != TrkrDefs::tpcId) continue;  // we want only TPC clusters
 	
-	if (Verbosity() >= 1)
+	if (Verbosity() > 1)
 	  {
 	  std::cout << " layer " << layer << " cluster : " << cluskey 
-		    << " position x,y,z " << cluster->getX() << "  " << cluster->getY() << "  " << cluster->getZ()
-		    << " ADC " << cluster->getAdc()
-		    << std::endl;
-	  std::cout << "       errors: r-phi " << cluster->getRPhiError() << " Z " << cluster->getZError() 
-		    << " phi size " << cluster->getPhiSize() << " Z size " << cluster->getZSize()
+		    << " ADC " << cluster->getAdc() << "       errors: r-phi " << cluster->getRPhiError() << " Z " << cluster->getZError() 
 		    << std::endl;
 	  }
 	
@@ -118,8 +114,8 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 	    // mark it for modification
 	    discard_set.insert(cluskey);
 	    if(Verbosity() > 0) 
-	      std::cout << "                       found cluster " << cluskey << " with ephi " << cluster->getRPhiError() << " adc " << cluster->getAdc() 
-			<< " phisize " << cluster->getPhiSize() << " Z size " << cluster->getZSize() << std::endl;
+	      std::cout << "                       discard cluster " << cluskey << " with ephi " << cluster->getRPhiError() << " adc " << cluster->getAdc() 
+			<< std::endl;
 	  }
       }
   }
@@ -130,36 +126,13 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
       // remove bad clusters from the node tree map
       _cluster_map->removeCluster(*iter);
 
-      /*      
-      // increase the errors on the bad clusters to _new_rphi_error in r-phi and _new_z_error in z
-      TrkrCluster *clus = _cluster_map->findCluster(*iter);
-      double clusphi = atan2(clus->getY() , clus->getX());
-      double error[3][3] = { {0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
-      rotate_error(_new_rphi_error, _new_z_error, clusphi, error);
-      for(int i = 0; i < 3; ++i)
-	for(int j = 0; j < 3; ++j)
-	  clus->setError(i,j,error[i][j]);
-
-      // set the local coordinates used by Acts
-      double ERR[3][3] = {0,0,0,0,0,0,0,0,0};
-      ERR[1][1] = _new_rphi_error * _new_rphi_error;  //cluster_v1 expects rad, arc, z as elementsof covariance
-      ERR[2][2] = _new_z_error * _new_z_error;
-
-      clus->setActsLocalError(0,0, ERR[1][1]);
-      clus->setActsLocalError(1,0, ERR[2][1]);
-      clus->setActsLocalError(0,1, ERR[1][2]);
-      clus->setActsLocalError(1,1, ERR[2][2]);
-      
-      if(Verbosity() > 1)
-	{
-	  TrkrDefs::cluskey ckey = clus->getClusKey();
-	  std::cout << " changed cluster " << ckey << " error to erphi " << clus->getRPhiError() << " ez " << clus->getZError() << std::endl;
-	}
-      */
     }
       
   if(Verbosity() > 0)
-    std::cout << "Clusters updated this event: " << count_discards << std::endl;
+    {
+      std::cout << "Clusters discarded this event: " << count_discards << std::endl;
+      std::cout << "Clusters remaining: " << _cluster_map->size() << std::endl;  
+    }
 
   /*
   // check the map on the node tree 


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The new versions of the cluster container do not have size or global position information. Removed the obsolete get methods from diagnostic output in TpcClusterCleaner. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

