### PR TITLE
updated simulation injection of distortions to cylindrical format etc.

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -172,6 +172,8 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
     std::cout << "Distortion Requested along axis " << axis << " which is invalid.  Exiting.\n" << std::endl;
     exit(1);
   }
+
+  double _distortion=0.;
   
   //select the appropriate histogram:
   if (m_do_static_distortions)
@@ -183,7 +185,15 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
       } else if (axis=='z'){
 	hdistortion=hDZint[zpart];
       }
-    } else if (m_do_time_ordered_distortions)
+      if (hdistortion){
+	_distortion+=hdistortion->Interpolate(phi, r, z);
+      } else {
+	std::cout << "Static Distortion Requested along axis " << axis << ", but distortion map does not exist.  Exiting.\n" << std::endl;
+    exit(1);
+      }
+    }
+
+  if (m_do_time_ordered_distortions)
     {
       if (axis=='r'){
 	hdistortion=TimehDR[zpart];
@@ -192,15 +202,13 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
       } else if (axis=='z'){
 	hdistortion=TimehDZ[zpart];
       }
-    } else {
-    return 0; //neither distortion exists, or we are not applying one.
-  }
+      if (hdistortion){
+	_distortion+=hdistortion->Interpolate(phi, r, z);
+      } else {
+	std::cout << "Time Series Distortion Requested along axis " << axis << ", but distortion map does not exist.  Exiting.\n" << std::endl;
+	exit(1);
+      }
+    }
 
-  if (hdistortion){
-    return hdistortion->Interpolate(phi, r, z);
-  } else {
-    std::cout << "Distortion Requested along axis " << axis << ", but distortion map does not exist.  Exiting.\n" << std::endl;
-    exit(1);
-  }
-  return 0;
+  return _distortion;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -42,12 +42,13 @@ void PHG4TpcDistortion::Init()
     }
 
     //Open Static Space Charge Maps
-    hDXint = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionX"));
-    hDYint = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionY"));
-    hDZint = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionZ"));
+    hDRint[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionR_negz"));
+    hDRint[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionR_posz"));
+    hDPint[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionP_negz"));
+    hDPint[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionP_posz"));
+    hDZint[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionZ_negz"));
+    hDZint[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionZ_posz"));
 
-    // if z = -50 is in the underflow bin, map is only one-sided.
-    m_static_map_onesided = (hDXint->GetZaxis()->FindBin(-50) == 0);
   }
 
   if (m_do_time_ordered_distortions)
@@ -61,14 +62,20 @@ void PHG4TpcDistortion::Init()
     }
 
     // create histograms
-    TimehDX = new TH3F();
-    TimehDY = new TH3F();
-    TimehDZ = new TH3F();
+    TimehDR[0] = new TH3F();
+    TimehDR[1] = new TH3F();
+    TimehDP[0] = new TH3F();
+    TimehDP[1] = new TH3F();
+    TimehDZ[0] = new TH3F();
+    TimehDZ[1] = new TH3F();
 
     TimeTree = static_cast<TTree*>(m_time_ordered_tfile->Get("TimeDists"));
-    TimeTree->SetBranchAddress("hIntDistortionX", &TimehDX);
-    TimeTree->SetBranchAddress("hIntDistortionY", &TimehDY);
-    TimeTree->SetBranchAddress("hIntDistortionZ", &TimehDZ);
+    TimeTree->SetBranchAddress("hIntDistortionR_negz", &(TimehDR[0]));
+    TimeTree->SetBranchAddress("hIntDistortionR_posz", &(TimehDR[1]));
+    TimeTree->SetBranchAddress("hIntDistortionP_negz", &(TimehDP[0]));
+    TimeTree->SetBranchAddress("hIntDistortionP_posz", &(TimehDP[1]));
+    TimeTree->SetBranchAddress("hIntDistortionZ_negz", &(TimehDZ[0]));
+    TimeTree->SetBranchAddress("hIntDistortionZ_posz", &(TimehDZ[1]));
   }
 }
 
@@ -84,51 +91,116 @@ void PHG4TpcDistortion::load_event(int event_num)
       std::cout << "Distortion map sequence repeating as of event number " << event_num << std::endl;
     }
     TimeTree->GetEntry(event_num);
-
-    // if z = -50 is in the underflow bin, map is only one-sided.
-    m_time_ordered_map_onesided = (TimehDX->GetZaxis()->FindBin(-50) == 0);
   }
 
   return;
 }
 
 //__________________________________________________________________________________________________________
