### PR TITLE
Fun4all inputmanager

### DIFF
--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -44,7 +44,7 @@ int Fun4AllInputManager::AddFile(const std::string &filename)
   return 0;
 }
 
-int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it)
+int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it, const int n_jobs, const int i_this_job)
 {
   // checking filesize to see if we have a text file
   if (boost::filesystem::exists(filename.c_str()))
@@ -88,7 +88,10 @@ int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_i
   {
     if (FullLine.size() && FullLine[0] != '#')  // remove comments
     {
-      AddFile(FullLine);
+      if (nfiles % n_jobs == i_this_job)
+      {
+        AddFile(FullLine);
+      }
       nfiles++;
     }
     else if (FullLine.size())

--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -44,7 +44,7 @@ int Fun4AllInputManager::AddFile(const std::string &filename)
   return 0;
 }
 
-int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it, const int n_jobs, const int i_this_job)
+int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it, const int every_nth_line, const int nth_line_offset)
 {
   // checking filesize to see if we have a text file
   if (boost::filesystem::exists(filename.c_str()))
@@ -88,7 +88,7 @@ int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_i
   {
     if (FullLine.size() && FullLine[0] != '#')  // remove comments
     {
-      if (nfiles % n_jobs == i_this_job)
+      if (nfiles % every_nth_line == nth_line_offset)
       {
         AddFile(FullLine);
       }

--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -44,7 +44,7 @@ int Fun4AllInputManager::AddFile(const std::string &filename)
   return 0;
 }
 
-int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it)
+int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it, const int this_job, const int n_jobs)
 {
   // checking filesize to see if we have a text file
   if (boost::filesystem::exists(filename.c_str()))
@@ -88,7 +88,10 @@ int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_i
   {
     if (FullLine.size() && FullLine[0] != '#')  // remove comments
     {
-      AddFile(FullLine);
+      if (nfiles % n_jobs == this_job)
+      {
+        AddFile(FullLine);
+      }
       nfiles++;
     }
     else if (FullLine.size())

--- a/offline/framework/fun4all/Fun4AllInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllInputManager.cc
@@ -44,7 +44,7 @@ int Fun4AllInputManager::AddFile(const std::string &filename)
   return 0;
 }
 
-int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it, const int this_job, const int n_jobs)
+int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_it)
 {
   // checking filesize to see if we have a text file
   if (boost::filesystem::exists(filename.c_str()))
@@ -88,10 +88,7 @@ int Fun4AllInputManager::AddListFile(const std::string &filename, const int do_i
   {
     if (FullLine.size() && FullLine[0] != '#')  // remove comments
     {
-      if (nfiles % n_jobs == this_job)
-      {
-        AddFile(FullLine);
-      }
+      AddFile(FullLine);
       nfiles++;
     }
     else if (FullLine.size())

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -38,7 +38,8 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int skip(const int nevt) { return PushBackEvents(-nevt); }
   virtual int NoSyncPushBackEvents(const int /*nevt*/) { return -1; }
   int AddFile(const std::string &filename);
-  int AddListFile(const std::string &filename, const int do_it = 0);
+  // read only files from lines "n" such that n%n_jobs==this_job. (Defaults n_jobs=1, this_job=0 result in reading read every line)
+  int AddListFile(const std::string &filename, const int do_it = 0, const int this_job=0, const int n_jobs=1);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
   void Repeat(const int i = -1) { m_Repeat = i; }

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -38,7 +38,8 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int skip(const int nevt) { return PushBackEvents(-nevt); }
   virtual int NoSyncPushBackEvents(const int /*nevt*/) { return -1; }
   int AddFile(const std::string &filename);
-  int AddListFile(const std::string &filename, const int do_it = 0);
+  // read only files from lines 'n' such that n%n_jobs==i_this_job. (Default n_jobs=1, i_this_job=0 result in reading read every line)
+  int AddListFile(const std::string &filename, const int do_it = 0, const int n_jobs=1, const int i_this_job=0);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
   void Repeat(const int i = -1) { m_Repeat = i; }

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -38,8 +38,7 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int skip(const int nevt) { return PushBackEvents(-nevt); }
   virtual int NoSyncPushBackEvents(const int /*nevt*/) { return -1; }
   int AddFile(const std::string &filename);
-  // read only files from lines "n" such that n%n_jobs==this_job. (Defaults n_jobs=1, this_job=0 result in reading read every line)
-  int AddListFile(const std::string &filename, const int do_it = 0, const int this_job=0, const int n_jobs=1);
+  int AddListFile(const std::string &filename, const int do_it = 0);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
   void Repeat(const int i = -1) { m_Repeat = i; }

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -39,7 +39,7 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int NoSyncPushBackEvents(const int /*nevt*/) { return -1; }
   int AddFile(const std::string &filename);
   // read only files from lines 'n' such that n%n_jobs==i_this_job. (Default n_jobs=1, i_this_job=0 result in reading read every line)
-  int AddListFile(const std::string &filename, const int do_it = 0, const int n_jobs=1, const int i_this_job=0);
+  int AddListFile(const std::string &filename, const int do_it = 0, const int every_nth_line=1, const int i_line_offset=0);
   int registerSubsystem(SubsysReco *subsystem);
   virtual int RejectEvent();
   void Repeat(const int i = -1) { m_Repeat = i; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Feature which adds two paramaters toFun4AllInputManager::AddListFile: 
    const int every_nth_line=1, const int i_line_offset=0
At their defaults, they will read every line in the input file. Otherwise, they allow the user to reach a unique, evenly offset, subset of the input lines. For example:

The code:
```c++
  Fun4AllInputManager *alllines = new Fun4AllDstInputManager("DSTtruth");
  alllines->AddListFile("dst_truth_jet.list",1,1,0); // adding the option "1" confirms to use, even if file is large
  cout << " File list every line: " << endl;
  alllines->Print("FILELIST");

  Fun4AllInputManager *oddlines = new Fun4AllDstInputManager("DSTtruth");
  oddlines->AddListFile("dst_truth_jet.list",1,2,0); // adding the option "1" confirms to use, even if file is large
  cout << " File list every odd line: " << endl;
  oddlines->Print("FILELIST");

  Fun4AllInputManager *evenlines = new Fun4AllDstInputManager("DSTtruth");
  evenlines->AddListFile("dst_truth_jet.list",1,2,1); // adding the option "1" confirms to use, even if file is large
  cout << " File list every even line: " << endl;
  evenlines->Print("FILELIST");
```
In which `dst_truth_jet.list` has only 12 files yields the following results:
```txt
 File list every line:
--------------------------------------

List of input files in Fun4AllInputManager DSTtruth:
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00000.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00001.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00002.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00003.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00004.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00005.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00006.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00007.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00008.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00009.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00010.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00011.root
 File list every odd line:
--------------------------------------

List of input files in Fun4AllInputManager DSTtruth:
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00000.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00002.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00004.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00006.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00008.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00010.root
 File list every even line:
--------------------------------------

List of input files in Fun4AllInputManager DSTtruth:
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00001.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00003.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00005.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00007.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00009.root
DST_TRUTH_JET_pythia8_Jet04_3MHz-0000000004-00011.root
```
As such, if the user has an input file that they wish to run over all jobs, it is only a matter of using `oddlines->AddListFile("dst_truth_jet.list",1,1000,i_job);` instead of having to generate a set of 1000 sub files.

It doesn't break any prior behavior. The user will just have to be careful to use the same parameters for each `AddListFile`, but that doesn't take any more care (and considerably less work and file clutter) than making the input file list.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

