### PR TITLE
Add catch for no track parameters

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -459,7 +459,7 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
   if (fitOutput.fittedParameters)
     {
        indexedParams.emplace(fitOutput.trackTip, 
-			    fitOutput.fittedParameters.value());
+			     fitOutput.fittedParameters.value());
 
       if (Verbosity() > 2)
         {
@@ -474,6 +474,12 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
                     << std::endl;
 	  std::cout << "For trackTip == " << fitOutput.trackTip << std::endl;
         }
+    }
+  else 
+    {
+      /// Track fit failed in some way if there are no fit parameters. Remove
+      m_trackMap->erase(track->get_id());
+      return;
     }
 
   auto trajectory = std::make_unique<Trajectory>(fitOutput.fittedStates,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This adds a catch for a rare crash where Acts returns that the fit was successful but the fit result has no fitted track parameters. I would consider that unsuccessful, so when this happens the track is now removed from the track map.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

