### PR TITLE
Truth track seeding position randomization fix

### DIFF
--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -144,16 +144,17 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
      * so that the seed momentum and 
      * position aren't completely exact
      */
-    const auto random = gsl_ran_flat(m_rng.get(), 0.95, 1.05);
-    svtx_track->set_px(g4particle->get_px() * random);
-    svtx_track->set_py(g4particle->get_py() * random);
-    svtx_track->set_pz(g4particle->get_pz() * random);
+    const auto random1 = gsl_ran_flat(m_rng.get(), 0.95, 1.05);
+    svtx_track->set_px(g4particle->get_px() * random1);
+    svtx_track->set_py(g4particle->get_py() * random1);
+    svtx_track->set_pz(g4particle->get_pz() * random1);
 
     // assign the track position using the truth vertex for this track
+    const auto random2 = gsl_ran_flat(m_rng.get(), -0.002, 0.002);   // 20 microns
     auto g4vertex = m_g4truth_container->GetVtx(vertexID);
-    svtx_track->set_x(g4vertex->get_x() * random);
-    svtx_track->set_y(g4vertex->get_y() * random);
-    svtx_track->set_z(g4vertex->get_z() * random);
+    svtx_track->set_x(g4vertex->get_x() + random2);
+    svtx_track->set_y(g4vertex->get_y() + random2);
+    svtx_track->set_z(g4vertex->get_z() + random2);
     
     // associate all cluster keys to the track
     for( const auto& cluskey : ClusterKeyList){


### PR DESCRIPTION
…ber. For z, 5% of 10 cm is 5 mm!

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Randomizing the track position by 5% produced up to 5 mm variation in track z, causing loss of tracking efficiency. Changed the position randomization to be an added fraction of +/- 20 microns. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

