### PR TITLE
Adding classes to store the central membrane flash clusters.

### DIFF
--- a/offline/packages/trackbase/CMFlashCluster.h
+++ b/offline/packages/trackbase/CMFlashCluster.h
@@ -1,0 +1,73 @@
+/**
+ * @file trackbase/CMFlashCluster.h
+ * @author Tony Frawley
+ * @date January 2022
+ * @brief Base class for central membrane flash cluster cluster object
+ */
+#ifndef TRACKBASE_CMFLASHCLUSTER_H
+#define TRACKBASE_CMFLASHCLUSTER_H
+
+#include <phool/PHObject.h>
+
+#include <climits>
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+
+/**
+ * @brief Base class for Central Membrane flassh combined cluster object
+ *
+ * Virtual base class for TPC CM flash cluster object 
+ */
+class CMFlashCluster : public PHObject
+{
+ public:
+  //! dtor
+  ~CMFlashCluster() override {}
+  // PHObject virtual overloads
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "CMFlashCluster base class" << std::endl;
+  }
+  void Reset() override {}
+  int isValid() const override { return 0; }
+
+  
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  
+  //! copy content from base class
+  virtual void CopyFrom( const CMFlashCluster& )  {}
+
+  //! copy content from base class
+  virtual void CopyFrom( CMFlashCluster* )  {}
+
+  //
+  // cluster id
+  //
+  virtual unsigned int getClusKey() const { return UINT_MAX; }
+  virtual void setClusKey(unsigned int) {}
+ 
+  //
+  // cluster position
+  //
+  virtual float getX() const { return NAN; }
+  virtual void setX(float) {}
+  virtual float getY() const { return NAN; }
+  virtual void setY(float) {}
+  virtual float getZ() const { return NAN; }
+  virtual void setZ(float) {}
+
+  //
+  // cluster info
+  //
+  virtual void setAdc(unsigned int) {}
+  virtual unsigned int getAdc() const { return UINT_MAX; }
+
+ protected:
+  CMFlashCluster() = default;
+  ClassDefOverride(CMFlashCluster, 1)
+};
+
+#endif //TRACKBASE_CMFLASHCLUSTER_H

--- a/offline/packages/trackbase/CMFlashClusterContainer.h
+++ b/offline/packages/trackbase/CMFlashClusterContainer.h
@@ -1,0 +1,75 @@
+#ifndef TRACKBASE_CMFLASHCLUSTERCONTAINER_H
+#define TRACKBASE_CMFLASHCLUSTERCONTAINER_H
+
+/**
+ * @file trackbase/CMFlashClusterContainer.h
+ * @author Tony Frawley
+ * @date January 2022
+ * @brief Central membrane flash cluster container base class
+ */
+
+#include <phool/PHObject.h>
+
+#include <map>
+#include <iostream>          // for cout, ostream
+#include <utility>           // for pair
+
+class CMFlashCluster;
+
+/**
+ * @brief Cluster container object
+ */
+class CMFlashClusterContainer : public PHObject
+{
+ public:
+
+  //!@name convenient shortuts
+  //@{
+  using Map = std::map<unsigned int, CMFlashCluster *>;
+  using Iterator = Map::iterator;
+  using ConstIterator = Map::const_iterator;
+  using Range = std::pair<Iterator, Iterator>;
+  using ConstRange = std::pair<ConstIterator, ConstIterator>;
+  //@}
+
+  //! reset method
+  void Reset() override {}
+
+  //! identify object
+  void identify(std::ostream &/*os*/ = std::cout) const override {}
+
+  //! add a cluster
+  virtual ConstIterator addCluster(CMFlashCluster*) = 0;
+
+  //! add a cluster with specific key
+  virtual ConstIterator addClusterSpecifyKey(const unsigned int, CMFlashCluster* ) = 0;
+
+  //! remove cluster
+  virtual void removeCluster(unsigned int) {}
+
+  //! remove cluster
+  virtual void removeCluster(CMFlashCluster* ) {}
+
+  //! find cluster matching key if any, add a new one otherwise and return cluster
+  virtual Iterator findOrAddCluster(unsigned int) = 0;
+  
+  //! return all clusters
+  virtual ConstRange getClusters() const = 0;
+
+  //! find cluster matching given key
+  virtual CMFlashCluster* findCluster(unsigned int) const { return nullptr; }
+
+  //! total number of clusters
+  virtual unsigned int size() const { return 0; }
+
+  protected:
+  //! constructor
+  CMFlashClusterContainer() = default;
+
+  private:
+
+  ClassDefOverride(CMFlashClusterContainer, 1)
+
+};
+
+#endif //TRACKBASE_CMFLASHCLUSTERCONTAINER_H

