### PR TITLE
print out stacktrace for invalid field to see who did this

### DIFF
--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -6,6 +6,7 @@
 
 #include <Geant4/G4SystemOfUnits.hh>
 
+#include <boost/stacktrace.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 
@@ -144,6 +145,9 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
                 << ", y: " << ysav / cm
                 << ", z: " << zsav / cm
                 << std::endl;
+      std::cout << "Here is the stacktrace: " << std::endl;
+      std::cout << boost::stacktrace::stacktrace();
+      std::cout << "This is not a segfault. Check the stacktrace for the guilty party (typically #2)" << std::endl;
       ifirst++;
     }
     return;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR prints out the stack trace if PHField3DCartesian::GetFieldValue gets called with not finite coordinates. I see nan's occasionally which seem to come from the tracking. The stacktrace print will tell us where this comes from

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

