### PR TITLE
Trackevaluation update

### DIFF
--- a/offline/packages/trackbase/TrkrClusterv3.h
+++ b/offline/packages/trackbase/TrkrClusterv3.h
@@ -98,6 +98,8 @@ class TrkrClusterv3 : public TrkrCluster
    { std::cout << "Deprecated size function"<< std::endl; return NAN;}
    float getZSize() const override 
    {std::cout << "Deprecated size function" << std::endl; return NAN;}
+   float getPhiError() const override 
+   { std::cout << "Deprecated getPhiError function"<< std::endl; return NAN;}
 
  protected:
 

--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -4,20 +4,26 @@
  */
 
 #include "TrackEvaluation.h"
-#include "TrackEvaluationContainerv1.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <intt/InttDefs.h>
+#include <micromegas/CylinderGeomMicromegas.h>
 #include <micromegas/MicromegasDefs.h>
 #include <mvtx/MvtxDefs.h>
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 #include <tpc/TpcDefs.h>
+#include <trackbase/ActsTrackingGeometry.h>
+#include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
@@ -28,6 +34,8 @@
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+
+#include <TVector3.h>
 
 #include <algorithm>
 #include <bitset>
@@ -51,7 +59,7 @@ namespace
   };
 
   //! square
-  template<class T> inline constexpr T square( T x ) { return x*x; }
+  template<class T> inline constexpr T square( const T& x ) { return x*x; }
 
   //! radius
   template<class T> inline constexpr T get_r( T x, T y ) { return std::sqrt( square(x) + square(y) ); }
@@ -65,51 +73,49 @@ namespace
   //! eta
   template<class T> T get_eta( T p, T pz ) { return std::log( (p+pz)/(p-pz) )/2; }
 
-  //! radius
-  float get_r( PHG4Hit* hit, int i )
-  {  return get_r( hit->get_x(i), hit->get_y(i) ); }
+  //! needed for weighted linear interpolation
+  struct interpolation_data_t
+  {
+    using list = std::vector<interpolation_data_t>;
+    double x() const { return position.x(); }
+    double y() const { return position.y(); }
+    double z() const { return position.z(); }
+
+    double px() const { return momentum.x(); }
+    double py() const { return momentum.y(); }
+    double pz() const { return momentum.z(); }
+
+    TVector3 position;
+    TVector3 momentum;
+    double weight = 1;
+  };
 
   //! calculate the average of member function called on all members in collection
-  template< float (PHG4Hit::*accessor)(int) const>
-  float interpolate( std::set<PHG4Hit*> hits, float rextrap )
+  template<double (interpolation_data_t::*accessor)() const>
+  double average( const interpolation_data_t::list& hits )
   {
     // calculate all terms needed for the interpolation
     // need to use double everywhere here due to numerical divergences
     double sw = 0;
-    double swr = 0;
-    double swr2 = 0;
     double swx = 0;
-    double swrx = 0;
 
     bool valid( false );
     for( const auto& hit:hits )
     {
 
-      const double x0 = (hit->*accessor)(0);
-      const double x1 = (hit->*accessor)(1);
-      if( std::isnan( x0 ) || std::isnan( x1 ) ) continue;
+      const double x = (hit.*accessor)();
+      if(std::isnan(x)) continue;
 
-      const double w = hit->get_edep();
-      if( w < 0 ) continue;
+      const double w = hit.weight;
+      if( w <= 0 ) continue;
 
       valid = true;
-      const double r0 = get_r( hit, 0 );
-      const double r1 = get_r( hit, 1 );
-
-      sw += w*2;
-      swr += w*(r0 + r1);
-      swr2 += w*(square(r0) + square(r1));
-      swx += w*(x0 + x1);
-      swrx += w*(r0*x0 + r1*x1);
+      sw += w;
+      swx += w*x;
     }
 
     if( !valid ) return NAN;
-
-    const auto alpha = (sw*swrx - swr*swx);
-    const auto beta = (swr2*swx - swr*swrx);
-    const auto denom = (sw*swr2 - square(swr));
-
-    return ( alpha*rextrap + beta )/denom;
+    return swx/sw;
   }
 
   //! true if a track is a primary
@@ -162,61 +168,6 @@ namespace
     trackStruct.eta = get_eta( trackStruct.p, trackStruct.pz );
 
     return trackStruct;
