### PR TITLE
Cluster silicon in local coordinates

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -295,11 +295,9 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
     // we have a single hitset, get the info that identifies the sensor
     int layer = TrkrDefs::getLayer(hitsetitr->first);
     int ladder_z_index = InttDefs::getLadderZId(hitsetitr->first);
-    int ladder_phi_index = InttDefs::getLadderPhiId(hitsetitr->first);
-
+   
     // we will need the geometry object for this layer to get the global position	
     CylinderGeomIntt* geom = dynamic_cast<CylinderGeomIntt*>(geom_container->GetLayerGeom(layer));
-    float thickness = geom->get_thickness();
     float pitch = geom->get_strip_y_spacing();
     float length = geom->get_strip_z_spacing();
     
@@ -373,9 +371,9 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	set<int> zbins;
 
 	// determine the cluster position...
-	double xsum = 0.0;
-	double ysum = 0.0;
-	double zsum = 0.0;
+	double xlocalsum = 0.0;
+	double ylocalsum = 0.0;
+	double zlocalsum = 0.0;
 	unsigned int clus_adc = 0.0;
 	unsigned nhits = 0;
 	
@@ -392,25 +390,22 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	    unsigned int hit_adc = (mapiter->second).second->getAdc();
 
 	    // now get the positions from the geometry
-	    
-	    double hit_location[3] = {0.0, 0.0, 0.0};
-	    geom->find_strip_center(ladder_z_index,
-				    ladder_phi_index,
-				    col,
-				    row,
-				    hit_location);
+	    double local_hit_location[3] = {0., 0., 0.};
+	    geom->find_strip_center_localcoords(ladder_z_index,
+					        row, col,
+						local_hit_location);
 	    
 	    if (_make_e_weights[layer])
 	      {
-		xsum += hit_location[0] * (double) hit_adc;
-		ysum += hit_location[1] * (double) hit_adc;
-		zsum += hit_location[2] * (double) hit_adc;
+		xlocalsum += local_hit_location[0] * (double) hit_adc;
+		ylocalsum += local_hit_location[1] * (double) hit_adc;
+		zlocalsum += local_hit_location[2] * (double) hit_adc;
 	      }
 	    else
 	      {
-		xsum += hit_location[0];
-		ysum += hit_location[1];
-		zsum += hit_location[2];
+		xlocalsum += local_hit_location[0];
+		ylocalsum += local_hit_location[1];
+		zlocalsum += local_hit_location[2];
 	      }
 
 	    clus_adc += hit_adc;
@@ -422,8 +417,8 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	    if (Verbosity() > 2) cout << "     nhits = " << nhits << endl;
 	    if (Verbosity() > 2)
 	      {
-		cout << "  From  geometry object: hit x " << hit_location[0] << " hit y " << hit_location[1] << " hit z " << hit_location[2] << endl;
-		cout << "     nhits " << nhits << " clusx  = " << xsum / nhits << " clusy " << ysum / nhits << " clusz " << zsum / nhits << " hit_adc " << hit_adc << endl;
+		cout << "  From  geometry object: hit x " << local_hit_location[0] << " hit y " << local_hit_location[1] << " hit z " << local_hit_location[2] << endl;
+		cout << "     nhits " << nhits << " clusx  = " << xlocalsum / nhits << " clusy " << ylocalsum / nhits << " clusz " << zlocalsum / nhits << " hit_adc " << hit_adc << endl;
 		
 	      }
 	  }
@@ -436,104 +431,41 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	  other clusters, which are very few and pathological, get a scale factor of 1
 	*/
 	static constexpr std::array<double, 2> scalefactors_phi = {{ 0.81, 0.31 }};
-	float phierror = pitch*invsqrt12;
+	float phierror = pitch * invsqrt12;
 	if( phibins.size() == 1 ) phierror*=scalefactors_phi[0];
 	else if( phibins.size() == 2 )  phierror*=scalefactors_phi[1];
 	
 	// z error. All clusters have a z-size of 1.
