### PR TITLE
Add check to see if correction is in use before loading into node.

### DIFF
--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -71,6 +71,9 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
 
   //create and populate the nodes for each distortion, if present:
   for (int i=0;i<3;i++){
+
+    if( !m_correction_in_use[i]) continue;
+
     // get distortion correction object and create if not found
     auto distortion_correction_object = findNode::getClass<TpcDistortionCorrectionContainer>( topNode, m_node_name[i] );
     if( !distortion_correction_object )


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Add a check that a correction is enabled before trying to load the correction file.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

