### PR TITLE
apply n_iteration fix to PHMicromegasTpcTrackMatching

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -314,12 +314,16 @@ int PHMicromegasTpcTrackMatching::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 {
-  _iteration_map = findNode::getClass<TrkrClusterIterationMapv1>(topNode, "CLUSTER_ITERATION_MAP");
-  if (!_iteration_map){
-    std::cerr << PHWHERE << "Cluster Iteration Map missing, aborting." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
 
+  if(_n_iteration >0)
+  {
+    _iteration_map = findNode::getClass<TrkrClusterIterationMapv1>(topNode, "CLUSTER_ITERATION_MAP");
+    if (!_iteration_map)
+    {
+      std::cerr << PHWHERE << "Cluster Iteration Map missing, aborting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
   // _track_map contains the TPC seed track stubs
   // We will add the micromegas cluster to the TPC tracks already on the node tree
   // We will have to expand the number of tracks whenever we find multiple matches to the silicon


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR applies the same n_iteration condition I found in the other sources. Now the code should not abort when micromegas are enabled

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

