### PR TITLE
New hcals

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -52,7 +52,7 @@ PHG4InnerHcalSteppingAction::PHG4InnerHcalSteppingAction(PHG4InnerHcalDetector* 
   , m_Params(parameters)
   , m_IsActive(m_Params->get_int_param("active"))
   , m_IsBlackHole(m_Params->get_int_param("blackhole"))
-  , m_LightScintModel(m_Params->get_int_param("light_scint_model"))
+  , m_LightScintModelFlag(m_Params->get_int_param("light_scint_model"))
 {
   SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
                      m_Params->get_double_param("light_balance_inner_corr"),
@@ -67,25 +67,33 @@ PHG4InnerHcalSteppingAction::~PHG4InnerHcalSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete m_Hit;
+  // since we have a copy in memory of this one - we need to delete it
+  delete m_MapCorrHist;
 }
 
 //____________________________________________________________________________..
 int PHG4InnerHcalSteppingAction::Init()
 {
-  const char* Calibroot = getenv("CALIBRATIONROOT");
-  if (!Calibroot)
+  if (m_LightScintModelFlag)
   {
-    std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
-    gSystem->Exit(1);
-  }
-  std::string ihcalmapname(Calibroot);
-  ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
-  TFile* file = new TFile(ihcalmapname.c_str());
-  file->GetObject("ihcalmapcombined", mapCorr);
-  if (!mapCorr)
-  {
-    std::cout << "ERROR: mapCorr is NULL" << std::endl;
-    gSystem->Exit(1);
+    const char* Calibroot = getenv("CALIBRATIONROOT");
+    if (!Calibroot)
+    {
+      std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
+      gSystem->Exit(1);
+    }
+    std::string ihcalmapname(Calibroot);
+    ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
+    TFile* file = TFile::Open(ihcalmapname.c_str());
+    file->GetObject("ihcalmapcombined", m_MapCorrHist);
+    m_MapCorrHist->SetDirectory(0); // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
+    if (!m_MapCorrHist)
+    {
+      std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
+      gSystem->Exit(1);
+    }
   }
   return 0;
 }
@@ -268,34 +276,34 @@ bool PHG4InnerHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (whichactive > 0)  // return of IsInInnerHcalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
-      if (m_LightScintModel != 2)
+      if (m_LightScintModelFlag != 2)
       {
         m_Hit->set_eion(m_Hit->get_eion() + eion);
         light_yield = eion;
       }
-      if (m_LightScintModel)
+      if (m_LightScintModelFlag)
       {
-        G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
-        G4ThreeVector worldPosition = postPoint->GetPosition();
-        G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
 
         light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
-        float lx = (localPosition.x() / cm);
-        float lz = fabs(localPosition.z() / cm);
-        if (m_LightScintModel == 2)
+        if (m_LightScintModelFlag == 2) // for debugging - save old light yield instead of ionization energy
         {
           m_Hit->set_eion(m_Hit->get_eion() + light_yield);
         }
-        if (mapCorr)
+        if (m_MapCorrHist)
         {
+	  G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
+	  G4ThreeVector worldPosition = postPoint->GetPosition();
+	  G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
+	  float lx = (localPosition.x() / cm);
+	  float lz = fabs(localPosition.z() / cm);
           //adjust to tilemap coordinates
           int lcz = (int) (5.0 * lz) + 1;
           int lcx = (int) (5.0 * (lx + 12.1)) + 1;
 
-          if ((lcx >= 1) && (lcx <= mapCorr->GetNbinsY()) &&
-              (lcz >= 1) && (lcz <= mapCorr->GetNbinsX()))
+          if ((lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsY()) &&
+              (lcz >= 1) && (lcz <= m_MapCorrHist->GetNbinsX()))
           {
-            light_yield *= (double) (mapCorr->GetBinContent(lcz, lcx));
+            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcz, lcx));
           }
           else
           {

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -33,26 +33,29 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4InnerHcalDetector *m_Detector;
+  PHG4InnerHcalDetector *m_Detector = nullptr;
+
+  //! efficiency maps from Mephi
+  TH2 *mapCorr = nullptr;
 
   //! pointer to hit container
-  PHG4HitContainer *m_Hits;
-  PHG4HitContainer *m_AbsorberHits;
-  PHG4Hit *m_Hit;
-  const PHParameters *m_Params;
-  PHG4HitContainer *m_SaveHitContainer;
-  PHG4Shower *m_SaveShower;
-  G4VPhysicalVolume *m_SaveVolPre;
-  G4VPhysicalVolume *m_SaveVolPost;
-  int m_SaveTrackId;
-  int m_SavePreStepStatus;
-  int m_SavePostStepStatus;
+  PHG4HitContainer *m_Hits = nullptr;
+  PHG4HitContainer *m_AbsorberHits = nullptr;
+  PHG4Hit *m_Hit = nullptr;
+  const PHParameters *m_Params = nullptr;
+  PHG4HitContainer *m_SaveHitContainer = nullptr;
+  PHG4Shower *m_SaveShower = nullptr;
+  G4VPhysicalVolume *m_SaveVolPre = nullptr;
+  G4VPhysicalVolume *m_SaveVolPost = nullptr;
+  int m_SaveTrackId = -1;
+  int m_SavePreStepStatus = -1;
+  int m_SavePostStepStatus = -1;
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActive;
-  int m_IsBlackHole;
-  int m_LightScintModel;
+  int m_IsActive = -1;
+  int m_IsBlackHole = -1;
+  int m_LightScintModel = -1;
 };
 
 #endif  // G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.h
@@ -13,6 +13,7 @@ class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class TH2;
 
 class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
 {
@@ -36,7 +37,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   PHG4InnerHcalDetector *m_Detector = nullptr;
 
   //! efficiency maps from Mephi
-  TH2 *mapCorr = nullptr;
+  TH2 *m_MapCorrHist = nullptr;
 
   //! pointer to hit container
   PHG4HitContainer *m_Hits = nullptr;
@@ -55,7 +56,7 @@ class PHG4InnerHcalSteppingAction : public PHG4SteppingAction
   // in the following variables
   int m_IsActive = -1;
   int m_IsBlackHole = -1;
-  int m_LightScintModel = -1;
+  int m_LightScintModelFlag = -1;
 };
 
 #endif  // G4DETECTORS_PHG4INNERHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -43,7 +43,6 @@
 #include <Geant4/G4TouchableHandle.hh>  // for G4TouchableHandle
 #include <Geant4/G4Track.hh>            // for G4Track
 #include <Geant4/G4TrackStatus.hh>      // for fStopAndKill
-//#include <Geant4/G4Transform3D.hh>
 #include <Geant4/G4TransportationManager.hh>
 #include <Geant4/G4Types.hh>                  // for G4double
 #include <Geant4/G4VPhysicalVolume.hh>        // for G4VPhysicalVolume
@@ -59,32 +58,21 @@
 
 class PHCompositeNode;
 
-using namespace std;
-
-TH2* MapCorr = nullptr;
-
 //____________________________________________________________________________..
 PHG4OuterHcalSteppingAction::PHG4OuterHcalSteppingAction(PHG4OuterHcalDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
-  , m_Hits(nullptr)
-  , m_AbsorberHits(nullptr)
-  , m_Hit(nullptr)
   , m_Params(parameters)
-  , m_SaveHitContainer(nullptr)
-  , m_SaveShower(nullptr)
-  , m_SaveVolPre(nullptr)
-  , m_SaveVolPost(nullptr)
-  , m_SaveTrackId(-1)
-  , m_SavePreStepStatus(-1)
-  , m_SavePostStepStatus(-1)
   , m_EnableFieldCheckerFlag(m_Params->get_int_param("field_check"))
   , m_IsActiveFlag(m_Params->get_int_param("active"))
   , m_IsBlackHoleFlag(m_Params->get_int_param("blackhole"))
   , m_NScintiPlates(m_Params->get_int_param(PHG4HcalDefs::scipertwr) * m_Params->get_int_param("n_towers"))
   , m_LightScintModelFlag(m_Params->get_int_param("light_scint_model"))
 {
-  SetName(m_Detector->GetName());
+  SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
+                     m_Params->get_double_param("light_balance_inner_corr"),
+                     m_Params->get_double_param("light_balance_outer_radius") * cm,
+                     m_Params->get_double_param("light_balance_outer_corr"));
 }
 
 PHG4OuterHcalSteppingAction::~PHG4OuterHcalSteppingAction()
@@ -94,38 +82,34 @@ PHG4OuterHcalSteppingAction::~PHG4OuterHcalSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete m_Hit;
+  // since we have a copy in memory of this one - we need to delete it
+  delete m_MapCorrHist;
 }
 
 int PHG4OuterHcalSteppingAction::Init()
 {
   m_EnableFieldCheckerFlag = m_Params->get_int_param("field_check");
-  // method in base class for light correction
-  SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
-                     m_Params->get_double_param("light_balance_inner_corr"),
-                     m_Params->get_double_param("light_balance_outer_radius") * cm,
-                     m_Params->get_double_param("light_balance_outer_corr"));
-
-  std::ostringstream mappingfilename;
-  const char* calibroot = getenv("CALIBRATIONROOT");
-  if (calibroot)
+  if (m_LightScintModelFlag)
   {
-    mappingfilename << calibroot;
+    const char* Calibroot = getenv("CALIBRATIONROOT");
+    if (!Calibroot)
+    {
+      std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
+      gSystem->Exit(1);
+    }
+    std::string mappingfilename(Calibroot);
+    mappingfilename += "/HCALOUT/tilemap/oHCALMaps092021.root";
+    TFile* file = TFile::Open(mappingfilename.c_str());
+    file->GetObject("hCombinedMap", m_MapCorrHist);
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
+    if (!m_MapCorrHist)
+    {
+      std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
+      gSystem->Exit(1);
+    }
   }
