### PR TITLE
CylinderGeomMicromegas

### DIFF
--- a/offline/QA/modules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/modules/QAG4SimulationMicromegas.cc
@@ -401,12 +401,13 @@ void QAG4SimulationMicromegas::evaluate_clusters()
 
       // convert cluster position to local tile coordinates
       const TVector3 cluster_world(global(0), global(1), global(2));
-      const TVector3 cluster_local = layergeom->get_local_from_world_coords(tileid, cluster_world);
+      const auto cluster_local = layergeom->get_local_from_world_coords(tileid, m_tGeometry, cluster_world);
 
       // find associated g4hits
       const auto g4hits = find_g4hits(key);
 
       // convert hits to list of interpolation_data_t
+      /* TODO: should actually use the same code as in TrackEvaluation */
       interpolation_data_t::list hits;
       for (const auto& g4hit : g4hits)
       {
@@ -415,11 +416,11 @@ void QAG4SimulationMicromegas::evaluate_clusters()
         {
           // convert position to local
           TVector3 g4hit_world(g4hit->get_x(i), g4hit->get_y(i), g4hit->get_z(i));
-          TVector3 g4hit_local = layergeom->get_local_from_world_coords(tileid, g4hit_world);
+          TVector3 g4hit_local = layergeom->get_local_from_world_coords(tileid, m_tGeometry, g4hit_world);
 
           // convert momentum to local
           TVector3 momentum_world(g4hit->get_px(i), g4hit->get_py(i), g4hit->get_pz(i));
-          TVector3 momentum_local = layergeom->get_local_from_world_vect(tileid, momentum_world);
+          TVector3 momentum_local = layergeom->get_local_from_world_vect(tileid, m_tGeometry, momentum_world);
 
           hits.push_back({.position = g4hit_local, .momentum = momentum_local, .weight = weight});
         }
@@ -436,23 +437,23 @@ void QAG4SimulationMicromegas::evaluate_clusters()
       auto fill = [](TH1* h, float value) { if( h ) h->Fill( value ); };
       switch (segmentation_type)
       {
-      case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-      {
-        const auto drphi = cluster_local.x() - interpolation_local.x();
-        fill(hiter->second.residual, drphi);
-        fill(hiter->second.residual_error, rphi_error);
-        fill(hiter->second.pulls, drphi / rphi_error);
-        break;
-      }
-
-      case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-      {
-        const auto dz = cluster_local.z() - interpolation_local.z();
-        fill(hiter->second.residual, dz);
-        fill(hiter->second.residual_error, z_error);
-        fill(hiter->second.pulls, dz / z_error);
-        break;
-      }
+        case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
+        {
+          const auto drphi = cluster_local.x() - interpolation_local.x();
+          fill(hiter->second.residual, drphi);
+          fill(hiter->second.residual_error, rphi_error);
+          fill(hiter->second.pulls, drphi / rphi_error);
+          break;
+        }
+        
+        case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
+        {
+          const auto dz = cluster_local.z() - interpolation_local.z();
+          fill(hiter->second.residual, dz);
+          fill(hiter->second.residual_error, z_error);
+          fill(hiter->second.pulls, dz / z_error);
+          break;
+        }
       }
 
       // cluster size

--- a/offline/QA/modules/QAG4SimulationMicromegas.h
+++ b/offline/QA/modules/QAG4SimulationMicromegas.h
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 
+class ActsGeometry;
 class PHCompositeNode;
 class PHG4CylinderGeomContainer;
 class PHG4Hit;
@@ -16,7 +17,6 @@ class TrkrClusterContainer;
 class TrkrHitSetContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
-class ActsGeometry;
 
 /// \class QAG4SimulationMicromegas
 class QAG4SimulationMicromegas : public SubsysReco

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -6,7 +6,7 @@
 #include "CylinderGeomMicromegas.h"
 
 #include <g4main/PHG4Hit.h>
-
+#include <trackbase/ActsGeometry.h>
 #include <TVector3.h>
 
 #include <cassert>
@@ -33,71 +33,102 @@ namespace
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_local_from_world_coords( uint tileid, const TVector3& world_coordinates ) const
+TVector3 CylinderGeomMicromegas::get_local_from_world_coords( uint tileid, ActsGeometry* geometry, const TVector3& world_coordinates ) const
 {
   assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  // store world coordinates in array
-  std::array<double,3> master;
-  world_coordinates.GetXYZ( &master[0] );
+  const Acts::Vector3 global(
+    world_coordinates.x()*Acts::UnitConstants::cm,
+    world_coordinates.y()*Acts::UnitConstants::cm,
+    world_coordinates.z()*Acts::UnitConstants::cm );
 
-  // convert to local coordinate
-  std::array<double,3> local;
-  transformation_matrix(tileid).MasterToLocal( &master[0], &local[0] );
-
-  return TVector3( &local[0] );
-
+  // convert to local
+  /* this is equivalent to calling surface->globalToLocal but without the "on surface" check, and while returning a full Acts::Vector3 */
+  const auto local = surface->transform(geometry->geometry().geoContext).inverse()*global;
+  return TVector3(
+    local.x()/Acts::UnitConstants::cm,
+    local.y()/Acts::UnitConstants::cm,
+    local.z()/Acts::UnitConstants::cm );
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_world_from_local_coords( uint tileid, const TVector3& local_coordinates ) const
+TVector3 CylinderGeomMicromegas::get_local_from_world_vect( uint tileid, ActsGeometry* geometry, const TVector3& world_vect ) const
 {
   assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  // store world coordinates in array
-  std::array<double,3> local;
-  local_coordinates.GetXYZ( &local[0] );
+  const Acts::Vector3 global(
+    world_vect.x()*Acts::UnitConstants::cm,
+    world_vect.y()*Acts::UnitConstants::cm,
+    world_vect.z()*Acts::UnitConstants::cm );
 
-  // convert to local coordinate
-  std::array<double,3> master;
-  transformation_matrix(tileid).LocalToMaster( &local[0], &master[0] );
-
-  return TVector3( &master[0] );
-
+  const auto local = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3()).inverse()*global;
+  return TVector3(
+    local.x()/Acts::UnitConstants::cm,
+    local.y()/Acts::UnitConstants::cm,
+    local.z()/Acts::UnitConstants::cm );
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_world_from_local_vect( uint tileid, const TVector3& local_vect ) const
+TVector3 CylinderGeomMicromegas::get_world_from_local_coords( uint tileid, ActsGeometry* geometry, const TVector2& local_coordinates ) const
 {
   assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  // store world vect in array
-  std::array<double,3> local;
-  local_vect.GetXYZ( &local[0] );
+  const Acts::Vector2 local(
+    local_coordinates.X()*Acts::UnitConstants::cm,
+    local_coordinates.Y()*Acts::UnitConstants::cm );
 
-  // convert to local coordinate
-  std::array<double,3> master;
-  transformation_matrix(tileid).LocalToMasterVect( &local[0], &master[0] );
-
-  return TVector3( &master[0] );
-
+  // convert to global
+  const auto global =  surface->localToGlobal(geometry->geometry().geoContext, local, Acts::Vector3());
+  return TVector3(
+    global.x()/Acts::UnitConstants::cm,
+    global.y()/Acts::UnitConstants::cm,
+    global.z()/Acts::UnitConstants::cm );
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_local_from_world_vect( uint tileid, const TVector3& world_vect ) const
+TVector3 CylinderGeomMicromegas::get_world_from_local_coords( uint tileid, ActsGeometry* geometry, const TVector3& local_coordinates ) const
 {
   assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  // store world vect in array
-  std::array<double,3> master;
-  world_vect.GetXYZ( &master[0] );
+  const Acts::Vector3 local(
+    local_coordinates.x()*Acts::UnitConstants::cm,
+    local_coordinates.y()*Acts::UnitConstants::cm,
+    local_coordinates.z()*Acts::UnitConstants::cm );
 
-  // convert to local coordinate
-  std::array<double,3> local;
-  transformation_matrix(tileid).MasterToLocalVect( &master[0], &local[0] );
+  // convert to global
+  /* this is equivalent to calling surface->localToGlobal but without assuming that the local point is on surface */
+  const auto global =  surface->transform(geometry->geometry().geoContext)*local;
+  return TVector3(
+    global.x()/Acts::UnitConstants::cm,
+    global.y()/Acts::UnitConstants::cm,
+    global.z()/Acts::UnitConstants::cm );
+}
 
-  return TVector3( &local[0] );
+//________________________________________________________________________________
+TVector3 CylinderGeomMicromegas::get_world_from_local_vect( uint tileid, ActsGeometry* geometry, const TVector3& local_vect ) const
+{
+  assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
+  Acts::Vector3 local(
+    local_vect.x()*Acts::UnitConstants::cm,
+    local_vect.x()*Acts::UnitConstants::cm,
+    local_vect.x()*Acts::UnitConstants::cm );
+
+  const auto global = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3())*local;
+  return TVector3(
+    global.x()/Acts::UnitConstants::cm,
+    global.y()/Acts::UnitConstants::cm,
+    global.z()/Acts::UnitConstants::cm );
 }
 
 //________________________________________________________________________________
@@ -124,38 +155,46 @@ int CylinderGeomMicromegas::find_tile_cylindrical( const TVector3& world_coordin
 }
 
 //________________________________________________________________________________
-int CylinderGeomMicromegas::find_strip_from_world_coords( uint tileid, const TVector3& world_coordinates ) const
+int CylinderGeomMicromegas::find_strip_from_world_coords( uint tileid, ActsGeometry* geometry, const TVector3& world_coordinates ) const
 {
+
+  // check point is on surface
+  if( !check_radius(world_coordinates) ) return -1;
+
   // convert to local coordinates
-  const auto local_coordinates = get_local_from_world_coords( tileid, world_coordinates );
-  return find_strip_from_local_coords( tileid, local_coordinates );
+  const auto local_coordinates = get_local_from_world_coords( tileid, geometry, world_coordinates );
+  return find_strip_from_local_coords( tileid, geometry, { local_coordinates.x(), local_coordinates.y() } );
 }
 
 //________________________________________________________________________________
-int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, const TVector3& local_coordinates ) const
+int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, ActsGeometry* geometry, const TVector2& local_coordinates ) const
 {
+  assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  // check against thickness
-  if( std::abs( local_coordinates.y() ) > m_thickness/2 ) return -1;
+  std::cout << "CylinderGeomMicromegas::find_strip_from_local_coords - bound: " << surface->bounds().type() << std::endl;
+
+  // todo rely on surface boundaries to define strip
 
   // get tile
   const auto& tile = m_tiles.at(tileid);
 
   // check azimuth
-  if( std::abs( local_coordinates.x() ) > tile.m_sizePhi*reference_radius/2 ) return -1;
-  
+  if( std::abs( local_coordinates.X() ) > tile.m_sizePhi*reference_radius/2 ) return -1;
+
   // check z extend
-  if( std::abs( local_coordinates.z() ) > tile.m_sizeZ/2 ) return -1;
+  if( std::abs( local_coordinates.Y() ) > tile.m_sizeZ/2 ) return -1;
 
   // we found a tile to which the hit belong
   // calculate strip index, depending on cylinder direction
   switch( m_segmentation_type )
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-    return (int) std::floor( (local_coordinates.x() + tile.m_sizePhi*reference_radius/2)/m_pitch );
+    return (int) std::floor( (local_coordinates.X() + tile.m_sizePhi*reference_radius/2)/m_pitch );
 
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-    return (int) std::floor( (local_coordinates.z() + tile.m_sizeZ/2)/m_pitch );
+    return (int) std::floor( (local_coordinates.Y() + tile.m_sizeZ/2)/m_pitch );
   }
 
   // unreachable
