### PR TITLE
Cleanup matcher

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -871,12 +871,8 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
       track->identify();      
     }
 
-  std::cout << "Here 1" << std::endl;
-
   if(!m_fitSiliconMMs)
     { track->clear_states(); }
-
-  std::cout << "Here 2" << std::endl;
 
   // create a state at pathlength = 0.0
   // This state holds the track parameters, which will be updated below
@@ -887,28 +883,18 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
   out.set_z(0.0);
   track->insert_state(&out);   
 
-  std::cout << "Here 3" << std::endl;
-
   auto trajState =
     Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
 
-  std::cout << "Here 3a" << std::endl;
- 
   const auto& params = traj.trackParameters(trackTip);
-
-  std::cout << "Here 3b" << std::endl;
 
   /// Acts default unit is mm. So convert to cm
   track->set_x(params.position(m_tGeometry->geoContext)(0)
 	       / Acts::UnitConstants::cm);
- std::cout << "Here 3c" << std::endl;
   track->set_y(params.position(m_tGeometry->geoContext)(1)
 	       / Acts::UnitConstants::cm);
- std::cout << "Here 3d" << std::endl;
   track->set_z(params.position(m_tGeometry->geoContext)(2)
 	       / Acts::UnitConstants::cm);
-
-  std::cout << "Here 4" << std::endl;
 
   track->set_px(params.momentum()(0));
   track->set_py(params.momentum()(1));
@@ -932,8 +918,6 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 	} 
     }
 
-  std::cout << "Here 5" << std::endl;
-
   // Also need to update the state list and cluster ID list for all measurements associated with the acts track  
   // loop over acts track states, copy over to SvtxTrackStates, and add to SvtxTrack
 
@@ -947,8 +931,6 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 				  m_tGeometry->geoContext);  
     }
 
-  std::cout << "Here 6" << std::endl;
-  
   trackStateTimer.stop();
   auto stateTime = trackStateTimer.get_accumulated_time();
   

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -232,8 +232,12 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       TrackSeed *siseed = m_siliconSeeds->get(siid);
       auto crossing = siseed->get_crossing();
 
-      // if the crossing was not determined, skip this case completely
-      if(crossing == SHRT_MAX) continue;
+      // if the crossing was not determined, skip this case completely?
+      if(crossing == SHRT_MAX) 
+	{
+	  // Eventually need to skip this in the pp case. For now, arbitrarily assign crossing 0
+	  crossing = 0;
+	}
 
       TrackSeed *tpcseed = m_tpcSeeds->get(tpcid);
 
@@ -376,15 +380,14 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	  else
 	    {
 	      auto newTrack = std::make_unique<SvtxTrack_v4>();
-	      /// We want to set the ID to the tpc track seed id so that
-	      /// the ghost rejection finds the right track
-	      newTrack->set_id(tpcid);
+	      unsigned int trid = m_trackMap->size();
+	      newTrack->set_id(trid);
 	      newTrack->set_tpc_seed(tpcseed);
 	      newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
 	      newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
 	
 	      if( getTrackFitResult(fitOutput, newTrack))
-		{ m_trackMap->insertWithKey(newTrack.get(), tpcid); }
+		{ m_trackMap->insertWithKey(newTrack.get(), trid); }
 	    }
 	}
       else if (!m_fitSiliconMMs)
@@ -503,7 +506,11 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
   SourceLinkVec sourcelinks;
 
   if(crossing == SHRT_MAX) 
-    { return sourcelinks; }
+    {
+      // Eventually need to skip this in the pp case, for now we assign crossing zero
+      crossing == 0;
+      // return sourcelinks; 
+    }
 
   // loop over all clusters
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_raw;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -232,19 +232,24 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       TrackSeed *siseed = m_siliconSeeds->get(siid);
       auto crossing = siseed->get_crossing();
 
-      // if the crossing was not determined, skip this case completely?
+      // if the crossing was not determined, skip this case completely
       if(crossing == SHRT_MAX) 
 	{
-	  // Eventually need to skip this in the pp case. For now, arbitrarily assign crossing 0
-	  crossing = 0;
+	  // Skip this in the pp case. For AuAu it should not happen
+	  continue;
 	}
 
       TrackSeed *tpcseed = m_tpcSeeds->get(tpcid);
 
-      /// Need to also check that the seed wasn't removed by the ghost finder
+      /// Need to also check that the tpc seed wasn't removed by the ghost finder
       if(!tpcseed)
 	{ std::cout << "no tpc seed"<<std::endl; continue; }
 
+      if(Verbosity() > 0) 
+	{
+	  std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
+	  std::cout << " tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
+	}
       PHTimer trackTimer("TrackTimer");
       trackTimer.stop();
       trackTimer.restart();
@@ -507,9 +512,8 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
 
   if(crossing == SHRT_MAX) 
     {
-      // Eventually need to skip this in the pp case, for now we assign crossing zero
-      crossing == 0;
-      // return sourcelinks; 
+      // Need to skip this in the pp case, for AuAu it should not happen
+      return sourcelinks; 
     }
 
   // loop over all clusters

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -2,7 +2,7 @@
  *  \file		PHActsTrkFitter.h
  *  \brief		Refit SvtxTracks with Acts.
  *  \details	Refit SvtxTracks with Acts
- *  \author		Tony Frawley <afrawley@fsu.edu>
+ *  \author		Joe Osborn, Tony Frawley <afrawley@fsu.edu>
  */
 
 #ifndef TRACKRECO_ACTSTRKFITTER_H
@@ -113,7 +113,8 @@ class PHActsTrkFitter : public SubsysReco
 
   void loopTracks(Acts::Logging::Level logLevel);
   SourceLinkVec getSourceLinks(TrackSeed *track, 
-			       ActsExamples::MeasurementContainer& measurements);
+			       ActsExamples::MeasurementContainer& measurements,
+			       short int crossing);
 
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(Trajectory traj, std::unique_ptr<SvtxTrack_v4>& track);

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -58,31 +58,31 @@ class PHSiliconTpcTrackMatching : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
-  double getBunchCrossing(unsigned int trid, double z_mismatch);
-  double getMedian(std::vector<double> &v);
-  void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
-  void addSiliconClusters(  std::multimap<unsigned int, unsigned int> &tpc_matches);
   void findEtaPhiMatches( std::set<unsigned int> &tpc_matched_set,
 			    std::multimap<unsigned int, unsigned int> &tpc_matches );
