### PR TITLE
Circle fit

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -7,6 +7,7 @@
 #include "TpcClusterMover.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <trackbase/TrackFitUtils.h>
 
 #include <cmath>
 #include <iostream>
@@ -69,18 +70,10 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     }
 	  
   // fit a circle to the TPC clusters
-  double R = 0;
-  double X0 = 0;
-  double Y0 = 0;
-  CircleFitByTaubin(tpc_global_vec, R, X0, Y0);
-
-  //std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+  const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin( tpc_global_vec );
   
   // get the straight line representing the z trajectory in the form of z vs radius
-  double A = 0; double B = 0;
-  line_fit(tpc_global_vec, A, B);
-
-  //std::cout << " Fitted line has A " << A << " B " << B << std::endl;
+  const auto [A, B] = TrackFitUtils::line_fit( tpc_global_vec );
   
   // Now we need to move each TPC cluster associated with this track to the readout layer radius
   for(unsigned int i=0; i< tpc_global_vec.size(); ++i)
@@ -120,124 +113,6 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   return global_moved;
 }
 
-void TpcClusterMover::CircleFitByTaubin (std::vector<Acts::Vector3> clusters, double &R, double &X0, double &Y0)
-/*  
-      Circle fit to a given set of data points (in 2D)
-      This is an algebraic fit, due to Taubin, based on the journal article
-      G. Taubin, "Estimation Of Planar Curves, Surfaces And Nonplanar
-                  Space Curves Defined By Implicit Equations, With 
-                  Applications To Edge And Range Image Segmentation",
-                  IEEE Trans. PAMI, Vol. 13, pages 1115-1138, (1991)
-     It works well whether data points are sampled along an entire circle or along a small arc. 
-     It still has a small bias and its statistical accuracy is slightly lower than that of the geometric fit (minimizing geometric distances),
-     It provides a very good initial guess for a subsequent geometric fit. 
-       Nikolai Chernov  (September 2012)
-*/
-{
-  int iter,IterMAX=99;
-  
-  double Mz,Mxy,Mxx,Myy,Mxz,Myz,Mzz,Cov_xy,Var_z;
-  double A0,A1,A2,A22,A3,A33;
-  double x,y;
-  double DET,Xcenter,Ycenter;
-  
-  // Compute x- and y- sample means   
-  double meanX = 0;
-  double meanY = 0;
-  double weight = 0;
-  for(unsigned int iclus = 0; iclus < clusters.size(); ++iclus)
-    {
-      meanX += clusters[iclus][0];
-      meanY += clusters[iclus][1];
-      weight++;
-    }
-  meanX /= weight;
-  meanY /= weight;
-
-  //     computing moments 
-  
-  Mxx=Myy=Mxy=Mxz=Myz=Mzz=0.;
-  
-  for (unsigned int i=0; i<clusters.size(); i++)
-    {
-      double Xi = clusters[i][0] - meanX;   //  centered x-coordinates
-      double Yi = clusters[i][1] - meanY;   //  centered y-coordinates
-      double Zi = Xi*Xi + Yi*Yi;
-      
-      Mxy += Xi*Yi;
-      Mxx += Xi*Xi;
-      Myy += Yi*Yi;
-      Mxz += Xi*Zi;
-      Myz += Yi*Zi;
-      Mzz += Zi*Zi;
-    }
-  Mxx /= weight;
-  Myy /= weight;
-  Mxy /= weight;
-  Mxz /= weight;
-  Myz /= weight;
-  Mzz /= weight;
-  
-  //  computing coefficients of the characteristic polynomial
-  
-  Mz = Mxx + Myy;
-  Cov_xy = Mxx*Myy - Mxy*Mxy;
-  Var_z = Mzz - Mz*Mz;
-  A3 = 4*Mz;
-  A2 = -3*Mz*Mz - Mzz;
-  A1 = Var_z*Mz + 4*Cov_xy*Mz - Mxz*Mxz - Myz*Myz;
-  A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
-  A22 = A2 + A2;
-  A33 = A3 + A3 + A3;
-  
-  //    finding the root of the characteristic polynomial
-  //    using Newton's method starting at x=0  
-  //    (it is guaranteed to converge to the right root)
-  
-  for (x=0.,y=A0,iter=0; iter<IterMAX; iter++)  // usually, 4-6 iterations are enough
-    {
-      double Dy = A1 + x*(A22 + A33*x);
-      double xnew = x - y/Dy;
-      if ((xnew == x)||(!std::isfinite(xnew))) break;
-      double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
-      if (fabs(ynew)>=fabs(y))  break;
-      x = xnew;  y = ynew;
-    }
-  
-  //  computing parameters of the fitting circle
-  
-  DET = x*x - x*Mz + Cov_xy;
-  Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
-  Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
-  
-  //  assembling the output
-  
-  X0 = Xcenter + meanX;
-  Y0 = Ycenter + meanY;
-  R = sqrt(Xcenter*Xcenter + Ycenter*Ycenter + Mz);
-}
-
-void  TpcClusterMover::line_fit(std::vector<Acts::Vector3> clusters, double &a, double &b)
-{
-  // copied from: https://www.bragitoff.com
-  // we want to fit z vs radius
-
-   double xsum=0,x2sum=0,ysum=0,xysum=0;                //variables for sums/sigma of xi,yi,xi^2,xiyi etc
-   for (unsigned int i=0; i<clusters.size(); ++i)
-    {
-      double z = clusters[i][2];
-      double r = sqrt(pow(clusters[i][0],2) + pow(clusters[i][1], 2));
-
-      xsum=xsum+r;                        //calculate sigma(xi)
-      ysum=ysum+z;                        //calculate sigma(yi)
-      x2sum=x2sum+pow(r,2);                //calculate sigma(x^2i)
-      xysum=xysum+r*z;                    //calculate sigma(xi*yi)
-    }
-   a=(clusters.size()*xysum-xsum*ysum)/(clusters.size()*x2sum-xsum*xsum);            //calculate slope
-   b=(x2sum*ysum-xsum*xysum)/(x2sum*clusters.size()-xsum*xsum);            //calculate intercept
-
-    return;
-}   
 
 void TpcClusterMover::circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus)
 {

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -113,49 +113,12 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   return global_moved;
 }
 
