### PR TITLE
Add vertex chisq/ndf calculation

### DIFF
--- a/offline/packages/trackreco/PHActsVertexPropagator.h
+++ b/offline/packages/trackreco/PHActsVertexPropagator.h
@@ -43,6 +43,8 @@ class PHActsVertexPropagator : public SubsysReco
   Acts::Vector3 getVertex(const unsigned int vtxid);
   void updateSvtxTrack(SvtxTrack* track, const Acts::BoundTrackParameters& params);
   void updateTrackDCA(SvtxTrack* track);
+  void setVtxChi2();
+  
   ActsTrackingGeometry *m_tGeometry = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The vertex chisq/ndf was previously just set to 0 because we didn't explicitly calculate it. This fixes that and assigns the vertex a proper chisq.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

