### PR TITLE
New Truth-Reco Track Tables

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -22,7 +22,9 @@ AM_LDFLAGS = \
 pkginclude_HEADERS = \
   ActsTransformations.h \
   PHG4ParticleSvtxMap.h \
+  PHG4ParticleSvtxMap_v1.h \
   SvtxPHG4ParticleMap.h \
+  SvtxPHG4ParticleMap_v1.h \
   SvtxTrack.h \
   SvtxTrack_v1.h \
   SvtxTrack_v2.h \
@@ -40,7 +42,9 @@ pkginclude_HEADERS = \
 
 ROOTDICTS = \
   PHG4ParticleSvtxMap_Dict.cc \
+  PHG4ParticleSvtxMap_v1_Dict.cc \
   SvtxPHG4ParticleMap_Dict.cc \
+  SvtxPHG4ParticleMap_v1_Dict.cc \
   SvtxTrack_Dict.cc \
   SvtxTrackState_Dict.cc \
   SvtxTrackState_v1_Dict.cc \
@@ -59,7 +63,9 @@ ROOTDICTS = \
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   PHG4ParticleSvtxMap_Dict_rdict.pcm \
+  PHG4ParticleSvtxMap_v1_Dict_rdict.pcm \
   SvtxPHG4ParticleMap_Dict_rdict.pcm \
+  SvtxPHG4ParticleMap_v1_Dict_rdict.pcm \
   SvtxTrack_Dict_rdict.pcm \
   SvtxTrackState_Dict_rdict.pcm \
   SvtxTrackState_v1_Dict_rdict.pcm \
@@ -80,7 +86,9 @@ libtrackbase_historic_io_la_SOURCES = \
   $(ROOTDICTS) \
   ActsTransformations.cc \
   PHG4ParticleSvtxMap.cc \
+  PHG4ParticleSvtxMap_v1.cc \
   SvtxPHG4ParticleMap.cc \
+  SvtxPHG4ParticleMap_v1.cc \
   SvtxTrackState_v1.cc \
   SvtxTrack.cc \
   SvtxTrack_v1.cc \

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -21,6 +21,8 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   ActsTransformations.h \
+  PHG4ParticleSvtxMap.h \
+  SvtxPHG4ParticleMap.h \
   SvtxTrack.h \
   SvtxTrack_v1.h \
   SvtxTrack_v2.h \
@@ -37,6 +39,8 @@ pkginclude_HEADERS = \
   SvtxVertexMap_v1.h 
 
 ROOTDICTS = \
+  PHG4ParticleSvtxMap_Dict.cc \
+  SvtxPHG4ParticleMap_Dict.cc \
   SvtxTrack_Dict.cc \
   SvtxTrackState_Dict.cc \
   SvtxTrackState_v1_Dict.cc \
@@ -54,6 +58,8 @@ ROOTDICTS = \
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
+  PHG4ParticleSvtxMap_Dict_rdict.pcm \
+  SvtxPHG4ParticleMap_Dict_rdict.pcm \
   SvtxTrack_Dict_rdict.pcm \
   SvtxTrackState_Dict_rdict.pcm \
   SvtxTrackState_v1_Dict_rdict.pcm \
@@ -73,6 +79,8 @@ nobase_dist_pcm_DATA = \
 libtrackbase_historic_io_la_SOURCES = \
   $(ROOTDICTS) \
   ActsTransformations.cc \
+  PHG4ParticleSvtxMap.cc \
+  SvtxPHG4ParticleMap.cc \
   SvtxTrackState_v1.cc \
   SvtxTrack.cc \
   SvtxTrack_v1.cc \

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
@@ -1,0 +1,50 @@
+#include "PHG4ParticleSvtxMap.h"
+
+PHG4ParticleSvtxMap::Map DummyPHG4ParticleSvtxMap;
+PHG4ParticleSvtxMap::WeightedRecoTrackMap emptyRecoMap;
+
+const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(unsigned int) const 
+{
+  return emptyRecoMap;
+}
+
+PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(unsigned int) 
+{
+  return emptyRecoMap;
+}
+
+PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::insert(const WeightedRecoTrackMap)
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::begin() const
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::find(unsigned int /*idkey*/) const
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::end() const
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+
+PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::begin()
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::find(unsigned int /*idkey*/)
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}
+
+PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::end()
+{
+  return DummyPHG4ParticleSvtxMap.end();
+}

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
@@ -3,19 +3,19 @@
 PHG4ParticleSvtxMap::Map DummyPHG4ParticleSvtxMap;
 PHG4ParticleSvtxMap::WeightedRecoTrackMap emptyRecoMap;
 
