### PR TITLE
Base-line shift tool PHG4TpcPadBaselineShift is added 

### DIFF
--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -30,6 +30,7 @@ pkginclude_HEADERS = \
   PHG4TpcDistortion.h \
   PHG4TpcElectronDrift.h \
   PHG4TpcEndCapSubsystem.h \
+  PHG4TpcPadBaselineShift.h \
   PHG4TpcPadPlane.h \
   PHG4TpcPadPlaneReadout.h \
   PHG4TpcSubsystem.h 
@@ -46,6 +47,7 @@ libg4tpc_la_SOURCES = \
   PHG4TpcEndCapDisplayAction.cc \
   PHG4TpcEndCapSteppingAction.cc \
   PHG4TpcEndCapSubsystem.cc \
+  PHG4TpcPadBaselineShift.cc \
   PHG4TpcPadPlane.cc \
   PHG4TpcPadPlaneReadout.cc \
   PHG4TpcSteppingAction.cc \

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -8,11 +8,7 @@
 #include <trackbase/TrkrClusterHitAssoc.h>   // for TrkrClusterHi...
 #include <trackbase/TrkrHit.h>               // for TrkrHit
 
-//#include <trackbase/TrkrClusterContainerv3.h>
-//#include <trackbase/TrkrClusterv2.h>
-//#include <trackbase/TrkrClusterHitAssocv3.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
-//#include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 
@@ -22,20 +18,11 @@
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
-//#include <Acts/Utilities/Units.hpp>
-//#include <Acts/Surfaces/Surface.hpp>
-
 #include <phool/PHCompositeNode.h>
-//#include <phool/PHIODataNode.h>                         // for PHIODataNode
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-//#include <phool/PHObject.h>                             // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
-
-// #include <TMatrixFfwd.h>    // for TMatrixF
-// #include <TMatrixT.h>       // for TMatrixT, ope...
-// #include <TMatrixTUtils.h>  // for TMatrixTRow
 
 #include <TF1.h>
 #include <TFile.h>
@@ -46,12 +33,7 @@
 #include <map>  // for _Rb_tree_cons...
 #include <string>
 #include <utility>  // for pair
-//#include <array>
 #include <vector>
-
-//#include <fun4all/Fun4AllReturnCodes.h>
-
-//#include <phool/PHCompositeNode.h>
 
 namespace
 {
@@ -61,9 +43,6 @@ namespace
     return x * x;
   }
 }  // namespace
