### PR TITLE
Possible memory leak fix in TPC clusterizer

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -461,9 +461,27 @@ namespace
 	  // Add the hit associations to the TrkrClusterHitAssoc node
 	  // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
 	  
-	  if(my_data.clusterlist) my_data.clusterlist->insert(std::make_pair(ckey, clus.release()));
-	  if(my_data.do_assoc && my_data.clusterhitassoc){
-	    for (unsigned int i = 0; i < hitkeyvec.size(); i++){
+    if(my_data.clusterlist)     
+    {
+      const auto [iter, inserted] = my_data.clusterlist->insert(std::make_pair(ckey, clus.get()));
+
+      /*
+       * if cluster was properly inserted in the map, one should release the unique_ptr,
+       * to make sure that the cluster is not deleted when going out-of-scope
+       */
+      if( inserted ) clus.release();
+      else {
+        // print error message. Duplicated cluster keys should not happen
+        std::cout 
+          << PHWHERE 
+          << "Error: duplicated cluster key: " << ckey << " - new cluster not inserted in map"
+          << std::endl;        
+      }
+      
+    }
+      
+    if(my_data.do_assoc && my_data.clusterhitassoc){
+      for (unsigned int i = 0; i < hitkeyvec.size(); i++){
         my_data.clusterhitassoc->insert(std::make_pair(ckey, hitkeyvec[i]));
 	    }
 	  }


### PR DESCRIPTION
Check that cluster was properly inserted in the map before releasing the unique_ptr.
This prevents potential memory leak
Add an error message if not inserted, since duplicated cluster keys should not happen.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

