### PR TITLE
Update cluster mover

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -395,6 +395,8 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(SvtxTrack* track)
     {
       auto key = *clusIter;
       auto cluster = m_clusterContainer->findCluster(key);
+      if(!cluster)
+	std::cout << "Failed to get cluster with key " << key << std::endl;
 
       auto subsurfkey = cluster->getSubSurfKey();
       
@@ -818,7 +820,17 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"TRKR_CLUSTER");
+  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"CORRECTED_TRKR_CLUSTER");
+  if(m_clusterContainer)
+    {
+      std::cout << " Using CORRECTED_TRKR_CLUSTER node " << std::endl;
+    }
+  else
+    {
+      std::cout << " CORRECTED_TRKR_CLUSTER node not found, using TRKR_CLUSTER" << std::endl;
+      m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"TRKR_CLUSTER");
+    }
+
   if(!m_clusterContainer)
     {
       std::cout << PHWHERE 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -201,6 +201,8 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       trackTimer.restart();
 
       auto sourceLinks = getSourceLinks(track);
+      if(sourceLinks.size() == 0) continue;
+
       /// If using directed navigation, collect surface list to navigate
    
       SurfacePtrVec surfaces;
@@ -396,7 +398,10 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(SvtxTrack* track)
       auto key = *clusIter;
       auto cluster = m_clusterContainer->findCluster(key);
       if(!cluster)
-	std::cout << "Failed to get cluster with key " << key << std::endl;
+	{
+	  if(Verbosity() > 0) std::cout << "Failed to get cluster with key " << key << " for track " << track->get_id() << std::endl;
+	  continue;
+	}
 
       auto subsurfkey = cluster->getSubSurfKey();
       

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -583,8 +583,18 @@ int  PHMicromegasTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
   if(_use_truth_clusters)
     _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
   else
-    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-
+    {
+      _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
+      if(_cluster_map)
+	{
+	  std::cout << " Using CORRECTED_TRKR_CLUSTER node " << std::endl;
+	}
+      else
+	{
+	  std::cout << " CORRECTED_TRKR_CLUSTER node not found, usimng TRKR_CLUSTER" << std::endl;
+	  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+	}
+    }
   if (!_cluster_map)
   {
     std:: cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -14,6 +14,8 @@ class SvtxTrack;
 class TF1;
 class TpcSeedTrackMap;
 class AssocInfoContainer;
+class TrkrClusterContainer;
+
 class PHSiliconTpcTrackMatching : public SubsysReco
 {
  public:
@@ -57,6 +59,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
+  void copySiliconClustersToCorrectedMap( );
+
   std::string _track_map_name_silicon;
 
   // default values, can be replaced from the macro
@@ -71,6 +75,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco
   SvtxTrackMap *_track_map_silicon{nullptr};
   SvtxTrack *_tracklet_tpc{nullptr};
   SvtxTrack *_tracklet_si{nullptr};
+  TrkrClusterContainer *_cluster_map{nullptr};
+  TrkrClusterContainer *_corrected_cluster_map{nullptr};
 
   TpcSeedTrackMap *_seed_track_map{nullptr};
   //std::multimap<unsigned int, unsigned int> _seed_track_map;

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -140,7 +140,7 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 
       // toss tracks for which the fitted circle could not have come from the vertex
-      if(R < 30.0) continue;
+      //if(R < 30.0) continue;
 
       // get the straight line representing the z trajectory in the form of z vs radius
       double A = 0; double B = 0;
@@ -203,7 +203,10 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	  TrkrCluster *cluster =  _cluster_map->findCluster(cluskey);	
 
 	  // put the corrected cluster in the new cluster map
-	  // ghost tracks can have repeat clusters, so use findOrAddClusters
+
+	  // ghost tracks can have repeat clusters, so check if cluster already moved
+	  if(_corrected_cluster_map->findCluster(cluskey)) continue;
+
 	  TrkrCluster *newclus = _corrected_cluster_map->findOrAddCluster(cluskey)->second;
 	  newclus->setSubSurfKey(subsurfkey);
 	  newclus->setAdc(cluster->getAdc());

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -15,6 +15,9 @@
 #include <string>
 #include <vector>
 
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/ActsTrackingGeometry.h>
+
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
@@ -38,10 +41,16 @@ class PHTpcClusterMover : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
-  void CircleFitByTaubin (std::vector<TrkrCluster*> clusters, double &R, double &X0, double &Y0);
+void CircleFitByTaubin (std::vector<Acts::Vector3D> clusters, double &R, double &X0, double &Y0);
   void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
-  void  line_fit(std::vector<TrkrCluster*> clusters, double &a, double &b);
-int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xref, double yref, double &x, double &y);
+void  line_fit(std::vector<Acts::Vector3D> clusters, double &a, double &b);
+  int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xref, double yref, double &x, double &y);
+
+  Surface get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitsetkey,
+					Acts::Vector3D world,
+					ActsSurfaceMaps *surfMaps,
+					ActsTrackingGeometry *tGeometry,
+					TrkrDefs::subsurfkey& subsurfkey);
 
   double _z_start=0.0; 
   double _y_start=0.0; 
