### PR TITLE
[WIP] MVTX hit timing and duplication

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -323,31 +323,6 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
           << " in angle = " << atan(g4hit->get_y(0) / g4hit->get_x(0)) - atan(location_in.Y() / location_in.X())
           << std::endl;
 
-        cout << "      PHG4MvtxHitReco:  Found world exit location from geometry for  "
-             << " stave number " << stave_number
-             << " half stave number " << half_stave_number
-             << " module number" << module_number
-             << endl
-             << " x = " << location_out.X()
-             << " y = " << location_out.Y()
-             << " z = " << location_out.Z()
-             << " radius " << sqrt(pow(location_out.X(), 2) + pow(location_out.Y(), 2))
-             << " angle " << atan(location_out.Y() / location_out.X())
-             << endl;
-        cout << "     PHG4MvtxHitReco: The world exit location from G4 was "
-             << endl
-             << " x = " << g4hit->get_x(1)
-             << " y = " << g4hit->get_y(1)
-             << " z = " << g4hit->get_z(1)
-             << " radius " << sqrt(pow(g4hit->get_x(1), 2) + pow(g4hit->get_y(1), 2))
-             << " angle " << atan(g4hit->get_y(1) / g4hit->get_x(1))
-             << endl;
-        cout << " difference in radius = " << sqrt(pow(g4hit->get_x(1), 2) + pow(g4hit->get_y(1), 2)) - sqrt(pow(location_out.X(), 2) + pow(location_out.Y(), 2))
-             << " in angle = " << atan(g4hit->get_y(1) / g4hit->get_x(1)) - atan(location_out.Y() / location_out.X())
-             << endl
-             << endl;
-      }
-*/
       // Get the pixel number of the entry location
       int pixel_number_in = layergeom->get_pixel_from_local_coords(local_in);
       // Get the pixel number of the exit location

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -253,8 +253,8 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
 
       // get_property_int(const PROPERTY prop_id) const {return INT_MIN;}
       int stave_number = g4hit->get_property_int(PHG4Hit::prop_stave_index);
-      int half_stave_number = g4hit->get_property_int(PHG4Hit::prop_half_stave_index);
-      int module_number = g4hit->get_property_int(PHG4Hit::prop_module_index);
+//      int half_stave_number = g4hit->get_property_int(PHG4Hit::prop_half_stave_index);
+//      int module_number = g4hit->get_property_int(PHG4Hit::prop_module_index);
       int chip_number = g4hit->get_property_int(PHG4Hit::prop_chip_index);
 
       TVector3 local_in(g4hit->get_local_x(0), g4hit->get_local_y(0), g4hit->get_local_z(0));
@@ -276,9 +276,10 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
           << std::endl;
 
         TVector3 world_in(g4hit->get_x(0), g4hit->get_y(0), g4hit->get_z(0));
-        TVector3 local_in_check = layergeom->get_local_from_world_coords(
-            stave_number, half_stave_number, module_number, chip_number, world_in);
+        auto hskey = MvtxDefs::genHitSetKey(layer,stave_number,chip_number,0);
+        auto surf = tgeometry->maps().getSiliconSurface(hskey);
 
