### PR TITLE
use xrootd for lustre

### DIFF
--- a/offline/framework/frog/FROG.cc
+++ b/offline/framework/frog/FROG.cc
@@ -119,7 +119,7 @@ FROG::location(const std::string &logical_name)
       {
         if (Verbosity() > 1)
         {
-          std::cout << "Searching FileCatalog for Lustre file via MinIO"
+          std::cout << "Searching FileCatalog for Lustre file via MinIO "
                << logical_name << std::endl;
         }
         if (MinIOSearch(logical_name))
@@ -208,6 +208,11 @@ bool FROG::PGSearch(const std::string &lname)
   }
   std::string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name <> 'hpss' and full_host_name <> 'dcache' and full_host_name <> 'lustre'";
 
+  if (Verbosity() > 1)
+  {
+    std::cout << "sql query:" << std::endl
+	      << sqlquery << std::endl;
+  }
   odbc::Statement *stmt = m_OdbcConnection->createStatement();
   odbc::ResultSet *rs = stmt->executeQuery(sqlquery);
 
@@ -230,6 +235,11 @@ bool FROG::dCacheSearch(const std::string &lname)
   }
   std::string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name = 'dcache'";
 
+  if (Verbosity() > 1)
+  {
+    std::cout << "sql query:" << std::endl
+	      << sqlquery << std::endl;
+  }
   odbc::Statement *stmt = m_OdbcConnection->createStatement();
   odbc::ResultSet *rs = stmt->executeQuery(sqlquery);
 
@@ -254,19 +264,20 @@ bool FROG::XRootDSearch(const std::string &lname)
   {
     return bret;
   }
-  std::string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name = 'dcache'";
-
+  std::string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name = 'lustre'";
+  if (Verbosity() > 1)
+  {
+    std::cout << "sql query:" << std::endl
+	      << sqlquery << std::endl;
+  }
   odbc::Statement *stmt = m_OdbcConnection->createStatement();
   odbc::ResultSet *rs = stmt->executeQuery(sqlquery);
 
   if (rs->next())
   {
     std::string xrootdfile = rs->getString(1);
-    if (std::ifstream(xrootdfile))
-    {
-      pfn = "root://dcsphdoor02.rcf.bnl.gov:1095" + xrootdfile;
-      bret = true;
-    }
+    pfn = "root://xrdsphenix.rcf.bnl.gov/"  + xrootdfile;
+    bret = true;
   }
   delete rs;
   delete stmt;
@@ -304,6 +315,11 @@ bool FROG::MinIOSearch(const std::string &lname)
   }
   std::string sqlquery = "SELECT full_file_path from files where lfn='" + lname + "' and full_host_name = 'lustre'";
 
+  if (Verbosity() > 1)
+  {
+    std::cout << "sql query:" << std::endl
+	      << sqlquery << std::endl;
+  }
   odbc::Statement *stmt = m_OdbcConnection->createStatement();
   odbc::ResultSet *rs = stmt->executeQuery(sqlquery);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR makes lustre files accessible via xrootd from the farm (only for sphenix accounts)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

