### PR TITLE
Micromegas display

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -18,10 +18,7 @@
 #include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
 #include <phool/phooldefs.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <boost/algorithm/string.hpp>
 

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -7,10 +7,7 @@
 #include <phool/PHNodeIterator.h>
 #include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <cstdlib>
 #include <iostream>

--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -8,10 +8,7 @@
 #include <TFile.h>
 #include <TH1.h>
 #include <TNamed.h>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TTree.h>
-#pragma GCC diagnostic pop
 
 #include <RVersion.h>
 #if ROOT_VERSION_CODE >= ROOT_VERSION(5, 20, 0)

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -1,9 +1,6 @@
 #include "Fun4AllMemoryTracker.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 #include <utility>  // for pair, make_pair

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -26,10 +26,7 @@
 #include <TROOT.h>
 #include <TSysEvtHandler.h>  // for ESignals
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <algorithm>
 #include <cmath>

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -8,10 +8,7 @@
 
 #include <phool/phool.h>  // for PHWHERE
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <cstdlib>
 #include <iostream>  // for operator<<, endl, basic_ostream

--- a/offline/framework/fun4all/Fun4AllUtils.cc
+++ b/offline/framework/fun4all/Fun4AllUtils.cc
@@ -1,18 +1,7 @@
 #include "Fun4AllUtils.h"
 
+#include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-// this is an ugly hack, the gcc optimizer has a bug which
-// triggers the uninitialized variable warning which
-// stops compilation because of our -Werror
-#include <boost/version.hpp>  // to get BOOST_VERSION
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && BOOST_VERSION == 105700)
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma message "ignoring bogus gcc warning in boost header lexical_cast.hpp"
-#include <boost/lexical_cast.hpp>
-#pragma GCC diagnostic warning "-Wuninitialized"
-#else
-#include <boost/lexical_cast.hpp>
-#endif
 
 #include <algorithm>  // for max
 #include <iostream>

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -3,7 +3,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
+  -isystem$(ROOTSYS)/include \
   -I$(OPT_SPHENIX)/include
 
 AM_LDFLAGS = \

