### PR TITLE
Silicon geometries to Acts

### DIFF
--- a/offline/packages/intt/CylinderGeomIntt.cc
+++ b/offline/packages/intt/CylinderGeomIntt.cc
@@ -37,7 +37,7 @@ bool CylinderGeomIntt::load_geometry()
 {
   return true;
 }
-TVector3 CylinderGeomIntt::get_world_from_local_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector2 local)
+TVector3 CylinderGeomIntt::get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector2 local)
 {
   Acts::Vector2 actslocal;
   actslocal(0) = local.X();
@@ -45,7 +45,7 @@ TVector3 CylinderGeomIntt::get_world_from_local_coords(Surface surface, ActsTrac
   actslocal *= Acts::UnitConstants::cm;
   
   /// Acts requires a dummy vector to be passed in the arg list
-  auto global = surface->localToGlobal(tGeometry->geoContext,
+  auto global = surface->localToGlobal(tGeometry->geometry().geoContext,
 				       actslocal,
 				       Acts::Vector3(1,1,1));
 
@@ -59,7 +59,7 @@ TVector3 CylinderGeomIntt::get_world_from_local_coords(Surface surface, ActsTrac
   return ret;
 
 }
-TVector3 CylinderGeomIntt::get_local_from_world_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector3 world)
+TVector3 CylinderGeomIntt::get_local_from_world_coords(Surface surface, ActsGeometry* tGeometry, TVector3 world)
 {
   Acts::Vector2 local;
   Acts::Vector3 global;
@@ -69,7 +69,7 @@ TVector3 CylinderGeomIntt::get_local_from_world_coords(Surface surface, ActsTrac
   global *= Acts::UnitConstants::cm;
 
   /// Acts requires a dummy vector to be passed in the arg list
-  auto localResult = surface->globalToLocal(tGeometry->geoContext,
+  auto localResult = surface->globalToLocal(tGeometry->geometry().geoContext,
 					    global,
 					    Acts::Vector3(1,1,1));
   TVector3 localR;

--- a/offline/packages/intt/CylinderGeomIntt.cc
+++ b/offline/packages/intt/CylinderGeomIntt.cc
@@ -81,7 +81,8 @@ TVector3 CylinderGeomIntt::get_local_from_world_coords(Surface surface, ActsGeom
 
   local /= Acts::UnitConstants::cm;
 
-  return TVector3(local(0), local(1), local(2));
+  /// The acts transform is offset by one element
+  return TVector3(local(2), local(0), local(1));
 }
 
 void CylinderGeomIntt::find_segment_center(Surface surface, ActsGeometry* tGeometry, double location[])

--- a/offline/packages/intt/CylinderGeomIntt.cc
+++ b/offline/packages/intt/CylinderGeomIntt.cc
@@ -84,18 +84,15 @@ TVector3 CylinderGeomIntt::get_local_from_world_coords(Surface surface, ActsGeom
   return TVector3(local(0), local(1), local(2));
 }
 
-void CylinderGeomIntt::find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[])
+void CylinderGeomIntt::find_segment_center(Surface surface, ActsGeometry* tGeometry, double location[])
 {
-  const double signz = (segment_z_bin > 1) ? 1. : -1.;
-  const int itype = segment_z_bin % 2;
+  TVector2 local(0.0,0.0);
 
-  // Ladder
-  const double phi = m_OffsetPhi + m_dPhi * segment_phi_bin;
-  location[0] = m_SensorRadius * cos(phi);
-  location[1] = m_SensorRadius * sin(phi);
-  location[2] = signz * m_LadderZ[itype];
-
-  //cout << "radius " << m_SensorRadius << " offsetphi " << m_OffsetPhi << " rad  dphi_ " << m_dPhi << " rad  segment_phi_bin " << segment_phi_bin << " phi " << phi  << " rad " << endl;
+  TVector3 global = get_world_from_local_coords(surface, tGeometry, local);
+  location[0] = global.X();
+  location[1] = global.Y();
+  location[2] = global.Z();
+  return;
 }
 
 void CylinderGeomIntt::find_indices_from_world_location(int &segment_z_bin, int &segment_phi_bin, double location[])
@@ -147,10 +144,10 @@ void CylinderGeomIntt::find_indices_from_segment_center(int &segment_z_bin, int 
   //cout << "radius " << m_SensorRadius << " offsetphi " << m_OffsetPhi << " rad  dphi_ " << m_dPhi << " rad  segment_phi_bin " << segment_phi_bin << " phi " << phi  << endl;
 }
 
-void CylinderGeomIntt::find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
+void CylinderGeomIntt::find_strip_center(Surface surface, ActsGeometry *tGeometry, const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[])
 {
   // Ladder
-  find_segment_center(segment_z_bin, segment_phi_bin, location);
+  find_segment_center(surface, tGeometry, location);
   CLHEP::Hep3Vector ladder(location[0], location[1], location[2]);
 
   // Strip

--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -3,6 +3,9 @@
 
 #include <g4detectors/PHG4CylinderGeom.h>
 
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/ActsTrackingGeometry.h>
+
 #include <cmath>
 #include <iostream>
 
@@ -98,7 +101,8 @@ class CylinderGeomIntt : public PHG4CylinderGeom
   bool load_geometry();
   void find_strip_center_localcoords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]);
   void find_indices_from_segment_center(int &segment_z_bin, int &segment_phi_bin, double location[]);
-  TVector3 get_local_from_world_coords(const int segment_z_bin, const int segment_phi_bin, TVector3 world);
+  TVector3 get_world_from_local_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector2 local);
+  TVector3 get_local_from_world_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector3 world);
   void find_indices_from_world_location(int &segment_z_bin, int &segment_phi_bin, double location[]);
 
   double get_strip_phi_tilt() const

--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -3,8 +3,7 @@
 
 #include <g4detectors/PHG4CylinderGeom.h>
 
-#include <trackbase/ActsSurfaceMaps.h>
-#include <trackbase/ActsTrackingGeometry.h>
+#include <trackbase/ActsGeometry.h>
 
 #include <cmath>
 #include <iostream>
@@ -101,8 +100,8 @@ class CylinderGeomIntt : public PHG4CylinderGeom
   bool load_geometry();
   void find_strip_center_localcoords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]);
   void find_indices_from_segment_center(int &segment_z_bin, int &segment_phi_bin, double location[]);