-	const float zerror = length*invsqrt12;
-	
-	double clusx = NAN;
-	double clusy = NAN;
-	double clusz = NAN;
+	const float zerror = length * invsqrt12;
 
+	double cluslocaly = NAN;
+	double cluslocalz = NAN;
 
 	if (_make_e_weights[layer])
 	  {
-	    clusx = xsum / (double) clus_adc;
-	    clusy = ysum / (double) clus_adc;
-	    clusz = zsum / (double) clus_adc;
+	    cluslocaly = ylocalsum / (double) clus_adc;
+	    cluslocalz = zlocalsum / (double) clus_adc;
 	  }
 	else
 	  {
-	    clusx = xsum / nhits;
-	    clusy = ysum / nhits;
-	    clusz = zsum / nhits;
+	    cluslocaly = ylocalsum / nhits;
+	    cluslocalz = zlocalsum / nhits;
 	  }
 	
-	double ladder_location[3] = {0.0, 0.0, 0.0};
-	geom->find_segment_center(ladder_z_index,
-				  ladder_phi_index,
-				  ladder_location);
-
-	const double ladderphi = atan2(ladder_location[1], ladder_location[0]) + geom->get_strip_phi_tilt();
-
 	// Fill the cluster fields
 	clus->setAdc(clus_adc);
 	
-	TMatrixF ERR(3, 3);
-	ERR[0][0] = square(thickness * invsqrt12);
-	ERR[0][1] = 0.0;
-	ERR[0][2] = 0.0;
-	ERR[1][0] = 0.0;
-	ERR[1][1] = square(phierror);
-	ERR[1][2] = 0.0;
-	ERR[2][0] = 0.0;
-	ERR[2][1] = 0.0;
-	ERR[2][2] = square(zerror);
-	
-	TMatrixF ROT(3, 3);
-	ROT[0][0] = cos(ladderphi);
-	ROT[0][1] = -1.0 * sin(ladderphi);
-	ROT[0][2] = 0.0;
-	ROT[1][0] = sin(ladderphi);
-	ROT[1][1] = cos(ladderphi);
-	ROT[1][2] = 0.0;
-	ROT[2][0] = 0.0;
-	ROT[2][1] = 0.0;
-	ROT[2][2] = 1.0;
-
-	TMatrixF R(3, 3);
-	R = ROT;
-	
-	TMatrixF R_T(3, 3);
-	R_T.Transpose(R);
-
-	TMatrixF GLOBAL_COV(3, 3);
-	GLOBAL_COV = R * ERR * R_T;
-
-	/// Now rotate back by cluster phi
-	/// We do this because the initial local cluster covariance produces
-	/// nontrivial pulls in rphi. This replicates the code formerly in 
-	/// TrkrCluster
-	float clusphi = -atan2(clusy, clusx);
-
-	const auto cosphi = std::cos(clusphi);
-	const auto sinphi = std::sin(clusphi);
-	float rphierr = sinphi*sinphi*GLOBAL_COV[0][0]
-	  + cosphi*cosphi*GLOBAL_COV[1][1] +
-	  2.*cosphi*sinphi*GLOBAL_COV[0][1];
-
 	if(Verbosity() > 10) clus->identify();
 
-	const unsigned int ladderZId = InttDefs::getLadderZId(ckey);
-	const unsigned int ladderPhiId = InttDefs::getLadderPhiId(ckey);
-
-	TVector3 local(0,0,0);
-	TVector3 global(clusx, clusy, clusz);
-	local = geom->get_local_from_world_coords(ladderZId,
-						  ladderPhiId,
-						  global);
-
-	clus->setLocalX(local[1]);
-	clus->setLocalY(local[2]);
+	clus->setLocalX(cluslocaly);
+	clus->setLocalY(cluslocalz);
 	/// silicon has a 1-1 map between hitsetkey and surfaces. So set to 
 	/// 0
 	clus->setSubSurfKey(0);
