### PR TITLE
G4Scintillation::SetScintillationYieldFactor is declared but not impl…

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -463,7 +463,9 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   theCerenkovProcess->SetMaxNumPhotonsPerStep(300);
   theCerenkovProcess->SetMaxBetaChangePerStep(10.0);
   theCerenkovProcess->SetTrackSecondariesFirst(false);  // current PHG4TruthTrackingAction does not support suspect active track and track secondary first
+#if G4VERSION_NUMBER < 1100
   theScintillationProcess->SetScintillationYieldFactor(1.0);
+#endif
   theScintillationProcess->SetTrackSecondariesFirst(false);
   // theScintillationProcess->SetScintillationExcitationRatio(1.0);
 


### PR DESCRIPTION
…emented causing a linker failure

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes an unresolved external for the new G4 version 11. For some reason G4Scintillation::SetScintillationYieldFactor is declared in the G4Scintillation.hh header but not implemented. The source does compile but then the testlink fails with an unresolved external. Hiding this behind a G4 version def, the factor is set to 1 which I assume is the default anyway.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