-  }
-
-  //! create cluster struct from svx cluster
-  TrackEvaluationContainerv1::ClusterStruct create_cluster( TrkrDefs::cluskey key, TrkrCluster* cluster )
-  {
-    TrackEvaluationContainerv1::ClusterStruct cluster_struct;
-    cluster_struct.layer = TrkrDefs::getLayer(key);
-    cluster_struct.x = cluster->getX();
-    cluster_struct.y = cluster->getY();
-    cluster_struct.z = cluster->getZ();
-    cluster_struct.r = get_r( cluster_struct.x, cluster_struct.y );
-    cluster_struct.phi = std::atan2( cluster_struct.y, cluster_struct.x );
-    cluster_struct.phi_error = cluster->getPhiError();
-    cluster_struct.z_error = cluster->getZError();
-
-    return cluster_struct;
-  }
-
-  //! add track information
-  void add_trk_information( TrackEvaluationContainerv1::ClusterStruct& cluster, SvtxTrackState* state )
-  {
-    // need to extrapolate the track state to the right cluster radius to get proper residuals  
-    const auto trk_r = get_r( state->get_x(), state->get_y() );
-    const auto dr = cluster.r - trk_r;
-    const auto trk_drdt = (state->get_x()*state->get_px() + state->get_y()*state->get_py())/trk_r;
-    const auto trk_dxdr = state->get_px()/trk_drdt;
-    const auto trk_dydr = state->get_py()/trk_drdt;
-    const auto trk_dzdr = state->get_pz()/trk_drdt;
-
-    // store state position
-    cluster.trk_x = state->get_x() + dr*trk_dxdr;
-    cluster.trk_y = state->get_y() + dr*trk_dydr;
-    cluster.trk_z = state->get_z() + dr*trk_dzdr;
-    cluster.trk_r = get_r( cluster.trk_x, cluster.trk_y );
-    cluster.trk_phi = std::atan2( cluster.trk_y, cluster.trk_x );
-
-    /* store local momentum information */
-    cluster.trk_px = state->get_px();
-    cluster.trk_py = state->get_py();
-    cluster.trk_pz = state->get_pz();
-
-    /*
-    store state angles in (r,phi) and (r,z) plans
-    they are needed to study space charge distortions
-    */
-    const auto cosphi( std::cos( cluster.trk_phi ) );
-    const auto sinphi( std::sin( cluster.trk_phi ) );
-    const auto trk_pphi = -state->get_px()*sinphi + state->get_py()*cosphi;
-    const auto trk_pr = state->get_px()*cosphi + state->get_py()*sinphi;
-    const auto trk_pz = state->get_pz();
-    cluster.trk_alpha = std::atan2( trk_pphi, trk_pr );
-    cluster.trk_beta = std::atan2( trk_pz, trk_pr );
-    cluster.trk_phi_error = state->get_phi_error();
-    cluster.trk_z_error = state->get_z_error();
-
   }
 
   //! number of hits associated to cluster
@@ -307,64 +258,6 @@ namespace
 
   }
 
