### PR TITLE
Remove hard-coded eta limits in HcalRawTowerBuilder

### DIFF
--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -154,10 +154,13 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
     phistart = phiend;
     m_RawTowerGeom->set_phibounds(i, range);
   }
-  double etalowbound = -1.1;
+  //double etalowbound = -1.1;
+  double etalowbound = -get_double_param("scinti_eta_coverage_neg");
   for (int i = 0; i < get_int_param("etabins"); i++)
   {
-    double etahibound = etalowbound + 2.2 / get_int_param("etabins");
+    //double etahibound = etalowbound + 2.2 / get_int_param("etabins");
+    double etahibound = etalowbound + 
+      (get_double_param("scinti_eta_coverage_neg")+get_double_param("scinti_eta_coverage_pos")) / get_int_param("etabins");
     std::pair<double, double> range = std::make_pair(etalowbound, etahibound);
     m_RawTowerGeom->set_etabounds(i, range);
     etalowbound = etahibound;
@@ -441,6 +444,10 @@ void HcalRawTowerBuilder::SetDefaultParameters()
   set_default_double_param("emin", 1.e-6);
   set_default_double_param(PHG4HcalDefs::outerrad, NAN);
   set_default_double_param(PHG4HcalDefs::innerrad, NAN);
+
+  set_default_double_param("scinti_eta_coverage_neg", 1.1);
+  set_default_double_param("scinti_eta_coverage_pos", 1.1);
+
 }
 
 void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
@@ -466,6 +473,8 @@ void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
   if (nTiles <= 0)
   {
     nTiles = pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_pos) + pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_neg);
+    set_double_param("scinti_eta_coverage_neg",pars->get_double_param("scinti_eta_coverage_neg")); 
+    set_double_param("scinti_eta_coverage_pos",pars->get_double_param("scinti_eta_coverage_pos"));     
   }
   set_int_param("etabins", nTiles);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

HcalRawTowerBuilder was using hard coded pseudorapidity limits for the towers of -1.1 to 1.1.  This is fine for sPHENIX, but does not work for ECCE with the modified inner HCAL covering -1.45 to 1.15.  The towers and clusters were coming out systematically shifted to the wrong pseudorapidity. 

The code was modified to pull in the corresponding limits from the geometry parameters. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

