### PR TITLE
changed retowering energy distribution to be based shadowed area

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -31,10 +31,11 @@ class RetowerCEMC : public SubsysReco
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
+  void SetEnergyDistribution(int val) { _WEIGHTED_ENERGY_DISTRIBUTION = val; }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
-
+  int _WEIGHTED_ENERGY_DISTRIBUTION;
   int _NETA;
   int _NPHI;
   std::vector<std::vector<float> > _EMCAL_RETOWER_E;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
New feature/bug fix: Modifies the method through which EMCal towers are combined into the inner hcal geometry.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The PR modifies the method through which the EMCal towers are combined and projected into the inner HCal geometry. Instead of simply identifying the closest inner HCal tower and attributing all the energy to that location, a fractional energy distribution method is implemented in eta, which improves uniformity of the retowered energy distribution and better matches reality. This can be turned off with a flag set in the Retowering. This was discussed in the Jet Structure Topical group meeting: https://indico.bnl.gov/event/16455/contributions/65981/attachments/42112/70517/Retowering%20the%20EMCal.pdf

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