--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -6,7 +6,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir`
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/framework/phool/PHNode.cc
+++ b/offline/framework/phool/PHNode.cc
@@ -4,11 +4,7 @@
 
 #include "phool.h"
 
-// root reuses kDefault
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 // boost stacktrace header causes a shadow warning
 #pragma GCC diagnostic push

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -7,8 +7,6 @@
 #include "PHNodeIterator.h"
 #include "phooldefs.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TBranch.h>  // for TBranch
 #include <TBranchElement.h>
 #include <TBranchObject.h>
@@ -21,7 +19,6 @@
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TTree.h>
-#pragma GCC diagnostic pop
 
 #include <boost/algorithm/string.hpp>
 

--- a/offline/framework/phool/PHObject.cc
+++ b/offline/framework/phool/PHObject.cc
@@ -2,11 +2,7 @@
 
 #include "phool.h"
 
-// root reuses kDefault
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <iostream>
 

--- a/simulation/g4simulation/g4micromegas/Makefile.am
+++ b/simulation/g4simulation/g4micromegas/Makefile.am
@@ -20,11 +20,12 @@ lib_LTLIBRARIES = \
   libg4micromegas.la
 
 libg4micromegas_la_SOURCES = \
-  PHG4MicromegasSubsystem.cc \
   PHG4MicromegasDetector.cc \
   PHG4MicromegasDigitizer.cc \
+  PHG4MicromegasDisplayAction.cc \
   PHG4MicromegasHitReco.cc \
-  PHG4MicromegasSteppingAction.cc
+  PHG4MicromegasSteppingAction.cc \
+  PHG4MicromegasSubsystem.cc
 
 libg4micromegas_la_LIBADD = \
   -lphool \

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
@@ -6,12 +6,15 @@
 
 #include "PHG4MicromegasDetector.h"
 
+#include "PHG4MicromegasDisplayAction.h"
+
 #include <phparameter/PHParameters.h>
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <g4main/PHG4Detector.h>
 #include <g4main/PHG4Subsystem.h>
+
 #include <micromegas/CylinderGeomMicromegas.h>
 
 #include <phool/getClass.h>
@@ -28,7 +31,6 @@
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4VisAttributes.hh>
 #include <Geant4/G4String.hh>                       // for G4String
 #include <Geant4/G4ThreeVector.hh>                  // for G4ThreeVector
 #include <Geant4/G4Tubs.hh>
@@ -52,6 +54,7 @@ namespace
 //____________________________________________________________________________..
 PHG4MicromegasDetector::PHG4MicromegasDetector(PHG4Subsystem *subsys, PHCompositeNode *Node, PHParameters *parameters, const std::string &dnam)
   : PHG4Detector(subsys, Node, dnam)
+  , m_DisplayAction(dynamic_cast<PHG4MicromegasDisplayAction*>(subsys->GetDisplayAction()))
   , m_Params(parameters)
 { setup_tiles(); }
 
@@ -402,12 +405,8 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_micromegas_tile( int tileid )
   const auto tilename = GetName() + "_tile_" + std::to_string(tileid);
   
   auto tile_solid = new G4Box( tilename+"_solid", tile_thickness/2, tile_dy/2, tile_dz/2 );
-  auto tile_logic = new G4LogicalVolume( tile_solid, world_material, tilename+"_logic");
-  auto vis = new G4VisAttributes(G4Colour::Grey());
-  vis->SetForceSolid(true);
-  vis->SetVisibility(false);
-
-  tile_logic->SetVisAttributes(vis);
+  auto tile_logic = new G4LogicalVolume( tile_solid, world_material, "invisible_" + tilename + "_logic");
+  GetDisplayAction()->AddVolume(tile_logic,G4Colour::Grey());
 
   /* we loop over registered layers and create volumes for each as daughter of the tile volume */
   auto current_radius_local = -tile_thickness/2;
@@ -437,10 +436,7 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_micromegas_tile( int tileid )
     
     auto component_solid = new G4Box(cname+"_solid", thickness/2, dy/2, dz/2 );
     auto component_logic = new G4LogicalVolume( component_solid, material, cname+"_logic");
-    auto visA = new G4VisAttributes( color );
-    visA->SetForceSolid(true);
-    visA->SetVisibility(true);
-    component_logic->SetVisAttributes(visA);
+    GetDisplayAction()->AddVolume(component_logic , color);
     
     const G4ThreeVector center( (current_radius_local + thickness/2), y_offset, z_offset );
     auto component_phys = new G4PVPlacement( nullptr, center, component_logic, cname+"_phys", tile_logic, false, 0, OverlapCheck() );
@@ -534,12 +530,8 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_fee_board( int id )
   const auto feename = GetName() + "_fee_" + std::to_string(id);
   
   auto fee_solid = new G4Box( feename+"_solid", fee_thickness/2, fee_dy/2, fee_dz/2 );
-  auto fee_logic = new G4LogicalVolume( fee_solid, world_material, feename+"_logic");
-  auto vis = new G4VisAttributes(G4Colour::Grey());
-  vis->SetForceSolid(true);
-  vis->SetVisibility(false);
-
-  fee_logic->SetVisAttributes(vis);
+  auto fee_logic = new G4LogicalVolume( fee_solid, world_material, "invisible_" + feename + "_logic");
+  GetDisplayAction()->AddVolume(fee_logic,G4Colour::Grey() );
 
   /* we loop over registered layers and create volumes for each as daughter of the fee volume */
   auto current_radius_local = -fee_thickness/2;
@@ -560,10 +552,7 @@ G4LogicalVolume* PHG4MicromegasDetector::construct_fee_board( int id )
         
     auto component_solid = new G4Box(cname+"_solid", thickness/2, fee_dy/2, fee_dz/2 );
     auto component_logic = new G4LogicalVolume( component_solid, material, cname+"_logic");
-    auto visA = new G4VisAttributes( color );
-    visA->SetForceSolid(true);
-    visA->SetVisibility(true);
-    component_logic->SetVisAttributes(visA);
+    GetDisplayAction()->AddVolume(component_logic , color);
     
     const G4ThreeVector center( (current_radius_local + thickness/2), 0, 0);
     auto component_phys = new G4PVPlacement( nullptr, center, component_logic, cname+"_phys", fee_logic, false, 0, OverlapCheck() );

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.h
@@ -18,6 +18,7 @@
 class G4LogicalVolume;
 class G4VPhysicalVolume;
 class PHCompositeNode;
+class PHG4MicromegasDisplayAction;
 class PHG4Subsystem;
 class PHParameters;
 
@@ -58,6 +59,9 @@ class PHG4MicromegasDetector : public PHG4Detector
 //   void set_tiles( const MicromegasTile::List& tiles )
 //   { m_tiles = tiles; }
 
+  //! access the display action
+  PHG4MicromegasDisplayAction* GetDisplayAction() { return m_DisplayAction; }
+
   private:
 
   //! setup tiles
@@ -81,6 +85,9 @@ class PHG4MicromegasDetector : public PHG4Detector
   /*! this handles the internal (module/strips) segmentation, needed for tracking*/
   void add_geometry_node();
   
+  //! vis attribute handling (save memory in batch)
+  PHG4MicromegasDisplayAction* m_DisplayAction = nullptr;
+
   //! detector parameters
   PHParameters* m_Params = nullptr;
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDisplayAction.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDisplayAction.cc
@@ -1,0 +1,52 @@
+#include "PHG4MicromegasDisplayAction.h"
+
+#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+
+#include <Geant4/G4Colour.hh>
+#include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4VisAttributes.hh>
+
+#include <iostream>  // for operator<<, basic_ostream, endl
+#include <utility>   // for pair
+#include <string>
+
+PHG4MicromegasDisplayAction::PHG4MicromegasDisplayAction(const std::string &name)
+  : PHG4DisplayAction(name)
+{
+}
+
+PHG4MicromegasDisplayAction::~PHG4MicromegasDisplayAction()
+{
+  for (auto &it : m_VisAttVec)
+  {
+    delete it;
+  }
+  m_VisAttVec.clear();
+}
+
+void PHG4MicromegasDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
+{
+  for (auto it : m_LogicalVolumeMap)
+  {
+    G4LogicalVolume *logvol = it.first;
+    if (logvol->GetVisAttributes())
+    {
+      continue;
+    }
+    G4VisAttributes *visatt = new G4VisAttributes();
+    visatt->SetVisibility(true);
+    visatt->SetForceSolid(true);
+    m_VisAttVec.push_back(visatt);  // for later deletion
+    if (it.first->GetName().find("invisible") != std::string::npos)
+    {
+      visatt->SetColour(it.second);
+      visatt->SetVisibility(false);
+    }
+    else
+    {
+      visatt->SetColour(it.second);
+    }
+    logvol->SetVisAttributes(visatt);
+  }
+  return;
+}

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDisplayAction.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDisplayAction.h
@@ -1,0 +1,34 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MICROMEGAS_PHG4MICROMEGASDISPLAYACTION_H
+#define G4MICROMEGAS_PHG4MICROMEGASDISPLAYACTION_H
+
+#include <g4main/PHG4DisplayAction.h>
+
+#include <Geant4/G4Color.hh>
+
+#include <map>
+#include <string>  // for string
+#include <vector>
+
+class G4LogicalVolume;
+class G4VisAttributes;
+class G4VPhysicalVolume;
+class G4Colour;
+
+class PHG4MicromegasDisplayAction : public PHG4DisplayAction
+{
+ public:
+  PHG4MicromegasDisplayAction(const std::string &name);
+
+  ~PHG4MicromegasDisplayAction() override;
+
+  void ApplyDisplayAction(G4VPhysicalVolume *physvol) override;
+  void AddVolume(G4LogicalVolume *logvol, G4Colour col ) { m_LogicalVolumeMap[logvol] = col; }
+
+ private:
+  std::map<G4LogicalVolume *, G4Colour> m_LogicalVolumeMap;
+  std::vector<G4VisAttributes *> m_VisAttVec;
+};
+
+#endif  // G4MICROMEGAS_PHG4MICROMEGASDISPLAYACTION_H

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
@@ -6,6 +6,7 @@
 #include "PHG4MicromegasSubsystem.h"
 
 #include "PHG4MicromegasDetector.h"
+#include "PHG4MicromegasDisplayAction.h"
 #include "PHG4MicromegasSteppingAction.h"
 
 #include <phparameter/PHParameters.h>
@@ -30,6 +31,13 @@ PHG4MicromegasSubsystem::PHG4MicromegasSubsystem(const std::string &name, int la
 
   SuperDetector(name);
 }
+
+//_______________________________________________________________________
+PHG4MicromegasSubsystem::~PHG4MicromegasSubsystem()
+{
+  delete m_DisplayAction;
+}
+
 
 //_______________________________________________________________________
 int PHG4MicromegasSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
@@ -57,6 +65,7 @@ int PHG4MicromegasSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   }
 
   // create detector
+  m_DisplayAction = new PHG4MicromegasDisplayAction(Name());
   m_Detector = new PHG4MicromegasDetector(this, topNode, GetParams(), Name());
   m_Detector->set_first_layer( GetLayer() );
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
@@ -16,6 +16,7 @@
 class PHCompositeNode;
 class PHG4Detector;
 class PHG4MicromegasDetector;
+class PHG4DisplayAction;
 class PHG4MicromegasSteppingAction;
 class PHG4SteppingAction;
 
@@ -31,6 +32,8 @@ class PHG4MicromegasSubsystem : public PHG4DetectorSubsystem
   public:
   //! constructor
   PHG4MicromegasSubsystem(const std::string& name = "MICROMEGAS", int layer = 0);
+
+  ~PHG4MicromegasSubsystem() override;
 
   /*!
   creates relevant hit nodes that will be populated by the stepping action and stored in the output DST
@@ -53,7 +56,10 @@ class PHG4MicromegasSubsystem : public PHG4DetectorSubsystem
   //! Print info (from SubsysReco)
   void Print(const std::string& what = "ALL") const override;
 
-  protected:
+  //! get the display action if display is started
+  PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
+
+  private:
   
   // \brief Set default parameter values
   void SetDefaultParameters() override;
@@ -67,6 +73,9 @@ class PHG4MicromegasSubsystem : public PHG4DetectorSubsystem
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
   PHG4MicromegasSteppingAction *m_SteppingAction = nullptr;
+
+  //! display attribute setting
+  PHG4DisplayAction* m_DisplayAction = nullptr;
 };
 
-#endif // MICROMEGASSUBSYSTEM_H
+#endif // G4MICROMEGAS_PHG4MICROMEGASSUBSYSTEM_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds the DisplayAction to the Micromegas. Just using VisAttributes leaves memory leaks and allocates memory only needed for displaying the detector. The DisplayAction makes this on demand which fixes a bunch of valgrind leaks.

Also revert a few of the pragmas in phool and fun4all which are obsolete when using -isystem$(ROOTSYS)/include which tells the compiler to ignore warnings in these includes
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