-  else
-  {
-    std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
-    gSystem->Exit(1);
-  }
-
-  mappingfilename << "/HCALOUT/tilemap/oHCALMaps092021.root";
-  TFile* f = new TFile(mappingfilename.str().c_str());
-  MapCorr = (TH2F*) f->Get("hCombinedMap");
-  if (!MapCorr)
-  {
-    std::cout << "ERROR: MapCorr is NULL" << std::endl;
-    gSystem->Exit(1);
-  }
-
   return 0;
 }
 
@@ -159,7 +143,7 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
   int tower_id = -1;
   if (whichactive > 0)  // scintillator
   {
-    pair<int, int> layer_tower = m_Detector->GetLayerTowerId(volume);
+    std::pair<int, int> layer_tower = m_Detector->GetLayerTowerId(volume);
     layer_id = layer_tower.first;
     tower_id = layer_tower.second;
   }
@@ -191,15 +175,15 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // an expensive string compare for every track when we know
     // geantino or chargedgeantino has pid=0
     if (aTrack->GetParticleDefinition()->GetPDGEncoding() == 0 &&
-        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != string::npos)
+        aTrack->GetParticleDefinition()->GetParticleName().find("geantino") != std::string::npos)
     {
       geantino = true;
     }
     G4StepPoint* prePoint = aStep->GetPreStepPoint();
     G4StepPoint* postPoint = aStep->GetPostStepPoint();