-const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(unsigned int) const 
+const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int) const 
 {
   return emptyRecoMap;
 }
 
-PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(unsigned int) 
+PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int) 
 {
   return emptyRecoMap;
 }
 
-PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::insert(const WeightedRecoTrackMap)
+PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::insert(const int, const WeightedRecoTrackMap)
 {
-  return DummyPHG4ParticleSvtxMap.end();
+  return emptyRecoMap;
 }
 
 PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::begin() const
@@ -23,7 +23,7 @@ PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::begin() const
   return DummyPHG4ParticleSvtxMap.end();
 }
 
-PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::find(unsigned int /*idkey*/) const
+PHG4ParticleSvtxMap::ConstIter PHG4ParticleSvtxMap::find(const int) const
 {
   return DummyPHG4ParticleSvtxMap.end();
 }
@@ -39,7 +39,7 @@ PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::begin()
   return DummyPHG4ParticleSvtxMap.end();
 }
 
-PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::find(unsigned int /*idkey*/)
+PHG4ParticleSvtxMap::Iter PHG4ParticleSvtxMap::find(const int)
 {
   return DummyPHG4ParticleSvtxMap.end();
 }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
@@ -28,20 +28,20 @@ class PHG4ParticleSvtxMap : public PHObject
   
   virtual bool empty() const { return true; }
   virtual std::size_t size() const { return 0; }
-  virtual std::size_t count() const { return 0; }
+  virtual std::size_t count(const int) const { return 0; }
   virtual void clear() {}
 
-  virtual const WeightedRecoTrackMap get(unsigned int) const;
-  virtual WeightedRecoTrackMap get(unsigned int);
-  virtual ConstIter insert(const WeightedRecoTrackMap);
-  virtual std::size_t erase(unsigned int) { return 0; }
+  virtual const WeightedRecoTrackMap get(const int) const;
+  virtual WeightedRecoTrackMap get(const int);
+  virtual WeightedRecoTrackMap insert(const int, const WeightedRecoTrackMap);
+  virtual std::size_t erase(const int) { return 0; }
 
   virtual ConstIter begin() const;
-  virtual ConstIter find(unsigned int) const;
+  virtual ConstIter find(const int) const;
   virtual ConstIter end() const;
 
   virtual Iter begin();
-  virtual Iter find(unsigned int);
+  virtual Iter find(const int);
   virtual Iter end();
 
  protected:

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
@@ -1,0 +1,55 @@
+#ifndef TRACKBASEHISTORIC_PHG4PARTICLESVTXMAP_H
+#define TRACKBASEHISTORIC_PHG4PARTICLESVTXMAP_H
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <map>
+#include <set>
+
+class PHG4ParticleSvtxMap : public PHObject
+{
+ public:
+  /// Truth->reco map with structure <g4part id, std::map< weight, std::set<reco track id>>>
+  typedef std::map<float, std::set<unsigned int>> WeightedRecoTrackMap;
+  typedef std::map<int, WeightedRecoTrackMap> Map;
+  typedef std::map<int, WeightedRecoTrackMap>::const_iterator ConstIter;
+  typedef std::map<int, WeightedRecoTrackMap>::iterator Iter;
+
+  ~PHG4ParticleSvtxMap() override {}
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "PHG4ParticleSvtxMap base class " << std::endl;
+  }
+  
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
+  
+  virtual bool empty() const { return true; }
+  virtual std::size_t size() const { return 0; }
+  virtual std::size_t count() const { return 0; }
+  virtual void clear() {}
+
+  virtual const WeightedRecoTrackMap get(unsigned int) const;
+  virtual WeightedRecoTrackMap get(unsigned int);
+  virtual ConstIter insert(const WeightedRecoTrackMap);
+  virtual std::size_t erase(unsigned int) { return 0; }
+
+  virtual ConstIter begin() const;
+  virtual ConstIter find(unsigned int) const;
+  virtual ConstIter end() const;
+
+  virtual Iter begin();
+  virtual Iter find(unsigned int);
+  virtual Iter end();
+
+ protected:
+  PHG4ParticleSvtxMap() {}
+
+ private:
+  ClassDefOverride(PHG4ParticleSvtxMap, 1);
+  
+};
+
+#endif

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
@@ -25,7 +25,8 @@ class PHG4ParticleSvtxMap : public PHObject
   
   int isValid() const override { return 0; }
   PHObject* CloneMe() const override { return nullptr; }
