### PR TITLE
Minor correction of cluster position reco due to shower depth

### DIFF
--- a/offline/packages/CaloReco/BEmcRecCEMC.cc
+++ b/offline/packages/CaloReco/BEmcRecCEMC.cc
@@ -235,11 +235,40 @@ float BEmcRecCEMC::GetProb(vector<EmcModule> HitList, float et, float xg, float 
 }
 */
 
-void BEmcRecCEMC::CorrectShowerDepth(float /*E*/, float xA, float yA, float zA, float& xC, float& yC, float& zC)
+void BEmcRecCEMC::CorrectShowerDepth(float E, float xA, float yA, float zA, float& xC, float& yC, float& zC)
 {
+  /*
   xC = xA;
   yC = yA;
   zC = zA;
+  */
+
+  float logE = log(0.1);
+  if( E>0.1 ) logE = log(E);
+
+  // Rotate by phi (towers are tilted by a fixed angle in phi by ~9 deg?)
+  // Just tuned from sim data
+  float phi = 0.002 - 0.001*logE;
+  xC = xA*cos(phi) - yA*sin(phi);
+  yC = xA*sin(phi) + yA*cos(phi);
+
+  // Correction in z
+  // Just tuned for sim data ... don't fully understand why it works like that
+  float rA = sqrt(xA*xA + yA*yA);
+  //  float theta_twr = GetTowerTheta(xA,yA,zA);
+  float theta_twr;
+  if( fabs(zA)<=15 ) theta_twr = 0;
+  else if( zA>15 )   theta_twr = atan2(zA-15,rA);
+  else               theta_twr = atan2(zA+15,rA);
+
+  float theta_tr = atan2(zA-fVz,rA);
+  float L = -1.3 + 0.7*logE; // Shower CG in long. direction
+  float dz = L*sin(theta_tr-theta_twr)/cos(theta_twr);
+
+  dz -= fVz*0.10;
+
+  zC = zA - dz;
+
   return;
 }
 


### PR DESCRIPTION
[comment]: Minor correction to cluster position measurements due to shower depth; sensitive to the position of the collision vertex (if not at z=0), which needs to be provided before the clustering is called; otherwise the reconstructed position will be a bit biased (~1cm for vertex at z=10cm)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

