### PR TITLE
New Lightweight SvtxTrack

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -17,7 +17,6 @@
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/TrackSeed.h>
-#include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
@@ -59,10 +58,8 @@ int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
 
   m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
-  m_silSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
-  m_tpcSeeds = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
 
-  if(!m_trackMap or !m_silSeeds or !m_tpcSeeds or !m_vertexMap)
+  if(!m_trackMap or !m_vertexMap)
     {
       std::cout << PHWHERE << " missing track related container(s). Quitting"
 		<< std::endl;
@@ -378,11 +375,8 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       int INTT_hits = 0;
       int TPC_hits = 0;
       
-      const unsigned int tpcid = track->get_tpc_id();
-      const unsigned int silid = track->get_silicon_id();
-      
-      TrackSeed *tpcseed = m_tpcSeeds->get(tpcid);
-      TrackSeed *silseed = m_silSeeds->get(silid);
+      TrackSeed *tpcseed = track->get_tpc_seed();
+      TrackSeed *silseed = track->get_silicon_seed();
 
       for (auto cluster_iter = silseed->begin_cluster_keys(); 
 	   cluster_iter != silseed->end_cluster_keys(); ++cluster_iter)
@@ -599,10 +593,9 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         int MVTX_hits = 0;
         int INTT_hits = 0;
         int TPC_hits = 0;
-	const unsigned int tpcid = track->get_tpc_id();
-	const unsigned int silid = track->get_silicon_id();
-	TrackSeed* tpcSeed = m_tpcSeeds->get(tpcid);
-	TrackSeed* silSeed = m_silSeeds->get(silid);
+
+	TrackSeed* tpcSeed = track->get_tpc_seed();
+	TrackSeed* silSeed = track->get_silicon_seed();
 	
         for (auto cluster_iter = silSeed->begin_cluster_keys(); 
 	     cluster_iter != silSeed->end_cluster_keys(); ++cluster_iter)

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -16,6 +16,9 @@
 #include <trackbase/TrkrHitTruthAssoc.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/TrackSeed.h>
+#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/SvtxVertexMap.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -54,7 +57,17 @@ int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
     m_svtxEvalStack->set_verbosity(Verbosity());
   }
 
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  m_silSeeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
+  m_tpcSeeds = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+
+  if(!m_trackMap or !m_silSeeds or !m_tpcSeeds or !m_vertexMap)
+    {
+      std::cout << PHWHERE << " missing track related container(s). Quitting"
+		<< std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -364,7 +377,15 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       int MVTX_hits = 0;
       int INTT_hits = 0;
       int TPC_hits = 0;
-      for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
+      
+      const unsigned int tpcid = track->get_tpc_id();
+      const unsigned int silid = track->get_silicon_id();
+      
+      TrackSeed *tpcseed = m_tpcSeeds->get(tpcid);
+      TrackSeed *silseed = m_silSeeds->get(silid);
+
+      for (auto cluster_iter = silseed->begin_cluster_keys(); 
+	   cluster_iter != silseed->end_cluster_keys(); ++cluster_iter)
       {
         const auto &cluster_key = *cluster_iter;
         const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
@@ -373,14 +394,18 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
           ++MVTX_hits;
         else if (trackerID == TrkrDefs::inttId)
           ++INTT_hits;
-        else if (trackerID == TrkrDefs::tpcId)
-          ++TPC_hits;
-        else
-        {
-          if (Verbosity())
-            std::cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << std::endl;
-        }
       }
+
+        for (auto cluster_iter = tpcseed->begin_cluster_keys(); 
+	   cluster_iter != tpcseed->end_cluster_keys(); ++cluster_iter)
+      {
+        const auto &cluster_key = *cluster_iter;
+        const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+
+        if (trackerID == TrkrDefs::tpcId)
+          ++TPC_hits;
+      }
+
       if (MVTX_hits >= 2 && INTT_hits >= 1 && TPC_hits >= 20)
       {
         h_nReco_pTReco_cuts->Fill(pt);  // normalization histogram fill with cuts
@@ -551,12 +576,10 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         h_nReco_etaGen->Fill(geta);
         h_nReco_pTGen->Fill(gpt);
 
-        // double dca2d = track->get_dca2d();
-        // double dca2dsigma = track->get_dca2d_error();
-        double dca3dxy = track->get_dca3d_xy();
-        double dca3dxysigma = track->get_dca3d_xy_error();
-        double dca3dz = track->get_dca3d_z();
-        double dca3dzsigma = track->get_dca3d_z_error();
+	float dca3dxy = NAN, dca3dz = NAN, 
+	  dca3dxysigma = NAN, dca3dzsigma = NAN;
+        get_dca(track, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
+
         double px = track->get_px();
         double py = track->get_py();
         double pz = track->get_pz();
@@ -576,24 +599,37 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         int MVTX_hits = 0;
         int INTT_hits = 0;
         int TPC_hits = 0;
-        for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
+	const unsigned int tpcid = track->get_tpc_id();
+	const unsigned int silid = track->get_silicon_id();
+	TrackSeed* tpcSeed = m_tpcSeeds->get(tpcid);
+	TrackSeed* silSeed = m_silSeeds->get(silid);
+	
+        for (auto cluster_iter = silSeed->begin_cluster_keys(); 
+	     cluster_iter != silSeed->end_cluster_keys(); ++cluster_iter)
         {
           const auto &cluster_key = *cluster_iter;
           const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-
+	  const auto layer = TrkrDefs::getLayer(cluster_key);
+		
+	  h_nClus_layer->Fill(layer);
           if (trackerID == TrkrDefs::mvtxId)
             ++MVTX_hits;
           else if (trackerID == TrkrDefs::inttId)
             ++INTT_hits;
-          else if (trackerID == TrkrDefs::tpcId)
+	}
+	for (auto cluster_iter = tpcSeed->begin_cluster_keys(); 
+	     cluster_iter != tpcSeed->end_cluster_keys(); ++cluster_iter)
+        {
+          const auto &cluster_key = *cluster_iter;
+          const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+	  const auto layer = TrkrDefs::getLayer(cluster_key);
+		
+	  h_nClus_layer->Fill(layer);
+          if (trackerID == TrkrDefs::tpcId)
             ++TPC_hits;
-          else
-          {
-            if (Verbosity())
-              std::cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << std::endl;
-          }
-        }
-        if (MVTX_hits >= 2 && INTT_hits >= 1 && TPC_hits >= 20)
+	}
+
+	if (MVTX_hits >= 2 && INTT_hits >= 1 && TPC_hits >= 20)
         {
           h_DCArPhi_pT_cuts->Fill(pt, dca3dxy);
           h_DCAZ_pT_cuts->Fill(pt, dca3dz);
@@ -601,39 +637,72 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
           h_SigmalizedDCAZ_pT->Fill(pt, dca3dz / dca3dzsigma);
         }
 
-        // tracker cluster stat.
-        std::array<unsigned int, 3> nclusters = {{0, 0, 0}};
-
-        // cluster stat.
-        for (auto cluster_iter = track->begin_cluster_keys(); cluster_iter != track->end_cluster_keys(); ++cluster_iter)
-        {
-          const auto &cluster_key = *cluster_iter;
-          const auto layer = TrkrDefs::getLayer(cluster_key);
-          const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-
-          h_nClus_layer->Fill(layer);
-
-          if (trackerID == TrkrDefs::mvtxId)
-            ++nclusters[0];
-          else if (trackerID == TrkrDefs::inttId)
-            ++nclusters[1];
-          else if (trackerID == TrkrDefs::tpcId)
-            ++nclusters[2];
-          else
-          {
-            if (Verbosity())
-              std::cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << std::endl;
-          }
-        }  // for
-        h_nMVTX_nReco_pTGen->Fill(gpt, nclusters[0]);
-        h_nINTT_nReco_pTGen->Fill(gpt, nclusters[1]);
-        h_nTPC_nReco_pTGen->Fill(gpt, nclusters[2]);
+      
+        h_nMVTX_nReco_pTGen->Fill(gpt, MVTX_hits);
+        h_nINTT_nReco_pTGen->Fill(gpt, INTT_hits);
+        h_nTPC_nReco_pTGen->Fill(gpt, TPC_hits);
       }  //      if (match_found)
 
     }  //    if (track)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void QAG4SimulationTracking::get_dca(SvtxTrack* track, float& dca3dxy, 
