### PR TITLE
Truth compress for simulation physics analysis based on tracking and calorimetry

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -315,6 +315,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
   using ParticleMap = std::map<int, KeySet>;
   ParticleMap g4particle_map;
 
+  if (m_cluster_map)
   {
     // loop over clusters
     for(const auto& hitsetkey:m_cluster_map->getHitSetKeys())
@@ -648,15 +649,15 @@ int QAG4SimulationTracking::load_nodes(PHCompositeNode *topNode)
 
   // cluster map
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-  assert(m_cluster_map);
+//  assert(m_cluster_map);
 
   // cluster hit association map
   m_cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
-  assert(m_cluster_hit_map);
+//  assert(m_cluster_hit_map);
 
   // cluster hit association map
   m_hit_truth_map = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
-  assert(m_hit_truth_map);
+//  assert(m_hit_truth_map);
 
   // g4hits
   m_g4hits_tpc = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_TPC");
@@ -675,6 +676,8 @@ QAG4SimulationTracking::get_histo_prefix()
 
 QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::cluskey cluster_key) const
 {
+  assert(m_cluster_hit_map);
+
   // find hitset associated to cluster
   G4HitSet out;
   const auto hitset_key = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
@@ -699,18 +702,22 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
       switch (TrkrDefs::getTrkrId(hitset_key))
       {
       case TrkrDefs::mvtxId:
+        assert(m_g4hits_mvtx);
         if (m_g4hits_mvtx) g4hit = m_g4hits_mvtx->findHit(g4hit_key);
         break;
 
       case TrkrDefs::inttId:
+        assert(m_g4hits_intt);
         if (m_g4hits_intt) g4hit = m_g4hits_intt->findHit(g4hit_key);
         break;
 
       case TrkrDefs::tpcId:
+        assert(m_g4hits_tpc);
         if (m_g4hits_tpc) g4hit = m_g4hits_tpc->findHit(g4hit_key);
         break;
 
       case TrkrDefs::micromegasId:
+        assert(m_g4hits_micromegas);
         if (m_g4hits_micromegas) g4hit = m_g4hits_micromegas->findHit(g4hit_key);
         break;
 

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.cc
@@ -3,12 +3,12 @@
 PHG4ParticleSvtxMap::Map DummyPHG4ParticleSvtxMap;
 PHG4ParticleSvtxMap::WeightedRecoTrackMap emptyRecoMap;
 
-const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int) const 
+const PHG4ParticleSvtxMap::WeightedRecoTrackMap & PHG4ParticleSvtxMap::get(const int) const
 {
   return emptyRecoMap;
 }
 
-PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int) 
+PHG4ParticleSvtxMap::WeightedRecoTrackMap & PHG4ParticleSvtxMap::get(const int)
 {
   return emptyRecoMap;
 }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
@@ -32,8 +32,8 @@ class PHG4ParticleSvtxMap : public PHObject
   virtual std::size_t count(const int) const { return 0; }
   virtual void clear() {}
 
-  virtual const WeightedRecoTrackMap get(const int) const;
-  virtual WeightedRecoTrackMap get(const int);
+  virtual const WeightedRecoTrackMap & get(const int) const;
+  virtual WeightedRecoTrackMap & get(const int);
   virtual WeightedRecoTrackMap insert(const int, const WeightedRecoTrackMap);
   virtual std::size_t erase(const int) { return 0; }
 

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
@@ -56,7 +56,7 @@ PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap_v1::insert(const i
   return map;
 }
 
-const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int key) const
+const PHG4ParticleSvtxMap::WeightedRecoTrackMap & PHG4ParticleSvtxMap_v1::get(const int key) const
 {
   const auto iter = m_map.find(key);
   if (iter == m_map.end())

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.cc
@@ -1,33 +1,33 @@
 #include "PHG4ParticleSvtxMap_v1.h"
 
-PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1() 
+PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1()
   : m_map()
-{}
+{
+}
 
 PHG4ParticleSvtxMap_v1::PHG4ParticleSvtxMap_v1(const PHG4ParticleSvtxMap_v1& map)
   : m_map()
 {
   for (ConstIter iter = map.begin(); iter != map.end(); ++iter)
-    {
-      WeightedRecoTrackMap trackmap = iter->second;
-      m_map.insert(std::make_pair(iter->first, trackmap));
-    }
+  {
+    WeightedRecoTrackMap trackmap = iter->second;
+    m_map.insert(std::make_pair(iter->first, trackmap));
+  }
 }
-
 
 PHG4ParticleSvtxMap_v1& PHG4ParticleSvtxMap_v1::operator=(const PHG4ParticleSvtxMap_v1& map)
 {
   Reset();
-  
-  for(ConstIter iter = map.begin(); iter != map.end(); ++iter)
-    {
-      m_map.insert(std::make_pair(iter->first, iter->second));
-    }
+
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter)
+  {
+    m_map.insert(std::make_pair(iter->first, iter->second));
+  }
 
   return *this;
 }
 