-	clus->setActsLocalError(0,0, rphierr);
-	clus->setActsLocalError(0,1, ERR[1][2]);
-	clus->setActsLocalError(1,0, ERR[2][1]);
-	clus->setActsLocalError(1,1, ERR[2][2]);
+	clus->setActsLocalError(0,0, square(phierror));
+	clus->setActsLocalError(0,1, 0.);
+	clus->setActsLocalError(1,0, 0.);
+	clus->setActsLocalError(1,1, square(zerror));
 	m_clusterlist->addCluster(clus.release());
 
       } // end loop over cluster ID's

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -429,12 +429,15 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	/*
 	  they corresponds to clusters of size 1 and 2 in phi
 	  other clusters, which are very few and pathological, get a scale factor of 1
+	  These scale factors are applied to produce cluster pulls with width unity
 	*/
-	static constexpr std::array<double, 2> scalefactors_phi = {{ 0.81, 0.31 }};
+
 	float phierror = pitch * invsqrt12;
-	if( phibins.size() == 1 ) phierror*=scalefactors_phi[0];
-	else if( phibins.size() == 2 )  phierror*=scalefactors_phi[1];
 	
+	static constexpr std::array<double, 3> scalefactors_phi = {{ 0.85, 0.4, 0.33 }};
+	if( phibins.size() == 1 && layer < 5) phierror*=scalefactors_phi[0];
+	else if( phibins.size() == 2 && layer < 5) phierror*=scalefactors_phi[1];
+	else if( phibins.size() == 2 && layer > 4) phierror*=scalefactors_phi[2]; 
 	// z error. All clusters have a z-size of 1.
 	const float zerror = length * invsqrt12;
 

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -155,6 +155,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
       DetNode->addNode(newNode);
     }
 
+
   //----------------
   // Report Settings
   //----------------
@@ -331,13 +332,12 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
       
 	  }  //mapiter
 
-
 	// This is the local position
 	locclusx = locxsum / nhits;
 	locclusz = loczsum / nhits;
 
 	clus->setAdc(nhits);
-	
+
 	const double pitch = layergeom->get_pixel_x();
 	const double length = layergeom->get_pixel_z();
 	const double phisize = phibins.size() * pitch;
@@ -349,13 +349,20 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	/*
 	  they corresponds to clusters of size (2,2), (2,3), (3,2) and (3,3) in phi and z
 	  other clusters, which are very few and pathological, get a scale factor of 1
+	  These scale factors are applied to produce cluster pulls with width unity
 	*/
-	static constexpr std::array<double, 4> scalefactors_phi = {{ 0.2, 0.18, 0.6, 0.31 }};
+
 	double phierror = pitch * invsqrt12;
-	if( phibins.size() == 2 && zbins.size() == 2 ) phierror*=scalefactors_phi[0];
+	
+	static constexpr std::array<double, 7> scalefactors_phi = {{ 0.36, 0.6,0.37,0.49,0.4,0.37,0.33 }};
+	if(phibins.size() == 1 && zbins.size() == 1) phierror*=scalefactors_phi[0];
+	else if(phibins.size() == 2 && zbins.size() == 1) phierror*=scalefactors_phi[1];
+	else if(phibins.size() == 1 && zbins.size() == 2) phierror*=scalefactors_phi[2];
+	else if( phibins.size() == 2 && zbins.size() == 2 ) phierror*=scalefactors_phi[0];
 	else if( phibins.size() == 2 && zbins.size() == 3 )  phierror*=scalefactors_phi[1];
 	else if( phibins.size() == 3 && zbins.size() == 2 )  phierror*=scalefactors_phi[2];
 	else if( phibins.size() == 3 && zbins.size() == 3 )  phierror*=scalefactors_phi[3];