-
-void TpcClusterMover::circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus)
-{
-  // r1 is radius of sPHENIX layer
-  // r2, x2 and y2 are parameters of circle fitted to TPC clusters
-  // the solutions are xplus, xminus, yplus, yminus
-
-  // The intersection of two circles occurs when
-  // (x-x1)^2 + (y-y1)^2 = r1^2,  / (x-x2)^2 + (y-y2)^2 = r2^2
-  // Here we assume that circle 1 is an sPHENIX layer centered on x1=y1=0, and circle 2 is arbitrary
-  //  x^2 +y^2 = r1^2,   (x-x2)^2 + (y-y2)^2 = r2^2
-  // expand the equations and subtract to eliminate the x^2 and y^2 terms, gives the radical line connecting the intersection points
-  // iy = - (2*x2*x - D) / 2*y2, 
-  // then substitute for y in equation of circle 1
-
-  double D = r1*r1 - r2*r2 + x2*x2 + y2*y2;
-  double a = 1.0 + (x2*x2) / (y2*y2);
-  double b = - D * x2/( y2*y2);
-  double c = D*D / (4.0*y2*y2) - r1*r1;
-
-  xplus = (-b + sqrt(b*b - 4.0* a * c) ) / (2.0 * a);
-  xminus = (-b - sqrt(b*b - 4.0* a * c) ) / (2.0 * a);
-
-  // both values of x are valid
-  // but for each of those values, there are two possible y values on circle 1
-  // but only one of those falls on the radical line:
-
-  yplus = - (2*x2*xplus - D) / (2.0*y2); 
-  yminus = -(2*x2*xminus - D) / (2.0*y2);
-
-}
-
 int TpcClusterMover::get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y)
 {
   // finds the intersection of the fitted circle with the cylinder having radius = target_radius
-  double xplus = 0;
-  double yplus = 0; 
-   double xminus = 0;
-   double yminus = 0;
+  const auto [xplus, yplus, xminus, yminus] = TrackFitUtils::circle_circle_intersection(target_radius, R, X0, Y0 );
    
-   circle_circle_intersection(target_radius, R, X0, Y0, xplus, yplus, xminus, yminus);
-   
-   // We only need to check xplus for failure, skip this TPC cluster in that case
+  // We only need to check xplus for failure, skip this TPC cluster in that case
    if(std::isnan(xplus)) 
      {
 	 {

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -19,12 +19,10 @@ class TpcClusterMover
 
   void set_verbosity(int verb) { _verbosity = verb; }
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(std::vector<std::pair<TrkrDefs::cluskey,Acts::Vector3>> global_in );
-  void CircleFitByTaubin (std::vector<Acts::Vector3> clusters, double &R, double &X0, double &Y0);
-  void  line_fit(std::vector<Acts::Vector3> clusters, double &a, double &b);
- void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
- int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y);
+  void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
+  int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y);
 
- double _z_start=0.0; 
+  double _z_start=0.0; 
   double _y_start=0.0; 
   double _x_start=0.0; 
 

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -19,7 +19,8 @@ class TpcClusterMover
 
   void set_verbosity(int verb) { _verbosity = verb; }
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(std::vector<std::pair<TrkrDefs::cluskey,Acts::Vector3>> global_in );
-  void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
+  
+  private:
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y);
 
   double _z_start=0.0; 

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -32,6 +32,7 @@ pkginclude_HEADERS = \
   MvtxDefs.h \
   TpcSeedTrackMap.h \
   TpcSeedTrackMapv1.h \
+  TrackFitUtils.h \
   TrkrCluster.h \
   TrkrClusterv1.h \
   TrkrClusterv2.h \
@@ -157,6 +158,7 @@ libtrack_io_la_SOURCES = \
   CMFlashDifferenceContainerv1.cc \
   InttDefs.cc \
   MvtxDefs.cc \
+  TrackFitUtils.cc \
   TrkrClusterv1.cc \
   TrkrClusterv2.cc \
   TrkrClusterv3.cc \

--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -12,13 +12,13 @@ namespace
 
 //_________________________________________________________________________________
 TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const TrackFitUtils::position_vector_t& positions )