-double PHG4TpcDistortion::get_x_distortion(double x, double y, double z) const
+double PHG4TpcDistortion::get_x_distortion_cartesian(double x, double y, double z) const
 {
-  return get_distortion(hDXint, TimehDX, x, y, z);
+  double r=sqrt(x*x+y*y);
+  double phi=std::atan2(y,x);
+
+  //get components
+  double dr=get_distortion('r', r, phi, z);
+  double dphi=get_distortion('p', r, phi, z);
+
+  //rotate into cartesian based on local r phi:
+  double cosphi=cos(phi);
+  double sinphi=sin(phi);
+  double dx=dr*cosphi-dphi*sinphi;
+  return dx;
 }
 
 //__________________________________________________________________________________________________________
-double PHG4TpcDistortion::get_y_distortion(double x, double y, double z) const
+double PHG4TpcDistortion::get_y_distortion_cartesian(double x, double y, double z) const
 {
-  return get_distortion(hDYint, TimehDY, x, y, z);
+  double r=sqrt(x*x+y*y);
+  double phi=std::atan2(y,x);
+
+  //get components
+  double dr=get_distortion('r', r, phi, z);
+  double dphi=get_distortion('p', r, phi, z);
+
+  //rotate into cartesian based on local r phi:
+  double cosphi=cos(phi);
+  double sinphi=sin(phi);
+  double dy=dphi*cosphi+dr*sinphi;
+  return dy;
 }
 
 //__________________________________________________________________________________________________________
-double PHG4TpcDistortion::get_z_distortion(double x, double y, double z) const
+double PHG4TpcDistortion::get_z_distortion_cartesian(double x, double y, double z) const
 {
-  return get_distortion(hDZint, TimehDZ, x, y, z);
+  double r=sqrt(x*x+y*y);
+  double phi=std::atan2(y,x);
+
+  //get components
+  double dz=get_distortion('z', r, phi, z);
+
+  return dz;
 }
 