@@ -53,9 +62,11 @@ int get_circle_circle_intersection(double target_radius, double R, double X0, do
 
   // range of TPC layers to use in projection to micromegas
 
-SvtxTrackMap *_track_map{nullptr};
-SvtxTrack *_track{nullptr};
-TrkrClusterContainer *_cluster_map{nullptr};
+  SvtxTrackMap *_track_map{nullptr};
+  SvtxTrack *_track{nullptr};
+  TrkrClusterContainer *_cluster_map{nullptr};						    
+  ActsSurfaceMaps *_surfmaps{nullptr};
+  ActsTrackingGeometry *_tGeometry{nullptr};
 
   double layer_radius[48] = {0};
   double inner_tpc_min_radius = 30.0;

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -17,6 +17,9 @@
 
 #include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase/ActsTrackingGeometry.h>
+#include <trackbase_historic/ActsTransformations.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
+#include <tpc/TpcDistortionCorrection.h>
 
 class PHCompositeNode;
 class SvtxTrack;
@@ -52,6 +55,13 @@ void  line_fit(std::vector<Acts::Vector3D> clusters, double &a, double &b);
 					ActsTrackingGeometry *tGeometry,
 					TrkrDefs::subsurfkey& subsurfkey);
 
+
+ /// acts transformation object
+  ActsTransformations _transformer;
+  
+  /// tpc distortion correction utility class
+  TpcDistortionCorrection _distortionCorrection;
+
   double _z_start=0.0; 
   double _y_start=0.0; 
   double _x_start=0.0; 
@@ -65,8 +75,10 @@ void  line_fit(std::vector<Acts::Vector3D> clusters, double &a, double &b);
   SvtxTrackMap *_track_map{nullptr};
   SvtxTrack *_track{nullptr};
   TrkrClusterContainer *_cluster_map{nullptr};						    
+  TrkrClusterContainer *_corrected_cluster_map{nullptr};						    
   ActsSurfaceMaps *_surfmaps{nullptr};
   ActsTrackingGeometry *_tGeometry{nullptr};
+  TpcDistortionCorrectionContainer* _dcc{nullptr};
 
   double layer_radius[48] = {0};
   double inner_tpc_min_radius = 30.0;

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -93,11 +93,11 @@ int PHTpcDeltaZCorrection::load_nodes( PHCompositeNode* topNode )
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
   if(m_cluster_map)
     {
-      std::cout << " Using CORRECTED_TRKR_CLUSTER node " << std::endl;
+      if(Verbosity() > 0) std::cout << " Using CORRECTED_TRKR_CLUSTER node " << std::endl;
     }
   else
     {
-      std::cout << " CORRECTED_TRKR_CLUSTER node not found, using TRKR_CLUSTER" << std::endl;
+      if(Verbosity() > 0) std::cout << " CORRECTED_TRKR_CLUSTER node not found, using TRKR_CLUSTER" << std::endl;
       m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
     }
   assert(m_cluster_map);

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -90,7 +90,16 @@ int PHTpcDeltaZCorrection::load_nodes( PHCompositeNode* topNode )
   m_track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
   assert(m_track_map);
 
