### PR TITLE
Fixing cluster mover surface finding

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -249,26 +249,56 @@ namespace
 	  
 	  double surfStepPhi = tGeometry->tpcSurfStepPhi;
 	  double surfStepZ = tGeometry->tpcSurfStepZ;
-	
+
 	  for(unsigned int i=0;i<surf_vec.size(); ++i)
 	    {
 	      Surface this_surf = surf_vec[i];
-	  
+	      
 	      auto vec3d = this_surf->center(tGeometry->geoContext);
 	      std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
 	      double surf_phi = atan2(surf_center[1], surf_center[0]);
 	      double surf_z = surf_center[2];
-	 
+	      
+	      // check for Z  at start - is this the correct side?
+	      if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0)
+		{
+		  // i=0 and i = surf_vec.size()-1 are special cases
+		  if(i==0)
+		    {
+		      if(world_phi > surf_phi - surfStepPhi  && world_phi < surf_phi + surfStepPhi / 2.0 )
+			{
+			  surf_index = i;	  
+			  break;
+			}
+		    }
+		  
+		  if(i==surf_vec.size() - 1)
+		    {
+		      if(world_phi > surf_phi - surfStepPhi/2.0  && world_phi < surf_phi + surfStepPhi  )
+			{
+			  surf_index = i;	  
+			  break;
+			}
+		    }
+		  
+		  if(world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
+		    {
+		      surf_index = i;	  
+		      break;
+		    }
+		}  
+	      /*
 	      if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
 		  (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
 		{
 		  surf_index = i;	  
 		  break;
 		}
+	      */
 	    }
 	  
 	  subsurfkey = surf_index;
