### PR TITLE
Cluster container

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -48,9 +48,9 @@ namespace
 {
   template<class T> inline constexpr T square( const T& x ) { return x*x; }
   
-  typedef std::pair<unsigned short, unsigned short> iphiz;
-  typedef std::pair<unsigned short, iphiz> ihit;
-  typedef std::pair<TrkrDefs::cluskey, TrkrDefs::hitkey> assoc;
+  using iphiz = std::pair<unsigned short, unsigned short>;
+  using ihit = std::pair<unsigned short, iphiz>;
+  using assoc = std::pair<TrkrDefs::cluskey, TrkrDefs::hitkey> ;
   
   struct thread_data 
   {
@@ -73,8 +73,6 @@ namespace
     double par0_neg = 0;
     double par0_pos = 0;
     int cluster_version = 3;
-    std::map<TrkrDefs::cluskey, TrkrCluster *> *clusterlist = nullptr;
-    //std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey>  *clusterhitassoc = nullptr;
     std::vector<assoc> *association_vector = nullptr;
     std::vector<TrkrCluster*> *cluster_vector = nullptr;
   };
@@ -486,13 +484,13 @@ namespace
 
       // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
       
-      if(my_data.clusterlist)     
+      if(my_data.cluster_vector)     
 	{
 	  if(my_data.cluster_version==3){
 	    
 	    // Fill in the cluster details
 	    //================
-	    TrkrClusterv3 *clus = new TrkrClusterv3();
+	    auto clus = new TrkrClusterv3;
 	    //auto clus = std::make_unique<TrkrClusterv3>();
 	    clus->setClusKey(ckey);
 	    clus->setAdc(adc_sum);      
@@ -507,7 +505,7 @@ namespace
 	    clus->setActsLocalError(1,1, ERR[2][2]);
 	    my_data.cluster_vector->push_back(clus);
 	  }else if(my_data.cluster_version==4){
-	    TrkrClusterv4 *clus = new TrkrClusterv4();
+	    auto clus = new TrkrClusterv4;
 	    //auto clus = std::make_unique<TrkrClusterv3>();
 	    clus->setClusKey(ckey);
 	    clus->setAdc(adc_sum);  
@@ -613,16 +611,7 @@ namespace
       // repeat untill all_hit_map empty
       calc_cluster_parameter(ihit_list,nclus++, *my_data, ntouch, nedge );
       remove_hits(ihit_list,all_hit_map, adcval);
-      ihit_list.clear();
     }
-
-    //std::multimap<TrkrDefs::cluskey, TrkrDefs::hitkey> empty_map;
-    // empty_map.swap(*my_data.clusterhitassoc);
-    // my_data->clusterhitassoc->clear();//HERE
-
-    adcval.clear();
-    all_hit_map.clear();
-    hit_vect.clear();
     pthread_exit(nullptr);
   }
 }
@@ -816,7 +805,6 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
        ++hitsetitr)
   {
     //if(count>0)continue;
-    const auto hitsetid = hitsetitr->first;
     // std::cout << " starting thread # " << count << std::endl;
     TrkrHitSet *hitset = hitsetitr->second;
     unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
@@ -834,9 +822,6 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     thread_pair.data.sector = sector;
     thread_pair.data.side = side;
     thread_pair.data.do_assoc = do_hit_assoc;
-    thread_pair.data.clusterlist = m_clusterlist->getClusterMap(hitsetid);
-    // thread_pair.data.clusterhitassoc = m_clusterhitassoc->getClusterMap(hitsetid);
-    // thread_pair.data.clusterhitassoc = m_clusterhitassoc;
     thread_pair.data.association_vector  = new std::vector<assoc>;
     thread_pair.data.cluster_vector  = new std::vector<TrkrCluster*>;
     thread_pair.data.tGeometry = m_tGeometry;
@@ -886,28 +871,17 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     int rc2 = pthread_join(thread_pair.thread, nullptr);
     if (rc2) 
     { std::cout << "Error:unable to join," << rc2 << std::endl; }
-    for(auto iter = thread_pair.data.association_vector->begin(); iter != thread_pair.data.association_vector->end();++iter){
-      TrkrDefs::cluskey ckey = iter->first;
-      TrkrDefs::hitkey hkey = iter->second;
-      m_clusterhitassoc->addAssoc(ckey,hkey);
-    }
-    thread_pair.data.association_vector->clear();
+
+    // copy hit associations to map
+    for( const auto& [ckey,hkey]:*thread_pair.data.association_vector)
+    { m_clusterhitassoc->addAssoc(ckey,hkey); }
     delete thread_pair.data.association_vector;
 
-    for(auto citer = thread_pair.data.cluster_vector->begin(); citer != thread_pair.data.cluster_vector->end();++citer){
-      m_clusterlist->addCluster(*citer);
-      // m_clusterlist->addClusToVec(*citer);
-      
-      // delete *citer;
-      //      const auto [iter, inserted] = my_data.clusterlist->insert(std::make_pair(ckey, clus.get()));
-	  
-	  /*
-	   * if cluster was properly inserted in the map, one should release the unique_ptr,
-	   * to make sure that the cluster is not deleted when going out-of-scope
-	   */
-    }
-    thread_pair.data.cluster_vector->clear();
+    // copy clusters to map
+    for( const auto& cluster:*thread_pair.data.cluster_vector )
+    { m_clusterlist->addCluster(cluster); }
     delete thread_pair.data.cluster_vector;
+
   }
 
   if (Verbosity() > 0)

