### PR TITLE
YCM remove overlaps with MVTX geometry defined in TrackingService macro

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -53,10 +53,10 @@ using namespace std;
 
 namespace mvtxGeomDef
 {
-  double mvtx_shell_inner_radius            =  4.8  * cm;
-  double skin_thickness                     =  0.01 * cm;
-  double foam_core_thickness                =  0.18 * cm;
-  double mvtx_shell_length                  = 50.   * cm;
+  double mvtx_shell_inner_radius            = 4.8  * cm;
+  double skin_thickness                     = 0.01 * cm;
+  double foam_core_thickness                = 0.18 * cm;
+  double mvtx_shell_length                  = 46.  * cm;
   double mvtx_shell_thickness =  skin_thickness + foam_core_thickness + skin_thickness;
 
   double wrap_rmin = 2.1 * cm;
@@ -349,9 +349,9 @@ int PHG4MvtxDetector::ConstructMvtxPassiveVol(G4LogicalVolume*& lv)
   //=======================================================
   // Add an outer shell for the MVTX - moved it from INTT PHG4InttDetector.cc
   //=======================================================
-  G4LogicalVolume *mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
-  new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
-                    "mvtx_shell_outer_skin_volume", lv, false, 0, OverlapCheck());
+  //G4LogicalVolume *mvtx_shell_outer_skin_volume = GetMvtxOuterShell(lv);
+  //new G4PVPlacement(0, G4ThreeVector(0, 0.0), mvtx_shell_outer_skin_volume,
+  //                  "mvtx_shell_outer_skin_volume", lv, false, 0, OverlapCheck());
 
   //===================================
   // Construct Services geometry


### PR DESCRIPTION
TODO:
we need to move all MVTX detector geometry from TrackingService to
MVTX detector module to avoid this cases. Keep detector geometry definitions
in several places are difficult to maintain and debug.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

