### PR TITLE
Clustercontainer

### DIFF
--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -15,7 +15,6 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/InttDefs.h>
 
@@ -178,12 +177,6 @@ int QAG4SimulationIntt::load_nodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if (!m_hitsets)
-  {
-    std::cout << PHWHERE << " ERROR: Can't find TrkrHitSetContainer." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!m_cluster_map)
   {
@@ -260,12 +253,9 @@ void QAG4SimulationIntt::evaluate_clusters()
   }
 
   ActsTransformations transformer;
-  auto hitsetrange = m_hitsets->getHitSets(TrkrDefs::TrkrId::inttId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr)
+  for(const auto& hitsetkey:m_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::inttId))
   {
-    auto range = m_cluster_map->getClusters(hitsetitr->first);
+    auto range = m_cluster_map->getClusters(hitsetkey);
     for (auto clusterIter = range.first; clusterIter != range.second; ++clusterIter)
     {
       // get cluster key, detector id and check

--- a/offline/QA/modules/QAG4SimulationIntt.h
+++ b/offline/QA/modules/QAG4SimulationIntt.h
@@ -13,7 +13,6 @@ class PHG4Hit;
 class PHG4HitContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
-class TrkrHitSetContainer;
 class TrkrHitTruthAssoc;
 
 struct ActsSurfaceMaps;
@@ -57,9 +56,6 @@ class QAG4SimulationIntt : public SubsysReco
 
   /// clusters to hit association
   TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;
-
-  /// hitsets
-  TrkrHitSetContainer* m_hitsets = nullptr;
 
   /// hit to g4hit association
   TrkrHitTruthAssoc* m_hit_truth_map = nullptr;

--- a/offline/QA/modules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/modules/QAG4SimulationMicromegas.cc
@@ -257,10 +257,7 @@ int QAG4SimulationMicromegas::load_nodes(PHCompositeNode* topNode)
 
   m_hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
   if (!m_hitsets)
-  {
-    std::cout << PHWHERE << " ERROR: Can't find TrkrHitSetContainer." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
+  { std::cout << PHWHERE << " ERROR: Can't find TrkrHitSetContainer." << std::endl; }
 
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!m_cluster_map)
@@ -296,6 +293,9 @@ int QAG4SimulationMicromegas::load_nodes(PHCompositeNode* topNode)
 //________________________________________________________________________
 void QAG4SimulationMicromegas::evaluate_hits()
 {
+  // do nothing if hitsets are not there
+  if( !m_hitsets ) return;
+  
   // histogram manager
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -376,12 +376,8 @@ void QAG4SimulationMicromegas::evaluate_clusters()
   ActsTransformations transformer;
 
   // loop over hitsets
-  const auto hitsetrange = m_hitsets->getHitSets(TrkrDefs::TrkrId::micromegasId);
-  for (auto hitsetiter = hitsetrange.first; hitsetiter != hitsetrange.second; ++hitsetiter)
+  for(const auto& hitsetkey:m_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::micromegasId))
   {
-    // get hitsetkey, layer and tileid
-    const auto hitsetkey = hitsetiter->first;
-
     // get layer
     const auto layer = TrkrDefs::getLayer(hitsetkey);
 

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -13,7 +13,6 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for getTrkrId, getHit...
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/MvtxDefs.h>
 
@@ -162,13 +161,6 @@ std::string QAG4SimulationMvtx::get_histo_prefix() const
 //________________________________________________________________________
 int QAG4SimulationMvtx::load_nodes(PHCompositeNode* topNode)
 {
-  m_hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if (!m_hitsets)
-  {
-    std::cout << PHWHERE << " ERROR: Can't find TrkrHitSetContainer." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
   m_surfmaps = findNode::getClass<ActsSurfaceMaps>(topNode, "ActsSurfaceMaps");
   if (!m_surfmaps)
   {
@@ -261,12 +253,9 @@ void QAG4SimulationMvtx::evaluate_clusters()
   }
 
   ActsTransformations transformer;
-  auto hitsetrange = m_hitsets->getHitSets(TrkrDefs::TrkrId::mvtxId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr)
+  for(const auto& hitsetkey:m_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::mvtxId))
   {
-    auto range = m_cluster_map->getClusters(hitsetitr->first);
+    auto range = m_cluster_map->getClusters(hitsetkey);
     for (auto clusterIter = range.first; clusterIter != range.second; ++clusterIter)
     {
       // get cluster key, detector id and check

--- a/offline/QA/modules/QAG4SimulationMvtx.h
+++ b/offline/QA/modules/QAG4SimulationMvtx.h
@@ -12,7 +12,6 @@ class PHCompositeNode;
 class PHG4Hit;
 class PHG4HitContainer;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
 
@@ -48,9 +47,6 @@ class QAG4SimulationMvtx : public SubsysReco
 
   /// cluster map
   TrkrClusterContainer* m_cluster_map = nullptr;
-
-  /// hitsets
-  TrkrHitSetContainer* m_hitsets = nullptr;
 
   /// clusters to hit association
   TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -13,7 +13,6 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getLayer
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -318,12 +317,9 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
   {
     // loop over clusters
-    auto hitsetrange = m_hitsets->getHitSets();
-    for (auto hitsetitr = hitsetrange.first;
-         hitsetitr != hitsetrange.second;
-         ++hitsetitr)
+    for(const auto& hitsetkey:m_cluster_map->getHitSetKeys())
     {
-      auto range = m_cluster_map->getClusters(hitsetitr->first);
+      auto range = m_cluster_map->getClusters(hitsetkey);
       for (auto clusterIter = range.first; clusterIter != range.second; ++clusterIter)
       {
         // store cluster key
@@ -641,13 +637,6 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
 int QAG4SimulationTracking::load_nodes(PHCompositeNode *topNode)
 {
-  m_hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if (!m_hitsets)
-  {
-    std::cout << PHWHERE << " ERROR: Can't find TrkrHitSetContainer." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
   m_truthContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (!m_truthContainer)
   {

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -16,7 +16,6 @@ class PHCompositeNode;
 class SvtxTrackMap;
 class PHG4Hit;
 class PHG4HitContainer;
-class TrkrHitSetContainer;
 class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
@@ -74,7 +73,6 @@ class QAG4SimulationTracking : public SubsysReco
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
 
-  TrkrHitSetContainer *m_hitsets = nullptr;
   TrkrClusterContainer *m_cluster_map = nullptr;
   TrkrClusterHitAssoc *m_cluster_hit_map = nullptr;
   TrkrHitTruthAssoc *m_hit_truth_map = nullptr;

--- a/offline/packages/PHTpcTracker/PHTpcEventExporter.cc
+++ b/offline/packages/PHTpcTracker/PHTpcEventExporter.cc
@@ -12,7 +12,6 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 #include <phool/PHLog.h>
 
@@ -29,7 +28,7 @@ PHTpcEventExporter::PHTpcEventExporter()
 {
 }
 
-void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets,std::vector<kdfinder::TrackCandidate<double>*> candidates,
+void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, std::vector<kdfinder::TrackCandidate<double>*> candidates,
                                      double B, const std::string& filename)
 {
   // export hits + seeds to json for checks
@@ -93,13 +92,10 @@ void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, TrkrHitS
       << "  },\n"
       << " \"HITS\": {\n"
       << "   \"TPC\": [\n";
-  
-  auto hitsetrange = hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
+  for(const auto& hitsetkey:cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  { 
     std::string separator = "";
-    auto range = cluster_map->getClusters(hitsetitr->first);
+    auto range = cluster_map->getClusters(hitsetkey);
     for( auto it = range.first; it != range.second; ++it )
       {
 	TrkrCluster* cluster = it->second;
@@ -137,7 +133,7 @@ void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, TrkrHitS
   ofile.close();
 }
 
-void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets, std::vector<PHGenFit2::Track*> gtracks,
+void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, std::vector<PHGenFit2::Track*> gtracks,
                                      double B, const std::string& filename)
 {
   // export hits + reco-d tracks to json for checks
@@ -215,12 +211,10 @@ void PHTpcEventExporter::exportEvent(TrkrClusterContainer* cluster_map, TrkrHitS
       << "  },\n"
       << " \"HITS\": {\n"
       << "   \"TPC\": [\n";
-  auto hitsetrange = hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
+  for(const auto& hitsetkey:cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  {
     std::string separator = "";
-    auto range = cluster_map->getClusters(hitsetitr->first);
+    auto range = cluster_map->getClusters(hitsetkey);
     for( auto it = range.first; it != range.second; ++it )
       {
 	TrkrCluster* cluster = it->second;

--- a/offline/packages/PHTpcTracker/PHTpcEventExporter.h
+++ b/offline/packages/PHTpcTracker/PHTpcEventExporter.h
@@ -11,7 +11,6 @@
 #include <vector>  // for vector
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 namespace PHGenFit2
 {
@@ -31,12 +30,12 @@ class PHTpcEventExporter
 {
  public:
   PHTpcEventExporter();
-  virtual ~PHTpcEventExporter() {}
+  virtual ~PHTpcEventExporter() = default;
 
-  void exportEvent(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets, std::vector<kdfinder::TrackCandidate<double>*> candidates,
+  void exportEvent(TrkrClusterContainer* cluster_map, std::vector<kdfinder::TrackCandidate<double>*> candidates,
                    double B, const std::string& filename);
 
-  void exportEvent(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets,std::vector<PHGenFit2::Track*> gtracks,
+  void exportEvent(TrkrClusterContainer* cluster_map, std::vector<PHGenFit2::Track*> gtracks,
                    double B, const std::string& filename);
 
   void exportEvent(std::vector<PHGenFit2::Track*> gtracks, double B, const std::string& filename);

--- a/offline/packages/PHTpcTracker/PHTpcLookup.cc
+++ b/offline/packages/PHTpcTracker/PHTpcLookup.cc
@@ -15,11 +15,9 @@
 #include <utility>  // for pair
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 PHTpcLookup::PHTpcLookup()
   : mClusterMap(nullptr)
-  , mHitsets(nullptr)
   , mKDindex(nullptr)
 {
 }
@@ -29,12 +27,11 @@ PHTpcLookup::~PHTpcLookup()
   delete mKDindex;
 }
 
-void PHTpcLookup::init(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets)
+void PHTpcLookup::init(TrkrClusterContainer* cluster_map)
 {
   mClusterMap = cluster_map;
-  mHitsets = hitsets;
   // convert cluster_map to kdhits
-  mKDhits = PHTpcTrackerUtil::convert_clusters_to_hits(mClusterMap, mHitsets);
+  mKDhits = PHTpcTrackerUtil::convert_clusters_to_hits(mClusterMap);
 
   // import kdhits into KDPointCloud
   const size_t TOTALHITS = mKDhits.size();

--- a/offline/packages/PHTpcTracker/PHTpcLookup.h
+++ b/offline/packages/PHTpcTracker/PHTpcLookup.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 /// \class PHTpcLookup
 ///
@@ -26,7 +25,7 @@ class PHTpcLookup
   PHTpcLookup();
   ~PHTpcLookup();
 
-  void init(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets);
+  void init(TrkrClusterContainer* cluster_map);
   void clear();
 
   std::vector<std::vector<double>*> find(double x, double y, double z, double radius, size_t& nMatches);
@@ -34,7 +33,6 @@ class PHTpcLookup
  protected:
 
   TrkrClusterContainer* mClusterMap;
-  TrkrHitSetContainer* mHitsets;
   std::vector<std::vector<double> > mKDhits;
   kdfinder::KDPointCloud<double> mCloud;
   nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, kdfinder::KDPointCloud<double> >,

--- a/offline/packages/PHTpcTracker/PHTpcSeedFinder.cc
+++ b/offline/packages/PHTpcTracker/PHTpcSeedFinder.cc
@@ -14,7 +14,6 @@
 #include <log4cpp/CategoryStream.hh>  // for CategoryStream
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 float round(float var)
 {
@@ -35,7 +34,7 @@ PHTpcSeedFinder::PHTpcSeedFinder()
 {
 }
 
-std::vector<kdfinder::TrackCandidate<double>*> PHTpcSeedFinder::findSeeds(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets, double B)
+std::vector<kdfinder::TrackCandidate<double>*> PHTpcSeedFinder::findSeeds(TrkrClusterContainer* cluster_map, double B)
 {
   LOG_WARN_IF("tracking.PHTpcSeedFnder.findSeeds", !cluster_map) << __FILE__ << "," << __LINE__ << " Can't find node TRKR_CLUSTER";
   std::vector<kdfinder::TrackCandidate<double>*> result;
@@ -43,14 +42,9 @@ std::vector<kdfinder::TrackCandidate<double>*> PHTpcSeedFinder::findSeeds(TrkrCl
   {
     return result;
   }
-  LOG_WARN_IF("tracking.PHTpcSeedFnder.findSeeds", !hitsets) << __FILE__ << "," << __LINE__ << " Can't find node TRKR_HITSET";
-  if (!hitsets)
-  {
-    return result;
-  }
 
   //----- convert clusters to kdhits -----
-  std::vector<std::vector<double> > kdhits(PHTpcTrackerUtil::convert_clusters_to_hits(cluster_map, hitsets));
+  std::vector<std::vector<double> > kdhits(PHTpcTrackerUtil::convert_clusters_to_hits(cluster_map));
   LOG_DEBUG("tracking.PHTpcSeedFinder.findSeeds") << "imported " << kdhits.size() << " clusters";
 
   //----- find unfitted kdtracks -----

--- a/offline/packages/PHTpcTracker/PHTpcSeedFinder.h
+++ b/offline/packages/PHTpcTracker/PHTpcSeedFinder.h
@@ -12,7 +12,6 @@
 #include <vector>   // for vector
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 namespace kdfinder
 {
@@ -50,7 +49,7 @@ class PHTpcSeedFinder
     mMaxLooperRadius = maxr;
   }
 
-  std::vector<kdfinder::TrackCandidate<double>*> findSeeds(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets, double B /* magfield */);
+  std::vector<kdfinder::TrackCandidate<double>*> findSeeds(TrkrClusterContainer* cluster_map, double B /* magfield */);
 
  protected:
  private:

--- a/offline/packages/PHTpcTracker/PHTpcTracker.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTracker.cc
@@ -23,7 +23,6 @@
 #include <phgeom/PHGeomUtility.h>
 
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey
 
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -130,11 +129,11 @@ int PHTpcTracker::Process(PHCompositeNode* topNode)
   // ----- Seed finding -----
   //TrkrClusterContainer* cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   std::vector<kdfinder::TrackCandidate<double>*> candidates;
-  candidates = mSeedFinder->findSeeds(_cluster_map, _hitsets, mB);
+  candidates = mSeedFinder->findSeeds(_cluster_map, mB);
   LOG_INFO("tracking.PHTpcTracker.process_event") << "SeedFinder produced " << candidates.size() << " track seeds";
 
   // ----- Track Following -----
-  mLookup->init(_cluster_map, _hitsets);
+  mLookup->init(_cluster_map);
   std::vector<PHGenFit2::Track*> gtracks;
   gtracks = mTrackFollower->followTracks(candidates, mField, mLookup, mFitter);
   LOG_INFO("tracking.PHTpcTracker.process_event") << "TrackFollower reconstructed " << gtracks.size() << " tracks";

--- a/offline/packages/PHTpcTracker/PHTpcTrackerUtil.cc
+++ b/offline/packages/PHTpcTracker/PHTpcTrackerUtil.cc
@@ -8,8 +8,6 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>  // for TrkrClusterContainer
-#include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <phool/PHLog.h>
@@ -21,7 +19,7 @@
 
 namespace PHTpcTrackerUtil
 {
-  std::vector<std::vector<double> > convert_clusters_to_hits(TrkrClusterContainer* cluster_map, TrkrHitSetContainer* hitsets )
+  std::vector<std::vector<double> > convert_clusters_to_hits(TrkrClusterContainer* cluster_map)
   {
     //***** convert clusters to kdhits
     std::vector<std::vector<double> > kdhits;
@@ -30,12 +28,10 @@ namespace PHTpcTrackerUtil
       LOG_WARN("tracking.PHTpcTrackerUtil.convert_clusters_to_hits") << "cluster map is not provided";
       return kdhits;
     }
-    auto hitsetrange = hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-    for (auto hitsetitr = hitsetrange.first;
-	 hitsetitr != hitsetrange.second;
-	 ++hitsetitr){
+    for(const auto& hitsetkey:cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+    {
       std::string separator = "";
-      auto range = cluster_map->getClusters(hitsetitr->first);
+      auto range = cluster_map->getClusters(hitsetkey);
       for( auto it = range.first; it != range.second; ++it )
 	{
 	  // TrkrDefs::cluskey cluskey = it->first;

--- a/offline/packages/PHTpcTracker/PHTpcTrackerUtil.h
+++ b/offline/packages/PHTpcTracker/PHTpcTrackerUtil.h
@@ -10,11 +10,10 @@
 #include <vector>
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 namespace PHTpcTrackerUtil
 {
-  std::vector<std::vector<double> > convert_clusters_to_hits(TrkrClusterContainer* cluster_map, TrkrHitSetContainer *hitsets);
+  std::vector<std::vector<double> > convert_clusters_to_hits(TrkrClusterContainer* cluster_map);
 
 }  // namespace PHTpcTrackerUtil
 

--- a/offline/packages/tpc/TpcClusterCleaner.cc
+++ b/offline/packages/tpc/TpcClusterCleaner.cc
@@ -56,12 +56,6 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
     std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-  _hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if (!_hitsets)
-  {
-    std::cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
 
   std::set<TrkrDefs::cluskey>  discard_set;
 
@@ -69,14 +63,11 @@ int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 
   // loop over all TPC clusters
   if(Verbosity() > 0) std::cout << std::endl << "original size of cluster map: " << _cluster_map->size() << std::endl;  
-  TrkrHitSetContainer::ConstRange hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
-      hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    TrkrClusterContainer::ConstRange clusRange = _cluster_map->getClusters(hitsetitr->first);
-    TrkrClusterContainer::ConstIterator clusiter;
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  {
+    TrkrClusterContainer::ConstRange clusRange = _cluster_map->getClusters(hitsetkey);
     
-    for (clusiter = clusRange.first; 
+    for ( auto clusiter = clusRange.first; 
 	 clusiter != clusRange.second; ++clusiter)
       {
 	TrkrDefs::cluskey cluskey = clusiter->first;

--- a/offline/packages/tpc/TpcClusterCleaner.h
+++ b/offline/packages/tpc/TpcClusterCleaner.h
@@ -18,7 +18,6 @@
 class PHCompositeNode;
 class TrkrCluster;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 class TpcClusterCleaner : public SubsysReco
 {
@@ -43,7 +42,6 @@ class TpcClusterCleaner : public SubsysReco
   void rotate_error(double erphi, double ez, double phi, double error[][3]);
 
   int GetNodes(PHCompositeNode* topNode);
-  TrkrHitSetContainer  *_hitsets = nullptr;
   TrkrClusterContainer *_cluster_map = nullptr;
 
   double _rphi_error_low_cut = 0.01;

--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
@@ -25,6 +25,8 @@
 #include <trackbase/CMFlashClusterContainerv1.h>
 #include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
 #include <trackbase_historic/ActsTransformations.h>
 
 

--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
@@ -23,18 +23,6 @@
 #include <tpc/TpcDefs.h>
 #include <trackbase/CMFlashClusterv1.h>
 #include <trackbase/CMFlashClusterContainerv1.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterContainerv3.h>
-#include <trackbase/TrkrClusterHitAssocv2.h>
-#include <trackbase/TrkrHitTruthAssoc.h>
-#include <trackbase_historic/SvtxTrack_v2.h>
-#include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase/TrkrHitSetContainerv1.h>
-#include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrHitv2.h>
-#include <trackbase/TrkrHitSetv1.h>
-
 #include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase_historic/ActsTransformations.h>
@@ -99,7 +87,6 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
     } 
   
   if(Verbosity() > 0) std::cout << std::endl << "original size of cluster map: " << _cluster_map->size() << std::endl;  
-  TrkrHitSetContainer::ConstRange hitsetrange = _hitset_map->getHitSets(TrkrDefs::TrkrId::tpcId);
   
   std::vector<TVector3>pos; //position vector in cartesian
   std::vector<int>layer; //cluster layer number
@@ -107,11 +94,9 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
   std::vector<float>energy;//vector for energy values of clusters
   int nTpcClust = 0;
 
-  for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr)
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
     {
-      auto clusRange = _cluster_map->getClusters(hitsetitr->first);
+      auto clusRange = _cluster_map->getClusters(hitsetkey);
       for (auto clusiter = clusRange.first; 
 	   clusiter != clusRange.second; ++clusiter)
 	{
@@ -408,22 +393,6 @@ int  PHTpcCentralMembraneClusterizer::GetNodes(PHCompositeNode* topNode)
   if (!_cluster_map)
   {
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-
-  _cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
-  if (!_cluster_hit_map)
-  {
-    cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTERHITASSOC" << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-
-  _hitset_map = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if (!_hitset_map)
-  {
-    cerr << PHWHERE << " ERROR: Can't find node TRKR_HITSET" << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 

--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
@@ -16,6 +16,7 @@ class PHCompositeNode;
 class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
+class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class CMFlashClusterContainer;
 class  PHG4CylinderCellGeomContainer;

--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
@@ -17,7 +17,6 @@ class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
 class TrkrClusterHitAssoc;
-class TrkrHitSetContainer;
 class CMFlashClusterContainer;
 class  PHG4CylinderCellGeomContainer;
 
@@ -63,8 +62,6 @@ class PHTpcCentralMembraneClusterizer : public SubsysReco
 
   TrkrClusterContainer *_cluster_map{nullptr};
   CMFlashClusterContainer *_corrected_CMcluster_map{nullptr};
-  TrkrClusterHitAssoc *_cluster_hit_map{nullptr};
-  TrkrHitSetContainer *_hitset_map{nullptr};
   PHG4CylinderCellGeomContainer *_geom_container{nullptr};
  TpcDistortionCorrectionContainer* _dcc{nullptr};
 

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -14,7 +14,6 @@
 #include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
@@ -223,9 +222,6 @@ int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
   m_track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
   assert(m_track_map);
 
-  // hitset container
-  m_hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-
   // clusters
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   assert(m_cluster_map);
@@ -262,10 +258,8 @@ void TpcDirectLaserReconstruction::process_tracks()
   if( !( m_track_map && m_cluster_map ) ) return;
 
   // count number of clusters in the TPC
-  for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
+  for(const auto& hitsetkey:m_cluster_map->getHitSetKeys(TrkrDefs::tpcId))
   {
-    if( TrkrDefs::getTrkrId( hitsetkey ) != TrkrDefs::tpcId ) continue;
-
     const auto range = m_cluster_map->getClusters(hitsetkey);
     m_total_clusters += std::distance( range.first, range.second );
   }
@@ -287,12 +281,9 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
   { std::cout << "TpcDirectLaserReconstruction::process_track - position: " << origin << " direction: " << direction << std::endl; }
 
   // loop over hitsets
-  for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
+  for(const auto& hitsetkey:m_cluster_map->getHitSetKeys(TrkrDefs::tpcId))
   {
-
-    // only check TPC hitsets
-    if( TrkrDefs::getTrkrId( hitsetkey ) != TrkrDefs::tpcId ) continue;
-
+    
     // store layer
     const auto layer = TrkrDefs::getLayer( hitsetkey );
 

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -20,7 +20,6 @@ class SvtxTrackMap;
 class TpcSpaceChargeMatrixContainer;
 class TrkrCluster;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 class TFile;
 class TH1;
@@ -119,9 +118,6 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// acts transformation
   ActsTransformations m_transformer;
-
-  /// hitset containers
-  TrkrHitSetContainer* m_hitsetcontainer = nullptr;
 
   /// tracks
   SvtxTrackMap* m_track_map = nullptr;

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -68,6 +68,14 @@ class TrkrClusterContainer : public PHObject
   virtual HitSetKeyList getHitSetKeys() const 
   { return HitSetKeyList(); }
 
+  //! get hitset key list for a given detector
+  virtual HitSetKeyList getHitSetKeys(const TrkrDefs::TrkrId) const 
+  { return HitSetKeyList(); }
+
+  //! get hitset key list for a given detector and layer
+  virtual HitSetKeyList getHitSetKeys(const TrkrDefs::TrkrId, const uint8_t /* layer */ ) const 
+  { return HitSetKeyList(); }
+
   //! total number of clusters
   virtual unsigned int size() const { return 0; }
 

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -32,6 +32,9 @@ class TrkrClusterContainer : public PHObject
   using ConstIterator = Map::const_iterator;
   using Range = std::pair<Iterator, Iterator>;
   using ConstRange = std::pair<ConstIterator, ConstIterator>;
+
+  using HitSetKeyList = std::vector<TrkrDefs::hitsetkey>;
+  
   //@}
 
   //! reset method
@@ -60,6 +63,10 @@ class TrkrClusterContainer : public PHObject
 
   //! find cluster matching given key
   virtual TrkrCluster* findCluster(TrkrDefs::cluskey) const { return nullptr; }
+  
+  //! get hitset key list
+  virtual HitSetKeyList getHitSetKeys() const 
+  { return HitSetKeyList(); }
 
   //! total number of clusters
   virtual unsigned int size() const { return 0; }

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -32,7 +32,6 @@ void TrkrClusterContainerv3::Reset()
 
 }
 
-
 //_________________________________________________________________
 void TrkrClusterContainerv3::identify(std::ostream& os) const
 {
@@ -142,6 +141,46 @@ TrkrClusterContainer::HitSetKeyList TrkrClusterContainerv3::getHitSetKeys() cons
   out.reserve( m_clusmap.size() );
   std::transform(
     m_clusmap.begin(), m_clusmap.end(), std::back_inserter( out ),
+    []( const std::pair<TrkrDefs::hitsetkey, Map>& pair ) { return pair.first; } );
+  return out;  
+}
+
+//_________________________________________________________________
+TrkrClusterContainer::HitSetKeyList TrkrClusterContainerv3::getHitSetKeys(const TrkrDefs::TrkrId trackerid) const
+{
+  /* copy the logic from TrkrHitSetContainerv1::getHitSets */
+  const TrkrDefs::hitsetkey keylo = TrkrDefs::getHitSetKeyLo(trackerid);
+  const TrkrDefs::hitsetkey keyhi = TrkrDefs::getHitSetKeyHi(trackerid);
+
+  // get relevant range in map
+  const auto begin = m_clusmap.lower_bound(keylo);
+  const auto end = m_clusmap.upper_bound(keyhi);
+  
+  // transform to a vector
+  HitSetKeyList out;
+  out.reserve( m_clusmap.size() );
+  std::transform(
+    begin, end, std::back_inserter( out ),
+    []( const std::pair<TrkrDefs::hitsetkey, Map>& pair ) { return pair.first; } );
+  return out;  
+}
+
+//_________________________________________________________________
+TrkrClusterContainer::HitSetKeyList TrkrClusterContainerv3::getHitSetKeys(const TrkrDefs::TrkrId trackerid, const uint8_t layer) const
+{
+  /* copy the logic from TrkrHitSetContainerv1::getHitSets */
+  TrkrDefs::hitsetkey keylo = TrkrDefs::getHitSetKeyLo(trackerid, layer);
+  TrkrDefs::hitsetkey keyhi = TrkrDefs::getHitSetKeyHi(trackerid, layer);
+
+  // get relevant range in map
+  const auto begin = m_clusmap.lower_bound(keylo);
+  const auto end = m_clusmap.upper_bound(keyhi);
+  
+  // transform to a vector
+  HitSetKeyList out;
+  out.reserve( m_clusmap.size() );
+  std::transform(
+    begin, end, std::back_inserter( out ),
     []( const std::pair<TrkrDefs::hitsetkey, Map>& pair ) { return pair.first; } );
   return out;  
 }

--- a/offline/packages/trackbase/TrkrClusterContainerv3.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.cc
@@ -8,7 +8,7 @@
 #include "TrkrCluster.h"
 #include "TrkrDefs.h"
 
-#include <cstdlib>
+#include <algorithm>
 
 namespace
 {
@@ -133,6 +133,17 @@ TrkrCluster* TrkrClusterContainerv3::findCluster(TrkrDefs::cluskey key) const
   } else {
     return nullptr;
   }
+}
+
+//_________________________________________________________________
+TrkrClusterContainer::HitSetKeyList TrkrClusterContainerv3::getHitSetKeys() const
+{
+  HitSetKeyList out;
+  out.reserve( m_clusmap.size() );
+  std::transform(
+    m_clusmap.begin(), m_clusmap.end(), std::back_inserter( out ),
+    []( const std::pair<TrkrDefs::hitsetkey, Map>& pair ) { return pair.first; } );
+  return out;  
 }
 
 //_________________________________________________________________

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -40,6 +40,10 @@ class TrkrClusterContainerv3 : public TrkrClusterContainer
   TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
   HitSetKeyList getHitSetKeys() const override;
+ 
+  HitSetKeyList getHitSetKeys(const TrkrDefs::TrkrId) const override;
+ 
+  HitSetKeyList getHitSetKeys(const TrkrDefs::TrkrId, const uint8_t /* layer */ ) const override;
   
   unsigned int size(void) const override;
 

--- a/offline/packages/trackbase/TrkrClusterContainerv3.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv3.h
@@ -39,6 +39,8 @@ class TrkrClusterContainerv3 : public TrkrClusterContainer
 
   TrkrCluster* findCluster(TrkrDefs::cluskey) const override;
 
+  HitSetKeyList getHitSetKeys() const override;
+  
   unsigned int size(void) const override;
 
   private:

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -27,7 +27,6 @@ class SvtxTrackMap;
 class SvtxVertexMap;
 class TrkrCluster;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class TrkrClusterIterationMapv1;
 
 /**
@@ -206,7 +205,6 @@ class PHActsSiliconSeeding : public SubsysReco
   ActsTrackingGeometry *m_tGeometry = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
   TrkrClusterContainer *m_clusterMap = nullptr;
-  TrkrHitSetContainer  *m_hitsets = nullptr;
   PHG4CylinderGeomContainer *m_geomContainerIntt = nullptr;
   ActsSurfaceMaps *m_surfMaps = nullptr;
   

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -28,7 +28,6 @@
 
 #include <trackbase/TrkrCluster.h>  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>  // for getLayer, clu...
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
@@ -250,11 +249,9 @@ PositionMap PHCASeeding::FillTree()
   PositionMap cachedPositions;
 
   for (int j = 0; j < 60; ++j) nlayer[j] = 0;
-  auto hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  {
+    auto range = _cluster_map->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
 
       TrkrCluster *cluster = clusIter->second;

--- a/offline/packages/trackreco/PHGenFitTrkProp.cc
+++ b/offline/packages/trackreco/PHGenFitTrkProp.cc
@@ -10,8 +10,6 @@
 #include <trackbase/TrkrCluster.h>                      // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>                         // for cluskey, getL...
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -1589,12 +1587,11 @@ int PHGenFitTrkProp::BuildLayerZPhiHitMap(unsigned int ivert)
   // make this map for each collision vertex
   std::multimap<unsigned int, TrkrDefs::cluskey> this_layer_thetaID_phiID_clusterID;
 
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
-    for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys())
+  {
+    auto range = _cluster_map->getClusters(hitsetkey);
+    for( auto clusIter = range.first; clusIter != range.second; ++clusIter )
+    {
       TrkrCluster *cluster = clusIter->second;
       TrkrDefs::cluskey cluskey = clusIter->first;
       

--- a/offline/packages/trackreco/PHHoughSeeding.cc
+++ b/offline/packages/trackreco/PHHoughSeeding.cc
@@ -25,8 +25,6 @@
 #include <trackbase/TrkrCluster.h>                      // for TrkrCluster
 #include <trackbase/TrkrDefs.h>                         // for getLayer, clu...
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 // sPHENIX Geant4 includes
 #include <g4detectors/PHG4CylinderCellGeom.h>
@@ -1091,11 +1089,9 @@ int PHHoughSeeding::translate_input()
   int nhits3d = -1;
   unsigned int clusid = -1;
 
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys())
+  {
+    auto range = _cluster_map->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       clusid += 1;
       TrkrCluster *cluster = clusIter->second;

--- a/offline/packages/trackreco/PHInitVertexing.cc
+++ b/offline/packages/trackreco/PHInitVertexing.cc
@@ -3,7 +3,6 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxVertexMap_v1.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>                   // for SubsysReco
@@ -22,11 +21,7 @@ using namespace std;
 
 PHInitVertexing::PHInitVertexing(const std::string& name)
   : SubsysReco(name)
-  , _cluster_map(nullptr)
-  , _hitsets(nullptr)
-  , _vertex_map(nullptr)
-{
-}
+{}
 
 int PHInitVertexing::InitRun(PHCompositeNode* topNode)
 {
@@ -97,14 +92,6 @@ int PHInitVertexing::GetNodes(PHCompositeNode* topNode)
     cerr << PHWHERE << " ERROR: Can't find node TrkrClusterContainer" << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-
-  _hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!_hitsets)
-    {
-      cerr << PHWHERE << "No hitset container on node tree. Bailing."
-		<< endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
 
   // Pull the reconstructed track information off the node tree...
   _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");

--- a/offline/packages/trackreco/PHInitVertexing.h
+++ b/offline/packages/trackreco/PHInitVertexing.h
@@ -17,7 +17,6 @@
 class PHCompositeNode;
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class SvtxVertexMap;
 
 /// \class PHInitVertexing
@@ -28,7 +27,7 @@ class PHInitVertexing : public SubsysReco
 {
  public:
   PHInitVertexing(const std::string &name = "PHInitVertexing");
-  ~PHInitVertexing() override {}
+  ~PHInitVertexing() override = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -44,9 +43,8 @@ class PHInitVertexing : public SubsysReco
   virtual int Process(PHCompositeNode *topNode) = 0;
 
 
-  TrkrClusterContainer *_cluster_map;
-  TrkrHitSetContainer  *_hitsets;
-  SvtxVertexMap *_vertex_map;
+  TrkrClusterContainer *_cluster_map = nullptr;
+  SvtxVertexMap *_vertex_map = nullptr;
 
  private:
   /// create new node output pointers

--- a/offline/packages/trackreco/PHInitZVertexing.cc
+++ b/offline/packages/trackreco/PHInitZVertexing.cc
@@ -22,8 +22,6 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrDefs.h>                         // for getLayer, clu...
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>
@@ -167,10 +165,10 @@ PHInitZVertexing::PHInitZVertexing(unsigned int nlayers,
 PHInitZVertexing::
 ~PHInitZVertexing()
 {
-  if (_t_output_io)  delete _t_output_io;
-  if (_hough_space) delete _hough_space;
-  if (_hough_funcs) delete _hough_funcs;
-//  delete ca;
+  delete _t_output_io;
+  delete _hough_space;
+  delete _hough_funcs;
+//
 }
 
 void PHInitZVertexing::set_min_zvtx_tracks(unsigned int min_zvtx_tracks)
@@ -730,11 +728,9 @@ int PHInitZVertexing::translate_input(PHCompositeNode* /*topNode*/) {
       cout << " _layer_ilayer_map has " << _layer_ilayer_map.size() << " entries" << endl;
     }
 
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+    for(const auto& hitsetkey:_cluster_map->getHitSetKeys())
+    {
+      auto range = _cluster_map->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       TrkrCluster *cluster = clusIter->second;
       TrkrDefs::cluskey cluskey = clusIter->first;

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -12,8 +12,6 @@
 #include <trackbase/TrkrClusterv3.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
 
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -20,7 +20,6 @@ class SvtxTrack;
 class TrkrCluster;
 class TF1;
 class TH1;
-class TrkrHitSetContainer;
 
 class PHMicromegasTpcTrackMatching : public SubsysReco
 {

--- a/offline/packages/trackreco/PHPatternReco.cc
+++ b/offline/packages/trackreco/PHPatternReco.cc
@@ -22,7 +22,6 @@
 
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrCluster.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 // sPHENIX Geant4 includes
 #include <g4detectors/PHG4CylinderGeom.h>
@@ -132,7 +131,6 @@ PHPatternReco::PHPatternReco(unsigned int nlayers,
       _vertex_list(),
       _bbc_vertexes(nullptr),
       _clustermap(nullptr),
-      _hitsets(nullptr),
       _trackmap(nullptr),
       _vertexmap(nullptr),
       _vertex_finder(),
@@ -727,13 +725,6 @@ int PHPatternReco::get_nodes(PHCompositeNode* topNode) {
 	    cerr << PHWHERE << " ERROR: Can't find node TrkrClusterContainer" << endl;
 	    return Fun4AllReturnCodes::ABORTEVENT;
 	  }
-	_hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-	if(!_hitsets)
-	  {
-	    std::cout << PHWHERE << "No hitset container on node tree. Bailing."
-		      << std::endl;
-	    return Fun4AllReturnCodes::ABORTEVENT;
-	  }
 	// Pull the reconstructed track information off the node tree...
 	_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
 	if (!_trackmap) {
@@ -755,12 +746,9 @@ int PHPatternReco::translate_input(PHCompositeNode* topNode) {
 
   unsigned int clusid = 0;
   unsigned int ilayer = 0;
-
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _clustermap->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_clustermap->getHitSetKeys())
+  {
+    auto range = _clustermap->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       TrkrCluster *cluster = clusIter->second;
       TrkrDefs::cluskey cluskey = clusIter->first;

--- a/offline/packages/trackreco/PHPatternReco.h
+++ b/offline/packages/trackreco/PHPatternReco.h
@@ -28,7 +28,6 @@ class HelixHoughFuncs;
 class PHCompositeNode;
 class PHTimer;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class SvtxTrackMap;
 class SvtxVertexMap;
 
@@ -276,7 +275,6 @@ private:
 	// node pointers
 	BbcVertexMap* _bbc_vertexes;
 	TrkrClusterContainer* _clustermap;
-	TrkrHitSetContainer  *_hitsets;
 	SvtxTrackMap* _trackmap;
 	SvtxVertexMap* _vertexmap;
 	VertexFitter _vertex_finder;

--- a/offline/packages/trackreco/PHRTreeSeeding.cc
+++ b/offline/packages/trackreco/PHRTreeSeeding.cc
@@ -18,8 +18,6 @@
 #include <trackbase/TrkrCluster.h>  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>  // for getLayer, clu...
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 // sPHENIX Geant4 includes
 #include <g4detectors/PHG4CylinderCellGeom.h>
@@ -447,11 +445,9 @@ void PHRTreeSeeding::FillTree()
   int nlayer[60];
   for (int j = 0; j < 60; j++) nlayer[j] = 0;
 
-  auto hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  {
+    auto range = _cluster_map->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       TrkrCluster *cluster = clusIter->second;
       TrkrDefs::cluskey ckey = clusIter->first;

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -10,8 +10,6 @@
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 
 #include <g4eval/SvtxClusterEval.h>
 #include <g4eval/SvtxEvalStack.h>
@@ -86,11 +84,9 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* /*topNode*/)
   TrkClustersMap m_trackID_clusters;
 
   // loop over all clusters
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys())
+  {
+    auto range = _cluster_map->getClusters(hitsetkey);
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
     TrkrCluster* cluster = clusIter->second;
     TrkrDefs::cluskey cluskey = clusIter->first;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -31,7 +31,6 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
 
@@ -310,14 +309,6 @@ int PHSimpleKFProp::get_nodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  _hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!_hitsets)
-    {
-      std::cerr << PHWHERE << "No hitset container on node tree. Bailing."
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-
   PHG4CylinderCellGeomContainer *geom_container =
       findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!geom_container)
@@ -406,10 +397,9 @@ PositionMap PHSimpleKFProp::PrepareKDTrees()
     return globalPositions;
   }
 
-  auto hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::tpcId);
-  for (auto hitsetitr = hitsetrange.first; hitsetitr != hitsetrange.second; ++hitsetitr)
+  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
   {
-    auto range = _cluster_map->getClusters(hitsetitr->first);
+    auto range = _cluster_map->getClusters(hitsetkey);
     for (TrkrClusterContainer::ConstIterator it = range.first; it != range.second; ++it)
     {
       TrkrDefs::cluskey cluskey = it->first;

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -31,7 +31,6 @@ class PHField;
 class SvtxTrack;
 class SvtxTrack_v3;
 class TpcDistortionCorrectionContainer;
-class TrkrHitSetContainer;
 class TrkrClusterContainer;
 class TrkrClusterIterationMapv1;
 class SvtxTrackMap;
@@ -96,7 +95,6 @@ class PHSimpleKFProp : public SubsysReco
 
   TrkrClusterContainer *_cluster_map = nullptr;
   SvtxTrackMap *_track_map = nullptr;
-  TrkrHitSetContainer *_hitsets = nullptr;
   PHField* _field_map = nullptr;
   
   /// acts geometry

--- a/offline/packages/trackreco/PHTrackPropagating.cc
+++ b/offline/packages/trackreco/PHTrackPropagating.cc
@@ -5,7 +5,6 @@
 
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -20,13 +19,7 @@ using namespace std;
 
 PHTrackPropagating::PHTrackPropagating(const std::string& name)
   : SubsysReco(name)
-  , _cluster_map(nullptr)
-  , _hitsets(nullptr)
-  , _vertex_map(nullptr)
-  , _track_map(nullptr)
-  , _track_map_name("SvtxTrackMap")
-{
-}
+{}
 
 int PHTrackPropagating::InitRun(PHCompositeNode* topNode)
 {
@@ -68,14 +61,6 @@ int PHTrackPropagating::GetNodes(PHCompositeNode* topNode)
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-
-  _hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-  if(!_hitsets)
-    {
-      cerr << PHWHERE << "No hitset container on node tree. Bailing."
-		<< endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
 
   _vertex_map = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   if (!_vertex_map)

--- a/offline/packages/trackreco/PHTrackPropagating.h
+++ b/offline/packages/trackreco/PHTrackPropagating.h
@@ -17,7 +17,6 @@
 class PHCompositeNode;
 
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class SvtxVertexMap;
 class SvtxTrackMap;
 
@@ -29,7 +28,7 @@ class PHTrackPropagating : public SubsysReco
 {
  public:
   PHTrackPropagating(const std::string &name = "PHTrackPropagating");
-  ~PHTrackPropagating() override {}
+  ~PHTrackPropagating() override = default;
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -51,12 +50,11 @@ class PHTrackPropagating : public SubsysReco
 
 
   //SvtxClusterMap *_cluster_map;
-  TrkrClusterContainer *_cluster_map;
-  TrkrHitSetContainer  *_hitsets;
-  SvtxVertexMap *_vertex_map;
-  SvtxTrackMap *_track_map;
+  TrkrClusterContainer *_cluster_map = nullptr;
+  SvtxVertexMap *_vertex_map = nullptr;
+  SvtxTrackMap *_track_map = nullptr;
 
-  std::string _track_map_name;
+  std::string _track_map_name = "SvtxTrackMap";
 
   bool _use_truth_clusters = false;
 

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -12,7 +12,6 @@
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
 
@@ -206,15 +205,16 @@ int PHTruthClustering::process_event(PHCompositeNode* topNode)
     }
 
   // For the other subsystems, we just copy over all of the the clusters from the reco map
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _reco_cluster_map->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_reco_cluster_map->getHitSetKeys())
+  {
+    auto range = _reco_cluster_map->getClusters(hitsetkey);
+    unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
+
+    // skip TPC
+    if(trkrid == TrkrDefs::tpcId)  continue;
+    
     for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
       TrkrDefs::cluskey cluskey = clusIter->first;
-      unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
-      if(trkrid == TrkrDefs::tpcId)  continue;
 
       // we have to make a copy of the cluster, to avoid problems later
       TrkrCluster* cluster = (TrkrCluster*) clusIter->second->CloneMe();

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -20,7 +20,6 @@ class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
 class TrkrCluster;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 
 #include <string>             // for string
 #include <vector>
@@ -63,7 +62,6 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
   int iclus = 0;
 
   TrkrClusterContainer *_reco_cluster_map{nullptr};
-  TrkrHitSetContainer  *_hitsets = {nullptr};
   PHG4TruthInfoContainer *_g4truth_container{nullptr};
 
   PHG4HitContainer* _g4hits_svtx{nullptr};

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -15,7 +15,6 @@ class SvtxTrackMap;
 class SvtxTrack;
 class SvtxVertexMap;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
 class PHG4TruthInfoContainer;
@@ -68,7 +67,6 @@ class PHTruthSiliconAssociation : public SubsysReco
   
   TrkrClusterContainer *_cluster_map{nullptr};
   TrkrClusterContainer *_corrected_cluster_map{nullptr};
-  TrkrHitSetContainer  *_hitsets{nullptr};
   TrkrClusterHitAssoc *_cluster_hit_map{nullptr};
   TrkrHitTruthAssoc *_hit_truth_map{nullptr};
   SvtxTrackMap *_track_map{nullptr};

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.cc
@@ -9,7 +9,6 @@
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase_historic/ActsTransformations.h>
 
 #include <g4main/PHG4Hit.h>
@@ -35,7 +34,6 @@ using namespace std;
 SvtxClusterEval::SvtxClusterEval(PHCompositeNode* topNode)
   : _hiteval(topNode)
   , _clustermap(nullptr)
-  , _hitsets(nullptr)
   , _truthinfo(nullptr)
   , _strict(false)
   , _verbosity(0)
@@ -922,11 +920,9 @@ void SvtxClusterEval::FillRecoClusterFromG4HitCache(){
 
   std::multimap<PHG4Particle*, TrkrDefs::cluskey> temp_clusters_from_particles;
   // loop over all the clusters
-  auto hitsetrange = _hitsets->getHitSets();
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _clustermap->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_clustermap->getHitSetKeys())
+  {
+    auto range = _clustermap->getClusters(hitsetkey);
     for( auto iter = range.first; iter != range.second; ++iter ){
       TrkrDefs::cluskey cluster_key = iter->first;
       
@@ -989,11 +985,9 @@ std::set<TrkrDefs::cluskey> SvtxClusterEval::all_clusters_from(PHG4Hit* truthhit
       // get all reco clusters
       if(_verbosity > 1) cout << "all_clusters_from_g4hit: list all reco clusters " << endl;
     
-      auto hitsetrange = _hitsets->getHitSets();
-      for (auto hitsetitr = hitsetrange.first;
-	   hitsetitr != hitsetrange.second;
-	   ++hitsetitr){
-	auto range = _clustermap->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_clustermap->getHitSetKeys())
+  {
+    auto range = _clustermap->getClusters(hitsetkey);
 	for( auto iter = range.first; iter != range.second; ++iter ){
 	  TrkrDefs::cluskey cluster_key = iter->first;
 	  int layer = TrkrDefs::getLayer(cluster_key);
@@ -1110,12 +1104,9 @@ TrkrDefs::cluskey SvtxClusterEval::best_cluster_by_nhit(int gid, int layer)
     // cout << "cache size ==0" << endl;
     if(_verbosity > 1) cout << "all_clusters: found # " << _clustermap->size() << endl;
     
-    // loop over clusters and get all contributing hits
-    auto hitsetrange = _hitsets->getHitSets();
-    for (auto hitsetitr = hitsetrange.first;
-	 hitsetitr != hitsetrange.second;
-	 ++hitsetitr){
-      auto range = _clustermap->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_clustermap->getHitSetKeys())
+  {
+      auto range = _clustermap->getClusters(hitsetkey);
       for( auto iter = range.first; iter != range.second; ++iter ){
 	TrkrDefs::cluskey cluster_key = iter->first;
 	int layer_in = TrkrDefs::getLayer(cluster_key);
@@ -1315,7 +1306,6 @@ void SvtxClusterEval::get_node_pointers(PHCompositeNode* topNode)
     }
   
 
-  _hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
   _cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
   _hit_truth_map = findNode::getClass<TrkrHitTruthAssoc>(topNode,"TRKR_HITTRUTHASSOC");
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
@@ -1334,11 +1324,9 @@ void SvtxClusterEval::fill_cluster_layer_map()
 {
   ActsTransformations transformer;
   // loop over all the clusters
-  auto hitsetrange = _hitsets->getHitSets(TrkrDefs::TrkrId::inttId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = _clustermap->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:_clustermap->getHitSetKeys())
+  {
+    auto range = _clustermap->getClusters(hitsetkey);
     for( auto iter = range.first; iter != range.second; ++iter ){
       TrkrDefs::cluskey cluster_key = iter->first;
       unsigned int ilayer = TrkrDefs::getLayer(cluster_key);

--- a/simulation/g4simulation/g4eval/SvtxClusterEval.h
+++ b/simulation/g4simulation/g4eval/SvtxClusterEval.h
@@ -22,7 +22,6 @@ class PHG4TruthInfoContainer;
 
 class TrkrCluster;
 class TrkrClusterContainer;
-class TrkrHitSetContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
 class SvtxTruthEval;
@@ -99,7 +98,6 @@ class SvtxClusterEval
   SvtxHitEval _hiteval;
   TrkrClusterContainer* _clustermap;
   TrkrClusterHitAssoc* _cluster_hit_map;
-  TrkrHitSetContainer  *_hitsets;
   TrkrHitTruthAssoc* _hit_truth_map;
   PHG4TruthInfoContainer* _truthinfo;
   PHG4HitContainer * _g4hits_tpc;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -10,6 +10,7 @@
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/ActsSurfaceMaps.h>
@@ -18,7 +19,6 @@
 
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
 
@@ -359,15 +359,11 @@ void SvtxEvaluator::printInputInfo(PHCompositeNode* topNode)
     if(!clustermap)
       clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
     
-    TrkrHitSetContainer* hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-    
-    if (clustermap!=nullptr&&hitsets!=nullptr){
+    if (clustermap!=nullptr){
       unsigned int icluster = 0;
-      auto hitsetrange = hitsets->getHitSets(TrkrDefs::TrkrId::inttId);
-      for (auto hitsetitr = hitsetrange.first;
-	   hitsetitr != hitsetrange.second;
-	   ++hitsetitr){
-	auto range = clustermap->getClusters(hitsetitr->first);
+      for(const auto& hitsetkey:clustermap->getHitSetKeys())
+      {
+	auto range = clustermap->getClusters(hitsetkey);
 	for( auto iter = range.first; iter != range.second; ++iter ){
 	  TrkrDefs::cluskey cluster_key = iter->first;
 	  cout << icluster << " with key " << cluster_key << " of " << clustermap->size();
@@ -905,19 +901,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	   << " occ316 = " << occ316
 	   << endl;
     }
-  TrkrHitSetContainer* hitsets = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-
   TrkrClusterContainer* clustermap_in = findNode::getClass<TrkrClusterContainer>(topNode, "CORRECTED_TRKR_CLUSTER");
   if(!clustermap_in)
     clustermap_in = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
   nclus_all = clustermap_in->size();
 
-  auto hitsetrange = hitsets->getHitSets(TrkrDefs::TrkrId::inttId);
-  for (auto hitsetitr = hitsetrange.first;
-       hitsetitr != hitsetrange.second;
-       ++hitsetitr){
-    auto range = clustermap_in->getClusters(hitsetitr->first);
+  for(const auto& hitsetkey:clustermap_in->getHitSetKeys())
+  {
+    auto range = clustermap_in->getClusters(hitsetkey);
     for( auto iter_cin = range.first; iter_cin != range.second; ++iter_cin ){
       TrkrDefs::cluskey cluster_key = iter_cin->first;
       unsigned int layer = TrkrDefs::getLayer(cluster_key);
@@ -1759,20 +1751,18 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	cout << "got clusterhitmap" << endl;
       else
 	cout << "no clusterhitmap" << endl;
-      
       if (hitsets != nullptr)
-	cout << "got hitsets" << endl;
+       cout << "got hitsets" << endl;
       else
-	cout << "no hitsets" << endl;
+       cout << "no hitsets" << endl;
+     
     }
 
-    if (clustermap != nullptr && clusterhitmap != nullptr && hitsets != nullptr){
-      auto hitsetrange = hitsets->getHitSets();
-      for (auto hitsetitr = hitsetrange.first;
-	   hitsetitr != hitsetrange.second;
-	   ++hitsetitr){
-	int hitsetlayer = TrkrDefs::getLayer(hitsetitr->first);
-	auto range = clustermap->getClusters(hitsetitr->first);
+    if (clustermap && clusterhitmap && hitsets ){
+      for(const auto& hitsetkey:clustermap->getHitSetKeys())
+      {
+        int hitsetlayer = TrkrDefs::getLayer(hitsetkey);
+	auto range = clustermap->getClusters(hitsetkey);
 	for( auto iter = range.first; iter != range.second; ++iter ){
 	  TrkrDefs::cluskey cluster_key = iter->first;
 	  TrkrCluster *cluster = clustermap->findCluster(cluster_key);

--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -433,32 +433,27 @@ void TrackEvaluation::evaluate_event()
 
   // create event struct
   TrackEvaluationContainerv1::EventStruct event;
-  if( m_hitsetcontainer )
+  if(m_cluster_map)
   {
-    // loop over hitsets
-    for(const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
+    for(const auto& hitsetkey:m_cluster_map->getHitSetKeys())
     {
       const auto trkrId = TrkrDefs::getTrkrId(hitsetkey);
       const auto layer = TrkrDefs::getLayer(hitsetkey);
       assert(layer<TrackEvaluationContainerv1::EventStruct::max_layer);
 
-      if(m_cluster_map)
+      // fill cluster related information
+      const auto clusters = m_cluster_map->getClusters(hitsetkey);
+      const int nclusters = std::distance( clusters.first, clusters.second );
+      
+      switch( trkrId )
       {
-
-        // fill cluster related information
-        const auto clusters = m_cluster_map->getClusters(hitsetkey);
-        const int nclusters = std::distance( clusters.first, clusters.second );
-
-        switch( trkrId )
-        {
-          case TrkrDefs::mvtxId: event.nclusters_mvtx += nclusters; break;
-          case TrkrDefs::inttId: event.nclusters_intt += nclusters; break;
-          case TrkrDefs::tpcId: event.nclusters_tpc += nclusters; break;
-          case TrkrDefs::micromegasId: event.nclusters_micromegas += nclusters; break;
-        }
-
-        event.nclusters[layer] += nclusters;
+        case TrkrDefs::mvtxId: event.nclusters_mvtx += nclusters; break;
+        case TrkrDefs::inttId: event.nclusters_intt += nclusters; break;
+        case TrkrDefs::tpcId: event.nclusters_tpc += nclusters; break;
+        case TrkrDefs::micromegasId: event.nclusters_micromegas += nclusters; break;
       }
+      
+      event.nclusters[layer] += nclusters;
     }
   }
 
@@ -476,7 +471,7 @@ void TrackEvaluation::evaluate_clusters()
   m_container->clearClusters();
 
   // first loop over hitsets
-  for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets()))
+  for( const auto& hitsetkey:m_cluster_map->getHitSetKeys())
   {
     for( const auto& [key,cluster]:range_adaptor(m_cluster_map->getClusters(hitsetkey)))
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR allows to loop over the relevant hitset keys in the clusterContainer without having to resort to looking into TrkrHitSetContainer. 
@bogui56 this should allow to run our track reconstruction code starting from clusters directly without having to also read the otherwise unused TrkrHitSetContainer from the input DST. 
Also makes the code cleaner. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

