### PR TITLE
move pointer check ahead of dereferencing it

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -86,14 +86,14 @@ int PHG4InnerHcalSteppingAction::Init()
     ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
     TFile* file = TFile::Open(ihcalmapname.c_str());
     file->GetObject("ihcalmapcombined", m_MapCorrHist);
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
-    file->Close();
-    delete file;
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
       gSystem->Exit(1);
     }
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
   }
   return 0;
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -101,14 +101,14 @@ int PHG4OuterHcalSteppingAction::Init()
     mappingfilename += "/HCALOUT/tilemap/oHCALMaps092021.root";
     TFile* file = TFile::Open(mappingfilename.c_str());
     file->GetObject("hCombinedMap", m_MapCorrHist);
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
-    file->Close();
-    delete file;
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
       gSystem->Exit(1);
     }
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
   }
   return 0;
 }

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -87,14 +87,14 @@ int PHG4IHCalSteppingAction::Init()
     ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
     TFile* file = TFile::Open(ihcalmapname.c_str());
     file->GetObject("ihcalmapcombined", m_MapCorrHist);
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
-    file->Close();
-    delete file;
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
       gSystem->Exit(1);
     }
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
   }
   return 0;
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -106,14 +106,14 @@ int PHG4OHCalSteppingAction::Init()
     mappingfilename += "/HCALOUT/tilemap/oHCALMaps092021.root";
     TFile* file = TFile::Open(mappingfilename.c_str());
     file->GetObject("hCombinedMap", m_MapCorrHist);
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
-    file->Close();
-    delete file;
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
       gSystem->Exit(1);
     }
+    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    file->Close();
+    delete file;
   }
   return 0;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes an issue found by coverity. The check if the histogram with the mephi maps is not a null pointer came after dereferencing the pointer (the code would have crashed here). Now the order is correct - the code will quit gracefully if the histos cannot be loaded

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