--- a/offline/packages/tpc/TpcSimpleClusterizer.h
+++ b/offline/packages/tpc/TpcSimpleClusterizer.h
@@ -48,20 +48,11 @@ class TpcSimpleClusterizer : public SubsysReco
   bool do_hit_assoc = true;
   double pedestal = 74.4;
   double SectorFiducialCut = 0.5;
-
+  
   // TPC shaping offset correction parameters
   // From Tony Frawley May 13, 2021
-//   std::pair<double,double> par0_neg = std::make_pair(0.0538913, 0.000252096);
-//   std::pair<double,double> par0_pos = std::make_pair(-0.0647731, 0.000296734);
-//   std::pair<double,double> par1_neg = std::make_pair(-0.000208279, 1.9205e-06);
-//   std::pair<double,double> par1_pos = std::make_pair(-0.000195514, 2.26467e-06);
-  
-  // revisited by Hugo May 28, 2021
-  // should check with Tony, in particular the inversion of the par0_pos layer slope
-  std::pair<double,double> par0_neg = std::make_pair(0.05465077, 0.000252096);
-  std::pair<double,double> par0_pos = std::make_pair(-0.05392444, -0.000296734);
-  std::pair<double,double> par1_neg = std::make_pair(-0.000208279, 1.9205e-06);
-  std::pair<double,double> par1_pos = std::make_pair(-0.000195514, 2.26467e-06);
+  double par0_neg = 0.0503;
+  double par0_pos = -0.0503;
 
 };
 

--- a/offline/packages/trackbase/TrkrClusterContainer.cc
+++ b/offline/packages/trackbase/TrkrClusterContainer.cc
@@ -11,18 +11,6 @@ namespace
 }
 
 //__________________________________________________________
-TrkrClusterContainer::ConstIterator TrkrClusterContainer::addCluster(TrkrCluster*)
-{ return dummy_map.cbegin(); }
-
-//__________________________________________________________
-TrkrClusterContainer::ConstIterator TrkrClusterContainer::addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster* )
-{ return dummy_map.cbegin(); }
-
-//__________________________________________________________
-TrkrClusterContainer::Iterator TrkrClusterContainer::findOrAddCluster(TrkrDefs::cluskey)
-{ return dummy_map.begin(); }
-
-//__________________________________________________________
 TrkrClusterContainer::ConstRange TrkrClusterContainer::getClusters() const
 { return std::make_pair( dummy_map.cbegin(), dummy_map.cend() ); }
 

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -58,9 +58,6 @@ class TrkrClusterContainer : public PHObject
   //! get all clusters matching hitset
   virtual ConstRange getClusters(TrkrDefs::hitsetkey) const;
 
-  //! get pointer to map containing clusters mathching hitset
-  virtual Map* getClusterMap(TrkrDefs::hitsetkey) { return nullptr; }
-
   //! find cluster matching given key
   virtual TrkrCluster* findCluster(TrkrDefs::cluskey) const { return nullptr; }
 

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -41,19 +41,16 @@ class TrkrClusterContainer : public PHObject
   void identify(std::ostream &/*os*/ = std::cout) const override {}
 
   //! add a cluster
-  virtual ConstIterator addCluster(TrkrCluster*);
+  virtual void addCluster(TrkrCluster*) {}
 
   //! add a cluster with specific key