-	
+	  
 	  if(surf_index == 999)
 	    {
 	      std::cout << PHWHERE 

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -246,7 +246,7 @@ namespace
 	  
 	  std::vector<Surface> surf_vec = mapIter->second;
 	  unsigned int surf_index = 999;
-	  
+
 	  // Predict which surface index this phi and z will correspond to
 	  // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
 	  double fraction =  (world_phi + M_PI) / (2.0 * M_PI);
@@ -263,18 +263,10 @@ namespace
 	  std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
 	  double surf_z = surf_center[2];
 	  double surf_phi = atan2(surf_center[1], surf_center[0]);
-	  
-	  if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0 &&
-	     world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
+
+	  if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
+	  (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )	
 	    {
-	      /*
-		std::cout <<  "     got it:  surf_phi " << surf_phi << " surf_z " << surf_z 
-			  << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
-			  << " world_phi " << world_phi << " world_z " << world_z 
-			  << " rounded_nsurf "<< rounded_nsurf << " surf_index " << nsurf
-			  << std::endl;        
-	      */
-	      
 	      surf_index = nsurf;
 	      subsurfkey = nsurf;
 	    }    

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -228,8 +228,10 @@ namespace
 					    ActsTrackingGeometry *tGeometry,
 					    TrkrDefs::subsurfkey& subsurfkey)
 	{
-	  std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
-	  mapIter = surfMaps->tpcSurfaceMap.find(hitsetkey);
+
+	  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+	  std::map<unsigned int, std::vector<Surface>>::iterator mapIter;
+	  mapIter = surfMaps->tpcSurfaceMap.find(layer);
 	  
 	  if(mapIter == surfMaps->tpcSurfaceMap.end())
 	    {

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -247,73 +247,58 @@ namespace
 	  std::vector<Surface> surf_vec = mapIter->second;
 	  unsigned int surf_index = 999;
 	  
+	  // Predict which surface index this phi and z will correspond to
+	  // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
+	  double fraction =  (world_phi + M_PI) / (2.0 * M_PI);
+	  double rounded_nsurf = round( (double) (surf_vec.size()/2) * fraction  - 0.5);
+	  unsigned int nsurf = (unsigned int) rounded_nsurf; 
+	  if(world_z < 0)
+	    nsurf += surf_vec.size()/2;
+
 	  double surfStepPhi = tGeometry->tpcSurfStepPhi;
 	  double surfStepZ = tGeometry->tpcSurfStepZ;
 
-	  for(unsigned int i=0;i<surf_vec.size(); ++i)
+	  Surface this_surf = surf_vec[nsurf];
+	  auto vec3d = this_surf->center(tGeometry->geoContext);
+	  std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
+	  double surf_z = surf_center[2];
+	  double surf_phi = atan2(surf_center[1], surf_center[0]);
+	  
+	  if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0 &&
+	     world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
 	    {
-	      Surface this_surf = surf_vec[i];
-	      
-	      auto vec3d = this_surf->center(tGeometry->geoContext);
-	      std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
-	      double surf_phi = atan2(surf_center[1], surf_center[0]);
-	      double surf_z = surf_center[2];
-	      
-	      // check for Z  at start - is this the correct side?
-	      if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0)
-		{
-		  // i=0 and i = surf_vec.size()-1 are special cases
-		  if(i==0)
-		    {
-		      if(world_phi > surf_phi - surfStepPhi  && world_phi < surf_phi + surfStepPhi / 2.0 )
-			{
-			  surf_index = i;	  
-			  break;
-			}
-		    }
-		  
-		  if(i==surf_vec.size() - 1)
-		    {
-		      if(world_phi > surf_phi - surfStepPhi/2.0  && world_phi < surf_phi + surfStepPhi  )
-			{
-			  surf_index = i;	  
-			  break;
-			}
-		    }
-		  
-		  if(world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
-		    {
-		      surf_index = i;	  
-		      break;
-		    }
-		}  
 	      /*
-	      if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
-		  (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
-		{
-		  surf_index = i;	  
-		  break;
-		}
+		std::cout <<  "     got it:  surf_phi " << surf_phi << " surf_z " << surf_z 
+			  << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
+			  << " world_phi " << world_phi << " world_z " << world_z 
+			  << " rounded_nsurf "<< rounded_nsurf << " surf_index " << nsurf
+			  << std::endl;        
 	      */
-	    }
-	  
-	  subsurfkey = surf_index;
-	  
-	  if(surf_index == 999)
+	      
+	      surf_index = nsurf;
+	      subsurfkey = nsurf;
+	    }    
+	  else
 	    {
 	      std::cout << PHWHERE 
 			<< "Error: TPC surface index not defined, skipping cluster!" 
 			<< std::endl;
+	      std::cout << "     coordinates: " << world[0] << "  " << world[1] << "  " << world[2] 
+			<< " radius " << sqrt(world[0]*world[0]+world[1]*world[1]) << std::endl;
+	      std::cout << "     world_phi " << world_phi << " world_z " << world_z << std::endl;
+	      std::cout << "     surf coords: " << surf_center[0] << "  " << surf_center[1] << "  " << surf_center[2] << std::endl;
+	      std::cout << "     surf_phi " << surf_phi << " surf_z " << surf_z << std::endl; 
+	      std::cout << " number of surfaces " << surf_vec.size() << std::endl;
 	      return nullptr;
 	    }
-	 
+	  	 
 	  return surf_vec[surf_index];
 	
 	}