-  TVector3 get_world_from_local_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector2 local);
-  TVector3 get_local_from_world_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector3 world);
+  TVector3 get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector2 local);
+  TVector3 get_local_from_world_coords(Surface surface, ActsGeometry* tGeometry, TVector3 world);
   void find_indices_from_world_location(int &segment_z_bin, int &segment_phi_bin, double location[]);
 
   double get_strip_phi_tilt() const

--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -101,6 +101,7 @@ class CylinderGeomIntt : public PHG4CylinderGeom
   void find_strip_center_localcoords(const int segment_z_bin, const int strip_y_index, const int strip_z_index, double location[]);
   void find_indices_from_segment_center(int &segment_z_bin, int &segment_phi_bin, double location[]);
   TVector3 get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector2 local);
+  TVector3 get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector3 local);
   TVector3 get_local_from_world_coords(Surface surface, ActsGeometry* tGeometry, TVector3 world);
   void find_indices_from_world_location(int &segment_z_bin, int &segment_phi_bin, double location[]);
 

--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -94,7 +94,7 @@ class CylinderGeomIntt : public PHG4CylinderGeom
 
 // our own
   void find_segment_center(Surface surface, ActsGeometry* tGeometry, double location[]);
-  void find_strip_center(Surface surface, ActsGeometry *tGeometry, const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
+  void find_strip_center(Surface surface, ActsGeometry *tGeometry, const int segment_z_bin,  const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
   void find_strip_index_values(const int segment_z_bin, const double ypos, const double zpos, int &strip_y_index, int &strip_z_index) override;
 
   bool load_geometry();
@@ -104,6 +104,12 @@ class CylinderGeomIntt : public PHG4CylinderGeom
   TVector3 get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector3 local);
   TVector3 get_local_from_world_coords(Surface surface, ActsGeometry* tGeometry, TVector3 world);
   void find_indices_from_world_location(int &segment_z_bin, int &segment_phi_bin, double location[]);
+
+  void find_strip_center(int, int, int, int, double*) override
+  { std::cout << "find_strip_center(int, int, int, int, double[]) is deprecated" << std::endl;
+  }
+  void find_segment_center(const int, const int, double*) override
+  { std::cout << "find_segment_center(const int, const int, double*) is deprecated" << std::endl; }
 
   double get_strip_phi_tilt() const
   {

--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -93,8 +93,8 @@ class CylinderGeomIntt : public PHG4CylinderGeom
   }
 
 // our own
-  void find_segment_center(const int segment_z_bin, const int segment_phi_bin, double location[]) override;
-  void find_strip_center(const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]) override;
+  void find_segment_center(Surface surface, ActsGeometry* tGeometry, double location[]);
+  void find_strip_center(Surface surface, ActsGeometry *tGeometry, const int segment_z_bin, const int segment_phi_bin, const int strip_column, const int strip_index, double location[]);
   void find_strip_index_values(const int segment_z_bin, const double ypos, const double zpos, int &strip_y_index, int &strip_z_index) override;
 
   bool load_geometry();

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -2,6 +2,8 @@
 
 #include "SegmentationAlpide.h"
 
+#include <Acts/Definitions/Units.hpp>
+
 #include <TRotation.h>
 #include <TVector3.h>
 
@@ -71,51 +73,40 @@ CylinderGeom_Mvtx::CylinderGeom_Mvtx(
 }
 
 TVector3
-CylinderGeom_Mvtx::get_local_from_world_coords(int stave, int /*half_stave*/, int /*module*/, int chip, TVector3 world_location)
+CylinderGeom_Mvtx::get_local_from_world_coords(Surface surface,
+					       ActsTrackingGeometry* tGeometry,
+					       TVector3 world)
 {
-  double stave_phi = stave_phi_0 + stave_phi_step * (double) stave;
-  double stave_phi_offset = M_PI / 2.0;  // stave initially points so that sensor faces upward in y
+  Acts::Vector2 local;
+  Acts::Vector3 global;
+  global(0) = world[0];
+  global(1) = world[1];
+  global(2) = world[2];
+  global *= Acts::UnitConstants::cm;
 
-  // Starting from its location in the world
-  TVector3 res = world_location;
-
-  // transform location of stave from its location in the world - this is just a translation
-  TVector3 tr4(layer_radius * cos(stave_phi), layer_radius * sin(stave_phi), 0.0);
-  res -= tr4;
-
-  // Rotate stave from its angle in the world
-  // This requires rotating it by:
-  //   removing the tilt
-  //   removing the offsetfor first layer
-  //   removing the angle that makes it point at the origin when it was at it's location in the world
-  //   rotating it by -90 degrees to make the face point vertically up in y
-  TRotation R;
-  R.RotateZ(-stave_phi - stave_phi_offset - stave_phi_tilt);
-  res = R * res;  // rotates res using R
-
-  // transform location in stave to location in half stave
-  TVector3 tr3(inner_loc_halfstave_in_stave[0],
-               inner_loc_halfstave_in_stave[1],
-               inner_loc_halfstave_in_stave[2]);
-  res -= tr3;
-
-  // transfor from half stave to location in module
-  TVector3 tr2a(inner_loc_module_in_halfstave[0],
-                inner_loc_module_in_halfstave[1],
-                inner_loc_module_in_halfstave[2]);
-  res -= tr2a;
-
-  // transform location in module to location in chip
-  TVector3 tr2(inner_loc_chip_in_module[chip][0],
-               inner_loc_chip_in_module[chip][1],
-               inner_loc_chip_in_module[chip][2]);
-  res -= tr2;
-
-  // transform location in chip to location in sensor
-  TVector3 tr1(loc_sensor_in_chip[0],
-               loc_sensor_in_chip[1],
-               loc_sensor_in_chip[2]);
-  res -= tr1;
+  /// Acts requires a dummy vector to be passed in the arg list
+  auto localResult = surface->globalToLocal(tGeometry->geoContext,
+					    global,
+					    Acts::Vector3(1,1,1));
+  
+  TVector3 res;
+  if(localResult.ok())
+    {
+      local = localResult.value();
+      local /= Acts::UnitConstants::cm;
+      
+      res[0] = local(0);
+      res[1] = 0;
+      res[2] = local(1);
+    }
+  else 
+    {
+      std::cout << "Could not perform transform on Acts::Surface. Returning NAN" 
+		<< std::endl;
+      res[0] = NAN;
+      res[1] = NAN;
+      res[2] = NAN;
+    }
 
   return res;
 }
