### PR TITLE
Improve silicon track purity

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -59,7 +59,7 @@ int PHActsSiliconSeeding::Init(PHCompositeNode */*topNode*/)
 
   if(m_seedAnalysis)
     {    
-      m_file = new TFile("seedingOutfile.root","recreate");
+      m_file = new TFile(std::string(Name() + ".root").c_str(),"recreate");
       createHistograms();
     }  
   
@@ -618,24 +618,19 @@ PHActsSiliconSeeding::makePossibleStubs(std::vector<TrkrCluster*>& allClusters,
   else
     {
       /// Otherwise we have 2 or more INTT matched hits
-      /// Find combinations of INTT clusters that were within
-      /// the nominal matching windows if each INTT layer group
-      /// had at least one cluster
+      std::vector<TrkrCluster*> dumVec = mvtxClusters;
+      std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
       for(int i=0; i<inttFirstLayerClusters.size(); i++)
 	{
-	  for(int j=0; j<inttSecondLayerClusters.size(); j++)
-	    {
-	      /// Start with the mvtx clusters
-	      std::vector<TrkrCluster*> dumVec = mvtxClusters;
-	      dumVec.push_back(inttFirstLayerClusters.at(i));
-	      dumVec.push_back(inttSecondLayerClusters.at(j));
-	      std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
-	      dumclusVec.push_back(inttFirstLayerClusPos.at(i));
-	      dumclusVec.push_back(inttSecondLayerClusPos.at(j));
-	      stubs.insert(std::make_pair(combo, std::make_pair(dumVec,dumclusVec)));
-	      combo++;
-	    }
+	  dumVec.push_back(inttFirstLayerClusters.at(i));
+	  dumclusVec.push_back(inttFirstLayerClusPos.at(i));
 	}
+      for(int i=0; i<inttSecondLayerClusters.size(); i++) {
+	dumVec.push_back(inttSecondLayerClusters.at(i));
+	dumclusVec.push_back(inttSecondLayerClusPos.at(i));
+      }
+      stubs.insert(std::make_pair(combo, std::make_pair(dumVec, dumclusVec)));
+      
     }
 
   return stubs;
@@ -881,7 +876,6 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	  layerGeom->find_segment_center(ladderzindex, ladderphiindex, ladderLocation);
 	  const double ladderphi = atan2(ladderLocation[1], ladderLocation[0]) + layerGeom->get_strip_phi_tilt();
 	  const auto stripZSpacing = layerGeom->get_strip_z_spacing();
-	  
 	  float dphi = ladderphi - projPhi;
 	  if(dphi > M_PI)
 	    { dphi -= 2. * M_PI; }
@@ -905,7 +899,21 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	    {
 	      const auto cluskey = clusIter->first;
 	      const auto cluster = clusIter->second;
-      
+	      /// Diagnostic
+	      if(m_seedAnalysis)
+		{ 
+		  const auto globalP = transform.getGlobalPosition(cluster, m_surfMaps,
+								   m_tGeometry);
+		  h_nInttProj->Fill(projectionLocal[1] - cluster->getLocalX(),
+				    projectionLocal[2] - cluster->getLocalY()); 
+		  h_hits->Fill(globalP(0), globalP(1));
+		  h_zhits->Fill(globalP(2),
+				sqrt(pow(globalP(0),2)+pow(globalP(1),2)));
+		  
+		  h_resids->Fill(zProj[inttlayer] - cluster->getLocalY(),
+				 projRphi - cluster->getLocalX());
+		}
+	     
 	      /// Z strip spacing is the entire strip, so because we use fabs
 	      /// we divide by two
 	      if(fabs(projectionLocal[1] - cluster->getLocalX()) < m_rPhiSearchWin and
@@ -918,27 +926,15 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 								     m_tGeometry);
 		  clusters.push_back(globalPos);
 
-		  /// Diagnostic
-		  float inttClusRphi = sqrt(pow(globalPos(0),2)+pow(globalPos(1),2)) * atan2(globalPos(1),globalPos(0));
-		  if(m_seedAnalysis)
-		    { 
-		      h_nInttProj->Fill(projectionLocal[1] - cluster->getLocalX(),
-					projectionLocal[2] - cluster->getLocalY()); 
-		      h_hits->Fill(globalPos(0), globalPos(1));
-		      h_zhits->Fill(globalPos(2),
-				    sqrt(pow(globalPos(0),2)+pow(globalPos(1),2)));
-		  
-		      h_resids->Fill(zProj[inttlayer] - globalPos(2),
-				     projRphi - inttClusRphi);
-		    }		  	      
+		 		  	      
 		  if(Verbosity() > 4)
 		    {
 		      std::cout << "Matched INTT cluster with cluskey " << cluskey 
 				<< " and position " << globalPos.transpose() 
 				<< std::endl << " with projections rphi "
-				<< projRphi << " and inttclus rphi " << inttClusRphi
+				<< projRphi << " and inttclus rphi " << cluster->getLocalX()
 				<< " and proj z " << zProj[inttlayer] << " and inttclus z "
-				<< globalPos(2) << " in layer " << inttlayer 
+				<< cluster->getLocalY() << " in layer " << inttlayer 
 				<< " with search windows " << m_rPhiSearchWin 
 				<< " in rphi and strip z spacing " << stripZSpacing 
 				<< std::endl;
@@ -948,6 +944,10 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	}  
     }
   
+  if(m_seedAnalysis) {
+    h_nMatchedClusters->Fill(matchedClusters.size());
+  }
+
   return matchedClusters;
 }
 void PHActsSiliconSeeding::circleCircleIntersection(const double layerRadius,
@@ -1523,6 +1523,7 @@ void PHActsSiliconSeeding::writeHistograms()
 {
   m_file->cd();
   h_nInttProj->Write();
+  h_nMatchedClusters->Write();
   h_nMvtxHits->Write();
   h_nSeeds->Write();
   h_nActsSeeds->Write();
@@ -1543,6 +1544,7 @@ void PHActsSiliconSeeding::writeHistograms()
 
 void PHActsSiliconSeeding::createHistograms()
 {
+  h_nMatchedClusters = new TH1F("nMatchedClusters",";N_{matches}", 50,0,50);
   h_nInttProj = new TH2F("nInttProj",";l_{0}^{proj}-l_{0}^{clus} [cm]; l_{1}^{proj}-l_{1}^{clus} [cm]",
 			 10000,-10,10,10000,-50,50);
   h_nMvtxHits = new TH1I("nMvtxHits",";N_{MVTX}",6,0,6);

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -587,52 +587,21 @@ PHActsSiliconSeeding::makePossibleStubs(std::vector<TrkrCluster*>& allClusters,
 	}
     }
   
-  /// if we have no INTT matches, we can just return one track stub
-  /// with the mvtx hits
-  if(inttFirstLayerClusters.size() == 0 and 
-     inttSecondLayerClusters.size() == 0)
+  /// Add the INTT measurements to the track stub
+  std::vector<TrkrCluster*> dumVec = mvtxClusters;
+  std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
+  for(int i=0; i<inttFirstLayerClusters.size(); i++)
     {
-      stubs.insert(std::make_pair(combo, std::make_pair(mvtxClusters, mvtxClusPos)));
+      dumVec.push_back(inttFirstLayerClusters.at(i));
+      dumclusVec.push_back(inttFirstLayerClusPos.at(i));
     }
+  for(int i=0; i<inttSecondLayerClusters.size(); i++) {
+    dumVec.push_back(inttSecondLayerClusters.at(i));
+    dumclusVec.push_back(inttSecondLayerClusPos.at(i));
+  }
 
-  /// If we have only one matched INTT hit, 
-  /// make a single stub and return
-  else if(inttFirstLayerClusters.size() == 1 and 
-     inttSecondLayerClusters.size() == 0)
-    {
-      std::vector<TrkrCluster*> dumVec = mvtxClusters;
-      dumVec.push_back(inttFirstLayerClusters.at(0));
-      std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
-      dumclusVec.push_back(inttFirstLayerClusPos.at(0));
-      stubs.insert(std::make_pair(combo, std::make_pair(dumVec,dumclusVec)));
-    }
-  else if(inttFirstLayerClusters.size() == 0 and 
-     inttSecondLayerClusters.size() == 1)
-    {
-      std::vector<TrkrCluster*> dumVec = mvtxClusters;
-      dumVec.push_back(inttSecondLayerClusters.at(0));
-      std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
-      dumclusVec.push_back(inttSecondLayerClusPos.at(0));
-      stubs.insert(std::make_pair(combo, std::make_pair(dumVec,dumclusVec)));
-    }
-  else
-    {
-      /// Otherwise we have 2 or more INTT matched hits
-      std::vector<TrkrCluster*> dumVec = mvtxClusters;
-      std::vector<Acts::Vector3> dumclusVec = mvtxClusPos;
-      for(int i=0; i<inttFirstLayerClusters.size(); i++)
-	{
-	  dumVec.push_back(inttFirstLayerClusters.at(i));
-	  dumclusVec.push_back(inttFirstLayerClusPos.at(i));
-	}
-      for(int i=0; i<inttSecondLayerClusters.size(); i++) {
-	dumVec.push_back(inttSecondLayerClusters.at(i));
-	dumclusVec.push_back(inttSecondLayerClusPos.at(i));
-      }
-      stubs.insert(std::make_pair(combo, std::make_pair(dumVec, dumclusVec)));
-      
-    }
-
+  stubs.insert(std::make_pair(combo, std::make_pair(dumVec, dumclusVec)));
+  
   return stubs;
 }
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -67,12 +67,21 @@ int PHActsSiliconSeeding::Init(PHCompositeNode */*topNode*/)
 }
 int PHActsSiliconSeeding::InitRun(PHCompositeNode *topNode)
 {
+
   if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    return Fun4AllReturnCodes::ABORTEVENT;
+    { return Fun4AllReturnCodes::ABORTEVENT; }
   
   if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    return Fun4AllReturnCodes::ABORTEVENT;
+    { return Fun4AllReturnCodes::ABORTEVENT; }
   
+  auto beginend = m_geomContainerIntt->get_begin_end();
+  int i = 0;
+  for(auto iter = beginend.first; iter != beginend.second; ++iter)
+    {
+      m_nInttLayerRadii[i] = iter->second->get_radius();
+      i++;
+    }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -213,10 +222,11 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       /// Loop over actual seeds in this grid volume
       for(auto& seed : seeds)
 	{
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 1) {
 	    std::cout << "Seed " << numSeeds << " has "
 		      << seed.sp().size() << " measurements " 
 		      << std::endl;
+	  }
 
 	  numSeeds++;
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -257,8 +257,7 @@ class PHActsSiliconSeeding : public SubsysReco
   double m_maxSeedPCA = 2.;
   
   const static unsigned int m_nInttLayers = 4;
-  const double m_nInttLayerRadii[m_nInttLayers] = 
-    {7.188, 7.732, 9.680,10.262}; /// cm
+  double m_nInttLayerRadii[m_nInttLayers];
   
   /// Search window for phi to match intt clusters in cm
   double m_rPhiSearchWin = 0.1;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -88,6 +88,8 @@ class PHActsSiliconSeeding : public SubsysReco
   void fieldMapName(const std::string& fieldmap)
     { m_fieldMapName = fieldmap; }
 
+  void setRPhiSearchWindow(const float win) { m_rPhiSearchWin = win; std::cout << "Search window is " << m_rPhiSearchWin<<std::endl;}
+
   /// For each MVTX+INTT seed, take the best INTT hits and form
   /// 1 silicon seed per MVTX seed
   void cleanSeeds(bool cleanSeeds)
@@ -256,6 +258,7 @@ class PHActsSiliconSeeding : public SubsysReco
   /// Maximum allowed transverse PCA for seed, cm
   double m_maxSeedPCA = 2.;
   
+  /// Doesn't change, we are building the INTT this way
   const static unsigned int m_nInttLayers = 4;
   double m_nInttLayerRadii[m_nInttLayers];
   
@@ -279,6 +282,7 @@ class PHActsSiliconSeeding : public SubsysReco
   TH2 *h_nInttProj = nullptr;
   TH1 *h_nMvtxHits = nullptr;
   TH1 *h_nInttHits = nullptr;
+  TH1 *h_nMatchedClusters = nullptr;
   TH2 *h_nHits = nullptr;
   TH1 *h_nSeeds = nullptr;
   TH1 *h_nActsSeeds = nullptr;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -260,7 +260,7 @@ class PHActsSiliconSeeding : public SubsysReco
   
   /// Doesn't change, we are building the INTT this way
   const static unsigned int m_nInttLayers = 4;
-  double m_nInttLayerRadii[m_nInttLayers];
+  double m_nInttLayerRadii[m_nInttLayers] = {0};;
   
   /// Search window for phi to match intt clusters in cm
   double m_rPhiSearchWin = 0.1;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR removes the duplication of matches in the INTT with MVTX triplets. Local tests show it boosts the track seed purity in 50 kHz by ~15-20% without a loss in efficiency. Slides to show in the next tracking meeting. Curious to see if Jenkins agrees

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