-  virtual ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster* );
+  virtual void addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster* ) {}
 
   //! remove cluster
   virtual void removeCluster(TrkrDefs::cluskey) {}
 
   //! remove cluster
   virtual void removeCluster(TrkrCluster* ) {}
-
-  //! find cluster matching key if any, add a new one otherwise and return cluster
-  virtual Iterator findOrAddCluster(TrkrDefs::cluskey);
   
   //! return all clusters
   virtual ConstRange getClusters() const;

--- a/offline/packages/trackbase/TrkrClusterContainerv1.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv1.cc
@@ -6,7 +6,6 @@
  */
 #include "TrkrClusterContainerv1.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv2.h"
 
 #include <cstdlib>
 
@@ -35,24 +34,20 @@ void TrkrClusterContainerv1::identify(std::ostream& os) const
   return;
 }
 
-TrkrClusterContainerv1::ConstIterator
-TrkrClusterContainerv1::addCluster(TrkrCluster* newclus)
-{
-  return addClusterSpecifyKey(newclus->getClusKey(), newclus);
-}
+void TrkrClusterContainerv1::addCluster(TrkrCluster* newclus)
+{ addClusterSpecifyKey(newclus->getClusKey(), newclus); }
 
-TrkrClusterContainerv1::ConstIterator
+void
 TrkrClusterContainerv1::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster* newclus)
 {
-  auto ret = m_clusmap.insert(std::make_pair(key, newclus));
-  if ( !ret.second )
+  const auto [iter,success] = m_clusmap.insert(std::make_pair(key, newclus));
+  if ( !success )
   {
     std::cout << "TrkrClusterContainerv1::AddClusterSpecifyKey: duplicate key: " << key << " exiting now" << std::endl;
     exit(1);
-  }
-  else
-  {
-    return ret.first;
+  } else {
+    // make sure that cluster key matches
+    iter->second->setClusKey( key );
   }
 }
 
@@ -61,19 +56,6 @@ void TrkrClusterContainerv1::removeCluster(TrkrDefs::cluskey key)
 
 void TrkrClusterContainerv1::removeCluster(TrkrCluster *clus)
 { removeCluster( clus->getClusKey() ); }
-
-TrkrClusterContainerv1::Iterator
-TrkrClusterContainerv1::findOrAddCluster(TrkrDefs::cluskey key)
-{
-  auto it = m_clusmap.lower_bound( key );
-  if (it == m_clusmap.end()|| (key < it->first ))
-  {
-    // add new cluster and set its key
-    it = m_clusmap.insert(it, std::make_pair(key, new TrkrClusterv2()));
-    it->second->setClusKey(key);
-  }
-  return it;
-}
 
 TrkrClusterContainer::ConstRange
 TrkrClusterContainerv1::getClusters() const

--- a/offline/packages/trackbase/TrkrClusterContainerv1.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv1.h
@@ -38,15 +38,13 @@ class TrkrClusterContainerv1 : public TrkrClusterContainer
 
   void identify(std::ostream &os = std::cout) const override;
 
-  ConstIterator addCluster(TrkrCluster *newClus) override;
+  void addCluster(TrkrCluster *newClus) override;
 
-  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster *newClus) override;
+  void addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster *newClus) override;
 
   void removeCluster(TrkrDefs::cluskey) override;
 
   void removeCluster(TrkrCluster*) override;
-
-  Iterator findOrAddCluster(TrkrDefs::cluskey key) override;
   
   ConstRange getClusters() const override;
 

--- a/offline/packages/trackbase/TrkrClusterContainerv2.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.cc
@@ -147,30 +147,6 @@ TrkrClusterContainerv2::getClusters(TrkrDefs::hitsetkey hitsetkey) const
     return std::make_pair( dummy_map.cbegin(), dummy_map.cend() );
   }
 }
-
-//_________________________________________________________________
-TrkrClusterContainerv2::Map*
-TrkrClusterContainerv2::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
-{
-  const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-  const unsigned int sector= TrkrDefs::getPhiElement(hitsetkey);
-  const unsigned int side  = TrkrDefs::getZElement(hitsetkey);
-
-  // bound check
-  if( layer < max_layer && sector < max_phisegment && side < max_zsegment )
-  {
-    return &m_clusmap[layer][sector][side];
-  } else {
-    std::cout
-      << "TrkrClusterContainerv2::getClusterMap - out of range access."
-      << " layer: " << layer
-      << " sector: " << sector
-      << " side: " << side
-      << std::endl;
-
-    return nullptr;
-  }
-}
   
 //_________________________________________________________________
 TrkrCluster* TrkrClusterContainerv2::findCluster(TrkrDefs::cluskey key) const