-{  
-  
+{
+
   // Compute x- and y- sample means
   double meanX = 0;
   double meanY = 0;
   double weight = 0;
-  
+
   for( const auto& [x,y] : positions)
   {
     meanX += x;
@@ -27,22 +27,22 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   }
   meanX /= weight;
   meanY /= weight;
-  
+
   //     computing moments
-  
+
   double Mxx = 0;
   double Myy = 0;
   double Mxy = 0;
   double Mxz = 0;
   double Myz = 0;
   double Mzz = 0;
-  
+
   for (auto& [x,y] : positions)
   {
     double Xi = x - meanX;   //  centered x-coordinates
     double Yi = y - meanY;   //  centered y-coordinates
     double Zi = square(Xi) + square(Yi);
-    
+
     Mxy += Xi*Yi;
     Mxx += Xi*Xi;
     Myy += Yi*Yi;
@@ -56,9 +56,9 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   Mxz /= weight;
   Myz /= weight;
   Mzz /= weight;
-  
+
   //  computing coefficients of the characteristic polynomial
-  
+
   const double Mz = Mxx + Myy;
   const double Cov_xy = Mxx*Myy - Mxy*Mxy;
   const double Var_z = Mzz - Mz*Mz;
@@ -68,39 +68,49 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   const double A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
   const double A22 = A2 + A2;
   const double A33 = A3 + A3 + A3;
-  
+
   //    finding the root of the characteristic polynomial
   //    using Newton's method starting at x=0
   //    (it is guaranteed to converge to the right root)
   static constexpr int iter_max = 99;
   double x = 0;
   double y = A0;
-  
+
   // usually, 4-6 iterations are enough
   for( int iter=0; iter<iter_max; ++iter)
   {
     const double Dy = A1 + x*(A22 + A33*x);
     const double xnew = x - y/Dy;
     if ((xnew == x)||(!std::isfinite(xnew))) break;
-    
+
     const double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
     if (std::abs(ynew)>=std::abs(y))  break;
-  
+
     x = xnew;  y = ynew;
-  
+
   }
-  
+
   //  computing parameters of the fitting circle
   const double DET = square(x) - x*Mz + Cov_xy;
   const double Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
   const double Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
-  
+
   //  assembling the output
   double X0 = Xcenter + meanX;
   double Y0 = Ycenter + meanY;
   double R = std::sqrt( square(Xcenter) + square(Ycenter) + Mz);
   return std::make_tuple( R, X0, Y0 );
-  
+
+}
+
+//_________________________________________________________________________________
+TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const std::vector<Acts::Vector3>& positions )
+{
+  position_vector_t positions_2d;
+  for( const auto& position:positions )
+  { positions_2d.emplace_back( position.x(), position.y() ); }
+
+  return circle_fit_by_taubin( positions_2d );
 }
 
 //_________________________________________________________________________________
@@ -109,7 +119,7 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::po
   double xsum=0;
   double x2sum=0;
   double ysum=0;
-  double xysum=0;           
+  double xysum=0;
   for( const auto& [r,z]:positions )
   {
     xsum=xsum+r;                        //calculate sigma(xi)
@@ -117,10 +127,20 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::po
     x2sum=x2sum+square(r);              //calculate sigma(x^2i)
     xysum=xysum+r*z;                    //calculate sigma(xi*yi)
   }
-  
+
   const auto npts = positions.size();
   const double denominator = (x2sum*npts-square(xsum));
   const double a= (xysum*npts-xsum*ysum)/denominator;            //calculate slope
   const double b= (x2sum*ysum-xsum*xysum)/denominator;           //calculate intercept
   return std::make_tuple( a, b );
+}
+
+//_________________________________________________________________________________
+TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit( const std::vector<Acts::Vector3>& positions )
+{
+  position_vector_t positions_2d;
+  for( const auto& position:positions )
+  { positions_2d.emplace_back( std::sqrt( square(position.x())+square(position.y())), position.z() ); }
+
+  return line_fit( positions_2d );
 }

--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -1,0 +1,126 @@
+#include "TrackFitUtils.h"
+
+#include <cmath>
+
+namespace
+{
+
+  //! convenience square method
+  template<class T>
+    inline constexpr T square( const T& x ) { return x*x; }
+}
+
+//_________________________________________________________________________________
+TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const TrackFitUtils::position_vector_t& positions )
+{  
+  
+  // Compute x- and y- sample means
+  double meanX = 0;
+  double meanY = 0;
+  double weight = 0;
+  
+  for( const auto& [x,y] : positions)
+  {
+    meanX += x;
+    meanY += y;
+    ++weight;
+  }
+  meanX /= weight;
+  meanY /= weight;
+  
+  //     computing moments
+  
+  double Mxx = 0;
+  double Myy = 0;
+  double Mxy = 0;
+  double Mxz = 0;
+  double Myz = 0;
+  double Mzz = 0;
+  
+  for (auto& [x,y] : positions)
+  {
+    double Xi = x - meanX;   //  centered x-coordinates
+    double Yi = y - meanY;   //  centered y-coordinates
+    double Zi = square(Xi) + square(Yi);
+    
+    Mxy += Xi*Yi;
+    Mxx += Xi*Xi;
+    Myy += Yi*Yi;
+    Mxz += Xi*Zi;
+    Myz += Yi*Zi;
+    Mzz += Zi*Zi;
+  }
+  Mxx /= weight;
+  Myy /= weight;
+  Mxy /= weight;
+  Mxz /= weight;
+  Myz /= weight;
+  Mzz /= weight;
+  
+  //  computing coefficients of the characteristic polynomial
+  
+  const double Mz = Mxx + Myy;
+  const double Cov_xy = Mxx*Myy - Mxy*Mxy;
+  const double Var_z = Mzz - Mz*Mz;
+  const double A3 = 4*Mz;
+  const double A2 = -3*Mz*Mz - Mzz;
+  const double A1 = Var_z*Mz + 4*Cov_xy*Mz - Mxz*Mxz - Myz*Myz;
+  const double A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
+  const double A22 = A2 + A2;
+  const double A33 = A3 + A3 + A3;
+  
+  //    finding the root of the characteristic polynomial
+  //    using Newton's method starting at x=0
+  //    (it is guaranteed to converge to the right root)
+  static constexpr int iter_max = 99;
+  double x = 0;
+  double y = A0;
+  
+  // usually, 4-6 iterations are enough
+  for( int iter=0; iter<iter_max; ++iter)
+  {
+    const double Dy = A1 + x*(A22 + A33*x);
+    const double xnew = x - y/Dy;
+    if ((xnew == x)||(!std::isfinite(xnew))) break;
+    
+    const double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
+    if (std::abs(ynew)>=std::abs(y))  break;
+  
+    x = xnew;  y = ynew;
+  
+  }
+  
+  //  computing parameters of the fitting circle
+  const double DET = square(x) - x*Mz + Cov_xy;
+  const double Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
+  const double Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
+  
+  //  assembling the output
+  double X0 = Xcenter + meanX;
+  double Y0 = Ycenter + meanY;
+  double R = std::sqrt( square(Xcenter) + square(Ycenter) + Mz);
+  return std::make_tuple( R, X0, Y0 );
+  
+}
+
+//_________________________________________________________________________________
+TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::position_vector_t& positions)
+{
+  double xsum=0;
+  double x2sum=0;
+  double ysum=0;
+  double xysum=0;           
+  for( const auto& [r,z]:positions )
+  {
+    xsum=xsum+r;                        //calculate sigma(xi)
+    ysum=ysum+z;                        //calculate sigma(yi)
+    x2sum=x2sum+square(r);              //calculate sigma(x^2i)
+    xysum=xysum+r*z;                    //calculate sigma(xi*yi)
+  }
+  
+  const auto npts = positions.size();
+  const double denominator = (x2sum*npts-square(xsum));
+  const double a= (xysum*npts-xsum*ysum)/denominator;            //calculate slope
+  const double b= (x2sum*ysum-xsum*xysum)/denominator;           //calculate intercept
+  return std::make_tuple( a, b );
+}

