### PR TITLE
Update TPOT strip geometry

### DIFF
--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.cc
@@ -128,7 +128,6 @@ int PHG4MicromegasHitReco::InitRun(PHCompositeNode *topNode)
   m_gain = get_double_param("micromegas_gain");
   m_cloud_sigma = get_double_param("micromegas_cloud_sigma");
   m_diffusion_trans = get_double_param("micromegas_diffusion_trans");
-  m_zigzag_strips = get_int_param("micromegas_zigzag_strips");
 
   // printout
   if( Verbosity() )
@@ -140,7 +139,6 @@ int PHG4MicromegasHitReco::InitRun(PHCompositeNode *topNode)
       << " m_gain: " << m_gain << "\n"
       << " m_cloud_sigma: " << m_cloud_sigma << "cm\n"
       << " m_diffusion_trans: " << m_diffusion_trans << "cm/sqrt(cm)\n"
-      << " m_zigzag_strips: " << std::boolalpha << m_zigzag_strips << "\n"
       << std::endl;
   }
 
@@ -405,9 +403,6 @@ void PHG4MicromegasHitReco::SetDefaultParameters()
 
   // transverse diffusion (cm/sqrt(cm))
   set_default_double_param("micromegas_diffusion_trans", 0.03 );
-  
-  // zigzag strips
-  set_default_int_param("micromegas_zigzag_strips", true );
 }
 
 //___________________________________________________________________________
@@ -466,8 +461,15 @@ PHG4MicromegasHitReco::charge_list_t PHG4MicromegasHitReco::distribute_charge(
       (strip_location.X() - local_coords.X()):
       (strip_location.Y() - local_coords.Y());
 
+    // decide of whether zigzag or straight strips are used depending on segmentation type
+    /*
+     * for the real detector SEGMENTATION_Z view has zigzag strip due to large pitch (2mm)
+     * whereas SEGMENTATION_PHI has straight strips
+     */
+    const bool zigzag_strips = (layergeom->get_segmentation_type() == MicromegasDefs::SegmentationType::SEGMENTATION_Z );
+    
     // calculate charge fraction
-    const auto fraction = m_zigzag_strips ?
+    const auto fraction = zigzag_strips ?
       get_zigzag_fraction( xloc, sigma, pitch ):
       get_rectangular_fraction( xloc, sigma, pitch );
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasHitReco.h
@@ -89,9 +89,6 @@ class PHG4MicromegasHitReco : public SubsysReco, public PHParameterInterface
   //! electron transverse diffusion (cm/sqrt(cm))
   double m_diffusion_trans = 0.03;
 
-  //! use zig zag pads
-  bool m_zigzag_strips = true;
-
   //! rng de-allocator
   class Deleter
   {


### PR DESCRIPTION
removed the possibility to set using zigzag on option
hardcode zigzag for Z view and straight for rphi view
This is consistent with the real detector

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

