### PR TITLE
Proper flag save retrieve

### DIFF
--- a/offline/framework/ffamodules/FlagHandler.cc
+++ b/offline/framework/ffamodules/FlagHandler.cc
@@ -14,8 +14,8 @@
 #include <phool/recoConsts.h>
 
 //____________________________________________________________________________..
-FlagHandler::FlagHandler(const std::string &name):
- SubsysReco(name)
+FlagHandler::FlagHandler(const std::string &name)
+  : SubsysReco(name)
 {
 }
 
@@ -24,8 +24,8 @@ int FlagHandler::InitRun(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
   PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
-  FlagSave *flgsv = findNode::getClass<FlagSave>(runNode,"Flags");
-  if (! flgsv)
+  FlagSave *flgsv = findNode::getClass<FlagSave>(runNode, "Flags");
+  if (!flgsv)
   {
     flgsv = new FlagSavev1();
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
@@ -34,7 +34,7 @@ int FlagHandler::InitRun(PHCompositeNode *topNode)
   else
   {
     recoConsts *rc = recoConsts::instance();
-    flgsv->PutFlagsBack(rc,false);
+    flgsv->PutFlagsBack(rc, false);
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -46,14 +46,14 @@ int FlagHandler::End(PHCompositeNode *topNode)
   if (flagsave)
   {
     recoConsts *rc = recoConsts::instance();
-    flagsave->FillFromPHFlag(rc,true);
+    flagsave->FillFromPHFlag(rc, true);
     flagsave->identify();
-  }  
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-void FlagHandler::Print(const std::string &/* what */) const
+void FlagHandler::Print(const std::string & /* what */) const
 {
   recoConsts *rc = recoConsts::instance();
   rc->Print();

--- a/offline/framework/ffamodules/FlagHandler.cc
+++ b/offline/framework/ffamodules/FlagHandler.cc
@@ -1,0 +1,60 @@
+#include "FlagHandler.h"
+
+#include <ffaobjects/FlagSave.h>
+#include <ffaobjects/FlagSavev1.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/recoConsts.h>
+
+//____________________________________________________________________________..
+FlagHandler::FlagHandler(const std::string &name):
+ SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+int FlagHandler::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  FlagSave *flgsv = findNode::getClass<FlagSave>(runNode,"Flags");
+  if (! flgsv)
+  {
+    flgsv = new FlagSavev1();
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
+    runNode->addNode(newNode);
+  }
+  else
+  {
+    recoConsts *rc = recoConsts::instance();
+    flgsv->PutFlagsBack(rc,false);
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FlagHandler::End(PHCompositeNode *topNode)
+{
+  FlagSave *flagsave = findNode::getClass<FlagSave>(topNode, "Flags");
+  if (flagsave)
+  {
+    recoConsts *rc = recoConsts::instance();
+    flagsave->FillFromPHFlag(rc,true);
+    flagsave->identify();
+  }  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+void FlagHandler::Print(const std::string &/* what */) const
+{
+  recoConsts *rc = recoConsts::instance();
+  rc->Print();
+}

--- a/offline/framework/ffamodules/FlagHandler.h
+++ b/offline/framework/ffamodules/FlagHandler.h
@@ -12,7 +12,6 @@ class PHCompositeNode;
 class FlagHandler : public SubsysReco
 {
  public:
-
   FlagHandler(const std::string &name = "FlagHandler");
 
   ~FlagHandler() override {}
@@ -30,4 +29,4 @@ class FlagHandler : public SubsysReco
  private:
 };
 
-#endif // FFAMODULES_FLAGHANDLER_H
+#endif  // FFAMODULES_FLAGHANDLER_H

--- a/offline/framework/ffamodules/FlagHandler.h
+++ b/offline/framework/ffamodules/FlagHandler.h
@@ -1,0 +1,33 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FFAMODULES_FLAGHANDLER_H
+#define FFAMODULES_FLAGHANDLER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+
+class FlagHandler : public SubsysReco
+{
+ public:
+
+  FlagHandler(const std::string &name = "FlagHandler");
+
+  ~FlagHandler() override {}
+
+  /** Create the Flag Node if it does not exist,
+      if it exists, read back flags and copy them into recoConsts
+   */
+  int InitRun(PHCompositeNode *topNode) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  void Print(const std::string &what = "ALL") const override;
+
+ private:
+};
+
+#endif // FFAMODULES_FLAGHANDLER_H

--- a/offline/framework/ffamodules/HeadReco.cc
+++ b/offline/framework/ffamodules/HeadReco.cc
@@ -2,8 +2,6 @@
 
 #include <ffaobjects/EventHeader.h>
 #include <ffaobjects/EventHeaderv1.h>
-#include <ffaobjects/FlagSave.h>
-#include <ffaobjects/FlagSavev1.h>
 #include <ffaobjects/RunHeader.h>
 #include <ffaobjects/RunHeaderv1.h>
 
@@ -42,10 +40,6 @@ int HeadReco::Init(PHCompositeNode *topNode)
   PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   RunHeader *runheader = new RunHeaderv1();
   PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(runheader, "RunHeader", "PHObject");
-  runNode->addNode(newNode);
-
-  FlagSave *flgsv = new FlagSavev1();
-  newNode = new PHIODataNode<PHObject>(flgsv, "Flags", "PHObject");
   runNode->addNode(newNode);
 
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
@@ -102,19 +96,5 @@ int HeadReco::process_event(PHCompositeNode *topNode)
     evtheader->identify();
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int HeadReco::EndRun(const int /*runno*/)
-{
-  Fun4AllServer *se = Fun4AllServer::instance();
-  FlagSave *flagsave = findNode::getClass<FlagSave>(se->topNode(), "Flags");
-  if (flagsave)
-  {
-    recoConsts *rc = recoConsts::instance();
-    std::cout << "Saving recoConst Flags: " << std::endl;
-    flagsave->FillFromPHFlag(rc);
-    flagsave->identify();
-  }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/ffamodules/HeadReco.cc
+++ b/offline/framework/ffamodules/HeadReco.cc
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <iterator>  // for operator!=, reverse_iterator
+#include <map>       // for _Rb_tree_iterator
 #include <utility>   // for pair
 
 HeadReco::HeadReco(const std::string &name)

--- a/offline/framework/ffamodules/HeadReco.h
+++ b/offline/framework/ffamodules/HeadReco.h
@@ -13,11 +13,10 @@ class HeadReco : public SubsysReco
 {
  public:
   HeadReco(const std::string &name = "HeadReco");
-  virtual ~HeadReco() {}
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int EndRun(const int runno);
+  ~HeadReco() override {}
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
  protected:
 };

--- a/offline/framework/ffamodules/Makefile.am
+++ b/offline/framework/ffamodules/Makefile.am
@@ -20,10 +20,12 @@ libffamodules_la_LIBADD = \
 
 
 pkginclude_HEADERS = \
+  FlagHandler.h \
   HeadReco.h \
   SyncReco.h
 
 libffamodules_la_SOURCES = \
+  FlagHandler.cc \
   HeadReco.cc \
   SyncReco.cc
 

--- a/offline/framework/ffamodules/SyncReco.h
+++ b/offline/framework/ffamodules/SyncReco.h
@@ -11,11 +11,11 @@ class SyncReco : public SubsysReco
 {
  public:
   SyncReco(const std::string &name = "SYNC");
-  virtual ~SyncReco() {}
+  ~SyncReco() override {}
 
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
  protected:
   int CreateNodeTree(PHCompositeNode *topNode);

--- a/offline/framework/ffaobjects/FlagSave.h
+++ b/offline/framework/ffaobjects/FlagSave.h
@@ -38,12 +38,12 @@ class FlagSave : public PHObject
     return 0;
   }
 
-/// Flags are read during InitRun() and written during End()
-/// Fills DST object with flags, if clearold is set, old flags from previous files
-/// which were deleted will not be saved
+  /// Flags are read during InitRun() and written during End()
+  /// Fills DST object with flags, if clearold is set, old flags from previous files
+  /// which were deleted will not be saved
   virtual int FillFromPHFlag(const PHFlag* /*flags*/, const bool /* clearold */) { return -1; }
-/// Read back flags from the DST, if overwrite is set: flags from DST object will overwrite
-/// flag values set in the macro
+  /// Read back flags from the DST, if overwrite is set: flags from DST object will overwrite
+  /// flag values set in the macro
   virtual int PutFlagsBack(PHFlag* /*flags*/, const bool /* overwrite */) { return -1; }
 
  private:

--- a/offline/framework/ffaobjects/FlagSave.h
+++ b/offline/framework/ffaobjects/FlagSave.h
@@ -38,8 +38,13 @@ class FlagSave : public PHObject
     return 0;
   }
 
-  virtual int FillFromPHFlag(const PHFlag* /*flags*/) { return -1; }
-  virtual int PutFlagsBack(PHFlag* /*flags*/) { return -1; }
+/// Flags are read during InitRun() and written during End()
+/// Fills DST object with flags, if clearold is set, old flags from previous files
+/// which were deleted will not be saved
+  virtual int FillFromPHFlag(const PHFlag* /*flags*/, const bool /* clearold */) { return -1; }
+/// Read back flags from the DST, if overwrite is set: flags from DST object will overwrite
+/// flag values set in the macro
+  virtual int PutFlagsBack(PHFlag* /*flags*/, const bool /* overwrite */) { return -1; }
 
  private:
   ClassDefOverride(FlagSave, 1)

--- a/offline/framework/ffaobjects/FlagSavev1.cc
+++ b/offline/framework/ffaobjects/FlagSavev1.cc
@@ -60,11 +60,11 @@ int FlagSavev1::FillFromPHFlag(const PHFlag *flags, const bool clearold)
 
 int FlagSavev1::PutFlagsBack(PHFlag *flags, const bool overwrite)
 {
-  int iret = PutIntToPHFlag(flags,overwrite);
-  iret += Putuint64ToPHFlag(flags,overwrite);
-  iret += PutDoubleToPHFlag(flags,overwrite);
-  iret += PutFloatToPHFlag(flags,overwrite);
-  iret += PutStringToPHFlag(flags,overwrite);
+  int iret = PutIntToPHFlag(flags, overwrite);
+  iret += Putuint64ToPHFlag(flags, overwrite);
+  iret += PutDoubleToPHFlag(flags, overwrite);
+  iret += PutFloatToPHFlag(flags, overwrite);
+  iret += PutStringToPHFlag(flags, overwrite);
   return iret;
 }
 
@@ -132,11 +132,11 @@ int FlagSavev1::PutIntToPHFlag(PHFlag *flags, const bool overwrite)
   {
     if (overwrite)
     {
-    flags->set_IntFlag(iter->first, iter->second);
+      flags->set_IntFlag(iter->first, iter->second);
     }
     else
     {
-    flags->get_IntFlag(iter->first, iter->second);
+      flags->get_IntFlag(iter->first, iter->second);
     }
   }
   return 0;
@@ -149,13 +149,12 @@ int FlagSavev1::Putuint64ToPHFlag(PHFlag *flags, const bool overwrite)
   {
     if (overwrite)
     {
-    flags->set_uint64Flag(iter->first, iter->second);
+      flags->set_uint64Flag(iter->first, iter->second);
     }
     else
     {
-    flags->get_uint64Flag(iter->first, iter->second);
+      flags->get_uint64Flag(iter->first, iter->second);
     }
-
   }
   return 0;
 }
@@ -167,13 +166,12 @@ int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags, const bool overwrite)
   {
     if (overwrite)
     {
-    flags->set_DoubleFlag(iter->first, iter->second);
+      flags->set_DoubleFlag(iter->first, iter->second);
     }
     else
     {
-    flags->get_DoubleFlag(iter->first, iter->second);
+      flags->get_DoubleFlag(iter->first, iter->second);
     }
-
   }
   return 0;
 }
@@ -185,11 +183,11 @@ int FlagSavev1::PutFloatToPHFlag(PHFlag *flags, const bool overwrite)
   {
     if (overwrite)
     {
-    flags->set_FloatFlag(iter->first, iter->second);
+      flags->set_FloatFlag(iter->first, iter->second);
     }
     else
     {
-    flags->get_FloatFlag(iter->first, iter->second);
+      flags->get_FloatFlag(iter->first, iter->second);
     }
   }
   return 0;
@@ -202,11 +200,11 @@ int FlagSavev1::PutStringToPHFlag(PHFlag *flags, const bool overwrite)
   {
     if (overwrite)
     {
-    flags->set_StringFlag(iter->first, iter->second);
+      flags->set_StringFlag(iter->first, iter->second);
     }
     else
     {
-    flags->get_StringFlag(iter->first, iter->second);
+      flags->get_StringFlag(iter->first, iter->second);
     }
   }
   return 0;

--- a/offline/framework/ffaobjects/FlagSavev1.cc
+++ b/offline/framework/ffaobjects/FlagSavev1.cc
@@ -44,8 +44,12 @@ void FlagSavev1::identify(std::ostream &out) const
   return;
 }
 
-int FlagSavev1::FillFromPHFlag(const PHFlag *flags)
+int FlagSavev1::FillFromPHFlag(const PHFlag *flags, const bool clearold)
 {
+  if (clearold)
+  {
+    ClearAll();
+  }
   int iret = FillIntFromPHFlag(flags);
   iret += Filluint64FromPHFlag(flags);
   iret += FillDoubleFromPHFlag(flags);
@@ -54,13 +58,13 @@ int FlagSavev1::FillFromPHFlag(const PHFlag *flags)
   return iret;
 }
 
-int FlagSavev1::PutFlagsBack(PHFlag *flags)
+int FlagSavev1::PutFlagsBack(PHFlag *flags, const bool overwrite)
 {
-  int iret = PutIntToPHFlag(flags);
-  iret += Putuint64ToPHFlag(flags);
-  iret += PutDoubleToPHFlag(flags);
-  iret += PutFloatToPHFlag(flags);
-  iret += PutStringToPHFlag(flags);
+  int iret = PutIntToPHFlag(flags,overwrite);
+  iret += Putuint64ToPHFlag(flags,overwrite);
+  iret += PutDoubleToPHFlag(flags,overwrite);
+  iret += PutFloatToPHFlag(flags,overwrite);
+  iret += PutStringToPHFlag(flags,overwrite);
   return iret;
 }
 
@@ -119,53 +123,91 @@ int FlagSavev1::FillStringFromPHFlag(const PHFlag *flags)
   }
   return 0;
 }