-  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
+  if(m_cluster_map)
+    {
+      std::cout << " Using CORRECTED_TRKR_CLUSTER node " << std::endl;
+    }
+  else
+    {
+      std::cout << " CORRECTED_TRKR_CLUSTER node not found, using TRKR_CLUSTER" << std::endl;
+      m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+    }
   assert(m_cluster_map);
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTpcTrackSeedCircleFit.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedCircleFit.cc
@@ -288,14 +288,25 @@ int PHTpcTrackSeedCircleFit::process_event(PHCompositeNode*)
 
       // Get the TPC clusters for this tracklet
       std::vector<TrkrCluster*> clusters = getTrackClusters(tracklet_tpc);
+      if(Verbosity() > 3) std::cout << " TPC tracklet " << tracklet_tpc->get_id() << " clusters.size " << clusters.size() << std::endl;
 
       // count TPC layers for this track
+      bool reject_track = false;
       std::set<unsigned int> layers;
       for (unsigned int i=0; i<clusters.size(); ++i)
 	{
+	  if(!clusters[i])
+	    {
+	      if(Verbosity() > 0) std::cout << " trackid " << phtrk_iter->first << " no cluster found, skip track" << std::endl;
+	      reject_track = true;
+	      break;
+	    }	      
 	  unsigned int layer = TrkrDefs::getLayer(clusters[i]->getClusKey());
 	  layers.insert(layer);
 	}
+
+      if(reject_track) continue;
+    
       unsigned int nlayers = layers.size();
       if(Verbosity() > 2) std::cout << "    TPC layers this track: " << nlayers << std::endl;
 

--- a/offline/packages/trackreco/PHTpcTrackSeedCircleFit.cc
+++ b/offline/packages/trackreco/PHTpcTrackSeedCircleFit.cc
@@ -243,15 +243,17 @@ PHTpcTrackSeedCircleFit::PHTpcTrackSeedCircleFit(const std::string &name):
 {}
 
 //____________________________________________________________________________..
-int PHTpcTrackSeedCircleFit::InitRun(PHCompositeNode*)
-{ return Fun4AllReturnCodes::EVENT_OK; }
-
-//____________________________________________________________________________..
-int PHTpcTrackSeedCircleFit::process_event(PHCompositeNode* topnode)
-{
+int PHTpcTrackSeedCircleFit::InitRun(PHCompositeNode *topnode)
+{ 
   // get relevant nodes
   int ret = GetNodes( topnode );
   if( ret != Fun4AllReturnCodes::EVENT_OK ) return ret;
+
+  return Fun4AllReturnCodes::EVENT_OK; }
+
+//____________________________________________________________________________..
+int PHTpcTrackSeedCircleFit::process_event(PHCompositeNode*)
+{
   
   // _track_map contains the TPC seed track stubs
   // We want to associate these TPC track seeds with a collision vertex
@@ -457,8 +459,18 @@ int  PHTpcTrackSeedCircleFit::GetNodes(PHCompositeNode* topNode)
   if(_use_truth_clusters)
     _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER_TRUTH");
   else
-    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-
+    {
+      _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
+      if(_cluster_map)
+	{
+	  std::cout << " using CORRECTED_TRKR_CLUSTER node  "<< std::endl;
+	}
+      else
+	{
+	  std::cout << " CORRECTED_TRKR_CLUSTER node not found, using TRKR_CLUSTER " << std::endl;
+	  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+	}
+    }
   if (!_cluster_map)
   {
     std::cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR does the following:
1) Updates PHTpcClusterMover to access distortion corrections from Hugo's new class. 
2) Updates PHTpcClusterMover to read clusters associated with TPC tracks from TRKR_CLUSTER, and write the distortion corrected clusters to a new map, CORRECTED_TRKR_CLUSTER.
3) Modifies PHSiliconTpcTrackMatching so that it copies the silicon clusters for matched tracks to CORRECTED_TRKR_CLUSTER (if it exists).
4) Modifies the downstream modules so that they use CORRECTED_TRKR_CLUSTER (if it exists) to access all clusters associated with tracks.
I verified that if PHTpcClusterMover (which runs between CA seeding and track matching) is not registered, everything runs as now. I also verified that if PHTpcClusterMover is run with zero distortion corrections, the output is identical to when it is not run.
Further testing will require availability of the distortion maps (Hugo is working on that). Merging these changes now will make further development a lot easier.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