-//__________________________________________________________________________________
-double PHG4TpcDistortion::get_distortion(TH3* hstatic, TH3* htimeOrdered, double x, double y, double z) const
+
+//__________________________________________________________________________________________________________
+double PHG4TpcDistortion::get_r_distortion(double r, double phi, double z) const
 {
-  double phi = std::atan2(y, x);
+  return get_distortion('r',r,phi, z);
+}
+
+//__________________________________________________________________________________________________________
+double PHG4TpcDistortion::get_phi_distortion(double r, double phi, double z) const
+{
+  return get_distortion('p',r,phi, z);
+}
+
+//__________________________________________________________________________________________________________
+double PHG4TpcDistortion::get_z_distortion(double r, double phi, double z) const
+{
+  return get_distortion('z',r,phi, z);
+}
+
+double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double z) const
+{
   if (phi < 0) phi += 2 * M_PI;
-  const double r = std::sqrt(square(x) + square(y));
+  const int zpart=(z>0?1:0); //z<0 corresponds to the negative side, which is element 0.
 
-  double x_distortion = 0;
-  if (hstatic)
-  {
-    const auto zmap = m_static_map_onesided ? std::abs(z) : z;
-    x_distortion += hstatic->Interpolate(phi, r, zmap);
+  TH3* hdistortion=nullptr;
+
+  if (axis!='r' && axis!='p' && axis !='z'){
+    std::cout << "Distortion Requested along axis " << axis << " which is invalid.  Exiting.\n" << std::endl;
+    exit(1);
+  }
+  
+  //select the appropriate histogram:
+  if (m_do_static_distortions)
+    {
+      if (axis=='r'){
+	hdistortion=hDRint[zpart];
+      } else if (axis=='p'){
+	hdistortion=hDPint[zpart];
+      } else if (axis=='z'){
+	hdistortion=hDZint[zpart];
+      }
+    } else if (m_do_time_ordered_distortions)
+    {
+      if (axis=='r'){
+	hdistortion=TimehDR[zpart];
+      } else if (axis=='p'){
+	hdistortion=TimehDP[zpart];
+      } else if (axis=='z'){
+	hdistortion=TimehDZ[zpart];
+      }
+    } else {
+    return 0; //neither distortion exists, or we are not applying one.
   }
 
-  if (htimeOrdered)
-  {
-    const auto zmap = m_time_ordered_map_onesided ? std::abs(z) : z;
-    x_distortion += htimeOrdered->Interpolate(phi, r, zmap);
+  if (hdistortion){
+    return hdistortion->Interpolate(phi, r, z);
+  } else {
+    std::cout << "Distortion Requested along axis " << axis << ", but distortion map does not exist.  Exiting.\n" << std::endl;
+    exit(1);
   }
-
-  return x_distortion;
+  return 0;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -150,7 +150,7 @@ double PHG4TpcDistortion::get_r_distortion(double r, double phi, double z) const
 }
 
 //__________________________________________________________________________________________________________
-double PHG4TpcDistortion::get_phi_distortion(double r, double phi, double z) const
+double PHG4TpcDistortion::get_rphi_distortion(double r, double phi, double z) const
 {
   return get_distortion('p',r,phi, z);
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -109,24 +109,22 @@ class PHG4TpcDistortion
   //!@name static histograms
   //@{
   bool m_do_static_distortions = false;
-  bool m_static_map_onesided = false;
   std::string m_static_distortion_filename;
   std::unique_ptr<TFile> m_static_tfile;
-  TH3 *hDRint[2];
-  TH3 *hDPint[2];
-  TH3 *hDZint[2];
+  TH3 *hDRint[2]={nullptr,nullptr};
+  TH3 *hDPint[2]={nullptr,nullptr};
+  TH3 *hDZint[2]={nullptr,nullptr};
   //@}
 
   //!@name time ordered histograms
   //@{
   bool m_do_time_ordered_distortions = false;
-  bool m_time_ordered_map_onesided = false;
   std::string m_time_ordered_distortion_filename;
   std::unique_ptr<TFile> m_time_ordered_tfile;
-  TTree *TimeTree;
-  TH3 *TimehDR[2];
-  TH3 *TimehDP[2];
-  TH3 *TimehDZ[2];
+  TTree *TimeTree=nullptr;
+  TH3 *TimehDR[2]={nullptr,nullptr};
+  TH3 *TimehDP[2]={nullptr,nullptr};
+  TH3 *TimehDZ[2]={nullptr,nullptr};
   //@}
 };
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -40,8 +40,8 @@ class PHG4TpcDistortion
   //! radial distortion for a given cylindrical truth location of the primary ionization
   double get_r_distortion(double r, double phi, double z) const;
 
-  //! phi distortion for a given cylindrical truth location of the primary ionization
-  double get_phi_distortion(double r, double phi, double z) const;
+  //! R*phi (hence the unitful phi-hat) distortion for a given cylindrical truth location of the primary ionization
+  double get_rphi_distortion(double r, double phi, double z) const;
 
   //! z distortion for a given cylindrical truth location of the primary ionization
   double get_z_distortion(double r, double phi, double z) const;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -3,7 +3,7 @@
 /*!
  * \file PHG4TPCDistortion.h
  * \brief
- * \author Jin Huang <jhuang@bnl.gov>, Henry Klest <henry.klest@stonybrook.edu>, Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ * \author Jin Huang <jhuang@bnl.gov>, Henry Klest <henry.klest@stonybrook.edu>, Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>, Ross Corliss <ross.corliss@stonybrook.edu>
  * \version $Revision:   $
  * \date $Date: $
  */
@@ -29,14 +29,27 @@ class PHG4TpcDistortion
   //@{
 
   //! x distortion for a given truth location of the primary ionization
-  double get_x_distortion(double x, double y, double z) const;
+  double get_x_distortion_cartesian(double x, double y, double z) const;
 
   //! y distortion for a given truth location of the primary ionization
-  double get_y_distortion(double x, double y, double z) const;
+  double get_y_distortion_cartesian(double x, double y, double z) const;
 
   //! z distortion for a given truth location of the primary ionization
-  double get_z_distortion(double x, double y, double z) const;
+  double get_z_distortion_cartesian(double x, double y, double z) const;
+  
+  //! radial distortion for a given cylindrical truth location of the primary ionization
+  double get_r_distortion(double r, double phi, double z) const;
 
+  //! phi distortion for a given cylindrical truth location of the primary ionization
+  double get_phi_distortion(double r, double phi, double z) const;
+
+  //! z distortion for a given cylindrical truth location of the primary ionization
+  double get_z_distortion(double r, double phi, double z) const;
+
+
+
+
+  
   //! Gets the verbosity of this module.
   int Verbosity() const
   {
@@ -48,13 +61,13 @@ class PHG4TpcDistortion
   //!@name modifiers
   //@{
 
-  //! enable static distortions
+  //! enable distortions from a single fixed source
   void set_do_static_distortions(bool value)
   {
     m_do_static_distortions = value;
   }
 
-  //! static distortion filename
+  //! set the filename for the single fixed distortion
   void set_static_distortion_filename(const std::string &value)
   {
     m_static_distortion_filename = value;
@@ -88,7 +101,7 @@ class PHG4TpcDistortion
 
  private:
   //! get distortion for a set of histogram and an input momentum distribution
-  double get_distortion(TH3 *hstatic, TH3 *htimeOrdered, double x, double y, double z) const;
+  double get_distortion(char axis, double r, double phi, double z) const;
 
   //! The verbosity level. 0 means not verbose at all.
   int verbosity = 0;
@@ -99,9 +112,9 @@ class PHG4TpcDistortion
   bool m_static_map_onesided = false;
   std::string m_static_distortion_filename;
   std::unique_ptr<TFile> m_static_tfile;
-  TH3 *hDXint = nullptr;
-  TH3 *hDYint = nullptr;
-  TH3 *hDZint = nullptr;
+  TH3 *hDRint[2];
+  TH3 *hDPint[2];
+  TH3 *hDZint[2];
   //@}
 
   //!@name time ordered histograms
@@ -110,10 +123,10 @@ class PHG4TpcDistortion
   bool m_time_ordered_map_onesided = false;
   std::string m_time_ordered_distortion_filename;
   std::unique_ptr<TFile> m_time_ordered_tfile;
-  TTree *TimeTree = nullptr;
-  TH3 *TimehDX = nullptr;
-  TH3 *TimehDY = nullptr;
-  TH3 *TimehDZ = nullptr;
+  TTree *TimeTree;
+  TH3 *TimehDR[2];
+  TH3 *TimehDP[2];
+  TH3 *TimehDZ[2];
   //@}
 };
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -373,7 +373,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       if (m_distortionMap)
       {
 	const double r_distortion = m_distortionMap->get_r_distortion(radstart, phistart, z_start);
-	const double phi_distortion = m_distortionMap->get_phi_distortion(radstart, phistart, z_start);
+	const double phi_distortion = m_distortionMap->get_rphi_distortion(radstart, phistart, z_start)/radstart;
 	const double z_distortion = m_distortionMap->get_z_distortion(radstart, phistart, z_start);
 
 	rad_final+=r_distortion;

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -372,24 +372,21 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
       if (m_distortionMap)
       {
-        const double x_distortion = m_distortionMap->get_x_distortion(x_start, y_start, z_start);
-        const double y_distortion = m_distortionMap->get_y_distortion(x_start, y_start, z_start);
-        const double z_distortion = m_distortionMap->get_z_distortion(x_start, y_start, z_start);
+	const double r_distortion = m_distortionMap->get_r_distortion(radstart, phistart, z_start);
+	const double phi_distortion = m_distortionMap->get_phi_distortion(radstart, phistart, z_start);
+	const double z_distortion = m_distortionMap->get_z_distortion(radstart, phistart, z_start);
 
-        x_final += x_distortion;
-        y_final += y_distortion;
+	rad_final+=r_distortion;
+	phi_final+=phi_distortion;
+	z_final += z_distortion;
 
-        // TODO: should check again against TPC acceptance
-        z_final += z_distortion;
-
-        // re-calculate rad and phi final, including distortions
-        rad_final = sqrt(square(x_final) + square(y_final));
-        phi_final = atan2(y_final, x_final);
+	x_final=rad_final*std::cos(phi_final);
+	y_final=rad_final*std::sin(phi_final);
 
         if (do_ElectronDriftQAHistos)
         {
-          const double phi_final_nodiff = atan2(y_start + y_distortion, x_start + x_distortion);
-          const double rad_final_nodiff = sqrt(pow(x_start + x_distortion, 2) + pow(y_start + y_distortion, 2));
+          const double phi_final_nodiff = phistart+phi_distortion;
+          const double rad_final_nodiff = radstart+r_distortion;
           deltarnodiff->Fill(radstart, rad_final_nodiff - radstart);    //delta r no diffusion, just distortion
           deltaphinodiff->Fill(phistart, phi_final_nodiff - phistart);  //delta phi no diffusion, just distortion
           deltaphivsRnodiff->Fill(radstart, phi_final_nodiff - phistart);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
 This changes the expected format of the input distortion maps applied in simulated data to match the format supplied in reconstructed data.  The new maps contain only cylindrical coordinate elements.  This reduces their size and makes it easier to compare same-in, same-out which previously did not read the same format.  Additionally, a temporary fix regarding how to handle positions quite close to the CM has been resolved by breaking the distortion maps up into a z>0 and z<0 histogram, which no longer attempts to interpolate between the two separate halves.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

This still needs testing with actual files.  The old G4_TPC.C macro default map filenames will need to be revised to use a working sample.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)