-
-int FlagSavev1::PutIntToPHFlag(PHFlag *flags)
+// general procedure, if overwrite is set, just set the flag
+// if overwrite is false, call get flag with initialization which is used if it does not exist
+int FlagSavev1::PutIntToPHFlag(PHFlag *flags, const bool overwrite)
 {
   std::map<std::string, int>::const_iterator iter;
   for (iter = intflag.begin(); iter != intflag.end(); ++iter)
   {
+    if (overwrite)
+    {
     flags->set_IntFlag(iter->first, iter->second);
+    }
+    else
+    {
+    flags->get_IntFlag(iter->first, iter->second);
+    }
   }
   return 0;
 }
 
-int FlagSavev1::Putuint64ToPHFlag(PHFlag *flags)
+int FlagSavev1::Putuint64ToPHFlag(PHFlag *flags, const bool overwrite)
 {
   std::map<std::string, uint64_t>::const_iterator iter;
   for (iter = m_uint64flag_map.begin(); iter != m_uint64flag_map.end(); ++iter)
   {
+    if (overwrite)
+    {
     flags->set_uint64Flag(iter->first, iter->second);
+    }
+    else
+    {
+    flags->get_uint64Flag(iter->first, iter->second);
+    }
+
   }
   return 0;
 }
 
-int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags)
+int FlagSavev1::PutDoubleToPHFlag(PHFlag *flags, const bool overwrite)
 {
   std::map<std::string, double>::const_iterator iter;
   for (iter = doubleflag.begin(); iter != doubleflag.end(); ++iter)
   {
+    if (overwrite)
+    {
     flags->set_DoubleFlag(iter->first, iter->second);
+    }
+    else
+    {
+    flags->get_DoubleFlag(iter->first, iter->second);
+    }
+
   }
   return 0;
 }
 