--- a/offline/packages/trackbase/CMFlashClusterContainerLinkDef.h
+++ b/offline/packages/trackbase/CMFlashClusterContainerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CMFlashClusterContainer+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase/CMFlashClusterContainerv1.cc
+++ b/offline/packages/trackbase/CMFlashClusterContainerv1.cc
@@ -1,0 +1,91 @@
+/**
+ * @file trackbase/CMFlashClusterContainerv1.cc
+ * @author D. McGlinchey
+ * @date June 2018
+ * @brief Implementation of CMFlashClusterContainerv1
+ */
+#include "CMFlashClusterContainerv1.h"
+#include "CMFlashCluster.h"
+#include "CMFlashClusterv1.h"
+
+#include <cstdlib>
+
+void CMFlashClusterContainerv1::Reset()
+{
+  while (m_clusmap.begin() != m_clusmap.end())
+  {
+    delete m_clusmap.begin()->second;
+    m_clusmap.erase(m_clusmap.begin());
+  }
+  return;
+}
+
+void CMFlashClusterContainerv1::identify(std::ostream& os) const
+{
+  os << "-----CMFlashClusterContainerv1-----" << std::endl;
+  ConstIterator iter;
+  os << "Number of clusters: " << size() << std::endl;
+  for (iter = m_clusmap.begin(); iter != m_clusmap.end(); ++iter)
+  {
+    os << "clus key " << iter->first  << std::endl;
+    (iter->second)->identify();
+  }
+  os << "------------------------------" << std::endl;
+  return;
+}
+
+CMFlashClusterContainerv1::ConstIterator
+CMFlashClusterContainerv1::addCluster(CMFlashCluster* newclus)
+{
+  return addClusterSpecifyKey(newclus->getClusKey(), newclus);
+}
+
+CMFlashClusterContainerv1::ConstIterator
+CMFlashClusterContainerv1::addClusterSpecifyKey(const unsigned int key, CMFlashCluster* newclus)
+{
+  auto ret = m_clusmap.insert(std::make_pair(key, newclus));
+  if ( !ret.second )
+  {
+    std::cout << "CMFlashClusterContainerv1::AddClusterSpecifyKey: duplicate key: " << key << " exiting now" << std::endl;
+    exit(1);
+  }
+  else
+  {
+    return ret.first;
+  }
+}
+
+void CMFlashClusterContainerv1::removeCluster(unsigned int key)
+{ m_clusmap.erase(key); }
+
+void CMFlashClusterContainerv1::removeCluster(CMFlashCluster *clus)
+{ removeCluster( clus->getClusKey() ); }
+
+CMFlashClusterContainerv1::Iterator
+CMFlashClusterContainerv1::findOrAddCluster(unsigned int key)
+{
+  auto it = m_clusmap.lower_bound( key );
+  if (it == m_clusmap.end()|| (key < it->first ))
+  {
+    // add new cluster and set its key
+    it = m_clusmap.insert(it, std::make_pair(key, new CMFlashClusterv1()));
+    it->second->setClusKey(key);
+  }
+  return it;
+}
+
+CMFlashClusterContainer::ConstRange
+CMFlashClusterContainerv1::getClusters() const
+{ return std::make_pair(m_clusmap.cbegin(), m_clusmap.cend()); }
+
+CMFlashCluster*
+CMFlashClusterContainerv1::findCluster(unsigned int key) const
+{
+  auto it = m_clusmap.find(key);
+  return it == m_clusmap.end() ? nullptr:it->second;
+}
+
+unsigned int CMFlashClusterContainerv1::size() const
+{
+  return m_clusmap.size();
+}

