### PR TITLE
moved gencluskey from detector specific implementation to TrkrDefs

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -359,7 +359,7 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit*>>::iterator mapiter = clusrange.first;
 	
 	// make the cluster directly in the node tree
-	TrkrDefs::cluskey ckey = InttDefs::genClusKey(hitset->getHitSetKey(), clusid);
+	TrkrDefs::cluskey ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
 	auto clus = std::make_unique<TrkrClusterv3>();
 	clus->setClusKey(ckey);
 

--- a/offline/packages/intt/InttDefs.cc
+++ b/offline/packages/intt/InttDefs.cc
@@ -73,17 +73,6 @@ InttDefs::genHitSetKey(const uint8_t lyr, const uint8_t ladder_z_index, uint8_t 
 TrkrDefs::cluskey
 InttDefs::genClusKey(const uint8_t lyr, const uint8_t ladder_z_index, const uint8_t ladder_phi_index, const uint32_t clusid)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(lyr, ladder_z_index, ladder_phi_index);
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
-}
-
-TrkrDefs::cluskey
-InttDefs::genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid)
-{
-  TrkrDefs::cluskey tmp = hskey;
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
+  const auto key = genHitSetKey(lyr, ladder_z_index, ladder_phi_index);
+  return TrkrDefs::genClusKey( key, clusid );
 }

--- a/offline/packages/intt/InttDefs.h
+++ b/offline/packages/intt/InttDefs.h
@@ -103,14 +103,6 @@ TrkrDefs::hitsetkey genHitSetKey(const uint8_t lyr, const uint8_t ladder_z_index
    */
 TrkrDefs::cluskey genClusKey(const uint8_t lyr, const uint8_t LadderZId, const uint8_t LadderPhiId, const uint32_t clusid);
 
-/**
-   * @brief Generate a cluster key using a hitsetkey and cluster id
-   * @param[in] hskey hitsetkey
-   * @param[in] clusid Cluster id
-   * @param[out] cluskey
-   */
-TrkrDefs::cluskey genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid);
-
 }  // namespace InttDefs
 
 #endif  //INTT_INTTDEFS_H

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -263,7 +263,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
     {
 
       // create cluster key and corresponding cluster
-      const auto cluster_key = MicromegasDefs::genClusterKey( hitsetkey, cluster_count++ );
+      const auto cluster_key = TrkrDefs::genClusKey( hitsetkey, cluster_count++ );
       auto cluster = std::make_unique<TrkrClusterv3>();
       cluster->setClusKey(cluster_key);
 

--- a/offline/packages/micromegas/MicromegasDefs.cc
+++ b/offline/packages/micromegas/MicromegasDefs.cc
@@ -65,15 +65,6 @@ namespace MicromegasDefs
   }
 
   //________________________________________________________________
-  TrkrDefs::cluskey genClusterKey(TrkrDefs::hitsetkey hitsetkey, uint32_t clusid)
-  {
-    TrkrDefs::cluskey tmp = hitsetkey;
-    TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-    key |= clusid;
-    return key;
-  }
-
-  //________________________________________________________________
   SegmentationType getSegmentationType(TrkrDefs::cluskey key)
   {
     TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -77,14 +77,6 @@ namespace MicromegasDefs
   //! get strip from hit key
   uint16_t getStrip(TrkrDefs::hitkey);
 
-  /**
-   * @brief Generate a cluster key using a hitsetkey and cluster id
-   * @param[in] hskey hitsetkey
-   * @param[in] clusid Cluster id
-   * @param[out] cluskey
-   */
-  TrkrDefs::cluskey genClusterKey(TrkrDefs::hitsetkey hskey, uint32_t clusid);
-
   /*!
    * @brief Get the segmentation type from cluster key
    * @param[in] cluskey

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -283,7 +283,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 	if (Verbosity() > 2) cout << "Filling cluster id " << clusid << " of " << std::distance(cluster_ids.begin(),clusiter )<< endl;
 
 	// make the cluster directly in the node tree
-	auto ckey = MvtxDefs::genClusKey(hitset->getHitSetKey(), clusid);
+	auto ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
 
 	auto clus = std::make_unique<TrkrClusterv3>();
 	clus->setClusKey(ckey);

--- a/offline/packages/mvtx/MvtxDefs.cc
+++ b/offline/packages/mvtx/MvtxDefs.cc
@@ -67,17 +67,7 @@ MvtxDefs::genHitSetKey(const uint8_t lyr, const uint8_t stave, const uint8_t chi
 TrkrDefs::cluskey
 MvtxDefs::genClusKey(const uint8_t lyr, const uint8_t stave, const uint8_t chip, const uint32_t clusid)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(lyr, stave, chip);
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
+  const auto key = genHitSetKey(lyr, stave, chip);
+  return TrkrDefs::genClusKey( key, clusid );
 }
 
-TrkrDefs::cluskey
-MvtxDefs::genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid)
-{
-  TrkrDefs::cluskey tmp = hskey;
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
-}

--- a/offline/packages/mvtx/MvtxDefs.h
+++ b/offline/packages/mvtx/MvtxDefs.h
@@ -108,14 +108,6 @@ TrkrDefs::hitsetkey genHitSetKey(const uint8_t lyr, const uint8_t stave, const u
    */
 TrkrDefs::cluskey genClusKey(const uint8_t lyr, const uint8_t stave, const uint8_t chip, const uint32_t clusid);
 
-/**
-   * @brief Generate a cluster key using a hitsetkey and cluster id
-   * @param[in] hskey hitsetkey
-   * @param[in] clusid Cluster id
-   * @param[out] cluskey
-   */
-TrkrDefs::cluskey genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid);
-
 }  // namespace MvtxDefs
 
 #endif  //MVTX_MVTXDEFUTIL_H

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -401,7 +401,7 @@ namespace
 	}
       // create the cluster entry directly in the node tree
       
