### PR TITLE
Node Tree Truth-Reco Match Lookup

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -19,6 +19,9 @@ class SvtxHitEval;
 class SvtxTrack;
 class SvtxTrackMap;
 class SvtxTruthEval;
+class PHG4ParticleSvtxMap;
+class SvtxPHG4ParticleMap;
+class PHG4TruthInfoContainer;
 
 class SvtxTrackEval
 {
@@ -79,6 +82,9 @@ class SvtxTrackEval
 
   SvtxClusterEval _clustereval;
   SvtxTrackMap* _trackmap;
+  PHG4TruthInfoContainer* _truthinfo;
+  PHG4ParticleSvtxMap* _truthRecoMap;
+  SvtxPHG4ParticleMap* _recoTruthMap;
 
   bool _strict;
   int _verbosity;

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
@@ -34,7 +34,7 @@ class SvtxTruthRecoTableEval : public SubsysReco
   void fillTruthMap(PHCompositeNode *topNode);
   void fillRecoMap(PHCompositeNode *topNode);
 
-  bool m_scanForPrimaries = true;
+  bool m_scanForPrimaries = false;
 
   PHG4ParticleSvtxMap *m_truthMap = nullptr;
   SvtxPHG4ParticleMap *m_recoMap = nullptr;


### PR DESCRIPTION
This PR adds functionality for the `SvtxTrackEval` class to lookup the truth-reco track matching via the new objects on the node tree rather than the cached maps in the evaluator. This should allow truth-reco track matching readback with the output DSTs.

Also tested without the new table evaluator (e.g. only the `SvtxEvaluator`) and it produces identical results when either only the cached maps are used or only the objects on the node tree are used.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