-  // add truth information
-  void add_truth_information( TrackEvaluationContainerv1::ClusterStruct& cluster, std::set<PHG4Hit*> hits )
-  {
-    // need to extrapolate g4hits position to the cluster r
-    /* this is done by using a linear extrapolation, with a straight line going through all provided G4Hits in and out positions */
-    const auto rextrap = cluster.r;
-    cluster.truth_size = hits.size();
-    cluster.truth_x = interpolate<&PHG4Hit::get_x>( hits, rextrap );
-    cluster.truth_y = interpolate<&PHG4Hit::get_y>( hits, rextrap );
-    cluster.truth_z = interpolate<&PHG4Hit::get_z>( hits, rextrap );
-    cluster.truth_r = get_r( cluster.truth_x, cluster.truth_y );
-    cluster.truth_phi = std::atan2( cluster.truth_y, cluster.truth_x );
-
-    /* add truth momentum information */
-    cluster.truth_px = interpolate<&PHG4Hit::get_px>( hits, rextrap );
-    cluster.truth_py = interpolate<&PHG4Hit::get_py>( hits, rextrap );
-    cluster.truth_pz = interpolate<&PHG4Hit::get_pz>( hits, rextrap );
-
-    /*
-    store state angles in (r,phi) and (r,z) plans
-    they are needed to study space charge distortions
-    */
-    const auto cosphi( std::cos( cluster.truth_phi ) );
-    const auto sinphi( std::sin( cluster.truth_phi ) );
-    const auto truth_pphi = -cluster.truth_px*sinphi + cluster.truth_py*cosphi;
-    const auto truth_pr = cluster.truth_px*cosphi + cluster.truth_py*sinphi;
-
-    cluster.truth_alpha = std::atan2( truth_pphi, truth_pr );
-    cluster.truth_beta = std::atan2( cluster.truth_pz, truth_pr );
-    if(std::isnan(cluster.truth_alpha) || std::isnan(cluster.truth_beta))
-    {
-      // recalculate
-      double truth_alpha = 0;
-      double truth_beta = 0;
-      double sum_w = 0;
-      for( const auto& hit:hits )
-      {
-        const auto px = hit->get_x(1) - hit->get_x(0);
-        const auto py = hit->get_y(1) - hit->get_y(0);
-        const auto pz = hit->get_z(1) - hit->get_z(0);
-        const auto pphi = -px*sinphi + py*cosphi;
-        const auto pr = px*cosphi + py*sinphi;
-
-        const auto w =  hit->get_edep();
-        if( w < 0 ) continue;
-
-        sum_w += w;
-        truth_alpha += w*std::atan2( pphi, pr );
-        truth_beta += w*std::atan2( pz, pr );
-      }
-      truth_alpha /= sum_w;
-      truth_beta /= sum_w;
-      cluster.truth_alpha = truth_alpha;
-      cluster.truth_beta = truth_beta;
-    }
-
-  }
-
   // ad}d truth information
   void add_truth_information( TrackEvaluationContainerv1::TrackStruct& track, PHG4Particle* particle )
   {
@@ -379,6 +272,43 @@ namespace
       track.truth_p = get_p( track.truth_px, track.truth_py, track.truth_pz );
       track.truth_eta = get_eta( track.truth_p, track.truth_pz );
     }
+  }
+
+  // calculate intersection between line and circle
+  double line_circle_intersection( const TVector3& p0, const TVector3& p1, double radius )
+  {
+    const double A = square(p1.x() - p0.x()) + square(p1.y() - p0.y());
+    const double B = 2*p0.x()*(p1.x()-p0.x()) + 2*p0.y()*(p1.y()-p0.y());
+    const double C = square(p0.x()) + square(p0.y()) - square(radius);
+    const double delta = square(B)-4*A*C;
+    if( delta < 0 ) return -1;
+
+    // check first intersection
+    const double tup = (-B + std::sqrt(delta))/(2*A);
+    if( tup >= 0 && tup < 1 ) return tup;
+
+    // check second intersection
+    const double tdn = (-B-sqrt(delta))/(2*A);
+    if( tdn >= 0 && tdn < 1 ) return tdn;
+
+    // no valid extrapolation
+    return -1;
+  }
+
+  // print to stream
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const TrackEvaluationContainerv1::ClusterStruct& cluster )
+  {
+    out << "ClusterStruct" << std::endl;
+    out << "  cluster: (" << cluster.x << "," << cluster.y << "," << cluster.z << ")" << std::endl;
+    out << "  track:   (" << cluster.trk_x << "," << cluster.trk_y << "," << cluster.trk_z << ")" << std::endl;
+    out << "  truth:   (" << cluster.truth_x << "," << cluster.truth_y << "," << cluster.truth_z << ")" << std::endl;
+    return out;
+  }
+
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const TVector3& position)
+  {
+    out << "(" << position.x() << ", " << position.y() << ", " << position.z() << ")";
+    return out;
   }
 
 }