-      const TrkrDefs::cluskey ckey = TpcDefs::genClusKey( my_data.hitset->getHitSetKey(), iclus );
+      const TrkrDefs::cluskey ckey = TrkrDefs::genClusKey( my_data.hitset->getHitSetKey(), iclus );
       
       // Estimate the errors
       const double phi_err_square = (phibinhi == phibinlo) ?

--- a/offline/packages/tpc/TpcDefs.cc
+++ b/offline/packages/tpc/TpcDefs.cc
@@ -73,17 +73,6 @@ TpcDefs::genHitSetKey(const uint8_t lyr, const uint8_t sector, const uint8_t sid
 TrkrDefs::cluskey
 TpcDefs::genClusKey(const uint8_t lyr, const uint8_t sector, const uint8_t side, const uint32_t clusid)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(lyr, sector, side);
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
-}
-
-TrkrDefs::cluskey
-TpcDefs::genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid)
-{
-  TrkrDefs::cluskey tmp = hskey;
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
-  key |= clusid;
-  return key;
+  const auto key = genHitSetKey(lyr, sector, side);
+  return TrkrDefs::genClusKey( key, clusid );
 }

--- a/offline/packages/tpc/TpcDefs.h
+++ b/offline/packages/tpc/TpcDefs.h
@@ -110,14 +110,6 @@ TrkrDefs::hitsetkey genHitSetKey(const uint8_t lyr, const uint8_t sector, const 
    */
 TrkrDefs::cluskey genClusKey(const uint8_t lyr, const uint8_t sector, const uint8_t side, const uint32_t clusid);
 
-/**
-   * @brief Generate a cluster key using a hitsetkey and cluster id
-   * @param[in] hskey hitsetkey
-   * @param[in] clusid Cluster id
-   * @param[out] cluskey
-   */
-TrkrDefs::cluskey genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid);
-
 }  // namespace TpcDefs
 
 #endif  //TPC_TPCDEFS_H

--- a/offline/packages/tpc/TpcSimpleClusterizer.cc
+++ b/offline/packages/tpc/TpcSimpleClusterizer.cc
@@ -237,7 +237,7 @@ namespace
 	
 	  // create the cluster entry directly in the node tree
 	
-	  TrkrDefs::cluskey ckey = TpcDefs::genClusKey(hitset->getHitSetKey(), iclus);
+	  TrkrDefs::cluskey ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), iclus);
 	
 	  TrkrClusterv2 *clus = new TrkrClusterv2();
 	  clus->setClusKey(ckey);

--- a/offline/packages/trackbase/TrkrDefs.cc
+++ b/offline/packages/trackbase/TrkrDefs.cc
@@ -80,28 +80,28 @@ TrkrDefs::getHitSetKeyHi(const TrkrDefs::TrkrId trkrId, const uint8_t lyr)
 TrkrDefs::cluskey
 TrkrDefs::getClusKeyLo(const TrkrDefs::TrkrId trkrId)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(trkrId, 0);