-    //       cout << "track id " << aTrack->GetTrackID() << endl;
-    //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
-    //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
+    //       std::cout << "track id " << aTrack->GetTrackID() << std::endl;
+    //       std::cout << "time prepoint: " << prePoint->GetGlobalTime() << std::endl;
+    //       std::cout << "time postpoint: " << postPoint->GetGlobalTime() << std::endl;
 
     switch (prePoint->GetStepStatus())
     {
@@ -210,17 +194,17 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       }
       else
       {
-        cout << GetName() << ": New Hit for  " << endl;
-        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-             << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-             << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-             << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
-        cout << "last track: " << m_SaveTrackId
-             << ", current trackid: " << aTrack->GetTrackID() << endl;
-        cout << "phys pre vol: " << volume->GetName()
-             << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-        cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-             << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+        std::cout << GetName() << ": New Hit for  " << std::endl;
+        std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+                  << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                  << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                  << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+        std::cout << "last track: " << m_SaveTrackId
+                  << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+        std::cout << "phys pre vol: " << volume->GetName()
+                  << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+        std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+                  << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       }
       [[fallthrough]];
     case fGeomBoundary:
@@ -286,27 +270,27 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     // check if this hit was created, if not print out last post step status
     if (!m_Hit || !isfinite(m_Hit->get_x(0)))
     {
-      cout << GetName() << ": hit was not created" << endl;
-      cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << endl;
-      cout << "last track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID() << endl;
-      cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-      cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-           << " previous phys post vol: " << m_SaveVolPost->GetName() << endl;
+      std::cout << GetName() << ": hit was not created" << std::endl;
+      std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+                << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+      std::cout << "last track: " << m_SaveTrackId
+                << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+      std::cout << "phys pre vol: " << volume->GetName()
+                << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+      std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+                << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
       gSystem->Exit(1);
     }
     m_SavePostStepStatus = postPoint->GetStepStatus();
     // check if track id matches the initial one when the hit was created
     if (aTrack->GetTrackID() != m_SaveTrackId)
     {
-      cout << GetName() << ": hits do not belong to the same track" << endl;
-      cout << "saved track: " << m_SaveTrackId
-           << ", current trackid: " << aTrack->GetTrackID()
-           << endl;
+      std::cout << GetName() << ": hits do not belong to the same track" << std::endl;
+      std::cout << "saved track: " << m_SaveTrackId
+                << ", current trackid: " << aTrack->GetTrackID()
+                << std::endl;
       gSystem->Exit(1);
     }
     m_SavePreStepStatus = prePoint->GetStepStatus();
