### PR TITLE
TPC Supports and minor central membrane improvement.

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -23,7 +23,6 @@
 #include <string>   // for string
 #include <utility>  // for pair
 
-class G4Tubs;
 class G4LogicalVolume;
 class G4UserLimits;
 class G4VPhysicalVolume;

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 class G4LogicalVolume;
 class G4Material;

--- a/simulation/g4simulation/g4main/PHG4Detector.h
+++ b/simulation/g4simulation/g4main/PHG4Detector.h
@@ -7,7 +7,6 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 
 class G4LogicalVolume;
 class G4Material;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -268,7 +268,9 @@ int PHG4TpcDetector::ConstructTpcExternalSupports(G4LogicalVolume *logicWorld)
   double rodAngleStart=M_PI/12.;
   double rodAngularSpacing=2*M_PI/12.;
   double rodRadius=31.04*inch;
-  G4VSolid *tieRod = new G4Tubs("tpc_tie_rod",0.9375*inch, 1.*inch,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);
+  double rodWallThickness=1./8.*inch;
+  double rodDiameter=3./4.*inch;
+  G4VSolid *tieRod = new G4Tubs("tpc_tie_rod",rodDiameter/2.-rodWallThickness, rodDiameter/2.,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);
   G4LogicalVolume *tieRodLogic = new G4LogicalVolume(tieRod,
 							carbonFiber,
 							"tpc_tie_rod");

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -268,7 +268,7 @@ int PHG4TpcDetector::ConstructTpcExternalSupports(G4LogicalVolume *logicWorld)
   G4Material *carbonFiber=GetDetectorMaterial("CFRP_INTT");
   double rodAngleStart=M_PI/12.;
   double rodAngularSpacing=2*M_PI/12.;
-  double rodRadius=31.1*inch;
+  double rodRadius=31.3*inch;
   double rodWallThickness=1./8.*inch;
   double rodDiameter=3./4.*inch;
   G4VSolid *tieRod = new G4Tubs("tpc_tie_rod",rodDiameter/2.-rodWallThickness, rodDiameter/2.,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -268,7 +268,7 @@ int PHG4TpcDetector::ConstructTpcExternalSupports(G4LogicalVolume *logicWorld)
   G4Material *carbonFiber=GetDetectorMaterial("CFRP_INTT");
   double rodAngleStart=M_PI/12.;
   double rodAngularSpacing=2*M_PI/12.;
-  double rodRadius=31.04*inch;
+  double rodRadius=31.1*inch;
   double rodWallThickness=1./8.*inch;
   double rodDiameter=3./4.*inch;
   G4VSolid *tieRod = new G4Tubs("tpc_tie_rod",rodDiameter/2.-rodWallThickness, rodDiameter/2.,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -268,7 +268,7 @@ int PHG4TpcDetector::ConstructTpcExternalSupports(G4LogicalVolume *logicWorld)
   G4Material *carbonFiber=GetDetectorMaterial("CFRP_INTT");
   double rodAngleStart=M_PI/12.;
   double rodAngularSpacing=2*M_PI/12.;
-  double rodRadius=31.3*inch;
+  double rodRadius=31.5*inch;
   double rodWallThickness=1./8.*inch;
   double rodDiameter=3./4.*inch;
   G4VSolid *tieRod = new G4Tubs("tpc_tie_rod",rodDiameter/2.-rodWallThickness, rodDiameter/2.,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -243,7 +243,8 @@ int PHG4TpcDetector::ConstructTpcExternalSupports(G4LogicalVolume *logicWorld)
   double hangerRadius=32.05*inch;
   double hangerX=std::sin(hangerAngle)*hangerRadius;
   double hangerY=std::cos(hangerAngle)*hangerRadius;
-  G4VSolid *hangerBeam = new G4Tubs("tpc_hanger_beam", 0, 2.*inch,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);
+  double hangerDiameter=2.*inch;
+  G4VSolid *hangerBeam = new G4Tubs("tpc_hanger_beam", 0,hangerDiameter/2.,(m_Params->get_double_param("tpc_length") * cm )/ 2., 0., 2*M_PI);
   G4LogicalVolume *hangerBeamLogic = new G4LogicalVolume(hangerBeam,
 							stainlessSteel,
 							"tpc_hanger_beam");

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -7,7 +7,6 @@
 
 #include <cmath>
 #include <set>
-#include <vector>
 
 class G4LogicalVolume;
 class G4UserLimits;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <set>
+#include <vector>
 
 class G4LogicalVolume;
 class G4UserLimits;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.h
@@ -7,7 +7,7 @@
 
 #include <cmath>
 #include <set>
-#include <string>
+#include <vector>
 
 class G4LogicalVolume;
 class G4UserLimits;
@@ -38,6 +38,10 @@ class PHG4TpcDetector : public PHG4Detector
  private:
   int ConstructTpcGasVolume(G4LogicalVolume *tpc_envelope);
   int ConstructTpcCageVolume(G4LogicalVolume *tpc_envelope);
+  int ConstructTpcExternalSupports(G4LogicalVolume *logicWorld);
+
+  void CreateCompositeMaterial(std::string compositeName, std::vector<std::string> materialName, std::vector<double> thickness);
+  
   PHG4TpcDisplayAction *m_DisplayAction = nullptr;
   PHParameters *m_Params = nullptr;
   G4UserLimits *m_G4UserLimits = nullptr;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDisplayAction.cc
@@ -69,10 +69,12 @@ void PHG4TpcDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
     }
     else
     {
-      std::cout << "did not assing color to " << it.first->GetName()
-                << " under " << it.second << std::endl;
-      gSystem->Exit(1);
-      exit(1);
+      std::cout << "did not assign specific color to " << it.first->GetName()
+                << " under " << it.second << ".  Defaulting to TpcWindow color." << std::endl;
+      visatt->SetColor(PHG4TpcColorDefs::tpc_pcb_color);
+
+      //gSystem->Exit(1);
+      //exit(1);
     }
     logvol->SetVisAttributes(visatt);
   }


### PR DESCRIPTION
…fiber rods.

Also modified central membrane to be enig surface.
clocking of the two stainless steel rods still needs to be confirmed.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This pull request creates the two stainless steel rods that support the TPC, as well as twelve hollow carbon fiber rods that provide rigidity.  It also corrects the material on the surface of the central membrane to ENIG from the previous copper.

It changes the behavior of the TPC visualization, which previously forced exit(1) if anything other than an explicitly listed set of volume names appears.  Now it throws a warning, gives a default color, and continues.

## TODOs (if applicable)
I was unable to get the visualizations working, so can't visually confirm the position of the stainless steel rods.  They should be 40 degrees to left and right of 12 o'clock.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