--- a/offline/packages/trackbase/TrkrClusterContainerv2.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.cc
@@ -6,7 +6,6 @@
  */
 #include "TrkrClusterContainerv2.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv2.h"
 #include "TrkrDefs.h"
 
 #include <cstdlib>
@@ -91,12 +90,12 @@ void TrkrClusterContainerv2::removeCluster(TrkrCluster *clus)
 { removeCluster( clus->getClusKey() ); }
 
 //_________________________________________________________________
-TrkrClusterContainerv2::ConstIterator
+void
 TrkrClusterContainerv2::addCluster(TrkrCluster* newclus)
-{ return addClusterSpecifyKey(newclus->getClusKey(), newclus); }
+{ addClusterSpecifyKey(newclus->getClusKey(), newclus); }
 
 //_________________________________________________________________
-TrkrClusterContainerv2::ConstIterator
+void
 TrkrClusterContainerv2::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster* newclus)
 {
   unsigned int layer = TrkrDefs::getLayer(key);
@@ -106,30 +105,23 @@ TrkrClusterContainerv2::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCl
   // bound check
   if( layer < max_layer && sector < max_phisegment && side < max_zsegment )
   {
-
-    auto ret = m_clusmap[layer][sector][side].insert(std::make_pair(key, newclus));
-    if ( !ret.second )
+    const auto [iter,success] = m_clusmap[layer][sector][side].insert(std::make_pair(key, newclus));
+    if ( !success )
     {
       std::cout << "TrkrClusterContainerv2::AddClusterSpecifyKey: duplicate key: " << key << " exiting now" << std::endl;
       exit(1);
     } else {
-      ret.first->second->setClusKey( key );
-      return ret.first;
+      // make sure that cluster key matches
+      iter->second->setClusKey( key );
     }
-
   } else {
-
     std::cout
       << "TrkrClusterContainerv2::addClusterSpecifyKey - out of range access."
       << " layer: " << layer
       << " sector: " << sector
       << " side: " << side
       << std::endl;
-
-    return dummy_map.begin();
-
   }
-
 }
 
 //_________________________________________________________________
@@ -180,38 +172,6 @@ TrkrClusterContainerv2::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
   }
 }
   
