### PR TITLE
Distortion extrapolation

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -27,16 +27,7 @@ namespace
     while( phi >= 2*M_PI ) phi -= 2*M_PI;
     return phi;
   }
-
-  // sector from angle
-  constexpr double get_sector( double phi ) 
-  {
-    int isec = std::floor( (phi+M_PI/12)/(M_PI/6) ); 
-    if( isec < 0 ) isec += 12;
-    if( isec >= 12 ) isec -= 12;
-    return isec;
-  }
-  
+ 
   // angle from a given sector
   constexpr double get_sector_phi( int isec ) { return isec*M_PI/6; }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR adapts the TPC distortion extrapolation procedure to new TPOT geometry and makes it more robust against distortion histogram binning. 
The procedure does not yet use an external distortion map (from e.g. Central Membrane clusters) to scale the distortions copy from one sector to the other. This will be the subject of a separate PR.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

