### PR TITLE
make dtor virtual since classes inherit from it, fix shadowed variables

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
@@ -3,8 +3,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir` \
-  -I$(OFFLINE_MAIN)/include/eigen3
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/PHGenFitPkg/PHGenFit/Measurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Measurement.h
@@ -23,7 +23,7 @@ class Measurement
     , _clusterID(UINT_MAX){};
 
   //!dtor
-  ~Measurement() {}
+  virtual ~Measurement() {}
 
   //!
   genfit::AbsMeasurement* getMeasurement()

--- a/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.h
@@ -24,7 +24,7 @@ class PlanarMeasurement : public Measurement
   void init(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv);
 
   //!dtor
-  ~PlanarMeasurement() {}
+  ~PlanarMeasurement() override {}
 
  protected:
 };

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
@@ -66,9 +66,4 @@ SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TMatrixD
   init(pos, cov);
 }
 
-SpacepointMeasurement::~SpacepointMeasurement()
-{
-  //delete _measurement;
-}
-
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
@@ -40,7 +40,7 @@ class SpacepointMeasurement : public Measurement
   void init(const TVector3& pos, const TMatrixDSym& cov);
 
   //!dtor
-  ~SpacepointMeasurement();
+  ~SpacepointMeasurement() override {}
 
  protected:
 };

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -594,12 +594,12 @@ int Track::updateOneMeasurementKalman(
       const genfit::MeasurementOnPlane& mOnPlane = **it;
       //const double weight = mOnPlane.getWeight();
 
-      const TVectorD& measurement(mOnPlane.getState());
+      const TVectorD& measurementA(mOnPlane.getState());
       const genfit::AbsHMatrix* H(mOnPlane.getHMatrix());
       // (weighted) cov
       const TMatrixDSym& V(mOnPlane.getCov());  //Covariance of measurement noise v_{k}
 
-      TVectorD res(measurement - H->Hv(stateVector));
+      TVectorD res(measurementA - H->Hv(stateVector));
 #ifdef _DEBUG_
       {
         std::cout << __LINE__ << std::endl;
@@ -663,7 +663,7 @@ int Track::updateOneMeasurementKalman(
 #endif
       }
 
-      TVectorD resNew(measurement - H->Hv(stateVector));
+      TVectorD resNew(measurementA - H->Hv(stateVector));
 
       // Calculate chi2
       TMatrixDSym HCHt(cov);  //C_{k|k}
@@ -684,7 +684,7 @@ int Track::updateOneMeasurementKalman(
       }
       chi2inc += HCHt.Similarity(resNew);
 
-      ndfInc += measurement.GetNrows();
+      ndfInc += measurementA.GetNrows();
 
 #ifdef _PRINT_MATRIX_
       std::cout << __LINE__ << ": V - HCHt:" << std::endl;

--- a/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
+++ b/offline/packages/PHGenFitPkg/PHGenFit/configure.ac
@@ -9,14 +9,10 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 fi
 
-dnl test for root 6
-if test `root-config --version | awk '{print $1>=6.?"1":"0"}'` = 1; then
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
-AC_SUBST(CINTDEFS)
-fi
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/offline/packages/PHTpcTracker/SpacepointMeasurement2.h
+++ b/offline/packages/PHTpcTracker/SpacepointMeasurement2.h
@@ -35,7 +35,7 @@ namespace PHGenFit
     void init(const TVector3& pos, const TMatrixDSym& cov);
 
     //!dtor
-    ~SpacepointMeasurement2();
+    ~SpacepointMeasurement2() override;
 
    protected:
   };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The measurement class did not have a virtual dtor which might be the reason for genfit leaks we see. coverity marked the dtors for the daughter classes as resource leak for that reason. This won't hurt - maybe it will do some good
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