+				     float& dca3dz, float& dca3dxysigma, 
+				     float& dca3dzsigma)
+{
+  Acts::Vector3 pos(track->get_x(),
+		    track->get_y(),
+		    track->get_z());
+  Acts::Vector3 mom(track->get_px(),
+		    track->get_py(),
+		    track->get_pz());
+
+  auto vtxid = track->get_vertex_id();
+  auto svtxVertex = m_vertexMap->get(vtxid);
+  Acts::Vector3 vertex(svtxVertex->get_x(),
+		       svtxVertex->get_y(),
+		       svtxVertex->get_z());
+
+  pos -= vertex;
+
+  Acts::ActsSymMatrix<3> posCov;
+  for(int i = 0; i < 3; ++i)
+    {
+      for(int j = 0; j < 3; ++j)
+	{
+	  posCov(i, j) = track->get_error(i, j);
+	} 
+    }
+  
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
+  float phi = atan2(r(1), r(0));
+  
+  Acts::RotationMatrix3 rot;
+  Acts::RotationMatrix3 rot_T;
+  rot(0,0) = cos(phi);
+  rot(0,1) = -sin(phi);
+  rot(0,2) = 0;
+  rot(1,0) = sin(phi);
+  rot(1,1) = cos(phi);
+  rot(1,2) = 0;
+  rot(2,0) = 0;
+  rot(2,1) = 0;
+  rot(2,2) = 1;
+  
+  rot_T = rot.transpose();
+
+  Acts::Vector3 pos_R = rot * pos;
+  Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
+
+  dca3dxy = pos_R(0);
+  dca3dz = pos_R(2);
+  dca3dxysigma = sqrt(rotCov(0,0));
+  dca3dzsigma = sqrt(rotCov(2,2));
+  
+  return;
 }
 
 int QAG4SimulationTracking::load_nodes(PHCompositeNode *topNode)

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -377,20 +377,21 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       
       TrackSeed *tpcseed = track->get_tpc_seed();
       TrackSeed *silseed = track->get_silicon_seed();
