### PR TITLE
 new cluster version with less data members + switch to use it in clu…

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -38,8 +38,8 @@ class TpcClusterizer : public SubsysReco
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_max_cluster_half_size_phi(unsigned short size) { MaxClusterHalfSizePhi = size ;}
   void set_max_cluster_half_size_z(unsigned short size) { MaxClusterHalfSizeZ = size ;}
-
   void set_drift_velocity_scale(double value) { m_drift_velocity_scale = value; }
+  void set_cluster_version(int value) { cluster_version = value; }
   
  private:
   bool is_in_sector_boundary(int phibin, int sector, PHG4CylinderCellGeom *layergeom) const;
@@ -49,13 +49,12 @@ class TpcClusterizer : public SubsysReco
   TrkrClusterHitAssocv3 *m_clusterhitassoc = nullptr;
   ActsSurfaceMaps *m_surfMaps = nullptr;
   ActsTrackingGeometry *m_tGeometry = nullptr;
-
   bool do_hit_assoc = true;
   double pedestal = 74.4;
   double SectorFiducialCut = 0.5;
   unsigned short MaxClusterHalfSizePhi = 3;
   unsigned short MaxClusterHalfSizeZ = 5;
-
+  int cluster_version = 3;
   /// drift velocity scale factor
   /** 
    * represents the ratio vdrift_measured/vdrift_true

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -34,6 +34,7 @@ pkginclude_HEADERS = \
   TrkrClusterv1.h \
   TrkrClusterv2.h \
   TrkrClusterv3.h \
+  TrkrClusterv4.h \
   TrkrClusterContainer.h \
   TrkrClusterContainerv1.h \
   TrkrClusterContainerv2.h \
@@ -68,6 +69,7 @@ ROOTDICTS = \
   TrkrClusterv1_Dict.cc \
   TrkrClusterv2_Dict.cc \
   TrkrClusterv3_Dict.cc \
+  TrkrClusterv4_Dict.cc \
   TrkrClusterContainer_Dict.cc \
   TrkrClusterContainerv1_Dict.cc \
   TrkrClusterContainerv2_Dict.cc \
@@ -138,6 +140,7 @@ libtrack_io_la_SOURCES = \
   TrkrClusterv1.cc \
   TrkrClusterv2.cc \
   TrkrClusterv3.cc \
+  TrkrClusterv4.cc \
   TrkrClusterContainer.cc \
   TrkrClusterContainerv1.cc \
   TrkrClusterContainerv2.cc \

--- a/offline/packages/trackbase/TrkrClusterv4.cc
+++ b/offline/packages/trackbase/TrkrClusterv4.cc
@@ -1,0 +1,76 @@
+/**
+ * @file trackbase/TrkrClusterv4.cc
+ * @author J. Osborn
+ * @date October 2021
+ * @brief Implementation of TrkrClusterv4
+ */
+#include "TrkrClusterv4.h"
+
+#include <cmath>
+#include <utility>          // for swap
+
+namespace
+{
+  // square convenience function
+  template<class T> inline constexpr T square( const T& x ) 
+    { return x*x; }
+}
+
+TrkrClusterv4::TrkrClusterv4()
+  : m_cluskey(TrkrDefs::CLUSKEYMAX)
+  , m_subsurfkey(TrkrDefs::SUBSURFKEYMAX)
+  , m_adc(0)
+  , m_valid(true)
+{
+  for (int i = 0; i < 2; i++)
+    {
+      m_local[i] = NAN;
+    }
+}
+
+void TrkrClusterv4::identify(std::ostream& os) const
+{
+  os << "---TrkrClusterv4--------------------" << std::endl;
+  os << "clusid: " << getClusKey() << std::dec << std::endl;
+
+  os << " (rphi,z) =  (" << getLocalX();
+  os << ", " << getLocalY() << ") cm ";
+
+  os << " valid = " << isValid() << std::endl;
+
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
+
+  return;
+}
+
+int TrkrClusterv4::isValid() const
+{
+  if (m_valid == false){return 0;}
+  if (m_cluskey == TrkrDefs::CLUSKEYMAX) { return 0; }
+
+  for (int i = 0; i < 2; ++i)
+  {
+    if (std::isnan(getPosition(i))) { return 0; }
+  }
+  if (m_adc == 0xFFFF) { return 0; }
+
+  return 1;
+}
+
+void TrkrClusterv4::CopyFrom( const TrkrCluster& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+ 
+  // parent class method
+  TrkrCluster::CopyFrom( source );
+ 
+  setClusKey( source.getClusKey() );
+  setLocalX( source.getLocalX() );
+  setLocalY( source.getLocalY() );
+  
+  setSubSurfKey( source.getSubSurfKey() );
+  setAdc( source.getAdc() );
+}
+

