### PR TITLE
Updated DecayFinder to look at Geant record and handle pile-up

### DIFF
--- a/generators/decayFinder/DecayFinder.h
+++ b/generators/decayFinder/DecayFinder.h
@@ -4,6 +4,8 @@
 //sPHENIX stuff
 #include <fun4all/SubsysReco.h>
 
+#include <g4main/PHG4Particle.h>
+
 #include <cstddef>              // for NULL
 #include <string>
 #include <vector>
@@ -11,6 +13,7 @@
 
 class DecayFinderContainer_v1;
 class PHCompositeNode;
+class PHG4TruthInfoContainer;
 class PHHepMCGenEvent;
 class PHHepMCGenEventMap;
 namespace HepMC { class GenParticle; }
@@ -38,7 +41,19 @@ class DecayFinder : public SubsysReco
 
   bool findParticle(std::string particle);
 
-  int checkIfCorrectParticle(HepMC::GenParticle *particle, bool &trackFailedPT, bool &trackFailedETA);
+  void searchHepMCRecord(HepMC::GenParticle* particle, std::vector<int> decayProducts, 
+                         bool &breakLoop, bool &hasPhoton, bool &hasPi0, bool &failedPT, bool &failedETA, 
+                         std::vector<int> &correctDecayProducts);
+
+  void searchGeant4Record(int barcode, int pid, std::vector<int> decayProducts,
+          		 bool &breakLoop, bool &hasPhoton, bool &hasPi0, bool &failedPT, bool &failedETA, 
+			 std::vector<int> &correctDecayProducts);
+
+  bool checkIfCorrectHepMCParticle(HepMC::GenParticle *particle, bool &trackFailedPT, bool &trackFailedETA);
+
+  bool checkIfCorrectGeant4Particle(PHG4Particle *particle, bool& hasPhoton, bool& hasPi0, bool& trackFailedPT, bool& trackFailedETA);
+
+  bool compareDecays(std::vector<int> required, std::vector<int> actual);
 
   int deleteElement(int arr[], int n, int x);
 
@@ -47,6 +62,8 @@ class DecayFinder : public SubsysReco
   int get_pdgcode(std::string name);
 
   int get_charge(std::string name);
+
+  bool isInRange(float min, float value, float max);
 
   int createDecayNode(PHCompositeNode *topNode);
 
@@ -107,12 +124,21 @@ class DecayFinder : public SubsysReco
  private:
   PHHepMCGenEventMap *m_geneventmap = nullptr;
   PHHepMCGenEvent *m_genevt = nullptr;
+  PHG4TruthInfoContainer *m_truthinfo = nullptr;
+
+  double m_eta_req = 1.1;
+  double m_eta_low_req = -1.1;
+  double m_pt_req = 0.2;
 
   int m_counter = 0;
   int m_nCandFail_pT = 0;
   int m_nCandFail_eta = 0;
   int m_nCandFail_pT_and_eta = 0;
   int m_nCandReconstructable = 0;
+  int m_nCandHas_Photon = 0;
+  int m_nCandHas_Pi0 = 0;
+  int m_nCandHas_Photon_and_Pi0 = 0;
+  int m_nCandHas_noPhoton_and_noPi0 = 0;
 
   bool m_getChargeConjugate = false;
 

--- a/generators/decayFinder/Makefile.am
+++ b/generators/decayFinder/Makefile.am
@@ -47,7 +47,8 @@ libdecayfinder_io_la_LIBADD = \
 libdecayfinder_la_LIBADD = \
   libdecayfinder_io.la \
   -lfun4all \
-  -lphhepmc
+  -lphhepmc \
+  -lphg4hit
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

DecayFinder was unable to handle any decays that were performed by Geant. These decays were never in the HepMC record. As a consequence, the module would crash when accessing the end vertex of some particle (because they were null pointers).

This PR updates the module so it will now jump back and forth between HepMC and Geant4 as required. This is transparent to users.

New features:

1. Seamless transition between HepMC and Geant4 records
2. New output info to see if your mother produced pi0s and photons on decay, these particles would cause incorrect mass reconstruction and could throw decays out our windows
3. We now trigger on decays that would be reconstructable. Previously we triggered on events that had the decay, regardless of whether all products were in the acceptance or not
4. We also loop over the pile-up events to see if the decay was in there too. 

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

