### PR TITLE
Fix field

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellDefs.cc
@@ -95,7 +95,7 @@ PHG4CellDefs::SpacalBinning::get_fiberid(const PHG4CellDefs::keytype key)
 
 // yes the arguments are flipped but it is consistent later on
 // changing this would just be a real headache
-// cppcheck-suppress *
+// cppcheck-suppress funcArgOrderDifferent
 PHG4CellDefs::keytype PHG4CellDefs::ScintillatorSlatBinning::genkey(const unsigned short detid, const unsigned short icolumn, const unsigned short irow)
 {
   PHG4CellDefs::keytype key = generic_16bit_genkey(detid, scintillatorslatbinning, icolumn, irow);

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalField.cc
@@ -58,7 +58,6 @@ void PHG4OuterHcalField::GetFieldValue(const double Point[4], double* Bfield) co
   if (default_field)
   {
     default_field->GetFieldValue(Point, Bfield);
-
     // scale_factor for field component along the plate surface
     double x = Point[0];
     double y = Point[1];
@@ -92,8 +91,7 @@ void PHG4OuterHcalField::GetFieldValue(const double Point[4], double* Bfield) co
       std::cout << "And this is who called it:" << std::endl;
       std::cout << boost::stacktrace::stacktrace();
       std::cout << std::endl;
-      gSystem->Exit(1);
-      exit(1);
+      return;
     }
     // sign definition of tilt_angle is rotation around the -z axis
     const G4Vector3D absorber_dir(cos(atan2(y, x) - tilt_angle),

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalFieldSetup.h
@@ -15,6 +15,8 @@
 
 #include <Geant4/G4Types.hh>  // for G4double, G4int
 
+#include <cmath>
+
 class G4ChordFinder;
 class G4FieldManager;
 class G4Mag_UsualEqRhs;
@@ -108,22 +110,22 @@ class PHG4OuterHcalFieldSetup
   }
 
  private:
-  G4FieldManager* fFieldManagerIron;
-  G4FieldManager* fFieldManagerGap;
-  G4Mag_UsualEqRhs* fEquationIron;
-  G4Mag_UsualEqRhs* fEquationGap;
-  G4ChordFinder* fChordFinderIron;
-  G4ChordFinder* fChordFinderGap;
-  G4MagneticField* fEMfieldIron;
-  G4MagneticField* fEMfieldGap;
-  G4MagIntegratorStepper* fStepperIron;
-  G4MagIntegratorStepper* fStepperGap;
+  G4FieldManager* fFieldManagerIron = nullptr;
+  G4FieldManager* fFieldManagerGap = nullptr;
+  G4Mag_UsualEqRhs* fEquationIron = nullptr;
+  G4Mag_UsualEqRhs* fEquationGap = nullptr;
+  G4ChordFinder* fChordFinderIron = nullptr;
+  G4ChordFinder* fChordFinderGap = nullptr;
+  G4MagneticField* fEMfieldIron = nullptr;
+  G4MagneticField* fEMfieldGap = nullptr;
+  G4MagIntegratorStepper* fStepperIron = nullptr;
+  G4MagIntegratorStepper* fStepperGap = nullptr;
 
-  G4double fMinStep;
+  G4double fMinStep = NAN;
 
-  G4int n_steel_plates;
-  G4double scinti_gap;
-  G4double tilt_angle;
+  G4int n_steel_plates = -1;
+  G4double scinti_gap = NAN;
+  G4double tilt_angle = NAN;
 };
 
 #endif /* PHG4OUTERHCALFIELDSETUP_H_ */

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSteppingAction.cc
@@ -150,7 +150,7 @@ bool PHG4ZDCSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
           const G4DynamicParticle* dypar = aTrack->GetDynamicParticle();
           G4ThreeVector pdirect = dypar->GetMomentumDirection();
 // this triggers cppcheck, the code is good and the warning is suppressed
-// cppcheck-suppress duplicateAssignExpression
+// cppcheck-suppress [duplicateAssignExpression, unmatchedSuppression]
           double dy = sqrt(2) / 2.;
           double dz = sqrt(2) / 2.;
           if (idx_j == 1) dz = -dz;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
We have rare exits in the outer hcal field where the geometry for the gaps doesn't add up. The reason is likely that the field is called also for the envelope. Makes sense - we have air gaps between the scintillators and the steel which should be treated like gaps. The problem is that the envelope extends slightly inside the hcal where the calculation of the gap size doesn't give meaningful results. Now the regular field is returned in these cases. I left the warning printout and we should keep an eye on the coordinates - they do look somewhat nonsensical (way inside the tpc as far as I can tell). But even in this case returning the normal field is the correct answer
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

