### PR TITLE
Silicon seed merger

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -60,6 +60,7 @@ pkginclude_HEADERS = \
   PHTrackCleaner.h \
   PHTrackSelector.h \
   PHRaveVertexing.h \
+  PHSiliconSeedMerger.h \
   PHSiliconTruthTrackSeeding.h \
   PHSimpleKFProp.h \
   PHTpcClusterMover.h \
@@ -157,6 +158,7 @@ libtrack_reco_la_SOURCES = \
   PHMicromegasTpcTrackMatching.cc \
   PHRaveVertexing.cc \
   PHRTreeSeeding.cc \
+  PHSiliconSeedMerger.cc \
   PHSiliconTpcTrackMatching.cc \
   PHSiliconTruthTrackSeeding.cc \
   PHSimpleKFProp.cc \

--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -84,12 +84,12 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode *)
 		{ mvtx2Keys.insert(ckey); }
 	    }
 
-	  std::vector<TrkrDefs::cluskey> intersection(mvtx1Keys.size() + mvtx2Keys.size());
+	  std::vector<TrkrDefs::cluskey> intersection;
 	  std::set_intersection(mvtx1Keys.begin(),
 				mvtx1Keys.end(),
 				mvtx2Keys.begin(),
 				mvtx2Keys.end(),
-				intersection.begin());
+				std::back_inserter(intersection));
 
 	  if(Verbosity() > 2) 
 	    {
@@ -99,9 +99,14 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode *)
 	      std::cout << "Track 2 keys " << std::endl;
 	      for(auto& key : mvtx2Keys) 
 		{ std::cout << "   ckey: " << key << std::endl; }
+	      std::cout << "Intersection keys " << std::endl;
+	      for(auto& key : intersection)
+		{ std::cout << "   ckey: " << key << std::endl; }
 	    }
 
-	  if(intersection.size() > 2) 
+	  /// If we have two clusters in common in the triplet, it is likely
+	  /// from the same track
+	  if(intersection.size() > 1) 
 	    {
 	      for(auto& key : mvtx2Keys)
 		{
@@ -120,6 +125,18 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode *)
 	      seedsToDelete.insert(track2ID);
 	    }
 	}
+    }
+
+  for(const auto& [trackKey, mvtxKeys] : matches)
+    {
+      auto track = m_siliconTrackMap->get(trackKey);
+     
+      for(auto& key : mvtxKeys) 
+	{
+	  if(track->find_cluster_key(key) == track->end_cluster_keys())
+	    { track->insert_cluster_key(key); }
+	}
+     
     }
 
   for(const auto& key : seedsToDelete) 

