### PR TITLE
Read in centrality calibrations from file and determine centiles

### DIFF
--- a/offline/packages/centrality/CentralityInfo.h
+++ b/offline/packages/centrality/CentralityInfo.h
@@ -32,7 +32,10 @@ class CentralityInfo : public PHObject
     //! sEPD South-side energy sum
     epd_S = 4,
     //! sEPD North+South energy sum
-    epd_NS = 5
+    epd_NS = 5,
+
+    //! Impact parameter (b) in HIJING event
+    bimp = 6
 
   };
 

--- a/simulation/g4simulation/g4centrality/Makefile.am
+++ b/simulation/g4simulation/g4centrality/Makefile.am
@@ -16,6 +16,7 @@ AM_LDFLAGS = \
 libg4centrality_la_LIBADD = \
   -lfun4all \
   -lphg4hit \
+  -lphparameter \
   -lcentrality_io \
   -lCGAL \
   -ltrackbase_historic_io

--- a/simulation/g4simulation/g4centrality/PHG4CentralityReco.cc
+++ b/simulation/g4simulation/g4centrality/PHG4CentralityReco.cc
@@ -14,6 +14,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
+#include <ffaobjects/EventHeaderv1.h>
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
@@ -21,16 +22,17 @@
 #include <map>        // for _Rb_tree_const_iterator
 #include <stdexcept>  // for runtime_error
 #include <utility>    // for pair
+#include <sstream>
 
 PHG4CentralityReco::PHG4CentralityReco(const std::string &name)