+  const TrkrDefs::cluskey tmp = genHitSetKey(trkrId, 0);
   return (tmp << kBitShiftClusId);
 }
 
 TrkrDefs::cluskey
 TrkrDefs::getClusKeyHi(const TrkrDefs::TrkrId trkrId)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(static_cast<TrkrDefs::TrkrId>(trkrId + 1), 0);
+  const TrkrDefs::cluskey tmp = genHitSetKey(static_cast<TrkrDefs::TrkrId>(trkrId + 1), 0);
   return (tmp << kBitShiftClusId) - 1;
 }
 
 TrkrDefs::cluskey
 TrkrDefs::getClusKeyLo(const TrkrDefs::TrkrId trkrId, const uint8_t lyr)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(trkrId, lyr);
+  const TrkrDefs::cluskey tmp = genHitSetKey(trkrId, lyr);
   return (tmp << kBitShiftClusId);
 }
 
 TrkrDefs::cluskey
 TrkrDefs::getClusKeyHi(const TrkrDefs::TrkrId trkrId, const uint8_t lyr)
 {
-  TrkrDefs::cluskey tmp = genHitSetKey(trkrId, lyr + 1);
+  const TrkrDefs::cluskey tmp = genHitSetKey(trkrId, lyr + 1);
   return (tmp << kBitShiftClusId) - 1;
 }
 
@@ -115,10 +115,18 @@ TrkrDefs::genHitSetKey(const TrkrDefs::TrkrId trkrId, const uint8_t lyr)
   return key;
 }
 
+TrkrDefs::cluskey
+  TrkrDefs::genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid)
+{
+  const TrkrDefs::cluskey tmp = hskey;
+  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
+  key |= clusid;
+  return key;
+}
 
 uint8_t TrkrDefs::getPhiElement(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftPhiElement);
+  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftPhiElement);
   return tmp;
 }
 
@@ -126,18 +134,18 @@ uint8_t TrkrDefs::getPhiElement(TrkrDefs::hitsetkey key)
 
 uint8_t TrkrDefs::getZElement(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftZElement);
+  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftZElement);
   return tmp;
 }
 
 uint8_t TrkrDefs::getPhiElement(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
   return getPhiElement(tmp);
 }
 
 uint8_t TrkrDefs::getZElement(TrkrDefs::cluskey key)//side
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
   return getZElement(tmp);
 }

--- a/offline/packages/trackbase/TrkrDefs.h
+++ b/offline/packages/trackbase/TrkrDefs.h
@@ -76,6 +76,9 @@ namespace TrkrDefs
   /// generate the common upper 16 bits for hitsetkey
   TrkrDefs::hitsetkey genHitSetKey(const TrkrDefs::TrkrId trkrId, const uint8_t lyr);
 
+  /// generate cluster key from hitset key and cluster index
+  TrkrDefs::cluskey genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid);
+  
   /// Get the upper 32 bits from cluster keys
   uint32_t getHitSetKeyFromClusKey(const TrkrDefs::cluskey key);
 

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -308,7 +308,7 @@ std::map<unsigned int, TrkrCluster* > PHTruthClustering::all_truth_clusters(PHG4
 	  MicromegasDefs::SegmentationType segtype;
 	  segtype  =  MicromegasDefs::SegmentationType::SEGMENTATION_PHI;
 	  TrkrDefs::hitsetkey hkey = MicromegasDefs::genHitSetKey(layer, segtype, tile);
-  	  ckey = MicromegasDefs::genClusterKey(hkey, iclus);
+    ckey = TrkrDefs::genClusKey(hkey, iclus);
 	}
       else
 	{

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -355,7 +355,7 @@ std::map<unsigned int, std::shared_ptr<TrkrCluster> > SvtxTruthEval::all_truth_c
 	  MicromegasDefs::SegmentationType segtype;
 	  segtype  =  MicromegasDefs::SegmentationType::SEGMENTATION_PHI;
 	  TrkrDefs::hitsetkey hkey = MicromegasDefs::genHitSetKey(layer, segtype, tile);
-  	  ckey = MicromegasDefs::genClusterKey(hkey, iclus);
+  	  ckey = TrkrDefs::genClusKey(hkey, iclus);
 	}
       else
 	{


### PR DESCRIPTION
Moved genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clus…id) from detector specific implementation to TrkrDefs because
- all detectors had the exact same implementation
- TrkrDefs::getClusIndex assumes a given implementation, so the detectors did not have the freedom to change this anyway, without breaking things
- having a unique way to go from hitsetkey+clusId to cluskey is necessary for the coming ClusterContainer reorganization

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

