### PR TITLE
Update to central membrane reco and matcher

### DIFF
--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
@@ -236,6 +236,7 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
   //==========================
   vector<float>aveenergy;
   vector<TVector3> avepos;
+  vector <unsigned int> nclusters;
     
   for (int i=0;i<nTpcClust;++i)
     {
@@ -261,9 +262,9 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
 	      double avePhi = (pos[i].Phi() * energy[i] + pos[i_pair[i]].Phi() * energy[i_pair[i]]) * (1./(energy[i]+energy[i_pair[i]]));	      
 	      double aveZ = (pos[i].Z() * energy[i] + pos[i_pair[i]].Z() * energy[i_pair[i]]) * (1./(energy[i]+energy[i_pair[i]])); 	      
 
-	      // Cannot use single padrow CM flash clusters, R position is not well defined because cluster is smaller than padrow
+	      // Single padrow CM flash clusters, R position is not well defined because cluster is smaller than padrow
 	      // 2-cluster case: Weighting by padrow center radius is not correct because distribution does not fill padrow (needs to be approximately linearly)
-	      // Use ratio of component cluster energies to estimate number of sigmas at row boundary
+	      //      Use ratio of component cluster energies to estimate number of sigmas at row boundary
 	      float efrac = energy[i] / (energy[i] + energy[i_pair[i]]);
 
 	      PHG4CylinderCellGeom *layergeom1 = _geom_container->GetLayerCellGeom(layer[i]);
@@ -303,6 +304,7 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
 	
 	      TVector3 temppos(aveR*cos(avePhi), aveR*sin(avePhi), aveZ);
 	      avepos.push_back(temppos);
+	      nclusters.push_back(2);
 
 	      if(Verbosity() > 0)
 		std::cout << " layer i " << layer[i] << " energy " << energy[i] << " pos i " << pos[i].X() << "  " << pos[i].Y() << "  " << pos[i].Z()
@@ -315,9 +317,10 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
       else 
 	{
 	  if(_histos)  hClustE[2]->Fill(energy[i]);
-	  // These single cluster cases do not have a good radius centroid estimate, skip them
-	  //aveenergy.push_back(energy[i]);
-	  //avepos.push_back(pos[i]);
+	  // These single cluster cases have good phi, but do not have a good radius centroid estimate - may want to skip them, record nclusters
+	  aveenergy.push_back(energy[i]);
+	  avepos.push_back(pos[i]);
+	  nclusters.push_back(1);
 	}
     }      
       
@@ -333,6 +336,7 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
       cmfc->setY(avepos[iv].Y());
       cmfc->setZ(avepos[iv].Z());
       cmfc->setAdc(aveenergy[iv]);
+      cmfc->setNclusters(nclusters[iv]);
       
       _corrected_CMcluster_map->addClusterSpecifyKey(iv, cmfc);
       
@@ -349,8 +353,9 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
       auto cmclus = cmitr->second;
 
       if(Verbosity() > 0)
-	std::cout << "found cluster " << cmkey << " with adc " << cmclus->getAdc() 
+	std::cout << "found CM cluster " << cmkey << " with adc " << cmclus->getAdc() 
 		  << " x " << cmclus->getX() << " y " << cmclus->getY() << " z " << cmclus->getZ() 
+		  << " nclusters " << cmclus->getNclusters()
 		  << std::endl; 
 
       if(_histos)

