### PR TITLE
Add deprecation comments to SvtxTrack 

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack.h
+++ b/offline/packages/trackbase_historic/SvtxTrack.h
@@ -93,30 +93,6 @@ class SvtxTrack : public PHObject
 
   virtual float get_quality() const { return NAN; }
 
-  virtual float get_dca() const { return NAN; }
-  virtual void set_dca(float) {}
-
-  virtual float get_dca_error() const { return NAN; }
-  virtual void set_dca_error(float) {}
-
-  virtual float get_dca2d() const { return NAN; }
-  virtual void set_dca2d(float) {}
-
-  virtual float get_dca2d_error() const { return NAN; }
-  virtual void set_dca2d_error(float) {}
-
-  virtual float get_dca3d_xy() const { return NAN; }
-  virtual void set_dca3d_xy(float) {}
-
-  virtual float get_dca3d_xy_error() const { return NAN; }
-  virtual void set_dca3d_xy_error(float) {}
-
-  virtual float get_dca3d_z() const { return NAN; }
-  virtual void set_dca3d_z(float) {}
-
-  virtual float get_dca3d_z_error() const { return NAN; }
-  virtual void set_dca3d_z_error(float) {}
-
   virtual float get_x() const { return NAN; }
   virtual void set_x(float) {}
 
@@ -167,38 +143,12 @@ class SvtxTrack : public PHObject
   virtual StateIter begin_states();
   virtual StateIter find_state(float pathlength);
   virtual StateIter end_states();
-
+  
   //
-  // associated cluster ids methods --------------------------------------------
+  // The folllowing functions are deprecated as of SvtxTrack_v4
+  // This includes the cluster key getters/setters, 
+  // any DCA getters/setters, and any calo projection getters/setters
   //
-
-  // needed by old tracking
-
-  //! deprecated - please use cluster keys instead
-  virtual void clear_clusters() {}
-  //! deprecated - please use cluster keys instead
-  virtual bool empty_clusters() const { return false; }
-  //! deprecated - please use cluster keys instead
-  virtual size_t size_clusters() const { return 0; }
-
-  //! deprecated - please use cluster keys instead
-  virtual void insert_cluster(unsigned int /*clusterid*/) {}
-  //! deprecated - please use cluster keys instead
-  virtual size_t erase_cluster(unsigned int /*clusterid*/) { return 0; }
-  //! deprecated - please use cluster keys instead
-  virtual ConstClusterIter begin_clusters() const;
-  //! deprecated - please use cluster keys instead
-  virtual ConstClusterIter find_cluster(unsigned int /*clusterid*/) const;
-  //! deprecated - please use cluster keys instead
-  virtual ConstClusterIter end_clusters() const;
-  //! deprecated - please use cluster keys instead
-  virtual ClusterIter begin_clusters();
-  //! deprecated - please use cluster keys instead
-  virtual ClusterIter find_cluster(unsigned int clusterid);
-  //! deprecated - please use cluster keys instead
-  virtual ClusterIter end_clusters();
-
-  // needed by new tracking
   virtual void clear_cluster_keys() {}
   virtual bool empty_cluster_keys() const { return false; }
   virtual size_t size_cluster_keys() const { return 0; }
@@ -211,36 +161,53 @@ class SvtxTrack : public PHObject
   virtual ClusterKeyIter begin_cluster_keys();
   virtual ClusterKeyIter find_cluster_keys(unsigned int clusterid);
   virtual ClusterKeyIter end_cluster_keys();
+  virtual void clear_clusters() {}
+  virtual bool empty_clusters() const { return false; }
+  virtual size_t size_clusters() const { return 0; }
+  virtual void insert_cluster(unsigned int /*clusterid*/) {}
+  virtual size_t erase_cluster(unsigned int /*clusterid*/) { return 0; }
+  virtual ConstClusterIter begin_clusters() const;
+  virtual ConstClusterIter find_cluster(unsigned int /*clusterid*/) const;
+  virtual ConstClusterIter end_clusters() const;
+  virtual ClusterIter begin_clusters();
+  virtual ClusterIter find_cluster(unsigned int clusterid);
+  virtual ClusterIter end_clusters();
 
-  //
-  // calo projection methods ---------------------------------------------------
-  //
   virtual float get_cal_dphi(CAL_LAYER /*layer*/) const { return 0.; }
   virtual void set_cal_dphi(CAL_LAYER /*layer*/, float /*dphi*/) {}
-
   virtual float get_cal_deta(CAL_LAYER /*layer*/) const { return 0.; }
   virtual void set_cal_deta(CAL_LAYER /*layer*/, float /*deta*/) {}
-
   virtual float get_cal_energy_3x3(CAL_LAYER /*layer*/) const { return 0.; }
   virtual void set_cal_energy_3x3(CAL_LAYER /*layer*/, float /*energy_3x3*/) {}
-
   virtual float get_cal_energy_5x5(CAL_LAYER /*layer*/) const { return 0.; }
   virtual void set_cal_energy_5x5(CAL_LAYER /*layer*/, float /*energy_5x5*/) {}
-
   virtual unsigned int get_cal_cluster_id(CAL_LAYER /*layer*/) const { return 0; }
   virtual void set_cal_cluster_id(CAL_LAYER /*layer*/, unsigned int /*id*/) {}
-
   virtual TrkrDefs::cluskey get_cal_cluster_key(CAL_LAYER /*layer*/) const { return 0; }
   virtual void set_cal_cluster_key(CAL_LAYER /*layer*/, TrkrDefs::cluskey /*key*/) {}
-
   virtual float get_cal_cluster_e(CAL_LAYER /*layer*/) const { return 0.; }
   virtual void set_cal_cluster_e(CAL_LAYER /*layer*/, float /*e*/) {}
 
-  // Acts methods for use by Acts modules only
   virtual float get_acts_covariance(unsigned int /*i*/, unsigned int /*j*/) const { return NAN;}
   virtual void set_acts_covariance(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
  
-  
+  virtual float get_dca() const { return NAN; }
+  virtual void set_dca(float) {}
+  virtual float get_dca_error() const { return NAN; }
+  virtual void set_dca_error(float) {}
+  virtual float get_dca2d() const { return NAN; }
+  virtual void set_dca2d(float) {}
+  virtual float get_dca2d_error() const { return NAN; }
+  virtual void set_dca2d_error(float) {}
+  virtual float get_dca3d_xy() const { return NAN; }
+  virtual void set_dca3d_xy(float) {}
+  virtual float get_dca3d_xy_error() const { return NAN; }
+  virtual void set_dca3d_xy_error(float) {}
+  virtual float get_dca3d_z() const { return NAN; }
+  virtual void set_dca3d_z(float) {}
+  virtual float get_dca3d_z_error() const { return NAN; }
+  virtual void set_dca3d_z_error(float) {}
+
 
   //
   // truth track interface ---------------------------------------------------


### PR DESCRIPTION
This PR shuffles some functions around and adds some comments to hopefully make it more clear what is deprecated in the SvtxTrack base class since the introduction of the lighter weight track object.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

