### PR TITLE
wrap in verb statement

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -82,6 +82,7 @@ namespace
     int cluster_version = 3;
     std::vector<assoc> association_vector;
     std::vector<TrkrCluster*> cluster_vector;
+    int verbosity = 0;
   };
   
   pthread_mutex_t mythreadlock;
@@ -275,7 +276,8 @@ namespace
 					    Acts::Vector3 world,
 					    ActsSurfaceMaps *surfMaps,
 					    ActsTrackingGeometry *tGeometry,
-					    TrkrDefs::subsurfkey& subsurfkey)
+					    TrkrDefs::subsurfkey& subsurfkey,
+					    int verbosity)
 	{
 
 	  unsigned int layer = TrkrDefs::getLayer(hitsetkey);
@@ -323,7 +325,7 @@ namespace
 	    }    
 	  else
 	    {
-	      if(Verbosity() > 2)
+	      if(verbosity > 2)
 		{
 		  std::cout << PHWHERE 
 			    << "Error: TPC surface index not defined, skipping cluster!" 
@@ -426,7 +428,8 @@ namespace
 						    global,
 						    my_data.surfmaps,
 						    my_data.tGeometry,
-						    subsurfkey);
+						    subsurfkey,
+						    my_data.verbosity);
       
       if(!surface)
 	{
@@ -830,6 +833,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     thread_pair.data.par0_neg = par0_neg;
     thread_pair.data.par0_pos = par0_pos;
     thread_pair.data.cluster_version = cluster_version;
+    thread_pair.data.verbosity = Verbosity();
     
     unsigned short NPhiBins = (unsigned short) layergeom->get_phibins();
     unsigned short NPhiBinsSector = NPhiBins/12;

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -323,16 +323,19 @@ namespace
 	    }    
 	  else
 	    {
-	      std::cout << PHWHERE 
-			<< "Error: TPC surface index not defined, skipping cluster!" 
-			<< std::endl;
-	      std::cout << "     coordinates: " << world[0] << "  " << world[1] << "  " << world[2] 
-			<< " radius " << sqrt(world[0]*world[0]+world[1]*world[1]) << std::endl;
-	      std::cout << "     world_phi " << world_phi << " world_z " << world_z << std::endl;
-	      std::cout << "     surf coords: " << surf_center[0] << "  " << surf_center[1] << "  " << surf_center[2] << std::endl;
-	      std::cout << "     surf_phi " << surf_phi << " surf_z " << surf_z << std::endl; 
-	      std::cout << "     surfStepPhi " << surfStepPhi << " surfStepZ " << surfStepZ << std::endl; 
-	      std::cout << " number of surfaces " << surf_vec.size() << " nsurf: "  << nsurf << std::endl;
+	      if(Verbosity() > 2)
+		{
+		  std::cout << PHWHERE 
+			    << "Error: TPC surface index not defined, skipping cluster!" 
+			    << std::endl;
+		  std::cout << "     coordinates: " << world[0] << "  " << world[1] << "  " << world[2] 
+			    << " radius " << sqrt(world[0]*world[0]+world[1]*world[1]) << std::endl;
+		  std::cout << "     world_phi " << world_phi << " world_z " << world_z << std::endl;
+		  std::cout << "     surf coords: " << surf_center[0] << "  " << surf_center[1] << "  " << surf_center[2] << std::endl;
+		  std::cout << "     surf_phi " << surf_phi << " surf_z " << surf_z << std::endl; 
+		  std::cout << "     surfStepPhi " << surfStepPhi << " surfStepZ " << surfStepZ << std::endl; 
+		  std::cout << " number of surfaces " << surf_vec.size() << " nsurf: "  << nsurf << std::endl;
+		}
 	      return nullptr;
 	    }
 	  	 


### PR DESCRIPTION
This PR wraps the tpc cluster surface warning into a verbosity statement.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