--- a/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.cc
@@ -45,10 +45,14 @@ PHTpcCentralMembraneMatcher::PHTpcCentralMembraneMatcher(const std::string &name
   hrdphi = new TH2F("hrdphi","dphi vs r",800,0.0,80.0,800,-0.001,0.001);
   hrdphi->GetXaxis()->SetTitle("r");  
   hrdphi->GetYaxis()->SetTitle("dphi");  
-  hdr1 = new TH1F("hdr1", "innner dr", 200,-0.2, 0.2);
-  hdr2 = new TH1F("hdr2", "mid dr", 200,-0.2, 0.2);
-  hdr3 = new TH1F("hdr3", "outer dr", 200,-0.2, 0.2);
+  hdr1_single = new TH1F("hdr1_single", "innner dr single", 200,-0.2, 0.2);
+  hdr2_single = new TH1F("hdr2_single", "mid dr single", 200,-0.2, 0.2);
+  hdr3_single = new TH1F("hdr3_single", "outer dr single", 200,-0.2, 0.2);
+  hdr1_double = new TH1F("hdr1_double", "innner dr double", 200,-0.2, 0.2);
+  hdr2_double = new TH1F("hdr2_double", "mid dr double", 200,-0.2, 0.2);
+  hdr3_double = new TH1F("hdr3_double", "outer dr double", 200,-0.2, 0.2);
   hdrphi = new TH1F("hdrphi","r * dphi", 200, -0.05, 0.05);
+  hnclus = new TH1F("hnclus", " nclusters ", 100, 0., 3.);
   
   // Get truth cluster positions
   //=====================
@@ -146,9 +150,10 @@ int PHTpcCentralMembraneMatcher::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
 {
+  reco_pos.clear();
+  reco_nclusters.clear();
  
   // read the reconstructed CM clusters
-
   auto clusrange = _corrected_CMcluster_map->getClusters();
   for (auto cmitr = clusrange.first;
        cmitr !=clusrange.second;
@@ -156,13 +161,15 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
     {
       auto cmkey = cmitr->first;
       auto cmclus = cmitr->second;
+      unsigned int nclus = cmclus->getNclusters();
 
       // Do the static + average distortion corrections if the container was found
       Acts::Vector3D pos(cmclus->getX(), cmclus->getY(), cmclus->getZ());
       if( _dcc)  pos = _distortionCorrection.get_corrected_position( pos, _dcc ); 
 
       TVector3 tmp_pos(pos[0], pos[1], pos[2]);
-      reco_pos.push_back(tmp_pos);
+      reco_pos.push_back(tmp_pos);      
+      reco_nclusters.push_back(nclus);
 
       if(Verbosity() > 0)
 	{
@@ -179,7 +186,10 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
     }
 
   // Match reco and truth positions
-  std::map<unsigned int, unsigned int> matched_pair;
+  //std::map<unsigned int, unsigned int> matched_pair;
+  std::vector<std::pair<unsigned int, unsigned int>> matched_pair;
+  std::vector<unsigned int> matched_nclus;
+
   // loop over truth positions
   for(unsigned int i=0; i<truth_pos.size(); ++i)
     {
@@ -187,20 +197,28 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
       double phi1 = truth_pos[i].Phi();
       for(unsigned int j = 0; j < reco_pos.size(); ++j)
 	{
+	  unsigned int nclus = reco_nclusters[j];
+
 	  double rad2=sqrt(reco_pos[j].X() * reco_pos[j].X() + reco_pos[j].Y() * reco_pos[j].Y());
 	  double phi2 = reco_pos[j].Phi();
 
 	  if(fabs(rad1-rad2) < _rad_cut && fabs(phi1-phi2) < _phi_cut)
 	    {
-	      matched_pair.insert(std::make_pair(i,j));
+	      //matched_pair.insert(std::make_pair(i,j));
+	      matched_pair.push_back(std::make_pair(i,j));
+	      matched_nclus.push_back(nclus);
 	      break;
 	    }
 	}      
     }
   
- 
-  for(const auto &p : matched_pair)
+  
+  //for(const auto &p : matched_pair)
+  for(unsigned int ip = 0; ip < matched_pair.size(); ++ip)
     {
+      std::pair<unsigned int, unsigned int> p = matched_pair[ip];
+      unsigned int nclus = matched_nclus[ip];
+      
       if(_histos)
 	{
 	  double rad1 = sqrt(reco_pos[p.second].X() * reco_pos[p.second].X() + reco_pos[p.second].Y() * reco_pos[p.second].Y());
@@ -214,20 +232,35 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
 	  hdrdphi->Fill(dr, dphi);
 	  hrdr->Fill(r,dr);
 	  hrdphi->Fill(r,dphi);
+	  hnclus->Fill( (float) nclus);
 
-	  if(r < 40.0) hdr1->Fill(dr); 
-	  if(r >= 40.0 && r < 58.0) hdr2->Fill(dr); 
-	  if(r >= 58.0) hdr3->Fill(dr); 	  
+	  if(nclus==1)
+	    {
+	      if(r < 40.0) hdr1_single->Fill(dr); 
+	      if(r >= 40.0 && r < 58.0) hdr2_single->Fill(dr); 
+	      if(r >= 58.0) hdr3_single->Fill(dr); 	  
+	    }
+	  else
+	    {
+	      if(r < 40.0) hdr1_double->Fill(dr); 
+	      if(r >= 40.0 && r < 58.0) hdr2_double->Fill(dr); 
+	      if(r >= 58.0) hdr3_double->Fill(dr); 	  
+	    }
 	}
 
       // add to node tree
       unsigned int key = p.first;
      auto cmdiff = new CMFlashDifferencev1();
-     cmdiff->setTruthX(truth_pos[p.first].X());
-     cmdiff->setTruthY(truth_pos[p.first].Y());      
-     cmdiff->setRecoX(reco_pos[p.second].X());
-     cmdiff->setRecoY(reco_pos[p.second].Y());
-     
+     cmdiff->setTruthPhi(truth_pos[p.first].Phi());
+     cmdiff->setTruthR(truth_pos[p.first].Perp());
+     cmdiff->setTruthZ(truth_pos[p.first].Z());
+
+     cmdiff->setRecoPhi(reco_pos[p.second].Phi());
+     cmdiff->setRecoR(reco_pos[p.second].Perp());
+     cmdiff->setRecoZ(reco_pos[p.second].Z());
+
+     cmdiff->setNclusters(nclus);
+
      _cm_flash_diffs->addDifferenceSpecifyKey(key, cmdiff);
     } 
   
@@ -242,10 +275,11 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
 	  auto key = cmitr->first;
 	  auto cmreco = cmitr->second;
 	  
-	  std::cout << " key " << key << " truth X " << cmreco->getTruthX() << " reco X " << cmreco->getRecoX()
-		    << " truth Y " << cmreco->getTruthY() << " reco Y " << cmreco->getRecoY() 
-		    << " truth R " << sqrt( pow(cmreco->getTruthX(), 2) + pow(cmreco->getTruthY(), 2) ) 
-		    << " reco R " << sqrt( pow(cmreco->getRecoX(), 2) + pow(cmreco->getRecoY(), 2) ) 
+	  std::cout << " key " << key 
+		    << " nclus " << cmreco->getNclusters() 
+		    << " truth Phi " << cmreco->getTruthPhi() << " reco Phi " << cmreco->getRecoPhi()
+		    << " truth R " << cmreco->getTruthR() << " reco R " << cmreco->getRecoR() 
+		    << " truth Z " << cmreco->getTruthZ() << " reco Z " << cmreco->getRecoZ() 
 		    << std::endl;
 	}
     }
@@ -267,9 +301,13 @@ int PHTpcCentralMembraneMatcher::End(PHCompositeNode * /*topNode*/ )
       hrdr->Write();
       hrdphi->Write();
       hdrphi->Write();
-      hdr1->Write();
-      hdr2->Write();
-      hdr3->Write();
+      hdr1_single->Write();
+      hdr2_single->Write();
+      hdr3_single->Write();
+      hdr1_double->Write();
+      hdr2_double->Write();
+      hdr3_double->Write();
+      hnclus->Write();
             
       fout->Close();
     }

--- a/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.h
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.h
@@ -62,13 +62,18 @@ class PHTpcCentralMembraneMatcher : public SubsysReco
   TH2F *hrdr;
   TH2F *hrdphi;
   TH1F *hdrphi;
-  TH1F *hdr1;
-  TH1F *hdr2;
-  TH1F *hdr3;
+  TH1F *hdr1_single;
+  TH1F *hdr2_single;
+  TH1F *hdr3_single;
+  TH1F *hdr1_double;
+  TH1F *hdr2_double;
+  TH1F *hdr3_double;
+  TH1F *hnclus;
 
    std::vector<TVector3> reco_pos;
    std::vector<TVector3> truth_pos;
-  
+   std::vector<unsigned int> reco_nclusters;
+
   int _process = 0;
   bool _histos = true;
 

--- a/offline/packages/trackbase/CMFlashCluster.h
+++ b/offline/packages/trackbase/CMFlashCluster.h
@@ -58,12 +58,13 @@ class CMFlashCluster : public PHObject
   virtual void setY(float) {}
   virtual float getZ() const { return NAN; }
   virtual void setZ(float) {}
-
   //
   // cluster info
   //
   virtual void setAdc(unsigned int) {}
   virtual unsigned int getAdc() const { return UINT_MAX; }
+  virtual unsigned int getNclusters() const {return UINT_MAX;}
+  virtual void setNclusters( unsigned int) {}
 
  protected:
   CMFlashCluster() = default;

--- a/offline/packages/trackbase/CMFlashClusterv1.h
+++ b/offline/packages/trackbase/CMFlashClusterv1.h
@@ -53,6 +53,8 @@ class CMFlashClusterv1 : public CMFlashCluster
   void setY(float y) override { m_pos[1] = y; }
   float getZ() const override { return m_pos[2]; }
   void setZ(float z) override { m_pos[2] = z; }
+  unsigned int getNclusters() const override {return m_nclusters;}
+  void setNclusters(unsigned int n) override { m_nclusters = n;}
 
   //
   // cluster info
@@ -64,7 +66,8 @@ class CMFlashClusterv1 : public CMFlashCluster
 
   unsigned int m_cluskey;  //< unique identifier within container
   float m_pos[3];               //< mean position x,y,z
-  unsigned int m_adc;           //< cluster sum adc (D. McGlinchey - Do we need this?)
+  unsigned int m_adc;           //< cluster sum adc 
+  unsigned int m_nclusters;
 
   ClassDefOverride(CMFlashClusterv1, 1)
 };

