### PR TITLE
Fix genfit

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -26,7 +26,7 @@ SvtxTrack_v4::SvtxTrack_v4(const SvtxTrack_v4& source)
 { SvtxTrack_v4::CopyFrom( source ); }
 
 SvtxTrack_v4& SvtxTrack_v4::operator=(const SvtxTrack_v4& source)
-{ if( this != &source ) CopyFrom( source ); return *this; }
+{ CopyFrom( source ); return *this; }
 
 SvtxTrack_v4::~SvtxTrack_v4()
 { clear_states(); }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -14,12 +14,12 @@
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/InttDefs.h>
 
-#include <trackbase_historic/TrackSeed.h>
-#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxTrack_v4.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
 #include <trackbase_historic/SvtxTrackMap_v2.h>
-#include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/TrackSeed.h>
+#include <trackbase_historic/TrackSeedContainer.h>
 
 #include <micromegas/MicromegasDefs.h>
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -378,8 +378,8 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	    {
 
 	      std::unique_ptr<SvtxTrack_v4> newTrack( static_cast<SvtxTrack_v4*>(track->CloneMe()) );
-	      if( getTrackFitResult(fitOutput, newTrack) )
-		{ m_directedTrackMap->insert(newTrack.release()); } 
+	      if( getTrackFitResult(fitOutput, newTrack.get()) )
+        { m_directedTrackMap->insert(newTrack.get()); } 
 	      
 	    }
 	  else
@@ -391,7 +391,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	      newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
 	      newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
 	
-	      if( getTrackFitResult(fitOutput, newTrack))
+	      if( getTrackFitResult(fitOutput, newTrack.get()))
 		{ m_trackMap->insertWithKey(newTrack.get(), trid); }
 	    }
 	}
@@ -703,8 +703,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
   return sourcelinks;
 }
 
-bool PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput,
-				        std::unique_ptr<SvtxTrack_v4>& track)
+bool PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput, SvtxTrack* track)
 {
   /// Make a trajectory state for storage, which conforms to Acts track fit
   /// analysis tool
@@ -867,8 +866,7 @@ void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces) const
 
 }
 
-void PHActsTrkFitter::updateSvtxTrack(Trajectory traj, 
-				      std::unique_ptr<SvtxTrack_v4>& track)
+void PHActsTrkFitter::updateSvtxTrack(Trajectory traj, SvtxTrack* track)
 {
   const auto& mj = traj.multiTrajectory();
   const auto& tips = traj.tips();
@@ -938,7 +936,7 @@ void PHActsTrkFitter::updateSvtxTrack(Trajectory traj,
 
   if(m_fillSvtxTrackStates)
     { 
-      rotater.fillSvtxTrackStates(mj, trackTip, track.get(),
+      rotater.fillSvtxTrackStates(mj, trackTip, track,
 				  m_tGeometry->geoContext);  
     }
 
@@ -1058,7 +1056,7 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
   if(!m_trajectories)
     {
       m_trajectories = new std::map<const unsigned int, Trajectory>;
-      PHDataNode<std::map<const unsigned int, Trajectory>> *node = 
+      auto node = 
 	new PHDataNode<std::map<const unsigned int, Trajectory>>(m_trajectories, "ActsTrajectories");
       svtxNode->addNode(node);
       

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -117,7 +117,7 @@ class PHActsTrkFitter : public SubsysReco
 			       short int crossing);
 
   /// Convert the acts track fit result to an svtx track
-  void updateSvtxTrack(Trajectory traj, std::unique_ptr<SvtxTrack_v4>& track);
+  void updateSvtxTrack(Trajectory traj, SvtxTrack* track);
 
   /// Helper function to call either the regular navigation or direct
   /// navigation, depending on m_fitSiliconMMs
@@ -134,7 +134,7 @@ class PHActsTrkFitter : public SubsysReco
 				 SurfacePtrVec& surfaces) const;
   void checkSurfaceVec(SurfacePtrVec& surfaces) const;
 
-  bool getTrackFitResult(const FitResult& fitOutput, std::unique_ptr<SvtxTrack_v4>& track);
+  bool getTrackFitResult(const FitResult& fitOutput, SvtxTrack* track);
 
   Surface getSurface(TrkrDefs::cluskey cluskey,TrkrDefs::subsurfkey surfkey) const;
   Surface getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -40,12 +40,11 @@
 
 class MakeActsGeometry;
 class SvtxTrack;
-class SvtxTrack_v4;
 class SvtxTrackMap;
 class TrackSeed;
 class TrackSeedContainer;
 class TrkrClusterContainer;
-class TrkrClusterIterationMapv1;
+class TrkrClusterIterationMap;
 
 using SourceLink = ActsExamples::IndexSourceLink;
 using FitResult = Acts::KalmanFitterResult;
@@ -201,7 +200,7 @@ class PHActsTrkFitter : public SubsysReco
   TpcClusterMover _clusterMover;
 
   std::string m_fieldMap = "";
-  TrkrClusterIterationMapv1* _iteration_map = nullptr;
+  TrkrClusterIterationMap* _iteration_map = nullptr;
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
   std::string _seed_track_map_name = "SeedTrackMap";

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -49,12 +49,13 @@ class Fitter;
 struct ActsSurfaceMaps;
 struct ActsTrackingGeometry;
 
+class PHCompositeNode;
+class PHG4TruthInfoContainer;
 class SvtxTrackMap;
 class SvtxVertexMap;
 class SvtxVertex;
-class PHCompositeNode;
-class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
+class TrackSeedContainer;
 class TTree;
 
 //! \brief		Refit SvtxTracks with PHGenFit.
@@ -330,14 +331,20 @@ class PHGenFitTrkFitter : public SubsysReco
   
   //! Input Node pointers
   PHG4TruthInfoContainer* _truth_container = nullptr;
-  TrkrClusterContainer* _clustermap = nullptr;
-  SvtxTrackMap* _trackmap = nullptr;
+  TrkrClusterContainer* m_clustermap = nullptr;
+  
+  // track seeds
+  TrackSeedContainer *m_seedMap = nullptr;
+  TrackSeedContainer *m_tpcSeeds = nullptr;
+  TrackSeedContainer *m_siliconSeeds = nullptr;
+
   SvtxVertexMap* _vertexmap = nullptr;
 
   //! Output Node pointers
-  SvtxTrackMap* _trackmap_refit = nullptr;
-  SvtxTrackMap* _primary_trackmap = nullptr;
-  SvtxVertexMap* _vertexmap_refit = nullptr;
+  SvtxTrackMap* m_trackMap = nullptr;
+  SvtxTrackMap* m_trackMap_refit = nullptr;
+  SvtxTrackMap* m_primary_trackMap = nullptr;
+  SvtxVertexMap* m_vertexMap_refit = nullptr;
 
   //! Evaluation
   //! switch eval out
@@ -353,7 +360,7 @@ class PHGenFitTrkFitter : public SubsysReco
   TClonesArray* _tca_vertexmap = nullptr;
   TClonesArray* _tca_trackmap_refit = nullptr;
   TClonesArray* _tca_primtrackmap = nullptr;
-  TClonesArray* _tca_vertexmap_refit = nullptr;
+  TClonesArray* _tcam_vertexMap_refit = nullptr;
 
   TTree* _cluster_eval_tree = nullptr;
   float _cluster_eval_tree_x = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR finishes moving genfit to the new Trackseed and track objects.
Like in PHActsTrkFitter, SvtxTrack objects are created on the fly, from Track seeds, before being fit. 
Also added some more checks in the QATracking module to prevent crashes when running genfit, and a few simplifications in the ActsTrkFitter code. 


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