@@ -322,29 +306,28 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
+    //sum up the energy to get total deposited
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
+
     if (whichactive > 0)
     {
-      // Local Coordinates:
-
-      //G4TouchableHandle theTouchable = postPoint->GetTouchableHandle();
-      // Use prePoint; sometimes the end point can be on the boundary/out of the scintillator
-      G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
-      G4ThreeVector worldPosition = postPoint->GetPosition();
-      G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
-
-      // DEBUG
-      // m_Hit->set_property(PHG4Hit::prop_local_x_1, (float)(localPosition.x()/cm));
-      // m_Hit->set_property(PHG4Hit::prop_local_y_1, (float)(localPosition.y()/cm));
-      // m_Hit->set_property(PHG4Hit::prop_local_z_1, (float)(localPosition.z()/cm));
-
-      // m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id);
-
+      if (m_LightScintModelFlag != 2)
+      {
+        m_Hit->set_eion(m_Hit->get_eion() + eion);
+        light_yield = eion;
+      }
       if (m_LightScintModelFlag)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);
-
-        if (MapCorr)
+        if (m_LightScintModelFlag == 2)  // for debugging - save old light yield instead of ionization energy
         {
+          m_Hit->set_eion(m_Hit->get_eion() + light_yield);
+        }
+        if (m_MapCorrHist)
+        {
+          G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
+          G4ThreeVector worldPosition = postPoint->GetPosition();
+          G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
           float lx = (localPosition.x() / cm);
           float lz = fabs(localPosition.z() / cm);  // reverse the sense for towerid<12
 
@@ -353,35 +336,22 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
           int lcz = (int) (2.0 * lz) + 1;
           int lcx = (int) (2.0 * (lx + 42.75)) + 1;
 
-          if ((lcx >= 1) && (lcx <= MapCorr->GetNbinsY()) &&
-              (lcz >= 1) && (lcz <= MapCorr->GetNbinsX()))
+          if ((lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsY()) &&
+              (lcz >= 1) && (lcz <= m_MapCorrHist->GetNbinsX()))
           {
-            light_yield *= (double) (MapCorr->GetBinContent(lcz, lcx));
+            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcz, lcx));
           }
           else
           {
             light_yield = 0.0;
           }
         }
+        else
+        {
+          // old correction (linear ligh yield dependence along r), never tested
+          light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), postPoint->GetPosition().y());
+        }
       }