-int FlagSavev1::PutFloatToPHFlag(PHFlag *flags)
+int FlagSavev1::PutFloatToPHFlag(PHFlag *flags, const bool overwrite)
 {
   std::map<std::string, float>::const_iterator iter;
   for (iter = floatflag.begin(); iter != floatflag.end(); ++iter)
   {
+    if (overwrite)
+    {
     flags->set_FloatFlag(iter->first, iter->second);
+    }
+    else
+    {
+    flags->get_FloatFlag(iter->first, iter->second);
+    }
   }
   return 0;
 }
 
-int FlagSavev1::PutStringToPHFlag(PHFlag *flags)
+int FlagSavev1::PutStringToPHFlag(PHFlag *flags, const bool overwrite)
 {
   std::map<std::string, std::string>::const_iterator iter;
   for (iter = stringflag.begin(); iter != stringflag.end(); ++iter)
   {
+    if (overwrite)
+    {
     flags->set_StringFlag(iter->first, iter->second);
+    }
+    else
+    {
+    flags->get_StringFlag(iter->first, iter->second);
+    }
   }
   return 0;
 }
@@ -243,4 +285,13 @@ void FlagSavev1::PrintStringFlag(std::ostream &os) const
     os << iter->first << ": " << iter->second << std::endl;
   }
   return;
