### PR TITLE
Modify truth track seeding for TPC to set track z to linefit value

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -93,8 +93,8 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
   findEtaPhiMatches(tpc_matched_set, tpc_matches);
 
   // Check that the crossing number is consistent with the tracklet z mismatch, discard the match otherwise
-  // Enabling this requires a change to truth seeding, so that it does not set the TPC seed z0 to the truth value
-  //checkCrossingMatches(tpc_matches);
+  // Enabling this required a change to truth seeding, so that it sets the TPC seed z0 to the line fit value, not the truth
+  checkCrossingMatches(tpc_matches);
   
   // We have a complete list of all eta/phi matched tracks in the map "tpc_matches"
   // make the combined track seeds from tpc_matches
@@ -460,15 +460,17 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int
 	{ 
 	  if(Verbosity() > 0)	  
 	    std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
+		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
 	}
       else
 	{
 	  if(Verbosity() > 0)
 	    std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
+		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
 
-	  //bad_map.insert(std::make_pair(tpcid, si_id));
+	  bad_map.insert(std::make_pair(tpcid, si_id));
 	}
     }
 

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -258,6 +258,8 @@ int PHTruthTrackSeeding::Process(PHCompositeNode* topNode)
 
 void PHTruthTrackSeeding::buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters, PHG4Particle *g4particle, TrackSeedContainer* container)
 {
+  // This method is called separately for silicon and tpc seeds
+
   auto track = std::make_unique<TrackSeed_FastSim_v1>();
   bool silicon = false;
   bool tpc = false;  
@@ -319,8 +321,11 @@ void PHTruthTrackSeeding::buildTrackSeed(std::vector<TrkrDefs::cluskey> clusters
   if(tpc)
     {
       // if this is the TPC, the track Z0 depends on the crossing
-      // we should determine it from the clusters instead of the truth - not implemented yet
-      
+      // we must determine Z0 from the clusters instead of the truth for the TPC
+      // this method calculates the Z0 and z slope from a fit to the clusters and overwrites them
+      unsigned int start_layer = 7;
+      unsigned int end_layer = 54;
+      track->lineFit(m_clusterMap, surfmaps, tgeometry, start_layer, end_layer);      
     }
   
   /// Need to find the right one for the bend angle


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR modifies the truth track seeding module so that for truth TPC seeding the track z position is set by running the track seed lineFit method, instead of assigning it from the truth track vertex. This is necessary for tracks that come from bunch crossings other than the triggered one. The change enables a new check in the silicon-tpc track matcher that the observed z-mismatch between the silicon and tpc track seeds is consistent with the bunch crossing obtained from the INTT. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