-PHG4ParticleSvtxMap_v1::~PHG4ParticleSvtxMap_v1() 
+PHG4ParticleSvtxMap_v1::~PHG4ParticleSvtxMap_v1()
 {
   Reset();
 }
@@ -36,21 +36,35 @@ void PHG4ParticleSvtxMap_v1::identify(std::ostream& os) const
 {
   os << "PHG4ParticleSvtxMap_v1 size = " << m_map.size() << std::endl;
 
-  for(const auto& [g4id, matchedRecoTracks] : m_map)
+  for (const auto& [g4id, matchedRecoTracks] : m_map)
+  {
+    os << "G4Particle " << g4id << " has matched reco tracks " << std::endl;
+    for (const auto& [weight, trackset] : matchedRecoTracks)
     {
-      os << "G4Particle " << g4id << " has matched reco tracks " << std::endl;
-      for(const auto& [weight, trackset] : matchedRecoTracks) 
-	{
-	  os << "  weight " << weight << " has reco tracks " << std::endl;
-	  for(const auto& track : trackset)
-	    { os << "    trackid : " << track << std::endl; }
-	}
+      os << "  weight " << weight << " has reco tracks " << std::endl;
+      for (const auto& track : trackset)
+      {
+        os << "    trackid : " << track << std::endl;
+      }
     }
-
+  }
 }
 
 PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap_v1::insert(const int key, const PHG4ParticleSvtxMap::WeightedRecoTrackMap map)
 {
-  m_map.insert(std::make_pair(key, map)); 
+  m_map.insert(std::make_pair(key, map));
   return map;
+}
+
+const PHG4ParticleSvtxMap::WeightedRecoTrackMap PHG4ParticleSvtxMap::get(const int key) const
+{
+  const auto iter = m_map.find(key);
+  if (iter == m_map.end())
+  {
+    return PHG4ParticleSvtxMap::get(key);
+  }
+  else
+  {
+    return iter->second;
+  }
 }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -3,10 +3,8 @@
 
 #include "PHG4ParticleSvtxMap.h"
 
-
 class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
 {
-
  public:
   PHG4ParticleSvtxMap_v1();
   PHG4ParticleSvtxMap_v1(const PHG4ParticleSvtxMap_v1& map);
@@ -23,16 +21,32 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
   void clear() override { m_map.clear(); }
 
   const WeightedRecoTrackMap get(const int key) const override
-    { return m_map.find(key)->second; }
+  {
+    const auto iter = m_map.find(key);
+    if (iter == m_map.end())
+    {
+      return PHG4ParticleSvtxMap::get(key);
+    }
+    else
+    {
+      return iter->second;
+    }
+  }
   WeightedRecoTrackMap get(const int key) override
-    { return m_map.find(key)->second; }
-  WeightedRecoTrackMap insert(const int key, const WeightedRecoTrackMap map) override;   
+  {
+    return m_map[key];
+  }
+  WeightedRecoTrackMap insert(const int key, const WeightedRecoTrackMap map) override;
   std::size_t erase(const int key) override
-    { return m_map.erase(key); }
+  {
+    return m_map.erase(key);
+  }
 
   ConstIter begin() const override { return m_map.begin(); }
-  ConstIter find(const int key) const override 
-    { return m_map.find(key); }
+  ConstIter find(const int key) const override
+  {
+    return m_map.find(key);
+  }
   ConstIter end() const override { return m_map.end(); }
 
   Iter begin() override { return m_map.begin(); }
@@ -44,6 +58,5 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
 
   ClassDefOverride(PHG4ParticleSvtxMap_v1, 1);
 };
-
 
 #endif

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -20,18 +20,7 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
   std::size_t count(const int key) const override { return m_map.count(key); }
   void clear() override { m_map.clear(); }
 
