### PR TITLE
Track Matching Table Processing Flag

### DIFF
--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap.h
@@ -32,6 +32,9 @@ class PHG4ParticleSvtxMap : public PHObject
   virtual std::size_t count(const int) const { return 0; }
   virtual void clear() {}
 
+  virtual bool processed() const { return false; }
+  virtual void setProcessed(const bool) {}
+
   virtual const WeightedRecoTrackMap & get(const int) const;
   virtual WeightedRecoTrackMap & get(const int);
   virtual WeightedRecoTrackMap insert(const int, const WeightedRecoTrackMap);

--- a/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
+++ b/offline/packages/trackbase_historic/PHG4ParticleSvtxMap_v1.h
@@ -16,11 +16,14 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
   void identify(std::ostream& os = std::cout) const override;
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new PHG4ParticleSvtxMap_v1(*this); }
-  void Reset() override { clear(); }
+  void Reset() override { clear(); m_processed = false; }
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }
   std::size_t count(const int key) const override { return m_map.count(key); }
   void clear() override { m_map.clear(); }
+
+  bool processed() const override { return m_processed; }
+  void setProcessed(const bool process) override { m_processed = process; }
 
   const WeightedRecoTrackMap & get(const int key) const override;
   WeightedRecoTrackMap & get(const int key) override
@@ -46,6 +49,7 @@ class PHG4ParticleSvtxMap_v1 : public PHG4ParticleSvtxMap
 
  private:
   PHG4ParticleSvtxMap::Map m_map;
+  bool m_processed = false;
 
   ClassDefOverride(PHG4ParticleSvtxMap_v1, 1);
 };

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap.h
@@ -31,6 +31,9 @@ class SvtxPHG4ParticleMap : public PHObject
   virtual std::size_t count(const unsigned int) const { return 0; }
   virtual void clear() {}
 
+  virtual bool processed() const { return false; }
+  virtual void setProcessed(const bool) {}
+
   virtual const WeightedTruthTrackMap & get(const unsigned int) const;
   virtual WeightedTruthTrackMap & get(const unsigned int);
   virtual WeightedTruthTrackMap insert(const unsigned int, const WeightedTruthTrackMap);

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -15,12 +15,15 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
   void identify(std::ostream& os = std::cout) const override;
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new SvtxPHG4ParticleMap_v1(*this); }
-  void Reset() override { clear(); }
+  void Reset() override { clear(); m_processed = false; }
 
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }
   std::size_t count(const unsigned int key) const override { return m_map.count(key); }
   void clear() override { m_map.clear(); }
+
+  bool processed() const override { return m_processed; }
+  void setProcessed(const bool process) override { m_processed = process; }
 
   const WeightedTruthTrackMap & get(const unsigned int key) const override;
   WeightedTruthTrackMap & get(const unsigned int key) override
@@ -46,6 +49,7 @@ class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
 
  private:
   SvtxPHG4ParticleMap::Map m_map;
+  bool m_processed = false;
 
   ClassDefOverride(SvtxPHG4ParticleMap_v1, 1);
 };

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -142,7 +142,7 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
     return std::set<PHG4Particle*>();
   }
 
-  if(_recoTruthMap != nullptr) 
+  if(_recoTruthMap->processed()) 
     {
       SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
       std::set<PHG4Particle*> returnset;
@@ -223,7 +223,7 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track)
     return nullptr;
   }
 
-  if(_recoTruthMap != nullptr)
+  if(_recoTruthMap->processed())
     {
       const SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
       if (map.size() == 0) return nullptr;
@@ -291,7 +291,7 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
     return std::set<SvtxTrack*>();
   }
 
-  if(_truthRecoMap != nullptr)
+  if(_truthRecoMap->processed())
     {
       std::set<SvtxTrack*> returnset;
  
@@ -456,7 +456,7 @@ SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle)
     return nullptr;
   }
   
-  if(_truthRecoMap != nullptr)
+  if(_truthRecoMap->processed())
     {
       const PHG4ParticleSvtxMap::WeightedRecoTrackMap map = _truthRecoMap->get(truthparticle->get_track_id());
       /// No reco tracks found

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
@@ -152,6 +152,9 @@ void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode *topNode)
 
     m_truthMap->insert(gtrackID, recomap);
   }
+  
+  m_truthMap->setProcessed(true);
+
 }
 
 void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode *topNode)
@@ -185,6 +188,9 @@ void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode *topNode)
 
     m_recoMap->insert(key, truthmap);
   }
+
+  m_recoMap->setProcessed(true);
+
 }
 
 int SvtxTruthRecoTableEval::createNodes(PHCompositeNode *topNode)


### PR DESCRIPTION
This adds a flag into the truth-reco track matching tables which is set to true when the tables are processed. The evaluation machinery looks up this flag when processing to determine whether or not to use the condensed tables or to use the full hit truth tracing. 

Tested with the previous configuration of the truth-reco table matching processing after the SvtxEvaluator and matched tracks are produced.

Any comments from @blackcathj welcome.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