+}
+
+void FlagSavev1::ClearAll()
+{
+  intflag.clear();
+  doubleflag.clear();
+  floatflag.clear();
+  stringflag.clear();
+  m_uint64flag_map.clear();
 }

--- a/offline/framework/ffaobjects/FlagSavev1.h
+++ b/offline/framework/ffaobjects/FlagSavev1.h
@@ -32,21 +32,22 @@ class FlagSavev1 : public FlagSave
    */
   void identify(std::ostream &os = std::cout) const override;
 
-  int FillFromPHFlag(const PHFlag *flags) override;
-  int PutFlagsBack(PHFlag *flags) override;
+  int FillFromPHFlag(const PHFlag *flags, const bool clearold) override;
+  int PutFlagsBack(PHFlag *flags, const bool overwrite) override;
 
  private:
+  void ClearAll();
   int FillIntFromPHFlag(const PHFlag *flags);
   int Filluint64FromPHFlag(const PHFlag *flags);
   int FillDoubleFromPHFlag(const PHFlag *flags);
   int FillFloatFromPHFlag(const PHFlag *flags);
   int FillStringFromPHFlag(const PHFlag *flags);
 
-  int PutIntToPHFlag(PHFlag *flags);
-  int Putuint64ToPHFlag(PHFlag *flags);
-  int PutDoubleToPHFlag(PHFlag *flags);
-  int PutFloatToPHFlag(PHFlag *flags);
-  int PutStringToPHFlag(PHFlag *flags);
+  int PutIntToPHFlag(PHFlag *flags, const bool overwrite);
+  int Putuint64ToPHFlag(PHFlag *flags, const bool overwrite);
+  int PutDoubleToPHFlag(PHFlag *flags, const bool overwrite);
+  int PutFloatToPHFlag(PHFlag *flags, const bool overwrite);
+  int PutStringToPHFlag(PHFlag *flags, const bool overwrite);
 
   void PrintIntFlag(std::ostream &os) const;
   void Printuint64Flag(std::ostream &os) const;