-//_________________________________________________________________
-TrkrClusterContainerv2::Iterator
-TrkrClusterContainerv2::findOrAddCluster(TrkrDefs::cluskey key)
-{
-  const unsigned int layer = TrkrDefs::getLayer(key);
-  const unsigned int sector= TrkrDefs::getPhiElement(key);
-  const unsigned int side  = TrkrDefs::getZElement(key);
-
-  // bound check
-  if( layer < max_layer && sector < max_phisegment && side < max_zsegment )
-  {
-    auto it = m_clusmap[layer][sector][side].lower_bound(key);
-    if( it == m_clusmap[layer][sector][side].end() || (key < it->first) )
-    {
-      // add new cluster and set its key
-      it = m_clusmap[layer][sector][side].insert(it, std::make_pair(key, new TrkrClusterv2()));
-      it->second->setClusKey( key );
-    }
-    return it;
-  } else {
-    std::cout
-      << "TrkrClusterContainerv2::findOrAddCluster - out of range access."
-      << " layer: " << layer
-      << " sector: " << sector
-      << " side: " << side
-      << std::endl;
-
-    return dummy_map.begin();
-  }
-
-}
-
 //_________________________________________________________________
 TrkrCluster* TrkrClusterContainerv2::findCluster(TrkrDefs::cluskey key) const
 {

--- a/offline/packages/trackbase/TrkrClusterContainerv2.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.h
@@ -27,15 +27,13 @@ class TrkrClusterContainerv2 : public TrkrClusterContainer
 
   void identify(std::ostream &os = std::cout) const override;
 
-  ConstIterator addCluster(TrkrCluster*) override;
+  void addCluster(TrkrCluster*) override;
 
-  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
+  void addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
 
   void removeCluster(TrkrDefs::cluskey) override;
 
   void removeCluster(TrkrCluster*) override;
-
-  Iterator findOrAddCluster(TrkrDefs::cluskey) override;
 
   ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 

--- a/offline/packages/trackbase/TrkrClusterContainerv2.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv2.h
@@ -37,8 +37,6 @@ class TrkrClusterContainerv2 : public TrkrClusterContainer
 
   ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 
-  Map* getClusterMap(TrkrDefs::hitsetkey) override;
-
   TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
   unsigned int size() const override;

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -20,17 +20,16 @@ namespace
 void TrkrClusterContainerv3::Reset()
 {
   // delete all clusters
-  for( auto& map_pair:m_clusmap ){
-    for( auto& pair:map_pair.second ){ 
-      delete pair.second; 
-    }
-    Map empty_map;
-    empty_map.swap(map_pair.second);
-
+  for( auto&& [key, map]:m_clusmap )
+  {
+    for( auto&& [cluskey,cluster]:map )
+    { delete cluster; }
   }
 
   // clear the maps
-  m_clusmap.clear();
+  /* using swap ensures that the memory is properly de-allocated */
+  std::map<TrkrDefs::hitsetkey, Map> empty;
+  m_clusmap.swap( empty );
 
 }
 

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -6,7 +6,6 @@
  */
 #include "TrkrClusterContainerv3.h"
 #include "TrkrCluster.h"
-#include "TrkrClusterv3.h"
 #include "TrkrDefs.h"
 
 #include <cstdlib>
@@ -76,12 +75,12 @@ void TrkrClusterContainerv3::removeCluster(TrkrCluster *clus)
 { removeCluster( clus->getClusKey() ); }
 
 //_________________________________________________________________
-TrkrClusterContainerv3::ConstIterator
+void
 TrkrClusterContainerv3::addCluster(TrkrCluster* newclus)
-{ return addClusterSpecifyKey(newclus->getClusKey(), newclus); }
+{ addClusterSpecifyKey(newclus->getClusKey(), newclus); }
 
 //_________________________________________________________________
-TrkrClusterContainerv3::ConstIterator
+void
 TrkrClusterContainerv3::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster* newclus)
 {
   // get hitsetkey from cluster
@@ -89,14 +88,14 @@ TrkrClusterContainerv3::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCl
 
   // find relevant cluster map or create one if not found
   Map& map = m_clusmap[hitsetkey];
-  const auto ret = map.insert(std::make_pair(key, newclus));
-  if ( !ret.second )
+  const auto [iter,success] = map.insert(std::make_pair(key, newclus));
+  if ( !success )
   {
     std::cout << "TrkrClusterContainerv3::AddClusterSpecifyKey: duplicate key: " << key << " exiting now" << std::endl;
     exit(1);
   } else {
-    ret.first->second->setClusKey( key );
-    return ret.first;
+    // make sure that cluster key matches
+    iter->second->setClusKey( key );
   }
 }
 
@@ -118,26 +117,6 @@ TrkrClusterContainerv3::getClusters(TrkrDefs::hitsetkey hitsetkey) const
 TrkrClusterContainerv3::Map*
 TrkrClusterContainerv3::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
 { return &m_clusmap[hitsetkey]; }
-  
-//_________________________________________________________________
-TrkrClusterContainerv3::Iterator
-TrkrClusterContainerv3::findOrAddCluster(TrkrDefs::cluskey key)
-{
-  // get hitsetkey from cluster
-  const TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey( key );
-
-  // find relevant cluster map or create one if not found
-  Map& map = m_clusmap[hitsetkey];
-  auto it = map.lower_bound(key);
-  if( it == map.end() || (key<it->first) )
-  {
-    // add new cluster and set its key
-    it = map.insert(it, std::make_pair(key, new TrkrClusterv3()));
-    it->second->setClusKey( key );
-  }
-  
-  return it;
-}
 
 //_________________________________________________________________
 TrkrCluster* TrkrClusterContainerv3::findCluster(TrkrDefs::cluskey key) const

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -114,11 +114,6 @@ TrkrClusterContainerv3::getClusters(TrkrDefs::hitsetkey hitsetkey) const
 }
 
 //_________________________________________________________________
