### PR TITLE
Configurable Projection Radii

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -402,8 +402,15 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode *topNode)
       if(setCaloContainerNodes(topNode, caloLayer) != Fun4AllReturnCodes::EVENT_OK)
 	return Fun4AllReturnCodes::ABORTEVENT;
       
-      const auto caloRadius = m_towerGeomContainer->get_radius() 
+      /// Default to using calo radius
+      double caloRadius = m_towerGeomContainer->get_radius() 
 	* Acts::UnitConstants::cm;
+      if(m_caloRadii.find(m_caloTypes.at(caloLayer)) != m_caloRadii.end())
+	{ 
+	  caloRadius = m_caloRadii.find(m_caloTypes.at(caloLayer))->second
+	    * Acts::UnitConstants::cm; 
+	}
+    
       /// Extend farther so that there is at least surface there, for high
       /// curling tracks. Can always reject later
       const auto eta = 2.5;

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -53,6 +53,16 @@ class PHActsTrackProjection : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   
+  /// Set an arbitrary radius to project to, in cm
+  void setLayerRadius(SvtxTrack::CAL_LAYER layer,
+		      const float rad) { 
+
+    if(m_caloRadii.find(layer) != m_caloRadii.end())
+      m_caloRadii[layer] = rad;
+    else
+      m_caloRadii.insert(std::make_pair(layer, rad));
+  }
+
  private:
   
   int getNodes(PHCompositeNode *topNode);
@@ -101,13 +111,17 @@ class PHActsTrackProjection : public SubsysReco
   std::vector<std::string> m_caloNames;
   std::vector<SvtxTrack::CAL_LAYER> m_caloTypes;
   std::map<std::string, SurfacePtr> m_caloSurfaces;
-  
+  /// An optional map that allows projection to an arbitrary radius
+  /// Results are written to the SvtxTrack based on the provided CAL_LAYER
+  std::map<SvtxTrack::CAL_LAYER, float> m_caloRadii;
+
   RawTowerGeomContainer *m_towerGeomContainer = nullptr;
   RawTowerContainer *m_towerContainer = nullptr;
   RawClusterContainer *m_clusterContainer = nullptr;
 
   bool m_useCemcPosRecalib = false;
 
+  
   int m_event = 0;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This allows you to configure the radius you want to project tracks too in the calorimeters. Default is the nominal radius provided by the geometry container.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

