### PR TITLE
Truth Seeding Bug Fix

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -8,6 +8,8 @@
 #define TRACKRECO_PHTRUTHTRACKSEEDING_H
 
 #include "PHTrackSeeding.h"
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/TrkrDefs.h>
 #include <string>  // for string
 #include <vector>
@@ -80,11 +82,11 @@ void helicalTrackFit(const bool helicalTrackFit)
   void circleFitSeed(std::vector<TrkrDefs::cluskey> clusters,
 		     double& x, double& y, double&z,
 		       double& px, double& py, double& pz, int charge);
-void circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
-			 double& R, double& X0, double& Y0);
+  std::vector<Acts::Vector3D> circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
+						double& R, double& X0, double& Y0);
   void findRoot(const double& R, const double& X0, const double& Y0,
 		double& x, double& y);
-  void lineFit(std::vector<TrkrDefs::cluskey>& clusters,
+  void lineFit(std::vector<Acts::Vector3D>& clusterPositions,
 	       double& A, double& B);
   PHG4TruthInfoContainer* _g4truth_container = nullptr;
   TrkrClusterContainer *m_clusterMap = nullptr;
@@ -106,6 +108,10 @@ void circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
 
   //! minimal truth momentum cut (GeV)
   double _min_momentum = 50e-3;
+
+  ActsTrackingGeometry *tgeometry = nullptr;
+  ActsSurfaceMaps *surfmaps = nullptr;
+
 };
 
 #endif


### PR DESCRIPTION
Update helical track fit option to use new global cluster position API

This PR makes two changes:

1. The default truth track seeding parameters somehow were changed to not be smeared out at all and taken as the truth values. This is not representative of an actual seeding algorithm, so this was changed back to a 5% smearing.
2. The optional helical fit code had become deprecated with the new cluster global position API. This is now fixed so that there is the option to perform a helical fit on the truth seed and get a more realistic set of initial track parameters.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

