### PR TITLE
Outlier finder

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -74,6 +74,7 @@ pkginclude_HEADERS = \
   PHTruthTrackSeeding.h \
   PHTruthSiliconAssociation.h \
   PHTruthVertexing.h \
+  ResidualOutlierFinder.h \
   VertexFitter.h
 
 ROOTDICTS = \

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -8,17 +8,15 @@
 #ifndef TRACKRECO_ACTSTRKFITTER_H
 #define TRACKRECO_ACTSTRKFITTER_H
 
+
 #include <fun4all/SubsysReco.h>
 
-#include <trackbase/ActsTrackingGeometry.h>
-#include <trackbase/TrkrDefs.h>
-#include <trackbase/ActsSurfaceMaps.h>
+#include "ResidualOutlierFinder.h"
 
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
-#include <Acts/EventData/MeasurementHelpers.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
@@ -26,8 +24,9 @@
 #include <ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp>
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <ActsExamples/EventData/Track.hpp>
-#include <ActsExamples/EventData/Measurement.hpp>
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
+
+
 
 #include <memory>
 #include <string>
@@ -91,6 +90,8 @@ class PHActsTrkFitter : public SubsysReco
 
   void setAbsPdgHypothesis(unsigned int pHypothesis)
   { m_pHypothesis = pHypothesis; }
+
+  void useOutlierFinder(bool outlier) { m_useOutlierFinder = outlier; }
 
   void SetIteration(int iter){_n_iteration = iter;}
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
@@ -163,6 +164,10 @@ class PHActsTrkFitter : public SubsysReco
   
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
+
+  /// A bool to use the chi2 outlier finder in the track fitting
+  bool m_useOutlierFinder = false;
+  ResidualOutlierFinder m_outlierFinder;
 
   bool m_actsEvaluator = false;
   std::map<const unsigned int, Trajectory> *m_trajectories = nullptr;

--- a/offline/packages/trackreco/ResidualOutlierFinder.h
+++ b/offline/packages/trackreco/ResidualOutlierFinder.h
@@ -1,0 +1,74 @@
+#include <Acts/Definitions/Units.hpp>
+#include <Acts/EventData/MultiTrajectory.hpp>
+
+#include <Acts/EventData/Measurement.hpp>
+#include <Acts/EventData/MeasurementHelpers.hpp>
+
+
+struct ResidualOutlierFinder {
+  int verbosity = 0;
+  std::vector<std::pair<long unsigned int, double>> chi2Cuts;
+
+ 
+  bool operator()(Acts::MultiTrajectory::ConstTrackStateProxy state) const {
+    // can't determine an outlier w/o a measurement or predicted parameters
+    if (!state.hasCalibrated() || !state.hasPredicted()) {
+      return false;
+    }
+
+    const auto predicted = state.predicted();
+    const auto predictedCovariance = state.predictedCovariance();
+    double chi2 = std::numeric_limits<double>::max();
+    
+    Acts::visit_measurement(state.calibrated(), state.calibratedCovariance(),
+			    state.calibratedSize(), 
+          [&](const auto calibrated, 
+	      const auto calibratedCovariance) {
+	        constexpr size_t kMeasurementSize = decltype(calibrated)::RowsAtCompileTime;
+			
+		using ParametersVector = Acts::ActsVector<kMeasurementSize>;
+		const auto H = state.projector().template topLeftCorner<kMeasurementSize, Acts::eBoundSize>().eval();
+		ParametersVector res;
+		res = calibrated - H * predicted;
+		chi2 = (res.transpose() * ((calibratedCovariance + H * predictedCovariance * H.transpose())).inverse() * res).eval()(0,0);
+        
+	        }); /// end lambda and call to visit meas
+			    
+    if(verbosity > 2)
+      {
+	const auto distance = (state.calibrated() - state.projector() * state.predicted()).norm();
+	std::cout << "Measurement has distance, chi2 "
+		  << distance << ", " << chi2 
+		  << std::endl;	
+      }
+
+    auto volume = state.referenceSurface().geometryId().volume();
+    auto layer = state.referenceSurface().geometryId().layer();
+
+
+    bool outlier = false;
+    for(auto& [vol, chi2cut] : chi2Cuts) 
+      {
+	if(verbosity > -1)
+	  {
+	    std::cout << "Meas vol id and layer " << volume << ", " << layer 
+		      << " checking for volume " << vol << " and chi2cut "
+		      << chi2cut << std::endl;
+	  
+	  }
+
+	if(volume == vol and chi2 > chi2cut)
+	  {
+	    outlier = true;
+	  }
+      }
+
+    return outlier;
+  
+  }
+};
+
+
+
+
+


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduces an outlier finder into the Acts track fitter. The outlier finder will reject clusters from the track fit based on a chi2 criteria set in the track fitting module. These criteria still need to be tuned and studied in greater detail in various event topologies. The outlier finder can be turned on/off by a switch, and is by default off for now.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

