### PR TITLE
Fix path length determination

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -383,14 +383,16 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode *topNode)
 	return Fun4AllReturnCodes::ABORTEVENT;
       
       /// Default to using calo radius
-      double caloRadius = m_towerGeomContainer->get_radius() 
-	* Acts::UnitConstants::cm;
+      double caloRadius = m_towerGeomContainer->get_radius();
       if(m_caloRadii.find(m_caloTypes.at(caloLayer)) != m_caloRadii.end())
 	{ 
-	  caloRadius = m_caloRadii.find(m_caloTypes.at(caloLayer))->second
-	    * Acts::UnitConstants::cm; 
+	  caloRadius = m_caloRadii.find(m_caloTypes.at(caloLayer))->second;
 	}
+      else
+	{ m_caloRadii.insert(std::make_pair(m_caloTypes.at(caloLayer), caloRadius)); }
     
+      caloRadius *= Acts::UnitConstants::cm;
+
       /// Extend farther so that there is at least surface there, for high
       /// curling tracks. Can always reject later
       const auto eta = 2.5;
@@ -405,7 +407,10 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode *topNode)
 	Acts::Surface::makeShared<Acts::CylinderSurface>(transform,
 							 caloRadius,
 							 halfZ);
-  
+      if(Verbosity() > 1)
+	{
+	  std::cout << "Creating  cylindrical surface at " << caloRadius << std::endl;
+	}
       m_caloSurfaces.insert(std::make_pair(m_caloNames.at(caloLayer),
 					   surf));
     }
@@ -415,7 +420,7 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode *topNode)
       for(const auto& [name, surfPtr] : m_caloSurfaces)
 	{
 	  std::cout << "Cylinder " << name << " has center "
-		    << surfPtr.get()->center(m_tGeometry->geoContext)
+		    << surfPtr.get()->center(m_tGeometry->geoContext).transpose()
 		    << std::endl;
 	}
     }


### PR DESCRIPTION
This fixes the path length determination from the Acts propagation which was off by a factor of mm->cm

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

