### PR TITLE
Fallback

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -47,7 +47,7 @@ my %proddesc = (
     );
 
 my %pileupdesc = (
-    "1" => "default (50kHz for Au+Au, 3MHz for p+p)",
+    "1" => "50kHz for Au+Au, 3MHz for p+p (default)",
     "2" => "25kHz for Au+Au",
     "3" => "10kHz for Au+Au"
     );
@@ -287,14 +287,14 @@ if ($#ARGV < 0)
 	print "-n     : <number of events>\n";
 	print "-nopileup : without pileup\n";
 	print "-rand  : randomize segments used\n";
-	print "-run   : runnumber\n";
+	print "-run   : runnumber (default = $runnumber)\n";
 	print "-s     : starting segment>\n";
 	print "\n-type  : production type\n";
 	foreach my $pd (sort { $a <=> $b } keys %proddesc)
 	{
 	    print "    $pd : $proddesc{$pd}\n";
 	}
-	print "\n-pileup : pileup rate selection\n";
+	print "\n-pileup : pileup rate selection (default = $pileup)\n";
 	foreach my $pd (sort { $a <=> $b } keys %pileupdesc)
 	{
 	    print "    $pd : $pileupdesc{$pd}\n";

--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -56,7 +56,7 @@ my $nEvents;
 my $start_segment;
 my $randomize;
 my $prodtype;
-my $runnumber = 4;
+my $runnumber = 40;
 my $verbose;
 my $nopileup;
 my $embed;

--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -56,7 +56,7 @@ my $nEvents;
 my $start_segment;
 my $randomize;
 my $prodtype;
-my $runnumber = 40;
+my $runnumber = 4;
 my $verbose;
 my $nopileup;
 my $embed;
@@ -185,7 +185,7 @@ if (defined $prodtype)
     elsif ($prodtype == 11)
     {
         $embedok = 1;
-	$filenamestring = "pythia8_Jet30";
+	$filenamestring = "pythia8_Jet04";
 	if (! defined $nopileup)
 	{
 	    if (defined $embed)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR reverts the previous replacement of Jet04 by Jet30. I had forgotten about the DST_TRUTH_JET files which still need to be produced. Sorry about that. Now the script without arguments prints out the default settings for the runnumber (and less important the pileup) so one can see if you need to explicitely set the runnumber. The current default is run = 40
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
[skip ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