-TrkrClusterContainerv3::Map*
-TrkrClusterContainerv3::getClusterMap(TrkrDefs::hitsetkey hitsetkey)
-{ return &m_clusmap[hitsetkey]; }
-
-//_________________________________________________________________
 TrkrCluster* TrkrClusterContainerv3::findCluster(TrkrDefs::cluskey key) const
 {
   

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -40,17 +40,15 @@ void TrkrClusterContainerv3::identify(std::ostream& os) const
   os << "-----TrkrClusterContainerv3-----" << std::endl;
   os << "Number of clusters: " << size() << std::endl;
 
-  for( const auto& map_pair:m_clusmap )
+  for( const auto& [hitsetkey,map]:m_clusmap )
   {
-
-    const unsigned int layer = TrkrDefs::getLayer(map_pair.first);
-    std::cout << "layer: " << layer << " hitsetkey: " << map_pair.first << std::endl;
-
-    for( const auto& pair:map_pair.second )
+    const unsigned int layer = TrkrDefs::getLayer(hitsetkey);
+    std::cout << "layer: " << layer << " hitsetkey: " << hitsetkey << std::endl;
+    for( const auto& [cluskey,cluster]:map )
     {
-      int layer = TrkrDefs::getLayer(pair.first);
-      os << "clus key " << pair.first  << " layer " << layer << std::endl;
-      (pair.second)->identify();
+      const unsigned int layer = TrkrDefs::getLayer(cluskey);
+      os << "clus key " << cluskey  << " layer " << layer << std::endl;
+      cluster->identify();
     }
   }
 

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -27,15 +27,13 @@ class TrkrClusterContainerv3 : public TrkrClusterContainer
 
   void identify(std::ostream &os = std::cout) const override;
 
-  ConstIterator addCluster(TrkrCluster*) override;
+  void addCluster(TrkrCluster*) override;
 
-  ConstIterator addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
+  void addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
 
   void removeCluster(TrkrDefs::cluskey) override;
 
   void removeCluster(TrkrCluster*) override;
-
-  Iterator findOrAddCluster(TrkrDefs::cluskey) override;
 
   ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -37,8 +37,6 @@ class TrkrClusterContainerv3 : public TrkrClusterContainer
 
   ConstRange getClusters(TrkrDefs::hitsetkey) const override;
 
-  Map* getClusterMap(TrkrDefs::hitsetkey) override;
-
   TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
   unsigned int size(void) const override;

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -10,6 +10,7 @@
 
 /// Tracking includes
 #include <trackbase/TrkrCluster.h>            // for TrkrCluster
+#include <trackbase/TrkrClusterv3.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSet.h>
@@ -650,29 +651,34 @@ int  PHMicromegasTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
 
 void PHMicromegasTpcTrackMatching::copyMicromegasClustersToCorrectedMap( )
 {
-  // loop over final track map, copy silicon clusters to corrected cluster map
-  for (auto phtrk_iter = _track_map->begin();
-       phtrk_iter != _track_map->end(); 
-       ++phtrk_iter)
+  // loop over final track map, copy micromegas clusters to corrected cluster map
+  for( auto track_iter = _track_map->begin(); track_iter != _track_map->end(); ++track_iter )
+  {    
+    SvtxTrack* track = track_iter->second;
+    // loop over associated clusters to get keys for micromegas cluster
+    for(auto iter = track->begin_cluster_keys(); iter != track->end_cluster_keys(); ++iter)
     {
-      SvtxTrack *track = phtrk_iter->second;
-
-      // loop over associated clusters to get keys for silicon cluster
-      for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-	   iter != track->end_cluster_keys();
-	   ++iter)
-	{
-	  TrkrDefs::cluskey cluster_key = *iter;
-   const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-	  if(trkrid == TrkrDefs::micromegasId)
+      TrkrDefs::cluskey cluster_key = *iter;
+      const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+      if(trkrid == TrkrDefs::micromegasId)
 	    {
-	      TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-       if( !cluster ) continue;
-      
-       TrkrCluster *newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
-       newclus->CopyFrom( cluster );
+
+        // check if clusters has not been inserted already
+        if( _corrected_cluster_map->findCluster( cluster_key ) ) continue;
+        
+        // get cluster from original map
+        auto cluster =  _cluster_map->findCluster(cluster_key);
+        if( !cluster ) continue;
+
+        // create a new cluster and copy from source
+        auto newclus = new TrkrClusterv3;
+        newclus->CopyFrom( cluster );
+
+        // insert in corrected map
+        _corrected_cluster_map->addCluster(newclus);
+
 	    }
-	}      
     }
+  }
 }
   

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -199,10 +199,8 @@ int PHTruthClustering::process_event(PHCompositeNode* topNode)
 
 	  if(trkrId == TrkrDefs::tpcId)
 	    {
-	      // add the filled out cluster to the truth cluster node for the TPC (and MM's)
-	      TrkrClusterContainer::ConstIterator iter = m_clusterlist->addCluster(gclus);
-	      if(iter->first != ckey)
-		std::cout << PHWHERE << " -------  Problem:  ckey = " << ckey<< " returned key " << iter->first << std::endl;
+        // add the filled out cluster to the truth cluster node for the TPC (and MM's)
+        m_clusterlist->addCluster(gclus);
 	    }
 	}
     }
