### PR TITLE
Track crossing

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack_v3.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v3.cc
@@ -53,6 +53,7 @@ void SvtxTrack_v3::CopyFrom( const SvtxTrack& source )
   _is_positive_charge = source.get_positive_charge();
   _chisq = source.get_chisq();
   _ndf = source.get_ndf();
+  _track_crossing = source.get_crossing();
   _dca = source.get_dca();
   _dca_error = source.get_dca_error();
   _dca2d = source.get_dca2d();

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -271,29 +271,22 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
        ++phtrk_iter)
     {
       SvtxTrack *track = phtrk_iter->second;
-      std::vector<short int > intt_crossings = getInttCrossings(track);
-      if(intt_crossings.size() == 0) 
+      const auto intt_crossings = getInttCrossings(track);
+      if(intt_crossings.empty()) 
 	{
 	  if(Verbosity() > 1) std::cout << " Silicon track " << track->get_id() << " has no INTT clusters" << std::endl;
 	  continue ;
-	}
-
-      short int crossing_keep = intt_crossings[0];
-      bool keep_it = true;
-      for(unsigned int ic=1; ic<intt_crossings.size(); ++ic)
-	{	  
-	  if(intt_crossings[ic] != crossing_keep)
-	    {
-	      if(Verbosity() > 1) 
-		std::cout << " INTT crossings not all the same for track " << track->get_id() << " crossing_keep " 
-			  << crossing_keep << " new crossing " << intt_crossings[ic] << "- dropping this match " << std::endl;
-	      keep_it = false;	      
-	    }
-	}
-      if(keep_it)
-	{            
-	  track->set_crossing(crossing_keep);
-	  if(Verbosity() > 1) std::cout << "                    Combined track " << track->get_id()  << " bunch crossing " << crossing_keep  << std::endl;           
+    
+	} else if( intt_crossings.size() > 1 ) {
+    
+    if(Verbosity() > 1) 
+    { std::cout << " INTT crossings not all the same for track " << track->get_id() << " crossing_keep - dropping this match " << std::endl; }
+    
+  } else {
+    
+    const auto& crossing = *intt_crossings.begin();
+	  track->set_crossing(crossing);
+	  if(Verbosity() > 1) std::cout << "                    Combined track " << track->get_id()  << " bunch crossing " << crossing << std::endl;           
 	}
     }
   
@@ -593,9 +586,9 @@ void PHTruthSiliconAssociation::copySiliconClustersToCorrectedMap( )
   }
 }
 
