### PR TITLE
Update particle flow

### DIFF
--- a/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
+++ b/calibrations/calorimeter/calo_tower_slope/LiteCaloEval.cc
@@ -70,7 +70,7 @@ int LiteCaloEval::InitRun(PHCompositeNode * /*topNode*/)
   if (calotype == LiteCaloEval::HCALIN)
   {
     hcalin_energy_eta = new TH2F("hcalin_energy_eta", "hcalin energy eta", 1000, 0, 100, 240, -1.1, 1.1);
-    hcalin_e_eta_phi = new TH3F("hcalin_e_eta_phi", "hcalin e eta phi", 50, 0, 14, 24, -1.1, 1.1, 64, -3.14159, 3.14159);
+    hcalin_e_eta_phi = new TH3F("hcalin_e_eta_phi", "hcalin e eta phi", 50, 0, 14, 24, -1.1, 1.1, 64, -M_PI, M_PI);
     for (int i = 0; i < 24; i++)
     {
       for (int j = 0; j < 64; j++)
@@ -91,7 +91,7 @@ int LiteCaloEval::InitRun(PHCompositeNode * /*topNode*/)
   else if (calotype == LiteCaloEval::HCALOUT)
   {
     hcalout_energy_eta = new TH2F("hcalout_energy_eta", "hcalout energy eta", 100, 0, 10, 240, -1.1, 1.1);
-    hcalout_e_eta_phi = new TH3F("hcalout_e_eta_phi", "hcalout e eta phi", 48, 0, 10, 24, -1.1, 1.1, 64, -3.14159, 3.14159);
+    hcalout_e_eta_phi = new TH3F("hcalout_e_eta_phi", "hcalout e eta phi", 48, 0, 10, 24, -1.1, 1.1, 64, -M_PI, M_PI);
     for (int i = 0; i < 24; i++)
     {
       for (int j = 0; j < 64; j++)
@@ -147,7 +147,7 @@ int LiteCaloEval::InitRun(PHCompositeNode * /*topNode*/)
     energy_eta_hist = new TH2F("energy_eta_hist", "energy eta and all phi", 512, 0, 10, 960, -1.15, 1.15);
 
     //make 3d histo
-    e_eta_phi = new TH3F("e_eta_phi", "e v eta v phi", 50, 0, 10, 192, -1.1335, 1.13350, 256, -3.14159, 3.14159);
+    e_eta_phi = new TH3F("e_eta_phi", "e v eta v phi", 50, 0, 10, 192, -1.1335, 1.13350, 256, -M_PI, M_PI);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/CaloReco/RawClusterBuilderTopo.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.cc
@@ -30,6 +30,7 @@
 #include <list>
 
 #include <algorithm>
+#include <cmath>
 
 bool sort_by_pair_second( const std::pair<int,float> &a,  const std::pair<int,float> &b) 
 { 
@@ -58,8 +59,8 @@ float RawClusterBuilderTopo::calculate_dR( float eta1, float eta2, float phi1, f
 
   float deta = eta1 - eta2;
   float dphi = phi1 - phi2;
-  while ( dphi > 3.14159 ) dphi -= 2 * 3.14159;
-  while ( dphi < -3.14159 ) dphi += 2 * 3.14159;
+  while ( dphi > M_PI ) dphi -= 2 * M_PI;
+  while ( dphi < -M_PI ) dphi += 2 * M_PI;
   return sqrt( pow( deta, 2 ) + pow( dphi ,2 ) );
 
 }
@@ -760,7 +761,7 @@ int RawClusterBuilderTopo::process_event(PHCompositeNode *topNode)
       if ( get_ilayer_from_ID( this_LM.first ) == 2 ) continue;
 
       float this_phi = _geom_containers[ get_ilayer_from_ID( this_LM.first ) ]->get_phicenter( get_iphi_from_ID( this_LM.first ) );
-      if ( this_phi > 3.14159 ) this_phi -= 2 * 3.14159;
+      if ( this_phi > M_PI ) this_phi -= 2 * M_PI;
       float this_eta = _geom_containers[ get_ilayer_from_ID( this_LM.first ) ]->get_etacenter( get_ieta_from_ID( this_LM.first ) );
 
       bool has_EM_overlap = false;
@@ -775,7 +776,7 @@ int RawClusterBuilderTopo::process_event(PHCompositeNode *topNode)
 	if ( get_ilayer_from_ID( this_LM2.first ) != 2 ) continue;
 
 	float this_phi2 = _geom_containers[ get_ilayer_from_ID( this_LM2.first ) ]->get_phicenter( get_iphi_from_ID( this_LM2.first ) );
-	if ( this_phi2 > 3.14159 ) this_phi -= 2 * 3.14159;
+	if ( this_phi2 > M_PI ) this_phi -= 2 * M_PI;
 	float this_eta2 = _geom_containers[ get_ilayer_from_ID( this_LM2.first ) ]->get_etacenter( get_ieta_from_ID( this_LM2.first ) );
 
 	// calculate geometric dR
@@ -807,7 +808,7 @@ int RawClusterBuilderTopo::process_event(PHCompositeNode *topNode)
 	int tower_ID = this_LM.first;
 	std::cout << "RawClusterBuilderTopo::process_event in cluster " << cl << ", tower ID " << tower_ID << " is LOCAL MAXIMUM with layer / E = " << get_ilayer_from_ID( tower_ID ) << " / " << get_E_from_ID( tower_ID ) << ", ";
 	float this_phi = _geom_containers[ get_ilayer_from_ID( tower_ID ) ]->get_phicenter( get_iphi_from_ID( tower_ID ) );
-	if ( this_phi > 3.14159 ) this_phi -= 2 * 3.14159;
+	if ( this_phi > M_PI ) this_phi -= 2 * M_PI;
 	std::cout << " eta / phi = " << _geom_containers[ get_ilayer_from_ID( tower_ID ) ]->get_etacenter( get_ieta_from_ID( tower_ID ) ) << " / " << this_phi << std::endl;
       }
       

--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -370,7 +370,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   {
     if (Verbosity() > 0)
     {
-      std::cout << "DetermineTowerBackground::process_event: flow not enabled, setting Psi2 = " << _Psi2 << " ( " << _Psi2 / 3.14159 << " * pi ) , v2 = " << _v2 << std::endl;
+      std::cout << "DetermineTowerBackground::process_event: flow not enabled, setting Psi2 = " << _Psi2 << " ( " << _Psi2 / M_PI << " * pi ) , v2 = " << _v2 << std::endl;
     }
   }
 
@@ -400,8 +400,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
           {
             float deta = this_eta - _seed_eta[iseed];
             float dphi = this_phi - _seed_phi[iseed];
-            if (dphi > 3.14159) dphi -= 2 * 3.14159;
-            if (dphi < -3.14159) dphi += 2 * 3.14159;
+            if (dphi > M_PI) dphi -= 2 * M_PI;
+            if (dphi < -M_PI) dphi += 2 * M_PI;
             float dR = sqrt(pow(deta, 2) + pow(dphi, 2));
             if (dR < 0.4)
             {
@@ -511,7 +511,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
         _Psi2 = atan2(Hijing_Qy, Hijing_Qx) / 2.0;
 
         if (Verbosity() > 0)
-          std::cout << "DetermineTowerBackground::process_event: flow extracted from Hijing truth particles, setting Psi2 = " << _Psi2 << " ( " << _Psi2 / 3.14159 << " * pi ) " << std::endl;
+          std::cout << "DetermineTowerBackground::process_event: flow extracted from Hijing truth particles, setting Psi2 = " << _Psi2 << " ( " << _Psi2 / M_PI << " * pi ) " << std::endl;
       }
 
       // determine v2 from calo regardless of origin of Psi2
@@ -537,7 +537,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     if (Verbosity() > 0)
     {
       std::cout << "DetermineTowerBackground::process_event: unnormalized Q vector (Qx, Qy) = ( " << Q_x << ", " << Q_y << " ) with Sum E_i = " << E << std::endl;
-      std::cout << "DetermineTowerBackground::process_event: Psi2 = " << _Psi2 << " ( " << _Psi2 / 3.14159 << " * pi " << (_do_flow == 2 ? "from Hijing " : "") << ") , v2 = " << _v2 << " ( using " << _nStrips << " ) " << std::endl;
+      std::cout << "DetermineTowerBackground::process_event: Psi2 = " << _Psi2 << " ( " << _Psi2 / M_PI << " * pi " << (_do_flow == 2 ? "from Hijing " : "") << ") , v2 = " << _v2 << " ( using " << _nStrips << " ) " << std::endl;
     }
   }  // if do flow
 
@@ -566,8 +566,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
         {
           float deta = this_eta - _seed_eta[iseed];
           float dphi = this_phi - _seed_phi[iseed];
-          if (dphi > 3.14159) dphi -= 2 * 3.14159;
-          if (dphi < -3.14159) dphi += 2 * 3.14159;
+          if (dphi > M_PI) dphi -= 2 * M_PI;
+          if (dphi < -M_PI) dphi += 2 * M_PI;
           float dR = sqrt(pow(deta, 2) + pow(dphi, 2));
           if (dR < 0.4)
           {

--- a/offline/packages/particleflow/Makefile.am
+++ b/offline/packages/particleflow/Makefile.am
@@ -52,6 +52,8 @@ libparticleflow_la_LIBADD = \
   -lphg4hit \
   -lg4jets_io \
   -ltrackbase_historic_io \
+  -lCLHEP \
+  -lg4vertex_io \
   -lSubsysReco
 
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -158,7 +158,8 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
   _pflow_HAD_match_TRK.clear();
 
   GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
-  GlobalVertex* vertex = (vertexmap->begin()->second);
+  GlobalVertex* vertex = nullptr;
+
   if(vertexmap)
     {
       if (!vertexmap->empty())

--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -29,6 +29,7 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>  // for gsl_rng_uniform_pos
 
+#include <cmath>
 #include <iostream>
 
 // examine second value of std::pair, sort by smallest
@@ -41,8 +42,8 @@ float ParticleFlowReco::calculate_dR( float eta1, float eta2, float phi1, float 
 
   float deta = eta1 - eta2;
   float dphi = phi1 - phi2;
-  while ( dphi > 3.14159 ) dphi -= 2 * 3.14159;
-  while ( dphi < -3.14159 ) dphi += 2 * 3.14159;
+  while ( dphi > M_PI ) dphi -= 2 * M_PI;
+  while ( dphi < -M_PI ) dphi += 2 * M_PI;
   return sqrt( pow( deta, 2 ) + pow( dphi ,2 ) );
 
 }
@@ -215,7 +216,7 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 	
 	float cluster_phi = hiter->second->get_phi();
 	/// default assume at vx_z = 0
-	float cluster_theta = 3.14159 / 2.0 - atan2( hiter->second->get_z() , hiter->second->get_r() );
+	float cluster_theta = M_PI / 2.0 - atan2( hiter->second->get_z() , hiter->second->get_r() );
 	float cluster_eta = -1 * log( tan( cluster_theta / 2.0 ) );
 	
 	if(vertex)
@@ -270,7 +271,7 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 	
 	float cluster_phi = hiter->second->get_phi();
 	// for now, assume event at vx_z = 0
-	float cluster_theta = 3.14159 / 2.0 - atan2( hiter->second->get_z() , hiter->second->get_r() );
+	float cluster_theta = M_PI / 2.0 - atan2( hiter->second->get_z() , hiter->second->get_r() );
 	float cluster_eta = -1 * log( tan( cluster_theta / 2.0 ) );
 	if(vertex)
 	  {
@@ -354,8 +355,8 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 
 	float deta = tower_eta - _pflow_TRK_eta[ trk ];
 	float dphi = tower_phi - _pflow_TRK_phi[ trk ];
-	if ( dphi > 3.14159 ) dphi -= 2 * 3.14159;
-	if ( dphi < -3.14159 ) dphi += 2 * 3.14159;
+	if ( dphi > M_PI ) dphi -= 2 * M_PI;
+	if ( dphi < -M_PI ) dphi += 2 * M_PI;
 
 	if ( fabs( deta ) < 0.025 * 2.5 && fabs( dphi ) < 0.025 * 2.5 ) {
 	  has_overlap = true;
@@ -432,8 +433,8 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 
 	float deta = tower_eta - _pflow_TRK_eta[ trk ];
 	float dphi = tower_phi - _pflow_TRK_phi[ trk ];
-	if ( dphi > 3.14159 ) dphi -= 2 * 3.14159;
-	if ( dphi < -3.14159 ) dphi += 2 * 3.14159;
+	if ( dphi > M_PI ) dphi -= 2 * M_PI;
+	if ( dphi < -M_PI ) dphi += 2 * M_PI;
 
 	if ( fabs( deta ) < 0.1 * 1.5 && fabs( dphi ) < 0.1 * 1.5 ) {
 	  has_overlap = true;
@@ -506,8 +507,8 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 
 	float deta = tower_eta - _pflow_EM_eta[ em ];
 	float dphi = tower_phi - _pflow_EM_phi[ em ];
-	if ( dphi > 3.14159 ) dphi -= 2 * 3.14159;
-	if ( dphi < -3.14159 ) dphi += 2 * 3.14159;
+	if ( dphi > M_PI ) dphi -= 2 * M_PI;
+	if ( dphi < -M_PI ) dphi += 2 * M_PI;
 
 	if ( fabs( deta ) < 0.1 * 1.5 && fabs( dphi ) < 0.1 * 1.5 ) {
 	  has_overlap = true;

--- a/offline/packages/trackbase/TrkrHitTruthClustersv1.cc
+++ b/offline/packages/trackbase/TrkrHitTruthClustersv1.cc
@@ -10,6 +10,7 @@
 #include "TrkrHitTruthClustersv1.h"
 
 #include <algorithm>
+#include <cmath>
 #include <ostream>               // for operator<<, endl, basic_ostream, bas...
 
 void
@@ -88,7 +89,7 @@ void TrkrHitTruthClustersv1::push_truth_cluster(const int i_track,
     if (phi_std > phiRz_calc[7]) {
         phi_std  = phiRz_calc[7];
         phi_mean = phiRz_calc[6];
-        if (phi_mean > 3.1415926536) phi_mean -= 6.2831853072;
+        if (phi_mean > M_PI) phi_mean -= 2*M_PI;
     }
     phiRz_entry [0] = phi_mean;
     phiRz_entry [1] = phi_std;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -1039,7 +1039,7 @@ TrkrDefs::hitsetkey MakeActsGeometry::getTpcHitSetKeyFromCoords(std::vector<doub
     if(layer == 30)
       std::cout << "   world = " << world[0] << "  " << world[1] 
 		<< "  " << world[2] << " phi_world " 
-		<< phi_world*180/3.14159 << " layer " << layer 
+		<< phi_world*180/M_PI << " layer " << layer
 		<< " readout_mod " << readout_mod << " side " << side 
 		<< " hitsetkey " << hitset_key<< std::endl;
   


### PR DESCRIPTION
Calculate cluster eta with global vertex instead of assuming at z=0

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR:
1. Fixes a stupid bug I introduced that rejected all tracks outside the sPHENIX acceptance
2. Calculates the cluster eta values based on the global vertex rather than assuming a z vertex of 0, if the global vertex is available.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