--- a/offline/packages/trackbase/CMFlashClusterv1.h
+++ b/offline/packages/trackbase/CMFlashClusterv1.h
@@ -67,7 +67,7 @@ class CMFlashClusterv1 : public CMFlashCluster
   unsigned int m_cluskey;  //< unique identifier within container
   float m_pos[3];               //< mean position x,y,z
   unsigned int m_adc;           //< cluster sum adc 
-  unsigned int m_nclusters;
+  unsigned int m_nclusters = UINT_MAX;
 
   ClassDefOverride(CMFlashClusterv1, 1)
 };

--- a/offline/packages/trackbase/CMFlashDifference.h
+++ b/offline/packages/trackbase/CMFlashDifference.h
@@ -52,15 +52,26 @@ class CMFlashDifference : public PHObject
   //
   // difference position
   //
-  virtual float getTruthX() const { return NAN; }
-  virtual void setTruthX(float) {}
-  virtual float getTruthY() const { return NAN; }
-  virtual void setTruthY(float) {}
+ virtual float getTruthPhi() const { return NAN; }
+  virtual  void setTruthPhi(float) {}
 
-  virtual float getRecoX() const { return NAN; }
-  virtual void setRecoX(float) {}
-  virtual float getRecoY() const { return NAN; }
-  virtual void setRecoY(float) {}
+  virtual float getRecoPhi() const { return NAN; }
+  virtual void setRecoPhi(float) {}
+
+  virtual float getTruthR() const { return NAN; }
+  virtual void setTruthR(float) {}
+
+  virtual float getRecoR() const { return NAN; }
+  virtual void setRecoR(float) {}
+
+  virtual float getTruthZ() const { return NAN; }
+  virtual void setTruthZ(float) {}
+
+  virtual float getRecoZ() const { return NAN; }
+  virtual void setRecoZ(float) {}
+
+  virtual unsigned int getNclusters() const { return UINT_MAX; }
+  virtual void setNclusters(unsigned int) {}
 
  protected:
   CMFlashDifference() = default;

