### PR TITLE
Prevent clang warning about a copy in range loop

### DIFF
--- a/offline/database/dbtools/xclient.cc
+++ b/offline/database/dbtools/xclient.cc
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
   {
     cout << "Found paths:\n";
 
-    for (const string& path : result.paths)
+    for (const string path : result.paths)
       cout << path << '\n';
   }
 


### PR DESCRIPTION
With "-Wall" option clang issues a warning if a range loop has an implicit cast that creates a copy

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

For details see https://github.com/BNLNPPS/xpload/issues/32

[skip ci]