-  const WeightedRecoTrackMap get(const int key) const override
-  {
-    const auto iter = m_map.find(key);
-    if (iter == m_map.end())
-    {
-      return PHG4ParticleSvtxMap::get(key);
-    }
-    else
-    {
-      return iter->second;
-    }
-  }
+  const WeightedRecoTrackMap get(const int key) const override;
   WeightedRecoTrackMap get(const int key) override
   {
     return m_map[key];

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -20,8 +20,8 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
   std::size_t count(const int key) const override { return m_map.count(key); }
   void clear() override { m_map.clear(); }
 
-  const WeightedRecoTrackMap get(const int key) const override;
-  WeightedRecoTrackMap get(const int key) override
+  const WeightedRecoTrackMap & get(const int key) const override;
+  WeightedRecoTrackMap & get(const int key) override
   {
     return m_map[key];
   }

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -3,6 +3,8 @@
 
 #include "PHG4ParticleSvtxMap.h"
 
+#include <iostream>
+
 class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
 {
  public:

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.cc
@@ -3,12 +3,12 @@
 SvtxPHG4ParticleMap::Map DummySvtxPHG4ParticleMap;
 SvtxPHG4ParticleMap::WeightedTruthTrackMap emptyTruthMap;
 
-const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int) const 
+const SvtxPHG4ParticleMap::WeightedTruthTrackMap & SvtxPHG4ParticleMap::get(const unsigned int) const
 {
   return emptyTruthMap;
 }
 
-SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int) 
+SvtxPHG4ParticleMap::WeightedTruthTrackMap & SvtxPHG4ParticleMap::get(const unsigned int)
 {
   return emptyTruthMap;
 }

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
@@ -31,8 +31,8 @@ class SvtxPHG4ParticleMap : public PHObject
   virtual std::size_t count(const unsigned int) const { return 0; }
   virtual void clear() {}
 
-  virtual const WeightedTruthTrackMap get(const unsigned int) const;
-  virtual WeightedTruthTrackMap get(const unsigned int);
+  virtual const WeightedTruthTrackMap & get(const unsigned int) const;
+  virtual WeightedTruthTrackMap & get(const unsigned int);
   virtual WeightedTruthTrackMap insert(const unsigned int, const WeightedTruthTrackMap);
   virtual std::size_t erase(const unsigned int) { return 0; }
 

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
@@ -55,7 +55,7 @@ SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap_v1::insert(const 
   return map;
 }
 
