### PR TITLE
change include order to prevent root crash

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -22,8 +22,15 @@
 #ifndef KFPARTICLESPHENIX_KFPARTICLESPHENIX_H
 #define KFPARTICLESPHENIX_KFPARTICLESPHENIX_H
 
-#include "KFParticle_DST.h"
 #include "KFParticle_eventReconstruction.h"
+
+// There is something broken in this package. clang format puts
+// #include "KFParticle_DST.h" first if there is no space but then
+// loading KFParticle makes root barf. I have no time to track this down
+// right now, it must be something in KFParticle_eventReconstruction.h and
+// the include files it uses (some include guard misfiring?)
+
+#include "KFParticle_DST.h"
 #include "KFParticle_nTuple.h"
 
 //sPHENIX stuff


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
The reorganization of the includes broke the loading of KFParticle into root. I tracked this down to a single include which needs to be includes out of order. I didn't track down the reason for this - doesn't bode well for the future. But KFParticle_sPHENIX.h is stable against running clang-format and I put a fat comment there
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

