### PR TITLE
Adapt to new track

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -67,7 +67,19 @@ namespace
   // specify bins for which one will save histograms
   static const std::vector<float> phi_rec = { get_sector_phi(9) };
   static const std::vector<float> z_rec = { 5. };
-  
+
+  //! get cluster keys from a given track
+  std::vector<TrkrDefs::cluskey> get_cluster_keys( SvtxTrack* track )
+  {
+    std::vector<TrkrDefs::cluskey> out;
+    for( const auto& seed: { track->get_silicon_seed(), track->get_tpc_seed() } )
+    {
+      if( seed )
+      { std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::back_inserter( out ) ); }
+    }
+    return out;
+  }
+
 }
 
 PHTpcResiduals::PHTpcResiduals(const std::string &name)
@@ -205,19 +217,13 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
   int nInttHits = 0;
   int nMMHits = 0;
 
-  for (SvtxTrack::ConstClusterKeyIter clusIter = track->begin_cluster_keys();
-       clusIter != track->end_cluster_keys();
-       ++clusIter)
-    {
-      auto key = *clusIter;
-      auto trkrId = TrkrDefs::getTrkrId(key);
-      if(trkrId == TrkrDefs::TrkrId::mvtxId)
-        ++nMvtxHits;
-      else if(trkrId == TrkrDefs::TrkrId::inttId)
-        ++nInttHits;
-      else if(trkrId == TrkrDefs::TrkrId::micromegasId)
-        ++nMMHits;
-    }
+  for( const auto& key:get_cluster_keys( track ) )
+  {
+    auto trkrId = TrkrDefs::getTrkrId(key);
+    if(trkrId == TrkrDefs::TrkrId::mvtxId) ++nMvtxHits;
+    else if(trkrId == TrkrDefs::TrkrId::inttId) ++nInttHits;
+    else if(trkrId == TrkrDefs::TrkrId::micromegasId) ++nMMHits;
+  }
 
   if(Verbosity() > 2)
     std::cout << "Number of mvtx/intt/MM hits "
@@ -286,12 +292,8 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
   auto trackParams = makeTrackParams(track);
 
   int initNBadProps = m_nBadProps;
-  for (SvtxTrack::ConstClusterKeyIter clusIter = track->begin_cluster_keys();
-       clusIter != track->end_cluster_keys();
-       ++clusIter)
-    {
-      auto cluskey = *clusIter;
-
+  for( const auto& cluskey:get_cluster_keys( track ) )
+  {
       ++m_total_clusters;
 
       // make sure cluster is from TPC


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR adapts a few classes to the new track interface and how we loop over clusters.
Adapted classes are:
g4eval/TrackEvaluation
tpccalib/PHTpcResiduals
trackreco/PHGenfitTrkFitter

The later needs more modifications: right now it expects fully built tracks (as opposed to seeds) to perform the fit. 
I'll copy what's in PHActsTrkFitter in a future pull request. 
As long as we have not resolved the differences between ACTS and GENFIT concerning distortion reconstructions (the latter having significantly better differences than the former), we must keep both fits alive. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