-
-      for (auto cluster_iter = silseed->begin_cluster_keys(); 
-	   cluster_iter != silseed->end_cluster_keys(); ++cluster_iter)
-      {
-        const auto &cluster_key = *cluster_iter;
-        const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-
-        if (trackerID == TrkrDefs::mvtxId)
-          ++MVTX_hits;
-        else if (trackerID == TrkrDefs::inttId)
-          ++INTT_hits;
-      }
-
-        for (auto cluster_iter = tpcseed->begin_cluster_keys(); 
+      if(silseed)
+	{
+	  for (auto cluster_iter = silseed->begin_cluster_keys(); 
+	       cluster_iter != silseed->end_cluster_keys(); ++cluster_iter)
+	    {
+	      const auto &cluster_key = *cluster_iter;
+	      const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+	      
+	      if (trackerID == TrkrDefs::mvtxId)
+		++MVTX_hits;
+	      else if (trackerID == TrkrDefs::inttId)
+		++INTT_hits;
+	    }
+	}
+      for (auto cluster_iter = tpcseed->begin_cluster_keys(); 
 	   cluster_iter != tpcseed->end_cluster_keys(); ++cluster_iter)
       {
         const auto &cluster_key = *cluster_iter;
@@ -597,19 +598,22 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 	TrackSeed* tpcSeed = track->get_tpc_seed();
 	TrackSeed* silSeed = track->get_silicon_seed();
 	
-        for (auto cluster_iter = silSeed->begin_cluster_keys(); 
-	     cluster_iter != silSeed->end_cluster_keys(); ++cluster_iter)
-        {
-          const auto &cluster_key = *cluster_iter;
-          const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-	  const auto layer = TrkrDefs::getLayer(cluster_key);
+	if(silSeed)
+	  {
+	    for (auto cluster_iter = silSeed->begin_cluster_keys(); 
+		 cluster_iter != silSeed->end_cluster_keys(); ++cluster_iter)
+	      {
+		const auto &cluster_key = *cluster_iter;
+		const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+		const auto layer = TrkrDefs::getLayer(cluster_key);
 		
-	  h_nClus_layer->Fill(layer);
-          if (trackerID == TrkrDefs::mvtxId)
-            ++MVTX_hits;
-          else if (trackerID == TrkrDefs::inttId)
-            ++INTT_hits;
-	}
+		h_nClus_layer->Fill(layer);
+		if (trackerID == TrkrDefs::mvtxId)
+		  ++MVTX_hits;
+		else if (trackerID == TrkrDefs::inttId)
+		  ++INTT_hits;
+	      }
+	  }
 	for (auto cluster_iter = tpcSeed->begin_cluster_keys(); 
 	     cluster_iter != tpcSeed->end_cluster_keys(); ++cluster_iter)
         {

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -20,7 +20,6 @@ class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
-class TrackSeedContainer;
 class SvtxVertexMap;
 
 /// \class QAG4SimulationTracking
@@ -77,8 +76,6 @@ class QAG4SimulationTracking : public SubsysReco
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap* m_vertexMap = nullptr;
-  TrackSeedContainer *m_silSeeds = nullptr;
-  TrackSeedContainer *m_tpcSeeds = nullptr;
 
   TrkrClusterContainer *m_cluster_map = nullptr;
   TrkrClusterHitAssoc *m_cluster_hit_map = nullptr;

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -20,6 +20,8 @@ class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
+class TrackSeedContainer;
+class SvtxVertexMap;
 
 /// \class QAG4SimulationTracking
 class QAG4SimulationTracking : public SubsysReco
@@ -57,6 +59,8 @@ class QAG4SimulationTracking : public SubsysReco
   /// load nodes
   int load_nodes(PHCompositeNode *);
 
+  void get_dca(SvtxTrack* track, float& dca3dxy, float& dca3dz, 
+	       float& dca3dxysigma, float& dca3dzsigma);
   // get geant hits associated to a cluster
   using G4HitSet = std::set<PHG4Hit *>;
   G4HitSet find_g4hits(TrkrDefs::cluskey) const;
@@ -72,6 +76,9 @@ class QAG4SimulationTracking : public SubsysReco
 
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
+  SvtxVertexMap* m_vertexMap = nullptr;
+  TrackSeedContainer *m_silSeeds = nullptr;
+  TrackSeedContainer *m_tpcSeeds = nullptr;
 
   TrkrClusterContainer *m_cluster_map = nullptr;
   TrkrClusterHitAssoc *m_cluster_hit_map = nullptr;

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -346,23 +346,25 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
 
 	TrackSeed* siliconSeed = track->get_tpc_seed();
 	TrackSeed* tpcSeed = track->get_silicon_seed();
-
-        for (auto cluster_iter = siliconSeed->begin_cluster_keys(); 
-	     cluster_iter != siliconSeed->end_cluster_keys(); ++cluster_iter)
-        {
-          const auto &cluster_key = *cluster_iter;
-          const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
-
-          if (trackerID == TrkrDefs::mvtxId)
-            ++MVTX_hits;
-          else if (trackerID == TrkrDefs::inttId)
-            ++INTT_hits;
-          else
-          {
-            if (Verbosity())
-              std::cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << std::endl;
-          }
-        }
+	if(siliconSeed)
+	  {
+	    for (auto cluster_iter = siliconSeed->begin_cluster_keys(); 
+		 cluster_iter != siliconSeed->end_cluster_keys(); ++cluster_iter)
+	      {
+		const auto &cluster_key = *cluster_iter;
+		const auto trackerID = TrkrDefs::getTrkrId(cluster_key);
+		
+		if (trackerID == TrkrDefs::mvtxId)
+		  ++MVTX_hits;
+		else if (trackerID == TrkrDefs::inttId)
+		  ++INTT_hits;
+		else
+		  {
+		    if (Verbosity())
+		      std::cout << "QAG4SimulationTracking::process_event - unkown tracker ID = " << trackerID << " from cluster " << cluster_key << std::endl;
+		  }
+	      }
+	  }
 	for (auto cluster_iter = tpcSeed->begin_cluster_keys(); 
 	     cluster_iter != tpcSeed->end_cluster_keys(); ++cluster_iter)
         {

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -16,7 +16,6 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertex.h>
 #include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeed.h>
 
 #include <g4main/PHG4Particle.h>
@@ -70,19 +69,6 @@ int QAG4SimulationVertex::InitRun(PHCompositeNode *topNode)
     std::cout << __PRETTY_FUNCTION__ << " Fatal Error : missing G4TruthInfo" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-
-  m_tpcSeeds = findNode::getClass<TrackSeedContainer>(topNode,"TpcTrackSeedContainer");
-  m_silSeeds = findNode::getClass<TrackSeedContainer>(topNode,"SiliconTrackSeedContainer");
-  if(!m_tpcSeeds)
-    { 
-      std::cout << __PRETTY_FUNCTION__ << "Fatal Error: missing tpc track seed container" << std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
-    if(!m_silSeeds)
-    { 
-      std::cout << __PRETTY_FUNCTION__ << "Fatal Error: missing silicon track seed container" << std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -358,11 +344,8 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
         int INTT_hits = 0;
         int TPC_hits = 0;
 
-	const unsigned int tpcid = track->get_tpc_id();
-	const unsigned int silid = track->get_silicon_id();
-	
-	TrackSeed* siliconSeed = m_silSeeds->get(silid);
-	TrackSeed* tpcSeed = m_tpcSeeds->get(tpcid);
+	TrackSeed* siliconSeed = track->get_tpc_seed();
+	TrackSeed* tpcSeed = track->get_silicon_seed();
 
         for (auto cluster_iter = siliconSeed->begin_cluster_keys(); 
 	     cluster_iter != siliconSeed->end_cluster_keys(); ++cluster_iter)

--- a/offline/QA/modules/QAG4SimulationVertex.h
+++ b/offline/QA/modules/QAG4SimulationVertex.h
@@ -15,6 +15,8 @@ class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class SvtxTrackMap;
 class SvtxVertexMap;
+class TrackSeed;
+class TrackSeedContainer;
 
 class QAG4SimulationVertex : public SubsysReco
 {
@@ -46,6 +48,8 @@ class QAG4SimulationVertex : public SubsysReco
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   PHG4TruthInfoContainer *m_truthInfo = nullptr;
+  TrackSeedContainer *m_tpcSeeds = nullptr;
+  TrackSeedContainer *m_silSeeds = nullptr;
 
   std::set<int> m_embeddingIDs;
 

--- a/offline/QA/modules/QAG4SimulationVertex.h
+++ b/offline/QA/modules/QAG4SimulationVertex.h
@@ -16,7 +16,6 @@ class PHG4TruthInfoContainer;
 class SvtxTrackMap;
 class SvtxVertexMap;
 class TrackSeed;
-class TrackSeedContainer;
 
 class QAG4SimulationVertex : public SubsysReco
 {
@@ -48,8 +47,6 @@ class QAG4SimulationVertex : public SubsysReco
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
   PHG4TruthInfoContainer *m_truthInfo = nullptr;
-  TrackSeedContainer *m_tpcSeeds = nullptr;
-  TrackSeedContainer *m_silSeeds = nullptr;
 
   std::set<int> m_embeddingIDs;
 

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -35,6 +35,7 @@ pkginclude_HEADERS = \
   SvtxTrack_v1.h \
   SvtxTrack_v2.h \
   SvtxTrack_v3.h \
+  SvtxTrack_v4.h \
   SvtxTrack_FastSim.h \
   SvtxTrack_FastSim_v1.h \
   SvtxTrack_FastSim_v2.h \
@@ -66,6 +67,7 @@ ROOTDICTS = \
   SvtxTrack_v1_Dict.cc \
   SvtxTrack_v2_Dict.cc \
   SvtxTrack_v3_Dict.cc \
+  SvtxTrack_v4_Dict.cc \
   SvtxTrack_FastSim_Dict.cc \
   SvtxTrack_FastSim_v1_Dict.cc \
   SvtxTrack_FastSim_v2_Dict.cc \
@@ -96,6 +98,7 @@ nobase_dist_pcm_DATA = \
   SvtxTrack_v1_Dict_rdict.pcm \
   SvtxTrack_v2_Dict_rdict.pcm \
   SvtxTrack_v3_Dict_rdict.pcm \
+  SvtxTrack_v4_Dict_rdict.pcm \
   SvtxTrack_FastSim_Dict_rdict.pcm \
   SvtxTrack_FastSim_v1_Dict_rdict.pcm \
   SvtxTrack_FastSim_v2_Dict_rdict.pcm \
@@ -127,6 +130,7 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrack_v1.cc \
   SvtxTrack_v2.cc \
   SvtxTrack_v3.cc \
+  SvtxTrack_v4.cc \
   SvtxTrack_FastSim.cc \
   SvtxTrack_FastSim_v1.cc \
   SvtxTrack_FastSim_v2.cc \

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -2,6 +2,7 @@
 #define TRACKBASEHISTORIC_SVTXTRACK_H
 
 #include "SvtxTrackState.h"
+#include "TrackSeed.h"
 
 #include <trackbase/TrkrDefs.h>
 
@@ -66,11 +67,11 @@ class SvtxTrack : public PHObject
   virtual unsigned int get_id() const { return UINT_MAX; }
   virtual void set_id(unsigned int) {}
 
-  virtual unsigned int get_tpc_id() const { return UINT_MAX; }
-  virtual void set_tpc_id(unsigned int) {}
+  virtual TrackSeed* get_tpc_seed() const { return nullptr; }
+  virtual void set_tpc_seed(TrackSeed*) {}
   
-  virtual unsigned int get_silicon_id() const { return UINT_MAX; }
-  virtual void set_silicon_id(unsigned int) {}
+  virtual TrackSeed* get_silicon_seed() const { return nullptr; }
+  virtual void set_silicon_seed(TrackSeed*) {}
 
   virtual short int get_crossing() const { return SHRT_MAX; }
   virtual void set_crossing(short int) {}

--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -66,6 +66,12 @@ class SvtxTrack : public PHObject
   virtual unsigned int get_id() const { return UINT_MAX; }
   virtual void set_id(unsigned int) {}
 
+  virtual unsigned int get_tpc_id() const { return UINT_MAX; }
+  virtual void set_tpc_id(unsigned int) {}
+  
+  virtual unsigned int get_silicon_id() const { return UINT_MAX; }
+  virtual void set_silicon_id(unsigned int) {}
+
   virtual short int get_crossing() const { return SHRT_MAX; }
   virtual void set_crossing(short int) {}
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -1,0 +1,132 @@
+#include "SvtxTrack_v4.h"
+#include "SvtxTrackState.h"
+#include "SvtxTrackState_v1.h"
+
+#include <trackbase/TrkrDefs.h>  // for cluskey
+
+#include <phool/PHObject.h>      // for PHObject
+
+#include <climits>
+#include <map>
+#include <vector>                // for vector
+
+SvtxTrack_v4::SvtxTrack_v4()
+{
+  // always include the pca point
+  _states.insert( std::make_pair(0, new SvtxTrackState_v1(0)));
+
+}
+
+SvtxTrack_v4::SvtxTrack_v4(const SvtxTrack& source)
+{ SvtxTrack_v4::CopyFrom( source ); }
+
+// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
+// cppcheck-suppress uninitMemberVar
+SvtxTrack_v4::SvtxTrack_v4(const SvtxTrack_v4& source)
+{ SvtxTrack_v4::CopyFrom( source ); }
+
+SvtxTrack_v4& SvtxTrack_v4::operator=(const SvtxTrack_v4& source)
+{ if( this != &source ) CopyFrom( source ); return *this; }
+
+SvtxTrack_v4::~SvtxTrack_v4()
+{ clear_states(); }
+
+void SvtxTrack_v4::CopyFrom( const SvtxTrack& source )
+{
+  // do nothing if copying onto oneself
+  if( this == &source ) return;
+  
+  // parent class method
+  SvtxTrack::CopyFrom( source );
+  
+  _track_id = source.get_id();
+  _tpc_id = source.get_tpc_id();
+  _silicon_id = source.get_silicon_id();
+  _vertex_id = source.get_vertex_id();
+  _is_positive_charge = source.get_positive_charge();
+  _chisq = source.get_chisq();
+  _ndf = source.get_ndf();
+  _track_crossing = source.get_crossing();
+  
+  // copy the states over into new state objects stored here
+  clear_states();
+  for( auto iter = source.begin_states(); iter != source.end_states(); ++iter )
+  { _states.insert( std::make_pair(iter->first, static_cast<SvtxTrackState*>(iter->second->CloneMe() ) ) ); }
+
+}
+
+void SvtxTrack_v4::identify(std::ostream& os) const
+{
+  os << "SvtxTrack_v4 Object ";
+  os << "id: " << get_id() << " ";
+  os << "silicon tracklet id : " << get_silicon_id() << " ";
+  os << "tpc tracklet id : " << get_tpc_id() << " ";
+  os << "vertex id: " << get_vertex_id() << " ";
+  os << "charge: " << get_charge() << " ";
+  os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
+  os << std::endl;
+
+  os << "(px,py,pz) = ("
+     << get_px() << ","
+     << get_py() << ","
+     << get_pz() << ")" << std::endl;
+
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
+
+  os << std::endl;
+
+  return;
+}
+
+void SvtxTrack_v4::clear_states()
+{
+  for( const auto& pair:_states )
+  { delete pair.second; }
+  
+  _states.clear();
+}
+
+int SvtxTrack_v4::isValid() const
+{
+  return 1;
+}
+
+const SvtxTrackState* SvtxTrack_v4::get_state(float pathlength) const
+{
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr:iter->second;
+}
+
+SvtxTrackState* SvtxTrack_v4::get_state(float pathlength)
+{
+  const auto iter = _states.find(pathlength);
+  return (iter == _states.end()) ? nullptr:iter->second;
+}
+
+SvtxTrackState* SvtxTrack_v4::insert_state(const SvtxTrackState* state)
+{
+  // find closest iterator
+  const auto pathlength = state->get_pathlength();
+  auto iterator = _states.lower_bound( pathlength );
+  if( iterator == _states.end() || pathlength < iterator->first )
+  {
+    // pathlength not found. Make a copy and insert
+    const auto copy =  static_cast<SvtxTrackState*> (state->CloneMe());
+    iterator = _states.insert(iterator, std::make_pair( pathlength, copy ));
+  }
+
+  // return matching state
+  return iterator->second;
+}
+
+size_t SvtxTrack_v4::erase_state(float pathlength)
+{
+  StateIter iter = _states.find(pathlength);
+  if (iter == _states.end()) return _states.size();
+
+  delete iter->second;
+  _states.erase(iter);
+  return _states.size();
+}
+
+

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -39,8 +39,8 @@ void SvtxTrack_v4::CopyFrom( const SvtxTrack& source )
   // parent class method
   SvtxTrack::CopyFrom( source );
   
-  _tpc_id = source.get_id();
-  _silicon_id = source.get_silicon_id();
+  _tpc_seed = source.get_tpc_seed();
+  _silicon_seed = source.get_silicon_seed();
   _vertex_id = source.get_vertex_id();
   _is_positive_charge = source.get_positive_charge();
   _chisq = source.get_chisq();
@@ -58,8 +58,6 @@ void SvtxTrack_v4::identify(std::ostream& os) const
 {
   os << "SvtxTrack_v4 Object ";
   os << "id: " << get_id() << " ";
-  os << "silicon tracklet id : " << get_silicon_id() << " ";
-  os << "tpc tracklet id : " << get_tpc_id() << " ";
   os << "vertex id: " << get_vertex_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
@@ -72,6 +70,21 @@ void SvtxTrack_v4::identify(std::ostream& os) const
 
   os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
 
+  os << "Silicon clusters " << std::endl;
+  for(auto iter = _silicon_seed->begin_cluster_keys(); 
+      iter != _silicon_seed->end_cluster_keys();
+      ++iter)
+    {
+      std::cout << *iter << ", ";
+    }
+  os << std::endl << "Tpc + TPOT clusters " << std::endl;
+    for(auto iter = _tpc_seed->begin_cluster_keys(); 
+      iter != _tpc_seed->end_cluster_keys();
+      ++iter)
+    {
+      std::cout << *iter << ", ";
+    }
+    
   os << std::endl;
 
   return;

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -39,8 +39,7 @@ void SvtxTrack_v4::CopyFrom( const SvtxTrack& source )
   // parent class method
   SvtxTrack::CopyFrom( source );
   
-  _track_id = source.get_id();
-  _tpc_id = source.get_tpc_id();
+  _tpc_id = source.get_id();
   _silicon_id = source.get_silicon_id();
   _vertex_id = source.get_vertex_id();
   _is_positive_charge = source.get_positive_charge();

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -71,11 +71,14 @@ void SvtxTrack_v4::identify(std::ostream& os) const
   os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << std::endl;
 
   os << "Silicon clusters " << std::endl;
-  for(auto iter = _silicon_seed->begin_cluster_keys(); 
-      iter != _silicon_seed->end_cluster_keys();
-      ++iter)
+  if(_silicon_seed)
     {
-      std::cout << *iter << ", ";
+      for(auto iter = _silicon_seed->begin_cluster_keys(); 
+	  iter != _silicon_seed->end_cluster_keys();
+	  ++iter)
+	{
+	  std::cout << *iter << ", ";
+	}
     }
   os << std::endl << "Tpc + TPOT clusters " << std::endl;
     for(auto iter = _tpc_seed->begin_cluster_keys(); 

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.h
@@ -48,8 +48,8 @@ class SvtxTrack_v4: public SvtxTrack
   // basic track information ---------------------------------------------------
   //
 
-  unsigned int get_id() const override { return _track_id; }
-  void set_id(unsigned int id) override { _track_id = id; }
+  unsigned int get_id() const override { return _tpc_id; }
+  void set_id(unsigned int id) override { _tpc_id = id; }
 
   unsigned int get_tpc_id() const override { return _tpc_id; }
   void set_tpc_id(unsigned int id) override { _tpc_id = id; }
@@ -131,10 +131,9 @@ class SvtxTrack_v4: public SvtxTrack
  private:
 
   // track information
-  unsigned int _track_id = UINT_MAX;
+  unsigned int _tpc_id = UINT_MAX;
   unsigned int _vertex_id = UINT_MAX;
   unsigned int _silicon_id = UINT_MAX;
-  unsigned int _tpc_id = UINT_MAX;
   bool _is_positive_charge = false;
   float _chisq = NAN;
   unsigned int _ndf = 0;

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.h
@@ -1,0 +1,149 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKV4_H
+#define TRACKBASEHISTORIC_SVTXTRACKV4_H
+
+#include "SvtxTrack.h"
+#include "SvtxTrackState.h"
+
+#include <trackbase/TrkrDefs.h>
+
+#include <cmath>
+#include <cstddef>  // for size_t
+#include <iostream>
+#include <map>
+#include <utility>  // for pair
+
+class PHObject;
+
+class SvtxTrack_v4: public SvtxTrack
+{
+ public:
+  SvtxTrack_v4();
+  
+  //* base class copy constructor
+  SvtxTrack_v4( const SvtxTrack& );
+  
+  //* copy constructor
+  SvtxTrack_v4(const SvtxTrack_v4& );
+  
+  //* assignment operator
+  SvtxTrack_v4& operator=(const SvtxTrack_v4& track);
+
+  //* destructor
+  ~SvtxTrack_v4() override; 
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override { *this = SvtxTrack_v4(); }
+  int isValid() const override;
+  PHObject* CloneMe() const override { return new SvtxTrack_v4(*this); }
+
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  // copy content from base class
+  void CopyFrom( const SvtxTrack& ) override;
+  void CopyFrom( SvtxTrack* source ) override
+  { CopyFrom( *source ); }
+
+  //
+  // basic track information ---------------------------------------------------
+  //
+
+  unsigned int get_id() const override { return _track_id; }
+  void set_id(unsigned int id) override { _track_id = id; }
+
+  unsigned int get_tpc_id() const override { return _tpc_id; }
+  void set_tpc_id(unsigned int id) override { _tpc_id = id; }
+
+  unsigned int get_silicon_id() const override { return _silicon_id; }
+  void set_silicon_id(unsigned int id) override { _silicon_id = id; }
+
+  short int get_crossing() const override { return _track_crossing; }
+  void set_crossing(short int cross) override { _track_crossing = cross; }
+
+  unsigned int get_vertex_id() const override { return _vertex_id; }
+  void set_vertex_id(unsigned int id) override { _vertex_id = id; }
+
+  bool get_positive_charge() const override { return _is_positive_charge; }
+  void set_positive_charge(bool ispos) override { _is_positive_charge = ispos; }
+
+  int get_charge() const override { return (get_positive_charge()) ? 1 : -1; }
+  void set_charge(int charge) override { (charge > 0) ? set_positive_charge(true) : set_positive_charge(false); }
+
+  float get_chisq() const override { return _chisq; }
+  void set_chisq(float chisq) override { _chisq = chisq; }
+
+  unsigned int get_ndf() const override { return _ndf; }
+  void set_ndf(int ndf) override { _ndf = ndf; }
+
+  float get_quality() const override { return (_ndf != 0) ? _chisq / _ndf : NAN; }
+
+  float get_x() const override { return _states.find(0.0)->second->get_x(); }
+  void set_x(float x) override { _states[0.0]->set_x(x); }
+
+  float get_y() const override { return _states.find(0.0)->second->get_y(); }
+  void set_y(float y) override { _states[0.0]->set_y(y); }
+
+  float get_z() const override { return _states.find(0.0)->second->get_z(); }
+  void set_z(float z) override { _states[0.0]->set_z(z); }
+
+  float get_pos(unsigned int i) const override { return _states.find(0.0)->second->get_pos(i); }
+
+  float get_px() const override { return _states.find(0.0)->second->get_px(); }
+  void set_px(float px) override { _states[0.0]->set_px(px); }
+
+  float get_py() const override { return _states.find(0.0)->second->get_py(); }
+  void set_py(float py) override { _states[0.0]->set_py(py); }
+
+  float get_pz() const override { return _states.find(0.0)->second->get_pz(); }
+  void set_pz(float pz) override { _states[0.0]->set_pz(pz); }
+
+  float get_mom(unsigned int i) const override { return _states.find(0.0)->second->get_mom(i); }
+
+  float get_p() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2) + pow(get_pz(), 2)); }
+  float get_pt() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2)); }
+  float get_eta() const override { return asinh(get_pz() / get_pt()); }
+  float get_phi() const override { return atan2(get_py(), get_px()); }
+
+  float get_error(int i, int j) const override { return _states.find(0.0)->second->get_error(i, j); }
+  void set_error(int i, int j, float value) override { return _states[0.0]->set_error(i, j, value); }
+
+  //
+  // state methods -------------------------------------------------------------
+  //
+  bool empty_states() const override { return _states.empty(); }
+  size_t size_states() const override { return _states.size(); }
+  size_t count_states(float pathlength) const override { return _states.count(pathlength); }
+  void clear_states() override;
+
+  const SvtxTrackState* get_state(float pathlength) const override;
+  SvtxTrackState* get_state(float pathlength) override;
+  SvtxTrackState* insert_state(const SvtxTrackState* state) override;
+  size_t erase_state(float pathlength) override;
+
+  ConstStateIter begin_states() const override { return _states.begin(); }
+  ConstStateIter find_state(float pathlength) const override { return _states.find(pathlength); }
+  ConstStateIter end_states() const override { return _states.end(); }
+
+  StateIter begin_states() override { return _states.begin(); }
+  StateIter find_state(float pathlength) override { return _states.find(pathlength); }
+  StateIter end_states() override { return _states.end(); }
+ 
+ private:
+
+  // track information
+  unsigned int _track_id = UINT_MAX;
+  unsigned int _vertex_id = UINT_MAX;
+  unsigned int _silicon_id = UINT_MAX;
+  unsigned int _tpc_id = UINT_MAX;
+  bool _is_positive_charge = false;
+  float _chisq = NAN;
+  unsigned int _ndf = 0;
+  short int _track_crossing = SHRT_MAX;
+
+  // track state information
+  StateMap _states;  //< path length => state object
+
+  ClassDefOverride(SvtxTrack_v4, 4)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.h
@@ -3,6 +3,7 @@
 
 #include "SvtxTrack.h"
 #include "SvtxTrackState.h"
+#include "TrackSeed.h"
 
 #include <trackbase/TrkrDefs.h>
 
@@ -48,14 +49,14 @@ class SvtxTrack_v4: public SvtxTrack
   // basic track information ---------------------------------------------------
   //
 
-  unsigned int get_id() const override { return _tpc_id; }
-  void set_id(unsigned int id) override { _tpc_id = id; }
+  unsigned int get_id() const override { return _track_id; }
+  void set_id(unsigned int id) override { _track_id = id; }
 
-  unsigned int get_tpc_id() const override { return _tpc_id; }
-  void set_tpc_id(unsigned int id) override { _tpc_id = id; }
+  TrackSeed* get_tpc_seed() const override { return _tpc_seed; }
+  void set_tpc_seed(TrackSeed* seed) override { _tpc_seed = seed; }
 
-  unsigned int get_silicon_id() const override { return _silicon_id; }
-  void set_silicon_id(unsigned int id) override { _silicon_id = id; }
+  TrackSeed* get_silicon_seed() const override { return _silicon_seed; }
+  void set_silicon_seed(TrackSeed* seed) override {_silicon_seed = seed; }
 
   short int get_crossing() const override { return _track_crossing; }
   void set_crossing(short int cross) override { _track_crossing = cross; }
@@ -131,9 +132,10 @@ class SvtxTrack_v4: public SvtxTrack
  private:
 
   // track information
-  unsigned int _tpc_id = UINT_MAX;
+  TrackSeed* _tpc_seed = nullptr;
+  TrackSeed* _silicon_seed = nullptr;
+  unsigned int _track_id = UINT_MAX;
   unsigned int _vertex_id = UINT_MAX;
-  unsigned int _silicon_id = UINT_MAX;
   bool _is_positive_charge = false;
   float _chisq = NAN;
   unsigned int _ndf = 0;

--- a/offline/packages/trackbase_historic/SvtxTrack_v4LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrack_v4 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -376,10 +376,11 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	      /// We want to set the ID to the tpc track seed id so that
 	      /// the ghost rejection finds the right track
 	      newTrack->set_id(tpcid);
-	      newTrack->set_silicon_id(siid);
+	      newTrack->set_tpc_seed(tpcseed);
 	      if(siid != std::numeric_limits<unsigned int>::max())
 		{ 
 		  newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
+		  newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
 		}
 	      else
 		{

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -40,7 +40,7 @@
 
 class MakeActsGeometry;
 class SvtxTrack;
-class SvtxTrack_v3;
+class SvtxTrack_v4;
 class SvtxTrackMap;
 class TrackSeed;
 class TrackSeedContainer;
@@ -116,12 +116,12 @@ class PHActsTrkFitter : public SubsysReco
 			       ActsExamples::MeasurementContainer& measurements);
 
   /// Convert the acts track fit result to an svtx track
-  void updateSvtxTrack(Trajectory traj, std::unique_ptr<SvtxTrack_v3>& track);
+  void updateSvtxTrack(Trajectory traj, std::unique_ptr<SvtxTrack_v4>& track);
 
   /// Helper function to call either the regular navigation or direct
   /// navigation, depending on m_fitSiliconMMs
   ActsExamples::TrackFittingAlgorithm::TrackFitterResult fitTrack(
-								  const std::vector<std::reference_wrapper<const SourceLink>>& sourceLinks, 
+           const std::vector<std::reference_wrapper<const SourceLink>>& sourceLinks, 
 	   const ActsExamples::TrackParameters& seed,
 	   const ActsExamples::TrackFittingAlgorithm::TrackFitterOptions& 
 	     kfOptions,
@@ -133,10 +133,7 @@ class PHActsTrkFitter : public SubsysReco
 				 SurfacePtrVec& surfaces) const;
   void checkSurfaceVec(SurfacePtrVec& surfaces) const;
 
-  void addKeys(std::unique_ptr<SvtxTrack_v3>& svtxtrack,
-	       TrackSeed* seed);
-
-  bool getTrackFitResult(const FitResult& fitOutput, std::unique_ptr<SvtxTrack_v3>& track);
+  bool getTrackFitResult(const FitResult& fitOutput, std::unique_ptr<SvtxTrack_v4>& track);
 
   Surface getSurface(TrkrDefs::cluskey cluskey,TrkrDefs::subsurfkey surfkey) const;
   Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const;

--- a/offline/packages/trackreco/PHActsVertexPropagator.h
+++ b/offline/packages/trackreco/PHActsVertexPropagator.h
@@ -42,7 +42,6 @@ class PHActsVertexPropagator : public SubsysReco
 					  const unsigned int vtxid);
   Acts::Vector3 getVertex(const unsigned int vtxid);
   void updateSvtxTrack(SvtxTrack* track, const Acts::BoundTrackParameters& params);
-  void updateTrackDCA(SvtxTrack* track);
   void setVtxChi2();
   
   ActsTrackingGeometry *m_tGeometry = nullptr;

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -283,7 +283,11 @@ void PHSimpleVertexFinder::checkDCAs()
       if(_require_mvtx)
 	{
 	  unsigned int nmvtx = 0;
-	  for(auto clusit = tr1->begin_cluster_keys(); clusit != tr1->end_cluster_keys(); ++clusit)
+	  TrackSeed *siliconseed = tr1->get_silicon_seed();
+	  if(!siliconseed)
+	    { continue; }
+
+	  for(auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
 	    {
 	      if(TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId )
 		{
@@ -304,7 +308,11 @@ void PHSimpleVertexFinder::checkDCAs()
 	  if(_require_mvtx)
 	    {
 	      unsigned int nmvtx = 0;
-	      for(auto clusit = tr2->begin_cluster_keys(); clusit != tr2->end_cluster_keys(); ++clusit)
+	      TrackSeed *siliconseed = tr2->get_silicon_seed();
+	      if(!siliconseed)
+		{ continue; }
+	     
+	      for(auto clusit = siliconseed->begin_cluster_keys(); clusit != siliconseed->end_cluster_keys(); ++clusit)
 		{
 		  if(TrkrDefs::getTrkrId(*clusit) == TrkrDefs::mvtxId)
 		    {
@@ -347,7 +355,7 @@ void PHSimpleVertexFinder::findDcaTwoTracks(SvtxTrack *tr1, SvtxTrack *tr2)
   double dca = dcaTwoLines(a1, b1, a2,  b2, PCA1, PCA2);
 
   // check dca cut is satisfied, and that PCA is close to beam line
-if( fabs(dca) < _dcacut && (fabs(PCA1.x()) < _beamline_xy_cut && fabs(PCA1.y()) < _beamline_xy_cut) )
+  if( fabs(dca) < _dcacut && (fabs(PCA1.x()) < _beamline_xy_cut && fabs(PCA1.y()) < _beamline_xy_cut) )
     {
       if(Verbosity() > 3)
 	{

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -20,6 +20,9 @@ class TrkrCluster;
 class SvtxEvalStack;
 class TFile;
 class TNtuple;
+class SvtxTrack;
+class SvtxVertexMap;
+
 //class TrkrClusterContainer;
 
 /// \class SvtxEvaluator
@@ -77,7 +80,9 @@ class SvtxEvaluator : public SubsysReco
   SvtxEvalStack *_svtxevalstack;
 
   TMatrixF calculateClusterError(TrkrCluster* c, float& clusphi);
-
+  void get_dca(SvtxTrack* track, SvtxVertexMap* vertexmap,
+	       float& dca3dxy, float& dca3dz,
+	       float& dca3dxysigma, float& dca3dzsigma);
   //TrkrClusterContainer *cluster_map{nullptr};
 
   //----------------------------------

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -95,14 +95,11 @@ std::set<PHG4Hit*> SvtxTrackEval::all_truth_hits(SvtxTrack* track)
   }
 
   std::set<PHG4Hit*> truth_hits;
-
+  std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+ 
   // loop over all clusters...
-  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-       iter != track->end_cluster_keys();
-       ++iter)
-  {
-    TrkrDefs::cluskey cluster_key = *iter;
-
+  for (const auto& cluster_key : cluster_keys)
+    {
     //    if (_strict)
     //    {
     //      assert(cluster_key);
@@ -177,12 +174,9 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
   }
   else{                
     // loop over all clusters...
-    for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-        iter != track->end_cluster_keys();
-        ++iter)
+    std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+    for (const auto& cluster_key : cluster_keys)
     {
-      TrkrDefs::cluskey cluster_key = *iter;
-
       //    if (_strict)
       //    {
       //      assert(cluster_key);
@@ -325,13 +319,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
        ++iter)
   {
     SvtxTrack* track = iter->second;
-
-    for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-         iter != track->end_cluster_keys();
-         ++iter)
+    std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+    for (const auto& cluster_key : cluster_keys)
     {
-      TrkrDefs::cluskey cluster_key = *iter;
-
       // remove this check as cluster key = 0 is MVTX layer 0 cluster #0.
       //      if (_strict)
       //      {
@@ -399,13 +389,10 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Hit* truthhit)
        ++iter)
   {
     SvtxTrack* track = iter->second;
-
+    std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
     // loop over all clusters
-    for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-         iter != track->end_cluster_keys();
-         ++iter)
+    for (const auto& cluster_key : cluster_keys)
     {
-      TrkrDefs::cluskey cluster_key = *iter;
 
       //      if (_strict)
       //      {
@@ -514,12 +501,11 @@ void SvtxTrackEval::create_cache_track_from_cluster()
        ++iter)
   {
     SvtxTrack* track = iter->second;
+    std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+
     // loop over all clusters
-    for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-         iter != track->end_cluster_keys();
-         ++iter)
+    for (const auto& candidate_key : cluster_keys)
     {
-      TrkrDefs::cluskey candidate_key = *iter;
       // unsigned int cluster_layer = TrkrDefs::getLayer(candidate_key);
       //      if (_strict)
       //      {
@@ -592,13 +578,11 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(TrkrDefs::cluskey cluster_ke
        ++iter)
   {
     SvtxTrack* track = iter->second;
+    std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
 
     // loop over all clusters
-    for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-         iter != track->end_cluster_keys();
-         ++iter)
+    for (const auto& candidate : cluster_keys)
     {
-      TrkrDefs::cluskey candidate = *iter;
 
       //      if (_strict)
       //      {
@@ -767,12 +751,9 @@ void SvtxTrackEval::calc_cluster_contribution(SvtxTrack* track, PHG4Particle* pa
   unsigned int nclusters = 0;
   unsigned int nwrong = 0;
   // loop over all clusters
-  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-       iter != track->end_cluster_keys();
-       ++iter)
+  std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+  for (const auto& cluster_key : cluster_keys)
   {
-    TrkrDefs::cluskey cluster_key = *iter;
-
     //    if (_strict)
     //    {
     //      assert(cluster_key);
@@ -839,11 +820,9 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
   for (int i = 0; i < 100; i++) layer_occupied[i] = 0;
 
   // loop over all clusters
-  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-       iter != track->end_cluster_keys();
-       ++iter)
+  std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+  for (const auto& cluster_key : cluster_keys)
   {
-    TrkrDefs::cluskey cluster_key = *iter;
     unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
 
     //    if (_strict)
@@ -907,11 +886,9 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
     layers[i] = 0;
   }
   // loop over all clusters
-  for (SvtxTrack::ConstClusterKeyIter iter = track->begin_cluster_keys();
-       iter != track->end_cluster_keys();
-       ++iter)
+  std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
+  for (const auto& cluster_key : cluster_keys)
   {
-    TrkrDefs::cluskey cluster_key = *iter;
     unsigned int cluster_layer = TrkrDefs::getLayer(cluster_key);
     if (cluster_layer >= end_layer) continue;
     if (cluster_layer < start_layer) continue;
@@ -972,3 +949,19 @@ bool SvtxTrackEval::has_node_pointers()
   return true;
 }
 
+std::vector<TrkrDefs::cluskey> SvtxTrackEval::get_track_ckeys(SvtxTrack* track)
+{
+  std::vector<TrkrDefs::cluskey> cluster_keys;
+  TrackSeed *tpcseed = track->get_tpc_seed();
+  TrackSeed *silseed = track->get_silicon_seed();
+  for(auto iter = silseed->begin_cluster_keys();
+      iter!= silseed->end_cluster_keys();
+      ++iter)
+    { cluster_keys.push_back(*iter); }
+  for(auto iter = tpcseed->begin_cluster_keys();
+      iter!= tpcseed->end_cluster_keys();
+      ++iter)
+    { cluster_keys.push_back(*iter); }
+  
+  return cluster_keys;
+}

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -303,10 +303,12 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
 
   if (_do_cache)
   {
+    std::cout << "do cache"<<std::endl;
     std::map<PHG4Particle*, std::set<SvtxTrack*> >::iterator iter =
         _cache_all_tracks_from_particle.find(truthparticle);
     if (iter != _cache_all_tracks_from_particle.end())
     {
+      std::cout << "returning iter"<<std::endl;
       return iter->second;
     }
   }
@@ -319,9 +321,11 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
        ++iter)
   {
     SvtxTrack* track = iter->second;
+    std::cout << "is there a problem here"<<std::endl;
     std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
     for (const auto& cluster_key : cluster_keys)
     {
+      std::cout << "ckey is " << cluster_key << std::endl;
       // remove this check as cluster key = 0 is MVTX layer 0 cluster #0.
       //      if (_strict)
       //      {
@@ -954,10 +958,13 @@ std::vector<TrkrDefs::cluskey> SvtxTrackEval::get_track_ckeys(SvtxTrack* track)
   std::vector<TrkrDefs::cluskey> cluster_keys;
   TrackSeed *tpcseed = track->get_tpc_seed();
   TrackSeed *silseed = track->get_silicon_seed();
-  for(auto iter = silseed->begin_cluster_keys();
-      iter!= silseed->end_cluster_keys();
-      ++iter)
-    { cluster_keys.push_back(*iter); }
+  if(silseed)
+    {
+      for(auto iter = silseed->begin_cluster_keys();
+	  iter!= silseed->end_cluster_keys();
+	  ++iter)
+	{ cluster_keys.push_back(*iter); }
+    }
   for(auto iter = tpcseed->begin_cluster_keys();
       iter!= tpcseed->end_cluster_keys();
       ++iter)

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -303,12 +303,10 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
 
   if (_do_cache)
   {
-    std::cout << "do cache"<<std::endl;
     std::map<PHG4Particle*, std::set<SvtxTrack*> >::iterator iter =
         _cache_all_tracks_from_particle.find(truthparticle);
     if (iter != _cache_all_tracks_from_particle.end())
     {
-      std::cout << "returning iter"<<std::endl;
       return iter->second;
     }
   }
@@ -321,11 +319,9 @@ std::set<SvtxTrack*> SvtxTrackEval::all_tracks_from(PHG4Particle* truthparticle)
        ++iter)
   {
     SvtxTrack* track = iter->second;
-    std::cout << "is there a problem here"<<std::endl;
     std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
     for (const auto& cluster_key : cluster_keys)
     {
-      std::cout << "ckey is " << cluster_key << std::endl;
       // remove this check as cluster key = 0 is MVTX layer 0 cluster #0.
       //      if (_strict)
       //      {

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -80,6 +80,8 @@ class SvtxTrackEval
   void get_node_pointers(PHCompositeNode* topNode);
   bool has_node_pointers();
 
+  std::vector<TrkrDefs::cluskey> get_track_ckeys(SvtxTrack* track);
+
   SvtxClusterEval _clustereval;
   SvtxTrackMap* _trackmap;
   PHG4TruthInfoContainer* _truthinfo;

--- a/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthRecoTableEval.cc
@@ -69,9 +69,13 @@ int SvtxTruthRecoTableEval::process_event(PHCompositeNode *topNode)
   {
     m_svtxevalstack->next_event(topNode);
   }
-
+  
+  if(Verbosity() > 1)
+    {std::cout << "Fill truth map "<< std::endl; }
   fillTruthMap(topNode);
 
+  if(Verbosity() > 1)
+    { std::cout << "Fill reco map "<< std::endl; }
   fillRecoMap(topNode);
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -103,8 +107,9 @@ void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode *topNode)
   assert(truthinfo);
 
   SvtxTrackEval *trackeval = m_svtxevalstack->get_track_eval();
+  trackeval->set_verbosity(Verbosity());
   assert(trackeval);
-
+  
   PHG4TruthInfoContainer::ConstRange range = truthinfo->GetParticleRange();
   if (m_scanForPrimaries)
   {
@@ -123,7 +128,6 @@ void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode *topNode)
     if (momentum < m_minMomentumTruthMap) continue;
 
     int gtrackID = g4particle->get_track_id();
-
     std::set<SvtxTrack *> alltracks = trackeval->all_tracks_from(g4particle);
 
     // not to record zero associations
@@ -149,7 +153,9 @@ void SvtxTruthRecoTableEval::fillTruthMap(PHCompositeNode *topNode)
         iterator->second.insert(track->get_id());
       }
     }
-
+    
+    if(Verbosity() > 1)
+      { std::cout << " Inserting gtrack id " << gtrackID << " with map size " << recomap.size() << std::endl; }
     m_truthMap->insert(gtrackID, recomap);
   }
   
@@ -185,7 +191,8 @@ void SvtxTruthRecoTableEval::fillRecoMap(PHCompositeNode *topNode)
         iterator->second.insert(g4particle->get_track_id());
       }
     }
-
+    if(Verbosity() > 1)
+      { std::cout << " Inserting track id " << key << " with truth map size " << truthmap.size() << std::endl; }
     m_recoMap->insert(key, truthmap);
   }
 


### PR DESCRIPTION
This PR introduces a new `SvtxTrack_v4` object that is significantly more lightweight than the current version. It removes extra floats and removes the calo projection information in favor of saving the projections at state objects.  Additionally, the cluster key set is removed and instead the track carries pointers to two `TrackSeed` objects corresponding to the relevant silicon and TPC+TPOT seeds that form the track. 

This changes the outward analyzer facing API potentially significantly by:
1. Removing the floats which store the DCA. Calculation of the DCA is now up to the analyzer rather than just storing a "default" DCA
2. Removing the calo projection cluster info, e.g. the delta-phi, delta-eta, etc. Instead, a `SvtxTrackState` is added to the state list which corresponds to the projection state at the radius of the projection.
3. The cluster keys can no longer be iterated over directly from an `SvtxTrack`. Instead, you must first access the corresponding `TrackSeed` pointers and iterate over the cluster keys of those seeds.


This probably should not be merged until we properly communicate this to analyzers, since it has the potential to affect some user analysis code.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

