### PR TITLE
Micromegas matching bug fix

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -492,7 +492,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
 	}
       else
 	{
-	  // silicon cluster, no corrections needed
+	  // silicon cluster or MM's cluster, no corrections needed
 	  global_raw.push_back(std::make_pair(key, global));
 	}
       

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -38,7 +38,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_sc_calib_mode(const bool mode){_sc_calib_mode = mode;}
   void set_collision_rate(const double rate){_collision_rate = rate;}
   void SetIteration(int iter){_n_iteration = iter;}
-  void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
+  //  void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
@@ -59,7 +59,9 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   TrkrClusterContainer *_cluster_map{nullptr};
   TrkrClusterContainer *_corrected_cluster_map{nullptr};
 
-  TrackSeedContainer *_track_map{nullptr};
+  TrackSeedContainer *_svtx_seed_map{nullptr};
+  TrackSeedContainer *_tpc_track_map{nullptr};
+  TrackSeedContainer *_si_track_map{nullptr};
 
   //! default rphi search window for each layer
   std::array<double,_n_mm_layers> _rphi_search_win = {0.25, 13.0}; 
@@ -90,7 +92,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   PHG4CylinderGeomContainer* _geomContainerMicromegas = nullptr;
   TrkrClusterIterationMapv1* _iteration_map = nullptr;
   int _n_iteration = 0;
-  std::string _track_map_name = "TpcTrackSeedContainer";
+  //  std::string _track_map_name = "TpcTrackSeedContainer";
 
   ActsGeometry *_tGeometry = nullptr;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -167,7 +167,7 @@ int  PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
   _track_map_silicon = findNode::getClass<TrackSeedContainer>(topNode, _silicon_track_map_name);
   if (!_track_map_silicon)
   {
-    cerr << PHWHERE << " ERROR: Can't find SvtxSiliconTrackMap: " << endl;
+    cerr << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 


### PR DESCRIPTION
…sing from silicon stub.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Micromegas-TPC matching was not properly converted to the new seed track scheme, so MM's clusters were not being attached to TPC track seeds. This PR fixes that.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