-  void tagInTimeTracks(  std::multimap<unsigned int, unsigned int> &tpc_matches,
-			 std::multimap<int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-			 std::map<unsigned int, int> &tpc_crossing_map );
-  void tagMatchCrossing( std::multimap<unsigned int, unsigned int> &tpc_matches,
-			 std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-			 std::map<unsigned int, short int> &tpc_crossing_map );
-  //   void copySiliconClustersToCorrectedMap( );
-   void correctTpcClusterZIntt(  std::map<unsigned int, short int> &tpc_crossing_map );
-   void getMatchCrossingIntt(  
-			       std::multimap<unsigned int, unsigned int> &tpc_matches,
-			       std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-			       std::map<unsigned int, short int> &tpc_crossing_map );
-    void addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches);	  
-   void addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map);	  
-   std::vector<short int> getInttCrossings(TrackSeed *si_track);
-   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
+  std::vector<short int> getInttCrossings(TrackSeed *si_track);
    void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);
    short int getCrossingIntt(TrackSeed *_tracklet_si);
 
+   //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
+  //double getBunchCrossing(unsigned int trid, double z_mismatch);
+  //double getMedian(std::vector<double> &v);
+  //void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
+  //void addSiliconClusters(  std::multimap<unsigned int, unsigned int> &tpc_matches);
+  //void tagInTimeTracks(  std::multimap<unsigned int, unsigned int> &tpc_matches,
+  //			 std::multimap<int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+  //			 std::map<unsigned int, int> &tpc_crossing_map );
+  //void tagMatchCrossing( std::multimap<unsigned int, unsigned int> &tpc_matches,
+  //			 std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+  //			 std::map<unsigned int, short int> &tpc_crossing_map );
+  //   void copySiliconClustersToCorrectedMap( );
+  //void correctTpcClusterZIntt(  std::map<unsigned int, short int> &tpc_crossing_map );
+   //void getMatchCrossingIntt(  
+   //			       std::multimap<unsigned int, unsigned int> &tpc_matches,
+   //			       std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+   //			       std::map<unsigned int, short int> &tpc_crossing_map );
+   //  void addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches);	  
+    //  void addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map);	  
   //  void addTrackBunchCrossing(
    //						   std::map<unsigned int, short int> &vertex_crossings_map,
    //						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map);	  

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -80,7 +80,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco
    void addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map);	  
    std::vector<short int> getInttCrossings(TrackSeed *si_track);
    void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
- 
+   void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);
+   short int getCrossingIntt(TrackSeed *_tracklet_si);
+
   //  void addTrackBunchCrossing(
    //						   std::map<unsigned int, short int> &vertex_crossings_map,
    //						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map);	  

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -15,7 +15,6 @@ class TrackSeedContainer;
 class TrackSeed;
 class TrkrClusterContainer;
 class TF1;
-class TpcSeedTrackMap;
 class TrkrClusterCrossingAssoc;
 
 class PHSiliconTpcTrackMatching : public SubsysReco
@@ -51,7 +50,6 @@ class PHSiliconTpcTrackMatching : public SubsysReco
   int End(PHCompositeNode*) override;
 
   void set_silicon_track_map_name(const std::string &map_name) { _silicon_track_map_name = map_name; }
-  void set_tpcseed_track_map_name(const std::string &map_name) { _tpcseed_track_map_name = map_name; }
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   void SetIteration(int iter){_n_iteration = iter;}
  private:
@@ -112,12 +110,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco
   TrackSeed *_tracklet_tpc{nullptr};
   TrackSeed *_tracklet_si{nullptr};
   TrkrClusterContainer *_cluster_map{nullptr};
-  //TrkrClusterContainer *_corrected_cluster_map{nullptr};
   ActsSurfaceMaps *_surfmaps{nullptr};
   ActsTrackingGeometry *_tGeometry{nullptr};
   TrkrClusterCrossingAssoc *_cluster_crossing_map{nullptr};
 
-  TpcSeedTrackMap *_seed_track_map{nullptr};
   std::map<unsigned int, double> _z_mismatch_map;
 
   double _collision_rate = 50e3;  // input rate for phi correction
@@ -134,7 +130,6 @@ class PHSiliconTpcTrackMatching : public SubsysReco
 
   int _n_iteration = 0;
   std::string _track_map_name = "TpcTrackSeedContainer";
-  std::string _tpcseed_track_map_name = "TpcSeedTrackMap";
   std::string _silicon_track_map_name = "SiliconTrackSeedContainer";
 };
 

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -5,7 +5,6 @@
 #include <trackbase/TrkrCluster.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TpcSeedTrackMap.h>
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertexMap.h>

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -24,7 +24,6 @@ class SvtxTrack;
 class SvtxTrackMap;
 class SvtxVertexMap;
 class TrkrCluster;
