### PR TITLE
Expand track seed covariance

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -234,7 +234,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       auto actsFourPos = Acts::Vector4(position(0), position(1),
 				       position(2),
 				       10 * Acts::UnitConstants::ns);
-      Acts::BoundSymMatrix cov = setDefaultCovariance(track->get_p());
+      Acts::BoundSymMatrix cov = setDefaultCovariance();
  
       int charge = track->get_charge();
       if(m_fieldMap.find("3d") != std::string::npos)
@@ -753,7 +753,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   
 }
 
-Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance(const float p) const
+Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance() const
 {
   Acts::BoundSymMatrix cov = Acts::BoundSymMatrix::Zero();
    
@@ -782,9 +782,6 @@ Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance(const float p) const
       double sigmaZ0 = 50 * Acts::UnitConstants::um;
       double sigmaPhi = 1 * Acts::UnitConstants::degree;
       double sigmaTheta = 1 * Acts::UnitConstants::degree;
-      /// Seed pt resolution is approximately 8%
-      double sigmaPRel = 0.08 * p;
-      double sigmaQOverP = sigmaPRel / (p*p);
       double sigmaT = 1. * Acts::UnitConstants::ns;
      
       cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = sigmaD0 * sigmaD0;
@@ -792,8 +789,9 @@ Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance(const float p) const
       cov(Acts::eBoundTime, Acts::eBoundTime) = sigmaT * sigmaT;
       cov(Acts::eBoundPhi, Acts::eBoundPhi) = sigmaPhi * sigmaPhi;
       cov(Acts::eBoundTheta, Acts::eBoundTheta) = sigmaTheta * sigmaTheta;
-      cov(Acts::eBoundQOverP, Acts::eBoundQOverP) = sigmaQOverP * sigmaQOverP;
-      
+      /// Acts takes this value very seriously - tuned to be in a "sweet spot"
+      cov(Acts::eBoundQOverP, Acts::eBoundQOverP) = 0.0001;
+
     }
 
   return cov;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -133,7 +133,7 @@ class PHActsTrkFitter : public SubsysReco
   Surface getTpcSurface(TrkrDefs::hitsetkey hitsetkey, TrkrDefs::subsurfkey surfkey) const;
   Surface getMMSurface(TrkrDefs::hitsetkey hitsetkey) const;
 
-  Acts::BoundSymMatrix setDefaultCovariance(const float p) const;
+  Acts::BoundSymMatrix setDefaultCovariance() const;
   void printTrackSeed(const SvtxTrack* seed) const;
 
   /// Event counter


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR tunes the covariance matrix entry for the track seeds to be something that is not too big or too small for Acts. It improves the high pT resolution and local tests indicate it improves the low pT resolution as well for the new Actsv17

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