@@ -141,54 +132,23 @@ CylinderGeom_Mvtx::get_sensor_indices_from_world_coords(std::vector<double> &wor
 }
 
 TVector3
-CylinderGeom_Mvtx::get_world_from_local_coords(int stave, int /*half_stave*/, int /*module*/, int chip, TVector3 sensor_local)
+CylinderGeom_Mvtx::get_world_from_local_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector2 local)
 {
-  double stave_phi = stave_phi_0 + stave_phi_step * (double) stave;
-  double stave_phi_offset = M_PI / 2.0;  // stave initially points so that sensor faces upward in y
+  Acts::Vector2 actslocal;
+  actslocal(0) = local.X();
+  actslocal(1) = local.Y();
+  actslocal *= Acts::UnitConstants::cm;
 
-  // Start with the point in sensor local coords
-  TVector3 res = sensor_local;
+  Acts::Vector3 global;
+  /// Acts requires a dummy vector to be passed in the arg list
+  global = surface->localToGlobal(tGeometry->geoContext,
+				  actslocal, Acts::Vector3(1,1,1));
+  global /= Acts::UnitConstants::cm;
 
-  // transform sensor location to location in chip
-  TVector3 tr1(loc_sensor_in_chip[0],
-               loc_sensor_in_chip[1],
-               loc_sensor_in_chip[2]);
-  res += tr1;
-
-  // transform location in chip to location in module
-  TVector3 tr2(inner_loc_chip_in_module[chip][0],
-               inner_loc_chip_in_module[chip][1],
-               inner_loc_chip_in_module[chip][2]);
-  res += tr2;
-
-  // module to half stave
-  TVector3 tr2a(inner_loc_module_in_halfstave[0],
-                inner_loc_module_in_halfstave[1],
-                inner_loc_module_in_halfstave[2]);
-  res += tr2a;
-
-  // transform location in half stave to location in stave
-  TVector3 tr3(inner_loc_halfstave_in_stave[0],
-               inner_loc_halfstave_in_stave[1],
-               inner_loc_halfstave_in_stave[2]);
-  res += tr3;
-
-  // Rotate stave to its angle in the world
-  // This requires rotating it by
-  //    90 degrees to make the face point to the origin instead of vertically up in y when it is at phi = 0 - stave_phi_offset is 90 degrees in CCW direction
-  //    Rotating it fiurther so that it points at the origin after being translated to the x and y coords of the stave phi location - stave_phi derived from
-  //    stave_phi_step  and stave (number), both constructor parameters
-  //    Adding the tilt (for layers 0-2) - stave_phi_tilt is a constructor parameter provided by PHG4MvtxDetector
-  // for a rotation
-  TRotation R;
-  R.RotateZ(stave_phi + stave_phi_offset + stave_phi_tilt);
-  res = R * res;  // rotates res using R
-
-  // transform location of stave to its location in the world
-  TVector3 tr4(layer_radius * cos(stave_phi),
-               layer_radius * sin(stave_phi),
-               0.0);
-  res += tr4;
+  TVector3 res;
+  res[0] = global(0);
+  res[1] = global(1);
+  res[2] = global(2);
 
   return res;
 }
@@ -270,11 +230,11 @@ void CylinderGeom_Mvtx::identify(std::ostream& os) const
   return;
 }
 
