### PR TITLE
added the possibility to change the number of TPC subsurface along phi

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -96,10 +96,11 @@ namespace
 
 MakeActsGeometry::MakeActsGeometry(const std::string &name)
 : SubsysReco(name)
-{ setPlanarSurfaceDivisions(); }
+{}
 
 int MakeActsGeometry::Init(PHCompositeNode */*topNode*/)
 {  
+  setPlanarSurfaceDivisions();
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -308,6 +309,9 @@ void MakeActsGeometry::addActsTpcSurfaces(TGeoVolume *tpc_gas_vol,
   TGeoMedium *tpc_gas_medium = tpc_gas_vol->GetMedium();
   assert(tpc_gas_medium);
 
+  // printout
+  std::cout << "MakeActsGeometry::addActsTpcSurfaces - m_nSurfPhi: " << m_nSurfPhi << std::endl;
+  
   TGeoVolume *tpc_gas_measurement_vol[m_nTpcLayers];
   double tan_half_phi = tan(m_surfStepPhi / 2.0);
   int copy = 0;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -91,6 +91,9 @@ class MakeActsGeometry : public SubsysReco
   void build_mm_surfaces( bool value )
   { m_buildMMs = value; }
     
+  void set_nSurfPhi( unsigned int value )
+  { m_nSurfPhi = value; }
+  
  private:
   /// Main function to build all acts geometry for use in the fitting modules
   int buildAllGeometry(PHCompositeNode *topNode);
@@ -165,9 +168,9 @@ class MakeActsGeometry : public SubsysReco
   std::map<TrkrDefs::hitsetkey, Surface> m_clusterSurfaceMapMmEdit;
   
   /// These don't change, we are building the tpc this way!
-  const static unsigned int m_nTpcLayers = 48;
-  const unsigned int m_nTpcModulesPerLayer = 12;
-  const unsigned int m_nTpcSides = 2;
+  static constexpr unsigned int m_nTpcLayers = 48;
+  static constexpr unsigned int m_nTpcModulesPerLayer = 12;
+  static constexpr unsigned int m_nTpcSides = 2;
 
   /// TPC Acts::Surface subdivisions
   double m_minSurfZ = 0.;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Title says it all. 
For this to work I had to move the call to setPlanarSurfaceDivisions from the constructor to ::Init method
Also changed some static const into static constexpr
Successfully tested with a twice larger number of phi subsurface on single particle simulations.
This has zero impact on the default reconstruction chain.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