@@ -228,9 +226,7 @@ int PHTruthClustering::process_event(PHCompositeNode* topNode)
 	  cluster->identify();
 	}
       
-      TrkrClusterContainer::ConstIterator iter = m_clusterlist->addCluster(cluster);    
-      if(iter->first != cluskey)
-	std::cout << PHWHERE << " -------  Problem:  cluskey = " << cluskey<< " returned key " << iter->first << std::endl;
+       m_clusterlist->addCluster(cluster);    
     }
   }
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -593,37 +593,31 @@ std::set<TrkrDefs::cluskey> PHTruthSiliconAssociation::getSiliconClustersFromPar
 void PHTruthSiliconAssociation::copySiliconClustersToCorrectedMap( )
 {
   // loop over final track map, copy silicon clusters to corrected cluster map
-  for (auto phtrk_iter = _track_map->begin();
-       phtrk_iter != _track_map->end(); 
-       ++phtrk_iter)
+  for( auto track_iter = _track_map->begin(); track_iter != _track_map->end(); ++track_iter )
+  {
+    SvtxTrack* track = track_iter->second;
+    // loop over associated clusters to get keys for micromegas cluster
+    for(auto iter = track->begin_cluster_keys(); iter != track->end_cluster_keys(); ++iter)
     {
-      SvtxTrack *track = phtrk_iter->second;
+      TrkrDefs::cluskey cluster_key = *iter;
+      const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+      if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
+      {
+        // check if clusters has not been inserted already
+        if( _corrected_cluster_map->findCluster( cluster_key ) ) continue;
 
-      // loop over associated clusters to get keys for silicon cluster
-      for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-	   iter != track->end_cluster_keys();
-	   ++iter)
-	{
-	  TrkrDefs::cluskey cluster_key = *iter;
-	  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-	  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
-	    {
-	      TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	      TrkrCluster *newclus = _corrected_cluster_map->findOrAddCluster(cluster_key)->second;
-	  
-	      newclus->setSubSurfKey(cluster->getSubSurfKey());
-	      newclus->setAdc(cluster->getAdc());
-	      
-	      newclus->setActsLocalError(0,0,cluster->getActsLocalError(0,0));
-	      newclus->setActsLocalError(1,0,cluster->getActsLocalError(1,0));
-	      newclus->setActsLocalError(0,1,cluster->getActsLocalError(0,1));
-	      newclus->setActsLocalError(1,1,cluster->getActsLocalError(1,1));
-	      
-	      newclus->setLocalX(cluster->getLocalX());
-	      newclus->setLocalY(cluster->getLocalY());
-	    }
-	}      
-    }
+        auto cluster = _cluster_map->findCluster(cluster_key);	
+        if( !cluster ) continue;
+        
+        // create a new cluster and copy from source
+        auto newclus = new TrkrClusterv3;
+        newclus->CopyFrom( cluster );
+
+        // insert in corrected map
+        _corrected_cluster_map->addCluster(newclus);
+      }
+    }      
+  }
 }
 
 std::vector<short int> PHTruthSiliconAssociation::getInttCrossings(SvtxTrack *si_track)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR simplifies the TrkrClusterContainer public interface in preparation for the new clusterContainer to minimize the number of function calls that make explicit assumptions to the underlying structure.
In particular: 
- ::findOrAddCluster has been removed 
- ::getClusterMap has been removed
- ::addCluster now returns void rather than an interator to the underlying map.
In addition ::getClusterRange( hitsetid ) has been made non const. 
The code calling these functions has been adapted accordingly, in principle with no loss of functionality nor performance
TpcSimpleClusterizer has been updated to incorporate recent changes to TpcClusterizer.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

