### PR TITLE
Adjust `G4VERSION_NUMBER` cuts to compile in G4.10.7 too

### DIFF
--- a/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
+++ b/simulation/g4simulation/g4gdml/PHG4GDMLWriteStructure.cc
@@ -368,7 +368,7 @@ PHG4GDMLWriteStructure::GetSkinSurface(const G4LogicalVolume* const lvol)
   return surf;
 }
 
-#if G4VERSION_NUMBER >= 1100
+#if G4VERSION_NUMBER >= 1007
 
 const G4LogicalBorderSurface* PHG4GDMLWriteStructure::GetBorderSurface(
     const G4VPhysicalVolume* const pvol)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

https://github.com/sPHENIX-Collaboration/coresoftware/pull/1423 was intended to make `g4gdml` lib to compile in G4.10.6 and G4.11.0 However, it do not compile in G4.10.7 yet, which is enabled by this pull request

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Downgrade G4.11 to G4.10.7 due to numerical reproducibility issue in G4.11.0.1

## Links to other PRs in macros and calibration repositories (if applicable)