--- a/offline/packages/trackbase/CMFlashDifferencev1.cc
+++ b/offline/packages/trackbase/CMFlashDifferencev1.cc
@@ -17,10 +17,10 @@ namespace
 CMFlashDifferencev1::CMFlashDifferencev1()
   : m_key(UINT_MAX)
 {
-
-  for (int i = 0; i < 2; ++i) m_pos_truth[i] = NAN;
-  for (int i = 0; i < 2; ++i) m_pos_reco[i] = NAN;
-
+  m_nclusters = UINT_MAX;
+  for (int i = 0; i < 2; ++i) m_Phi[i] = NAN;
+  for (int i = 0; i < 2; ++i) m_R[i] = NAN;
+  for (int i = 0; i < 2; ++i) m_Z[i] = NAN;
  }
 
 void CMFlashDifferencev1::identify(std::ostream& os) const
@@ -28,12 +28,16 @@ void CMFlashDifferencev1::identify(std::ostream& os) const
   os << "---CMFlashDifferencev1--------------------" << std::endl;
   os << "key: " << getKey() << std::dec << std::endl;
 
-  os << " truth (x,y) =  (" << m_pos_truth[0];
-  os << ", " << m_pos_truth[1] << ") cm";
+  os << "nclusters: " << m_nclusters << std::dec << std::endl;
 
-  os << " reco (x,y) =  (" << m_pos_reco[0];
-  os << ", " << m_pos_reco[1] << ") cm";
+  os << " truth Phi =  " << m_Phi[0];
+  os << ",  reco Phi = " << m_Phi[1] << ") rad";
 
