### PR TITLE
Improve INTT Matching Time

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -633,9 +633,6 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
 		<< std::endl;
   }
   
-  auto fitTimer = std::make_unique<PHTimer>("circlefitTimer");
-  fitTimer->stop();
-  fitTimer->restart();
 
   /// Circle radius at x,y center
   /// Note - units are sPHENIX cm since we are using TrkrClusters
@@ -647,10 +644,6 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
 	      << ", " << Y0 << std::endl;
 
   findRoot(R, X0, Y0, x, y);
-
-  fitTimer->stop();
-  auto circlefittime = fitTimer->get_accumulated_time();
-  fitTimer->restart();
   
   /// If the xy position is O(100s) microns, the initial vertex 
   /// finder will throw an eigen stepper error trying to propagate 
@@ -722,10 +715,10 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
 		<< py << ", " << pz << ") " << std::endl;
     }
   
+  auto fitTimer = std::make_unique<PHTimer>("inttMatchTimer");
   fitTimer->stop();
-  auto linefit = fitTimer->get_accumulated_time();
   fitTimer->restart();
-  
+
   /// Project to INTT and find matches
   auto additionalClusters = findInttMatches(clusGlobPos, R, X0, Y0, z, m);
   
@@ -736,12 +729,10 @@ int PHActsSiliconSeeding::circleFitSeed(std::vector<TrkrCluster*>& clusters,
   
   fitTimer->stop();
   auto addClusters = fitTimer->get_accumulated_time();
-  
 
   if(Verbosity() > 0)
     {
-      std::cout << "circle+root fit time " << circlefittime << ", charge+linefit "
-		<< linefit << ", find intt clusters " << addClusters << std::endl;
+      std::cout << "find intt clusters time " << addClusters << std::endl;
     }
   
   return charge;
@@ -761,10 +752,6 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findInttMatches(
   double yProj[m_nInttLayers];
   double zProj[m_nInttLayers];
   
-  auto fitTimer = std::make_unique<PHTimer>("inttMatchTimer");
-  fitTimer->stop();
-  fitTimer->restart();
-
   /// Diagnostic 
   if(m_seedAnalysis)
     {
@@ -839,23 +826,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findInttMatches(
 	}
     }
   
-  fitTimer->stop();
-  auto projectionTime = fitTimer->get_accumulated_time();
-  fitTimer->restart();
-  
-  auto additionalClusters = matchInttClusters(clusters, xProj, yProj, zProj);
-
-  fitTimer->stop();
-  auto matchTime = fitTimer->get_accumulated_time();
-  
-  if(Verbosity() > 0)
-    { 
-      std::cout << "INTT projection time " << projectionTime 
-		<< " and match time " << matchTime
-		<< std::endl; 
-    }
-  
-  return additionalClusters;
+  return matchInttClusters(clusters, xProj, yProj, zProj);
 }
 
 std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -867,21 +867,6 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
   std::vector<TrkrDefs::cluskey> matchedClusters;
   ActsTransformations transform;
 
-  auto totalrange = m_hitsets->getHitSets(TrkrDefs::TrkrId::inttId);
-  int totalHitSets=0;
-  int totalInttClusters = 0;
-  for(auto hititr = totalrange.first; hititr != totalrange.second; ++hititr)
-    {
-      totalHitSets++;
-      auto range = m_clusterMap->getClusters(hititr->first);
-      for(auto clusIter = range.first; clusIter != range.second; ++clusIter )
-	{
-	  totalInttClusters++;
-	}
-    }
-
-  std::cout << "Total INTT Hit sets " << totalHitSets << std::endl;
-  std::cout << "Total INTT clusters " << totalInttClusters << std::endl;
   for(int inttlayer = 0; inttlayer < m_nInttLayers; inttlayer++)
     {
       auto hitsetrange = m_hitsets->getHitSets(TrkrDefs::TrkrId::inttId, inttlayer+3);
@@ -890,10 +875,6 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
       const double projPhi = atan2(yProj[inttlayer], xProj[inttlayer]);
       const double projRphi = projR * projPhi;
 
-      int hitsetsIterated = 0;
-      int hitsetsPassed = 0;
-      int totalClustersVisitedInLayer = 0;
-      std::cout << "Iterating hisets in layer " << inttlayer << std::endl;
       for (auto hitsetitr = hitsetrange.first;
 	   hitsetitr != hitsetrange.second;
 	   ++hitsetitr)
@@ -901,8 +882,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	  const int ladderzindex = InttDefs::getLadderZId(hitsetitr->first);
 	  const int ladderphiindex = InttDefs::getLadderPhiId(hitsetitr->first);
 	  double ladderLocation[3] = {0.,0.,0.};
-	  hitsetsIterated++;
-	  std::cout << "iterating hitsetkey" << hitsetitr->first << std::endl;
+
 	  // Add three to skip the mvtx layers for comparison
 	  // to projections
 	  auto layerGeom = dynamic_cast<CylinderGeomIntt*>
@@ -919,18 +899,16 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	    { dphi += 2. * M_PI; }
 	  
 	  /// Check that the projection is within some reasonable amount of the segment
-	  /// to reject e.g. looking at segments in the opposite hemisphere
+	  /// to reject e.g. looking at segments in the opposite hemisphere. This is about
+	  /// the size of one intt segment (256 * 80 micron strips in a segment)
 	  if(fabs(dphi) > 0.2)
 	    { continue; }
-	  
-	  hitsetsPassed++;
-	  std::cout << "key passed, iterating hitsetkey's clusters"<<std::endl;
+
 	  auto range = m_clusterMap->getClusters(hitsetitr->first);	
 	  for(auto clusIter = range.first; clusIter != range.second; ++clusIter )
 	    {
 	      const auto cluskey = clusIter->first;
 	      const auto cluster = clusIter->second;
-	      totalClustersVisitedInLayer++;
 	      const auto globalPos = transform.getGlobalPosition(cluster,
 								 m_surfMaps,
 								 m_tGeometry);
@@ -978,9 +956,6 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 		    }
 		}
 	    }
-	  std::cout << "Total layer hitsets iterated " << hitsetsIterated << " and total passed " 
-		    << hitsetsPassed << " and total clusters visited in layer " << totalClustersVisitedInLayer
-		    << std::endl;
 	}  
     }
   

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -276,6 +276,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   bool m_seedAnalysis = false;
   TFile *m_file = nullptr;
+  TH2 *h_nInttProj = nullptr;
   TH1 *h_nMvtxHits = nullptr;
   TH1 *h_nInttHits = nullptr;
   TH2 *h_nHits = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR improves the time needed to match INTT clusters by only looking at INTT segments that are azimuthally within the nominal projection region from the MVTX triplet. Currently all INTT segments are iterated for each projection. Improves the speed of the code significantly.

## TODOs (if applicable)

Further improvements can be made, for example by caching the INTT geometry for quick geometric lookup based on the projection position.

## Links to other PRs in macros and calibration repositories (if applicable)