--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -144,3 +144,26 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit( const std::vector<Acts
 
   return line_fit( positions_2d );
 }
+
+//_________________________________________________________________________________
+TrackFitUtils::circle_circle_intersection_output_t TrackFitUtils::circle_circle_intersection(double r1, double r2, double x2, double y2 )
+{
+  
+  const double D = square(r1) - square(r2) + square(x2) + square(y2);
+  const double a = 1.0 + square(x2/y2);
+  const double b = - D * x2/square(y2);
+  const double c = square(D/(2.*y2)) - square(r1);
+  const double delta = square(b)-4.*a*c;
+  
+  const double sqdelta = std::sqrt( delta );
+  
+  const double xplus = (-b + sqdelta ) / (2. * a);
+  const double xminus = (-b - sqdelta ) / (2. * a);
+  
+  const double yplus  = -(2*x2*xplus - D) / (2.*y2);
+  const double yminus = -(2*x2*xminus - D) / (2.*y2);
+
+  
+  return std::make_tuple( xplus, yplus, xminus, yminus );
+
+}

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -1,18 +1,20 @@
 #ifndef TRACKBASE_TRACKFITUTILS_H
 #define TRACKBASE_TRACKFITUTILS_H
 
+#include <Acts/Definitions/Algebra.hpp>
+
 #include <tuple>
 #include <utility>
 #include <vector>
 
 class TrackFitUtils
 {
-  
+
   public:
 
   using position_t = std::pair<double, double>;
   using position_vector_t = std::vector<position_t>;
-  
+
   /// circle fit output [R, x0, y0]
   using circle_fit_output_t = std::tuple<double, double, double>;
 
@@ -30,15 +32,21 @@ class TrackFitUtils
    */
   static circle_fit_output_t circle_fit_by_taubin(const position_vector_t&);
 
+  /// convenient overload
+  static circle_fit_output_t circle_fit_by_taubin(const std::vector<Acts::Vector3>& );
+
   /// line fit output [slope, intercept]
   using line_fit_output_t = std::tuple<double,double>;
-  
+
   /// line_fit
   /**
    * copied from: https://www.bragitoff.com
    * typically used to fit we want to fit z vs radius
    */
   static line_fit_output_t line_fit(const position_vector_t&);
+
+  /// convenient overload
+  static line_fit_output_t line_fit(const std::vector<Acts::Vector3>& );
 
 };
 

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -48,6 +48,25 @@ class TrackFitUtils
   /// convenient overload
   static line_fit_output_t line_fit(const std::vector<Acts::Vector3>& );
 
+  /// circle-circle intersection output. (xplus, yplus, xminus, yminus)
+  using circle_circle_intersection_output_t = std::tuple<double, double, double, double>;
+
+  
+  /**
+   * r1 is radius of sPHENIX layer
+   * r2, x2 and y2 are parameters of circle fitted to TPC clusters
+   * the solutions are xplus, xminus, yplus, yminus
+
+   * The intersection of two circles occurs when
+   * (x-x1)^2 + (y-y1)^2 = r1^2,  / (x-x2)^2 + (y-y2)^2 = r2^2
+   * Here we assume that circle 1 is an sPHENIX layer centered on x1=y1=0, and circle 2 is arbitrary
+   * x^2 +y^2 = r1^2,   (x-x2)^2 + (y-y2)^2 = r2^2
+   * expand the equations and subtract to eliminate the x^2 and y^2 terms, gives the radical line connecting the intersection points
+   * iy = - (2*x2*x - D) / 2*y2,
+   * then substitute for y in equation of circle 1
+   */
+  static circle_circle_intersection_output_t circle_circle_intersection( double r1, double r2, double x2, double y2 );  
+  
 };
 
 #endif

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -1,0 +1,45 @@
+#ifndef TRACKBASE_TRACKFITUTILS_H
+#define TRACKBASE_TRACKFITUTILS_H
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+class TrackFitUtils
+{
+  
+  public:
+
+  using position_t = std::pair<double, double>;
+  using position_vector_t = std::vector<position_t>;
+  
+  /// circle fit output [R, x0, y0]
+  using circle_fit_output_t = std::tuple<double, double, double>;
+
+  /**
+   * Circle fit to a given set of data points (in 2D)
+   * This is an algebraic fit, due to Taubin, based on the journal article
+   * G. Taubin, "Estimation Of Planar Curves, Surfaces And Nonplanar
+   * Space Curves Defined By Implicit Equations, With
+   * Applications To Edge And Range Image Segmentation",
+   * IEEE Trans. PAMI, Vol. 13, pages 1115-1138, (1991)
+   * It works well whether data points are sampled along an entire circle or along a small arc.
+   * It still has a small bias and its statistical accuracy is slightly lower than that of the geometric fit (minimizing geometric distances),
+   * It provides a very good initial guess for a subsequent geometric fit.
+   * Nikolai Chernov  (September 2012)
+   */
+  static circle_fit_output_t circle_fit_by_taubin(const position_vector_t&);
+
+  /// line fit output [slope, intercept]
+  using line_fit_output_t = std::tuple<double,double>;
+  
+  /// line_fit
+  /**
+   * copied from: https://www.bragitoff.com
+   * typically used to fit we want to fit z vs radius
+   */
+  static line_fit_output_t line_fit(const position_vector_t&);
+
+};
+
+#endif

