### PR TITLE
save raw light yield in cell only if it exists in the PHG4Hit

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -182,7 +182,11 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
     slatarray[irow][icolumn]->add_edep(hiter->second->get_edep());
     slatarray[irow][icolumn]->add_eion(hiter->second->get_eion());
     slatarray[irow][icolumn]->add_light_yield(hiter->second->get_light_yield());
-    slatarray[irow][icolumn]->add_raw_light_yield(hiter->second->get_raw_light_yield());
+    float raw_light = hiter->second->get_raw_light_yield();
+    if (std::isfinite(raw_light))
+    {
+      slatarray[irow][icolumn]->add_raw_light_yield(raw_light);
+    }
     slatarray[irow][icolumn]->add_edep(hiter->first, hiter->second->get_edep());
     slatarray[irow][icolumn]->add_shower_edep(hiter->second->get_shower_id(), hiter->second->get_edep());
   }  // end loop over g4hits


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Store the new raw light yield in cell only if it was set in the PHG4Hits, so old DSTs don't waste space by just filling cells with NAN's
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