@@ -163,8 +202,16 @@ int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, const TVe
 }
 
 //________________________________________________________________________________
-double CylinderGeomMicromegas::get_strip_length( uint tileid ) const
+double CylinderGeomMicromegas::get_strip_length( uint tileid, ActsGeometry* geometry ) const
 {
+  assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
+
+  std::cout << "CylinderGeomMicromegas::get_strip_length - bound: " << surface->bounds().type() << std::endl;
+
+  // todo rely on surface boundaries to define strip
+
   assert( tileid < m_tiles.size() );
   switch( m_segmentation_type )
   {
@@ -180,9 +227,15 @@ double CylinderGeomMicromegas::get_strip_length( uint tileid ) const
 }
 
 //________________________________________________________________________________
-uint CylinderGeomMicromegas::get_strip_count( uint tileid ) const
+uint CylinderGeomMicromegas::get_strip_count( uint tileid, ActsGeometry* geometry ) const
 {
   assert( tileid < m_tiles.size() );
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
+
+  std::cout << "CylinderGeomMicromegas::get_strip_count - bound: " << surface->bounds().type() << std::endl;
+
+  // todo rely on surface boundaries to define strip
   switch( m_segmentation_type )
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
@@ -197,33 +250,35 @@ uint CylinderGeomMicromegas::get_strip_count( uint tileid ) const
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_local_coordinates( uint tileid, uint stripnum ) const
+TVector2 CylinderGeomMicromegas::get_local_coordinates( uint tileid, ActsGeometry* geometry, uint stripnum ) const
 {
   assert( tileid < m_tiles.size() );
-  
+  const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
+  const auto surface = geometry->maps().getMMSurface(hitsetkey);
+
+  std::cout << "CylinderGeomMicromegas::get_local_coordinates - bound: " << surface->bounds().type() << std::endl;
+
+  // todo rely on surface boundaries to define strip
   // get tile
   const auto& tile = m_tiles[tileid];
-  
+
   switch( m_segmentation_type )
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-    return TVector3( (0.5+stripnum)*m_pitch - tile.m_sizePhi*reference_radius/2, 0, 0 );
-    
+    return TVector2( (0.5+stripnum)*m_pitch - tile.m_sizePhi*reference_radius/2, 0 );
+
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-    return TVector3( 0, 0, (0.5+stripnum)*m_pitch - tile.m_sizeZ/2 );
+    return TVector2( 0, (0.5+stripnum)*m_pitch - tile.m_sizeZ/2 );
   }
-  
+
   // unreachable
-  return TVector3();
+  return TVector2();
 }
 
 //________________________________________________________________________________
-TVector3 CylinderGeomMicromegas::get_world_coordinates( uint tileid, uint stripnum ) const
-{
-  assert( tileid < m_tiles.size() );
-  return get_world_from_local_coords( tileid, get_local_coordinates( tileid, stripnum ) );
-}
- 
+TVector3 CylinderGeomMicromegas::get_world_coordinates( uint tileid, ActsGeometry* geometry, uint stripnum ) const
+{ return get_world_from_local_coords( tileid, geometry, get_local_coordinates( tileid, geometry, stripnum ) ); }
+
 //________________________________________________________________________________
 void CylinderGeomMicromegas::identify( std::ostream& out ) const
 {
@@ -244,24 +299,4 @@ bool  CylinderGeomMicromegas::check_radius( const TVector3& world_coordinates ) 
 {
   const auto radius = get_r( world_coordinates.x(), world_coordinates.y() );
   return std::abs( radius - m_radius ) <= m_thickness/2;
-}
-
-//________________________________________________________________________________
-TGeoHMatrix CylinderGeomMicromegas::transformation_matrix( uint tileid ) const
-{
-  assert( tileid < m_tiles.size() );
-  const auto& tile = m_tiles[tileid];
-
-  // local to master transformation matrix
-  TGeoHMatrix matrix;
-
-  // rotate around z axis
-  matrix.RotateZ( tile.m_centerPhi*180./M_PI - 90 );
-
-  // translate to tile center
-  matrix.SetDx( m_radius*std::cos( tile.m_centerPhi ) );
-  matrix.SetDy( m_radius*std::sin( tile.m_centerPhi ) );
-  matrix.SetDz( tile.m_centerZ );
-
-  return matrix;
 }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -124,34 +124,6 @@ int CylinderGeomMicromegas::find_tile_cylindrical( const TVector3& world_coordin
 }
 
 //________________________________________________________________________________
-int CylinderGeomMicromegas::find_tile_planar( const TVector3& world_coordinates ) const
-{
-
-  for( size_t itile = 0; itile < m_tiles.size(); ++itile )
-  {
-
-    // get local coordinates
-    const auto local_coordinates = get_local_from_world_coords( itile, world_coordinates );
-
-    // store tile struct locally
-    const auto& tile = m_tiles.at(itile);
-
-    // check against thickness
-    if( std::abs( local_coordinates.y() ) > m_thickness/2 ) continue;
-
-    // check azimuth
-    if( std::abs( local_coordinates.x() ) > tile.m_sizePhi*reference_radius/2 ) continue;
-
-    // check z extend
-    if( std::abs( local_coordinates.z() ) > tile.m_sizeZ/2 ) continue;
-
-    return itile;
-  }
-
-  return -1;
-}
-
-//________________________________________________________________________________
 int CylinderGeomMicromegas::find_strip_from_world_coords( uint tileid, const TVector3& world_coordinates ) const
 {
   // convert to local coordinates

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -186,11 +186,6 @@ int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, ActsGeome
   const auto half_length_x = rectangle_bounds->halfLengthX()/Acts::UnitConstants::cm;
   const auto half_length_y = rectangle_bounds->halfLengthY()/Acts::UnitConstants::cm;
 
-  std::cout << "CylinderGeomMicromegas::find_strip_from_local_coords -"
-    << " halfLengthX " << half_length_x
-    << " halfLengthX " << half_length_y
-    << std::endl;
-
   // check azimuth
   if( std::abs( local_coordinates.X() ) >  half_length_x ) return -1;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -121,8 +121,8 @@ TVector3 CylinderGeomMicromegas::get_world_from_local_vect( uint tileid, ActsGeo
 
   Acts::Vector3 local(
     local_vect.x()*Acts::UnitConstants::cm,
-    local_vect.x()*Acts::UnitConstants::cm,
-    local_vect.x()*Acts::UnitConstants::cm );
+    local_vect.y()*Acts::UnitConstants::cm,
+    local_vect.z()*Acts::UnitConstants::cm );
 
   const auto global = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3())*local;
   return TVector3(
@@ -173,8 +173,6 @@ int CylinderGeomMicromegas::find_strip_from_local_coords( uint tileid, ActsGeome
   const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
   const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  std::cout << "CylinderGeomMicromegas::find_strip_from_local_coords - bound: " << surface->bounds().type() << std::endl;
-
   // todo rely on surface boundaries to define strip
 
   // get tile
@@ -208,8 +206,6 @@ double CylinderGeomMicromegas::get_strip_length( uint tileid, ActsGeometry* geom
   const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
   const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  std::cout << "CylinderGeomMicromegas::get_strip_length - bound: " << surface->bounds().type() << std::endl;
-
   // todo rely on surface boundaries to define strip
 
   assert( tileid < m_tiles.size() );
@@ -233,8 +229,6 @@ uint CylinderGeomMicromegas::get_strip_count( uint tileid, ActsGeometry* geometr
   const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
   const auto surface = geometry->maps().getMMSurface(hitsetkey);
 
-  std::cout << "CylinderGeomMicromegas::get_strip_count - bound: " << surface->bounds().type() << std::endl;
-
   // todo rely on surface boundaries to define strip
   switch( m_segmentation_type )
   {
@@ -255,8 +249,6 @@ TVector2 CylinderGeomMicromegas::get_local_coordinates( uint tileid, ActsGeometr
   assert( tileid < m_tiles.size() );
   const auto hitsetkey = MicromegasDefs::genHitSetKey(get_layer(), get_segmentation_type(), tileid);
   const auto surface = geometry->maps().getMMSurface(hitsetkey);
-
-  std::cout << "CylinderGeomMicromegas::get_local_coordinates - bound: " << surface->bounds().type() << std::endl;
 
   // todo rely on surface boundaries to define strip
   // get tile

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -108,13 +108,6 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //! get world coordinates for a given tile and strip
   TVector3 get_world_coordinates( uint tileid, ActsGeometry*, uint stripnum ) const;
 
-  //! get phi angle at center of tile
-  double get_center_phi( uint tileid ) const
-  {
-    assert( tileid < m_tiles.size() );
-    return m_tiles[tileid].m_centerPhi;
-  }
-
   /// reference radius used in macro to convert tile size in azimuth into a angle range (cm)
   static constexpr double reference_radius = 82;
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -166,6 +166,10 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   double m_pitch = 0.1;
 
   //! tiles
+  /** 
+   * \brief tiles are only used in "find_tile_cylindrical". 
+   * For all other methods we use ACTS surfaces instead 
+   */
   MicromegasTile::List m_tiles;
 
   ClassDefOverride(CylinderGeomMicromegas, 1)

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -89,9 +89,6 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
    */
   int find_tile_cylindrical( const TVector3& ) const;
 
-  //! get tile for a given world location assuming tiles are planes centered on tile center and tengent to local cylinder
-  int find_tile_planar( const TVector3& ) const;
-
   //! get number of tiles
   size_t get_tiles_count() const { return m_tiles.size(); }
 

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -19,6 +19,8 @@
 #include <cmath>
 #include <iostream>
 
+class ActsGeometry;
+class TVector2;
 class TVector3;
 class PHG4Hit;
 
@@ -57,33 +59,22 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   bool check_radius( const TVector3& ) const;
 
   //! convert world to local position coordinates in (planar) tile reference frame
-  /**
-   * each (planar) tile has a local ref system defined as:
-   * - origin at center of the tile
-   * - z axis same as phenix,
-   * - y axis perpendicular to the surface, outward,
-   * - x axis perpendicular to y and z to have a direct ref. frame
-   **/
-  TVector3 get_local_from_world_coords( uint tileid, const TVector3& ) const;
+  TVector3 get_local_from_world_coords( uint tileid, ActsGeometry*, const TVector3& ) const;
 
   //! convert world to local direction coordinates in (planar) tile reference frame
-  TVector3 get_local_from_world_vect( uint tileid, const TVector3& ) const;
+  TVector3 get_local_from_world_vect( uint tileid, ActsGeometry*, const TVector3& ) const;
 
   //! convert local to world position coordinates in (planar) tile reference frame
-  /**
-   * each (planar) tile has a local ref system defined as:
-   * - origin at center of the tile
-   * - z axis same as phenix,
-   * - y axis perpendicular to the surface, outward,
-   * - x axis perpendicular to y and z to have a direct ref. system
-   **/
-  TVector3 get_world_from_local_coords( uint tileid, const TVector3& ) const;
+  TVector3 get_world_from_local_coords( uint tileid, ActsGeometry*, const TVector2& ) const;
+
+  //! convert local to world position coordinates in (planar) tile reference frame
+  TVector3 get_world_from_local_coords( uint tileid, ActsGeometry*, const TVector3& ) const;
 
   //! convert local to world direction coordinates in (planar) tile reference frame
-  TVector3 get_world_from_local_vect( uint tileid, const TVector3& ) const;
+  TVector3 get_world_from_local_vect( uint tileid, ActsGeometry*, const TVector3& ) const;
 
   //! get tile for a given world location assuming tiles are portion of cylinder centered around tile center
-  /** it is used to find the tile hit by a given track. 
+  /** it is used to find the tile hit by a given track.
    * The track is first extrapolated to the layer cylinder, the relevant tile is found, if any
    * the track is then extrapolated a second time to the correct tile plane
    */
@@ -100,22 +91,22 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   }
 
   //! get strip for a give world location and tile
-  int find_strip_from_world_coords( uint tileid, const TVector3& ) const;
+  int find_strip_from_world_coords( uint tileid, ActsGeometry*, const TVector3& ) const;
 
   //! get strip for a give world location and tile
-  int find_strip_from_local_coords( uint tileid, const TVector3& ) const;
+  int find_strip_from_local_coords( uint tileid, ActsGeometry*, const TVector2& ) const;
 
   //! get strip length for a given tile
-  double get_strip_length( uint tileid ) const;
+  double get_strip_length( uint tileid, ActsGeometry* ) const;
 
   //! get number of strips
-  uint get_strip_count( uint tileid ) const;
+  uint get_strip_count( uint tileid, ActsGeometry* ) const;
 
   //! get local coordinates for a given tile and strip
-  TVector3 get_local_coordinates( uint tileid, uint stripnum ) const;
+  TVector2 get_local_coordinates( uint tileid, ActsGeometry*, uint stripnum ) const;
 
   //! get world coordinates for a given tile and strip
-  TVector3 get_world_coordinates( uint tileid, uint stripnum ) const;
+  TVector3 get_world_coordinates( uint tileid, ActsGeometry*, uint stripnum ) const;
 
   //! get phi angle at center of tile
   double get_center_phi( uint tileid ) const
@@ -149,9 +140,6 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   //@}
 
   private:
-
-  // get local to master transformation matrix for a given tile
-  TGeoHMatrix transformation_matrix( uint tileid ) const;
 
   //! layer id
   int m_layer = 0;

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -10,6 +10,7 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4CylinderGeom.h>           // for PHG4CylinderGeom
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainerv4.h>        // for TrkrCluster
 #include <trackbase/TrkrClusterv3.h>
 #include <trackbase/TrkrClusterv4.h>
@@ -146,7 +147,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
   // cluster-hit association
   auto trkrClusterHitAssoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
   assert( trkrClusterHitAssoc );
-  
+
   // geometry
   auto acts_geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   assert( acts_geometry );
@@ -177,12 +178,12 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       continue;
     }
 
-    // get normal to acts surface
-    const auto normal = acts_surface->normal(acts_geometry->geometry().geoContext);
-   
-    if( Verbosity() )
+    // if( Verbosity() )
     {
-      const auto geo_normal = layergeom->get_world_from_local_vect( tileid, {0, 1, 0} );
+      
+      const auto normal = acts_surface->normal(acts_geometry->geometry().geoContext);
+
+      const auto geo_normal = layergeom->get_world_from_local_vect( tileid, acts_geometry, {0, 0, 1} );
       std::cout << "MicromegasClusterizer::process_event -"
         << " layer: " << (int) layer
         << " tile: " << (int) tileid
@@ -198,7 +199,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
     const auto segmentation_type = layergeom->get_segmentation_type();
     const double thickness = layergeom->get_thickness();
     const double pitch = layergeom->get_pitch();
-    const double strip_length = layergeom->get_strip_length( tileid );
+    const double strip_length = layergeom->get_strip_length( tileid, acts_geometry );
 
     // keep a list of ranges corresponding to each cluster
     using range_list_t = std::vector<TrkrHitSet::ConstRange>;
@@ -258,7 +259,7 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       // create cluster key and corresponding cluster
       const auto ckey = TrkrDefs::genClusKey( hitsetkey, cluster_count++ );
 
-      TVector3 local_coordinates;
+      TVector2 local_coordinates;
       double weight_sum = 0;
 
       // needed for proper error calculation
@@ -291,22 +292,22 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
         adc_sum += hit->getAdc();
 
         // get strip local coordinate and update relevant sums
-        const auto strip_local_coordinate = layergeom->get_local_coordinates( tileid, strip );
+        const auto strip_local_coordinate = layergeom->get_local_coordinates( tileid, acts_geometry, strip );
         local_coordinates += strip_local_coordinate*weight;
         switch( segmentation_type )
         {
           case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
           {
 
-            coord_sum += strip_local_coordinate.x()*weight;
-            coordsquare_sum += square(strip_local_coordinate.x())*weight;
+            coord_sum += strip_local_coordinate.X()*weight;
+            coordsquare_sum += square(strip_local_coordinate.X())*weight;
             break;
           }
 
           case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
           {
-            coord_sum += strip_local_coordinate.z()*weight;
-            coordsquare_sum += square(strip_local_coordinate.z())*weight;
+            coord_sum += strip_local_coordinate.Y()*weight;
+            coordsquare_sum += square(strip_local_coordinate.Y())*weight;
             break;
           }
         }
@@ -321,54 +322,57 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       static const float invsqrt12 = 1./std::sqrt(12);
       static constexpr float error_scale_phi = 1.6;
       static constexpr float error_scale_z = 0.8;
-      
+
       using matrix_t = Eigen::Matrix<float, 3, 3>;
       matrix_t error = matrix_t::Zero();
-      
+
       auto coord_cov = coordsquare_sum/weight_sum - square( coord_sum/weight_sum );
       auto coord_error_sq = coord_cov/weight_sum;
       switch( segmentation_type )
-	{
-	case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-	  if( coord_error_sq == 0 ) coord_error_sq = square(pitch)/12;
-	  else coord_error_sq *= square(error_scale_phi);
-	  error(0,0) = square(thickness*invsqrt12);
-	  error(1,1) = coord_error_sq;
-	  error(2,2) = square(strip_length*invsqrt12);
-	  break;
-	  
-	case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-	  if( coord_error_sq == 0 ) coord_error_sq = square(pitch)/12;
-	  else coord_error_sq *= square(error_scale_z);
-	  error(0,0) = square(thickness*invsqrt12);
-	  error(1,1) = square(strip_length*invsqrt12);
-	  error(2,2) = coord_error_sq;
-	  break;
-	}
+      {
+        case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
+        if( coord_error_sq == 0 ) coord_error_sq = square(pitch)/12;
+        else coord_error_sq *= square(error_scale_phi);
+        error(0,0) = square(thickness*invsqrt12);
+        error(1,1) = coord_error_sq;
+        error(2,2) = square(strip_length*invsqrt12);
+        break;
+
+        case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
+        if( coord_error_sq == 0 ) coord_error_sq = square(pitch)/12;
+        else coord_error_sq *= square(error_scale_z);
+        error(0,0) = square(thickness*invsqrt12);
+        error(1,1) = square(strip_length*invsqrt12);
+        error(2,2) = coord_error_sq;
+        break;
+      }
+
       /*
        * convert CylinderGeom coordinates to world
        * use acts surfaces to convert back to local coordinates,
        * this is to accomodate possible discrepencies between the two
+       * TODO: this should not be necessary at all any more
        */
-      
-      const auto world_coordinates = layergeom->get_world_from_local_coords( tileid, local_coordinates);
+
+      const auto world_coordinates = layergeom->get_world_from_local_coords( tileid, acts_geometry, local_coordinates);
       const Acts::Vector3 world_coordinates_acts = {
-	world_coordinates.x()*Acts::UnitConstants::cm,
-	world_coordinates.y()*Acts::UnitConstants::cm,
-	world_coordinates.z()*Acts::UnitConstants::cm };
-      
-      auto local = acts_surface->globalToLocal( acts_geometry->geometry().geoContext, world_coordinates_acts, normal );
-      
-      if(m_cluster_version==3){
-	auto cluster = std::make_unique<TrkrClusterv3>();
-	cluster->setAdc( adc_sum );
-	
+        world_coordinates.x()*Acts::UnitConstants::cm,
+        world_coordinates.y()*Acts::UnitConstants::cm,
+        world_coordinates.z()*Acts::UnitConstants::cm
+      };
+
+      auto local = acts_surface->globalToLocal( acts_geometry->geometry().geoContext, world_coordinates_acts, Acts::Vector3() );
+
+      if(m_cluster_version==3)
+      {
+        auto cluster = std::make_unique<TrkrClusterv3>();
+        cluster->setAdc( adc_sum );
+
         if( local.ok() )
-	  {
-	    const auto local_coordinates = local.value()/ Acts::UnitConstants::cm;
-	    cluster->setLocalX(local_coordinates.x());
-	    cluster->setLocalY(local_coordinates.y());
-	  } else {
+        {
+          cluster->setLocalX(local.value().x()/Acts::UnitConstants::cm);
+          cluster->setLocalY(local.value().y()/Acts::UnitConstants::cm);
+        } else {
           std::cout
             << "MicromegasClusterizer::process_event -"
             << " failed convert cluster coordinates to local surface."
@@ -376,50 +380,53 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
             << std::endl;
           continue;
         }
-	
-	// assign errors
-	cluster->setActsLocalError(0,0, error(1,1));
-	cluster->setActsLocalError(0,1, error(1,2));
-	cluster->setActsLocalError(1,0, error(2,1));
-	cluster->setActsLocalError(1,1,error(2,2));
-	
-	// add to container
-	trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-      }else if(m_cluster_version==4){
-	auto cluster = std::make_unique<TrkrClusterv4>();
-	cluster->setAdc( adc_sum );
-	
-	if( local.ok() )
-	  {
-	    const auto local_coordinates = local.value()/ Acts::UnitConstants::cm;
-	    cluster->setLocalX(local_coordinates.x());
-	    cluster->setLocalY(local_coordinates.y());
-	  } else {
-	  std::cout
-	    << "MicromegasClusterizer::process_event -"
-	    << " failed convert cluster coordinates to local surface."
-	    << " skipping cluster"
-	    << std::endl;
-	  continue;
-	} 
-	switch( segmentation_type )
-	  {
+
+        // assign errors
+        cluster->setActsLocalError(0,0, error(1,1));
+        cluster->setActsLocalError(0,1, error(1,2));
+        cluster->setActsLocalError(1,0, error(2,1));
+        cluster->setActsLocalError(1,1,error(2,2));
+
+        // add to container
+        trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
+
+      } else if(m_cluster_version==4) {
+
+        auto cluster = std::make_unique<TrkrClusterv4>();
+        cluster->setAdc( adc_sum );
+
+        if( local.ok() )
+        {
+          const auto local_coordinates = local.value()/ Acts::UnitConstants::cm;
+          cluster->setLocalX(local_coordinates.x());
+          cluster->setLocalY(local_coordinates.y());
+        } else {
+          std::cout
+            << "MicromegasClusterizer::process_event -"
+            << " failed convert cluster coordinates to local surface."
+            << " skipping cluster"
+            << std::endl;
+          continue;
+        }
+
+        switch( segmentation_type )
+        {
           case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-	    {
-	      cluster->setPhiSize(strip_count);
-	      cluster->setZSize(1);
-	      break;
-	    }
-	    
+          {
+            cluster->setPhiSize(strip_count);
+            cluster->setZSize(1);
+            break;
+          }
+
           case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-	    {
-	      cluster->setPhiSize(1);
-	      cluster->setZSize(strip_count);
-	      break;
-	    }
-	  }
-	// add to container
-	trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
+          {
+            cluster->setPhiSize(1);
+            cluster->setZSize(strip_count);
+            break;
+          }
+        }
+        // add to container
+        trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
       }
 
     }

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -178,20 +178,6 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       continue;
     }
 
-    // if( Verbosity() )
-    {
-      
-      const auto normal = acts_surface->normal(acts_geometry->geometry().geoContext);
-
-      const auto geo_normal = layergeom->get_world_from_local_vect( tileid, acts_geometry, {0, 0, 1} );
-      std::cout << "MicromegasClusterizer::process_event -"
-        << " layer: " << (int) layer
-        << " tile: " << (int) tileid
-        << " normal (acts): " << normal
-        << " geo: " << geo_normal
-        << std::endl;
-    }
-
     /*
      * get segmentation type, layer thickness, strip length and pitch.
      * They are used to calculate cluster errors

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -10,8 +10,6 @@
  */
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/TrkrCluster.h>
-#include <trackbase/ActsGeometry.h>
 
 #include <string>                // for string
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -729,7 +729,7 @@ void MakeActsGeometry::makeMmMapPairs(TrackingVolumePtr &mmVolume)
       }
 
       // get matching tile
-      int tileid = layergeom->find_tile_planar( world_center );
+      int tileid = layergeom->find_tile_cylindrical( world_center );
       if( tileid < 0 ) 
       {
         std::cout << "MakeActsGeometry::makeMmMapPairs - could not file Micromegas tile matching ACTS surface" << std::endl;

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -45,6 +45,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrCluster.h>                  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
@@ -1097,9 +1098,9 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
         auto geom = static_cast<CylinderGeomMicromegas*>(geom_container_micromegas->GetLayerGeom(layer));
         const auto tileid = MicromegasDefs::getTileId( cluster_key );
 
-        // in local coordinate, n is along y axis
+        // in local coordinate, n is along z axis
         // convert to global coordinates
-        n = geom->get_world_from_local_vect( tileid, TVector3( 0, 1, 0 ) );
+        n = geom->get_world_from_local_vect( tileid, m_tgeometry, TVector3( 0, 0, 1 ) );
       }
 
       default: break;

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -9,7 +9,6 @@
 #define TRACKRECO_PHGENFITTRKFITTER_H
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/ActsGeometry.h>
 #include <trackbase_historic/ActsTransformations.h>
 
 #if defined(__CLING__)
@@ -47,6 +46,7 @@ namespace PHGenFit
 class Fitter;
 } /* namespace PHGenFit */
 
+class ActsGeometry;
 class PHCompositeNode;
 class PHG4TruthInfoContainer;
 class SvtxTrackMap;

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -344,6 +344,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
          * apply SC correction to the local intersection,
          * to make sure that the corrected intersection is still in the micromegas plane
          * in local tile coordinates, the rphi direction, to which the correction is applied, corresponds to the x direction
+         * TODO: this is probably completely obsolete. Check/Remove
          */
         local_intersection_planar.SetX( local_intersection_planar.x() - fdrphi->Eval(z) );
       }
@@ -388,7 +389,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
           {
             // cluster rphi and z
             const double mm_clus_rphi = get_r( glob.x(), glob.y() ) * std::atan2( glob.y(),  glob.x() );
-            const double mm_clus_z = glob(2);
+            const double mm_clus_z = glob.z();
 
             // projection phi and z, without correction
             const double rphi_proj = get_r( world_intersection_planar.x(), world_intersection_planar.y() ) * std::atan2( world_intersection_planar.y(), world_intersection_planar.x() );

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -354,8 +354,8 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 
       // generate tilesetid and get corresponding clusters
       const auto tilesetid = MicromegasDefs::genHitSetKey(layer, segmentation_type, tileid);
-      const auto mm_clusrange = _cluster_map->getClusters(tilesetid);
-
+      const auto mm_clusrange = _cluster_map->getClusters(tilesetid);      
+      
       // convert to tile local coordinate and compare
       for(auto clusiter = mm_clusrange.first; clusiter != mm_clusrange.second; ++clusiter)
       {
@@ -368,16 +368,11 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
         
         // store cluster and key
         const auto& [key, cluster] = *clusiter;
-        const auto glob = _tGeometry->getGlobalPosition(key, cluster);
-        const TVector3 world_cluster(glob.x(), glob.y(), glob.z());
         
-        // TODO: it is probably enough to use the cluster local coordinates directly
-        const auto local_cluster = layergeom->get_local_from_world_coords( tileid, _tGeometry, world_cluster );
-
         // compute residuals and store
         /* in local tile coordinate, x is along rphi, and z is along y) */
-        const double drphi = local_intersection_planar.x() - local_cluster.x();
-        const double dz = local_intersection_planar.y() - local_cluster.y();
+        const double drphi = local_intersection_planar.x() - cluster->getLocalX();
+        const double dz = local_intersection_planar.y() - cluster->getLocalY();
 
         // compare to cuts and add to track if matching
         if( std::abs(drphi) < _rphi_search_win[imm] && std::abs(dz) < _z_search_win[imm] )

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -382,7 +382,9 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
           // prints out a line that can be grep-ed from the output file to feed to a display macro
           if( _test_windows )
           {
+            
             // cluster rphi and z
+            const auto glob = _tGeometry->getGlobalPosition(key, cluster);
             const double mm_clus_rphi = get_r( glob.x(), glob.y() ) * std::atan2( glob.y(),  glob.x() );
             const double mm_clus_z = glob.z();
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -303,13 +303,14 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       int tileid = layergeom->find_tile_cylindrical( world_intersection_cylindrical );
       if( tileid < 0 ) continue;
 
-      // get tile coordinates
-      const auto tile_center_phi = layergeom->get_center_phi( tileid );
-      const double x0 = r*std::cos( tile_center_phi );
-      const double y0 = r*std::sin( tile_center_phi );
+      // get tile center and norm vector
+      const auto tile_center = layergeom->get_world_from_local_coords( tileid, _tGeometry, {0, 0} );
+      const double x0 = tile_center.x();
+      const double y0 = tile_center.y();
 
-      const double nx = x0;
-      const double ny = y0;
+      const auto tile_norm = layergeom->get_world_from_local_vect( tileid, _tGeometry, {0, 0, 1 } );
+      const double nx = tile_norm.x();
+      const double ny = tile_norm.y();
 
       // calculate intersection to tile
       if( !circle_line_intersection( R, X0, Y0, x0, y0, nx, ny, xplus, yplus, xminus, yminus) )

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -4,14 +4,16 @@
 #define PHMICROMEGASTPCTRACKMATCHING_H
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/ActsGeometry.h>
 #include <tpc/TpcDistortionCorrection.h>
 #include <tpc/TpcClusterZCrossingCorrection.h>
+
+#include <trackbase/TrkrDefs.h>
 
 #include <array>
 #include <string>
 #include <vector>
 
+class ActsGeometry;
 class TrkrClusterContainer;
 class TrkrClusterIterationMapv1;
 class TrackSeedContainer;

--- a/simulation/g4simulation/g4eval/TrackEvaluation.h
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.h
@@ -10,7 +10,6 @@
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/ActsGeometry.h>
 
 #include <trackbase_historic/SvtxTrackState.h>
 #include <map>
@@ -18,7 +17,7 @@
 #include <string>
 #include <vector>
 
-
+class ActsGeometry;
 class PHG4CylinderCellGeomContainer;
 class PHG4CylinderGeomContainer;
 class PHG4Hit;

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.h
@@ -55,10 +55,6 @@ class PHG4MicromegasDetector : public PHG4Detector
   //! super detector name
   const std::string SuperDetector() const { return m_SuperDetector; }
 
-//   //! set micromegas tiles
-//   void set_tiles( const MicromegasTile::List& tiles )
-//   { m_tiles = tiles; }
-
   //! access the display action
   PHG4MicromegasDisplayAction* GetDisplayAction() { return m_DisplayAction; }
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -5,14 +5,8 @@
 
 #include "PHG4MicromegasHitReco.h"
 
-#include <micromegas/CylinderGeomMicromegas.h>
-#include <micromegas/MicromegasDefs.h>
-
-#include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrHitv2.h>
-#include <trackbase/TrkrHitSet.h>
-#include <trackbase/TrkrHitSetContainerv1.h>
-#include <trackbase/TrkrHitTruthAssocv1.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                     // for SubsysReco
 
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
@@ -21,10 +15,9 @@
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4HitContainer.h>
 
-#include <phparameter/PHParameterInterface.h>       // for PHParameterInterface
+#include <micromegas/CylinderGeomMicromegas.h>
+#include <micromegas/MicromegasDefs.h>
 
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                     // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -35,7 +28,16 @@
 #include <phool/phool.h>
 #include <phool/PHObject.h>                         // for PHObject
 
+#include <phparameter/PHParameterInterface.h>       // for PHParameterInterface
 
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitv2.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainerv1.h>
+#include <trackbase/TrkrHitTruthAssocv1.h>
+
+#include <TVector2.h>
 #include <TVector3.h>
 
 #include <gsl/gsl_randist.h>
@@ -204,6 +206,10 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
   auto g4hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, g4hitnodename);
   assert(g4hitcontainer);
 
+  // acts geometry
+  m_acts_geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  assert( m_acts_geometry );
+
   // geometry
   const auto geonodename = full_geonodename();
   auto geonode =  findNode::getClass<PHG4CylinderGeomContainer>(topNode, geonodename.c_str());
@@ -268,10 +274,10 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
 
       // get tile id from g4hit
       const int tileid = g4hit->get_property_int( PHG4Hit::prop_index_i );
-
+      
       // convert to local coordinate
-      const auto local_in = layergeom->get_local_from_world_coords( tileid, world_in );
-      const auto local_out = layergeom->get_local_from_world_coords( tileid, world_out );
+      const auto local_in = layergeom->get_local_from_world_coords( tileid, m_acts_geometry, world_in );
+      const auto local_out = layergeom->get_local_from_world_coords( tileid, m_acts_geometry, world_out );
 
       // number of primary elections
       const auto nprimary = get_primary_electrons( g4hit );
@@ -290,9 +296,10 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       {
         // put the electron at a random position along the g4hit path
         // in local reference frame, drift occurs along the y axis, from local y to mesh_local_y
+
         const auto t = gsl_ran_flat(m_rng.get(), 0.0, 1.0);
         auto local = local_in*t + local_out*(1.0-t);
-
+        
         if( m_diffusion_trans > 0 )
         {
           // add transeverse diffusion
@@ -303,11 +310,11 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
           const double diffusion_angle = gsl_ran_flat(m_rng.get(), -M_PI, M_PI);
 
           // diffusion occurs in x,z plane with a magnitude 'diffusion' and an angle 'diffusion angle'
-          local += TVector3( diffusion*std::cos(diffusion_angle), 0, diffusion*std::sin(diffusion_angle) );
+          local += TVector3( diffusion*std::cos(diffusion_angle), diffusion*std::sin(diffusion_angle), 0 );
         }
         
         // distribute charge among adjacent strips
-        const auto fractions = distribute_charge( layergeom, tileid, local, m_cloud_sigma );
+        const auto fractions = distribute_charge( layergeom, tileid, { local.x(), local.y() }, m_cloud_sigma );
 
         // make sure fractions adds up to unity
         if( Verbosity() > 0 )
@@ -324,13 +331,12 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
         for( const auto& pair: fractions )
         {
           const int strip = pair.first;
-          if( strip < 0 || strip >= (int) layergeom->get_strip_count( tileid ) ) continue;
+          if( strip < 0 || strip >= (int) layergeom->get_strip_count( tileid, m_acts_geometry ) ) continue;
 
           const auto it = total_charges.lower_bound( strip );
           if( it != total_charges.end() && it->first == strip ) it->second += pair.second*gain;
           else total_charges.insert( it, std::make_pair( strip, pair.second*gain ) );
         }
-
       }
 
       // generate the key for this hit
@@ -356,9 +362,7 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
         // associate this hitset and hit to the geant4 hit key
         hittruthassoc->addAssoc(hitsetkey, hitkey, g4hit_it->first);
       }
-
     }
-
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -425,12 +429,12 @@ uint PHG4MicromegasHitReco::get_single_electron_amplification() const
 PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   CylinderGeomMicromegas* layergeom,
   uint tileid,
-  const TVector3& local_coords,
+  const TVector2& local_coords,
   double sigma ) const
 {
 
   // find tile and strip matching center position
-  auto stripnum = layergeom->find_strip_from_local_coords( tileid, local_coords );
+  auto stripnum = layergeom->find_strip_from_local_coords( tileid, m_acts_geometry, local_coords );
 
   // check tile and strip
   if( stripnum < 0 ) return charge_list_t();
@@ -439,7 +443,7 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   const auto pitch = layergeom->get_pitch();
 
   // find relevant strip indices
-  const auto strip_count = layergeom->get_strip_count( tileid );
+  const auto strip_count = layergeom->get_strip_count( tileid, m_acts_geometry );
   const int nstrips = 5.*sigma/pitch + 1;
   const auto stripnum_min = std::clamp<int>( stripnum - nstrips, 0, strip_count );
   const auto stripnum_max = std::clamp<int>( stripnum + nstrips, 0, strip_count );
@@ -451,7 +455,7 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
   for( int strip = stripnum_min; strip <= stripnum_max; ++strip )
   {
     // get strip center
-    const TVector3 strip_location = layergeom->get_local_coordinates( tileid, strip );
+    const auto strip_location = layergeom->get_local_coordinates( tileid, m_acts_geometry, strip );
 
     /*
      * find relevant strip coordinate with respect to location
@@ -459,8 +463,8 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
      * in local coordinate, z segmented view has strips along phi and measures along z
      */
     const auto xloc = layergeom->get_segmentation_type() == MicromegasDefs::SegmentationType::SEGMENTATION_PHI ?
-      strip_location.x() - local_coords.x():
-      strip_location.z() - local_coords.z();
+      strip_location.X() - local_coords.X():
+      strip_location.Y() - local_coords.Y();
 
     // calculate charge fraction
     const auto fraction = m_zigzag_strips ?

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -236,12 +236,12 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
 
     /*
      * get the position of the detector mesh in local coordinates
-     * in local coordinate the mesh is a plane perpendicular to the y axis
+     * in local coordinate the mesh is a plane perpendicular to the z axis
      * Its position along z depends on the drift direction
      * it is used to calculate the drift distance of the primary electrons, and the
      * corresponding transverse diffusion
      */
-    const auto mesh_local_y = layergeom->get_drift_direction() == MicromegasDefs::DriftDirection::OUTWARD ?
+    const auto mesh_local_z = layergeom->get_drift_direction() == MicromegasDefs::DriftDirection::OUTWARD ?
       layergeom->get_thickness()/2:
       -layergeom->get_thickness()/2;
 
@@ -295,7 +295,7 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
       for( uint ie = 0; ie < nprimary; ++ie )
       {
         // put the electron at a random position along the g4hit path
-        // in local reference frame, drift occurs along the y axis, from local y to mesh_local_y
+        // in local reference frame, drift occurs along the y axis, from local y to mesh_local_z
 
         const auto t = gsl_ran_flat(m_rng.get(), 0.0, 1.0);
         auto local = local_in*t + local_out*(1.0-t);
@@ -304,8 +304,8 @@ int PHG4MicromegasHitReco::process_event(PHCompositeNode *topNode)
         {
           // add transeverse diffusion
           // first convert to polar coordinates
-          const double y = local.y();
-          const double drift_distance = std::abs(y - mesh_local_y);
+          const double z = local.z();
+          const double drift_distance = std::abs(z - mesh_local_z);
           const double diffusion = gsl_ran_gaussian(m_rng.get(), m_diffusion_trans*std::sqrt(drift_distance));
           const double diffusion_angle = gsl_ran_flat(m_rng.get(), -M_PI, M_PI);
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -463,8 +463,8 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
      * in local coordinate, z segmented view has strips along phi and measures along z
      */
     const auto xloc = layergeom->get_segmentation_type() == MicromegasDefs::SegmentationType::SEGMENTATION_PHI ?
-      strip_location.X() - local_coords.X():
-      strip_location.Y() - local_coords.Y();
+      (strip_location.X() - local_coords.X()):
+      (strip_location.Y() - local_coords.Y());
 
     // calculate charge fraction
     const auto fraction = m_zigzag_strips ?

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -19,10 +19,12 @@
 #include <utility>
 #include <vector>
 
+class ActsGeometry;
+
 class CylinderGeomMicromegas;
 class PHCompositeNode;
 class PHG4Hit;
-class TVector3;
+class TVector2;
 
 class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
 {
@@ -61,8 +63,11 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   using charge_list_t = std::vector<charge_pair_t>;
 
   //! distribute a Gaussian charge across adjacent strips
-  charge_list_t distribute_charge( CylinderGeomMicromegas*, uint tileid, const TVector3& local_position, double sigma ) const;
+  charge_list_t distribute_charge( CylinderGeomMicromegas*, uint tileid, const TVector2& local_position, double sigma ) const;
 
+  //! acts geometry
+  ActsGeometry* m_acts_geometry = nullptr;
+  
   //! detector name
   std::string m_detector;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR modifies CylinderGeomMicromegas to use acts sufaces for all local_to_master and master_to_global transformation instead of locally stored geometry description. Ultimately this would allow to seamlessly include alignment parameters without the need to maintain to instances of the geometry in parallel. 
There is one remaining place where the internal geometry is used and not acts surfaces. It is in "find_tiles_cylindrical" 
The reason is that this is the method used to match a given Acts surface to a TPOT tile number (in MakeActsGeometry). 
It is also a quick (and coarse) way to match MM clusters to extrapolated TPC seeds. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

