### PR TITLE
Fix Crash in ACTS fit due to invalid starting parameters

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -53,6 +53,12 @@
 #include <iostream>
 #include <vector>
 
+namespace
+{
+  // check vector validity
+  inline bool is_valid( const Acts::Vector3 vec )
+  {  return !( std::isnan( vec.x() ) || std::isnan( vec.y() ) || std::isnan( vec.z() ) ); }  
+}
 
 PHActsTrkFitter::PHActsTrkFitter(const std::string& name)
   : SubsysReco(name)
@@ -273,6 +279,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       position(0) = siseed->get_x() * Acts::UnitConstants::cm;
       position(1) = siseed->get_y() * Acts::UnitConstants::cm;
       position(2) = siseed->get_z() * Acts::UnitConstants::cm;
+      if( !is_valid( position ) ) continue;
 
       if(sourceLinks.size() == 0) { continue; }
 
@@ -296,6 +303,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	       tpcseed->get_px(m_clusterContainer, m_tGeometry), 
 	       tpcseed->get_py(m_clusterContainer, m_tGeometry),
 	       tpcseed->get_pz());
+      if( !is_valid( momentum ) ) continue;
  
       auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
 					  position);


### PR DESCRIPTION
added validity check on momentum and position to prevent acts fit crash
It can happen when running truth track seeding that either the initial track seed momentum or position contains nan values, which results in the acts fit crashing. 
This PR prevents that by explicitely checking all values and skipping the track when an invalid number is found.
One should still determine the root cause of these "nan" values from the truth track seeding.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