-class TpcSeedTrackMap;
 
 class PHSimpleVertexFinder : public SubsysReco
 {

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -7,7 +7,6 @@
 #include <trackbase/TrkrCluster.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TpcSeedTrackMap.h>
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/TrackSeedContainer.h>
@@ -207,15 +206,6 @@ int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
     std::cout << PHWHERE << " ERROR: Can't find SvtxTrackMap: " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-
-  /*
-  _tpc_seed_map = findNode::getClass<TpcSeedTrackMap>(topNode, "TpcSeedTrackMap");
-  if (!_tpc_seed_map)
-  {
-    std::cout << PHWHERE << " ERROR: Can't find node TpcSeedTrackMap: " << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-  */
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -10,6 +10,7 @@
 #include <trackbase/TpcSeedTrackMap.h>
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/TrackSeedContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -49,8 +50,7 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
 {
 
   if(Verbosity() > 0)
-    std::cout << PHWHERE << " track map size " << _track_map->size() 
-	      << " _seed_track_map size " << _seed_track_map->size() << std::endl;
+    std::cout << PHWHERE << " track map size " << _track_map->size()  << std::endl;
 
   std::set<unsigned int> track_keep_list;
   std::set<unsigned int> track_delete_list;
@@ -58,27 +58,37 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
   unsigned int good_track = 0;  // for diagnostic output only
   unsigned int ok_track = 0;   // tracks to keep
 
-  // loop over the TPC seed - track map and make a set containing all TPC seed ID's
-  std::set<unsigned int> seed_id_list;
-  auto map_range =  _seed_track_map->getAll();
-  for(auto it = map_range.first; it != map_range.second; ++it)
+  std::multimap<unsigned int, unsigned int> tpcid_track_mmap;
+  std::set<unsigned int> tpc_id_set;
+  // loop over the fitted tracks
+  for (auto it = _track_map->begin(); it != _track_map->end(); ++it)
     {
-      seed_id_list.insert( (*it).first );
+      auto track_id = (*it).first;
+      auto track = (*it).second;
+      if(!track) continue;
+      
+      auto tpc_seed =  track->get_tpc_seed();
+      unsigned int tpc_index = _tpc_seed_map->find(tpc_seed);      
+
+      auto tpc_track_pair = std::make_pair(tpc_index, track_id);
+
+      tpc_id_set.insert(tpc_index);
+      tpcid_track_mmap.insert(tpc_track_pair);
     }
 
   if(Verbosity() > 0)
-    std::cout << " seed_id_list size " << seed_id_list.size() << std::endl;
+    std::cout << " tpcid_track_mmap  size " << tpcid_track_mmap.size() << std::endl;
 
   // loop over the TPC seed ID's
 
-  for(auto seed_iter = seed_id_list.begin(); seed_iter != seed_id_list.end(); ++seed_iter)
+  for(auto seed_iter = tpc_id_set.begin(); seed_iter != tpc_id_set.end(); ++seed_iter)
     {
       unsigned int tpc_id = *seed_iter;
 
       if(Verbosity() > 1)
 	std::cout << " TPC ID " << tpc_id << std::endl;
 
-      auto tpc_range =   _seed_track_map->getAssocTracks(tpc_id);
+      auto tpc_range = tpcid_track_mmap.equal_range(tpc_id);
 
       unsigned int best_id = 99999;
       double min_chisq_df = 99999.0;
@@ -184,7 +194,13 @@ int PHTrackCleaner::End(PHCompositeNode */*topNode*/)
 
 int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
 {
-
+ _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  if (!_tpc_seed_map)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find TpcTrackSeedContainer: " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  
   _track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
   if (!_track_map)
   {
@@ -192,12 +208,14 @@ int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  _seed_track_map = findNode::getClass<TpcSeedTrackMap>(topNode, "TpcSeedTrackMap");
-  if (!_seed_track_map)
+  /*
+  _tpc_seed_map = findNode::getClass<TpcSeedTrackMap>(topNode, "TpcSeedTrackMap");
+  if (!_tpc_seed_map)
   {
     std::cout << PHWHERE << " ERROR: Can't find node TpcSeedTrackMap: " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+  */
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -20,7 +20,8 @@ class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
 class TrkrCluster;
-class TpcSeedTrackMap;
+//class TpcSeedTrackMap;
+class TrackSeedContainer;
 
 class PHTrackCleaner : public SubsysReco
 {
@@ -43,8 +44,9 @@ class PHTrackCleaner : public SubsysReco
 
 SvtxTrackMap *_track_map{nullptr};
 SvtxTrack *_track{nullptr};
+ TrackSeedContainer *_tpc_seed_map{nullptr};
 
- TpcSeedTrackMap *_seed_track_map{nullptr};
+// TpcSeedTrackMap *_seed_track_map{nullptr};
 
  double min_ndf = 25;
  bool _pp_mode = false;

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -20,7 +20,6 @@ class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
 class TrkrCluster;
-//class TpcSeedTrackMap;
 class TrackSeedContainer;
 
 class PHTrackCleaner : public SubsysReco
@@ -45,8 +44,6 @@ class PHTrackCleaner : public SubsysReco
 SvtxTrackMap *_track_map{nullptr};
 SvtxTrack *_track{nullptr};
  TrackSeedContainer *_tpc_seed_map{nullptr};
-
-// TpcSeedTrackMap *_seed_track_map{nullptr};
 
  double min_ndf = 25;
  bool _pp_mode = false;

--- a/offline/packages/trackreco/PHTrackSelector.cc
+++ b/offline/packages/trackreco/PHTrackSelector.cc
@@ -5,7 +5,6 @@
 #include <trackbase/TrkrCluster.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TpcSeedTrackMap.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>

--- a/offline/packages/trackreco/PHTrackSelector.h
+++ b/offline/packages/trackreco/PHTrackSelector.h
@@ -20,7 +20,6 @@ class PHCompositeNode;
 class SvtxTrack;
 class SvtxTrackMap;
 class TrkrCluster;
-class TpcSeedTrackMap;
 class TrkrClusterIterationMapv1;
 
 class PHTrackSelector : public SubsysReco
@@ -51,8 +50,6 @@ class PHTrackSelector : public SubsysReco
   SvtxTrackMap *_track_map{nullptr};
   SvtxTrack *_track{nullptr};
   TrkrClusterIterationMapv1* _iteration_map = nullptr;
-
-  TpcSeedTrackMap *_seed_track_map{nullptr};
 
   int _n_iter = 1;
   unsigned int min_tpc_clusters = 35;

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -20,7 +20,6 @@
 #include <trackbase_historic/SvtxTrackSeed_v1.h>
 #include <trackbase_historic/TrackSeedContainer_v1.h>
 #include <trackbase_historic/SvtxVertexMap.h>
-#include <trackbase/TpcSeedTrackMapv1.h>    
 #include <trackbase/TrkrClusterCrossingAssoc.h> 
 #include <trackbase_historic/TrackSeed_FastSim_v1.h>
 
@@ -97,9 +96,6 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 	    << ": Total tracks: " << _tpc_track_map->size()
 	    << endl;
 	}
-
-      // this one is always there
-      _seed_track_map->addAssoc(phtrk_iter, phtrk_iter );
 
       // identify the best truth track match(es) for this seed track       
       std::vector<PHG4Particle*> g4particle_vec = getG4PrimaryParticle(_tracklet);
@@ -316,11 +312,6 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
 	new PHIODataNode<PHObject>(_silicon_track_map, "SiliconTrackSeedContainer", "PHObject");
       svtxNode->addNode(si_tracks_node);
     }
-
-  _seed_track_map = new TpcSeedTrackMapv1;
-  PHIODataNode<PHObject> *node
-    = new PHIODataNode<PHObject>(_seed_track_map, _tpcseed_track_map_name);
-  svtxNode->addNode(node);
 
   _tpc_track_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
   if (!_tpc_track_map)

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -123,15 +123,21 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 	  // Make a silicon track seed 
 	  unsigned int silicon_seed_index = buildTrackSeed(clusters, g4particle, _silicon_track_map);
 
+
 	  // Add this entry to the SvtxTrackSeedContainer	  
 	  auto seed = std::make_unique<SvtxTrackSeed_v1>();
 	  seed->set_tpc_seed_index(phtrk_iter);
 	  seed->set_silicon_seed_index(silicon_seed_index);
 	  _svtx_seed_map->insert(seed.get());
 
+	  unsigned int combined_seed_index = _svtx_seed_map->size()-1;
+
 	  if (Verbosity() >= 1)
 	    {
-	      std::cout << " Created SvtxTrackSeed  with tpcid " << seed->get_tpc_seed_index() << " and silicon ID " << seed->get_silicon_seed_index() << std::endl;
+	      std::cout << " Created SvtxTrackSeed  " << combined_seed_index 
+			<< " with tpcid " << _svtx_seed_map->get(combined_seed_index)->get_tpc_seed_index()  
+			<< " and silicon ID " << _svtx_seed_map->get(combined_seed_index)->get_silicon_seed_index() 
+			<< std::endl;
 	    }
 	}
     }
@@ -149,12 +155,20 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 	  auto tpc_index =  seed->get_tpc_seed_index();
 	  auto silicon_index =  seed->get_silicon_seed_index();
 	  
-	  std::cout << "SvtxSeedTrack " << phtrk_iter << " tpc_index " <<  tpc_index << " silicon_index " << silicon_index << std::endl;
+	  std::cout << "SvtxSeedTrack: " << phtrk_iter 
+		    << " tpc_index " <<  tpc_index 
+		    << " silicon_index " << silicon_index 
+		    << std::endl;
 	  
-	  std::cout << " silicon tracklet " << silicon_index << std::endl;
+	  std::cout << " ----------  silicon tracklet " << silicon_index << std::endl;
 	  auto silicon_tracklet = _silicon_track_map->get(silicon_index);
 	  if(!silicon_tracklet) continue;
 	  silicon_tracklet->identify();
+
+	  std::cout << " ---------- tpc tracklet " << tpc_index << std::endl;
+	  auto tpc_tracklet = _tpc_track_map->get(tpc_index);
+	  if(!tpc_tracklet) continue;
+	  tpc_tracklet->identify();
 	}
     }
 