-void CylinderGeom_Mvtx::find_sensor_center(int stave, int half_stave, int module, int chip, double location[])
+void CylinderGeom_Mvtx::find_sensor_center(Surface surface, ActsTrackingGeometry* tGeometry, double location[])
 {
-  TVector3 sensor_local(0.0, 0.0, 0.0);
+  TVector2 sensor_local(0.0, 0.0);
 
-  TVector3 sensor_world = get_world_from_local_coords(stave, half_stave, module, chip, sensor_local);
+  TVector3 sensor_world = get_world_from_local_coords(surface, tGeometry, sensor_local);
 
   location[0] = sensor_world.X();
   location[1] = sensor_world.Y();

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -74,7 +74,7 @@ CylinderGeom_Mvtx::CylinderGeom_Mvtx(
 
 TVector3
 CylinderGeom_Mvtx::get_local_from_world_coords(Surface surface,
-					       ActsTrackingGeometry* tGeometry,
+					       ActsGeometry* tGeometry,
 					       TVector3 world)
 {
   Acts::Vector2 local;
@@ -85,7 +85,7 @@ CylinderGeom_Mvtx::get_local_from_world_coords(Surface surface,
   global *= Acts::UnitConstants::cm;
 
   /// Acts requires a dummy vector to be passed in the arg list
-  auto localResult = surface->globalToLocal(tGeometry->geoContext,
+  auto localResult = surface->globalToLocal(tGeometry->geometry().geoContext,
 					    global,
 					    Acts::Vector3(1,1,1));
   
@@ -132,7 +132,7 @@ CylinderGeom_Mvtx::get_sensor_indices_from_world_coords(std::vector<double> &wor
 }
 
 TVector3
-CylinderGeom_Mvtx::get_world_from_local_coords(Surface surface, ActsTrackingGeometry* tGeometry, TVector2 local)
+CylinderGeom_Mvtx::get_world_from_local_coords(Surface surface, ActsGeometry* tGeometry, TVector2 local)
 {
   Acts::Vector2 actslocal;
   actslocal(0) = local.X();
@@ -141,7 +141,7 @@ CylinderGeom_Mvtx::get_world_from_local_coords(Surface surface, ActsTrackingGeom
 
   Acts::Vector3 global;
   /// Acts requires a dummy vector to be passed in the arg list
-  global = surface->localToGlobal(tGeometry->geoContext,
+  global = surface->localToGlobal(tGeometry->geometry().geoContext,
 				  actslocal, Acts::Vector3(1,1,1));
   global /= Acts::UnitConstants::cm;
 
@@ -230,7 +230,7 @@ void CylinderGeom_Mvtx::identify(std::ostream& os) const
   return;
 }
 
-void CylinderGeom_Mvtx::find_sensor_center(Surface surface, ActsTrackingGeometry* tGeometry, double location[])
+void CylinderGeom_Mvtx::find_sensor_center(Surface surface, ActsGeometry* tGeometry, double location[])
 {
   TVector2 sensor_local(0.0, 0.0);
 

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -81,12 +81,14 @@ CylinderGeom_Mvtx::get_local_from_world_coords(Surface surface,
   global(0) = world[0];
   global(1) = world[1];
   global(2) = world[2];
+
   global *= Acts::UnitConstants::cm;
 
   Acts::Vector3 local = surface->transform(tGeometry->geometry().geoContext).inverse() * global;
   local /= Acts::UnitConstants::cm;
-  std::cout << "local mvtx pos is " << local.transpose() << std::endl;
-  return TVector3(local(2), local(0), local(1));
+
+  /// The Acts transform swaps a few of the coordinates
+  return TVector3(local(0), local(2) * -1, local(1));
 }
 
 void

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -85,8 +85,8 @@ CylinderGeom_Mvtx::get_local_from_world_coords(Surface surface,
 
   Acts::Vector3 local = surface->transform(tGeometry->geometry().geoContext).inverse() * global;
   local /= Acts::UnitConstants::cm;
-
-  return TVector3(local(0), local(1), local(2));
+  std::cout << "local mvtx pos is " << local.transpose() << std::endl;
+  return TVector3(local(2), local(0), local(1));
 }
 
 void

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -4,8 +4,7 @@
 #include <g4detectors/PHG4CylinderGeom.h>
 
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/ActsSurfaceMaps.h>
-#include <trackbase/ActsTrackingGeometry.h>
+#include <trackbase/ActsGeometry.h>
 
 #include <TVector3.h>
 
@@ -50,8 +49,8 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   double get_pixel_thickness() const override { return pixel_thickness; }
 
 // our own - no override
-  TVector3 get_local_from_world_coords(Surface surface, ActsTrackingGeometry *tGeometry, TVector3 world);
-  TVector3 get_world_from_local_coords(Surface surface, ActsTrackingGeometry *tGeometry, TVector2 local);
+  TVector3 get_local_from_world_coords(Surface surface, ActsGeometry *tGeometry, TVector3 world);
+  TVector3 get_world_from_local_coords(Surface surface, ActsGeometry *tGeometry, TVector2 local);
 
   void get_sensor_indices_from_world_coords(std::vector<double> &world, unsigned int &stave, unsigned int &chip);
 
@@ -73,7 +72,7 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   int get_ladder_phi_index(int stave, int /*half_stave*/, int /*chip*/) {return stave; }
   int get_ladder_z_index(int /*module*/, int chip) { return chip; }
 
-  void find_sensor_center(Surface surface, ActsTrackingGeometry* tGeometry, double location[]);
+  void find_sensor_center(Surface surface, ActsGeometry* tGeometry, double location[]);
 
   int get_N_staves() const { return N_staves; }
   int get_N_half_staves() const { return N_half_staves; }

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -3,6 +3,10 @@
 
 #include <g4detectors/PHG4CylinderGeom.h>
 
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/ActsSurfaceMaps.h>
+#include <trackbase/ActsTrackingGeometry.h>
+
 #include <TVector3.h>
 
 #include <iostream>
@@ -33,11 +37,10 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
 
   ~CylinderGeom_Mvtx() override {}
 
-// from PHObject
+  // from PHObject
   void identify(std::ostream& os = std::cout) const override;
 
-
-// from base class
+  // from base class
   void set_layer(const int i) override { layer = i; }
   int get_layer() const override { return layer; }
   double get_radius() const override { return layer_radius; }
@@ -47,19 +50,8 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   double get_pixel_thickness() const override { return pixel_thickness; }
 
 // our own - no override
-  TVector3 get_local_from_world_coords(int stave, int half_stave, int module, int chip, TVector3 world_location);
-  TVector3 get_world_from_local_coords(int stave, int half_stave, int module, int chip, TVector3 sensor_local);
-
-  TVector3 get_local_from_world_coords(int stave, int chip, TVector3 world_location)
-  {
-    return get_local_from_world_coords(stave, 0, 0, chip, world_location);
-  }
-
-
-  TVector3 get_world_from_local_coords(int stave, int chip, TVector3 sensor_local)
-  {
-    return get_world_from_local_coords(stave, 0, 0, chip, sensor_local);
-  }
+  TVector3 get_local_from_world_coords(Surface surface, ActsTrackingGeometry *tGeometry, TVector3 world);
+  TVector3 get_world_from_local_coords(Surface surface, ActsTrackingGeometry *tGeometry, TVector2 local);
 
   void get_sensor_indices_from_world_coords(std::vector<double> &world, unsigned int &stave, unsigned int &chip);
 
@@ -81,7 +73,7 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   int get_ladder_phi_index(int stave, int /*half_stave*/, int /*chip*/) {return stave; }
   int get_ladder_z_index(int /*module*/, int chip) { return chip; }
 
-  void find_sensor_center(int stave_number, int half_stave_number, int module_number, int chip_number, double location[]);
+  void find_sensor_center(Surface surface, ActsTrackingGeometry* tGeometry, double location[]);
 
   int get_N_staves() const { return N_staves; }
   int get_N_half_staves() const { return N_half_staves; }

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -51,6 +51,7 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
 // our own - no override
   TVector3 get_local_from_world_coords(Surface surface, ActsGeometry *tGeometry, TVector3 world);
   TVector3 get_world_from_local_coords(Surface surface, ActsGeometry *tGeometry, TVector2 local);
+  TVector3 get_world_from_local_coords(Surface surface, ActsGeometry *tGeometry, TVector3 local);
 
   void get_sensor_indices_from_world_coords(std::vector<double> &world, unsigned int &stave, unsigned int &chip);
 

--- a/offline/packages/trackbase/ActsSurfaceMaps.cc
+++ b/offline/packages/trackbase/ActsSurfaceMaps.cc
@@ -29,10 +29,8 @@ bool ActsSurfaceMaps::isTpcSurface( const Acts::Surface* surface ) const
 bool ActsSurfaceMaps::isMicromegasSurface( const Acts::Surface* surface ) const
 { return m_micromegasVolumeIds.find( surface->geometryId().volume() ) != m_micromegasVolumeIds.end(); }
 
-
-
 Surface ActsSurfaceMaps::getSurface(TrkrDefs::cluskey key,       
-					TrkrCluster *cluster) const
+				    TrkrCluster *cluster) const
 {
   const auto trkrid = TrkrDefs::getTrkrId(key);
   const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(key);

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -992,9 +992,6 @@ TrkrDefs::hitsetkey MakeActsGeometry::getMvtxHitSetKeyFromCoords(unsigned int la
   unsigned int chip = 0;
   layergeom->get_sensor_indices_from_world_coords(world, stave, chip);
 
-  double check_pos[3] = {0, 0, 0};
-  layergeom->find_sensor_center(stave, 0, 0, chip, check_pos);
-
   unsigned int strobe = 0;
   TrkrDefs::hitsetkey mvtx_hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, strobe);
 
@@ -1018,9 +1015,6 @@ TrkrDefs::hitsetkey MakeActsGeometry::getInttHitSetKeyFromCoords(unsigned int la
   int segment_phi_bin = 0;
   layergeom->find_indices_from_segment_center(segment_z_bin, 
 					      segment_phi_bin, location);
-
-  double check_pos[3] = {0, 0, 0};
-  layergeom->find_segment_center(segment_z_bin, segment_phi_bin, check_pos);
 
   int crossing = 0;
   TrkrDefs::hitsetkey intt_hitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin, crossing);

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -48,7 +48,6 @@ pkginclude_HEADERS = \
   PHCASeeding.h \
   PHGenFitTrackProjection.h \
   PHGenFitTrkFitter.h \
-  PHGenFitTrkProp.h \
   PHGhostRejection.h \
   PHInitVertexing.h \
   PHInitZVertexing.h \
@@ -147,7 +146,6 @@ libtrack_reco_la_SOURCES = \
   PHCASeeding.cc \
   PHGenFitTrackProjection.cc \
   PHGenFitTrkFitter.cc \
-  PHGenFitTrkProp.cc \
   PHGhostRejection.cc \
   PHInitVertexing.cc \
   PHInitZVertexing.cc \

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -465,7 +465,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	  
 	  auto surf = m_tGeometry->maps().getSiliconSurface(hitsetkey);
 	  layerGeom->find_segment_center(surf, m_tGeometry, ladderLocation);
-	  std::cout << "segment center for hitsetkey " << hitsetkey << ", " << ladderLocation[0] << ", " << ladderLocation[1] << ", " << ladderLocation[2] << std::endl;
+        
 	  const double ladderphi = atan2(ladderLocation[1], ladderLocation[0]) + layerGeom->get_strip_phi_tilt();
 	  const auto stripZSpacing = layerGeom->get_strip_z_spacing();
 	  float dphi = ladderphi - projPhi;
@@ -482,12 +482,11 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 
 	  TVector3 projectionLocal(0,0,0);
 	  TVector3 projectionGlobal(xProj[inttlayer],yProj[inttlayer],zProj[inttlayer]);
-	  std::cout << "global " << projectionGlobal.x() << ", " << projectionGlobal.y() << ", " << projectionGlobal.z() << std::endl;
 	 
 	  projectionLocal = layerGeom->get_local_from_world_coords(surf, 
 								   m_tGeometry,
 								   projectionGlobal);
-	  std::cout << "local " << projectionLocal.x() << ", " << projectionLocal.y() << ", " << projectionLocal.z() << std::endl;
+        
 	  auto range = m_clusterMap->getClusters(hitsetkey);	
 	  for(auto clusIter = range.first; clusIter != range.second; ++clusIter )
 	    {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -482,10 +482,12 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 
 	  TVector3 projectionLocal(0,0,0);
 	  TVector3 projectionGlobal(xProj[inttlayer],yProj[inttlayer],zProj[inttlayer]);
+	  std::cout << "global " << projectionGlobal.x() << ", " << projectionGlobal.y() << ", " << projectionGlobal.z() << std::endl;
+	 
 	  projectionLocal = layerGeom->get_local_from_world_coords(surf, 
 								   m_tGeometry,
 								   projectionGlobal);
-
+	  std::cout << "local " << projectionLocal.x() << ", " << projectionLocal.y() << ", " << projectionLocal.z() << std::endl;
 	  auto range = m_clusterMap->getClusters(hitsetkey);	
 	  for(auto clusIter = range.first; clusIter != range.second; ++clusIter )
 	    {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -666,7 +666,7 @@ std::vector<const SpacePoint*> PHActsSiliconSeeding::getMvtxSpacePoints(Acts::Ex
 	  const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
 	  const auto surface = m_tGeometry->maps().getSiliconSurface(hitsetkey);
 	  if(!surface)
-	    continue;
+	    { continue; }
 
 	  auto sp = makeSpacePoint(surface, cluskey, cluster).release();
 	  spVec.push_back(sp);

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -454,10 +454,8 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
       const double projPhi = std::atan2(yProj[inttlayer], xProj[inttlayer]);
       const double projRphi = projR * projPhi;
 
-      for( const auto& hitsetkey:m_clusterMap->getHitSetKeys(TrkrDefs::TrkrId::inttId, inttlayer+3))
+      for( const auto& hitsetkey : m_clusterMap->getHitSetKeys(TrkrDefs::TrkrId::inttId, inttlayer+3))
       {
-	  const int ladderzindex = InttDefs::getLadderZId(hitsetkey);
-	  const int ladderphiindex = InttDefs::getLadderPhiId(hitsetkey);
 	  double ladderLocation[3] = {0.,0.,0.};
 
 	  // Add three to skip the mvtx layers for comparison
@@ -465,7 +463,8 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	  auto layerGeom = dynamic_cast<CylinderGeomIntt*>
 	    (m_geomContainerIntt->GetLayerGeom(inttlayer+3));
 	  
-	  layerGeom->find_segment_center(ladderzindex, ladderphiindex, ladderLocation);
+	  auto surf = m_tGeometry->maps().getSiliconSurface(hitsetkey);
+	  layerGeom->find_segment_center(surf, m_tGeometry, ladderLocation);
 	  const double ladderphi = atan2(ladderLocation[1], ladderLocation[0]) + layerGeom->get_strip_phi_tilt();
 	  const auto stripZSpacing = layerGeom->get_strip_z_spacing();
 	  float dphi = ladderphi - projPhi;
@@ -482,8 +481,8 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 
 	  TVector3 projectionLocal(0,0,0);
 	  TVector3 projectionGlobal(xProj[inttlayer],yProj[inttlayer],zProj[inttlayer]);
-	  projectionLocal = layerGeom->get_local_from_world_coords(ladderzindex, 
-								   ladderphiindex,
+	  projectionLocal = layerGeom->get_local_from_world_coords(surf, 
+								   m_tGeometry,
 								   projectionGlobal);
 
 	  auto range = m_clusterMap->getClusters(hitsetkey);	

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -465,6 +465,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	  
 	  auto surf = m_tGeometry->maps().getSiliconSurface(hitsetkey);
 	  layerGeom->find_segment_center(surf, m_tGeometry, ladderLocation);
+	  std::cout << "segment center for hitsetkey " << hitsetkey << ", " << ladderLocation[0] << ", " << ladderLocation[1] << ", " << ladderLocation[2] << std::endl;
 	  const double ladderphi = atan2(ladderLocation[1], ladderLocation[0]) + layerGeom->get_strip_phi_tilt();
 	  const auto stripZSpacing = layerGeom->get_strip_z_spacing();
 	  float dphi = ladderphi - projPhi;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -224,7 +224,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       /// has a silicon match, we skip those cases completely
       if(siid == std::numeric_limits<unsigned int>::max()) 
 	{
-	  if(Verbosity() > 0) std::cout << "SvtxSeedTrack has no silicon match, skip it" << std::endl;
+	  if(Verbosity() > 1) std::cout << "SvtxSeedTrack has no silicon match, skip it" << std::endl;
 	  continue;
 	}
 
@@ -236,6 +236,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       if(crossing == SHRT_MAX) 
 	{
 	  // Skip this in the pp case. For AuAu it should not happen
+	  if(Verbosity() > 1) std::cout << "Crossing not determined, skipping track" << std::endl;
 	  continue;
 	}
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1058,15 +1058,13 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     {
 
       case TrkrDefs::mvtxId:
-      {
-        int stave_index = MvtxDefs::getStaveId(cluster_key);
-        int chip_index = MvtxDefs::getChipId(cluster_key);
-
+	{
         double ladder_location[3] = {0.0, 0.0, 0.0};
         auto geom = static_cast<CylinderGeom_Mvtx*>(geom_container_mvtx->GetLayerGeom(layer));
+	auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
+	auto surf = m_tgeometry->maps().getSiliconSurface(hitsetkey);
         // returns the center of the sensor in world coordinates - used to get the ladder phi location
-        geom->find_sensor_center(stave_index, 0,
-          0, chip_index, ladder_location);
+        geom->find_sensor_center(surf, m_tgeometry, ladder_location);
 
         //cout << " MVTX stave phi tilt = " <<  geom->get_stave_phi_tilt()
         //   << " seg.X " << ladder_location[0] << " seg.Y " << ladder_location[1] << " seg.Z " << ladder_location[2] << endl;
@@ -1079,8 +1077,9 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
       {
         auto geom = static_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(layer));
         double hit_location[3] = {0.0, 0.0, 0.0};
-        geom->find_segment_center(InttDefs::getLadderZId(cluster_key),
-          InttDefs::getLadderPhiId(cluster_key), hit_location);
+	auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
+	auto surf = m_tgeometry->maps().getSiliconSurface(hitsetkey);
+        geom->find_segment_center(surf, m_tgeometry, hit_location);
 
         //cout << " Intt strip phi tilt = " <<  geom->get_strip_phi_tilt()
         //   << " seg.X " << hit_location[0] << " seg.Y " << hit_location[1] << " seg.Z " << hit_location[2] << endl;

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -331,7 +331,7 @@ std::map<TrkrDefs::cluskey, TrkrCluster* > PHTruthClustering::all_truth_clusters
       // Estimate the size of the truth cluster
       float g4phisize = NAN;
       float g4zsize = NAN;
-      G4ClusterSize(layer, contributing_hits_entry, contributing_hits_exit, g4phisize, g4zsize);
+      G4ClusterSize(ckey, layer, contributing_hits_entry, contributing_hits_exit, g4phisize, g4zsize);
 
       /*
       std::cout << PHWHERE << " g4trackID " << particle->get_track_id() << " gedep " << gedep << " adc value " << adc_output 
@@ -710,7 +710,7 @@ void PHTruthClustering::LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::v
   return;
 }
 
-void PHTruthClustering::G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize)
+void PHTruthClustering::G4ClusterSize(TrkrDefs::cluskey& ckey,unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize)
 {
 
   // sort the contributing g4hits in radius
@@ -821,7 +821,7 @@ void PHTruthClustering::G4ClusterSize(unsigned int layer, std::vector<std::vecto
 
       int segment_z_bin, segment_phi_bin;
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
-      auto hitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
+      auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto surf = _tgeometry->maps().getSiliconSurface(hitsetkey);
       TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(surf,_tgeometry, world_inner_vec);
       double yin = local_inner_vec[1];
@@ -834,7 +834,7 @@ void PHTruthClustering::G4ClusterSize(unsigned int layer, std::vector<std::vecto
       TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
 
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
-      auto outerhitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin, 0);
+      auto outerhitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto outersurf = _tgeometry->maps().getSiliconSurface(outerhitsetkey);
       TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(outersurf,_tgeometry, world_outer_vec);
       double yout = local_outer_vec[1];
@@ -880,14 +880,14 @@ void PHTruthClustering::G4ClusterSize(unsigned int layer, std::vector<std::vecto
       TVector3 world_inner = {inner_x, inner_y, inner_z};
       std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
       layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
-      auto ihitsetkey = MvtxDefs::genHitSetKey(layer,stave,chip,0);
+      auto ihitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto isurf = _tgeometry->maps().getSiliconSurface(ihitsetkey);
       TVector3 local_inner = layergeom->get_local_from_world_coords(isurf,_tgeometry, world_inner);
 
       TVector3 world_outer = {outer_x, outer_y, outer_z};
       std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
       layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
-      auto ohitsetkey = MvtxDefs::genHitSetKey(layer,stave_outer, chip_outer,0);
+      auto ohitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
       TVector3 local_outer = layergeom->get_local_from_world_coords(osurf,_tgeometry, world_outer);
 

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -54,7 +54,7 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
 
   void LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::vector<PHG4Hit*> &contributing_hits, std::vector<double> &contributing_hits_energy, std::vector<std::vector<double>> &contributing_hits_entry, std::vector<std::vector<double>> &contributing_hits_exit, float layer, float &x, float &y, float &z,  float &t, float &e);
   
-  void G4ClusterSize(unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
+  void G4ClusterSize(TrkrDefs::cluskey& ckey, unsigned int layer, std::vector<std::vector<double>> contributing_hits_entry,std::vector<std::vector<double>> contributing_hits_exit, float &g4phisize, float &g4zsize);
 
   float line_circle_intersection(float x[], float y[], float z[], float radius);
   unsigned int getTpcSector(double x, double y);

--- a/offline/packages/trackreco/PHTruthClustering.h
+++ b/offline/packages/trackreco/PHTruthClustering.h
@@ -21,6 +21,7 @@ class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
 class TrkrCluster;
 class TrkrClusterContainer;
+class ActsGeometry;
 
 #include <string>             // for string
 #include <vector>
@@ -74,7 +75,7 @@ std::set<PHG4Hit*> all_truth_hits(PHG4Particle* particle);
   PHG4CylinderGeomContainer *_intt_geom_container{nullptr};
   PHG4CylinderGeomContainer* _mvtx_geom_container{nullptr};
   PHG4CylinderGeomContainer* _mms_geom_container{nullptr};
-
+  ActsGeometry* _tgeometry{nullptr};
  const unsigned int _nlayers_maps = 3;
   const unsigned int _nlayers_intt = 4;
   const unsigned int _nlayers_tpc = 48;

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -803,7 +803,7 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
       int segment_z_bin, segment_phi_bin;
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
       
-      auto hitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
+      TrkrDefs::hitsetkey hitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
       auto surf = _tgeometry->maps().getSiliconSurface(hitsetkey);
       TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(surf, _tgeometry, world_inner);
       double yin = local_inner_vec[1];
@@ -816,7 +816,7 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
       TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
 
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
-      auto ohitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
+      TrkrDefs::hitsetkey ohitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
       auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
       TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(osurf,_tgeometry, world_outer_vec);
       double yout = local_outer_vec[1];
@@ -862,14 +862,14 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
       TVector3 world_inner = {inner_x, inner_y, inner_z};
       std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
       layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
-      auto ihitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
+      TrkrDefs::hitsetkey ihitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
       auto isurf = _tgeometry->maps().getSiliconSurface(ihitsetkey);
       TVector3 local_inner = layergeom->get_local_from_world_coords(isurf,_tgeometry, world_inner);
 
       TVector3 world_outer = {outer_x, outer_y, outer_z};
       std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
       layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
-      auto ohitsetkey = MvtxDefs::genHitSetKey(layer, stave_outer, chip_outer,0);
+      TrkrDefs::hitsetkey ohitsetkey = MvtxDefs::genHitSetKey(layer, stave_outer, chip_outer,0);
       auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
       TVector3 local_outer = layergeom->get_local_from_world_coords(osurf,_tgeometry,world_outer);
 

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -12,6 +12,7 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
+#include <trackbase/ActsGeometry.h>
 
 #include <tpc/TpcDefs.h>
 #include <micromegas/MicromegasDefs.h>
@@ -801,8 +802,10 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
 
       int segment_z_bin, segment_phi_bin;
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_inner);
-
-      TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_inner_vec);
+      
+      auto hitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
+      auto surf = _tgeometry->maps().getSiliconSurface(hitsetkey);
+      TVector3 local_inner_vec =  layergeom->get_local_from_world_coords(surf, _tgeometry, world_inner);
       double yin = local_inner_vec[1];
       double zin = local_inner_vec[2];
       int strip_y_index, strip_z_index;
@@ -813,8 +816,9 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
       TVector3 world_outer_vec = {outer_x, outer_y, outer_z};
 
       layergeom->find_indices_from_world_location(segment_z_bin, segment_phi_bin, world_outer);
-
-      TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(segment_z_bin, segment_phi_bin, world_outer_vec);
+      auto ohitsetkey = InttDefs::genHitSetKey(layer, segment_z_bin, segment_phi_bin,0);
+      auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
+      TVector3 local_outer_vec =  layergeom->get_local_from_world_coords(osurf,_tgeometry, world_outer_vec);
       double yout = local_outer_vec[1];
       double zout = local_outer_vec[2];
       int strip_y_index_out, strip_z_index_out;
@@ -858,12 +862,16 @@ void SvtxTruthEval::G4ClusterSize(unsigned int layer, std::vector<std::vector<do
       TVector3 world_inner = {inner_x, inner_y, inner_z};
       std::vector<double> world_inner_vec = { world_inner[0], world_inner[1], world_inner[2] };
       layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
-      TVector3 local_inner = layergeom->get_local_from_world_coords(stave, chip, world_inner);
+      auto ihitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
+      auto isurf = _tgeometry->maps().getSiliconSurface(ihitsetkey);
+      TVector3 local_inner = layergeom->get_local_from_world_coords(isurf,_tgeometry, world_inner);
 
       TVector3 world_outer = {outer_x, outer_y, outer_z};
       std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
       layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
-      TVector3 local_outer = layergeom->get_local_from_world_coords(stave_outer, chip_outer, world_outer);
+      auto ohitsetkey = MvtxDefs::genHitSetKey(layer, stave_outer, chip_outer,0);
+      auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
+      TVector3 local_outer = layergeom->get_local_from_world_coords(osurf,_tgeometry,world_outer);
 
       double diff =  max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
       if(local_outer[0] < local_inner[0])
@@ -1096,6 +1104,7 @@ bool SvtxTruthEval::are_same_vertex(PHG4VtxPoint* vtx1, PHG4VtxPoint* vtx2)
 
 void SvtxTruthEval::get_node_pointers(PHCompositeNode* topNode)
 {
+  _tgeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   _truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
   _g4hits_mms = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_MICROMEGAS");

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.h
@@ -15,7 +15,7 @@ class PHG4CylinderGeomContainer;
 class PHG4CylinderCellGeomContainer;
 class PHG4VtxPoint;
 class TrkrCluster;
-
+class ActsGeometry;
 
 #include <map>
 #include <set>
@@ -88,12 +88,13 @@ class SvtxTruthEval
   PHG4CylinderGeomContainer *_intt_geom_container;
   PHG4CylinderGeomContainer* _mvtx_geom_container;
   PHG4CylinderGeomContainer* _mms_geom_container;
+  ActsGeometry* _tgeometry{nullptr};
 
   bool _strict;
   int _verbosity;
   unsigned int _errors;
   unsigned long iclus;
-
+  
   const unsigned int _nlayers_maps = 3;
   const unsigned int _nlayers_intt = 4;
   const unsigned int _nlayers_tpc = 48;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -226,7 +226,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       TVector3 local_out(hiter->second->get_local_x(1), hiter->second->get_local_y(1), hiter->second->get_local_z(1));
       TVector3 midpoint((local_in.X() + local_out.X()) / 2.0, (local_in.Y() + local_out.Y()) / 2.0, (local_in.Z() + local_out.Z()) / 2.0);
 
-      if (Verbosity() > 4)
+      if (Verbosity() > -1)
       {
         cout << endl
              << "  world entry point position: " << hiter->second->get_x(0) << " " << hiter->second->get_y(0) << " " << hiter->second->get_z(0) << endl;
@@ -235,7 +235,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         TVector3 world_in(hiter->second->get_x(0), hiter->second->get_y(0), hiter->second->get_z(0));
 	auto hskey = MvtxDefs::genHitSetKey(*layer,stave_number,chip_number,strobe);
 	auto surf = tgeometry->maps().getSiliconSurface(hskey);
-
+	std::cout << "Global is " << world_in.X() << ", " << world_in.Y() << ", " << world_in.Z() << std::endl;
         TVector3 local_in_check = layergeom->get_local_from_world_coords(surf, tgeometry, world_in);
         cout << "  local coords of entry point from geom (a check) " << local_in_check.X() << " " << local_in_check.Y() << " " << local_in_check.Z() << endl;
         cout << "  local coords of exit point from G4 " << hiter->second->get_local_x(1) << " " << hiter->second->get_local_y(1) << " " << hiter->second->get_local_z(1) << endl;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -126,6 +126,12 @@ int PHG4MvtxHitReco::InitRun(PHCompositeNode *topNode)
 int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
 {
   //cout << PHWHERE << "Entering process_event for PHG4MvtxHitReco" << endl;
+  ActsGeometry *tgeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if(!tgeometry)
+    {
+      std::cout << "Could not locate acts geometry" << std::endl;
+      exit(1);
+    }
 
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
   if (!g4hit)
@@ -227,7 +233,10 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         cout << "  world exit  point position: " << hiter->second->get_x(1) << " " << hiter->second->get_y(1) << " " << hiter->second->get_z(1) << endl;
         cout << "  local coords of entry point from G4 " << hiter->second->get_local_x(0) << " " << hiter->second->get_local_y(0) << " " << hiter->second->get_local_z(0) << endl;
         TVector3 world_in(hiter->second->get_x(0), hiter->second->get_y(0), hiter->second->get_z(0));
-        TVector3 local_in_check = layergeom->get_local_from_world_coords(stave_number, half_stave_number, module_number, chip_number, world_in);
+	auto hskey = MvtxDefs::genHitSetKey(*layer,stave_number,chip_number,strobe);
+	auto surf = tgeometry->maps().getSiliconSurface(hskey);
+
+        TVector3 local_in_check = layergeom->get_local_from_world_coords(surf, tgeometry, world_in);
         cout << "  local coords of entry point from geom (a check) " << local_in_check.X() << " " << local_in_check.Y() << " " << local_in_check.Z() << endl;
         cout << "  local coords of exit point from G4 " << hiter->second->get_local_x(1) << " " << hiter->second->get_local_y(1) << " " << hiter->second->get_local_z(1) << endl;
         cout << "  local coords of exit point from geom (a check) " << local_out.X() << " " << local_out.Y() << " " << local_out.Z() << endl;
@@ -237,8 +246,11 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       if (Verbosity() > 2)
       {
         // As a check, get the positions of the hit pixels in world coordinates from the geo object
-        TVector3 location_in = layergeom->get_world_from_local_coords(stave_number, half_stave_number, module_number, chip_number, local_in);
-        TVector3 location_out = layergeom->get_world_from_local_coords(stave_number, half_stave_number, module_number, chip_number, local_out);
+	auto hskey = MvtxDefs::genHitSetKey(*layer,stave_number,chip_number,strobe);
+	auto surf = tgeometry->maps().getSiliconSurface(hskey);
+
+        TVector3 location_in = layergeom->get_world_from_local_coords(surf,tgeometry, local_in);
+        TVector3 location_out = layergeom->get_world_from_local_coords(surf,tgeometry, local_out);
 
         cout << endl
              << "      PHG4MvtxHitReco:  Found world entry location from geometry for  "

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -226,7 +226,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
       TVector3 local_out(hiter->second->get_local_x(1), hiter->second->get_local_y(1), hiter->second->get_local_z(1));
       TVector3 midpoint((local_in.X() + local_out.X()) / 2.0, (local_in.Y() + local_out.Y()) / 2.0, (local_in.Z() + local_out.Z()) / 2.0);
 
-      if (Verbosity() > -1)
+      if (Verbosity() > 2)
       {
         cout << endl
              << "  world entry point position: " << hiter->second->get_x(0) << " " << hiter->second->get_y(0) << " " << hiter->second->get_z(0) << endl;
@@ -235,7 +235,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
         TVector3 world_in(hiter->second->get_x(0), hiter->second->get_y(0), hiter->second->get_z(0));
 	auto hskey = MvtxDefs::genHitSetKey(*layer,stave_number,chip_number,strobe);
 	auto surf = tgeometry->maps().getSiliconSurface(hskey);
-	std::cout << "Global is " << world_in.X() << ", " << world_in.Y() << ", " << world_in.Z() << std::endl;
+
         TVector3 local_in_check = layergeom->get_local_from_world_coords(surf, tgeometry, world_in);
         cout << "  local coords of entry point from geom (a check) " << local_in_check.X() << " " << local_in_check.Y() << " " << local_in_check.Z() << endl;
         cout << "  local coords of exit point from G4 " << hiter->second->get_local_x(1) << " " << hiter->second->get_local_y(1) << " " << hiter->second->get_local_z(1) << endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR moves the silicon cylinder geometry classes to call Acts for transformations instead of use their own defined transforms. This will be necessary for alignment as the Acts surfaces will contain the alignment info.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

