### PR TITLE
Allow to set m_buildMMs externally

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -86,8 +86,12 @@ class MakeActsGeometry : public SubsysReco
   double getSurfStepPhi() {return m_surfStepPhi;}
   double getSurfStepZ() {return m_surfStepZ;}
 
-  void add_fake_surfaces(bool add){fake_surfaces = add;}
+  void add_fake_surfaces(bool add)
+  {fake_surfaces = add;}
 
+  void build_mm_surfaces( bool value )
+  { m_buildMMs = value; }
+    
  private:
   /// Main function to build all acts geometry for use in the fitting modules
   int buildAllGeometry(PHCompositeNode *topNode);


### PR DESCRIPTION
Allow to set m_buildMMs externally, so that it can be conditioned to Enable::MICROMEGAS
This is the first set of commits related to updated TPOT geometry. 
This one really does nothing but is needed to then update the steering macros without crashing.
The core of the changes will be pushed once the changes G4_Tracking and G4_Micromegas are also pushed 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