--- a/offline/packages/trackbase/CMFlashClusterContainerv1.h
+++ b/offline/packages/trackbase/CMFlashClusterContainerv1.h
@@ -1,0 +1,61 @@
+/**
+ * @file trackbase/CMFlashClusterContainerv1.h
+ * @author Tony Frawley
+ * @date January 2022
+ * @brief Implementation of central membrane flash cluster container object
+ */
+#ifndef TRACKBASE_CMFLASHCLUSTERCONTAINERV1_H
+#define TRACKBASE_CMFLASHCLUSTERCONTAINERV1_H
+
+#include "CMFlashClusterContainer.h"
+
+#include <phool/PHObject.h>
+
+#include <map>
+#include <iostream>          // for cout, ostream
+#include <utility>           // for pair
+
+class CMFlashCluster;
+
+/**
+ * @brief CM flash cluster container object
+ *
+ * Container for CMFlashCluster objects
+ */
+class CMFlashClusterContainerv1 : public CMFlashClusterContainer
+{
+ public:
+  typedef std::map<unsigned int, CMFlashCluster *> Map;
+  typedef Map::iterator Iterator;
+  typedef Map::const_iterator ConstIterator;
+  typedef std::pair<Iterator, Iterator> Range;
+  typedef std::pair<ConstIterator, ConstIterator> ConstRange;
+
+  CMFlashClusterContainerv1() = default;
+  
+  void Reset() override;
+
+  void identify(std::ostream &os = std::cout) const override;
+
+  ConstIterator addCluster(CMFlashCluster *newClus) override;
+
+  ConstIterator addClusterSpecifyKey(const unsigned int, CMFlashCluster *newClus) override;
+
+  void removeCluster(unsigned int) override;
+
+  void removeCluster(CMFlashCluster*) override;
+
+  Iterator findOrAddCluster(unsigned int  key) override;
+  
+  ConstRange getClusters() const override;
+
+  CMFlashCluster *findCluster(unsigned int key) const override;
+
+  unsigned int size() const override;
+
+  private:
+  Map m_clusmap;
+  ClassDefOverride(CMFlashClusterContainerv1, 1)
+};
+
+#endif //TRACKBASE_CMFLASHCLUSTERCONTAINER_H

--- a/offline/packages/trackbase/CMFlashClusterContainerv1LinkDef.h
+++ b/offline/packages/trackbase/CMFlashClusterContainerv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CMFlashClusterContainerv1+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase/CMFlashClusterLinkDef.h
+++ b/offline/packages/trackbase/CMFlashClusterLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CMFlashCluster+;
+
+#endif

