### PR TITLE
Use integer iterator in track matching

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -73,17 +73,15 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
     return Fun4AllReturnCodes::EVENT_OK;
  
   // loop over the silicon seeds and add the crossing to them
-  for (auto phtrk_iter_si = _track_map_silicon->begin();
-       phtrk_iter_si != _track_map_silicon->end(); 
-       ++phtrk_iter_si)
+  for (unsigned int trackid = 0; trackid != _track_map_silicon->size(); ++trackid) 
     {
-      _tracklet_si = *phtrk_iter_si;	  
+      _tracklet_si = _track_map_silicon->get(trackid);	  
       if(!_tracklet_si) { continue; }
 
       short int crossing= getCrossingIntt(_tracklet_si);
       _tracklet_si->set_crossing(crossing);
 
-      if(Verbosity() > 1) cout << " Si track " << _track_map_silicon->index(phtrk_iter_si) << " crossing " << crossing << endl;
+      if(Verbosity() > 1) cout << " Si track " << trackid << " crossing " << crossing << endl;
     }  
   
   // Find all matches of tpc and si tracklets in eta and phi, x and y


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR changes the iterator over the silicon track map from the vector::iterator object to an integer. This is a faster way to iterate as the object doesn't have to be looked up, we just access it with the element in the vector.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