+  os << " truth R =  " << m_R[0];
+  os << ",  reco R = " << m_R[1] << ") cm";
+
+  os << " truth Z =  " << m_Z[0];
+  os << ",  reco Z = " << m_Z[1] << ") cm";
 
   os << std::endl;
   os << "-----------------------------------------------" << std::endl;
@@ -44,11 +48,16 @@ void CMFlashDifferencev1::identify(std::ostream& os) const
 int CMFlashDifferencev1::isValid() const
 {
   if (m_key == UINT_MAX) return 0;
+  if (m_nclusters == UINT_MAX) return 0;
 
-  if(std::isnan(getTruthX())) return 0;
-  if(std::isnan(getTruthY())) return 0;
-  if(std::isnan(getRecoX())) return 0;
-  if(std::isnan(getRecoY())) return 0;
+  if(std::isnan(getTruthPhi())) return 0;
+  if(std::isnan(getTruthR())) return 0;
+  if(std::isnan(getTruthZ())) return 0;
+
+  if(std::isnan(getRecoPhi())) return 0;
+  if(std::isnan(getRecoR())) return 0;
+  if(std::isnan(getRecoZ())) return 0;
+
 
   return 1;
 }
@@ -62,10 +71,15 @@ void CMFlashDifferencev1::CopyFrom( const CMFlashDifference& source )
   CMFlashDifference::CopyFrom( source );
 
   setKey( source.getKey() );
-  setTruthX( source.getTruthX() );
-  setTruthY( source.getTruthY() );
-  setRecoX( source.getRecoX() );
-  setRecoY( source.getRecoY() );
+  setNclusters( source.getNclusters() );
+
+  setTruthPhi( source.getTruthPhi() );
+  setTruthR( source.getTruthR() );
+  setTruthZ( source.getTruthZ() );
+
+  setRecoPhi( source.getRecoPhi() );
+  setRecoR( source.getRecoR() );
+  setRecoZ( source.getRecoZ() );
 
 }
 

--- a/offline/packages/trackbase/CMFlashDifferencev1.h
+++ b/offline/packages/trackbase/CMFlashDifferencev1.h
@@ -40,24 +40,50 @@ class CMFlashDifferencev1 : public CMFlashDifference
 
   void setKey(unsigned int id) override { m_key = id; }
   unsigned int getKey() const override { return m_key; }
+
+  void setNclusters(unsigned int n) override { m_nclusters = n; }
+  unsigned int getNclusters() const override { return m_nclusters; }
   //
   // difference position
   //
+  float getTruthPhi() const override { return m_Phi[0]; }
+  void setTruthPhi(float phi) override { m_Phi[0] = phi; }
+
+  float getRecoPhi() const override { return m_Phi[1]; }
+  void setRecoPhi(float phi) override { m_Phi[1] = phi; }
+
+  float getTruthR() const override { return m_R[0]; }
+  void setTruthR(float r) override { m_R[0] = r; }
+
+  float getRecoR() const override { return m_R[1]; }
+  void setRecoR(float r) override { m_R[1] = r; }
+
+  float getTruthZ() const override { return m_Z[0]; }
+  void setTruthZ(float z) override { m_Z[0] = z; }
+
+  float getRecoZ() const override { return m_Z[1]; }
+  void setRecoZ(float z) override { m_Z[1] = z; }
+
+
+  /*
   float getTruthX() const override { return m_pos_truth[0]; }
   void setTruthX(float x) override { m_pos_truth[0] = x; }
   float getTruthY() const override { return m_pos_truth[1]; }
   void setTruthY(float y) override { m_pos_truth[1] = y; }
-
   float getRecoX() const override { return m_pos_reco[0]; }
   void setRecoX(float x) override { m_pos_reco[0] = x; }
   float getRecoY() const override { return m_pos_reco[1]; }
   void setRecoY(float y) override { m_pos_reco[1] = y; }
-
+  */
 
  protected:
   unsigned int m_key;
-  float m_pos_truth[2];              //< truth x,y
-  float m_pos_reco[2];               //< reco x,y
+  unsigned int m_nclusters;
+
+  float m_Phi[2];  // (truth, reco)
+  float m_R[2];
+  float m_Z[2];
+
 
 
   ClassDefOverride(CMFlashDifferencev1, 1)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Following the discussion at the distortions meeting this morning, this pull request:
1) Adds the number of component clusters in a CM flash cluster to the CM cluster object and the difference object.
2) Stores the positions as (R, phi, Z) in the difference object, instead of (X, Y, Z).
The behavior of the code is unchanged.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