--- a/offline/packages/trackbase/CMFlashClusterv1.cc
+++ b/offline/packages/trackbase/CMFlashClusterv1.cc
@@ -1,0 +1,71 @@
+/**
+ * @file trackbase/CMFlashClusterv1.cc
+ * @author Tony Frawley
+ * @date January 2022
+ * @brief Implementation of CMFlashClusterv1
+ */
+#include "CMFlashClusterv1.h"
+
+#include <cmath>
+#include <utility>          // for swap
+
+namespace
+{
+
+}
+
+CMFlashClusterv1::CMFlashClusterv1()
+  : m_cluskey(UINT_MAX)
+  , m_adc(0xFFFFFFFF)
+{
+
+  for (int i = 0; i < 3; ++i) m_pos[i] = NAN;
+
+ }
+
+void CMFlashClusterv1::identify(std::ostream& os) const
+{
+  os << "---CMFlashClusterv1--------------------" << std::endl;
+  os << "clusid: " << getClusKey() << std::dec << std::endl;
+
+  os << " (x,y,z) =  (" << m_pos[0];
+  os << ", " << m_pos[1] << ", ";
+  os << m_pos[2] << ") cm";
+
+  os << " adc = " << getAdc() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int CMFlashClusterv1::isValid() const
+{
+  if (m_cluskey == UINT_MAX) return 0;
+
+  if(std::isnan(getX())) return 0;
+  if(std::isnan(getY())) return 0;
+  if(std::isnan(getZ())) return 0;
+
+  if (m_adc == 0xFFFFFFFF) return 0;
+
+  return 1;
+}
+
+void CMFlashClusterv1::CopyFrom( const CMFlashCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
+  // parent class method
+  CMFlashCluster::CopyFrom( source );
+
+  setClusKey( source.getClusKey() );
+  setX( source.getX() );
+  setY( source.getY() );
+  setZ( source.getZ() );
+  setAdc( source.getAdc() );
+
+}
+

--- a/offline/packages/trackbase/CMFlashClusterv1.h
+++ b/offline/packages/trackbase/CMFlashClusterv1.h
@@ -1,0 +1,72 @@
+/**
+ * @file trackbase/CMFlashClusterv1.h
+ * @author Tony Frawley
+ * @date January 2022
+ * @brief Version 1 of CMFLashCluster
+ */
+#ifndef TRACKBASE_CMFLASHCLUSTERV1_H
+#define TRACKBASE_CMFLASHCLUSTERV1_H
+
+#include "CMFlashCluster.h"
+
+#include <iostream>
+
+class PHObject;
+
+/**
+ * @brief Version 1 of CMFlashCluster
+ *
+ * Note - D. McGlinchey June 2018:
+ *   CINT does not like "override", so ignore where CINT
+ *   complains. Should be checked with ROOT 6 once
+ *   migration occurs.
+ */
+class CMFlashClusterv1 : public CMFlashCluster
+{
+ public:
+  //! ctor
+  CMFlashClusterv1();
+
+  //!dtor
+  ~CMFlashClusterv1() override {}
+  // PHObject virtual overloads
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new CMFlashClusterv1(*this); }
+ 
+  //! copy content from base class
+  void CopyFrom( const CMFlashCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( CMFlashCluster* source ) override
+  { CopyFrom( *source ); }
+
+  void setClusKey(unsigned int id) override { m_cluskey = id; }
+  unsigned int getClusKey() const override { return m_cluskey; }
+  //
+  // cluster position
+  //
+  float getX() const override { return m_pos[0]; }
+  void setX(float x) override { m_pos[0] = x; }
+  float getY() const override { return m_pos[1]; }
+  void setY(float y) override { m_pos[1] = y; }
+  float getZ() const override { return m_pos[2]; }
+  void setZ(float z) override { m_pos[2] = z; }
+
+  //
+  // cluster info
+  //
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+
+ protected:
+
+  unsigned int m_cluskey;  //< unique identifier within container
+  float m_pos[3];               //< mean position x,y,z
+  unsigned int m_adc;           //< cluster sum adc (D. McGlinchey - Do we need this?)
+
+  ClassDefOverride(CMFlashClusterv1, 1)
+};
+
+#endif //TRACKBASE_CMFLASHCLUSTERV1_H

--- a/offline/packages/trackbase/CMFlashClusterv1LinkDef.h
+++ b/offline/packages/trackbase/CMFlashClusterv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class CMFlashClusterv1+;
+
+#endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -20,6 +20,10 @@ AM_LDFLAGS = \
 pkginclude_HEADERS = \
   ActsSurfaceMaps.h \
   ActsTrackingGeometry.h \
+  CMFlashCluster.h \
+  CMFlashClusterv1.h \
+  CMFlashClusterContainer.h \
+  CMFlashClusterContainerv1.h \
   TpcSeedTrackMap.h \
   TpcSeedTrackMapv1.h \
   TrkrCluster.h \
@@ -48,6 +52,10 @@ pkginclude_HEADERS = \
   TrkrHitSetContainerv1.h
 
 ROOTDICTS = \
+  CMFlashCluster_Dict.cc \
+  CMFlashClusterv1_Dict.cc \
+  CMFlashClusterContainer_Dict.cc \
+  CMFlashClusterContainerv1_Dict.cc \
   TrkrCluster_Dict.cc \
   TrkrClusterv1_Dict.cc \
   TrkrClusterv2_Dict.cc \
@@ -77,6 +85,10 @@ ROOTDICTS = \
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
+  CMFlashCluster_Dict_rdict.pcm \
+  CMFlashClusterv1_Dict_rdict.pcm \
+  CMFlashClusterContainer_Dict_rdict.pcm \
+  CMFlashClusterContainerv1_Dict_rdict.pcm \
   TrkrCluster_Dict_rdict.pcm \
   TrkrClusterv1_Dict_rdict.pcm \
   TrkrClusterv2_Dict_rdict.pcm \
@@ -107,6 +119,8 @@ nobase_dist_pcm_DATA = \
 libtrack_io_la_SOURCES = \
   $(ROOTDICTS) \
   ActsSurfaceMaps.cc \
+  CMFlashClusterv1.cc \
+  CMFlashClusterContainerv1.cc \
   TrkrClusterv1.cc \
   TrkrClusterv2.cc \
   TrkrClusterv3.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds classes to store reconstructed clusters from the central membrane flash on the node tree. Because these reconstructed clusters are not uniquely associated with a layer, the TrkrCluster classes are not suitable to store them. they are stored as 3D space points, with an ADC value. These storage classes will be used throughout the central membrane flash calibration procedure.
They are presently not implemented by any module in the repository. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