-std::vector<short int> PHTruthSiliconAssociation::getInttCrossings(SvtxTrack *si_track)
+std::set<short int> PHTruthSiliconAssociation::getInttCrossings(SvtxTrack *si_track) const
 {
-  std::vector<short int> intt_crossings;
+  std::set<short int> intt_crossings;
 
   // If the Si track contains an INTT hit, use it to get the bunch crossing offset
   // loop over associated clusters to get keys for silicon cluster
@@ -610,17 +603,16 @@ std::vector<short int> PHTruthSiliconAssociation::getInttCrossings(SvtxTrack *si
 	{
 	  // std::cout << "      INTT cluster key " << cluster_key << std::endl; 
 	  
-	  TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	  if( !cluster ) continue;	  
-	  
-	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
+	  const unsigned int layer = TrkrDefs::getLayer(cluster_key);
 	  
 	  // get the bunch crossings for all hits in this cluster
 	  auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
 	  for(auto iter = crossings.first; iter != crossings.second; ++iter)
 	    {
-	      std::cout << "      si Track " << si_track->get_id() << " cluster " << iter->first << " layer " << layer << " crossing " << iter->second  << std::endl;
-	      intt_crossings.push_back(iter->second);
+        const auto& [key, crossing] = *iter;
+        if( Verbosity() )
+        { std::cout << "PHTruthSiliconAssociation::getInttCrossings - si Track " << si_track->get_id() << " cluster " << key << " layer " << layer << " crossing " << crossing  << std::endl; }
+	      intt_crossings.insert(crossing);
 	    }
 	}
     }

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -56,7 +56,7 @@ class PHTruthSiliconAssociation : public SubsysReco
 
   std::vector<PHG4Particle*> getG4PrimaryParticle(SvtxTrack *track);
   std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
-  std::vector<short int> getInttCrossings(SvtxTrack *si_track);
+  std::set<short int> getInttCrossings(SvtxTrack *si_track) const;
 
   PHG4TruthInfoContainer* _g4truth_container{nullptr};
   PHG4HitContainer *_g4hits_tpc{nullptr};

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -1,17 +1,6 @@
 #include "PHTruthTrackSeeding.h"
 
-#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
-#include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
-#include <trackbase_historic/SvtxTrack_FastSim_v3.h>
-
-#include <trackbase/TrkrCluster.h>
-#include <trackbase/TrkrClusterContainer.h>
-
-
-#include <trackbase/TrkrHitTruthAssoc.h>
-#include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase_historic/SvtxVertex.h>
-#include <trackbase_historic/ActsTransformations.h>
+#include <fun4all/Fun4AllReturnCodes.h>
 
 #include <g4eval/SvtxClusterEval.h>
 #include <g4eval/SvtxEvalStack.h>
@@ -25,29 +14,32 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
-#include <fun4all/Fun4AllReturnCodes.h>
-
 #include <phool/getClass.h>
 #include <phool/phool.h>
+
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterCrossingAssoc.h> 
+#include <trackbase/TrkrHitTruthAssoc.h>
+#include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTra...
+#include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, Svtx...
+#include <trackbase_historic/SvtxTrack_FastSim_v3.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+#include <trackbase_historic/SvtxVertex.h>
 
 #include <TDatabasePDG.h>
 #include <TParticlePDG.h>
 
 #include <cstdlib>   // for exit
-#include <iostream>  // for operator<<, endl
+#include <iostream>  // for operator<<, std::endl 
 #include <map>       // for multimap, map<>::c...
 #include <memory>
 #include <utility>  // for pair
 #include <cassert>
 #include <set>
 
-#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-
 class PHCompositeNode;
-
-using namespace std;
 
 namespace
 { template< class T> inline constexpr T square( const T& x ) { return x*x; } }
@@ -59,7 +51,7 @@ PHTruthTrackSeeding::PHTruthTrackSeeding(const std::string& name)
 
 int PHTruthTrackSeeding::Setup(PHCompositeNode* topNode)
 {
-  cout << "Enter PHTruthTrackSeeding:: Setup" << endl;
+  std::cout << "Enter PHTruthTrackSeeding:: Setup" << std::endl ;
 
   int ret = PHTrackSeeding::Setup(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
@@ -68,8 +60,6 @@ int PHTruthTrackSeeding::Setup(PHCompositeNode* topNode)
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   _clustereval = new  SvtxClusterEval(topNode);
   _clustereval->do_caching(true);
-  // _clustereval.set_strict(strict);
-  //  _clustereval.set_verbosity(verbosity);
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -78,13 +68,12 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
   _clustereval->next_event(topNode);
   _track_map->Clear();
 
-  typedef std::map<int, std::set<TrkrCluster*> > TrkClustersMap;
+  using TrkClustersMap = std::map<int, std::set<TrkrCluster*> >;
   TrkClustersMap m_trackID_clusters;
 
-  vector<TrkrDefs::cluskey> ClusterKeyList; 
+  std::vector<TrkrDefs::cluskey> ClusterKeyList; 
 
-  PHG4TruthInfoContainer::ConstRange range = _g4truth_container->GetPrimaryParticleRange();
-  //  Float_t gntracks = (Float_t) truthinfo->GetNumPrimaryVertexParticles();
+  PHG4TruthInfoContainer::ConstRange range = m_g4truth_container->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second;
        ++iter){
@@ -92,7 +81,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     PHG4Particle* g4particle = iter->second;
 
     if (g4particle==NULL){
-      cout <<__PRETTY_FUNCTION__<<" - validity check failed: missing truth particle" <<endl;
+      std::cout <<__PRETTY_FUNCTION__<<" - validity check failed: missing truth particle" << std::endl;
       exit(1);
     }
 
@@ -107,7 +96,7 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
       
       if (monentum2 < _min_momentum * _min_momentum){
 	if (Verbosity() >= 3){
-	  cout <<__PRETTY_FUNCTION__<<" ignore low momentum particle "<< gtrackID <<endl;
+	  std::cout <<__PRETTY_FUNCTION__<<" ignore low momentum particle "<< gtrackID << std::endl;
 	  g4particle->identify();
 	}
 	continue;
@@ -153,50 +142,68 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
     svtx_track->set_pz(g4particle->get_pz() * (1 + random));
 
     // assign the track position using the truth vertex for this track
-    auto g4vertex = _g4truth_container->GetVtx(vertexID);
+    auto g4vertex = m_g4truth_container->GetVtx(vertexID);
     svtx_track->set_x(g4vertex->get_x() * (1 + random));
     svtx_track->set_y(g4vertex->get_y() * (1 + random));
     svtx_track->set_z(g4vertex->get_z() * (1 + random));
-      
-    for (TrkrDefs::cluskey cluskey : ClusterKeyList){
+    
+    // associate all cluster keys to the track
+    for( const auto& cluskey : ClusterKeyList){
       svtx_track->insert_cluster_key(cluskey);
     }
 
+    // set intt crossing
+    /* inspired from PHtruthSiliconAssociation */
+    const auto intt_crossings = getInttCrossings(svtx_track.get());
+    if(intt_crossings.empty()) 
+    {
+      if(Verbosity() > 1)  std::cout << "PHTruthTrackSeeding::Process - Silicon track " << svtx_track->get_id() << " has no INTT clusters" << std::endl;
+      continue ;
+    } else if( intt_crossings.size() > 1 ) {
+    
+      if(Verbosity() > 1) 
+      { std::cout << "PHTruthTrackSeeding::Process - INTT crossings not all the same for track " << svtx_track->get_id() << " crossing_keep - dropping this match " << std::endl; }
+      
+    } else {
+      
+      const auto& crossing = *intt_crossings.begin();
+      svtx_track->set_crossing(crossing);
+      if(Verbosity() > 1)
+        std::cout << "PHTruthTrackSeeding::Process - Combined track " << svtx_track->get_id()  << " bunch crossing " << crossing << std::endl;           
+    }
+    
+    // track fit
     if(m_helicalTrackFit)
-      {
-	double x, y, z, px, py, pz;
-	circleFitSeed(ClusterKeyList, x, y, z,
-		      px, py, pz, svtx_track->get_charge());
-	svtx_track->set_x(x);
-	svtx_track->set_y(y);
-	svtx_track->set_z(z);
-	svtx_track->set_px(px);
-	svtx_track->set_py(py);
-	svtx_track->set_pz(pz);
-      }
-
+    {
+      double x, y, z, px, py, pz;
+      circleFitSeed(ClusterKeyList, x, y, z,
+        px, py, pz, svtx_track->get_charge());
+      svtx_track->set_x(x);
+      svtx_track->set_y(y);
+      svtx_track->set_z(z);
+      svtx_track->set_px(px);
+      svtx_track->set_py(py);
+      svtx_track->set_pz(pz);
+    }
+    
     svtx_track->set_ndf(ClusterKeyList.size()*3-5);
     svtx_track->set_chisq(1.5*ClusterKeyList.size()*3-5);
+    
     _track_map->insert(svtx_track.get());
   }
-  
+
   if (Verbosity() >= 5)
   {
-    cout << "Loop over TrackMap " << _track_map_name << " entries " << endl;
-    for (SvtxTrackMap::Iter iter = _track_map->begin();
-         iter != _track_map->end(); ++iter)
+    std::cout << "Loop over TrackMap " << _track_map_name << " entries " << std::endl ;
+    for( const auto& [key,svtx_track]:*_track_map )
     {
-      SvtxTrack* svtx_track = iter->second;
-
-      //svtx_track->identify();
-      //continue;
-
-      cout << "Track ID: " << svtx_track->get_id() << ", Dummy Track pT: "
+    
+      std::cout << "Track ID: " << svtx_track->get_id() << ", Dummy Track pT: "
            << svtx_track->get_pt() << ", Truth Track/Particle ID: "
            << svtx_track->get_truth_track_id() 
 	   << " (X,Y,Z) " << svtx_track->get_x() << ", " << svtx_track->get_y() << ", " << svtx_track->get_z()  
-	   << endl;
-      cout << " nhits: " << svtx_track->size_cluster_keys()<< endl;
+	   << std::endl ;
+      std::cout << " nhits: " << svtx_track->size_cluster_keys()<< std::endl ;
       //Print associated clusters;
       ActsTransformations transformer;
       for (SvtxTrack::ConstClusterKeyIter iter_clus =
@@ -204,16 +211,16 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
            iter_clus != svtx_track->end_cluster_keys(); ++iter_clus)
       {
         TrkrDefs::cluskey cluster_key = *iter_clus;
-        cout << "Key: "  << cluster_key<< endl;
-        TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
+        std::cout << "Key: "  << cluster_key<< std::endl ;
+        TrkrCluster* cluster = m_clusterMap->findCluster(cluster_key);
         Acts::Vector3 global = transformer.getGlobalPosition(
           cluster_key, cluster,
           surfmaps,
           tgeometry);
         float radius = std::sqrt(square(global(0)) + square(global(1)));
-        cout << "       cluster ID: "
+        std::cout << "       cluster ID: "
              << cluster_key << ", cluster radius: " << radius
-             << endl;
+             << std::endl ;
       }
     }
   }
@@ -235,26 +242,32 @@ int PHTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-  m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode,
-							  "TRKR_CLUSTER");
+  m_clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   
   if(!m_clusterMap)
     {
-      cerr << PHWHERE << "Error: Can't find node TRKR_CLUSTER" << endl;
+      std::cerr << PHWHERE << "Error: Can't find node TRKR_CLUSTER" << std::endl ;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-  
-  _g4truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-  if (!_g4truth_container)
+
+  m_cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
+  if (!m_cluster_crossing_map)
   {
-    cerr << PHWHERE << " ERROR: Can't find node G4TruthInfo" << endl;
+    std::cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << std::endl ;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+    
+  m_g4truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!m_g4truth_container)
+  {
+    std::cerr << PHWHERE << " ERROR: Can't find node G4TruthInfo" << std::endl ;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   hittruthassoc = findNode::getClass<TrkrHitTruthAssoc>(topNode, "TRKR_HITTRUTHASSOC");
   if (!hittruthassoc)
   {
-    cout << PHWHERE << "Failed to find TRKR_HITTRUTHASSOC node, quit!" << endl;
+    std::cout << PHWHERE << "Failed to find TRKR_HITTRUTHASSOC node, quit!" << std::endl ;
     exit(1);
   }
 
@@ -277,16 +290,46 @@ int PHTruthTrackSeeding::GetNodes(PHCompositeNode* topNode)
 }
 
 int PHTruthTrackSeeding::End()
+{ return 0; }
+
+//_____________________________________________________________________________________________
+std::set<short int> PHTruthTrackSeeding::getInttCrossings(SvtxTrack *si_track) const
 {
-  return 0;
+  std::set<short int> intt_crossings;
+
+  // If the Si track contains an INTT hit, use it to get the bunch crossing offset
+  // loop over associated clusters to get keys for silicon cluster
+  
+  for( auto iter = si_track->begin_cluster_keys(); iter != si_track->end_cluster_keys(); ++iter)
+  {
+    
+    const TrkrDefs::cluskey& cluster_key = *iter;
+    const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+    if(trkrid == TrkrDefs::inttId)
+    {
+      
+      // get layre from cluster key
+      const unsigned int layer = TrkrDefs::getLayer(cluster_key);
+      
+      // get the bunch crossings for all hits in this cluster
+      const auto crossings = m_cluster_crossing_map->getCrossings(cluster_key);
+      for(auto iter = crossings.first; iter != crossings.second; ++iter)
+      {
+        const auto& [key, crossing] = *iter;
+        if( Verbosity() )
+        { std::cout << "PHTruthTrackSeeding::getInttCrossings - si Track " << si_track->get_id() << " cluster " << key << " layer " << layer << " crossing " << crossing  << std::endl; }
+        intt_crossings.insert(crossing);
+      }
+    }
+  }
+  
+  return intt_crossings;
 }
-
-
 
 void PHTruthTrackSeeding::circleFitSeed(std::vector<TrkrDefs::cluskey> clusters,
 					double& x, double& y, double& z,
 					double& px, double& py, double& pz, 
-					int charge)
+					int charge) const 
 {
   double R, X0, Y0;
   auto globalPositions = circleFitByTaubin(clusters, R, X0, Y0);
@@ -325,7 +368,7 @@ void PHTruthTrackSeeding::circleFitSeed(std::vector<TrkrDefs::cluskey> clusters,
 }
 
 void PHTruthTrackSeeding::lineFit(std::vector<Acts::Vector3>& clusterPositions,
-				  double& A, double& B)
+				  double& A, double& B) const 
 {
   
   double xsum = 0,x2sum = 0,ysum = 0,xysum = 0;    
@@ -347,7 +390,7 @@ void PHTruthTrackSeeding::lineFit(std::vector<Acts::Vector3>& clusterPositions,
   B = (x2sum*ysum-xsum*xysum) / (x2sum*clusterPositions.size()-xsum*xsum);
   
 }
-void PHTruthTrackSeeding::findRoot(const double& R, const double& X0, const double& Y0, double& x, double& y)
+void PHTruthTrackSeeding::findRoot(const double& R, const double& X0, const double& Y0, double& x, double& y) const 
 {
   
   double miny = (sqrt(pow(X0, 2) * pow(R, 2) * pow(Y0, 2) + pow(R, 2) 
@@ -375,7 +418,7 @@ void PHTruthTrackSeeding::findRoot(const double& R, const double& X0, const doub
 }
 
 std::vector<Acts::Vector3> PHTruthTrackSeeding::circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
-								   double& R, double& X0, double& Y0)
+								   double& R, double& X0, double& Y0) const
 {
   /**  
    *   Circle fit to a given set of data points (in 2D)

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -20,7 +20,9 @@ class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 class TrkrHitTruthAssoc;
 class TrkrClusterContainer;
+class TrkrClusterCrossingAssoc;
 class SvtxClusterEval;
+class SvtxTrack;
 
 //class SvtxHitMap;
 //class PHG4CellContainer;
@@ -79,17 +81,23 @@ void helicalTrackFit(const bool helicalTrackFit)
   /// fetch node pointers
   int GetNodes(PHCompositeNode* topNode);
 
+  /// get crossing id from intt clusters associated to track
+  /* this is a copy of the code in PHTruthSiliconAssociation */
+  std::set<short int> getInttCrossings(SvtxTrack*) const;
+
   void circleFitSeed(std::vector<TrkrDefs::cluskey> clusters,
 		     double& x, double& y, double&z,
-		       double& px, double& py, double& pz, int charge);
+		       double& px, double& py, double& pz, int charge) const;
   std::vector<Acts::Vector3> circleFitByTaubin(std::vector<TrkrDefs::cluskey>& clusters,
-						double& R, double& X0, double& Y0);
+						double& R, double& X0, double& Y0) const ;
   void findRoot(const double& R, const double& X0, const double& Y0,
-		double& x, double& y);
+		double& x, double& y) const ;
   void lineFit(std::vector<Acts::Vector3>& clusterPositions,
-	       double& A, double& B);
-  PHG4TruthInfoContainer* _g4truth_container = nullptr;
+	       double& A, double& B) const ;
+      
+  PHG4TruthInfoContainer* m_g4truth_container = nullptr;
   TrkrClusterContainer *m_clusterMap = nullptr;
+  TrkrClusterCrossingAssoc *m_cluster_crossing_map = nullptr;
   PHG4HitContainer* phg4hits_tpc = nullptr;
   PHG4HitContainer* phg4hits_intt = nullptr;
   PHG4HitContainer* phg4hits_mvtx = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR fixes passing around the crossing number from INTT clusters to the SvtxTracks when running truth track seeding. 
It also simplifies how multiple/no crossings are found for a give (truth) track, by using std::set instead of std::vector

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