-	
-	void calc_cluster_parameter(const std::vector<ihit> &ihit_list,int iclus, const thread_data& my_data )
-	{
-	
+  
+    void calc_cluster_parameter(const std::vector<ihit> &ihit_list,int iclus, const thread_data& my_data )
+    {
+    
     // get z range from layer geometry
     /* these are used for rescaling the drift velocity */
     const double z_min = -105.5;

--- a/offline/packages/trackbase/ActsSurfaceMaps.h
+++ b/offline/packages/trackbase/ActsSurfaceMaps.h
@@ -34,7 +34,7 @@ struct ActsSurfaceMaps
   std::map<TrkrDefs::hitsetkey, Surface> siliconSurfaceMap;
 
   //! map hitset to surface vector for the TPC
-  std::map<TrkrDefs::hitsetkey, SurfaceVec> tpcSurfaceMap;
+  std::map<unsigned int, SurfaceVec> tpcSurfaceMap;   // uses layer as key
 
   //! map hitset to surface vector for the micromegas
   std::map<TrkrDefs::hitsetkey, Surface> mmSurfaceMap;

--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -359,7 +359,6 @@ Surface ActsTransformations::getTpcSurface(TrkrDefs::hitsetkey hitsetkey,
 					   TrkrDefs::subsurfkey surfkey,
 					   ActsSurfaceMaps* maps) const
 {
-  //const auto iter = maps->tpcSurfaceMap.find(hitsetkey);
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
   const auto iter = maps->tpcSurfaceMap.find(layer);
   if(iter != maps->tpcSurfaceMap.end())

--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -359,7 +359,9 @@ Surface ActsTransformations::getTpcSurface(TrkrDefs::hitsetkey hitsetkey,
 					   TrkrDefs::subsurfkey surfkey,
 					   ActsSurfaceMaps* maps) const
 {
-  const auto iter = maps->tpcSurfaceMap.find(hitsetkey);
+  //const auto iter = maps->tpcSurfaceMap.find(hitsetkey);
+  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+  const auto iter = maps->tpcSurfaceMap.find(layer);
   if(iter != maps->tpcSurfaceMap.end())
   {
     auto surfvec = iter->second;

--- a/offline/packages/trackreco/ActsEvaluator.cc
+++ b/offline/packages/trackreco/ActsEvaluator.cc
@@ -848,7 +848,8 @@ Surface ActsEvaluator::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey)
 //___________________________________________________________________________________
 Surface ActsEvaluator::getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey)
 {
-  const auto iter = m_surfMaps->tpcSurfaceMap.find(hitsetkey);
+  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+  const auto iter = m_surfMaps->tpcSurfaceMap.find(layer);
   if(iter != m_surfMaps->tpcSurfaceMap.end())
   {
     auto surfvec = iter->second;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -746,11 +746,14 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
 					      vec3d(2) / 10.0};
 	
 	  TrkrDefs::hitsetkey hitsetkey = getTpcHitSetKeyFromCoords(world_center);
+	  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
 
 	  /// If there is already an entry for this hitsetkey, add the surface
 	  /// to its corresponding vector
-	  std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
-	  mapIter = m_clusterSurfaceMapTpcEdit.find(hitsetkey);
+	  //std::map<TrkrDefs::hitsetkey, std::vector<Surface>>::iterator mapIter;
+	  std::map<unsigned int, std::vector<Surface>>::iterator mapIter;
+	  //mapIter = m_clusterSurfaceMapTpcEdit.find(hitsetkey);
+	  mapIter = m_clusterSurfaceMapTpcEdit.find(layer);
 	  
 	  if(mapIter != m_clusterSurfaceMapTpcEdit.end())
 	    {
@@ -761,8 +764,8 @@ void MakeActsGeometry::makeTpcMapPairs(TrackingVolumePtr &tpcVolume)
 	      /// Otherwise make a new map entry
 	      std::vector<Surface> dumvec;
 	      dumvec.push_back(surf);
-	      std::pair<TrkrDefs::hitsetkey, std::vector<Surface>> tmp = 
-		std::make_pair(hitsetkey, dumvec);
+	      std::pair<unsigned int, std::vector<Surface>> tmp = 
+		std::make_pair(layer, dumvec);
 	      m_clusterSurfaceMapTpcEdit.insert(tmp);
 	    }
 	  

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -164,7 +164,7 @@ class MakeActsGeometry : public SubsysReco
   /// Several maps that connect Acts world to sPHENIX G4 world 
   std::map<TrkrDefs::hitsetkey, TGeoNode*> m_clusterNodeMap;
   std::map<TrkrDefs::hitsetkey, Surface> m_clusterSurfaceMapSilicon;
-  std::map<TrkrDefs::hitsetkey, std::vector<Surface>> m_clusterSurfaceMapTpcEdit;
+  std::map<unsigned int, std::vector<Surface>> m_clusterSurfaceMapTpcEdit;  // uses layer as key
   std::map<TrkrDefs::hitsetkey, Surface> m_clusterSurfaceMapMmEdit;
   
   /// These don't change, we are building the tpc this way!

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -174,7 +174,7 @@ class MakeActsGeometry : public SubsysReco
 
   /// TPC Acts::Surface subdivisions
   double m_minSurfZ = 0.;
-  double m_maxSurfZ = 105.5;
+  double m_maxSurfZ = 105.78;
   unsigned int m_nSurfZ = 1;
   unsigned int m_nSurfPhi = 12;
   double m_surfStepPhi = 0;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -367,7 +367,8 @@ Surface PHActsTrkFitter::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const
 //___________________________________________________________________________________
 Surface PHActsTrkFitter::getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey) const
 {
-  const auto iter = m_surfMaps->tpcSurfaceMap.find(hitsetkey);
+  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+  const auto iter = m_surfMaps->tpcSurfaceMap.find(layer);
   if(iter != m_surfMaps->tpcSurfaceMap.end())
   {
     auto surfvec = iter->second;

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -105,19 +105,20 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	  unsigned int trkrId = TrkrDefs::getTrkrId(cluster_key);
 	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
 
-    // non Tpc clusters are copied unchanged to the new map
+	  // non Tpc clusters are copied unchanged to the new map if they are present
+	  // This is needed for truth seeding case, where the tracks already have silicon clusters 
 	  if(trkrId != TrkrDefs::tpcId) 
-    {
-      // get cluster from original map
-      auto cluster =  _cluster_map->findCluster(cluster_key);	
-      if( !cluster ) continue;
-      
-      // create in corrected map and copy content
-      auto newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
-      newclus->CopyFrom( cluster );
-      continue;      
-    }
-    
+	    {
+	      // get cluster from original map
+	      auto cluster =  _cluster_map->findCluster(cluster_key);	
+	      if( !cluster ) continue;
+	      
+	      // create in corrected map and copy content
+	      auto newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
+	      newclus->CopyFrom( cluster );
+	      continue;      
+	    }
+	  
 	  // get the cluster in 3D coordinates
 	  TrkrCluster *tpc_clus =  _cluster_map->findCluster(cluster_key);
 	  auto global = _transformer.getGlobalPosition(tpc_clus,
@@ -165,7 +166,6 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	   ++clus_iter)
 	{
 	  TrkrDefs::cluskey cluskey = clus_iter->first;
-	  //	  TrkrCluster *cluster = _clustermap->
 	  unsigned int layer = TrkrDefs::getLayer(cluskey);
 	  Acts::Vector3D global = clus_iter->second;
 
@@ -266,7 +266,7 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	  newclus->setLocalY(localPos(1));
 	}
 
-      // The silicon clusters  for this track will be copied over after the matching is done
+      // For normal reconstruction, the silicon clusters  for this track will be copied over after the matching is done
     }
   
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -579,8 +579,8 @@ Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitse
   double surfStepPhi = tGeometry->tpcSurfStepPhi;
   double surfStepZ = tGeometry->tpcSurfStepZ;
 
-  if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0 &&
-    world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
+  if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
+      (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )	
     {
       if(Verbosity() > 2)
 	std::cout <<  "     got it:  surf_phi " << surf_phi << " surf_z " << surf_z 

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -571,47 +571,46 @@ Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitse
       
       auto vec3d = this_surf->center(tGeometry->geoContext);
       std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
-      double surf_phi = atan2(surf_center[1], surf_center[0]);
       double surf_z = surf_center[2];
 
-      // check for wrong side
-      if(world_z / surf_z < 0) continue;   // wrong side
-
-      if(Verbosity() > 2)
-	std::cout << "  try surf_phi " << surf_phi << " surf_z " << surf_z 
-		  << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
-		  << " world_phi " << world_phi << " world_z " << world_z 
-		  << std::endl;        
-
-      // i=0 and i = surf_vec.size()-1 are special cases
-      if(i==0)
+      // check for Z  at start - is this the correct side?
+      if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0)
 	{
-	  if( (world_phi > surf_phi - surfStepPhi  && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
-	      (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
+
+	  double surf_phi = atan2(surf_center[1], surf_center[0]);
+	  
+	  if(Verbosity() > 2)
+	    std::cout << "  try surf_phi " << surf_phi << " surf_z " << surf_z 
+		      << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
+		      << " world_phi " << world_phi << " world_z " << world_z 
+		      << std::endl;        
+	  
+	  // i=0 and i = surf_vec.size()-1 are special cases
+	  if(i==0)
+	    {
+	      if(world_phi > surf_phi - surfStepPhi  && world_phi < surf_phi + surfStepPhi / 2.0 )
+		{
+		  surf_index = i;	  
+		  break;
+		}
+	    }
+	  
+	  if(i==surf_vec.size() - 1)
+	    {
+	      if(world_phi > surf_phi - surfStepPhi/2.0  && world_phi < surf_phi + surfStepPhi  )
+		{
+		  surf_index = i;	  
+		  break;
+		}
+	    }
+	  
+	  if(world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
 	    {
 	      surf_index = i;	  
 	      break;
 	    }
-	}
-
-      if(i==surf_vec.size() - 1)
-	{
-	  if( (world_phi > surf_phi - surfStepPhi/2.0  && world_phi < surf_phi + surfStepPhi  ) &&
-	      (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
-	    {
-	      surf_index = i;	  
-	      break;
-	    }
-	}
-
-      if( (world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 ) &&
-	  (world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0) )
-	{
-	  surf_index = i;	  
-	  break;
 	}
     }
-
 	  
   subsurfkey = surf_index;
   

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -206,7 +206,7 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	    {
 	      /// If the surface can't be found, we can't track with it. So 
 	      /// just continue and don't modify the cluster to the container
-	      std::cout << PHWHERE << "Faild to find surface for cluster " << cluskey << std::endl;
+	      std::cout << PHWHERE << "Failed to find surface for cluster " << cluskey << std::endl;
 	      continue;
 	    }
 
@@ -588,6 +588,8 @@ Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitse
       std::cout << PHWHERE 
 		<< "Error: TPC surface index not defined, skipping cluster!" 
 		<< std::endl;
+      std::cout << "     coordinates: " << world[0] << "  " << world[1] << "  " << world[2] 
+		<< " radius " << sqrt(world[0]*world[0]+world[1]*world[1]) << std::endl;
       return nullptr;
     }
   

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -561,60 +561,38 @@ Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitse
   
   std::vector<Surface> surf_vec = mapIter->second;
   unsigned int surf_index = 999;
-  
+    
+  // Predict which surface index this phi and z will correspond to
+  // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
+  double fraction =  (world_phi + M_PI) / (2.0 * M_PI);
+  double rounded_nsurf = round( (double) (surf_vec.size()/2) * fraction  - 0.5);
+  unsigned int nsurf = (unsigned int) rounded_nsurf; 
+  if(world_z < 0)
+    nsurf += surf_vec.size()/2;
+
+  Surface this_surf = surf_vec[nsurf];
+      
+  auto vec3d = this_surf->center(tGeometry->geoContext);
+  std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
+  double surf_z = surf_center[2];
+  double surf_phi = atan2(surf_center[1], surf_center[0]);
   double surfStepPhi = tGeometry->tpcSurfStepPhi;
   double surfStepZ = tGeometry->tpcSurfStepZ;
-  
-  for(unsigned int i=0;i<surf_vec.size(); ++i)
+
+  if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0 &&
+    world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
     {
-      Surface this_surf = surf_vec[i];
+      if(Verbosity() > 2)
+	std::cout <<  "     got it:  surf_phi " << surf_phi << " surf_z " << surf_z 
+		  << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
+		  << " world_phi " << world_phi << " world_z " << world_z 
+		  << " rounded_nsurf "<< rounded_nsurf << " surf_index " << nsurf
+		  << std::endl;        
       
-      auto vec3d = this_surf->center(tGeometry->geoContext);
-      std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
-      double surf_z = surf_center[2];
-
-      // check for Z  at start - is this the correct side?
-      if(world_z > surf_z - surfStepZ / 2.0 && world_z < surf_z + surfStepZ / 2.0)
-	{
-
-	  double surf_phi = atan2(surf_center[1], surf_center[0]);
-	  
-	  if(Verbosity() > 2)
-	    std::cout << "  try surf_phi " << surf_phi << " surf_z " << surf_z 
-		      << " surfStepPhi/2 " << surfStepPhi/2.0 << " surfStepZ/2 " << surfStepZ/2.0  
-		      << " world_phi " << world_phi << " world_z " << world_z 
-		      << std::endl;        
-	  
-	  // i=0 and i = surf_vec.size()-1 are special cases
-	  if(i==0)
-	    {
-	      if(world_phi > surf_phi - surfStepPhi  && world_phi < surf_phi + surfStepPhi / 2.0 )
-		{
-		  surf_index = i;	  
-		  break;
-		}
-	    }
-	  
-	  if(i==surf_vec.size() - 1)
-	    {
-	      if(world_phi > surf_phi - surfStepPhi/2.0  && world_phi < surf_phi + surfStepPhi  )
-		{
-		  surf_index = i;	  
-		  break;
-		}
-	    }
-	  
-	  if(world_phi > surf_phi - surfStepPhi / 2.0 && world_phi < surf_phi + surfStepPhi / 2.0 )
-	    {
-	      surf_index = i;	  
-	      break;
-	    }
-	}
-    }
-	  
-  subsurfkey = surf_index;
-  
-  if(surf_index == 999)
+      surf_index = nsurf;
+      subsurfkey = nsurf;
+    }    
+  else
     {
       std::cout << PHWHERE 
 		<< "Error: TPC surface index not defined, skipping cluster!" 
@@ -622,6 +600,9 @@ Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitse
       std::cout << "     coordinates: " << world[0] << "  " << world[1] << "  " << world[2] 
 		<< " radius " << sqrt(world[0]*world[0]+world[1]*world[1]) << std::endl;
       std::cout << "     world_phi " << world_phi << " world_z " << world_z << std::endl;
+      std::cout << "     surf coords: " << surf_center[0] << "  " << surf_center[1] << "  " << surf_center[2] << std::endl;
+      std::cout << "     surf_phi " << surf_phi << " surf_z " << surf_z << std::endl; 
+      std::cout << " number of surfaces " << surf_vec.size() << std::endl;
       return nullptr;
     }
   


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes issues with getting the TPC subsurface key from global cluster coordinates after distortion corrections. The subsurface is found from coordinates in PHTpcClusterizer and in PHTpcClusterMover, so both are affected by this PR.
1) The cause of the occasional failure to find a TPC surface for distortion corrected clusters is that they sometimes change hitsets. In that case,  the surface vector returned using the hitset key is the wrong one. Discussed this with Joe, and we decided to use a single surface vector for each layer in the TPC (240 surfaces per layer), rather than subdividing the surfaces by hitset. This is the only way we could think of to keep the same cluster key for the corrected clusters. So now the TPC surface map uses the layer, an unsigned int, as the key instead of a hitset key. The user interfaces did not change, since the layer can be determined from the hitsetkey.  
2) Searching 240 surfaces in a layer every time we need to get the subsurface key from coordinates is pretty slow. I replaced that search with a direct calculation of the surface index, based on the world phi and z values. Seems to work reliably. It does rely on the surface vector being ordered in phi and z as it is now. The code screams loudly if it does not find a surface though. This change was made in PHTpcClusterMover and PHTpcClusterizer.
3) The surface Z step size set in MakeActsGeometry was slightly smaller than the surface center value, so clusters within 0.14 cm of zero were not assigned to a surface. That is now fixed.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