--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -1,0 +1,167 @@
+
+#include "PHSiliconSeedMerger.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHObject.h>
+#include <phool/PHTimer.h>
+
+#include <trackbase/TrkrDefs.h>
+
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrack.h>
+
+
+#include <phool/PHCompositeNode.h>
+
+//____________________________________________________________________________..
+PHSiliconSeedMerger::PHSiliconSeedMerger(const std::string &name):
+ SubsysReco(name)
+{}
+
+//____________________________________________________________________________..
+PHSiliconSeedMerger::~PHSiliconSeedMerger()
+{
+}
+
+//____________________________________________________________________________..
+int PHSiliconSeedMerger::Init(PHCompositeNode*)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHSiliconSeedMerger::InitRun(PHCompositeNode *topNode)
+{
+  int ret = getNodes(topNode);
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHSiliconSeedMerger::process_event(PHCompositeNode *)
+{
+
+  std::multimap<unsigned int, std::set<TrkrDefs::cluskey>> matches;
+  std::set<unsigned int> seedsToDelete;
+
+  for(auto iter1 = m_siliconTrackMap->begin();
+      iter1 != m_siliconTrackMap->end(); 
+      ++iter1)
+    {
+      unsigned int track1ID = iter1->first;
+      SvtxTrack* track1 = iter1->second;
+
+      if(seedsToDelete.find(track1ID) != seedsToDelete.end())
+	{ continue; }
+
+      std::set<TrkrDefs::cluskey> mvtx1Keys;
+      for (SvtxTrack::ConstClusterKeyIter iter = track1->begin_cluster_keys();
+           iter != track1->end_cluster_keys();
+           ++iter)
+	{
+	  TrkrDefs::cluskey ckey = *iter;
+	  if(TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::mvtxId)
+	    { mvtx1Keys.insert(ckey); }
+	}
+
+      for(auto iter2 = m_siliconTrackMap->begin();
+	  iter2 != m_siliconTrackMap->end();
+	  ++iter2) 
+	{
+	  unsigned int track2ID = iter2->first;
+	  if(track1ID == track2ID) { continue; }
+	  SvtxTrack* track2 = iter2->second;
+	  std::set<TrkrDefs::cluskey> mvtx2Keys;
+	  for (SvtxTrack::ConstClusterKeyIter iter = track2->begin_cluster_keys();
+	       iter != track2->end_cluster_keys();
+	       ++iter)
+	    {
+	      TrkrDefs::cluskey ckey = *iter;
+	      if(TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::mvtxId)
+		{ mvtx2Keys.insert(ckey); }
+	    }
+
+	  std::vector<TrkrDefs::cluskey> intersection(mvtx1Keys.size() + mvtx2Keys.size());
+	  std::set_intersection(mvtx1Keys.begin(),
+				mvtx1Keys.end(),
+				mvtx2Keys.begin(),
+				mvtx2Keys.end(),
+				intersection.begin());
+
+	  if(Verbosity() > 2) 
+	    {
+	      std::cout << "Track 1 keys " << std::endl;
+	      for(auto& key : mvtx1Keys) 
+		{ std::cout << "   ckey: " << key << std::endl; }
+	      std::cout << "Track 2 keys " << std::endl;
+	      for(auto& key : mvtx2Keys) 
+		{ std::cout << "   ckey: " << key << std::endl; }
+	    }
+
+	  if(intersection.size() > 2) 
+	    {
+	      for(auto& key : mvtx2Keys)
+		{
+		  if(mvtx1Keys.find(key) == mvtx1Keys.end())
+		    { mvtx1Keys.insert(key); }
+		}
+	      
+	      if(Verbosity() > 2)
+		{ 
+		  std::cout << "Match IDed"<<std::endl; 
+		  for(auto& key : mvtx1Keys)
+		    { std::cout << "  total track keys " << key << std::endl; }
+		}
+
+	      matches.insert(std::make_pair(track1ID, mvtx1Keys)); 
+	      seedsToDelete.insert(track2ID);
+	    }
+	}
+    }
+
+  for(const auto& key : seedsToDelete) 
+    {
+      m_siliconTrackMap->erase(key);
+    }
+
+  if(Verbosity() > 2)
+    {
+      for(const auto& [key, track] : *m_siliconTrackMap)
+	{ track->identify(); }
+    }
+	  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHSiliconSeedMerger::ResetEvent(PHCompositeNode *)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+//____________________________________________________________________________..
+int PHSiliconSeedMerger::End(PHCompositeNode *)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconSeedMerger::getNodes(PHCompositeNode *topNode)
+{
+  m_siliconTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_trackMapName.c_str());
+  if(!m_siliconTrackMap)
+    {
+      std::cout << PHWHERE << "No silicon track map, can't merge seeds"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  
+return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -67,7 +67,11 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode *)
 	    { mvtx1Keys.insert(ckey); }
 	}
 
-      for(auto iter2 = m_siliconTrackMap->begin();
+      /// We can speed up the code by only iterating over the track seeds
+      /// that are further in the map container from the current track,
+      /// since the comparison of e.g. track 1 with track 2 doesn't need
+      /// to be repeated with track 2 to track 1.
+      for(auto iter2 = m_siliconTrackMap->find(track1ID);
 	  iter2 != m_siliconTrackMap->end();
 	  ++iter2) 
 	{

--- a/offline/packages/trackreco/PHSiliconSeedMerger.h
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.h
@@ -1,0 +1,40 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHSILICONSEEDMERGER_H
+#define PHSILICONSEEDMERGER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+class PHCompositeNode;
+class SvtxTrackMap;
+
+class PHSiliconSeedMerger : public SubsysReco
+{
+ public:
+
+  PHSiliconSeedMerger(const std::string &name = "PHSiliconSeedMerger");
+
+  virtual ~PHSiliconSeedMerger();
+
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+  void trackMapName(const std::string& name) { m_trackMapName = name; }
+
+ private:
+
+  int getNodes(PHCompositeNode *topNode);
+
+  SvtxTrackMap *m_siliconTrackMap = nullptr;
+  std::string m_trackMapName = "SvtxSiliconTrackMap";
+
+};
+
+#endif // PHSILICONSEEDMERGER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduces a module that merges silicon seeds based on common MVTX hits. Something like ~10% of single tracks result in duplicate silicon seeds because the track leaves 4 MVTX hits, and since the Acts seeder finds triplets it finds two seeds for a single track. This PR introduces a module that finds seeds that have at least 2 common MVTX measurements and merges them, which results in a ~10% boost in purity at no efficiency expense.

## TODOs (if applicable)

After a few more tests I will introduce a macros PR to implement this in the workflow.


## Links to other PRs in macros and calibration repositories (if applicable)