--- a/offline/packages/trackbase_historic/TrackSeed_FastSim_v1.cc
+++ b/offline/packages/trackbase_historic/TrackSeed_FastSim_v1.cc
@@ -42,9 +42,6 @@ float TrackSeed_FastSim_v1::get_phi(TrkrClusterContainer *clusters,
 				    ActsSurfaceMaps *surfMaps, 
 				    ActsTrackingGeometry *tGeometry) const
 {
-  float x=NAN, y=NAN;
-  findRoot(x,y);
-  float phi = atan2(-1* (TrackSeed_v1::get_X0()-x), (TrackSeed_v1::get_Y0()-y));
-  
-  return phi;
+  const auto [x,y] = findRoot();
+  return std::atan2(-1* (TrackSeed_v1::get_X0()-x), (TrackSeed_v1::get_Y0()-y));
 }

--- a/offline/packages/trackbase_historic/TrackSeed_v1.h
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.h
@@ -96,9 +96,9 @@ class TrackSeed_v1 : public TrackSeed
 	       uint8_t endLayer = 58) override;
 
  protected:
+
   /// Returns transverse PCA to (0,0)
-  void findRoot(float& x ,float& y) const;
-  float findRoot(bool findX) const;
+  std::pair<float,float> findRoot() const;
 
  private:
 

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -53,12 +53,10 @@ class ALICEKF
   void repairCovariance(Eigen::Matrix<double,6,6>& cov) const;
   bool checknan(double val, const std::string &msg, int num) const;
   double get_Bz(double x, double y, double z) const;
-  void CircleFitByTaubin(const std::vector<std::pair<double,double>>& pts, double &R, double &X0, double &Y0) const;
   void useConstBField(bool opt) {_use_const_field = opt;}
   void useFixedClusterError(bool opt) {_use_fixed_clus_error = opt;}
   void setFixedClusterError(int i,double val) {_fixed_clus_error.at(i)=val;}
   double getClusterError(TrkrCluster* c, Acts::Vector3 global, int i, int j) const;
-  void line_fit(const std::vector<std::pair<double,double>>& pts, double& a, double& b) const;
   std::vector<double> GetCircleClusterResiduals(const std::vector<std::pair<double,double>>& pts, double R, double X0, double Y0) const;
   std::vector<double> GetLineClusterResiduals(const std::vector<std::pair<double,double>>& pts, double A, double B) const; 
   double get_Bzconst() const { return _Bzconst; }

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -8,6 +8,7 @@
 #include <micromegas/MicromegasDefs.h>
 
 /// Tracking includes
+#include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrCluster.h>            // for TrkrCluster
 #include <trackbase/TrkrClusterv3.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
@@ -48,130 +49,6 @@ namespace
   //! get radius from x and y
   template<class T>
     inline constexpr T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
