### PR TITLE
add opening files in pnfs via xrootd

### DIFF
--- a/offline/framework/frog/FROG.cc
+++ b/offline/framework/frog/FROG.cc
@@ -83,6 +83,23 @@ FROG::location(const string &logical_name)
           break;
         }
       }
+      else if (iter == "XROOTD")
+      {
+        if (Verbosity() > 1)
+        {
+          cout << "Searching FileCatalog for XRootD file "
+               << logical_name << endl;
+        }
+        if (XRootDSearch(logical_name))
+        {
+          if (Verbosity() > 1)
+          {
+            cout << "Found " << logical_name << " in XRootD, returning "
+                 << pfn << endl;
+          }
+          break;
+        }
+      }
       else  // assuming this is a file path
       {
         if (Verbosity() > 0)
@@ -190,6 +207,32 @@ bool FROG::dCacheSearch(const string &lname)
     if (std::ifstream(dcachefile))
     {
       pfn = "dcache:" + dcachefile;
+      bret = true;
+    }
+  }
+  delete rs;
+  delete stmt;
+  return bret;
+}
+
+bool FROG::XRootDSearch(const string &lname)
+{
+  bool bret = false;
+  if (!GetConnection())
+  {
+    return bret;
+  }
+  string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name = 'dcache'";
+
+  odbc::Statement *stmt = m_OdbcConnection->createStatement();
+  odbc::ResultSet *rs = stmt->executeQuery(sqlquery);
+
+  if (rs->next())
+  {
+    string xrootdfile = rs->getString(1);
+    if (std::ifstream(xrootdfile))
+    {
+      pfn = "root://dcsphdoor02.rcf.bnl.gov:1095" + xrootdfile;
       bret = true;
     }
   }

--- a/offline/framework/frog/FROG.h
+++ b/offline/framework/frog/FROG.h
@@ -18,6 +18,7 @@ class FROG
   const char *location(const std::string &logical_name);
   bool localSearch(const std::string &lname);
   bool dCacheSearch(const std::string &lname);
+  bool XRootDSearch(const std::string &lname);
   bool PGSearch(const std::string &lname);
   void Verbosity(const int i) { m_Verbosity = i; }
   int Verbosity() const { return m_Verbosity; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds enables the XRootD interface of root. Basically all it needs is to add root://dcsphdoor02.rcf.bnl.gov:1095 in front of the pnfs path. It needs XROOTD in the GSEARCHPATH which will be added once this is working. DCACHE and XROOTD will be mutually exclusive, it depends on the order in the GSEARCHPATH which protocol is chosen

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

