### PR TITLE
Implement the fix suggested by GEANT 4 developers to allow external decayers for heavy flavor particles. 

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -231,6 +231,7 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
 
   if (m_ActiveDecayerFlag)
   {
+    G4HadronicParameters::Instance()->SetEnableBCParticles(false); //Disable the Geant4 built in HF Decay and use external decayers for them
     P6DExtDecayerPhysics *decayer = new P6DExtDecayerPhysics();
     if (m_ActiveForceDecayFlag)
     {
@@ -238,7 +239,6 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     }
     myphysicslist->RegisterPhysics(decayer);
   }
-  G4HadronicParameters::Instance()->SetEnableBCParticles(false); //Disable HF Decay
   myphysicslist->RegisterPhysics(new G4StepLimiterPhysics());
   // initialize cuts so we can ask the world region for it's default
   // cuts to propagate them to other regions in DefineRegions()

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -84,6 +84,7 @@
 #include <Geant4/G4Version.hh>
 #include <Geant4/G4VisExecutive.hh>
 #include <Geant4/G4VisManager.hh>  // for G4VisManager
+#include <G4HadronicParameters.hh> // for G4HadronicParameters
 
 // physics lists
 #include <Geant4/FTFP_BERT.hh>
@@ -237,6 +238,7 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
     }
     myphysicslist->RegisterPhysics(decayer);
   }
+  G4HadronicParameters::Instance()->SetEnableBCParticles(false); //Disable HF Decay
   myphysicslist->RegisterPhysics(new G4StepLimiterPhysics());
   // initialize cuts so we can ask the world region for it's default
   // cuts to propagate them to other regions in DefineRegions()


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

In this change, I added a line G4HadronicParameters::Instance()->SetEnableBCParticles(false) in the PHG4Reco.cc file to allow GEANT to use external decayers for heavy flavor particles by disabling the Geant4 existing decay tables. We have tested the PYTHIA 6 decayer indeed runs for heavy flavor particles with the update. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

