### PR TITLE
Fixed issue in decay finder where 2 iterators were compared

### DIFF
--- a/generators/decayFinder/DecayFinder.cc
+++ b/generators/decayFinder/DecayFinder.cc
@@ -413,7 +413,7 @@ int DecayFinder::checkIfCorrectParticle(HepMC::GenParticle* particle, bool& trac
     std::vector<int> actualIntermediateDecayProducts;
     //Which intermediate decay list to we need
     auto it = std::find(positive_intermediates_ID.begin(), positive_intermediates_ID.end(), abs(particle->pdg_id()));
-    int index = it - m_intermediates_ID.begin();
+    int index = std::distance(positive_intermediates_ID.begin(), it);
 
     unsigned int trackStart = 0, trackStop = 0;
     if (index == 0)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -124,7 +124,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   //float *m_calculated_intermediate_cov[max_intermediates];
   float m_calculated_intermediate_cov[max_intermediates][21] = {{0},{0}};
 
-  static const int max_tracks = 20;
+  //static const int max_tracks = 20;
   float m_calculated_daughter_mass[max_tracks] = {0};
   float m_calculated_daughter_ip[max_tracks] = {0};
   float m_calculated_daughter_ip_xy[max_tracks] = {0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Jenkins found an issue where I compared two different iterators (one of the vectors used was just the modulus of the other so we couldn't go out of scope). Anyway, fixed this so it actually does what it should rather than do funny things with our memory
From 
```c++
//Which intermediate decay list to we need
auto it = std::find(positive_intermediates_ID.begin(), positive_intermediates_ID.end(), abs(particle->pdg_id()));
int index = it - m_intermediates_ID.begin();
```
to
```c++
//Which intermediate decay list to we need
auto it = std::find(positive_intermediates_ID.begin(), positive_intermediates_ID.end(), abs(particle->pdg_id()));
int index = std::distance(positive_intermediates_ID.begin(), it);
```

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

