### PR TITLE
removed GeoContext from cov matrix transformations. (it is not used)

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -249,12 +249,17 @@ Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track) con
   
   Acts::BoundSymMatrix cov;
   for(int i =0; i<6; i++)
-    {
-      for(int j =0; j<6; j++)
-	{
-	  cov(i,j) = track->get_acts_covariance(i, j);
-	}
-    }
+    for(int j =0; j<6; j++)
+  { cov(i,j) = track->get_acts_covariance(i, j); }
+
+  /* convert from track parameters */
+  const auto cov2 = m_transformer.rotateSvtxTrackCovToActs( track );
+  
+  // compare
+  for( int i = 0; i < 6; ++i )
+    for( int j = 0; j < 6; ++j )
+  { std::cout << "PHTpcResiduals::makeTrackParams - (" << i << ", " << j << ") cov: " << cov(i,j) << " cov2: " << cov2(i,j) << std::endl; }
+  
   const Acts::Vector3 position(track->get_x() * Acts::UnitConstants::cm,
     track->get_y() * Acts::UnitConstants::cm,
     track->get_z() * Acts::UnitConstants::cm);
@@ -266,7 +271,6 @@ Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track) con
 					    actsFourPos, momentum,
 					    trackQ/p, cov).value();
  
-
 }
 
 void PHTpcResiduals::processTrack(SvtxTrack* track)
@@ -399,7 +403,7 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, float pathlength, const Ac
   state.set_pz(momentum.z());
 
   // covariance
-  const auto globalCov = m_transformer.rotateActsCovToSvtxTrack(params, m_tGeometry->geoContext);
+  const auto globalCov = m_transformer.rotateActsCovToSvtxTrack(params);
   for (int i = 0; i < 6; ++i)
     for (int j = 0; j < 6; ++j)
   { state.set_error(i, j, globalCov(i,j)); }

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -73,7 +73,7 @@ class PHTpcResiduals : public SubsysReco
   void setUseMicromegas( bool value )
   { m_useMicromegas = value; }
   
- private:
+  private:
 
   using BoundTrackParamPtr = 
     std::unique_ptr<const Acts::BoundTrackParameters>;

--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -11,9 +11,8 @@ namespace
   { return std::sqrt(square(x) + square(y));}
 }
 
-Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
-			        const SvtxTrack *track,
-				Acts::GeometryContext /*geoCtxt*/) const
+//_______________________________________________________________________________
+Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs( const SvtxTrack *track ) const
 {
   Acts::BoundSymMatrix svtxCovariance = Acts::BoundSymMatrix::Zero();
 
@@ -46,7 +45,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 
   //Acts version
   const double cosTheta = uPz;
-  const double sinTheta = sqrt(uPx * uPx + uPy * uPy);
+  const double sinTheta = std::sqrt(square(uPx) + square(uPy));
   const double invSinTheta = 1. / sinTheta;
   const double cosPhi = uPx * invSinTheta; // equivalent to x/r
   const double sinPhi = uPy * invSinTheta; // equivalent to y/r
@@ -90,8 +89,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 
   /// Since we are using the local to global jacobian we do R^TCR instead of 
   /// RCR^T
-  Acts::BoundSymMatrix actsLocalCov = 
-  jacobianLocalToGlobal.transpose() * rotatedMatrix * jacobianLocalToGlobal;
+  auto actsLocalCov = jacobianLocalToGlobal.transpose() * rotatedMatrix * jacobianLocalToGlobal;
 
   printMatrix("Rotated to Acts local cov : ",actsLocalCov);
   return actsLocalCov;
@@ -99,9 +97,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateSvtxTrackCovToActs(
 }
 
 
-Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
-			        const Acts::BoundTrackParameters params,
-				Acts::GeometryContext /*geoCtxt*/) const
+Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack( const Acts::BoundTrackParameters params ) const
 {
 
   auto covarianceMatrix = *params.covariance();
@@ -183,8 +179,7 @@ Acts::BoundSymMatrix ActsTransformations::rotateActsCovToSvtxTrack(
 }
 
 
-void ActsTransformations::printMatrix(const std::string &message,
-					Acts::BoundSymMatrix matrix) const
+void ActsTransformations::printMatrix(const std::string &message, const Acts::BoundSymMatrix& matrix) const
 {
  
   if(m_verbosity > 10)
@@ -421,7 +416,7 @@ void ActsTransformations::fillSvtxTrackStates(const Acts::MultiTrajectory& traj,
       out.set_pz(momentum.z());
       
       /// covariance    
-      const auto globalCov = rotateActsCovToSvtxTrack(params, geoContext);
+      const auto globalCov = rotateActsCovToSvtxTrack(params);
       for (int i = 0; i < 6; ++i)
         for (int j = 0; j < 6; ++j)
       { out.set_error(i, j, globalCov(i,j)); }

--- a/offline/packages/trackbase_historic/ActsTransformations.h
+++ b/offline/packages/trackbase_historic/ActsTransformations.h
@@ -43,17 +43,14 @@ class ActsTransformations
   /// cartesian coordinates to (d0, z0, phi, theta, q/p, time) coordinates for
   /// Acts. The track fitter performs the fitting with respect to the nominal
   /// origin of sPHENIX, so we rotate accordingly
-  Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack *track,
-						Acts::GeometryContext geoCtxt) const;
+  Acts::BoundSymMatrix rotateSvtxTrackCovToActs(const SvtxTrack* ) const;
   
   /// Same as above, but rotate from Acts basis to global (x,y,z,px,py,pz)
-  Acts::BoundSymMatrix rotateActsCovToSvtxTrack(
-                       const ActsExamples::TrackParameters params,
-		       Acts::GeometryContext geoCtxt) const;
+  Acts::BoundSymMatrix rotateActsCovToSvtxTrack( const ActsExamples::TrackParameters ) const;
 
   void setVerbosity(int verbosity) {m_verbosity = verbosity;}
 
-  void printMatrix(const std::string &message, Acts::BoundSymMatrix matrix) const;
+  void printMatrix(const std::string &message, const Acts::BoundSymMatrix& matrix) const;
 
   /// Calculate the DCA for a given Acts fitted track parameters and 
   /// vertex

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -721,9 +721,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
  
   if(params.covariance())
     {     
-      Acts::BoundSymMatrix rotatedCov = 
-	rotater.rotateActsCovToSvtxTrack(params,
-					  m_tGeometry->geoContext);
+      auto rotatedCov = rotater.rotateActsCovToSvtxTrack(params);
       
       for(int i = 0; i < 6; i++)
 	{

--- a/offline/packages/trackreco/PHActsVertexPropagator.cc
+++ b/offline/packages/trackreco/PHActsVertexPropagator.cc
@@ -111,7 +111,7 @@ void PHActsVertexPropagator::updateSvtxTrack(SvtxTrack* track,
   rotater.setVerbosity(Verbosity());
   if(params.covariance())
     {
-      auto rotatedCov = rotater.rotateActsCovToSvtxTrack(params, m_tGeometry->geoContext);
+      auto rotatedCov = rotater.rotateActsCovToSvtxTrack(params);
       
       /// Update covariance
       for(int i = 0; i < 3; i++) {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR cleansup ActsTransformation::Rotate... methods to not require Acts geometry context any more, which was not used anyway. This simplifies the code.
@jdosbo: is this ok ? 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