-  
+  void Reset() override {}
+
   virtual bool empty() const { return true; }
   virtual std::size_t size() const { return 0; }
   virtual std::size_t count(const int) const { return 0; }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMapLinkDef.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMapLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link C++ class std::map<float, std::set<unsigned int>>+;
+
+#pragma link C++ class std::map<int, std::map<float, std::set<unsigned int>>>+;
+
+#pragma link C++ class PHG4ParticleSvtxMap + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
@@ -1,0 +1,43 @@
+#include "PHG4ParticleSvtxMap_v1.h"
+
+PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1() 
+  : m_map()
+{}
+
+PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1(const PHG4ParticleSvtxMap_v1& map)
+  : m_map()
+{
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter)
+    {
+      WeightedRecoTrackMap trackmap = iter->second;
+      m_map.insert(std::make_pair(iter->first, trackmap));
+    }
+}
+
+
+PHG4ParticleSvtxMap_v1& PHG4ParticleSvtxMap_v1::operator=(const PHG4ParticleSvtxMap_v1& map)
+{
+  clear();
+  
+  for(ConstIter iter = map.begin(); iter != map.end(); ++iter)
+    {
+      m_map.insert(std::make_pair(iter->first, iter->second));
+    }
+
+  return *this;
+}
+
+PHG4ParticleSvtxMap_v1::~PHG4ParticleSvtxMap_v1() 
+{
+}
+
+void PHG4ParticleSvtxMap_v1::identify(std::ostream& os) const
+{
+  os << "PHG4ParticleSvtxMap_v1 size = " << m_map.size() << std::endl;
+}
+
+PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap_v1::insert(const int key, const PHG4ParticleSvtxMap::WeightedRecoTrackMap map)
+{
+  m_map.insert(std::make_pair(key, map)); 
+  return map;
+}

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
@@ -17,7 +17,7 @@ PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1(const PHG4ParticleSvtxMap_v1& map
 
 PHG4ParticleSvtxMap_v1& PHG4ParticleSvtxMap_v1::operator=(const PHG4ParticleSvtxMap_v1& map)
 {
-  clear();
+  Reset();
   
   for(ConstIter iter = map.begin(); iter != map.end(); ++iter)
     {
@@ -29,11 +29,24 @@ PHG4ParticleSvtxMap_v1& PHG4ParticleSvtxMap_v1::operator=(const PHG4ParticleSvtx
 
 PHG4ParticleSvtxMap_v1::~PHG4ParticleSvtxMap_v1() 
 {
+  Reset();
 }
 
 void PHG4ParticleSvtxMap_v1::identify(std::ostream& os) const
 {
   os << "PHG4ParticleSvtxMap_v1 size = " << m_map.size() << std::endl;
+
+  for(const auto& [g4id, matchedRecoTracks] : m_map)
+    {
+      os << "G4Particle " << g4id << " has matched reco tracks " << std::endl;
+      for(const auto& [weight, trackset] : matchedRecoTracks) 
+	{
+	  os << "  weight " << weight << " has reco tracks " << std::endl;
+	  for(const auto& track : trackset)
+	    { os << "    trackid : " << track << std::endl; }
+	}
+    }
+
 }
 
 PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap_v1::insert(const int key, const PHG4ParticleSvtxMap::WeightedRecoTrackMap map)

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -16,7 +16,7 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
   void identify(std::ostream& os = std::cout) const override;
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new PHG4ParticleSvtxMap_v1(*this); }
-
+  void Reset() override { clear(); }
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }
   std::size_t count(const int key) const override { return m_map.count(key); }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -1,0 +1,49 @@
+#ifndef TRACKBASEHISTORIC_PHG4PARTICLESVTXMAP_V1_H
+#define TRACKBASEHISTORIC_PHG4PARTICLESVTXMAP_V1_H
+
+#include "PHG4ParticleSvtxMap.h"
+
+
+class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
+{
+
+ public:
+  PHG4ParticleSvtxMap_v1();
+  PHG4ParticleSvtxMap_v1(const PHG4ParticleSvtxMap_v1& map);
+  PHG4ParticleSvtxMap_v1& operator=(const PHG4ParticleSvtxMap_v1& map);
+  ~PHG4ParticleSvtxMap_v1() override;
+
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override { return 1; }
+  PHObject* CloneMe() const override { return new PHG4ParticleSvtxMap_v1(*this); }
+
+  bool empty() const override { return m_map.empty(); }
+  std::size_t size() const override { return m_map.size(); }
+  std::size_t count(const int key) const override { return m_map.count(key); }
+  void clear() override { m_map.clear(); }
+
+  const WeightedRecoTrackMap get(const int key) const override
+    { return m_map.find(key)->second; }
+  WeightedRecoTrackMap get(const int key) override
+    { return m_map.find(key)->second; }
+  WeightedRecoTrackMap insert(const int key, const WeightedRecoTrackMap map) override;   
+  std::size_t erase(const int key) override
+    { return m_map.erase(key); }
+
+  ConstIter begin() const override { return m_map.begin(); }
+  ConstIter find(const int key) const override 
+    { return m_map.find(key); }
+  ConstIter end() const override { return m_map.end(); }
+
+  Iter begin() override { return m_map.begin(); }
+  Iter find(const int key) override { return m_map.find(key); }
+  Iter end() override { return m_map.end(); }
+
+ private:
+  PHG4ParticleSvtxMap::Map m_map;
+
+  ClassDefOverride(PHG4ParticleSvtxMap_v1, 1);
+};
+
+
+#endif

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link C++ class std::map<float, std::set<unsigned int>>+;
+
+#pragma link C++ class std::map<int, std::map<float, std::set<unsigned int>>>+;
+
+#pragma link C++ class PHG4ParticleSvtxMap_v1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
@@ -3,19 +3,19 @@
 SvtxPHG4ParticleMap::Map DummySvtxPHG4ParticleMap;
 SvtxPHG4ParticleMap::WeightedTruthTrackMap emptyTruthMap;
 
-const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(unsigned int) const 
+const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int) const 
 {
   return emptyTruthMap;
 }
 
-SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(unsigned int) 
+SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int) 
 {
   return emptyTruthMap;
 }
 
-SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::insert(const WeightedTruthTrackMap)
+SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::insert(const unsigned int, const WeightedTruthTrackMap)
 {
-  return DummySvtxPHG4ParticleMap.end();
+  return emptyTruthMap;
 }
 
 SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::begin() const
@@ -23,7 +23,7 @@ SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::begin() const
   return DummySvtxPHG4ParticleMap.end();
 }
 
-SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::find(unsigned int /*idkey*/) const
+SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::find(const unsigned int) const
 {
   return DummySvtxPHG4ParticleMap.end();
 }
@@ -39,7 +39,7 @@ SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::begin()
   return DummySvtxPHG4ParticleMap.end();
 }
 
-SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::find(unsigned int /*idkey*/)
+SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::find(unsigned int)
 {
   return DummySvtxPHG4ParticleMap.end();
 }

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
@@ -1,0 +1,50 @@
+#include "SvtxPHG4ParticleMap.h"
+
+SvtxPHG4ParticleMap::Map DummySvtxPHG4ParticleMap;
+SvtxPHG4ParticleMap::WeightedTruthTrackMap emptyTruthMap;
+
+const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(unsigned int) const 
+{
+  return emptyTruthMap;
+}
+
+SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(unsigned int) 
+{
+  return emptyTruthMap;
+}
+
+SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::insert(const WeightedTruthTrackMap)
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::begin() const
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::find(unsigned int /*idkey*/) const
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+SvtxPHG4ParticleMap::ConstIter SvtxPHG4ParticleMap::end() const
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+
+SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::begin()
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::find(unsigned int /*idkey*/)
+{
+  return DummySvtxPHG4ParticleMap.end();
+}
+
+SvtxPHG4ParticleMap::Iter SvtxPHG4ParticleMap::end()
+{
+  return DummySvtxPHG4ParticleMap.end();
+}

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
@@ -1,0 +1,55 @@
+#ifndef TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_H
+#define TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_H
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <map>
+#include <set>
+
+class SvtxPHG4ParticleMap : public PHObject
+{
+ public:
+  /// Reco->Truth map with structure <reco track key, std::map< weight, std::set<g4part id>>>
+  typedef std::map<float, std::set<int>> WeightedTruthTrackMap;
+  typedef std::map<unsigned int, WeightedTruthTrackMap> Map;
+  typedef std::map<unsigned int, WeightedTruthTrackMap>::const_iterator ConstIter;
+  typedef std::map<unsigned int, WeightedTruthTrackMap>::iterator Iter;
+
+  ~SvtxPHG4ParticleMap() override {}
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "SvtxPHG4ParticleMap base class " << std::endl;
+  }
+  
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
+  
+  virtual bool empty() const { return true; }
+  virtual std::size_t size() const { return 0; }
+  virtual std::size_t count() const { return 0; }
+  virtual void clear() {}
+
+  virtual const WeightedTruthTrackMap get(unsigned int) const;
+  virtual WeightedTruthTrackMap get(unsigned int);
+  virtual ConstIter insert(const WeightedTruthTrackMap);
+  virtual std::size_t erase(unsigned int) { return 0; }
+
+  virtual ConstIter begin() const;
+  virtual ConstIter find(unsigned int) const;
+  virtual ConstIter end() const;
+
+  virtual Iter begin();
+  virtual Iter find(unsigned int);
+  virtual Iter end();
+
+ protected:
+  SvtxPHG4ParticleMap() {}
+
+ private:
+  ClassDefOverride(SvtxPHG4ParticleMap, 1);
+  
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
@@ -28,20 +28,20 @@ class SvtxPHG4ParticleMap : public PHObject
   
   virtual bool empty() const { return true; }
   virtual std::size_t size() const { return 0; }