@@ -448,13 +378,21 @@ int TrackEvaluation::End(PHCompositeNode* )
 int TrackEvaluation::load_nodes( PHCompositeNode* topNode )
 {
 
+  // acts surface map
+  m_surfmaps = findNode::getClass<ActsSurfaceMaps>(topNode, "ActsSurfaceMaps");
+  assert( m_surfmaps );
+
+  // acts geometry
+  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
+  assert( m_tGeometry );
+
   // get necessary nodes
   m_track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
 
   // cluster map
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
-  if(!m_cluster_map)
-    m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if( !m_cluster_map )
+  { m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER"); }
 
   // cluster hit association map
   m_cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
@@ -476,6 +414,13 @@ int TrackEvaluation::load_nodes( PHCompositeNode* topNode )
 
   // g4 truth info
   m_g4truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
+  // tpc geometry
+  m_tpc_geom_container = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  assert( m_tpc_geom_container );
+
+  // micromegas geometry
+  m_micromegas_geom_container = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL" );
 
   return Fun4AllReturnCodes::EVENT_OK;
 
@@ -503,7 +448,7 @@ void TrackEvaluation::evaluate_event()
         // fill cluster related information
         const auto clusters = m_cluster_map->getClusters(hitsetkey);
         const int nclusters = std::distance( clusters.first, clusters.second );
-        
+
         switch( trkrId )
         {
           case TrkrDefs::mvtxId: event.nclusters_mvtx += nclusters; break;
@@ -542,15 +487,20 @@ void TrackEvaluation::evaluate_clusters()
 
       // truth information
       const auto g4hits = find_g4hits( key );
-      add_truth_information( cluster_struct, g4hits );
+      const bool is_micromegas( TrkrDefs::getTrkrId(key) == TrkrDefs::micromegasId );
+      if( is_micromegas )
+      {
+        const int tileid = MicromegasDefs::getTileId(key);
+        add_truth_information_micromegas( cluster_struct, tileid, g4hits );
+      } else {
+        add_truth_information( cluster_struct, g4hits );
+      }
 
       // add in array
       m_container->addCluster( cluster_struct );
     }
   }
-  
-  std::cout << "TrackEvaluation::evaluate_clusters - clusters: " << m_container->clusters().size() << std::endl;
-  
+
 }
 
 //_____________________________________________________________________
@@ -570,11 +520,11 @@ void TrackEvaluation::evaluate_tracks()
     // truth information
     const auto [id,contributors] = get_max_contributor( track );
     track_struct.contributors = contributors;
-    
+
     // get particle
     auto particle = m_g4truthinfo->GetParticle(id);
     track_struct.embed = get_embed(particle);
-    add_truth_information(track_struct, particle);
+    ::add_truth_information(track_struct, particle);
 
     // running iterator over track states, used to match a given cluster to a track state
     auto state_iter = track->begin_states();
@@ -598,7 +548,14 @@ void TrackEvaluation::evaluate_tracks()
 
       // truth information
       const auto g4hits = find_g4hits( cluster_key );
-      add_truth_information( cluster_struct, g4hits );
+      const bool is_micromegas( TrkrDefs::getTrkrId(cluster_key) == TrkrDefs::micromegasId );
+      if( is_micromegas )
+      {
+        const int tileid = MicromegasDefs::getTileId(cluster_key);
+        add_truth_information_micromegas( cluster_struct, tileid, g4hits );
+      } else {
+        add_truth_information( cluster_struct, g4hits );
+      }
 
       // find track state that is the closest to cluster
       /* this assumes that both clusters and states are sorted along r */
@@ -615,17 +572,19 @@ void TrackEvaluation::evaluate_tracks()
       }
 
       // store track state in cluster struct
-      add_trk_information( cluster_struct, state_iter->second );
+      if( is_micromegas )
+      {
+        const int tileid = MicromegasDefs::getTileId(cluster_key);
+        add_trk_information_micromegas( cluster_struct, tileid, state_iter->second );
+      } else {
+        add_trk_information( cluster_struct, state_iter->second );
+      }
 
       // add to track
       track_struct.clusters.push_back( cluster_struct );
     }
     m_container->addTrack( track_struct );
   }
-  
-  std::cout << "TrackEvaluation::evaluate_tracks - tracks: " << m_container->tracks().size() << std::endl;
-
-  
 }
 
 //_____________________________________________________________________
@@ -724,3 +683,303 @@ std::pair<int,int> TrackEvaluation::get_max_contributor( SvtxTrack* track ) cons
 //_____________________________________________________________________
 int TrackEvaluation::get_embed( PHG4Particle* particle ) const
 { return (m_g4truthinfo && particle) ? m_g4truthinfo->isEmbeded( particle->get_primary_id() ):0; }
