### PR TITLE
put cppcheck suppression for false positive back

### DIFF
--- a/offline/framework/fun4all/Fun4AllMonitoring.cc
+++ b/offline/framework/fun4all/Fun4AllMonitoring.cc
@@ -85,7 +85,7 @@ void Fun4AllMonitoring::Get_Memory()
       tokenizer::iterator tok_iter = tok.begin();
       if ((*tok_iter).find("Pss") != std::string::npos)
       {
-        tok_iter++;
+        ++tok_iter;
         std::string number = *tok_iter;
         boost::trim(number);
         if (libraryname.find("[heap]") != std::string::npos)

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
@@ -149,6 +149,8 @@ bool PHG4ZDCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
           //calculate incidence angle
           const G4DynamicParticle* dypar = aTrack->GetDynamicParticle();
           G4ThreeVector pdirect = dypar->GetMomentumDirection();
+// this triggers cppcheck, the code is good and the warning is suppressed
+// cppcheck-suppress duplicateAssignExpression
           double dy = sqrt(2) / 2.;
           double dz = sqrt(2) / 2.;
           if (idx_j == 1) dz = -dz;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR put the suppression of a known false positive for cppcheck in simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc back. Running jenkins to establish a new baseline for cppcheck warnings
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

