### PR TITLE
Master corrected clusters

### DIFF
--- a/offline/packages/trackbase/TrkrCluster.h
+++ b/offline/packages/trackbase/TrkrCluster.h
@@ -34,6 +34,19 @@ class TrkrCluster : public PHObject
   }
   void Reset() override {}
   int isValid() const override { return 0; }
+
+  
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  
+  //! copy content from base class
+  virtual void CopyFrom( const TrkrCluster& ) 
+  {}
+
+  //! copy content from base class
+  virtual void CopyFrom( TrkrCluster* ) 
+  {}
+
   //
   // cluster id
   //
@@ -81,7 +94,7 @@ class TrkrCluster : public PHObject
   virtual void setPosition(int /*coor*/, float /*xi*/) {}
   virtual void setGlobal() {}
   virtual void setLocal() {}
-  virtual bool isGlobal() { return true; }
+  virtual bool isGlobal() const { return true; }
   virtual float getError(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
   virtual void setError(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
   virtual float getSize(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -6,7 +6,7 @@
  */
 #include "TrkrClusterContainerv3.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv2.h"
+#include "TrkrClusterv3.h"
 #include "TrkrDefs.h"
 
 #include <cstdlib>
@@ -123,7 +123,7 @@ TrkrClusterContainerv3::findOrAddCluster(TrkrDefs::cluskey key)
   if( it == map.end() || (key<it->first) )
   {
     // add new cluster and set its key
-    it = map.insert(it, std::make_pair(key, new TrkrClusterv2()));
+    it = map.insert(it, std::make_pair(key, new TrkrClusterv3()));
     it->second->setClusKey( key );
   }
   

--- a/offline/packages/trackbase/TrkrClusterv1.cc
+++ b/offline/packages/trackbase/TrkrClusterv1.cc
@@ -125,6 +125,29 @@ int TrkrClusterv1::isValid() const
   return 1;
 }
 
+void TrkrClusterv1::CopyFrom( const TrkrCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
+  // parent class method
+  TrkrCluster::CopyFrom( source );
+
+  setClusKey( source.getClusKey() );
+  setX( source.getX() );
+  setY( source.getY() );
+  setZ( source.getZ() );
+  m_isGlobal = source.isGlobal();
+  setAdc( source.getAdc() );
+
+  for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 3; ++i)
+  {
+    setSize(i, j, source.getSize(i, j));
+    setError(i, j, source.getError(i, j));
+  }
+}
+
 void TrkrClusterv1::setSize(unsigned int i, unsigned int j, float value)
 {
   m_size[covarIndex(i, j)] = value;

--- a/offline/packages/trackbase/TrkrClusterv1.h
+++ b/offline/packages/trackbase/TrkrClusterv1.h
@@ -35,6 +35,13 @@ class TrkrClusterv1 : public TrkrCluster
   void Reset() override {}
   int isValid() const override;
   PHObject* CloneMe() const override { return new TrkrClusterv1(*this); }
+ 
+  //! copy content from base class
+  void CopyFrom( const TrkrCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( TrkrCluster* source ) override
+  { CopyFrom( *source ); }
 
   void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
   TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
@@ -51,7 +58,7 @@ class TrkrClusterv1 : public TrkrCluster
   void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
   void setGlobal() override { m_isGlobal = true; }
   void setLocal() override { m_isGlobal = false; }
-  bool isGlobal() override { return m_isGlobal; }
+  bool isGlobal() const override { return m_isGlobal; }
   //
   // cluster info
   //

--- a/offline/packages/trackbase/TrkrClusterv2.cc
+++ b/offline/packages/trackbase/TrkrClusterv2.cc
@@ -131,6 +131,37 @@ int TrkrClusterv2::isValid() const
   return 1;
 }
 
+void TrkrClusterv2::CopyFrom( const TrkrCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
+  // parent class method
+  TrkrCluster::CopyFrom( source );
+
+  setClusKey( source.getClusKey() );
+  setX( source.getX() );
+  setY( source.getY() );
+  setZ( source.getZ() );
+  m_isGlobal = source.isGlobal();
+  setAdc( source.getAdc() );
+
+  for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 3; ++i)
+  {
+    setSize(i, j, source.getSize(i, j));
+    setError(i, j, source.getError(i, j));
+  }
+
+  setSubSurfKey( source.getSubSurfKey() );
+  setLocalX( source.getLocalX() );
+  setLocalY( source.getLocalY() );
+  
+  for (int j = 0; j < 2; ++j)
+    for (int i = 0; i < 2; ++i)
+  { setActsLocalError(i, j, source.getActsLocalError(i, j)); }
+}
+  
 void TrkrClusterv2::setSize(unsigned int i, unsigned int j, float value)
 {
   m_size[covarIndex(i, j)] = value;

--- a/offline/packages/trackbase/TrkrClusterv2.h
+++ b/offline/packages/trackbase/TrkrClusterv2.h
@@ -33,6 +33,13 @@ class TrkrClusterv2 : public TrkrCluster
   void Reset() override {}
   int isValid() const override;
   PHObject* CloneMe() const override { return new TrkrClusterv2(*this); }
+  
+  //! copy content from base class
+  void CopyFrom( const TrkrCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( TrkrCluster* source ) override
+  { CopyFrom( *source ); }
 
   void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
   TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
@@ -51,7 +58,7 @@ class TrkrClusterv2 : public TrkrCluster
   void setPosition(int coor, float xi) override { m_pos[coor] = xi; }
   void setGlobal() override { m_isGlobal = true; }
   void setLocal() override { m_isGlobal = false; }
-  bool isGlobal() override { return m_isGlobal; }
+  bool isGlobal() const override { return m_isGlobal; }
 
   float getLocalX() const override { return m_local[0]; }
   void setLocalX(float loc0) override { m_local[0] = loc0; }

--- a/offline/packages/trackbase/TrkrClusterv3.cc
+++ b/offline/packages/trackbase/TrkrClusterv3.cc
@@ -69,6 +69,26 @@ int TrkrClusterv3::isValid() const
   return 1;
 }
 
+void TrkrClusterv3::CopyFrom( const TrkrCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
+  // parent class method
+  TrkrCluster::CopyFrom( source );
+ 
+  setClusKey( source.getClusKey() );
+  setLocalX( source.getLocalX() );
+  setLocalY( source.getLocalY() );
+  
+  for (int j = 0; j < 2; ++j)
+    for (int i = 0; i < 2; ++i)
+  { setActsLocalError(i, j, source.getActsLocalError(i, j)); }
+  
+  setSubSurfKey( source.getSubSurfKey() );
+  setAdc( source.getAdc() );
+}
+
 float TrkrClusterv3::getRPhiError() const
 { return std::sqrt(m_actsLocalErr[0][0]); }
 

--- a/offline/packages/trackbase/TrkrClusterv3.h
+++ b/offline/packages/trackbase/TrkrClusterv3.h
@@ -33,6 +33,13 @@ class TrkrClusterv3 : public TrkrCluster
   void Reset() override {}
   int isValid() const override;
   PHObject* CloneMe() const override { return new TrkrClusterv3(*this); }
+  
+  //! copy content from base class
+  void CopyFrom( const TrkrCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( TrkrCluster* source ) override
+  { CopyFrom( *source ); }
 
   void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
   TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.cc
@@ -18,6 +18,9 @@ SvtxTrack_FastSim_v1::SvtxTrack_FastSim_v1(const SvtxTrack& source)
 
 void SvtxTrack_FastSim_v1::CopyFrom( const SvtxTrack& source )
 {
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
   // parent class method
   SvtxTrack_FastSim::CopyFrom( source );
   

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v2.cc
@@ -17,6 +17,9 @@ SvtxTrack_FastSim_v2::SvtxTrack_FastSim_v2(const SvtxTrack& source)
 
 void SvtxTrack_FastSim_v2::CopyFrom( const SvtxTrack& source )
 {
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
   // parent class method
   SvtxTrack_v2::CopyFrom( source );
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.cc
@@ -34,7 +34,9 @@ SvtxTrack_v1::~SvtxTrack_v1()
 
 void SvtxTrack_v1::CopyFrom( const SvtxTrack& source )
 {
-
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
   // parent class method
   SvtxTrack::CopyFrom( source );
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -37,7 +37,9 @@ SvtxTrack_v2::~SvtxTrack_v2()
 
 void SvtxTrack_v2::CopyFrom( const SvtxTrack& source )
 {
-
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+  
   // parent class method
   SvtxTrack::CopyFrom( source );
   

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -49,12 +49,16 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   //! load nodes relevant for the analysis
   int GetNodes(PHCompositeNode* topNode);
+
+  void copyMicromegasClustersToCorrectedMap( );
     
   //! number of layers in the micromegas
   static constexpr unsigned int _n_mm_layers = 2;
   
   bool _use_truth_clusters = false;
   TrkrClusterContainer *_cluster_map{nullptr};
+  TrkrClusterContainer *_corrected_cluster_map{nullptr};
+
   SvtxTrackMap *_track_map{nullptr};
   AssocInfoContainer *_assoc_container{nullptr};
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -521,22 +521,14 @@ void PHSiliconTpcTrackMatching::copySiliconClustersToCorrectedMap( )
 	   ++iter)
 	{
 	  TrkrDefs::cluskey cluster_key = *iter;
-	  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+   const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
 	  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
 	    {
 	      TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	      TrkrCluster *newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
-	  
-	      newclus->setSubSurfKey(cluster->getSubSurfKey());
-	      newclus->setAdc(cluster->getAdc());
-	      
-	      newclus->setActsLocalError(0,0,cluster->getActsLocalError(0,0));
-	      newclus->setActsLocalError(1,0,cluster->getActsLocalError(1,0));
-	      newclus->setActsLocalError(0,1,cluster->getActsLocalError(0,1));
-	      newclus->setActsLocalError(1,1,cluster->getActsLocalError(1,1));
-	      
-	      newclus->setLocalX(cluster->getLocalX());
-	      newclus->setLocalY(cluster->getLocalY());
+       if( !cluster ) continue;
+      
+       TrkrCluster *newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
+       newclus->CopyFrom( cluster );
 	    }
 	}      
     }

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -105,8 +105,19 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	  unsigned int trkrId = TrkrDefs::getTrkrId(cluster_key);
 	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
 
-	  if(trkrId != TrkrDefs::tpcId) continue;  // we want only TPC clusters
-
+    // non Tpc clusters are copied unchanged to the new map
+	  if(trkrId != TrkrDefs::tpcId) 
+    {
+      // get cluster from original map
+      auto cluster =  _cluster_map->findCluster(cluster_key);	
+      if( !cluster ) continue;
+      
+      // create in corrected map and copy content
+      auto newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
+      newclus->CopyFrom( cluster );
+      continue;      
+    }
+    
 	  // get the cluster in 3D coordinates
 	  TrkrCluster *tpc_clus =  _cluster_map->findCluster(cluster_key);
 	  auto global = _transformer.getGlobalPosition(tpc_clus,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR makes sure that clusters other than TPC are always copied, unchanged, from the full cluster map to the tpc-distortion-corrected cluster map. More explicitly
- in TPC-Micromegas matching module, make sure that the Micromegas clusters are looked after in the full map, and copied onty the corrected map when a match is found
- in case of Truth track finding, make sure that all non-TPC clusters are copied over to the corrected cluster map, when running the cluster mover.

In addition:
- To reduce code duplication, make copying clusters easier and more future proof, introduced a "CopyFrom" method to all TrkrCluster variants (similar to what is done for SvtxTrack)
- Fixed  TrkrCluster version created in TrkrClusterContainerV3::findOrAdd (was v2, should be v3)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