-      else
-      {
-        light_yield = eion;
-      }
-
-      if (ValidCorrection())
-      {
-        double cor = GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
-        cout << "applying cor: " << cor << endl;
-        light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
-      }
-    }
-
-    //sum up the energy to get total deposited
-    m_Hit->set_edep(m_Hit->get_edep() + edep);
-    if (whichactive > 0)
-    {
-      m_Hit->set_eion(m_Hit->get_eion() + eion);
       m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
     if (geantino)
@@ -445,8 +415,8 @@ bool PHG4OuterHcalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 //____________________________________________________________________________..
 void PHG4OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
 {
-  string hitnodename;
-  string absorbernodename;
+  std::string hitnodename;
+  std::string absorbernodename;
   if (m_Detector->SuperDetector() != "NONE")
   {
     hitnodename = "G4HIT_" + m_Detector->SuperDetector();
@@ -471,7 +441,7 @@ void PHG4OuterHcalSteppingAction::SetInterfacePointers(PHCompositeNode* topNode)
   {
     if (Verbosity() > 1)
     {
-      cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << endl;
+      std::cout << "PHG4HcalSteppingAction::SetTopNode - unable to find " << absorbernodename << std::endl;
     }
   }
 }
@@ -481,17 +451,17 @@ void PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
   Fun4AllServer* se = Fun4AllServer::instance();
   assert(se);
 
-  static const string h_field_name = "hOuterHcalField";
+  static const std::string h_field_name = "hOuterHcalField";
 
   if (not se->isHistoRegistered(h_field_name))
   {
     TH2* h = new TH2F(h_field_name.c_str(), "Magnetic field (Tesla) in HCal;X (cm);Y (cm)", 2400,
-                       -300, 300, 2400, -300, 300);
+                      -300, 300, 2400, -300, 300);
 
     se->registerHisto(h, 1);
 
-    cout << "PHG4OuterHcalSteppingAction::FieldChecker - make a histograme to check outer Hcal field map."
-         << " Saved to Fun4AllServer Histo with name " << h_field_name << endl;
+    std::cout << "PHG4OuterHcalSteppingAction::FieldChecker - make a histograme to check outer Hcal field map."
+              << " Saved to Fun4AllServer Histo with name " << h_field_name << std::endl;
   }
 
   TH2* h = dynamic_cast<TH2F*>(se->getHisto(h_field_name));
@@ -543,9 +513,9 @@ void PHG4OuterHcalSteppingAction::FieldChecker(const G4Step* aStep)
 
     h->SetBinContent(binx, biny, B);
 
-    cout << "PHG4OuterHcalSteppingAction::FieldChecker - "
-         << "bin " << binx
-         << ", " << biny << " := " << B << " Tesla @ x,y = " << globPosVec[0] / cm
-         << "," << globPosVec[1] / cm << " cm" << endl;
+    std::cout << "PHG4OuterHcalSteppingAction::FieldChecker - "
+              << "bin " << binx
+              << ", " << biny << " := " << B << " Tesla @ x,y = " << globPosVec[0] / cm
+              << "," << globPosVec[1] / cm << " cm" << std::endl;
   }
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.h
@@ -13,6 +13,7 @@ class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class TH2;
 
 class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
 {
@@ -36,29 +37,32 @@ class PHG4OuterHcalSteppingAction : public PHG4SteppingAction
 
  private:
   //! pointer to the detector
-  PHG4OuterHcalDetector *m_Detector;
+  PHG4OuterHcalDetector *m_Detector = nullptr;
+
+  //! efficiency maps from Mephi
+  TH2 *m_MapCorrHist = nullptr;
 
   //! pointer to hit container
-  PHG4HitContainer *m_Hits;
-  PHG4HitContainer *m_AbsorberHits;
-  PHG4Hit *m_Hit;
-  const PHParameters *m_Params;
-  PHG4HitContainer *m_SaveHitContainer;
-  PHG4Shower *m_SaveShower;
-  G4VPhysicalVolume *m_SaveVolPre;
-  G4VPhysicalVolume *m_SaveVolPost;
-  int m_SaveTrackId;
-  int m_SavePreStepStatus;
-  int m_SavePostStepStatus;
-  int m_EnableFieldCheckerFlag;
+  PHG4HitContainer *m_Hits = nullptr;
+  PHG4HitContainer *m_AbsorberHits = nullptr;
+  PHG4Hit *m_Hit = nullptr;
+  const PHParameters *m_Params = nullptr;
+  PHG4HitContainer *m_SaveHitContainer = nullptr;
+  PHG4Shower *m_SaveShower = nullptr;
+  G4VPhysicalVolume *m_SaveVolPre = nullptr;
+  G4VPhysicalVolume *m_SaveVolPost = nullptr;
+  int m_SaveTrackId = -1;
+  int m_SavePreStepStatus = -1;
+  int m_SavePostStepStatus = -1;
+  int m_EnableFieldCheckerFlag = -1;
 
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActiveFlag;
-  int m_IsBlackHoleFlag;
-  int m_NScintiPlates;
-  int m_LightScintModelFlag;
+  int m_IsActiveFlag = -1;
+  int m_IsBlackHoleFlag = -1;
+  int m_NScintiPlates = -1;
+  int m_LightScintModelFlag = 0;
 };
 
 #endif  // G4DETECTORS_PHG4OUTERHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -381,19 +381,13 @@ int PHG4IHCalDetector::map_layerid(const int layer_id)
   {
     rowid = 60 - layer_id;
   }
-  else if (layer_id > 60 && layer_id <= 191)
+  else if (layer_id <= 191)
   {
     rowid = 191 - layer_id + 125;
   }