+	
 	
 	// scale factors (z direction)
 	/*

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -292,23 +292,18 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	set<int> zbins;
 
 	// determine the cluster position...
-	double xsum = 0.0;
-	double ysum = 0.0;
-	double zsum = 0.0;
+	double locxsum = 0.;
+	double loczsum = 0.;
 	const unsigned int nhits = std::distance( clusrange.first, clusrange.second );
 
-	double clusx = NAN;
-	double clusy = NAN;
-	double clusz = NAN;
+	double locclusx = NAN;
+	double locclusz = NAN;
 
 	// we need the geometry object for this layer to get the global positions
 	int layer = TrkrDefs::getLayer(ckey);
 	auto layergeom = dynamic_cast<CylinderGeom_Mvtx *>(geom_container->GetLayerGeom(layer));
 	if (!layergeom)
 	  exit(1);
-
-	int chip = MvtxDefs::getChipId(ckey);
-	int stave =  MvtxDefs::getStaveId(ckey);
 
 	for ( auto mapiter = clusrange.first; mapiter != clusrange.second; ++mapiter)
 	  {
@@ -318,7 +313,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	    zbins.insert(col);
 	    phibins.insert(row);
 
-	    // get local coordinates, in stafe reference frame, for hit
+	    // get local coordinates, in stae reference frame, for hit
 	    auto local_coords = layergeom->get_local_coords_from_pixel(row,col);
 	    
 	    /*
@@ -328,28 +323,21 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	    */
 	    local_coords.SetY( 1e-4 );
 	    
-	    // convert to world coordinates
-	    const auto world_coords = layergeom->get_world_from_local_coords( stave, chip, local_coords );
-	    
 	    // update cluster position
-	    xsum += world_coords.X();
-	    ysum += world_coords.Y();
-	    zsum += world_coords.Z();
-	    
+	    locxsum += local_coords.X();
+	    loczsum += local_coords.Z();
 	    // add the association between this cluster key and this hitkey to the table
 	    m_clusterhitassoc->addAssoc(ckey, mapiter->second.first);
       
 	  }  //mapiter
 
 
-	// This is the global position
-	clusx = xsum / nhits;
-	clusy = ysum / nhits;
-	clusz = zsum / nhits;
+	// This is the local position
+	locclusx = locxsum / nhits;
+	locclusz = loczsum / nhits;
 
 	clus->setAdc(nhits);
 	
-	const double thickness = layergeom->get_pixel_thickness();
 	const double pitch = layergeom->get_pixel_x();
 	const double length = layergeom->get_pixel_z();
 	const double phisize = phibins.size() * pitch;
@@ -363,7 +351,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	  other clusters, which are very few and pathological, get a scale factor of 1
 	*/
 	static constexpr std::array<double, 4> scalefactors_phi = {{ 0.2, 0.18, 0.6, 0.31 }};
-	double phierror = pitch*invsqrt12;
+	double phierror = pitch * invsqrt12;
 	if( phibins.size() == 2 && zbins.size() == 2 ) phierror*=scalefactors_phi[0];
 	else if( phibins.size() == 2 && zbins.size() == 3 )  phierror*=scalefactors_phi[1];
 	else if( phibins.size() == 3 && zbins.size() == 2 )  phierror*=scalefactors_phi[2];
@@ -385,75 +373,13 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	  cout << " MvtxClusterizer: layer " << layer << " rad " << layergeom->get_radius() << " phibins " << phibins.size() << " pitch " << pitch << " phisize " << phisize
 	       << " zbins " << zbins.size() << " length " << length << " zsize " << zsize << endl;
 	