+        TVector3 local_in_check = layergeom->get_local_from_world_coords(surf, tgeometry, world_in);
         std::cout
           << " local coords of entry point from geom (a check) "
           << local_in_check.X() << " " << local_in_check.Y() << " " << local_in_check.Z() << "\n"

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -49,11 +49,16 @@ PHG4MvtxHitReco::PHG4MvtxHitReco(const std::string& name, const std::string& det
   : SubsysReco(name)
   , PHParameterInterface(name)
   , m_detector(detector)
+  , m_tmin(-5000.)
+  , m_tmax(5000.)
+  , m_strobe_width(5.)
+  , m_strobe_separation(0.)
 {
 
   if (Verbosity())
+  {
     std::cout << "Creating PHG4MvtxHitReco for detector = " << detector << std::endl;
-
+  }
   // initialize rng
   const uint seed = PHRandomSeed();
   m_rng.reset(gsl_rng_alloc(gsl_rng_mt19937));
@@ -322,7 +327,8 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
           << sqrt(pow(g4hit->get_x(0), 2) + pow(g4hit->get_y(0), 2)) - sqrt(pow(location_in.X(), 2) + pow(location_in.Y(), 2))
           << " in angle = " << atan(g4hit->get_y(0) / g4hit->get_x(0)) - atan(location_in.Y() / location_in.X())
           << std::endl;
-
+      }
+  */
       // Get the pixel number of the entry location
       int pixel_number_in = layergeom->get_pixel_from_local_coords(local_in);
       // Get the pixel number of the exit location
@@ -432,8 +438,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
 
       // skip this hit if it involves an unreasonable  number of pixels
       // this skips it if either the xbin or ybin range traversed is greater than 8 (for 8 adding two pixels at each end makes the range 12)
-      if (xbin_max - xbin_min > 12 || zbin_max - zbin_min > 12)
-        continue;
+      if (xbin_max - xbin_min > 12 || zbin_max - zbin_min > 12) continue;
 
       // this hit is skipped earlier if this dimensioning would be exceeded
       double pixenergy[12][12] = {};  // init to 0
@@ -611,7 +616,9 @@ std::pair<double, double> PHG4MvtxHitReco::generate_alpide_pulse(const double en
 {
   // We need to translate energy deposited to num/ electrons released
   if (Verbosity() > 2)
+  {
     std::cout << "energy_deposited: " << energy_deposited << std::endl;
+  }
   //int silicon_band_gap = 1.12; //Band gap energy in eV
   //int Q_in = rand() % 5000 + 50;
   //int clipping_point = 110;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -221,6 +221,10 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
 
       if (lead_edge > m_tmax or fall_edge < m_tmin) continue;
 
+      // chop alpide pulse into the readout time window
+      lead_edge = (lead_edge < m_tmin) ? m_tmin : lead_edge;
+      fall_edge = (fall_edge > m_tmax) ? m_tmax : fall_edge;
+
       double t0_strobe_frame = get_strobe_frame(lead_edge, strobe_zero_tm_start);
       double t1_strobe_frame = get_strobe_frame(fall_edge, strobe_zero_tm_start);
       n_replica += t1_strobe_frame - t0_strobe_frame;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -39,11 +39,21 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
 
  private:
 
+  std::pair<double, double> generate_alpide_pulse(const double energy_deposited);
+
+  double generate_strobe_zero_tm_start();
+
+  int get_strobe_frame(double alpide_time, double strobe_zero_tm_start);
+
   std::string m_detector;
 
   double m_tmin;
   double m_tmax;
+  double m_strobe_width;
+  double m_strobe_separation;
   double crossing_period = 106.0;
+
+  bool m_in_sphenix_srdo = false;
 
   class Deleter
   {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -51,7 +51,7 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_tmax;
   double m_strobe_width;
   double m_strobe_separation;
-  double crossing_period = 106.0;
+  //double crossing_period = 106.0;
 
   bool m_in_sphenix_srdo = false;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR try to implement a more realistic MVTX detector response in the hit reconstruction simulation.
A set of new features is reported below:

* Use a common readout/digitalization time window for all layers
* Add configurable strobe setting to the parameter list
* Move all MVTX configuration to PHParameter Interfaces. Remove public set member function, modification through PHParameterInterface only.
  * Keep set_timing_window member for backward compatibility in the G4_MVTX macro but It DOES NOT change timing parameter values. It will be removed in the future.
* Save all parameters in DST to keep record of run configuration (simulation of DB in real Runs).
* digitalization windows is restricted to 2 strobe windows (strobe zero with L1 trigger and it previous strobe window) in case TPC is running in TRG mode (Au-Au collisions). In TPC SRO mode digitalization windows is extended to mvtx_tmin and mvtx_tmax parameters values. Flag "mvtx_in_sphenix_srdo" in the parameter select digitalization mode.
* Add random strobe train relative to the trigger time and shift time windows accordingly. 
* determination of strobe frame and number of replica from the ALPIDE integration time.
  * ALPIDE integration time = [1.5, 5.9] microseconds for now.
* duplicate hits in case the integration time shares more than one strobe inside the digitalization time window.



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