@@ -530,7 +544,7 @@ unsigned int PHTruthSiliconAssociation::buildTrackSeed(std::set<TrkrDefs::cluske
   float pz = g4particle->get_pz() * random1;
 
   const auto g4vertex = _g4truth_container->GetVtx(g4particle->get_vtx_id());
-  auto random2 = gsl_ran_flat(m_rng.get(), -0.02, 0.02);
+  auto random2 = gsl_ran_flat(m_rng.get(), -0.002, 0.002);
   float x = g4vertex->get_x() + random2; 
   float y = g4vertex->get_y() + random2;
   float z = g4vertex->get_z() + random2;

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -5,6 +5,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/PHRandomSeed.h>
 
 /// Tracking includes
 #include <trackbase/ActsTrackingGeometry.h>
@@ -21,6 +22,7 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase/TpcSeedTrackMapv1.h>    
 #include <trackbase/TrkrClusterCrossingAssoc.h> 
+#include <trackbase_historic/TrackSeed_FastSim_v1.h>
 
 #include <g4main/PHG4Hit.h>  // for PHG4Hit
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
@@ -29,12 +31,25 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
+#include <TDatabasePDG.h>
+#include <TParticlePDG.h>
+
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_rng.h>                            // for gsl_rng_alloc
+
 using namespace std;
+
+namespace
+{ template< class T> inline constexpr T square( const T& x ) { return x*x; } }
 
 //____________________________________________________________________________..
 PHTruthSiliconAssociation::PHTruthSiliconAssociation(const std::string &name):
  SubsysReco(name)
 {
+  // initialize random generator
+  const uint seed = PHRandomSeed();
+  m_rng.reset( gsl_rng_alloc(gsl_rng_mt19937) );
+  gsl_rng_set( m_rng.get(), seed );
 }
 
 //____________________________________________________________________________..
@@ -58,27 +73,28 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
   if (Verbosity() >= 1) 
     cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Processing Event" << endl;
 
-  // Loop over all SvtxTracks from the CA seeder
+  // Reset the silicon seed node
+  _silicon_track_map->Reset();
+
+  // Loop over all SeedTracks from the CA seeder
   // These should contain all TPC clusters already
 
-  const unsigned int original_track_map_lastkey = _track_map->empty() ? 0 : _track_map->size() - 1;
-  if(Verbosity() > 0) std::cout << " track map last key = " <<  original_track_map_lastkey << std::endl;
-
   for (unsigned int phtrk_iter = 0;
-       phtrk_iter < _track_map->size();
+       phtrk_iter < _tpc_track_map->size();
        ++phtrk_iter)
     {
-      // we may add tracks to the map, so we stop at the last original track
-      if(phtrk_iter > original_track_map_lastkey)  break;
+      _tracklet = _tpc_track_map->get(phtrk_iter);
 
-      _tracklet = _track_map->get(phtrk_iter);
+      if(!_tracklet)
+	continue;
+	
       if (Verbosity() >= 1)
 	{
 	  std::cout
 	    << __LINE__
 	    << ": Processing seed itrack: " << phtrk_iter
 	    << ": nhits: " << _tracklet-> size_cluster_keys()
-	    << ": Total tracks: " << _track_map->size()
+	    << ": Total tracks: " << _tpc_track_map->size()
 	    << endl;
 	}
 
@@ -91,175 +107,56 @@ int PHTruthSiliconAssociation::process_event(PHCompositeNode */*topNode*/)
 
       if(g4particle_vec.size() < 1) continue;
 
-      bool test_phi_matching = false;   // normally false
-      if(test_phi_matching)
-	{
-	  // for getting the pT dependence of dphi  to eliminate the bias in phi from PHTpcTracker
-	  if(g4particle_vec.size() == 1)
-	    {
-	      // print out the eta and phi values for analysis in case where match is unique
-	      
-	      double si_phi = atan2(g4particle_vec[0]->get_py(), g4particle_vec[0]->get_px());
-	      double si_eta = asinh(g4particle_vec[0]->get_pz() / sqrt( pow(g4particle_vec[0]->get_px(),2)+pow( g4particle_vec[0]->get_py(),2)));
-	      double si_pt = sqrt(pow(g4particle_vec[0]->get_px(),2)+pow( g4particle_vec[0]->get_py(),2));
-	      
-	      double tpc_phi = _tracklet->get_phi(_cluster_map, _surfmaps, _tgeometry) ;
-	      double tpc_eta = _tracklet->get_eta();
-	      
-	      if(Verbosity() > 0)
-		{ 
-		  cout << "         Try: " << "  pt " << si_pt << " tpc_phi " << tpc_phi << " si_phi " <<  si_phi 
-		   << " tpc_eta " << tpc_eta << " si_eta " << si_eta << endl;
-		}
-	    }
-	}
-      
-      // make copies of the original track for later use
-      std::vector<TrackSeed*> extraTrack; 
-      for(unsigned int ig4=0;ig4 < g4particle_vec.size()-1; ++ig4)
-	{      
-	  //	  float time = g4particle_vec[ig4]->
-
-	  auto newTrack = std::make_unique<TrackSeed_v1>(*_tracklet);
-	  // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-
-	  _seed_track_map->addAssoc(phtrk_iter, phtrk_iter) ;
-
-	  // loop over associated clusters to get hits for original TPC track, copy to new track
-	  for (auto iter = _tracklet->begin_cluster_keys();
-	       iter != _tracklet->end_cluster_keys();
-	       ++iter)
-	    {
-	      TrkrDefs::cluskey cluster_key = *iter;
-	      newTrack->insert_cluster_key(cluster_key);
-	    }
-	  
-	  extraTrack.push_back(newTrack.get());
-	}
-
-      // we just add the silicon clusters to the original track for the first returned g4particle
-      
       if (Verbosity() >= 1) 
 	{
-	  std::cout << "  original track:" << endl;
+	  std::cout << "  tpc seed track:" << endl;
 	  _tracklet->identify(); 
 	}
-      
-      // identify the clusters that are associated with this g4particle
-      PHG4Particle* g4particle = g4particle_vec[0];
-      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
 
-      for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
-	   jter != clusters.end();
-	   ++jter)
-	{
-	  TrkrDefs::cluskey cluster_key = *jter;
-	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
-	  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-	  if (Verbosity() >= 1)  std::cout << "     found silicon cluster with key: " << cluster_key << " in layer " << layer << std::endl;
-	  
-	  // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
-	  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
+      for(unsigned int ig4=0;ig4 < g4particle_vec.size(); ++ig4)
+	{      
+	  // identify the clusters that are associated with this g4particle
+	  PHG4Particle* g4particle = g4particle_vec[ig4];
+	  std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
+	  if(clusters.size() < 3) continue;
+
+	  // Make a silicon track seed 
+	  unsigned int silicon_seed_index = buildTrackSeed(clusters, g4particle, _silicon_track_map);
+
+	  // Add this entry to the SvtxTrackSeedContainer	  
+	  auto seed = std::make_unique<SvtxTrackSeed_v1>();
+	  seed->set_tpc_seed_index(phtrk_iter);
+	  seed->set_silicon_seed_index(silicon_seed_index);
+	  _svtx_seed_map->insert(seed.get());
+
+	  if (Verbosity() >= 1)
 	    {
-	      if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX or INTT, add to track " << std::endl;
-	      _tracklet->insert_cluster_key(cluster_key);
-	    }
-	}
-      
-      if (Verbosity() >= 1)
-	{
-	  std::cout << " updated original track:" << std::endl;
-	  _tracklet->identify(); 
-	  std::cout << " new cluster keys size " << _tracklet->size_cluster_keys() << endl;
-	  std::cout << "Done with original track " << phtrk_iter << std::endl;
-	}
-      
-      // now add any extra copies of the track      
-      if(g4particle_vec.size() > 1)
-	{
-	  for(unsigned int ig4=0;ig4 < g4particle_vec.size()-1; ++ ig4)
-	    {      
-	      PHG4Particle* g4particle = g4particle_vec[ig4];
-
-	      if (Verbosity() >= 1)
-		std::cout << "   ig4  " << ig4 << " g4particleID " << g4particle->get_track_id() 
-			  << " px " <<  g4particle->get_px() 
-			  << " py " <<  g4particle->get_py() 
-			  << " phi " << atan2(g4particle->get_py(), g4particle->get_px() )
-			  << std::endl;
-	      
-	      // identify the clusters that are associated with this g4particle
-	      std::set<TrkrDefs::cluskey> clusters = getSiliconClustersFromParticle(g4particle);
-	      	
-	      // Not the first g4particle in the list, we need to add a new copy of the track to the track map and add the silicon clusters to that
-	      const unsigned int lastTrackKey =  _track_map->empty() ? 0 :_track_map->size() - 1;
-	    	      
-	      if (Verbosity() >= 1) 
-		{
-		  std::cout << "  original (copy) track:" << endl;
-		  extraTrack[ig4]->identify(); 
-		}
-	      
-	      _track_map->insert(extraTrack[ig4]);
-	      
-	      for (std::set<TrkrDefs::cluskey>::iterator jter = clusters.begin();
-		   jter != clusters.end();
-		   ++jter)
-		{
-		  TrkrDefs::cluskey cluster_key = *jter;
-		  unsigned int layer = TrkrDefs::getLayer(cluster_key);
-		  unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-		  if (Verbosity() >= 1)  std::cout << "     found cluster with key: " << cluster_key << " in layer " << layer << std::endl;
-		  
-		  // Identify the MVTX and INTT clusters and add them to the SvtxTrack cluster key list
-		  if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
-		    {
-		      if (Verbosity() >= 1)  std::cout << "            cluster belongs to MVTX or INTT, add to track " << std::endl;
-		      extraTrack[ig4]->insert_cluster_key(cluster_key);
-		    }
-		}
-
-	      if (Verbosity() >= 1)
-		{
-		  std::cout << " updated additional track:" << std::endl;
-		  extraTrack[ig4]->identify(); 
-		  std::cout << " new cluster keys size " << extraTrack[ig4]->size_cluster_keys() << endl;
-		  std::cout << "Done with extra track " << lastTrackKey << std::endl;
-		}
+	      std::cout << " Created SvtxTrackSeed  with tpcid " << seed->get_tpc_seed_index() << " and silicon ID " << seed->get_silicon_seed_index() << std::endl;
 	    }
 	}
     }
 
-  // loop over all tracks and copy the silicon clusters to the corrected cluster map
-  if(_corrected_cluster_map)
-    copySiliconClustersToCorrectedMap();
-
-  // loop over all tracks and get the bunch crossing from the INTT cluster - crossing map and add it to the track
-  for (unsigned int phtrk_iter = 0;
-       phtrk_iter < _track_map->size(); 
-       ++phtrk_iter)
+  if(Verbosity() > 0)
     {
-      TrackSeed *track = _track_map->get(phtrk_iter);
-      const auto intt_crossings = getInttCrossings(track);
-      if(intt_crossings.empty()) 
+      // loop over the assembled tracks
+      for (unsigned int phtrk_iter = 0;
+	   phtrk_iter < _svtx_seed_map->size();
+	   ++phtrk_iter)
 	{
-	  if(Verbosity() > 1) std::cout << " Silicon track " << phtrk_iter << " has no INTT clusters" << std::endl;
-	  continue ;
-    
-	} else if( intt_crossings.size() > 1 ) {
-    
-    if(Verbosity() > 1) 
-    { std::cout << " INTT crossings not all the same for track " << phtrk_iter << " crossing_keep - dropping this match " << std::endl; }
-    
-  } else {
-    
-    const auto& crossing = *intt_crossings.begin();
-	  track->set_crossing(crossing);
-	  if(Verbosity() > 1) std::cout << "                    Combined track " << phtrk_iter  << " bunch crossing " << crossing << std::endl;           
+	  auto seed = _svtx_seed_map->get(phtrk_iter);
+	  if(!seed) continue;
+	  
+	  auto tpc_index =  seed->get_tpc_seed_index();
+	  auto silicon_index =  seed->get_silicon_seed_index();
+	  
+	  std::cout << "SvtxSeedTrack " << phtrk_iter << " tpc_index " <<  tpc_index << " silicon_index " << silicon_index << std::endl;
+	  
+	  std::cout << " silicon tracklet " << silicon_index << std::endl;
+	  auto silicon_tracklet = _silicon_track_map->get(silicon_index);
+	  if(!silicon_tracklet) continue;
+	  silicon_tracklet->identify();
 	}
     }
-  
-  makeSvtxSeedMap();
 
   if (Verbosity() >= 1)
     cout << "PHTruthSiliconAssociation::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
@@ -298,6 +195,7 @@ void PHTruthSiliconAssociation::Print(const std::string &/*what*/) const
   //cout << "PHTruthSiliconAssociation::Print(const std::string &what) const Printing info for " << what << endl;
 }
 