-  : SubsysReco(name)
+  : SubsysReco(name), _centrality_calibration_params(name)
 {
 }
 
 int PHG4CentralityReco::InitRun(PHCompositeNode *topNode)
 {
   if (Verbosity() >= 1)
-    std::cout << " PHG4CentralityReco::InitRun : enter " << std::endl;
+    std::cout << "PHG4CentralityReco::InitRun : enter " << std::endl;
 
   try
   {
@@ -49,14 +51,56 @@ int PHG4CentralityReco::InitRun(PHCompositeNode *topNode)
   auto ehits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_EPD");
   if (!ehits)
     std::cout << "PHG4CentralityReco::InitRun : cannot find G4HIT_EPD, will not use sEPD centrality";
+  
+  if ( _centrality_calibration_params.exist_string_param("description") ) {
+    if (Verbosity() >= 1 ) {
+      std::cout << "PHG4CentralityReco::InitRun : Centrality calibration description : " << std::endl << "    ";
+      std::cout << _centrality_calibration_params.get_string_param("description") << std::endl;
+
+      // search for possible centile definitions
+      for (int n = 0; n < 101; n++) {
+	std::ostringstream s1; s1 << "epd_centile_" << n;
+	if ( _centrality_calibration_params.exist_double_param( s1.str().c_str() ) ) {
+	  _cent_cal_epd[ _centrality_calibration_params.get_double_param( s1.str().c_str() ) ] = n;
+	  if (Verbosity() >= 2 ) 
+	    std::cout << "PHG4CentralityReco::InitRun : sEPD centrality calibration, centile " << n << "% is " << _centrality_calibration_params.get_double_param( s1.str().c_str() ) << std::endl;
+	}
+      }
+      for (int n = 0; n < 101; n++) {
+	std::ostringstream s2; s2 << "mbd_centile_" << n;
+	if ( _centrality_calibration_params.exist_double_param( s2.str().c_str() ) ) {
+	  _cent_cal_mbd[ _centrality_calibration_params.get_double_param( s2.str().c_str() ) ] = n;
+	  if (Verbosity() >= 2 ) 
+	    std::cout << "PHG4CentralityReco::InitRun : MBD centrality calibration, centile " << n << "% is " << _centrality_calibration_params.get_double_param( s2.str().c_str() ) << std::endl;
+	}
+      }
+      for (int n = 0; n < 101; n++) {
+	std::ostringstream s3; s3 << "bimp_centile_" << n;
+	if ( _centrality_calibration_params.exist_double_param( s3.str().c_str() ) ) {
+	  _cent_cal_bimp[ _centrality_calibration_params.get_double_param( s3.str().c_str() ) ] = n;
+	  if (Verbosity() >= 2 ) 
+	    std::cout << "PHG4CentralityReco::InitRun : b (impact parameter) centrality calibration, centile " << n << "% is " << _centrality_calibration_params.get_double_param( s3.str().c_str() ) << std::endl;
+	}
+      }
+
+    }
+  } else {
+    std::cout << "PHG4CentralityReco::InitRun : no centrality calibration found!" << std::endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHG4CentralityReco::process_event(PHCompositeNode *topNode)
 {
-  std::cout << "PHG4CentralityReco::process_event -- heartbeat" << std::endl;
 
+  _bimp = 101;
+  
+  auto event_header = findNode::getClass<EventHeaderv1>(topNode, "EventHeader" );
+  if ( event_header ) {
+    _bimp = event_header->get_floatval("bimp");
+  }
+  
   _mbd_N = 0;
   _mbd_S = 0;
   _mbd_NS = 0;
@@ -120,6 +164,104 @@ int PHG4CentralityReco::process_event(PHCompositeNode *topNode)
   if (Verbosity() >= 1)
     std::cout << "PHG4CentralityReco::process_event : summary MBD (N, S, N+S) = (" << _mbd_N << ", " << _mbd_S << ", " << _mbd_NS << "), sEPD (N, S, N+S) = (" << _epd_N << ", " << _epd_S << ", " << _epd_NS << ")" << std::endl;
 
+  if (_do_centrality_calibration) {
+
+    // sEPD centrality
+    float low_epd_val = -1;
+    float high_epd_val = 10000;
+    int low_epd_centile = -1;
+    int high_epd_centile = -1;
+    
+    for(std::map<float,int>::iterator it = _cent_cal_epd.begin(); it != _cent_cal_epd.end(); ++it) {
+      float signal = it->first;
+      int cent = it->second;
+      
+      if (signal < _epd_NS && signal > low_epd_val) {
+	low_epd_val = signal;
+	low_epd_centile = cent;
+      }
+      if (signal > _epd_NS && signal < high_epd_val) {
+	high_epd_val = signal;
+	high_epd_centile = cent;
+      }
+      
+    } // close iterate through sEPD cuts
+    
+    if ( low_epd_centile >= 0 && high_epd_centile >= 0 ) {
+      _epd_cent = ( low_epd_centile + high_epd_centile ) / 2.0;
+      if (Verbosity() >= 10)
+	std::cout << "PHG4CentralityReco::process_event : lower EPD value is " << low_epd_val << " (" << low_epd_centile << "%), higher is " << high_epd_val << " (" << high_epd_centile << "%), assigning " << _epd_cent << "%" << std::endl;
+    } else {
+      _epd_cent = 101;
+      if (Verbosity() >= 5)
+	std::cout << "PHG4CentralityReco::process_event : not able to map EPD value to a centrality. debug info = " << low_epd_val << "/" << low_epd_centile << "/" << high_epd_val << "/" << high_epd_centile << std::endl;      
+    }
+
+    // MBD centrality
+    float low_mbd_val = -1;
+    float high_mbd_val = 10000;
+    int low_mbd_centile = -1;
+    int high_mbd_centile = -1;
+    
+    for(std::map<float,int>::iterator it = _cent_cal_mbd.begin(); it != _cent_cal_mbd.end(); ++it) {
+      float signal = it->first;
+      int cent = it->second;
+      
+      if (signal < _mbd_NS && signal > low_mbd_val) {
+	low_mbd_val = signal;
+	low_mbd_centile = cent;
+      }
+      if (signal > _mbd_NS && signal < high_mbd_val) {
+	high_mbd_val = signal;
+	high_mbd_centile = cent;
+      }
+      
+    } // close iterate through MBD cuts
+    
+    if ( low_mbd_centile >= 0 && high_mbd_centile >= 0 ) {
+      _mbd_cent = ( low_mbd_centile + high_mbd_centile ) / 2.0;
+      if (Verbosity() >= 10)
+	std::cout << "PHG4CentralityReco::process_event : lower MBD value is " << low_mbd_val << " (" << low_mbd_centile << "%), higher is " << high_mbd_val << " (" << high_mbd_centile << "%), assigning " << _mbd_cent << "%" << std::endl;
+    } else {
+      _mbd_cent = 101;
+      if (Verbosity() >= 5)
+	std::cout << "PHG4CentralityReco::process_event : not able to map MBD value to a centrality. debug info = " << low_mbd_val << "/" << low_mbd_centile << "/" << high_mbd_val << "/" << high_mbd_centile << std::endl;      
+    }
+
+    // b (impact parameter) centrality
+    float low_bimp_val = -1;
+    float high_bimp_val = 10000;
+    int low_bimp_centile = -1;
+    int high_bimp_centile = -1;
+    
+    for(std::map<float,int>::iterator it = _cent_cal_bimp.begin(); it != _cent_cal_bimp.end(); ++it) {
+      float signal = it->first;
+      int cent = it->second;
+      
+      if (signal < _bimp && signal > low_bimp_val) {
+	low_bimp_val = signal;
+	low_bimp_centile = cent;
+      }
+      if (signal > _bimp && signal < high_bimp_val) {
+	high_bimp_val = signal;
+	high_bimp_centile = cent;
+      }
+      
+    } // close iterate through bimp cuts
+    
+    if ( low_bimp_centile >= 0 && high_bimp_centile >= 0 ) {
+      _bimp_cent = ( low_bimp_centile + high_bimp_centile ) / 2.0;
+      if (Verbosity() >= 10)
+	std::cout << "PHG4CentralityReco::process_event : lower b value is " << low_bimp_val << " (" << low_bimp_centile << "%), higher is " << high_bimp_val << " (" << high_bimp_centile << "%), assigning " << _bimp_cent << "%" << std::endl;
+    } else {
+      _bimp_cent = 101;
+      if (Verbosity() >= 5)
+	std::cout << "PHG4CentralityReco::process_event : not able to map b value to a centrality. debug info = " << low_bimp_val << "/" << low_bimp_centile << "/" << high_bimp_val << "/" << high_bimp_centile << std::endl;      
+    }
+
+  } // close centrality calibration
+    
+
   FillNode(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -146,6 +288,11 @@ void PHG4CentralityReco::FillNode(PHCompositeNode *topNode)
     cent->set_quantity(CentralityInfo::PROP::epd_N, _epd_N);
     cent->set_quantity(CentralityInfo::PROP::epd_S, _epd_S);
     cent->set_quantity(CentralityInfo::PROP::epd_NS, _epd_NS);
+    cent->set_quantity(CentralityInfo::PROP::bimp, _bimp);
+    
+    cent->set_centile(CentralityInfo::PROP::epd_NS, _epd_cent);
+    cent->set_centile(CentralityInfo::PROP::mbd_NS, _mbd_cent);
+    cent->set_centile(CentralityInfo::PROP::bimp, _bimp_cent);
   }
 }
 

--- a/simulation/g4simulation/g4centrality/PHG4CentralityReco.h
+++ b/simulation/g4simulation/g4centrality/PHG4CentralityReco.h
@@ -8,6 +8,7 @@
 //===========================================================
 
 #include <fun4all/SubsysReco.h>
+#include <phparameter/PHParameters.h>
 
 #include <cmath>
 #include <string>
@@ -24,17 +25,38 @@ class PHG4CentralityReco : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
+  void DoCentralityCalibration(bool do_centrality_calibration ) {
+    _do_centrality_calibration = do_centrality_calibration;
+  }
+
+  PHParameters& GetCalibrationParameters() {
+    return  _centrality_calibration_params;
+  }
+  
  private:
   void CreateNode(PHCompositeNode *topNode);
   void FillNode(PHCompositeNode *topNode);
 
+  PHParameters _centrality_calibration_params;
+
+  bool _do_centrality_calibration = true;
+
+  std::map<float,int> _cent_cal_bimp;
+  std::map<float,int> _cent_cal_epd;
+  std::map<float,int> _cent_cal_mbd;
+
+  float _bimp = NAN;
+  float _bimp_cent = NAN;
+
   float _epd_N = NAN;
   float _epd_S = NAN;
   float _epd_NS = NAN;
+  float _epd_cent = NAN;
 
   float _mbd_N = NAN;
   float _mbd_S = NAN;
   float _mbd_NS = NAN;
+  float _mbd_cent = NAN;
 };
 
 #endif


### PR DESCRIPTION
[comment]: Functionality to read in centrality calibration (cuts on centrality observables), determine the centile % of the event, and save the result

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: PHG4CentralityReco will check if its parameter file (configured via macro when defining subsystem reco) contains centrality calibration information. If so, we now determine the centile % values according to the sEPD, MBD, and HIJING b impact parameter, and store the best result on the node tree.

## TODOs (if applicable)

[comment]: PRs in calibrations and macros repositories to follow


## Links to other PRs in macros and calibration repositories (if applicable)

