### PR TITLE
force TGeoManager to use the Fun4All unit of cm

### DIFF
--- a/offline/packages/PHGeometry/PHGeomIOTGeo.cc
+++ b/offline/packages/PHGeometry/PHGeomIOTGeo.cc
@@ -71,6 +71,15 @@ PHGeomIOTGeo::
 {
   if (not isValid()) return nullptr;
 
+  // force TGeoManager to use the Fun4All unit of cm
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,23,2)
+  TGeoManager::LockDefaultUnits(kFALSE);
+  TGeoManager::SetDefaultUnits( TGeoManager::kRootUnits );
+  TGeoManager::LockDefaultUnits(kTRUE);
+#else
+  TGeoManager::SetDefaultRootUnits();
+#endif
+
   // build new TGeoManager
   TGeoManager* tgeo = new TGeoManager("PHGeometry", "");
   assert(tgeo);

--- a/offline/packages/PHGeometry/PHGeomUtility.cc
+++ b/offline/packages/PHGeometry/PHGeomUtility.cc
@@ -71,6 +71,15 @@ int PHGeomUtility::ImportGeomFile(PHCompositeNode *topNode,
   dst_geom->Reset();
 
   TGeoManager::SetVerboseLevel(GetVerbosity());
+
+  // force TGeoManager to use the Fun4All unit of cm
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,23,2)
+  TGeoManager::SetDefaultUnits( TGeoManager::kRootUnits );
+  TGeoManager::LockDefaultUnits(kTRUE);
+#else
+  TGeoManager::SetDefaultRootUnits();
+#endif
+
   dst_geom->SetGeometry(TGeoManager::Import(geometry_file.c_str()));
 
   if (dst_geom->GetGeometry() == nullptr)

--- a/offline/packages/PHGeometry/PHGeomUtility.cc
+++ b/offline/packages/PHGeometry/PHGeomUtility.cc
@@ -74,6 +74,7 @@ int PHGeomUtility::ImportGeomFile(PHCompositeNode *topNode,
 
   // force TGeoManager to use the Fun4All unit of cm
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,23,2)
+  TGeoManager::LockDefaultUnits(kFALSE);
   TGeoManager::SetDefaultUnits( TGeoManager::kRootUnits );
   TGeoManager::LockDefaultUnits(kTRUE);
 #else

--- a/offline/packages/PHGeometry/PHGeomUtility.cc
+++ b/offline/packages/PHGeometry/PHGeomUtility.cc
@@ -47,6 +47,15 @@ PHGeomUtility::GetTGeoManager(PHCompositeNode *topNode)
     dst_geom = LoadFromIONode(topNode);
   }
 
+  if (TGeoManager::GetDefaultUnits() != TGeoManager::kRootUnits )
+  {
+    cout << __PRETTY_FUNCTION__ << " TGeoManager was not constructed with RootUnits, which potentially leads to unit mismatch with Fun4All. This is considered a fatal error."
+        <<endl;
+
+    exit(1);
+    return nullptr;
+  }
+
   UpdateIONode(topNode);
 
   return dst_geom->GetGeometry();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

ROOT has been changing default units from cm to mm in Feb 2019 ( https://github.com/root-project/root/pull/3417 ) and back to cm again in sept 2021 ( https://github.com/root-project/root/pull/8955 ). The unit interface also changed, e.g. in https://github.com/root-project/root/pull/7165 . This interferes with the stability for our reconstruction geometry, showing up in recent ACTS code updates by @jdosbo 

This pull request lock the TGeo to use the Fun4All length units to keep our geometry objects stable. 

Meanwhile, it is recommend that TGeo user code verifies `TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits`, prior to assuming the length dimension is given in `cm`


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Verify this fix works for ACTS by @jdosbo 

## Links to other PRs in macros and calibration repositories (if applicable)