-
-//typedef std::pair<unsigned short, unsigned short> iphiz;
-//typedef std::pair<unsigned short, iphiz> ihit;
 
 int findRBin(float R)
 {
@@ -187,7 +166,9 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
   //  int print_layer = 18;
 
   if (Verbosity() > 1000)
+  {
     std::cout << "PHG4TpcPadBaselineShift::Process_Event" << std::endl;
+  }
 
   PHNodeIterator iter(topNode);
   PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
@@ -326,7 +307,9 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
       float_t fadc = (hitr->second->getAdc());  // proper int rounding +0.5
       unsigned short adc = 0;
       if (fadc > 0)
+      {
         adc = (unsigned short) fadc;
+      }
       if (phibin >= phibins) continue;
       if (zbin >= zbins) continue;  // zbin is unsigned int, <0 cannot happen
       adcval[zbin] = (unsigned short) adc;
@@ -335,7 +318,7 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
     //Define ion-induced charge
     sumADC /= phibins;
     float ind_charge = -0.5 * sumADC * _CScale;  //CScale is the coefficient related to the capacitance of the bottom layer of the bottom GEM
-    double pi = 2 * acos(0.0);
+    double pi = M_PI;
 
     for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second; ++hitr)
     {

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -1,0 +1,452 @@
+#include "PHG4TpcPadBaselineShift.h"
+
+#include <tpc/TpcDefs.h>
+
+#include <trackbase/TrkrClusterContainerv3.h>
+#include <trackbase/TrkrClusterv2.h>
+#include <trackbase/TrkrClusterHitAssocv3.h>
+#include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
+#include <trackbase/TrkrHitv2.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                         // for SubsysReco
+
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+
+#include <Acts/Utilities/Units.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>                         // for PHIODataNode
+#include <phool/PHNode.h>                               // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>                             // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+
+#include <TMatrixFfwd.h>    // for TMatrixF
+#include <TMatrixT.h>       // for TMatrixT, ope...
+#include <TMatrixTUtils.h>  // for TMatrixTRow
+
+#include <TFile.h>  
+#include <TF1.h>
+#include <TTree.h>
+
+#include <cmath>  // for sqrt, cos, sin
+#include <iostream>
+#include <map>  // for _Rb_tree_cons...
+#include <string>
+#include <utility>  // for pair
+#include <array>
+#include <vector>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+//#include <phool/PHCompositeNode.h>
+
+namespace 
+{
+  template<class T> inline constexpr T square( const T& x ) { return x*x; }
+}
+
+typedef std::pair<unsigned short, unsigned short> iphiz;
+typedef std::pair<unsigned short, iphiz> ihit;
+
+int findRBin(float R){
+  // Finding pad number from the center (bin) for hits
+  int binR=-1;
+  //Realistic binning
+  //double r_bins[r_bins_N+1] = {217.83, 
+  //                            311.05,317.92,323.31,329.27,334.63,340.59,345.95,351.91,357.27,363.23,368.59,374.55,379.91,385.87,391.23,397.19,402.49,
+  //                            411.53,421.70,431.90,442.11,452.32,462.52,472.73,482.94,493.14,503.35,513.56,523.76,533.97,544.18,554.39,564.59,574.76,
+  //                            583.67,594.59,605.57,616.54,627.51,638.48,649.45,660.42,671.39,682.36,693.33,704.30,715.27,726.24,737.21,748.18,759.11};
+  const int r_bins_N = 53;
+  double r_bins[r_bins_N+1];
+  r_bins[0]=30.3125;
+  double bin_width=0.625;
+  for(int i=1;i<r_bins_N;i++){
+    if(i==16) bin_width=0.9375;
+    if(i>16) bin_width=1.25;
+    if(i==31) bin_width=1.1562;
+    if(i>31) bin_width=1.0624;
+
+    r_bins[i]=r_bins[i-1]+bin_width;
+
+  }
+
+
+  double R_min = 30;
+  while(R>R_min){
+    binR+=1;
+    R_min=r_bins[binR];
+  }
+  return binR;
+
+}
+
+//____________________________________________________________________________..
+PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name):
+ SubsysReco(name)
+  , m_hits(nullptr)
+  , m_clusterlist(nullptr)
+  , m_clusterhitassoc(nullptr)
+  , m_surfMaps(nullptr)
+  , m_tGeometry(nullptr)
+  , do_hit_assoc(true)
+  , pedestal(74.4)
+  ,_writeTree(0)
+  , SectorFiducialCut(0.5)
+  , NSearch(2)
+  , NZBinsMax(0)
+  , _CScale(1)
+  , outfile(nullptr)
+  , _filename("./hitsBLS.root")
+
+  {
+  std::cout << "PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name) Calling ctor" << std::endl;
+}
+
+bool PHG4TpcPadBaselineShift::is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom)
+{
+  bool reject_it = false;
+
+  // sector boundaries occur every 1/12 of the full phi bin range  
+  int PhiBins = layergeom->get_phibins();
+  int PhiBinsSector = PhiBins/12;
+
+  double radius = layergeom->get_radius();
+  double PhiBinSize = 2.0* radius * M_PI / (double) PhiBins;
+
+  // sector starts where?
+  int sector_lo = sector * PhiBinsSector;
+  int sector_hi = sector_lo + PhiBinsSector - 1;
+
+  int sector_fiducial_bins = (int) (SectorFiducialCut / PhiBinSize);
+
+  if(phibin < sector_lo + sector_fiducial_bins || phibin > sector_hi - sector_fiducial_bins)
+    {
+      reject_it = true;
+    }
+
+  return reject_it;
+}
+//____________________________________________________________________________..
+PHG4TpcPadBaselineShift::~PHG4TpcPadBaselineShift()
+{
+  std::cout << "PHG4TpcPadBaselineShift::~PHG4TpcPadBaselineShift() Calling dtor" << std::endl;
+}
+
+//____________________________________________________________________________..
+int PHG4TpcPadBaselineShift::Init(PHCompositeNode */*topNode*/)
+{
+  //outfile = new TFile(_filename.c_str(), "RECREATE");
+  _hit_z   = 0;
+  _hit_r   = 0;
+  _hit_phi = 0;
+  _hit_e = 0;
+  _hit_adc = 0;
+  _hit_adc_bls = 0;
+  _hit_layer=-1;
+  _hit_sector=-1;
+  if(_writeTree==1){
+    outfile = new TFile(_filename.c_str(), "RECREATE");
+    _rawHits=new TTree("hTree","tpc hit tree for base-line shift tests");
+    _rawHits->Branch("z",&_hit_z);
+    _rawHits->Branch("r",&_hit_r);
+    _rawHits->Branch("phi",&_hit_phi);
+    _rawHits->Branch("e",&_hit_e);
+    _rawHits->Branch("adc",&_hit_adc);
+    _rawHits->Branch("adc_BLS",&_hit_adc_bls);
+    _rawHits->Branch("hit_layer",&_hit_layer);
+    _rawHits->Branch("_hit_sector",&_hit_sector);
+  }
+  return 0;
+  //std::cout << "PHG4TpcPadBaselineShift::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  //return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  std::cout << "PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
+{
+  //  int print_layer = 18;
+  
+  if (Verbosity() > 1000)
+    std::cout << "PHG4TpcPadBaselineShift::Process_Event" << std::endl;
+
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // get node containing the digitized hits
+  m_hits = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  if (!m_hits)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // get node for clusters
+  m_clusterlist = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!m_clusterlist)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTER." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  // get node for cluster hit associations
+  m_clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  if (!m_clusterhitassoc)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERHITASSOC" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  
+  PHG4CylinderCellGeomContainer *geom_container =
+      findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom_container)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode,
+							 "ActsTrackingGeometry");
+  if(!m_tGeometry)
+    {
+      std::cout << PHWHERE
+		<< "ActsTrackingGeometry not found on node tree. Exiting"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+  m_surfMaps = findNode::getClass<ActsSurfaceMaps>(topNode,
+						   "ActsSurfaceMaps");
+  if(!m_surfMaps)
+    {
+      std::cout << PHWHERE 
+		<< "ActsSurfaceMaps not found on node tree. Exiting"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
+
+  // The hits are stored in hitsets, where each hitset contains all hits in a given TPC readout (layer, sector, side), so clusters are confined to a hitset
+  // The TPC clustering is more complicated than for the silicon, because we have to deal with overlapping clusters
+
+  // loop over the TPC HitSet objects
+  TrkrHitSetContainer::ConstRange hitsetrange = m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);
+  //const int num_hitsets = std::distance(hitsetrange.first,hitsetrange.second);
+
+
+  
+
+  //Loop over R positions & sectors
+  for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
+       hitsetitr != hitsetrange.second;
+       ++hitsetitr)
+       {
+    TrkrHitSet *hitset = hitsetitr->second;
+    unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
+    int side = TpcDefs::getSide(hitsetitr->first);
+    unsigned int sector= TpcDefs::getSectorId(hitsetitr->first);
+    PHG4CylinderCellGeom *layergeom = geom_container->GetLayerCellGeom(layer);
+    
+    _hit_sector=sector;
+    _hit_layer=layer;
+
+    double radius = layergeom->get_radius();//in cm
+
+    _hit_r=radius  ;
+
+
+    unsigned short NPhiBins = (unsigned short) layergeom->get_phibins();
+    unsigned short NPhiBinsSector = NPhiBins/12;
+    unsigned short NZBins = (unsigned short)layergeom->get_zbins();
+    unsigned short NZBinsSide = NZBins/2;
+    unsigned short NZBinsMin = 0;
+    unsigned short PhiOffset = NPhiBinsSector * sector;
+
+
+
+    if (side == 0){
+      NZBinsMin = 0;
+      NZBinsMax = NZBins / 2 -1;
+    }
+    else{
+      NZBinsMin = NZBins / 2;
+      NZBinsMax = NZBins;
+    }
+    unsigned short ZOffset = NZBinsMin;
+    //Gives per pad ADC for particular R and sector in event
+    int perPadADC=0;
+    unsigned short phibins = NPhiBinsSector;
+    unsigned short phioffset = PhiOffset;
+    unsigned short zbins=NZBinsSide;
+    unsigned short zoffset=ZOffset;
+    float sumADC = perPadADC;
+
+    //phibins - number of pads in the sector
+    //The Sampa clock time is 18.8 MHz, so the sampling time is 53.2 ns = 1 Z bin.
+    //The Z bin range for one side of the TPC is 0-248.
+    //Check: 249 bins x 53.2 ns = 13.2 microseconds.
+    //The maximum drift time in the TPC is 13.2 microseconds.
+    //So, 53.2 ns / Z bin.
+
+    TF1 *f1 = new TF1("f1","[0]*exp(-(x-[1])/[2])",0,1000);
+    f1->SetParameter(0,0.005);
+    f1->SetParameter(1,0);
+    f1->SetParameter(2,60); // in terms of 50nsec time bins
+
+    sumADC=0;
+    TrkrHitSet::ConstRange hitrangei = hitset->getHits();
+
+    std::vector<unsigned short> adcval(zbins, 0);
+    std::multimap<unsigned short, ihit> all_hit_map;
+    std::vector<ihit> hit_vect;
+    // Loop over phi & z
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second;++hitr){
+      unsigned short phibin = TpcDefs::getPad(hitr->first) - phioffset;
+      unsigned short zbin = TpcDefs::getTBin(hitr->first) - zoffset;
+      float_t fadc = (hitr->second->getAdc()) ; // proper int rounding +0.5
+      unsigned short adc = 0;
+      if(fadc>0) 
+        adc =  (unsigned short) fadc;
+      if(phibin >= phibins) continue;
+      if(zbin   >= zbins) continue; // zbin is unsigned int, <0 cannot happen
+      adcval[zbin] = (unsigned short) adc;
+      sumADC+=adc;
+      }
+    //Define ion-induced charge
+    sumADC/=phibins;
+    float ind_charge = -0.5*sumADC*_CScale;//CScale is the coefficient related to the capacitance of the bottom layer of the bottom GEM
+    double pi = 2 * acos(0.0);
+
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second;++hitr){
+      unsigned short phibin = TpcDefs::getPad(hitr->first);
+      unsigned short zbin = TpcDefs::getTBin(hitr->first) ;
+     	// Get the hitkey
+	  	TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(phibin, zbin);
+	  	TrkrHit *hit = nullptr;
+      hit = hitsetitr->second->getHit(hitkey);
+
+      zbin = TpcDefs::getTBin(hitr->first);
+      phibin = TpcDefs::getPad(hitr->first);
+      double phi_center = layergeom->get_phicenter(phibin);
+      if (phi_center<0) phi_center+=2*pi;
+      _hit_phi = phi_center;
+      _hit_z = layergeom->get_zcenter(zbin);
+
+      if(hit)_hit_e = hit->getEnergy();        
+      _hit_adc=0;
+      _hit_adc_bls=0;
+
+      float_t fadc = (hitr->second->getAdc()) ;// proper int rounding +0.5
+      _hit_adc=fadc;
+      _hit_adc_bls=_hit_adc+int(ind_charge);
+
+      if(hit && _hit_adc>0){ 
+        //Trkr hit has only one value m_adc which is energy and ADC at the same time
+        if(_hit_adc_bls>0){hit->setAdc(_hit_adc_bls);}
+        else{hit->setAdc(0);}
+      }
+      if(_writeTree==1)_rawHits->Fill();
+    }
+
+
+
+
+    //hitsetitr++;
+
+  }
+  
+  //pthread_attr_destroy(&attr);
+
+  // wait for completion of all threads
+  //for( const auto& thread_pair:threads )
+  //{ 
+  //  int rc2 = pthread_join(thread_pair.thread, nullptr);
+  //  if (rc2) 
+  //  { std::cout << "Error:unable to join," << rc2 << std::endl; }
+  //}
+
+  if (Verbosity() > 0)
+    std::cout << "TPC Clusterizer found " << m_clusterlist->size() << " Clusters "  << std::endl;
+  std::cout << "PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+//int PHG4TpcPadBaselineShift::ResetEvent(PHCompositeNode *topNode)
+//{
+//  std::cout << "PHG4TpcPadBaselineShift::ResetEvent(PHCompositeNode *topNode) Resetting internal structures, prepare for next event" << std::endl;
+//  return Fun4AllReturnCodes::EVENT_OK;
+//}
+
+//____________________________________________________________________________..
+//int PHG4TpcPadBaselineShift::EndRun(const int runnumber)
+//{
+//  std::cout << "PHG4TpcPadBaselineShift::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
+//  return Fun4AllReturnCodes::EVENT_OK;
+//}
+
+//____________________________________________________________________________..
+int PHG4TpcPadBaselineShift::End(PHCompositeNode */*topNode*/)
+{
+  if(_writeTree==1){
+    outfile->cd();
+    outfile->Write();
+    outfile->Close();
+    std::cout << "PHG4TpcPadBaselineShift::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  }
+  //return 0;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+//int PHG4TpcPadBaselineShift::Reset(PHCompositeNode *topNode)
+//{
+// std::cout << "PHG4TpcPadBaselineShift::Reset(PHCompositeNode *topNode) being Reset" << std::endl;
+//  return Fun4AllReturnCodes::EVENT_OK;
+//}
+
+//____________________________________________________________________________..
+//void PHG4TpcPadBaselineShift::Print(const std::string &what) const
+//{
+//  std::cout << "PHG4TpcPadBaselineShift::Print(const std::string &what) const Printing info for " << what << std::endl;
+//}
+void PHG4TpcPadBaselineShift::setScale(float CScale){
+  _CScale = CScale;
+  std::cout << "PHG4TpcPadBaselineShift::setFileName: Scale factor is set to:" << CScale << std::endl;
+}
+void PHG4TpcPadBaselineShift::setFileName(std::string filename){
+  _filename=filename;
+  std::cout << "PHG4TpcPadBaselineShift::setFileName: Output file name for PHG4TpcPadBaselineShift is set to:" << filename << std::endl;
+}
+void PHG4TpcPadBaselineShift::writeTree(int f_writeTree){
+  _writeTree=f_writeTree;
+  std::cout << "PHG4TpcPadBaselineShift::writeTree: True" << std::endl;
+}
+

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -2,11 +2,11 @@
 
 #include <tpc/TpcDefs.h>
 
-#include <trackbase/ActsSurfaceMaps.h>                  // for ActsSurfaceMaps
-#include <trackbase/ActsTrackingGeometry.h>             // for ActsTrackingG...
-#include <trackbase/TrkrClusterContainer.h>             // for TrkrClusterCo...
-#include <trackbase/TrkrClusterHitAssoc.h>              // for TrkrClusterHi...
-#include <trackbase/TrkrHit.h>                          // for TrkrHit
+#include <trackbase/ActsSurfaceMaps.h>       // for ActsSurfaceMaps
+#include <trackbase/ActsTrackingGeometry.h>  // for ActsTrackingG...
+#include <trackbase/TrkrClusterContainer.h>  // for TrkrClusterCo...
+#include <trackbase/TrkrClusterHitAssoc.h>   // for TrkrClusterHi...
+#include <trackbase/TrkrHit.h>               // for TrkrHit
 
 //#include <trackbase/TrkrClusterContainerv3.h>
 //#include <trackbase/TrkrClusterv2.h>
@@ -17,7 +17,7 @@
 #include <trackbase/TrkrHitSetContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
@@ -27,7 +27,7 @@
 
 #include <phool/PHCompositeNode.h>
 //#include <phool/PHIODataNode.h>                         // for PHIODataNode
-#include <phool/PHNode.h>                               // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
 //#include <phool/PHObject.h>                             // for PHObject
 #include <phool/getClass.h>
@@ -37,8 +37,8 @@
 // #include <TMatrixT.h>       // for TMatrixT, ope...
 // #include <TMatrixTUtils.h>  // for TMatrixTRow
 
-#include <TFile.h>  
 #include <TF1.h>
+#include <TFile.h>
 #include <TTree.h>
 
 #include <cmath>  // for sqrt, cos, sin
@@ -53,50 +53,54 @@
 
 //#include <phool/PHCompositeNode.h>
 
-namespace 
+namespace
 {
-  template<class T> inline constexpr T square( const T& x ) { return x*x; }
-}
+  template <class T>
+  inline constexpr T square(const T &x)
+  {
+    return x * x;
+  }
+}  // namespace
 
 //typedef std::pair<unsigned short, unsigned short> iphiz;
 //typedef std::pair<unsigned short, iphiz> ihit;
 
-int findRBin(float R){
+int findRBin(float R)
+{
   // Finding pad number from the center (bin) for hits
-  int binR=-1;
+  int binR = -1;
   //Realistic binning
-  //double r_bins[r_bins_N+1] = {217.83, 
+  //double r_bins[r_bins_N+1] = {217.83,
   //                            311.05,317.92,323.31,329.27,334.63,340.59,345.95,351.91,357.27,363.23,368.59,374.55,379.91,385.87,391.23,397.19,402.49,
   //                            411.53,421.70,431.90,442.11,452.32,462.52,472.73,482.94,493.14,503.35,513.56,523.76,533.97,544.18,554.39,564.59,574.76,
   //                            583.67,594.59,605.57,616.54,627.51,638.48,649.45,660.42,671.39,682.36,693.33,704.30,715.27,726.24,737.21,748.18,759.11};
   const int r_bins_N = 53;
-  double r_bins[r_bins_N+1];
-  r_bins[0]=30.3125;
-  double bin_width=0.625;
-  for(int i=1;i<r_bins_N;i++){
-    if(i==16) bin_width=0.9375;
-    if(i>16) bin_width=1.25;
-    if(i==31) bin_width=1.1562;
-    if(i>31) bin_width=1.0624;
+  double r_bins[r_bins_N + 1];
+  r_bins[0] = 30.3125;
+  double bin_width = 0.625;
+  for (int i = 1; i < r_bins_N; i++)
+  {
+    if (i == 16) bin_width = 0.9375;
+    if (i > 16) bin_width = 1.25;
+    if (i == 31) bin_width = 1.1562;
+    if (i > 31) bin_width = 1.0624;
 
-    r_bins[i]=r_bins[i-1]+bin_width;
-
+    r_bins[i] = r_bins[i - 1] + bin_width;
   }
-
 
   double R_min = 30;
-  while(R>R_min){
-    binR+=1;
-    R_min=r_bins[binR];
+  while (R > R_min)
+  {
+    binR += 1;
+    R_min = r_bins[binR];
   }
   return binR;
-
 }
 
 //____________________________________________________________________________..
-PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name):
- SubsysReco(name)
-  {
+PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name)
+  : SubsysReco(name)
+{
   std::cout << "PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name) Calling ctor" << std::endl;
 }
 
@@ -104,12 +108,12 @@ bool PHG4TpcPadBaselineShift::is_in_sector_boundary(int phibin, int sector, PHG4
 {
   bool reject_it = false;
 
-  // sector boundaries occur every 1/12 of the full phi bin range  
+  // sector boundaries occur every 1/12 of the full phi bin range
   int PhiBins = layergeom->get_phibins();
-  int PhiBinsSector = PhiBins/12;
+  int PhiBinsSector = PhiBins / 12;
 
   double radius = layergeom->get_radius();
-  double PhiBinSize = 2.0* radius * M_PI / (double) PhiBins;
+  double PhiBinSize = 2.0 * radius * M_PI / (double) PhiBins;
 
   // sector starts where?
   int sector_lo = sector * PhiBinsSector;
@@ -117,10 +121,10 @@ bool PHG4TpcPadBaselineShift::is_in_sector_boundary(int phibin, int sector, PHG4
 
   int sector_fiducial_bins = (int) (SectorFiducialCut / PhiBinSize);
 
-  if(phibin < sector_lo + sector_fiducial_bins || phibin > sector_hi - sector_fiducial_bins)
-    {
-      reject_it = true;
-    }
+  if (phibin < sector_lo + sector_fiducial_bins || phibin > sector_hi - sector_fiducial_bins)
+  {
+    reject_it = true;
+  }
 
   return reject_it;
 }
@@ -131,28 +135,29 @@ PHG4TpcPadBaselineShift::~PHG4TpcPadBaselineShift()
 }
 
 //____________________________________________________________________________..
-int PHG4TpcPadBaselineShift::Init(PHCompositeNode */*topNode*/)
+int PHG4TpcPadBaselineShift::Init(PHCompositeNode * /*topNode*/)
 {
   //outfile = new TFile(_filename.c_str(), "RECREATE");
-  _hit_z   = 0;
-  _hit_r   = 0;
+  _hit_z = 0;
+  _hit_r = 0;
   _hit_phi = 0;
   _hit_e = 0;
   _hit_adc = 0;
   _hit_adc_bls = 0;
-  _hit_layer=-1;
-  _hit_sector=-1;
-  if(_writeTree==1){
+  _hit_layer = -1;
+  _hit_sector = -1;
+  if (_writeTree == 1)
+  {
     outfile = new TFile(_filename.c_str(), "RECREATE");
-    _rawHits=new TTree("hTree","tpc hit tree for base-line shift tests");
-    _rawHits->Branch("z",&_hit_z);
-    _rawHits->Branch("r",&_hit_r);
-    _rawHits->Branch("phi",&_hit_phi);
-    _rawHits->Branch("e",&_hit_e);
-    _rawHits->Branch("adc",&_hit_adc);
-    _rawHits->Branch("adc_BLS",&_hit_adc_bls);
-    _rawHits->Branch("hit_layer",&_hit_layer);
-    _rawHits->Branch("_hit_sector",&_hit_sector);
+    _rawHits = new TTree("hTree", "tpc hit tree for base-line shift tests");
+    _rawHits->Branch("z", &_hit_z);
+    _rawHits->Branch("r", &_hit_r);
+    _rawHits->Branch("phi", &_hit_phi);
+    _rawHits->Branch("e", &_hit_e);
+    _rawHits->Branch("adc", &_hit_adc);
+    _rawHits->Branch("adc_BLS", &_hit_adc_bls);
+    _rawHits->Branch("hit_layer", &_hit_layer);
+    _rawHits->Branch("_hit_sector", &_hit_sector);
   }
   return 0;
   //std::cout << "PHG4TpcPadBaselineShift::Init(PHCompositeNode *topNode) Initializing" << std::endl;
@@ -180,7 +185,7 @@ int PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode)
 int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
 {
   //  int print_layer = 18;
-  
+
   if (Verbosity() > 1000)
     std::cout << "PHG4TpcPadBaselineShift::Process_Event" << std::endl;
 
@@ -215,7 +220,7 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
     std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERHITASSOC" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  
+
   PHG4CylinderCellGeomContainer *geom_container =
       findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!geom_container)
@@ -225,24 +230,24 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
   }
 
   m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode,
-							 "ActsTrackingGeometry");
-  if(!m_tGeometry)
-    {
-      std::cout << PHWHERE
-		<< "ActsTrackingGeometry not found on node tree. Exiting"
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+                                                         "ActsTrackingGeometry");
+  if (!m_tGeometry)
+  {
+    std::cout << PHWHERE
+              << "ActsTrackingGeometry not found on node tree. Exiting"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
 
   m_surfMaps = findNode::getClass<ActsSurfaceMaps>(topNode,
-						   "ActsSurfaceMaps");
-  if(!m_surfMaps)
-    {
-      std::cout << PHWHERE 
-		<< "ActsSurfaceMaps not found on node tree. Exiting"
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+                                                   "ActsSurfaceMaps");
+  if (!m_surfMaps)
+  {
+    std::cout << PHWHERE
+              << "ActsSurfaceMaps not found on node tree. Exiting"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
 
   // The hits are stored in hitsets, where each hitset contains all hits in a given TPC readout (layer, sector, side), so clusters are confined to a hitset
   // The TPC clustering is more complicated than for the silicon, because we have to deal with overlapping clusters
@@ -251,53 +256,49 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
   TrkrHitSetContainer::ConstRange hitsetrange = m_hits->getHitSets(TrkrDefs::TrkrId::tpcId);
   //const int num_hitsets = std::distance(hitsetrange.first,hitsetrange.second);
 
-
-  
-
   //Loop over R positions & sectors
   for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
        hitsetitr != hitsetrange.second;
        ++hitsetitr)
-       {
+  {
     TrkrHitSet *hitset = hitsetitr->second;
     unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
     int side = TpcDefs::getSide(hitsetitr->first);
-    unsigned int sector= TpcDefs::getSectorId(hitsetitr->first);
+    unsigned int sector = TpcDefs::getSectorId(hitsetitr->first);
     PHG4CylinderCellGeom *layergeom = geom_container->GetLayerCellGeom(layer);
-    
-    _hit_sector=sector;
-    _hit_layer=layer;
 
-    double radius = layergeom->get_radius();//in cm
+    _hit_sector = sector;
+    _hit_layer = layer;
 
-    _hit_r=radius  ;
+    double radius = layergeom->get_radius();  //in cm
 
+    _hit_r = radius;
 
     unsigned short NPhiBins = (unsigned short) layergeom->get_phibins();
-    unsigned short NPhiBinsSector = NPhiBins/12;
-    unsigned short NZBins = (unsigned short)layergeom->get_zbins();
-    unsigned short NZBinsSide = NZBins/2;
+    unsigned short NPhiBinsSector = NPhiBins / 12;
+    unsigned short NZBins = (unsigned short) layergeom->get_zbins();
+    unsigned short NZBinsSide = NZBins / 2;
     unsigned short NZBinsMin = 0;
     unsigned short PhiOffset = NPhiBinsSector * sector;
 
-
-
-    if (side == 0){
+    if (side == 0)
+    {
       NZBinsMin = 0;
-      NZBinsMax = NZBins / 2 -1;
+      NZBinsMax = NZBins / 2 - 1;
     }
-    else{
+    else
+    {
       NZBinsMin = NZBins / 2;
       NZBinsMax = NZBins;
     }
     unsigned short ZOffset = NZBinsMin;
     //Gives per pad ADC for particular R and sector in event
-    int perPadADC=0;
+    int perPadADC = 0;
     unsigned short phibins = NPhiBinsSector;
     unsigned short phioffset = PhiOffset;
-    unsigned short zbins=NZBinsSide;
-    unsigned short zoffset=ZOffset;
-    float sumADC = perPadADC; // 14 lines later just set to zero
+    unsigned short zbins = NZBinsSide;
+    unsigned short zoffset = ZOffset;
+    float sumADC = perPadADC;  // 14 lines later just set to zero
 
     //phibins - number of pads in the sector
     //The Sampa clock time is 18.8 MHz, so the sampling time is 53.2 ns = 1 Z bin.
@@ -306,85 +307,90 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
     //The maximum drift time in the TPC is 13.2 microseconds.
     //So, 53.2 ns / Z bin.
 
-    TF1 *f1 = new TF1("f1","[0]*exp(-(x-[1])/[2])",0,1000);
-    f1->SetParameter(0,0.005);
-    f1->SetParameter(1,0);
-    f1->SetParameter(2,60); // in terms of 50nsec time bins
+    TF1 *f1 = new TF1("f1", "[0]*exp(-(x-[1])/[2])", 0, 1000);
+    f1->SetParameter(0, 0.005);
+    f1->SetParameter(1, 0);
+    f1->SetParameter(2, 60);  // in terms of 50nsec time bins
 
-//    sumADC=0.; // this is set to zero 14 lines up (perPadADC is zero)
+    //    sumADC=0.; // this is set to zero 14 lines up (perPadADC is zero)
     TrkrHitSet::ConstRange hitrangei = hitset->getHits();
 
     std::vector<unsigned short> adcval(zbins, 0);
-//    std::multimap<unsigned short, ihit> all_hit_map;
-//    std::vector<ihit> hit_vect;
+    //    std::multimap<unsigned short, ihit> all_hit_map;
+    //    std::vector<ihit> hit_vect;
     // Loop over phi & z
-    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second;++hitr){
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second; ++hitr)
+    {
       unsigned short phibin = TpcDefs::getPad(hitr->first) - phioffset;
       unsigned short zbin = TpcDefs::getTBin(hitr->first) - zoffset;
-      float_t fadc = (hitr->second->getAdc()) ; // proper int rounding +0.5
+      float_t fadc = (hitr->second->getAdc());  // proper int rounding +0.5
       unsigned short adc = 0;
-      if(fadc>0) 
-        adc =  (unsigned short) fadc;
-      if(phibin >= phibins) continue;
-      if(zbin   >= zbins) continue; // zbin is unsigned int, <0 cannot happen
+      if (fadc > 0)
+        adc = (unsigned short) fadc;
+      if (phibin >= phibins) continue;
+      if (zbin >= zbins) continue;  // zbin is unsigned int, <0 cannot happen
       adcval[zbin] = (unsigned short) adc;
-      sumADC+=adc;
-      }
+      sumADC += adc;
+    }
     //Define ion-induced charge
-    sumADC/=phibins;
-    float ind_charge = -0.5*sumADC*_CScale;//CScale is the coefficient related to the capacitance of the bottom layer of the bottom GEM
+    sumADC /= phibins;
+    float ind_charge = -0.5 * sumADC * _CScale;  //CScale is the coefficient related to the capacitance of the bottom layer of the bottom GEM
     double pi = 2 * acos(0.0);
 
-    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second;++hitr){
+    for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second; ++hitr)
+    {
       unsigned short phibin = TpcDefs::getPad(hitr->first);
-      unsigned short zbin = TpcDefs::getTBin(hitr->first) ;
-     	// Get the hitkey
-	  	TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(phibin, zbin);
-	  	TrkrHit *hit = nullptr;
+      unsigned short zbin = TpcDefs::getTBin(hitr->first);
+      // Get the hitkey
+      TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(phibin, zbin);
+      TrkrHit *hit = nullptr;
       hit = hitsetitr->second->getHit(hitkey);
 
       zbin = TpcDefs::getTBin(hitr->first);
       phibin = TpcDefs::getPad(hitr->first);
       double phi_center = layergeom->get_phicenter(phibin);
-      if (phi_center<0) phi_center+=2*pi;
+      if (phi_center < 0) phi_center += 2 * pi;
       _hit_phi = phi_center;
       _hit_z = layergeom->get_zcenter(zbin);
 
-      if(hit)_hit_e = hit->getEnergy();        
-      _hit_adc=0;
-      _hit_adc_bls=0;
+      if (hit) _hit_e = hit->getEnergy();
+      _hit_adc = 0;
+      _hit_adc_bls = 0;
 
-      float_t fadc = (hitr->second->getAdc()) ;// proper int rounding +0.5
-      _hit_adc=fadc;
-      _hit_adc_bls=_hit_adc+int(ind_charge);
+      float_t fadc = (hitr->second->getAdc());  // proper int rounding +0.5
+      _hit_adc = fadc;
+      _hit_adc_bls = _hit_adc + int(ind_charge);
 
-      if(hit && _hit_adc>0){ 
+      if (hit && _hit_adc > 0)
+      {
         //Trkr hit has only one value m_adc which is energy and ADC at the same time
-        if(_hit_adc_bls>0){hit->setAdc(_hit_adc_bls);}
-        else{hit->setAdc(0);}
+        if (_hit_adc_bls > 0)
+        {
+          hit->setAdc(_hit_adc_bls);
+        }
+        else
+        {
+          hit->setAdc(0);
+        }
       }
-      if(_writeTree==1)_rawHits->Fill();
+      if (_writeTree == 1) _rawHits->Fill();
     }
 
-
-
-
     //hitsetitr++;
-
   }
-  
+
   //pthread_attr_destroy(&attr);
 
   // wait for completion of all threads
   //for( const auto& thread_pair:threads )
-  //{ 
+  //{
   //  int rc2 = pthread_join(thread_pair.thread, nullptr);
-  //  if (rc2) 
+  //  if (rc2)
   //  { std::cout << "Error:unable to join," << rc2 << std::endl; }
   //}
 
   if (Verbosity() > 0)
-    std::cout << "TPC Clusterizer found " << m_clusterlist->size() << " Clusters "  << std::endl;
+    std::cout << "TPC Clusterizer found " << m_clusterlist->size() << " Clusters " << std::endl;
   std::cout << "PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -404,9 +410,10 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
 //}
 
 //____________________________________________________________________________..
-int PHG4TpcPadBaselineShift::End(PHCompositeNode */*topNode*/)
+int PHG4TpcPadBaselineShift::End(PHCompositeNode * /*topNode*/)
 {
-  if(_writeTree==1){
+  if (_writeTree == 1)
+  {
     outfile->cd();
     outfile->Write();
     outfile->Close();
@@ -428,16 +435,18 @@ int PHG4TpcPadBaselineShift::End(PHCompositeNode */*topNode*/)
 //{
 //  std::cout << "PHG4TpcPadBaselineShift::Print(const std::string &what) const Printing info for " << what << std::endl;
 //}
-void PHG4TpcPadBaselineShift::setScale(float CScale){
+void PHG4TpcPadBaselineShift::setScale(float CScale)
+{
   _CScale = CScale;
   std::cout << "PHG4TpcPadBaselineShift::setFileName: Scale factor is set to:" << CScale << std::endl;
 }
-void PHG4TpcPadBaselineShift::setFileName(const std::string &filename){
-  _filename=filename;
+void PHG4TpcPadBaselineShift::setFileName(const std::string &filename)
+{
+  _filename = filename;
   std::cout << "PHG4TpcPadBaselineShift::setFileName: Output file name for PHG4TpcPadBaselineShift is set to:" << filename << std::endl;
 }
-void PHG4TpcPadBaselineShift::writeTree(int f_writeTree){
-  _writeTree=f_writeTree;
+void PHG4TpcPadBaselineShift::writeTree(int f_writeTree)
+{
+  _writeTree = f_writeTree;
   std::cout << "PHG4TpcPadBaselineShift::writeTree: True" << std::endl;
 }
-

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -2,11 +2,17 @@
 
 #include <tpc/TpcDefs.h>
 
-#include <trackbase/TrkrClusterContainerv3.h>
-#include <trackbase/TrkrClusterv2.h>
-#include <trackbase/TrkrClusterHitAssocv3.h>
+#include <trackbase/ActsSurfaceMaps.h>                  // for ActsSurfaceMaps
+#include <trackbase/ActsTrackingGeometry.h>             // for ActsTrackingG...
+#include <trackbase/TrkrClusterContainer.h>             // for TrkrClusterCo...
+#include <trackbase/TrkrClusterHitAssoc.h>              // for TrkrClusterHi...
+#include <trackbase/TrkrHit.h>                          // for TrkrHit
+
+//#include <trackbase/TrkrClusterContainerv3.h>
+//#include <trackbase/TrkrClusterv2.h>
+//#include <trackbase/TrkrClusterHitAssocv3.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
-#include <trackbase/TrkrHitv2.h>
+//#include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
 
@@ -16,20 +22,20 @@
 #include <g4detectors/PHG4CylinderCellGeom.h>
 #include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
-#include <Acts/Utilities/Units.hpp>
-#include <Acts/Surfaces/Surface.hpp>
+//#include <Acts/Utilities/Units.hpp>
+//#include <Acts/Surfaces/Surface.hpp>
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>                         // for PHIODataNode
+//#include <phool/PHIODataNode.h>                         // for PHIODataNode
 #include <phool/PHNode.h>                               // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                             // for PHObject
+//#include <phool/PHObject.h>                             // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <TMatrixFfwd.h>    // for TMatrixF
-#include <TMatrixT.h>       // for TMatrixT, ope...
-#include <TMatrixTUtils.h>  // for TMatrixTRow
+// #include <TMatrixFfwd.h>    // for TMatrixF
+// #include <TMatrixT.h>       // for TMatrixT, ope...
+// #include <TMatrixTUtils.h>  // for TMatrixTRow
 
 #include <TFile.h>  
 #include <TF1.h>
@@ -40,10 +46,10 @@
 #include <map>  // for _Rb_tree_cons...
 #include <string>
 #include <utility>  // for pair
-#include <array>
+//#include <array>
 #include <vector>
 
-#include <fun4all/Fun4AllReturnCodes.h>
+//#include <fun4all/Fun4AllReturnCodes.h>
 
 //#include <phool/PHCompositeNode.h>
 
@@ -52,8 +58,8 @@ namespace
   template<class T> inline constexpr T square( const T& x ) { return x*x; }
 }
 
-typedef std::pair<unsigned short, unsigned short> iphiz;
-typedef std::pair<unsigned short, iphiz> ihit;
+//typedef std::pair<unsigned short, unsigned short> iphiz;
+//typedef std::pair<unsigned short, iphiz> ihit;
 
 int findRBin(float R){
   // Finding pad number from the center (bin) for hits
@@ -90,21 +96,6 @@ int findRBin(float R){
 //____________________________________________________________________________..
 PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name):
  SubsysReco(name)
-  , m_hits(nullptr)
-  , m_clusterlist(nullptr)
-  , m_clusterhitassoc(nullptr)
-  , m_surfMaps(nullptr)
-  , m_tGeometry(nullptr)
-  , do_hit_assoc(true)
-  , pedestal(74.4)
-  ,_writeTree(0)
-  , SectorFiducialCut(0.5)
-  , NSearch(2)
-  , NZBinsMax(0)
-  , _CScale(1)
-  , outfile(nullptr)
-  , _filename("./hitsBLS.root")
-
   {
   std::cout << "PHG4TpcPadBaselineShift::PHG4TpcPadBaselineShift(const std::string &name) Calling ctor" << std::endl;
 }
@@ -306,7 +297,7 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
     unsigned short phioffset = PhiOffset;
     unsigned short zbins=NZBinsSide;
     unsigned short zoffset=ZOffset;
-    float sumADC = perPadADC;
+    float sumADC = perPadADC; // 14 lines later just set to zero
 
     //phibins - number of pads in the sector
     //The Sampa clock time is 18.8 MHz, so the sampling time is 53.2 ns = 1 Z bin.
@@ -320,12 +311,12 @@ int PHG4TpcPadBaselineShift::process_event(PHCompositeNode *topNode)
     f1->SetParameter(1,0);
     f1->SetParameter(2,60); // in terms of 50nsec time bins
 
-    sumADC=0;
+//    sumADC=0.; // this is set to zero 14 lines up (perPadADC is zero)
     TrkrHitSet::ConstRange hitrangei = hitset->getHits();
 
     std::vector<unsigned short> adcval(zbins, 0);
-    std::multimap<unsigned short, ihit> all_hit_map;
-    std::vector<ihit> hit_vect;
+//    std::multimap<unsigned short, ihit> all_hit_map;
+//    std::vector<ihit> hit_vect;
     // Loop over phi & z
     for (TrkrHitSet::ConstIterator hitr = hitrangei.first; hitr != hitrangei.second;++hitr){
       unsigned short phibin = TpcDefs::getPad(hitr->first) - phioffset;
@@ -441,7 +432,7 @@ void PHG4TpcPadBaselineShift::setScale(float CScale){
   _CScale = CScale;
   std::cout << "PHG4TpcPadBaselineShift::setFileName: Scale factor is set to:" << CScale << std::endl;
 }
-void PHG4TpcPadBaselineShift::setFileName(std::string filename){
+void PHG4TpcPadBaselineShift::setFileName(const std::string &filename){
   _filename=filename;
   std::cout << "PHG4TpcPadBaselineShift::setFileName: Output file name for PHG4TpcPadBaselineShift is set to:" << filename << std::endl;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -10,10 +10,10 @@
 
 #include <climits>
 #include <cmath>
-//#include <map> 
+//#include <map>
 //#include <vector>
 #include <string>
-#include <utility>               // for pair
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
@@ -36,14 +36,12 @@ class PHG4TpcPadBaselineShift : public SubsysReco
   typedef std::pair<unsigned short, iphiz> ihit;
 
  public:
-
-
   PHG4TpcPadBaselineShift(const std::string &name = "PHG4TpcPadBaselineShift");
 
   virtual ~PHG4TpcPadBaselineShift();
   int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
-  int process_event(PHCompositeNode *topNode) override; 
+  int process_event(PHCompositeNode *topNode) override;
   //int ResetEvent(PHCompositeNode *topNode) override;
 
   //int EndRun(const int runnumber) override;
@@ -54,42 +52,40 @@ class PHG4TpcPadBaselineShift : public SubsysReco
 
   //void Print(const std::string &what = "ALL") const override;
 
-   void setScale(float CScale);
-   void setFileName(const std::string &filename);
-   void writeTree(int f_writeTree);
- 
+  void setScale(float CScale);
+  void setFileName(const std::string &filename);
+  void writeTree(int f_writeTree);
 
  private:
-   bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
-   float _hit_z = NAN ;
-   float _hit_r = NAN ;
-   float _hit_phi= NAN;
-   float _hit_e= NAN;
-   int _hit_adc = INT_MIN;
-   int _hit_adc_bls = INT_MIN;
-   int _hit_layer = INT_MIN;
-   int _hit_sector = INT_MIN;
+  bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
+  float _hit_z = NAN;
+  float _hit_r = NAN;
+  float _hit_phi = NAN;
+  float _hit_e = NAN;
+  int _hit_adc = INT_MIN;
+  int _hit_adc_bls = INT_MIN;
+  int _hit_layer = INT_MIN;
+  int _hit_sector = INT_MIN;
 
-   TrkrHitSetContainer *m_hits = nullptr;
-   TrkrClusterContainer *m_clusterlist = nullptr;
-   TrkrClusterHitAssoc *m_clusterhitassoc = nullptr;
-   ActsSurfaceMaps *m_surfMaps = nullptr;
-   ActsTrackingGeometry *m_tGeometry = nullptr;
+  TrkrHitSetContainer *m_hits = nullptr;
+  TrkrClusterContainer *m_clusterlist = nullptr;
+  TrkrClusterHitAssoc *m_clusterhitassoc = nullptr;
+  ActsSurfaceMaps *m_surfMaps = nullptr;
+  ActsTrackingGeometry *m_tGeometry = nullptr;
 
-//   bool do_hit_assoc = true;
-//   double pedestal = 74.4;
-   int _writeTree = 0;
-   double SectorFiducialCut = 0.5;
+  //   bool do_hit_assoc = true;
+  //   double pedestal = 74.4;
+  int _writeTree = 0;
+  double SectorFiducialCut = 0.5;
 
-//   int NSearch = 2;
-   int NZBinsMax = 0;
-   float _CScale = 1.;
+  //   int NSearch = 2;
+  int NZBinsMax = 0;
+  float _CScale = 1.;
 
-   TFile *outfile = nullptr;
-   std::string _filename = "./hitsBLS.root";
+  TFile *outfile = nullptr;
+  std::string _filename = "./hitsBLS.root";
 
-   TTree *_rawHits = nullptr;
-
+  TTree *_rawHits = nullptr;
 };
 
-#endif // PHG4TpcPadBaselineShift_H
+#endif  // PHG4TpcPadBaselineShift_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -1,0 +1,88 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4TPC_PHG4TpcPadBaselineShift_H
+#define G4TPC_PHG4TpcPadBaselineShift_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/ActsTrackingGeometry.h>
+
+#include <map> 
+#include <vector>
+#include <string>
+
+class PHCompositeNode;
+
+class TTree;
+class TFile;
+
+class TrkrHitSet;
+class TrkrHitSetContainer;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+class PHG4CylinderCellGeom;
+class PHG4CylinderCellGeomContainer;
+
+typedef std::pair<unsigned short, unsigned short> iphiz;
+typedef std::pair<unsigned short, iphiz> ihit;
+
+class PHG4TpcPadBaselineShift : public SubsysReco
+{
+ public:
+
+  PHG4TpcPadBaselineShift(const std::string &name = "PHG4TpcPadBaselineShift");
+
+  virtual ~PHG4TpcPadBaselineShift();
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override; 
+  //int ResetEvent(PHCompositeNode *topNode) override;
+
+  //int EndRun(const int runnumber) override;
+
+  int End(PHCompositeNode *topNode) override;
+
+  //int Reset(PHCompositeNode * /*topNode*/) override;
+
+  //void Print(const std::string &what = "ALL") const override;
+
+   void setScale(float CScale);
+   void setFileName(std::string filename);
+   void writeTree(int f_writeTree);
+ 
+
+ private:
+   bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
+   float _hit_z  ;
+   float _hit_r  ;
+   float _hit_phi;
+   float _hit_e;
+   int _hit_adc;
+   int _hit_adc_bls;
+   int _hit_layer;
+   int _hit_sector;
+
+   TrkrHitSetContainer *m_hits;
+   TrkrClusterContainer *m_clusterlist;
+   TrkrClusterHitAssoc *m_clusterhitassoc;
+   ActsSurfaceMaps *m_surfMaps;
+   ActsTrackingGeometry *m_tGeometry;
+
+   bool do_hit_assoc;
+   double pedestal;
+   int _writeTree;
+   double SectorFiducialCut;
+
+   int NSearch;
+   int NZBinsMax;
+   float _CScale;
+
+   TFile *outfile;
+   std::string _filename;
+
+   TTree *_rawHits;
+
+};
+
+#endif // PHG4TpcPadBaselineShift_H

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -4,32 +4,39 @@
 #define G4TPC_PHG4TpcPadBaselineShift_H
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrCluster.h>
-#include <trackbase/ActsSurfaceMaps.h>
-#include <trackbase/ActsTrackingGeometry.h>
+//#include <trackbase/TrkrCluster.h>
+//#include <trackbase/ActsSurfaceMaps.h>
+//#include <trackbase/ActsTrackingGeometry.h>
 
-#include <map> 
-#include <vector>
+#include <climits>
+#include <cmath>
+//#include <map> 
+//#include <vector>
 #include <string>
+#include <utility>               // for pair
 
 class PHCompositeNode;
 
 class TTree;
 class TFile;
 
-class TrkrHitSet;
+//class TrkrHitSet;
 class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class PHG4CylinderCellGeom;
-class PHG4CylinderCellGeomContainer;
+//class PHG4CylinderCellGeomContainer;
 
-typedef std::pair<unsigned short, unsigned short> iphiz;
-typedef std::pair<unsigned short, iphiz> ihit;
+struct ActsSurfaceMaps;
+struct ActsTrackingGeometry;
 
 class PHG4TpcPadBaselineShift : public SubsysReco
 {
+  typedef std::pair<unsigned short, unsigned short> iphiz;
+  typedef std::pair<unsigned short, iphiz> ihit;
+
  public:
+
 
   PHG4TpcPadBaselineShift(const std::string &name = "PHG4TpcPadBaselineShift");
 
@@ -48,40 +55,40 @@ class PHG4TpcPadBaselineShift : public SubsysReco
   //void Print(const std::string &what = "ALL") const override;
 
    void setScale(float CScale);
-   void setFileName(std::string filename);
+   void setFileName(const std::string &filename);
    void writeTree(int f_writeTree);
  
 
  private:
    bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom);
-   float _hit_z  ;
-   float _hit_r  ;
-   float _hit_phi;
-   float _hit_e;
-   int _hit_adc;
-   int _hit_adc_bls;
-   int _hit_layer;
-   int _hit_sector;
+   float _hit_z = NAN ;
+   float _hit_r = NAN ;
+   float _hit_phi= NAN;
+   float _hit_e= NAN;
+   int _hit_adc = INT_MIN;
+   int _hit_adc_bls = INT_MIN;
+   int _hit_layer = INT_MIN;
+   int _hit_sector = INT_MIN;
 
-   TrkrHitSetContainer *m_hits;
-   TrkrClusterContainer *m_clusterlist;
-   TrkrClusterHitAssoc *m_clusterhitassoc;
-   ActsSurfaceMaps *m_surfMaps;
-   ActsTrackingGeometry *m_tGeometry;
+   TrkrHitSetContainer *m_hits = nullptr;
+   TrkrClusterContainer *m_clusterlist = nullptr;
+   TrkrClusterHitAssoc *m_clusterhitassoc = nullptr;
+   ActsSurfaceMaps *m_surfMaps = nullptr;
+   ActsTrackingGeometry *m_tGeometry = nullptr;
 
-   bool do_hit_assoc;
-   double pedestal;
-   int _writeTree;
-   double SectorFiducialCut;
+//   bool do_hit_assoc = true;
+//   double pedestal = 74.4;
+   int _writeTree = 0;
+   double SectorFiducialCut = 0.5;
 
-   int NSearch;
-   int NZBinsMax;
-   float _CScale;
+//   int NSearch = 2;
+   int NZBinsMax = 0;
+   float _CScale = 1.;
 
-   TFile *outfile;
-   std::string _filename;
+   TFile *outfile = nullptr;
+   std::string _filename = "./hitsBLS.root";
 
-   TTree *_rawHits;
+   TTree *_rawHits = nullptr;
 
 };
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.h
@@ -4,14 +4,9 @@
 #define G4TPC_PHG4TpcPadBaselineShift_H
 
 #include <fun4all/SubsysReco.h>
-//#include <trackbase/TrkrCluster.h>
-//#include <trackbase/ActsSurfaceMaps.h>
-//#include <trackbase/ActsTrackingGeometry.h>
 
 #include <climits>
 #include <cmath>
-//#include <map>
-//#include <vector>
 #include <string>
 #include <utility>  // for pair
 
@@ -20,21 +15,16 @@ class PHCompositeNode;
 class TTree;
 class TFile;
 
-//class TrkrHitSet;
 class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class PHG4CylinderCellGeom;
-//class PHG4CylinderCellGeomContainer;
 
 struct ActsSurfaceMaps;
 struct ActsTrackingGeometry;
 
 class PHG4TpcPadBaselineShift : public SubsysReco
 {
-  typedef std::pair<unsigned short, unsigned short> iphiz;
-  typedef std::pair<unsigned short, iphiz> ihit;
-
  public:
   PHG4TpcPadBaselineShift(const std::string &name = "PHG4TpcPadBaselineShift");
 

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -7,7 +7,7 @@ LT_INIT([disable-static])
 
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation -Wextra -Wno-deprecated-copy"
  ;;
  *g++)
   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"


### PR DESCRIPTION
Base-line shift tool PHG4TpcPadBaselineShift is added


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? ( feature, ...)
Base-line shift tool PHG4TpcPadBaselineShift is added to simulate charge sharing from the bottom layer of the bottom GEM [TPC general meeting talk]: <https://indico.bnl.gov/event/13864/contributions/57472/attachments/38504/63503/BLShift_eshulga_221121.pdf> 


## TODOs (if applicable)
- [ ] The scale factor has to be tuned during the X-ray tests/measurements at the SBU.
- [ ] Ion tail distribution also could be added.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

