### PR TITLE
Use distortion corrected clusters in pre-propagator circle fitter

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -271,6 +271,19 @@ PositionMap PHCASeeding::FillTree()
 
       // get global position, convert to Acts::Vector3F and store in map
       const Acts::Vector3D globalpos_d = getGlobalPosition(cluster);
+
+      if(Verbosity() > 3)
+	{
+	  ActsTransformations transformer;
+	  auto global_before = transformer.getGlobalPosition(cluster,
+							     surfMaps,
+							     tGeometry);
+	  TrkrDefs::cluskey key = cluster->getClusKey();
+	  std::cout << "CaSeeder: Cluster: " << key << std::endl;
+	  std::cout << " Global before: " << global_before[0] << "  " << global_before[1] << "  " << global_before[2] << std::endl;
+	  std::cout << " Global after   : " << globalpos_d[0] << "  " << globalpos_d[1] << "  " << globalpos_d[2] << std::endl;
+	}
+
       const Acts::Vector3F globalpos = { (float) globalpos_d.x(), (float) globalpos_d.y(), (float) globalpos_d.z()};
       cachedPositions.insert(std::make_pair(ckey, globalpos));
 

--- a/offline/packages/trackreco/PHTpcTrackSeedCircleFit.h
+++ b/offline/packages/trackreco/PHTpcTrackSeedCircleFit.h
@@ -6,6 +6,7 @@
 #include <fun4all/SubsysReco.h>
 #include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase/ActsTrackingGeometry.h>
+#include <tpc/TpcDistortionCorrection.h>
 
 #include <string>
 #include <vector>
@@ -41,13 +42,20 @@ class PHTpcTrackSeedCircleFit : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
   std::vector<TrkrCluster*> getTrackClusters(SvtxTrack *);
+  Acts::Vector3D getGlobalPosition( TrkrCluster* cluster ) const;
 						    
   ActsSurfaceMaps *_surfmaps{nullptr};
   ActsTrackingGeometry *_tGeometry{nullptr};
   SvtxTrackMap *_track_map{nullptr};
   
   bool _use_truth_clusters = false;
+  bool _are_clusters_corrected = true;
   TrkrClusterContainer *_cluster_map = nullptr;
+  /// distortion correction container
+  TpcDistortionCorrectionContainer* _dcc = nullptr;
+ /// tpc distortion correction utility class
+  TpcDistortionCorrection _distortionCorrection;
+
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
 


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Modified PHTpcTrackSeedCircleFit so that it uses distortion corrected clusters, whether in the pre-propagator or final instance. It now checks to see if:
a) It is using the original cluster map.
b) A distortion correction map is available.
If both are true (happens in pre-propagator case when distortion corrections are enabled only) it corrects the clusters for distortions. The circle fit after the cluster mover uses corrected clusters from the node tree, and is not affected.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

