### PR TITLE
add option to create v4 clusters to clusterizers and matching evaluator

### DIFF
--- a/offline/packages/intt/InttClusterizer.h
+++ b/offline/packages/intt/InttClusterizer.h
@@ -69,7 +69,8 @@ class InttClusterizer : public SubsysReco
     if (_make_e_weights.find(layer) == _make_e_weights.end()) return false;
     return _make_e_weights.find(layer)->second;
   }
-
+  void set_cluster_version(int value) { m_cluster_version = value; }
+  void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
  private:
   bool ladder_are_adjacent(const std::pair<TrkrDefs::hitkey, TrkrHit*> &lhs, const std::pair<TrkrDefs::hitkey, TrkrHit*> &rhs, const int layer);
 
@@ -88,7 +89,8 @@ class InttClusterizer : public SubsysReco
   std::map<int, float> _thresholds_by_layer;  // layer->threshold
   std::map<int, bool> _make_z_clustering;     // layer->z_clustering_option
   std::map<int, bool> _make_e_weights;        // layer->energy_weighting_option
-
+  bool do_hit_assoc = true;
+  int m_cluster_version = 3;
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -34,11 +34,13 @@ class MicromegasClusterizer : public SubsysReco
   //! event processing
   int process_event(PHCompositeNode*) override;
 
+  void set_cluster_version(int value) { m_cluster_version = value; }
+
   private:
 
   //! detector name
   std::string m_detector;
-
+  int m_cluster_version = 3;
 };
 
 #endif

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -51,6 +51,8 @@ class MvtxClusterizer : public SubsysReco
   {
     return m_makeZClustering;
   }
+  void set_cluster_version(int value) { m_cluster_version = value; }
+  void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
 
  private:
   //bool are_adjacent(const pixel lhs, const pixel rhs);
@@ -65,10 +67,10 @@ class MvtxClusterizer : public SubsysReco
 
   TrkrClusterHitAssoc *m_clusterhitassoc;
 
-
-
   // settings
   bool m_makeZClustering;  // z_clustering_option
+  bool do_hit_assoc = true;
+  int m_cluster_version = 3;
 };
 
 #endif  // MVTX_MVTXCLUSTERIZER_H

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -70,7 +70,7 @@ class SvtxEvaluator : public SubsysReco
   void do_vtx_eval_light(bool b) { _do_vtx_eval_light = b;}
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
   void scan_for_primaries(bool b) { _scan_for_primaries = b; }
-
+  void set_cluster_version(int value) { m_cluster_version = value; }
 
  private:
   unsigned int _ievent;
@@ -138,6 +138,7 @@ class SvtxEvaluator : public SubsysReco
   void fillOutputNtuples(PHCompositeNode *topNode);  ///< dump the evaluator information into ntuple for external analysis
   void printInputInfo(PHCompositeNode *topNode);     ///< print out the input object information (debugging upstream components)
   void printOutputInfo(PHCompositeNode *topNode);    ///< print out the ancestry information for detailed diagnosis
+    int m_cluster_version = 3;
 };
 
 #endif  // G4EVAL_SVTXEVALUATOR_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

adds option to write TrkrClusterv4 to clusterizers, controlled by setter for cluster version number.
also contains update to SvtxEvaluator to process v4 clusters.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

