### PR TITLE
Constant field calo projection

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -23,6 +23,7 @@
 #include <calobase/RawClusterUtility.h>
 #include <phgeom/PHGeomUtility.h>
 
+#include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
 #include <Acts/Surfaces/PerigeeSurface.hpp>
@@ -347,7 +348,16 @@ BoundTrackParamPtrResult PHActsTrackProjection::propagateTrack(
   using Stepper = Acts::EigenStepper<>;
   using Propagator = Acts::Propagator<Stepper>;
 
-  Stepper stepper(m_tGeometry->magField);
+  auto field = m_tGeometry->magField;
+
+  if(m_constField)
+    {
+      std::cout << "use const field"<<std::endl;
+      Acts::Vector3 fieldVec(0,0,-1.4*Acts::UnitConstants::T);
+      field = std::make_shared<Acts::ConstantBField>(fieldVec);
+    }
+
+  Stepper stepper(field);
   Propagator propagator(stepper);
 
   

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -352,8 +352,7 @@ BoundTrackParamPtrResult PHActsTrackProjection::propagateTrack(
 
   if(m_constField)
     {
-      std::cout << "use const field"<<std::endl;
-      Acts::Vector3 fieldVec(0,0,-1.4*Acts::UnitConstants::T);
+      Acts::Vector3 fieldVec(0,0,1.4*Acts::UnitConstants::T);
       field = std::make_shared<Acts::ConstantBField>(fieldVec);
     }
 

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -53,6 +53,8 @@ class PHActsTrackProjection : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   
+  void useConstField(bool field) { m_constField = field; }
+
   /// Set an arbitrary radius to project to, in cm
   void setLayerRadius(SvtxTrack::CAL_LAYER layer,
 		      const float rad) { 
@@ -118,6 +120,8 @@ class PHActsTrackProjection : public SubsysReco
   RawTowerGeomContainer *m_towerGeomContainer = nullptr;
   RawTowerContainer *m_towerContainer = nullptr;
   RawClusterContainer *m_clusterContainer = nullptr;
+
+  bool m_constField = true;
 
   bool m_useCemcPosRecalib = false;
 


### PR DESCRIPTION


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds an option to run the calo projections with a constant magnetic field. It is turned to true by default for now in this PR, so that we can run with the highly reduced field map in the tracking volume only. Future tests can be iterated on with a reduced field map in the calo volumes.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