+
+//_____________________________________________________________________
+TrackEvaluationContainerv1::ClusterStruct TrackEvaluation::create_cluster( TrkrDefs::cluskey key, TrkrCluster* cluster ) const
+{
+  // get global coordinates
+  const auto global = m_transformer.getGlobalPosition(cluster,m_surfmaps, m_tGeometry);
+
+  TrackEvaluationContainerv1::ClusterStruct cluster_struct;
+  cluster_struct.layer = TrkrDefs::getLayer(key);
+  cluster_struct.x = global.x();
+  cluster_struct.y = global.y();
+  cluster_struct.z = global.z();
+  cluster_struct.r = get_r( cluster_struct.x, cluster_struct.y );
+  cluster_struct.phi = std::atan2( cluster_struct.y, cluster_struct.x );
+  cluster_struct.phi_error = cluster->getPhiError();
+  cluster_struct.z_error = cluster->getZError();
+
+  return cluster_struct;
+}
+
+//_____________________________________________________________________
+void TrackEvaluation::add_trk_information( TrackEvaluationContainerv1::ClusterStruct& cluster, SvtxTrackState* state ) const
+{
+  // need to extrapolate to the right r
+  const auto trk_r = get_r( state->get_x(), state->get_y() );
+  const auto dr = cluster.r - trk_r;
+  const auto trk_drdt = (state->get_x()*state->get_px() + state->get_y()*state->get_py())/trk_r;
+  const auto trk_dxdr = state->get_px()/trk_drdt;
+  const auto trk_dydr = state->get_py()/trk_drdt;
+  const auto trk_dzdr = state->get_pz()/trk_drdt;
+
+  // store state position
+  cluster.trk_x = state->get_x() + dr*trk_dxdr;
+  cluster.trk_y = state->get_y() + dr*trk_dydr;
+  cluster.trk_z = state->get_z() + dr*trk_dzdr;
+  cluster.trk_r = get_r( cluster.trk_x, cluster.trk_y );
+  cluster.trk_phi = std::atan2( cluster.trk_y, cluster.trk_x );
+
+  /* store local momentum information */
+  cluster.trk_px = state->get_px();
+  cluster.trk_py = state->get_py();
+  cluster.trk_pz = state->get_pz();
+
+  /*
+  store state angles in (r,phi) and (r,z) plans
+  they are needed to study space charge distortions
+  */
+  const auto cosphi( std::cos( cluster.trk_phi ) );
+  const auto sinphi( std::sin( cluster.trk_phi ) );
+  const auto trk_pphi = -state->get_px()*sinphi + state->get_py()*cosphi;
+  const auto trk_pr = state->get_px()*cosphi + state->get_py()*sinphi;
+  const auto trk_pz = state->get_pz();
+  cluster.trk_alpha = std::atan2( trk_pphi, trk_pr );
+  cluster.trk_beta = std::atan2( trk_pz, trk_pr );
+  cluster.trk_phi_error = state->get_phi_error();
+  cluster.trk_z_error = state->get_z_error();
+
+}
+
+//_____________________________________________________________________
+void TrackEvaluation::add_trk_information_micromegas( TrackEvaluationContainerv1::ClusterStruct& cluster, int tileid, SvtxTrackState* state ) const
+{
+
+  // get geometry cylinder from layer
+  const auto layer = cluster.layer;
+  const auto layergeom = dynamic_cast<CylinderGeomMicromegas*>(m_micromegas_geom_container->GetLayerGeom(layer));
+  assert( layergeom );
+
+  // convert cluster position to local tile coordinates
+  const TVector3 cluster_world( cluster.x, cluster.y, cluster.z );
+  const TVector3 cluster_local = layergeom->get_local_from_world_coords( tileid, cluster_world );
+
+  // convert track position to local tile coordinates
+  TVector3 track_world( state->get_x(), state->get_y(), state->get_z() );
+  TVector3 track_local = layergeom->get_local_from_world_coords( tileid, track_world );
+
+  // convert direction to local tile coordinates
+  const TVector3 direction_world( state->get_px(), state->get_py(), state->get_pz() );
+  const TVector3 direction_local = layergeom->get_local_from_world_vect( tileid, direction_world );
+
+  // extrapolate to same local y (should be zero) as cluster
+  const auto delta_y = cluster_local.y() - track_local.y();
+  track_local += TVector3(
+    delta_y*direction_local.x()/direction_local.y(),
+    delta_y,
+    delta_y*direction_local.z()/direction_local.y() );
+
+  // convert back to global coordinates
+  track_world = layergeom->get_world_from_local_coords( tileid, track_local );
+
+  // store state position
+  cluster.trk_x = track_world.x();
+  cluster.trk_y = track_world.y();
+  cluster.trk_z = track_world.z();
+  cluster.trk_r = get_r( cluster.trk_x, cluster.trk_y );
+  cluster.trk_phi = std::atan2( cluster.trk_y, cluster.trk_x );
+
+  /* store local momentum information */
+  cluster.trk_px = state->get_px();
+  cluster.trk_py = state->get_py();
+  cluster.trk_pz = state->get_pz();
+
+  /*
+  store state angles in (r,phi) and (r,z) plans
+  they are needed to study space charge distortions
+  */
+  const auto cosphi( std::cos( cluster.trk_phi ) );
+  const auto sinphi( std::sin( cluster.trk_phi ) );
+  const auto trk_pphi = -state->get_px()*sinphi + state->get_py()*cosphi;
+  const auto trk_pr = state->get_px()*cosphi + state->get_py()*sinphi;
+  const auto trk_pz = state->get_pz();
+  cluster.trk_alpha = std::atan2( trk_pphi, trk_pr );
+  cluster.trk_beta = std::atan2( trk_pz, trk_pr );
+  cluster.trk_phi_error = state->get_phi_error();
+  cluster.trk_z_error = state->get_z_error();
+
+}
+
+//_____________________________________________________________________
+void TrackEvaluation::add_truth_information( TrackEvaluationContainerv1::ClusterStruct& cluster, std::set<PHG4Hit*> g4hits ) const
+{
+  // store number of contributing g4hits
+  cluster.truth_size = g4hits.size();
+
+  // get layer, tpc flag and corresponding layer geometry
+  const auto layer = cluster.layer;
+  const bool is_tpc( layer >= 7 && layer < 55 );
+  const PHG4CylinderCellGeom* layergeom = is_tpc ? m_tpc_geom_container->GetLayerCellGeom(layer):nullptr;
+  const auto rin = layergeom ? layergeom->get_radius()-layergeom->get_thickness()/2:0;
+  const auto rout = layergeom ? layergeom->get_radius()+layergeom->get_thickness()/2:0;
+
+  // convert hits to list of interpolation_data_t
+  interpolation_data_t::list hits;
+  for( const auto& g4hit:g4hits )
+  {
+    interpolation_data_t::list tmp_hits;
+    const auto weight = g4hit->get_edep();
+    for( int i = 0; i < 2; ++i )
+    {
+      const TVector3 g4hit_world(g4hit->get_x(i), g4hit->get_y(i), g4hit->get_z(i));
+      const TVector3 momentum_world(g4hit->get_px(i), g4hit->get_py(i), g4hit->get_pz(i));
+      tmp_hits.push_back( {.position = g4hit_world, .momentum = momentum_world, .weight = weight } );
+    }
+
+    if( is_tpc )
+    {
+      // add layer boundary checks
+      // ensure first hit has lowest r
+      auto r0 = get_r(tmp_hits[0].x(),tmp_hits[0].y());
+      auto r1 = get_r(tmp_hits[1].x(),tmp_hits[1].y());
+      if( r0 > r1 )
+      {
+        std::swap(tmp_hits[0],tmp_hits[1]);
+        std::swap(r0, r1);
+      }
+
+      // do nothing if out of bound
+      if( r1 <= rin || r0 >= rout ) continue;
+
+      // keep track of original deltar
+      const auto dr_old = r1-r0;
+
+      // clamp r0 to rin
+      if( r0 < rin )
+      {
+        const auto t = line_circle_intersection( tmp_hits[0].position, tmp_hits[1].position, rin );
+        if( t<0 ) continue;
+
+        tmp_hits[0].position = tmp_hits[0].position*(1.-t) + tmp_hits[1].position*t;
+        tmp_hits[0].momentum = tmp_hits[0].momentum*(1.-t) + tmp_hits[1].momentum*t;
+        r0 = rin;
+      }
+
+      if( r1 > rout )
+      {
+        const auto t = line_circle_intersection( tmp_hits[0].position, tmp_hits[1].position, rout );
+        if( t<0 ) continue;
+
+        tmp_hits[1].position = tmp_hits[0].position*(1.-t) + tmp_hits[1].position*t;
+        tmp_hits[1].momentum = tmp_hits[0].momentum*(1.-t) + tmp_hits[1].momentum*t;
+        r1 = rout;
+      }
+
+      // update weights, only if clamping occured
+      const auto dr_new = r1-r0;
+      tmp_hits[0].weight *= dr_new/dr_old;
+      tmp_hits[1].weight *= dr_new/dr_old;
+    }
+
+    // store in global list
+    hits.push_back(std::move(tmp_hits[0]));
+    hits.push_back(std::move(tmp_hits[1]));
+  }
+
+  // add truth position
+  cluster.truth_x = average<&interpolation_data_t::x>( hits );
+  cluster.truth_y = average<&interpolation_data_t::y>( hits );
+  cluster.truth_z = average<&interpolation_data_t::z>( hits );
+
+  // add truth momentum information
+  cluster.truth_px = average<&interpolation_data_t::px>( hits );
+  cluster.truth_py = average<&interpolation_data_t::py>( hits );
+  cluster.truth_pz = average<&interpolation_data_t::pz>( hits );
+
+  cluster.truth_r = get_r( cluster.truth_x, cluster.truth_y );
+  cluster.truth_phi = std::atan2( cluster.truth_y, cluster.truth_x );
+
+  /*
+  store state angles in (r,phi) and (r,z) plans
+  they are needed to study space charge distortions
+  */
+  const auto cosphi( std::cos( cluster.truth_phi ) );
+  const auto sinphi( std::sin( cluster.truth_phi ) );
+  const auto truth_pphi = -cluster.truth_px*sinphi + cluster.truth_py*cosphi;
+  const auto truth_pr = cluster.truth_px*cosphi + cluster.truth_py*sinphi;
+
+  cluster.truth_alpha = std::atan2( truth_pphi, truth_pr );
+  cluster.truth_beta = std::atan2( cluster.truth_pz, truth_pr );
+
+}
+
+//_____________________________________________________________________
+void TrackEvaluation::add_truth_information_micromegas( TrackEvaluationContainerv1::ClusterStruct& cluster, int tileid, std::set<PHG4Hit*> g4hits ) const
+{
+  // store number of contributing g4hits
+  cluster.truth_size = g4hits.size();
+
+  const auto layer = cluster.layer;
+  const auto layergeom = dynamic_cast<CylinderGeomMicromegas*>(m_micromegas_geom_container->GetLayerGeom(layer));
+  assert( layergeom );
+
+  // convert cluster position to local tile coordinates
+  const TVector3 cluster_world( cluster.x, cluster.y, cluster.z );
+  const TVector3 cluster_local = layergeom->get_local_from_world_coords( tileid, cluster_world );
+
+  // convert hits to list of interpolation_data_t
+  interpolation_data_t::list hits;
+  for( const auto& g4hit:g4hits )
+  {
+    const auto weight = g4hit->get_edep();
+
+    // convert g4hit to planar coordinate
+    PHG4Hitv1 g4hit_copy( g4hit );
+    layergeom->convert_to_planar( tileid, &g4hit_copy );
+
+    for( int i = 0; i < 2; ++i )
+    {
+
+      // convert position to local
+      TVector3 g4hit_world(g4hit_copy.get_x(i), g4hit_copy.get_y(i), g4hit_copy.get_z(i));
+      TVector3 g4hit_local = layergeom->get_local_from_world_coords( tileid, g4hit_world );
+
+      // convert momentum to local
+      TVector3 momentum_world(g4hit_copy.get_px(i), g4hit_copy.get_py(i), g4hit_copy.get_pz(i));
+      TVector3 momentum_local = layergeom->get_local_from_world_vect( tileid, momentum_world );
+
+      hits.push_back( {.position = g4hit_local, .momentum = momentum_local, .weight = weight } );
+    }
+  }
+
+  // do position interpolation
+  const TVector3 interpolation_local(
+    average<&interpolation_data_t::x>(hits),
+    average<&interpolation_data_t::y>(hits),
+    average<&interpolation_data_t::z>(hits) );
+
+  const TVector3 interpolation_world = layergeom->get_world_from_local_coords( tileid, interpolation_local );
+
+  // do momentum interpolation
+  const TVector3 momentum_local(
+    average<&interpolation_data_t::px>(hits),
+    average<&interpolation_data_t::py>(hits),
+    average<&interpolation_data_t::pz>(hits));
+
+  const TVector3 momentum_world = layergeom->get_world_from_local_vect( tileid, momentum_local );
+
+  cluster.truth_x = interpolation_world.x();
+  cluster.truth_y = interpolation_world.y();
+  cluster.truth_z = interpolation_world.z();
+  cluster.truth_r = get_r( cluster.truth_x, cluster.truth_y );
+  cluster.truth_phi = std::atan2( cluster.truth_y, cluster.truth_x );
+
+  /* add truth momentum information */
+  cluster.truth_px = momentum_world.x();
+  cluster.truth_py = momentum_world.y();
+  cluster.truth_pz = momentum_world.z();
+
+  /*
+  store state angles in (r,phi) and (r,z) plans
+  they are needed to study space charge distortions
+  */
+  const auto cosphi( std::cos( cluster.truth_phi ) );
+  const auto sinphi( std::sin( cluster.truth_phi ) );
+  const auto truth_pphi = -cluster.truth_px*sinphi + cluster.truth_py*cosphi;
+  const auto truth_pr = cluster.truth_px*cosphi + cluster.truth_py*sinphi;
+
+  cluster.truth_alpha = std::atan2( truth_pphi, truth_pr );
+  cluster.truth_beta = std::atan2( cluster.truth_pz, truth_pr );
+
+}