-  else if (layer_id > 191)
-  {
-    rowid = 255 - layer_id + 61;
-  }
   else
   {
-    std::cout << PHWHERE << " cannot map layer " << layer_id << std::endl;
-    gSystem->Exit(1);
-    exit(1);
+    rowid = 255 - layer_id + 61;
   }
   return rowid;
 }

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -46,7 +46,6 @@
 
 class PHCompositeNode;
 
-TH2F* mapCorr = nullptr;
 //____________________________________________________________________________..
 PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
@@ -54,7 +53,7 @@ PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, co
   , m_Params(parameters)
   , m_IsActive(m_Params->get_int_param("active"))
   , m_IsBlackHole(m_Params->get_int_param("blackhole"))
-  , m_LightScintModel(m_Params->get_int_param("light_scint_model"))
+  , m_LightScintModelFlag(m_Params->get_int_param("light_scint_model"))
 {
   SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
                      m_Params->get_double_param("light_balance_inner_corr"),
@@ -69,30 +68,33 @@ PHG4IHCalSteppingAction::~PHG4IHCalSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete m_Hit;
+  // since we have a copy in memory of this one - we need to delete it
+  delete m_MapCorrHist;
 }
 
 //____________________________________________________________________________..
 int PHG4IHCalSteppingAction::Init()
 {
-  std::ostringstream ihcalmapname;
-  const char* Calibroot = getenv("CALIBRATIONROOT");
-  if (Calibroot)
+  if (m_LightScintModelFlag)
   {
-    ihcalmapname << Calibroot;
-  }
-  else
-  {
-    std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
-    gSystem->Exit(1);
-  }
-
-  ihcalmapname << "/HCALIN/tilemap/iHCALMapsNorm020922.root";
-  TFile* file = new TFile(ihcalmapname.str().c_str());
-  mapCorr = (TH2F*) file->Get("ihcalmapcombined");
-  if (!mapCorr)
-  {
-    std::cout << "ERROR: mapCorr is NULL" << std::endl;
-    gSystem->Exit(1);
+    const char* Calibroot = getenv("CALIBRATIONROOT");
+    if (!Calibroot)
+    {
+      std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
+      gSystem->Exit(1);
+    }
+    std::string ihcalmapname(Calibroot);
+    ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
+    TFile* file = TFile::Open(ihcalmapname.c_str());
+    file->GetObject("ihcalmapcombined", m_MapCorrHist);
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
+    if (!m_MapCorrHist)
+    {
+      std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
+      gSystem->Exit(1);
+    }
   }
   return 0;
 }
@@ -278,37 +280,46 @@ bool PHG4IHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     m_Hit->set_edep(m_Hit->get_edep() + edep);
     if (whichactive > 0)  // return of IsInIHCalDetector, > 0 hit in scintillator, < 0 hit in absorber
     {
-      G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
-      G4ThreeVector worldPosition = postPoint->GetPosition();
-      G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
-
-      m_Hit->set_eion(m_Hit->get_eion() + eion);
-      light_yield = eion;
-
-      if (m_LightScintModel)
+      if (m_LightScintModelFlag != 2)
+      {
+        m_Hit->set_eion(m_Hit->get_eion() + eion);
+        light_yield = eion;
+      }
+      if (m_LightScintModelFlag)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);  // for scintillator only, calculate light yields
-        float lx = (localPosition.x() / cm);
-        float lz = fabs(localPosition.z() / cm);
-
-        if (mapCorr)
+        if (m_LightScintModelFlag == 2)                   // for debugging - save old light yield instead of ionization energy
         {
+          m_Hit->set_eion(m_Hit->get_eion() + light_yield);
+        }
+
+        if (m_MapCorrHist)
+        {
+          G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
+          G4ThreeVector worldPosition = postPoint->GetPosition();
+          G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
+          float lx = (localPosition.x() / cm);
+          float lz = fabs(localPosition.z() / cm);
+
           //adjust to tilemap coordinates
           int lcz = (int) (5.0 * lz) + 1;
           int lcx = (int) (5.0 * (lx + 12.1)) + 1;
 
-          if ((lcx >= 1) && (lcx <= mapCorr->GetNbinsY()) &&
-              (lcz >= 1) && (lcz <= mapCorr->GetNbinsX()))
+          if ((lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsY()) &&
+              (lcz >= 1) && (lcz <= m_MapCorrHist->GetNbinsX()))
           {
-            light_yield *= (double) (mapCorr->GetBinContent(lcz, lcx));
+            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcz, lcx));
           }
           else
           {
             light_yield = 0.0;
           }
         }
