### PR TITLE
Flag for track projections

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -54,6 +54,14 @@ int PHActsTrackProjection::InitRun(PHCompositeNode *topNode)
   if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
     ret = Fun4AllReturnCodes::ABORTEVENT;
 
+  if(ret == Fun4AllReturnCodes::ABORTEVENT)
+    {
+      /// If calos aren't available, set a flag so that job doesn't
+      /// quit processing but the flag will skip process event
+      m_calosAvailable = false;
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+
   if(Verbosity() > 1)
     std::cout << "PHActsTrackProjection finished Init" << std::endl;
   
@@ -63,8 +71,12 @@ int PHActsTrackProjection::InitRun(PHCompositeNode *topNode)
 int PHActsTrackProjection::process_event(PHCompositeNode *topNode)
 {
   if(Verbosity() > 1)
-    std::cout << "PHActsTrackProjection : Starting process_event event "
+    {
+      std::cout << "PHActsTrackProjection : Starting process_event event "
 	      << m_event << std::endl;
+    }
+
+  if(!m_calosAvailable) { return Fun4AllReturnCodes::EVENT_OK; }
 
   for(int layer = 0; layer < m_nCaloLayers; layer++)
     {
@@ -387,8 +399,9 @@ int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode *topNode,
   if(!m_towerGeomContainer or !m_towerContainer or !m_clusterContainer)
     {
       std::cout << PHWHERE 
-		<< "Calo geometry and/or cluster container not found on node tree. Bailing."
+		<< "Calo geometry and/or cluster container not found on node tree. Track projections to calos won't be filled."
 		<< std::endl;
+      m_calosAvailable = false;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
   

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -121,6 +121,7 @@ class PHActsTrackProjection : public SubsysReco
 
   bool m_useCemcPosRecalib = false;
 
+  bool m_calosAvailable = true;
   
   int m_event = 0;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This adds a flag to skip the track projections to the calos if the calo nodes are not available on the node tree. This way the module can run without crashing a job if the calo nodes aren't available (e.g. for tracking development testing without the calo nodes for faster simulation execution).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

