### PR TITLE
Fix fake TPC surface overlaps

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -334,8 +334,7 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol,
   for (unsigned int iz = 0; iz < m_nSurfZ; ++iz)
     {
       // The (half) tpc gas volume is 105.5 cm long and is symmetric around (x,y,z) = (0,0,0) in its frame
-      double z_center = -105.5/2.0 + m_surfStepZ / 2.0 + (double) iz * m_surfStepZ;
-      
+      double z_center = 0.0;
       for (unsigned int imod = 0; imod < m_nTpcModulesPerLayer; ++imod)
 	{
 	  for (unsigned int iphi = 0; iphi < m_nSurfPhi; ++iphi)

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -172,7 +172,9 @@ class MakeActsGeometry : public SubsysReco
 
   /// TPC Acts::Surface subdivisions
   double m_minSurfZ = 0.;
-  double m_maxSurfZ = 105.78;
+  /// This value must be less than the TPC gas volume in TGeo, which 
+  /// is 105.22 cm
+  double m_maxSurfZ = 105.219999;
   unsigned int m_nSurfZ = 1;
   unsigned int m_nSurfPhi = 12;
   double m_surfStepPhi = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

As part of the Acts update, we found that the fake TPC surfaces overlap the end wheels. This PR fixes the overlaps so that Jenkins can now routinely check this in the CI.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