+        else
+        {
+          light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), postPoint->GetPosition().y());
+        }
       }
-      light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), postPoint->GetPosition().y());
       m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
     if (geantino)

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
@@ -15,6 +15,7 @@ class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class TH2;
 
 class PHG4IHCalSteppingAction : public PHG4SteppingAction
 {
@@ -39,6 +40,9 @@ class PHG4IHCalSteppingAction : public PHG4SteppingAction
   //! pointer to the detector
   PHG4IHCalDetector *m_Detector = nullptr;
 
+  //! efficiency maps from Mephi
+  TH2 *m_MapCorrHist = nullptr;
+
   //! pointer to hit container
   PHG4HitContainer *m_HitContainer = nullptr;
   PHG4HitContainer *m_AbsorberHitContainer = nullptr;
@@ -56,7 +60,7 @@ class PHG4IHCalSteppingAction : public PHG4SteppingAction
   // in the following variables
   int m_IsActive = 0;
   int m_IsBlackHole = 0;
-  int m_LightScintModel = 0;
+  int m_LightScintModelFlag = 0;
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
 };

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -62,8 +62,6 @@
 
 class PHCompositeNode;
 
-TH2F* MapCorr = nullptr;
-
 //____________________________________________________________________________..
 PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, const PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
@@ -75,7 +73,10 @@ PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, co
   , m_NScintiPlates(m_Params->get_int_param(PHG4HcalDefs::scipertwr) * m_Params->get_int_param("n_towers"))
   , m_LightScintModelFlag(m_Params->get_int_param("light_scint_model"))
 {
-  SetName(m_Detector->GetName());
+  SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
+                     m_Params->get_double_param("light_balance_inner_corr"),
+                     m_Params->get_double_param("light_balance_outer_radius") * cm,
+                     m_Params->get_double_param("light_balance_outer_corr"));
 }
 
 PHG4OHCalSteppingAction::~PHG4OHCalSteppingAction()
@@ -85,38 +86,35 @@ PHG4OHCalSteppingAction::~PHG4OHCalSteppingAction()
   // if the last hit was saved, hit is a nullptr pointer which are
   // legal to delete (it results in a no operation)
   delete m_Hit;
+  // since we have a copy in memory of this one - we need to delete it
+  delete m_MapCorrHist;
 }
 
 int PHG4OHCalSteppingAction::Init()
 {
   m_EnableFieldCheckerFlag = m_Params->get_int_param("field_check");
-  // method in base class for light correction
-  SetLightCorrection(m_Params->get_double_param("light_balance_inner_radius") * cm,
-                     m_Params->get_double_param("light_balance_inner_corr"),
-                     m_Params->get_double_param("light_balance_outer_radius") * cm,
-                     m_Params->get_double_param("light_balance_outer_corr"));
 
-  std::ostringstream mappingfilename;
-  const char* calibroot = getenv("CALIBRATIONROOT");
-  if (calibroot)
+  if (m_LightScintModelFlag)
   {
-    mappingfilename << calibroot;
+    const char* Calibroot = getenv("CALIBRATIONROOT");
+    if (!Calibroot)
+    {
+      std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
+      gSystem->Exit(1);
+    }
+    std::string mappingfilename(Calibroot);
+    mappingfilename += "/HCALOUT/tilemap/oHCALMaps092021.root";
+    TFile* file = TFile::Open(mappingfilename.c_str());
+    file->GetObject("hCombinedMap", m_MapCorrHist);
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
+    if (!m_MapCorrHist)
+    {
+      std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
+      gSystem->Exit(1);
+    }
   }
-  else
-  {
-    std::cout << "no CALIBRATIONROOT environment variable" << std::endl;
-    gSystem->Exit(1);
-  }
-
-  mappingfilename << "/HCALOUT/tilemap/oHCALMaps092021.root";
-  TFile* f = new TFile(mappingfilename.str().c_str());
-  MapCorr = (TH2F*) f->Get("hCombinedMap");
-  if (!MapCorr)
-  {
-    std::cout << "ERROR: MapCorr is NULL" << std::endl;
-    gSystem->Exit(1);
-  }
-
   return 0;
 }
 