-const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int key) const
+const SvtxPHG4ParticleMap::WeightedTruthTrackMap & SvtxPHG4ParticleMap_v1::get(const unsigned int key) const
 {
   const auto iter = m_map.find(key);
   if (iter == m_map.end())

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.cc
@@ -54,3 +54,16 @@ SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap_v1::insert(const 
   m_map.insert(std::make_pair(key, map)); 
   return map;
 }
+
+const SvtxPHG4ParticleMap::WeightedTruthTrackMap SvtxPHG4ParticleMap::get(const unsigned int key) const
+{
+  const auto iter = m_map.find(key);
+  if (iter == m_map.end())
+  {
+    return SvtxPHG4ParticleMap::get(key);
+  }
+  else
+  {
+    return iter->second;
+  }
+}

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -3,10 +3,8 @@
 
 #include "SvtxPHG4ParticleMap.h"
 
-
 class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
 {
-
  public:
   SvtxPHG4ParticleMap_v1();
   SvtxPHG4ParticleMap_v1(const SvtxPHG4ParticleMap_v1& map);
@@ -24,16 +22,32 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
   void clear() override { m_map.clear(); }
 
   const WeightedTruthTrackMap get(const unsigned int key) const override
-    { return m_map.find(key)->second; }
+  {
+    const auto iter = m_map.find(key);
+    if (iter == m_map.end())
+    {
+      return SvtxPHG4ParticleMap::get(key);
+    }
+    else
+    {
+      return iter->second;
+    }
+  }
   WeightedTruthTrackMap get(const unsigned int key) override
-    { return m_map.find(key)->second; }
-  WeightedTruthTrackMap insert(const unsigned int key, const WeightedTruthTrackMap map) override;   
+  {
+    return m_map[key];
+  }
+  WeightedTruthTrackMap insert(const unsigned int key, const WeightedTruthTrackMap map) override;
   std::size_t erase(const unsigned int key) override
-    { return m_map.erase(key); }
+  {
+    return m_map.erase(key);
+  }
 
   ConstIter begin() const override { return m_map.begin(); }
-  ConstIter find(const unsigned int key) const override 
-    { return m_map.find(key); }
+  ConstIter find(const unsigned int key) const override
+  {
+    return m_map.find(key);
+  }
   ConstIter end() const override { return m_map.end(); }
 
   Iter begin() override { return m_map.begin(); }
@@ -45,6 +59,5 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
 
   ClassDefOverride(SvtxPHG4ParticleMap_v1, 1);
 };
-
 
 #endif

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -2,6 +2,7 @@
 #define TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_V1_H
 
 #include "SvtxPHG4ParticleMap.h"
+#include <iostream>
 
 class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
 {

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -21,19 +21,8 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
   std::size_t count(const unsigned int key) const override { return m_map.count(key); }
   void clear() override { m_map.clear(); }
 
-  const WeightedTruthTrackMap get(const unsigned int key) const override
-  {
-    const auto iter = m_map.find(key);
-    if (iter == m_map.end())
-    {
-      return SvtxPHG4ParticleMap::get(key);
-    }
-    else
-    {
-      return iter->second;
-    }
-  }
-  WeightedTruthTrackMap get(const unsigned int key) override
+  const WeightedTruthTrackMap & get(const unsigned int key) const override;
+  WeightedTruthTrackMap & get(const unsigned int key) override
   {
     return m_map[key];
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3LinkDef.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3LinkDef.h
@@ -3,5 +3,7 @@
 #pragma link C++ class PHG4CylinderGeom_Spacalv3 + ;
 #pragma link C++ class PHG4CylinderGeom_Spacalv3::geom_tower + ;
 #pragma link C++ class PHG4CylinderGeom_Spacalv3::scint_id_coder + ;
+#pragma link C++ class std::map<int,PHG4CylinderGeom_Spacalv3::geom_tower> + ;
+#pragma link C++ class std::pair<int,PHG4CylinderGeom_Spacalv3::geom_tower> + ;
 
 #endif /* __CINT__ */

--- a/simulation/g4simulation/g4eval/PHG4DstCompressReco.h
+++ b/simulation/g4simulation/g4eval/PHG4DstCompressReco.h
@@ -10,6 +10,8 @@ class PHCompositeNode;
 
 class PHG4CellContainer;
 class PHG4HitContainer;
+class SvtxPHG4ParticleMap;
+class PHG4ParticleSvtxMap;
 class PHG4TruthInfoContainer;
 
 class RawTowerContainer;
@@ -29,11 +31,19 @@ class PHG4DstCompressReco : public SubsysReco
   void AddHitContainer(const std::string &name) { _compress_g4hit_names.insert(name); }
   void AddCellContainer(const std::string &name) { _compress_g4cell_names.insert(name); }
   void AddTowerContainer(const std::string &name) { _compress_tower_names.insert(name); }
+  //! whether to compress tracker hits based on truth association table produced by PHG4DstCompressReco
+  void KeepRecoTrackMatchedParticles(bool b = true) { m_keepRecoTrackMatchedParticles = b; }
 
  private:
   void SearchG4HitNodes(PHCompositeNode *topNode);
 
+  //! whether to compress tracker hits based on truth association table produced by PHG4DstCompressReco
+  //! default to false
+  bool m_keepRecoTrackMatchedParticles = false;
+
   PHG4TruthInfoContainer *_truth_info;
+  PHG4ParticleSvtxMap *_truthRecoMap = nullptr;
+  SvtxPHG4ParticleMap *_recoTruthMap = nullptr;
   std::set<std::string> _compress_g4hit_names;
   std::set<std::string> _compress_g4cell_names;
   std::set<std::string> _compress_tower_names;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -905,22 +905,25 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
   if(!clustermap_in)
     clustermap_in = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
 
-  nclus_all = clustermap_in->size();
-
-  for(const auto& hitsetkey:clustermap_in->getHitSetKeys())
+  if (clustermap_in)
   {
-    auto range = clustermap_in->getClusters(hitsetkey);
-    for( auto iter_cin = range.first; iter_cin != range.second; ++iter_cin ){
-      TrkrDefs::cluskey cluster_key = iter_cin->first;
-      unsigned int layer = TrkrDefs::getLayer(cluster_key);
-      if (_nlayers_maps > 0)
-	if (layer < _nlayers_maps) nclus_maps++;
-      if (_nlayers_intt > 0)
-	if (layer >= _nlayers_maps && layer < _nlayers_maps + _nlayers_intt) nclus_intt++;
-      if (_nlayers_tpc > 0)
-	if (layer >= _nlayers_maps + _nlayers_intt && layer <  _nlayers_maps + _nlayers_intt + _nlayers_tpc) nclus_tpc++;
-      if (_nlayers_mms > 0)
-	if (layer >= _nlayers_maps + _nlayers_intt + _nlayers_tpc) nclus_mms++;
+    nclus_all = clustermap_in->size();
+
+    for(const auto& hitsetkey:clustermap_in->getHitSetKeys())
+    {
+      auto range = clustermap_in->getClusters(hitsetkey);
+      for( auto iter_cin = range.first; iter_cin != range.second; ++iter_cin ){
+        TrkrDefs::cluskey cluster_key = iter_cin->first;
+        unsigned int layer = TrkrDefs::getLayer(cluster_key);
+        if (_nlayers_maps > 0)
+    if (layer < _nlayers_maps) nclus_maps++;
+        if (_nlayers_intt > 0)
+    if (layer >= _nlayers_maps && layer < _nlayers_maps + _nlayers_intt) nclus_intt++;
+        if (_nlayers_tpc > 0)
+    if (layer >= _nlayers_maps + _nlayers_intt && layer <  _nlayers_maps + _nlayers_intt + _nlayers_tpc) nclus_tpc++;
+        if (_nlayers_mms > 0)
+    if (layer >= _nlayers_maps + _nlayers_intt + _nlayers_tpc) nclus_mms++;
+      }
     }
   }
   //-----------------------

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -225,7 +225,7 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track)
 
   if(_recoTruthMap != nullptr)
     {
-      SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
+      const SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
       if (map.size() == 0) return nullptr;
       auto itr = map.end();
       --itr;

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -226,6 +226,7 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track)
   if(_recoTruthMap != nullptr)
     {
       SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
+      if (map.size() == 0) return nullptr;
       auto itr = map.end();
       --itr;
       std::set<int> bestPartSet = itr->second;
@@ -457,7 +458,7 @@ SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle)
   
   if(_truthRecoMap != nullptr)
     {
-      PHG4ParticleSvtxMap::WeightedRecoTrackMap map = _truthRecoMap->get(truthparticle->get_track_id());
+      const PHG4ParticleSvtxMap::WeightedRecoTrackMap map = _truthRecoMap->get(truthparticle->get_track_id());
       /// No reco tracks found
       if(map.size() == 0)
 	{ return nullptr; }
@@ -954,12 +955,7 @@ void SvtxTrackEval::get_node_pointers(PHCompositeNode* topNode)
 
   _truthRecoMap = findNode::getClass<PHG4ParticleSvtxMap>(topNode, "PHG4ParticleSvtxMap");
 
-  if(_truthRecoMap && _truthRecoMap->size() == 0)
-    { _truthRecoMap = nullptr; }
-
   _recoTruthMap = findNode::getClass<SvtxPHG4ParticleMap>(topNode, "SvtxPHG4ParticleMap");
-  if(_recoTruthMap && _recoTruthMap->size() == 0)
-    { _recoTruthMap = nullptr; }
 
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
  

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -83,8 +83,8 @@ class SvtxTrackEval
   SvtxClusterEval _clustereval;
   SvtxTrackMap* _trackmap;
   PHG4TruthInfoContainer* _truthinfo;
-  PHG4ParticleSvtxMap* _truthRecoMap;
-  SvtxPHG4ParticleMap* _recoTruthMap;
+  const PHG4ParticleSvtxMap* _truthRecoMap;
+  const SvtxPHG4ParticleMap* _recoTruthMap;
 
   bool _strict;
   int _verbosity;

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
@@ -3,18 +3,18 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHDataNode.h>
 #include <phool/PHNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
-#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
 #include <trackbase_historic/PHG4ParticleSvtxMap_v1.h>
+#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
@@ -25,8 +25,8 @@
 #include <phool/PHCompositeNode.h>
 
 //____________________________________________________________________________..
-SvtxTruthRecoTableEval::SvtxTruthRecoTableEval(const std::string &name):
- SubsysReco(name)
+SvtxTruthRecoTableEval::SvtxTruthRecoTableEval(const std::string &name)
+  : SubsysReco(name)
 {
 }
 
@@ -36,7 +36,7 @@ SvtxTruthRecoTableEval::~SvtxTruthRecoTableEval()
 }
 
 //____________________________________________________________________________..
-int SvtxTruthRecoTableEval::Init(PHCompositeNode*)
+int SvtxTruthRecoTableEval::Init(PHCompositeNode *)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -44,8 +44,10 @@ int SvtxTruthRecoTableEval::Init(PHCompositeNode*)
 //____________________________________________________________________________..
 int SvtxTruthRecoTableEval::InitRun(PHCompositeNode *topNode)
 {
-  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    { return Fun4AllReturnCodes::ABORTEVENT; }
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -53,7 +55,6 @@ int SvtxTruthRecoTableEval::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int SvtxTruthRecoTableEval::process_event(PHCompositeNode *topNode)
 {
-
   if (!m_svtxevalstack)
   {
     m_svtxevalstack = new SvtxEvalStack(topNode);
@@ -69,9 +70,8 @@ int SvtxTruthRecoTableEval::process_event(PHCompositeNode *topNode)
   }
 
   fillTruthMap(topNode);
-  
-  fillRecoMap(topNode);
 
+  fillRecoMap(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -79,118 +79,112 @@ int SvtxTruthRecoTableEval::process_event(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int SvtxTruthRecoTableEval::ResetEvent(PHCompositeNode *)
 {
-  if(Verbosity() > 0) 
-    {
-      std::cout << "Truth track map " << std::endl;
-      m_truthMap->identify();
-      std::cout << std::endl << "Reco track map " << std::endl;
-      m_recoMap->identify();
-    }
+  if (Verbosity() > 0)
+  {
+    std::cout << "Truth track map " << std::endl;
+    m_truthMap->identify();
+    std::cout << std::endl
+              << "Reco track map " << std::endl;
+    m_recoMap->identify();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
-
 
 //____________________________________________________________________________..
 int SvtxTruthRecoTableEval::End(PHCompositeNode *)
 {
-  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode* topNode)
+void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode *topNode)
 {
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   assert(truthinfo);
-  
-  SvtxTrackEval* trackeval = m_svtxevalstack->get_track_eval();
+
+  SvtxTrackEval *trackeval = m_svtxevalstack->get_track_eval();
   assert(trackeval);
-  
+
   PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
-  if(m_scanForPrimaries)
+  if (m_scanForPrimaries)
+  {
+    range = truthinfo->GetPrimaryParticleRange();
+  }
+
+  for (auto iter = range.first; iter != range.second; ++iter)
+  {
+    PHG4Particle *g4particle = iter->second;
+    int gtrackID = g4particle->get_track_id();
+
+    std::set<SvtxTrack *> alltracks = trackeval->all_tracks_from(g4particle);
+    PHG4ParticleSvtxMap::WeightedRecoTrackMap recomap;
+
+    for (const auto &track : alltracks)
     {
-      range = truthinfo->GetPrimaryParticleRange();
+      /// We fill the map with a key corresponding to the ncluster contribution.
+      /// This weight could in principle be anything we choose
+      float clusCont = trackeval->get_nclusters_contribution(track, g4particle);
+      auto iterator = recomap.find(clusCont);
+      if (iterator == recomap.end())
+      {
+        std::set<unsigned int> dumset;
+        dumset.insert(track->get_id());
+        recomap.insert(std::make_pair(clusCont, dumset));
+      }
+      else
+      {
+        iterator->second.insert(track->get_id());
+      }
     }
 
-  for(auto iter = range.first; iter != range.second; ++iter)
-    {
-      PHG4Particle *g4particle = iter->second;
-      int gtrackID = g4particle->get_track_id();
-  
-      std::set<SvtxTrack*> alltracks = trackeval->all_tracks_from(g4particle);
-      PHG4ParticleSvtxMap::WeightedRecoTrackMap recomap;
-
-      for(const auto& track : alltracks)
-	{
-	  /// We fill the map with a key corresponding to the ncluster contribution.
-	  /// This weight could in principle be anything we choose
-	  float clusCont = trackeval->get_nclusters_contribution(track, g4particle);
-	  auto iterator = recomap.find(clusCont);
-	  if(iterator == recomap.end())
-	    {
-	      std::set<unsigned int> dumset;
-	      dumset.insert(track->get_id());
-	      recomap.insert(std::make_pair(clusCont, dumset));
-	    }
-	  else
-	    {
-	      iterator->second.insert(track->get_id());
-	    }
-	}
-
-      m_truthMap->insert(gtrackID, recomap);
-      
-    }
-
+    m_truthMap->insert(gtrackID, recomap);
+  }
 }
 
-void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode* topNode)
+void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode *topNode)
 {
-  SvtxTrackMap *trackMap = findNode::getClass<SvtxTrackMap>(topNode,"SvtxTrackMap");
-  
+  SvtxTrackMap *trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+
   assert(trackMap);
-  
-  SvtxTrackEval* trackeval = m_svtxevalstack->get_track_eval();
+
+  SvtxTrackEval *trackeval = m_svtxevalstack->get_track_eval();
   assert(trackeval);
 
-  for(const auto& [key, track] : *trackMap)
+  for (const auto &[key, track] : *trackMap)
+  {
+    std::set<PHG4Particle *> allparticles = trackeval->all_truth_particles(track);
+    SvtxPHG4ParticleMap::WeightedTruthTrackMap truthmap;
+    for (const auto &g4particle : allparticles)
     {
-      
-      std::set<PHG4Particle*> allparticles = trackeval->all_truth_particles(track);
-      SvtxPHG4ParticleMap::WeightedTruthTrackMap truthmap;
-      for(const auto& g4particle : allparticles)
-	{
-	  float  clusCont = trackeval->get_nclusters_contribution(track, g4particle);
-	  auto iterator = truthmap.find(clusCont);
-	  if(iterator == truthmap.end())
-	    {
-	      std::set<int> dumset;
-	      dumset.insert(g4particle->get_track_id());
-	      truthmap.insert(std::make_pair(clusCont, dumset));
-	    }
-	  else
-	    {
-	      iterator->second.insert(g4particle->get_track_id());
-	    }
-	}
-
-      m_recoMap->insert(key, truthmap);
-
+      float clusCont = trackeval->get_nclusters_contribution(track, g4particle);
+      auto iterator = truthmap.find(clusCont);
+      if (iterator == truthmap.end())
+      {
+        std::set<int> dumset;
+        dumset.insert(g4particle->get_track_id());
+        truthmap.insert(std::make_pair(clusCont, dumset));
+      }
+      else
+      {
+        iterator->second.insert(g4particle->get_track_id());
+      }
     }
+
+    m_recoMap->insert(key, truthmap);
+  }
 }
 
-int SvtxTruthRecoTableEval::createNodes(PHCompositeNode* topNode)
+int SvtxTruthRecoTableEval::createNodes(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
-  
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
   if (!dstNode)
   {
     std::cerr << "DST node is missing, quitting" << std::endl;
     throw std::runtime_error("Failed to find DST node in SvtxTruthRecoTableEval::createNodes");
   }
-  
+
   PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
 
   if (!svtxNode)
@@ -199,25 +193,23 @@ int SvtxTruthRecoTableEval::createNodes(PHCompositeNode* topNode)
     dstNode->addNode(svtxNode);
   }
 
+  m_truthMap = findNode::getClass<PHG4ParticleSvtxMap>(topNode, "PHG4ParticleSvtxMap");
+  if (!m_truthMap)
+  {
+    m_truthMap = new PHG4ParticleSvtxMap_v1;
+    PHIODataNode<PHObject> *truthNode =
+        new PHIODataNode<PHObject>(m_truthMap, "PHG4ParticleSvtxMap", "PHObject");
+    svtxNode->addNode(truthNode);
+  }
 
-  m_truthMap = findNode::getClass<PHG4ParticleSvtxMap>(topNode,"PHG4ParticleSvtxMap");
-  if(!m_truthMap)
-    {
-      m_truthMap = new PHG4ParticleSvtxMap_v1;
-      PHIODataNode<PHObject> *truthNode = 
-	new PHIODataNode<PHObject>(m_truthMap,"PHG4ParticleSvtxMap","PHObject");
-      svtxNode->addNode(truthNode);
-
-    } 
-
-  m_recoMap = findNode::getClass<SvtxPHG4ParticleMap>(topNode,"SvtxPHG4ParticleMap");
-  if(!m_recoMap)
-    {
-      m_recoMap = new SvtxPHG4ParticleMap_v1;
-      PHIODataNode<PHObject> *recoNode = 
-	new PHIODataNode<PHObject>(m_recoMap,"SvtxPHG4ParticleMap","PHObject");
-      svtxNode->addNode(recoNode);
-    }
+  m_recoMap = findNode::getClass<SvtxPHG4ParticleMap>(topNode, "SvtxPHG4ParticleMap");
+  if (!m_recoMap)
+  {
+    m_recoMap = new SvtxPHG4ParticleMap_v1;
+    PHIODataNode<PHObject> *recoNode =
+        new PHIODataNode<PHObject>(m_recoMap, "SvtxPHG4ParticleMap", "PHObject");
+    svtxNode->addNode(recoNode);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.h
@@ -15,30 +15,36 @@ class SvtxEvalStack;
 class SvtxTruthRecoTableEval : public SubsysReco
 {
  public:
-
   SvtxTruthRecoTableEval(const std::string &name = "SvtxTruthRecoTableEval");
 
   virtual ~SvtxTruthRecoTableEval();
 
-  int Init(PHCompositeNode*) override;
+  int Init(PHCompositeNode *) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int ResetEvent(PHCompositeNode *topNode) override;
- 
+
   int End(PHCompositeNode *topNode) override;
 
+  //! minimal momentum of particle to trigger an analysis and entry into the truth map.
+  //! default to 50MeV, bending before reaching the active TPC
+  void setMinMomentumTruthMap(const double v) { m_minMomentumTruthMap = v; }
 
  private:
-  int createNodes(PHCompositeNode* topNode);
+  int createNodes(PHCompositeNode *topNode);
 
   void fillTruthMap(PHCompositeNode *topNode);
   void fillRecoMap(PHCompositeNode *topNode);
 
   bool m_scanForPrimaries = false;
 
+  //! minimal momentum of particle to trigger an analysis and entry into the truth map.
+  //! default to 50MeV, bending before reaching the active TPC
+  double m_minMomentumTruthMap = 50e-3;
+
   PHG4ParticleSvtxMap *m_truthMap = nullptr;
   SvtxPHG4ParticleMap *m_recoMap = nullptr;
   SvtxEvalStack *m_svtxevalstack = nullptr;
 };
 
-#endif // SVTXTRUTHRECOTABLEEVAL_H
+#endif  // SVTXTRUTHRECOTABLEEVAL_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR implements the truth compress for generic simulation physics analysis based on tracking and calorimetry, following these previous work: 
* For calorimeters: the shower truth compression was built in long time ago by Mike McCumber with `PHG4DstCompressReco`
* Tracker compression was introduced at https://github.com/sPHENIX-Collaboration/coresoftware/pull/1465 and evaluator by passing at https://github.com/sPHENIX-Collaboration/coresoftware/pull/1470 

Then this PR introduce changes to
* `SvtxTruthRecoTableEval` to zero suppress empty entries. And user code to handle zero-suppressed entries (need more edge case tests)
* And for the truth->reco track map, only analyze those PHG4Particle that is above 50 MeV/c which loops before reaching the TPC active area. 
* Update to `PHG4DstCompressReco` to be aware of the particle that has track matching and not to delete them
* Modification to `SvtxEvaluator` and tracking QA to tolerate missing clusters if not configured to evaluate clustering

This allow us to 
* Drop all `PHG4Hit`s in tracker and calorimeter
* Has fast and high level association interface to ask the contributing track/calo-tower to `PHG4Particle`
* Drop `PHG4Particle` and `PHG4Vertex` that is not used in the high level association. 

## Example compression for MDC2

Here is a macro performing the compress and save a single DST for truth analysis with tracking and calorimeter for physics observables: 
https://github.com/blackcathj/FileCatalogTest/blob/master/Fun4All_DST_Compress.C 
and example readback macro: 
https://github.com/blackcathj/FileCatalogTest/blob/master/Fun4All_DST_ReadBack.C 
which still under validation. 

Currently, it free the analysis from [the large DSTs](https://nbviewer.org/github/blackcathj/FileCatalogTest/blob/master/FileCatalog.ipynb) such as 
* 5GB/segment `DST_CALO_G4HIT_pythia8_Charm_3MHz`
* 9GB/segment `DST_TRKR_G4HIT_pythia8_Charm_3MHz`
* 9GB/segment `DST_TRUTH_G4HIT_pythia8_Charm_3MHz`
* 2GB/segment `DST_TRKR_HIT_pythia8_Charm_3MHz`
* 2GB/segment `DST_TRACKS_pythia8_Charm_3MHz`
* 12GB/segment `DST_TRUTH_pythia8_Charm_3MHz`
And save [a single analysis DST `DST_TRUTH_RECO_ANALYSIS`](https://nbviewer.org/github/blackcathj/FileCatalogTest/blob/master/FileInspection_DST_TRUTH_RECO_ANALYSIS.ipynb), that is 1.6GB/segment

Note this is intended for analysis requiring simulation truth association. For analysis intended to mimic real data, please use the DST with reco objects only, `DST_TRACKS_pythia8_Charm_3MHz` and `DST_CALO_CLUSTER_pythia8_Charm_3MHz`

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Testing, validation. Not for merging yet. 

## Links to other PRs in macros and calibration repositories (if applicable)

