### PR TITLE
Scan embed clusters bug

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -76,9 +76,8 @@ namespace
     unsigned short maxHalfSizeT = 0;
     unsigned short maxHalfSizePhi = 0;
     double m_tdriftmax = 0;
-    double par0_neg = 0;
-    double par0_pos = 0;
-    int cluster_version = 3;
+    double sampa_tbias = 0;
+     int cluster_version = 3;
     std::vector<assoc> association_vector;
     std::vector<TrkrCluster*> cluster_vector;
     int verbosity = 0;
@@ -383,11 +382,7 @@ namespace
       // Equivalent charge per T bin is then  (ADU x 2200 mV / 1024) / 2.4 x (1/20) fC/mV x (1/1.6e-04) electrons/fC x (1/2000) = ADU x 0.14
 
       // SAMPA shaping bias correction
-      //clusz -= (clusz<0) ? my_data.par0_neg:my_data.par0_pos;
-      if(my_data.side == 0) 
-	clust -= my_data.par0_neg / my_data.tGeometry->get_drift_velocity();
-      else
-	clust -= my_data.par0_pos / my_data.tGeometry->get_drift_velocity();
+      clust = clust + my_data.sampa_tbias;
 
       Acts::Vector3 center = surface->center(my_data.tGeometry->geometry().geoContext)/Acts::UnitConstants::cm;
   
@@ -769,8 +764,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
     thread_pair.data.tGeometry = m_tGeometry;
     thread_pair.data.maxHalfSizeT =  MaxClusterHalfSizeT;
     thread_pair.data.maxHalfSizePhi = MaxClusterHalfSizePhi;
-    thread_pair.data.par0_neg = par0_neg;
-    thread_pair.data.par0_pos = par0_pos;
+    thread_pair.data.sampa_tbias = m_sampa_tbias;
     thread_pair.data.cluster_version = cluster_version;
     thread_pair.data.verbosity = Verbosity();
     

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -56,11 +56,9 @@ class TpcClusterizer : public SubsysReco
   double m_tdriftmax = 0;
   double AdcClockPeriod = 53.0;   // ns 
 
-  // TPC shaping offset correction parameters
-  // From Tony Frawley May 13, 2021
-  double par0_neg = 0.0503;
-  double par0_pos = -0.0503;
-  
+  // TPC shaping offset correction parameter
+  // From Tony Frawley July 5, 2022
+  double m_sampa_tbias = 13.5;  // ns  
 };
 
 #endif

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -68,7 +68,6 @@ void PHTpcDeltaZCorrection::SetDefaultParameters()
   // http://www.slac.stanford.edu/pubs/icfa/summer98/paper3/paper3.pdf
   // diffusion and drift velocity for 400kV for NeCF4 50/50 from calculations:
   // http://skipper.physics.sunysb.edu/~prakhar/tpc/HTML_Gases/split.html
-  //  set_default_double_param("drift_velocity", 8.0 / 1000.0);  // cm/ns
   set_default_double_param("bz_const", 1.4);  // Tesla
   return;
 }

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -173,18 +173,18 @@ void PHTpcDeltaZCorrection::process_track( unsigned int key, TrackSeed* track )
 
     // helical path length
     const double pathlength = std::sqrt( square( delta_z ) + square( radius*delta_phi ) );
-    if( Verbosity() )
-      { std::cout << "PHTpcDeltaZCorrection::process_track - cluster: " << cluster_key << " path length: " << pathlength << std::endl; }
     
     // adjust cluster position to account for particles propagation time
     /*
      * accounting for particles finite velocity results in reducing the electron drift time by pathlenght/c
      * this in turn affects the cluster z, so that it is always closer to the readout plane
      */
-    const double z_correction = pathlength * m_tGeometry->get_drift_velocity()/speed_of_light;
-    if( global.z() > 0 ) cluster->setLocalY( cluster->getLocalY()+z_correction);
-    else cluster->setLocalY( cluster->getLocalY()-z_correction);
-    
+    const double t_correction = pathlength /speed_of_light;  
+    cluster->setLocalY( cluster->getLocalY() - t_correction);
+
+    if( Verbosity() )
+      { std::cout << "PHTpcDeltaZCorrection::process_track - cluster: " << cluster_key 
+		  << " path length: " << pathlength << " t correction " << t_correction << std::endl; }
 	}
   
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR does three things:
1) It fixes the evaluator bug that caused the cluster ntuple to not be filled when the scan-for-embedded flag was set.
2) Fixes a bug in the calculation of the flight time correction in PHTpcDeltaZCorrection.
3) Changes the SAMPA shaping offset correction in TpcClusterizer to be a time in ns, and tunes it so that z values match in the TPC north and south at z = 0.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

