### PR TITLE
add detector specific bunchcrossings pileup window

### DIFF
--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.cc
@@ -164,6 +164,7 @@ int Fun4AllDstPileupInputManager::run(const int nevents)
 
   // create merger node
   Fun4AllDstPileupMerger merger;
+  merger.copyDetectorActiveCrossings(m_DetectorTiming);
   merger.load_nodes(m_dstNode);
 
   // generate background collisions
@@ -386,4 +387,17 @@ readagain:
     goto readagain;
   }
   return 0;
+}
+
+void Fun4AllDstPileupInputManager::setDetectorActiveCrossings(const std::string &name, const int nbcross)
+{
+  setDetectorActiveCrossings(name,-nbcross,nbcross);
+}
+
+void Fun4AllDstPileupInputManager::setDetectorActiveCrossings(const std::string &name, const int min, const int max)
+{
+  std::string nodename = "G4HIT_" + name;
+// compensate that active for one bunch crossign means delta_t = 0
+  m_DetectorTiming.insert(std::make_pair(nodename,std::make_pair(m_time_between_crossings * (min+1), m_time_between_crossings * (max-1))));
+  return;
 }

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -57,6 +57,10 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
     m_tmin = tmin;
     m_tmax = tmax;
   }
+  //! for symmetric windows
+  void setDetectorActiveCrossings(const std::string &name, const int nbcross);
+
+  void setDetectorActiveCrossings(const std::string &name, const int min, const int max);
 
  private:
 
@@ -113,6 +117,8 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   };
 
   std::unique_ptr<gsl_rng, Deleter> m_rng;
+
+  std::map<std::string,std::pair<double,double>> m_DetectorTiming;
 
 };
 

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.cc
@@ -288,7 +288,15 @@ void Fun4AllDstPileupMerger::copy_background_event(PHCompositeNode *dstNode, dou
       std::cout << "Fun4AllDstPileupMerger::copy_background_event - invalid source container " << pair.first << std::endl;
       continue;
     }
-
+    auto detiter = m_DetectorTiming.find(pair.first);
+// apply special  cuts for selected detectors
+    if (detiter != m_DetectorTiming.end())
+    {
+      if (delta_t < detiter->second.first || delta_t > detiter->second.second)
+      {
+	continue;
+      }
+    }
     {
       // hits
       const auto range = container_hit->getHits();

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
@@ -38,6 +38,8 @@ class Fun4AllDstPileupMerger final
   //! time-shift and copy content of source nodes to destination
   void copy_background_event(PHCompositeNode *, double delta_t) const;
 
+  void copyDetectorActiveCrossings(const std::map<std::string,std::pair<double ,double>> &dmap) {m_DetectorTiming = dmap;}
+
   private:
 
   //! hepmc
@@ -49,6 +51,7 @@ class Fun4AllDstPileupMerger final
   //! truth information
   PHG4TruthInfoContainer *m_g4truthinfo = nullptr;
 
+  std::map<std::string,std::pair<double ,double>> m_DetectorTiming;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds detector specific active bunch crossings to the pileup generator. (active for one bc --> 1). This doesn't adjust the truth info, particles with hits which are rejected by the timing cut are still in the truth info

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

