### PR TITLE
set XPload flags to some default if not set to prevent crashes

### DIFF
--- a/offline/framework/ffamodules/XploadInterface.cc
+++ b/offline/framework/ffamodules/XploadInterface.cc
@@ -103,26 +103,12 @@ void XploadInterface::Print(const std::string & /* what */) const
   }
 }
 
-std::string XploadInterface::getUrl(const std::string &domain)
-{
-  recoConsts *rc = recoConsts::instance();
-  uint64_t timestamp = rc->get_uint64Flag("TIMESTAMP");
-  xpload::Result result = xpload::fetch(rc->get_StringFlag("XPLOAD_TAG"), domain, timestamp, xpload::Configurator(rc->get_StringFlag("XPLOAD_CONFIG")));
-  auto pret = m_UrlVector.insert(make_tuple(domain, result.payload, timestamp));
-  if (!pret.second && Verbosity() > 1)
-  {
-    std::cout << "duplicate entry " << domain << ", url: " << result.payload
-              << ", time stamp: " << timestamp << std::endl;
-  }
-  return result.payload;
-}
-
 std::string XploadInterface::getUrl(const std::string &domain, const std::string &filename)
 {
   std::string return_url = filename;
   recoConsts *rc = recoConsts::instance();
-  uint64_t timestamp = rc->get_uint64Flag("TIMESTAMP");
-  xpload::Result result = xpload::fetch(rc->get_StringFlag("XPLOAD_TAG"), domain, timestamp, xpload::Configurator(rc->get_StringFlag("XPLOAD_CONFIG")));
+  uint64_t timestamp = rc->get_uint64Flag("TIMESTAMP",12345678912345);
+  xpload::Result result = xpload::fetch(rc->get_StringFlag("XPLOAD_TAG","TEST"), domain, timestamp, xpload::Configurator(rc->get_StringFlag("XPLOAD_CONFIG","sPHENIX_cdb")));
   if (!result.payload.empty())
   {
     return_url = result.payload;

--- a/offline/framework/ffamodules/XploadInterface.h
+++ b/offline/framework/ffamodules/XploadInterface.h
@@ -24,8 +24,7 @@ class XploadInterface : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
-  std::string getUrl(const std::string &domain);
-  std::string getUrl(const std::string &domain, const std::string &filename);
+  std::string getUrl(const std::string &domain, const std::string &filename = "");
 
  private:
   XploadInterface(const std::string &name = "XploadInterface");


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
If the flags related to xpload were not set the lookup fails badly. This PR sets the flags (timestamp, config and global tag) to a working default if they are not set.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