-	double ladder_location[3] = {0.0, 0.0, 0.0};
-	// returns the center of the sensor in world coordinates - used to get the ladder phi location
-	layergeom->find_sensor_center(stave, 0, 0, chip, ladder_location);
-
-
-	// tilt refers to a rotation around the radial vector from the origin, and this is zero for the MVTX ladders
-	//float tilt = 0.0;
-
-	TMatrixF ERR(3, 3);
-	ERR[0][0] = square(thickness*invsqrt12);
-	ERR[0][1] = 0.0;
-	ERR[0][2] = 0.0;
-	ERR[1][0] = 0.0;
-	ERR[1][1] = square( phierror );
-	ERR[1][2] = 0.0;
-	ERR[2][0] = 0.0;
-	ERR[2][1] = 0.0;
-	ERR[2][2] = square( zerror );
-	
-	// returns the center of the sensor in world coordinates - used to get the ladder phi location
-	layergeom->find_sensor_center(stave, 0, 0, chip, ladder_location);
-	const double ladderphi = std::atan2(ladder_location[1], ladder_location[0]) + layergeom->get_stave_phi_tilt();
-	
-	TMatrixF ROT(3, 3);
-	ROT[0][0] = cos(ladderphi);
-	ROT[0][1] = -1.0 * sin(ladderphi);
-	ROT[0][2] = 0.0;
-	ROT[1][0] = sin(ladderphi);
-	ROT[1][1] = cos(ladderphi);
-	ROT[1][2] = 0.0;
-	ROT[2][0] = 0.0;
-	ROT[2][1] = 0.0;
-	ROT[2][2] = 1.0;
-
-	TMatrixF &R = ROT;
-	TMatrixF R_T(3, 3);
-	R_T.Transpose(R);
-
-	TMatrixF GLOBAL_COV(3, 3);
-	GLOBAL_COV = R * ERR * R_T;
-
-	/// Now rotate back by cluster phi
-	/// We do this because the initial local cluster covariance produces
-	/// nontrivial pulls in rphi. This replicates the code formerly in 
-	/// TrkrCluster
-	float clusphi = -atan2(clusy, clusx);
-
-	const auto cosphi = std::cos(clusphi);
-	const auto sinphi = std::sin(clusphi);
-	float rphierr = sinphi*sinphi*GLOBAL_COV[0][0]
-	  + cosphi*cosphi*GLOBAL_COV[1][1] +
-	  2.*cosphi*sinphi*GLOBAL_COV[0][1];
-        
-	if(Verbosity() > 2)
-	  cout << " Local ERR = " << ERR[0][0] << "  " << ERR[1][1] << "  " << ERR[2][2] << endl;
-
-	TVector3 local(0,0,0);
-	TVector3 world(clusx, clusy, clusz);
-	local = layergeom->get_local_from_world_coords(stave, 0, 0,
-						       chip,
-						       world);
-
-	clus->setLocalX(local[0]);
-	clus->setLocalY(local[2]);
+	clus->setLocalX(locclusx);
+	clus->setLocalY(locclusz);
 	/// Take the rphi and z uncertainty of the cluster
-	clus->setActsLocalError(0,0,rphierr);
-	clus->setActsLocalError(0,1,ERR[1][2]);
-	clus->setActsLocalError(1,0,ERR[2][1]);
-	clus->setActsLocalError(1,1,ERR[2][2]);
+	clus->setActsLocalError(0,0,square(phierror));
+	clus->setActsLocalError(0,1,0.);
+	clus->setActsLocalError(1,0,0.);
+	clus->setActsLocalError(1,1,square(zerror));
 	
 	/// All silicon surfaces have a 1-1 map to hitsetkey. 
 	/// So set subsurface key to 0


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR changes the silicon clustering to local coordinates instead of global coordinates. It removes the need for transforming between global/local, which is unnecessary and wastes time.

It also fixes  a bug in the silicon uncertainty calculations. Previously the silicon uncertainty was calculated in local coordinates. It was then rotated to global coordinate uncertainty via the stave/ladder azimuth. When stored in the `TrkrCluster` object, to get the local uncertainty with e.g. `getRPhiError()`, it was rotated from global to local based on the cluster azimuth and not the stave/ladder azimuth. This PR fixes this by just storing the local uncertainty as it is determined directly from the geometry, which corresponds to the pitch of the stave/ladder.

Therefore, it should be expected that the silicon cluster QA looks different; however, any large change in the overall tracking QA would be unexpected as the silicon uncertainties will change (affecting the tracking) but it should not be substantial.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