--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -697,7 +697,7 @@ TrackEvaluationContainerv1::ClusterStruct TrackEvaluation::create_cluster( TrkrD
   cluster_struct.z = global.z();
   cluster_struct.r = get_r( cluster_struct.x, cluster_struct.y );
   cluster_struct.phi = std::atan2( cluster_struct.y, cluster_struct.x );
-  cluster_struct.phi_error = cluster->getPhiError();
+  cluster_struct.phi_error = cluster->getRPhiError()/cluster_struct.r;
   cluster_struct.z_error = cluster->getZError();
 
   return cluster_struct;

--- a/simulation/g4simulation/g4eval/TrackEvaluation.h
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.h
@@ -6,21 +6,27 @@
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
+#include "TrackEvaluationContainerv1.h"
+
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/ActsTransformations.h>
 
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
 
+struct ActsSurfaceMaps;
+struct ActsTrackingGeometry;
+class PHG4CylinderCellGeomContainer;
+class PHG4CylinderGeomContainer;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Particle;
 class PHG4TruthInfoContainer;
 class SvtxTrack;
 class SvtxTrackMap;
-class TrackEvaluationContainerv1;
 class TrkrCluster;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
@@ -81,11 +87,43 @@ class TrackEvaluation : public SubsysReco
   //! get embedded id for given g4track
   int get_embed(PHG4Particle*) const;
 
+  //! create cluster structure from cluster
+  TrackEvaluationContainerv1::ClusterStruct create_cluster( TrkrDefs::cluskey, TrkrCluster* ) const;
+
+  //! add track information to a cluster
+  void add_trk_information( TrackEvaluationContainerv1::ClusterStruct&, SvtxTrackState* ) const;
+
+  //! add track information to a cluster for the micromegas case
+  /*!
+   * the difference between this and the generic method is that the track state to
+   * the tiles detector plane, and not to the same radius as the cluster
+   */
+  void add_trk_information_micromegas( TrackEvaluationContainerv1::ClusterStruct&, int /* tileid */, SvtxTrackState* ) const;
+
+  // add truth information
+  void add_truth_information( TrackEvaluationContainerv1::ClusterStruct&, std::set<PHG4Hit*> ) const;
+
+  // add truth information
+  /*!
+   * the difference between this and the generic method is that the track state to
+   * the tiles detector plane, and not to the same radius as the cluster
+   */
+  void add_truth_information_micromegas( TrackEvaluationContainerv1::ClusterStruct&, int /* tileid */, std::set<PHG4Hit*> ) const;
+
   //! evaluation node
   TrackEvaluationContainerv1* m_container = nullptr;
 
   //! flags
   int m_flags = EvalEvent | EvalClusters | EvalTracks;
+
+  /// Acts surface maps for surface lookup
+  ActsSurfaceMaps *m_surfmaps = nullptr;
+
+  /// Acts tracking geometry for surface lookup
+  ActsTrackingGeometry *m_tGeometry = nullptr;
+
+  /// acts transformation
+  ActsTransformations m_transformer;
 
   //! hits
   TrkrHitSetContainer* m_hitsetcontainer = nullptr;
@@ -112,6 +150,12 @@ class TrackEvaluation : public SubsysReco
 
   //! truth information
   PHG4TruthInfoContainer* m_g4truthinfo = nullptr;
+
+  //! tpc geometry
+  PHG4CylinderCellGeomContainer* m_tpc_geom_container = nullptr;
+
+  //! micromegas geometry
+  PHG4CylinderGeomContainer* m_micromegas_geom_container = nullptr;
 
   // map cluster keys to g4hits
   using G4HitMap = std::map<TrkrDefs::cluskey,G4HitSet>;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR updates the g4eval/TrackEvaluation module, dedicated to residuals and pulls to: 
- use ActsTransformation to get global from local cluster coordinates
- properly calculate residuals in Micromegas
- properly calculate residuals in TPC with proper handling of layer boundaries, similar to what is done in SvtxEval
- get the right error information along phi

Also adds an error message when trying to access TrkrClusterv3->getPhiError()

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