-
-  /**
-   * Circle fit to a given set of data points (in 2D)
-   * This is an algebraic fit, due to Taubin, based on the journal article
-   * G. Taubin, "Estimation Of Planar Curves, Surfaces And Nonplanar
-   * Space Curves Defined By Implicit Equations, With
-   * Applications To Edge And Range Image Segmentation",
-   * IEEE Trans. PAMI, Vol. 13, pages 1115-1138, (1991)
-   * It works well whether data points are sampled along an entire circle or along a small arc.
-   * It still has a small bias and its statistical accuracy is slightly lower than that of the geometric fit (minimizing geometric distances),
-   * It provides a very good initial guess for a subsequent geometric fit.
-   * Nikolai Chernov  (September 2012)
-   */
-  void CircleFitByTaubin (std::vector<Acts::Vector3>& clusters, double &R, double &X0, double &Y0)
-  {
-    int iter,IterMAX=99;
-
-    double Mz,Mxy,Mxx,Myy,Mxz,Myz,Mzz,Cov_xy,Var_z;
-    double A0,A1,A2,A22,A3,A33;
-    double x,y;
-    double DET,Xcenter,Ycenter;
-
-    // Compute x- and y- sample means
-    double meanX = 0;
-    double meanY = 0;
-    double weight = 0;
-
-    for(auto& global : clusters)
-    {
-      meanX += global(0);
-      meanY += global(1);
-      weight++;
-    }
-    meanX /= weight;
-    meanY /= weight;
-
-    //     computing moments
-
-    Mxx=Myy=Mxy=Mxz=Myz=Mzz=0.;
-
-    for (auto& global : clusters)
-    {
-      double Xi = global(0) - meanX;   //  centered x-coordinates
-      double Yi = global(1) - meanY;   //  centered y-coordinates
-      double Zi = Xi*Xi + Yi*Yi;
-
-      Mxy += Xi*Yi;
-      Mxx += Xi*Xi;
-      Myy += Yi*Yi;
-      Mxz += Xi*Zi;
-      Myz += Yi*Zi;
-      Mzz += Zi*Zi;
-    }
-    Mxx /= weight;
-    Myy /= weight;
-    Mxy /= weight;
-    Mxz /= weight;
-    Myz /= weight;
-    Mzz /= weight;
-
-    //  computing coefficients of the characteristic polynomial
-
-    Mz = Mxx + Myy;
-    Cov_xy = Mxx*Myy - Mxy*Mxy;
-    Var_z = Mzz - Mz*Mz;
-    A3 = 4*Mz;
-    A2 = -3*Mz*Mz - Mzz;
-    A1 = Var_z*Mz + 4*Cov_xy*Mz - Mxz*Mxz - Myz*Myz;
-    A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
-    A22 = A2 + A2;
-    A33 = A3 + A3 + A3;
-
-    //    finding the root of the characteristic polynomial
-    //    using Newton's method starting at x=0
-    //    (it is guaranteed to converge to the right root)
-
-    for (x=0.,y=A0,iter=0; iter<IterMAX; iter++)  // usually, 4-6 iterations are enough
-    {
-      double Dy = A1 + x*(A22 + A33*x);
-      double xnew = x - y/Dy;
-      if ((xnew == x)||(!isfinite(xnew))) break;
-      double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
-      if (std::abs(ynew)>=std::abs(y))  break;
-      x = xnew;  y = ynew;
-    }
-
-    //  computing parameters of the fitting circle
-
-    DET = x*x - x*Mz + Cov_xy;
-    Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
-    Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
-
-    //  assembling the output
-
-    X0 = Xcenter + meanX;
-    Y0 = Ycenter + meanY;
-    R = sqrt(Xcenter*Xcenter + Ycenter*Ycenter + Mz);
-  }
-
-  // 2D linear fit
-void line_fit(std::vector<Acts::Vector3>& clusters, double &a, double &b)
-  {
-    // copied from: https://www.bragitoff.com
-    // we want to fit z vs radius
-
-    //variables for sums/sigma of xi,yi,xi^2,xiyi etc
-    double xsum=0,x2sum=0,ysum=0,xysum=0;
- 
-    for (auto& global : clusters)
-    {
-      const double z = global(2);
-      const double r = get_r( global(0), global(1) );
-
-      xsum=xsum+r;                        //calculate sigma(xi)
-      ysum=ysum+z;                        //calculate sigma(yi)
-      x2sum=x2sum+ square(r);             //calculate sigma(x^2i)
-      xysum=xysum+r*z;                    //calculate sigma(xi*yi)
-    }
-
-    a=(clusters.size()*xysum-xsum*ysum)/(clusters.size()*x2sum-xsum*xsum); //calculate slope
-    b=(x2sum*ysum-xsum*xysum)/(x2sum*clusters.size()-xsum*xsum);           //calculate intercept
-    return;
-  }
-
 
   /**
    * r1 is radius of sPHENIX layer
@@ -410,18 +287,14 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
     }
 
     // fit a circle to the clusters
-    double R = 0;
-    double X0 = 0;
-    double Y0 = 0;
-    CircleFitByTaubin(clusGlobPos, R, X0, Y0);
+    const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin( clusGlobPos );
     if(Verbosity() > 10) std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
 
     // toss tracks for which the fitted circle could not have come from the vertex
     if(R < 40.0) continue;
 
     // get the straight line representing the z trajectory in the form of z vs radius
-    double A = 0; double B = 0;
-    line_fit(clusGlobPos, A, B);
+    const auto [A, B] = TrackFitUtils::line_fit( clusGlobPos );
     if(Verbosity() > 10) std::cout << " Fitted line has A " << A << " B " << B << std::endl;
 
     // loop over micromegas layer

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -28,14 +28,14 @@
 // tpc distortion correction
 #include <tpc/TpcDistortionCorrectionContainer.h>
 
-#include <trackbase_historic/ActsTransformations.h>
-#include <trackbase_historic/TrackSeedContainer.h>
-#include <trackbase_historic/TrackSeed_v1.h>
-
+#include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
+#include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/TrackSeed_v1.h>
 
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
@@ -1075,15 +1075,15 @@ std::vector<keylist> PHSimpleKFProp::RemoveBadClusters(const std::vector<keylist
       rz_pts.push_back(std::make_pair(r,global(2)));
     }
     if(Verbosity()>0) std::cout << "chain size: " << chain.size() << std::endl;
-    double A;
-    double B;
-    double R;
-    double X0;
-    double Y0;
-    fitter->CircleFitByTaubin(xy_pts,R,X0,Y0);
-    fitter->line_fit(rz_pts,A,B);
-    std::vector<double> xy_resid = fitter->GetCircleClusterResiduals(xy_pts,R,X0,Y0);
-    std::vector<double> rz_resid = fitter->GetLineClusterResiduals(rz_pts,A,B);
+
+    //fit a circle through x,y coordinates and calculate residuals
+    const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin( xy_pts );
+    const std::vector<double> xy_resid = fitter->GetCircleClusterResiduals(xy_pts,R,X0,Y0);
+
+    // fit a line through r,z coordinates and calculate residuals
+    const auto [A, B] = TrackFitUtils::line_fit( rz_pts );
+    const std::vector<double> rz_resid = fitter->GetLineClusterResiduals(rz_pts,A,B);
+    
     for(size_t i=0;i<chain.size();i++)
     {
       if(xy_resid[i]>_xy_outlier_threshold) continue;

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -352,12 +352,7 @@ int  PHTpcClusterMover::GetNodes(PHCompositeNode* topNode)
 int PHTpcClusterMover::get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y)
 {
   // finds the intersection of the fitted circle with the cylinder having radius = target_radius
-  double xplus = 0;
-  double yplus = 0; 
-   double xminus = 0;
-   double yminus = 0;
-   
-   circle_circle_intersection(target_radius, R, X0, Y0, xplus, yplus, xminus, yminus);
+  const auto [xplus, yplus, xminus, yminus] = TrackFitUtils::circle_circle_intersection(target_radius, R, X0, Y0 );
    
    // We only need to check xplus for failure, skip this TPC cluster in that case
    if(std::isnan(xplus)) 
@@ -383,37 +378,6 @@ int PHTpcClusterMover::get_circle_circle_intersection(double target_radius, doub
      }
    return Fun4AllReturnCodes::EVENT_OK;   
  }
-
-void PHTpcClusterMover::circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus)
-{
-  // r1 is radius of sPHENIX layer
-  // r2, x2 and y2 are parameters of circle fitted to TPC clusters
-  // the solutions are xplus, xminus, yplus, yminus
-
-  // The intersection of two circles occurs when
-  // (x-x1)^2 + (y-y1)^2 = r1^2,  / (x-x2)^2 + (y-y2)^2 = r2^2
-  // Here we assume that circle 1 is an sPHENIX layer centered on x1=y1=0, and circle 2 is arbitrary
-  //  x^2 +y^2 = r1^2,   (x-x2)^2 + (y-y2)^2 = r2^2
-  // expand the equations and subtract to eliminate the x^2 and y^2 terms, gives the radical line connecting the intersection points
-  // iy = - (2*x2*x - D) / 2*y2, 
-  // then substitute for y in equation of circle 1
-
-  double D = r1*r1 - r2*r2 + x2*x2 + y2*y2;
-  double a = 1.0 + (x2*x2) / (y2*y2);
-  double b = - D * x2/( y2*y2);
-  double c = D*D / (4.0*y2*y2) - r1*r1;
-
-  xplus = (-b + sqrt(b*b - 4.0* a * c) ) / (2.0 * a);
-  xminus = (-b - sqrt(b*b - 4.0* a * c) ) / (2.0 * a);
-
-  // both values of x are valid
-  // but for each of those values, there are two possible y values on circle 1
-  // but only one of those falls on the radical line:
-
-  yplus = - (2*x2*xplus - D) / (2.0*y2); 
-  yminus = -(2*x2*xminus - D) / (2.0*y2);
-
-}
 
 Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitsetkey,
 						       Acts::Vector3 world,

--- a/offline/packages/trackreco/PHTpcClusterMover.cc
+++ b/offline/packages/trackreco/PHTpcClusterMover.cc
@@ -4,6 +4,7 @@
 
 /// Tracking includes
 
+#include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrClusterv3.h>            // for TrkrCluster
 #include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
 #include <trackbase/TrkrClusterContainerv4.h>
@@ -29,15 +30,7 @@
 //____________________________________________________________________________..
 PHTpcClusterMover::PHTpcClusterMover(const std::string &name)
   : SubsysReco(name)
-{
-
-}
-
-//____________________________________________________________________________..
-PHTpcClusterMover::~PHTpcClusterMover()
-{
-
-}
+{}
 
 //____________________________________________________________________________..
 int PHTpcClusterMover::InitRun(PHCompositeNode *topNode)
@@ -150,31 +143,23 @@ int PHTpcClusterMover::process_event(PHCompositeNode */*topNode*/)
 	  continue;  // skip to the next TPC track
 	}
 
