### PR TITLE
Fix crash in QA

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -27,16 +27,6 @@ using namespace std;
 
 SvtxTrackEval::SvtxTrackEval(PHCompositeNode* topNode)
   : _clustereval(topNode)
-  , _trackmap(nullptr)
-  , _truthinfo(nullptr)
-  , _truthRecoMap(nullptr)
-  , _recoTruthMap(nullptr)
-  , _strict(false)
-  , _verbosity(0)
-  , _errors(0)
-  , _do_cache(true)
-  , _cache_track_from_cluster_exists(false)
-  , m_TrackNodeName("SvtxTrackMap")  // typically set upstream by SvtxVertexEval
 {
   get_node_pointers(topNode);
 }
@@ -142,7 +132,7 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
     return std::set<PHG4Particle*>();
   }
 
-  if(_recoTruthMap->processed()) 
+  if(_recoTruthMap && _recoTruthMap->processed()) 
     {
       SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
       std::set<PHG4Particle*> returnset;
@@ -223,7 +213,7 @@ PHG4Particle* SvtxTrackEval::max_truth_particle_by_nclusters(SvtxTrack* track)
     return nullptr;
   }
 
-  if(_recoTruthMap->processed())
+  if(_recoTruthMap && _recoTruthMap->processed())
     {
       const SvtxPHG4ParticleMap::WeightedTruthTrackMap map = _recoTruthMap->get(track->get_id());
       if (map.size() == 0) return nullptr;
@@ -291,7 +281,7 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
     return std::set<SvtxTrack*>();
   }
 
-  if(_truthRecoMap->processed())
+  if(_truthRecoMap && _truthRecoMap->processed())
     {
       std::set<SvtxTrack*> returnset;
  
@@ -456,7 +446,7 @@ SvtxTrack* SvtxTrackEval::best_track_from(PHG4Particle* truthparticle)
     return nullptr;
   }
   
-  if(_truthRecoMap->processed())
+  if(_truthRecoMap && _truthRecoMap->processed())
     {
       const PHG4ParticleSvtxMap::WeightedRecoTrackMap map = _truthRecoMap->get(truthparticle->get_track_id());
       /// No reco tracks found

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -81,17 +81,17 @@ class SvtxTrackEval
   bool has_node_pointers();
 
   SvtxClusterEval _clustereval;
-  SvtxTrackMap* _trackmap;
-  PHG4TruthInfoContainer* _truthinfo;
-  const PHG4ParticleSvtxMap* _truthRecoMap;
-  const SvtxPHG4ParticleMap* _recoTruthMap;
+  SvtxTrackMap* _trackmap = nullptr;
+  PHG4TruthInfoContainer* _truthinfo = nullptr;
+  const PHG4ParticleSvtxMap* _truthRecoMap = nullptr;
+  const SvtxPHG4ParticleMap* _recoTruthMap = nullptr;
 
-  bool _strict;
-  int _verbosity;
-  unsigned int _errors;
+  bool _strict = false;
+  int _verbosity = 0;
+  unsigned int _errors = 0;
 
-  bool _do_cache;
-  bool _cache_track_from_cluster_exists;
+  bool _do_cache = true;
+  bool _cache_track_from_cluster_exists = false;
   std::map<SvtxTrack*, std::set<PHG4Hit*> > _cache_all_truth_hits;
   std::map<SvtxTrack*, std::set<PHG4Particle*> > _cache_all_truth_particles;
   std::map<SvtxTrack*, PHG4Particle*> _cache_max_truth_particle_by_nclusters;
@@ -103,7 +103,7 @@ class SvtxTrackEval
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution;
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nclusters_contribution_by_layer;
   std::map<std::pair<SvtxTrack*, PHG4Particle*>, unsigned int> _cache_get_nwrongclusters_contribution;
-  std::string m_TrackNodeName;
+  std::string m_TrackNodeName = "SvtxTrackMap";
 };
 
 #endif  // G4EVAL_SVTXTRACKEVAL_H


### PR DESCRIPTION
Check for _recoTruthMap and TruthRecoMap every time they are used to prevent crash when not found
This can happen when running the QA (which calls the evaluator internally) without first running Tracking_Eval(), where SvtxTruthRecoTableEval is registered. 

also moved member initialization to header

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

