### PR TITLE
MVTX timing using strobe pulses

### DIFF
--- a/simulation/g4simulation/g4mvtx/Makefile.am
+++ b/simulation/g4simulation/g4mvtx/Makefile.am
@@ -20,6 +20,7 @@ libg4mvtx_la_LIBADD = \
   -lfun4all \
   -lphg4hit \
   -lg4detectors \
+  -lgsl \
   -ltrack_io \
   -lmvtx_io
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.cc
@@ -387,7 +387,7 @@ int PHG4MvtxDetector::ConstructMvtxPassiveVol(G4LogicalVolume*& lv)
     av_EW_N->MakeImprint(lv, TrN, 0, OverlapCheck());
   }
   //Now construct service barrel, CYSS, cones and cables
-  PHG4MvtxSupport *mvtxSupportSystem = new PHG4MvtxSupport(m_DisplayAction);
+  PHG4MvtxSupport *mvtxSupportSystem = new PHG4MvtxSupport(m_DisplayAction, OverlapCheck());
   mvtxSupportSystem->ConstructMvtxSupport(lv); 
 
   delete mvtxSupportSystem;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -46,9 +46,16 @@ PHG4MvtxHitReco::PHG4MvtxHitReco(const string &name)
   , PHParameterContainerInterface(name)
   , detector(name)
 {
+  m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   SetDefaultParameters();  // sets default timing window
   if (Verbosity() > 0)
     cout << "Creating PHG4MvtxHitReco for name = " << name << endl;
+}
+
+PHG4MvtxHitReco::~PHG4MvtxHitReco()
+{
+  gsl_rng_free(m_RandomGenerator);
+  return;
 }
 
 int PHG4MvtxHitReco::InitRun(PHCompositeNode *topNode)
@@ -157,6 +164,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
   // loop over all of the layers in the g4hit container
   PHG4HitContainer::LayerIter layer;
   pair<PHG4HitContainer::LayerIter, PHG4HitContainer::LayerIter> layer_begin_end = g4hit->getLayers();
+  double strobe_time = generate_strobe();
   for (layer = layer_begin_end.first; layer != layer_begin_end.second; ++layer)
   {
     //cout << "---------- PHG4MvtxHitReco:  Looping over layers " << endl;
@@ -194,13 +202,31 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         cout << PHWHERE << "Mvtx layers only go up to three! Quit." << endl;
         exit(1);
       }
-      if (Verbosity() > 1)
-        cout << " layer " << *layer << " t0 " << hiter->second->get_t(0) << " t1 " << hiter->second->get_t(1)
-             << " tmin " << tmin_max[*layer].first << " tmax " << tmin_max[*layer].second
-             << endl;
-      if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
-      if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
-
+      if (m_use_strobe)
+      {
+        std::pair<double, double> alpide_pulse = generate_alpide_pulse(hiter->second->get_edep()); //Function returns us, we need ns
+        if (Verbosity() > 1)
+        {
+          cout << "MVTX is in strobed timing mode" << endl;
+          cout << " layer " << *layer << " t0 " << hiter->second->get_t(0) << " t1 " << hiter->second->get_t(1) << endl;
+          cout << "strobe_start: " << strobe_time << ", strobe width: " << m_strobe_width << ", strobe separation: " << m_strobe_separation << endl;
+          cout << "alpide pulse start: " << alpide_pulse.first << ", alpide pulse end: " << alpide_pulse.second << endl;
+        }
+        if (strobe_time + m_strobe_width < hiter->second->get_t(0) + alpide_pulse.first) continue;
+        if (strobe_time + m_strobe_width > hiter->second->get_t(0) + alpide_pulse.first + alpide_pulse.second) continue;
+      }
+      else
+      {
+        if (Verbosity() > 1)
+        {
+          cout << "MVTX is in default timing mode" << endl;
+          cout << " layer " << *layer << " t0 " << hiter->second->get_t(0) << " t1 " << hiter->second->get_t(1)
+               << " tmin " << tmin_max[*layer].first << " tmax " << tmin_max[*layer].second
+               << endl;
+        }
+        if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
+        if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
+      }
       // get_property_int(const PROPERTY prop_id) const {return INT_MIN;}
       int stave_number = hiter->second->get_property_int(PHG4Hit::prop_stave_index);
       int half_stave_number = hiter->second->get_property_int(PHG4Hit::prop_half_stave_index);