--- a/offline/packages/trackbase/TrkrClusterv4.cc
+++ b/offline/packages/trackbase/TrkrClusterv4.cc
@@ -21,6 +21,11 @@ TrkrClusterv4::TrkrClusterv4()
   , m_subsurfkey(TrkrDefs::SUBSURFKEYMAX)
   , m_adc(0)
   , m_valid(true)
+  , m_size(0)
+  , m_phisize(0)
+  , m_zsize(0)
+  , m_overlap(0)
+  , m_edge(0)
 {
   for (int i = 0; i < 2; i++)
     {

--- a/offline/packages/trackbase/TrkrClusterv4.h
+++ b/offline/packages/trackbase/TrkrClusterv4.h
@@ -1,0 +1,137 @@
+/**
+ * @file trackbase/TrkrClusterv4.h
+ * @author C. Roland
+ * @date April 2022
+ * @brief Version 4 of TrkrCluster
+ */
+#ifndef TRACKBASE_TRKRCLUSTERV4_H
+#define TRACKBASE_TRKRCLUSTERV4_H
+
+#include "TrkrCluster.h"
+#include "TrkrDefs.h"
+#include <iostream>
+
+class PHObject;
+
+/**
+ * @brief Version 4 of TrkrCluster
+ *
+ * This version of TrkrCluster is reduced to a minimal number of data members
+ */
+class TrkrClusterv4 : public TrkrCluster
+{
+ public:
+ 
+  //! ctor
+  TrkrClusterv4();
+
+  //!dtor
+  ~TrkrClusterv4() override {}
+  // PHObject virtual overloads
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override {}
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new TrkrClusterv4(*this); }
+  
+  //! copy content from base class
+  void CopyFrom( const TrkrCluster& ) override;
+
+  //! copy content from base class
+  void CopyFrom( TrkrCluster* source ) override
+  { CopyFrom( *source ); }
+
+  void setClusKey(TrkrDefs::cluskey id) override { m_cluskey = id; }
+  TrkrDefs::cluskey getClusKey() const override { return m_cluskey; }
+  
+  
+  //
+  // cluster position
+  //
+  float getPosition(int coor) const override { return m_local[coor]; }
+  void setPosition(int coor, float xi) override { m_local[coor] = xi; }
+  float getLocalX() const override { return m_local[0]; }
+  void setLocalX(float loc0) override { m_local[0] = loc0; }
+  float getLocalY() const override { return m_local[1]; }
+  void setLocalY(float loc1) override { m_local[1] = loc1; }
+
+  TrkrDefs::subsurfkey getSubSurfKey() const override { return m_subsurfkey; }
+  void setSubSurfKey(TrkrDefs::subsurfkey id) override { m_subsurfkey = id; }
+
+  //
+  // cluster info
+  //
+  unsigned int getAdc() const override { return m_adc; }
+  void setAdc(unsigned int adc) override { m_adc = adc; }
+
+  //
+  // convenience interface
+  //
+  float getRPhiError() const override
+  { std::cout << "Deprecated getRPhiError trkrcluster function!"<<std::endl; return NAN;}
+  float getZError() const override
+  { std::cout << "Deprecated getZError trkrcluster function!"<<std::endl; return NAN;}
+
+  /// deprecated global funtions with a warning
+  float getX() const override 
+  { std::cout << "Deprecated getx trkrcluster function!"<<std::endl; return NAN;}
+  float getY() const override 
+  { std::cout << "Deprecated gety trkrcluster function!"<<std::endl; return NAN;}
+  float getZ() const override 
+  { std::cout << "Deprecated getz trkrcluster function!"<<std::endl; return NAN;}
+   void setX(float) override 
+   { std::cout << "Deprecated setx trkrcluster function!"<<std::endl;} 
+   void setY(float) override 
+   { std::cout << "Deprecated sety trkrcluster function!"<<std::endl;} 
+   void setZ(float) override 
+   { std::cout << "Deprecated setz trkrcluster function!"<<std::endl;}
+   float getSize(unsigned int, unsigned int) const override 
+   {std::cout << "Deprecated getsize trkrcluster function!" << std::endl; return NAN;}       
+   void setSize(unsigned int, unsigned int, float) override 
+   {std::cout << "Deprecated setsize trkrcluster function!" << std::endl;}
+   float getError(unsigned int, unsigned int) const override 
+   {std::cout << "Deprecated geterr trkrcluster function!" << std::endl; return NAN;}
+   void setError(unsigned int, unsigned int, float) override 
+   { std::cout << "Deprecated seterr trkrcluster function!" << std::endl; }
+
+   char getSize() { return m_size; }
+   void setSize(char size) { m_size = size; }
+ 
+   char getPhiSize() { return m_phisize; }
+   void setPhiSize(char phisize) { m_phisize = phisize; }
+ 
+   char getZSize() { return m_zsize; }
+   void setZSize(char zsize) { m_zsize = zsize; }
+ 
+   char getOverlap() { return m_overlap; }
+   void setOverlap(char overlap) { m_overlap = overlap; }
+ 
+   char getEdge() { return m_edge; }
+   void setEdge(char edge) { m_edge = edge; }
+
+   //float getPhiSize() const override 
+   //{ std::cout << "Deprecated size function"<< std::endl; return NAN;}
+   //float getZSize() const override 
+   //{std::cout << "Deprecated size function" << std::endl; return NAN;}
+   //float getPhiError() const override 
+   //{ std::cout << "Deprecated getPhiError function"<< std::endl; return NAN;}
+
+ protected:
+
+  TrkrDefs::cluskey m_cluskey;  //< unique identifier within container
+  TrkrDefs::subsurfkey m_subsurfkey; //< unique identifier for hitsetkey-surface maps
+
+  unsigned short int m_adc;           //< cluster sum adc
+  
+  float m_local[2];          //< 2D local position [cm]
+  bool m_valid;
+  char m_size;
+  char m_phisize;
+  char m_zsize;
+  char m_overlap;
+  char m_edge;
+
+  ClassDefOverride(TrkrClusterv4, 2)
+};
+
+#endif //TRACKBASE_TRKRCLUSTERV4_H

--- a/offline/packages/trackbase/TrkrClusterv4.h
+++ b/offline/packages/trackbase/TrkrClusterv4.h
@@ -97,10 +97,10 @@ class TrkrClusterv4 : public TrkrCluster
    char getSize() { return m_size; }
    void setSize(char size) { m_size = size; }
  
-   char getPhiSize() { return m_phisize; }
+   float getPhiSize() const override { return (float) m_phisize; }
    void setPhiSize(char phisize) { m_phisize = phisize; }
  
-   char getZSize() { return m_zsize; }
+   float getZSize() const override { return (float) m_zsize; }
    void setZSize(char zsize) { m_zsize = zsize; }
  
    char getOverlap() { return m_overlap; }

--- a/offline/packages/trackbase/TrkrClusterv4LinkDef.h
+++ b/offline/packages/trackbase/TrkrClusterv4LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrClusterv4+;
+
+#endif


### PR DESCRIPTION
…sterizer

[comment]: <> (Please tell us something about this pull request)

Adds leaner TrkrClusterv4.h and Clusterizer update to use it. Default remains to use TrkrClusterv3, so no changes to default execution. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

