### PR TITLE
Use geant config

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -116,9 +116,9 @@ class Fitter
     return verbosity;
   }
 
-  void set_verbosity(int verbosity)
+  void set_verbosity(int v)
   {
-    this->verbosity = verbosity;
+    this->verbosity = v;
     if (verbosity >= 1)
       genfit::Exception::quiet(false);
     else

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -127,9 +127,9 @@ class Track
     return verbosity;
   }
 
-  void set_verbosity(int verbosity)
+  void set_verbosity(int v)
   {
-    this->verbosity = verbosity;
+    this->verbosity = v;
   }
 
   //SMART(genfit::Track) getGenFitTrack() {return _track;}

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim.h
@@ -26,6 +26,7 @@ class SvtxTrack_FastSim: public SvtxTrack_v1
   SvtxTrack_FastSim( const SvtxTrack& );
 
   // copy content from base class
+  using PHObject::CopyFrom; // avoid warning for not implemented CopyFrom methods
   void CopyFrom( const SvtxTrack& ) override;
   void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }

--- a/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_FastSim_v1.h
@@ -22,6 +22,7 @@ class SvtxTrack_FastSim_v1 final: public SvtxTrack_FastSim
   ~SvtxTrack_FastSim_v1() override = default;
 
   // copy content from base class
+  using PHObject::CopyFrom; // avoid warning for not implemented CopyFrom methods
   void CopyFrom( const SvtxTrack& ) override;
   void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.h
@@ -37,6 +37,7 @@ class SvtxTrack_v1 : public SvtxTrack
   PHObject* CloneMe() const override { return new SvtxTrack_v1(*this); }
   
   // copy content from base class
+  using PHObject::CopyFrom; // avoid warning for not implemented CopyFrom methods
   void CopyFrom( const SvtxTrack& ) override;
   void CopyFrom( SvtxTrack* source ) override
   { CopyFrom( *source ); }

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.h
@@ -37,6 +37,8 @@ class SvtxTrack_v2: public SvtxTrack
   int isValid() const override;
   PHObject* CloneMe() const override { return new SvtxTrack_v2(*this); }
 
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
   // copy content from base class
   void CopyFrom( const SvtxTrack& ) override;
   void CopyFrom( SvtxTrack* source ) override

--- a/offline/packages/vararray/VariableArrayIds.h
+++ b/offline/packages/vararray/VariableArrayIds.h
@@ -3,11 +3,11 @@
 
 namespace varids
 {
-enum types
-{
-  G4VTXV1 = 1,
-  G4PARTICLEV1 = 2
-};
-};
+  enum types
+  {
+    G4VTXV1 = 1,
+    G4PARTICLEV1 = 2
+  };
+}
 
 #endif

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -33,11 +33,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-// TSystem shadows an enum (kDefault)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <cmath>      // for fabs, NAN, cos
 #include <exception>  // for exception

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -33,7 +33,11 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
+// TSystem shadows an enum (kDefault)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <cmath>      // for fabs, NAN, cos
 #include <exception>  // for exception

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -53,7 +53,6 @@ HcalRawTowerBuilder::HcalRawTowerBuilder(const std::string &name)
   , PHParameterInterface(name)
 {
   InitializeParameters();
-
 }
 
 int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
@@ -169,8 +168,8 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   for (int i = 0; i < get_int_param("etabins"); i++)
   {
     //double etahibound = etalowbound + 2.2 / get_int_param("etabins");
-    double etahibound = etalowbound + 
-      (get_double_param("scinti_eta_coverage_neg")+get_double_param("scinti_eta_coverage_pos")) / get_int_param("etabins");
+    double etahibound = etalowbound +
+                        (get_double_param("scinti_eta_coverage_neg") + get_double_param("scinti_eta_coverage_pos")) / get_int_param("etabins");
     std::pair<double, double> range = std::make_pair(etalowbound, etahibound);
     m_RawTowerGeom->set_etabounds(i, range);
     etalowbound = etahibound;
@@ -196,20 +195,20 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
         if (fabs(tg->get_center_x() - x) > 1e-4)
         {
           std::cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
-               << std::endl;
+                    << std::endl;
 
           return Fun4AllReturnCodes::ABORTRUN;
         }
         if (fabs(tg->get_center_y() - y) > 1e-4)
         {
           std::cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
-               << std::endl;
+                    << std::endl;
           return Fun4AllReturnCodes::ABORTRUN;
         }
         if (fabs(tg->get_center_z() - z) > 1e-4)
         {
           std::cout << "HcalRawTowerBuilder::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
-               << std::endl;
+                    << std::endl;
           return Fun4AllReturnCodes::ABORTRUN;
         }
       }
@@ -237,46 +236,48 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   int m = m_DecalArray[0].size();
   int n = m_DecalArray.size();
 
-  for(int i = 0; i < n; i++){
-    for(int j= 0; j < m; j++){
-          m_DecalArray[i][j] = 1.;
-	}}
+  for (int i = 0; i < n; i++)
+  {
+    for (int j = 0; j < m; j++)
+    {
+      m_DecalArray[i][j] = 1.;
+    }
+  }
 
-    if (!m_DeCalibrationFileName.empty())
+  if (!m_DeCalibrationFileName.empty())
+  {
+    if (std::filesystem::exists(m_DeCalibrationFileName))
+    {
+      std::ifstream decalibrate_tower;
+      decalibrate_tower.open(m_DeCalibrationFileName, std::ifstream::in);
+      if (decalibrate_tower.is_open())
       {
-        if (std::filesystem::exists(m_DeCalibrationFileName))
+        while (!decalibrate_tower.eof())
         {
-          std::ifstream decalibrate_tower;
-          decalibrate_tower.open(m_DeCalibrationFileName, std::ifstream::in);
-          if (decalibrate_tower.is_open())
+          int etabin = -1;
+          int phibin = -1;
+          for (int i = 0; i < n; i++)
           {
-            while (!decalibrate_tower.eof())
+            for (int j = 0; j < m; j++)
             {
-            int etabin = -1;
-            int phibin = -1;
-            for(int i = 0; i < n ; i++)
-             {
-                for(int j = 0; j < m; j++)
-                  {
-                    decalibrate_tower >> etabin >> phibin >> m_DecalArray[i][j];
-                      if (!std::isfinite(m_DecalArray[i][j]))
-                      {
-                          std::cout << "Calibration constant at etabin " << etabin
-                            << ", phibin " << phibin << " in " << m_DeCalibrationFileName
-                            << " is not finite: " << m_DecalArray[i][j] << std::endl;
-                          gSystem->Exit(1);
-                          exit(1);
-                      }
-                      
-                  }
-             }
+              decalibrate_tower >> etabin >> phibin >> m_DecalArray[i][j];
+              if (!std::isfinite(m_DecalArray[i][j]))
+              {
+                std::cout << "Calibration constant at etabin " << etabin
+                          << ", phibin " << phibin << " in " << m_DeCalibrationFileName
+                          << " is not finite: " << m_DecalArray[i][j] << std::endl;
+                gSystem->Exit(1);
+                exit(1);
+              }
             }
-            decalibrate_tower.close();
           }
         }
+        decalibrate_tower.close();
       }
+    }
+  }
 
- return Fun4AllReturnCodes::EVENT_OK;
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
@@ -322,26 +323,25 @@ int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
 
     if (m_TowerEnergySrc == kEnergyDeposition)
     {
-        cell_weight = cell->get_edep();
+      cell_weight = cell->get_edep();
     }
     else if (m_TowerEnergySrc == kLightYield)
     {
-        cell_weight = cell->get_light_yield();
+      cell_weight = cell->get_light_yield();
     }
     else if (m_TowerEnergySrc == kIonizationEnergy)
     {
-        cell_weight = cell->get_eion();
+      cell_weight = cell->get_eion();
     }
     else
     {
       std::cout << Name() << ": unknown tower energy source "
-           << m_TowerEnergySrc << std::endl;
+                << m_TowerEnergySrc << std::endl;
       gSystem->Exit(1);
       exit(1);
     }
-  
-    cell_weight *= m_DecalArray.at(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid())).
-                                at(PHG4CellDefs::ScintillatorSlatBinning::get_row(cell->get_cellid()));
+
+    cell_weight *= m_DecalArray.at(PHG4CellDefs::ScintillatorSlatBinning::get_column(cell->get_cellid())).at(PHG4CellDefs::ScintillatorSlatBinning::get_row(cell->get_cellid()));
     tower->add_ecell(cell->get_cellid(), cell_weight);
 
     PHG4Cell::ShowerEdepConstRange range = cell->get_g4showers();
@@ -363,7 +363,7 @@ int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
     if (fabs(cellE - towerE) / cellE > 1e-5)
     {
       std::cout << "towerE: " << towerE << ", cellE: " << cellE << ", delta: "
-           << cellE - towerE << std::endl;
+                << cellE - towerE << std::endl;
     }
   }
 
@@ -376,8 +376,8 @@ int HcalRawTowerBuilder::process_event(PHCompositeNode *topNode)
   if (Verbosity())
   {
     std::cout << "Energy lost by dropping towers with less than " << m_Emin
-         << " energy, lost energy: " << towerE - m_Towers->getTotalEdep()
-         << std::endl;
+              << " energy, lost energy: " << towerE - m_Towers->getTotalEdep()
+              << std::endl;
     m_Towers->identify();
     RawTowerContainer::ConstRange begin_end = m_Towers->getTowers();
     RawTowerContainer::ConstIterator iter;
@@ -456,7 +456,6 @@ void HcalRawTowerBuilder::SetDefaultParameters()
 
   set_default_double_param("scinti_eta_coverage_neg", 1.1);
   set_default_double_param("scinti_eta_coverage_pos", 1.1);
-
 }
 
 void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
@@ -483,12 +482,12 @@ void HcalRawTowerBuilder::ReadParamsFromNodeTree(PHCompositeNode *topNode)
   if (nTiles <= 0)
   {
     nTiles = pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_pos) + pars->get_int_param(PHG4HcalDefs::n_scinti_tiles_neg);
-    set_double_param("scinti_eta_coverage_neg",pars->get_double_param("scinti_eta_coverage_neg")); 
-    set_double_param("scinti_eta_coverage_pos",pars->get_double_param("scinti_eta_coverage_pos"));     
+    set_double_param("scinti_eta_coverage_neg", pars->get_double_param("scinti_eta_coverage_neg"));
+    set_double_param("scinti_eta_coverage_pos", pars->get_double_param("scinti_eta_coverage_pos"));
   }
   set_int_param("etabins", nTiles);
-  m_DecalArray.resize(nTiles, std::vector<double> (nPhislices));
- 
+  m_DecalArray.resize(nTiles, std::vector<double>(nPhislices));
+
   delete pars;
   return;
 }
@@ -502,7 +501,7 @@ void HcalRawTowerBuilder::SetTowerDecalFactors()
 {
   for (auto iter = m_TowerDecalFactors.begin(); iter != m_TowerDecalFactors.end(); ++iter)
   {
-    set_tower_decal_factor_real(iter->first.first,iter->first.second,iter->second);
+    set_tower_decal_factor_real(iter->first.first, iter->first.second, iter->second);
   }
 }
 
@@ -510,15 +509,15 @@ void HcalRawTowerBuilder::set_tower_decal_factor(const int etabin, const int phi
 {
   // since we do not have the number of scintillators per tower at this point
   // the decal values are cached in m_TowerDecalFactors to be set during the InitRun
-  std::pair<int, int> etaphi = std::make_pair(etabin,phibin);
+  std::pair<int, int> etaphi = std::make_pair(etabin, phibin);
   m_TowerDecalFactors[etaphi] = d;
 }
 
 void HcalRawTowerBuilder::set_tower_decal_factor_real(const int etabin, const int phibin, const double d)
 {
-  for (int i=0; i<m_NcellToTower; i++)
+  for (int i = 0; i < m_NcellToTower; i++)
   {
-    int istart = phibin*m_NcellToTower + i;
+    int istart = phibin * m_NcellToTower + i;
     m_DecalArray.at(etabin).at(istart) = d;
   }
 }

--- a/simulation/g4simulation/g4calo/Makefile.am
+++ b/simulation/g4simulation/g4calo/Makefile.am
@@ -12,7 +12,7 @@ AM_CXXFLAGS = `geant4-config --cflags`
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
   HcalRawTowerBuilder.h \

--- a/simulation/g4simulation/g4calo/Makefile.am
+++ b/simulation/g4simulation/g4calo/Makefile.am
@@ -7,23 +7,25 @@ AUTOMAKE_OPTIONS = foreign
 lib_LTLIBRARIES = \
   libg4calo.la
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I${G4_MAIN}/include
+  -I$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
   HcalRawTowerBuilder.h \
   RawTowerBuilder.h \
   RawTowerBuilderByHitIndex.h \
   RawTowerDigitizer.h 
+
 libg4calo_la_SOURCES = \
   HcalRawTowerBuilder.cc \
   RawTowerBuilder.cc \
   RawTowerBuilderByHitIndex.cc \
   RawTowerDigitizer.cc 
-  
+
 libg4calo_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib

--- a/simulation/g4simulation/g4calo/configure.ac
+++ b/simulation/g4simulation/g4calo/configure.ac
@@ -7,14 +7,7 @@ LT_INIT([disable-static])
 
 dnl leaving this here in case we want to play with different compiler 
 dnl specific flags
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4centrality/Makefile.am
+++ b/simulation/g4simulation/g4centrality/Makefile.am
@@ -3,8 +3,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I${G4_MAIN}/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 lib_LTLIBRARIES = \
    libg4centrality.la

--- a/simulation/g4simulation/g4centrality/configure.ac
+++ b/simulation/g4simulation/g4centrality/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/simulation/g4simulation/g4decayer/Makefile.am
+++ b/simulation/g4simulation/g4decayer/Makefile.am
@@ -14,8 +14,7 @@ AM_CXXFLAGS=`geant4-config --cflags`
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include  \
-  -I${G4_MAIN}/include
+  -I$(OFFLINE_MAIN)/include
 
 libg4decayer_la_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4decayer/configure.ac
+++ b/simulation/g4simulation/g4decayer/configure.ac
@@ -20,25 +20,19 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 fi
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template -Wno-shadow"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
  ;;
 esac
 
 dnl   AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)
-fi
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
@@ -9,7 +9,10 @@
 
 #include <phool/phool.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ChordFinder.hh>
 #include <Geant4/G4ClassicalRK4.hh>

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
@@ -9,10 +9,7 @@
 
 #include <phool/phool.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ChordFinder.hh>
 #include <Geant4/G4ClassicalRK4.hh>

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
@@ -8,10 +8,7 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
@@ -8,7 +8,10 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
@@ -310,7 +310,7 @@ void BeamLineMagnetSteppingAction::SetInterfacePointers(PHCompositeNode* topNode
   }
 }
 
-void BeamLineMagnetSteppingAction::SetHitNodeName(const std::string &type, const std::string &name)
+void BeamLineMagnetSteppingAction::SetHitNodeName(const std::string& type, const std::string& name)
 {
   if (type == "G4HIT")
   {

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
@@ -14,10 +14,7 @@
 
 #include <phool/getClass.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.cc
@@ -14,7 +14,10 @@
 
 #include <phool/getClass.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSteppingAction.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4SteppingAction.h>
 
-#include <string>                       // for string
+#include <string>  // for string
 
 class G4Step;
 class G4VPhysicalVolume;
@@ -30,7 +30,7 @@ class BeamLineMagnetSteppingAction : public PHG4SteppingAction
   //! reimplemented from base class
   void SetInterfacePointers(PHCompositeNode*) override;
 
-  void SetHitNodeName(const std::string &type, const std::string &name) override;
+  void SetHitNodeName(const std::string& type, const std::string& name) override;
 
  private:
   //! pointer to the detector

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
@@ -89,8 +89,8 @@ int BeamLineMagnetSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
       }
     }
     m_SteppingAction = new BeamLineMagnetSteppingAction(m_Detector, GetParams());
-    m_SteppingAction->SetHitNodeName("G4HIT",m_HitNodeName);
-    m_SteppingAction->SetHitNodeName("G4HIT_ABSORBER",m_AbsorberNodeName);
+    m_SteppingAction->SetHitNodeName("G4HIT", m_HitNodeName);
+    m_SteppingAction->SetHitNodeName("G4HIT_ABSORBER", m_AbsorberNodeName);
   }
   else if (GetParams()->get_int_param("blackhole"))
   {
@@ -142,7 +142,7 @@ void BeamLineMagnetSubsystem::SetDefaultParameters()
   set_default_double_param("rot_z", 0.);
   set_default_double_param("inner_radius", 4);
   set_default_double_param("outer_radius", 100);
-  set_default_double_param("skin_thickness",0.); // Fe thickness before tracks are terminated
+  set_default_double_param("skin_thickness", 0.);  // Fe thickness before tracks are terminated
 }
 
 void BeamLineMagnetSubsystem::Print(const std::string & /*what*/) const

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -5,14 +5,14 @@ lib_LTLIBRARIES = \
   libg4detectors_io.la \
   libg4detectors.la
 
-#AM_CXXFLAGS = `geant4-config --cflags  | sed s/-Woverloaded-virtual// | sed s/-pedantic// | sed s/-Wshadow// | sed s/-W\ //`
 AM_CXXFLAGS = `geant4-config --cflags`
 
 AM_CPPFLAGS = \
   -DCGAL_DISABLE_ROUNDING_MATH_CHECK \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
+  -isystem$(ROOTSYS)/include \
+  -isystem$(XERCESROOT)/include \
   -I$(OPT_SPHENIX)/include
 
 # set in configure.in to check if gcc version >= 4.8

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -5,14 +5,14 @@ lib_LTLIBRARIES = \
   libg4detectors_io.la \
   libg4detectors.la
 
-AM_CXXFLAGS = `geant4-config --cflags  | sed s/-Woverloaded-virtual// | sed s/-pedantic// | sed s/-Wshadow// | sed s/-W\ //`
+#AM_CXXFLAGS = `geant4-config --cflags  | sed s/-Woverloaded-virtual// | sed s/-pedantic// | sed s/-Wshadow// | sed s/-W\ //`
+AM_CXXFLAGS = `geant4-config --cflags`
 
 AM_CPPFLAGS = \
   -DCGAL_DISABLE_ROUNDING_MATH_CHECK \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
   -I$(ROOTSYS)/include \
-  -I$(G4_MAIN)/include \
   -I$(OPT_SPHENIX)/include
 
 # set in configure.in to check if gcc version >= 4.8

--- a/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
@@ -202,71 +202,70 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   // The north inverts the x coordinate (x -> -x)
   // (NB: Should probably move this to a geometry object...)
   float TubeLoc[64][2] = {
-    { -12.2976,	4.26 },
-    { -12.2976,	1.42 },
-    { -9.83805,	8.52 },
-    { -9.83805,	5.68 },
-    { -9.83805,	2.84 },
-    { -7.37854,	9.94 },
-    { -7.37854,	7.1 },
-    { -7.37854,	4.26 },
-    { -7.37854,	1.42 },
-    { -4.91902,	11.36 },
-    { -4.91902,	8.52 },
-    { -4.91902,	5.68 },
-    { -2.45951,	12.78 },
-    { -2.45951,	9.94 },
-    { -2.45951,	7.1 },
-    { 0,	11.36 },
-    { 0,	8.52 },
-    { 2.45951,	12.78 },
-    { 2.45951,	9.94 },
-    { 2.45951,	7.1 },
-    { 4.91902,	11.36 },
-    { 4.91902,	8.52 },
-    { 4.91902,	5.68 },
-    { 7.37854,	9.94 },
-    { 7.37854,	7.1 },
-    { 7.37854,	4.26 },
-    { 7.37854,	1.42 },
-    { 9.83805,	8.52 },
-    { 9.83805,	5.68 },
-    { 9.83805,	2.84 },
-    { 12.2976,	4.26 },
-    { 12.2976,	1.42 },
-    { 12.2976,	-4.26 },
-    { 12.2976,	-1.42 },
-    { 9.83805,	-8.52 },
-    { 9.83805,	-5.68 },
-    { 9.83805,	-2.84 },
-    { 7.37854,	-9.94 },
-    { 7.37854,	-7.1 },
-    { 7.37854,	-4.26 },
-    { 7.37854,	-1.42 },
-    { 4.91902,	-11.36 },
-    { 4.91902,	-8.52 },
-    { 4.91902,	-5.68 },
-    { 2.45951,	-12.78 },
-    { 2.45951,	-9.94 },
-    { 2.45951,	-7.1 },
-    { 0,	-11.36 },
-    { 0,	-8.52 },
-    { -2.45951,	-12.78 },
-    { -2.45951,	-9.94 },
-    { -2.45951,	-7.1 },
-    { -4.91902,	-11.36 },
-    { -4.91902,	-8.52 },
-    { -4.91902,	-5.68 },
-    { -7.37854,	-9.94 },
-    { -7.37854,	-7.1 },
-    { -7.37854,	-4.26 },
-    { -7.37854,	-1.42 },
-    { -9.83805,	-8.52 },
-    { -9.83805,	-5.68 },
-    { -9.83805,	-2.84 },
-    { -12.2976,	-4.26 },
-    { -12.2976,	-1.42 }
-  };    
+      {-12.2976, 4.26},
+      {-12.2976, 1.42},
+      {-9.83805, 8.52},
+      {-9.83805, 5.68},
+      {-9.83805, 2.84},
+      {-7.37854, 9.94},
+      {-7.37854, 7.1},
+      {-7.37854, 4.26},
+      {-7.37854, 1.42},
+      {-4.91902, 11.36},
+      {-4.91902, 8.52},
+      {-4.91902, 5.68},
+      {-2.45951, 12.78},
+      {-2.45951, 9.94},
+      {-2.45951, 7.1},
+      {0, 11.36},
+      {0, 8.52},
+      {2.45951, 12.78},
+      {2.45951, 9.94},
+      {2.45951, 7.1},
+      {4.91902, 11.36},
+      {4.91902, 8.52},
+      {4.91902, 5.68},
+      {7.37854, 9.94},
+      {7.37854, 7.1},
+      {7.37854, 4.26},
+      {7.37854, 1.42},
+      {9.83805, 8.52},
+      {9.83805, 5.68},
+      {9.83805, 2.84},
+      {12.2976, 4.26},
+      {12.2976, 1.42},
+      {12.2976, -4.26},
+      {12.2976, -1.42},
+      {9.83805, -8.52},
+      {9.83805, -5.68},
+      {9.83805, -2.84},
+      {7.37854, -9.94},
+      {7.37854, -7.1},
+      {7.37854, -4.26},
+      {7.37854, -1.42},
+      {4.91902, -11.36},
+      {4.91902, -8.52},
+      {4.91902, -5.68},
+      {2.45951, -12.78},
+      {2.45951, -9.94},
+      {2.45951, -7.1},
+      {0, -11.36},
+      {0, -8.52},
+      {-2.45951, -12.78},
+      {-2.45951, -9.94},
+      {-2.45951, -7.1},
+      {-4.91902, -11.36},
+      {-4.91902, -8.52},
+      {-4.91902, -5.68},
+      {-7.37854, -9.94},
+      {-7.37854, -7.1},
+      {-7.37854, -4.26},
+      {-7.37854, -1.42},
+      {-9.83805, -8.52},
+      {-9.83805, -5.68},
+      {-9.83805, -2.84},
+      {-12.2976, -4.26},
+      {-12.2976, -1.42}};
 
   //m_bbcz = m_Params->get_double_param("z") * cm;
   m_bbcz = 250.0 * cm;  // The front face of the quartz is at 250 cm
@@ -298,7 +297,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
       // Full PMT Housing with Active Quartz Cerenkov Radiators
       float tube_xpos = xside * TubeLoc[itube][0] * cm;
       float tube_ypos = TubeLoc[itube][1] * cm;
-      new G4PVPlacement(arm_rot[iarm], G4ThreeVector( tube_xpos, tube_ypos, zside*tube_zpos ),
+      new G4PVPlacement(arm_rot[iarm], G4ThreeVector(tube_xpos, tube_ypos, zside * tube_zpos),
                         bbcd_lv, "BBCD", logicWorld, false, iarm * NPMT + itube, OverlapCheck());
     }
   }
@@ -355,48 +354,48 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
                                     bbc_plate_lv, "BBC_BPLATE", logicWorld, false, 0, OverlapCheck());
 
   // Place BBC Cables
-  G4Material* Cu = manager->FindOrBuildMaterial("G4_Cu");
-  const G4double len_cable = 120*cm;
-  const G4double r_CableConductor = 0.09525*cm;
-  G4Tubs *bbc_cablecond = new G4Tubs("bbc_cablecond",0.,r_CableConductor,len_cable*0.5,0*deg,360*deg);
+  G4Material *Cu = manager->FindOrBuildMaterial("G4_Cu");
+  const G4double len_cable = 120 * cm;
+  const G4double r_CableConductor = 0.09525 * cm;
+  G4Tubs *bbc_cablecond = new G4Tubs("bbc_cablecond", 0., r_CableConductor, len_cable * 0.5, 0 * deg, 360 * deg);
 
   G4LogicalVolume *bbc_cablecond_lv = new G4LogicalVolume(bbc_cablecond, Cu, G4String("Bbc_CableCond"));
 
-  const G4double rIn_CableShield = 0.302876*cm;
-  const G4double rOut_CableShield = 0.3175*cm;
-  G4Tubs *bbc_cableshield = new G4Tubs("bbc_cableshield",rIn_CableShield,rOut_CableShield,len_cable*0.5,0*deg,360*deg);
+  const G4double rIn_CableShield = 0.302876 * cm;
+  const G4double rOut_CableShield = 0.3175 * cm;
+  G4Tubs *bbc_cableshield = new G4Tubs("bbc_cableshield", rIn_CableShield, rOut_CableShield, len_cable * 0.5, 0 * deg, 360 * deg);
 
   G4LogicalVolume *bbc_cableshield_lv = new G4LogicalVolume(bbc_cableshield, Cu, G4String("Bbc_CableShield"));
 
-  ypos = len_cable/2 + 5*cm;
+  ypos = len_cable / 2 + 5 * cm;
 
   // For now we make this vertical, but they should be slanted toward the endcap
   G4RotationMatrix *rot_cable = new G4RotationMatrix();
-  rot_cable->rotateX( 90*deg );
+  rot_cable->rotateX(90 * deg);
 
   int icable = 0;
 
-  for (int iarm=0; iarm<2; iarm++)
+  for (int iarm = 0; iarm < 2; iarm++)
   {
     float zsign = -1.0;
-    if ( iarm == 1 )
+    if (iarm == 1)
     {
       zsign = 1.0;
     }
 
-    for (int iring=1; iring<5; iring++)
+    for (int iring = 1; iring < 5; iring++)
     {
-      float ring_radius = iring*0.67*cm; 
-      int ncables = 2*M_PI*ring_radius/(0.635*cm);
-      double dphi = 2*M_PI/ncables;
+      float ring_radius = iring * 0.67 * cm;
+      int ncables = 2 * M_PI * ring_radius / (0.635 * cm);
+      double dphi = 2 * M_PI / ncables;
 
       //G4cout << "BBC_CABLE " << iring << "\t" << ring_radius << "\t" << ncables << "\t" << dphi*180/3.14 << G4endl;
 
       // place cables in ring
-      for (int ic=0; ic<ncables; ic++)
+      for (int ic = 0; ic < ncables; ic++)
       {
-        xpos = cos(dphi*ic)*ring_radius;
-        zpos = sin(dphi*ic)*ring_radius + zsign*(m_bbcz + 30*cm);
+        xpos = cos(dphi * ic) * ring_radius;
+        zpos = sin(dphi * ic) * ring_radius + zsign * (m_bbcz + 30 * cm);
         // Place Inner Conductor
         new G4PVPlacement(rot_cable, G4ThreeVector(xpos, ypos, zpos), bbc_cablecond_lv, "BBC_Cable_Cond", logicWorld, false, icable, OverlapCheck());
         // Place Shield
@@ -406,7 +405,7 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   }
 
   // this is more to prevent compiler warnings about unused variables
-  if ( !fplate_vol[0] || !fplate_vol[1] || !bplate_vol[0] || !bplate_vol[1] )
+  if (!fplate_vol[0] || !fplate_vol[1] || !bplate_vol[0] || !bplate_vol[1])
   {
     std::cout << "problem placing BBC Sheets" << std::endl;
   }

--- a/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
@@ -6,10 +6,7 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
@@ -6,7 +6,10 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
@@ -14,10 +14,7 @@
 
 #include <phool/getClass.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
@@ -14,7 +14,10 @@
 
 #include <phool/getClass.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSteppingAction.cc
@@ -169,8 +169,8 @@ bool PHG4BbcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     {
       m_Hit = new PHG4Hitv1();
     }
-    m_Hit->set_layer( tube_id );
-    m_Hit->set_scint_id( tube_id );
+    m_Hit->set_layer(tube_id);
+    m_Hit->set_scint_id(tube_id);
 
     //here we set the entrance values in cm
     m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
@@ -187,10 +187,10 @@ bool PHG4BbcSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was_u
     if (whichactive > 0)
     {
       m_EionSum = 0;
-      m_Hit->set_eion( 0 );
+      m_Hit->set_eion(0);
 
       m_PathLen = 0.;
-      m_Hit->set_path_length( m_PathLen );
+      m_Hit->set_path_length(m_PathLen);
 
       m_SaveHitContainer = m_HitContainer;
     }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.h
@@ -5,23 +5,22 @@
 
 #include "PHG4DetectorSubsystem.h"
 
-#include <string>                   // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4BeamlineMagnetDetector;
 class PHG4Detector;
 
-class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
+class PHG4BeamlineMagnetSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4BeamlineMagnetSubsystem( const std::string &name = "CYLINDER", const int layer = 0 );
+  PHG4BeamlineMagnetSubsystem(const std::string &name = "CYLINDER", const int layer = 0);
 
   //! destructor
-  ~PHG4BeamlineMagnetSubsystem( void ) override
-  {}
+  ~PHG4BeamlineMagnetSubsystem(void) override
+  {
+  }
 
   //! init runwise stuff
   /*!
@@ -42,15 +41,14 @@ class PHG4BeamlineMagnetSubsystem: public PHG4DetectorSubsystem
   void Print(const std::string &what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const override;
+  PHG4Detector *GetDetector(void) const override;
 
  private:
   void SetDefaultParameters() override;
 
   //! detector geometry
   /*! defives from PHG4Detector */
-  PHG4BeamlineMagnetDetector* detector_;
-
+  PHG4BeamlineMagnetDetector *detector_;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.cc
@@ -6,35 +6,32 @@
 
 using namespace std;
 
-PHG4BlockCellGeom::PHG4BlockCellGeom():
-  _layer(-9999),
-  _binning(0),
-  _nzbins(-1),
-  _zmin(NAN),
-  _zstep(NAN),
-  _nxbins(-1),
-  _xmin(NAN),
-  _xstep(NAN)
+PHG4BlockCellGeom::PHG4BlockCellGeom()
+  : _layer(-9999)
+  , _binning(0)
+  , _nzbins(-1)
+  , _zmin(NAN)
+  , _zstep(NAN)
+  , _nxbins(-1)
+  , _xmin(NAN)
+  , _xstep(NAN)
 {
   return;
 }
 
-void
-PHG4BlockCellGeom::set_zbins(const int i)
+void PHG4BlockCellGeom::set_zbins(const int i)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _nzbins = i;
 }
 
-void
-PHG4BlockCellGeom::set_zmin(const double z)
+void PHG4BlockCellGeom::set_zmin(const double z)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _zmin = z;
 }
 
-int
-PHG4BlockCellGeom::get_zbins() const
+int PHG4BlockCellGeom::get_zbins() const
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return _nzbins;
@@ -54,15 +51,13 @@ PHG4BlockCellGeom::get_zstep() const
   return _zstep;
 }
 
-void
-PHG4BlockCellGeom::set_zstep(const double z)
+void PHG4BlockCellGeom::set_zstep(const double z)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   _zstep = z;
 }
 
-int
-PHG4BlockCellGeom::get_xbins() const
+int PHG4BlockCellGeom::get_xbins() const
 {
   check_binning_method_x("PHG4BlockCellGeom::get_xbins");
   return _nxbins;
@@ -82,29 +77,25 @@ PHG4BlockCellGeom::get_xmin() const
   return _xmin;
 }
 
-void
-PHG4BlockCellGeom::set_xbins(const int i)
+void PHG4BlockCellGeom::set_xbins(const int i)
 {
   check_binning_method_x("PHG4BlockCellGeom::set_xbins");
   _nxbins = i;
 }
 
-void
-PHG4BlockCellGeom::set_xstep(const double r)
+void PHG4BlockCellGeom::set_xstep(const double r)
 {
   check_binning_method_x("PHG4BlockCellGeom::set_xstep");
   _xstep = r;
 }
 
-void
-PHG4BlockCellGeom::set_xmin(const double r)
+void PHG4BlockCellGeom::set_xmin(const double r)
 {
   check_binning_method_x("PHG4BlockCellGeom::set_xmin");
   _xmin = r;
 }
 
-int
-PHG4BlockCellGeom::get_etabins() const
+int PHG4BlockCellGeom::get_etabins() const
 {
   check_binning_method_eta("PHG4BlockCellGeom::get_etabins");
   return _nzbins;
@@ -123,29 +114,25 @@ PHG4BlockCellGeom::get_etamin() const
   return _zmin;
 }
 
-void
-PHG4BlockCellGeom::set_etamin(const double z)
+void PHG4BlockCellGeom::set_etamin(const double z)
 {
   check_binning_method_eta("PHG4BlockCellGeom::set_etamin");
   _zmin = z;
 }
 
-void
-PHG4BlockCellGeom::set_etastep(const double z)
+void PHG4BlockCellGeom::set_etastep(const double z)
 {
   check_binning_method_eta("PHG4BlockCellGeom::set_etastep");
   _zstep = z;
 }
 
-void
-PHG4BlockCellGeom::set_etabins(const int i)
+void PHG4BlockCellGeom::set_etabins(const int i)
 {
   check_binning_method_eta("PHG4BlockCellGeom::set_etabins");
   _nzbins = i;
 }
 
-void
-PHG4BlockCellGeom::identify(std::ostream& os) const
+void PHG4BlockCellGeom::identify(std::ostream& os) const
 {
   os << "layer: " << _layer;
   switch (_binning)
@@ -185,10 +172,10 @@ pair<double, double>
 PHG4BlockCellGeom::get_zbounds(const int ibin) const
 {
   if (ibin < 0 || ibin > _nzbins)
-    {
-      cout << "Asking for invalid bin in z: " << ibin << endl;
-      exit(1);
-    }
+  {
+    cout << "Asking for invalid bin in z: " << ibin << endl;
+    exit(1);
+  }
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   double zlow = _zmin + ibin * _zstep;
   double zhigh = zlow + _zstep;
@@ -199,10 +186,10 @@ pair<double, double>
 PHG4BlockCellGeom::get_etabounds(const int ibin) const
 {
   if (ibin < 0 || ibin > _nzbins)
-    {
-      cout << "Asking for invalid bin in z: " << ibin << endl;
-      exit(1);
-    }
+  {
+    cout << "Asking for invalid bin in z: " << ibin << endl;
+    exit(1);
+  }
   check_binning_method_eta("PHG4BlockCellGeom::get_etabounds");
   //  check_binning_method(PHG4CylinderCellDefs::etaphibinning);
   double zlow = _zmin + ibin * _zstep;
@@ -210,57 +197,53 @@ PHG4BlockCellGeom::get_etabounds(const int ibin) const
   return make_pair(zlow, zhigh);
 }
 
-
 pair<double, double>
 PHG4BlockCellGeom::get_xbounds(const int ibin) const
 {
   if (ibin < 0 || ibin > _nxbins)
-    {
-      cout << "Asking for invalid bin in x: " << ibin << endl;
-      exit(1);
-    }
+  {
+    cout << "Asking for invalid bin in x: " << ibin << endl;
+    exit(1);
+  }
 
   double xlow = _xmin + ibin * _xstep;
   double xhigh = xlow + _xstep;
   return make_pair(xlow, xhigh);
 }
 
-int
-PHG4BlockCellGeom::get_zbin(const double z) const
+int PHG4BlockCellGeom::get_zbin(const double z) const
 {
-  if (z < _zmin || z > (_zmin+_nzbins*_zstep))
+  if (z < _zmin || z > (_zmin + _nzbins * _zstep))
   {
     cout << "Asking for bin for z outside of z range: " << z << endl;
     return -1;
   }
-  
+
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
-  return floor( (z-_zmin)/_zstep );
+  return floor((z - _zmin) / _zstep);
 }
 
-int
-PHG4BlockCellGeom::get_etabin(const double eta) const
+int PHG4BlockCellGeom::get_etabin(const double eta) const
 {
-  if (eta < _zmin || eta > (_zmin+_nzbins*_zstep))
+  if (eta < _zmin || eta > (_zmin + _nzbins * _zstep))
   {
     cout << "Asking for bin for eta outside of eta range: " << eta << endl;
     return -1;
   }
   check_binning_method_eta();
-  return floor( (eta-_zmin)/_zstep );
+  return floor((eta - _zmin) / _zstep);
 }
 
-int
-PHG4BlockCellGeom::get_xbin(const double x) const
+int PHG4BlockCellGeom::get_xbin(const double x) const
 {
   double norm_x = x;
-  if(x < _xmin || x > (_xmin+_nxbins*_xstep))
+  if (x < _xmin || x > (_xmin + _nxbins * _xstep))
   {
     cout << "Asking for bin for x outside of x range: " << x << endl;
     return -1;
   }
   check_binning_method_x();
-  return floor( (norm_x-_xmin)/_xstep );
+  return floor((norm_x - _xmin) / _xstep);
 }
 
 double
@@ -272,7 +255,7 @@ PHG4BlockCellGeom::get_zcenter(const int ibin) const
     exit(1);
   }
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
-  return _zmin + (ibin + 0.5)*_zstep;
+  return _zmin + (ibin + 0.5) * _zstep;
 }
 
 double
@@ -281,11 +264,11 @@ PHG4BlockCellGeom::get_etacenter(const int ibin) const
   if (ibin < 0 || ibin > _nzbins)
   {
     cout << "Asking for invalid bin in eta: " << ibin << endl;
-    cout << "minbin: 0, maxbin " << _nzbins << endl; 
+    cout << "minbin: 0, maxbin " << _nzbins << endl;
     exit(1);
   }
   check_binning_method_eta();
-  return _zmin + (ibin + 0.5)*_zstep;
+  return _zmin + (ibin + 0.5) * _zstep;
 }
 
 double
@@ -298,7 +281,7 @@ PHG4BlockCellGeom::get_xcenter(const int ibin) const
   }
 
   check_binning_method_x();
-  return (_xmin + (ibin + 0.5)*_xstep);
+  return (_xmin + (ibin + 0.5) * _xstep);
 }
 
 string
@@ -321,8 +304,7 @@ PHG4BlockCellGeom::methodname(const int i) const
   return "Unknown";
 }
 
-void
-PHG4BlockCellGeom::check_binning_method(const int i) const
+void PHG4BlockCellGeom::check_binning_method(const int i) const
 {
   if (_binning != i)
   {
@@ -334,15 +316,14 @@ PHG4BlockCellGeom::check_binning_method(const int i) const
   return;
 }
 
-void
-PHG4BlockCellGeom::check_binning_method_eta(const std::string & src) const
+void PHG4BlockCellGeom::check_binning_method_eta(const std::string& src) const
 {
-  if (_binning != PHG4CylinderCellDefs::etaphibinning && 
+  if (_binning != PHG4CylinderCellDefs::etaphibinning &&
       _binning != PHG4CylinderCellDefs::etaslatbinning)
   {
     if (src.size())
-      cout << src<<" : ";
-    
+      cout << src << " : ";
+
     cout << "different binning method used " << methodname(_binning)
          << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
          << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
@@ -352,16 +333,15 @@ PHG4BlockCellGeom::check_binning_method_eta(const std::string & src) const
   return;
 }
 
-void
-PHG4BlockCellGeom::check_binning_method_x(const std::string & src) const
+void PHG4BlockCellGeom::check_binning_method_x(const std::string& src) const
 {
-  if (_binning != PHG4CylinderCellDefs::etaphibinning && 
+  if (_binning != PHG4CylinderCellDefs::etaphibinning &&
       _binning != PHG4CylinderCellDefs::sizebinning &&
       _binning != PHG4CylinderCellDefs::etaslatbinning)
   {
     if (src.size())
-      cout << src<<" : ";
-    
+      cout << src << " : ";
+
     cout << "different binning method used " << methodname(_binning)
          << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
          << " or " << methodname(PHG4CylinderCellDefs::sizebinning)

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeom.h
@@ -5,22 +5,22 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <string>
-#include <utility>           // for pair
+#include <utility>  // for pair
 
-class PHG4BlockCellGeom: public PHObject
+class PHG4BlockCellGeom : public PHObject
 {
  public:
   PHG4BlockCellGeom();
 
   ~PHG4BlockCellGeom() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  int get_layer() const {return _layer;}
-  int get_binning() const {return _binning;}
+  int get_layer() const { return _layer; }
+  int get_binning() const { return _binning; }
 
   int get_zbins() const;
   double get_zstep() const;
@@ -46,25 +46,25 @@ class PHG4BlockCellGeom: public PHObject
   int get_zbin(const double z) const;
   int get_xbin(const double x) const;
 
-  void set_layer(const int i) {_layer = i;}
-  void set_binning(const int i) {_binning = i;}
+  void set_layer(const int i) { _layer = i; }
+  void set_binning(const int i) { _binning = i; }
 
   void set_zbins(const int i);
   void set_zmin(const double z);
   void set_zstep(const double z);
-  
+
   void set_xbins(const int i);
   void set_xstep(const double x);
   void set_xmin(const double x);
-  
+
   void set_etabins(const int i);
   void set_etamin(const double z);
   void set_etastep(const double z);
-  
+
  protected:
   void check_binning_method(const int i) const;
-  void check_binning_method_eta(const std::string & src = "") const;
-  void check_binning_method_x(const std::string & src = "") const;
+  void check_binning_method_eta(const std::string& src = "") const;
+  void check_binning_method_x(const std::string& src = "") const;
   std::string methodname(const int i) const;
 
   int _layer;
@@ -78,7 +78,7 @@ class PHG4BlockCellGeom: public PHObject
   double _xmin;
   double _xstep;
 
-  ClassDefOverride(PHG4BlockCellGeom,1)
+  ClassDefOverride(PHG4BlockCellGeom, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.cc
@@ -6,48 +6,45 @@ using namespace std;
 
 PHG4BlockCellGeomContainer::~PHG4BlockCellGeomContainer()
 {
-  while(layergeoms.begin() != layergeoms.end())
-    {
-      delete layergeoms.begin()->second;
-      layergeoms.erase(layergeoms.begin());
-    }
+  while (layergeoms.begin() != layergeoms.end())
+  {
+    delete layergeoms.begin()->second;
+    layergeoms.erase(layergeoms.begin());
+  }
   return;
 }
 
-void
-PHG4BlockCellGeomContainer::identify(std::ostream& os) const
+void PHG4BlockCellGeomContainer::identify(std::ostream &os) const
 {
-  map<int,PHG4BlockCellGeom *>::const_iterator iter;
-  for (iter=layergeoms.begin(); iter != layergeoms.end(); ++iter)
-    {
-      cout << "layer " << iter->first << endl;
-      (iter->second)->identify(os);
-    }
+  map<int, PHG4BlockCellGeom *>::const_iterator iter;
+  for (iter = layergeoms.begin(); iter != layergeoms.end(); ++iter)
+  {
+    cout << "layer " << iter->first << endl;
+    (iter->second)->identify(os);
+  }
   return;
 }
 
-int
-PHG4BlockCellGeomContainer::AddLayerCellGeom(const int i, PHG4BlockCellGeom *mygeom)
+int PHG4BlockCellGeomContainer::AddLayerCellGeom(const int i, PHG4BlockCellGeom *mygeom)
 {
   if (layergeoms.find(i) != layergeoms.end())
-    {
-      cout << "layer " << i << " already added to PHBlockCellGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << i << " already added to PHBlockCellGeomContainer" << endl;
+    return -1;
+  }
   mygeom->set_layer(i);
   layergeoms[i] = mygeom;
   return 0;
 }
 
-int
-PHG4BlockCellGeomContainer::AddLayerCellGeom(PHG4BlockCellGeom *mygeom)
+int PHG4BlockCellGeomContainer::AddLayerCellGeom(PHG4BlockCellGeom *mygeom)
 {
   int layer = mygeom->get_layer();
   if (layergeoms.find(layer) != layergeoms.end())
-    {
-      cout << "layer " << layer << " already added to PHBlockCellGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << layer << " already added to PHBlockCellGeomContainer" << endl;
+    return -1;
+  }
   layergeoms[layer] = mygeom;
   return 0;
 }
@@ -55,12 +52,11 @@ PHG4BlockCellGeomContainer::AddLayerCellGeom(PHG4BlockCellGeom *mygeom)
 PHG4BlockCellGeom *
 PHG4BlockCellGeomContainer::GetLayerCellGeom(const int i)
 {
-  map<int,PHG4BlockCellGeom *>::const_iterator iter = layergeoms.find(i);
-  if (iter !=  layergeoms.end())
-    {
-      return iter->second;
-    }
+  map<int, PHG4BlockCellGeom *>::const_iterator iter = layergeoms.find(i);
+  if (iter != layergeoms.end())
+  {
+    return iter->second;
+  }
   cout << "Could not locate layer " << i << " in PHG4BlockCellGeomContainer" << endl;
   return nullptr;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainer.h
@@ -5,36 +5,36 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>           // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHG4BlockCellGeom;
 
-class PHG4BlockCellGeomContainer: public PHObject
+class PHG4BlockCellGeomContainer : public PHObject
 {
  public:
-  typedef std::map<int, PHG4BlockCellGeom*> Map;
+  typedef std::map<int, PHG4BlockCellGeom *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
-  PHG4BlockCellGeomContainer(){}
+  PHG4BlockCellGeomContainer() {}
   ~PHG4BlockCellGeomContainer() override;
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
   int AddLayerCellGeom(const int i, PHG4BlockCellGeom *mygeom);
   int AddLayerCellGeom(PHG4BlockCellGeom *mygeom);
   PHG4BlockCellGeom *GetLayerCellGeom(const int i);
-  int get_NLayers() const {return layergeoms.size();}
-  std::pair<std::map<int,PHG4BlockCellGeom *>::const_iterator, std::map<int,PHG4BlockCellGeom *>::const_iterator> get_begin_end() const {return std::make_pair(layergeoms.begin(), layergeoms.end());}
+  int get_NLayers() const { return layergeoms.size(); }
+  std::pair<std::map<int, PHG4BlockCellGeom *>::const_iterator, std::map<int, PHG4BlockCellGeom *>::const_iterator> get_begin_end() const { return std::make_pair(layergeoms.begin(), layergeoms.end()); }
 
  protected:
-  std::map<int,PHG4BlockCellGeom *> layergeoms ;
-  ClassDefOverride(PHG4BlockCellGeomContainer,1)
+  std::map<int, PHG4BlockCellGeom *> layergeoms;
+  ClassDefOverride(PHG4BlockCellGeomContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockCellGeomContainer+;
+#pragma link C++ class PHG4BlockCellGeomContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockCellGeom+;
+#pragma link C++ class PHG4BlockCellGeom + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellGeomv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellGeomv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockCellGeomv1+;
+#pragma link C++ class PHG4BlockCellGeomv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -46,7 +46,7 @@ PHG4BlockCellReco::PHG4BlockCellReco(const string &name)
   SetDefaultParameters();
 }
 
-int PHG4BlockCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+int PHG4BlockCellReco::ResetEvent(PHCompositeNode * /*topNode*/)
 {
   sum_energy_g4hit = 0.;
   return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -76,29 +76,29 @@ void PHG4BlockDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   G4RotationMatrix *rotm = new G4RotationMatrix();
   int nRotation(0);
-  if (m_Params->get_double_param("rot_x") !=0 )
+  if (m_Params->get_double_param("rot_x") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
   }
-  if (m_Params->get_double_param("rot_y") !=0 )
+  if (m_Params->get_double_param("rot_y") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
   }
-  if (m_Params->get_double_param("rot_z") !=0 )
+  if (m_Params->get_double_param("rot_z") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
   }
 
-  if (nRotation>=2)
+  if (nRotation >= 2)
   {
-    cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
-        <<"("<<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<") degrees. "
-        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    cout << __PRETTY_FUNCTION__ << ": Warning : " << GetName() << " is configured with more than one of the x-y-z rotations of "
+         << "(" << m_Params->get_double_param("rot_x") << ", "
+         << m_Params->get_double_param("rot_x") << ", "
+         << m_Params->get_double_param("rot_x") << ") degrees. "
+         << "The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
     rotm->print(cout);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDisplayAction.cc
@@ -26,7 +26,7 @@ PHG4BlockDisplayAction::~PHG4BlockDisplayAction()
   delete m_Colour;
 }
 
-void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4BlockDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   if (m_MyVolume->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeom.cc
@@ -2,8 +2,7 @@
 
 using namespace std;
 
-void
-PHG4BlockGeom::identify(std::ostream& os) const
+void PHG4BlockGeom::identify(std::ostream& os) const
 {
   os << "virtual PHG4BlockGeom"
      << endl;

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeom.h
@@ -7,51 +7,106 @@
 
 #include <phool/phool.h>
 
-#include <iostream>          // for cout, ostream
 #include <cmath>
+#include <iostream>  // for cout, ostream
 
-class PHG4BlockGeom: public PHObject
+class PHG4BlockGeom : public PHObject
 {
  public:
-
   ~PHG4BlockGeom() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual int get_layer() const {PHOOL_VIRTUAL_WARN("get_layer()"); return -99999;}
-  virtual double get_size_x() const {PHOOL_VIRTUAL_WARN("get_size_x()");return NAN;}
-  virtual double get_size_y() const {PHOOL_VIRTUAL_WARN("get_size_y()");return NAN;}
-  virtual double get_size_z() const {PHOOL_VIRTUAL_WARN("get_size_z()");return NAN;}
-  virtual double get_center_x() const {PHOOL_VIRTUAL_WARN("get_place_x()");return NAN;}
-  virtual double get_center_y() const {PHOOL_VIRTUAL_WARN("get_place_y()");return NAN;}
-  virtual double get_center_z() const {PHOOL_VIRTUAL_WARN("get_place_z()");return NAN;}
-  virtual double get_z_rot() const {PHOOL_VIRTUAL_WARN("get_z_rot()");return NAN;}
+  virtual int get_layer() const
+  {
+    PHOOL_VIRTUAL_WARN("get_layer()");
+    return -99999;
+  }
+  virtual double get_size_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_size_x()");
+    return NAN;
+  }
+  virtual double get_size_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_size_y()");
+    return NAN;
+  }
+  virtual double get_size_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_size_z()");
+    return NAN;
+  }
+  virtual double get_center_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_place_x()");
+    return NAN;
+  }
+  virtual double get_center_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_place_y()");
+    return NAN;
+  }
+  virtual double get_center_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_place_z()");
+    return NAN;
+  }
+  virtual double get_z_rot() const
+  {
+    PHOOL_VIRTUAL_WARN("get_z_rot()");
+    return NAN;
+  }
 
-  virtual double get_width() const {PHOOL_VIRTUAL_WARN("get_width()");return NAN;}
-  virtual double get_length() const {PHOOL_VIRTUAL_WARN("get_length()");return NAN;}
-  virtual double get_thickness() const {PHOOL_VIRTUAL_WARN("get_thickness()");return NAN;}
+  virtual double get_width() const
+  {
+    PHOOL_VIRTUAL_WARN("get_width()");
+    return NAN;
+  }
+  virtual double get_length() const
+  {
+    PHOOL_VIRTUAL_WARN("get_length()");
+    return NAN;
+  }
+  virtual double get_thickness() const
+  {
+    PHOOL_VIRTUAL_WARN("get_thickness()");
+    return NAN;
+  }
 
-  virtual double get_rot_matrix(const int, const int) const {PHOOL_VIRTUAL_WARN("get_rot_matrix(const int, const int)"); return NAN;}
+  virtual double get_rot_matrix(const int, const int) const
+  {
+    PHOOL_VIRTUAL_WARN("get_rot_matrix(const int, const int)");
+    return NAN;
+  }
 
-  virtual void set_layer(const int) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
+  virtual void set_layer(const int) { PHOOL_VIRTUAL_WARN("set_layer(const int)"); }
   virtual void set_size(const double /*sizex*/, const double /*sizey*/, const double /*sizez*/)
-    {PHOOL_VIRTUAL_WARN("set_size(const double, const double, const double)");}
+  {
+    PHOOL_VIRTUAL_WARN("set_size(const double, const double, const double)");
+  }
   virtual void set_place(const double /*placex*/, const double /*placey*/, const double /*placez*/)
-    {PHOOL_VIRTUAL_WARN("set_place(const double, const double, const double)");}
-  virtual void set_z_rot(const double) {PHOOL_VIRTUAL_WARN("set_z_rot(const double)");}
+  {
+    PHOOL_VIRTUAL_WARN("set_place(const double, const double, const double)");
+  }
+  virtual void set_z_rot(const double) { PHOOL_VIRTUAL_WARN("set_z_rot(const double)"); }
 
   virtual void convert_local_to_global(const double, const double, const double,
                                        double &, double &, double &) const
-    {PHOOL_VIRTUAL_WARN("convert_local_to_global(const double, const double, const double, double &, double &, double &)");}
-  virtual void convert_global_to_local(const double, const double, const double, 
-                                         double &, double &, double &) const
-    {PHOOL_VIRTUAL_WARN("convert_global_to_local(const double, const double, const double, double &, double &, double &)");}
+  {
+    PHOOL_VIRTUAL_WARN("convert_local_to_global(const double, const double, const double, double &, double &, double &)");
+  }
+  virtual void convert_global_to_local(const double, const double, const double,
+                                       double &, double &, double &) const
+  {
+    PHOOL_VIRTUAL_WARN("convert_global_to_local(const double, const double, const double, double &, double &, double &)");
+  }
 
  protected:
   PHG4BlockGeom() {}
 
-  ClassDefOverride(PHG4BlockGeom,1)
+  ClassDefOverride(PHG4BlockGeom, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.cc
@@ -7,12 +7,13 @@
 using namespace std;
 
 PHG4BlockGeomContainer::PHG4BlockGeomContainer()
-  :  _magfield(NAN)
-{}
+  : _magfield(NAN)
+{
+}
 
 PHG4BlockGeomContainer::~PHG4BlockGeomContainer()
 {
-  while(_layergeoms.begin() != _layergeoms.end())
+  while (_layergeoms.begin() != _layergeoms.end())
   {
     delete _layergeoms.begin()->second;
     _layergeoms.erase(_layergeoms.begin());
@@ -20,21 +21,19 @@ PHG4BlockGeomContainer::~PHG4BlockGeomContainer()
   return;
 }
 
-void
-PHG4BlockGeomContainer::identify(std::ostream& os) const
+void PHG4BlockGeomContainer::identify(std::ostream &os) const
 {
   os << "mag field: " << _magfield << endl;
   os << "number of layers: " << _layergeoms.size() << endl;
-  map<int,PHG4BlockGeom *>::const_iterator iter;
-  for (iter=_layergeoms.begin(); iter != _layergeoms.end(); ++iter)
+  map<int, PHG4BlockGeom *>::const_iterator iter;
+  for (iter = _layergeoms.begin(); iter != _layergeoms.end(); ++iter)
   {
     (iter->second)->identify(os);
   }
   return;
 }
 
-int
-PHG4BlockGeomContainer::AddLayerGeom(const int i, PHG4BlockGeom *mygeom)
+int PHG4BlockGeomContainer::AddLayerGeom(const int i, PHG4BlockGeom *mygeom)
 {
   if (_layergeoms.find(i) != _layergeoms.end())
   {
@@ -46,8 +45,7 @@ PHG4BlockGeomContainer::AddLayerGeom(const int i, PHG4BlockGeom *mygeom)
   return 0;
 }
 
-int
-PHG4BlockGeomContainer::AddLayerGeom(PHG4BlockGeom *mygeom)
+int PHG4BlockGeomContainer::AddLayerGeom(PHG4BlockGeom *mygeom)
 {
   int layer = mygeom->get_layer();
   if (_layergeoms.find(layer) != _layergeoms.end())
@@ -62,12 +60,11 @@ PHG4BlockGeomContainer::AddLayerGeom(PHG4BlockGeom *mygeom)
 PHG4BlockGeom *
 PHG4BlockGeomContainer::GetLayerGeom(const int i)
 {
-  map<int,PHG4BlockGeom *>::const_iterator iter = _layergeoms.find(i);
-  if (iter !=  _layergeoms.end())
+  map<int, PHG4BlockGeom *>::const_iterator iter = _layergeoms.find(i);
+  if (iter != _layergeoms.end())
   {
     return iter->second;
   }
   cout << "Could not locate layer " << i << " in PHG4BlockGeomContainer" << endl;
   return nullptr;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomContainer.h
@@ -5,16 +5,16 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>           // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHG4BlockGeom;
 
-class PHG4BlockGeomContainer: public PHObject
+class PHG4BlockGeomContainer : public PHObject
 {
  public:
-  typedef std::map<int,PHG4BlockGeom *> Map;
+  typedef std::map<int, PHG4BlockGeom *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -23,20 +23,20 @@ class PHG4BlockGeomContainer: public PHObject
   PHG4BlockGeomContainer();
   ~PHG4BlockGeomContainer() override;
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
   int AddLayerGeom(const int i, PHG4BlockGeom *mygeom);
   int AddLayerGeom(PHG4BlockGeom *mygeom);
   PHG4BlockGeom *GetLayerGeom(const int i);
-  int get_NLayers() const {return _layergeoms.size();}
-  std::pair<std::map<int,PHG4BlockGeom *>::const_iterator, std::map<int,PHG4BlockGeom *>::const_iterator> get_begin_end() const {return std::make_pair(_layergeoms.begin(), _layergeoms.end());}
+  int get_NLayers() const { return _layergeoms.size(); }
+  std::pair<std::map<int, PHG4BlockGeom *>::const_iterator, std::map<int, PHG4BlockGeom *>::const_iterator> get_begin_end() const { return std::make_pair(_layergeoms.begin(), _layergeoms.end()); }
 
  protected:
-  std::map<int,PHG4BlockGeom *> _layergeoms;
+  std::map<int, PHG4BlockGeom *> _layergeoms;
   float _magfield;
 
-  ClassDefOverride(PHG4BlockGeomContainer,1)
+  ClassDefOverride(PHG4BlockGeomContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockGeomContainer+;
+#pragma link C++ class PHG4BlockGeomContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockGeom+;
+#pragma link C++ class PHG4BlockGeom + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.cc
@@ -5,24 +5,24 @@
 
 using namespace std;
 
-PHG4BlockGeomv1::PHG4BlockGeomv1() :
-  PHG4BlockGeom(),
-  _layer(-1),
-  _rotation_z(NAN)
+PHG4BlockGeomv1::PHG4BlockGeomv1()
+  : PHG4BlockGeom()
+  , _layer(-1)
+  , _rotation_z(NAN)
 {
   const double filldval = 1.;
-  fill( _size, _size + sizeof(_size)/sizeof(double),NAN);
-  fill( _center, _center + sizeof(_center)/sizeof(double),NAN);
-  fill( &_rot_matrix[0][0], &_rot_matrix[0][0] + sizeof(_rot_matrix)/sizeof(double),filldval);
+  fill(_size, _size + sizeof(_size) / sizeof(double), NAN);
+  fill(_center, _center + sizeof(_center) / sizeof(double), NAN);
+  fill(&_rot_matrix[0][0], &_rot_matrix[0][0] + sizeof(_rot_matrix) / sizeof(double), filldval);
 }
 
-PHG4BlockGeomv1::PHG4BlockGeomv1( const int layer,
-                                  const double sizex, const double sizey, const double sizez, 
-                                  const double centerx, const double centery, const double centerz, 
-                                  const double zrot) :
-  PHG4BlockGeom(),
-  _layer(layer),
-  _rotation_z(zrot)
+PHG4BlockGeomv1::PHG4BlockGeomv1(const int layer,
+                                 const double sizex, const double sizey, const double sizez,
+                                 const double centerx, const double centery, const double centerz,
+                                 const double zrot)
+  : PHG4BlockGeom()
+  , _layer(layer)
+  , _rotation_z(zrot)
 {
   _size[0] = sizex;
   _size[1] = sizey;
@@ -34,19 +34,17 @@ PHG4BlockGeomv1::PHG4BlockGeomv1( const int layer,
   _build_rot_matrix();
 }
 
-void
-PHG4BlockGeomv1::identify(std::ostream& os) const
+void PHG4BlockGeomv1::identify(std::ostream &os) const
 {
-  os << "PHG4BlockGeomv1: layer: " << _layer 
-     << ", rotation in z: " << _rotation_z 
-     << ", size: (" << _size[0] << ", " << _size[1] << ", " << _size[2] << ")" 
-     << ", center: (" << _center[0] << ", " << _center[1] << ", " << _center[2] << ")" 
+  os << "PHG4BlockGeomv1: layer: " << _layer
+     << ", rotation in z: " << _rotation_z
+     << ", size: (" << _size[0] << ", " << _size[1] << ", " << _size[2] << ")"
+     << ", center: (" << _center[0] << ", " << _center[1] << ", " << _center[2] << ")"
      << endl;
   return;
 }
 
-void 
-PHG4BlockGeomv1::set_size(const double sizex, const double sizey, const double sizez)
+void PHG4BlockGeomv1::set_size(const double sizex, const double sizey, const double sizez)
 {
   _size[0] = sizex;
   _size[1] = sizey;
@@ -54,8 +52,7 @@ PHG4BlockGeomv1::set_size(const double sizex, const double sizey, const double s
   return;
 }
 
-void 
-PHG4BlockGeomv1::set_center(const double centerx, const double centery, const double centerz)
+void PHG4BlockGeomv1::set_center(const double centerx, const double centery, const double centerz)
 {
   _center[0] = centerx;
   _center[1] = centery;
@@ -67,25 +64,25 @@ void PHG4BlockGeomv1::convert_local_to_global(double lx, double ly, double lz,
                                               double &gx, double &gy, double &gz) const
 {
   // gvec = R^T lvec + offset
-  gx = _rot_matrix[0][0]*lx + _rot_matrix[1][0]*ly + _rot_matrix[2][0]*lz;
-  gy = _rot_matrix[0][1]*lx + _rot_matrix[1][1]*ly + _rot_matrix[2][1]*lz;
-  gz = _rot_matrix[0][2]*lx + _rot_matrix[1][2]*ly + _rot_matrix[2][2]*lz;
+  gx = _rot_matrix[0][0] * lx + _rot_matrix[1][0] * ly + _rot_matrix[2][0] * lz;
+  gy = _rot_matrix[0][1] * lx + _rot_matrix[1][1] * ly + _rot_matrix[2][1] * lz;
+  gz = _rot_matrix[0][2] * lx + _rot_matrix[1][2] * ly + _rot_matrix[2][2] * lz;
   gx += _center[0];
   gy += _center[1];
   gz += _center[2];
   return;
 }
 
-void PHG4BlockGeomv1::convert_global_x_to_local(double gx, double gy, double gz, 
+void PHG4BlockGeomv1::convert_global_x_to_local(double gx, double gy, double gz,
                                                 double &lx, double &ly, double &lz) const
 {
   // lvec = R (gvec - offset)
   gx -= _center[0];
   gy -= _center[1];
   gz -= _center[2];
-  lx = _rot_matrix[0][0]*gx + _rot_matrix[0][1]*gy + _rot_matrix[0][2]*gz;
-  ly = _rot_matrix[1][0]*gx + _rot_matrix[1][1]*gy + _rot_matrix[1][2]*gz;
-  lz = _rot_matrix[2][0]*gx + _rot_matrix[2][1]*gy + _rot_matrix[2][2]*gz;
+  lx = _rot_matrix[0][0] * gx + _rot_matrix[0][1] * gy + _rot_matrix[0][2] * gz;
+  ly = _rot_matrix[1][0] * gx + _rot_matrix[1][1] * gy + _rot_matrix[1][2] * gz;
+  lz = _rot_matrix[2][0] * gx + _rot_matrix[2][1] * gy + _rot_matrix[2][2] * gz;
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomv1.h
@@ -5,50 +5,54 @@
 
 #include "PHG4BlockGeom.h"
 
-#include <iostream>         // for cout, ostream
+#include <iostream>  // for cout, ostream
 
-class PHG4BlockGeomv1: public PHG4BlockGeom
+class PHG4BlockGeomv1 : public PHG4BlockGeom
 {
  public:
   PHG4BlockGeomv1();
-  PHG4BlockGeomv1( const int layer,
-                   const double sizex, const double sizey, const double sizez, 
-                   const double centerx, const double centery, const double centerz,
-                   const double zrot );
+  PHG4BlockGeomv1(const int layer,
+                  const double sizex, const double sizey, const double sizez,
+                  const double centerx, const double centery, const double centerz,
+                  const double zrot);
 
   ~PHG4BlockGeomv1() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
-  int get_layer() const override {return _layer;}
-  double get_width() const override {return _size[0];}
-  double get_thickness() const override {return _size[1];}
-  double get_length() const override {return _size[2];}
-  double get_center_x() const override {return _center[0];}
-  double get_center_y() const override {return _center[1];}
-  double get_center_z() const override {return _center[2];}
-  double get_z_rot() const override {return _rotation_z;}
+  int get_layer() const override { return _layer; }
+  double get_width() const override { return _size[0]; }
+  double get_thickness() const override { return _size[1]; }
+  double get_length() const override { return _size[2]; }
+  double get_center_x() const override { return _center[0]; }
+  double get_center_y() const override { return _center[1]; }
+  double get_center_z() const override { return _center[2]; }
+  double get_z_rot() const override { return _rotation_z; }
 
-  double get_size_x() const override {return _size[0];}
-  double get_size_y() const override {return _size[1];}
-  double get_size_z() const override {return _size[2];}
+  double get_size_x() const override { return _size[0]; }
+  double get_size_y() const override { return _size[1]; }
+  double get_size_z() const override { return _size[2]; }
 
-  double get_rot_matrix(const int i, const int j) const override {return _rot_matrix[i][j];}
+  double get_rot_matrix(const int i, const int j) const override { return _rot_matrix[i][j]; }
 
-  void set_layer(const int i) override {_layer = i;}
+  void set_layer(const int i) override { _layer = i; }
 
   // size in local coordinates
   void set_size(const double sizex, const double sizey, const double sizez) override;
 
-  void set_z_rot(const double zrot) override {_build_rot_matrix(); _rotation_z = zrot;}
+  void set_z_rot(const double zrot) override
+  {
+    _build_rot_matrix();
+    _rotation_z = zrot;
+  }
 
   void convert_local_to_global(double, double, double,
                                double &, double &, double &) const override;
 
-// our own (not inherited)
+  // our own (not inherited)
   void set_center(const double centerx, const double centery, const double centerz);
-  void convert_global_x_to_local(double, double, double, 
+  void convert_global_x_to_local(double, double, double,
                                  double &, double &, double &) const;
 
  protected:
@@ -60,7 +64,7 @@ class PHG4BlockGeomv1: public PHG4BlockGeom
   void _build_rot_matrix();
   double _rot_matrix[3][3];  // global -> local coordinates rotation matrix
 
-  ClassDefOverride(PHG4BlockGeomv1,1)
+  ClassDefOverride(PHG4BlockGeomv1, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4BlockGeomv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockGeomv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4BlockGeomv1+;
+#pragma link C++ class PHG4BlockGeomv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -9,7 +9,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
@@ -17,23 +17,23 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fPostSt...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fPostSt...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cmath>                               // for isfinite
-#include <cstdlib>                            // for exit
+#include <cmath>    // for isfinite
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                              // for operator<<, string
+#include <string>  // for operator<<, string
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -8,18 +8,18 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
-#include <phool/PHIODataNode.h>         // for PHIODataNode
-#include <phool/PHNode.h>               // for PHNode
-#include <phool/PHNodeIterator.h>       // for PHNodeIterator
-#include <phool/PHObject.h>             // for PHObject
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
 
-#include <cmath>                       // for NAN
+#include <cmath>  // for NAN
 #include <sstream>
 
 class PHG4BlockGeom;
@@ -52,12 +52,12 @@ int PHG4BlockSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 
   // create display settings before detector (detector adds its volumes to it)
   PHG4BlockDisplayAction *disp_action = new PHG4BlockDisplayAction(Name(), GetParams());
-   if (isfinite(m_ColorArray[0]) &&
+  if (isfinite(m_ColorArray[0]) &&
       isfinite(m_ColorArray[1]) &&
       isfinite(m_ColorArray[2]) &&
       isfinite(m_ColorArray[3]))
   {
-    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1],m_ColorArray[2],m_ColorArray[3]);
+    disp_action->SetColor(m_ColorArray[0], m_ColorArray[1], m_ColorArray[2], m_ColorArray[3]);
   }
   m_DisplayAction = disp_action;
   // create detector

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.h
@@ -52,10 +52,10 @@ class PHG4BlockSubsystem : public PHG4DetectorSubsystem
     m_ColorArray[2] = blue;
     m_ColorArray[3] = alpha;
   }
-// this method is used to check if it can be used as mothervolume
-// Subsystems which can be mothervolume need to implement this 
-// and return true
-  bool CanBeMotherSubsystem() const override {return true;}
+  // this method is used to check if it can be used as mothervolume
+  // Subsystems which can be mothervolume need to implement this
+  // and return true
+  bool CanBeMotherSubsystem() const override { return true; }
 
  private:
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.cc
@@ -2,11 +2,11 @@
 
 #include "PHG4CEmcTestBeamDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
@@ -14,38 +14,38 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fUndefined
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fUndefined
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <iostream>
-#include <string>                              // for operator+, string, ope...
+#include <string>  // for operator+, string, ope...
 
 class G4VPhysicalVolume;
 class PHCompositeNode;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4CEmcTestBeamSteppingAction::PHG4CEmcTestBeamSteppingAction( PHG4CEmcTestBeamDetector* detector ):
-  PHG4SteppingAction(detector->GetName()),
-  detector_( detector ),
-  hits_(nullptr),
-  absorberhits_(nullptr),
-  hit(nullptr)
-{}
+PHG4CEmcTestBeamSteppingAction::PHG4CEmcTestBeamSteppingAction(PHG4CEmcTestBeamDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+{
+}
 
 //____________________________________________________________________________..
-bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
-
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
@@ -53,165 +53,161 @@ bool PHG4CEmcTestBeamSteppingAction::UserSteppingAction( const G4Step* aStep, bo
   int whichactive = detector_->IsInCEmcTestBeam(volume);
 
   if (!whichactive)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
 
   // collect energy and track length step by step
   G4double edep = aStep->GetTotalEnergyDeposit() / GeV;
-  G4double eion = (aStep->GetTotalEnergyDeposit()-aStep->GetNonIonizingEnergyDeposit()) / GeV;
+  G4double eion = (aStep->GetTotalEnergyDeposit() - aStep->GetNonIonizingEnergyDeposit()) / GeV;
 
   const G4Track* aTrack = aStep->GetTrack();
 
   // if this block stops everything, just put all kinetic energy into edep
   if (detector_->IsBlackHole())
-    {
-      edep = aTrack->GetKineticEnergy() / GeV;
-      G4Track* killtrack = const_cast<G4Track *> (aTrack);
-      killtrack->SetTrackStatus(fStopAndKill);
-    }
+  {
+    edep = aTrack->GetKineticEnergy() / GeV;
+    G4Track* killtrack = const_cast<G4Track*>(aTrack);
+    killtrack->SetTrackStatus(fStopAndKill);
+  }
 
-  int tower_id = touch->GetCopyNumber(2); // tower number
+  int tower_id = touch->GetCopyNumber(2);  // tower number
   // make sure we are in a volume
-  if ( detector_->IsActive() )
+  if (detector_->IsActive())
+  {
+    bool geantino = false;
+    // the check for the pdg code speeds things up, I do not want to make
+    // an expensive string compare for every track when we know
+    // geantino or chargedgeantino has pid=0
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      bool geantino = false;
-      // the check for the pdg code speeds things up, I do not want to make
-      // an expensive string compare for every track when we know
-      // geantino or chargedgeantino has pid=0
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-	  aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
-      //       cout << "track id " << aTrack->GetTrackID() << endl;
-      //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-      //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	  hit = new PHG4Hitv1();
-	  hit->set_layer((unsigned int)tower_id);
-	  hit->set_scint_id(touch->GetCopyNumber(1)); // the copy number of the sandwich
-	  //here we set the entrance values in cm
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
-	  // time in ns
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
-	  //set the track ID
-	  {
-            hit->set_trkid(aTrack->GetTrackID());
-            if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
-
-	  //set the initial energy deposit
-	  hit->set_edep(0);
-	  hit->set_eion(0); // only implemented for v5 otherwise empty
-          PHG4HitContainer *hitcontainer;
-	  // here we do things which are different between scintillator and absorber hits
-	  if (whichactive > 0) // return of isinCEmcTestDetector, > 0 hit in scintillator, < 0 hit in absorber
-	    {
-              hitcontainer = hits_;
-	    }
-	  else
-	    {
-	      hitcontainer = absorberhits_;
-	    }
-	  // here we set what is common for scintillator and absorber hits
-	  hitcontainer->AddHit(tower_id, hit);
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->GetShower()->add_g4hit_id(hitcontainer->GetID(),hit->get_hit_id());
-		}
-	    }
-	  break;
-	default:
-	  break;
-	}
-      // here we just update the exit values, it will be overwritten
-      // for every step until we leave the volume or the particle
-      // ceases to exist
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
-
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
-      //sum up the energy to get total deposited
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-          hit->set_eion(-1);
-	}
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-
-
-	    }
-	}
-
-      //       hit->identify();
-      // return true to indicate the hit was used
-      return true;
-
+      geantino = true;
     }
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    //       cout << "track id " << aTrack->GetTrackID() << endl;
+    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
+    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      hit = new PHG4Hitv1();
+      hit->set_layer((unsigned int) tower_id);
+      hit->set_scint_id(touch->GetCopyNumber(1));  // the copy number of the sandwich
+      //here we set the entrance values in cm
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
+      // time in ns
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
+      //set the track ID
+      {
+        hit->set_trkid(aTrack->GetTrackID());
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+        {
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            hit->set_trkid(pp->GetUserTrackId());
+            hit->set_shower_id(pp->GetShower()->get_id());
+          }
+        }
+      }
+
+      //set the initial energy deposit
+      hit->set_edep(0);
+      hit->set_eion(0);  // only implemented for v5 otherwise empty
+      PHG4HitContainer* hitcontainer;
+      // here we do things which are different between scintillator and absorber hits
+      if (whichactive > 0)  // return of isinCEmcTestDetector, > 0 hit in scintillator, < 0 hit in absorber
+      {
+        hitcontainer = hits_;
+      }
+      else
+      {
+        hitcontainer = absorberhits_;
+      }
+      // here we set what is common for scintillator and absorber hits
+      hitcontainer->AddHit(tower_id, hit);
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->GetShower()->add_g4hit_id(hitcontainer->GetID(), hit->get_hit_id());
+        }
+      }
+      break;
+    default:
+      break;
+    }
+    // here we just update the exit values, it will be overwritten
+    // for every step until we leave the volume or the particle
+    // ceases to exist
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
+
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
+    //sum up the energy to get total deposited
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
+    if (geantino)
+    {
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
+    }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+
+    //       hit->identify();
+    // return true to indicate the hit was used
+    return true;
+  }
   else
-    {
-      return false;
-    }
+  {
+    return false;
+  }
 }
 
 //____________________________________________________________________________..
-void PHG4CEmcTestBeamSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+void PHG4CEmcTestBeamSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-
   string hitnodename;
   string absorbernodename;
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_" + detector_->SuperDetector();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->SuperDetector();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_" + detector_->GetName();
-      absorbernodename =  "G4HIT_ABSORBER_" + detector_->GetName();
-    }
+  {
+    hitnodename = "G4HIT_" + detector_->GetName();
+    absorbernodename = "G4HIT_ABSORBER_" + detector_->GetName();
+  }
 
   //now look for the map and grab a pointer to it.
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
-  absorberhits_ =  findNode::getClass<PHG4HitContainer>( topNode , absorbernodename.c_str() );
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  absorberhits_ = findNode::getClass<PHG4HitContainer>(topNode, absorbernodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
+  if (!hits_)
+  {
+    std::cout << "PHG4CEmcTestBeamSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
+  if (!absorberhits_)
+  {
+    if (Verbosity() > 0)
     {
-      std::cout << "PHG4CEmcTestBeamSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
     }
-  if ( ! absorberhits_)
-    {
-      if (Verbosity() > 0)
-	{
-	  cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
-	}
-    }
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSteppingAction.h
@@ -13,32 +13,29 @@ class PHG4HitContainer;
 
 class PHG4CEmcTestBeamSteppingAction : public PHG4SteppingAction
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CEmcTestBeamSteppingAction( PHG4CEmcTestBeamDetector* );
+  PHG4CEmcTestBeamSteppingAction(PHG4CEmcTestBeamDetector*);
 
   //! destroctor
   ~PHG4CEmcTestBeamSteppingAction() override
-  {}
+  {
+  }
 
   //! stepping action
   bool UserSteppingAction(const G4Step*, bool) override;
 
   //! reimplemented from base class
-  void SetInterfacePointers( PHCompositeNode* ) override;
+  void SetInterfacePointers(PHCompositeNode*) override;
 
-  private:
-
+ private:
   //! pointer to the detector
   PHG4CEmcTestBeamDetector* detector_;
 
   //! pointer to hit container
-  PHG4HitContainer * hits_;
-  PHG4HitContainer * absorberhits_;
-  PHG4Hit *hit;
+  PHG4HitContainer* hits_;
+  PHG4HitContainer* absorberhits_;
+  PHG4Hit* hit;
 };
 
-
-#endif // PHG4CEmcTestBeamSteppingAction_h
+#endif  // PHG4CEmcTestBeamSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.h
@@ -7,7 +7,7 @@
 
 #include <Geant4/G4Types.hh>
 
-#include <string>                  // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4CEmcTestBeamDetector;
@@ -16,17 +16,16 @@ class PHG4Detector;
 class PHG4EventAction;
 class PHG4SteppingAction;
 
-class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
+class PHG4CEmcTestBeamSubsystem : public PHG4Subsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4CEmcTestBeamSubsystem( const std::string &name = "BLOCK", const int layer = 0 );
+  PHG4CEmcTestBeamSubsystem(const std::string& name = "BLOCK", const int layer = 0);
 
   //! destructor
-  ~PHG4CEmcTestBeamSubsystem( void ) override
-  {}
+  ~PHG4CEmcTestBeamSubsystem(void) override
+  {
+  }
 
   //! init
   /*!
@@ -34,36 +33,39 @@ class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
   reates the stepping action and place it on the node tree, under "ACTIONS" node
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int Init(PHCompositeNode *) override;
+  int Init(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *) override;
+  int process_event(PHCompositeNode*) override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const override;
-  PHG4SteppingAction* GetSteppingAction( void ) const override;
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override;
 
   void SetSize(const G4double sizex, const G4double sizey, const G4double sizez)
-     {dimension[0] = sizex; dimension[1] = sizey; dimension[2] = sizez;}
+  {
+    dimension[0] = sizex;
+    dimension[1] = sizey;
+    dimension[2] = sizez;
+  }
   void SetPlaceZ(const G4double dbl);
   void SetPlace(const G4double place_x, const G4double place_y, const G4double place_z);
   void SetXRot(const G4double dbl);
   void SetYRot(const G4double dbl);
   void SetZRot(const G4double dbl);
-  PHG4EventAction* GetEventAction() const override {return eventAction_;}
-  void SetActive(const int i = 1) {active = i;}
-  void SetAbsorberActive(const int i = 1) {absorberactive = i;}
-  void SuperDetector(const std::string &name) {superdetector = name;}
-  const std::string SuperDetector() {return superdetector;}
+  PHG4EventAction* GetEventAction() const override { return eventAction_; }
+  void SetActive(const int i = 1) { active = i; }
+  void SetAbsorberActive(const int i = 1) { absorberactive = i; }
+  void SuperDetector(const std::string& name) { superdetector = name; }
+  const std::string SuperDetector() { return superdetector; }
 
-  void BlackHole(const int i=1) {blackhole = i;}
+  void BlackHole(const int i = 1) { blackhole = i; }
 
-  private:
-
+ private:
   //! detector geometry
   /*! defives from PHG4Detector */
   PHG4CEmcTestBeamDetector* detector_;
@@ -71,7 +73,7 @@ class PHG4CEmcTestBeamSubsystem: public PHG4Subsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4CEmcTestBeamSteppingAction* steppingAction_;
-  PHG4EventAction *eventAction_;
+  PHG4EventAction* eventAction_;
   G4double dimension[3];
   G4double place_in_x;
   G4double place_in_y;

--- a/simulation/g4simulation/g4detectors/PHG4Cell.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.cc
@@ -2,120 +2,115 @@
 
 #include <g4main/PHG4HitDefs.h>  // for keytype
 
-#include <phool/PHObject.h>      // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 
 #include <cassert>
 #include <cstdlib>
 
 using namespace std;
 
-void
-PHG4Cell::CopyFrom(const PHObject *phobj)
+void PHG4Cell::CopyFrom(const PHObject* phobj)
 {
-  const PHG4Cell *g4cell = dynamic_cast<const PHG4Cell *> (phobj);
+  const PHG4Cell* g4cell = dynamic_cast<const PHG4Cell*>(phobj);
   assert(g4cell);
   set_cellid(g4cell->get_cellid());
   for (unsigned char ic = 0; ic < UCHAR_MAX; ic++)
+  {
+    PROPERTY prop_id = static_cast<PHG4Cell::PROPERTY>(ic);
+    if (g4cell->has_property(prop_id))
     {
-      PROPERTY prop_id = static_cast<PHG4Cell::PROPERTY> (ic);
-      if (g4cell->has_property(prop_id))
-        {
-	  set_property_nocheck(prop_id,g4cell->get_property_nocheck(prop_id));
-	}
+      set_property_nocheck(prop_id, g4cell->get_property_nocheck(prop_id));
     }
+  }
 }
 
-
-void
-PHG4Cell::identify(ostream& os) const
+void PHG4Cell::identify(ostream& os) const
 {
   os << "Class " << this->ClassName() << endl;
   return;
 }
 
-ostream& operator<<(ostream& stream, const PHG4Cell * /*cell*/){
-  stream << "PHG4Cell"  << endl;
+ostream& operator<<(ostream& stream, const PHG4Cell* /*cell*/)
+{
+  stream << "PHG4Cell" << endl;
   return stream;
 }
 
 PHG4Cell::EdepConstRange PHG4Cell::get_g4hits()
 {
-  static map <PHG4HitDefs::keytype, float> dummy;
+  static map<PHG4HitDefs::keytype, float> dummy;
   return make_pair(dummy.begin(), dummy.end());
 }
 
 PHG4Cell::ShowerEdepConstRange PHG4Cell::get_g4showers()
 {
-  static map <int, float> dummy;
+  static map<int, float> dummy;
   return make_pair(dummy.begin(), dummy.end());
 }
 
-void
-PHG4Cell::Reset()
+void PHG4Cell::Reset()
 {
   cout << "Reset not implemented by daughter class" << endl;
   return;
 }
 
-std::pair<const std::string,PHG4Cell::PROPERTY_TYPE> 
-PHG4Cell::get_property_info(const PROPERTY prop_id) 
+std::pair<const std::string, PHG4Cell::PROPERTY_TYPE>
+PHG4Cell::get_property_info(const PROPERTY prop_id)
 {
   switch (prop_id)
   {
   case prop_stave_index:
-    return make_pair("stave index",PHG4Cell::type_int);
+    return make_pair("stave index", PHG4Cell::type_int);
   case prop_half_stave_index:
-    return make_pair("half stave index",PHG4Cell::type_int);
+    return make_pair("half stave index", PHG4Cell::type_int);
   case prop_module_index:
-    return make_pair("module index",PHG4Cell::type_int);
+    return make_pair("module index", PHG4Cell::type_int);
   case prop_chip_index:
-    return make_pair("chip index",PHG4Cell::type_int);
+    return make_pair("chip index", PHG4Cell::type_int);
   case prop_pixel_index:
-    return make_pair("pixel index",PHG4Cell::type_int);
+    return make_pair("pixel index", PHG4Cell::type_int);
   case prop_phibin:
-    return make_pair("phibin",PHG4Cell::type_int);
+    return make_pair("phibin", PHG4Cell::type_int);
   case prop_zbin:
-    return make_pair("zbin",PHG4Cell::type_int);
+    return make_pair("zbin", PHG4Cell::type_int);
   case prop_ladder_z_index:
-    return make_pair("ladder z index",PHG4Cell::type_int);
+    return make_pair("ladder z index", PHG4Cell::type_int);
   case prop_ladder_phi_index:
-    return make_pair("ladder phi index",PHG4Cell::type_int);
-  case  prop_edep:
-    return make_pair("energy deposition",PHG4Cell::type_float);
-  case  prop_eion:
-    return make_pair("ionizing energy loss",PHG4Cell::type_float);
-  case   prop_light_yield:
-    return make_pair("light yield",PHG4Cell::type_float);
+    return make_pair("ladder phi index", PHG4Cell::type_int);
+  case prop_edep:
+    return make_pair("energy deposition", PHG4Cell::type_float);
+  case prop_eion:
+    return make_pair("ionizing energy loss", PHG4Cell::type_float);
+  case prop_light_yield:
+    return make_pair("light yield", PHG4Cell::type_float);
   default:
     cout << "PHG4Cell::get_property_info - Fatal Error - unknown index " << prop_id << endl;
     exit(1);
   }
 }
 
-
-bool
-PHG4Cell::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
+bool PHG4Cell::check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type)
 {
-  pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id);
+  pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
   if (property_info.second != prop_type)
-    {
-      return false;
-    }
+  {
+    return false;
+  }
   return true;
 }
 
 string
 PHG4Cell::get_property_type(const PROPERTY_TYPE prop_type)
 {
-  switch(prop_type)
-    {
-    case type_int:
-      return "int";
-    case type_uint:
-      return "unsigned int";
-    case type_float:
-      return "float";
-    default:
-      return "unkown";
-    }
+  switch (prop_type)
+  {
+  case type_int:
+    return "int";
+  case type_uint:
+    return "unsigned int";
+  case type_float:
+    return "float";
+  default:
+    return "unkown";
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4Cell.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cell.h
@@ -9,14 +9,14 @@
 
 #include <phool/PHObject.h>
 
-#include <cmath>
 #include <climits>
-#include <iostream>              // for ostream, cout, operator<<, endl, bas...
+#include <cmath>
+#include <iostream>  // for ostream, cout, operator<<, endl, bas...
 #include <map>
-#include <string>                // for string
-#include <utility>               // for pair, make_pair
+#include <string>   // for string
+#include <utility>  // for pair, make_pair
 
-class PHG4Cell: public PHObject
+class PHG4Cell : public PHObject
 {
  public:
   typedef std::map<PHG4HitDefs::keytype, float> EdepMap;
@@ -33,82 +33,81 @@ class PHG4Cell: public PHObject
 
   ~PHG4Cell() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
   void CopyFrom(const PHObject *phobj) override;
   void Reset() override;
 
-  friend std::ostream &operator<<(std::ostream & stream, const PHG4Cell * cell);
+  friend std::ostream &operator<<(std::ostream &stream, const PHG4Cell *cell);
 
   // all methods connected to the cell id (encoding/decoding
-  virtual void set_cellid(const PHG4CellDefs::keytype) {return;}
+  virtual void set_cellid(const PHG4CellDefs::keytype) { return; }
 
-  virtual PHG4CellDefs::keytype get_cellid() const {return ~0x0;}
-  virtual bool has_binning(const PHG4CellDefs::CellBinning) const {return false;}
+  virtual PHG4CellDefs::keytype get_cellid() const { return ~0x0; }
+  virtual bool has_binning(const PHG4CellDefs::CellBinning) const { return false; }
 
   // this adds hits to the g4 hit list map
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/) {return;}
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/, const float /*light_yield*/) {return;}
-  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const int /*tbin*/, const float /*edep*/) {return;}
+  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/) { return; }
+  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const float /*edep*/, const float /*light_yield*/) { return; }
+  virtual void add_edep(const PHG4HitDefs::keytype /*g4hitid*/, const int /*tbin*/, const float /*edep*/) { return; }
   // this adds showers to the shower map
-  virtual void add_shower_edep(const int /*g4showerid*/, const float /*edep*/) {return;}
+  virtual void add_shower_edep(const int /*g4showerid*/, const float /*edep*/) { return; }
 
   virtual EdepConstRange get_g4hits();
 
   virtual ShowerEdepConstRange get_g4showers();
 
-  virtual short int get_detid() const {return -1;}
+  virtual short int get_detid() const { return -1; }
   // for backward compatibility, layers and detector ids are identical
-  short int get_layer() const {return get_detid();}
+  short int get_layer() const { return get_detid(); }
 
-  virtual void add_edep(const float) {return;}
-  virtual double get_edep() const {return NAN;}
+  virtual void add_edep(const float) { return; }
+  virtual double get_edep() const { return NAN; }
 
-  virtual void add_eion(const float) {return;}
-  virtual double get_eion() const {return NAN;}
+  virtual void add_eion(const float) { return; }
+  virtual double get_eion() const { return NAN; }
 
-  virtual void add_light_yield(const float){return;}
-  virtual float get_light_yield() const {return NAN;}
+  virtual void add_light_yield(const float) { return; }
+  virtual float get_light_yield() const { return NAN; }
 
   // get/set methodes - PLEASE add those ALPHABETICALLY
 
-  virtual void set_chip_index(const int) {return;}
-  virtual int get_chip_index() const {return ~0x0;}
+  virtual void set_chip_index(const int) { return; }
+  virtual int get_chip_index() const { return ~0x0; }
 
-  virtual void set_half_stave_index(const int) {return;}
-  virtual int get_half_stave_index() const {return ~0x0;}
+  virtual void set_half_stave_index(const int) { return; }
+  virtual int get_half_stave_index() const { return ~0x0; }
 
-  virtual void set_ladder_phi_index(const int) {return;}
-  virtual int get_ladder_phi_index() const {return ~0x0;}
+  virtual void set_ladder_phi_index(const int) { return; }
+  virtual int get_ladder_phi_index() const { return ~0x0; }
 
-  virtual void set_ladder_z_index(const int) {return;}
-  virtual int get_ladder_z_index() const {return ~0x0;}
+  virtual void set_ladder_z_index(const int) { return; }
+  virtual int get_ladder_z_index() const { return ~0x0; }
 
-  virtual void set_module_index(const int) {return;}
-  virtual int get_module_index() const {return ~0x0;}
+  virtual void set_module_index(const int) { return; }
+  virtual int get_module_index() const { return ~0x0; }
 
-  virtual void set_phibin(const int) {return;}
-  virtual int get_phibin() const {return ~0x0;}
+  virtual void set_phibin(const int) { return; }
+  virtual int get_phibin() const { return ~0x0; }
 
-  virtual void set_pixel_index(const int) {return;}
-  virtual int get_pixel_index() const {return ~0x0;}
+  virtual void set_pixel_index(const int) { return; }
+  virtual int get_pixel_index() const { return ~0x0; }
 
-  virtual void set_stave_index(const int) {return;}
-  virtual int get_stave_index() const {return ~0x0;}
+  virtual void set_stave_index(const int) { return; }
+  virtual int get_stave_index() const { return ~0x0; }
 
-//  virtual tpctod* get_train_of_digits() {return 0;}
+  //  virtual tpctod* get_train_of_digits() {return 0;}
 
-  virtual void set_zbin(const int) {return;}
-  virtual int get_zbin() const {return ~0x0;}
+  virtual void set_zbin(const int) { return; }
+  virtual int get_zbin() const { return ~0x0; }
 
-
-  virtual void print() const {std::cout<<"virtual PHG4Cell"<<std::endl;}
+  virtual void print() const { std::cout << "virtual PHG4Cell" << std::endl; }
 
   //! Procedure to add a new PROPERTY tag:
   //! 1.add new tag below with unique value,
   //! 2.add a short name to PHG4Cell::get_property_info
-  enum PROPERTY 
-  {//
+  enum PROPERTY
+  {  //
     // first various coordinates 1-20
     //! Maps coordinates
     prop_stave_index = 1,
@@ -133,31 +132,30 @@ class PHG4Cell: public PHObject
     prop_MAX_NUMBER = UCHAR_MAX
   };
 
-  enum PROPERTY_TYPE 
-  {//
+  enum PROPERTY_TYPE
+  {  //
     type_int = 1,
     type_uint = 2,
     type_float = 3,
     type_unknown = -1
   };
 
-  virtual bool  has_property(const PROPERTY /*prop_id*/) const {return false;}
-  virtual float get_property_float(const PROPERTY /*prop_id*/) const {return NAN;}
-  virtual int   get_property_int(const PROPERTY /*prop_id*/) const {return INT_MIN;}
-  virtual unsigned int   get_property_uint(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const float /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const int /*value*/) {return;}
-  virtual void  set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) {return;}
-  static std::pair<const std::string,PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
+  virtual bool has_property(const PROPERTY /*prop_id*/) const { return false; }
+  virtual float get_property_float(const PROPERTY /*prop_id*/) const { return NAN; }
+  virtual int get_property_int(const PROPERTY /*prop_id*/) const { return INT_MIN; }
+  virtual unsigned int get_property_uint(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const float /*value*/) { return; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const int /*value*/) { return; }
+  virtual void set_property(const PROPERTY /*prop_id*/, const unsigned int /*value*/) { return; }
+  static std::pair<const std::string, PROPERTY_TYPE> get_property_info(PROPERTY prop_id);
   static bool check_property(const PROPERTY prop_id, const PROPERTY_TYPE prop_type);
   static std::string get_property_type(const PROPERTY_TYPE prop_type);
 
  protected:
   PHG4Cell() {}
-  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const {return UINT_MAX;}
-  virtual void set_property_nocheck(const PROPERTY /*prop_id*/,const unsigned int) {return;}
-  ClassDefOverride(PHG4Cell,2)
+  virtual unsigned int get_property_nocheck(const PROPERTY /*prop_id*/) const { return UINT_MAX; }
+  virtual void set_property_nocheck(const PROPERTY /*prop_id*/, const unsigned int) { return; }
+  ClassDefOverride(PHG4Cell, 2)
 };
-
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellContainer.cc
@@ -1,90 +1,90 @@
 #include "PHG4CellContainer.h"
 
-#include "PHG4Cell.h"      // for PHG4Cell
-#include "PHG4Cellv1.h"
+#include "PHG4Cell.h"  // for PHG4Cell
 #include "PHG4CellDefs.h"
+#include "PHG4Cellv1.h"
 
 #include <cstdlib>
 
 using namespace std;
 
 PHG4CellContainer::PHG4CellContainer()
-{}
-
-void
-PHG4CellContainer::Reset()
 {
-   while(cellmap.begin() != cellmap.end())
-     {
-       delete cellmap.begin()->second;
-       cellmap.erase(cellmap.begin());
-     }
+}
+
+void PHG4CellContainer::Reset()
+{
+  while (cellmap.begin() != cellmap.end())
+  {
+    delete cellmap.begin()->second;
+    cellmap.erase(cellmap.begin());
+  }
   return;
 }
 
-void
-PHG4CellContainer::identify(ostream& os) const
+void PHG4CellContainer::identify(ostream& os) const
 {
-   ConstIterator iter;
-   os << "Number of cells: " << size() << endl;
-   for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
-     {
-       os << "cell key 0x" << hex << iter->first << dec << endl;
-       (iter->second)->identify();
-     }
+  ConstIterator iter;
+  os << "Number of cells: " << size() << endl;
+  for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
+  {
+    os << "cell key 0x" << hex << iter->first << dec << endl;
+    (iter->second)->identify();
+  }
   return;
 }
 
 PHG4CellContainer::ConstIterator
-PHG4CellContainer::AddCell(PHG4Cell *newcell)
+PHG4CellContainer::AddCell(PHG4Cell* newcell)
 {
   PHG4CellDefs::keytype key = newcell->get_cellid();
   if (cellmap.find(key) != cellmap.end())
-    {
-      cout << "overwriting cell 0x" << hex << key << dec << endl;
-      cout << "layer: " << PHG4CellDefs::get_detid(key) << endl;
-    }
+  {
+    cout << "overwriting cell 0x" << hex << key << dec << endl;
+    cout << "layer: " << PHG4CellDefs::get_detid(key) << endl;
+  }
   cellmap[key] = newcell;
   return cellmap.find(key);
 }
 
 PHG4CellContainer::ConstIterator
-PHG4CellContainer::AddCellSpecifyKey(const PHG4CellDefs::keytype key, PHG4Cell *newcell)
+PHG4CellContainer::AddCellSpecifyKey(const PHG4CellDefs::keytype key, PHG4Cell* newcell)
 {
-  if(cellmap.find(key)!=cellmap.end())
-   {
-     cout << "PHG4CellContainer::AddCellSpecifyKey: duplicate key: " << key << " exiting now" << endl;
-     exit(1);
-   }
+  if (cellmap.find(key) != cellmap.end())
+  {
+    cout << "PHG4CellContainer::AddCellSpecifyKey: duplicate key: " << key << " exiting now" << endl;
+    exit(1);
+  }
   newcell->set_cellid(key);
   cellmap[key] = newcell;
   return cellmap.find(key);
 }
 
-PHG4CellContainer::ConstRange 
+PHG4CellContainer::ConstRange
 PHG4CellContainer::getCells(const unsigned short int detid) const
 {
   PHG4CellDefs::keytype tmp = detid;
   PHG4CellDefs::keytype keylow = tmp << PHG4CellDefs::bitshift_layer;
-  PHG4CellDefs::keytype keyup = ((tmp + 1)<< PHG4CellDefs::bitshift_layer) -1 ;
-//   cout << "keylow: 0x" << hex << keylow << dec << endl;
-//   cout << "keyup: 0x" << hex << keyup << dec << endl;
+  PHG4CellDefs::keytype keyup = ((tmp + 1) << PHG4CellDefs::bitshift_layer) - 1;
+  //   cout << "keylow: 0x" << hex << keylow << dec << endl;
+  //   cout << "keyup: 0x" << hex << keyup << dec << endl;
   ConstRange retpair;
   retpair.first = cellmap.lower_bound(keylow);
   retpair.second = cellmap.upper_bound(keyup);
   return retpair;
 }
 
-PHG4CellContainer::ConstRange 
-PHG4CellContainer::getCells( void ) const
-{ return std::make_pair( cellmap.begin(), cellmap.end() ); }
+PHG4CellContainer::ConstRange
+PHG4CellContainer::getCells(void) const
+{
+  return std::make_pair(cellmap.begin(), cellmap.end());
+}
 
-
-PHG4CellContainer::Iterator 
+PHG4CellContainer::Iterator
 PHG4CellContainer::findOrAddCell(PHG4CellDefs::keytype key)
 {
   PHG4CellContainer::Iterator it = cellmap.find(key);
-  if(it == cellmap.end())
+  if (it == cellmap.end())
   {
     cellmap[key] = new PHG4Cellv1();
     it = cellmap.find(key);
@@ -94,15 +94,15 @@ PHG4CellContainer::findOrAddCell(PHG4CellDefs::keytype key)
   return it;
 }
 
-PHG4Cell* 
+PHG4Cell*
 PHG4CellContainer::findCell(PHG4CellDefs::keytype key)
 {
   PHG4CellContainer::ConstIterator it = cellmap.find(key);
 
-  if(it != cellmap.end())
-    {
-      return it->second;
-    }
+  if (it != cellmap.end())
+  {
+    return it->second;
+  }
 
   return 0;
 }
@@ -113,8 +113,8 @@ PHG4CellContainer::getTotalEdep() const
   ConstIterator iter;
   double totalenergy = 0;
   for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
-    {
-      totalenergy += iter->second->get_edep();
-    }
+  {
+    totalenergy += iter->second->get_edep();
+  }
   return totalenergy;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CellContainer.h
@@ -3,21 +3,20 @@
 #ifndef G4DETECTORS_PHG4CELLCONTAINER_H
 #define G4DETECTORS_PHG4CELLCONTAINER_H
 
-#include "PHG4CellDefs.h"    // for keytype
+#include "PHG4CellDefs.h"  // for keytype
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>           // for pair
+#include <utility>  // for pair
 
 class PHG4Cell;
 
-class PHG4CellContainer: public PHObject
+class PHG4CellContainer : public PHObject
 {
-
-  public:
-  typedef std::map<PHG4CellDefs::keytype,PHG4Cell *> Map;
+ public:
+  typedef std::map<PHG4CellDefs::keytype, PHG4Cell *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -27,15 +26,16 @@ class PHG4CellContainer: public PHObject
 
   ~PHG4CellContainer() override {}
 
-// from PHObject
+  // from PHObject
   void Reset() override;
-  void identify(std::ostream& os = std::cout) const override;
+  void identify(std::ostream &os = std::cout) const override;
 
   ConstIterator AddCell(PHG4Cell *newCell);
   ConstIterator AddCellSpecifyKey(const PHG4CellDefs::keytype key, PHG4Cell *newCell);
-  
+
   //! preferred removal method, key is currently the cell id
-  void RemoveCell(PHG4CellDefs::keytype key) {
+  void RemoveCell(PHG4CellDefs::keytype key)
+  {
     cellmap.erase(key);
   }
 
@@ -45,18 +45,17 @@ class PHG4CellContainer: public PHObject
     Iterator its = cellmap.begin();
     Iterator last = cellmap.end();
     for (; its != last;)
+    {
+      if (its->second == cell)
       {
-	if (its->second == cell)
-	  {
-	    cellmap.erase(its++);
-	  }
-	else
-	  {
-	    ++its;
-	  }
+        cellmap.erase(its++);
       }
+      else
+      {
+        ++its;
+      }
+    }
   }
-
 
   Iterator findOrAddCell(PHG4CellDefs::keytype key);
 
@@ -64,18 +63,20 @@ class PHG4CellContainer: public PHObject
   ConstRange getCells(const unsigned short int detid) const;
 
   //! return all hist
-  ConstRange getCells( void ) const;
+  ConstRange getCells(void) const;
 
-  PHG4Cell* findCell(PHG4CellDefs::keytype key);
+  PHG4Cell *findCell(PHG4CellDefs::keytype key);
 
-  unsigned int size( void ) const
-  { return cellmap.size(); }
+  unsigned int size(void) const
+  {
+    return cellmap.size();
+  }
 
   double getTotalEdep() const;
 
  protected:
   Map cellmap;
-  ClassDefOverride(PHG4CellContainer,1)
+  ClassDefOverride(PHG4CellContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CellContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CellContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CellContainer+;
+#pragma link C++ class PHG4CellContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
@@ -2,7 +2,7 @@
 
 #include <phool/phool.h>
 
-#include <cstdlib>       // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
 
 using namespace std;
@@ -93,7 +93,6 @@ PHG4CellDefs::SpacalBinning::get_fiberid(const PHG4CellDefs::keytype key)
   return fiberid;
 }
 
-
 PHG4CellDefs::keytype
 PHG4CellDefs::ScintillatorSlatBinning::genkey(const unsigned short detid, const unsigned short icolumn, const unsigned short irow)
 {
@@ -145,7 +144,7 @@ PHG4CellDefs::MVTXBinning::genkey(const unsigned short detid, const unsigned int
 unsigned int
 PHG4CellDefs::MVTXBinning::get_index(const PHG4CellDefs::keytype key)
 {
-  unsigned int index = generic_32bit_key(key,mvtxbinning);
+  unsigned int index = generic_32bit_key(key, mvtxbinning);
   return index;
 }
 
@@ -170,21 +169,17 @@ PHG4CellDefs::TPCBinning::get_phibin(const PHG4CellDefs::keytype key)
   return phibin;
 }
 
-
-
-bool
-PHG4CellDefs::has_binning(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning)
+bool PHG4CellDefs::has_binning(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning)
 {
- keytype tmp = (key >> bitshift_binning) & 0xFFFF;
- if (tmp == binning)
-   {
-     return true;
-   }
- return false;
+  keytype tmp = (key >> bitshift_binning) & 0xFFFF;
+  if (tmp == binning)
+  {
+    return true;
+  }
+  return false;
 }
 
-short
-PHG4CellDefs::get_binning(const PHG4CellDefs::keytype key)
+short PHG4CellDefs::get_binning(const PHG4CellDefs::keytype key)
 {
   keytype tmp = (key >> bitshift_binning) & 0xFFFF;
   short int i = tmp;
@@ -198,65 +193,64 @@ PHG4CellDefs::get_detid(const PHG4CellDefs::keytype key)
   return tmp;
 }
 
-unsigned short 
+unsigned short
 generic_lower_16bit_key(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning)
 {
   // check correct binning first
- PHG4CellDefs::keytype tmp = binning;
- tmp = (tmp << PHG4CellDefs::bitshift_binning);
- if ((key & tmp) == tmp)
-   {
-     unsigned short int low16bitkey = (key & 0xFFFF);
-     return low16bitkey;
-   }
- cout << PHWHERE << " could not decode 0x" << hex <<  key << dec << endl; 
- cout << "key 0x" << hex << key << ", binning: 0x" << tmp
-      << " and: " <<  (key & tmp) << dec << endl;
- exit(1);
+  PHG4CellDefs::keytype tmp = binning;
+  tmp = (tmp << PHG4CellDefs::bitshift_binning);
+  if ((key & tmp) == tmp)
+  {
+    unsigned short int low16bitkey = (key & 0xFFFF);
+    return low16bitkey;
+  }
+  cout << PHWHERE << " could not decode 0x" << hex << key << dec << endl;
+  cout << "key 0x" << hex << key << ", binning: 0x" << tmp
+       << " and: " << (key & tmp) << dec << endl;
+  exit(1);
 }
 
-unsigned short 
+unsigned short
 generic_upper_16bit_key(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning)
 {
   // check correct binning first
- PHG4CellDefs::keytype tmp = binning;
- tmp = (tmp << PHG4CellDefs::bitshift_binning);
- if ((key & tmp) == tmp)
-   {
-     PHG4CellDefs::keytype keytmp = key >> PHG4CellDefs::bitshift_upperkey;
-     unsigned short int hi16bitkey = (keytmp & 0xFFFF);
-     return hi16bitkey;
-   }
- cout << PHWHERE << " could not decode 0x" << hex <<  key << dec << endl; 
- exit(1);
+  PHG4CellDefs::keytype tmp = binning;
+  tmp = (tmp << PHG4CellDefs::bitshift_binning);
+  if ((key & tmp) == tmp)
+  {
+    PHG4CellDefs::keytype keytmp = key >> PHG4CellDefs::bitshift_upperkey;
+    unsigned short int hi16bitkey = (keytmp & 0xFFFF);
+    return hi16bitkey;
+  }
+  cout << PHWHERE << " could not decode 0x" << hex << key << dec << endl;
+  exit(1);
 }
 
 unsigned int
 generic_32bit_key(const PHG4CellDefs::keytype key, const PHG4CellDefs::CellBinning binning)
 {
   // check correct binning first
- PHG4CellDefs::keytype tmp = binning;
- tmp = (tmp << PHG4CellDefs::bitshift_binning);
- if ((key & tmp) == tmp)
- {
-   unsigned int bit32key = (key & 0xFFFFFFFF);
-     return bit32key;
- }
- cout << PHWHERE << " could not decode 0x" << hex <<  key << dec << endl; 
- exit(1);
+  PHG4CellDefs::keytype tmp = binning;
+  tmp = (tmp << PHG4CellDefs::bitshift_binning);
+  if ((key & tmp) == tmp)
+  {
+    unsigned int bit32key = (key & 0xFFFFFFFF);
+    return bit32key;
+  }
+  cout << PHWHERE << " could not decode 0x" << hex << key << dec << endl;
+  exit(1);
 }
 
- 
 PHG4CellDefs::keytype
 generic_16bit_genkey(const unsigned short detid, const PHG4CellDefs::CellBinning binning, const unsigned short upper16bits, const unsigned short lower16bits)
 {
   PHG4CellDefs::keytype tmp = detid;
-  PHG4CellDefs::keytype key = tmp << PHG4CellDefs::bitshift_layer; // layer/detector id used by extrating ranges
+  PHG4CellDefs::keytype key = tmp << PHG4CellDefs::bitshift_layer;  // layer/detector id used by extrating ranges
   tmp = binning;
-  key |= (tmp << PHG4CellDefs::bitshift_binning); // binning method used to decode the key
+  key |= (tmp << PHG4CellDefs::bitshift_binning);  // binning method used to decode the key
   tmp = upper16bits;
-  key |= (tmp << PHG4CellDefs::bitshift_upperkey); // upper bits used by column, so we can easily extract 
-                                  // slats by column which are combined to towers
+  key |= (tmp << PHG4CellDefs::bitshift_upperkey);  // upper bits used by column, so we can easily extract
+                                                    // slats by column which are combined to towers
   key |= lower16bits;
   return key;
 }
@@ -265,10 +259,9 @@ PHG4CellDefs::keytype
 generic_32bit_genkey(const unsigned short detid, const PHG4CellDefs::CellBinning binning, const unsigned int bit32)
 {
   PHG4CellDefs::keytype tmp = detid;
-  PHG4CellDefs::keytype key = tmp << PHG4CellDefs::bitshift_layer; // layer/detector id used by extrating ranges
+  PHG4CellDefs::keytype key = tmp << PHG4CellDefs::bitshift_layer;  // layer/detector id used by extrating ranges
   tmp = binning;
-  key |= (tmp << PHG4CellDefs::bitshift_binning); // binning method used to decode the key
+  key |= (tmp << PHG4CellDefs::bitshift_binning);  // binning method used to decode the key
   key |= bit32;
   return key;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
@@ -93,8 +93,10 @@ PHG4CellDefs::SpacalBinning::get_fiberid(const PHG4CellDefs::keytype key)
   return fiberid;
 }
 
-PHG4CellDefs::keytype
-PHG4CellDefs::ScintillatorSlatBinning::genkey(const unsigned short detid, const unsigned short icolumn, const unsigned short irow)
+// yes the arguments are flipped but it is consistent later on
+// changing this would just be a real headache
+// cppcheck-suppress *
+PHG4CellDefs::keytype PHG4CellDefs::ScintillatorSlatBinning::genkey(const unsigned short detid, const unsigned short icolumn, const unsigned short irow)
 {
   PHG4CellDefs::keytype key = generic_16bit_genkey(detid, scintillatorslatbinning, icolumn, irow);
   return key;

--- a/simulation/g4simulation/g4detectors/PHG4CellDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4CellDefs.h
@@ -7,24 +7,23 @@
 
 namespace PHG4CellDefs
 {
-
-// we rely on 64 bit keys - no point using
-// unsigned long long or whatever else C++ types
-// are currently implemented as 64 bit
+  // we rely on 64 bit keys - no point using
+  // unsigned long long or whatever else C++ types
+  // are currently implemented as 64 bit
   typedef uint64_t keytype;
 
   // key layout
   // bit
   // 48-64 detector id (scintillator slat id, layer,...)
   // 32-48 binning method
-  // 
+  //
   // 16-32 binning dependant 1st key
   // 0-16 binning dependant 2nd key
 
   /* static unsigned int layer_bits = 16; */
   /* static unsigned int keybits = 16; */
   // __attribute__((unused)) prevents warnings about unused variables
-  // common upper 32 bits 
+  // common upper 32 bits
   static unsigned int bitshift_layer __attribute__((unused)) = 64 - 16;
   static unsigned int bitshift_binning __attribute__((unused)) = bitshift_layer - 16;
   // binning dependeant bit shifts for lower 32 bits
@@ -32,7 +31,18 @@ namespace PHG4CellDefs
   static unsigned int bitshift_row __attribute__((unused)) = 16;
   static unsigned int bitshift_phi __attribute__((unused)) = 16;
 
-  enum CellBinning {undefined = 0, sizebinning = 1, etaphibinning = 2, etaslatbinning = 3, spacalbinning = 4, scintillatorslatbinning = 5, etaxsizebinning = 6, mvtxbinning = 7, tpcbinning = 8};
+  enum CellBinning
+  {
+    undefined = 0,
+    sizebinning = 1,
+    etaphibinning = 2,
+    etaslatbinning = 3,
+    spacalbinning = 4,
+    scintillatorslatbinning = 5,
+    etaxsizebinning = 6,
+    mvtxbinning = 7,
+    tpcbinning = 8
+  };
   bool has_binning(PHG4CellDefs::keytype key, PHG4CellDefs::CellBinning binning);
   short get_binning(const PHG4CellDefs::keytype key);
   short int get_detid(const PHG4CellDefs::keytype key);
@@ -42,14 +52,14 @@ namespace PHG4CellDefs
     keytype genkey(const unsigned short layer, const unsigned short zbin, const unsigned short iphibin);
     unsigned short int get_zbin(const PHG4CellDefs::keytype key);
     unsigned short int get_phibin(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace SizeBinning
 
   namespace EtaPhiBinning
   {
     keytype genkey(const unsigned short layer, const unsigned short etabin, const unsigned short phibin);
     unsigned short int get_etabin(const PHG4CellDefs::keytype key);
     unsigned short int get_phibin(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace EtaPhiBinning
 
   namespace SpacalBinning
   {
@@ -57,36 +67,35 @@ namespace PHG4CellDefs
     unsigned short get_etabin(const PHG4CellDefs::keytype key);
     unsigned short get_phibin(const PHG4CellDefs::keytype key);
     unsigned short get_fiberid(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace SpacalBinning
 
-  namespace ScintillatorSlatBinning 
+  namespace ScintillatorSlatBinning
   {
     keytype genkey(const unsigned short layer, const unsigned short irow, const unsigned short icolumn);
     unsigned short int get_row(const PHG4CellDefs::keytype key);
     unsigned short int get_column(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace ScintillatorSlatBinning
 
   namespace EtaXsizeBinning
   {
     keytype genkey(const unsigned short layer, const unsigned short etabin, const unsigned short xbin);
     unsigned short int get_etabin(const PHG4CellDefs::keytype key);
     unsigned short int get_xsizebin(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace EtaXsizeBinning
 
   namespace MVTXBinning
   {
     keytype genkey(const unsigned short layer, const unsigned int bit32_index);
     unsigned int get_index(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace MVTXBinning
 
   namespace TPCBinning
   {
     keytype genkey(const unsigned short lyr, const unsigned short mod, const unsigned short pad);
     unsigned short get_radbin(const PHG4CellDefs::keytype key);
     unsigned short get_phibin(const PHG4CellDefs::keytype key);
-  }
+  }  // namespace TPCBinning
 
+}  // namespace PHG4CellDefs
 
-}
-
-#endif // G4DETECTORS_PHG4CELLDEFS_H
+#endif  // G4DETECTORS_PHG4CELLDEFS_H

--- a/simulation/g4simulation/g4detectors/PHG4CellLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CellLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4Cell+;
+#pragma link C++ class PHG4Cell + ;
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
@@ -4,21 +4,23 @@
 
 #include <phool/phool.h>
 
-#include <climits>       // for UINT_MAX, INT_MIN
-#include <cmath>         // for NAN
-#include <cstdlib>       // for exit
+#include <climits>  // for UINT_MAX, INT_MIN
+#include <cmath>    // for NAN
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>         // for operator<<, string
+#include <string>  // for operator<<, string
 
 using namespace std;
 
-PHG4Cellv1::PHG4Cellv1():
-  cellid(~0x0)
-{}
+PHG4Cellv1::PHG4Cellv1()
+  : cellid(~0x0)
+{
+}
 
-PHG4Cellv1::PHG4Cellv1(const PHG4CellDefs::keytype g4cellid):
-  cellid(g4cellid)
-{}
+PHG4Cellv1::PHG4Cellv1(const PHG4CellDefs::keytype g4cellid)
+  : cellid(g4cellid)
+{
+}
 
 PHG4Cellv1::~PHG4Cellv1()
 {
@@ -28,22 +30,19 @@ PHG4Cellv1::~PHG4Cellv1()
   return;
 }
 
-void
-PHG4Cellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
+void PHG4Cellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
 {
   hitedeps[g4hitid] = edep;
   return;
 }
 
-void
-PHG4Cellv1::add_shower_edep(const int g4showerid, const float edep)
+void PHG4Cellv1::add_shower_edep(const int g4showerid, const float edep)
 {
   showeredeps[g4showerid] += edep;
   return;
 }
 
-bool
-PHG4Cellv1::has_binning(const PHG4CellDefs::CellBinning binning) const
+bool PHG4Cellv1::has_binning(const PHG4CellDefs::CellBinning binning) const
 {
   return PHG4CellDefs::has_binning(cellid, binning);
 }
@@ -54,45 +53,42 @@ PHG4Cellv1::get_detid() const
   return PHG4CellDefs::get_detid(cellid);
 }
 
-bool
-PHG4Cellv1::has_property(const PROPERTY prop_id) const
+bool PHG4Cellv1::has_property(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator i = prop_map.find(prop_id);
-  return i!=prop_map.end();
+  return i != prop_map.end();
 }
 
-float
-PHG4Cellv1::get_property_float(const PROPERTY prop_id) const
+float PHG4Cellv1::get_property_float(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_float))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_float) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_float))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_float) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).fdata;
+  if (i != prop_map.end()) return u_property(i->second).fdata;
 
-  return   NAN ;
+  return NAN;
 }
 
-int
-PHG4Cellv1::get_property_int(const PROPERTY prop_id) const
+int PHG4Cellv1::get_property_int(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_int))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_int) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_int))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_int) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).idata;
+  if (i != prop_map.end()) return u_property(i->second).idata;
 
   return INT_MIN;
 }
@@ -100,117 +96,111 @@ PHG4Cellv1::get_property_int(const PROPERTY prop_id) const
 unsigned int
 PHG4Cellv1::get_property_uint(const PROPERTY prop_id) const
 {
-  if (!check_property(prop_id,type_uint))
-    {
-      pair<const string,PROPERTY_TYPE> property_info =get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_uint) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_uint))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_uint) << endl;
+    exit(1);
+  }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
 
-  if (i!=prop_map.end()) return u_property(i->second).uidata;
+  if (i != prop_map.end()) return u_property(i->second).uidata;
 
-  return UINT_MAX ;
+  return UINT_MAX;
 }
 
-void
-PHG4Cellv1::add_property(const PROPERTY prop_id, const float value)
+void PHG4Cellv1::add_property(const PROPERTY prop_id, const float value)
 {
-  if (!check_property(prop_id,type_float))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_float) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_float))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_float) << endl;
+    exit(1);
+  }
   float val = value;
   if (prop_map.find(prop_id) != prop_map.end())
-    {
-      val += get_property_float(prop_id);
-    }
+  {
+    val += get_property_float(prop_id);
+  }
   prop_map[prop_id] = u_property(val).get_storage();
 }
 
-void
-PHG4Cellv1::add_property(const PROPERTY prop_id, const int value)
+void PHG4Cellv1::add_property(const PROPERTY prop_id, const int value)
 {
-  if (!check_property(prop_id,type_int))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_int) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_int))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_int) << endl;
+    exit(1);
+  }
   int val = value;
   if (prop_map.find(prop_id) != prop_map.end())
-    {
-      val += get_property_int(prop_id);
-    }
+  {
+    val += get_property_int(prop_id);
+  }
   prop_map[prop_id] += u_property(val).get_storage();
 }
 
-void
-PHG4Cellv1::add_property(const PROPERTY prop_id, const unsigned int value)
+void PHG4Cellv1::add_property(const PROPERTY prop_id, const unsigned int value)
 {
-  if (!check_property(prop_id,type_uint))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_uint) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_uint))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_uint) << endl;
+    exit(1);
+  }
   unsigned int val = value;
   if (prop_map.find(prop_id) != prop_map.end())
-    {
-      val += get_property_uint(prop_id);
-    }
+  {
+    val += get_property_uint(prop_id);
+  }
   prop_map[prop_id] += u_property(val).get_storage();
 }
 
-void
-PHG4Cellv1::set_property(const PROPERTY prop_id, const float value)
+void PHG4Cellv1::set_property(const PROPERTY prop_id, const float value)
 {
-  if (!check_property(prop_id,type_float))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_float) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_float))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_float) << endl;
+    exit(1);
+  }
   prop_map[prop_id] = u_property(value).get_storage();
 }
 
-void
-PHG4Cellv1::set_property(const PROPERTY prop_id, const int value)
+void PHG4Cellv1::set_property(const PROPERTY prop_id, const int value)
 {
-  if (!check_property(prop_id,type_int))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_int) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_int))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_int) << endl;
+    exit(1);
+  }
   prop_map[prop_id] += u_property(value).get_storage();
 }
 
-void
-PHG4Cellv1::set_property(const PROPERTY prop_id, const unsigned int value)
+void PHG4Cellv1::set_property(const PROPERTY prop_id, const unsigned int value)
 {
-  if (!check_property(prop_id,type_uint))
-    {
-      pair<const string,PROPERTY_TYPE> property_info = get_property_info(prop_id); 
-      cout << PHWHERE << " Property " << property_info.first << " with id "
-           << prop_id << " is of type " << get_property_type(property_info.second) 
-	   << " not " << get_property_type(type_uint) << endl; 
-      exit(1);
-    }
+  if (!check_property(prop_id, type_uint))
+  {
+    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    cout << PHWHERE << " Property " << property_info.first << " with id "
+         << prop_id << " is of type " << get_property_type(property_info.second)
+         << " not " << get_property_type(type_uint) << endl;
+    exit(1);
+  }
   prop_map[prop_id] += u_property(value).get_storage();
 }
 
@@ -219,20 +209,18 @@ PHG4Cellv1::get_property_nocheck(const PROPERTY prop_id) const
 {
   prop_map_t::const_iterator iter = prop_map.find(prop_id);
   if (iter != prop_map.end())
-    {
-      return iter->second;
-    }
+  {
+    return iter->second;
+  }
   return UINT_MAX;
 }
 
-void
-PHG4Cellv1::print() const
+void PHG4Cellv1::print() const
 {
   identify(cout);
 }
 
-void
-PHG4Cellv1::Reset()
+void PHG4Cellv1::Reset()
 {
   hitedeps.clear();
   showeredeps.clear();
@@ -244,16 +232,16 @@ void PHG4Cellv1::identify(std::ostream& os) const
 {
   os << "PHG4Cellv1  0x" << hex << cellid << dec << endl;
 
-  os <<"Associated to "<<hitedeps.size()<<" hits"<<endl;
-  for (const auto pair :hitedeps)
+  os << "Associated to " << hitedeps.size() << " hits" << endl;
+  for (const auto pair : hitedeps)
   {
-    os <<"\t PHG4hit "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
+    os << "\t PHG4hit " << pair.first << " -> " << pair.second << " GeV" << endl;
   }
 
-  os <<"Associated to "<<showeredeps.size()<<" showers"<<endl;
-  for (const auto pair :showeredeps)
+  os << "Associated to " << showeredeps.size() << " showers" << endl;
+  for (const auto pair : showeredeps)
   {
-    os <<"\t Shower "<<pair.first<<" -> "<<pair.second<<" GeV"<<endl;
+    os << "\t Shower " << pair.first << " -> " << pair.second << " GeV" << endl;
   }
   os << "Properties:" << endl;
   for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -11,11 +11,10 @@
 #include <cstdint>
 #include <iostream>
 #include <map>
-#include <type_traits>           // for __decay_and_strip<>::__type
-#include <utility>               // for make_pair
+#include <type_traits>  // for __decay_and_strip<>::__type
+#include <utility>      // for make_pair
 
-
-class PHG4Cellv1: public PHG4Cell
+class PHG4Cellv1 : public PHG4Cell
 {
  public:
   PHG4Cellv1();
@@ -25,77 +24,77 @@ class PHG4Cellv1: public PHG4Cell
   void identify(std::ostream& os = std::cout) const override;
   void Reset() override;
 
-  void set_cellid(const PHG4CellDefs::keytype i) override {cellid = i;}
+  void set_cellid(const PHG4CellDefs::keytype i) override { cellid = i; }
 
-  PHG4CellDefs::keytype get_cellid() const override {return cellid;}
+  PHG4CellDefs::keytype get_cellid() const override { return cellid; }
   bool has_binning(const PHG4CellDefs::CellBinning binning) const override;
   short int get_detid() const override;
 
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) override;
   void add_shower_edep(const int g4showerid, const float edep) override;
 
-  EdepConstRange get_g4hits() override {
+  EdepConstRange get_g4hits() override
+  {
     return std::make_pair(hitedeps.begin(), hitedeps.end());
   }
-  
-  ShowerEdepConstRange get_g4showers() override {
-    return std::make_pair(showeredeps.begin(),showeredeps.end());
-  } 
 
+  ShowerEdepConstRange get_g4showers() override
+  {
+    return std::make_pair(showeredeps.begin(), showeredeps.end());
+  }
 
-  void add_edep(const float f) override {add_property(prop_edep,f);}
-  double get_edep() const override {return get_property_float(prop_edep);}
+  void add_edep(const float f) override { add_property(prop_edep, f); }
+  double get_edep() const override { return get_property_float(prop_edep); }
 
-  void add_eion(const float f) override {add_property(prop_eion,f);}
-  double get_eion() const override {return get_property_float(prop_eion);}
+  void add_eion(const float f) override { add_property(prop_eion, f); }
+  double get_eion() const override { return get_property_float(prop_eion); }
 
-  void add_light_yield(const float f) override {add_property(prop_light_yield,f);}
-  float get_light_yield() const override {return get_property_float(prop_light_yield);}
+  void add_light_yield(const float f) override { add_property(prop_light_yield, f); }
+  float get_light_yield() const override { return get_property_float(prop_light_yield); }
 
-  void set_chip_index(const int i) override {set_property(prop_chip_index,i);}
-  int get_chip_index() const override {return get_property_int(prop_chip_index);}
+  void set_chip_index(const int i) override { set_property(prop_chip_index, i); }
+  int get_chip_index() const override { return get_property_int(prop_chip_index); }
 
-  void set_half_stave_index(const int i) override {set_property(prop_half_stave_index,i);}
-  int get_half_stave_index() const override {return get_property_int(prop_half_stave_index);}
+  void set_half_stave_index(const int i) override { set_property(prop_half_stave_index, i); }
+  int get_half_stave_index() const override { return get_property_int(prop_half_stave_index); }
 
-  void set_ladder_phi_index(const int i) override {set_property(prop_ladder_phi_index,i);}
-  int get_ladder_phi_index() const override {return get_property_int(prop_ladder_phi_index);}
+  void set_ladder_phi_index(const int i) override { set_property(prop_ladder_phi_index, i); }
+  int get_ladder_phi_index() const override { return get_property_int(prop_ladder_phi_index); }
 
-  void set_ladder_z_index(const int i) override {set_property(prop_ladder_z_index,i);}
-  int get_ladder_z_index() const override {return get_property_int(prop_ladder_z_index);}
+  void set_ladder_z_index(const int i) override { set_property(prop_ladder_z_index, i); }
+  int get_ladder_z_index() const override { return get_property_int(prop_ladder_z_index); }
 
-  void set_module_index(const int i) override {set_property(prop_module_index,i);}
-  int get_module_index() const override {return get_property_int(prop_module_index);}
+  void set_module_index(const int i) override { set_property(prop_module_index, i); }
+  int get_module_index() const override { return get_property_int(prop_module_index); }
 
-  void set_phibin(const int i) override {set_property(prop_phibin,i);}
-  int get_phibin() const override {return get_property_int(prop_phibin);}
+  void set_phibin(const int i) override { set_property(prop_phibin, i); }
+  int get_phibin() const override { return get_property_int(prop_phibin); }
 
-  void set_pixel_index(const int i) override {set_property(prop_pixel_index,i);}
-  int get_pixel_index() const override {return get_property_int(prop_pixel_index);}
+  void set_pixel_index(const int i) override { set_property(prop_pixel_index, i); }
+  int get_pixel_index() const override { return get_property_int(prop_pixel_index); }
 
-  void set_stave_index(const int i) override {set_property(prop_stave_index,i);}
-  int get_stave_index() const override {return get_property_int(prop_stave_index);}
+  void set_stave_index(const int i) override { set_property(prop_stave_index, i); }
+  int get_stave_index() const override { return get_property_int(prop_stave_index); }
 
-  void set_zbin(const int i) override {set_property(prop_zbin,i);}
-  int get_zbin() const override {return get_property_int(prop_zbin);}
+  void set_zbin(const int i) override { set_property(prop_zbin, i); }
+  int get_zbin() const override { return get_property_int(prop_zbin); }
 
   void print() const override;
 
-  bool  has_property(const PROPERTY prop_id) const override;
+  bool has_property(const PROPERTY prop_id) const override;
   float get_property_float(const PROPERTY prop_id) const override;
-  int   get_property_int(const PROPERTY prop_id) const override;
-  unsigned int   get_property_uint(const PROPERTY prop_id) const override;
-  void  add_property(const PROPERTY prop_id, const float value);
-  void  add_property(const PROPERTY prop_id, const int value);
-  void  add_property(const PROPERTY prop_id, const unsigned int value);
-  void  set_property(const PROPERTY prop_id, const float value) override;
-  void  set_property(const PROPERTY prop_id, const int value) override;
-  void  set_property(const PROPERTY prop_id, const unsigned int value) override;
-
+  int get_property_int(const PROPERTY prop_id) const override;
+  unsigned int get_property_uint(const PROPERTY prop_id) const override;
+  void add_property(const PROPERTY prop_id, const float value);
+  void add_property(const PROPERTY prop_id, const int value);
+  void add_property(const PROPERTY prop_id, const unsigned int value);
+  void set_property(const PROPERTY prop_id, const float value) override;
+  void set_property(const PROPERTY prop_id, const int value) override;
+  void set_property(const PROPERTY prop_id, const unsigned int value) override;
 
  protected:
   unsigned int get_property_nocheck(const PROPERTY prop_id) const override;
-  void set_property_nocheck(const PROPERTY prop_id,const unsigned int ui) override {prop_map[prop_id]=ui;}
+  void set_property_nocheck(const PROPERTY prop_id, const unsigned int ui) override { prop_map[prop_id] = ui; }
 
   PHG4CellDefs::keytype cellid;
   EdepMap hitedeps;
@@ -107,24 +106,36 @@ class PHG4Cellv1: public PHG4Cell
   typedef std::map<prop_id_t, prop_storage_t> prop_map_t;
 
   //! convert between 32bit inputs and storage type prop_storage_t
-  union u_property{
+  union u_property
+  {
     float fdata;
     int32_t idata;
     uint32_t uidata;
 
-    u_property(int32_t in): idata(in) {}
-    u_property(uint32_t in): uidata(in) {}
-    u_property(float in): fdata(in) {}
-    u_property(): uidata(0) {}
+    u_property(int32_t in)
+      : idata(in)
+    {
+    }
+    u_property(uint32_t in)
+      : uidata(in)
+    {
+    }
+    u_property(float in)
+      : fdata(in)
+    {
+    }
+    u_property()
+      : uidata(0)
+    {
+    }
 
-    prop_storage_t get_storage() const {return uidata;}
+    prop_storage_t get_storage() const { return uidata; }
   };
 
   //! container for additional property
   prop_map_t prop_map;
 
-
-  ClassDefOverride(PHG4Cellv1,3)
+  ClassDefOverride(PHG4Cellv1, 3)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -30,6 +30,8 @@ class PHG4Cellv1 : public PHG4Cell
   bool has_binning(const PHG4CellDefs::CellBinning binning) const override;
   short int get_detid() const override;
 
+  using PHG4Cell::add_edep;
+
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) override;
   void add_shower_edep(const int g4showerid, const float edep) override;
 

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4Cellv1+;
+#pragma link C++ class PHG4Cellv1 + ;
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4Cellv2LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv2LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4Cellv2+;
+#pragma link C++ class PHG4Cellv2 + ;
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -3,8 +3,8 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>  // for PHG4Detector
-#include <g4main/PHG4DisplayAction.h>    // for PHG4DisplayAction
+#include <g4main/PHG4Detector.h>       // for PHG4Detector
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
 
 #include <Geant4/G4Cons.hh>
@@ -66,29 +66,29 @@ void PHG4ConeDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4RotationMatrix *rotm = new G4RotationMatrix();
 
   int nRotation(0);
-  if (m_Params->get_double_param("rot_x") !=0 )
+  if (m_Params->get_double_param("rot_x") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
   }
-  if (m_Params->get_double_param("rot_y") !=0 )
+  if (m_Params->get_double_param("rot_y") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
   }
-  if (m_Params->get_double_param("rot_z") !=0 )
+  if (m_Params->get_double_param("rot_z") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
   }
 
-  if (nRotation>=2)
+  if (nRotation >= 2)
   {
-    std::cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
-        <<"("<<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<") degrees. "
-        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    std::cout << __PRETTY_FUNCTION__ << ": Warning : " << GetName() << " is configured with more than one of the x-y-z rotations of "
+              << "(" << m_Params->get_double_param("rot_x") << ", "
+              << m_Params->get_double_param("rot_x") << ", "
+              << m_Params->get_double_param("rot_x") << ") degrees. "
+              << "The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
     rotm->print(std::cout);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDisplayAction.cc
@@ -29,7 +29,7 @@ PHG4ConeDisplayAction::~PHG4ConeDisplayAction()
   delete m_Colour;
 }
 
-void PHG4ConeDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4ConeDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   if (m_MyVolume->GetVisAttributes())
   {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
@@ -17,51 +17,49 @@
 class PHG4CylinderCell : public PHG4Cell
 {
  public:
-  
-  ~PHG4CylinderCell() override{}
+  ~PHG4CylinderCell() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override 
+  // from PHObject
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "PHG4CylinderCell base class" << std::endl;
   }
-  
-    void set_ladder_phi_index(const int) override {return;}
-  int get_ladder_phi_index() const override {return -9999;}
 
-  void set_ladder_z_index(const int) override {return;}
-  int get_ladder_z_index() const override {return -9999;}
+  void set_ladder_phi_index(const int) override { return; }
+  int get_ladder_phi_index() const override { return -9999; }
 
-// our own - not inherited  
-  virtual void set_cell_id(const PHG4CylinderCellDefs::keytype) {return;}
-  virtual void set_layer(const unsigned int) {return;}
+  void set_ladder_z_index(const int) override { return; }
+  int get_ladder_z_index() const override { return -9999; }
 
-  virtual unsigned int get_layer() const {return 0xFFFFFFFF;}
-  virtual PHG4CylinderCellDefs::keytype get_cell_id() const {return 0xFFFFFFFF;}
-  virtual int get_binz() const {return -1;}
-  virtual int get_binphi() const {return -1;}
-  virtual int get_bineta() const {return -1;}
+  // our own - not inherited
+  virtual void set_cell_id(const PHG4CylinderCellDefs::keytype) { return; }
+  virtual void set_layer(const unsigned int) { return; }
 
-  virtual void set_etabin(const int) {return;}
-  virtual void set_light_yield(float)  {   return;  }
+  virtual unsigned int get_layer() const { return 0xFFFFFFFF; }
+  virtual PHG4CylinderCellDefs::keytype get_cell_id() const { return 0xFFFFFFFF; }
+  virtual int get_binz() const { return -1; }
+  virtual int get_binphi() const { return -1; }
+  virtual int get_bineta() const { return -1; }
 
-  virtual void set_fiber_ID(int) {   return;  }
-  virtual int get_fiber_ID() const {return -1;}
+  virtual void set_etabin(const int) { return; }
+  virtual void set_light_yield(float) { return; }
 
-  virtual void set_sensor_index(const std::string &) {return;}
-  virtual std::string get_sensor_index() const {return "";}
+  virtual void set_fiber_ID(int) { return; }
+  virtual int get_fiber_ID() const { return -1; }
 
-  virtual int get_j_index() const {return -9999;}
-  virtual void set_j_index(const int) {return;}
-  virtual int get_k_index() const {return -9999;}
-  virtual void set_k_index(const int) {return;}
-  virtual int get_l_index() const {return -9999;}
-  virtual void set_l_index(const int) {return;}
+  virtual void set_sensor_index(const std::string&) { return; }
+  virtual std::string get_sensor_index() const { return ""; }
 
-   protected:
+  virtual int get_j_index() const { return -9999; }
+  virtual void set_j_index(const int) { return; }
+  virtual int get_k_index() const { return -9999; }
+  virtual void set_k_index(const int) { return; }
+  virtual int get_l_index() const { return -9999; }
+  virtual void set_l_index(const int) { return; }
 
+ protected:
   PHG4CylinderCell() {}
-  ClassDefOverride(PHG4CylinderCell,2)
+  ClassDefOverride(PHG4CylinderCell, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCell.h
@@ -31,6 +31,7 @@ class PHG4CylinderCell : public PHG4Cell
   void set_ladder_z_index(const int) override { return; }
   int get_ladder_z_index() const override { return -9999; }
 
+
   // our own - not inherited
   virtual void set_cell_id(const PHG4CylinderCellDefs::keytype) { return; }
   virtual void set_layer(const unsigned int) { return; }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
@@ -1,66 +1,63 @@
 #include "PHG4CylinderCellContainer.h"
 
-#include "PHG4CylinderCell.h"      // for PHG4CylinderCell
-#include "PHG4CylinderCellv1.h"
+#include "PHG4CylinderCell.h"  // for PHG4CylinderCell
 #include "PHG4CylinderCellDefs.h"
+#include "PHG4CylinderCellv1.h"
 
 #include <cstdlib>
 
 using namespace std;
 
-void
-PHG4CylinderCellContainer::Reset()
+void PHG4CylinderCellContainer::Reset()
 {
-   while(cellmap.begin() != cellmap.end())
-     {
-       delete cellmap.begin()->second;
-       cellmap.erase(cellmap.begin());
-     }
+  while (cellmap.begin() != cellmap.end())
+  {
+    delete cellmap.begin()->second;
+    cellmap.erase(cellmap.begin());
+  }
   return;
 }
 
-void
-PHG4CylinderCellContainer::identify(ostream& os) const
+void PHG4CylinderCellContainer::identify(ostream& os) const
 {
-   map<unsigned int,PHG4CylinderCell *>::const_iterator iter;
-   os << "Number of cells: " << size() << endl;
-   for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
-     {
-       os << "cell key 0x" << hex << iter->first << dec << endl;
-       (iter->second)->identify();
-     }
-   set<int>::const_iterator siter;
-   os << "Number of layers: " << num_layers() << endl;
-   for (siter = layers.begin(); siter != layers.end(); ++siter)
-     {
-       os << "layer : " << *siter << endl;
-     }
+  map<unsigned int, PHG4CylinderCell*>::const_iterator iter;
+  os << "Number of cells: " << size() << endl;
+  for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
+  {
+    os << "cell key 0x" << hex << iter->first << dec << endl;
+    (iter->second)->identify();
+  }
+  set<int>::const_iterator siter;
+  os << "Number of layers: " << num_layers() << endl;
+  for (siter = layers.begin(); siter != layers.end(); ++siter)
+  {
+    os << "layer : " << *siter << endl;
+  }
   return;
 }
-
 
 PHG4CylinderCellDefs::keytype
 PHG4CylinderCellContainer::genkey(const unsigned int detid)
 {
   if ((detid >> PHG4CylinderCellDefs::keybits) > 0)
-    {
-      cout << " detector id too large: " << detid << endl;
-      exit(1);
-    }
+  {
+    cout << " detector id too large: " << detid << endl;
+    exit(1);
+  }
   unsigned int shiftval = detid << PHG4CylinderCellDefs::cell_idbits;
   unsigned int cellid = cellmap.size();
   cellid++;
   PHG4CylinderCellDefs::keytype newkey = cellid | shiftval;
   if (cellmap.find(newkey) != cellmap.end())
-    {
-      cout << " duplicate key: " << newkey << " exiting now" << endl;
-      exit(1);
-    }
+  {
+    cout << " duplicate key: " << newkey << " exiting now" << endl;
+    exit(1);
+  }
   return newkey;
 }
 
 PHG4CylinderCellContainer::ConstIterator
-PHG4CylinderCellContainer::AddCylinderCell(const unsigned int detid, PHG4CylinderCell *newcell)
+PHG4CylinderCellContainer::AddCylinderCell(const unsigned int detid, PHG4CylinderCell* newcell)
 {
   PHG4CylinderCellDefs::keytype key = genkey(detid);
   layers.insert(newcell->get_layer());
@@ -70,67 +67,68 @@ PHG4CylinderCellContainer::AddCylinderCell(const unsigned int detid, PHG4Cylinde
 }
 
 PHG4CylinderCellContainer::ConstIterator
-PHG4CylinderCellContainer::AddCylinderCellSpecifyKey(const PHG4CylinderCellDefs::keytype key, PHG4CylinderCell *newcell)
+PHG4CylinderCellContainer::AddCylinderCellSpecifyKey(const PHG4CylinderCellDefs::keytype key, PHG4CylinderCell* newcell)
 {
-  if(cellmap.find(key)!=cellmap.end())
-   {
-     cout << "PHG4CylinderCellContainer::AddCylinderCellSpecifyKey: duplicate key: " << key << " exiting now" << endl;
-     exit(1);
-   }
+  if (cellmap.find(key) != cellmap.end())
+  {
+    cout << "PHG4CylinderCellContainer::AddCylinderCellSpecifyKey: duplicate key: " << key << " exiting now" << endl;
+    exit(1);
+  }
   layers.insert(newcell->get_layer());
   newcell->set_cell_id(key);
   cellmap[key] = newcell;
   return cellmap.find(key);
 }
 
-PHG4CylinderCellContainer::ConstRange 
+PHG4CylinderCellContainer::ConstRange
 PHG4CylinderCellContainer::getCylinderCells(const unsigned int detid) const
 {
   if ((detid >> PHG4CylinderCellDefs::keybits) > 0)
-    {
-      cout << " detector id too large: " << detid << endl;
-      exit(1);
-    }
+  {
+    cout << " detector id too large: " << detid << endl;
+    exit(1);
+  }
   //  unsigned int shiftval = detid << cell_idbits;
   PHG4CylinderCellDefs::keytype keylow = detid << PHG4CylinderCellDefs::cell_idbits;
-  PHG4CylinderCellDefs::keytype keyup = ((detid + 1)<< PHG4CylinderCellDefs::cell_idbits) -1 ;
-//   cout << "keylow: 0x" << hex << keylow << dec << endl;
-//   cout << "keyup: 0x" << hex << keyup << dec << endl;
+  PHG4CylinderCellDefs::keytype keyup = ((detid + 1) << PHG4CylinderCellDefs::cell_idbits) - 1;
+  //   cout << "keylow: 0x" << hex << keylow << dec << endl;
+  //   cout << "keyup: 0x" << hex << keyup << dec << endl;
   ConstRange retpair;
   retpair.first = cellmap.lower_bound(keylow);
   retpair.second = cellmap.upper_bound(keyup);
   return retpair;
 }
 
-PHG4CylinderCellContainer::ConstRange 
-PHG4CylinderCellContainer::getCylinderCells( void ) const
-{ return std::make_pair( cellmap.begin(), cellmap.end() ); }
+PHG4CylinderCellContainer::ConstRange
+PHG4CylinderCellContainer::getCylinderCells(void) const
+{
+  return std::make_pair(cellmap.begin(), cellmap.end());
+}
 
-
-PHG4CylinderCellContainer::Iterator 
+PHG4CylinderCellContainer::Iterator
 PHG4CylinderCellContainer::findOrAddCylinderCell(PHG4CylinderCellDefs::keytype key)
 {
   PHG4CylinderCellContainer::Iterator it = cellmap.find(key);
-  if(it == cellmap.end())
+  if (it == cellmap.end())
   {
     cellmap[key] = new PHG4CylinderCellv1();
     it = cellmap.find(key);
     PHG4CylinderCell* mcell = it->second;
     mcell->set_cell_id(key);
-    layers.insert(mcell->get_layer()); // add layer to our set of layers
+    layers.insert(mcell->get_layer());  // add layer to our set of layers
   }
   return it;
 }
 
-PHG4CylinderCell* 
+PHG4CylinderCell*
 PHG4CylinderCellContainer::findCylinderCell(PHG4CylinderCellDefs::keytype key)
 {
   PHG4CylinderCellContainer::ConstIterator it = cellmap.find(key);
 
-  if(it != cellmap.end())
-    {
-      return it->second;
-    }
+  if (it != cellmap.end())
+  {
+    return it->second;
+  }
 
   return 0;
 }
@@ -141,8 +139,8 @@ PHG4CylinderCellContainer::getTotalEdep() const
   ConstIterator iter;
   double totalenergy = 0;
   for (iter = cellmap.begin(); iter != cellmap.end(); ++iter)
-    {
-      totalenergy += iter->second->get_edep();
-    }
+  {
+    totalenergy += iter->second->get_edep();
+  }
   return totalenergy;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.h
@@ -7,18 +7,17 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>                // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
 #include <set>
-#include <utility>                 // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class PHG4CylinderCell;
 
-class PHG4CylinderCellContainer: public PHObject
+class PHG4CylinderCellContainer : public PHObject
 {
-
-  public:
-  typedef std::map<PHG4CylinderCellDefs::keytype,PHG4CylinderCell *> Map;
+ public:
+  typedef std::map<PHG4CylinderCellDefs::keytype, PHG4CylinderCell *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -26,19 +25,20 @@ class PHG4CylinderCellContainer: public PHObject
   typedef std::set<int>::const_iterator LayerIter;
   typedef std::pair<LayerIter, LayerIter> LayerRange;
 
-  PHG4CylinderCellContainer(){}
+  PHG4CylinderCellContainer() {}
 
   ~PHG4CylinderCellContainer() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
   void Reset() override;
 
   ConstIterator AddCylinderCell(const unsigned int detid, PHG4CylinderCell *newcylinderCell);
   ConstIterator AddCylinderCellSpecifyKey(const PHG4CylinderCellDefs::keytype key, PHG4CylinderCell *newcylinderCell);
-  
+
   //! preferred removal method, key is currently the cell id
-  void RemoveCylinderCell(PHG4CylinderCellDefs::keytype key) {
+  void RemoveCylinderCell(PHG4CylinderCellDefs::keytype key)
+  {
     cellmap.erase(key);
   }
 
@@ -48,18 +48,17 @@ class PHG4CylinderCellContainer: public PHObject
     Iterator its = cellmap.begin();
     Iterator last = cellmap.end();
     for (; its != last;)
+    {
+      if (its->second == cell)
       {
-	if (its->second == cell)
-	  {
-	    cellmap.erase(its++);
-	  }
-	else
-	  {
-	    ++its;
-	  }
+        cellmap.erase(its++);
       }
+      else
+      {
+        ++its;
+      }
+    }
   }
-
 
   Iterator findOrAddCylinderCell(PHG4CylinderCellDefs::keytype key);
 
@@ -69,24 +68,30 @@ class PHG4CylinderCellContainer: public PHObject
   ConstRange getCylinderCells(const unsigned int detid) const;
 
   //! return all hist
-  ConstRange getCylinderCells( void ) const;
+  ConstRange getCylinderCells(void) const;
 
-  PHG4CylinderCell* findCylinderCell(PHG4CylinderCellDefs::keytype key);
+  PHG4CylinderCell *findCylinderCell(PHG4CylinderCellDefs::keytype key);
 
-  unsigned int size( void ) const
-  { return cellmap.size(); }
+  unsigned int size(void) const
+  {
+    return cellmap.size();
+  }
   unsigned int num_layers(void) const
-  { return layers.size(); }
+  {
+    return layers.size();
+  }
   LayerRange getLayers() const
-  { return make_pair(layers.begin(), layers.end());}
+  {
+    return make_pair(layers.begin(), layers.end());
+  }
 
   double getTotalEdep() const;
 
  protected:
   Map cellmap;
-  std::set<int> layers; // layers is not reset since layers must not change event by event
+  std::set<int> layers;  // layers is not reset since layers must not change event by event
 
-  ClassDefOverride(PHG4CylinderCellContainer,1)
+  ClassDefOverride(PHG4CylinderCellContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellContainer+;
+#pragma link C++ class PHG4CylinderCellContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellDefs.h
@@ -8,7 +8,14 @@ namespace PHG4CylinderCellDefs
   typedef unsigned int keytype;
   static int keybits = 8;
   static int cell_idbits = 32 - keybits;
-  enum {undefined = 0, sizebinning = 1, etaphibinning = 2, etaslatbinning = 3, spacalbinning = 4};
-}
+  enum
+  {
+    undefined = 0,
+    sizebinning = 1,
+    etaphibinning = 2,
+    etaslatbinning = 3,
+    spacalbinning = 4
+  };
+}  // namespace PHG4CylinderCellDefs
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.cc
@@ -4,22 +4,19 @@
 #include <phool/phool.h>
 #include <cstdlib>
 
-void
-PHG4CylinderCellGeom::set_zbins(const int i)
+void PHG4CylinderCellGeom::set_zbins(const int i)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   nzbins = i;
 }
 
-void
-PHG4CylinderCellGeom::set_zmin(const double z)
+void PHG4CylinderCellGeom::set_zmin(const double z)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   zmin = z;
 }
 
-int
-PHG4CylinderCellGeom::get_zbins() const
+int PHG4CylinderCellGeom::get_zbins() const
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   return nzbins;
@@ -39,57 +36,51 @@ PHG4CylinderCellGeom::get_zstep() const
   return zstep;
 }
 
-void
-PHG4CylinderCellGeom::set_zstep(const double z)
+void PHG4CylinderCellGeom::set_zstep(const double z)
 {
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   zstep = z;
 }
 
-int
-PHG4CylinderCellGeom::get_phibins() const
+int PHG4CylinderCellGeom::get_phibins() const
 {
   check_binning_method_phi("PHG4CylinderCellGeom::get_phibins");
-return  nphibins;
+  return nphibins;
 }
 
 double
 PHG4CylinderCellGeom::get_phistep() const
 {
   check_binning_method_phi("PHG4CylinderCellGeom::get_phistep");
-  return  phistep;
+  return phistep;
 }
 
 double
 PHG4CylinderCellGeom::get_phimin() const
 {
   check_binning_method_phi("PHG4CylinderCellGeom::get_phimin");
-  return  phimin;
+  return phimin;
 }
 
-void
-PHG4CylinderCellGeom::set_phibins(const int i)
+void PHG4CylinderCellGeom::set_phibins(const int i)
 {
   check_binning_method_phi("PHG4CylinderCellGeom::set_phibins");
   nphibins = i;
 }
 
-void
-PHG4CylinderCellGeom::set_phistep(const double r)
+void PHG4CylinderCellGeom::set_phistep(const double r)
 {
   check_binning_method_phi("PHG4CylinderCellGeom::set_phistep");
   phistep = r;
 }
 
-void
-PHG4CylinderCellGeom::set_phimin(const double r)
+void PHG4CylinderCellGeom::set_phimin(const double r)
 {
   check_binning_method_phi("PHG4CylinderCellGeom::set_phimin");
   phimin = r;
 }
 
-int
-PHG4CylinderCellGeom::get_etabins() const
+int PHG4CylinderCellGeom::get_etabins() const
 {
   check_binning_method_eta("PHG4CylinderCellGeom::get_etabins");
   return nzbins;
@@ -108,58 +99,54 @@ PHG4CylinderCellGeom::get_etamin() const
   return zmin;
 }
 
-void
-PHG4CylinderCellGeom::set_etamin(const double z)
+void PHG4CylinderCellGeom::set_etamin(const double z)
 {
   check_binning_method_eta("PHG4CylinderCellGeom::set_etamin");
   zmin = z;
 }
 
-void
-PHG4CylinderCellGeom::set_etastep(const double z)
+void PHG4CylinderCellGeom::set_etastep(const double z)
 {
   check_binning_method_eta("PHG4CylinderCellGeom::set_etastep");
   zstep = z;
 }
 
-void
-PHG4CylinderCellGeom::set_etabins(const int i)
+void PHG4CylinderCellGeom::set_etabins(const int i)
 {
   check_binning_method_eta("PHG4CylinderCellGeom::set_etabins");
   nzbins = i;
 }
 
-void
-PHG4CylinderCellGeom::identify(std::ostream& os) const
+void PHG4CylinderCellGeom::identify(std::ostream& os) const
 {
   os << "PHG4CylinderCellGeom::identify - layer: " << layer
      << ", radius: " << radius
      << ", thickness: " << thickness;
   switch (binning)
-    {
-    case PHG4CylinderCellDefs::sizebinning:
-      os << ", zbins: " << nzbins
-	 << ", zmin: " << zmin
-	 << ", zstepsize: " << zstep;
-      break;
-    case PHG4CylinderCellDefs::etaphibinning:
-      os << ", etabins: " << nzbins
-	 << ", etamin: " << zmin
-	 << ", etastepsize: " << zstep;
-      break;
-    case PHG4CylinderCellDefs::etaslatbinning:
-      os << ", etabins: " << nzbins
-   << ", etamin: " << zmin
-   << ", etastepsize: " << zstep;
-      break;
-    case PHG4CylinderCellDefs::spacalbinning:
-      os << ", etabins: " << nzbins<<" for Spacal";
-      break;
-    default:
-      os << "no valid binning method: " << binning << std::endl;
-      return;
-      break;
-    }
+  {
+  case PHG4CylinderCellDefs::sizebinning:
+    os << ", zbins: " << nzbins
+       << ", zmin: " << zmin
+       << ", zstepsize: " << zstep;
+    break;
+  case PHG4CylinderCellDefs::etaphibinning:
+    os << ", etabins: " << nzbins
+       << ", etamin: " << zmin
+       << ", etastepsize: " << zstep;
+    break;
+  case PHG4CylinderCellDefs::etaslatbinning:
+    os << ", etabins: " << nzbins
+       << ", etamin: " << zmin
+       << ", etastepsize: " << zstep;
+    break;
+  case PHG4CylinderCellDefs::spacalbinning:
+    os << ", etabins: " << nzbins << " for Spacal";
+    break;
+  default:
+    os << "no valid binning method: " << binning << std::endl;
+    return;
+    break;
+  }
   os << ", phimin: " << phimin
      << ", phibins: " << nphibins
      << ", phistep: " << phistep
@@ -171,10 +158,10 @@ std::pair<double, double>
 PHG4CylinderCellGeom::get_zbounds(const int ibin) const
 {
   if (ibin < 0 || ibin > nzbins)
-    {
-      std::cout << PHWHERE << " Asking for invalid bin in z: " << ibin << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << " Asking for invalid bin in z: " << ibin << std::endl;
+    exit(1);
+  }
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
   double zlow = zmin + ibin * zstep;
   double zhigh = zlow + zstep;
@@ -185,182 +172,175 @@ std::pair<double, double>
 PHG4CylinderCellGeom::get_etabounds(const int ibin) const
 {
   if (ibin < 0 || ibin > nzbins)
-    {
-      std::cout << PHWHERE << " Asking for invalid bin in z: " << ibin << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << " Asking for invalid bin in z: " << ibin << std::endl;
+    exit(1);
+  }
   check_binning_method_eta("PHG4CylinderCellGeom::get_etabounds");
-//  check_binning_method(PHG4CylinderCellDefs::etaphibinning);
+  //  check_binning_method(PHG4CylinderCellDefs::etaphibinning);
   double zlow = zmin + ibin * zstep;
   double zhigh = zlow + zstep;
   return std::make_pair(zlow, zhigh);
 }
 
-
 std::pair<double, double>
 PHG4CylinderCellGeom::get_phibounds(const int ibin) const
 {
   if (ibin < 0 || ibin > nphibins)
-    {
-      std::cout << PHWHERE << "Asking for invalid bin in phi: " << ibin << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "Asking for invalid bin in phi: " << ibin << std::endl;
+    exit(1);
+  }
 
   double philow = phimin + ibin * phistep;
   double phihigh = philow + phistep;
   return std::make_pair(philow, phihigh);
 }
 
-int
-PHG4CylinderCellGeom::get_zbin(const double z) const
+int PHG4CylinderCellGeom::get_zbin(const double z) const
 {
-  if (z < zmin || z > (zmin+nzbins*zstep))
+  if (z < zmin || z > (zmin + nzbins * zstep))
   {
     //    cout << PHWHERE << "Asking for bin for z outside of z range: " << z << endl;
     return -1;
   }
-  
+
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
-  return floor( (z-zmin)/zstep );
+  return floor((z - zmin) / zstep);
 }
 
-int
-PHG4CylinderCellGeom::get_etabin(const double eta) const
+int PHG4CylinderCellGeom::get_etabin(const double eta) const
 {
-  if (eta < zmin || eta > (zmin+nzbins*zstep))
+  if (eta < zmin || eta > (zmin + nzbins * zstep))
   {
     //    cout << "Asking for bin for eta outside of eta range: " << eta << endl;
     return -1;
   }
   check_binning_method_eta();
-  return floor( (eta-zmin)/zstep );
+  return floor((eta - zmin) / zstep);
 }
 
-int
-PHG4CylinderCellGeom::get_phibin(const double phi) const
+int PHG4CylinderCellGeom::get_phibin(const double phi) const
 {
   double norm_phi = phi;
-  if(phi < phimin || phi > (phimin+nphibins*phistep))
+  if (phi < phimin || phi > (phimin + nphibins * phistep))
   {
-    int nwraparound = -floor((phi-phimin) * 0.5 / M_PI);
-    norm_phi += 2*M_PI*nwraparound;
+    int nwraparound = -floor((phi - phimin) * 0.5 / M_PI);
+    norm_phi += 2 * M_PI * nwraparound;
   }
   check_binning_method_phi();
-  return floor( (norm_phi-phimin)/phistep );
+  return floor((norm_phi - phimin) / phistep);
 }
 
 double
 PHG4CylinderCellGeom::get_zcenter(const int ibin) const
 {
   if (ibin < 0 || ibin > nzbins)
-    {
-      std::cout << PHWHERE << "Asking for invalid bin in z: " << ibin << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "Asking for invalid bin in z: " << ibin << std::endl;
+    exit(1);
+  }
   check_binning_method(PHG4CylinderCellDefs::sizebinning);
-  return zmin + (ibin + 0.5)*zstep;
+  return zmin + (ibin + 0.5) * zstep;
 }
 
 double
 PHG4CylinderCellGeom::get_etacenter(const int ibin) const
 {
   if (ibin < 0 || ibin > nzbins)
-    {
-      std::cout << PHWHERE << "Asking for invalid bin in eta: " << ibin << std::endl;
-      std::cout << "minbin: 0, maxbin " << nzbins << std::endl; 
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "Asking for invalid bin in eta: " << ibin << std::endl;
+    std::cout << "minbin: 0, maxbin " << nzbins << std::endl;
+    exit(1);
+  }
   check_binning_method_eta();
-  return zmin + (ibin + 0.5)*zstep;
+  return zmin + (ibin + 0.5) * zstep;
 }
 
 double
 PHG4CylinderCellGeom::get_phicenter(const int ibin) const
 {
   if (ibin < 0 || ibin > nphibins)
-    {
-      std::cout << PHWHERE << "Asking for invalid bin in phi: " << ibin << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "Asking for invalid bin in phi: " << ibin << std::endl;
+    exit(1);
+  }
 
   check_binning_method_phi();
-  return (phimin + (ibin + 0.5)*phistep);
+  return (phimin + (ibin + 0.5) * phistep);
 }
 
 std::string
 PHG4CylinderCellGeom::methodname(const int i) const
 {
   switch (i)
-    {
-    case PHG4CylinderCellDefs::sizebinning:
-      return "Bins in cm";
-      break;
-    case PHG4CylinderCellDefs::etaphibinning:
-      return "Eta/Phi bins";
-      break;
-    case PHG4CylinderCellDefs::etaslatbinning:
-      return "Eta/numslat bins";
-      break;
-    case PHG4CylinderCellDefs::spacalbinning:
-      return "SPACAL Tower bins";
-      break;
-    default:
-      break;
-    }
+  {
+  case PHG4CylinderCellDefs::sizebinning:
+    return "Bins in cm";
+    break;
+  case PHG4CylinderCellDefs::etaphibinning:
+    return "Eta/Phi bins";
+    break;
+  case PHG4CylinderCellDefs::etaslatbinning:
+    return "Eta/numslat bins";
+    break;
+  case PHG4CylinderCellDefs::spacalbinning:
+    return "SPACAL Tower bins";
+    break;
+  default:
+    break;
+  }
   return "Unknown";
 }
 
-void
-PHG4CylinderCellGeom::check_binning_method(const int i) const
+void PHG4CylinderCellGeom::check_binning_method(const int i) const
 {
   if (binning != i)
-    {
-      std::cout << "different binning method used " << methodname(binning)
-           << ", not : " << methodname(i)
-           << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << "different binning method used " << methodname(binning)
+              << ", not : " << methodname(i)
+              << std::endl;
+    exit(1);
+  }
   return;
 }
 
-void
-PHG4CylinderCellGeom::check_binning_method_eta(const std::string & src) const
+void PHG4CylinderCellGeom::check_binning_method_eta(const std::string& src) const
 {
-  if (binning != PHG4CylinderCellDefs::etaphibinning && 
-      binning != PHG4CylinderCellDefs::etaslatbinning&&
+  if (binning != PHG4CylinderCellDefs::etaphibinning &&
+      binning != PHG4CylinderCellDefs::etaslatbinning &&
       binning != PHG4CylinderCellDefs::spacalbinning)
-    {
-      if (src.size())
-        std::cout << src<<" : ";
+  {
+    if (src.size())
+      std::cout << src << " : ";
 
-      std::cout << "different binning method used " << methodname(binning)
-        << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
-        << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
-        << " or " << methodname(PHG4CylinderCellDefs::spacalbinning)
-        << std::endl;
-      exit(1);
-    }
+    std::cout << "different binning method used " << methodname(binning)
+              << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+              << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
+              << " or " << methodname(PHG4CylinderCellDefs::spacalbinning)
+              << std::endl;
+    exit(1);
+  }
   return;
 }
 
-void
-PHG4CylinderCellGeom::check_binning_method_phi(const std::string & src) const
+void PHG4CylinderCellGeom::check_binning_method_phi(const std::string& src) const
 {
-  if (binning != PHG4CylinderCellDefs::etaphibinning && 
+  if (binning != PHG4CylinderCellDefs::etaphibinning &&
       binning != PHG4CylinderCellDefs::sizebinning &&
       binning != PHG4CylinderCellDefs::etaslatbinning &&
       binning != PHG4CylinderCellDefs::spacalbinning)
-    {
-      if (src.size())
-        std::cout << src<<" : ";
+  {
+    if (src.size())
+      std::cout << src << " : ";
 
-      std::cout << "different binning method used " << methodname(binning)
-           << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
-           << " or " << methodname(PHG4CylinderCellDefs::sizebinning)
-           << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
-           << " or " << methodname(PHG4CylinderCellDefs::spacalbinning)
-           << std::endl;
-      exit(1);
-    }
+    std::cout << "different binning method used " << methodname(binning)
+              << ", not : " << methodname(PHG4CylinderCellDefs::etaphibinning)
+              << " or " << methodname(PHG4CylinderCellDefs::sizebinning)
+              << " or " << methodname(PHG4CylinderCellDefs::etaslatbinning)
+              << " or " << methodname(PHG4CylinderCellDefs::spacalbinning)
+              << std::endl;
+    exit(1);
+  }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom.h
@@ -6,24 +6,24 @@
 #include <phool/PHObject.h>
 
 #include <cmath>
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <string>
-#include <utility>           // for pair
+#include <utility>  // for pair
 
-class PHG4CylinderCellGeom: public PHObject
+class PHG4CylinderCellGeom : public PHObject
 {
  public:
   PHG4CylinderCellGeom() = default;
 
   ~PHG4CylinderCellGeom() override = default;
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  int get_layer() const {return layer;}
-  double get_radius() const {return radius;}
-  double get_thickness() const {return thickness;}
-  int get_binning() const {return binning;}
+  int get_layer() const { return layer; }
+  double get_radius() const { return radius; }
+  double get_thickness() const { return thickness; }
+  int get_binning() const { return binning; }
   int get_zbins() const;
   int get_phibins() const;
   double get_zmin() const;
@@ -45,24 +45,24 @@ class PHG4CylinderCellGeom: public PHObject
   virtual int get_zbin(const double z) const;
   virtual int get_phibin(const double phi) const;
 
-   void set_layer(const int i) {layer = i;}
-   void set_binning(const int i) {binning = i;}
-   void set_radius(const double r) {radius = r;}
-   void set_thickness(const double t) {thickness = t;}
-   void set_zbins(const int i);
-   void set_zmin(const double z);
-   void set_zstep(const double z);
-   void set_phibins(const int i);
-   void set_phistep(const double phi);
-   void set_phimin(const double phi);
-   void set_etabins(const int i);
-   void set_etamin(const double z);
-   void set_etastep(const double z);
-  
+  void set_layer(const int i) { layer = i; }
+  void set_binning(const int i) { binning = i; }
+  void set_radius(const double r) { radius = r; }
+  void set_thickness(const double t) { thickness = t; }
+  void set_zbins(const int i);
+  void set_zmin(const double z);
+  void set_zstep(const double z);
+  void set_phibins(const int i);
+  void set_phistep(const double phi);
+  void set_phimin(const double phi);
+  void set_etabins(const int i);
+  void set_etamin(const double z);
+  void set_etastep(const double z);
+
  protected:
   void check_binning_method(const int i) const;
-  void check_binning_method_eta(const std::string & src = "") const;
-  void check_binning_method_phi(const std::string & src = "") const;
+  void check_binning_method_eta(const std::string& src = "") const;
+  void check_binning_method_phi(const std::string& src = "") const;
   std::string methodname(const int i) const;
   int layer = -999;
   int binning = 0;
@@ -75,7 +75,7 @@ class PHG4CylinderCellGeom: public PHObject
   double phistep = NAN;
   double thickness = NAN;
 
-  ClassDefOverride(PHG4CylinderCellGeom,1)
+  ClassDefOverride(PHG4CylinderCellGeom, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.cc
@@ -2,53 +2,49 @@
 
 #include "PHG4CylinderCellGeom.h"
 
-
 using namespace std;
 
 PHG4CylinderCellGeomContainer::~PHG4CylinderCellGeomContainer()
 {
-  while(layergeoms.begin() != layergeoms.end())
-    {
-      delete layergeoms.begin()->second;
-      layergeoms.erase(layergeoms.begin());
-    }
+  while (layergeoms.begin() != layergeoms.end())
+  {
+    delete layergeoms.begin()->second;
+    layergeoms.erase(layergeoms.begin());
+  }
   return;
 }
 
-void
-PHG4CylinderCellGeomContainer::identify(std::ostream& os) const
+void PHG4CylinderCellGeomContainer::identify(std::ostream &os) const
 {
-  map<int,PHG4CylinderCellGeom *>::const_iterator iter;
-  for (iter=layergeoms.begin(); iter != layergeoms.end(); ++iter)
-    {
-      cout << "layer " << iter->first << endl;
-      (iter->second)->identify(os);
-    }
+  map<int, PHG4CylinderCellGeom *>::const_iterator iter;
+  for (iter = layergeoms.begin(); iter != layergeoms.end(); ++iter)
+  {
+    cout << "layer " << iter->first << endl;
+    (iter->second)->identify(os);
+  }
   return;
 }
 
-int
-PHG4CylinderCellGeomContainer::AddLayerCellGeom(const int i, PHG4CylinderCellGeom *mygeom)
+int PHG4CylinderCellGeomContainer::AddLayerCellGeom(const int i, PHG4CylinderCellGeom *mygeom)
 {
   if (layergeoms.find(i) != layergeoms.end())
-    {
-      cout << "layer " << i << " already added to PHCylinderCellGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << i << " already added to PHCylinderCellGeomContainer" << endl;
+    return -1;
+  }
   mygeom->set_layer(i);
   layergeoms[i] = mygeom;
   return 0;
 }
 
-int
-PHG4CylinderCellGeomContainer::AddLayerCellGeom(PHG4CylinderCellGeom *mygeom)
+int PHG4CylinderCellGeomContainer::AddLayerCellGeom(PHG4CylinderCellGeom *mygeom)
 {
   int layer = mygeom->get_layer();
   if (layergeoms.find(layer) != layergeoms.end())
-    {
-      cout << "layer " << layer << " already added to PHCylinderCellGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << layer << " already added to PHCylinderCellGeomContainer" << endl;
+    return -1;
+  }
   layergeoms[layer] = mygeom;
   return 0;
 }
@@ -56,11 +52,11 @@ PHG4CylinderCellGeomContainer::AddLayerCellGeom(PHG4CylinderCellGeom *mygeom)
 PHG4CylinderCellGeom *
 PHG4CylinderCellGeomContainer::GetLayerCellGeom(const int i)
 {
-  map<int,PHG4CylinderCellGeom *>::const_iterator iter = layergeoms.find(i);
-  if (iter !=  layergeoms.end())
-    {
-      return iter->second;
-    }
+  map<int, PHG4CylinderCellGeom *>::const_iterator iter = layergeoms.find(i);
+  if (iter != layergeoms.end())
+  {
+    return iter->second;
+  }
   cout << "Could not locate layer " << i << " in PHG4CylinderCellGeomContainer" << endl;
   return nullptr;
 }
@@ -69,9 +65,8 @@ PHG4CylinderCellGeom *
 PHG4CylinderCellGeomContainer::GetFirstLayerCellGeom()
 {
   if (layergeoms.empty())
-    {
-      return nullptr;
-    }
+  {
+    return nullptr;
+  }
   return layergeoms.begin()->second;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainer.h
@@ -5,37 +5,37 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>           // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHG4CylinderCellGeom;
 
-class PHG4CylinderCellGeomContainer: public PHObject
+class PHG4CylinderCellGeomContainer : public PHObject
 {
  public:
-  typedef std::map<int, PHG4CylinderCellGeom*> Map;
+  typedef std::map<int, PHG4CylinderCellGeom *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
   typedef std::pair<ConstIterator, ConstIterator> ConstRange;
 
-  PHG4CylinderCellGeomContainer(){}
+  PHG4CylinderCellGeomContainer() {}
   ~PHG4CylinderCellGeomContainer() override;
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
   int AddLayerCellGeom(const int i, PHG4CylinderCellGeom *mygeom);
   int AddLayerCellGeom(PHG4CylinderCellGeom *mygeom);
   PHG4CylinderCellGeom *GetLayerCellGeom(const int i);
   PHG4CylinderCellGeom *GetFirstLayerCellGeom();
-  int get_NLayers() const {return layergeoms.size();}
-  std::pair<std::map<int,PHG4CylinderCellGeom *>::const_iterator, std::map<int,PHG4CylinderCellGeom *>::const_iterator> get_begin_end() const {return std::make_pair(layergeoms.begin(), layergeoms.end());}
+  int get_NLayers() const { return layergeoms.size(); }
+  std::pair<std::map<int, PHG4CylinderCellGeom *>::const_iterator, std::map<int, PHG4CylinderCellGeom *>::const_iterator> get_begin_end() const { return std::make_pair(layergeoms.begin(), layergeoms.end()); }
 
  protected:
-  std::map<int,PHG4CylinderCellGeom *> layergeoms ;
-  ClassDefOverride(PHG4CylinderCellGeomContainer,1)
+  std::map<int, PHG4CylinderCellGeom *> layergeoms;
+  ClassDefOverride(PHG4CylinderCellGeomContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellGeomContainer+;
+#pragma link C++ class PHG4CylinderCellGeomContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeomLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellGeom+;
+#pragma link C++ class PHG4CylinderCellGeom + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
@@ -1,4 +1,4 @@
-// $Id: $                                                                                             
+// $Id: $
 
 /*!
  * \file PHG4CylinderCellGeomSpacalv1.cc
@@ -16,14 +16,13 @@
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 using namespace std;
 
 PHG4CylinderCellGeom_Spacalv1::PHG4CylinderCellGeom_Spacalv1()
 {
-
 }
 
 PHG4CylinderCellGeom_Spacalv1::~PHG4CylinderCellGeom_Spacalv1()
@@ -31,74 +30,73 @@ PHG4CylinderCellGeom_Spacalv1::~PHG4CylinderCellGeom_Spacalv1()
   // TODO Auto-generated destructor stub
 }
 
-void
-PHG4CylinderCellGeom_Spacalv1::identify(std::ostream& os) const
+void PHG4CylinderCellGeom_Spacalv1::identify(std::ostream& os) const
 {
   PHG4CylinderCellGeom::identify(os);
 
   cout << "PHG4CylinderCellGeom_Spacalv1::identify - Tower mapping:" << endl;
-  BOOST_FOREACH(const tower_z_ID_eta_bin_map_t::value_type& tower_z_ID_eta_bin,
-      get_tower_z_ID_eta_bin_map())
-    {
-      cout << "\t" << "Tower Z ID[" << tower_z_ID_eta_bin.first
-          << "] \t-> Eta Bin " << tower_z_ID_eta_bin.second << endl;
-    }
+  BOOST_FOREACH (const tower_z_ID_eta_bin_map_t::value_type& tower_z_ID_eta_bin,
+                 get_tower_z_ID_eta_bin_map())
+  {
+    cout << "\t"
+         << "Tower Z ID[" << tower_z_ID_eta_bin.first
+         << "] \t-> Eta Bin " << tower_z_ID_eta_bin.second << endl;
+  }
 
   cout << "PHG4CylinderCellGeom_Spacalv1::identify - Bin -> z range:" << endl;
-  BOOST_FOREACH(const bound_map_t::value_type& b, z_bound_map)
-    {
-      cout << "\t" << "bin[" << b.first << "] \t-> z = " << b.second.first
-          << " - " << b.second.second << endl;
-    }
+  BOOST_FOREACH (const bound_map_t::value_type& b, z_bound_map)
+  {
+    cout << "\t"
+         << "bin[" << b.first << "] \t-> z = " << b.second.first
+         << " - " << b.second.second << endl;
+  }
 
   cout << "PHG4CylinderCellGeom_Spacalv1::identify - Bin -> eta range:" << endl;
-  BOOST_FOREACH(const bound_map_t::value_type& b, eta_bound_map)
-    {
-      cout << "\t" << "bin[" << b.first << "] \t-> eta = " << b.second.first
-          << " - " << b.second.second << endl;
-    }
+  BOOST_FOREACH (const bound_map_t::value_type& b, eta_bound_map)
+  {
+    cout << "\t"
+         << "bin[" << b.first << "] \t-> eta = " << b.second.first
+         << " - " << b.second.second << endl;
+  }
   return;
 }
 
-void
-PHG4CylinderCellGeom_Spacalv1::map_consistency_check() const
+void PHG4CylinderCellGeom_Spacalv1::map_consistency_check() const
 {
   if ((size_t) nzbins != z_bound_map.size())
-    {
-      cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
-          << "z_bound_map.size() of " << z_bound_map.size()
-          << " in inconsistent with nzbins of " << nzbins << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
+         << "z_bound_map.size() of " << z_bound_map.size()
+         << " in inconsistent with nzbins of " << nzbins << endl;
+    exit(1);
+  }
   if ((size_t) nzbins != eta_bound_map.size())
-    {
-      cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
-          << "eta_bound_map.size() of " << eta_bound_map.size()
-          << " in inconsistent with nzbins of " << nzbins << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
+         << "eta_bound_map.size() of " << eta_bound_map.size()
+         << " in inconsistent with nzbins of " << nzbins << endl;
+    exit(1);
+  }
   if ((size_t) nzbins < tower_z_ID_eta_bin_map.size())
-    {
-      cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
-          << "tower_z_ID_eta_bin_map.size() of " << tower_z_ID_eta_bin_map.size()
-          << " in inconsistent with nzbins of " << nzbins << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4CylinderCellGeom_Spacalv1::map_consistency_check - "
+         << "tower_z_ID_eta_bin_map.size() of " << tower_z_ID_eta_bin_map.size()
+         << " in inconsistent with nzbins of " << nzbins << endl;
+    exit(1);
+  }
 }
 
-void
-PHG4CylinderCellGeom_Spacalv1::set_zbounds(const int ibin,
-    const std::pair<double, double> & bounds)
+void PHG4CylinderCellGeom_Spacalv1::set_zbounds(const int ibin,
+                                                const std::pair<double, double>& bounds)
 {
-  assert(ibin>=0);
+  assert(ibin >= 0);
   z_bound_map[ibin] = bounds;
 }
 
-void
-PHG4CylinderCellGeom_Spacalv1::set_etabounds(const int ibin,
-    const std::pair<double, double> & bounds)
+void PHG4CylinderCellGeom_Spacalv1::set_etabounds(const int ibin,
+                                                  const std::pair<double, double>& bounds)
 {
-  assert(ibin>=0);
+  assert(ibin >= 0);
   eta_bound_map[ibin] = bounds;
 }
 
@@ -108,16 +106,16 @@ PHG4CylinderCellGeom_Spacalv1::get_zbounds(const int ibin) const
   map_consistency_check();
   check_binning_method(PHG4CylinderCellDefs::spacalbinning);
   bound_map_t ::const_iterator iter =
-  z_bound_map.find(ibin);
+      z_bound_map.find(ibin);
 
   if (iter == z_bound_map.end())
-    {
-      cout
-          << "PHG4CylinderCellGeom_Spacalv1::get_zbounds - Fatal Error - Asking for invalid bin in z: "
-          << ibin<<". Print of content:" << endl;
-      identify();
-      exit(1);
-    }
+  {
+    cout
+        << "PHG4CylinderCellGeom_Spacalv1::get_zbounds - Fatal Error - Asking for invalid bin in z: "
+        << ibin << ". Print of content:" << endl;
+    identify();
+    exit(1);
+  }
   return iter->second;
 }
 
@@ -128,29 +126,27 @@ PHG4CylinderCellGeom_Spacalv1::get_etabounds(const int ibin) const
   check_binning_method(PHG4CylinderCellDefs::spacalbinning);
 
   bound_map_t ::const_iterator iter =
-  eta_bound_map.find(ibin);
+      eta_bound_map.find(ibin);
 
   if (iter == eta_bound_map.end())
-    {
-      cout
-          << "PHG4CylinderCellGeom_Spacalv1::get_etabounds - Fatal Error - Asking for invalid bin in z: "
-          << ibin<<". Print of content:" << endl;
-      identify();
-      exit(1);
-    }
+  {
+    cout
+        << "PHG4CylinderCellGeom_Spacalv1::get_etabounds - Fatal Error - Asking for invalid bin in z: "
+        << ibin << ". Print of content:" << endl;
+    identify();
+    exit(1);
+  }
   return iter->second;
 }
 
-int
-PHG4CylinderCellGeom_Spacalv1::get_zbin(const double /*z*/) const
+int PHG4CylinderCellGeom_Spacalv1::get_zbin(const double /*z*/) const
 {
   cout << "PHG4CylinderCellGeom_Spacalv1::get_zbin is invalid" << endl;
   exit(1);
   return -1;
 }
 
-int
-PHG4CylinderCellGeom_Spacalv1::get_etabin(const double /*eta*/) const
+int PHG4CylinderCellGeom_Spacalv1::get_etabin(const double /*eta*/) const
 {
   cout << "PHG4CylinderCellGeom_Spacalv1::get_etabin is invalid" << endl;
   exit(1);
@@ -178,13 +174,13 @@ int PHG4CylinderCellGeom_Spacalv1::get_etabin_block(const int tower_z_ID) const
   tower_z_ID_eta_bin_map_t::const_iterator iter = tower_z_ID_eta_bin_map.find(tower_z_ID);
 
   if (iter == tower_z_ID_eta_bin_map.end())
-    {
-      ostringstream o;
+  {
+    ostringstream o;
 
-      o <<"PHG4CylinderCellGeom_Spacalv1::get_etabin - Fatal Error - can not find tower_z_ID of "<<tower_z_ID<<".";
+    o << "PHG4CylinderCellGeom_Spacalv1::get_etabin - Fatal Error - can not find tower_z_ID of " << tower_z_ID << ".";
 
-      throw range_error(o.str());
-    }
+    throw range_error(o.str());
+  }
 
   return iter->second;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.h
@@ -1,6 +1,6 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-// $Id: $                                                                                             
+// $Id: $
 
 /*!
  * \file PHG4CylinderCellGeomSpacalv1.h
@@ -15,16 +15,16 @@
 
 #include "PHG4CylinderCellGeom.h"
 
-#include <iostream>                // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>                 // for pair
+#include <utility>  // for pair
 
 /*!
  * \brief PHG4CylinderCellGeom_Spacalv1
  */
 class PHG4CylinderCellGeom_Spacalv1 : public PHG4CylinderCellGeom
 {
-public:
+ public:
   PHG4CylinderCellGeom_Spacalv1();
   ~PHG4CylinderCellGeom_Spacalv1() override;
 
@@ -40,20 +40,18 @@ public:
   double
   get_zcenter(const int ibin) const override;
 
-  int
-  get_etabin(const double eta) const override;
-  int
-  get_zbin(const double z) const override;
+  int get_etabin(const double eta) const override;
+  int get_zbin(const double z) const override;
 
   void
-  set_zbounds(const int ibin, const std::pair<double, double> & bounds);
+  set_zbounds(const int ibin, const std::pair<double, double>& bounds);
   void
-  set_etabounds(const int ibin, const std::pair<double, double> & bounds);
+  set_etabounds(const int ibin, const std::pair<double, double>& bounds);
 
   typedef std::pair<double, double> bound_t;
   typedef std::map<int, bound_t> bound_map_t;
 
-  const bound_map_t &
+  const bound_map_t&
   get_eta_bound_map() const
   {
     map_consistency_check();
@@ -61,12 +59,12 @@ public:
   }
 
   void
-  set_eta_bound_map(const bound_map_t & etaBoundMap)
+  set_eta_bound_map(const bound_map_t& etaBoundMap)
   {
     eta_bound_map = etaBoundMap;
   }
 
-  const bound_map_t &
+  const bound_map_t&
   get_z_bound_map() const
   {
     map_consistency_check();
@@ -74,7 +72,7 @@ public:
   }
 
   void
-  set_z_bound_map(const bound_map_t & boundMap)
+  set_z_bound_map(const bound_map_t& boundMap)
   {
     z_bound_map = boundMap;
   }
@@ -83,7 +81,7 @@ public:
   typedef std::map<int, int> tower_z_ID_eta_bin_map_t;
 
   //! map tower_z_ID -> eta_bin number
-  const tower_z_ID_eta_bin_map_t &
+  const tower_z_ID_eta_bin_map_t&
   get_tower_z_ID_eta_bin_map() const
   {
     return tower_z_ID_eta_bin_map;
@@ -94,13 +92,12 @@ public:
 
   //! map tower_z_ID -> eta_bin number for blocks
   void
-  set_tower_z_ID_eta_bin_map(const tower_z_ID_eta_bin_map_t & m)
+  set_tower_z_ID_eta_bin_map(const tower_z_ID_eta_bin_map_t& m)
   {
     tower_z_ID_eta_bin_map = m;
   }
 
-protected:
-
+ protected:
   void
   map_consistency_check() const;
 
@@ -110,8 +107,7 @@ protected:
   //! map tower_z_ID -> eta_bin number for blocks
   tower_z_ID_eta_bin_map_t tower_z_ID_eta_bin_map;
 
-ClassDefOverride(PHG4CylinderCellGeom_Spacalv1,2)
-
+  ClassDefOverride(PHG4CylinderCellGeom_Spacalv1, 2)
 };
 
 #endif /* PHG4CYLINDERCELLGEOMSPACALV1_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellGeom_Spacalv1+;
+#pragma link C++ class PHG4CylinderCellGeom_Spacalv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCell+;
-#pragma link C++ namespace PHG4CylinderCellDefs-!;
+#pragma link C++ class PHG4CylinderCell + ;
+#pragma link C++ namespace PHG4CylinderCellDefs - !;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -48,7 +48,7 @@ PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name)
   memset(nbins, 0, sizeof(nbins));
 }
 
-int PHG4CylinderCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+int PHG4CylinderCellReco::ResetEvent(PHCompositeNode * /*topNode*/)
 {
   sum_energy_before_cuts = 0.;
   sum_energy_g4hit = 0.;
@@ -171,21 +171,21 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       zmin_max[layer] = make_pair(etamin, etamax);
       double etastepsize = (sizeiter->second).first;
       double d_etabins;
-// if the eta cell size is larger than the eta range, make one bin
+      // if the eta cell size is larger than the eta range, make one bin
       if (etastepsize > etamax - etamin)
       {
-	d_etabins = 1;
+        d_etabins = 1;
       }
       else
       {
-	// it is unlikely that the eta range is a multiple of the eta cell size
-	// then fract is 0, if not - add 1 bin which makes the
-	// cells a tiny bit smaller but makes them fit
-	double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
-	if (fract != 0)
-	{
-	  d_etabins++;
-	}
+        // it is unlikely that the eta range is a multiple of the eta cell size
+        // then fract is 0, if not - add 1 bin which makes the
+        // cells a tiny bit smaller but makes them fit
+        double fract = modf((etamax - etamin) / etastepsize, &d_etabins);
+        if (fract != 0)
+        {
+          d_etabins++;
+        }
       }
       etastepsize = (etamax - etamin) / d_etabins;
       (sizeiter->second).first = etastepsize;
@@ -205,20 +205,20 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       double phimax = M_PI;
       double phistepsize = (sizeiter->second).second;
       double d_phibins;
-      if (phistepsize >= phimax-phimin)
+      if (phistepsize >= phimax - phimin)
       {
-	d_phibins = 1;
+        d_phibins = 1;
       }
       else
       {
-	// it is unlikely that the phi range is a multiple of the phi cell size
-	// then fract is 0, if not - add 1 bin which makes the
-	// cells a tiny bit smaller but makes them fit
-	double fract = modf((phimax - phimin) / phistepsize, &d_phibins);
-	if (fract != 0)
-	{
-	  d_phibins++;
-	}
+        // it is unlikely that the phi range is a multiple of the phi cell size
+        // then fract is 0, if not - add 1 bin which makes the
+        // cells a tiny bit smaller but makes them fit
+        double fract = modf((phimax - phimin) / phistepsize, &d_phibins);
+        if (fract != 0)
+        {
+          d_phibins++;
+        }
       }
       phistepsize = (phimax - phimin) / d_phibins;
       (sizeiter->second).second = phistepsize;
@@ -254,18 +254,18 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       // if the size is larger than circumference, make it one bin
       if (size_r >= circumference)
       {
-	bins_r = 1;
+        bins_r = 1;
       }
       else
       {
-	// unlikely but if the circumference is a multiple of the cell size
-	// use result of division, if not - add 1 bin which makes the
-	// cells a tiny bit smaller but makes them fit
-	double fract = modf(circumference / size_r, &bins_r);
-	if (fract != 0)
-	{
-	  bins_r++;
-	}
+        // unlikely but if the circumference is a multiple of the cell size
+        // use result of division, if not - add 1 bin which makes the
+        // cells a tiny bit smaller but makes them fit
+        double fract = modf(circumference / size_r, &bins_r);
+        if (fract != 0)
+        {
+          bins_r++;
+        }
       }
       nbins[0] = bins_r;
       size_r = circumference / bins_r;
@@ -286,18 +286,18 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
       // if the size is larger than length, make it one bin
       if (size_z >= length_in_z)
       {
-	bins_r = 1;
+        bins_r = 1;
       }
       else
       {
-	// unlikely but if the length is a multiple of the cell size
-	// use result of division, if not - add 1 bin which makes the
-	// cells a tiny bit smaller but makes them fit
-	double fract = modf(length_in_z / size_z, &bins_r);
-	if (fract != 0)
-	{
-	  bins_r++;
-	}
+        // unlikely but if the length is a multiple of the cell size
+        // use result of division, if not - add 1 bin which makes the
+        // cells a tiny bit smaller but makes them fit
+        double fract = modf(length_in_z / size_z, &bins_r);
+        if (fract != 0)
+        {
+          bins_r++;
+        }
       }
       nbins[1] = bins_r;
       pair<int, int> phi_z_bin = make_pair(nbins[0], nbins[1]);

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.cc
@@ -4,63 +4,63 @@
 
 using namespace std;
 
-PHG4CylinderCellv1::PHG4CylinderCellv1():
-  layer(0xFFFFFFFF),
-  cellid(0xFFFFFFFF),
-  binz(-1),
-  binphi(-1),
-  edeps(), showeredeps(), light_yield(0)
-{}
-
-void
-PHG4CylinderCellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
+PHG4CylinderCellv1::PHG4CylinderCellv1()
+  : layer(0xFFFFFFFF)
+  , cellid(0xFFFFFFFF)
+  , binz(-1)
+  , binphi(-1)
+  , edeps()
+  , showeredeps()
+  , light_yield(0)
 {
-  if (edeps.find(g4hitid) == edeps.end())
-    {
-      edeps[g4hitid] = edep;
-    }
-  else
-    {
-      edeps[g4hitid]+= edep;
-    }
 }
 
-void
-PHG4CylinderCellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep, const float ly)
+void PHG4CylinderCellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep)
+{
+  if (edeps.find(g4hitid) == edeps.end())
+  {
+    edeps[g4hitid] = edep;
+  }
+  else
+  {
+    edeps[g4hitid] += edep;
+  }
+}
+
+void PHG4CylinderCellv1::add_edep(const PHG4HitDefs::keytype g4hitid, const float edep, const float ly)
 {
   add_edep(g4hitid, edep);
   light_yield += ly;
 }
 
-void
-PHG4CylinderCellv1::add_shower_edep(const int g4showerid, const float edep)
+void PHG4CylinderCellv1::add_shower_edep(const int g4showerid, const float edep)
 {
   if (showeredeps.find(g4showerid) == showeredeps.end())
-    {
-      showeredeps[g4showerid] = edep;
-    }
+  {
+    showeredeps[g4showerid] = edep;
+  }
   else
-    {
-      showeredeps[g4showerid]+= edep;
-    }
+  {
+    showeredeps[g4showerid] += edep;
+  }
 }
 
-double PHG4CylinderCellv1::get_edep() const {
-  
+double PHG4CylinderCellv1::get_edep() const
+{
   double esum = 0.0;
   EdepConstIterator iter;
-  for (iter = edeps.begin(); iter != edeps.end(); ++iter) {
+  for (iter = edeps.begin(); iter != edeps.end(); ++iter)
+  {
     esum += iter->second;
   }
   return esum;
 }
 
-void
-PHG4CylinderCellv1::identify(std::ostream& os) const
+void PHG4CylinderCellv1::identify(std::ostream& os) const
 {
   os << "PHG4CylinderCellv1: #" << cellid << " ";
   os << "(layer,binz,binphi,e) = (";
-  os << layer << ","; 
+  os << layer << ",";
   os << binz << ",";
   os << binphi << ",";
   os << get_edep();

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
@@ -26,6 +26,8 @@ class PHG4CylinderCellv1 : public PHG4CylinderCell
   {
     return std::make_pair(edeps.begin(), edeps.end());
   }
+
+  using PHG4Cell::add_edep; // avoid warning for not including all overrides of add_edep
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) override;
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep, const float light_yield) override;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1.h
@@ -10,46 +10,47 @@
 
 #include <g4main/PHG4HitDefs.h>
 
-#include <iostream>                // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>                 // for make_pair
+#include <utility>  // for make_pair
 
 class PHG4CylinderCellv1 : public PHG4CylinderCell
 {
  public:
-
   PHG4CylinderCellv1();
-  ~PHG4CylinderCellv1() override{}
+  ~PHG4CylinderCellv1() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 
   EdepConstRange get_g4hits() override
-  {return std::make_pair(edeps.begin(), edeps.end());}
+  {
+    return std::make_pair(edeps.begin(), edeps.end());
+  }
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep) override;
   void add_edep(const PHG4HitDefs::keytype g4hitid, const float edep, const float light_yield) override;
-  
+
   ShowerEdepConstRange get_g4showers() override
-  {return std::make_pair(showeredeps.begin(), showeredeps.end());}
+  {
+    return std::make_pair(showeredeps.begin(), showeredeps.end());
+  }
   void add_shower_edep(const int g4showerid, const float edep) override;
-  
-  void set_cell_id(const PHG4CylinderCellDefs::keytype id) override {cellid = id;}
-  void set_layer(const unsigned int i) override {layer = i;}
+
+  void set_cell_id(const PHG4CylinderCellDefs::keytype id) override { cellid = id; }
+  void set_layer(const unsigned int i) override { layer = i; }
   double get_edep() const override;
-  unsigned int get_layer() const override {return layer;}
-  PHG4CylinderCellDefs::keytype get_cell_id() const override {return cellid;}
-  int get_binz() const override {return binz;}
-  int get_binphi() const override {return binphi;}
-  int get_bineta() const override {return get_binz();}
-  float get_light_yield() const override {return light_yield;}
+  unsigned int get_layer() const override { return layer; }
+  PHG4CylinderCellDefs::keytype get_cell_id() const override { return cellid; }
+  int get_binz() const override { return binz; }
+  int get_binphi() const override { return binphi; }
+  int get_bineta() const override { return get_binz(); }
+  float get_light_yield() const override { return light_yield; }
 
-
-  void set_zbin(const int i) override {binz = i;}
-  void set_etabin(const int i) override {set_zbin(i);}
-  void set_phibin(const int i) override {binphi = i;}
-  void set_light_yield(const float lightYield) override { light_yield = lightYield;}
+  void set_zbin(const int i) override { binz = i; }
+  void set_etabin(const int i) override { set_zbin(i); }
+  void set_phibin(const int i) override { binphi = i; }
+  void set_light_yield(const float lightYield) override { light_yield = lightYield; }
 
  protected:
-
   unsigned int layer;
   PHG4CylinderCellDefs::keytype cellid;
   int binz;
@@ -57,8 +58,8 @@ class PHG4CylinderCellv1 : public PHG4CylinderCell
   EdepMap edeps;
   ShowerEdepMap showeredeps;
   float light_yield;
-   
-  ClassDefOverride(PHG4CylinderCellv1,2)
+
+  ClassDefOverride(PHG4CylinderCellv1, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellv1+;
+#pragma link C++ class PHG4CylinderCellv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.cc
@@ -3,18 +3,18 @@
 using namespace std;
 
 PHG4CylinderCellv2::PHG4CylinderCellv2()
-: PHG4CylinderCellv1(),
-  ladder_phi_index(-9999),
-  ladder_z_index(-9999),
-  sensor_index("")
-{}
+  : PHG4CylinderCellv1()
+  , ladder_phi_index(-9999)
+  , ladder_z_index(-9999)
+  , sensor_index("")
+{
+}
 
-void
-PHG4CylinderCellv2::identify(std::ostream& os) const
+void PHG4CylinderCellv2::identify(std::ostream& os) const
 {
   os << "PHG4CylinderCellv2: #" << cellid << " ";
   os << "(layer,binz,binphi,e,sensor_index,phi_index,z_index) = (";
-  os << layer << ","; 
+  os << layer << ",";
   os << binz << ",";
   os << binphi << ",";
   os << get_edep() << ",";

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv2.h
@@ -6,34 +6,32 @@
 #include "PHG4CylinderCellv1.h"
 
 #include <iostream>
-#include <string>                // for string
+#include <string>  // for string
 
 class PHG4CylinderCellv2 : public PHG4CylinderCellv1
 {
  public:
-
   PHG4CylinderCellv2();
-  ~PHG4CylinderCellv2() override{}
+  ~PHG4CylinderCellv2() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  void set_sensor_index(const std::string &si) override {sensor_index = si;}
-  std::string get_sensor_index() const override {return sensor_index;}
+  void set_sensor_index(const std::string& si) override { sensor_index = si; }
+  std::string get_sensor_index() const override { return sensor_index; }
 
-  void set_ladder_phi_index(const int i) override {ladder_phi_index = i;}
-  int get_ladder_phi_index() const override {return ladder_phi_index;}
+  void set_ladder_phi_index(const int i) override { ladder_phi_index = i; }
+  int get_ladder_phi_index() const override { return ladder_phi_index; }
 
-  void set_ladder_z_index(const int i) override {ladder_z_index = i;}
-  int get_ladder_z_index() const override {return ladder_z_index;}
-  
+  void set_ladder_z_index(const int i) override { ladder_z_index = i; }
+  int get_ladder_z_index() const override { return ladder_z_index; }
+
  protected:
-
   int ladder_phi_index;
-  int ladder_z_index; 
+  int ladder_z_index;
   std::string sensor_index;
-  
-  ClassDefOverride(PHG4CylinderCellv2,1)
+
+  ClassDefOverride(PHG4CylinderCellv2, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv2LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv2LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellv2+;
+#pragma link C++ class PHG4CylinderCellv2 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.cc
@@ -3,18 +3,18 @@
 using namespace std;
 
 PHG4CylinderCellv3::PHG4CylinderCellv3()
-: PHG4CylinderCellv1(),
-  j_index(-9999),
-  k_index(-9999),
-  l_index(-9999)
-{}
+  : PHG4CylinderCellv1()
+  , j_index(-9999)
+  , k_index(-9999)
+  , l_index(-9999)
+{
+}
 
-void
-PHG4CylinderCellv3::identify(std::ostream& os) const
+void PHG4CylinderCellv3::identify(std::ostream& os) const
 {
   os << "PHG4CylinderCellv3: #" << cellid << " ";
   os << "(layer,e,j_index,k_index,l_index) = (";
-  os << layer << ","; 
+  os << layer << ",";
   os << get_edep() << ",";
   os << get_j_index() << ",";
   os << get_k_index() << ",";

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv3.h
@@ -10,29 +10,27 @@
 class PHG4CylinderCellv3 : public PHG4CylinderCellv1
 {
  public:
-
   PHG4CylinderCellv3();
-  ~PHG4CylinderCellv3() override{}
+  ~PHG4CylinderCellv3() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  void set_j_index(const int i) override {j_index = i;}
-  int get_j_index() const override {return j_index;}
+  void set_j_index(const int i) override { j_index = i; }
+  int get_j_index() const override { return j_index; }
 
-  void set_k_index(const int i) override {k_index = i;}
-  int get_k_index() const override {return k_index;}
+  void set_k_index(const int i) override { k_index = i; }
+  int get_k_index() const override { return k_index; }
 
-  void set_l_index(const int i) override {l_index = i;}
-  int get_l_index() const override {return l_index;}
-  
+  void set_l_index(const int i) override { l_index = i; }
+  int get_l_index() const override { return l_index; }
+
  protected:
-
   int j_index;
-  int k_index; 
-  int l_index; 
-  
-  ClassDefOverride(PHG4CylinderCellv3,1)
+  int k_index;
+  int l_index;
+
+  ClassDefOverride(PHG4CylinderCellv3, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellv3LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellv3LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderCellv3+;
+#pragma link C++ class PHG4CylinderCellv3 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -19,10 +19,7 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <cmath>
 #include <iostream>  // for operator<<, endl, basic_ost...

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -19,7 +19,10 @@
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4UserLimits.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <cmath>
 #include <iostream>  // for operator<<, endl, basic_ost...

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -12,8 +12,8 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4RotationMatrix.hh>            // for G4RotationMatrix
-#include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Tubs.hh>
@@ -91,36 +91,36 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
 
   G4RotationMatrix *rotm = new G4RotationMatrix();
   int nRotation(0);
-  if (m_Params->get_double_param("rot_x") !=0 )
+  if (m_Params->get_double_param("rot_x") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateX(m_Params->get_double_param("rot_x") * deg);
   }
-  if (m_Params->get_double_param("rot_y") !=0 )
+  if (m_Params->get_double_param("rot_y") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateY(m_Params->get_double_param("rot_y") * deg);
   }
-  if (m_Params->get_double_param("rot_z") !=0 )
+  if (m_Params->get_double_param("rot_z") != 0)
   {
-    ++ nRotation;
+    ++nRotation;
     rotm->rotateZ(m_Params->get_double_param("rot_z") * deg);
   }
 
-  if (nRotation>=2)
+  if (nRotation >= 2)
   {
-    cout <<__PRETTY_FUNCTION__<<": Warning : " <<GetName()<<" is configured with more than one of the x-y-z rotations of "
-        <<"("<<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<", "
-        <<m_Params->get_double_param("rot_x")<<") degrees. "
-        <<"The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
+    cout << __PRETTY_FUNCTION__ << ": Warning : " << GetName() << " is configured with more than one of the x-y-z rotations of "
+         << "(" << m_Params->get_double_param("rot_x") << ", "
+         << m_Params->get_double_param("rot_x") << ", "
+         << m_Params->get_double_param("rot_x") << ") degrees. "
+         << "The rotation is instruction is ambiguous and they are performed in the order of X->Y->Z rotations with result rotation matrix of:";
     rotm->print(cout);
   }
 
   m_CylinderPhysicalVolume = new G4PVPlacement(rotm,
-					       G4ThreeVector(m_Params->get_double_param("place_x") * cm,
-							     m_Params->get_double_param("place_y") * cm,
-							     m_Params->get_double_param("place_z") * cm),
+                                               G4ThreeVector(m_Params->get_double_param("place_x") * cm,
+                                                             m_Params->get_double_param("place_y") * cm,
+                                                             m_Params->get_double_param("place_z") * cm),
                                                cylinder_logic,
                                                G4String(GetName()),
                                                logicWorld, 0, false, OverlapCheck());

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.cc
@@ -28,7 +28,7 @@ PHG4CylinderDisplayAction::~PHG4CylinderDisplayAction()
   delete m_Colour;
 }
 
-void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   if (m_MyVolume->GetVisAttributes())
   {
@@ -56,17 +56,17 @@ void PHG4CylinderDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
   }
-// drawing 200 segments per circle makes it look smoother than default
+  // drawing 200 segments per circle makes it look smoother than default
   m_VisAtt->SetForceLineSegmentsPerCircle(200);
   m_MyVolume->SetVisAttributes(m_VisAtt);
   return;
 }
 
-void  PHG4CylinderDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
+void PHG4CylinderDisplayAction::SetColor(const double red, const double green, const double blue, const double alpha)
 {
   if (std::isfinite(red) && std::isfinite(green) && std::isfinite(blue) && std::isfinite(alpha))
   {
-    m_Colour = new G4Colour(red,green,blue,alpha);
+    m_Colour = new G4Colour(red, green, blue, alpha);
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDisplayAction.h
@@ -5,7 +5,7 @@
 
 #include <g4main/PHG4DisplayAction.h>
 
-#include <string>                      // for string
+#include <string>  // for string
 
 class G4Colour;
 class G4LogicalVolume;
@@ -22,7 +22,7 @@ class PHG4CylinderDisplayAction : public PHG4DisplayAction
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyVolume(G4LogicalVolume *vol) { m_MyVolume = vol; }
-  void SetColor(const double red, const double green, const double blue, const double alpha=1.);
+  void SetColor(const double red, const double green, const double blue, const double alpha = 1.);
 
  private:
   PHParameters *m_Params;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.cc
@@ -2,8 +2,7 @@
 
 using namespace std;
 
-void
-PHG4CylinderGeom::identify(std::ostream& os) const
+void PHG4CylinderGeom::identify(std::ostream& os) const
 {
   os << "virtual PHG4CylinderGeom"
      << endl;

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom.h
@@ -8,61 +8,156 @@
 #include <phool/phool.h>
 
 #include <cmath>
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 class PHParameters;
 
-class PHG4CylinderGeom: public PHObject
+class PHG4CylinderGeom : public PHObject
 {
  public:
-
   ~PHG4CylinderGeom() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
-  virtual int get_layer() const {PHOOL_VIRTUAL_WARN("get_layer()"); return -99999;}
-  virtual double get_radius() const {PHOOL_VIRTUAL_WARN("get_radius()");return NAN;}
-  virtual double get_thickness() const {PHOOL_VIRTUAL_WARN("get_thickness()");return NAN;}
-  virtual double get_zmin() const {PHOOL_VIRTUAL_WARN("get_zmin()");return NAN;}
-  virtual double get_zmax() const {PHOOL_VIRTUAL_WARN("get_zmax()");return NAN;}
-  virtual int get_nscint() const {PHOOL_VIRTUAL_WARN("get_nscint()"); return -99999;}
-  virtual double get_tiltangle() const {PHOOL_VIRTUAL_WARN("get_tiltangle()");return NAN;}
-  virtual double get_phi_slat_zero() const {PHOOL_VIRTUAL_WARN("get_phi_slat_zero()"); return NAN;}
+  virtual int get_layer() const
+  {
+    PHOOL_VIRTUAL_WARN("get_layer()");
+    return -99999;
+  }
+  virtual double get_radius() const
+  {
+    PHOOL_VIRTUAL_WARN("get_radius()");
+    return NAN;
+  }
+  virtual double get_thickness() const
+  {
+    PHOOL_VIRTUAL_WARN("get_thickness()");
+    return NAN;
+  }
+  virtual double get_zmin() const
+  {
+    PHOOL_VIRTUAL_WARN("get_zmin()");
+    return NAN;
+  }
+  virtual double get_zmax() const
+  {
+    PHOOL_VIRTUAL_WARN("get_zmax()");
+    return NAN;
+  }
+  virtual int get_nscint() const
+  {
+    PHOOL_VIRTUAL_WARN("get_nscint()");
+    return -99999;
+  }
+  virtual double get_tiltangle() const
+  {
+    PHOOL_VIRTUAL_WARN("get_tiltangle()");
+    return NAN;
+  }
+  virtual double get_phi_slat_zero() const
+  {
+    PHOOL_VIRTUAL_WARN("get_phi_slat_zero()");
+    return NAN;
+  }
 
-  virtual void set_layer(const int) {PHOOL_VIRTUAL_WARN("set_layer(const int)");}
-  virtual void set_radius(const double) {PHOOL_VIRTUAL_WARN("set_radius(const double)");}
-  virtual void set_thickness(const double) {PHOOL_VIRTUAL_WARN("set_thickness(const double)");}
-  virtual void set_zmin(const double) {PHOOL_VIRTUAL_WARN("set_zmin(const double)");}
-  virtual void set_zmax(const double) {PHOOL_VIRTUAL_WARN("set_zmax(const double)");}
-  virtual void set_nscint(const int) {PHOOL_VIRTUAL_WARN("set_nscint(const int)"); return;}
-  virtual void set_tiltangle(const double) {PHOOL_VIRTUAL_WARN("set_tiltangle(const double)"); return;}
-  virtual void set_phi_slat_zero (const double) {PHOOL_VIRTUAL_WARN("set_phi_slat_zero (const double)"); return;}
+  virtual void set_layer(const int) { PHOOL_VIRTUAL_WARN("set_layer(const int)"); }
+  virtual void set_radius(const double) { PHOOL_VIRTUAL_WARN("set_radius(const double)"); }
+  virtual void set_thickness(const double) { PHOOL_VIRTUAL_WARN("set_thickness(const double)"); }
+  virtual void set_zmin(const double) { PHOOL_VIRTUAL_WARN("set_zmin(const double)"); }
+  virtual void set_zmax(const double) { PHOOL_VIRTUAL_WARN("set_zmax(const double)"); }
+  virtual void set_nscint(const int)
+  {
+    PHOOL_VIRTUAL_WARN("set_nscint(const int)");
+    return;
+  }
+  virtual void set_tiltangle(const double)
+  {
+    PHOOL_VIRTUAL_WARN("set_tiltangle(const double)");
+    return;
+  }
+  virtual void set_phi_slat_zero(const double)
+  {
+    PHOOL_VIRTUAL_WARN("set_phi_slat_zero (const double)");
+    return;
+  }
 
-  virtual void find_segment_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_sensor_center"); return;}
-  virtual void find_strip_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, const int /*strip_column*/, const int /*strip_index*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_strip_center"); return;}
- virtual void find_strip_index_values(const int /*segment_z_bin*/, const double /*ypos*/, const double /*zpos*/, int &/*strip_y_index*/, int &/*strip_z_index*/){PHOOL_VIRTUAL_WARN("find_strip_index_values"); return;}
-  virtual void find_strip_center_local_coords(const int /*segment_z_bin*/, const int /*strip_y_index*/, const int /*strip_z_index*/, double /*location*/[]){PHOOL_VIRTUAL_WARN("find_strip_center_localcoords"); return;}
+  virtual void find_segment_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, double /*location*/[])
+  {
+    PHOOL_VIRTUAL_WARN("find_sensor_center");
+    return;
+  }
+  virtual void find_strip_center(const int /*segment_z_bin*/, const int /*segment_phi_bin*/, const int /*strip_column*/, const int /*strip_index*/, double /*location*/[])
+  {
+    PHOOL_VIRTUAL_WARN("find_strip_center");
+    return;
+  }
+  virtual void find_strip_index_values(const int /*segment_z_bin*/, const double /*ypos*/, const double /*zpos*/, int & /*strip_y_index*/, int & /*strip_z_index*/)
+  {
+    PHOOL_VIRTUAL_WARN("find_strip_index_values");
+    return;
+  }
+  virtual void find_strip_center_local_coords(const int /*segment_z_bin*/, const int /*strip_y_index*/, const int /*strip_z_index*/, double /*location*/[])
+  {
+    PHOOL_VIRTUAL_WARN("find_strip_center_localcoords");
+    return;
+  }
 
-  virtual double get_strip_y_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_y_spacing"); return NAN;}
-  virtual double get_strip_z_spacing() const {PHOOL_VIRTUAL_WARN("get_strip_z_spacing"); return NAN;}
-  virtual double get_strip_tilt() const {PHOOL_VIRTUAL_WARN("get_strip_tilt"); return NAN;}
+  virtual double get_strip_y_spacing() const
+  {
+    PHOOL_VIRTUAL_WARN("get_strip_y_spacing");
+    return NAN;
+  }
+  virtual double get_strip_z_spacing() const
+  {
+    PHOOL_VIRTUAL_WARN("get_strip_z_spacing");
+    return NAN;
+  }
+  virtual double get_strip_tilt() const
+  {
+    PHOOL_VIRTUAL_WARN("get_strip_tilt");
+    return NAN;
+  }
 
-  virtual int get_N_strip_columns() const {PHOOL_VIRTUAL_WARN("get_N_strip_columns"); return -9999;}
-  virtual int get_N_strips_per_column() const {PHOOL_VIRTUAL_WARN("get_N_strips_per_column"); return -9999;}
-  virtual int get_N_sensors_in_layer() const {PHOOL_VIRTUAL_WARN("get_N_sensors_in_layer"); return -9999;}
+  virtual int get_N_strip_columns() const
+  {
+    PHOOL_VIRTUAL_WARN("get_N_strip_columns");
+    return -9999;
+  }
+  virtual int get_N_strips_per_column() const
+  {
+    PHOOL_VIRTUAL_WARN("get_N_strips_per_column");
+    return -9999;
+  }
+  virtual int get_N_sensors_in_layer() const
+  {
+    PHOOL_VIRTUAL_WARN("get_N_sensors_in_layer");
+    return -9999;
+  }
 
-  virtual double get_pixel_z() const {PHOOL_VIRTUAL_WARN("get_pixel_z"); return NAN;}
-  virtual double get_pixel_x() const {PHOOL_VIRTUAL_WARN("get_pixel_x"); return NAN;}
-  virtual double get_pixel_thickness() const {PHOOL_VIRTUAL_WARN("get_pixel_thickness"); return NAN;}
+  virtual double get_pixel_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_pixel_z");
+    return NAN;
+  }
+  virtual double get_pixel_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_pixel_x");
+    return NAN;
+  }
+  virtual double get_pixel_thickness() const
+  {
+    PHOOL_VIRTUAL_WARN("get_pixel_thickness");
+    return NAN;
+  }
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  virtual void ImportParameters(const PHParameters & /*param*/) {return ;}
+  virtual void ImportParameters(const PHParameters & /*param*/) { return; }
 
  protected:
   PHG4CylinderGeom() {}
 
-  ClassDefOverride(PHG4CylinderGeom,1)
+  ClassDefOverride(PHG4CylinderGeom, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.cc
@@ -1,59 +1,57 @@
 #include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderGeom.h"
 #include <cmath>
+#include "PHG4CylinderGeom.h"
 
 using namespace std;
 
-PHG4CylinderGeomContainer::PHG4CylinderGeomContainer():
-  magfield(NAN)
-{}
+PHG4CylinderGeomContainer::PHG4CylinderGeomContainer()
+  : magfield(NAN)
+{
+}
 
 PHG4CylinderGeomContainer::~PHG4CylinderGeomContainer()
 {
-  while(layergeoms.begin() != layergeoms.end())
-    {
-      delete layergeoms.begin()->second;
-      layergeoms.erase(layergeoms.begin());
-    }
+  while (layergeoms.begin() != layergeoms.end())
+  {
+    delete layergeoms.begin()->second;
+    layergeoms.erase(layergeoms.begin());
+  }
   return;
 }
 
-void
-PHG4CylinderGeomContainer::identify(std::ostream& os) const
+void PHG4CylinderGeomContainer::identify(std::ostream &os) const
 {
   os << "mag field: " << magfield << endl;
   os << "number of layers: " << layergeoms.size() << endl;
-  map<int,PHG4CylinderGeom *>::const_iterator iter;
-  for (iter=layergeoms.begin(); iter != layergeoms.end(); ++iter)
-    {
-      (iter->second)->identify(os);
-    }
+  map<int, PHG4CylinderGeom *>::const_iterator iter;
+  for (iter = layergeoms.begin(); iter != layergeoms.end(); ++iter)
+  {
+    (iter->second)->identify(os);
+  }
 
   return;
 }
 
-int
-PHG4CylinderGeomContainer::AddLayerGeom(const int i, PHG4CylinderGeom *mygeom)
+int PHG4CylinderGeomContainer::AddLayerGeom(const int i, PHG4CylinderGeom *mygeom)
 {
   if (layergeoms.find(i) != layergeoms.end())
-    {
-      cout << "layer " << i << " already added to PHCylinderGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << i << " already added to PHCylinderGeomContainer" << endl;
+    return -1;
+  }
   mygeom->set_layer(i);
   layergeoms[i] = mygeom;
   return 0;
 }
 
-int
-PHG4CylinderGeomContainer::AddLayerGeom(PHG4CylinderGeom *mygeom)
+int PHG4CylinderGeomContainer::AddLayerGeom(PHG4CylinderGeom *mygeom)
 {
   int layer = mygeom->get_layer();
   if (layergeoms.find(layer) != layergeoms.end())
-    {
-      cout << "layer " << layer << " already added to PHCylinderGeomContainer" << endl;
-      return -1;
-    }
+  {
+    cout << "layer " << layer << " already added to PHCylinderGeomContainer" << endl;
+    return -1;
+  }
   layergeoms[layer] = mygeom;
   return 0;
 }
@@ -61,11 +59,11 @@ PHG4CylinderGeomContainer::AddLayerGeom(PHG4CylinderGeom *mygeom)
 PHG4CylinderGeom *
 PHG4CylinderGeomContainer::GetLayerGeom(const int i)
 {
-  map<int,PHG4CylinderGeom *>::const_iterator iter = layergeoms.find(i);
-  if (iter !=  layergeoms.end())
-    {
-      return iter->second;
-    }
+  map<int, PHG4CylinderGeom *>::const_iterator iter = layergeoms.find(i);
+  if (iter != layergeoms.end())
+  {
+    return iter->second;
+  }
   cout << "Could not locate layer " << i << " in PHG4CylinderGeomContainer" << endl;
   return nullptr;
 }
@@ -74,9 +72,8 @@ PHG4CylinderGeom *
 PHG4CylinderGeomContainer::GetFirstLayerGeom()
 {
   if (layergeoms.empty())
-    {
-      return nullptr;
-    }
+  {
+    return nullptr;
+  }
   return layergeoms.begin()->second;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainer.h
@@ -5,16 +5,16 @@
 
 #include <phool/PHObject.h>
 
-#include <iostream>          // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
-#include <utility>           // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHG4CylinderGeom;
 
-class PHG4CylinderGeomContainer: public PHObject
+class PHG4CylinderGeomContainer : public PHObject
 {
  public:
-  using Map = std::map<int,PHG4CylinderGeom *>;
+  using Map = std::map<int, PHG4CylinderGeom *>;
   using Iterator = Map::iterator;
   using ConstIterator = Map::const_iterator;
   using Range = std::pair<Iterator, Iterator>;
@@ -23,20 +23,20 @@ class PHG4CylinderGeomContainer: public PHObject
   PHG4CylinderGeomContainer();
   ~PHG4CylinderGeomContainer() override;
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
 
   int AddLayerGeom(const int i, PHG4CylinderGeom *mygeom);
   int AddLayerGeom(PHG4CylinderGeom *mygeom);
   PHG4CylinderGeom *GetLayerGeom(const int i);
   PHG4CylinderGeom *GetFirstLayerGeom();
-  int get_NLayers() const {return layergeoms.size();}
-  ConstRange get_begin_end() const {return std::make_pair(layergeoms.begin(), layergeoms.end());}
+  int get_NLayers() const { return layergeoms.size(); }
+  ConstRange get_begin_end() const { return std::make_pair(layergeoms.begin(), layergeoms.end()); }
 
  protected:
   Map layergeoms;
   float magfield;
-  ClassDefOverride(PHG4CylinderGeomContainer,1)
+  ClassDefOverride(PHG4CylinderGeomContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeomContainer+;
+#pragma link C++ class PHG4CylinderGeomContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeom+;
+#pragma link C++ class PHG4CylinderGeom + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
@@ -14,11 +14,11 @@
 
 #include <Geant4/G4PhysicalConstants.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>    // for twopi
+#include <CLHEP/Units/SystemOfUnits.h>  // for twopi
 
 #include <cmath>
 #include <sstream>
-#include <utility>                        // for pair
+#include <utility>  // for pair
 
 using namespace std;
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -14,7 +14,7 @@
 
 #include "PHG4CylinderGeomv2.h"
 
-#include <iostream>              // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <map>
 #include <string>
 
@@ -33,10 +33,10 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
     sector_map.clear();
   }
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream &os = std::cout) const override;
 
-// from TObject
+  // from TObject
   void Print(Option_t *option = "") const override;
 
   virtual void SetDefault();

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.h
@@ -74,9 +74,9 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
   }
 
   void
-  set_xpos(double xpos)
+  set_xpos(double x)
   {
-    this->xpos = xpos;
+    this->xpos = x;
   }
 
   double
@@ -86,9 +86,9 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
   }
 
   void
-  set_ypos(double ypos)
+  set_ypos(double y)
   {
-    this->ypos = ypos;
+    this->ypos = y;
   }
 
   double
@@ -98,9 +98,9 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
   }
 
   void
-  set_zpos(double zpos)
+  set_zpos(double z)
   {
-    this->zpos = zpos;
+    this->zpos = z;
   }
 
   ///@}
@@ -272,9 +272,9 @@ class PHG4CylinderGeom_Spacalv1 : public PHG4CylinderGeomv2
   }
 
   void
-  set_config(config_t config)
+  set_config(config_t c)
   {
-    this->config = config;
+    this->config = c;
   }
 
   bool

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeom_Spacalv1+;
+#pragma link C++ class PHG4CylinderGeom_Spacalv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.cc
@@ -14,12 +14,11 @@
 
 #include <Geant4/G4PhysicalConstants.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>    // for twopi, halfpi, pi
+#include <CLHEP/Units/SystemOfUnits.h>  // for twopi, halfpi, pi
 
 #include <cmath>
-#include <cstdlib>                       // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
-
 
 using namespace std;
 
@@ -28,46 +27,52 @@ PHG4CylinderGeom_Spacalv2::PHG4CylinderGeom_Spacalv2()
   SetDefault();
 }
 
-void
-PHG4CylinderGeom_Spacalv2::identify(std::ostream& os) const
+void PHG4CylinderGeom_Spacalv2::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeom_Spacalv2: layer: " << layer //
-      << ", radius: " << radius //
-      << ", thickness: " << thickness //
-      << ", zmin: " << zmin //
-      << ", zmax: " << zmax << //
+  os << "PHG4CylinderGeom_Spacalv2: layer: " << layer  //
+     << ", radius: " << radius                         //
+     << ", thickness: " << thickness                   //
+     << ", zmin: " << zmin                             //
+     << ", zmax: " << zmax <<                          //
       ", num scint: " << nscint
 
-      << endl;
+     << endl;
   return;
 }
 
-void
-PHG4CylinderGeom_Spacalv2::Print(Option_t *opt) const
+void PHG4CylinderGeom_Spacalv2::Print(Option_t* opt) const
 {
   PHG4CylinderGeom_Spacalv1::Print(opt);
 
-  cout << "\t" << "is_azimuthal_seg_visible() = " << is_azimuthal_seg_visible()
-      << endl;
-  cout << "\t" << "azimuthal_tilt() = " << get_azimuthal_tilt() << endl;
-  cout << "\t" << "get_polar_taper_ratio() = " << get_polar_taper_ratio()
-      << endl;
-  cout << "\t" << "get_sec_azimuthal_width() = " << get_sec_azimuthal_width()
-      << endl;
-  cout << "\t" << "get_sec_depth() = " << get_sec_depth() << endl;
-  cout << "\t" << "get_block_width() = " << get_block_width() << endl;
-  cout << "\t" << "get_block_depth() = " << get_block_depth() << endl;
-  cout << "\t" << "get_assembly_spacing() = " << get_assembly_spacing() << endl;
-  cout << "\t" << "get_reg_fiber_grid_distance_taper() = "
-      << get_reg_fiber_grid_distance_taper() << " = sqrt(3)*"
-      << get_reg_fiber_grid_distance_taper() / sqrt(3.) << endl;
-  cout << "\t" << "get_reg_fiber_grid_distance_nontaper() = "
-      << get_reg_fiber_grid_distance_nontaper() << endl;
-
+  cout << "\t"
+       << "is_azimuthal_seg_visible() = " << is_azimuthal_seg_visible()
+       << endl;
+  cout << "\t"
+       << "azimuthal_tilt() = " << get_azimuthal_tilt() << endl;
+  cout << "\t"
+       << "get_polar_taper_ratio() = " << get_polar_taper_ratio()
+       << endl;
+  cout << "\t"
+       << "get_sec_azimuthal_width() = " << get_sec_azimuthal_width()
+       << endl;
+  cout << "\t"
+       << "get_sec_depth() = " << get_sec_depth() << endl;
+  cout << "\t"
+       << "get_block_width() = " << get_block_width() << endl;
+  cout << "\t"
+       << "get_block_depth() = " << get_block_depth() << endl;
+  cout << "\t"
+       << "get_assembly_spacing() = " << get_assembly_spacing() << endl;
+  cout << "\t"
+       << "get_reg_fiber_grid_distance_taper() = "
+       << get_reg_fiber_grid_distance_taper() << " = sqrt(3)*"
+       << get_reg_fiber_grid_distance_taper() / sqrt(3.) << endl;
+  cout << "\t"
+       << "get_reg_fiber_grid_distance_nontaper() = "
+       << get_reg_fiber_grid_distance_nontaper() << endl;
 }
 
-void
-PHG4CylinderGeom_Spacalv2::SetDefault()
+void PHG4CylinderGeom_Spacalv2::SetDefault()
 {
   PHG4CylinderGeom_Spacalv1::SetDefault();
 
@@ -75,14 +80,12 @@ PHG4CylinderGeom_Spacalv2::SetDefault()
   azimuthal_tilt = 0;
   azimuthal_seg_visible = false;
   polar_taper_ratio = 1 + 1.1 / 42.;
-  assembly_spacing = 0.0001; // order ~1um clearance around all structures
+  assembly_spacing = 0.0001;  // order ~1um clearance around all structures
 
-//  init_default_sector_map();
-
+  //  init_default_sector_map();
 }
 
-void
-PHG4CylinderGeom_Spacalv2::ImportParameters(const PHParameters & param)
+void PHG4CylinderGeom_Spacalv2::ImportParameters(const PHParameters& param)
 {
   PHG4CylinderGeom_Spacalv1::ImportParameters(param);
 
@@ -104,14 +107,12 @@ PHG4CylinderGeom_Spacalv2::ImportParameters(const PHParameters & param)
 double
 PHG4CylinderGeom_Spacalv2::get_sec_azimuthal_width() const
 {
-  const double azimuthal_width_base = get_radius() * twopi
-      / (double) (get_azimuthal_n_sec()) - get_assembly_spacing();
+  const double azimuthal_width_base = get_radius() * twopi / (double) (get_azimuthal_n_sec()) - get_assembly_spacing();
 
   // triggernometry stuff to make a tight connection after tilting
 
   const double theta1 = get_azimuthal_tilt();
-  const double theta2 = pi + (twopi / get_azimuthal_n_sec()) - halfpi
-      - get_azimuthal_tilt();
+  const double theta2 = pi + (twopi / get_azimuthal_n_sec()) - halfpi - get_azimuthal_tilt();
 
   return azimuthal_width_base * sin(theta2) / sin(theta1 + theta2);
 }
@@ -120,52 +121,48 @@ double
 PHG4CylinderGeom_Spacalv2::get_half_polar_taper_angle() const
 {
   return atan2(get_block_width() * 0.5 * (get_polar_taper_ratio() - 1),
-      get_block_depth());
+               get_block_depth());
 }
 
-int
-PHG4CylinderGeom_Spacalv2::get_azimuthal_n_sec() const
+int PHG4CylinderGeom_Spacalv2::get_azimuthal_n_sec() const
 {
-//  if (config == kNonProjective)
-//    //For kNonProjective geometry, azimuthal_n_sec is calculated, and can not be set externally
-//    return PHG4CylinderGeom_Spacalv1::get_azimuthal_n_sec();
-//  else
-    return azimuthal_n_sec;
+  //  if (config == kNonProjective)
+  //    //For kNonProjective geometry, azimuthal_n_sec is calculated, and can not be set externally
+  //    return PHG4CylinderGeom_Spacalv1::get_azimuthal_n_sec();
+  //  else
+  return azimuthal_n_sec;
 }
 
-void
-PHG4CylinderGeom_Spacalv2::set_azimuthal_n_sec(int azimuthalNSec)
+void PHG4CylinderGeom_Spacalv2::set_azimuthal_n_sec(int azimuthalNSec)
 {
   if (config == kNonProjective)
-    {
-      cout
-          << "PHG4CylinderGeom_Spacalv2::set_azimuthal_n_sec - Fatal Error - "
-              "Spacal is configured as NonProjective geometry. In this case azimuthal_n_sec is calculated, and can not be set externally."
-          << endl;
-      exit(10);
-    }
+  {
+    cout
+        << "PHG4CylinderGeom_Spacalv2::set_azimuthal_n_sec - Fatal Error - "
+           "Spacal is configured as NonProjective geometry. In this case azimuthal_n_sec is calculated, and can not be set externally."
+        << endl;
+    exit(10);
+  }
 
   azimuthal_n_sec = azimuthalNSec;
-//  init_default_sector_map();
+  //  init_default_sector_map();
 }
 
-bool
-PHG4CylinderGeom_Spacalv2::is_azimuthal_seg_visible() const
+bool PHG4CylinderGeom_Spacalv2::is_azimuthal_seg_visible() const
 {
   return azimuthal_seg_visible;
 }
 
-void
-PHG4CylinderGeom_Spacalv2::set_azimuthal_seg_visible(bool b)
+void PHG4CylinderGeom_Spacalv2::set_azimuthal_seg_visible(bool b)
 {
   if (config == kNonProjective)
-    {
-      cout
-          << "PHG4CylinderGeom_Spacalv2::set_azimuthal_seg_visible - Fatal Error - "
-              "Spacal is configured as NonProjective geometry. In this case azimuthal_seg_visible is false, and can not be set externally."
-          << endl;
-      exit(10);
-    }
+  {
+    cout
+        << "PHG4CylinderGeom_Spacalv2::set_azimuthal_seg_visible - Fatal Error - "
+           "Spacal is configured as NonProjective geometry. In this case azimuthal_seg_visible is false, and can not be set externally."
+        << endl;
+    exit(10);
+  }
 
   azimuthal_seg_visible = b;
   ;
@@ -175,8 +172,7 @@ PHG4CylinderGeom_Spacalv2::set_azimuthal_seg_visible(bool b)
 double
 PHG4CylinderGeom_Spacalv2::get_reg_fiber_grid_distance_taper() const
 {
-  const double mid_plane_width = get_block_width()
-      * ((get_polar_taper_ratio() - 1) * 0.5 + 1) - get_assembly_spacing();
+  const double mid_plane_width = get_block_width() * ((get_polar_taper_ratio() - 1) * 0.5 + 1) - get_assembly_spacing();
 
   const int n_grid = floor(mid_plane_width / (get_fiber_distance() * sqrt(3.)));
 
@@ -191,4 +187,3 @@ PHG4CylinderGeom_Spacalv2::get_reg_fiber_grid_distance_nontaper() const
   const int n_grid = floor(mid_plane_width / (get_fiber_distance()));
   return mid_plane_width / n_grid;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2.h
@@ -15,31 +15,29 @@
 #include "PHG4CylinderGeom_Spacalv1.h"
 
 #include <cmath>
-#include <iostream>                     // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 class PHParameters;
 
 class PHG4CylinderGeom_Spacalv2 : public PHG4CylinderGeom_Spacalv1
 {
-public:
+ public:
   PHG4CylinderGeom_Spacalv2();
 
-  
   ~PHG4CylinderGeom_Spacalv2() override
   {
   }
 
-
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-// from TObject
+  // from TObject
   void Print(Option_t* option = "") const override;
 
   void SetDefault() override;
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  void ImportParameters(const PHParameters & param) override;
+  void ImportParameters(const PHParameters& param) override;
 
   int get_azimuthal_n_sec() const override;
 
@@ -59,16 +57,14 @@ public:
     azimuthal_tilt = azimuthalTilt;
   }
 
-  
   bool is_azimuthal_seg_visible() const override;
 
-  virtual
-  void set_azimuthal_seg_visible(bool b = true);
+  virtual void set_azimuthal_seg_visible(bool b = true);
 
   double get_polar_taper_ratio() const
-    {
-      return polar_taper_ratio;
-    }
+  {
+    return polar_taper_ratio;
+  }
 
   void
   set_polar_taper_ratio(double polarTaperRatio)
@@ -84,17 +80,12 @@ public:
   double
   get_sec_depth() const
   {
-    const double available_depth = get_thickness()
-        - (sqrt(
-            (get_radius()) * (get_radius())
-                + (get_sec_azimuthal_width() / 2)
-                    * (get_sec_azimuthal_width() / 2)) - get_radius()) - get_assembly_spacing();
+    const double available_depth = get_thickness() - (sqrt((get_radius()) * (get_radius()) + (get_sec_azimuthal_width() / 2) * (get_sec_azimuthal_width() / 2)) - get_radius()) - get_assembly_spacing();
     if (available_depth < get_sec_azimuthal_width())
       return NAN;
     else
       return sqrt(
-          available_depth * available_depth
-              - get_sec_azimuthal_width() * get_sec_azimuthal_width());
+          available_depth * available_depth - get_sec_azimuthal_width() * get_sec_azimuthal_width());
   }
 
   double
@@ -106,14 +97,13 @@ public:
   double
   get_block_depth() const
   {
-    return sqrt(get_sec_depth()*get_sec_depth() - get_polar_taper_ratio()* get_polar_taper_ratio()* get_block_width()*get_block_width()) - get_assembly_spacing();
+    return sqrt(get_sec_depth() * get_sec_depth() - get_polar_taper_ratio() * get_polar_taper_ratio() * get_block_width() * get_block_width()) - get_assembly_spacing();
   }
 
-
   double get_assembly_spacing() const
-    {
-      return assembly_spacing;
-    }
+  {
+    return assembly_spacing;
+  }
 
   void
   set_assembly_spacing(double assemblySpacing)
@@ -129,9 +119,7 @@ public:
   double
   get_reg_fiber_grid_distance_nontaper() const;
 
-
-protected:
-
+ protected:
   int azimuthal_n_sec;
 
   //! azimuthal tilt in rad
@@ -140,9 +128,7 @@ protected:
   double polar_taper_ratio;
   double assembly_spacing;
 
-  ClassDefOverride(PHG4CylinderGeom_Spacalv2,2)
-
-
+  ClassDefOverride(PHG4CylinderGeom_Spacalv2, 2)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv2LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeom_Spacalv2+;
+#pragma link C++ class PHG4CylinderGeom_Spacalv2 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -9,20 +9,20 @@
  */
 
 #include "PHG4CylinderGeom_Spacalv3.h"
-#include "PHG4CylinderGeom_Spacalv1.h"    // for PHG4CylinderGeom_Spacalv1::...
+#include "PHG4CylinderGeom_Spacalv1.h"  // for PHG4CylinderGeom_Spacalv1::...
 
 #include <phparameter/PHParameters.h>
 
 #include <Geant4/G4PhysicalConstants.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>    // for twopi
+#include <CLHEP/Units/SystemOfUnits.h>  // for twopi
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>                       // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <limits>       // std::numeric_limits
+#include <limits>  // std::numeric_limits
 #include <map>
 #include <sstream>
 
@@ -39,67 +39,71 @@ PHG4CylinderGeom_Spacalv3::~PHG4CylinderGeom_Spacalv3()
   sector_tower_map.erase(sector_tower_map.begin(), sector_tower_map.end());
 }
 
-void
-PHG4CylinderGeom_Spacalv3::identify(std::ostream& os) const
+void PHG4CylinderGeom_Spacalv3::identify(std::ostream& os) const
 {
   os << "PHG4CylinderGeom_Spacalv3: layer: " << layer
-      //
-      << ", radius: " << radius
-      //
-      << ", thickness: " << thickness
-      //
-      << ", zmin: " << zmin
-      //
-      << ", zmax: " << zmax << ", num scint: " << nscint << ", num sector: "
-      << azimuthal_n_sec << ", unique tower: " << sector_tower_map.size()
-      << endl;
-
+     //
+     << ", radius: " << radius
+     //
+     << ", thickness: " << thickness
+     //
+     << ", zmin: " << zmin
+     //
+     << ", zmax: " << zmax << ", num scint: " << nscint << ", num sector: "
+     << azimuthal_n_sec << ", unique tower: " << sector_tower_map.size()
+     << endl;
 }
 
-void
-PHG4CylinderGeom_Spacalv3::Print(Option_t *opt) const
+void PHG4CylinderGeom_Spacalv3::Print(Option_t* opt) const
 {
   PHG4CylinderGeom_Spacalv2::Print(opt);
 
-  cout << "\t" << "get_sidewall_outer_torr() = " << get_sidewall_outer_torr()
-      << endl;
-  cout << "\t" << "get_sidewall_thickness() = " << get_sidewall_thickness()
-      << endl;
-  cout << "\t" << "get_sidewall_mat() = " << get_sidewall_mat() << endl;
-  cout << "\t" << "get_max_phi_bin_in_sec() = " << get_max_phi_bin_in_sec()
-      << endl;
+  cout << "\t"
+       << "get_sidewall_outer_torr() = " << get_sidewall_outer_torr()
+       << endl;
+  cout << "\t"
+       << "get_sidewall_thickness() = " << get_sidewall_thickness()
+       << endl;
+  cout << "\t"
+       << "get_sidewall_mat() = " << get_sidewall_mat() << endl;
+  cout << "\t"
+       << "get_max_phi_bin_in_sec() = " << get_max_phi_bin_in_sec()
+       << endl;
 
   subtower_consistency_check();
-  cout << "\t" << "get_n_subtower_eta() = " << get_n_subtower_eta() << endl;
-  cout << "\t" << "get_n_subtower_phi() = " << get_n_subtower_phi() << endl;
+  cout << "\t"
+       << "get_n_subtower_eta() = " << get_n_subtower_eta() << endl;
+  cout << "\t"
+       << "get_n_subtower_phi() = " << get_n_subtower_phi() << endl;
 
-  cout << "\t" << "get_max_lightguide_height() = "
-      << get_max_lightguide_height() << endl;
-  cout << "\t" << "Containing " << sector_tower_map.size()
-      << " unique towers per sector." << endl;
+  cout << "\t"
+       << "get_max_lightguide_height() = "
+       << get_max_lightguide_height() << endl;
+  cout << "\t"
+       << "Containing " << sector_tower_map.size()
+       << " unique towers per sector." << endl;
 
   if (get_construction_verbose() >= 2)
     for (tower_map_t::const_iterator it = sector_tower_map.begin();
-        it != sector_tower_map.end(); ++it)
-      {
-        cout << "\t";
-        cout << "\t";
-        it->second.identify(cout);
-      }
+         it != sector_tower_map.end(); ++it)
+    {
+      cout << "\t";
+      cout << "\t";
+      it->second.identify(cout);
+    }
 }
 
-void
-PHG4CylinderGeom_Spacalv3::SetDefault()
+void PHG4CylinderGeom_Spacalv3::SetDefault()
 {
   PHG4CylinderGeom_Spacalv2::SetDefault();
 
-//  radius = 90.000000;
-//  thickness = 26.130000;
-//  zmin = 149.470000;
-//  zmax = -zmin;
-//  azimuthal_n_sec = 32;
-//  polar_taper_ratio = 1.;
-//  assembly_spacing = 0.002500;
+  //  radius = 90.000000;
+  //  thickness = 26.130000;
+  //  zmin = 149.470000;
+  //  zmax = -zmin;
+  //  azimuthal_n_sec = 32;
+  //  polar_taper_ratio = 1.;
+  //  assembly_spacing = 0.002500;
   sidewall_thickness = 0.075000;
   sidewall_outer_torr = 0.030000;
   sidewall_mat = "SS310";
@@ -108,8 +112,7 @@ PHG4CylinderGeom_Spacalv3::SetDefault()
   divider_width = 14.5;
 }
 
-void
-PHG4CylinderGeom_Spacalv3::ImportParameters(const PHParameters & param)
+void PHG4CylinderGeom_Spacalv3::ImportParameters(const PHParameters& param)
 {
   PHG4CylinderGeom_Spacalv2::ImportParameters(param);
 
@@ -128,73 +131,95 @@ PHG4CylinderGeom_Spacalv3::ImportParameters(const PHParameters & param)
 
   // load sector_tower_map
   if (param.exist_int_param("sector_tower_map_size"))
+  {
+    sector_tower_map.clear();
+
+    const int n = param.get_int_param("sector_tower_map_size");
+
+    for (int i = 0; i < n; i++)
     {
-      sector_tower_map.clear();
+      stringstream prefix;
+      prefix << "sector_tower_map";
+      prefix << "[" << i << "]"
+             << ".";
 
-      const int n = param.get_int_param("sector_tower_map_size");
+      geom_tower t;
+      t.ImportParameters(param, prefix.str());
 
-      for (int i = 0; i < n; i++)
-        {
-          stringstream prefix;
-          prefix << "sector_tower_map";
-          prefix << "[" << i << "]" << ".";
-
-          geom_tower t;
-          t.ImportParameters(param, prefix.str());
-
-          sector_tower_map[t.id] = t;
-        }
+      sector_tower_map[t.id] = t;
     }
+  }
 
   return;
 }
 
-PHG4CylinderGeom_Spacalv3::geom_tower::geom_tower() :
-    id(numeric_limits<int>::min()), //
-    pDz(numeric_limits<double>::signaling_NaN()), //
-    pDy1(numeric_limits<double>::signaling_NaN()), //
-    pDx1(numeric_limits<double>::signaling_NaN()), //
-    pDx2(numeric_limits<double>::signaling_NaN()), //
-    pDy2(numeric_limits<double>::signaling_NaN()), //
-    pDx3(numeric_limits<double>::signaling_NaN()), //
-    pDx4(numeric_limits<double>::signaling_NaN()), //
-    pTheta(numeric_limits<double>::signaling_NaN()), //
-    pPhi(numeric_limits<double>::signaling_NaN()), //
-    pAlp1(numeric_limits<double>::signaling_NaN()), //
-    pAlp2(numeric_limits<double>::signaling_NaN()), //
-    pRotationAngleX(numeric_limits<double>::signaling_NaN()), //
-    centralX(numeric_limits<double>::signaling_NaN()), //
-    centralY(numeric_limits<double>::signaling_NaN()), //
-    centralZ(numeric_limits<double>::signaling_NaN()), //
-    ModuleSkinThickness(numeric_limits<double>::signaling_NaN()), //
-    NFiberX(numeric_limits<int>::min()), //
-    NFiberY(numeric_limits<int>::min()), //
-    NSubtowerX(1), //
-    NSubtowerY(1), //
-    LightguideHeight(0), //
-    LightguideTaperRatio(numeric_limits<double>::signaling_NaN()), //
-    LightguideMaterial("PMMA")
+PHG4CylinderGeom_Spacalv3::geom_tower::geom_tower()
+  : id(numeric_limits<int>::min())
+  ,  //
+  pDz(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDy1(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDx1(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDx2(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDy2(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDx3(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pDx4(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pTheta(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pPhi(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pAlp1(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pAlp2(numeric_limits<double>::signaling_NaN())
+  ,  //
+  pRotationAngleX(numeric_limits<double>::signaling_NaN())
+  ,  //
+  centralX(numeric_limits<double>::signaling_NaN())
+  ,  //
+  centralY(numeric_limits<double>::signaling_NaN())
+  ,  //
+  centralZ(numeric_limits<double>::signaling_NaN())
+  ,  //
+  ModuleSkinThickness(numeric_limits<double>::signaling_NaN())
+  ,  //
+  NFiberX(numeric_limits<int>::min())
+  ,  //
+  NFiberY(numeric_limits<int>::min())
+  ,  //
+  NSubtowerX(1)
+  ,  //
+  NSubtowerY(1)
+  ,  //
+  LightguideHeight(0)
+  ,  //
+  LightguideTaperRatio(numeric_limits<double>::signaling_NaN())
+  ,  //
+  LightguideMaterial("PMMA")
 {
 }
 
 //! fiber layout -> fiber_id
-int
-PHG4CylinderGeom_Spacalv3::geom_tower::compose_fiber_id(int index_x,
-    int index_y) const
+int PHG4CylinderGeom_Spacalv3::geom_tower::compose_fiber_id(int index_x,
+                                                            int index_y) const
 {
   return NFiberY * index_x + index_y;
 }
 
 //! fiber_id -> sub tower ID x: 0 ... NSubtowerX -1
-int
-PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_x(int fiber_id) const
+int PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_x(int fiber_id) const
 {
   const int index_x = fiber_id / NFiberY;
   assert(index_x < NFiberX);
   assert(index_x >= 0);
 
   const double sub_tower_width_x = (double) NFiberX / NSubtowerX;
-  const int tower_ID_x = (NSubtowerX - 1) - floor(index_x / sub_tower_width_x); //! x is negative azimuthal direction
+  const int tower_ID_x = (NSubtowerX - 1) - floor(index_x / sub_tower_width_x);  //! x is negative azimuthal direction
   assert(tower_ID_x < NSubtowerX);
   assert(tower_ID_x >= 0);
 
@@ -202,8 +227,7 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_x(int fiber_id) const
 }
 
 //! fiber_id -> sub tower ID y: 0 ... NSubtowerY -1
-int
-PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_y(int fiber_id) const
+int PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_y(int fiber_id) const
 {
   assert(fiber_id >= 0);
   const int index_y = fiber_id % NFiberY;
@@ -211,7 +235,7 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_sub_tower_ID_y(int fiber_id) const
   const double sub_tower_width_y = (double) NFiberY / NSubtowerY;
 
   assert(pRotationAngleX < 0);
-  const int tower_ID_y = (NSubtowerY - 1) - floor(index_y / sub_tower_width_y); //! y is negative polar direction
+  const int tower_ID_y = (NSubtowerY - 1) - floor(index_y / sub_tower_width_y);  //! y is negative polar direction
   assert(tower_ID_y < NSubtowerY);
   assert(tower_ID_y >= 0);
 
@@ -226,8 +250,8 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_x_in_sub_tower(int 
   assert(index_x >= 0);
 
   const double sub_tower_width_x = (double) NFiberX / NSubtowerX;
-  const double x_in_sub_tower = (fmod(index_x,  sub_tower_width_x)+0.5)/sub_tower_width_x ; //! x is negative azimuthal direction
-  assert(x_in_sub_tower <=1 );
+  const double x_in_sub_tower = (fmod(index_x, sub_tower_width_x) + 0.5) / sub_tower_width_x;  //! x is negative azimuthal direction
+  assert(x_in_sub_tower <= 1);
   assert(x_in_sub_tower >= 0);
 
   return x_in_sub_tower;
@@ -242,36 +266,34 @@ PHG4CylinderGeom_Spacalv3::geom_tower::get_position_fraction_y_in_sub_tower(int 
   const double sub_tower_width_y = (double) NFiberY / NSubtowerY;
 
   assert(pRotationAngleX < 0);
-  const double y_in_sub_tower = (fmod(index_y ,  sub_tower_width_y) + 0.5)/sub_tower_width_y; //! y is negative polar direction
-  assert(y_in_sub_tower <=1 );
+  const double y_in_sub_tower = (fmod(index_y, sub_tower_width_y) + 0.5) / sub_tower_width_y;  //! y is negative polar direction
+  assert(y_in_sub_tower <= 1);
   assert(y_in_sub_tower >= 0);
 
   return y_in_sub_tower;
 }
 
-void
-PHG4CylinderGeom_Spacalv3::geom_tower::identify(std::ostream& os) const
+void PHG4CylinderGeom_Spacalv3::geom_tower::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeom_Spacalv3::geom_super_tower" << "[" << id << "]"
-      << " @ <Azimuthal, R, z> = " << centralX << ", " << centralY << ", "
-      << centralZ << " cm"
-      //
-      << " with "
-      //
-      << "Half length = " << pDz << ", " << pDy1 << ", " << pDx1 << ", " << pDx2
-      << ", " << pDy2 << ", " << pDx3 << ", " << pDx4 << ", "
-      //
-      << "Angles = " << pTheta << ", " << pPhi << ", " << pAlp1 << ", " << pAlp2
-      << ", " //
-      << "Rotation = " << pRotationAngleX //
-      << endl;
+  os << "PHG4CylinderGeom_Spacalv3::geom_super_tower"
+     << "[" << id << "]"
+     << " @ <Azimuthal, R, z> = " << centralX << ", " << centralY << ", "
+     << centralZ << " cm"
+     //
+     << " with "
+     //
+     << "Half length = " << pDz << ", " << pDy1 << ", " << pDx1 << ", " << pDx2
+     << ", " << pDy2 << ", " << pDx3 << ", " << pDx4 << ", "
+     //
+     << "Angles = " << pTheta << ", " << pPhi << ", " << pAlp1 << ", " << pAlp2
+     << ", "                              //
+     << "Rotation = " << pRotationAngleX  //
+     << endl;
 }
 
-void
-PHG4CylinderGeom_Spacalv3::geom_tower::ImportParameters(
-    const PHParameters & param, const std::string & param_prefix)
+void PHG4CylinderGeom_Spacalv3::geom_tower::ImportParameters(
+    const PHParameters& param, const std::string& param_prefix)
 {
-
   id = param.get_int_param(param_prefix + "id");
   pDz = param.get_double_param(param_prefix + "pDz");
 
@@ -306,18 +328,19 @@ PHG4CylinderGeom_Spacalv3::geom_tower::ImportParameters(
       param_prefix + "LightguideMaterial");
 }
 
-PHG4CylinderGeom_Spacalv3::scint_id_coder::scint_id_coder(int scint_id) :
-    scint_ID(scint_id)
+PHG4CylinderGeom_Spacalv3::scint_id_coder::scint_id_coder(int scint_id)
+  : scint_ID(scint_id)
 {
-  sector_ID = (scint_ID >> (kfiber_bit + ktower_bit))
-      & ((1 << ksector_bit) - 1);
+  sector_ID = (scint_ID >> (kfiber_bit + ktower_bit)) & ((1 << ksector_bit) - 1);
   tower_ID = (scint_ID >> kfiber_bit) & ((1 << ktower_bit) - 1);
   fiber_ID = (scint_ID) & ((1 << kfiber_bit) - 1);
 }
 
 PHG4CylinderGeom_Spacalv3::scint_id_coder::scint_id_coder(int sector_id,
-    int tower_id, int fiber_id) :
-    sector_ID(sector_id), tower_ID(tower_id), fiber_ID(fiber_id)
+                                                          int tower_id, int fiber_id)
+  : sector_ID(sector_id)
+  , tower_ID(tower_id)
+  , fiber_ID(fiber_id)
 {
   assert(fiber_ID < (1 << kfiber_bit) and fiber_ID >= 0);
   assert(tower_ID < (1 << ktower_bit) and tower_ID >= 0);
@@ -328,7 +351,7 @@ PHG4CylinderGeom_Spacalv3::scint_id_coder::scint_id_coder(int sector_id,
 
 std::pair<int, int>
 PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID(const int tower_ID,
-    const int sector_ID) const
+                                              const int sector_ID) const
 {
   // tower_ID to eta/z within a sector
   int z_bin = floor(tower_ID / 10);
@@ -342,13 +365,13 @@ PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID(const int tower_ID,
     phi_bin_in_sec = (tower_ID % 10);
 
   if (!(phi_bin_in_sec < max_phi_bin_in_sec and phi_bin_in_sec >= 0))
-    {
-      cout
-          << "PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID - Fatal Error - invalid in put with "
-          << "tower_ID = " << tower_ID << ", sector_ID = " << sector_ID<< ", phi_bin_in_sec = " << phi_bin_in_sec
-          << ". Dump object:" << endl;
-      Print();
-    }
+  {
+    cout
+        << "PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID - Fatal Error - invalid in put with "
+        << "tower_ID = " << tower_ID << ", sector_ID = " << sector_ID << ", phi_bin_in_sec = " << phi_bin_in_sec
+        << ". Dump object:" << endl;
+    Print();
+  }
 
   assert(phi_bin_in_sec < max_phi_bin_in_sec and phi_bin_in_sec >= 0);
 
@@ -359,76 +382,73 @@ PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID(const int tower_ID,
 
 //! get approximate radial position of tower
 double PHG4CylinderGeom_Spacalv3::
-get_tower_radial_position(const PHG4CylinderGeom_Spacalv3::geom_tower & tower) const
+    get_tower_radial_position(const PHG4CylinderGeom_Spacalv3::geom_tower& tower) const
 {
   if (get_config() == kFullProjective_2DTaper_SameLengthFiberPerTower or get_config() == kFullProjective_2DTaper)
     return tower.centralY;
   else if (get_config() == kFullProjective_2DTaper_Tilted_SameLengthFiberPerTower or get_config() == kFullProjective_2DTaper_Tilted)
-    {
-      const double outter_wall_shift = get_sidewall_thickness() + get_sidewall_outer_torr() + get_assembly_spacing();
-      assert(outter_wall_shift>=0);
-      const double tilted_radial_shift = outter_wall_shift / sin(M_PI / get_azimuthal_n_sec());
-      assert(tilted_radial_shift>=0);
-      const double tower_radial = //
-          tilted_radial_shift * cos(get_azimuthal_tilt()) +
-          get_half_radius() * sin(get_azimuthal_tilt()) * sin(get_azimuthal_tilt()) +
-          tower.centralY * cos(get_azimuthal_tilt());
+  {
+    const double outter_wall_shift = get_sidewall_thickness() + get_sidewall_outer_torr() + get_assembly_spacing();
+    assert(outter_wall_shift >= 0);
+    const double tilted_radial_shift = outter_wall_shift / sin(M_PI / get_azimuthal_n_sec());
+    assert(tilted_radial_shift >= 0);
+    const double tower_radial =  //
+        tilted_radial_shift * cos(get_azimuthal_tilt()) +
+        get_half_radius() * sin(get_azimuthal_tilt()) * sin(get_azimuthal_tilt()) +
+        tower.centralY * cos(get_azimuthal_tilt());
 
-
-      if (get_construction_verbose()>=2)
-        {
-          cout
-              << "PHG4CylinderGeom_Spacalv3::get_tower_radial_position - tower radial adjustment: "
-              "from "<<tower.centralY<<" to "<<tower_radial
-              << endl;
-        }
-
-      return tower_radial;
-    }
-  else
+    if (get_construction_verbose() >= 2)
     {
       cout
-          << "PHG4CylinderGeom_Spacalv3::get_tower_radial_position - ERROR - "
-          "unsupported configuration!"
+          << "PHG4CylinderGeom_Spacalv3::get_tower_radial_position - tower radial adjustment: "
+             "from "
+          << tower.centralY << " to " << tower_radial
           << endl;
-      Print();
-      exit(10);
     }
+
+    return tower_radial;
+  }
+  else
+  {
+    cout
+        << "PHG4CylinderGeom_Spacalv3::get_tower_radial_position - ERROR - "
+           "unsupported configuration!"
+        << endl;
+    Print();
+    exit(10);
+  }
   return NAN;
 }
 
 //! check that all towers has consistent sub-tower divider
-void
-PHG4CylinderGeom_Spacalv3::subtower_consistency_check() const
+void PHG4CylinderGeom_Spacalv3::subtower_consistency_check() const
 {
   if (sector_tower_map.begin() == sector_tower_map.end()) return;
 
   for (tower_map_t::const_iterator it = sector_tower_map.begin();
-      it != sector_tower_map.end(); ++it)
-    {
-      assert(get_n_subtower_eta() == it->second.NSubtowerY);
-      assert(get_n_subtower_phi() == it->second.NSubtowerX);
-    }
+       it != sector_tower_map.end(); ++it)
+  {
+    assert(get_n_subtower_eta() == it->second.NSubtowerY);
+    assert(get_n_subtower_phi() == it->second.NSubtowerX);
+  }
 
   if (get_construction_verbose())
-    {
-      cout
-          << "PHG4CylinderGeom_Spacalv3::subtower_consistency_check - Passed with get_n_subtower_phi() = "
-          << get_n_subtower_phi() << " and get_n_subtower_eta()"
-          << get_n_subtower_eta() << endl;
-    }
+  {
+    cout
+        << "PHG4CylinderGeom_Spacalv3::subtower_consistency_check - Passed with get_n_subtower_phi() = "
+        << get_n_subtower_phi() << " and get_n_subtower_eta()"
+        << get_n_subtower_eta() << endl;
+  }
 }
 //! sub-tower divider along the polar direction
-int
-PHG4CylinderGeom_Spacalv3::get_n_subtower_eta() const
+int PHG4CylinderGeom_Spacalv3::get_n_subtower_eta() const
 {
   if (sector_tower_map.begin() == sector_tower_map.end()) return 0;
   assert(sector_tower_map.begin() != sector_tower_map.end());
   return sector_tower_map.begin()->second.NSubtowerY;
 }
 //! sub-tower divider along the azimuthal direction
-int
-PHG4CylinderGeom_Spacalv3::get_n_subtower_phi() const
+int PHG4CylinderGeom_Spacalv3::get_n_subtower_phi() const
 {
   if (sector_tower_map.begin() == sector_tower_map.end()) return 0;
   assert(sector_tower_map.begin() != sector_tower_map.end());
@@ -441,20 +461,19 @@ PHG4CylinderGeom_Spacalv3::get_max_lightguide_height() const
   double max_height = 0;
 
   for (tower_map_t::const_iterator it = sector_tower_map.begin();
-      it != sector_tower_map.end(); ++it)
-    {
-      const double h = it->second.LightguideHeight;
-      max_height = max(max_height, h);
-    }
+       it != sector_tower_map.end(); ++it)
+  {
+    const double h = it->second.LightguideHeight;
+    max_height = max(max_height, h);
+  }
 
   return max_height;
 }
 
-void
-PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map1()
+void PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map1()
 {
   cout << "PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map1 - "
-      << "load four example central towers" << endl;
+       << "load four example central towers" << endl;
 
   // Chris Cullen 2D spacal design July 2015
   radius = 90.000000;
@@ -464,7 +483,7 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map1()
   azimuthal_n_sec = 32;
   max_phi_bin_in_sec = 8;
   sector_map.clear();
-  sector_map[0] = 0; // only install one sector
+  sector_map[0] = 0;  // only install one sector
 
   azimuthal_tilt = 0;
   azimuthal_seg_visible = false;
@@ -474,63 +493,61 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map1()
   sidewall_outer_torr = 0.030000;
   sector_tower_map.clear();
 
-    {
-      // tower 1023 based Row/Col = 102/3
-      geom_tower geom;
-      geom.id = 1023;
-      geom.pDz = 6.751948;
-      geom.pTheta = 0.038660;
-      geom.pPhi = -2.829992;
-      geom.pAlp1 = -0.000872;
-      geom.pAlp2 = -0.000872;
-      geom.pDy1 = 1.121195;
-      geom.pDx1 = 1.191868;
-      geom.pDx2 = 1.192521;
-      geom.pDy2 = 1.281451;
-      geom.pDx3 = 1.357679;
-      geom.pDx4 = 1.358425;
-      geom.centralX = -3.829796;
-      geom.centralY = 105.060369;
-      geom.centralZ = 3.686651;
-      geom.pRotationAngleX = -1.547057;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
+  {
+    // tower 1023 based Row/Col = 102/3
+    geom_tower geom;
+    geom.id = 1023;
+    geom.pDz = 6.751948;
+    geom.pTheta = 0.038660;
+    geom.pPhi = -2.829992;
+    geom.pAlp1 = -0.000872;
+    geom.pAlp2 = -0.000872;
+    geom.pDy1 = 1.121195;
+    geom.pDx1 = 1.191868;
+    geom.pDx2 = 1.192521;
+    geom.pDy2 = 1.281451;
+    geom.pDx3 = 1.357679;
+    geom.pDx4 = 1.358425;
+    geom.centralX = -3.829796;
+    geom.centralY = 105.060369;
+    geom.centralZ = 3.686651;
+    geom.pRotationAngleX = -1.547057;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
 
-    {
-      // tower 1024 based Row/Col = 102/4
-      geom_tower geom;
-      geom.id = 1024;
-      geom.pDz = 6.751948;
-      geom.pTheta = 0.017060;
-      geom.pPhi = -2.373142;
-      geom.pAlp1 = -0.000290;
-      geom.pAlp2 = -0.000290;
-      geom.pDy1 = 1.121195;
-      geom.pDx1 = 1.190432;
-      geom.pDx2 = 1.191082;
-      geom.pDy2 = 1.281451;
-      geom.pDx3 = 1.356043;
-      geom.pDx4 = 1.356787;
-      geom.centralX = -1.276086;
-      geom.centralY = 105.060369;
-      geom.centralZ = 3.686651;
-      geom.pRotationAngleX = -1.547057;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-
+  {
+    // tower 1024 based Row/Col = 102/4
+    geom_tower geom;
+    geom.id = 1024;
+    geom.pDz = 6.751948;
+    geom.pTheta = 0.017060;
+    geom.pPhi = -2.373142;
+    geom.pAlp1 = -0.000290;
+    geom.pAlp2 = -0.000290;
+    geom.pDy1 = 1.121195;
+    geom.pDx1 = 1.190432;
+    geom.pDx2 = 1.191082;
+    geom.pDy2 = 1.281451;
+    geom.pDx3 = 1.356043;
+    geom.pDx4 = 1.356787;
+    geom.centralX = -1.276086;
+    geom.centralY = 105.060369;
+    geom.centralZ = 3.686651;
+    geom.pRotationAngleX = -1.547057;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
 }
 
-void
-PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map2()
+void PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map2()
 {
   cout << "PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map2 - "
-      << "load one row of example forward towers" << endl;
+       << "load one row of example forward towers" << endl;
 
   // Chris Cullen 2D spacal design July 2015
   radius = 90.000000;
@@ -540,7 +557,7 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map2()
   azimuthal_n_sec = 32;
   max_phi_bin_in_sec = 8;
   sector_map.clear();
-  sector_map[0] = 0; // only install one sector
+  sector_map[0] = 0;  // only install one sector
   azimuthal_tilt = 0;
   azimuthal_seg_visible = false;
   polar_taper_ratio = 1.;
@@ -549,207 +566,205 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map2()
   sidewall_outer_torr = 0.030000;
   sector_tower_map.clear();
 
-    {
-      // tower 541 based Row/Col = 54/1
-      geom_tower geom;
-      geom.id = 541;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.053578;
-      geom.pPhi = -3.015910;
-      geom.pAlp1 = 0.068143;
-      geom.pAlp2 = 0.068127;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.235953;
-      geom.pDx2 = 1.214052;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.363889;
-      geom.pDx4 = 1.339743;
-      geom.centralX = -9.019696;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 542 based Row/Col = 54/2
-      geom_tower geom;
-      geom.id = 542;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.038558;
-      geom.pPhi = -2.966436;
-      geom.pAlp1 = 0.048643;
-      geom.pAlp2 = 0.048632;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.234208;
-      geom.pDx2 = 1.212398;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.361965;
-      geom.pDx4 = 1.337918;
-      geom.centralX = -6.439665;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 543 based Row/Col = 54/3
-      geom_tower geom;
-      geom.id = 543;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.023752;
-      geom.pPhi = -2.854692;
-      geom.pAlp1 = 0.029174;
-      geom.pAlp2 = 0.029167;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.233047;
-      geom.pDx2 = 1.211297;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.360684;
-      geom.pDx4 = 1.336703;
-      geom.centralX = -3.862610;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 544 based Row/Col = 54/4
-      geom_tower geom;
-      geom.id = 544;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.010142;
-      geom.pPhi = -2.416982;
-      geom.pAlp1 = 0.009723;
-      geom.pAlp2 = 0.009720;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.232467;
-      geom.pDx2 = 1.210746;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.360044;
-      geom.pDx4 = 1.336096;
-      geom.centralX = -1.287339;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 545 based Row/Col = 54/5
-      geom_tower geom;
-      geom.id = 545;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.010142;
-      geom.pPhi = -0.724610;
-      geom.pAlp1 = -0.009723;
-      geom.pAlp2 = -0.009720;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.232467;
-      geom.pDx2 = 1.210746;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.360044;
-      geom.pDx4 = 1.336096;
-      geom.centralX = 1.287339;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 546 based Row/Col = 54/6
-      geom_tower geom;
-      geom.id = 546;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.023752;
-      geom.pPhi = -0.286901;
-      geom.pAlp1 = -0.029174;
-      geom.pAlp2 = -0.029167;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.233047;
-      geom.pDx2 = 1.211297;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.360684;
-      geom.pDx4 = 1.336703;
-      geom.centralX = 3.862610;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 547 based Row/Col = 54/7
-      geom_tower geom;
-      geom.id = 547;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.038558;
-      geom.pPhi = -0.175156;
-      geom.pAlp1 = -0.048643;
-      geom.pAlp2 = -0.048632;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.234208;
-      geom.pDx2 = 1.212398;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.361965;
-      geom.pDx4 = 1.337918;
-      geom.centralX = 6.439665;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-    {
-      // tower 548 based Row/Col = 54/8
-      geom_tower geom;
-      geom.id = 548;
-      geom.pDz = 8.326697;
-      geom.pTheta = 0.053578;
-      geom.pPhi = -0.125683;
-      geom.pAlp1 = -0.068143;
-      geom.pAlp2 = -0.068127;
-      geom.pDy1 = 1.116997;
-      geom.pDx1 = 1.235953;
-      geom.pDx2 = 1.214052;
-      geom.pDy2 = 1.231781;
-      geom.pDx3 = 1.363889;
-      geom.pDx4 = 1.339743;
-      geom.centralX = 9.019696;
-      geom.centralY = 105.782078;
-      geom.centralZ = -134.504208;
-      geom.pRotationAngleX = -2.482741;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 48;
-      sector_tower_map[geom.id] = geom;
-    }
-
+  {
+    // tower 541 based Row/Col = 54/1
+    geom_tower geom;
+    geom.id = 541;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.053578;
+    geom.pPhi = -3.015910;
+    geom.pAlp1 = 0.068143;
+    geom.pAlp2 = 0.068127;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.235953;
+    geom.pDx2 = 1.214052;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.363889;
+    geom.pDx4 = 1.339743;
+    geom.centralX = -9.019696;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 542 based Row/Col = 54/2
+    geom_tower geom;
+    geom.id = 542;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.038558;
+    geom.pPhi = -2.966436;
+    geom.pAlp1 = 0.048643;
+    geom.pAlp2 = 0.048632;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.234208;
+    geom.pDx2 = 1.212398;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.361965;
+    geom.pDx4 = 1.337918;
+    geom.centralX = -6.439665;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 543 based Row/Col = 54/3
+    geom_tower geom;
+    geom.id = 543;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.023752;
+    geom.pPhi = -2.854692;
+    geom.pAlp1 = 0.029174;
+    geom.pAlp2 = 0.029167;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.233047;
+    geom.pDx2 = 1.211297;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.360684;
+    geom.pDx4 = 1.336703;
+    geom.centralX = -3.862610;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 544 based Row/Col = 54/4
+    geom_tower geom;
+    geom.id = 544;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.010142;
+    geom.pPhi = -2.416982;
+    geom.pAlp1 = 0.009723;
+    geom.pAlp2 = 0.009720;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.232467;
+    geom.pDx2 = 1.210746;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.360044;
+    geom.pDx4 = 1.336096;
+    geom.centralX = -1.287339;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 545 based Row/Col = 54/5
+    geom_tower geom;
+    geom.id = 545;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.010142;
+    geom.pPhi = -0.724610;
+    geom.pAlp1 = -0.009723;
+    geom.pAlp2 = -0.009720;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.232467;
+    geom.pDx2 = 1.210746;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.360044;
+    geom.pDx4 = 1.336096;
+    geom.centralX = 1.287339;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 546 based Row/Col = 54/6
+    geom_tower geom;
+    geom.id = 546;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.023752;
+    geom.pPhi = -0.286901;
+    geom.pAlp1 = -0.029174;
+    geom.pAlp2 = -0.029167;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.233047;
+    geom.pDx2 = 1.211297;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.360684;
+    geom.pDx4 = 1.336703;
+    geom.centralX = 3.862610;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 547 based Row/Col = 54/7
+    geom_tower geom;
+    geom.id = 547;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.038558;
+    geom.pPhi = -0.175156;
+    geom.pAlp1 = -0.048643;
+    geom.pAlp2 = -0.048632;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.234208;
+    geom.pDx2 = 1.212398;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.361965;
+    geom.pDx4 = 1.337918;
+    geom.centralX = 6.439665;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
+  {
+    // tower 548 based Row/Col = 54/8
+    geom_tower geom;
+    geom.id = 548;
+    geom.pDz = 8.326697;
+    geom.pTheta = 0.053578;
+    geom.pPhi = -0.125683;
+    geom.pAlp1 = -0.068143;
+    geom.pAlp2 = -0.068127;
+    geom.pDy1 = 1.116997;
+    geom.pDx1 = 1.235953;
+    geom.pDx2 = 1.214052;
+    geom.pDy2 = 1.231781;
+    geom.pDx3 = 1.363889;
+    geom.pDx4 = 1.339743;
+    geom.centralX = 9.019696;
+    geom.centralY = 105.782078;
+    geom.centralZ = -134.504208;
+    geom.pRotationAngleX = -2.482741;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 48;
+    sector_tower_map[geom.id] = geom;
+  }
 }
 
-void
-PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4()
+void PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4()
 {
   cout << "PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4 - "
-      << "FermiLab test beam 2014. Need to move to calibration database"
-      << endl;
+       << "FermiLab test beam 2014. Need to move to calibration database"
+       << endl;
 
   // From Oleg's documents
 
@@ -773,8 +788,7 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4()
   assert(module_length > 0);
 
   //tapering, dxwidth/dlength
-  const double tapering_ratio = (wide_width_x - nawrrow_width_x)
-      / module_length;
+  const double tapering_ratio = (wide_width_x - nawrrow_width_x) / module_length;
   assert(tapering_ratio < 1);
   assert(tapering_ratio > 0);
 
@@ -784,32 +798,29 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4()
   assembly_spacing = 0.002500;
 
   radius = (nawrrow_width_x) / tapering_ratio;
-  thickness = module_length * 1.5; // keep a large torlerence space
+  thickness = module_length * 1.5;  // keep a large torlerence space
   zmin = -(0.5 * ny * screen_size_y + 2 * assembly_spacing * (ny + 1));
   zmax = -zmin;
   azimuthal_n_sec = floor(2 * M_PI / atan(tapering_ratio));
   max_phi_bin_in_sec = 1;
 
-  const double nawrrow_width_x_construction = radius * 2
-      * tan(M_PI / azimuthal_n_sec) - 2 * assembly_spacing;
-  const double wide_width_x_construction = (radius + module_length) * 2
-      * tan(M_PI / azimuthal_n_sec) - 2 * assembly_spacing;
+  const double nawrrow_width_x_construction = radius * 2 * tan(M_PI / azimuthal_n_sec) - 2 * assembly_spacing;
+  const double wide_width_x_construction = (radius + module_length) * 2 * tan(M_PI / azimuthal_n_sec) - 2 * assembly_spacing;
 
   cout << "PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4 - "
 
-  << "Adjust wide end width by ratio of "
-      << wide_width_x_construction / wide_width_x
-      << " and narrow end by ratio of "
-      << nawrrow_width_x_construction / nawrrow_width_x << endl;
+       << "Adjust wide end width by ratio of "
+       << wide_width_x_construction / wide_width_x
+       << " and narrow end by ratio of "
+       << nawrrow_width_x_construction / nawrrow_width_x << endl;
 
   sector_map.clear();
   for (int sec = 0; sec < nx; ++sec)
-    {
-      const double rot = twopi / (double) (get_azimuthal_n_sec())
-          * ((double) (sec) - 1);
+  {
+    const double rot = twopi / (double) (get_azimuthal_n_sec()) * ((double) (sec) -1);
 
-      sector_map[sec] = rot;
-    }
+    sector_map[sec] = rot;
+  }
 
   azimuthal_tilt = 0;
   azimuthal_seg_visible = true;
@@ -819,33 +830,29 @@ PHG4CylinderGeom_Spacalv3::load_demo_sector_tower_map4()
   sector_tower_map.clear();
 
   for (int y = 0; y < ny; y++)
-    {
+  {
+    geom_tower geom;
+    geom.id = y;
+    geom.pDz = module_length / 2;
+    geom.pTheta = 0.;
+    geom.pPhi = 0.;
+    geom.pAlp1 = 0.;
+    geom.pAlp2 = 0.;
+    geom.pDy1 = 0.5 * screen_size_y;
+    geom.pDx1 = 0.5 * nawrrow_width_x_construction;
+    geom.pDx2 = 0.5 * nawrrow_width_x_construction;
+    geom.pDy2 = 0.5 * screen_size_y;
+    geom.pDx3 = 0.5 * wide_width_x_construction;
+    geom.pDx4 = 0.5 * wide_width_x_construction;
 
-      geom_tower geom;
-      geom.id = y;
-      geom.pDz = module_length / 2;
-      geom.pTheta = 0.;
-      geom.pPhi = 0.;
-      geom.pAlp1 = 0.;
-      geom.pAlp2 = 0.;
-      geom.pDy1 = 0.5 * screen_size_y;
-      geom.pDx1 = 0.5 * nawrrow_width_x_construction;
-      geom.pDx2 = 0.5 * nawrrow_width_x_construction;
-      geom.pDy2 = 0.5 * screen_size_y;
-      geom.pDx3 = 0.5 * wide_width_x_construction;
-      geom.pDx4 = 0.5 * wide_width_x_construction;
+    geom.centralX = 0.;
+    geom.centralY = module_length * 0.5 + radius + assembly_spacing;
+    geom.centralZ = screen_size_y * (y - 1);
 
-      geom.centralX = 0.;
-      geom.centralY = module_length * 0.5 + radius + assembly_spacing;
-      geom.centralZ = screen_size_y * (y - 1);
-
-      geom.pRotationAngleX = -M_PI / 2.;
-      geom.ModuleSkinThickness = 0.010000;
-      geom.NFiberX = 30;
-      geom.NFiberY = 26 * 2 * 2;
-      sector_tower_map[geom.id] = geom;
-    }
-
+    geom.pRotationAngleX = -M_PI / 2.;
+    geom.ModuleSkinThickness = 0.010000;
+    geom.NFiberX = 30;
+    geom.NFiberY = 26 * 2 * 2;
+    sector_tower_map[geom.id] = geom;
+  }
 }
-
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.h
@@ -14,7 +14,7 @@
 
 #include "PHG4CylinderGeom_Spacalv2.h"
 
-#include <iostream>                     // for operator<<, basic_ostream::op...
+#include <iostream>  // for operator<<, basic_ostream::op...
 #include <map>
 #include <string>
 #include <utility>  // std::pair, std::make_pair
@@ -28,10 +28,10 @@ class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
 
   ~PHG4CylinderGeom_Spacalv3() override;
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-// from TObject
+  // from TObject
   void Print(Option_t* option = "") const override;
 
   void SetDefault() override;
@@ -70,7 +70,7 @@ class PHG4CylinderGeom_Spacalv3 : public PHG4CylinderGeom_Spacalv2
   }
 
   void
-  set_sidewall_mat(const std::string &absorberMat)
+  set_sidewall_mat(const std::string& absorberMat)
   {
     sidewall_mat = absorberMat;
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3LinkDef.h
@@ -1,7 +1,7 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeom_Spacalv3+;
-#pragma link C++ class PHG4CylinderGeom_Spacalv3::geom_tower+;
-#pragma link C++ class PHG4CylinderGeom_Spacalv3::scint_id_coder+;
+#pragma link C++ class PHG4CylinderGeom_Spacalv3 + ;
+#pragma link C++ class PHG4CylinderGeom_Spacalv3::geom_tower + ;
+#pragma link C++ class PHG4CylinderGeom_Spacalv3::scint_id_coder + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.cc
@@ -2,21 +2,18 @@
 
 #include <phparameter/PHParameters.h>
 
-void
-PHG4CylinderGeomv1::identify(std::ostream& os) const
+void PHG4CylinderGeomv1::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeomv1: layer: " << layer 
-     << ", radius: " << radius 
+  os << "PHG4CylinderGeomv1: layer: " << layer
+     << ", radius: " << radius
      << ", thickness: " << thickness
-     << ", zmin: " << zmin 
-     << ", zmax: " << zmax 
+     << ", zmin: " << zmin
+     << ", zmax: " << zmax
      << std::endl;
   return;
 }
 
-
-void
-PHG4CylinderGeomv1::ImportParameters(const PHParameters & param)
+void PHG4CylinderGeomv1::ImportParameters(const PHParameters& param)
 {
   PHG4CylinderGeom::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1.h
@@ -24,7 +24,7 @@ class PHG4CylinderGeomv1 : public PHG4CylinderGeom
 
   ~PHG4CylinderGeomv1() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
   int get_layer() const override { return layer; }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeomv1+;
+#pragma link C++ class PHG4CylinderGeomv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.cc
@@ -2,21 +2,19 @@
 
 #include <phparameter/PHParameters.h>
 
-void
-PHG4CylinderGeomv2::identify(std::ostream& os) const
+void PHG4CylinderGeomv2::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeomv2: layer: " << layer 
-     << ", radius: " << radius 
+  os << "PHG4CylinderGeomv2: layer: " << layer
+     << ", radius: " << radius
      << ", thickness: " << thickness
-     << ", zmin: " << zmin 
-     << ", zmax: " << zmax 
+     << ", zmin: " << zmin
+     << ", zmax: " << zmax
      << ", num scint: " << nscint
      << std::endl;
   return;
 }
 
-void
-PHG4CylinderGeomv2::ImportParameters(const PHParameters & param)
+void PHG4CylinderGeomv2::ImportParameters(const PHParameters& param)
 {
   PHG4CylinderGeomv1::ImportParameters(param);
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2.h
@@ -5,34 +5,35 @@
 
 #include "PHG4CylinderGeomv1.h"
 
-#include <iostream>              // for cout, ostream
+#include <iostream>  // for cout, ostream
 
 class PHParameters;
 
-class PHG4CylinderGeomv2: public PHG4CylinderGeomv1
+class PHG4CylinderGeomv2 : public PHG4CylinderGeomv1
 {
  public:
-  PHG4CylinderGeomv2(){}
-  PHG4CylinderGeomv2(const double r, const double zmi, const double zma, const double thickn, const int n_scint):
-    PHG4CylinderGeomv1(r,zmi,zma,thickn),
-    nscint(n_scint)
-      {}
+  PHG4CylinderGeomv2() {}
+  PHG4CylinderGeomv2(const double r, const double zmi, const double zma, const double thickn, const int n_scint)
+    : PHG4CylinderGeomv1(r, zmi, zma, thickn)
+    , nscint(n_scint)
+  {
+  }
 
   ~PHG4CylinderGeomv2() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  void set_nscint(const int i) override {nscint = i;}
-  int get_nscint() const override {return nscint;}
+  void set_nscint(const int i) override { nscint = i; }
+  int get_nscint() const override { return nscint; }
 
   //! load parameters from PHParameters, which interface to Database/XML/ROOT files
-  void ImportParameters(const PHParameters & param) override;
+  void ImportParameters(const PHParameters& param) override;
 
  protected:
   int nscint = -9999;
 
-  ClassDefOverride(PHG4CylinderGeomv2,1)
+  ClassDefOverride(PHG4CylinderGeomv2, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv2LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeomv2+;
+#pragma link C++ class PHG4CylinderGeomv2 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.cc
@@ -4,24 +4,23 @@
 
 using namespace std;
 
-PHG4CylinderGeomv3::PHG4CylinderGeomv3():
-  tiltangle(NAN),
-  phi_slat_zero(NAN)
+PHG4CylinderGeomv3::PHG4CylinderGeomv3()
+  : tiltangle(NAN)
+  , phi_slat_zero(NAN)
 {
   return;
 }
 
-void
-PHG4CylinderGeomv3::identify(std::ostream& os) const
+void PHG4CylinderGeomv3::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeomv3: layer: " << layer 
-     << ", radius: " << radius 
+  os << "PHG4CylinderGeomv3: layer: " << layer
+     << ", radius: " << radius
      << ", thickness: " << thickness
-     << ", zmin: " << zmin 
-     << ", zmax: " << zmax 
+     << ", zmin: " << zmin
+     << ", zmax: " << zmax
      << ", num scint: " << nscint
-     << ", tilt: " << tiltangle/M_PI*180. << " deg"
-     << ", phi at slat #0: " << phi_slat_zero/M_PI*180.
+     << ", tilt: " << tiltangle / M_PI * 180. << " deg"
+     << ", phi at slat #0: " << phi_slat_zero / M_PI * 180.
      << endl;
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3.h
@@ -5,35 +5,36 @@
 
 #include "PHG4CylinderGeomv2.h"
 
-#include <iostream>              // for cout, ostream
+#include <iostream>  // for cout, ostream
 
-class PHG4CylinderGeomv3: public PHG4CylinderGeomv2
+class PHG4CylinderGeomv3 : public PHG4CylinderGeomv2
 {
  public:
   PHG4CylinderGeomv3();
   PHG4CylinderGeomv3(const double r, const double zmi, const double zma, const double thickn, const int n_scint,
-                     const double tangl, const double phi_slat_null):
-    PHG4CylinderGeomv2(r,zmi,zma,thickn,n_scint),
-    tiltangle(tangl),
-    phi_slat_zero(phi_slat_null)
-      {}
+                     const double tangl, const double phi_slat_null)
+    : PHG4CylinderGeomv2(r, zmi, zma, thickn, n_scint)
+    , tiltangle(tangl)
+    , phi_slat_zero(phi_slat_null)
+  {
+  }
 
   ~PHG4CylinderGeomv3() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  void set_tiltangle (const double phi) override {tiltangle=phi;}
-  void set_phi_slat_zero (const double phi) override {phi_slat_zero=phi;}
+  void set_tiltangle(const double phi) override { tiltangle = phi; }
+  void set_phi_slat_zero(const double phi) override { phi_slat_zero = phi; }
 
-  double get_phi_slat_zero() const override {return phi_slat_zero;}
-  double get_tiltangle() const override {return tiltangle;}
+  double get_phi_slat_zero() const override { return phi_slat_zero; }
+  double get_tiltangle() const override { return tiltangle; }
 
  protected:
   double tiltangle;
   double phi_slat_zero;
 
-  ClassDefOverride(PHG4CylinderGeomv3,1)
+  ClassDefOverride(PHG4CylinderGeomv3, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv3LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeomv3+;
+#pragma link C++ class PHG4CylinderGeomv3 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.cc
@@ -4,43 +4,42 @@
 
 using namespace std;
 
-PHG4CylinderGeomv4::PHG4CylinderGeomv4():
-  N_sensors_in_layer(-1),
-  layer(-1),
-  layer_radius(NAN),
-  radius_stagger(NAN),
-  layer_NZ(-1),
-  segment_z_step(NAN),
-  segment_phi_step(NAN),
-  sensor_x_offset(NAN),
-  sensor_y_offset(NAN),
-  N_strip_columns(-1),
-  N_strips_per_column(-1),
-  N_staggers(-1),
-  strip_z_spacing(NAN),
-  strip_y_spacing(NAN),
-  thickness(NAN),
-  strip_tilt(NAN)
+PHG4CylinderGeomv4::PHG4CylinderGeomv4()
+  : N_sensors_in_layer(-1)
+  , layer(-1)
+  , layer_radius(NAN)
+  , radius_stagger(NAN)
+  , layer_NZ(-1)
+  , segment_z_step(NAN)
+  , segment_phi_step(NAN)
+  , sensor_x_offset(NAN)
+  , sensor_y_offset(NAN)
+  , N_strip_columns(-1)
+  , N_strips_per_column(-1)
+  , N_staggers(-1)
+  , strip_z_spacing(NAN)
+  , strip_y_spacing(NAN)
+  , thickness(NAN)
+  , strip_tilt(NAN)
 
 {
   return;
 }
 
-void
-PHG4CylinderGeomv4::identify(std::ostream& os) const
+void PHG4CylinderGeomv4::identify(std::ostream& os) const
 {
-  os << "PHG4CylinderGeomv4: layer: " << layer 
-     << ", layer_radius: " << layer_radius 
-     << ", radius_stagger: " << radius_stagger 
+  os << "PHG4CylinderGeomv4: layer: " << layer
+     << ", layer_radius: " << layer_radius
+     << ", radius_stagger: " << radius_stagger
      << ", N_sensors_in_layer: " << N_sensors_in_layer
-     << ", layer_NZ: " << layer_NZ 
+     << ", layer_NZ: " << layer_NZ
      << ", segment_z_step: " << segment_z_step
      << ", segment_phi_step: " << segment_phi_step
      << ", sensor_x_offset: " << sensor_x_offset
      << ", sensor_y_offset: " << sensor_y_offset
-     << ", N_strip_columns: " << N_strip_columns 
+     << ", N_strip_columns: " << N_strip_columns
      << ", N_strips_per_column: " << N_strips_per_column
-     << ", N_staggers " << N_staggers 
+     << ", N_staggers " << N_staggers
      << ", strip_z_spacing: " << strip_z_spacing
      << ", strip_y_spacing: " << strip_y_spacing
      << ", strip_tilt: " << strip_tilt
@@ -50,21 +49,20 @@ PHG4CylinderGeomv4::identify(std::ostream& os) const
 
 void PHG4CylinderGeomv4::find_segment_center(int segment_z_bin, int segment_phi_bin, double location[])
 {
-  double z_location =  (double) (segment_z_bin -  layer_NZ/2) * segment_z_step;
-
+  double z_location = (double) (segment_z_bin - layer_NZ / 2) * segment_z_step;
 
   // this determines the stggered layer radius
   int istagger = segment_phi_bin % N_staggers;
-  
+
   // We need to stagger the radii at alternate phi values by radius_stagger, since the ladders overlap in phi
   // The number of staggers is an input number, since it has to be the same for both parts of a double layer!
   double R_layer = layer_radius + (double) istagger * radius_stagger;
-  
-  // Place the ladder segment envelopes at the correct z and phi
-  double phi  = (double) segment_phi_bin * segment_phi_step;
 
-  double  x_location = R_layer * cos(phi);
-  double  y_location = R_layer * sin(phi);
+  // Place the ladder segment envelopes at the correct z and phi
+  double phi = (double) segment_phi_bin * segment_phi_step;
+
+  double x_location = R_layer * cos(phi);
+  double y_location = R_layer * sin(phi);
 
   location[0] = x_location;
   location[1] = y_location;
@@ -81,19 +79,19 @@ void PHG4CylinderGeomv4::find_strip_center(int segment_z_bin, int segment_phi_bi
   // if it is odd, the center of the sensor is in the middle of a strip column, one strip is centered at zero
 
   double strip_sensor_z = 0.0;
-  if(N_strip_columns%2)
-    strip_sensor_z  =  ((double) (strip_column - N_strip_columns/2) ) * strip_z_spacing;
+  if (N_strip_columns % 2)
+    strip_sensor_z = ((double) (strip_column - N_strip_columns / 2)) * strip_z_spacing;
   else
-    strip_sensor_z  =  ((double) (strip_column - N_strip_columns/2) + 0.5) * strip_z_spacing; 
+    strip_sensor_z = ((double) (strip_column - N_strip_columns / 2) + 0.5) * strip_z_spacing;
 
   double strip_sensor_y = 0.0;
-  if(N_strips_per_column%2)
-    strip_sensor_y = (double) (strip_index - N_strips_per_column/2) * strip_y_spacing;
+  if (N_strips_per_column % 2)
+    strip_sensor_y = (double) (strip_index - N_strips_per_column / 2) * strip_y_spacing;
   else
-    strip_sensor_y = ((double) (strip_index - N_strips_per_column/2) + 0.5) * strip_y_spacing;
+    strip_sensor_y = ((double) (strip_index - N_strips_per_column / 2) + 0.5) * strip_y_spacing;
 
   // The sensor is set forward of the center in the ladder segment volume
-  double strip_sensor_x =  sensor_x_offset;
+  double strip_sensor_x = sensor_x_offset;
 
   // If there is only an upper ROC, the sensor is not centered in the ladder segment
   // Add the sensor offset to the strip_sensor_y value
@@ -102,7 +100,7 @@ void PHG4CylinderGeomv4::find_strip_center(int segment_z_bin, int segment_phi_bi
 
   // Now we need to transform the position in the ladder segment frame to that in the sPHENIX frame
   // this is just a rotation around the z axis in phi
-  double phi  = (double) segment_phi_bin * segment_phi_step;
+  double phi = (double) segment_phi_bin * segment_phi_step;
   double x = strip_sensor_x * cos(phi) - strip_sensor_y * sin(phi);
   double y = strip_sensor_y * cos(phi) + strip_sensor_x * sin(phi);
 
@@ -110,7 +108,6 @@ void PHG4CylinderGeomv4::find_strip_center(int segment_z_bin, int segment_phi_bi
   location[0] += x;
   location[1] += y;
   location[2] += strip_sensor_z;
-  
+
   return;
 }
-

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4.h
@@ -5,71 +5,71 @@
 
 #include "PHG4CylinderGeom.h"
 
-#include <iostream>            // for cout, ostream
+#include <iostream>  // for cout, ostream
 
-class PHG4CylinderGeomv4: public PHG4CylinderGeom
+class PHG4CylinderGeomv4 : public PHG4CylinderGeom
 {
  public:
   PHG4CylinderGeomv4();
   PHG4CylinderGeomv4(const int lnsensors,
-		    const int lnz,
-		    const int nspc,
-		    int nsc,
-		    const int nstag,
-		    const double lr,
-		    const double rs,
-		    const double szs,
-		    const double sps,
-		    const double sxo,
-		    double syo,
-		    const double szsp,
-		    const double sys,
-		    const double tck,
-		    const double st) :
-    N_sensors_in_layer(lnsensors),
-    layer(-1),
-    layer_radius(lr),
-    radius_stagger(rs),
-    layer_NZ(lnz),
-    segment_z_step(szs),
-    segment_phi_step(sps),
-    sensor_x_offset(sxo),
-    sensor_y_offset(syo),
-    N_strip_columns(nsc),
-    N_strips_per_column(nspc),
-    N_staggers(nstag),
-    strip_z_spacing(szsp),
-    strip_y_spacing(sys),
-    thickness(tck),
-    strip_tilt(st)
-  {}
+                     const int lnz,
+                     const int nspc,
+                     int nsc,
+                     const int nstag,
+                     const double lr,
+                     const double rs,
+                     const double szs,
+                     const double sps,
+                     const double sxo,
+                     double syo,
+                     const double szsp,
+                     const double sys,
+                     const double tck,
+                     const double st)
+    : N_sensors_in_layer(lnsensors)
+    , layer(-1)
+    , layer_radius(lr)
+    , radius_stagger(rs)
+    , layer_NZ(lnz)
+    , segment_z_step(szs)
+    , segment_phi_step(sps)
+    , sensor_x_offset(sxo)
+    , sensor_y_offset(syo)
+    , N_strip_columns(nsc)
+    , N_strips_per_column(nspc)
+    , N_staggers(nstag)
+    , strip_z_spacing(szsp)
+    , strip_y_spacing(sys)
+    , thickness(tck)
+    , strip_tilt(st)
+  {
+  }
 
   ~PHG4CylinderGeomv4() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-  void set_layer(const int i) override {layer = i;}
-  int get_layer() const override {return layer;}
-  double get_radius() const override {return layer_radius;}
+  void set_layer(const int i) override { layer = i; }
+  int get_layer() const override { return layer; }
+  double get_radius() const override { return layer_radius; }
 
   void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]) override;
   void find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]) override;
 
-  double get_thickness() const override {return thickness;}
-  double get_strip_y_spacing() const override {return strip_y_spacing;}
-  double get_strip_z_spacing() const override {return strip_z_spacing;}
-  double get_strip_tilt() const override {return strip_tilt;}  
-  int get_N_strip_columns() const override {return N_strip_columns;}
-  int get_N_strips_per_column() const override {return N_strips_per_column;}
-  int get_N_sensors_in_layer() const override {return N_sensors_in_layer;}
+  double get_thickness() const override { return thickness; }
+  double get_strip_y_spacing() const override { return strip_y_spacing; }
+  double get_strip_z_spacing() const override { return strip_z_spacing; }
+  double get_strip_tilt() const override { return strip_tilt; }
+  int get_N_strip_columns() const override { return N_strip_columns; }
+  int get_N_strips_per_column() const override { return N_strips_per_column; }
+  int get_N_sensors_in_layer() const override { return N_sensors_in_layer; }
 
-// our own (not inherited from base class)
-  double get_sensor_x_offset() const {return sensor_x_offset;}  
-  double get_sensor_y_offset() const {return sensor_y_offset;}  
+  // our own (not inherited from base class)
+  double get_sensor_x_offset() const { return sensor_x_offset; }
+  double get_sensor_y_offset() const { return sensor_y_offset; }
 
-protected:
-
+ protected:
   int N_sensors_in_layer;
   int layer;
 
@@ -92,8 +92,8 @@ protected:
   double strip_y_spacing;
   double thickness;
   double strip_tilt;
-  
-  ClassDefOverride(PHG4CylinderGeomv4,1)
+
+  ClassDefOverride(PHG4CylinderGeomv4, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeomv4LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4CylinderGeomv4+;
+#pragma link C++ class PHG4CylinderGeomv4 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.cc
@@ -21,7 +21,7 @@
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4StepPoint.hh>   // for G4StepPoint
 #include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fPostSt...
-#include <Geant4/G4String.hh>                         // for G4String
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
@@ -142,15 +142,15 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         std::cout << GetName() << ": New Hit for  " << std::endl;
         std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+                  << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                  << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                  << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
         std::cout << "last track: " << m_SaveTrackId
-             << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+                  << ", current trackid: " << aTrack->GetTrackID() << std::endl;
         std::cout << "phys pre vol: " << volume->GetName()
-             << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+                  << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
         std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-             << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+                  << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       }
 
       if (!m_Hit)
@@ -198,9 +198,9 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         boost::io::ios_precision_saver ips(std::cout);
         std::cout << m_Detector->SuperDetector() << std::setprecision(9)
-             << " PHG4CylinderSteppingAction: Entry hit z " << m_Hit->get_z(0) * cm
-             << " outside acceptance,  zmin " << m_Zmin
-             << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
+                  << " PHG4CylinderSteppingAction: Entry hit z " << m_Hit->get_z(0) * cm
+                  << " outside acceptance,  zmin " << m_Zmin
+                  << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
       }
     }
     // here we just update the exit values, it will be overwritten
@@ -212,15 +212,15 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       std::cout << GetName() << ": hit was not created" << std::endl;
       std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+                << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
       std::cout << "last track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+                << ", current trackid: " << aTrack->GetTrackID() << std::endl;
       std::cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+                << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
       std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-           << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+                << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       exit(1);
     }
     m_SavePostStepStatus = postPoint->GetStepStatus();
@@ -229,8 +229,8 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       std::cout << "hits do not belong to the same track" << std::endl;
       std::cout << "saved track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID()
-           << std::endl;
+                << ", current trackid: " << aTrack->GetTrackID()
+                << std::endl;
       exit(1);
     }
     m_SavePreStepStatus = prePoint->GetStepStatus();
@@ -252,9 +252,9 @@ bool PHG4CylinderSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     if (!hasMotherSubsystem() && (m_Hit->get_z(1) * cm > m_Zmax || m_Hit->get_z(1) * cm < m_Zmin))
     {
       std::cout << m_Detector->SuperDetector() << std::setprecision(9)
-           << " PHG4CylinderSteppingAction: Exit hit z " << m_Hit->get_z(1) * cm
-           << " outside acceptance zmin " << m_Zmin
-           << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
+                << " PHG4CylinderSteppingAction: Exit hit z " << m_Hit->get_z(1) * cm
+                << " outside acceptance zmin " << m_Zmin
+                << ", zmax " << m_Zmax << ", layer: " << layer_id << std::endl;
     }
     if (geantino)
     {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSteppingAction.h
@@ -45,7 +45,7 @@ class PHG4CylinderSteppingAction : public PHG4SteppingAction
   // this to our parameters
   void SaveAllHits(bool i = true) { m_SaveAllHitsFlag = i; }
 
-  void HitNodeName(const std::string &name) {m_HitNodeName = name;}
+  void HitNodeName(const std::string &name) { m_HitNodeName = name; }
 
  private:
   //! pointer to the Subsystem

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -14,15 +14,13 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
+#include <boost/format.hpp>
+
+// boost stacktrace has shadowed variables
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wc11-extensions"
-#include <boost/format.hpp>
 #include <boost/stacktrace.hpp>
 #pragma GCC diagnostic pop
 

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -14,10 +14,17 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wc11-extensions"
 #include <boost/format.hpp>
 #include <boost/stacktrace.hpp>
+#pragma GCC diagnostic pop
 
 #include <cassert>  // for assert
 #include <cstdlib>  // for exit

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -154,8 +154,8 @@ int PHG4DetectorGroupSubsystem::InitRun(PHCompositeNode *topNode)
   }
   m_ParamsContainer->SaveToNodeTree(RunDetNode, paramnodename);
   // define the materials for the detector
-// at this point all flags are known so materials set in the macro can
-// be implemented here
+  // at this point all flags are known so materials set in the macro can
+  // be implemented here
   DefineMaterials();
   int iret = InitRunSubsystem(topNode);
   m_ParamsContainer->UpdateNodeTree(RunDetNode, paramnodename);
@@ -509,7 +509,7 @@ int PHG4DetectorGroupSubsystem::SaveParamsToDB()
   return iret;
 }
 
-int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string &/*name*/, const int /*issuper*/)
+int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const string & /*name*/, const int /*issuper*/)
 {
   int iret = 1;
   // if (issuper)
@@ -557,7 +557,7 @@ int PHG4DetectorGroupSubsystem::SaveParamsToFile(const PHG4DetectorGroupSubsyste
   return iret;
 }
 
-int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string &/*name*/, const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp, const int /*issuper*/)
+int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const string & /*name*/, const PHG4DetectorGroupSubsystem::FILE_TYPE ftyp, const int /*issuper*/)
 {
   string extension;
   switch (ftyp)

--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -118,9 +118,9 @@ int PHG4DetectorSubsystem::InitRun(PHCompositeNode *topNode)
   }
   // put parameters on the node tree so the subsystem can read them from there (it does not have to)
   params->SaveToNodeTree(RunDetNode, paramnodename, layer);
-// define the materials for the detector
-// at this point all flags are known so materials set in the macro can
-// be implemented here
+  // define the materials for the detector
+  // at this point all flags are known so materials set in the macro can
+  // be implemented here
   DefineMaterials();
   int iret = InitRunSubsystem(topNode);
   // update parameters on node tree in case the subsystem has changed them

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -7,7 +7,7 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
-#include <Geant4/G4String.hh>              // for G4String
+#include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4SystemOfUnits.hh>   // for mm, m
 #include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>     // for G4Transform3D

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.h
@@ -22,7 +22,7 @@ class PHG4EnvelopeDetector : public PHG4Detector
   PHG4EnvelopeDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &dnam);
 
   //Destructor
-  ~PHG4EnvelopeDetector() override{}
+  ~PHG4EnvelopeDetector() override {}
 
   //Construct
   void ConstructMe(G4LogicalVolume *world) override;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.cc
@@ -1,11 +1,11 @@
 #include "PHG4EnvelopeSteppingAction.h"
 #include "PHG4EnvelopeDetector.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <g4main/PHG4TrackUserInfoV1.h>
 
@@ -14,20 +14,20 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fUndefined
-#include <Geant4/G4String.hh>                  // for G4String
-#include <Geant4/G4SystemOfUnits.hh>       // for mm, m
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4StepPoint.hh>              // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fUndefined
+#include <Geant4/G4String.hh>                 // for G4String
+#include <Geant4/G4SystemOfUnits.hh>          // for mm, m
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <iostream>
-#include <string>                              // for string, operator+, ope...
+#include <string>  // for string, operator+, ope...
 
 class G4VPhysicalVolume;
 class PHCompositeNode;
@@ -35,27 +35,27 @@ class PHCompositeNode;
 using namespace std;
 
 //______________________________________________________________
-PHG4EnvelopeSteppingAction::PHG4EnvelopeSteppingAction( PHG4EnvelopeDetector* detector ):
-  PHG4SteppingAction(detector->GetName()),
-  detector_( detector ),
-  hits_(nullptr),
-  hit(nullptr)
+PHG4EnvelopeSteppingAction::PHG4EnvelopeSteppingAction(PHG4EnvelopeDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
+  , hit(nullptr)
 {
 }
 
 //____________________________________________________________________________..
-bool PHG4EnvelopeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
+bool PHG4EnvelopeSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 {
   G4TouchableHandle touch = aStep->GetPreStepPoint()->GetTouchableHandle();
   G4VPhysicalVolume* volume = touch->GetVolume();
-	
+
   int whichactive = detector_->IsInEnvelope(volume);
 
-  if ( !whichactive  )
-    {
-      return false;
-    }
-	
+  if (!whichactive)
+  {
+    return false;
+  }
+
   int layer_id = detector_->get_Layer();
   int tower_id = touch->GetCopyNumber();
 
@@ -65,144 +65,142 @@ bool PHG4EnvelopeSteppingAction::UserSteppingAction( const G4Step* aStep, bool )
 
   /* Get pointer to associated Geant4 track */
   const G4Track* aTrack = aStep->GetTrack();
-	
+
   //This detector is a black hole! Just put all kinetic energy into edep
   G4double edep = aTrack->GetKineticEnergy() / GeV;
-  G4Track* killtrack = const_cast<G4Track *> (aTrack);
+  G4Track* killtrack = const_cast<G4Track*>(aTrack);
   killtrack->SetTrackStatus(fStopAndKill);
-	
+
   /* Make sure we are in a volume */
-  if ( detector_->IsActive() )
+  if (detector_->IsActive())
+  {
+    /* Check if particle is 'geantino' */
+    bool geantino = false;
+    if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 && aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
     {
-      /* Check if particle is 'geantino' */
-      bool geantino = false;
-      if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 && aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
-	{
-	  geantino = true;
-	}
+      geantino = true;
+    }
 
-      /* Get Geant4 pre- and post-step points */
-      G4StepPoint * prePoint = aStep->GetPreStepPoint();
-      G4StepPoint * postPoint = aStep->GetPostStepPoint();
+    /* Get Geant4 pre- and post-step points */
+    G4StepPoint* prePoint = aStep->GetPreStepPoint();
+    G4StepPoint* postPoint = aStep->GetPostStepPoint();
 
-      switch (prePoint->GetStepStatus())
-	{
-	case fGeomBoundary:
-	case fUndefined:
-	  hit = new PHG4Hitv1();
-	  //	  hit->set_layer(0);
-	  hit->set_scint_id(tower_id);
+    switch (prePoint->GetStepStatus())
+    {
+    case fGeomBoundary:
+    case fUndefined:
+      hit = new PHG4Hitv1();
+      //	  hit->set_layer(0);
+      hit->set_scint_id(tower_id);
 
-	  /* Set hit location (tower index) */
-	  //hit->set_index_j(idx_j);
-	  //hit->set_index_k(idx_k);
-	  //hit->set_index_l(idx_l);
-	  hit->set_index_j(0);
-	  hit->set_index_k(0);
-	  hit->set_index_l(0);
+      /* Set hit location (tower index) */
+      //hit->set_index_j(idx_j);
+      //hit->set_index_k(idx_k);
+      //hit->set_index_l(idx_l);
+      hit->set_index_j(0);
+      hit->set_index_k(0);
+      hit->set_index_l(0);
 
-	  /* Set hit location (space point) */
-	  hit->set_x( 0, prePoint->GetPosition().x() / cm);
-	  hit->set_y( 0, prePoint->GetPosition().y() / cm );
-	  hit->set_z( 0, prePoint->GetPosition().z() / cm );
+      /* Set hit location (space point) */
+      hit->set_x(0, prePoint->GetPosition().x() / cm);
+      hit->set_y(0, prePoint->GetPosition().y() / cm);
+      hit->set_z(0, prePoint->GetPosition().z() / cm);
 
-	  /* Set momentum */
-	  hit->set_x( 0, prePoint->GetMomentum().x() / GeV );
-	  hit->set_y( 0, prePoint->GetMomentum().y() / GeV );
-	  hit->set_z( 0, prePoint->GetMomentum().z() / GeV );
+      /* Set momentum */
+      hit->set_x(0, prePoint->GetMomentum().x() / GeV);
+      hit->set_y(0, prePoint->GetMomentum().y() / GeV);
+      hit->set_z(0, prePoint->GetMomentum().z() / GeV);
 
-	  /* Set hit time */
-	  hit->set_t( 0, prePoint->GetGlobalTime() / nanosecond );
+      /* Set hit time */
+      hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
 
-	  /* set the track ID */
-	  {
-	    hit->set_trkid(aTrack->GetTrackID());
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    hit->set_trkid(pp->GetUserTrackId());
-		    hit->set_shower_id(pp->GetShower()->get_id());
-		  }
-	      }
-	  }
+      /* set the track ID */
+      {
+        hit->set_trkid(aTrack->GetTrackID());
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+        {
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            hit->set_trkid(pp->GetUserTrackId());
+            hit->set_shower_id(pp->GetShower()->get_id());
+          }
+        }
+      }
 
-	  /* set intial energy deposit */
-	  hit->set_edep( 0 );
-	  hit->set_eion( 0 );
+      /* set intial energy deposit */
+      hit->set_edep(0);
+      hit->set_eion(0);
 
-	  hits_->AddHit(layer_id, hit);
-	  
-	  {
-	    if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	      {
-		if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		  {
-		    pp->GetShower()->add_g4hit_id(hits_->GetID(),hit->get_hit_id());
-		  }
-	      }
-	  }
-	  
-	  break;
-	default:
-	  break;
-	}
+      hits_->AddHit(layer_id, hit);
 
-      /* Update exit values- will be overwritten with every step until
+      {
+        if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+        {
+          if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+          {
+            pp->GetShower()->add_g4hit_id(hits_->GetID(), hit->get_hit_id());
+          }
+        }
+      }
+
+      break;
+    default:
+      break;
+    }
+
+    /* Update exit values- will be overwritten with every step until
        * we leave the volume or the particle ceases to exist */
-      hit->set_x( 1, postPoint->GetPosition().x() / cm );
-      hit->set_y( 1, postPoint->GetPosition().y() / cm );
-      hit->set_z( 1, postPoint->GetPosition().z() / cm );
+    hit->set_x(1, postPoint->GetPosition().x() / cm);
+    hit->set_y(1, postPoint->GetPosition().y() / cm);
+    hit->set_z(1, postPoint->GetPosition().z() / cm);
 
-      hit->set_t( 1, postPoint->GetGlobalTime() / nanosecond );
+    hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
-      /* sum up the energy to get total deposited */
-      hit->set_edep(hit->get_edep() + edep);
-      hit->set_eion(hit->get_eion() + eion);
+    /* sum up the energy to get total deposited */
+    hit->set_edep(hit->get_edep() + edep);
+    hit->set_eion(hit->get_eion() + eion);
 
-      if (geantino)
-	{
-	  hit->set_edep(-1); // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-	  hit->set_eion(-1);
-	}
-      if (edep > 0)
-	{
-	  if ( G4VUserTrackInformation* p = aTrack->GetUserInformation() )
-	    {
-	      if ( PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p) )
-		{
-		  pp->SetKeep(1); // we want to keep the track
-		}
-	    }
-	}
-      return true;
-    }
-  else
+    if (geantino)
     {
-      return false;
+      hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+      hit->set_eion(-1);
     }
+    if (edep > 0)
+    {
+      if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
+      {
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
+      }
+    }
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
-	
-void PHG4EnvelopeSteppingAction::SetInterfacePointers( PHCompositeNode* topNode )
+
+void PHG4EnvelopeSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
   string hitnodename;
 
   if (detector_->SuperDetector() != "NONE")
-    {
-      hitnodename = "G4HIT_ENVELOPE_" + detector_->SuperDetector();
-    }
+  {
+    hitnodename = "G4HIT_ENVELOPE_" + detector_->SuperDetector();
+  }
   else
-    {
-      hitnodename = "G4HIT_ENVELOPE_" + detector_->GetName();
-    }
-	
-  hits_ =  findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str() );
+  {
+    hitnodename = "G4HIT_ENVELOPE_" + detector_->GetName();
+  }
+
+  hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
 
   // if we do not find the node it's messed up.
-  if ( ! hits_ )
-    {
-      std::cout << "PHG4CrystalCalorimeterSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
-    }
-	
-	
+  if (!hits_)
+  {
+    std::cout << "PHG4CrystalCalorimeterSteppingAction::SetTopNode - unable to find " << hitnodename << std::endl;
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSteppingAction.h
@@ -11,30 +11,30 @@ class PHG4EnvelopeDetector;
 class PHG4Hit;
 class PHG4HitContainer;
 
-class PHG4EnvelopeSteppingAction: public PHG4SteppingAction
+class PHG4EnvelopeSteppingAction : public PHG4SteppingAction
 {
-	public:
-		//Constructor
-		PHG4EnvelopeSteppingAction( PHG4EnvelopeDetector* );
-	
-		//Destructor
-		~PHG4EnvelopeSteppingAction() override
-		{}
-	
-		//Stepping Action
-		bool UserSteppingAction( const G4Step*, bool) override;
-	
-		//reimplemented from base class
-		void SetInterfacePointers( PHCompositeNode* ) override;
-	
-	private:
-		
-		//pointer to the detector
-		PHG4EnvelopeDetector* detector_;
-	
-		//pointer to hit container
-		PHG4HitContainer * hits_;
-		PHG4Hit *hit;	
+ public:
+  //Constructor
+  PHG4EnvelopeSteppingAction(PHG4EnvelopeDetector*);
+
+  //Destructor
+  ~PHG4EnvelopeSteppingAction() override
+  {
+  }
+
+  //Stepping Action
+  bool UserSteppingAction(const G4Step*, bool) override;
+
+  //reimplemented from base class
+  void SetInterfacePointers(PHCompositeNode*) override;
+
+ private:
+  //pointer to the detector
+  PHG4EnvelopeDetector* detector_;
+
+  //pointer to hit container
+  PHG4HitContainer* hits_;
+  PHG4Hit* hit;
 };
 
-#endif //PHG4EnvelopeSteppingAction_h
+#endif  //PHG4EnvelopeSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.h
@@ -7,7 +7,7 @@
 
 #include <Geant4/G4String.hh>
 
-#include <string>                  // for string
+#include <string>  // for string
 
 class PHG4Detector;
 class PHG4EnvelopeDetector;
@@ -15,43 +15,43 @@ class PHG4EnvelopeSteppingAction;
 class PHG4SteppingAction;
 class PHCompositeNode;
 
-class PHG4EnvelopeSubsystem: public PHG4Subsystem
+class PHG4EnvelopeSubsystem : public PHG4Subsystem
 {
-	public:
-		//Constructor
-		PHG4EnvelopeSubsystem ( const std::string &name = "ENVELOPE_DEFAULT", const int layer = 0 );
-		
-		//Destructor
-		~PHG4EnvelopeSubsystem ( void ) override
-		{}
-			
-		/*
+ public:
+  //Constructor
+  PHG4EnvelopeSubsystem(const std::string& name = "ENVELOPE_DEFAULT", const int layer = 0);
+
+  //Destructor
+  ~PHG4EnvelopeSubsystem(void) override
+  {
+  }
+
+  /*
 			Creates the detector_ object and place it on the node tree, under "DETECTORS" node (or whatever)
 			Creates the stepping action and place it on the node tree, under "ACTIONS" node
 			Creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
 		*/
-	
-		int Init(PHCompositeNode *) override;
-	
-		//Event Processing
-		int process_event(PHCompositeNode *) override;
-	
-		//Accessors (reimplemented)
-		PHG4Detector* GetDetector( void ) const override;
-		PHG4SteppingAction* GetSteppingAction( void ) const override;
-	
-	private:
-		//Pointer to Geant4 implementation of detector
-		PHG4EnvelopeDetector* detector_;
-	
-		//Stepping Action
-		PHG4EnvelopeSteppingAction* steppingAction_;
-			
-		G4String material;
-		int active;
-	
-		std::string detector_type;
-			
+
+  int Init(PHCompositeNode*) override;
+
+  //Event Processing
+  int process_event(PHCompositeNode*) override;
+
+  //Accessors (reimplemented)
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction(void) const override;
+
+ private:
+  //Pointer to Geant4 implementation of detector
+  PHG4EnvelopeDetector* detector_;
+
+  //Stepping Action
+  PHG4EnvelopeSteppingAction* steppingAction_;
+
+  G4String material;
+  int active;
+
+  std::string detector_type;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.cc
@@ -6,28 +6,26 @@
 #include <boost/foreach.hpp>
 
 //___________________________________________________
-PHG4EventActionClearZeroEdep::PHG4EventActionClearZeroEdep( PHCompositeNode *node, const std::string &name ):
-  topNode(node)
+PHG4EventActionClearZeroEdep::PHG4EventActionClearZeroEdep(PHCompositeNode *node, const std::string &name)
+  : topNode(node)
 {
   AddNode(name);
 }
 
-
-void
-PHG4EventActionClearZeroEdep::AddNode(const std::string &name)
+void PHG4EventActionClearZeroEdep::AddNode(const std::string &name)
 {
   nodename_set.insert(name);
 }
 
 //___________________________________________________
-void PHG4EventActionClearZeroEdep::EndOfEventAction(const G4Event* /*evt*/)
+void PHG4EventActionClearZeroEdep::EndOfEventAction(const G4Event * /*evt*/)
 {
-  BOOST_FOREACH(std::string node, nodename_set)
+  BOOST_FOREACH (std::string node, nodename_set)
+  {
+    PHG4HitContainer *generic_hits = findNode::getClass<PHG4HitContainer>(topNode, node);
+    if (generic_hits)
     {
-      PHG4HitContainer* generic_hits =  findNode::getClass<PHG4HitContainer>( topNode , node);
-      if (generic_hits)
-	{
-	  generic_hits->RemoveZeroEDep();
-	}
+      generic_hits->RemoveZeroEDep();
     }
+  }
 }

--- a/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.h
+++ b/simulation/g4simulation/g4detectors/PHG4EventActionClearZeroEdep.h
@@ -5,34 +5,30 @@
 
 #include <g4main/PHG4EventAction.h>
 
-#include <string>
 #include <set>
+#include <string>
 
 class G4Event;
 class PHCompositeNode;
 
-class PHG4EventActionClearZeroEdep: public PHG4EventAction
+class PHG4EventActionClearZeroEdep : public PHG4EventAction
 {
-
-public:
-
+ public:
   //! constructor
-  PHG4EventActionClearZeroEdep( PHCompositeNode *topNode, const std::string &name);
+  PHG4EventActionClearZeroEdep(PHCompositeNode *topNode, const std::string &name);
 
   void AddNode(const std::string &name);
 
   //! destuctor
   ~PHG4EventActionClearZeroEdep() override
-  {}
+  {
+  }
 
-  void EndOfEventAction(const G4Event*) override;
-  
+  void EndOfEventAction(const G4Event *) override;
+
  private:
-  
   std::set<std::string> nodename_set;
   PHCompositeNode *topNode;
-  
 };
-
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -320,8 +320,8 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
       ParDetNode = new PHCompositeNode(detector);
       parNode->addNode(ParDetNode);
     }
-  string geonodename = "G4CELLGEO_" + detector;
-  PutOnParNode(ParDetNode,geonodename);
+  std::string cellgeonodename = "G4CELLGEO_" + detector;
+  PutOnParNode(ParDetNode,cellgeonodename);
   tmin = get_double_param("tmin");
   tmax = get_double_param("tmax");
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -1,13 +1,13 @@
 #include "PHG4FullProjSpacalCellReco.h"
 
-#include "PHG4Cell.h"                          // for PHG4Cell
-#include "PHG4CylinderGeom.h"                  // for PHG4CylinderGeom
-#include "PHG4CylinderGeom_Spacalv1.h"         // for PHG4CylinderGeom_Spaca...
-#include "PHG4CylinderGeomContainer.h"
-#include "PHG4CylinderGeom_Spacalv3.h"
-#include "PHG4CylinderCellGeomContainer.h"
+#include "PHG4Cell.h"  // for PHG4Cell
 #include "PHG4CylinderCellGeom.h"
+#include "PHG4CylinderCellGeomContainer.h"
 #include "PHG4CylinderCellGeom_Spacalv1.h"
+#include "PHG4CylinderGeom.h"  // for PHG4CylinderGeom
+#include "PHG4CylinderGeomContainer.h"
+#include "PHG4CylinderGeom_Spacalv1.h"  // for PHG4CylinderGeom_Spaca...
+#include "PHG4CylinderGeom_Spacalv3.h"
 
 #include "PHG4CellContainer.h"
 #include "PHG4CellDefs.h"
@@ -18,24 +18,24 @@
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 
-#include <fun4all/Fun4AllBase.h>               // for Fun4AllBase::VERBOSITY...
+#include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY...
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
-#include <fun4all/SubsysReco.h>                // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                      // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                    // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <TAxis.h>                             // for TAxis
+#include <TAxis.h>  // for TAxis
 #include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TObject.h>                           // for TObject
+#include <TObject.h>  // for TObject
 
 #include <boost/foreach.hpp>
 
@@ -45,113 +45,110 @@
 #include <exception>
 #include <iostream>
 #include <sstream>
-#include <utility>                             // for pair
-
+#include <utility>  // for pair
 
 using namespace std;
 
-PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name) :
-  SubsysReco(name),
-  PHParameterInterface(name),
-  sum_energy_g4hit(0),
-  chkenergyconservation(0),
-  tmin(NAN),
-  tmax(NAN),
-  light_collection_model()
+PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+  , sum_energy_g4hit(0)
+  , chkenergyconservation(0)
+  , tmin(NAN)
+  , tmax(NAN)
+  , light_collection_model()
 {
   InitializeParameters();
 }
 
-int
-PHG4FullProjSpacalCellReco::ResetEvent(PHCompositeNode */*topNode*/)
+int PHG4FullProjSpacalCellReco::ResetEvent(PHCompositeNode * /*topNode*/)
 {
   sum_energy_g4hit = 0.;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
+int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
   PHCompositeNode *dstNode;
-  dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
-    {
-      std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
-      exit(1);
-    }
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
   hitnodename = "G4HIT_" + detector;
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "PHG4FullProjSpacalCellReco::InitRun - Could not locate g4 hit node "
-           << hitnodename << endl;
-      topNode->print();
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::InitRun - Could not locate g4 hit node "
+         << hitnodename << endl;
+    topNode->print();
+    exit(1);
+  }
   cellnodename = "G4CELL_" + detector;
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
   if (!cells)
+  {
+    PHNodeIterator dstiter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", detector));
+    if (!DetNode)
     {
-      PHNodeIterator dstiter(dstNode);
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstiter.findFirst("PHCompositeNode", detector));
-      if (!DetNode)
-        {
-          DetNode = new PHCompositeNode(detector);
-          dstNode->addNode(DetNode);
-        }
-      cells = new PHG4CellContainer();
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str(), "PHObject");
-      DetNode->addNode(newNode);
+      DetNode = new PHCompositeNode(detector);
+      dstNode->addNode(DetNode);
     }
+    cells = new PHG4CellContainer();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(cells, cellnodename.c_str(), "PHObject");
+    DetNode->addNode(newNode);
+  }
 
   geonodename = "CYLINDERGEOM_" + detector;
   PHG4CylinderGeomContainer *geo =
       findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
   if (!geo)
-    {
-      cout << "PHG4FullProjSpacalCellReco::InitRun - Could not locate geometry node "
-           << geonodename << endl;
-      topNode->print();
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::InitRun - Could not locate geometry node "
+         << geonodename << endl;
+    topNode->print();
+    exit(1);
+  }
   if (Verbosity() > 0)
-    {
-      cout << "PHG4FullProjSpacalCellReco::InitRun - incoming geometry:"
-           << endl;
-      geo->identify();
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::InitRun - incoming geometry:"
+         << endl;
+    geo->identify();
+  }
   seggeonodename = "CYLINDERCELLGEOM_" + detector;
   PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
   if (!seggeo)
-    {
-      seggeo = new PHG4CylinderCellGeomContainer();
-      PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
-      PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str(), "PHObject");
-      runNode->addNode(newNode);
-    }
+  {
+    seggeo = new PHG4CylinderCellGeomContainer();
+    PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str(), "PHObject");
+    runNode->addNode(newNode);
+  }
 
   const PHG4CylinderGeom *layergeom_raw = geo->GetFirstLayerGeom();
   assert(layergeom_raw);
 
   // a special implimentation of PHG4CylinderGeom is required here.
   const PHG4CylinderGeom_Spacalv3 *layergeom =
-    dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
+      dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
 
   if (!layergeom)
-    {
-      cout << "PHG4FullProjSpacalCellReco::InitRun - Fatal Error -"
-	   << " require to work with a version of SPACAL geometry of PHG4CylinderGeom_Spacalv3 or higher. "
-	   << "However the incoming geometry has version "
-	   << layergeom_raw->ClassName() << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::InitRun - Fatal Error -"
+         << " require to work with a version of SPACAL geometry of PHG4CylinderGeom_Spacalv3 or higher. "
+         << "However the incoming geometry has version "
+         << layergeom_raw->ClassName() << endl;
+    exit(1);
+  }
   if (Verbosity() > 1)
-    {
-      layergeom->identify();
-    }
+  {
+    layergeom->identify();
+  }
 
   layergeom->subtower_consistency_check();
 
@@ -159,7 +156,7 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 
   // create geo object and fill with variables common to all binning methods
   PHG4CylinderCellGeom_Spacalv1 *layerseggeo =
-    new PHG4CylinderCellGeom_Spacalv1();
+      new PHG4CylinderCellGeom_Spacalv1();
   layerseggeo->set_layer(layergeom->get_layer());
   layerseggeo->set_radius(layergeom->get_radius());
   layerseggeo->set_thickness(layergeom->get_thickness());
@@ -167,110 +164,108 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 
   // construct a map to convert tower_ID into the older eta bins.
 
-  const PHG4CylinderGeom_Spacalv3::tower_map_t & tower_map =
-    layergeom->get_sector_tower_map();
-  const PHG4CylinderGeom_Spacalv3::sector_map_t & sector_map =
-    layergeom->get_sector_map();
-  const int nphibin = layergeom->get_azimuthal_n_sec() // sector
-    * layergeom->get_max_phi_bin_in_sec() // blocks per sector
-    * layergeom->get_n_subtower_phi(); // subtower per block
+  const PHG4CylinderGeom_Spacalv3::tower_map_t &tower_map =
+      layergeom->get_sector_tower_map();
+  const PHG4CylinderGeom_Spacalv3::sector_map_t &sector_map =
+      layergeom->get_sector_map();
+  const int nphibin = layergeom->get_azimuthal_n_sec()       // sector
+                      * layergeom->get_max_phi_bin_in_sec()  // blocks per sector
+                      * layergeom->get_n_subtower_phi();     // subtower per block
   const double deltaphi = 2. * M_PI / nphibin;
 
   typedef map<double, int> map_z_tower_z_ID_t;
   map_z_tower_z_ID_t map_z_tower_z_ID;
   double phi_min = NAN;
 
-  BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
+  BOOST_FOREACH (const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type &tower_pair, tower_map)
+  {
+    const int &tower_ID = tower_pair.first;
+    const PHG4CylinderGeom_Spacalv3::geom_tower &tower =
+        tower_pair.second;
+
+    // inspect index in sector 0
+    pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
+
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+
+    if (tower_ID_phi == 0)
     {
+      //assign phi min according phi bin 0
+      phi_min = M_PI_2 - deltaphi * (layergeom->get_max_phi_bin_in_sec() * layergeom->get_n_subtower_phi() / 2)  // shift of first tower in sector
+                + sector_map.begin()->second;
+    }
 
-      const int & tower_ID = tower_pair.first;
-      const PHG4CylinderGeom_Spacalv3::geom_tower & tower =
-	tower_pair.second;
+    if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
+    {
+      //assign eta min according phi bin 0
+      map_z_tower_z_ID[tower.centralZ] = tower_ID_z;
+    }
+    // ...
+  }  //       BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
 
-      // inspect index in sector 0
-      pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
-
-      const int & tower_ID_z = tower_z_phi_ID.first;
-      const int & tower_ID_phi = tower_z_phi_ID.second;
-
-      if (tower_ID_phi == 0)
-	{
-	  //assign phi min according phi bin 0
-	  phi_min = M_PI_2 - deltaphi *(layergeom->get_max_phi_bin_in_sec()* layergeom->get_n_subtower_phi()/2) // shift of first tower in sector
-	    + sector_map.begin()->second;
-	}
-
-      if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
-	{
-	  //assign eta min according phi bin 0
-	  map_z_tower_z_ID[tower.centralZ] = tower_ID_z;
-	}
-      // ...
-    } //       BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
-
-  assert(! std::isnan(phi_min));
+  assert(!std::isnan(phi_min));
   layerseggeo->set_phimin(phi_min);
   layerseggeo->set_phistep(deltaphi);
   layerseggeo->set_phibins(nphibin);
 
   PHG4CylinderCellGeom_Spacalv1::tower_z_ID_eta_bin_map_t tower_z_ID_eta_bin_map;
   int eta_bin = 0;
-  BOOST_FOREACH( map_z_tower_z_ID_t::value_type& z_tower_z_ID, map_z_tower_z_ID)
-    {
-      tower_z_ID_eta_bin_map[z_tower_z_ID.second] = eta_bin;
-      eta_bin++;
-    }
+  BOOST_FOREACH (map_z_tower_z_ID_t::value_type &z_tower_z_ID, map_z_tower_z_ID)
+  {
+    tower_z_ID_eta_bin_map[z_tower_z_ID.second] = eta_bin;
+    eta_bin++;
+  }
   layerseggeo->set_tower_z_ID_eta_bin_map(tower_z_ID_eta_bin_map);
   layerseggeo->set_etabins(eta_bin * layergeom->get_n_subtower_eta());
   layerseggeo->set_etamin(NAN);
   layerseggeo->set_etastep(NAN);
 
   //build eta bin maps
-  BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
+  BOOST_FOREACH (const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type &tower_pair, tower_map)
+  {
+    const int &tower_ID = tower_pair.first;
+    const PHG4CylinderGeom_Spacalv3::geom_tower &tower =
+        tower_pair.second;
+
+    // inspect index in sector 0
+    std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+    const int &etabin = tower_z_ID_eta_bin_map[tower_ID_z];
+
+    if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
     {
+      // half z-range
+      const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
+      const double tower_radial = layergeom->get_tower_radial_position(tower);
 
-      const int & tower_ID = tower_pair.first;
-      const PHG4CylinderGeom_Spacalv3::geom_tower & tower =
-	tower_pair.second;
+      auto z_to_eta = [&tower_radial](const double &z) { return -log(tan(0.5 * atan2(tower_radial, z))); };
 
-      // inspect index in sector 0
-      std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
-      const int & tower_ID_z = tower_z_phi_ID.first;
-      const int & tower_ID_phi = tower_z_phi_ID.second;
-      const int & etabin = tower_z_ID_eta_bin_map[tower_ID_z];
+      const double eta_central = z_to_eta(tower.centralZ);
+      // half eta-range
+      const double deta = (z_to_eta(tower.centralZ + dz) - z_to_eta(tower.centralZ - dz)) / 2;
+      assert(deta > 0);
 
-      if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
-	{
-	  // half z-range
-	  const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
-	  const double tower_radial = layergeom->get_tower_radial_position(tower);
+      for (int sub_tower_ID_y = 0; sub_tower_ID_y < tower.NSubtowerY;
+           ++sub_tower_ID_y)
+      {
+        assert(tower.NSubtowerY <= layergeom->get_n_subtower_eta());
+        // do not overlap to the next bin.
+        const int sub_tower_etabin = etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
 
-	  auto z_to_eta = [&tower_radial](const double &z){return -log(tan(0.5 * atan2(tower_radial, z)));};
+        const pair<double, double> etabounds(eta_central - deta + sub_tower_ID_y * 2 * deta / tower.NSubtowerY,
+                                             eta_central - deta + (sub_tower_ID_y + 1) * 2 * deta / tower.NSubtowerY);
 
-	  const double eta_central = z_to_eta(tower.centralZ);
-	  // half eta-range
-	  const double deta = (z_to_eta( tower.centralZ + dz) - z_to_eta( tower.centralZ - dz))/2;
-	  assert(deta > 0);
+        const pair<double, double> zbounds(tower.centralZ - dz + sub_tower_ID_y * 2 * dz / tower.NSubtowerY,
+                                           tower.centralZ - dz + (sub_tower_ID_y + 1) * 2 * dz / tower.NSubtowerY);
 
-	  for (int sub_tower_ID_y = 0; sub_tower_ID_y < tower.NSubtowerY;
-	       ++sub_tower_ID_y)
-	    {
-	      assert(tower.NSubtowerY <=layergeom->get_n_subtower_eta());
-	      // do not overlap to the next bin.
-	      const int sub_tower_etabin = etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
+        layerseggeo->set_etabounds(sub_tower_etabin, etabounds);
+        layerseggeo->set_zbounds(sub_tower_etabin, zbounds);
 
-	      const pair<double, double>etabounds  (eta_central - deta + sub_tower_ID_y * 2 * deta / tower.NSubtowerY,
-            eta_central - deta + (sub_tower_ID_y + 1) * 2 * deta / tower.NSubtowerY);
-
-	      const pair<double, double>zbounds  (tower.centralZ - dz + sub_tower_ID_y * 2 * dz / tower.NSubtowerY,
-            tower.centralZ - dz + (sub_tower_ID_y + 1) * 2 * dz / tower.NSubtowerY);
-
-	      layerseggeo->set_etabounds(sub_tower_etabin,etabounds);
-	      layerseggeo->set_zbounds(sub_tower_etabin,zbounds);
-
-	      if (Verbosity() >= VERBOSITY_SOME)
-	        {
-	          cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
+        if (Verbosity() >= VERBOSITY_SOME)
+        {
+          cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
                << "\t tower_ID_z = " << tower_ID_z
                << "\t tower_ID_phi = " << tower_ID_phi
                << "\t sub_tower_ID_y = " << sub_tower_ID_y
@@ -279,282 +274,273 @@ PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
                << "\t tower_radial = " << tower_radial
                << "\t eta_central = " << eta_central
                << "\t deta = " << deta
-               << "\t etabounds = [" <<etabounds.first << ", " << etabounds.second<<"]"
-               << "\t zbounds = [" <<zbounds.first << ", " << zbounds.second<<"]"
-               <<endl;
-	        }
+               << "\t etabounds = [" << etabounds.first << ", " << etabounds.second << "]"
+               << "\t zbounds = [" << zbounds.first << ", " << zbounds.second << "]"
+               << endl;
+        }
+      }
+    }
+    // ...
+  }  //       BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
 
-	    }
-
-	}
-      // ...
-    } //       BOOST_FOREACH(const PHG4CylinderGeom_Spacalv3::tower_map_t::value_type& tower_pair, tower_map)
-
-      // add geo object filled by different binning methods
+  // add geo object filled by different binning methods
   seggeo->AddLayerCellGeom(layerseggeo);
   if (Verbosity() >= VERBOSITY_SOME)
-    {
-      cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
-	   << " - Done layer" << (layergeom->get_layer())
-	   << ". Print out the cell geometry:" << endl;
-      layerseggeo->identify();
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::InitRun::" << Name()
+         << " - Done layer" << (layergeom->get_layer())
+         << ". Print out the cell geometry:" << endl;
+    layerseggeo->identify();
+  }
   UpdateParametersWithMacro();
   // save this to the run wise tree to store on DST
-  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN" ));
-  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "PAR" ));
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
   PHNodeIterator runIter(runNode);
-  PHCompositeNode *RunDetNode =  dynamic_cast<PHCompositeNode*>(runIter.findFirst("PHCompositeNode",detector));
-  if (! RunDetNode)
-    {
-      RunDetNode = new PHCompositeNode(detector);
-      runNode->addNode(RunDetNode);
-    }
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
   string paramnodename = "G4CELLPARAM_" + detector;
-  SaveToNodeTree(RunDetNode,paramnodename);
+  SaveToNodeTree(RunDetNode, paramnodename);
   // save this to the parNode for use
   PHNodeIterator parIter(parNode);
-  PHCompositeNode *ParDetNode =  dynamic_cast<PHCompositeNode*>(parIter.findFirst("PHCompositeNode",detector));
-  if (! ParDetNode)
-    {
-      ParDetNode = new PHCompositeNode(detector);
-      parNode->addNode(ParDetNode);
-    }
+  PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+  if (!ParDetNode)
+  {
+    ParDetNode = new PHCompositeNode(detector);
+    parNode->addNode(ParDetNode);
+  }
   std::string cellgeonodename = "G4CELLGEO_" + detector;
-  PutOnParNode(ParDetNode,cellgeonodename);
+  PutOnParNode(ParDetNode, cellgeonodename);
   tmin = get_double_param("tmin");
   tmax = get_double_param("tmax");
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
+int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 {
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hit)
-    {
-      cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - Could not locate g4 hit node "
-           << hitnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - Could not locate g4 hit node "
+         << hitnodename << endl;
+    exit(1);
+  }
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
   if (!cells)
-    {
-      cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - could not locate cell node "
-           << cellnodename << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - could not locate cell node "
+         << cellnodename << endl;
+    exit(1);
+  }
 
   PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
   if (!seggeo)
-    {
-      cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - could not locate cell geometry node "
-           << seggeonodename << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - could not locate cell geometry node "
+         << seggeonodename << endl;
+    exit(1);
+  }
 
   PHG4CylinderGeomContainer *layergeo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
   if (!layergeo)
-    {
-      cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - Could not locate sim geometry node "
-           << geonodename << endl;
-      exit(1);
-    }
+  {
+    cout << "PHG4FullProjSpacalCellReco::process_event - Fatal Error - Could not locate sim geometry node "
+         << geonodename << endl;
+    exit(1);
+  }
 
-    
   PHG4HitContainer::ConstIterator hiter;
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
 
   PHG4CylinderCellGeom *geo_raw = seggeo->GetFirstLayerCellGeom();
-  PHG4CylinderCellGeom_Spacalv1 * geo = dynamic_cast<PHG4CylinderCellGeom_Spacalv1 *>(geo_raw);
+  PHG4CylinderCellGeom_Spacalv1 *geo = dynamic_cast<PHG4CylinderCellGeom_Spacalv1 *>(geo_raw);
   assert(geo);
   const PHG4CylinderGeom *layergeom_raw = layergeo->GetFirstLayerGeom();
   assert(layergeom_raw);
   // a special implimentation of PHG4CylinderGeom is required here.
   const PHG4CylinderGeom_Spacalv3 *layergeom =
-    dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
+      dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
   assert(layergeom);
 
   for (hiter = hit_begin_end.first; hiter != hit_begin_end.second; ++hiter)
+  {
+    // checking ADC timing integration window cut
+    if (hiter->second->get_t(0) > tmax) continue;
+    if (hiter->second->get_t(1) < tmin) continue;
+
+    sum_energy_g4hit += hiter->second->get_edep();
+
+    // hit loop
+    int scint_id = hiter->second->get_scint_id();
+
+    // decode scint_id
+    PHG4CylinderGeom_Spacalv3::scint_id_coder decoder(scint_id);
+
+    // convert to z_ID, phi_ID
+    std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(decoder.tower_ID, decoder.sector_ID);
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+
+    PHG4CylinderGeom_Spacalv3::tower_map_t::const_iterator it_tower =
+        layergeom->get_sector_tower_map().find(decoder.tower_ID);
+    assert(it_tower != layergeom->get_sector_tower_map().end());
+
+    unsigned int key = static_cast<unsigned int>(scint_id);
+    PHG4Cell *cell = nullptr;
+    map<unsigned int, PHG4Cell *>::iterator it = celllist.find(key);
+    if (it != celllist.end())
     {
-      // checking ADC timing integration window cut
-      if (hiter->second->get_t(0)>tmax) continue;
-      if (hiter->second->get_t(1)<tmin) continue;
+      cell = it->second;
+    }
+    else
+    {
+      // convert tower_ID_z to to eta bin number
+      int etabin = -1;
+      try
+      {
+        etabin = geo->get_etabin_block(tower_ID_z);  // block eta bin
+      }
+      catch (exception &e)
+      {
+        cout << "Print cell geometry:" << endl;
+        geo->identify();
+        cout << "Print scint_id_coder:" << endl;
+        decoder.identify();
+        cout << "Print the hit:" << endl;
+        hiter->second->print();
+        cout << "PHG4FullProjSpacalCellReco::process_event::"
+             << Name() << " - Fatal Error - " << e.what() << endl;
+        exit(1);
+      }
 
-      sum_energy_g4hit += hiter->second->get_edep();
+      const int sub_tower_ID_x = it_tower->second.get_sub_tower_ID_x(decoder.fiber_ID);
+      const int sub_tower_ID_y = it_tower->second.get_sub_tower_ID_y(decoder.fiber_ID);
+      unsigned short fiber_ID = decoder.fiber_ID;
+      unsigned short etabinshort = etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
+      unsigned short phibin = tower_ID_phi * layergeom->get_n_subtower_phi() + sub_tower_ID_x;
+      PHG4CellDefs::keytype cellkey = PHG4CellDefs::SpacalBinning::genkey(etabinshort, phibin, fiber_ID);
+      cell = new PHG4Cellv1(cellkey);
+      celllist[key] = cell;
+    }
 
-      // hit loop
-      int scint_id = hiter->second->get_scint_id();
+    double light_yield = hiter->second->get_light_yield();
 
-      // decode scint_id
-      PHG4CylinderGeom_Spacalv3::scint_id_coder decoder(scint_id);
+    // light yield correction from fiber attenuation:
+    if (light_collection_model.use_fiber_model())
+    {
+      const double z = 0.5 * (hiter->second->get_local_z(0) + hiter->second->get_local_z(1));
+      assert(not std::isnan(z));
 
-      // convert to z_ID, phi_ID
-      std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(decoder.tower_ID, decoder.sector_ID);
-      const int & tower_ID_z = tower_z_phi_ID.first;
-      const int & tower_ID_phi = tower_z_phi_ID.second;
+      light_yield *= light_collection_model.get_fiber_transmission(z);
+    }
 
-      PHG4CylinderGeom_Spacalv3::tower_map_t::const_iterator it_tower =
-	layergeom->get_sector_tower_map().find(decoder.tower_ID);
-      assert(it_tower != layergeom->get_sector_tower_map().end());
+    // light yield correction from light guide collection efficiency:
+    if (light_collection_model.use_fiber_model())
+    {
+      const double x = it_tower->second.get_position_fraction_x_in_sub_tower(decoder.fiber_ID);
+      const double y = it_tower->second.get_position_fraction_y_in_sub_tower(decoder.fiber_ID);
 
-      unsigned int key = static_cast<unsigned int>(scint_id);
-      PHG4Cell *cell = nullptr;
-      map<unsigned int, PHG4Cell *>::iterator it = celllist.find(key);
-      if (it != celllist.end())
-	{
-	  cell = it->second;
-	}
-      else
-	{
+      light_yield *= light_collection_model.get_light_guide_efficiency(x, y);
+    }
 
-	  // convert tower_ID_z to to eta bin number
-	  int etabin = -1;
-	  try
-	    {
-	      etabin = geo->get_etabin_block(tower_ID_z); // block eta bin
-	    }
-	  catch (exception & e)
-	    {
-	      cout << "Print cell geometry:" << endl;
-	      geo->identify();
-	      cout << "Print scint_id_coder:" << endl;
-	      decoder.identify();
-	      cout << "Print the hit:" << endl;
-	      hiter->second->print();
-	      cout << "PHG4FullProjSpacalCellReco::process_event::"
-		   << Name() << " - Fatal Error - " << e.what() << endl;
-	      exit(1);
-	    }
+    cell->add_edep(hiter->first, hiter->second->get_edep());
+    cell->add_edep(hiter->second->get_edep());
+    cell->add_light_yield(light_yield);
+    cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
 
-	  const int sub_tower_ID_x = it_tower->second.get_sub_tower_ID_x(decoder.fiber_ID);
-	  const int sub_tower_ID_y = it_tower->second.get_sub_tower_ID_y(decoder.fiber_ID);
-	  unsigned short fiber_ID = decoder.fiber_ID;
-	  unsigned short etabinshort  =  etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
-	  unsigned short phibin = tower_ID_phi * layergeom->get_n_subtower_phi() + sub_tower_ID_x;
-	  PHG4CellDefs::keytype cellkey = PHG4CellDefs::SpacalBinning::genkey(etabinshort,phibin,fiber_ID);
-	  cell = new PHG4Cellv1(cellkey);
-	  celllist[key] = cell;
-	}
-
-      double light_yield = hiter->second->get_light_yield();
-
-      // light yield correction from fiber attenuation:
-      if (light_collection_model.use_fiber_model())
-	{
-	  const double z = 0.5
-	    * (hiter->second->get_local_z(0)
-	       + hiter->second->get_local_z(1));
-	  assert(not std::isnan(z));
-
-	  light_yield *= light_collection_model.get_fiber_transmission(z);
-	}
-
-      // light yield correction from light guide collection efficiency:
-      if (light_collection_model.use_fiber_model())
-	{
-	  const double x = it_tower->second.get_position_fraction_x_in_sub_tower(decoder.fiber_ID);
-	  const double y = it_tower->second.get_position_fraction_y_in_sub_tower(decoder.fiber_ID);
-
-	  light_yield *= light_collection_model.get_light_guide_efficiency(x, y);
-	}
-
-      cell->add_edep(hiter->first, hiter->second->get_edep());
-      cell->add_edep(hiter->second->get_edep());
-      cell->add_light_yield(light_yield);
-      cell->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
-
-    } // end loop over g4hits
+  }  // end loop over g4hits
   int numcells = 0;
   for (map<unsigned int, PHG4Cell *>::const_iterator mapiter =
-	 celllist.begin(); mapiter != celllist.end(); ++mapiter)
-    {
-      cells->AddCell(mapiter->second);
-      numcells++;
-      if (Verbosity() > 1)
-	{
-	  cout << "PHG4FullProjSpacalCellReco::process_event::" << Name()
-	       << " - " << "Adding cell in bin eta "
-	       << PHG4CellDefs::SpacalBinning::get_etabin(mapiter->second->get_cellid()) 
-	       << " phi "
-	       << PHG4CellDefs::SpacalBinning::get_phibin(mapiter->second->get_cellid()) 
-	       << " fiber "
-	       << PHG4CellDefs::SpacalBinning::get_fiberid(mapiter->second->get_cellid()) 
-	       << ", energy dep: "
-	       << mapiter->second->get_edep() << ", light yield: "
-	       << mapiter->second->get_light_yield() << endl;
-	}
-    }
-  celllist.clear();
-  if (Verbosity() > 0)
+           celllist.begin();
+       mapiter != celllist.end(); ++mapiter)
+  {
+    cells->AddCell(mapiter->second);
+    numcells++;
+    if (Verbosity() > 1)
     {
       cout << "PHG4FullProjSpacalCellReco::process_event::" << Name()
-	   << " - " << " found " << numcells
-	   << " fibers with energy deposition" << endl;
+           << " - "
+           << "Adding cell in bin eta "
+           << PHG4CellDefs::SpacalBinning::get_etabin(mapiter->second->get_cellid())
+           << " phi "
+           << PHG4CellDefs::SpacalBinning::get_phibin(mapiter->second->get_cellid())
+           << " fiber "
+           << PHG4CellDefs::SpacalBinning::get_fiberid(mapiter->second->get_cellid())
+           << ", energy dep: "
+           << mapiter->second->get_edep() << ", light yield: "
+           << mapiter->second->get_light_yield() << endl;
     }
-    
+  }
+  celllist.clear();
+  if (Verbosity() > 0)
+  {
+    cout << "PHG4FullProjSpacalCellReco::process_event::" << Name()
+         << " - "
+         << " found " << numcells
+         << " fibers with energy deposition" << endl;
+  }
 
   if (chkenergyconservation || Verbosity() > 4)
-    {
-      CheckEnergy(topNode);
-    }
+  {
+    CheckEnergy(topNode);
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int
-PHG4FullProjSpacalCellReco::CheckEnergy(PHCompositeNode *topNode)
+int PHG4FullProjSpacalCellReco::CheckEnergy(PHCompositeNode *topNode)
 {
   PHG4CellContainer *cells = findNode::getClass<PHG4CellContainer>(topNode, cellnodename);
   double sum_energy_cells = 0.;
   PHG4CellContainer::ConstRange cell_begin_end = cells->getCells();
   PHG4CellContainer::ConstIterator citer;
   for (citer = cell_begin_end.first; citer != cell_begin_end.second; ++citer)
-    {
-      sum_energy_cells += citer->second->get_edep();
-
-    }
+  {
+    sum_energy_cells += citer->second->get_edep();
+  }
   // the fractional eloss for particles traversing eta bins leads to minute rounding errors
   if (fabs(sum_energy_cells - sum_energy_g4hit) / sum_energy_g4hit > 1e-6)
-    {
-      cout
-          << "PHG4FullProjSpacalCellReco::CheckEnergy - energy mismatch between cells: "
-          << sum_energy_cells << " and hits: " << sum_energy_g4hit
-          << " diff sum(cells) - sum(hits): "
-          << sum_energy_cells - sum_energy_g4hit << endl;
-      return -1;
-    }
+  {
+    cout
+        << "PHG4FullProjSpacalCellReco::CheckEnergy - energy mismatch between cells: "
+        << sum_energy_cells << " and hits: " << sum_energy_g4hit
+        << " diff sum(cells) - sum(hits): "
+        << sum_energy_cells - sum_energy_g4hit << endl;
+    return -1;
+  }
   else
+  {
+    if (Verbosity() > 0)
     {
-      if (Verbosity() > 0)
-        {
-          cout << "PHG4FullProjSpacalCellReco::CheckEnergy::" << Name()
-              << " - total energy for this event: " << sum_energy_g4hit
-              << " GeV. Passed CheckEnergy" << endl;
-        }
+      cout << "PHG4FullProjSpacalCellReco::CheckEnergy::" << Name()
+           << " - total energy for this event: " << sum_energy_g4hit
+           << " GeV. Passed CheckEnergy" << endl;
     }
+  }
   return 0;
 }
 
-PHG4FullProjSpacalCellReco::LightCollectionModel::LightCollectionModel() :
-    data_grid_light_guide_efficiency(nullptr), 
-    data_grid_fiber_trans(nullptr)
+PHG4FullProjSpacalCellReco::LightCollectionModel::LightCollectionModel()
+  : data_grid_light_guide_efficiency(nullptr)
+  , data_grid_fiber_trans(nullptr)
 {
-
   data_grid_light_guide_efficiency_verify = new TH2F("data_grid_light_guide_efficiency_verify",
-      "light collection efficiency as used in PHG4FullProjSpacalCellReco::LightCollectionModel;x positio fraction;y position fraction", //
-      100, 0., 1., 100, 0., 1.);
+                                                     "light collection efficiency as used in PHG4FullProjSpacalCellReco::LightCollectionModel;x positio fraction;y position fraction",  //
+                                                     100, 0., 1., 100, 0., 1.);
 
   data_grid_fiber_trans_verify = new TH1F("data_grid_fiber_trans",
-      "SCSF-78 Fiber Transmission as used in PHG4FullProjSpacalCellReco::LightCollectionModel;position in fiber (cm);Effective transmission",
-      100, -15, 15);
+                                          "SCSF-78 Fiber Transmission as used in PHG4FullProjSpacalCellReco::LightCollectionModel;position in fiber (cm);Effective transmission",
+                                          100, -15, 15);
 
   // register histograms
   Fun4AllServer *se = Fun4AllServer::instance();
 
   se->registerHisto(data_grid_light_guide_efficiency_verify);
   se->registerHisto(data_grid_fiber_trans_verify);
-
 }
 
 PHG4FullProjSpacalCellReco::LightCollectionModel::~LightCollectionModel()
@@ -563,13 +549,12 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::~LightCollectionModel()
   delete data_grid_fiber_trans;
 }
 
-void
-PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_file(
-    const std::string & input_file,
-    const std::string & histogram_light_guide_model,
-    const std::string & histogram_fiber_model)
+void PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_file(
+    const std::string &input_file,
+    const std::string &histogram_light_guide_model,
+    const std::string &histogram_fiber_model)
 {
-  TFile * fin = TFile::Open(input_file.c_str());
+  TFile *fin = TFile::Open(input_file.c_str());
 
   assert(fin);
   assert(fin->IsOpen());
@@ -597,13 +582,13 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::get_light_guide_efficiency(con
   assert(y_fraction <= 1);
 
   const double eff = data_grid_light_guide_efficiency->Interpolate(x_fraction,
-      y_fraction);
+                                                                   y_fraction);
 
-  data_grid_light_guide_efficiency_verify->SetBinContent( //
-      data_grid_light_guide_efficiency_verify->GetXaxis()->FindBin(x_fraction), //
-      data_grid_light_guide_efficiency_verify->GetYaxis()->FindBin(y_fraction), //
-      eff //
-      );
+  data_grid_light_guide_efficiency_verify->SetBinContent(                        //
+      data_grid_light_guide_efficiency_verify->GetXaxis()->FindBin(x_fraction),  //
+      data_grid_light_guide_efficiency_verify->GetYaxis()->FindBin(y_fraction),  //
+      eff                                                                        //
+  );
 
   return eff;
 }
@@ -615,25 +600,23 @@ PHG4FullProjSpacalCellReco::LightCollectionModel::get_fiber_transmission(const d
 
   const double eff = data_grid_fiber_trans->Interpolate(z_distance);
 
-  data_grid_fiber_trans_verify->SetBinContent( //
-      data_grid_fiber_trans_verify->GetXaxis()->FindBin(z_distance), //
-      eff //
-      );
+  data_grid_fiber_trans_verify->SetBinContent(                        //
+      data_grid_fiber_trans_verify->GetXaxis()->FindBin(z_distance),  //
+      eff                                                             //
+  );
 
   return eff;
 }
 
-void
-PHG4FullProjSpacalCellReco::SetDefaultParameters()
+void PHG4FullProjSpacalCellReco::SetDefaultParameters()
 {
-  set_default_double_param("tmax",60.0);
-  set_default_double_param("tmin",-20.0); // collision has a timing spread around the triggered event. Accepting negative time too.
+  set_default_double_param("tmax", 60.0);
+  set_default_double_param("tmin", -20.0);  // collision has a timing spread around the triggered event. Accepting negative time too.
   return;
 }
 
-void
-PHG4FullProjSpacalCellReco::set_timing_window(const double tmi, const double tma)
+void PHG4FullProjSpacalCellReco::set_timing_window(const double tmi, const double tma)
 {
-  set_double_param("tmin",tmi);
-  set_double_param("tmax",tma);
+  set_double_param("tmin", tmi);
+  set_double_param("tmax", tma);
 }

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -15,45 +15,44 @@ class PHG4Cell;
 class TH2;
 class TH1;
 
-class PHG4FullProjSpacalCellReco : public SubsysReco,  public PHParameterInterface
+class PHG4FullProjSpacalCellReco : public SubsysReco, public PHParameterInterface
 {
  public:
-
   PHG4FullProjSpacalCellReco(const std::string &name = "HCALCELLRECO");
 
-  ~PHG4FullProjSpacalCellReco() override{}
-  
+  ~PHG4FullProjSpacalCellReco() override {}
+
   //! module initialization
   int InitRun(PHCompositeNode *topNode) override;
-  
-    //! event processing
+
+  //! event processing
   int process_event(PHCompositeNode *topNode) override;
 
-  //! reset after event processing  
+  //! reset after event processing
   int ResetEvent(PHCompositeNode *topNode) override;
 
   void SetDefaultParameters() override;
 
-  void Detector(const std::string &d) {detector = d;}
+  void Detector(const std::string &d) { detector = d; }
 
-  void checkenergy(const int i=1) {chkenergyconservation = i;}
+  void checkenergy(const int i = 1) { chkenergyconservation = i; }
 
-  void   set_timing_window(const double tmin, const double tmax);
+  void set_timing_window(const double tmin, const double tmax);
 
   class LightCollectionModel
   {
-  public:
+   public:
     LightCollectionModel();
     virtual ~LightCollectionModel();
 
     //! input data file
-    void load_data_file(const std::string & input_file, const std::string & histogram_light_guide_model, const std::string & histogram_fiber_model);
+    void load_data_file(const std::string &input_file, const std::string &histogram_light_guide_model, const std::string &histogram_fiber_model);
 
     //! Whether use light collection model
-    bool use_light_guide_model() const {return data_grid_light_guide_efficiency != nullptr;}
+    bool use_light_guide_model() const { return data_grid_light_guide_efficiency != nullptr; }
 
     //! Whether use Light Transmission Efficiency model for the fiber
-    bool use_fiber_model() const {return data_grid_fiber_trans != nullptr;}
+    bool use_fiber_model() const { return data_grid_fiber_trans != nullptr; }
 
     //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
     double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
@@ -61,22 +60,20 @@ class PHG4FullProjSpacalCellReco : public SubsysReco,  public PHParameterInterfa
     //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber. Z=0 is at the middle of the fiber
     double get_fiber_transmission(const double z_distance);
 
-  private:
+   private:
     //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
-    TH2 * data_grid_light_guide_efficiency;
+    TH2 *data_grid_light_guide_efficiency;
 
     //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to location in the fiber. Z=0 is at the middle of the fiber
-    TH1 * data_grid_fiber_trans;
+    TH1 *data_grid_fiber_trans;
 
-    TH2 * data_grid_light_guide_efficiency_verify;
-    TH1 * data_grid_fiber_trans_verify;
-
+    TH2 *data_grid_light_guide_efficiency_verify;
+    TH1 *data_grid_fiber_trans_verify;
   };
 
-  LightCollectionModel & get_light_collection_model() {return light_collection_model;}
+  LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
  protected:
-
   int CheckEnergy(PHCompositeNode *topNode);
 
   std::string detector;
@@ -94,7 +91,6 @@ class PHG4FullProjSpacalCellReco : public SubsysReco,  public PHParameterInterfa
   double tmax;
 
   LightCollectionModel light_collection_model;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -15,7 +15,7 @@
 #include <phool/recoConsts.h>
 
 #include <Geant4/G4Box.hh>
-#include <Geant4/G4Exception.hh>      // for G4Exception, G4ExceptionD
+#include <Geant4/G4Exception.hh>          // for G4Exception, G4ExceptionD
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -110,7 +110,7 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
                                  halfpi - pi / get_geom_v3()->get_azimuthal_n_sec(),
                                  twopi / get_geom_v3()->get_azimuthal_n_sec());
 
-  recoConsts *rc = recoConsts::instance();
+  recoConsts* rc = recoConsts::instance();
   G4Material* cylinder_mat = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   assert(cylinder_mat);
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -28,10 +28,7 @@
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <boost/foreach.hpp>
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -28,7 +28,10 @@
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <boost/foreach.hpp>
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -31,7 +31,10 @@
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <boost/foreach.hpp>
 
@@ -144,9 +147,9 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
   const G4double block_edge1_half_width = enclosure_half_height_half_width - (get_geom_v3()->get_sidewall_thickness() * cm + get_geom_v3()->get_sidewall_outer_torr() * cm + 2.0 * get_geom_v3()->get_assembly_spacing() * cm) / cos(edge1_tilt_angle);
   const G4double block_edge2_half_width = enclosure_half_height_half_width - (get_geom_v3()->get_sidewall_thickness() * cm + get_geom_v3()->get_sidewall_outer_torr() * cm + 2.0 * get_geom_v3()->get_assembly_spacing() * cm) / cos(edge2_tilt_angle);
   G4double block_width_ratio = 0;
-  for (int s = 0; s < phi_bin_in_sec; ++s)
+  for (int n = 0; n < phi_bin_in_sec; ++n)
   {
-    block_width_ratio += 1 / cos(block_azimuth_angle * (0.5 + s) + edge1_tilt_angle);
+    block_width_ratio += 1 / cos(block_azimuth_angle * (0.5 + n) + edge1_tilt_angle);
   }
   const G4double block_half_height_width = (block_edge1_half_width + block_edge2_half_width) / block_width_ratio;
   assert(block_half_height_width > 0);
@@ -167,9 +170,9 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                      numeric_limits<double>::signaling_NaN(),
                                                      numeric_limits<double>::signaling_NaN()});  // [phi-bin in sector] -> azimuth geometry
   G4double block_x_edge1 = block_edge1_half_width;
-  for (int s = 0; s < phi_bin_in_sec; ++s)
+  for (int n = 0; n < phi_bin_in_sec; ++n)
   {
-    block_azimuth_geom& geom = block_azimuth_geoms[s];
+    block_azimuth_geom& geom = block_azimuth_geoms[n];
 
     geom.angle = block_azimuth_angle * (0.5 + s) + edge1_tilt_angle;
     const G4double block_x_size = block_half_height_width / cos(geom.angle);
@@ -208,14 +211,14 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
   if (get_geom_v3()->get_sidewall_thickness() > 0)
   {
-    for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+    for (int n = 0; n < phi_bin_in_sec - 1; ++n)
     {
-      block_divider_azimuth_geom& geom = divider_azimuth_geoms[s];
+      block_divider_azimuth_geom& geom = divider_azimuth_geoms[n];
 
-      geom.angle = 0.5 * (block_azimuth_geoms[s].angle + block_azimuth_geoms[s + 1].angle);
-      geom.projection_center_y = 0.5 * (block_azimuth_geoms[s].projection_center_y + block_azimuth_geoms[s + 1].projection_center_y);
-      geom.projection_center_x = 0.5 * (block_azimuth_geoms[s].projection_center_x + block_azimuth_geoms[s + 1].projection_center_x);
-      geom.radial_displacement = 0.5 * (block_azimuth_geoms[s].projection_length + block_azimuth_geoms[s + 1].projection_length);
+      geom.angle = 0.5 * (block_azimuth_geoms[n].angle + block_azimuth_geoms[n + 1].angle);
+      geom.projection_center_y = 0.5 * (block_azimuth_geoms[n].projection_center_y + block_azimuth_geoms[n + 1].projection_center_y);
+      geom.projection_center_x = 0.5 * (block_azimuth_geoms[n].projection_center_x + block_azimuth_geoms[n + 1].projection_center_x);
+      geom.radial_displacement = 0.5 * (block_azimuth_geoms[n].projection_length + block_azimuth_geoms[n + 1].projection_length);
 
       geom.thickness = 2.0 * get_geom_v3()->get_assembly_spacing() * cm * cos(block_azimuth_angle / 2.) - 2 * um;
       geom.width = get_geom_v3()->get_divider_width() * cm;
@@ -249,20 +252,20 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
          << "\t block_width_ratio = " << block_width_ratio << endl
          << "\t block_half_height_width = " << block_half_height_width << endl;
 
-    for (int s = 0; s < phi_bin_in_sec; ++s)
+    for (int n = 0; n < phi_bin_in_sec; ++n)
     {
-      cout << "\t block[" << s << "].angle = " << block_azimuth_geoms[s].angle << endl;
-      cout << "\t block[" << s << "].projection_center_y = " << block_azimuth_geoms[s].projection_center_y << endl;
-      cout << "\t block[" << s << "].projection_center_x = " << block_azimuth_geoms[s].projection_center_x << endl;
+      cout << "\t block[" << n << "].angle = " << block_azimuth_geoms[n].angle << endl;
+      cout << "\t block[" << n << "].projection_center_y = " << block_azimuth_geoms[n].projection_center_y << endl;
+      cout << "\t block[" << n << "].projection_center_x = " << block_azimuth_geoms[n].projection_center_x << endl;
     }
-    for (int s = 0; s < phi_bin_in_sec - 1; ++s)
+    for (int n = 0; n < phi_bin_in_sec - 1; ++n)
     {
-      cout << "\t divider[" << s << "].angle = " << divider_azimuth_geoms[s].angle << endl;
-      cout << "\t divider[" << s << "].projection_center_x = " << divider_azimuth_geoms[s].projection_center_x << endl;
-      cout << "\t divider[" << s << "].projection_center_y = " << divider_azimuth_geoms[s].projection_center_y << endl;
-      cout << "\t divider[" << s << "].radial_displacement = " << divider_azimuth_geoms[s].radial_displacement << endl;
-      cout << "\t divider[" << s << "].thickness = " << divider_azimuth_geoms[s].thickness << endl;
-      cout << "\t divider[" << s << "].width = " << divider_azimuth_geoms[s].width << endl;
+      cout << "\t divider[" << n << "].angle = " << divider_azimuth_geoms[n].angle << endl;
+      cout << "\t divider[" << n << "].projection_center_x = " << divider_azimuth_geoms[n].projection_center_x << endl;
+      cout << "\t divider[" << n << "].projection_center_y = " << divider_azimuth_geoms[n].projection_center_y << endl;
+      cout << "\t divider[" << n << "].radial_displacement = " << divider_azimuth_geoms[n].radial_displacement << endl;
+      cout << "\t divider[" << n << "].thickness = " << divider_azimuth_geoms[n].thickness << endl;
+      cout << "\t divider[" << n << "].width = " << divider_azimuth_geoms[n].width << endl;
     }
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -17,7 +17,7 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>
-#include <Geant4/G4Exception.hh>          // for G4Exception
+#include <Geant4/G4Exception.hh>  // for G4Exception
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
@@ -144,9 +144,9 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
   const G4double block_edge1_half_width = enclosure_half_height_half_width - (get_geom_v3()->get_sidewall_thickness() * cm + get_geom_v3()->get_sidewall_outer_torr() * cm + 2.0 * get_geom_v3()->get_assembly_spacing() * cm) / cos(edge1_tilt_angle);
   const G4double block_edge2_half_width = enclosure_half_height_half_width - (get_geom_v3()->get_sidewall_thickness() * cm + get_geom_v3()->get_sidewall_outer_torr() * cm + 2.0 * get_geom_v3()->get_assembly_spacing() * cm) / cos(edge2_tilt_angle);
   G4double block_width_ratio = 0;
-  for (int n = 0; n < phi_bin_in_sec; ++n)
+  for (int sa = 0; sa < phi_bin_in_sec; ++sa)
   {
-    block_width_ratio += 1 / cos(block_azimuth_angle * (0.5 + n) + edge1_tilt_angle);
+    block_width_ratio += 1 / cos(block_azimuth_angle * (0.5 + sa) + edge1_tilt_angle);
   }
   const G4double block_half_height_width = (block_edge1_half_width + block_edge2_half_width) / block_width_ratio;
   assert(block_half_height_width > 0);
@@ -167,11 +167,11 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                                      numeric_limits<double>::signaling_NaN(),
                                                      numeric_limits<double>::signaling_NaN()});  // [phi-bin in sector] -> azimuth geometry
   G4double block_x_edge1 = block_edge1_half_width;
-  for (int n = 0; n < phi_bin_in_sec; ++n)
+  for (int sa = 0; sa < phi_bin_in_sec; ++sa)
   {
-    block_azimuth_geom& geom = block_azimuth_geoms[n];
+    block_azimuth_geom& geom = block_azimuth_geoms[sa];
 
-    geom.angle = block_azimuth_angle * (0.5 + s) + edge1_tilt_angle;
+    geom.angle = block_azimuth_angle * (0.5 + sa) + edge1_tilt_angle;
     const G4double block_x_size = block_half_height_width / cos(geom.angle);
     assert(block_x_size > 0);
     const G4double x_center = block_x_edge1 - 0.5 * block_x_size;
@@ -208,14 +208,14 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
 
   if (get_geom_v3()->get_sidewall_thickness() > 0)
   {
-    for (int n = 0; n < phi_bin_in_sec - 1; ++n)
+    for (int sa = 0; sa < phi_bin_in_sec - 1; ++sa)
     {
-      block_divider_azimuth_geom& geom = divider_azimuth_geoms[n];
+      block_divider_azimuth_geom& geom = divider_azimuth_geoms[sa];
 
-      geom.angle = 0.5 * (block_azimuth_geoms[n].angle + block_azimuth_geoms[n + 1].angle);
-      geom.projection_center_y = 0.5 * (block_azimuth_geoms[n].projection_center_y + block_azimuth_geoms[n + 1].projection_center_y);
-      geom.projection_center_x = 0.5 * (block_azimuth_geoms[n].projection_center_x + block_azimuth_geoms[n + 1].projection_center_x);
-      geom.radial_displacement = 0.5 * (block_azimuth_geoms[n].projection_length + block_azimuth_geoms[n + 1].projection_length);
+      geom.angle = 0.5 * (block_azimuth_geoms[sa].angle + block_azimuth_geoms[sa + 1].angle);
+      geom.projection_center_y = 0.5 * (block_azimuth_geoms[sa].projection_center_y + block_azimuth_geoms[sa + 1].projection_center_y);
+      geom.projection_center_x = 0.5 * (block_azimuth_geoms[sa].projection_center_x + block_azimuth_geoms[sa + 1].projection_center_x);
+      geom.radial_displacement = 0.5 * (block_azimuth_geoms[sa].projection_length + block_azimuth_geoms[sa + 1].projection_length);
 
       geom.thickness = 2.0 * get_geom_v3()->get_assembly_spacing() * cm * cos(block_azimuth_angle / 2.) - 2 * um;
       geom.width = get_geom_v3()->get_divider_width() * cm;
@@ -249,20 +249,20 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
          << "\t block_width_ratio = " << block_width_ratio << endl
          << "\t block_half_height_width = " << block_half_height_width << endl;
 
-    for (int n = 0; n < phi_bin_in_sec; ++n)
+    for (int sa = 0; sa < phi_bin_in_sec; ++sa)
     {
-      cout << "\t block[" << n << "].angle = " << block_azimuth_geoms[n].angle << endl;
-      cout << "\t block[" << n << "].projection_center_y = " << block_azimuth_geoms[n].projection_center_y << endl;
-      cout << "\t block[" << n << "].projection_center_x = " << block_azimuth_geoms[n].projection_center_x << endl;
+      cout << "\t block[" << sa << "].angle = " << block_azimuth_geoms[sa].angle << endl;
+      cout << "\t block[" << sa << "].projection_center_y = " << block_azimuth_geoms[sa].projection_center_y << endl;
+      cout << "\t block[" << sa << "].projection_center_x = " << block_azimuth_geoms[sa].projection_center_x << endl;
     }
-    for (int n = 0; n < phi_bin_in_sec - 1; ++n)
+    for (int sa = 0; sa < phi_bin_in_sec - 1; ++sa)
     {
-      cout << "\t divider[" << n << "].angle = " << divider_azimuth_geoms[n].angle << endl;
-      cout << "\t divider[" << n << "].projection_center_x = " << divider_azimuth_geoms[n].projection_center_x << endl;
-      cout << "\t divider[" << n << "].projection_center_y = " << divider_azimuth_geoms[n].projection_center_y << endl;
-      cout << "\t divider[" << n << "].radial_displacement = " << divider_azimuth_geoms[n].radial_displacement << endl;
-      cout << "\t divider[" << n << "].thickness = " << divider_azimuth_geoms[n].thickness << endl;
-      cout << "\t divider[" << n << "].width = " << divider_azimuth_geoms[n].width << endl;
+      cout << "\t divider[" << sa << "].angle = " << divider_azimuth_geoms[sa].angle << endl;
+      cout << "\t divider[" << sa << "].projection_center_x = " << divider_azimuth_geoms[sa].projection_center_x << endl;
+      cout << "\t divider[" << sa << "].projection_center_y = " << divider_azimuth_geoms[sa].projection_center_y << endl;
+      cout << "\t divider[" << sa << "].radial_displacement = " << divider_azimuth_geoms[sa].radial_displacement << endl;
+      cout << "\t divider[" << sa << "].thickness = " << divider_azimuth_geoms[sa].thickness << endl;
+      cout << "\t divider[" << sa << "].width = " << divider_azimuth_geoms[sa].width << endl;
     }
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -17,7 +17,7 @@
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>
-#include <Geant4/G4Exception.hh>  // for G4Exception
+#include <Geant4/G4Exception.hh>          // for G4Exception
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -31,10 +31,7 @@
 #include <Geant4/G4Types.hh>  // for G4double
 #include <Geant4/G4Vector3D.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <boost/foreach.hpp>
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -15,12 +15,11 @@
 #include <g4main/PHG4Utils.h>
 
 #include <phparameter/PHParameters.h>
+
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4GDMLParser.hh>
-#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
@@ -30,6 +29,13 @@
 #include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 #include <Geant4/G4VisAttributes.hh>
+
+// Xerces has shadowed variables
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#include <Geant4/G4GDMLParser.hh>
+#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
+#pragma GCC diagnostic pop
 
 #include <CLHEP/Units/SystemOfUnits.h>  // for cm, degree
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -101,7 +101,7 @@ int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 }
 
 //_______________________________________________________________________
-int PHG4GDMLSubsystem::process_event(PHCompositeNode */*topNode*/)
+int PHG4GDMLSubsystem::process_event(PHCompositeNode * /*topNode*/)
 {
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.h
@@ -28,10 +28,8 @@ class PHG4SteppingAction;
 class PHG4GDMLSubsystem : public PHG4DetectorSubsystem
 {
  public:
-
-  PHG4GDMLSubsystem(const std::string &name);
+  PHG4GDMLSubsystem(const std::string& name);
   ~PHG4GDMLSubsystem() override;
-
 
   /*!
   creates the m_Detector object and place it on the node tree, under "DETECTORS" node (or whatever)
@@ -60,7 +58,6 @@ class PHG4GDMLSubsystem : public PHG4DetectorSubsystem
   //! detector geometry
   /*! derives from PHG4Detector */
   PHG4GDMLDetector* m_Detector;
-
 };
 
 #endif /* PHG4GDMLSUBSYSTEM_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4GenHit.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GenHit.cc
@@ -1,53 +1,53 @@
 #include "PHG4GenHit.h"
-#include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeom.h"
+#include "PHG4CylinderGeomContainer.h"
 
-#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>          // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/getClass.h>
 
 #include <cmath>
-#include <iostream>                      // for operator<<, basic_ostream
+#include <iostream>  // for operator<<, basic_ostream
 
 class PHCompositeNode;
 
 using namespace std;
 
-PHG4GenHit::PHG4GenHit(const string &name):
-  SubsysReco(name),
-  phi(NAN),
-  theta(NAN),
-  eloss(NAN),
-  layer(-9999)
-{}
+PHG4GenHit::PHG4GenHit(const string &name)
+  : SubsysReco(name)
+  , phi(NAN)
+  , theta(NAN)
+  , eloss(NAN)
+  , layer(-9999)
+{
+}
 
-int
-PHG4GenHit::process_event(PHCompositeNode *topNode)
+int PHG4GenHit::process_event(PHCompositeNode *topNode)
 {
   string hitnodename = "G4HIT_" + detector;
   string geonodename = "CYLINDERGEOM_" + detector;
-  PHG4CylinderGeomContainer *geo =  findNode::getClass<PHG4CylinderGeomContainer>(topNode , geonodename.c_str());
-  if (! geo)
-    {
-      cout << "cannot find geo node " << geonodename << endl;
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
-  PHG4HitContainer *hits_ = findNode::getClass<PHG4HitContainer>( topNode , hitnodename.c_str());
-  if (! hits_)
-    {
-      cout << "cannot find hit node " << hitnodename << endl;
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
+  PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
+  if (!geo)
+  {
+    cout << "cannot find geo node " << geonodename << endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+  PHG4HitContainer *hits_ = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  if (!hits_)
+  {
+    cout << "cannot find hit node " << hitnodename << endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
   PHG4CylinderGeom *mygeom = geo->GetLayerGeom(layer);
   double inner_radius = mygeom->get_radius();
   double outer_radius = inner_radius + mygeom->get_thickness();
   PHG4Hit *hit = new PHG4Hitv1();
-  hit->set_layer((unsigned int)layer);
+  hit->set_layer((unsigned int) layer);
   double x0 = inner_radius * cos(phi * M_PI / 180.);
   double y0 = inner_radius * sin(phi * M_PI / 180.);
   double z0 = inner_radius * cos(theta * M_PI / 180.);
@@ -64,13 +64,13 @@ PHG4GenHit::process_event(PHCompositeNode *topNode)
   hit->set_trkid(-1);
   hits_->AddHit(layer, hit);
   if (Verbosity() > 0)
-    {
-  cout << "phi " << phi << " inner rad: " << inner_radius
-       << ", outer rad: " << outer_radius
-       << " x0/y0/z0: " << x0 << "/" << y0 << "/" << z0
-       << " x1/y1/z1: " << x1 << "/" << y1 << "/" << z1
+  {
+    cout << "phi " << phi << " inner rad: " << inner_radius
+         << ", outer rad: " << outer_radius
+         << " x0/y0/z0: " << x0 << "/" << y0 << "/" << z0
+         << " x1/y1/z1: " << x1 << "/" << y1 << "/" << z1
          << " edep: " << eloss
          << endl;
-    }
-    return Fun4AllReturnCodes::EVENT_OK;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4detectors/PHG4GenHit.h
+++ b/simulation/g4simulation/g4detectors/PHG4GenHit.h
@@ -5,11 +5,11 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>                // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 
-class PHG4GenHit: public SubsysReco
+class PHG4GenHit : public SubsysReco
 {
  public:
   PHG4GenHit(const std::string &name = "PHG4GenHit");
@@ -17,11 +17,11 @@ class PHG4GenHit: public SubsysReco
 
   int process_event(PHCompositeNode *topNode) override;
 
-  void set_phi(const double d) {phi = d;}
-  void set_theta(const double d) {theta = d;}
-  void set_eloss(const double d) {eloss = d;}
-  void set_layer(const int i) {layer = i;}
-  void Detector(const std::string &n) {detector = n;}
+  void set_phi(const double d) { phi = d; }
+  void set_theta(const double d) { theta = d; }
+  void set_eloss(const double d) { eloss = d; }
+  void set_layer(const int i) { layer = i; }
+  void Detector(const std::string &n) { detector = n; }
 
  protected:
   double phi;
@@ -29,7 +29,6 @@ class PHG4GenHit: public SubsysReco
   double eloss;
   int layer;
   std::string detector;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -22,7 +22,10 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <array>  // for array, array<>::value_...
 #include <cmath>

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -134,16 +134,16 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
     {
       maxrow = 256;
     }
-    for (int icolumn = 0 ; icolumn <  maxcolumn; icolumn++)
+    for (int icolumn = 0; icolumn < maxcolumn; icolumn++)
     {
       for (int irow = 0; irow < maxrow; irow++)
       {
-      PHG4CellDefs::keytype key = PHG4CellDefs::ScintillatorSlatBinning::genkey(0, icolumn, irow);
-      PHG4Cell *cell = new PHG4Cellv1(key);
-      cell->add_edep(m_FixedEnergy);
-      cell->add_eion(m_FixedEnergy);
-      cell->add_light_yield(m_FixedEnergy);
-      slats->AddCell(cell);
+        PHG4CellDefs::keytype key = PHG4CellDefs::ScintillatorSlatBinning::genkey(0, icolumn, irow);
+        PHG4Cell *cell = new PHG4Cellv1(key);
+        cell->add_edep(m_FixedEnergy);
+        cell->add_eion(m_FixedEnergy);
+        cell->add_light_yield(m_FixedEnergy);
+        slats->AddCell(cell);
       }
     }
     return Fun4AllReturnCodes::EVENT_OK;
@@ -212,7 +212,7 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4HcalCellReco::End(PHCompositeNode */*topNode*/)
+int PHG4HcalCellReco::End(PHCompositeNode * /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -22,10 +22,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <array>  // for array, array<>::value_...
 #include <cmath>

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -35,7 +35,7 @@ class PHG4HcalCellReco : public SubsysReco, public PHParameterInterface
 
   void set_timing_window(const double tmi, const double tma);
 
-  void set_fixed_energy(const double efix) {m_FixedEnergy = efix;}
+  void set_fixed_energy(const double efix) { m_FixedEnergy = efix; }
 
  protected:
   int CheckEnergy(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDefs.h
@@ -15,6 +15,6 @@ namespace PHG4HcalDefs
   static const std::string n_scinti_tiles = "n_scinti_tiles";
   static const std::string n_scinti_tiles_pos = "n_scinti_tiles_pos";
   static const std::string n_scinti_tiles_neg = "n_scinti_tiles_neg";
-}
+}  // namespace PHG4HcalDefs
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -29,10 +29,10 @@
 #include <Geant4/G4TwoVector.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#include <algorithm> // for max
-#include <cmath>     // for sin, cos, sqrt, M_PI, asin
-#include <cstdlib>   // for exit
-#include <iostream>  // for operator<<, basic_ostream
+#include <algorithm>  // for max
+#include <cmath>      // for sin, cos, sqrt, M_PI, asin
+#include <cstdlib>    // for exit
+#include <iostream>   // for operator<<, basic_ostream
 #include <sstream>
 #include <utility>  // for pair
 #include <vector>   // for vector

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -101,23 +101,23 @@ PHG4InnerHcalDetector::PHG4InnerHcalDetector(PHG4Subsystem *subsys, PHCompositeN
   , m_Layer(0)
   , m_ScintiLogicNamePrefix("HcalInnerScinti")
 {
-  
   // n_scinti_tiles takes precedence
 
-  int nTiles = 2 * m_Params->get_int_param(PHG4HcalDefs::n_scinti_tiles); 
-  if(nTiles <= 0){
-    nTiles =  m_NumScintiTilesPos +  m_NumScintiTilesNeg; 
+  int nTiles = 2 * m_Params->get_int_param(PHG4HcalDefs::n_scinti_tiles);
+  if (nTiles <= 0)
+  {
+    nTiles = m_NumScintiTilesPos + m_NumScintiTilesNeg;
   }
-  else{
-    m_NumScintiTilesPos = nTiles/2; 
-    m_Params->set_int_param("n_scinti_tiles_pos", nTiles/2);
-    m_NumScintiTilesNeg = nTiles/2; 
-    m_Params->set_int_param("n_scinti_tiles_neg", nTiles/2);
+  else
+  {
+    m_NumScintiTilesPos = nTiles / 2;
+    m_Params->set_int_param("n_scinti_tiles_pos", nTiles / 2);
+    m_NumScintiTilesNeg = nTiles / 2;
+    m_Params->set_int_param("n_scinti_tiles_neg", nTiles / 2);
   }
 
   // allocate memory for scintillator plates
   m_ScintiTilesVec.assign(nTiles, static_cast<G4VSolid *>(nullptr));
-
 }
 
 PHG4InnerHcalDetector::~PHG4InnerHcalDetector()
@@ -147,7 +147,7 @@ int PHG4InnerHcalDetector::IsInInnerHcal(G4VPhysicalVolume *volume) const
 }
 
 G4VSolid *
-PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*/)
+PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume * /*hcalenvelope*/)
 {
   double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   Point_2 p_in_1(mid_radius, 0);  // center of scintillator
@@ -224,7 +224,7 @@ PHG4InnerHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*
 }
 
 G4VSolid *
-PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
+PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume * /*hcalenvelope*/)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap
@@ -302,7 +302,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
   Point_2 upperright;
   Point_2 mid_upperscint(xmidpoint, ymidpoint);
   Point_2 p_upperedge(xcoordup, ycoordup);
-  Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
+  Line_2 sup(mid_upperscint, p_upperedge);        // center vertical
   Line_2 perpA = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
   Point_2 sc1A(m_InnerRadius, 0), sc2A(0, m_InnerRadius), sc3A(-m_InnerRadius, 0);
   Circle_2 inner_circleA(sc1A, sc2A, sc3A);
@@ -317,9 +317,9 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
     {
       if (CGAL::to_double(point->first.x()) > pxmax)
       {
-	pxmax = CGAL::to_double(point->first.x());
-	Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	upperleft = pntmp;
+        pxmax = CGAL::to_double(point->first.x());
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperleft = pntmp;
       }
     }
     else
@@ -331,7 +331,7 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
   double xcoordup2 = xmidpoint - m_ScintiOuterGap / 2. * sin(angle_mid_scinti / rad);
   double ycoordup2 = ymidpoint - m_ScintiOuterGap / 2. * cos(angle_mid_scinti / rad);
   Point_2 p_upperedge2(xcoordup2, ycoordup2);
-  Line_2 sup2(mid_upperscint, p_upperedge2);        // center vertical
+  Line_2 sup2(mid_upperscint, p_upperedge2);         // center vertical
   Line_2 perpA2 = sup2.perpendicular(p_upperedge2);  // that is the upper edge of the steel plate
 
   Point_2 so1A(m_OuterRadius, 0), so2A(0, m_OuterRadius), so3A(-m_OuterRadius, 0);
@@ -345,8 +345,8 @@ PHG4InnerHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
       {
-	Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	upperright = pntmp;
+        Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
       }
     }
     else
@@ -429,7 +429,7 @@ void PHG4InnerHcalDetector::ShiftSecantToTangent(Point_2 &lowleft, Point_2 &uple
 // actual inner hcal construction
 void PHG4InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
-  recoConsts* rc = recoConsts::instance();
+  recoConsts *rc = recoConsts::instance();
   G4Material *Air = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
@@ -584,8 +584,9 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
 
   // eta->theta
   // scinti_eta_coverage takes precedence
-  G4double eta_cov = m_Params->get_double_param("scinti_eta_coverage"); 
-  if(eta_cov>0){
+  G4double eta_cov = m_Params->get_double_param("scinti_eta_coverage");
+  if (eta_cov > 0)
+  {
     m_Params->set_double_param("scinti_eta_coverage_pos", eta_cov);
     m_Params->set_double_param("scinti_eta_coverage_neg", eta_cov);
   }
@@ -609,15 +610,15 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
   {
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[0] = m_InnerRadius - overhang;
-    z[0] = tan(theta) * m_InnerRadius; 
+    z[0] = tan(theta) * m_InnerRadius;
     x[1] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[1] = tan(theta) * m_OuterRadius; 
+    z[1] = tan(theta) * m_OuterRadius;
     eta += delta_eta_pos;
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[2] = m_InnerRadius - overhang;
-    z[2] = tan(theta) * m_InnerRadius; 
+    z[2] = tan(theta) * m_InnerRadius;
     x[3] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[3] = tan(theta) * m_OuterRadius; 
+    z[3] = tan(theta) * m_OuterRadius;
     // apply gap between scintillators
     z[0] += scinti_gap_neighbor / 2.;
     z[1] += scinti_gap_neighbor / 2.;
@@ -656,23 +657,22 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
     G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, -m_Params->get_double_param("place_z") * cm));
     delete rotm;
     m_ScintiTilesVec[i + m_NumScintiTilesNeg] = scinti_tile;
-
   }
-  
-  eta = 0.0; // reset
+
+  eta = 0.0;  // reset
   for (int i = 0; i < m_NumScintiTilesNeg; i++)
   {
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[0] = m_InnerRadius - overhang;
-    z[0] = tan(theta) * m_InnerRadius; 
+    z[0] = tan(theta) * m_InnerRadius;
     x[1] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[1] = tan(theta) * m_OuterRadius; 
+    z[1] = tan(theta) * m_OuterRadius;
     eta += delta_eta_neg;
     theta = M_PI / 2 - PHG4Utils::get_theta(eta);  // theta = 90 for eta=0
     x[2] = m_InnerRadius - overhang;
-    z[2] = tan(theta) * m_InnerRadius; 
+    z[2] = tan(theta) * m_InnerRadius;
     x[3] = m_OuterRadius + overhang;  // since the tile is tilted, x is not at the outer radius but beyond
-    z[3] = tan(theta) * m_OuterRadius; 
+    z[3] = tan(theta) * m_OuterRadius;
     // apply gap between scintillators
     z[0] += scinti_gap_neighbor / 2.;
     z[1] += scinti_gap_neighbor / 2.;
@@ -712,7 +712,6 @@ void PHG4InnerHcalDetector::ConstructHcalSingleScintillators(G4LogicalVolume *hc
     G4VSolid *scinti_tile = new G4IntersectionSolid(name.str(), bigtile, scinti, rotm, G4ThreeVector(-(m_InnerRadius + m_OuterRadius) / 2., 0, -m_Params->get_double_param("place_z") * cm));
     m_ScintiTilesVec[m_NumScintiTilesNeg - i - 1] = scinti_tile;
     delete rotm;
-
   }
 
   // for (unsigned int i=0; i<m_ScintiTilesVec.size(); i++)

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -14,10 +14,7 @@
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
@@ -39,6 +36,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Exact_circular_kernel_2.h>

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -7,7 +7,6 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wc11-extensions"
 #include <CGAL/Cartesian.h>  // for Cartesian_base_ref_count::...
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/Point_2.h>  // for Point_2

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.h
@@ -5,9 +5,13 @@
 
 #include <g4main/PHG4Detector.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wc11-extensions"
 #include <CGAL/Cartesian.h>  // for Cartesian_base_ref_count::...
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/Point_2.h>  // for Point_2
+#pragma GCC diagnostic pop
 
 #include <map>
 #include <set>

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDisplayAction.cc
@@ -25,7 +25,7 @@ PHG4InnerHcalDisplayAction::~PHG4InnerHcalDisplayAction()
   m_ScintiLogVolSet.clear();
 }
 
-void PHG4InnerHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4InnerHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   for (auto &it : m_ScintiLogVolSet)
   {

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -9,7 +9,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
@@ -22,23 +22,23 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cmath>                               // for isfinite
+#include <cmath>  // for isfinite
 #include <iostream>
-#include <string>                              // for operator<<, operator+
-#include <utility>                             // for pair
+#include <string>   // for operator<<, operator+
+#include <utility>  // for pair
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -14,10 +14,7 @@
 
 #include <phool/getClass.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -14,7 +14,10 @@
 
 #include <phool/getClass.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -7,21 +7,21 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4DisplayAction.h>     // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>    // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>           // for PHIODataNode
-#include <phool/PHNode.h>                 // for PHNode
-#include <phool/PHNodeIterator.h>         // for PHNodeIterator
-#include <phool/PHObject.h>               // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <cmath>                         // for NAN
-#include <iostream>                       // for operator<<, basic_ostream
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic_ostream
 #include <set>
 #include <sstream>
 

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.h
@@ -60,7 +60,6 @@ class PHG4InnerHcalSubsystem : public PHG4DetectorSubsystem
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction* m_DisplayAction;
-
 };
 
 #endif  // G4DETECTORS_PHG4INNERHCALSUBSYSTEM_H

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -14,7 +14,10 @@
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
@@ -35,11 +38,14 @@
 #include <Geant4/G4VPhysicalVolume.hh>
 #include <Geant4/G4VSolid.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/Object.h>
 #include <CGAL/point_generators_2.h>
+#pragma GCC diagnostic pop
 
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
@@ -278,51 +284,49 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
   PHG4OuterHcalDetector::Point_2 upperright;
   PHG4OuterHcalDetector::Point_2 mid_upperscint(xmidpoint, ymidpoint);
   PHG4OuterHcalDetector::Point_2 p_upperedge(xcoordup, ycoordup);
+  Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
+  Line_2 perpA = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
+  PHG4OuterHcalDetector::Point_2 sc1A(m_InnerRadius, 0), sc2A(0, m_InnerRadius), sc3A(-m_InnerRadius, 0);
+  Circle_2 inner_circleA(sc1A, sc2A, sc3A);
+  vector<CGAL::Object> resA;
+  CGAL::intersection(inner_circleA, perpA, std::back_inserter(resA));
+  vector<CGAL::Object>::const_iterator iterA;
+  double pxmax = 0.;
+  for (iterA = resA.begin(); iterA != resA.end(); ++iterA)
   {
-    Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
-    Line_2 perp = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
-    PHG4OuterHcalDetector::Point_2 sc1(m_InnerRadius, 0), sc2(0, m_InnerRadius), sc3(-m_InnerRadius, 0);
-    Circle_2 inner_circle(sc1, sc2, sc3);
-    vector<CGAL::Object> res;
-    CGAL::intersection(inner_circle, perp, std::back_inserter(res));
-    vector<CGAL::Object>::const_iterator iter;
-    double pxmax = 0.;
-    for (iter = res.begin(); iter != res.end(); ++iter)
+    CGAL::Object obj = *iterA;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
+      if (CGAL::to_double(point->first.x()) > pxmax)
       {
-        if (CGAL::to_double(point->first.x()) > pxmax)
-        {
-          pxmax = CGAL::to_double(point->first.x());
-          PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-          upperleft = pntmp;
-        }
-      }
-      else
-      {
-        cout << "CGAL::Object type not pair..." << endl;
+	pxmax = CGAL::to_double(point->first.x());
+	PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+	upperleft = pntmp;
       }
     }
-    PHG4OuterHcalDetector::Point_2 so1(m_OuterRadius, 0), so2(0, m_OuterRadius), so3(-m_OuterRadius, 0);
-    Circle_2 outer_circle(so1, so2, so3);
-    res.clear();  // just clear the content from the last intersection search
-    CGAL::intersection(outer_circle, perp, std::back_inserter(res));
-    for (iter = res.begin(); iter != res.end(); ++iter)
+    else
     {
-      CGAL::Object obj = *iter;
-      if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
+      cout << "CGAL::Object type not pair..." << endl;
+    }
+  }
+  PHG4OuterHcalDetector::Point_2 so1A(m_OuterRadius, 0), so2A(0, m_OuterRadius), so3A(-m_OuterRadius, 0);
+  Circle_2 outer_circleA(so1A, so2A, so3A);
+  resA.clear();  // just clear the content from the last intersection search
+  CGAL::intersection(outer_circleA, perpA, std::back_inserter(resA));
+  for (iterA = resA.begin(); iterA != resA.end(); ++iterA)
+  {
+    CGAL::Object obj = *iterA;
+    if (const std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned> *point = CGAL::object_cast<std::pair<CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>, unsigned>>(&obj))
+    {
+      if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
       {
-        if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
-        {
-          PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-          upperright = pntmp;
-        }
+	PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+	upperright = pntmp;
       }
-      else
-      {
-        cout << "CGAL::Object type not pair..." << endl;
-      }
+    }
+    else
+    {
+      cout << "CGAL::Object type not pair..." << endl;
     }
   }
   // the left corners are on a secant with the inner boundary, they need to be shifted
@@ -749,8 +753,8 @@ PHG4OuterHcalDetector::x_at_y(PHG4OuterHcalDetector::Point_2 &p0, PHG4OuterHcalD
   double newx = fabs(x[0]) + fabs(x[1]);
   PHG4OuterHcalDetector::Point_2 p0new(-newx, yin);
   PHG4OuterHcalDetector::Point_2 p1new(newx, yin);
-  Segment_2 s(p0new, p1new);
-  CGAL::Object result = CGAL::intersection(l, s);
+  Segment_2 seg(p0new, p1new);
+  CGAL::Object result = CGAL::intersection(l, seg);
   if (const PHG4OuterHcalDetector::Point_2 *ipoint = CGAL::object_cast<PHG4OuterHcalDetector::Point_2>(&result))
   {
     xret = CGAL::to_double(ipoint->x());

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -14,10 +14,7 @@
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4Box.hh>
@@ -40,6 +37,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Circular_kernel_intersections.h>
 #include <CGAL/Exact_circular_kernel_2.h>

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -136,7 +136,7 @@ int PHG4OuterHcalDetector::IsInOuterHcal(G4VPhysicalVolume *volume) const
 }
 
 G4VSolid *
-PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*/)
+PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume * /*hcalenvelope*/)
 {
   double mid_radius = m_InnerRadius + (m_OuterRadius - m_InnerRadius) / 2.;
   PHG4OuterHcalDetector::Point_2 p_in_1(mid_radius, 0);  // center of scintillator
@@ -213,7 +213,7 @@ PHG4OuterHcalDetector::ConstructScintillatorBox(G4LogicalVolume */*hcalenvelope*
 }
 
 G4VSolid *
-PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
+PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume * /*hcalenvelope*/)
 {
   // calculate steel plate on top of the scinti box. Lower edge is the upper edge of
   // the scintibox + 1/2 the airgap
@@ -284,7 +284,7 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
   PHG4OuterHcalDetector::Point_2 upperright;
   PHG4OuterHcalDetector::Point_2 mid_upperscint(xmidpoint, ymidpoint);
   PHG4OuterHcalDetector::Point_2 p_upperedge(xcoordup, ycoordup);
-  Line_2 sup(mid_upperscint, p_upperedge);       // center vertical
+  Line_2 sup(mid_upperscint, p_upperedge);        // center vertical
   Line_2 perpA = sup.perpendicular(p_upperedge);  // that is the upper edge of the steel plate
   PHG4OuterHcalDetector::Point_2 sc1A(m_InnerRadius, 0), sc2A(0, m_InnerRadius), sc3A(-m_InnerRadius, 0);
   Circle_2 inner_circleA(sc1A, sc2A, sc3A);
@@ -299,9 +299,9 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
     {
       if (CGAL::to_double(point->first.x()) > pxmax)
       {
-	pxmax = CGAL::to_double(point->first.x());
-	PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	upperleft = pntmp;
+        pxmax = CGAL::to_double(point->first.x());
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperleft = pntmp;
       }
     }
     else
@@ -320,8 +320,8 @@ PHG4OuterHcalDetector::ConstructSteelPlate(G4LogicalVolume */*hcalenvelope*/)
     {
       if (CGAL::to_double(point->first.x()) > CGAL::to_double(p_loweredge.x()))
       {
-	PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
-	upperright = pntmp;
+        PHG4OuterHcalDetector::Point_2 pntmp(CGAL::to_double(point->first.x()), CGAL::to_double(point->first.y()));
+        upperright = pntmp;
       }
     }
     else

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -9,7 +9,6 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wc11-extensions"
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/point_generators_2.h>
 #pragma GCC diagnostic pop

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.h
@@ -7,8 +7,12 @@
 
 #include <Geant4/G4Types.hh>  // for G4double
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wc11-extensions"
 #include <CGAL/Exact_circular_kernel_2.h>
 #include <CGAL/point_generators_2.h>
+#pragma GCC diagnostic pop
 
 #include <map>
 #include <set>

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.cc
@@ -15,7 +15,7 @@ PHG4OuterHcalDisplayAction::PHG4OuterHcalDisplayAction(const std::string &name)
 
 PHG4OuterHcalDisplayAction::~PHG4OuterHcalDisplayAction()
 {
-  for (auto &it:m_VisAttVec)
+  for (auto &it : m_VisAttVec)
   {
     delete it;
   }
@@ -23,9 +23,9 @@ PHG4OuterHcalDisplayAction::~PHG4OuterHcalDisplayAction()
   m_ScintiLogVolSet.clear();
 }
 
-void PHG4OuterHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4OuterHcalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
-  for (auto &it:m_ScintiLogVolSet)
+  for (auto &it : m_ScintiLogVolSet)
   {
     if (it->GetVisAttributes())
     {

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDisplayAction.h
@@ -6,7 +6,7 @@
 #include <g4main/PHG4DisplayAction.h>
 
 #include <set>
-#include <string>                      // for string
+#include <string>  // for string
 #include <vector>
 
 class G4LogicalVolume;
@@ -22,8 +22,8 @@ class PHG4OuterHcalDisplayAction : public PHG4DisplayAction
 
   void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
   void SetMyTopVolume(G4VPhysicalVolume *vol) { m_MyTopVolume = vol; }
-  void AddScintiVolume(G4LogicalVolume *vol) { m_ScintiLogVolSet.insert(vol);}
-  void AddSteelVolume(G4LogicalVolume *vol) {m_SteelVol = vol;}
+  void AddScintiVolume(G4LogicalVolume *vol) { m_ScintiLogVolSet.insert(vol); }
+  void AddSteelVolume(G4LogicalVolume *vol) { m_SteelVol = vol; }
 
  private:
   G4VPhysicalVolume *m_MyTopVolume;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
@@ -10,7 +10,10 @@
 
 #include "PHG4OuterHcalField.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4Field.hh>  // for G4Field
 #include <Geant4/G4FieldManager.hh>

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
@@ -10,10 +10,7 @@
 
 #include "PHG4OuterHcalField.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4Field.hh>  // for G4Field
 #include <Geant4/G4FieldManager.hh>

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.cc
@@ -24,8 +24,8 @@ PHG4OuterHcalFieldSetup::PHG4OuterHcalFieldSetup(G4int steelPlates,
                                                  G4double scintiGap, G4double tiltAngle)
   : fMinStep(0.005 * mm)
   , n_steel_plates(steelPlates) /*G4int*/
-  , scinti_gap(scintiGap) /*G4double*/
-  , tilt_angle(tiltAngle) /*G4double*/
+  , scinti_gap(scintiGap)       /*G4double*/
+  , tilt_angle(tiltAngle)       /*G4double*/
 {
   G4int nvar = 8;
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.h
@@ -1,6 +1,6 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-// $Id: $                                                                                             
+// $Id: $
 
 /*!
  * \file PHG4OuterHcalFieldSetup.h
@@ -26,11 +26,10 @@ class G4MagneticField;
  */
 class PHG4OuterHcalFieldSetup
 {
-public:
+ public:
   PHG4OuterHcalFieldSetup(G4int steelPlates, G4double scintiGap,
-      G4double tiltAngle);
-  virtual
-    ~PHG4OuterHcalFieldSetup(){}
+                          G4double tiltAngle);
+  virtual ~PHG4OuterHcalFieldSetup() {}
 
   G4FieldManager*
   get_Field_Manager_Gap() const
@@ -104,8 +103,7 @@ public:
     tilt_angle = tiltAngle;
   }
 
-private:
-
+ private:
   G4FieldManager* fFieldManagerIron;
   G4FieldManager* fFieldManagerGap;
   G4Mag_UsualEqRhs* fEquationIron;

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -21,15 +21,12 @@
 #include <phool/getClass.h>
 
 // Root headers
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TAxis.h>  // for TAxis
 #include <TFile.h>
 #include <TH2.h>
 #include <TH2F.h>
 #include <TNamed.h>  // for TNamed
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 // Geant4 headers
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -15,7 +15,7 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
@@ -23,49 +23,49 @@
 // Root headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#include <TAxis.h>                             // for TAxis
+#include <TAxis.h>  // for TAxis
+#include <TFile.h>
 #include <TH2.h>
 #include <TH2F.h>
-#include <TNamed.h>                            // for TNamed
+#include <TNamed.h>  // for TNamed
 #include <TSystem.h>
-#include <TFile.h>
 #pragma GCC diagnostic pop
 
 // Geant4 headers
 
 #include <Geant4/G4Field.hh>
 #include <Geant4/G4FieldManager.hh>
-#include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
+#include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4PropagatorInField.hh>
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4TransportationManager.hh>
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>      // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>  // for G4TouchableHandle
+#include <Geant4/G4Track.hh>            // for G4Track
+#include <Geant4/G4TrackStatus.hh>      // for fStopAndKill
 #include <Geant4/G4Transform3D.hh>
+#include <Geant4/G4TransportationManager.hh>
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 // finally system headers
 #include <cassert>
-#include <cmath>                               // for isfinite, sqrt
+#include <cmath>  // for isfinite, sqrt
 #include <iostream>
-#include <string>                              // for operator<<, string
-#include <utility>                             // for pair
+#include <string>   // for operator<<, string
+#include <utility>  // for pair
 
 class PHCompositeNode;
 
 using namespace std;
 
-TH2F *MapCorr = NULL;
+TH2F* MapCorr = NULL;
 
 //____________________________________________________________________________..
 PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHParameters* parameters)
@@ -103,13 +103,11 @@ PHG4OuterHcalSteppingAction::~PHG4OuterHcalSteppingAction()
 int PHG4OuterHcalSteppingAction::Init()
 {
   m_EnableFieldCheckerFlag = m_Params->get_int_param("field_check");
-// method in base class for light correction
+  // method in base class for light correction
   SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
-		     m_Params->get_double_param("light_balance_inner_corr"),
-		     m_Params->get_double_param("light_balance_outer_radius") * cm,
-		     m_Params->get_double_param("light_balance_outer_corr")
-    );
-
+                     m_Params->get_double_param("light_balance_inner_corr"),
+                     m_Params->get_double_param("light_balance_outer_radius") * cm,
+                     m_Params->get_double_param("light_balance_outer_corr"));
 
   std::ostringstream mappingfilename;
   const char* calibroot = getenv("CALIBRATIONROOT");
@@ -124,11 +122,12 @@ int PHG4OuterHcalSteppingAction::Init()
   }
 
   mappingfilename << "/HCALOUT/tilemap/oHCALMaps092021.root";
-  TFile *f = new TFile(mappingfilename.str().c_str()); 
-  MapCorr = (TH2F *)f->Get("hCombinedMap");
-  if(!MapCorr){
-    std::cout << "ERROR: MapCorr is NULL" << std::endl; 
-    gSystem->Exit(1); 
+  TFile* f = new TFile(mappingfilename.str().c_str());
+  MapCorr = (TH2F*) f->Get("hCombinedMap");
+  if (!MapCorr)
+  {
+    std::cout << "ERROR: MapCorr is NULL" << std::endl;
+    gSystem->Exit(1);
   }
 
   return 0;
@@ -247,11 +246,11 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       // 	G4ThreeVector worldPosition = prePoint->GetPosition();
       // 	G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
 
-      // 	m_Hit->set_property(PHG4Hit::prop_local_x_0, (float)(localPosition.x()/cm)); 
-      // 	m_Hit->set_property(PHG4Hit::prop_local_y_0, (float)(localPosition.y()/cm)); 
-      // 	m_Hit->set_property(PHG4Hit::prop_local_z_0, (float)(localPosition.z()/cm)); 
+      // 	m_Hit->set_property(PHG4Hit::prop_local_x_0, (float)(localPosition.x()/cm));
+      // 	m_Hit->set_property(PHG4Hit::prop_local_y_0, (float)(localPosition.y()/cm));
+      // 	m_Hit->set_property(PHG4Hit::prop_local_z_0, (float)(localPosition.z()/cm));
 
-      //   m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id); 
+      //   m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id);
 
       // }
 
@@ -329,8 +328,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     if (whichactive > 0)
     {
-
-      // Local Coordinates: 
+      // Local Coordinates:
 
       //G4TouchableHandle theTouchable = postPoint->GetTouchableHandle();
       // Use prePoint; sometimes the end point can be on the boundary/out of the scintillator
@@ -338,39 +336,37 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       G4ThreeVector worldPosition = postPoint->GetPosition();
       G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
 
-      // DEBUG 
-      // m_Hit->set_property(PHG4Hit::prop_local_x_1, (float)(localPosition.x()/cm)); 
-      // m_Hit->set_property(PHG4Hit::prop_local_y_1, (float)(localPosition.y()/cm)); 
-      // m_Hit->set_property(PHG4Hit::prop_local_z_1, (float)(localPosition.z()/cm)); 
+      // DEBUG
+      // m_Hit->set_property(PHG4Hit::prop_local_x_1, (float)(localPosition.x()/cm));
+      // m_Hit->set_property(PHG4Hit::prop_local_y_1, (float)(localPosition.y()/cm));
+      // m_Hit->set_property(PHG4Hit::prop_local_z_1, (float)(localPosition.z()/cm));
 
-      // m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id); 
+      // m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id);
 
       if (m_LightScintModelFlag)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);
 
-	if(MapCorr){
+        if (MapCorr)
+        {
+          float lx = (localPosition.x() / cm);
+          float lz = fabs(localPosition.z() / cm);  // reverse the sense for towerid<12
 
-	  float lx = (localPosition.x()/cm); 
-	  float lz = fabs(localPosition.z()/cm); // reverse the sense for towerid<12
+          // convert to the map bin coordinates:
+          // map is in 0.5 cm bins
+          int lcz = (int) (2.0 * lz) + 1;
+          int lcx = (int) (2.0 * (lx + 42.75)) + 1;
 
-	  // convert to the map bin coordinates:
-	  // map is in 0.5 cm bins
-	  int lcz = (int)(2.0*lz) + 1; 
-	  int lcx = (int)(2.0*(lx+42.75)) + 1;
-
-	  if( (lcx>=1) && (lcx<=MapCorr->GetNbinsY()) &&
-	      (lcz>=1) && (lcz<=MapCorr->GetNbinsX()) ){
-	  
-	    light_yield *= (double) (MapCorr->GetBinContent(lcz, lcx));
-
-	  }
-	  else{
-	    light_yield = 0.0; 
-	  }
-
-	} 
-      
+          if ((lcx >= 1) && (lcx <= MapCorr->GetNbinsY()) &&
+              (lcz >= 1) && (lcz <= MapCorr->GetNbinsX()))
+          {
+            light_yield *= (double) (MapCorr->GetBinContent(lcz, lcx));
+          }
+          else
+          {
+            light_yield = 0.0;
+          }
+        }
       }
       else
       {
@@ -379,9 +375,9 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
       if (ValidCorrection())
       {
-	double cor =  GetLightCorrection(postPoint->GetPosition().x() , (postPoint->GetPosition().y() ));
-	cout << "applying cor: " << cor << endl;
-        light_yield = light_yield *  GetLightCorrection(postPoint->GetPosition().x() , (postPoint->GetPosition().y() ));
+        double cor = GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
+        cout << "applying cor: " << cor << endl;
+        light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
       }
     }
 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -21,12 +21,15 @@
 #include <phool/getClass.h>
 
 // Root headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TAxis.h>                             // for TAxis
 #include <TH2.h>
 #include <TH2F.h>
 #include <TNamed.h>                            // for TNamed
 #include <TSystem.h>
 #include <TFile.h>
+#pragma GCC diagnostic pop
 
 // Geant4 headers
 
@@ -121,7 +124,7 @@ int PHG4OuterHcalSteppingAction::Init()
   }
 
   mappingfilename << "/HCALOUT/tilemap/oHCALMaps092021.root";
-  TFile *f = new TFile(mappingfilename.str().data()); 
+  TFile *f = new TFile(mappingfilename.str().c_str()); 
   MapCorr = (TH2F *)f->Get("hCombinedMap");
   if(!MapCorr){
     std::cout << "ERROR: MapCorr is NULL" << std::endl; 

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -1,28 +1,28 @@
 #include "PHG4OuterHcalSubsystem.h"
 
+#include "PHG4HcalDefs.h"
 #include "PHG4OuterHcalDetector.h"
 #include "PHG4OuterHcalDisplayAction.h"
 #include "PHG4OuterHcalSteppingAction.h"
-#include "PHG4HcalDefs.h"
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4DisplayAction.h>     // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4SteppingAction.h>    // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>           // for PHIODataNode
-#include <phool/PHNode.h>                 // for PHNode
-#include <phool/PHNodeIterator.h>         // for PHNodeIterator
-#include <phool/PHObject.h>               // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <boost/foreach.hpp>
 
-#include <cmath>                         // for NAN
-#include <iostream>                       // for operator<<, basic_ostream
-#include <set>                            // for set
+#include <cmath>     // for NAN
+#include <iostream>  // for operator<<, basic_ostream
+#include <set>       // for set
 #include <sstream>
 
 class PHG4Detector;
@@ -30,11 +30,11 @@ class PHG4Detector;
 using namespace std;
 
 //_______________________________________________________________________
-PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem( const std::string &name, const int lyr ):
-  PHG4DetectorSubsystem( name, lyr ),
-  m_Detector( nullptr ),
-  m_SteppingAction( nullptr ),
-  m_DisplayAction(nullptr)
+PHG4OuterHcalSubsystem::PHG4OuterHcalSubsystem(const std::string &name, const int lyr)
+  : PHG4DetectorSubsystem(name, lyr)
+  , m_Detector(nullptr)
+  , m_SteppingAction(nullptr)
+  , m_DisplayAction(nullptr)
 {
   InitializeParameters();
 }
@@ -46,11 +46,10 @@ PHG4OuterHcalSubsystem::~PHG4OuterHcalSubsystem()
 }
 
 //_______________________________________________________________________
-int
-PHG4OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
+int PHG4OuterHcalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
 {
-  PHNodeIterator iter( topNode );
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   // create display settings before detector
   m_DisplayAction = new PHG4OuterHcalDisplayAction(Name());
@@ -61,96 +60,92 @@ PHG4OuterHcalSubsystem::InitRunSubsystem( PHCompositeNode* topNode )
   m_Detector->OverlapCheck(CheckOverlap());
   set<string> nodes;
   if (GetParams()->get_int_param("active"))
+  {
+    PHNodeIterator dstIter(dstNode);
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", SuperDetector()));
+    if (!DetNode)
     {
-      PHNodeIterator dstIter( dstNode );
-      PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode",SuperDetector()));
-      if (! DetNode)
-	{
-          DetNode = new PHCompositeNode(SuperDetector());
-          dstNode->addNode(DetNode);
-        }
-      ostringstream nodename;
+      DetNode = new PHCompositeNode(SuperDetector());
+      dstNode->addNode(DetNode);
+    }
+    ostringstream nodename;
+    if (SuperDetector() != "NONE")
+    {
+      nodename << "G4HIT_" << SuperDetector();
+    }
+    else
+    {
+      nodename << "G4HIT_" << Name();
+    }
+    nodes.insert(nodename.str());
+    if (GetParams()->get_int_param("absorberactive"))
+    {
+      nodename.str("");
       if (SuperDetector() != "NONE")
-	{
-	  nodename <<  "G4HIT_" << SuperDetector();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << SuperDetector();
+      }
       else
-	{
-	  nodename <<  "G4HIT_" << Name();
-	}
+      {
+        nodename << "G4HIT_ABSORBER_" << Name();
+      }
       nodes.insert(nodename.str());
-      if (GetParams()->get_int_param("absorberactive"))
-	{
-	  nodename.str("");
-	  if (SuperDetector() != "NONE")
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << SuperDetector();
-	    }
-	  else
-	    {
-	      nodename <<  "G4HIT_ABSORBER_" << Name();
-	    }
-          nodes.insert(nodename.str());
-	}
-      BOOST_FOREACH(string node, nodes)
-	{
-	  PHG4HitContainer* g4_hits =  findNode::getClass<PHG4HitContainer>( topNode , node.c_str());
-	  if ( !g4_hits )
-	    {
-	      g4_hits = new PHG4HitContainer(node);
-	      DetNode->addNode( new PHIODataNode<PHObject>( g4_hits, node.c_str(), "PHObject" ));
-	    }
-	}
-      // create stepping action
+    }
+    BOOST_FOREACH (string node, nodes)
+    {
+      PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node.c_str());
+      if (!g4_hits)
+      {
+        g4_hits = new PHG4HitContainer(node);
+        DetNode->addNode(new PHIODataNode<PHObject>(g4_hits, node.c_str(), "PHObject"));
+      }
+    }
+    // create stepping action
+    m_SteppingAction = new PHG4OuterHcalSteppingAction(m_Detector, GetParams());
+    m_SteppingAction->Init();
+  }
+  else
+  {
+    if (GetParams()->get_int_param("blackhole"))
+    {
       m_SteppingAction = new PHG4OuterHcalSteppingAction(m_Detector, GetParams());
       m_SteppingAction->Init();
     }
-  else
-    {
-      if (GetParams()->get_int_param("blackhole"))
-	{
-	  m_SteppingAction = new PHG4OuterHcalSteppingAction(m_Detector, GetParams());
-	  m_SteppingAction->Init();
-	}
-    }
+  }
 
   return 0;
 }
 
 //_______________________________________________________________________
-int
-PHG4OuterHcalSubsystem::process_event( PHCompositeNode * topNode )
+int PHG4OuterHcalSubsystem::process_event(PHCompositeNode *topNode)
 {
   // pass top node to stepping action so that it gets
   // relevant nodes needed internally
-    if (m_SteppingAction)
-        {
-            m_SteppingAction->SetInterfacePointers( topNode );
-        }
-    return 0;
+  if (m_SteppingAction)
+  {
+    m_SteppingAction->SetInterfacePointers(topNode);
+  }
+  return 0;
 }
 
-void
-PHG4OuterHcalSubsystem::Print(const string &what) const
+void PHG4OuterHcalSubsystem::Print(const string &what) const
 {
   cout << "Outer Hcal Parameters: " << endl;
   GetParams()->Print();
   if (m_Detector)
-    {
-      m_Detector->Print(what);
-    }
+  {
+    m_Detector->Print(what);
+  }
   return;
 }
 
-
 //_______________________________________________________________________
-PHG4Detector* PHG4OuterHcalSubsystem::GetDetector( void ) const
+PHG4Detector *PHG4OuterHcalSubsystem::GetDetector(void) const
 {
-    return m_Detector;
+  return m_Detector;
 }
 
-void
-PHG4OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr)
+void PHG4OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr)
 {
   set_double_param("light_balance_inner_corr", inner_corr);
   set_double_param("light_balance_inner_radius", inner_radius);
@@ -159,23 +154,22 @@ PHG4OuterHcalSubsystem::SetLightCorrection(const double inner_radius, const doub
   return;
 }
 
-void
-PHG4OuterHcalSubsystem::SetDefaultParameters()
+void PHG4OuterHcalSubsystem::SetDefaultParameters()
 {
   set_default_double_param("inner_radius", 183.3);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-// some math issue in the code does not subtract the magnet cutout correctly
-// (maybe some factor of 2 in a G4 volume creation)
-// The engineering drawing values are:
-//  set_default_double_param("magnet_cutout_radius", 195.31);
-//  set_default_double_param("magnet_cutout_scinti_radius", 195.96);
-// seting this to these values results in the correct edges
-// (verified by looking at the G4 hit coordinates of the inner edges)
+  // some math issue in the code does not subtract the magnet cutout correctly
+  // (maybe some factor of 2 in a G4 volume creation)
+  // The engineering drawing values are:
+  //  set_default_double_param("magnet_cutout_radius", 195.31);
+  //  set_default_double_param("magnet_cutout_scinti_radius", 195.96);
+  // seting this to these values results in the correct edges
+  // (verified by looking at the G4 hit coordinates of the inner edges)
   set_default_double_param("magnet_cutout_radius", 195.72);
-  set_default_double_param("magnet_cutout_scinti_radius",  197.04);
+  set_default_double_param("magnet_cutout_scinti_radius", 197.04);
   set_default_double_param("outer_radius", 264.71);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
@@ -186,23 +180,23 @@ PHG4OuterHcalSubsystem::SetDefaultParameters()
   set_default_double_param("scinti_eta_coverage", 1.1);
   set_default_double_param("scinti_gap", 0.85);
   set_default_double_param("scinti_gap_neighbor", 0.1);
-  set_default_double_param("scinti_inner_radius",183.89);
-// some math issue in the code subtracts 0.1mm+ so the scintillator
-// does not end at 263.27 as per drawing but at 263.26
-// adding 0.125mm compensates for this (so 263.2825 gives the desired 263.27
-  set_default_double_param("scinti_outer_radius",263.2825);
+  set_default_double_param("scinti_inner_radius", 183.89);
+  // some math issue in the code subtracts 0.1mm+ so the scintillator
+  // does not end at 263.27 as per drawing but at 263.26
+  // adding 0.125mm compensates for this (so 263.2825 gives the desired 263.27
+  set_default_double_param("scinti_outer_radius", 263.2825);
   set_default_double_param("scinti_tile_thickness", 0.7);
   set_default_double_param("size_z", 304.91 * 2);
   set_default_double_param("steplimits", NAN);
-  set_default_double_param("tilt_angle", -11.23); // engineering drawing
-// corresponds very closely to 4 crossinge (-11.7826 deg)
+  set_default_double_param("tilt_angle", -11.23);  // engineering drawing
+                                                   // corresponds very closely to 4 crossinge (-11.7826 deg)
 
   set_default_int_param("field_check", 0);
   set_default_int_param("light_scint_model", 1);
-  set_default_int_param("magnet_cutout_first_scinti", 8); // tile start at 0, drawing tile starts at 1
+  set_default_int_param("magnet_cutout_first_scinti", 8);  // tile start at 0, drawing tile starts at 1
 
-// if ncross is set (and tilt_angle is NAN) tilt_angle is calculated 
-// from number of crossings
+  // if ncross is set (and tilt_angle is NAN) tilt_angle is calculated
+  // from number of crossings
   set_default_int_param("ncross", 0);
   set_default_int_param("n_towers", 64);
   set_default_int_param(PHG4HcalDefs::scipertwr, 5);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.h
@@ -13,13 +13,11 @@ class PHG4DisplayAction;
 class PHG4OuterHcalDetector;
 class PHG4SteppingAction;
 
-class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
+class PHG4OuterHcalSubsystem : public PHG4DetectorSubsystem
 {
-
-  public:
-
+ public:
   //! constructor
-  PHG4OuterHcalSubsystem( const std::string &name = "HCALOUT", const int layer = 0 );
+  PHG4OuterHcalSubsystem(const std::string& name = "HCALOUT", const int layer = 0);
 
   //! destructor
   ~PHG4OuterHcalSubsystem() override;
@@ -28,27 +26,26 @@ class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
   creates the Detector object. Creates the stepping action
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
   */
-  int InitRunSubsystem(PHCompositeNode *) override;
+  int InitRunSubsystem(PHCompositeNode*) override;
 
   //! event processing
   /*!
   get all relevant nodes from top nodes (namely hit list)
   and pass that to the stepping action
   */
-  int process_event(PHCompositeNode *) override;
+  int process_event(PHCompositeNode*) override;
 
   //! Print info (from SubsysReco)
-  void Print(const std::string &what = "ALL") const override;
+  void Print(const std::string& what = "ALL") const override;
 
   //! accessors (reimplemented)
-  PHG4Detector* GetDetector( void ) const override;
-  PHG4SteppingAction* GetSteppingAction( ) const override { return m_SteppingAction; }
+  PHG4Detector* GetDetector(void) const override;
+  PHG4SteppingAction* GetSteppingAction() const override { return m_SteppingAction; }
   PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
-  void SetLightCorrection(const double inner_radius, const double inner_corr,const double outer_radius, const double outer_corr);
+  void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
-  private:
-
+ private:
   void SetDefaultParameters() override;
 
   //! detector geometry
@@ -57,12 +54,11 @@ class PHG4OuterHcalSubsystem: public PHG4DetectorSubsystem
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction *m_SteppingAction;
+  PHG4SteppingAction* m_SteppingAction;
 
   //! display attribute setting
   /*! derives from PHG4DisplayAction */
   PHG4DisplayAction* m_DisplayAction;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -12,7 +12,10 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>                       // for PHWHERE
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -6,11 +6,11 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>         // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -20,22 +20,22 @@
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>               // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>              // for fGeomBoundary, fAtRest...
-#include <Geant4/G4String.hh>                  // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRest...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4ThreeVector.hh>             // for G4ThreeVector
-#include <Geant4/G4TouchableHandle.hh>         // for G4TouchableHandle
-#include <Geant4/G4Track.hh>                   // for G4Track
-#include <Geant4/G4TrackStatus.hh>             // for fStopAndKill
-#include <Geant4/G4Types.hh>                   // for G4double
-#include <Geant4/G4VPhysicalVolume.hh>         // for G4VPhysicalVolume
-#include <Geant4/G4VTouchable.hh>              // for G4VTouchable
-#include <Geant4/G4VUserTrackInformation.hh>   // for G4VUserTrackInformation
+#include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
+#include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
+#include <Geant4/G4Track.hh>                  // for G4Track
+#include <Geant4/G4TrackStatus.hh>            // for fStopAndKill
+#include <Geant4/G4Types.hh>                  // for G4double
+#include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
+#include <Geant4/G4VTouchable.hh>             // for G4VTouchable
+#include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cmath>                               // for isfinite
+#include <cmath>  // for isfinite
 #include <iostream>
-#include <string>                              // for operator<<, string
+#include <string>  // for operator<<, string
 
 class PHCompositeNode;
 
@@ -54,7 +54,8 @@ PHG4PSTOFSteppingAction::PHG4PSTOFSteppingAction(PHG4PSTOFDetector* detector, co
   , savepoststepstatus(-1)
   , edepsum(0)
   , eionsum(0)
-{}
+{
+}
 
 PHG4PSTOFSteppingAction::~PHG4PSTOFSteppingAction()
 {
@@ -72,10 +73,10 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
   G4TouchableHandle touchpost = aStep->GetPostStepPoint()->GetTouchableHandle();
   // get volume of the current step
   G4VPhysicalVolume* volume = touch->GetVolume();
-// IsInPSTOF(volume) returns
-//  == 0 outside of pstof
-//   > 0 for hits in active volume
-//  < 0 for hits in passive material
+  // IsInPSTOF(volume) returns
+  //  == 0 outside of pstof
+  //   > 0 for hits in active volume
+  //  < 0 for hits in passive material
   int whichactive = detector_->IsInPSTOF(volume);
   if (!whichactive)
   {
@@ -106,24 +107,24 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
   layer_id = touch->GetCopyNumber();
   if (layer_id != whichactive)
   {
-    cout << PHWHERE << " inconsistency between G4 copy number: " 
-	 << layer_id << " and module id from detector: "
-	 << whichactive << endl;
+    cout << PHWHERE << " inconsistency between G4 copy number: "
+         << layer_id << " and module id from detector: "
+         << whichactive << endl;
     gSystem->Exit(1);
   }
 
   switch (prePoint->GetStepStatus())
   {
-    case fPostStepDoItProc:
-      if (savepoststepstatus != fGeomBoundary)
-      {
-        break;
-      }
-      else
-      {
-	cout << GetName() << ": New Hit for  " << endl;
-cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-<< ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+  case fPostStepDoItProc:
+    if (savepoststepstatus != fGeomBoundary)
+    {
+      break;
+    }
+    else
+    {
+      cout << GetName() << ": New Hit for  " << endl;
+      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
            << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
            << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
       cout << "last track: " << savetrackid
@@ -132,7 +133,7 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
            << " post vol : " << touchpost->GetVolume()->GetName() << endl;
       cout << " previous phys pre vol: " << savevolpre->GetName()
            << " previous phys post vol: " << savevolpost->GetName() << endl;
-      }
+    }
     [[fallthrough]];
   case fGeomBoundary:
   case fUndefined:
@@ -154,12 +155,12 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
     {
       if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
-	hit->set_trkid(pp->GetUserTrackId());
+        hit->set_trkid(pp->GetUserTrackId());
       }
     }
     //set the initial energy deposit
     edepsum = 0;
-    if (whichactive > 0) 
+    if (whichactive > 0)
     {
       eionsum = 0;
       hit->set_eion(0);
@@ -175,7 +176,7 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
       {
         hit->set_trkid(pp->GetUserTrackId());
-	pp->GetShower()->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
+        pp->GetShower()->add_g4hit_id(savehitcontainer->GetID(), hit->get_hit_id());
       }
     }
 
@@ -183,46 +184,46 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
   default:
     break;
   }
-    
-    // some sanity checks for inconsistencies
-    // check if this hit was created, if not print out last post step status
-    if (!hit || !isfinite(hit->get_x(0)))
-    {
-      cout << GetName() << ": hit was not created" << endl;
-      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-      cout << "last track: " << savetrackid
-           << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-      cout << " previous phys pre vol: " << savevolpre->GetName()
-           << " previous phys post vol: " << savevolpost->GetName() << endl;
-      gSystem->Exit(1);
-    }
-    // check if track id matches the initial one when the hit was created
-    if (aTrack->GetTrackID() != savetrackid)
-    {
-      cout << GetName() << ": hits do not belong to the same track" << endl;
-      cout << "saved track: " << savetrackid
-           << ", current trackid: " << aTrack->GetTrackID()
-           << ", prestep status: " << prePoint->GetStepStatus()
-           << ", previous post step status: " << savepoststepstatus
-           << endl;
 
-      gSystem->Exit(1);
-    }
-    saveprestepstatus = prePoint->GetStepStatus();
-    savepoststepstatus = postPoint->GetStepStatus();
-    savevolpre = volume;
-    savevolpost = touchpost->GetVolume();
- 
+  // some sanity checks for inconsistencies
+  // check if this hit was created, if not print out last post step status
+  if (!hit || !isfinite(hit->get_x(0)))
+  {
+    cout << GetName() << ": hit was not created" << endl;
+    cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+         << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+         << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+         << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+    cout << "last track: " << savetrackid
+         << ", current trackid: " << aTrack->GetTrackID() << endl;
+    cout << "phys pre vol: " << volume->GetName()
+         << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+    cout << " previous phys pre vol: " << savevolpre->GetName()
+         << " previous phys post vol: " << savevolpost->GetName() << endl;
+    gSystem->Exit(1);
+  }
+  // check if track id matches the initial one when the hit was created
+  if (aTrack->GetTrackID() != savetrackid)
+  {
+    cout << GetName() << ": hits do not belong to the same track" << endl;
+    cout << "saved track: " << savetrackid
+         << ", current trackid: " << aTrack->GetTrackID()
+         << ", prestep status: " << prePoint->GetStepStatus()
+         << ", previous post step status: " << savepoststepstatus
+         << endl;
+
+    gSystem->Exit(1);
+  }
+  saveprestepstatus = prePoint->GetStepStatus();
+  savepoststepstatus = postPoint->GetStepStatus();
+  savevolpre = volume;
+  savevolpost = touchpost->GetVolume();
+
   // here we just update the exit values, it will be overwritten
   // for every step until we leave the volume or the particle
   // ceases to exist
   //sum up the energy to get total deposited
-    edepsum += edep;
+  edepsum += edep;
   if (whichactive > 0)
   {
     eionsum += eion;
@@ -243,8 +244,8 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
     // save only hits with energy deposit (or geantino)
     if (edepsum > 0 || geantino)
     {
-// update values at exit coordinates and set keep flag
-// of track to keep
+      // update values at exit coordinates and set keep flag
+      // of track to keep
       hit->set_x(1, postPoint->GetPosition().x() / cm);
       hit->set_y(1, postPoint->GetPosition().y() / cm);
       hit->set_z(1, postPoint->GetPosition().z() / cm);
@@ -252,26 +253,26 @@ cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetS
       hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
       if (G4VUserTrackInformation* p = aTrack->GetUserInformation())
       {
-	if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
-	{
-	  pp->SetKeep(1);  // we want to keep the track
-	}
+        if (PHG4TrackUserInfoV1* pp = dynamic_cast<PHG4TrackUserInfoV1*>(p))
+        {
+          pp->SetKeep(1);  // we want to keep the track
+        }
       }
       if (geantino)
       {
-	hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
-	if (whichactive > 0)
-	{
-	  hit->set_eion(-1);
-	}
+        hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression
+        if (whichactive > 0)
+        {
+          hit->set_eion(-1);
+        }
       }
       else
       {
-	hit->set_edep(edepsum);
+        hit->set_edep(edepsum);
       }
       if (whichactive > 0)
       {
-	hit->set_eion(eionsum);
+        hit->set_eion(eionsum);
       }
       savehitcontainer->AddHit(layer_id, hit);
       // ownership has been transferred to container, set to null

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -12,10 +12,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
 #include <Geant4/G4ReferenceCountedHandle.hh>  // for G4ReferenceCountedHandle

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.h
@@ -34,10 +34,10 @@ class PHG4PSTOFSteppingAction : public PHG4SteppingAction
   //! pointer to hit container
   PHG4HitContainer* hits_;
   PHG4Hit* hit;
-  PHG4HitContainer *savehitcontainer;
+  PHG4HitContainer* savehitcontainer;
 
-  G4VPhysicalVolume *savevolpre;
-  G4VPhysicalVolume *savevolpost;
+  G4VPhysicalVolume* savevolpre;
+  G4VPhysicalVolume* savevolpost;
   int savetrackid;
   int saveprestepstatus;
   int savepoststepstatus;

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.h
@@ -74,7 +74,6 @@ class PHG4PSTOFSubsystem : public PHG4DetectorGroupSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4SteppingAction* steppingAction_;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlat.h
@@ -14,33 +14,31 @@
 class PHG4ScintillatorSlat : public PHObject
 {
  public:
-  
-  ~PHG4ScintillatorSlat() override{}
+  ~PHG4ScintillatorSlat() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override {
+  // from PHObject
+  void identify(std::ostream& os = std::cout) const override
+  {
     os << "PHG4ScintillatorSlat base class" << std::endl;
   }
-  
-  virtual void add_edep(const double /*edep*/, const double /*e*/, const double /*light_yield*/) {return;}
 
-  virtual void set_key(const PHG4ScintillatorSlatDefs::keytype) {return;}
-  virtual void add_hit_key(PHG4HitDefs::keytype) {return;}
+  virtual void add_edep(const double /*edep*/, const double /*e*/, const double /*light_yield*/) { return; }
 
-  virtual short get_column() const {return -1;}
-  virtual short get_row() const {return -1;}
-  virtual PHG4ScintillatorSlatDefs::keytype get_key() const {return 0xFFFFFFFF;}
+  virtual void set_key(const PHG4ScintillatorSlatDefs::keytype) { return; }
+  virtual void add_hit_key(PHG4HitDefs::keytype) { return; }
 
-  virtual double get_edep() const {return NAN;}
-  virtual double get_eion() const {return NAN;}
-  virtual double get_light_yield() const  {return NAN;}
+  virtual short get_column() const { return -1; }
+  virtual short get_row() const { return -1; }
+  virtual PHG4ScintillatorSlatDefs::keytype get_key() const { return 0xFFFFFFFF; }
+
+  virtual double get_edep() const { return NAN; }
+  virtual double get_eion() const { return NAN; }
+  virtual double get_light_yield() const { return NAN; }
   virtual std::pair<std::set<PHG4HitDefs::keytype>::const_iterator, std::set<PHG4HitDefs::keytype>::const_iterator> get_hit_ids() const = 0;
 
-  
  protected:
-
   PHG4ScintillatorSlat() {}
-  ClassDefOverride(PHG4ScintillatorSlat,1)
+  ClassDefOverride(PHG4ScintillatorSlat, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.cc
@@ -1,6 +1,6 @@
 #include "PHG4ScintillatorSlatContainer.h"
 
-#include "PHG4ScintillatorSlat.h"      // for PHG4ScintillatorSlat
+#include "PHG4ScintillatorSlat.h"  // for PHG4ScintillatorSlat
 #include "PHG4ScintillatorSlatDefs.h"
 
 #include <cstdlib>
@@ -11,77 +11,75 @@ PHG4ScintillatorSlatContainer::PHG4ScintillatorSlatContainer()
 {
 }
 
-void
-PHG4ScintillatorSlatContainer::Reset()
+void PHG4ScintillatorSlatContainer::Reset()
 {
-   while(slatmap.begin() != slatmap.end())
-     {
-       delete slatmap.begin()->second;
-       slatmap.erase(slatmap.begin());
-     }
+  while (slatmap.begin() != slatmap.end())
+  {
+    delete slatmap.begin()->second;
+    slatmap.erase(slatmap.begin());
+  }
   return;
 }
 
-void
-PHG4ScintillatorSlatContainer::identify(ostream& os) const
+void PHG4ScintillatorSlatContainer::identify(ostream& os) const
 {
-   map<unsigned int,PHG4ScintillatorSlat *>::const_iterator iter;
-   os << "Number of slats: " << size() << endl;
-   for (iter = slatmap.begin(); iter != slatmap.end(); ++iter)
-     {
-       os << "slat key 0x" << hex << iter->first << dec << endl;
-       (iter->second)->identify();
-     }
+  map<unsigned int, PHG4ScintillatorSlat*>::const_iterator iter;
+  os << "Number of slats: " << size() << endl;
+  for (iter = slatmap.begin(); iter != slatmap.end(); ++iter)
+  {
+    os << "slat key 0x" << hex << iter->first << dec << endl;
+    (iter->second)->identify();
+  }
   return;
 }
 
 PHG4ScintillatorSlatContainer::ConstIterator
-PHG4ScintillatorSlatContainer::AddScintillatorSlat(const PHG4ScintillatorSlatDefs::keytype key, PHG4ScintillatorSlat *newslat)
+PHG4ScintillatorSlatContainer::AddScintillatorSlat(const PHG4ScintillatorSlatDefs::keytype key, PHG4ScintillatorSlat* newslat)
 {
-  if(slatmap.find(key)!=slatmap.end())
-   {
-     cout << "PHG4ScintillatorSlatContainer::AddScintillatorSlatSpecifyKey: duplicate key: " << key << " exiting now" << endl;
-     exit(1);
-   }
+  if (slatmap.find(key) != slatmap.end())
+  {
+    cout << "PHG4ScintillatorSlatContainer::AddScintillatorSlatSpecifyKey: duplicate key: " << key << " exiting now" << endl;
+    exit(1);
+  }
   newslat->set_key(key);
   slatmap[key] = newslat;
   return slatmap.find(key);
 }
 
-
-PHG4ScintillatorSlatContainer::ConstRange 
+PHG4ScintillatorSlatContainer::ConstRange
 PHG4ScintillatorSlatContainer::getScintillatorSlats(const short icolumn) const
 {
   if ((icolumn >> PHG4ScintillatorSlatDefs::columnbits) > 0)
-    {
-      cout << " column id too large: " << icolumn << endl;
-      exit(1);
-    }
+  {
+    cout << " column id too large: " << icolumn << endl;
+    exit(1);
+  }
   //  unsigned int shiftval = detid << slat_idbits;
   PHG4ScintillatorSlatDefs::keytype keylow = icolumn << PHG4ScintillatorSlatDefs::columnbits;
-  PHG4ScintillatorSlatDefs::keytype keyup = ((icolumn + 1)<< PHG4ScintillatorSlatDefs::columnbits) -1 ;
-//   cout << "keylow: 0x" << hex << keylow << dec << endl;
-//   cout << "keyup: 0x" << hex << keyup << dec << endl;
+  PHG4ScintillatorSlatDefs::keytype keyup = ((icolumn + 1) << PHG4ScintillatorSlatDefs::columnbits) - 1;
+  //   cout << "keylow: 0x" << hex << keylow << dec << endl;
+  //   cout << "keyup: 0x" << hex << keyup << dec << endl;
   ConstRange retpair;
   retpair.first = slatmap.lower_bound(keylow);
   retpair.second = slatmap.upper_bound(keyup);
   return retpair;
 }
 
-PHG4ScintillatorSlatContainer::ConstRange 
-PHG4ScintillatorSlatContainer::getScintillatorSlats( void ) const
-{ return std::make_pair( slatmap.begin(), slatmap.end() ); }
+PHG4ScintillatorSlatContainer::ConstRange
+PHG4ScintillatorSlatContainer::getScintillatorSlats(void) const
+{
+  return std::make_pair(slatmap.begin(), slatmap.end());
+}
 
-
-PHG4ScintillatorSlat* 
+PHG4ScintillatorSlat*
 PHG4ScintillatorSlatContainer::findScintillatorSlat(PHG4ScintillatorSlatDefs::keytype key)
 {
   PHG4ScintillatorSlatContainer::ConstIterator it = slatmap.find(key);
 
-  if(it != slatmap.end())
-    {
-      return it->second;
-    }
+  if (it != slatmap.end())
+  {
+    return it->second;
+  }
 
   return nullptr;
 }
@@ -92,8 +90,8 @@ PHG4ScintillatorSlatContainer::getTotalEdep() const
   ConstIterator iter;
   double totalenergy = 0;
   for (iter = slatmap.begin(); iter != slatmap.end(); ++iter)
-    {
-      totalenergy += iter->second->get_edep();
-    }
+  {
+    totalenergy += iter->second->get_edep();
+  }
   return totalenergy;
 }

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.h
@@ -7,18 +7,17 @@
 
 #include <phool/PHObject.h>
 
+#include <iostream>  // for cout, ostream
 #include <map>
 #include <set>
-#include <iostream>                    // for cout, ostream
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 class PHG4ScintillatorSlat;
 
-class PHG4ScintillatorSlatContainer: public PHObject
+class PHG4ScintillatorSlatContainer : public PHObject
 {
-
-  public:
-  typedef std::map<PHG4ScintillatorSlatDefs::keytype,PHG4ScintillatorSlat *> Map;
+ public:
+  typedef std::map<PHG4ScintillatorSlatDefs::keytype, PHG4ScintillatorSlat *> Map;
   typedef Map::iterator Iterator;
   typedef Map::const_iterator ConstIterator;
   typedef std::pair<Iterator, Iterator> Range;
@@ -30,14 +29,15 @@ class PHG4ScintillatorSlatContainer: public PHObject
 
   ~PHG4ScintillatorSlatContainer() override {}
 
-// from PHObject
-  void identify(std::ostream& os = std::cout) const override;
+  // from PHObject
+  void identify(std::ostream &os = std::cout) const override;
   void Reset() override;
 
   ConstIterator AddScintillatorSlat(const PHG4ScintillatorSlatDefs::keytype key, PHG4ScintillatorSlat *newscintillatorSlat);
-  
+
   //! preferred removal method, key is currently the slat id
-  void RemoveScintillatorSlat(PHG4ScintillatorSlatDefs::keytype key) {
+  void RemoveScintillatorSlat(PHG4ScintillatorSlatDefs::keytype key)
+  {
     slatmap.erase(key);
   }
 
@@ -47,36 +47,37 @@ class PHG4ScintillatorSlatContainer: public PHObject
     Iterator its = slatmap.begin();
     Iterator last = slatmap.end();
     for (; its != last;)
+    {
+      if (its->second == slat)
       {
-	if (its->second == slat)
-	  {
-	    slatmap.erase(its++);
-	  }
-	else
-	  {
-	    ++its;
-	  }
+        slatmap.erase(its++);
       }
+      else
+      {
+        ++its;
+      }
+    }
   }
-
 
   //! return all scintillatorSlats matching a given detid
   ConstRange getScintillatorSlats(const short icolumn) const;
 
   //! return all hist
-  ConstRange getScintillatorSlats( void ) const;
+  ConstRange getScintillatorSlats(void) const;
 
-  PHG4ScintillatorSlat* findScintillatorSlat(PHG4ScintillatorSlatDefs::keytype key);
+  PHG4ScintillatorSlat *findScintillatorSlat(PHG4ScintillatorSlatDefs::keytype key);
 
-  unsigned int size( void ) const
-  { return slatmap.size(); }
+  unsigned int size(void) const
+  {
+    return slatmap.size();
+  }
 
   double getTotalEdep() const;
 
  protected:
   Map slatmap;
 
-  ClassDefOverride(PHG4ScintillatorSlatContainer,1)
+  ClassDefOverride(PHG4ScintillatorSlatContainer, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainerLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainerLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4ScintillatorSlatContainer+;
+#pragma link C++ class PHG4ScintillatorSlatContainer + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefs.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefs.cc
@@ -3,16 +3,16 @@
 PHG4ScintillatorSlatDefs::keytype
 PHG4ScintillatorSlatDefs::genkey(const short irow, const short icolumn)
 {
-  keytype key = irow; // lower bits used by row
-  key |= (icolumn << columnbits); // upper bits used by column, so we can easily extract 
-                                  // slats by column which are combined to towers
+  keytype key = irow;              // lower bits used by row
+  key |= (icolumn << columnbits);  // upper bits used by column, so we can easily extract
+                                   // slats by column which are combined to towers
   return key;
 }
 
-std::pair<short,short>
+std::pair<short, short>
 PHG4ScintillatorSlatDefs::getrowcol(const keytype key)
 {
-  short irow = key&0xFFFF;
+  short irow = key & 0xFFFF;
   short icolumn = key >> columnbits;
-  return std::make_pair(irow,icolumn);
+  return std::make_pair(irow, icolumn);
 }

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefs.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefs.h
@@ -8,13 +8,12 @@
 namespace PHG4ScintillatorSlatDefs
 {
   typedef unsigned int keytype;
-  static int columnbits = 16; // upper bits used for searching, we want columns
-                              // which allows us to create towers quickly by
-                              // bunching them up in groups of 5
-  static int rowbits = 32-columnbits;
+  static int columnbits = 16;  // upper bits used for searching, we want columns
+                               // which allows us to create towers quickly by
+                               // bunching them up in groups of 5
+  static int rowbits = 32 - columnbits;
   keytype genkey(const short irow, const short icolumn);
-  std::pair<short,short> getrowcol(const keytype key);
-}
-
+  std::pair<short, short> getrowcol(const keytype key);
+}  // namespace PHG4ScintillatorSlatDefs
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefsLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatDefsLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4ScintillatorSlatDefs-!;
+#pragma link C++ class PHG4ScintillatorSlatDefs - !;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatLinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4ScintillatorSlat+;
+#pragma link C++ class PHG4ScintillatorSlat + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.cc
@@ -4,27 +4,25 @@
 
 using namespace std;
 
-PHG4ScintillatorSlatv1::PHG4ScintillatorSlatv1():
-  key(0xFFFFFFFF),
-  edep(0),
-  eion(0),
-  light_yield(0)
-{}
-
-short
-PHG4ScintillatorSlatv1::get_row() const
+PHG4ScintillatorSlatv1::PHG4ScintillatorSlatv1()
+  : key(0xFFFFFFFF)
+  , edep(0)
+  , eion(0)
+  , light_yield(0)
 {
-  return (key&0xFFFF);
 }
 
-short
-PHG4ScintillatorSlatv1::get_column() const
+short PHG4ScintillatorSlatv1::get_row() const
 {
-  return (key>>16);
+  return (key & 0xFFFF);
 }
 
-void
-PHG4ScintillatorSlatv1::identify(std::ostream& os) const
+short PHG4ScintillatorSlatv1::get_column() const
+{
+  return (key >> 16);
+}
+
+void PHG4ScintillatorSlatv1::identify(std::ostream& os) const
 {
   os << "row " << get_row() << " ";
   os << " column " << get_column() << " ";

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
@@ -9,33 +9,36 @@
 
 #include <g4main/PHG4HitDefs.h>
 
-#include <iostream>                    // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <set>
-#include <utility>                     // for make_pair, pair
+#include <utility>  // for make_pair, pair
 
 class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
 {
  public:
-
   PHG4ScintillatorSlatv1();
-  ~PHG4ScintillatorSlatv1() override{}
+  ~PHG4ScintillatorSlatv1() override {}
 
   void identify(std::ostream& os = std::cout) const override;
 
-  void add_edep(const double f, const double e, const double ly) override {edep+=f; eion+= e; light_yield+=ly;}
-  void add_hit_key(PHG4HitDefs::keytype i) override {hit_id.insert(i);}
-  
-  void set_key(PHG4ScintillatorSlatDefs::keytype i) override {key = i;}
-  void set_light_yield(const double lightYield)  {light_yield = lightYield;}
+  void add_edep(const double f, const double e, const double ly) override
+  {
+    edep += f;
+    eion += e;
+    light_yield += ly;
+  }
+  void add_hit_key(PHG4HitDefs::keytype i) override { hit_id.insert(i); }
+
+  void set_key(PHG4ScintillatorSlatDefs::keytype i) override { key = i; }
+  void set_light_yield(const double lightYield) { light_yield = lightYield; }
 
   short get_row() const override;
   short get_column() const override;
-  PHG4ScintillatorSlatDefs::keytype get_key() const override {return key;}
-  double get_edep() const override {return edep;}
-  double get_eion() const override {return eion;}
-  double get_light_yield() const override {return light_yield;}
-  std::pair<std::set<PHG4HitDefs::keytype>::const_iterator, std::set<PHG4HitDefs::keytype>::const_iterator> get_hit_ids() const override {return std::make_pair(hit_id.begin(),hit_id.end());}
-
+  PHG4ScintillatorSlatDefs::keytype get_key() const override { return key; }
+  double get_edep() const override { return edep; }
+  double get_eion() const override { return eion; }
+  double get_light_yield() const override { return light_yield; }
+  std::pair<std::set<PHG4HitDefs::keytype>::const_iterator, std::set<PHG4HitDefs::keytype>::const_iterator> get_hit_ids() const override { return std::make_pair(hit_id.begin(), hit_id.end()); }
 
  protected:
   PHG4ScintillatorSlatDefs::keytype key;
@@ -44,8 +47,7 @@ class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
   double light_yield;
   std::set<PHG4HitDefs::keytype> hit_id;
 
-   
-  ClassDefOverride(PHG4ScintillatorSlatv1,1)
+  ClassDefOverride(PHG4ScintillatorSlatv1, 1)
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
@@ -23,7 +23,7 @@ class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
   void identify(std::ostream& os = std::cout) const override;
 
   void add_edep(const double f, const double e, const double ly) override {edep+=f; eion+= e; light_yield+=ly;}
-  void add_hit_key(PHG4HitDefs::keytype key) override {hit_id.insert(key);}
+  void add_hit_key(PHG4HitDefs::keytype i) override {hit_id.insert(i);}
   
   void set_key(PHG4ScintillatorSlatDefs::keytype i) override {key = i;}
   void set_light_yield(const double lightYield)  {light_yield = lightYield;}

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class PHG4ScintillatorSlatv1+;
+#pragma link C++ class PHG4ScintillatorSlatv1 + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -9,13 +9,13 @@
 #include "PHG4SectorConstructor.h"
 #include "PHG4SectorDisplayAction.h"
 
-#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
-#include <g4main/PHG4Subsystem.h>         // for PHG4Subsystem
 #include <g4main/PHG4Detector.h>
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4Subsystem.h>      // for PHG4Subsystem
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>     // for G4DisplacedSolid
-#include <Geant4/G4Exception.hh>  // for G4Exception
+#include <Geant4/G4Exception.hh>          // for G4Exception
 #include <Geant4/G4ExceptionSeverity.hh>  // for FatalException, JustWarning
 #include <Geant4/G4IntersectionSolid.hh>
 #include <Geant4/G4LogicalVolume.hh>
@@ -28,14 +28,14 @@
 #include <Geant4/G4ThreeVector.hh>    // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>    // for G4Transform3D, G4RotateX3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>              // for G4int
+#include <Geant4/G4Types.hh>  // for G4int
 
 #include <algorithm>  // for max
 #include <cassert>
+#include <climits>
 #include <cmath>
 #include <iostream>
 #include <sstream>
-#include <climits>
 
 PHG4Sector::PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys)
   : overlapcheck_sector(false)
@@ -185,9 +185,9 @@ void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *World
   {
     std::ostringstream strstr;
     strstr << name_base << " - accumulated thickness = "
-      << (z_start + geom.get_total_thickness() / 2) / um
-      << " um expected thickness = " << geom.get_total_thickness() / um
-      << " um";
+           << (z_start + geom.get_total_thickness() / 2) / um
+           << " um expected thickness = " << geom.get_total_thickness() / um
+           << " um";
     G4Exception(
         (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
         __FILE__, FatalException, strstr.str().c_str());
@@ -197,22 +197,22 @@ void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *World
   if (Verbosity() > 1)
   {
     std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base
-	   << " - total thickness = " << geom.get_total_thickness() / cm << " cm"
-	   << std::endl;
+              << " - total thickness = " << geom.get_total_thickness() / cm << " cm"
+              << std::endl;
     std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
-	   << map_log_vol.size() << " logical volume constructed" << std::endl;
+              << map_log_vol.size() << " logical volume constructed" << std::endl;
     std::cout << "PHG4SectorConstructor::Construct_Sectors::" << name_base << " - "
-	   << map_phy_vol.size() << " physical volume constructed; "
-	   << map_active_phy_vol.size() << " is active." << std::endl;
+              << map_phy_vol.size() << " physical volume constructed; "
+              << map_active_phy_vol.size() << " is active." << std::endl;
   }
 }
 
 G4VSolid *
 PHG4Sector::PHG4SectorConstructor::Construct_Sectors_Plane(  //
-    const std::string &name,                     //
-    const double start_z,                        //
-    const double thickness,                      //
-    G4VSolid *SecConeBoundary_Det                //
+    const std::string &name,                                 //
+    const double start_z,                                    //
+    const double thickness,                                  //
+    G4VSolid *SecConeBoundary_Det                            //
 )
 {
   assert(SecConeBoundary_Det);
@@ -270,7 +270,7 @@ PHG4Sector::PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
   if (map_log_vol.find(v->GetName()) != map_log_vol.end())
   {
     std::cout << "PHG4SectorConstructor::RegisterVolume - Warning - replacing "
-           << v->GetName() << std::endl;
+              << v->GetName() << std::endl;
   }
 
   map_log_vol[v->GetName()] = v;
@@ -280,7 +280,7 @@ PHG4Sector::PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
 
 G4PVPlacement *
 PHG4Sector::PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
-                                              const bool active)
+                                                          const bool active)
 {
   if (!v)
   {
@@ -337,7 +337,7 @@ PHG4Sector::Sector_Geometry::get_max_R() const
       strstr << "min_polar_angle = " << min_polar_angle << std::endl;
       strstr << "max_polar_angle = " << max_polar_angle << std::endl;
       strstr << "cos(min_polar_angle + normal_polar_angle) = "
-        << cos(min_polar_angle + normal_polar_angle) << std::endl;
+             << cos(min_polar_angle + normal_polar_angle) << std::endl;
 
       G4Exception("Sector_Geometry::get_max_R", __FILE__, FatalException,
                   strstr.str().c_str());
@@ -350,7 +350,7 @@ PHG4Sector::Sector_Geometry::get_max_R() const
       strstr << "min_polar_angle = " << min_polar_angle << std::endl;
       strstr << "max_polar_angle = " << max_polar_angle << std::endl;
       strstr << "cos(max_polar_angle + normal_polar_angle) = "
-        << cos(max_polar_angle + normal_polar_angle) << std::endl;
+             << cos(max_polar_angle + normal_polar_angle) << std::endl;
 
       G4Exception("Sector_Geometry::get_max_R", __FILE__, FatalException,
                   strstr.str().c_str());
@@ -460,7 +460,7 @@ void PHG4Sector::Sector_Geometry::AddLayers_HBD_Readout()
 //! refractive index aerogel radiator. Nucl. Instrum. Meth., A548:383 390, 2005. arXiv:
 //! physics/0504220, doi:10.1016/j.nima.2005.05.030
 void PHG4Sector::Sector_Geometry::AddLayers_AeroGel_ePHENIX(const double radiator_length,
-                                                const double expansion_length, std::string radiator)
+                                                            const double expansion_length, std::string radiator)
 {
   if (radiator == "Default")
   {

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -37,10 +37,7 @@
 #include <sstream>
 #include <climits>
 
-using namespace PHG4Sector;
-using namespace std;
-
-PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys)
+PHG4Sector::PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys)
   : overlapcheck_sector(false)
   , name_base(name)
   , m_DisplayAction(dynamic_cast<PHG4SectorDisplayAction *>(subsys->GetDisplayAction()))
@@ -48,13 +45,13 @@ PHG4SectorConstructor::PHG4SectorConstructor(const std::string &name, PHG4Subsys
 {
 }
 
-void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
+void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
 {
   // geometry checks
   if (geom.get_total_thickness() == 0)
   {
     G4Exception(
-        (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
+        (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
         __FILE__, FatalException,
         " detector configured with zero thickness!");
   }
@@ -62,13 +59,13 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
   if (geom.get_min_polar_angle() == geom.get_max_polar_angle())
   {
     G4Exception(
-        (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
+        (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
         __FILE__, FatalException, "min_polar_angle = max_polar_angle!");
   }
   if (geom.get_min_polar_angle() > geom.get_max_polar_angle())
   {
     G4Exception(
-        (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
+        (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
         __FILE__, JustWarning,
         "min and max polar angle got reversed. Correcting them.");
 
@@ -79,7 +76,7 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
   if ((geom.get_min_polar_edge() == Sector_Geometry::kFlatEdge or geom.get_max_polar_edge() == Sector_Geometry::kFlatEdge) and geom.get_N_Sector() <= 2)
   {
     G4Exception(
-        (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
+        (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
         __FILE__, FatalException,
         "can NOT use flat edge for single or double sector detector!");
   }
@@ -92,7 +89,7 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
 
   // during GDML export, numerical value may change at the large digit and go beyond the 0 or pi limit.
   // therefore recess 0/pi by a small amount to avoid such problem
-  static const double epsilon = numeric_limits<float>::epsilon();
+  static const double epsilon = std::numeric_limits<float>::epsilon();
   const double sph_min_polar_angle =
       (geom.get_min_polar_edge() == Sector_Geometry::kConeEdge) ? geom.get_min_polar_angle() : (0 + epsilon);
   const double sph_max_polar_angle =
@@ -156,18 +153,18 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
   {
     const Layer &l = (*it);
 
-    if (l.percentage_filled > 100. or l.percentage_filled < 0)
+    if (l.percentage_filled > 100. || l.percentage_filled < 0)
     {
-      stringstream s;
-      s << name_base << " have invalid layer ";
-      s << l.name << " with percentage_filled =" << l.percentage_filled;
+      std::ostringstream strstr;
+      strstr << name_base << " have invalid layer ";
+      strstr << l.name << " with percentage_filled =" << l.percentage_filled;
 
       G4Exception(
-          (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(), __FILE__, FatalException,
-          s.str().c_str());
+          (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(), __FILE__, FatalException,
+          strstr.str().c_str());
     }
 
-    const string layer_name = name_base + "_" + l.name;
+    const std::string layer_name = name_base + "_" + l.name;
 
     G4VSolid *LayerSol_Det = Construct_Sectors_Plane(layer_name + "_Sol",
                                                      z_start, l.depth * l.percentage_filled * perCent, Boundary_Det);
@@ -184,16 +181,16 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
     z_start += l.depth;
   }
 
-  if (abs(z_start - geom.get_total_thickness() / 2) > 1 * um)
+  if (std::abs(z_start - geom.get_total_thickness() / 2) > 1 * um)
   {
-    stringstream s;
-    s << name_base << " - accumulated thickness = "
+    std::ostringstream strstr;
+    strstr << name_base << " - accumulated thickness = "
       << (z_start + geom.get_total_thickness() / 2) / um
       << " um expected thickness = " << geom.get_total_thickness() / um
       << " um";
     G4Exception(
-        (string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
-        __FILE__, FatalException, s.str().c_str());
+        (std::string("PHG4SectorConstructor::Construct_Sectors::") + (name_base)).c_str(),
+        __FILE__, FatalException, strstr.str().c_str());
   }
 
   m_DisplayAction->AddVolume(DetectorLog_Det, "DetectorBox");
@@ -211,7 +208,7 @@ void PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *WorldLog)
 }
 
 G4VSolid *
-PHG4SectorConstructor::Construct_Sectors_Plane(  //
+PHG4Sector::PHG4SectorConstructor::Construct_Sectors_Plane(  //
     const std::string &name,                     //
     const double start_z,                        //
     const double thickness,                      //
@@ -238,7 +235,7 @@ PHG4SectorConstructor::Construct_Sectors_Plane(  //
   //  return Sol_Place;
 }
 
-void Sector_Geometry::SetDefault()
+void PHG4Sector::Sector_Geometry::SetDefault()
 {
   N_Sector = 8;
   material = "G4_AIR";
@@ -261,7 +258,7 @@ void Sector_Geometry::SetDefault()
 }
 
 G4LogicalVolume *
-PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
+PHG4Sector::PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
 {
   if (!v)
   {
@@ -282,7 +279,7 @@ PHG4SectorConstructor::RegisterLogicalVolume(G4LogicalVolume *v)
 }
 
 G4PVPlacement *
-PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
+PHG4Sector::PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
                                               const bool active)
 {
   if (!v)
@@ -311,7 +308,7 @@ PHG4SectorConstructor::RegisterPhysicalVolume(G4PVPlacement *v,
 }
 
 double
-Sector_Geometry::get_total_thickness() const
+PHG4Sector::Sector_Geometry::get_total_thickness() const
 {
   double sum = 0;
   for (t_layer_list::const_iterator it = layer_list.begin();
@@ -323,40 +320,40 @@ Sector_Geometry::get_total_thickness() const
 }
 
 double
-Sector_Geometry::get_max_R() const
+PHG4Sector::Sector_Geometry::get_max_R() const
 {
   // Geometry check
-  assert(abs(min_polar_angle - normal_polar_angle) < pi / 2);
-  assert(abs(max_polar_angle - normal_polar_angle) < pi / 2);
+  assert(std::abs(min_polar_angle - normal_polar_angle) < pi / 2);
+  assert(std::abs(max_polar_angle - normal_polar_angle) < pi / 2);
 
   if (N_Sector <= 2)
   {
     // Geometry check
     if (cos(min_polar_angle + normal_polar_angle) <= 0)
     {
-      stringstream s;
-      s << "Geometry check failed. " << endl;
-      s << "normal_polar_angle = " << normal_polar_angle << endl;
-      s << "min_polar_angle = " << min_polar_angle << endl;
-      s << "max_polar_angle = " << max_polar_angle << endl;
-      s << "cos(min_polar_angle + normal_polar_angle) = "
-        << cos(min_polar_angle + normal_polar_angle) << endl;
+      std::stringstream strstr;
+      strstr << "Geometry check failed. " << std::endl;
+      strstr << "normal_polar_angle = " << normal_polar_angle << std::endl;
+      strstr << "min_polar_angle = " << min_polar_angle << std::endl;
+      strstr << "max_polar_angle = " << max_polar_angle << std::endl;
+      strstr << "cos(min_polar_angle + normal_polar_angle) = "
+        << cos(min_polar_angle + normal_polar_angle) << std::endl;
 
       G4Exception("Sector_Geometry::get_max_R", __FILE__, FatalException,
-                  s.str().c_str());
+                  strstr.str().c_str());
     }
     if (cos(max_polar_angle + normal_polar_angle) <= 0)
     {
-      stringstream s;
-      s << "Geometry check failed. " << endl;
-      s << "normal_polar_angle = " << normal_polar_angle << endl;
-      s << "min_polar_angle = " << min_polar_angle << endl;
-      s << "max_polar_angle = " << max_polar_angle << endl;
-      s << "cos(max_polar_angle + normal_polar_angle) = "
-        << cos(max_polar_angle + normal_polar_angle) << endl;
+      std::stringstream strstr;
+      strstr << "Geometry check failed. " << std::endl;
+      strstr << "normal_polar_angle = " << normal_polar_angle << std::endl;
+      strstr << "min_polar_angle = " << min_polar_angle << std::endl;
+      strstr << "max_polar_angle = " << max_polar_angle << std::endl;
+      strstr << "cos(max_polar_angle + normal_polar_angle) = "
+        << cos(max_polar_angle + normal_polar_angle) << std::endl;
 
       G4Exception("Sector_Geometry::get_max_R", __FILE__, FatalException,
-                  s.str().c_str());
+                  strstr.str().c_str());
     }
 
     const double max_tan_angle = std::max(
@@ -378,7 +375,7 @@ Sector_Geometry::get_max_R() const
 //! add Entrace window and drift volume
 //! Ref: P. Abbon et al. The COMPASS experiment at CERN. Nucl. Instrum. Meth., A577:455
 //! 518, 2007. arXiv:hep-ex/0703049, doi:10.1016/j.nima.2007.03.026. 3
-void Sector_Geometry::AddLayers_DriftVol_COMPASS(const double drift_vol_thickness)
+void PHG4Sector::Sector_Geometry::AddLayers_DriftVol_COMPASS(const double drift_vol_thickness)
 {
   //  (drift chamber) is enclosed by two Mylarr [52] cathode foils of 25um thickness,
   //  coated with about 10um of graphite,
@@ -392,7 +389,7 @@ void Sector_Geometry::AddLayers_DriftVol_COMPASS(const double drift_vol_thicknes
 //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
 //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
 //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
-void Sector_Geometry::AddLayers_HBD_GEM(const int n_GEM_layers)
+void PHG4Sector::Sector_Geometry::AddLayers_HBD_GEM(const int n_GEM_layers)
 {
   // Internal HBD structure
   // From doi:10.1016/j.nima.2011.04.015
@@ -407,7 +404,7 @@ void Sector_Geometry::AddLayers_HBD_GEM(const int n_GEM_layers)
 
   for (int gem = 1; gem <= n_GEM_layers; gem++)
   {
-    stringstream sid;
+    std::stringstream sid;
     sid << gem;
 
     //  GEM Copper 1.43 0.0005x6 64 0.134
@@ -446,7 +443,7 @@ void Sector_Geometry::AddLayers_HBD_GEM(const int n_GEM_layers)
 //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
 //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
 //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
-void Sector_Geometry::AddLayers_HBD_Readout()
+void PHG4Sector::Sector_Geometry::AddLayers_HBD_Readout()
 {
   //  Readout
   //  Readout board FR4/copper 17.1/1.43 0.05/0.001 100 0.367
@@ -462,7 +459,7 @@ void Sector_Geometry::AddLayers_HBD_Readout()
 //! Ref: T. Iijima et al. A Novel type of proximity focusing RICH counter with multiple
 //! refractive index aerogel radiator. Nucl. Instrum. Meth., A548:383 390, 2005. arXiv:
 //! physics/0504220, doi:10.1016/j.nima.2005.05.030
-void Sector_Geometry::AddLayers_AeroGel_ePHENIX(const double radiator_length,
+void PHG4Sector::Sector_Geometry::AddLayers_AeroGel_ePHENIX(const double radiator_length,
                                                 const double expansion_length, std::string radiator)
 {
   if (radiator == "Default")

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -15,8 +15,7 @@
 #include <Geant4/G4PhysicalConstants.hh>
 #include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4Types.hh>   // for G4int
-
+#include <Geant4/G4Types.hh>  // for G4int
 
 class G4LogicalVolume;
 class G4PVPlacement;
@@ -34,377 +33,375 @@ class PHG4Subsystem;
 
 namespace PHG4Sector
 {
-//! layer description data
-//! use GEANT units!
-class Layer
-{
- public:
-  Layer(  //! name base for this layer
-      const std::string &_name,
-
-      //! material name in G4
-      const std::string &_material,
-
-      //! depth in G4 units
-      double _depth,
-
-      //! percentage filled
-      double _percentage_filled,
-
-      //! whether it is active
-      bool _active)
-    : name(_name)
-    , material(_material)
-    , depth(_depth)
-    , percentage_filled(
-          _percentage_filled)
-    , active(_active)
+  //! layer description data
+  //! use GEANT units!
+  class Layer
   {
-  }
+   public:
+    Layer(  //! name base for this layer
+        const std::string &_name,
 
- public:
-  //! name base for this layer
-  std::string name;
+        //! material name in G4
+        const std::string &_material,
 
-  //! material name in G4
-  std::string material;
+        //! depth in G4 units
+        double _depth,
 
-  //! depth in G4 units
-  double depth;
+        //! percentage filled
+        double _percentage_filled,
 
-  //! percentage filled
-  double percentage_filled;
+        //! whether it is active
+        bool _active)
+      : name(_name)
+      , material(_material)
+      , depth(_depth)
+      , percentage_filled(
+            _percentage_filled)
+      , active(_active)
+    {
+    }
 
-  //! whether it is active
-  bool active;
-};
+   public:
+    //! name base for this layer
+    std::string name;
 
-//! geometry data
-//! use GEANT units! Use
-class Sector_Geometry
-{
- public:
-  Sector_Geometry()
+    //! material name in G4
+    std::string material;
+
+    //! depth in G4 units
+    double depth;
+
+    //! percentage filled
+    double percentage_filled;
+
+    //! whether it is active
+    bool active;
+  };
+
+  //! geometry data
+  //! use GEANT units! Use
+  class Sector_Geometry
   {
+   public:
+    Sector_Geometry()
+    {
+      SetDefault();
+    }
+
+    void
     SetDefault();
-  }
 
-  void
-  SetDefault();
+    int get_N_Sector() const
+    {
+      return N_Sector;
+    }
 
-  int get_N_Sector() const
+    std::vector<Layer> &
+    get_layer_list()
+    {
+      return layer_list;
+    }
+
+    std::string
+    get_material() const
+    {
+      return material;
+    }
+
+    double
+    get_max_polar_angle() const
+    {
+      return max_polar_angle;
+    }
+
+    double
+    get_min_polar_angle() const
+    {
+      return min_polar_angle;
+    }
+
+    double
+    get_normal_polar_angle() const
+    {
+      return normal_polar_angle;
+    }
+
+    double
+    get_normal_start() const
+    {
+      return normal_start;
+    }
+
+    void
+    set_N_Sector(int sector)
+    {
+      assert(sector >= 1);
+
+      N_Sector = sector;
+    }
+
+    void
+    set_layer_list(const std::vector<Layer> &layerList)
+    {
+      layer_list = layerList;
+    }
+
+    void
+    set_material(const std::string &_material)
+    {
+      material = _material;
+    }
+
+    void
+    set_max_polar_angle(double maxPolarAngle)
+    {
+      assert(maxPolarAngle >= 0);
+      assert(maxPolarAngle <= pi);
+
+      max_polar_angle = maxPolarAngle;
+    }
+
+    void
+    set_min_polar_angle(double minPolarAngle)
+    {
+      assert(minPolarAngle >= 0);
+      assert(minPolarAngle <= pi);
+
+      min_polar_angle = minPolarAngle;
+    }
+
+    void
+    set_normal_polar_angle(double normalPolarAngle)
+    {
+      assert(normalPolarAngle >= 0);
+      assert(normalPolarAngle <= pi);
+
+      normal_polar_angle = normalPolarAngle;
+    }
+
+    void
+    set_normal_start(double normalZStart)
+    {
+      normal_start = normalZStart;
+    }
+
+    // derivative constants
+
+    //   ! max radius from IP
+    double
+    get_max_R() const;
+
+    double
+    get_total_thickness() const;
+
+    //!Unit
+    static double
+    Unit_cm()
+    {
+      return cm;
+    }
+
+    //!Intercept certain z point at certain polar angle
+    void
+    set_normal_start(const double z_intercept, const double angle_intercept)
+    {
+      set_normal_start(
+          z_intercept / cos(angle_intercept) * cos(normal_polar_angle - angle_intercept));
+    }
+
+    //! Pseudorapidity
+    static double
+    eta_to_polar_angle(const double eta)
+    {
+      return 2. * atan(exp(-eta));
+    }
+
+    // layer descriptions
+   public:
+    typedef std::vector<Layer> t_layer_list;
+    t_layer_list layer_list;
+
+    int GetNumActiveLayers() const
+    {
+      int n = 0;
+      for (t_layer_list::const_iterator it = layer_list.begin();
+           it != layer_list.end(); ++it)
+        if ((*it).active)
+          n++;
+      return n;
+    }
+
+    void
+    AddLayer(                            //
+        std::string _name,               //! name base for this layer
+        std::string _material,           //! material name in G4
+        double _depth,                   //! depth in G4 units
+        bool _active = false,            //! active detector element for sensitive detector?
+        double _percentage_filled = 100  //! percentage filled//
+    )
+    {
+      layer_list.push_back(
+          Layer(_name, _material, _depth, _percentage_filled, _active));
+    }
+
+    //! add Entrace window and drift volume
+    //! Ref: P. Abbon et al. The COMPASS experiment at CERN. Nucl. Instrum. Meth., A577:455
+    //! 518, 2007. arXiv:hep-ex/0703049, doi:10.1016/j.nima.2007.03.026. 3
+    void
+    AddLayers_DriftVol_COMPASS(const double drift_vol_thickness = 3 * mm);
+
+    //! add HBD GEM to the layer list,
+    //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
+    //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
+    //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
+    void
+    AddLayers_HBD_GEM(const int n_GEM_layers = 3);
+
+    //! add HBD readout,
+    //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
+    //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
+    //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
+    void
+    AddLayers_HBD_Readout();
+
+    //! Rough AeroGel detector
+    //! Ref: T. Iijima et al. A Novel type of proximity focusing RICH counter with multiple
+    //! refractive index aerogel radiator. Nucl. Instrum. Meth., A548:383 390, 2005. arXiv:
+    //! physics/0504220, doi:10.1016/j.nima.2005.05.030
+    void
+    AddLayers_AeroGel_ePHENIX(const double radiator_length = 2 * cm,
+                              const double expansion_length = 18 * cm, std::string radiator = "Default");
+
+   public:
+    typedef enum
+    {
+
+      //! cone cut for the polar edge
+      kConeEdge = 0,
+
+      //! flat line edge in the azimuthal direction and along the normal_polar_angle
+      kFlatEdge = 1
+
+    } e_edge_typ;
+
+    static e_edge_typ
+    ConeEdge()
+    {
+      return kConeEdge;
+    }
+
+    static e_edge_typ
+    FlatEdge()
+    {
+      return kFlatEdge;
+    }
+
+    e_edge_typ
+    get_max_polar_edge() const
+    {
+      return max_polar_edge;
+    }
+
+    e_edge_typ
+    get_min_polar_edge() const
+    {
+      return min_polar_edge;
+    }
+
+    void
+    set_max_polar_edge(e_edge_typ maxPolarEdge)
+    {
+      max_polar_edge = maxPolarEdge;
+    }
+
+    void
+    set_min_polar_edge(e_edge_typ minPolarEdge)
+    {
+      min_polar_edge = minPolarEdge;
+    }
+
+   private:
+    //! number of sectors
+    int N_Sector;
+
+    //! polar angle for the normal vector
+    double normal_polar_angle;
+
+    //! polar angle for edges
+    double min_polar_angle;
+
+    //! edge type
+    e_edge_typ min_polar_edge;
+
+    //! polar angle for edges
+    double max_polar_angle;
+
+    //! edge type
+    e_edge_typ max_polar_edge;
+
+    //! distance that detector starts from the normal direction
+    double normal_start;
+
+    //! base material, usually the gas. Will fill between layers
+    std::string material;
+  };
+
+  //! \brief Generalized detector which use sectors of flat panels to cover full azimuthal acceptance
+  class PHG4SectorConstructor
   {
-    return N_Sector;
-  }
-
-  std::vector<Layer> &
-  get_layer_list()
-  {
-    return layer_list;
-  }
-
-  std::string
-  get_material() const
-  {
-    return material;
-  }
-
-  double
-  get_max_polar_angle() const
-  {
-    return max_polar_angle;
-  }
-
-  double
-  get_min_polar_angle() const
-  {
-    return min_polar_angle;
-  }
-
-  double
-  get_normal_polar_angle() const
-  {
-    return normal_polar_angle;
-  }
-
-  double
-  get_normal_start() const
-  {
-    return normal_start;
-  }
-
-  void
-  set_N_Sector(int sector)
-  {
-    assert(sector >= 1);
-
-    N_Sector = sector;
-  }
-
-  void
-  set_layer_list(const std::vector<Layer> &layerList)
-  {
-    layer_list = layerList;
-  }
-
-  void
-  set_material(const std::string &_material)
-  {
-    material = _material;
-  }
-
-  void
-  set_max_polar_angle(double maxPolarAngle)
-  {
-    assert(maxPolarAngle >= 0);
-    assert(maxPolarAngle <= pi);
-
-    max_polar_angle = maxPolarAngle;
-  }
-
-  void
-  set_min_polar_angle(double minPolarAngle)
-  {
-    assert(minPolarAngle >= 0);
-    assert(minPolarAngle <= pi);
-
-    min_polar_angle = minPolarAngle;
-  }
-
-  void
-  set_normal_polar_angle(double normalPolarAngle)
-  {
-    assert(normalPolarAngle >= 0);
-    assert(normalPolarAngle <= pi);
-
-    normal_polar_angle = normalPolarAngle;
-  }
-
-  void
-  set_normal_start(double normalZStart)
-  {
-    normal_start = normalZStart;
-  }
-
-  // derivative constants
-
-  //   ! max radius from IP
-  double
-  get_max_R() const;
-
-  double
-  get_total_thickness() const;
-
-  //!Unit
-  static double
-  Unit_cm()
-  {
-    return cm;
-  }
-
-  //!Intercept certain z point at certain polar angle
-  void
-  set_normal_start(const double z_intercept, const double angle_intercept)
-  {
-    set_normal_start(
-        z_intercept / cos(angle_intercept) * cos(normal_polar_angle - angle_intercept));
-  }
-
-  //! Pseudorapidity
-  static double
-  eta_to_polar_angle(const double eta)
-  {
-    return 2. * atan(exp(-eta));
-  }
-
-  // layer descriptions
- public:
-
-  typedef std::vector<Layer> t_layer_list;
-  t_layer_list layer_list;
-
-  int GetNumActiveLayers() const
-  {
-    int n = 0;
-    for (t_layer_list::const_iterator it = layer_list.begin();
-         it != layer_list.end(); ++it)
-      if ((*it).active)
-        n++;
-    return n;
-  }
-
-  void
-  AddLayer(                            //
-      std::string _name,               //! name base for this layer
-      std::string _material,           //! material name in G4
-      double _depth,                   //! depth in G4 units
-      bool _active = false,            //! active detector element for sensitive detector?
-      double _percentage_filled = 100  //! percentage filled//
-  )
-  {
-    layer_list.push_back(
-        Layer(_name, _material, _depth, _percentage_filled, _active));
-  }
-
-  //! add Entrace window and drift volume
-  //! Ref: P. Abbon et al. The COMPASS experiment at CERN. Nucl. Instrum. Meth., A577:455
-  //! 518, 2007. arXiv:hep-ex/0703049, doi:10.1016/j.nima.2007.03.026. 3
-  void
-  AddLayers_DriftVol_COMPASS(const double drift_vol_thickness = 3 * mm);
-
-  //! add HBD GEM to the layer list,
-  //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
-  //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
-  //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
-  void
-  AddLayers_HBD_GEM(const int n_GEM_layers = 3);
-
-  //! add HBD readout,
-  //! Ref: W. Anderson et al. Design, Construction, Operation and Performance of a Hadron
-  //! Blind Detector for the PHENIX Experiment. Nucl. Instrum. Meth., A646:35 58, 2011.
-  //! arXiv:1103.4277, doi:10.1016/j.nima.2011.04.015. 3.5.1
-  void
-  AddLayers_HBD_Readout();
-
-  //! Rough AeroGel detector
-  //! Ref: T. Iijima et al. A Novel type of proximity focusing RICH counter with multiple
-  //! refractive index aerogel radiator. Nucl. Instrum. Meth., A548:383 390, 2005. arXiv:
-  //! physics/0504220, doi:10.1016/j.nima.2005.05.030
-  void
-  AddLayers_AeroGel_ePHENIX(const double radiator_length = 2 * cm,
-                            const double expansion_length = 18 * cm, std::string radiator = "Default");
-
- public:
-  typedef enum
-  {
-
-    //! cone cut for the polar edge
-    kConeEdge = 0,
-
-    //! flat line edge in the azimuthal direction and along the normal_polar_angle
-    kFlatEdge = 1
-
-  } e_edge_typ;
-
-  static e_edge_typ
-  ConeEdge()
-  {
-    return kConeEdge;
-  }
-
-  static e_edge_typ
-  FlatEdge()
-  {
-    return kFlatEdge;
-  }
-
-  e_edge_typ
-  get_max_polar_edge() const
-  {
-    return max_polar_edge;
-  }
-
-  e_edge_typ
-  get_min_polar_edge() const
-  {
-    return min_polar_edge;
-  }
-
-  void
-  set_max_polar_edge(e_edge_typ maxPolarEdge)
-  {
-    max_polar_edge = maxPolarEdge;
-  }
-
-  void
-  set_min_polar_edge(e_edge_typ minPolarEdge)
-  {
-    min_polar_edge = minPolarEdge;
-  }
-
- private:
-  //! number of sectors
-  int N_Sector;
-
-  //! polar angle for the normal vector
-  double normal_polar_angle;
-
-  //! polar angle for edges
-  double min_polar_angle;
-
-  //! edge type
-  e_edge_typ min_polar_edge;
-
-  //! polar angle for edges
-  double max_polar_angle;
-
-  //! edge type
-  e_edge_typ max_polar_edge;
-
-  //! distance that detector starts from the normal direction
-  double normal_start;
-
-  //! base material, usually the gas. Will fill between layers
-  std::string material;
-};
-
-
-//! \brief Generalized detector which use sectors of flat panels to cover full azimuthal acceptance
-class PHG4SectorConstructor
-{
- public:
-  PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys);
-  virtual ~PHG4SectorConstructor() {}
-
-  void
-  Construct_Sectors(G4LogicalVolume *WorldLog);
-
-  void
-  OverlapCheck(bool check)
-  {
-    overlapcheck_sector = check;
-  }
-
-  void Verbosity(int v) {m_Verbosity = v;}
-  int Verbosity() const {return m_Verbosity;}
-
- protected:
-  bool overlapcheck_sector;
-
-  G4VSolid *
-  Construct_Sectors_Plane(           //
-      const std::string &name,       //
-      const double start_z,          //
-      const double thickness,        //
-      G4VSolid *SecConeBoundary_Det  //
-  );
-
- public:
-  // properties
-
-  std::string name_base;
-
-  Sector_Geometry geom;
-
- private:
-  PHG4SectorDisplayAction *m_DisplayAction;
-  int m_Verbosity;
-
- protected:
-  G4LogicalVolume *
-  RegisterLogicalVolume(G4LogicalVolume *);
-
-  typedef std::map<G4String, G4LogicalVolume *> map_log_vol_t;
-  map_log_vol_t map_log_vol;
-
-  G4PVPlacement *
-  RegisterPhysicalVolume(G4PVPlacement *v, const bool active = false);
-
-  typedef std::pair<G4String, G4int> phy_vol_idx_t;
-  typedef std::map<phy_vol_idx_t, G4PVPlacement *> map_phy_vol_t;
-  map_phy_vol_t map_phy_vol;         //! all physics volume
-  map_phy_vol_t map_active_phy_vol;  //! active physics volume
-};
+   public:
+    PHG4SectorConstructor(const std::string &name, PHG4Subsystem *subsys);
+    virtual ~PHG4SectorConstructor() {}
+
+    void
+    Construct_Sectors(G4LogicalVolume *WorldLog);
+
+    void
+    OverlapCheck(bool check)
+    {
+      overlapcheck_sector = check;
+    }
+
+    void Verbosity(int v) { m_Verbosity = v; }
+    int Verbosity() const { return m_Verbosity; }
+
+   protected:
+    bool overlapcheck_sector;
+
+    G4VSolid *
+    Construct_Sectors_Plane(           //
+        const std::string &name,       //
+        const double start_z,          //
+        const double thickness,        //
+        G4VSolid *SecConeBoundary_Det  //
+    );
+
+   public:
+    // properties
+
+    std::string name_base;
+
+    Sector_Geometry geom;
+
+   private:
+    PHG4SectorDisplayAction *m_DisplayAction;
+    int m_Verbosity;
+
+   protected:
+    G4LogicalVolume *
+    RegisterLogicalVolume(G4LogicalVolume *);
+
+    typedef std::map<G4String, G4LogicalVolume *> map_log_vol_t;
+    map_log_vol_t map_log_vol;
+
+    G4PVPlacement *
+    RegisterPhysicalVolume(G4PVPlacement *v, const bool active = false);
+
+    typedef std::pair<G4String, G4int> phy_vol_idx_t;
+    typedef std::map<phy_vol_idx_t, G4PVPlacement *> map_phy_vol_t;
+    map_phy_vol_t map_phy_vol;         //! all physics volume
+    map_phy_vol_t map_active_phy_vol;  //! active physics volume
+  };
 
 }  // namespace PHG4Sector
 #endif /* PHG4SectorConstructor_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.h
@@ -37,7 +37,8 @@ class PHG4SectorDetector : public PHG4Detector, public PHG4Sector::PHG4SectorCon
   void SuperDetector(const std::string &name) { superdetector = name; }
   const std::string SuperDetector() const { return superdetector; }
 
-  void OverlapCheck(const bool chk = true) override
+  using PHG4Detector::OverlapCheck; // not implementing all OverlapChecc methods
+  void OverlapCheck(const bool chk) override
   {
     PHG4Detector::OverlapCheck(chk);
     PHG4SectorConstructor::OverlapCheck(chk);

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
@@ -6,7 +6,7 @@
 #include <Geant4/G4Colour.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4String.hh>          // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4VisAttributes.hh>
 
 #pragma GCC diagnostic push
@@ -15,7 +15,7 @@
 #pragma GCC diagnostic pop
 
 #include <iostream>
-#include <utility>                     // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -33,7 +33,7 @@ PHG4SectorDisplayAction::~PHG4SectorDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4SectorDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4SectorDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
@@ -9,10 +9,7 @@
 #include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4VisAttributes.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
@@ -9,7 +9,10 @@
 #include <Geant4/G4String.hh>          // for G4String
 #include <Geant4/G4VisAttributes.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>                     // for pair

--- a/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSteppingAction.cc
@@ -5,12 +5,12 @@
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4ParticleDefinition.hh>     // for G4ParticleDefinition
+#include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4Step.hh>
 #include <Geant4/G4StepPoint.hh>              // for G4StepPoint
 #include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fAtRestD...
@@ -25,7 +25,7 @@
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <iostream>
-#include <string>                             // for string, operator+, oper...
+#include <string>  // for string, operator+, oper...
 
 class G4VPhysicalVolume;
 class PHCompositeNode;

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
@@ -3,16 +3,16 @@
 #include "PHG4SectorDisplayAction.h"
 #include "PHG4SectorSteppingAction.h"
 
-#include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4Subsystem.h>       // for PHG4Subsystem
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>         // for PHIODataNode
-#include <phool/PHNode.h>               // for PHNode
-#include <phool/PHNodeIterator.h>       // for PHNodeIterator
-#include <phool/PHObject.h>             // for PHObject
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
 #include <sstream>

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
@@ -7,7 +7,7 @@
 
 #include <g4main/PHG4Subsystem.h>
 
-#include <string>                   // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 class PHG4Detector;

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.h
@@ -61,9 +61,9 @@ class PHG4SectorSubsystem : public PHG4Subsystem
 
   //! geometry manager PHG4Sector::Sector_Geometry
   void
-  set_geometry(const PHG4Sector::Sector_Geometry& g)
+  set_geometry(const PHG4Sector::Sector_Geometry& geo)
   {
-    geom = g;
+    geom = geo;
   }
 
  private:

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -25,7 +25,10 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -25,10 +25,7 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
@@ -5,7 +5,10 @@
 #include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
 #include <g4main/PHG4Utils.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4String.hh>           // for G4String

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
@@ -2,7 +2,7 @@
 
 #include "PHG4CylinderGeom_Spacalv1.h"  // for PHG4CylinderGeom_Spacalv1
 
-#include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Utils.h>
 
 #pragma GCC diagnostic push
@@ -11,11 +11,11 @@
 #pragma GCC diagnostic pop
 
 #include <Geant4/G4LogicalVolume.hh>
-#include <Geant4/G4String.hh>           // for G4String
+#include <Geant4/G4String.hh>  // for G4String
 #include <Geant4/G4VisAttributes.hh>
 
 #include <iostream>
-#include <utility>                      // for pair
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -34,7 +34,7 @@ PHG4SpacalDisplayAction::~PHG4SpacalDisplayAction()
   m_VisAttVec.clear();
 }
 
-void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume */*physvol*/)
+void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
   for (auto it : m_LogicalVolumeMap)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
@@ -5,10 +5,7 @@
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Utils.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4String.hh>  // for G4String

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.cc
@@ -10,23 +10,23 @@
 #include "PHG4CylinderGeom_Spacalv3.h"
 #include "PHG4SpacalDetector.h"
 
+#include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4HitContainer.h>
-#include <g4main/PHG4Hit.h>                   // for PHG4Hit
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
-#include <g4main/PHG4SteppingAction.h>        // for PHG4SteppingAction
+#include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
 #include <phool/getClass.h>
 
-#include <Geant4/G4IonisParamMat.hh>          // for G4IonisParamMat
-#include <Geant4/G4Material.hh>               // for G4Material
+#include <Geant4/G4IonisParamMat.hh>  // for G4IonisParamMat
+#include <Geant4/G4Material.hh>       // for G4Material
 #include <Geant4/G4MaterialCutsCouple.hh>
-#include <Geant4/G4ParticleDefinition.hh>     // for G4ParticleDefinition
+#include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4Step.hh>
-#include <Geant4/G4StepPoint.hh>              // for G4StepPoint
-#include <Geant4/G4StepStatus.hh>             // for fGeomBoundary, fAtRestD...
-#include <Geant4/G4String.hh>                 // for G4String
+#include <Geant4/G4StepPoint.hh>   // for G4StepPoint
+#include <Geant4/G4StepStatus.hh>  // for fGeomBoundary, fAtRestD...
+#include <Geant4/G4String.hh>      // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>            // for G4ThreeVector
 #include <Geant4/G4TouchableHandle.hh>        // for G4TouchableHandle
@@ -36,25 +36,26 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#include <cmath>                              // for isfinite
-#include <cstdlib>                           // for exit
+#include <cmath>    // for isfinite
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <string>                             // for operator<<, char_traits
+#include <string>  // for operator<<, char_traits
 
 class G4VPhysicalVolume;
 class PHCompositeNode;
 
 using namespace std;
 //____________________________________________________________________________..
-PHG4SpacalSteppingAction::PHG4SpacalSteppingAction(PHG4SpacalDetector* detector) : PHG4SteppingAction(detector->GetName()),
-                                                                                   detector_(detector),
-                                                                                   hits_(nullptr),
-                                                                                   absorberhits_(nullptr),
-                                                                                   hit(nullptr),
-                                                                                   savehitcontainer(nullptr),
-                                                                                   saveshower(nullptr),
-                                                                                   savetrackid(-1),
-                                                                                   savepoststepstatus(-1)
+PHG4SpacalSteppingAction::PHG4SpacalSteppingAction(PHG4SpacalDetector* detector)
+  : PHG4SteppingAction(detector->GetName())
+  , detector_(detector)
+  , hits_(nullptr)
+  , absorberhits_(nullptr)
+  , hit(nullptr)
+  , savehitcontainer(nullptr)
+  , saveshower(nullptr)
+  , savetrackid(-1)
+  , savepoststepstatus(-1)
 {
 }
 
@@ -99,15 +100,15 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     G4StepPoint* postPoint = aStep->GetPostStepPoint();
     int scint_id = -1;
 
-    if (                                                                                                                          //
-        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper                          //
-        or                                                                                                                        //
-        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_SameLengthFiberPerTower  //
-        or                                                                                                                        //
-        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_Tilted  //
-        or                                                                                                                        //
+    if (                                                                                                                                 //
+        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper                                 //
+        or                                                                                                                               //
+        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_SameLengthFiberPerTower         //
+        or                                                                                                                               //
+        detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_Tilted                          //
+        or                                                                                                                               //
         detector_->get_geom()->get_config() == PHG4SpacalDetector::SpacalGeom_t::kFullProjective_2DTaper_Tilted_SameLengthFiberPerTower  //
-        )
+    )
     {
       //SPACAL ID that is associated with towers
       int sector_ID = 0;
@@ -138,9 +139,9 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       {
         tower_ID = prePoint->GetTouchable()->GetReplicaNumber(0);
         sector_ID = prePoint->GetTouchable()->GetReplicaNumber(1);
-        fiber_ID =  (1 << (PHG4CylinderGeom_Spacalv3::scint_id_coder::kfiber_bit)) - 1; // use max fiber ID to flag for support strucrtures.
+        fiber_ID = (1 << (PHG4CylinderGeom_Spacalv3::scint_id_coder::kfiber_bit)) - 1;  // use max fiber ID to flag for support strucrtures.
 
-//        cout <<"PHG4SpacalSteppingAction::UserSteppingAction - SUPPORT tower_ID = "<<tower_ID<<endl;
+        //        cout <<"PHG4SpacalSteppingAction::UserSteppingAction - SUPPORT tower_ID = "<<tower_ID<<endl;
       }
 
       // compact the tower/sector/fiber ID into 32 bit scint_id, so we could save some space for SPACAL hits
@@ -187,8 +188,8 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       // Now add the hit
       if (isactive == PHG4SpacalDetector::FIBER_CORE)  // the slat ids start with zero
       {
-          // store all pre local coordinates
-          StoreLocalCoordinate(hit, aStep, true, false);
+        // store all pre local coordinates
+        StoreLocalCoordinate(hit, aStep, true, false);
         hit->set_eion(0);  // only implemented for v5 otherwise empty
         hit->set_light_yield(0);
         savehitcontainer = hits_;
@@ -249,8 +250,8 @@ bool PHG4SpacalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     if (isactive == PHG4SpacalDetector::FIBER_CORE)  // only for active areas
     {
-        // store all pre local coordinates
-        StoreLocalCoordinate(hit, aStep, false, true);
+      // store all pre local coordinates
+      StoreLocalCoordinate(hit, aStep, false, true);
 
       hit->set_eion(hit->get_eion() + eion);
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -27,7 +27,10 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>  // for operator<<, basic_ostream
 #include <sstream>

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -27,10 +27,7 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>  // for operator<<, basic_ostream
 #include <sstream>

--- a/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
+++ b/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
@@ -2,7 +2,10 @@
 
 #include <Geant4/G4StepStatus.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
+++ b/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
@@ -2,10 +2,7 @@
 
 #include <Geant4/G4StepStatus.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4TrackStatusDecode.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TrackStatusDecode.cc
@@ -2,10 +2,7 @@
 
 #include <Geant4/G4TrackStatus.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4TrackStatusDecode.cc
+++ b/simulation/g4simulation/g4detectors/PHG4TrackStatusDecode.cc
@@ -2,7 +2,10 @@
 
 #include <Geant4/G4TrackStatus.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <map>

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
@@ -13,7 +13,10 @@
 
 #include <phool/recoConsts.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4LogicalVolume.hh>

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
@@ -13,10 +13,7 @@
 
 #include <phool/recoConsts.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4LogicalVolume.hh>

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
@@ -6,10 +6,7 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
@@ -6,7 +6,10 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VisAttributes.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
@@ -34,10 +34,7 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
@@ -34,7 +34,10 @@
 #include <Geant4/G4VTouchable.hh>             // for G4VTouchable
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.h
@@ -36,9 +36,9 @@ class PHG4ZDCSubsystem : public PHG4DetectorSubsystem
   /** Accessors (reimplemented)
    */
   PHG4Detector* GetDetector() const override;
-  PHG4SteppingAction* GetSteppingAction() const  override { return m_SteppingAction; }
+  PHG4SteppingAction* GetSteppingAction() const override { return m_SteppingAction; }
 
-  PHG4DisplayAction* GetDisplayAction() const  override { return m_DisplayAction; }
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
  private:
   void SetDefaultParameters() override;

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -10,9 +10,9 @@ if test $ac_cv_prog_gxx = yes; then
 fi
 
 case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template -Wno-tautological-overlap-compare -Wno-deprecated-copy"
- ;;
+  clang++)
+    CXXFLAGS="$CXXFLAGS -Wno-c11-extensions -Wno-deprecated-copy -Wno-tautological-overlap-compare"
+  ;;
 esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/simulation/g4simulation/g4detectors/configure.ac
+++ b/simulation/g4simulation/g4detectors/configure.ac
@@ -6,7 +6,7 @@ AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
 if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror"
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror -Wshadow"
 fi
 
 case $CXX in

--- a/simulation/g4simulation/g4epd/Makefile.am
+++ b/simulation/g4simulation/g4epd/Makefile.am
@@ -5,7 +5,7 @@ AM_CXXFLAGS = `geant4-config --cflags`
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4epd/Makefile.am
+++ b/simulation/g4simulation/g4epd/Makefile.am
@@ -1,10 +1,11 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I$(G4_MAIN)/include
+  -I$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4epd/PHG4EPDSteppingAction.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDSteppingAction.cc
@@ -15,11 +15,7 @@
 #include <g4main/PHG4SteppingAction.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
-// TSystem shadows an enum (kDefault)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>
 #include <Geant4/G4ReferenceCountedHandle.hh>

--- a/simulation/g4simulation/g4epd/PHG4EPDSteppingAction.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDSteppingAction.cc
@@ -15,7 +15,11 @@
 #include <g4main/PHG4SteppingAction.h>
 #include <g4main/PHG4TrackUserInfoV1.h>
 
+// TSystem shadows an enum (kDefault)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
+#pragma GCC diagnostic pop
 
 #include <Geant4/G4ParticleDefinition.hh>
 #include <Geant4/G4ReferenceCountedHandle.hh>

--- a/simulation/g4simulation/g4epd/configure.ac
+++ b/simulation/g4simulation/g4epd/configure.ac
@@ -6,12 +6,11 @@ AC_PROG_CXX(CC g++)
 
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
+
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
  ;;
 esac
 

--- a/simulation/g4simulation/g4gdml/Makefile.am
+++ b/simulation/g4simulation/g4gdml/Makefile.am
@@ -1,23 +1,17 @@
 AUTOMAKE_OPTIONS = foreign
 
-AM_CXXFLAGS = `geant4-config --cflags | sed s/-Woverloaded-virtual// | sed s/-W\ // |  sed s/-Wshadow//`
-
-# set in configure.in to check if gcc version >= 4.8
-#if GCC_GE_48
-#  AM_CXXFLAGS += -std=c++11
-#endif
+AM_CXXFLAGS = `geant4-config --cflags`
 
 # List of shared libraries to produce
 lib_LTLIBRARIES = \
     libphg4gdml.la 
 
 AM_CPPFLAGS = \
-    -I$(includedir) \
-    -I$(XERCESCROOT)/include \
-    -isystem $(OFFLINE_MAIN)/include \
-    -isystem $(ROOTSYS)/include \
-    -isystem ${G4_MAIN}/include \
-    -I$(OPT_SPHENIX)/include
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include \
+  -isystem$(XERCESCROOT)/include \
+  -I$(OPT_SPHENIX)/include
 
 libphg4gdml_la_LDFLAGS = \
   -L$(libdir) \
@@ -52,6 +46,9 @@ pkginclude_HEADERS = \
 
 ################################################
 # linking tests
+
+BUILT_SOURCES = \
+  testexternals.cc
 
 noinst_PROGRAMS = \
   testexternals_g4gdml 

--- a/simulation/g4simulation/g4gdml/configure.ac
+++ b/simulation/g4simulation/g4gdml/configure.ac
@@ -6,16 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-if test $ac_cv_prog_gxx = yes; then
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
-  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
-fi
-
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
-CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
-AC_SUBST(CINTDEFS)
-fi
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4histos/Makefile.am
+++ b/simulation/g4simulation/g4histos/Makefile.am
@@ -1,5 +1,7 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 lib_LTLIBRARIES = \
     libg4histos.la
 
@@ -12,15 +14,14 @@ libg4histos_la_LDFLAGS = \
    -L$(OFFLINE_MAIN)/lib \
    -lcalo_io \
    -lfun4all \
-   -lphg4hit \
-   -lg4detectors \
-   -lg4testbench
+   -lg4detectors_io \
+   -lphg4hit
+
 
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I$(G4_MAIN)/include
+  -isystem$(ROOTSYS)/include
 
 noinst_HEADERS = \
   G4RootHitContainer.h \

--- a/simulation/g4simulation/g4histos/configure.ac
+++ b/simulation/g4simulation/g4histos/configure.ac
@@ -6,16 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-dnl leaving this here in case we want to play with different compiler 
-dnl specific flags
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 ROOTLIBS=`root-config --libs`
 AC_SUBST(ROOTLIBS)

--- a/simulation/g4simulation/g4intt/Makefile.am
+++ b/simulation/g4simulation/g4intt/Makefile.am
@@ -1,5 +1,7 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 # List of shared libraries to produce
 lib_LTLIBRARIES = \
     libg4intt_io.la \
@@ -8,8 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
     -I$(includedir) \
     -I$(OFFLINE_MAIN)/include \
-    -I$(ROOTSYS)/include \
-    -I$(G4_MAIN)/include
+    -isystem$(ROOTSYS)/include
 
 # set in configure.in to check if gcc version >= 4.8
 #if GCC_GE_48
@@ -41,7 +42,9 @@ pkginclude_HEADERS = \
 ROOTDICTS = \
   InttDeadMap_Dict.cc \
   InttDeadMapv1_Dict.cc
+
 pcmdir = $(libdir)
+
 nobase_dist_pcm_DATA = \
   InttDeadMap_Dict_rdict.pcm \
   InttDeadMapv1_Dict_rdict.pcm

--- a/simulation/g4simulation/g4intt/PHG4InttDefs.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDefs.h
@@ -44,6 +44,6 @@ static const int FPHX_GLUE = -22; // new 29/05/2020
 // detid of support structures
 static const int SUPPORT_DETID = 100;
 
-};  // namespace PHG4InttDefs
+}  // namespace PHG4InttDefs
 
 #endif

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -5,13 +5,12 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+
 case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-range-loop-construct -Wextra -Wno-macro-redefined"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
+  clang++)
+    CXXFLAGS="$CXXFLAGS -Wno-c11-extensions"
+  ;;
 esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/simulation/g4simulation/g4intt/configure.ac
+++ b/simulation/g4simulation/g4intt/configure.ac
@@ -5,7 +5,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 case $CXX in
   clang++)

--- a/simulation/g4simulation/g4jets/Makefile.am
+++ b/simulation/g4simulation/g4jets/Makefile.am
@@ -1,10 +1,12 @@
 AUTOMAKE_OPTIONS = foreign
 
+
+AM_CXXFLAGS = `geant4-config --cflags`
+
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I${G4_MAIN}/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 lib_LTLIBRARIES = \
    libg4jets_io.la \

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -6,18 +6,14 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 dnl leaving this here in case we want to play with different compiler 
 dnl specific flags
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
  ;;
  *g++)
-  if test `g++ -dumpversion | gawk '{print $1>=8.0?"1":"0"}'` = 1; then
    CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations"
-  else
-   CXXFLAGS="$CXXFLAGS"
-  fi
  ;;
 esac
 

--- a/simulation/g4simulation/g4jets/configure.ac
+++ b/simulation/g4simulation/g4jets/configure.ac
@@ -10,6 +10,9 @@ CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 dnl leaving this here in case we want to play with different compiler 
 dnl specific flags
 case $CXX in
+ *analyzer)
+   CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations"
+ ;;
  clang++)
  ;;
  *g++)

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 
-AM_CXXFLAGS = `geant4-config --cflags | sed s/-Woverloaded-virtual// | sed s/-W\ // | sed s/-Wshadow//`
+AM_CXXFLAGS = `geant4-config --cflags`
 
 # set in configure.in to check if gcc version >= 4.8
 #if GCC_GE_48
@@ -14,22 +14,10 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(XERCESCROOT)/include \
-  -isystem $(OFFLINE_MAIN)/include \
-  -isystem $(ROOTSYS)/include \
-  -isystem ${G4_MAIN}/include \
-  -I$(OPT_SPHENIX)/include
-
-# rootcint barfs on isystem
-RINCLUDES = \
-  -I$(includedir) \
-  -I$(XERCESCROOT)/include \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I${G4_MAIN}/include \
-  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -isystem$(ROOTSYS)/include \
+  -isystem$(XERCESCROOT)/include \
   -I$(OPT_SPHENIX)/include
-
 
 libphg4hit_la_LDFLAGS = \
   -L$(libdir) \
@@ -256,7 +244,7 @@ testexternals.cc:
 	echo "}" >> $@
 
 %_Dict.cc: %.h %LinkDef.h
-	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(RINCLUDES) $^
+	rootcint -f $@ @CINTDEFS@ $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;

--- a/simulation/g4simulation/g4main/PHG4ColorDefs.h
+++ b/simulation/g4simulation/g4main/PHG4ColorDefs.h
@@ -13,6 +13,6 @@ namespace PHG4TpcColorDefs
   static G4Colour tpc_honeycomb_color = G4Colour::White();
   static G4Colour tpc_kapton_color = G4Colour::Green();
   static G4Colour tpc_pcb_color = G4Colour::Blue();
-};
+}
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Detector.cc
+++ b/simulation/g4simulation/g4main/PHG4Detector.cc
@@ -13,7 +13,10 @@
 #include <Geant4/G4ThreeVector.hh>     // for G4ThreeVector
 #include <Geant4/G4VisAttributes.hh>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <boost/stacktrace.hpp>
+#pragma GCC diagnostic pop
 
 PHG4Detector::PHG4Detector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam)
   : m_topNode(Node)

--- a/simulation/g4simulation/g4main/PHG4EtaParameterization.h
+++ b/simulation/g4simulation/g4main/PHG4EtaParameterization.h
@@ -37,6 +37,7 @@ public:
   void ComputeTransformation(const G4int copyNo,
 			     G4VPhysicalVolume* physVol) const override;
   
+  using G4VPVParameterisation::ComputeDimensions;// avoid warning for not implemented ComputeDimension methods
   void ComputeDimensions(G4Tubs& ring, const G4int copyNo,
 			 const G4VPhysicalVolume* physVol) const override;
 

--- a/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.h
+++ b/simulation/g4simulation/g4main/PHG4EtaPhiParameterization.h
@@ -34,10 +34,10 @@ public:
   ~PHG4EtaPhiParameterization() override;
   
   virtual void Print(std::ostream& os = std::cout) const;
-
   void ComputeTransformation(const G4int copyNo,
 			     G4VPhysicalVolume* physVol) const override;
   
+  using G4VPVParameterisation::ComputeDimensions; // avoid warning for not implemented ComputeDimension methods
   void ComputeDimensions(G4Tubs& ring, const G4int copyNo,
 			 const G4VPhysicalVolume* physVol) const override;
 

--- a/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthEventAction.cc
@@ -21,7 +21,11 @@
 #include <Geant4/G4PrimaryVertex.hh>                    // for G4PrimaryVertex
 #include <Geant4/G4VUserPrimaryParticleInformation.hh>  // for G4VUserPrimar...
 
+// eigen has some shadowed variables
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <Eigen/Dense>
+#pragma GCC diagnostic pop
 
 #include <cmath>     // for isnan
 #include <cstdlib>   // for abs

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -239,9 +239,9 @@ PHG4Particle* PHG4TruthTrackingAction::AddParticle(PHG4TruthInfoContainer& truth
   // determine the momentum vector
   G4ParticleDefinition* def = track.GetDefinition();
   int pdgid = def->GetPDGEncoding();
-  double m = def->GetPDGMass();
+  double mass = def->GetPDGMass();
   double ke = track.GetVertexKineticEnergy();
-  double ptot = sqrt(ke * ke + 2.0 * m * ke);
+  double ptot = sqrt(ke * ke + 2.0 * mass * ke);
   G4ThreeVector pdir = track.GetVertexMomentumDirection();
   pdir *= ptot;
   PHG4Particle* ti = nullptr;

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -6,17 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-dnl leaving this here in case we want to play with different compiler 
-dnl specific flags
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
-
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 

--- a/simulation/g4simulation/g4main/configure.ac
+++ b/simulation/g4simulation/g4main/configure.ac
@@ -10,6 +10,11 @@ CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 dnl  AM_CONDITIONAL(GCC_GE_48, test `g++ -dumpversion | awk '{print $1>=4.8?"1":"0"}'` = 1)
 
+case $CXX in
+  clang++)
+    CXXFLAGS="$CXXFLAGS -Wno-c11-extensions -Wno-deprecated-copy"
+  ;;
+esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)

--- a/simulation/g4simulation/g4micromegas/Makefile.am
+++ b/simulation/g4simulation/g4micromegas/Makefile.am
@@ -1,10 +1,11 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I$(G4_MAIN)/include
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
@@ -437,10 +437,10 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_micromegas_tile( int tileid )
     
     auto component_solid = new G4Box(cname+"_solid", thickness/2, dy/2, dz/2 );
     auto component_logic = new G4LogicalVolume( component_solid, material, cname+"_logic");
-    auto vis = new G4VisAttributes( color );
-    vis->SetForceSolid(true);
-    vis->SetVisibility(true);
-    component_logic->SetVisAttributes(vis);
+    auto visA = new G4VisAttributes( color );
+    visA->SetForceSolid(true);
+    visA->SetVisibility(true);
+    component_logic->SetVisAttributes(visA);
     
     const G4ThreeVector center( (current_radius_local + thickness/2), y_offset, z_offset );
     auto component_phys = new G4PVPlacement( nullptr, center, component_logic, cname+"_phys", tile_logic, false, 0, OverlapCheck() );
@@ -560,10 +560,10 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_fee_board( int id )
         
     auto component_solid = new G4Box(cname+"_solid", thickness/2, fee_dy/2, fee_dz/2 );
     auto component_logic = new G4LogicalVolume( component_solid, material, cname+"_logic");
-    auto vis = new G4VisAttributes( color );
-    vis->SetForceSolid(true);
-    vis->SetVisibility(true);
-    component_logic->SetVisAttributes(vis);
+    auto visA = new G4VisAttributes( color );
+    visA->SetForceSolid(true);
+    visA->SetVisibility(true);
+    component_logic->SetVisAttributes(visA);
     
     const G4ThreeVector center( (current_radius_local + thickness/2), 0, 0);
     auto component_phys = new G4PVPlacement( nullptr, center, component_logic, cname+"_phys", fee_logic, false, 0, OverlapCheck() );

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
@@ -21,8 +21,8 @@
 #include <phool/getClass.h>
 
 //_______________________________________________________________________
-PHG4MicromegasSubsystem::PHG4MicromegasSubsystem(const std::string &name, int layer)
-  : PHG4DetectorSubsystem(name, layer)
+PHG4MicromegasSubsystem::PHG4MicromegasSubsystem(const std::string &name, int layerno)
+  : PHG4DetectorSubsystem(name, layerno)
 {
   // call base class method which will set up parameter infrastructure
   // and call our SetDefaultParameters() method

--- a/simulation/g4simulation/g4micromegas/configure.ac
+++ b/simulation/g4simulation/g4micromegas/configure.ac
@@ -6,14 +6,7 @@ AC_PROG_CXX(CC g++)
 
 LT_INIT([disable-static])
 
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4mvtx/Makefile.am
+++ b/simulation/g4simulation/g4mvtx/Makefile.am
@@ -1,13 +1,14 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 lib_LTLIBRARIES = \
   libg4mvtx.la
 
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include \
-  -I$(G4_MAIN)/include
+  -isystem$(ROOTSYS)/include
 
 
 AM_LDFLAGS = \

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxDetector.cc
@@ -22,8 +22,6 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4GDMLParser.hh>
-#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
@@ -33,6 +31,13 @@
 #include <Geant4/G4Transform3D.hh>      // for G4Transform3D
 #include <Geant4/G4Types.hh>            // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
+
+// xerces has some shadowed variables
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#include <Geant4/G4GDMLParser.hh>
+#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
+#pragma GCC diagnostic pop
 
 #include <cmath>
 #include <cstdio>    // for sprintf

--- a/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4EICMvtxSteppingAction.cc
@@ -367,19 +367,19 @@ bool PHG4EICMvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     if (Verbosity() > 0)
     {
-      G4StepPoint* prePoint = aStep->GetPreStepPoint();
-      G4StepPoint* postPoint = aStep->GetPostStepPoint();
+      G4StepPoint* prePointA = aStep->GetPreStepPoint();
+      G4StepPoint* postPointA = aStep->GetPostStepPoint();
       cout << "----- PHg4MvtxSteppingAction::UserSteppingAction - active volume = " << sensor_volume->GetName() << endl;
       cout << "       layer = " << layer_id << endl;
       cout << "       stave number = " << stave_id << " half_stave_number = " << half_stave_number << endl;
       cout << "       module number  = " << module_number << endl;
       cout << "       chip number = " << chip_number << endl;
-      cout << "       prepoint x position " << prePoint->GetPosition().x() / cm << endl;
-      cout << "       prepoint y position " << prePoint->GetPosition().y() / cm << endl;
-      cout << "       prepoint z position " << prePoint->GetPosition().z() / cm << endl;
-      cout << "       postpoint x position " << postPoint->GetPosition().x() / cm << endl;
-      cout << "       postpoint y position " << postPoint->GetPosition().y() / cm << endl;
-      cout << "       postpoint z position " << postPoint->GetPosition().z() / cm << endl;
+      cout << "       prepoint x position " << prePointA->GetPosition().x() / cm << endl;
+      cout << "       prepoint y position " << prePointA->GetPosition().y() / cm << endl;
+      cout << "       prepoint z position " << prePointA->GetPosition().z() / cm << endl;
+      cout << "       postpoint x position " << postPointA->GetPosition().x() / cm << endl;
+      cout << "       postpoint y position " << postPointA->GetPosition().y() / cm << endl;
+      cout << "       postpoint z position " << postPointA->GetPosition().z() / cm << endl;
       cout << "       edep " << edep << endl;
     }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDefs.h
@@ -30,6 +30,6 @@ namespace PHG4MvtxDefs
 
 // detid of support structures
 
-};  // namespace PHG4MvtxDefs
+}  // namespace PHG4MvtxDefs
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -22,8 +22,6 @@
 #include <phool/getClass.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
-#include <Geant4/G4GDMLParser.hh>
-#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4RotationMatrix.hh>  // for G4RotationMatrix
@@ -35,6 +33,13 @@
 #include <Geant4/G4VPhysicalVolume.hh>  // for G4VPhysicalVolume
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4Tubs.hh>
+
+// xerces has some shadowed variables
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#include <Geant4/G4GDMLParser.hh>
+#include <Geant4/G4GDMLReadStructure.hh>  // for G4GDMLReadStructure
+#pragma GCC diagnostic pop
 
 #include <cmath>
 #include <cstdio>    // for sprintf
@@ -57,7 +62,7 @@ namespace mvtxGeomDef
   double wrap_rmin = 2.1 * cm;
   double wrap_rmax = mvtx_shell_inner_radius + mvtx_shell_thickness;
   double wrap_zlen = mvtx_shell_length;
-};
+}
 
 PHG4MvtxDetector::PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam)
   : PHG4Detector(subsys, Node, dnam)

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDigitizer.cc
@@ -72,17 +72,17 @@ int PHG4MvtxDigitizer::InitRun(PHCompositeNode *topNode)
   if (Verbosity() > 0)
   {
     cout << "====================== PHG4MvtxDigitizer::InitRun() =====================" << endl;
-    for (std::map<int, unsigned short>::iterator iter = _max_adc.begin();
-         iter != _max_adc.end();
-         ++iter)
+    for (std::map<int, unsigned short>::iterator miter = _max_adc.begin();
+         miter != _max_adc.end();
+         ++miter)
     {
-      cout << " Max ADC in Layer #" << iter->first << " = " << iter->second << endl;
+      cout << " Max ADC in Layer #" << miter->first << " = " << miter->second << endl;
     }
-    for (std::map<int, float>::iterator iter = _energy_scale.begin();
-         iter != _energy_scale.end();
-         ++iter)
+    for (std::map<int, float>::iterator miter = _energy_scale.begin();
+         miter != _energy_scale.end();
+         ++miter)
     {
-      cout << " Energy per ADC in Layer #" << iter->first << " = " << 1.0e6 * iter->second << " keV" << endl;
+      cout << " Energy per ADC in Layer #" << miter->first << " = " << 1.0e6 * miter->second << " keV" << endl;
     }
     cout << "===========================================================================" << endl;
   }

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSteppingAction.cc
@@ -367,19 +367,19 @@ bool PHG4MvtxSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     if (Verbosity() > 0)
     {
-      G4StepPoint* prePoint = aStep->GetPreStepPoint();
-      G4StepPoint* postPoint = aStep->GetPostStepPoint();
+      G4StepPoint* prePointA = aStep->GetPreStepPoint();
+      G4StepPoint* postPointA = aStep->GetPostStepPoint();
       cout << "----- PHg4MvtxSteppingAction::UserSteppingAction - active volume = " << sensor_volume->GetName() << endl;
       cout << "       layer = " << layer_id << endl;
       cout << "       stave number = " << stave_id << " half_stave_number = " << half_stave_number << endl;
       cout << "       module number  = " << module_number << endl;
       cout << "       chip number = " << chip_number << endl;
-      cout << "       prepoint x position " << prePoint->GetPosition().x() / cm << endl;
-      cout << "       prepoint y position " << prePoint->GetPosition().y() / cm << endl;
-      cout << "       prepoint z position " << prePoint->GetPosition().z() / cm << endl;
-      cout << "       postpoint x position " << postPoint->GetPosition().x() / cm << endl;
-      cout << "       postpoint y position " << postPoint->GetPosition().y() / cm << endl;
-      cout << "       postpoint z position " << postPoint->GetPosition().z() / cm << endl;
+      cout << "       prepoint x position " << prePointA->GetPosition().x() / cm << endl;
+      cout << "       prepoint y position " << prePointA->GetPosition().y() / cm << endl;
+      cout << "       prepoint z position " << prePointA->GetPosition().z() / cm << endl;
+      cout << "       postpoint x position " << postPointA->GetPosition().x() / cm << endl;
+      cout << "       postpoint y position " << postPointA->GetPosition().y() / cm << endl;
+      cout << "       postpoint z position " << postPointA->GetPosition().z() / cm << endl;
       cout << "       edep " << edep << endl;
     }
 

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -6,12 +6,11 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wextra -Wshadow"
+
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wno-undefined-var-template -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
  ;;
 esac
 

--- a/simulation/g4simulation/g4mvtx/configure.ac
+++ b/simulation/g4simulation/g4mvtx/configure.ac
@@ -6,13 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-CXXFLAGS="$CXXFLAGS -Wall  -Werror -Wextra -Wshadow"
-
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-undefined-var-template"
- ;;
-esac
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/simulation/g4simulation/g4tpc/Makefile.am
+++ b/simulation/g4simulation/g4tpc/Makefile.am
@@ -3,14 +3,15 @@
 
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 lib_LTLIBRARIES = \
   libg4tpc.la
 
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(G4_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
@@ -276,10 +276,10 @@ void PHG4TpcCentralMembrane::CalculateVertices(
       corner[3].SetXYZ(padfrac - arc_r, (widthmod[j] * str_width[i][j]) / 2, 0);    //"2b" = length of the pad, but not including the arc piece
 
       TVector3 rotatedcorner[4];
-      for (int i = 0; i < 4; i++)
+      for (int n = 0; n < 4; n++)
       {
-        rotatedcorner[i] = corner[i];
-        rotatedcorner[i].RotateZ(theta);
+        rotatedcorner[n] = corner[n];
+        rotatedcorner[n].RotateZ(theta);
       }
 
       x1a[i_out][j] = rotatedcorner[0].X() + cx[i_out][j];
@@ -338,8 +338,14 @@ void PHG4TpcCentralMembrane::CalculateVertices(
       nStripesBefore_R1_e[0] = 0;
 
       nStripesIn[j] = keepUntil[j] - keepThisAndAfter[j];
-
-      nStripesBefore[j] = nStripesIn[j - 1] + nStripesBefore[j - 1];
+      if (j==0)
+      {
+	nStripesBefore[j] = 0;
+      }
+      else
+      {
+        nStripesBefore[j] = nStripesIn[j - 1] + nStripesBefore[j - 1];
+      }
       nStripesBefore_R1_e[0] = 0;
     }
     nGoodStripes[j] = i_out;

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
@@ -21,7 +21,6 @@ class PHG4TpcCentralMembrane : public SubsysReco, public PHParameterInterface
  public:
   /// constructor
   PHG4TpcCentralMembrane(const std::string& name = "PHG4TpcDirectLaser");
-  ;
 
   /// destructor
   ~PHG4TpcCentralMembrane() override;

--- a/simulation/g4simulation/g4tpc/PHG4TpcDefs.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDefs.h
@@ -14,6 +14,6 @@ namespace PHG4TpcDefs
     Window = 100,
     WindowCore
   };
-};  // namespace PHG4TpcDefs
+}  // namespace PHG4TpcDefs
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -90,17 +90,17 @@ int PHG4TpcDigitizer::InitRun(PHCompositeNode *topNode)
   if (Verbosity() > 0)
   {
     std::cout << "====================== PHG4TpcDigitizer::InitRun() =====================" << std::endl;
-    for (std::map<int, unsigned int>::iterator iter = _max_adc.begin();
-         iter != _max_adc.end();
-         ++iter)
+    for (std::map<int, unsigned int>::iterator tpiter = _max_adc.begin();
+         tpiter != _max_adc.end();
+         ++tpiter)
     {
-      std::cout << " Max ADC in Layer #" << iter->first << " = " << iter->second << std::endl;
+      std::cout << " Max ADC in Layer #" << tpiter->first << " = " << tpiter->second << std::endl;
     }
-    for (std::map<int, float>::iterator iter = _energy_scale.begin();
-         iter != _energy_scale.end();
-         ++iter)
+    for (std::map<int, float>::iterator tpiter = _energy_scale.begin();
+         tpiter != _energy_scale.end();
+         ++tpiter)
     {
-      std::cout << " Energy per ADC in Layer #" << iter->first << " = " << 1.0e6 * iter->second << " keV" << std::endl;
+      std::cout << " Energy per ADC in Layer #" << tpiter->first << " = " << 1.0e6 * tpiter->second << " keV" << std::endl;
     }
     std::cout << "===========================================================================" << std::endl;
   }

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -102,7 +102,7 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   const std::string geonodename = "G4CELLPAR_" + detector;
   const std::string tpcgeonodename = "G4GEO_" + detector;
   hitnodename = "G4HIT_" + detector;
-  PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   if (!g4hit)
   {
     std::cout << Name() << " Could not locate G4HIT node " << hitnodename << std::endl;
@@ -145,12 +145,11 @@ int PHG4TpcElectronDrift::InitRun(PHCompositeNode *topNode)
   }
 
   seggeonodename = "CYLINDERCELLGEOM_SVTX";  // + detector;
-  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename.c_str());
+  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, seggeonodename);
   if (!seggeo)
   {
     seggeo = new PHG4CylinderCellGeomContainer();
-    auto runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
-    auto newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename.c_str(), "PHObject");
+    auto newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename, "PHObject");
     runNode->addNode(newNode);
   }
 
@@ -264,7 +263,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   }
 
   // g4hits
-  auto g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
+  auto g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   if (!g4hit)
   {
     std::cout << "Could not locate g4 hit node " << hitnodename << std::endl;
@@ -588,9 +587,9 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void PHG4TpcElectronDrift::MapToPadPlane(const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit)
+void PHG4TpcElectronDrift::MapToPadPlane(const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *padnt, TNtuple *hitnt)
 {
-  padplane->MapToPadPlane(single_hitsetcontainer.get(), temp_hitsetcontainer.get(), hittruthassoc, x_gem, y_gem, t_gem, hiter, ntpad, nthit);
+  padplane->MapToPadPlane(single_hitsetcontainer.get(), temp_hitsetcontainer.get(), hittruthassoc, x_gem, y_gem, t_gem, hiter, padnt, hitnt);
 }
 
 int PHG4TpcElectronDrift::End(PHCompositeNode * /*topNode*/)

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -27,7 +27,9 @@
 
 #include <CLHEP/Vector/RotationZ.h>
 
+
 #include <boost/format.hpp>
+
 
 #include <algorithm>  // for max, copy
 #include <cassert>

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -2,8 +2,12 @@
 
 #include <tpc/TpcDefs.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <trackbase/ActsSurfaceMaps.h>       // for ActsSurfaceMaps
 #include <trackbase/ActsTrackingGeometry.h>  // for ActsTrackingG...
+#pragma GCC diagnostic pop
+
 #include <trackbase/TrkrClusterContainer.h>  // for TrkrClusterCo...
 #include <trackbase/TrkrClusterHitAssoc.h>   // for TrkrClusterHi...
 #include <trackbase/TrkrHit.h>               // for TrkrHit

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -333,7 +333,7 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *single_hitsetcon
   if (Verbosity() > 100)
     if (layernum == print_layer)
     {
-      std::cout << " hit " << hit << " quick centroid for this electron " << std::endl;
+      std::cout << " hit " << m_NHits << " quick centroid for this electron " << std::endl;
       std::cout << "      phi centroid = " << phi_integral / weight << " phi in " << phi << " phi diff " << phi_integral / weight - phi << std::endl;
       std::cout << "      z centroid = " << z_integral / weight << " z in " << z_gem << " z diff " << z_integral / weight - z_gem << std::endl;
       // For a single track event, this captures the distribution of single electron centroids on the pad plane for layer print_layer.
@@ -346,12 +346,12 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(TrkrHitSetContainer *single_hitsetcon
       */
     }
 
-  hit++;
+  m_NHits++;
 
   return;
 }
 
-void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &pad_phibin, std::vector<double> &pad_phibin_share)
+void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum, const double phi, const double cloud_sig_rp, std::vector<int> &phibin_pad, std::vector<double> &phibin_pad_share)
 {
   const double radius = LayerGeom->get_radius();
   const double phistepsize = LayerGeom->get_phistep();
@@ -428,15 +428,15 @@ void PHG4TpcPadPlaneReadout::populate_zigzag_phibins(const unsigned int layernum
   // now we have the overlap for each pad
   for (int ipad = 0; ipad <= npads; ipad++)
   {
-    pad_phibin.push_back(pad_keep[ipad]);
-    pad_phibin_share.push_back(overlap[ipad]);
+    phibin_pad.push_back(pad_keep[ipad]);
+    phibin_pad_share.push_back(overlap[ipad]);
     if (rad_gem < output_radius) std::cout << "         zigzags: for pad " << ipad << " integral is " << overlap[ipad] << std::endl;
   }
 
   return;
 }
 
-void PHG4TpcPadPlaneReadout::populate_zbins(const double z, const std::array<double, 2> &cloud_sig_zz, std::vector<int> &adc_zbin, std::vector<double> &adc_zbin_share)
+void PHG4TpcPadPlaneReadout::populate_zbins(const double z, const std::array<double, 2> &cloud_sig_zz, std::vector<int> &zbin_adc, std::vector<double> &zbin_adc_share)
 {
   int zbin = LayerGeom->get_zbin(z);
   if (zbin < 0 || zbin > LayerGeom->get_zbins())
@@ -542,8 +542,8 @@ void PHG4TpcPadPlaneReadout::populate_zbins(const double z, const std::array<dou
                     << " index " << index << "  zLim1 " << zLim1 << " zLim2 " << zLim2 << " z_integral " << z_integral << std::endl;
     }
 
-    adc_zbin.push_back(cur_z_bin);
-    adc_zbin_share.push_back(z_integral);
+    zbin_adc.push_back(cur_z_bin);
+    zbin_adc_share.push_back(z_integral);
   }
 
   return;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -32,6 +32,9 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
 
   //  void MapToPadPlane(PHG4CellContainer *g4cells, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) override;
 
+// otherwise warning of inconsistent overload since only one MapToPadPlane methow is overridden
+  using PHG4TpcPadPlane::MapToPadPlane; 
+
   void MapToPadPlane(TrkrHitSetContainer *single_hitsetcontainer, TrkrHitSetContainer *hitsetcontainer, TrkrHitTruthAssoc *hittruthassoc, const double x_gem, const double y_gem, const double t_gem, PHG4HitContainer::ConstIterator hiter, TNtuple *ntpad, TNtuple *nthit) override;
 
   void SetDefaultParameters() override;
@@ -70,7 +73,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   int NZBins = INT_MAX;
   std::array<int, 3> NPhiBins;
   std::array<int, 3> NTpcLayers;
-  int hit = 0;
+  int m_NHits = 0;
 
   // gaussian sampling
   static constexpr double _nsigmas = 5;

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -5,13 +5,15 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
+
 case $CXX in
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template -Wno-misleading-indentation -Wextra -Wno-deprecated-copy"
- ;;
+  CXXFLAGS="$CXXFLAGS -Wno-vla-extension -Wno-c11-extensions -Wno-deprecated-copy"
+;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
+  CXXFLAGS="$CXXFLAGS -Wno-vla"
+;;
 esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -8,12 +8,15 @@ LT_INIT([disable-static])
 CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 case $CXX in
+ *analyzer)
+   CXXFLAGS="$CXXFLAGS -Wno-vla"
+ ;;
  clang++)
-  CXXFLAGS="$CXXFLAGS -Wno-vla-extension -Wno-c11-extensions -Wno-deprecated-copy"
-;;
+   CXXFLAGS="$CXXFLAGS -Wno-vla-extension -Wno-c11-extensions -Wno-deprecated-copy"
+ ;;
  *g++)
-  CXXFLAGS="$CXXFLAGS -Wno-vla"
-;;
+   CXXFLAGS="$CXXFLAGS -Wno-vla"
+ ;;
 esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "

--- a/simulation/g4simulation/g4trackfastsim/Makefile.am
+++ b/simulation/g4simulation/g4trackfastsim/Makefile.am
@@ -1,14 +1,14 @@
 AUTOMAKE_OPTIONS = foreign
 
+AM_CXXFLAGS = `geant4-config --cflags`
+
 lib_LTLIBRARIES = \
   libg4trackfastsim.la 
 
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(OFFLINE_MAIN)/include/eigen3  \
-  -I$(G4_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 
 AM_LDFLAGS = \

--- a/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
+++ b/simulation/g4simulation/g4trackfastsim/PHG4TrackFastSimEval.cc
@@ -491,9 +491,9 @@ void PHG4TrackFastSimEval::fill_vertex_tree(PHCompositeNode */*topNode*/)
     PHG4VtxPoint *best_vtx = nullptr;
     int best_n_match = -1;
     map<PHG4VtxPoint *, int> vertex_match_map;
-    for (auto iter = vertex->begin_tracks(); iter != vertex->end_tracks(); ++iter)
+    for (auto iterA = vertex->begin_tracks(); iterA != vertex->end_tracks(); ++iterA)
     {
-      const auto &trackid = *iter;
+      const auto &trackid = *iterA;
       const auto trackIter = m_TrackMap->find(trackid);
 
       if (trackIter == m_TrackMap->end()) continue;

--- a/simulation/g4simulation/g4trackfastsim/configure.ac
+++ b/simulation/g4simulation/g4trackfastsim/configure.ac
@@ -6,16 +6,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
-dnl leaving this here in case we want to play with different compiler 
-dnl specific flags
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR replaces the -I$(G4_MAIN)/include in the various Makefile.am's by AM_CXXFLAGS=`geant4-config --cflags`. This introduces new warning flags mainly -Wshadow, -Woverloaded-virtual and -Wpedantic which then crashed the compilation of a lot of our sources. The shadowed variables are actually dangerous - G4 seems to activate using namespace clhep, so variables like "s" are defined (as are all the other units like "m"). We should consider making -Wshadow part of our standard compiler flags 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