@@ -317,29 +315,29 @@ bool PHG4OHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
+    //sum up the energy to get total deposited
+    m_Hit->set_edep(m_Hit->get_edep() + edep);
+
     if (whichactive > 0)
     {
-      // Local Coordinates:
-
-      //G4TouchableHandle theTouchable = postPoint->GetTouchableHandle();
-      // Use prePoint; sometimes the end point can be on the boundary/out of the scintillator
-      G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
-      G4ThreeVector worldPosition = postPoint->GetPosition();
-      G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
-
-      // DEBUG
-      // m_Hit->set_property(PHG4Hit::prop_local_x_1, (float)(localPosition.x()/cm));
-      // m_Hit->set_property(PHG4Hit::prop_local_y_1, (float)(localPosition.y()/cm));
-      // m_Hit->set_property(PHG4Hit::prop_local_z_1, (float)(localPosition.z()/cm));
-
-      // m_Hit->set_property(PHG4Hit::prop_layer, (unsigned int) layer_id);
-
+      if (m_LightScintModelFlag != 2)
+      {
+        m_Hit->set_eion(m_Hit->get_eion() + eion);
+        light_yield = eion;
+      }
       if (m_LightScintModelFlag)
       {
         light_yield = GetVisibleEnergyDeposition(aStep);
 
-        if (MapCorr)
+        if (m_LightScintModelFlag == 2)  // for debugging - save old light yield instead of ionization energy
         {
+          m_Hit->set_eion(m_Hit->get_eion() + light_yield);
+        }
+        if (m_MapCorrHist)
+        {
+          G4TouchableHandle theTouchable = prePoint->GetTouchableHandle();
+          G4ThreeVector worldPosition = postPoint->GetPosition();
+          G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
           float lx = (localPosition.x() / cm);
           float lz = fabs(localPosition.z() / cm);  // reverse the sense for towerid<12
 
@@ -348,37 +346,25 @@ bool PHG4OHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
           int lcz = (int) (2.0 * lz) + 1;
           int lcx = (int) (2.0 * (lx + 42.75)) + 1;
 
-          if ((lcx >= 1) && (lcx <= MapCorr->GetNbinsY()) &&
-              (lcz >= 1) && (lcz <= MapCorr->GetNbinsX()))
+          if ((lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsY()) &&
+              (lcz >= 1) && (lcz <= m_MapCorrHist->GetNbinsX()))
           {
-            light_yield *= (double) (MapCorr->GetBinContent(lcz, lcx));
+            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcz, lcx));
           }
           else
           {
             light_yield = 0.0;
           }
         }
+        else
+        {
+          // old correction (linear ligh yield dependence along r), never tested
+          light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), postPoint->GetPosition().y());
+        }
       }
-      else
-      {
-        light_yield = eion;
-      }
-
-      if (ValidCorrection())
-      {
-        double cor = GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
-        std::cout << "applying cor: " << cor << std::endl;
-        light_yield = light_yield * GetLightCorrection(postPoint->GetPosition().x(), (postPoint->GetPosition().y()));
-      }
-    }
-
-    //sum up the energy to get total deposited
-    m_Hit->set_edep(m_Hit->get_edep() + edep);
-    if (whichactive > 0)
-    {
-      m_Hit->set_eion(m_Hit->get_eion() + eion);
       m_Hit->set_light_yield(m_Hit->get_light_yield() + light_yield);
     }
+
     if (geantino)
     {
       m_Hit->set_edep(-1);  // only energy=0 g4hits get dropped, this way geantinos survive the g4hit compression

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
@@ -15,6 +15,7 @@ class PHParameters;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class TH2;
 
 class PHG4OHCalSteppingAction : public PHG4SteppingAction
 {
@@ -41,6 +42,9 @@ class PHG4OHCalSteppingAction : public PHG4SteppingAction
  private:
   //! pointer to the detector
   PHG4OHCalDetector *m_Detector = nullptr;
+
+  //! efficiency maps from Mephi
+  TH2 *m_MapCorrHist = nullptr;
 
   //! pointer to hit container
   PHG4HitContainer *m_HitContainer = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
The light yield before correction with the Mephi maps can be stored in the ionization energy field if light_scint_model is 2: 
hcal->set_int_param("light_scint_model", 2);
I didn't want to blow up the hcal output even more. Also the root file with those maps is now closed after the histogram is copied to memory (nice rootism with directory setting needed to get this to work). This is implemented for the old and new hcals
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

