### PR TITLE
Add code to generate a vector to access the JetMap data.

### DIFF
--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -50,6 +50,17 @@ class Jet : public PHObject
     EEMC_CLUSTER = 24,
   };
 
+
+  enum SORT  // used as criteria for sorting output in JetMap
+  {
+    NO_SORT = 0, // a blank input to not sort input
+    PT   = 1, // PT descending order
+    E    = 2, // E  descending order
+    P    = 3, // P descending order
+    MASS = 4, // Mass descending order
+    AREA = 5, // AREA descending order --> maybe used in future, as jets don't have area for now...
+  };
+
   enum PROPERTY
   {
 

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <map>
 #include <vector>
+#include <functional>
 #include <set>
 
 class JetMap : public PHObject
@@ -78,6 +79,7 @@ class JetMap : public PHObject
   virtual Iter end();
 
   virtual std::vector<Jet*> vec(Jet::SORT=Jet::SORT::PT)=0;
+  virtual std::vector<Jet*> vec(std::function<bool (Jet*, Jet*)> custom_sort)=0;
 
  private:
   ClassDefOverride(JetMap, 1);

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -9,6 +9,7 @@
 #include <cstddef>          // for size_t
 #include <iostream>
 #include <map>
+#include <vector>
 #include <set>
 
 class JetMap : public PHObject
@@ -18,6 +19,8 @@ class JetMap : public PHObject
   typedef std::map<unsigned int, Jet*> typ_JetMap;
   typedef typ_JetMap::const_iterator ConstIter;
   typedef typ_JetMap::iterator Iter;
+
+  typedef std::vector<Jet*> vec_JetMap; // to be used when sorting typ_JetMap to iterate over
 
   // source identifier iterators
   typedef std::set<Jet::SRC>::const_iterator ConstSrcIter;
@@ -51,6 +54,7 @@ class JetMap : public PHObject
   virtual SrcIter find_src(Jet::SRC src);
   virtual SrcIter end_src();
 
+
   // map access to jets --------------------------------------------------------
 
   virtual bool empty() const { return true; }
@@ -64,6 +68,7 @@ class JetMap : public PHObject
   virtual Jet* insert(Jet* /*jet*/) { return nullptr; }
   virtual size_t erase(unsigned int /*idkey*/) { return 0; }
 
+
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int idkey) const;
   virtual ConstIter end() const;
@@ -71,6 +76,8 @@ class JetMap : public PHObject
   virtual Iter begin();
   virtual Iter find(unsigned int idkey);
   virtual Iter end();
+
+  virtual std::vector<Jet*> vec(Jet::SORT=Jet::SORT::PT)=0;
 
  private:
   ClassDefOverride(JetMap, 1);

--- a/simulation/g4simulation/g4jets/JetMapv1.cc
+++ b/simulation/g4simulation/g4jets/JetMapv1.cc
@@ -157,3 +157,10 @@ std::vector<Jet*> JetMapv1::vec(Jet::SORT sort_criteria) {
   }
   return v_data;
 }
+
+std::vector<Jet*> JetMapv1::vec(std::function<bool (Jet*, Jet*)> custom_sort) {
+  vector<Jet*> v_data;
+  for (auto& _ : _map) { v_data.push_back(_.second); }
+  std::sort(v_data.begin(), v_data.end(), custom_sort );
+  return v_data;
+}

--- a/simulation/g4simulation/g4jets/JetMapv1.cc
+++ b/simulation/g4simulation/g4jets/JetMapv1.cc
@@ -9,6 +9,7 @@
 #include <iterator>  // for reverse_iterator
 #include <ostream>   // for operator<<, endl, ostream, basic_ostream::operat...
 #include <utility>   // for pair, make_pair
+#include <algorithm>
 
 using namespace std;
 
@@ -128,4 +129,31 @@ Jet* JetMapv1::insert(Jet* jet)
   _map.insert(make_pair(index, jet));
   _map[index]->set_id(index);
   return (_map[index]);
+}
+
+std::vector<Jet*> JetMapv1::vec(Jet::SORT sort_criteria) {
+  vector<Jet*> v_data;
+  for (auto& _ : _map) { v_data.push_back(_.second); }
+  switch (sort_criteria) 
+  {
+    case Jet::SORT::PT:
+      std::sort(v_data.begin(), v_data.end(), [](Jet* a, Jet* b) { return a->get_pt() > b->get_pt(); });
+      break;
+    case Jet::SORT::E:
+      std::sort(v_data.begin(), v_data.end(), [](Jet* a, Jet* b) { return a->get_e() > b->get_e(); });
+      break;
+    case Jet::SORT::P:
+      std::sort(v_data.begin(), v_data.end(), [](Jet* a, Jet* b) { return a->get_p() > b->get_p(); });
+      break;
+    case Jet::SORT::MASS:
+      std::sort(v_data.begin(), v_data.end(), [](Jet* a, Jet* b) { return a->get_mass() > b->get_mass(); });
+      break;
+    case Jet::SORT::NO_SORT:
+      // do nothing
+      break;
+    default:
+        std::cout << "Fatal error: option to JetMap::vec( option ) was not recognized." << std::endl;
+        exit(1);
+  }
+  return v_data;
 }

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -68,6 +68,7 @@ class JetMapv1 : public JetMap
   Iter end() override { return _map.end(); }
 
   std::vector<Jet*> vec(Jet::SORT sort=Jet::SORT::PT) override; // defaulted to PT in JetMap.h
+  std::vector<Jet*> vec(std::function<bool (Jet*, Jet*)> custom_sort) override; // defaulted to PT in JetMap.h
 
  private:
   Jet::ALGO _algo;          //< algorithm used to reconstruct jets

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -67,6 +67,8 @@ class JetMapv1 : public JetMap
   Iter find(unsigned int idkey) override { return _map.find(idkey); }
   Iter end() override { return _map.end(); }
 
+  std::vector<Jet*> vec(Jet::SORT sort=Jet::SORT::PT) override; // defaulted to PT in JetMap.h
+
  private:
   Jet::ALGO _algo;          //< algorithm used to reconstruct jets
   float _par;               //< algorithm parameter setting (e.g. radius)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This pull request is in respond to todays Jet Substructure meeting, as a version 2. Here are the proposed slides for next weeks meeting: https://d.pr/f/k0OOcK . I wish to make this pull request as a reference point for that meeting. (In something of a chicken-and-egg situation)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