-      // fit a circle to the clusters
-      double R = 0;
-      double X0 = 0;
-      double Y0 = 0;
-      CircleFitByTaubin(globalClusterPositions, R, X0, Y0);
-      if(Verbosity() > 10) 
-	std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+  // fit a circle to the clusters
+  const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin( globalClusterPositions );
+  if(Verbosity() > 10) 
+  { std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl; }
 
-      // toss tracks for which the fitted circle could not have come from the vertex
-      //if(R < 30.0) continue;
+  // toss tracks for which the fitted circle could not have come from the vertex
+  //if(R < 30.0) continue;
+  
+  // get the straight line representing the z trajectory in the form of z vs radius
+  const auto [A, B] = TrackFitUtils::line_fit( globalClusterPositions );
+  if(Verbosity() > 10)  
+  { std::cout << " Fitted line has A " << A << " B " << B << std::endl; }
 
-      // get the straight line representing the z trajectory in the form of z vs radius
-      double A = 0; double B = 0;
-      line_fit(globalClusterPositions, A, B);
-      if(Verbosity() > 10) 
-	std::cout << " Fitted line has A " << A << " B " << B << std::endl;
-
-      // Now we need to move each cluster associated with this track to the readout layer radius
-      for (auto clus_iter = tpc_clusters.begin();
-	   clus_iter != tpc_clusters.end(); 
-	   ++clus_iter)
-	{
-	  TrkrDefs::cluskey cluskey = clus_iter->first;
-	  unsigned int layer = TrkrDefs::getLayer(cluskey);
-	  Acts::Vector3 global = clus_iter->second;
+  // Now we need to move each cluster associated with this track to the readout layer radius
+  for( const auto& [cluskey, global]:tpc_clusters )
+  {
+    const unsigned int layer = TrkrDefs::getLayer(cluskey);
 
 	  // get circle position at target surface radius 
 	  double target_radius = layer_radius[layer-7];
@@ -398,103 +383,6 @@ int PHTpcClusterMover::get_circle_circle_intersection(double target_radius, doub
      }
    return Fun4AllReturnCodes::EVENT_OK;   
  }
-void PHTpcClusterMover::CircleFitByTaubin (std::vector<Acts::Vector3> clusters, double &R, double &X0, double &Y0)
-/*  
-      Circle fit to a given set of data points (in 2D)
-      This is an algebraic fit, due to Taubin, based on the journal article
-      G. Taubin, "Estimation Of Planar Curves, Surfaces And Nonplanar
-                  Space Curves Defined By Implicit Equations, With 
-                  Applications To Edge And Range Image Segmentation",
-                  IEEE Trans. PAMI, Vol. 13, pages 1115-1138, (1991)
-     It works well whether data points are sampled along an entire circle or along a small arc. 
-     It still has a small bias and its statistical accuracy is slightly lower than that of the geometric fit (minimizing geometric distances),
-     It provides a very good initial guess for a subsequent geometric fit. 
-       Nikolai Chernov  (September 2012)
-*/
-{
-  int iter,IterMAX=99;
-  
-  double Mz,Mxy,Mxx,Myy,Mxz,Myz,Mzz,Cov_xy,Var_z;
-  double A0,A1,A2,A22,A3,A33;
-  double x,y;
-  double DET,Xcenter,Ycenter;
-  
-  // Compute x- and y- sample means   
-  double meanX = 0;
-  double meanY = 0;
-  double weight = 0;
-  for(unsigned int iclus = 0; iclus < clusters.size(); ++iclus)
-    {
-      if(Verbosity() > 3)  std::cout << "    add cluster with x " << clusters[iclus][0] << " and y " << clusters[iclus][1] << std::endl;
-      meanX += clusters[iclus][0];
-      meanY += clusters[iclus][1];
-      weight++;
-    }
-  meanX /= weight;
-  meanY /= weight;
-
-  //     computing moments 
-  
-  Mxx=Myy=Mxy=Mxz=Myz=Mzz=0.;
-  
-  for (unsigned int i=0; i<clusters.size(); i++)
-    {
-      double Xi = clusters[i][0] - meanX;   //  centered x-coordinates
-      double Yi = clusters[i][1] - meanY;   //  centered y-coordinates
-      double Zi = Xi*Xi + Yi*Yi;
-      
-      Mxy += Xi*Yi;
-      Mxx += Xi*Xi;
-      Myy += Yi*Yi;
-      Mxz += Xi*Zi;
-      Myz += Yi*Zi;
-      Mzz += Zi*Zi;
-    }
-  Mxx /= weight;
-  Myy /= weight;
-  Mxy /= weight;
-  Mxz /= weight;
-  Myz /= weight;
-  Mzz /= weight;
-  
-  //  computing coefficients of the characteristic polynomial
-  
-  Mz = Mxx + Myy;
-  Cov_xy = Mxx*Myy - Mxy*Mxy;
-  Var_z = Mzz - Mz*Mz;
-  A3 = 4*Mz;
-  A2 = -3*Mz*Mz - Mzz;
-  A1 = Var_z*Mz + 4*Cov_xy*Mz - Mxz*Mxz - Myz*Myz;
-  A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
-  A22 = A2 + A2;
-  A33 = A3 + A3 + A3;
-  
-  //    finding the root of the characteristic polynomial
-  //    using Newton's method starting at x=0  
-  //    (it is guaranteed to converge to the right root)
-  
-  for (x=0.,y=A0,iter=0; iter<IterMAX; iter++)  // usually, 4-6 iterations are enough
-    {
-      double Dy = A1 + x*(A22 + A33*x);
-      double xnew = x - y/Dy;
-      if ((xnew == x)||(!std::isfinite(xnew))) break;
-      double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
-      if (fabs(ynew)>=fabs(y))  break;
-      x = xnew;  y = ynew;
-    }
-  
-  //  computing parameters of the fitting circle
-  
-  DET = x*x - x*Mz + Cov_xy;
-  Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
-  Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
-  
-  //  assembling the output
-  
-  X0 = Xcenter + meanX;
-  Y0 = Ycenter + meanY;
-  R = sqrt(Xcenter*Xcenter + Ycenter*Ycenter + Mz);
-}
 
 void PHTpcClusterMover::circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus)
 {
@@ -526,28 +414,6 @@ void PHTpcClusterMover::circle_circle_intersection(double r1, double r2, double 
   yminus = -(2*x2*xminus - D) / (2.0*y2);
 
 }
-
-void  PHTpcClusterMover::line_fit(std::vector<Acts::Vector3> clusters, double &a, double &b)
-{
-  // copied from: https://www.bragitoff.com
-  // we want to fit z vs radius
-
-   double xsum=0,x2sum=0,ysum=0,xysum=0;                //variables for sums/sigma of xi,yi,xi^2,xiyi etc
-   for (unsigned int i=0; i<clusters.size(); ++i)
-    {
-      double z = clusters[i][2];
-      double r = sqrt(pow(clusters[i][0],2) + pow(clusters[i][1], 2));
-
-      xsum=xsum+r;                        //calculate sigma(xi)
-      ysum=ysum+z;                        //calculate sigma(yi)
-      x2sum=x2sum+pow(r,2);                //calculate sigma(x^2i)
-      xysum=xysum+r*z;                    //calculate sigma(xi*yi)
-    }
-   a=(clusters.size()*xysum-xsum*ysum)/(clusters.size()*x2sum-xsum*xsum);            //calculate slope
-   b=(x2sum*ysum-xsum*xysum)/(x2sum*clusters.size()-xsum*xsum);            //calculate intercept
-
-    return;
-}   
 
 Surface PHTpcClusterMover::get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitsetkey,
 						       Acts::Vector3 world,

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -33,8 +33,6 @@ class PHTpcClusterMover : public SubsysReco
 
   PHTpcClusterMover(const std::string &name = "PHTpcClusterMover");
 
-  ~PHTpcClusterMover() override;
-
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
@@ -44,9 +42,7 @@ class PHTpcClusterMover : public SubsysReco
 
   int GetNodes(PHCompositeNode* topNode);
 
-void CircleFitByTaubin (std::vector<Acts::Vector3> clusters, double &R, double &X0, double &Y0);
   void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
-void  line_fit(std::vector<Acts::Vector3> clusters, double &a, double &b);
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xref, double yref, double &x, double &y);
 
   Surface get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitsetkey,

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -41,8 +41,6 @@ class PHTpcClusterMover : public SubsysReco
  private:
 
   int GetNodes(PHCompositeNode* topNode);
-
-  void circle_circle_intersection(double r1, double r2, double x2, double y2, double &xplus, double &yplus, double &xminus, double &yminus);
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xref, double yref, double &x, double &y);
 
   Surface get_tpc_surface_from_coords(TrkrDefs::hitsetkey hitsetkey,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR moves all the implementations of circle_fit_by_taubin, and (r,z) line_fit to a single place: trackbase/TrackFitUtils, to avoid code duplication.

Also moved is the "circle_circle_intersection" code, that was used in both the TPC Micromegas matcher and the Cluster mover code. 

The reason the utility code is in trackbase, rather than e.g. trackreco is that it can then be used internally inside trackbase_historic/TrackSeed_v1.cc

This should have no impact on the performances. 
 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

