### PR TITLE
Track Timing Fix

### DIFF
--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -68,7 +68,7 @@ TVector3 CylinderGeomMicromegas::get_local_from_world_vect( uint tileid, ActsGeo
     world_vect.y()*Acts::UnitConstants::cm,
     world_vect.z()*Acts::UnitConstants::cm );
 
-  const auto local = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3()).inverse()*global;
+  const Acts::Vector3 local = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3()).inverse()*global;
   return TVector3(
     local.x()/Acts::UnitConstants::cm,
     local.y()/Acts::UnitConstants::cm,
@@ -127,7 +127,7 @@ TVector3 CylinderGeomMicromegas::get_world_from_local_vect( uint tileid, ActsGeo
     local_vect.y()*Acts::UnitConstants::cm,
     local_vect.z()*Acts::UnitConstants::cm );
 
-  const auto global = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3())*local;
+  const Acts::Vector3 global = surface->referenceFrame(geometry->geometry().geoContext, Acts::Vector3(), Acts::Vector3())*local;
   return TVector3(
     global.x()/Acts::UnitConstants::cm,
     global.y()/Acts::UnitConstants::cm,

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -136,10 +136,9 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   TrkrDefs::subsurfkey& subsurfkey) const
 {
   unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-  auto tpcmap = maps().m_tpcSurfaceMap;
-  auto mapIter = tpcmap.find(layer);
+  auto mapIter = maps().m_tpcSurfaceMap.find(layer);
   
-  if(mapIter == tpcmap.end())
+  if(mapIter == maps().m_tpcSurfaceMap.end())
     {
       std::cout << "Error: hitsetkey not found in ActsGeometry::get_tpc_surface_from_coords, hitsetkey = "
 		<< hitsetkey << std::endl;

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -12,15 +12,15 @@ class ActsGeometry {
   ActsGeometry() = default;
   ~ActsGeometry() {} 
 
-  void setGeometry(const ActsTrackingGeometry tGeometry) 
+  void setGeometry(const ActsTrackingGeometry& tGeometry) 
     { m_tGeometry = tGeometry; }
 
-  void setSurfMaps(const ActsSurfaceMaps surfMaps)
+  void setSurfMaps(const ActsSurfaceMaps& surfMaps)
     { m_surfMaps = surfMaps; }
   
-  ActsTrackingGeometry geometry() const 
+  const ActsTrackingGeometry& geometry() const 
     { return m_tGeometry; }
-  ActsSurfaceMaps maps() const 
+  const ActsSurfaceMaps& maps() const 
     { return m_surfMaps; }
 
   void set_drift_velocity(double vd) {_drift_velocity = vd;}

--- a/simulation/g4simulation/g4eval/DSTEmulator.cc
+++ b/simulation/g4simulation/g4eval/DSTEmulator.cc
@@ -724,8 +724,7 @@ void DSTEmulator::evaluate_tracks()
     //    TrkrDefs::subsurfkey subsurfkey = cluster->getSubSurfKey();
 
     //    std::cout << " subsurfkey: " << subsurfkey << std::endl;
-    std::map<unsigned int, std::vector<Surface>>::iterator mapIter;
-    mapIter = m_tGeometry->maps().m_tpcSurfaceMap.find(layer);
+    auto mapIter = m_tGeometry->maps().m_tpcSurfaceMap.find(layer);
     
     if(mapIter == m_tGeometry->maps().m_tpcSurfaceMap.end()){
       std::cout << PHWHERE 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes the track timing issue I inadvertently introduced with `const ref` accessors. This also pulled up a few other compilation issues, which required fixing (e.g. in the micromegas cylinders Eigen could apparently not deduce what `auto` was referring to at compile time and thought that the vector might go uninitialized, and declaring it explicitly as `Acts::Vector3` seems to make gcc happy).

Thanks to Jin and Jenkins for finding the issue, and to Hugo for pointing out that I made some mistake on the first attempt at using const ref accessors


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