@@ -546,6 +572,25 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+pair<double, double> PHG4MvtxHitReco::generate_alpide_pulse(const double energy_deposited)
+{
+  // We need to translate energy deposited to num/ electrons released
+  if (Verbosity() > 2) cout << "energy_deposited: " << energy_deposited << endl;
+  //int silicon_band_gap = 1.12; //Band gap energy in eV
+  int Q_in = rand() % 5000 + 50;
+  int clipping_point = 110;
+  double ToT_start = Q_in < 200 ? 395.85*exp(-0.5*pow((Q_in+851.43)/286.91, 2)) : 0.5;
+  double ToT_end = Q_in < clipping_point ? 5.90*exp(-0.5*pow((Q_in-99.86)/54.80, 2)) : 5.8 - 6.4e-4 * Q_in;
+
+  return make_pair(ToT_start*1e3, ToT_end*1e3);
+}
+
+double PHG4MvtxHitReco::generate_strobe()
+{
+  double t_start = gsl_rng_uniform_pos(m_RandomGenerator)*(m_strobe_separation);
+  return t_start*1e3;
 }
 
 void PHG4MvtxHitReco::set_timing_window(const int detid, const double tmin, const double tmax)

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -589,7 +589,7 @@ pair<double, double> PHG4MvtxHitReco::generate_alpide_pulse(const double energy_
 
 double PHG4MvtxHitReco::generate_strobe()
 {
-  double t_start = gsl_rng_uniform_pos(m_RandomGenerator)*(m_strobe_separation);
+  double t_start = gsl_rng_uniform_pos(m_RandomGenerator)*(m_strobe_separation + m_strobe_width);
   return t_start*1e3;
 }
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -5,6 +5,8 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <gsl/gsl_rng.h>
+
 #include <map>
 #include <string>
 #include <utility>  // for pair
@@ -16,7 +18,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
  public:
   explicit PHG4MvtxHitReco(const std::string &name = "PHG4MvtxRECO");
 
-  ~PHG4MvtxHitReco() override {}
+  ~PHG4MvtxHitReco();
 
   //! module initialization
   int InitRun(PHCompositeNode *topNode) override;
@@ -28,7 +30,11 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
 
   double get_timing_window_min(const int i) { return tmin_max[i].first; }
   double get_timing_window_max(const int i) { return tmin_max[i].second; }
+  std::pair<double, double> generate_alpide_pulse(const double energy_deposited);
+  double generate_strobe();
   void set_timing_window(const int detid, const double tmin, const double tmax);
+  void use_strobed_mode(bool use) {m_use_strobe = use;}
+  void set_strobe_properties(double width, double separation) {m_strobe_width = width; m_strobe_separation = separation;}
 
   void SetDefaultParameters() override;
 
@@ -37,6 +43,12 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterContainerInterface
   std::string hitnodename;
   std::string geonodename;
   std::map<int, std::pair<double, double> > tmin_max;
+  bool m_use_strobe = false;
+  double m_strobe_width = 5.;
+  double m_strobe_separation = 0.;
+
+private:
+  gsl_rng *m_RandomGenerator = nullptr;
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSupport.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSupport.cc
@@ -30,14 +30,16 @@ namespace ServiceProperties
 
 using namespace ServiceProperties;
 
-PHG4MvtxSupport::PHG4MvtxSupport(PHG4MvtxDisplayAction* dispAct)
+PHG4MvtxSupport::PHG4MvtxSupport(PHG4MvtxDisplayAction* dispAct, bool overlapCheck)
   : m_DisplayAction(dispAct)
   , m_avSupport(nullptr)
   , m_avBarrelCable(nullptr)
   , m_avL0Cable(nullptr)
   , m_avL1Cable(nullptr)
   , m_avL2Cable(nullptr)
-{}
+{
+  m_overlapCheck = overlapCheck;
+}
 
 PHG4MvtxSupport::~PHG4MvtxSupport()
 {
@@ -436,7 +438,7 @@ void PHG4MvtxSupport::ConstructMvtxSupport(G4LogicalVolume *&lv)
   G4ThreeVector place;
   place.setZ(ServiceOffset*cm);
   G4Transform3D transform(rot, place);
-  m_avSupport->MakeImprint(lv, transform, 0, true);
+  m_avSupport->MakeImprint(lv, transform, 0, m_overlapCheck);
 
   m_avBarrelCable = buildBarrelCable();
   G4ThreeVector placeBarrelCable;
@@ -449,7 +451,7 @@ void PHG4MvtxSupport::ConstructMvtxSupport(G4LogicalVolume *&lv)
     G4RotationMatrix rotBarrelCable;
     rotBarrelCable.rotateZ(phi + (-90.*degToRad));
     G4Transform3D transformBarrelCable(rotBarrelCable, placeBarrelCable);
-    m_avBarrelCable->MakeImprint(lv, transformBarrelCable, 0, true);
+    m_avBarrelCable->MakeImprint(lv, transformBarrelCable, 0, m_overlapCheck);
   }
 
   m_avL0Cable = buildL0Cable();
@@ -468,9 +470,9 @@ void PHG4MvtxSupport::ConstructMvtxSupport(G4LogicalVolume *&lv)
       placeCable.setZ((ServiceOffset)*cm);
       rotCable.rotateZ(phi + ((-90. + cableRotate[iLayer])*degToRad));
       G4Transform3D transformCable(rotCable, placeCable);
-      if (iLayer == 0) m_avL0Cable->MakeImprint(lv, transformCable, 0, true);
-      if (iLayer == 1) m_avL1Cable->MakeImprint(lv, transformCable, 0, true);
-      if (iLayer == 2) m_avL2Cable->MakeImprint(lv, transformCable, 0, true);
+      if (iLayer == 0) m_avL0Cable->MakeImprint(lv, transformCable, 0, m_overlapCheck);
+      if (iLayer == 1) m_avL1Cable->MakeImprint(lv, transformCable, 0, m_overlapCheck);
+      if (iLayer == 2) m_avL2Cable->MakeImprint(lv, transformCable, 0, m_overlapCheck);
     }
   }
 }

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSupport.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSupport.h
@@ -29,7 +29,7 @@
 class PHG4MvtxSupport
 {
  public:
-  PHG4MvtxSupport(PHG4MvtxDisplayAction* dispAct);
+  PHG4MvtxSupport(PHG4MvtxDisplayAction* dispAct, bool overlapCheck);
 
   ~PHG4MvtxSupport();
 
@@ -57,6 +57,8 @@ class PHG4MvtxSupport
   G4AssemblyVolume *m_avL1Cable;
   G4AssemblyVolume *m_avL2Cable;
   //std::vector<G4AssemblyVolume*> m_endwheelCable;
+  
+  bool m_overlapCheck = false;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
First version of MVTX timing using strobe pulses.

This draft is for the review and alterations of Yasser, @blackcathj @adfrawley @jdosbo 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This adds an alternate timing mode for the MVTX where a random alpide timing window is generated from an approximation of the start and end time distributions as a function of number of electrons deposited.

A strobe pulse start is randomly generated from a uniform distribution of the sum of strobe width and strobe separation (separation is the difference between falling and rising edges!!!). 

The hit must land in the following range to be accepted:

geant4 hit time + alpide pulse start time < strobe start + strobe width < geant4 hit time + alpide pulse start time + alpide pulse end time

The alpide pulse start and end time are **different** for each hit. The strobe start time is the **same** for each event

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

We should figure out how to make the number of electrons released a function of the deposited energy as measured by Geant4. The initial work for this is done, we just need a conversion factor as initial tests gave too large a number of electrons. The number of electrons defines the alpide pulse window

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

This should be backward compatible but lines can be added to macros/common/G4_Mvtx.C to test this:

```c++
  PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
  maps_hits->Verbosity(verbosity);
  maps_hits->use_strobed_mode(true);
```
the strobe properties are defaulted to a width of 5us and separation of 0us. They can be altered from the function:
```c++
void set_strobe_properties(double width, double separation) {m_strobe_width = width; m_strobe_separation = separation;}
```
