### PR TITLE
Distortion gen namefix

### DIFF
--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -2709,6 +2709,9 @@ void AnnularFieldSim::PlotFieldSlices(const char *filebase, TVector3 pos, char w
 
 void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r_subsamples, int p_subsamples, int z_subsamples, int /*z_substeps*/, bool andCartesian)
 {
+  //generates the distortion map for one or both sides of the detector, separating them so
+  //they do not try to interpolate across the CM.
+  
   //1) pick a map spacing ('s')
   TVector3 s(step.Perp() / r_subsamples, 0, step.Z() / z_subsamples);
   s.SetPhi(step.Phi() / p_subsamples);
@@ -2770,15 +2773,17 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
   TH3F *hIntDistortionX = new TH3F("hIntDistortionX", "Integrated X Distortion from (phi,r,z) to z=0 (centered in r,phi, and z);phi;r;z", nph, pih, pfh, nrh, rih, rfh, nzh, zih, zfh);
   TH3F *hIntDistortionY = new TH3F("hIntDistortionY", "Integrated Y Distortion from (phi,r,z) to z=0 (centered in r,phi, and z);phi;r;z", nph, pih, pfh, nrh, rih, rfh, nzh, zih, zfh);
 
-  TH3F *hSeparatedMapComponent[2][5];  //side, then xyzrp
+
+  const int nMapComponents=6;
+  TH3F *hSeparatedMapComponent[2][6];  //side, then xyzrp
   TString side[2];
-  side[0] = "Solo";
+  side[0] = "soloz";
   if (hasTwin)
   {
-    side[0] = "Pos";
-    side[1] = "Neg";
+    side[0] = "posz";
+    side[1] = "negz";
   }
-  char sepAxis[] = "XYZRP";
+  TString sepAxis[] = {"X","Y","Z","R","P","RPhi");
   float zlower, zupper;
   for (int i = 0; i < nSides; i++)
   {
@@ -2792,10 +2797,10 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
       zlower = -1 * fmax(zih, zfh);
       zupper = -1 * fmin(zih, zfh);
     }
-    for (int j = 0; j < 5; j++)
+    for (int j = 0; j < nMapComponents; j++)
     {
-      hSeparatedMapComponent[i][j] = new TH3F(Form("hIntDistortion%s%c", side[i].Data(), sepAxis[j]),
-                                              Form("Integrated %c Deflection drifting from (phi,r,z) to z=endcap);phi;r;z (%s side)", sepAxis[j], side[i].Data()),
+      hSeparatedMapComponent[i][j] = new TH3F(Form("hIntDistortion%s_%s", sepAxis[j].Data,side[i].Data()),
+                                              Form("Integrated %s Deflection drifting from (phi,r,z) to z=endcap);phi;r;z (%s side)", sepAxis[j].Data(), side[i].Data()),
                                               nph, pih, pfh, nrh, rih, rfh, nzh, zlower, zupper);
     }
   }
@@ -2962,14 +2967,15 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
           distortR = distort.X();          //and the r component is the x component
           distortZ = distort.Z();
 
-          float distComp[5];  //by components
+          float distComp[nMapComponents];  //by components
           distComp[0] = distortX;
           distComp[1] = distortY;
           distComp[2] = distortZ;
           distComp[3] = distortR;
-          distComp[4] = distortP;
+          distComp[4] = distortP/partR; // 'P' now refers to phi in radians, rather than unitful
+          distComp[5] = distortP; // 'RPhi' is the one that correponds to the []meter unitful phi-hat value 
 
-          for (int c = 0; c < 5; c++)
+          for (int c = 0; c < nMapComponents; c++)
           {
             hSeparatedMapComponent[side][c]->Fill(partP, partR, partZ, distComp[c]);
           }
@@ -3197,7 +3203,7 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
   for (int i = 0; i < nSides; i++)
   {
     printf("Saving side '%s'\n",side[i].Data());
-    for (int j = 0; j < 5; j++)
+    for (int j = 0; j < nMapComponents; j++)
     {
       hSeparatedMapComponent[i][j]->GetSumw2()->Set(0);
       hSeparatedMapComponent[i][j]->Write();
@@ -3240,6 +3246,12 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
 
 void AnnularFieldSim::GenerateDistortionMaps(const char *filebase, int r_subsamples, int p_subsamples, int z_subsamples, int /*z_substeps*/, bool andCartesian)
 {
+  //generates the distortion map for the full detector instead of one map per side.
+  //This produces wrong behavior when interpolating across the CM and should not be used
+  //unless you're doing some debugging/backward compatibility checking.  Eventually this should be removed  (said in early 2022)
+  printf("WARNING:  You called the version of the distortion generator that generates a unified map.  Are you sure you meant to do this?\n");
+
+  
   //1) pick a map spacing ('s')
   bool makeUnifiedMap = true;  //if true, generate a single map across the whole TPC.  if false, save two maps, one for each side.
 

--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -2799,7 +2799,7 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
     }
     for (int j = 0; j < nMapComponents; j++)
     {
-      hSeparatedMapComponent[i][j] = new TH3F(Form("hIntDistortion%s_%s", sepAxis[j].Data,side[i].Data()),
+      hSeparatedMapComponent[i][j] = new TH3F(Form("hIntDistortion%s_%s", sepAxis[j].Data(),side[i].Data()),
                                               Form("Integrated %s Deflection drifting from (phi,r,z) to z=endcap);phi;r;z (%s side)", sepAxis[j].Data(), side[i].Data()),
                                               nph, pih, pfh, nrh, rih, rfh, nzh, zlower, zupper);
     }

--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -2783,7 +2783,7 @@ void AnnularFieldSim::GenerateSeparateDistortionMaps(const char *filebase, int r
     side[0] = "posz";
     side[1] = "negz";
   }
-  TString sepAxis[] = {"X","Y","Z","R","P","RPhi");
+  TString sepAxis[] = {"X","Y","Z","R","P","RPhi"};
   float zlower, zupper;
   for (int i = 0; i < nSides; i++)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This alters the behavior of the TPC truth-distortion generator in two ways:
1) It corrects an error in the naming convention of the histograms that previously required an afterburner macro to rename them.  Distortion histograms are now named hIntDistortion%s_%s where the first argument is the component (R, P, Z, corresponding to r-hat, phi, and z-hat) and the second argument is the half of the tpc (posz or negz)
2)  It changes the behavior of the 'P' component.  Previously, this was the phi-hat direction, carrying the same units as r-hat and z-hat.  After this pull req, 'P' refers to the phi component of the distortion, in units of radians.  An additional histogram, hIntDistortionRPhi_%s has been added, which carries the old behavior.
This change, pending a follow-up pull request to modify the distortion handling in the TPC electron drift code, will remove an ambiguity about whether this distortion should be applied before, or after, the R position is modified.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )
Follow up with a change to PHG4TpcElectronDrift.  Until this is done, new distortion maps generated with this macro will not be interoperable.


## Links to other PRs in macros and calibration repositories (if applicable)
