### PR TITLE
Fix crash

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrackMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackMap_v1.cc
@@ -87,3 +87,17 @@ SvtxTrack* SvtxTrackMap_v1::insert(const SvtxTrack* track)
   _map[index]->set_id(index);
   return _map[index];
 }
+
+size_t SvtxTrackMap_v1::erase(unsigned int idkey)
+{
+  const auto iter = _map.find(idkey);
+  if( iter != _map.end() ) 
+  { 
+  
+    delete iter->second;
+    _map.erase( iter );
+    return 1;
+  
+  } else return 0;
+}
+

--- a/offline/packages/trackbase_historic/SvtxTrackMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackMap_v1.h
@@ -30,11 +30,7 @@ class SvtxTrackMap_v1 : public SvtxTrackMap
   const SvtxTrack* get(unsigned int idkey) const override;
   SvtxTrack* get(unsigned int idkey) override;
   SvtxTrack* insert(const SvtxTrack* track) override;
-  size_t erase(unsigned int idkey) override
-  {
-    delete _map[idkey];
-    return _map.erase(idkey);
-  }
+  size_t erase(unsigned int idkey) override;
 
   ConstIter begin() const override { return _map.begin(); }
   ConstIter find(unsigned int idkey) const override { return _map.find(idkey); }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -332,9 +332,9 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	  
 	  if(m_fitSiliconMMs)
 	    {
-	      auto newTrack = (SvtxTrack_v3*)(track->CloneMe());
-	      getTrackFitResult(fitOutput, newTrack);
-	      m_directedTrackMap->insert(newTrack);
+        std::unique_ptr<SvtxTrack_v3> newTrack( static_cast<SvtxTrack_v3*>(track->CloneMe()) );
+	      if( getTrackFitResult(fitOutput, newTrack.get()) )
+        { m_directedTrackMap->insert(newTrack.release()); } 
 	    }
 	  else
 	    {
@@ -621,7 +621,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(SvtxTrack* track,
   return sourcelinks;
 }
 
-void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
+bool PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
 				        SvtxTrack* track)
 {
   /// Make a trajectory state for storage, which conforms to Acts track fit
@@ -654,7 +654,7 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
       /// Track fit failed in some way if there are no fit parameters. Remove
       m_trackMap->erase(track->get_id());
       std::cout << " track fit failed for track " << track->get_id() << std::endl;
-      return;
+      return false;
     }
 
   Trajectory trajectory(fitOutput.fittedStates,
@@ -681,7 +681,7 @@ void PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
   if(m_timeAnalysis)
     h_updateTime->Fill(updateTime);
   
-  return;
+  return true;
 }
 
 ActsExamples::TrackFittingAlgorithm::TrackFitterResult PHActsTrkFitter::fitTrack(

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -128,8 +128,7 @@ class PHActsTrkFitter : public SubsysReco
   SourceLinkVec getSurfaceVector(const SourceLinkVec& sourceLinks, 
 				 SurfacePtrVec& surfaces) const;
   void checkSurfaceVec(SurfacePtrVec& surfaces) const;
-  void getTrackFitResult(const FitResult& fitOutput, 
-			 SvtxTrack* track);
+  bool getTrackFitResult(const FitResult& fitOutput, SvtxTrack* track);
 
   Surface getSurface(TrkrDefs::cluskey cluskey,TrkrDefs::subsurfkey surfkey) const;
   Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This fixes a crash in SvtxTrackMap_v1::erase, when the track to be erased is not already in the map.
Can happen if SC_CALIBMODE = true
Also modify ActsTrkFitter to not saved tracks for which the fit fails when SC_CALIBMODE=true

This addresses the crash reported by @pinkenburg  when runnign the JobA macro sent earlier today

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