--- a/simulation/g4simulation/g4bbc/BbcVertexMap.cc
+++ b/simulation/g4simulation/g4bbc/BbcVertexMap.cc
@@ -1,5 +1,7 @@
 #include "BbcVertexMap.h"
 
+class BbcVertex;
+
 std::map<unsigned int, BbcVertex*> DummyBbcVertexMap;
 
 BbcVertexMap::ConstIter BbcVertexMap::begin() const
@@ -17,8 +19,7 @@ BbcVertexMap::ConstIter BbcVertexMap::end() const
   return DummyBbcVertexMap.end();
 }
 
-
-BbcVertexMap::Iter BbcVertexMap:: begin()
+BbcVertexMap::Iter BbcVertexMap::begin()
 {
   return DummyBbcVertexMap.end();
 }

--- a/simulation/g4simulation/g4bbc/BbcVertexMap.h
+++ b/simulation/g4simulation/g4bbc/BbcVertexMap.h
@@ -1,11 +1,13 @@
 #ifndef G4BBC_BBCVERTEXMAP_H
 #define G4BBC_BBCVERTEXMAP_H
 
-#include "BbcVertex.h"
-
 #include <phool/PHObject.h>
+
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
+
+class BbcVertex;
 
 class BbcVertexMap : public PHObject
 {

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -6,7 +6,6 @@
 #include <calobase/RawTowerDefs.h>  // for keytype
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
-#include <calobase/RawTowerv1.h>
 #include <calobase/RawTowerv2.h>
 
 #include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY_MORE

--- a/simulation/g4simulation/g4centrality/PHG4CentralityReco.h
+++ b/simulation/g4simulation/g4centrality/PHG4CentralityReco.h
@@ -8,9 +8,11 @@
 //===========================================================
 
 #include <fun4all/SubsysReco.h>
+
 #include <phparameter/PHParameters.h>
 
 #include <cmath>
+#include <map>
 #include <string>
 
 class PHCompositeNode;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR cleans up the flag handling (writing to DST and readback). So far flags were only written to DST by the header reconstruction for the initial pass. Any flags set for subsequent processing were not save. This PR creates a module (FlagHandler) which creates the Flags node if it doesn't exist already and then saves the content of the recoConst flags to the output. WHen run on a DST, the FlagHandler will read the flags and copy them into the recoConsts. If a flag already exists (which means it was set in the macro) it will not overwrite its value. In the End() the content of recoConst is save again. If existing flags were deleted (which is now possible), they will not be saved.  The basic idea is to have an accurate record of what flags were set during a given processing step (including flags which were read back but not deleted)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