-  virtual std::size_t count() const { return 0; }
+  virtual std::size_t count(const unsigned int key) const { return 0; }
   virtual void clear() {}
 
-  virtual const WeightedTruthTrackMap get(unsigned int) const;
-  virtual WeightedTruthTrackMap get(unsigned int);
-  virtual ConstIter insert(const WeightedTruthTrackMap);
-  virtual std::size_t erase(unsigned int) { return 0; }
+  virtual const WeightedTruthTrackMap get(const unsigned int) const;
+  virtual WeightedTruthTrackMap get(const unsigned int);
+  virtual WeightedTruthTrackMap insert(const unsigned int, const WeightedTruthTrackMap);
+  virtual std::size_t erase(const unsigned int) { return 0; }
 
   virtual ConstIter begin() const;
-  virtual ConstIter find(unsigned int) const;
+  virtual ConstIter find(const unsigned int) const;
   virtual ConstIter end() const;
 
   virtual Iter begin();
-  virtual Iter find(unsigned int);
+  virtual Iter find(const unsigned int);
   virtual Iter end();
 
  protected:

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
@@ -25,10 +25,10 @@ class SvtxPHG4ParticleMap : public PHObject
   
   int isValid() const override { return 0; }
   PHObject* CloneMe() const override { return nullptr; }
-  
+  void Reset() override {}
   virtual bool empty() const { return true; }
   virtual std::size_t size() const { return 0; }
