### PR TITLE
Add Flag for Acts Magnetic Field

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -106,7 +106,6 @@ int MakeActsGeometry::Init(PHCompositeNode */*topNode*/)
 
 int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
 {
-
   if(buildAllGeometry(topNode) != Fun4AllReturnCodes::EVENT_OK)
     return Fun4AllReturnCodes::ABORTEVENT;
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -536,8 +536,10 @@ void MakeActsGeometry::makeGeometry(int argc, char* argv[],
 
   m_tGeometry = geometry.first;
   m_contextDecorators = geometry.second;
-
-  m_magneticField = ActsExamples::Options::readMagneticField(vm);
+  if(m_useField)
+    { m_magneticField = ActsExamples::Options::readMagneticField(vm); }
+  else
+    { m_magneticField = nullptr; }
 
   size_t ievt = 0;
   size_t ialg = 0;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -77,6 +77,7 @@ class MakeActsGeometry : public SubsysReco
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator>> getContextDecorators()
     { return m_contextDecorators; }
 
+  void loadMagField(const bool field) { m_useField = field; }
   void setMagField(const std::string &magField)
     {m_magField = magField;}
   void setMagFieldRescale(double magFieldRescale)
@@ -154,8 +155,9 @@ class MakeActsGeometry : public SubsysReco
   PHG4CylinderGeomContainer* m_geomContainerIntt = nullptr;
   PHG4CylinderGeomContainer* m_geomContainerMicromegas = nullptr;
   PHG4CylinderCellGeomContainer* m_geomContainerTpc = nullptr;
-
   TGeoManager* m_geoManager = nullptr;
+
+  bool m_useField = true;
 
   /// Acts Context decorators, which may contain e.g. calibration information
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator> > 


### PR DESCRIPTION
This PR adds a flag for loading the magnetic field map into Acts. It is set to true by default.

This will allow us to run the clustering in a separate job without loading in the magnetic field, which should conserve memory consumption since the clustering only requires the detector geometry.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

