### PR TITLE
Revert "TPC cluster transform simplification"

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -384,11 +384,34 @@ namespace
       // SAMPA shaping bias correction
       clust = clust + my_data.sampa_tbias;
 
-      /// convert to Acts units
-      global *= Acts::UnitConstants::cm;
-      Acts::Vector3 local = surface->transform(my_data.tGeometry->geometry().geoContext).inverse() * global;
+      Acts::Vector3 center = surface->center(my_data.tGeometry->geometry().geoContext)/Acts::UnitConstants::cm;
+  
+      // no conversion needed, only used in acts
+      Acts::Vector3 normal = surface->normal(my_data.tGeometry->geometry().geoContext);
+      double clusRadius = sqrt(clusx * clusx + clusy * clusy);
+      double rClusPhi = clusRadius * clusphi;
+      double surfRadius = sqrt(center(0)*center(0) + center(1)*center(1));
+      double surfPhiCenter = atan2(center[1], center[0]);
+      double surfRphiCenter = surfPhiCenter * surfRadius;
+      double surfZCenter = center[2];
+     
+      auto local = surface->globalToLocal(my_data.tGeometry->geometry().geoContext,
+					  global * Acts::UnitConstants::cm,
+					  normal);
+      Acts::Vector2 localPos;
 
-      local /= Acts::UnitConstants::cm;     
+      // Prefer Acts transformation since we build the TPC surfaces manually
+      if(local.ok())
+	{
+	  localPos = local.value() / Acts::UnitConstants::cm;
+	}
+      else
+	{
+	  /// otherwise take the manual calculation
+	  localPos(0) = rClusPhi - surfRphiCenter;
+	  localPos(1) = clusz - surfZCenter; 
+	}
+      
       
       // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
       
@@ -400,7 +423,7 @@ namespace
 	//auto clus = std::make_unique<TrkrClusterv3>();
 	clus->setAdc(adc_sum);      
 	clus->setSubSurfKey(subsurfkey);      
-	clus->setLocalX(local(0));
+	clus->setLocalX(localPos(0));
 	clus->setLocalY(clust);
 	clus->setActsLocalError(0,0, phi_err_square);
 	clus->setActsLocalError(1,0, 0);
@@ -416,7 +439,7 @@ namespace
 	clus->setPhiSize(phisize);
 	clus->setZSize(tsize);
 	clus->setSubSurfKey(subsurfkey);      
-	clus->setLocalX(local(0));
+	clus->setLocalX(localPos(0));
 	clus->setLocalY(clust);
 	my_data.cluster_vector.push_back(clus);
 	

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -428,7 +428,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 //___________________________________________________________________________________
 SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
 					      ActsExamples::MeasurementContainer& measurements,
-					      short int crossing )
+				   short int crossing )
 {
 
   SourceLinkVec sourcelinks;
@@ -507,7 +507,20 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       Acts::Vector3 global = global_moved[i].second;
    
       auto cluster = m_clusterContainer->findCluster(cluskey);
-      Surface surf = m_tGeometry->maps().getSurface(cluskey, cluster);
+      Surface surf;
+      if(TrkrDefs::getTrkrId(cluskey) == TrkrDefs::tpcId)
+	{ 
+	  /// Take into account any movement from distortions
+	  auto subsurfkey = cluster->getSubSurfKey();
+        
+	  surf = m_tGeometry->get_tpc_surface_from_coords(
+            TrkrDefs::getHitSetKeyFromClusKey(cluskey), 
+	    global, subsurfkey);
+	}
+      else
+	{
+	  surf = m_tGeometry->maps().getSurface(cluskey, cluster);
+	}
    
       if(!surf)
 	{ continue; }
@@ -515,21 +528,29 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       // get local coordinates
       Acts::Vector2 localPos;
       Acts::Vector3 normal = surf->normal(m_tGeometry->geometry().geoContext);
-      global *= Acts::UnitConstants::cm;
       auto local = surf->globalToLocal(m_tGeometry->geometry().geoContext,
-				       global, normal);
+				       global * Acts::UnitConstants::cm,
+				       normal);
      
-      /// silicon
       if(local.ok())
-	{ localPos = local.value() / Acts::UnitConstants::cm; }
+	{
+	  localPos = local.value() / Acts::UnitConstants::cm;
+	}
       else
 	{
-	  /// tpc 
-	  Acts::Vector3 loct = surf->transform(m_tGeometry->geometry().geoContext).inverse() * global;
-	  loct /= Acts::UnitConstants::cm;
-
-	  localPos(0) = loct(0);
-	  localPos(1) = loct(2);
+	  /// otherwise take the manual calculation
+	  Acts::Vector3 center = surf->center(m_tGeometry->geometry().geoContext)/Acts::UnitConstants::cm;
+	 
+	  double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
+	  double clusphi = atan2(global[1], global[0]);
+	  double rClusPhi = clusRadius * clusphi;
+	  double surfRadius = sqrt(center(0)*center(0) + center(1)*center(1));
+	  double surfPhiCenter = atan2(center[1], center[0]);
+	  double surfRphiCenter = surfPhiCenter * surfRadius;
+	  double surfZCenter = center[2];
+	  
+	  localPos(0) = rClusPhi - surfRphiCenter;
+	  localPos(1) = global[2] - surfZCenter; 
 	}
       
       if(Verbosity() > 0)
@@ -576,7 +597,9 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       
       sourcelinks.push_back(sl);
       measurements.push_back(meas);
+ 
     }
+  
     
   return sourcelinks;
 }


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/coresoftware#1572

https://nbviewer.org/github/sPHENIX-Collaboration/QA-gallery/blob/jenkins-sPHENIX-test-tracking-low-occupancy-qa-2271-test-tracking_Event1000_Sum16/QA-vertexing.ipynb

This PR somehow screwed up the number of tracks associated to vertices as in the QA. Reverting it for now and will re-check what happened.