-  virtual std::size_t count(const unsigned int key) const { return 0; }
+  virtual std::size_t count(const unsigned int) const { return 0; }
   virtual void clear() {}
 
   virtual const WeightedTruthTrackMap get(const unsigned int) const;

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMapLinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMapLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link C++ class std::map<float, std::set<int>>+;
+
+#pragma link C++ class std::map<unsigned int, std::map<float, std::set<int>>>+;
+
+#pragma link C++ class SvtxPHG4ParticleMap + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
@@ -1,0 +1,43 @@
+#include "SvtxPHG4ParticleMap_v1.h"
+
+SvtxPHG4ParticleMap_v1::SvtxPHG4ParticleMap_v1() 
+  : m_map()
+{}
+
+SvtxPHG4ParticleMap_v1::SvtxPHG4ParticleMap_v1(const SvtxPHG4ParticleMap_v1& map)
+  : m_map()
+{
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter)
+    {
+      WeightedTruthTrackMap trackmap = iter->second;
+      m_map.insert(std::make_pair(iter->first, trackmap));
+    }
+}
+
+
+SvtxPHG4ParticleMap_v1& SvtxPHG4ParticleMap_v1::operator=(const SvtxPHG4ParticleMap_v1& map)
+{
+  clear();
+  
+  for(ConstIter iter = map.begin(); iter != map.end(); ++iter)
+    {
+      m_map.insert(std::make_pair(iter->first, iter->second));
+    }
+
+  return *this;
+}
+
+SvtxPHG4ParticleMap_v1::~SvtxPHG4ParticleMap_v1() 
+{
+}
+
+void SvtxPHG4ParticleMap_v1::identify(std::ostream& os) const
+{
+  os << "SvtxPHG4ParticleMap_v1 size = " << m_map.size() << std::endl;
+}
+
+SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap_v1::insert(const unsigned int key, const SvtxPHG4ParticleMap::WeightedTruthTrackMap map)
+{
+  m_map.insert(std::make_pair(key, map)); 
+  return map;
+}

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
@@ -17,7 +17,7 @@ SvtxPHG4ParticleMap_v1::SvtxPHG4ParticleMap_v1(const SvtxPHG4ParticleMap_v1& map
 
 SvtxPHG4ParticleMap_v1& SvtxPHG4ParticleMap_v1::operator=(const SvtxPHG4ParticleMap_v1& map)
 {
-  clear();
+  Reset();
   
   for(ConstIter iter = map.begin(); iter != map.end(); ++iter)
     {
@@ -29,11 +29,24 @@ SvtxPHG4ParticleMap_v1& SvtxPHG4ParticleMap_v1::operator=(const SvtxPHG4Particle
 
 SvtxPHG4ParticleMap_v1::~SvtxPHG4ParticleMap_v1() 
 {
+  Reset();
 }
 
 void SvtxPHG4ParticleMap_v1::identify(std::ostream& os) const
 {
   os << "SvtxPHG4ParticleMap_v1 size = " << m_map.size() << std::endl;
+  
+   for(const auto& [trackID, matchedTruthTracks] : m_map)
+    {
+      os << "Reco track " << trackID << " has matched truth tracks " << std::endl;
+      for(const auto& [weight, partset] : matchedTruthTracks) 
+	{
+	  os << "  weight " << weight << " has truth tracks " << std::endl;
+	  for(const auto& g4part : partset)
+	    { os << "    g4id : " << g4part << std::endl; }
+	}
+    }
+
 }
 
 SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap_v1::insert(const unsigned int key, const SvtxPHG4ParticleMap::WeightedTruthTrackMap map)

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -16,6 +16,7 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
   void identify(std::ostream& os = std::cout) const override;
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new SvtxPHG4ParticleMap_v1(*this); }
+  void Reset() override { clear(); }
 
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -1,0 +1,49 @@
+#ifndef TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_V1_H
+#define TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_V1_H
+
+#include "SvtxPHG4ParticleMap.h"
+
+
+class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
+{
+
+ public:
+  SvtxPHG4ParticleMap_v1();
+  SvtxPHG4ParticleMap_v1(const SvtxPHG4ParticleMap_v1& map);
+  SvtxPHG4ParticleMap_v1& operator=(const SvtxPHG4ParticleMap_v1& map);
+  ~SvtxPHG4ParticleMap_v1() override;
+
+  void identify(std::ostream& os = std::cout) const override;
+  int isValid() const override { return 1; }
+  PHObject* CloneMe() const override { return new SvtxPHG4ParticleMap_v1(*this); }
+
+  bool empty() const override { return m_map.empty(); }
+  std::size_t size() const override { return m_map.size(); }
+  std::size_t count(const unsigned int key) const override { return m_map.count(key); }
+  void clear() override { m_map.clear(); }
+
+  const WeightedTruthTrackMap get(const unsigned int key) const override
+    { return m_map.find(key)->second; }
+  WeightedTruthTrackMap get(const unsigned int key) override
+    { return m_map.find(key)->second; }
+  WeightedTruthTrackMap insert(const unsigned int key, const WeightedTruthTrackMap map) override;   
+  std::size_t erase(const unsigned int key) override
+    { return m_map.erase(key); }
+
+  ConstIter begin() const override { return m_map.begin(); }
+  ConstIter find(const unsigned int key) const override 
+    { return m_map.find(key); }
+  ConstIter end() const override { return m_map.end(); }
+
+  Iter begin() override { return m_map.begin(); }
+  Iter find(const unsigned int key) override { return m_map.find(key); }
+  Iter end() override { return m_map.end(); }
+
+ private:
+  SvtxPHG4ParticleMap::Map m_map;
+
+  ClassDefOverride(SvtxPHG4ParticleMap_v1, 1);
+};
+
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link C++ class std::map<float, std::set<int>>+;
+
+#pragma link C++ class std::map<unsigned int, std::map<float, std::set<int>>>+;
+
+#pragma link C++ class SvtxPHG4ParticleMap_v1 + ;
+
+#endif /* __CINT__ */

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -58,6 +58,7 @@ pkginclude_HEADERS = \
   SvtxClusterEval.h \
   SvtxTrackEval.h \
   SvtxTruthEval.h \
+  SvtxTruthRecoTableEval.h \
   SvtxVertexEval.h \
   TrackEvaluation.h \
   DSTEmulator.h \
@@ -100,6 +101,7 @@ libg4eval_la_SOURCES = \
   SvtxHitEval.cc \
   SvtxClusterEval.cc \
   SvtxTrackEval.cc \
+  SvtxTruthRecoTableEval.cc \
   SvtxVertexEval.cc \
   SvtxEvaluator.cc \
   TrackEvaluation.cc \

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
@@ -1,0 +1,223 @@
+
+#include "SvtxTruthRecoTableEval.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
+#include <trackbase_historic/PHG4ParticleSvtxMap_v1.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include "SvtxEvalStack.h"
+#include "SvtxTrackEval.h"
+#include "SvtxTruthEval.h"
+
+#include <phool/PHCompositeNode.h>
+
+//____________________________________________________________________________..
+SvtxTruthRecoTableEval::SvtxTruthRecoTableEval(const std::string &name):
+ SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+SvtxTruthRecoTableEval::~SvtxTruthRecoTableEval()
+{
+}
+
+//____________________________________________________________________________..
+int SvtxTruthRecoTableEval::Init(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTruthRecoTableEval::InitRun(PHCompositeNode *topNode)
+{
+  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+    { return Fun4AllReturnCodes::ABORTEVENT; }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTruthRecoTableEval::process_event(PHCompositeNode *topNode)
+{
+
+  if (!m_svtxevalstack)
+  {
+    m_svtxevalstack = new SvtxEvalStack(topNode);
+    m_svtxevalstack->set_strict(false);
+    m_svtxevalstack->set_verbosity(Verbosity());
+    m_svtxevalstack->set_use_initial_vertex(true);
+    m_svtxevalstack->set_use_genfit_vertex(false);
+    m_svtxevalstack->next_event(topNode);
+  }
+  else
+  {
+    m_svtxevalstack->next_event(topNode);
+  }
+
+  fillTruthMap(topNode);
+  
+  fillRecoMap(topNode);
+
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTruthRecoTableEval::ResetEvent(PHCompositeNode *)
+{
+  if(Verbosity() > 0) 
+    {
+      std::cout << "Truth track map " << std::endl;
+      m_truthMap->identify();
+      std::cout << std::endl << "Reco track map " << std::endl;
+      m_recoMap->identify();
+    }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+//____________________________________________________________________________..
+int SvtxTruthRecoTableEval::End(PHCompositeNode *)
+{
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode* topNode)
+{
+  PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  assert(truthinfo);
+  
+  SvtxTrackEval* trackeval = m_svtxevalstack->get_track_eval();
+  assert(trackeval);
+  
+  PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
+  if(m_scanForPrimaries)
+    {
+      range = truthinfo->GetPrimaryParticleRange();
+    }
+
+  for(auto iter = range.first; iter != range.second; ++iter)
+    {
+      PHG4Particle *g4particle = iter->second;
+      int gtrackID = g4particle->get_track_id();
+  
+      std::set<SvtxTrack*> alltracks = trackeval->all_tracks_from(g4particle);
+      PHG4ParticleSvtxMap::WeightedRecoTrackMap recomap;
+
+      for(const auto& track : alltracks)
+	{
+	  /// We fill the map with a key corresponding to the ncluster contribution.
+	  /// This weight could in principle be anything we choose
+	  float clusCont = trackeval->get_nclusters_contribution(track, g4particle);
+	  auto iterator = recomap.find(clusCont);
+	  if(iterator == recomap.end())
+	    {
+	      std::set<unsigned int> dumset;
+	      dumset.insert(track->get_id());
+	      recomap.insert(std::make_pair(clusCont, dumset));
+	    }
+	  else
+	    {
+	      iterator->second.insert(track->get_id());
+	    }
+	}
+
+      m_truthMap->insert(gtrackID, recomap);
+      
+    }
+
+}
+
+void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode* topNode)
+{
+  SvtxTrackMap *trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
+  
+  assert(trackMap);
+  
+  SvtxTrackEval* trackeval = m_svtxevalstack->get_track_eval();
+  assert(trackeval);
+
+  for(const auto& [key, track] : *trackMap)
+    {
+      
+      std::set<PHG4Particle*> allparticles = trackeval->all_truth_particles(track);
+      SvtxPHG4ParticleMap::WeightedTruthTrackMap truthmap;
+      for(const auto& g4particle : allparticles)
+	{
+	  float  clusCont = trackeval->get_nclusters_contribution(track, g4particle);
+	  auto iterator = truthmap.find(clusCont);
+	  if(iterator == truthmap.end())
+	    {
+	      std::set<int> dumset;
+	      dumset.insert(g4particle->get_track_id());
+	      truthmap.insert(std::make_pair(clusCont, dumset));
+	    }
+	  else
+	    {
+	      iterator->second.insert(g4particle->get_track_id());
+	    }
+	}
+
+      m_recoMap->insert(key, truthmap);
+
+    }
+}
+
+int SvtxTruthRecoTableEval::createNodes(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  if (!dstNode)
+  {
+    std::cerr << "DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in SvtxTruthRecoTableEval::createNodes");
+  }
+  
+  PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
+
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+
+  m_truthMap = findNode::getClass<PHG4ParticleSvtxMap>(topNode,"PHG4ParticleSvtxMap");
+  if(!m_truthMap)
+    {
+      m_truthMap = new PHG4ParticleSvtxMap_v1;
+      PHIODataNode<PHObject> *truthNode = 
+	new PHIODataNode<PHObject>(m_truthMap,"PHG4ParticleSvtxMap","PHObject");
+      svtxNode->addNode(truthNode);
+
+    } 
+
+  m_recoMap = findNode::getClass<SvtxPHG4ParticleMap>(topNode,"SvtxPHG4ParticleMap");
+  if(!m_recoMap)
+    {
+      m_recoMap = new SvtxPHG4ParticleMap_v1;
+      PHIODataNode<PHObject> *recoNode = 
+	new PHIODataNode<PHObject>(m_recoMap,"SvtxPHG4ParticleMap","PHObject");
+      svtxNode->addNode(recoNode);
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
@@ -38,7 +38,6 @@ class SvtxTruthRecoTableEval : public SubsysReco
 
   PHG4ParticleSvtxMap *m_truthMap = nullptr;
   SvtxPHG4ParticleMap *m_recoMap = nullptr;
-  PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxEvalStack *m_svtxevalstack = nullptr;
 };
 

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
@@ -1,0 +1,45 @@
+#ifndef SVTXTRUTHRECOTABLEEVAL_H
+#define SVTXTRUTHRECOTABLEEVAL_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <trackbase_historic/PHG4ParticleSvtxMap.h>
+#include <trackbase_historic/SvtxPHG4ParticleMap.h>
+
+#include <string>
+
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
+class SvtxEvalStack;
+
+class SvtxTruthRecoTableEval : public SubsysReco
+{
+ public:
+
+  SvtxTruthRecoTableEval(const std::string &name = "SvtxTruthRecoTableEval");
+
+  virtual ~SvtxTruthRecoTableEval();
+
+  int Init(PHCompositeNode*) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int ResetEvent(PHCompositeNode *topNode) override;
+ 
+  int End(PHCompositeNode *topNode) override;
+
+
+ private:
+  int createNodes(PHCompositeNode* topNode);
+
+  void fillTruthMap(PHCompositeNode *topNode);
+  void fillRecoMap(PHCompositeNode *topNode);
+
+  bool m_scanForPrimaries = true;
+
+  PHG4ParticleSvtxMap *m_truthMap = nullptr;
+  SvtxPHG4ParticleMap *m_recoMap = nullptr;
+  PHG4TruthInfoContainer *m_truthContainer = nullptr;
+  SvtxEvalStack *m_svtxevalstack = nullptr;
+};
+
+#endif // SVTXTRUTHRECOTABLEEVAL_H


### PR DESCRIPTION
This PR adds two new objects that correlate truth to reco and reco to truth tracks. They are intended to be a fix for the current tracking truth-reco limitation of carrying around too much information and thus being too large. The maps are of form:

```
/// Map of form std::map<gtrack id, std::map<weight, std::set<reco track id>>>
std::map<int, std::map<float, std::set<unsigned int>>> TruthToRecoTrackMap

/// Map of form std::map<reco track id, std::map<weight, std::set<gtrack id>>>
std::map<unsigned int, std::map<float, std::set<int>>> RecoToTruthTrackMap
```

The tables are filled with a new module that can be added to the G4_Tracking macro.


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

A macros PR that adds this to the nominal `G4_Tracking::Eval()` function is opened [here](https://github.com/sPHENIX-Collaboration/macros/pull/505).


## Links to other PRs in macros and calibration repositories (if applicable)