+/*
 void PHTruthSiliconAssociation::makeSvtxSeedMap()
 {
   /// The track fitter expects a full svtxtrackseed container, so just 
@@ -311,6 +209,7 @@ void PHTruthSiliconAssociation::makeSvtxSeedMap()
     }
 
 }
+*/
 
 int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
 {
@@ -331,24 +230,18 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
     cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-
+  /*
   _corrected_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode,"CORRECTED_TRKR_CLUSTER");
   if(_corrected_cluster_map)
     {
       std::cout << " Found CORRECTED_TRKR_CLUSTER node " << std::endl;
     }
+  */
   
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
   {
     cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  _track_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
-  if (!_track_map)
-  {
-    cerr << PHWHERE << " ERROR: Can't find TpcTrackSeedContainer: " << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -400,11 +293,27 @@ int  PHTruthSiliconAssociation::GetNodes(PHCompositeNode* topNode)
       svtxNode = new PHCompositeNode("SVTX");
       dstNode->addNode(svtxNode);
     }
-  
+
+  _silicon_track_map = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
+   if(!_silicon_track_map)
+    {
+      _silicon_track_map = new TrackSeedContainer_v1;
+      PHIODataNode<PHObject>* si_tracks_node = 
+	new PHIODataNode<PHObject>(_silicon_track_map, "SiliconTrackSeedContainer", "PHObject");
+      svtxNode->addNode(si_tracks_node);
+    }
+
   _seed_track_map = new TpcSeedTrackMapv1;
   PHIODataNode<PHObject> *node
     = new PHIODataNode<PHObject>(_seed_track_map, _tpcseed_track_map_name);
   svtxNode->addNode(node);
+
+  _tpc_track_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  if (!_tpc_track_map)
+  {
+    cerr << PHWHERE << " ERROR: Can't find TpcTrackSeedContainer: " << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
   
   _svtx_seed_map = findNode::getClass<TrackSeedContainer>(topNode, "SvtxTrackSeedContainer");
   if(!_svtx_seed_map)
@@ -561,37 +470,6 @@ std::set<TrkrDefs::cluskey> PHTruthSiliconAssociation::getSiliconClustersFromPar
   
 }
 
-void PHTruthSiliconAssociation::copySiliconClustersToCorrectedMap( )
-{
-  // loop over final track map, copy silicon clusters to corrected cluster map
-  for( unsigned int track_iter = 0; 
-       track_iter < _track_map->size(); ++track_iter )
-  {
-    TrackSeed* track = _track_map->get(track_iter);
-    // loop over associated clusters to get keys for micromegas cluster
-    for(auto iter = track->begin_cluster_keys(); iter != track->end_cluster_keys(); ++iter)
-    {
-      TrkrDefs::cluskey cluster_key = *iter;
-      const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-      if(trkrid == TrkrDefs::mvtxId || trkrid == TrkrDefs::inttId)
-      {
-        // check if clusters has not been inserted already
-        if( _corrected_cluster_map->findCluster( cluster_key ) ) continue;
-
-        auto cluster = _cluster_map->findCluster(cluster_key);	
-        if( !cluster ) continue;
-        
-        // create a new cluster and copy from source
-        auto newclus = new TrkrClusterv3;
-        newclus->CopyFrom( cluster );
-
-        // insert in corrected map
-        _corrected_cluster_map->addClusterSpecifyKey(cluster_key, newclus);
-      }
-    }      
-  }
-}
-
 std::set<short int> PHTruthSiliconAssociation::getInttCrossings(TrackSeed *si_track) const
 {
   std::set<short int> intt_crossings;
@@ -625,4 +503,132 @@ std::set<short int> PHTruthSiliconAssociation::getInttCrossings(TrackSeed *si_tr
   //      std::cout << " intt_crossings size is " << intt_crossings.size() << std::endl;
   
   return intt_crossings;
+}
+
+unsigned int PHTruthSiliconAssociation::buildTrackSeed(std::set<TrkrDefs::cluskey> clusters, PHG4Particle *g4particle, TrackSeedContainer* container)
+{
+  auto track = std::make_unique<TrackSeed_FastSim_v1>();
+  bool silicon = false;
+  for (const auto& cluskey : clusters){
+    if( TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::mvtxId || 
+	TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::inttId)
+      { silicon = true; }
+    track->insert_cluster_key(cluskey);
+  }
+  
+  const auto particle = TDatabasePDG::Instance()->GetParticle(g4particle->get_pid());
+  int charge = 1;
+  if(particle) 
+    { 
+      if(particle->Charge() < 0)
+	{ charge = -1; }
+    }
+
+  auto random1 = gsl_ran_flat(m_rng.get(), 0.95, 1.05);  
+  float px = g4particle->get_px() * random1;
+  float py = g4particle->get_py() * random1;
+  float pz = g4particle->get_pz() * random1;
+
+  const auto g4vertex = _g4truth_container->GetVtx(g4particle->get_vtx_id());
+  auto random2 = gsl_ran_flat(m_rng.get(), -0.02, 0.02);
+  float x = g4vertex->get_x() + random2; 
+  float y = g4vertex->get_y() + random2;
+  float z = g4vertex->get_z() + random2;
+
+  float pt = sqrt(px*px+py*py);
+  float phi = atan2(py,px);
+  float R = 100 * pt / (0.3*1.4);
+  float theta = atan2(pt,pz);
+  if(theta < 0)
+    { theta += M_PI; }
+  if(theta > M_PI)
+    { theta -= M_PI; }
+  
+  float eta = -log(tan(theta/2.));
+
+  // We have two equations, phi = atan2(-(X0-x),y-Y0) and 
+  //R^2 = (x-X0)^2 + (y-Y0)^2. Solve for X0 and Y0 knowing R and phi
+  float tanphisq = square(tan(phi));
+  float a = tanphisq + 1;
+  float b =-2*y*(tanphisq+1);
+  float c = (tanphisq+1)*square(y)-square(R);
+  
+  float Y0_1 = (-b + sqrt(square(b)-4*a*c)) / (2.*a);
+  float Y0_2 = (-b - sqrt(square(b)-4*a*c)) / (2.*a);
+  float X0_1 = sqrt(pow(R, 2) - pow(Y0_1 - y, 2)) + x;
+  float X0_2 = -sqrt(pow(R, 2) - pow(Y0_2 - y, 2)) + x;
+  track->set_X0(X0_1);
+  track->set_Y0(Y0_1);
+  track->set_qOverR(charge / R);
+  track->set_slope(1. / tan(theta));
+  track->set_Z0(z);
+  
+  /// Need to find the right one for the bend angle
+  
+  float newphi = track->get_phi(_cluster_map, _surfmaps, _tgeometry);
+  /// We have to pick the right one based on the bend angle, so iterate
+  /// through until you find the closest phi match
+  if( fabs(newphi-phi) > 0.03)
+    {
+      track->set_X0(X0_2);
+      newphi = track->get_phi(_cluster_map, _surfmaps, _tgeometry);
+  
+      if( fabs(newphi-phi) > 0.03)
+	{
+	  track->set_Y0(Y0_2);
+	  newphi = track->get_phi(_cluster_map, _surfmaps, _tgeometry);
+
+	  if( fabs(newphi-phi) > 0.03)
+	    {
+	      track->set_X0(X0_1);
+	      newphi = track->get_phi(_cluster_map, _surfmaps, _tgeometry);
+	    }
+	}
+    }
+  
+  if(Verbosity() > 2)
+    {
+      std::cout << "Charge is " << charge << std::endl;
+      std::cout << "truth/reco px " << px << ", " << track->get_px(_cluster_map, _surfmaps, _tgeometry) << std::endl;
+      std::cout << "truth/reco py " << py << ", " << track->get_py(_cluster_map, _surfmaps, _tgeometry) << std::endl;
+      std::cout << "truth/reco pz " << pz << ", " << track->get_pz() << std::endl;
+      std::cout << "truth/reco pt " << pt << ", " << track->get_pt() << std::endl;
+      std::cout << "truth/reco phi " << phi << ", " << track->get_phi(_cluster_map, _surfmaps, _tgeometry) << std::endl;
+      std::cout << "truth/reco eta " << eta << ", " << track->get_eta() << std::endl;
+      std::cout << "truth/reco x " << x << ", " << track->get_x() << std::endl;
+      std::cout << "truth/reco y " << y << ", " << track->get_y() << std::endl;
+      std::cout << "truth/reco z " << z << ", " << track->get_z() << std::endl;
+	
+    }
+  
+  // set intt crossing
+  if(silicon)
+    {
+      // silicon tracklet
+      /* inspired from PHtruthSiliconAssociation */
+      const auto intt_crossings = getInttCrossings(track.get());
+      if(intt_crossings.empty()) 
+	{
+	  if(Verbosity() > 1)  std::cout << "PHTruthTrackSeeding::Process - Silicon track " << container->size() - 1 << " has no INTT clusters" << std::endl;
+	  return (container->size() -1);
+	} else if( intt_crossings.size() > 1 ) {
+	if(Verbosity() > 1) 
+	  { std::cout << "PHTruthTrackSeeding::Process - INTT crossings not all the same for track " << container->size() - 1 << " crossing_keep - dropping this match " << std::endl; }
+	
+      } else {
+	const auto& crossing = *intt_crossings.begin();
+	track->set_crossing(crossing);
+	if(Verbosity() > 1)
+	  std::cout << "PHTruthTrackSeeding::Process - Combined track " << container->size() - 1  << " bunch crossing " << crossing << std::endl;           
+      }
+    }  // end if _min_layer
+  else
+    {
+      // no INTT layers, crossing is unknown
+      track->set_crossing(SHRT_MAX);	
+    }
+
+  container->insert(track.get());
+
+  return (container->size() - 1);
 }

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <set>
 #include <vector>
+#include <memory>
+#include <gsl/gsl_rng.h>
 
 class PHCompositeNode;
 class TrackSeedContainer;
@@ -54,8 +56,10 @@ class PHTruthSiliconAssociation : public SubsysReco
  private:
 
   int GetNodes(PHCompositeNode* topNode);
-  void copySiliconClustersToCorrectedMap( );
-  void makeSvtxSeedMap();
+  //  void copySiliconClustersToCorrectedMap( );
+  //void makeSvtxSeedMap();
+
+  unsigned int buildTrackSeed(std::set<TrkrDefs::cluskey> clusters, PHG4Particle *g4particle, TrackSeedContainer* container);
 
   std::vector<PHG4Particle*> getG4PrimaryParticle(TrackSeed *track);
   std::set<TrkrDefs::cluskey> getSiliconClustersFromParticle(PHG4Particle* g4particle);
@@ -70,7 +74,8 @@ class PHTruthSiliconAssociation : public SubsysReco
   TrkrClusterContainer *_corrected_cluster_map{nullptr};
   TrkrClusterHitAssoc *_cluster_hit_map{nullptr};
   TrkrHitTruthAssoc *_hit_truth_map{nullptr};
-  TrackSeedContainer *_track_map{nullptr};
+  TrackSeedContainer *_tpc_track_map{nullptr};
+  TrackSeedContainer *_silicon_track_map{nullptr};
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeed *_tracklet{nullptr};
   SvtxVertexMap * _vertex_map{nullptr};
@@ -80,6 +85,18 @@ class PHTruthSiliconAssociation : public SubsysReco
   ActsSurfaceMaps *_surfmaps{nullptr};
 
   std::string _tpcseed_track_map_name = "TpcSeedTrackMap";
+
+  //! rng de-allocator
+  class Deleter
+  {
+    public:
+    //! deletion operator
+    void operator() (gsl_rng* rng) const { gsl_rng_free(rng); }
+  };
+
+ //! random generator that conform with sPHENIX standard
+  /*! using a unique_ptr with custom Deleter ensures that the structure is properly freed when parent object is destroyed */
+  std::unique_ptr<gsl_rng, Deleter> m_rng;
 
 };
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -22,7 +22,6 @@ class TrkrHitTruthAssoc;
 class PHG4TruthInfoContainer;
 class PHG4HitContainer;
 class PHG4Particle;
-class TpcSeedTrackMap;
 class TrkrClusterCrossingAssoc;
 struct ActsTrackingGeometry;
 struct ActsSurfaceMaps;
@@ -79,12 +78,9 @@ class PHTruthSiliconAssociation : public SubsysReco
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeed *_tracklet{nullptr};
   SvtxVertexMap * _vertex_map{nullptr};
-  TpcSeedTrackMap *_seed_track_map{nullptr};
   TrkrClusterCrossingAssoc *_cluster_crossing_map{nullptr};
   ActsTrackingGeometry *_tgeometry{nullptr};
   ActsSurfaceMaps *_surfmaps{nullptr};
-
-  std::string _tpcseed_track_map_name = "TpcSeedTrackMap";
 
   //! rng de-allocator
   class Deleter

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -282,10 +282,13 @@ void PHTruthTrackSeeding::buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters
 {
   auto track = std::make_unique<TrackSeed_FastSim_v1>();
   bool silicon = false;
+  bool tpc = false;  
   for (const auto& cluskey : clusters){
     if( TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::mvtxId || 
 	TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::inttId)
       { silicon = true; }
+    if(TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::tpcId)
+      { tpc = true; }
     track->insert_cluster_key(cluskey);
   }
     
@@ -334,6 +337,13 @@ void PHTruthTrackSeeding::buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters
   track->set_qOverR(charge / R);
   track->set_slope(1. / tan(theta));
   track->set_Z0(z);
+
+  if(tpc)
+    {
+      // if this is the TPC, the track Z0 depends on the crossing
+      // we should determine it from the clusters instead of the truth - not implemented yet
+      
+    }
   
   /// Need to find the right one for the bend angle
   

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -255,31 +255,6 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-/*
-void PHTruthTrackSeeding::buildFullTrack(std::vector<TrkrDefs::cluskey>& clusters,
-					 PHG4Particle *g4particle)
-{
-  auto track = std::make_unique<SvtxTrackSeed_v1>();
-
-  buildTrackSeed(clusters, g4particle, _track_map);
-
-  /// The ids will by definition be the last entry in the container because
-  /// the seeds were just added
-  track->set_tpc_seed_index(_track_map->size()-1); 
- 
-  if(Verbosity() > 2)
-    {
-      std::cout << "adding svtxtrackseed " << std::endl;
-      track->identify();
-      auto tpcseed = _track_map->get(track->get_tpc_seed_index());
-      tpcseed->identify();
- 
-    }
-
-  _track_map_combined->insert(track.get());
-
-}
-*/
 
 void PHTruthTrackSeeding::buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters, PHG4Particle *g4particle, TrackSeedContainer* container)
 {

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -109,8 +109,9 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   //! minimal truth momentum cut (GeV)
   double _min_momentum = 50e-3;
 
-  TrackSeedContainer *_tpc_seeds = nullptr;
-  TrackSeedContainer *_silicon_seeds = nullptr;
+  TrackSeedContainer *_tpc_seed_map = nullptr;
+  TrackSeedContainer *_silicon_seed_map = nullptr;
+  TrackSeedContainer* _track_map;
 
   ActsTrackingGeometry *tgeometry = nullptr;
   ActsSurfaceMaps *surfmaps = nullptr;

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -13,6 +13,7 @@
 #include <trackbase/TrkrDefs.h>
 #include <string>  // for string
 #include <vector>
+#include <memory>
 #include <gsl/gsl_rng.h>
 
 // forward declarations

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -82,8 +82,9 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   int GetNodes(PHCompositeNode* topNode);
   int CreateNodes(PHCompositeNode* topNode);
 
-  void buildFullTrack(std::vector<TrkrDefs::cluskey>& clusters, 
-		      PHG4Particle *g4particle);
+  //  void buildFullTrack(std::vector<TrkrDefs::cluskey>& clusters, 
+  //		      PHG4Particle *g4particle);
+
   void buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters, 
 		      PHG4Particle *g4particle, TrackSeedContainer* container);
   PHG4TruthInfoContainer* m_g4truth_container = nullptr;
@@ -109,9 +110,8 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   //! minimal truth momentum cut (GeV)
   double _min_momentum = 50e-3;
 
-  TrackSeedContainer *_tpc_seed_map = nullptr;
-  TrackSeedContainer *_silicon_seed_map = nullptr;
-  TrackSeedContainer* _track_map;
+  TrackSeedContainer *_track_map_silicon = nullptr;
+  TrackSeedContainer *_track_map_combined = nullptr;
 
   ActsTrackingGeometry *tgeometry = nullptr;
   ActsSurfaceMaps *surfmaps = nullptr;

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -82,9 +82,6 @@ class PHTruthTrackSeeding : public PHTrackSeeding
   int GetNodes(PHCompositeNode* topNode);
   int CreateNodes(PHCompositeNode* topNode);
 
-  //  void buildFullTrack(std::vector<TrkrDefs::cluskey>& clusters, 
-  //		      PHG4Particle *g4particle);
-
   void buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters, 
 		      PHG4Particle *g4particle, TrackSeedContainer* container);
   PHG4TruthInfoContainer* m_g4truth_container = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR modifies the truth track seeding, truth silicon matching, and normal track matching chains to make full use of, and fully conform to, the new track seeding scheme. The changes are:
1) PHTruthTrackSeeding makes separate seeds for the silicon and tpc clusters instead of putting them all in the tpc seed.
2) PHTruthSiliconAssociation makes a new seed for the silicon clusters, instead of adding them to the tpc seed.
3) PHSiliconTpcTrackMatching no longer duplicates tpc tracks for multiple matches. A new SvtxTrackSeed is made for each combination of tpc and silicon seed, where the silicon seed knows the beam crossing. The matching module is greatly simplified by using the new scheme.
4) PHActsTrkFitter and PHTrackCleaner are modified accordingly.
5) The map that was required in the old scheme to relate fitted SvtxTrack ID to tpc seed ID is no longer used.
6) A few issues with the truth tracking and truth silicon matching were fixed.

The result is that all combinations of truth and normal track seeding and matching now produce track seeds with the same look and feel. The changes have been tested in triggered mode using 100 pion events. The truth tracking, truth silicon matching and normal track matching chains were checked, with the expected performance. The performance in pp mode with extended readout was checked using PYTHIA8 MB + 3 MHz pileup files made for me by Chris, with the expected good performance.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

