### PR TITLE
Expand TPC surface length

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -174,7 +174,7 @@ class MakeActsGeometry : public SubsysReco
   double m_minSurfZ = 0.;
   /// This value must be less than the TPC gas volume in TGeo, which 
   /// is 105.22 cm
-  double m_maxSurfZ = 105.219999;
+  double m_maxSurfZ = 105.42;
   unsigned int m_nSurfZ = 1;
   unsigned int m_nSurfPhi = 12;
   double m_surfStepPhi = 0;
@@ -196,7 +196,8 @@ class MakeActsGeometry : public SubsysReco
   // Spaces to prevent boxes from touching when placed
   const double half_width_clearance_thick = 0.4999;
   const double half_width_clearance_phi = 0.4999;
-  const double half_width_clearance_z = 0.4999;
+  /// z does not need spacing as the boxes are rotated around the z axis
+  const double half_width_clearance_z = 0.5;
 
   /// The acts geometry object
   TGeoDetector m_detector;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR makes the TPC fake surfaces as long as possible in z in the TPC gas volume without introducing overlaps (Jenkins should confirm).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

