### PR TITLE
Protect jets

### DIFF
--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -157,6 +157,12 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   m_RawTowerGeom->set_etabins(get_int_param("etabins"));
   double geom_ref_radius = innerrad + thickness / 2.;
   double phistart = get_double_param("phistart");
+  if (! std::isfinite(phistart))
+  {
+    std::cout << PHWHERE << " phistart is not finite: " << phistart
+	      << ", exiting now (this will crash anyway)" << std::endl;
+    gSystem->Exit(1);
+  }
   for (int i = 0; i < get_int_param(PHG4HcalDefs::n_towers); i++)
   {
     double phiend = phistart + 2. * M_PI / get_int_param(PHG4HcalDefs::n_towers);

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -157,10 +157,10 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   m_RawTowerGeom->set_etabins(get_int_param("etabins"));
   double geom_ref_radius = innerrad + thickness / 2.;
   double phistart = get_double_param("phistart");
-  if (! std::isfinite(phistart))
+  if (!std::isfinite(phistart))
   {
     std::cout << PHWHERE << " phistart is not finite: " << phistart
-	      << ", exiting now (this will crash anyway)" << std::endl;
+              << ", exiting now (this will crash anyway)" << std::endl;
     gSystem->Exit(1);
   }
   for (int i = 0; i < get_int_param(PHG4HcalDefs::n_towers); i++)

--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.h
@@ -23,7 +23,11 @@ class HcalRawTowerBuilder : public SubsysReco, public PHParameterInterface
 
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  void Detector(const std::string &d) { m_InputDetector = d; m_OutputDetector = d;}
+  void Detector(const std::string &d)
+  {
+    m_InputDetector = d;
+    m_OutputDetector = d;
+  }
   void InDetector(const std::string &d) { m_InputDetector = d; }
   void OutDetector(const std::string &d) { m_OutputDetector = d; }
   void EminCut(const double e) { m_Emin = e; }

--- a/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
+++ b/simulation/g4simulation/g4calo/RawTowerDigitizer.cc
@@ -90,11 +90,11 @@ int RawTowerDigitizer::InitRun(PHCompositeNode *topNode)
   {
     if (m_Detector.c_str()[0] == 'H')
     {
-      m_CalDBFile =  new HcalCaloCalibSimpleCorrFilev1();
+      m_CalDBFile = new HcalCaloCalibSimpleCorrFilev1();
     }
     else if (m_Detector.c_str()[0] == 'C')
     {
-      m_CalDBFile =  new CEmcCaloCalibSimpleCorrFilev1();
+      m_CalDBFile = new CEmcCaloCalibSimpleCorrFilev1();
     }
     else
     {

--- a/simulation/g4simulation/g4jets/ClusterJetInput.cc
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 ClusterJetInput::ClusterJetInput(Jet::SRC input)
-  :  m_Input(input)
+  : m_Input(input)
 {
 }
 

--- a/simulation/g4simulation/g4jets/ClusterJetInput.cc
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.cc
@@ -9,7 +9,6 @@
 #include <calobase/RawCluster.h>
 #include <calobase/RawClusterContainer.h>
 #include <calobase/RawClusterUtility.h>
-#include <calobase/RawTowerGeomContainer.h>
 
 #include <g4vertex/GlobalVertex.h>
 #include <g4vertex/GlobalVertexMap.h>
@@ -23,35 +22,40 @@
 #include <utility>  // for pair
 #include <vector>
 
-using namespace std;
-
 ClusterJetInput::ClusterJetInput(Jet::SRC input)
-  : _verbosity(0)
-  , _input(input)
+  :  m_Input(input)
 {
 }
 
 void ClusterJetInput::identify(std::ostream &os)
 {
   os << "   ClusterJetInput: ";
-  if (_input == Jet::CEMC_CLUSTER)
+  if (m_Input == Jet::CEMC_CLUSTER)
+  {
     os << "CLUSTER_CEMC to Jet::CEMC_CLUSTER";
-  if (_input == Jet::EEMC_CLUSTER)
+  }
+  else if (m_Input == Jet::EEMC_CLUSTER)
+  {
     os << "CLUSTER_EEMC to Jet::EEMC_CLUSTER";
-  else if (_input == Jet::HCALIN_CLUSTER)
+  }
+  else if (m_Input == Jet::HCALIN_CLUSTER)
+  {
     os << "CLUSTER_HCALIN to Jet::HCALIN_CLUSTER";
-  else if (_input == Jet::HCALOUT_CLUSTER)
+  }
+  else if (m_Input == Jet::HCALOUT_CLUSTER)
+  {
     os << "CLUSTER_HCALOUT to Jet::HCALOUT_CLUSTER";
-  os << endl;
+  }
+  os << std::endl;
 }
 
 std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (_verbosity > 0) cout << "ClusterJetInput::process_event -- entered" << endl;
+  if (m_Verbosity > 0) std::cout << "ClusterJetInput::process_event -- entered" << std::endl;
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
-    cout << "ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is missing. Please turn on the do_global flag in the main macro in order to reconstruct the global vertex." << endl;
+    std::cout << "ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is missing. Please turn on the do_global flag in the main macro in order to reconstruct the global vertex." << std::endl;
     assert(vertexmap);  // force quit
 
     return std::vector<Jet *>();
@@ -59,12 +63,12 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
 
   if (vertexmap->empty())
   {
-    cout << "ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << endl;
+    std::cout << "ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
     return std::vector<Jet *>();
   }
 
   RawClusterContainer *clusters = nullptr;
-  if (_input == Jet::CEMC_CLUSTER)
+  if (m_Input == Jet::CEMC_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_CEMC");
     if (!clusters)
@@ -72,7 +76,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::EEMC_CLUSTER)
+  else if (m_Input == Jet::EEMC_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_EEMC");
     if (!clusters)
@@ -80,7 +84,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::HCALIN_CLUSTER)
+  else if (m_Input == Jet::HCALIN_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_HCALIN");
     if (!clusters)
@@ -88,7 +92,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::HCALOUT_CLUSTER)
+  else if (m_Input == Jet::HCALOUT_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_HCALOUT");
     if (!clusters)
@@ -96,7 +100,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::HCAL_TOPO_CLUSTER)
+  else if (m_Input == Jet::HCAL_TOPO_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_HCAL");
     if (!clusters)
@@ -104,7 +108,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::ECAL_TOPO_CLUSTER)
+  else if (m_Input == Jet::ECAL_TOPO_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_EMCAL");
     if (!clusters)
@@ -112,7 +116,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::FEMC_CLUSTER)
+  else if (m_Input == Jet::FEMC_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_FEMC");
     if (!clusters)
@@ -120,7 +124,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
-  else if (_input == Jet::FHCAL_CLUSTER)
+  else if (m_Input == Jet::FHCAL_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_FHCAL");
     if (!clusters)
@@ -137,9 +141,13 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   GlobalVertex *vtx = vertexmap->begin()->second;
   CLHEP::Hep3Vector vertex;
   if (vtx)
+  {
     vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+  }
   else
+  {
     return std::vector<Jet *>();
+  }
 
   std::vector<Jet *> pseudojets;
   RawClusterContainer::ConstRange begin_end = clusters->getClusters();
@@ -155,11 +163,11 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
     jet->set_py(E_vec_cluster.y());
     jet->set_pz(E_vec_cluster.z());
     jet->set_e(cluster->get_energy());
-    jet->insert_comp(_input, cluster->get_id());
+    jet->insert_comp(m_Input, cluster->get_id());
     pseudojets.push_back(jet);
   }
 
-  if (_verbosity > 0) cout << "ClusterJetInput::process_event -- exited" << endl;
+  if (m_Verbosity > 0) std::cout << "ClusterJetInput::process_event -- exited" << std::endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/ClusterJetInput.h
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.h
@@ -22,13 +22,13 @@ class ClusterJetInput : public JetInput
 
   void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() override { return _input; }
+  Jet::SRC get_src() override { return m_Input; }
 
   std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
  private:
-  int _verbosity;
-  Jet::SRC _input;
+  int m_Verbosity = 0;
+  Jet::SRC m_Input = Jet::VOID;
 };
 
 #endif

--- a/simulation/g4simulation/g4jets/ClusterJetInput.h
+++ b/simulation/g4simulation/g4jets/ClusterJetInput.h
@@ -8,7 +8,7 @@
 #include "Jet.h"
 
 // finally system includes
-#include <iostream>    // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <vector>
 
 // forward declarations

--- a/simulation/g4simulation/g4jets/FastJetAlgo.cc
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.cc
@@ -7,22 +7,22 @@
 
 // fastjet includes
 #include <fastjet/ClusterSequence.hh>
-#include <fastjet/FunctionOfPseudoJet.hh>               // for FunctionOfPse...
+#include <fastjet/FunctionOfPseudoJet.hh>  // for FunctionOfPse...
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 
 // SoftDrop includes
-#include <fastjet/contrib/SoftDrop.hh>
 #include <fastjet/contrib/RecursiveSymmetryCutBase.hh>  // for RecursiveSymm...
+#include <fastjet/contrib/SoftDrop.hh>
 
 #include <TSystem.h>
 
 // standard includes
-#include <cmath>                                        // for isfinite
+#include <cmath>  // for isfinite
 #include <iostream>
 #include <map>      // for _Rb_tree_iterator
 #include <memory>   // for allocator_traits<>::value_type
-#include <string>                                       // for operator<<
+#include <string>   // for operator<<
 #include <utility>  // for pair
 #include <vector>
 

--- a/simulation/g4simulation/g4jets/FastJetAlgo.cc
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.cc
@@ -1,4 +1,3 @@
-
 #include "FastJetAlgo.h"
 
 #include "Jet.h"
@@ -8,18 +7,22 @@
 
 // fastjet includes
 #include <fastjet/ClusterSequence.hh>
+#include <fastjet/FunctionOfPseudoJet.hh>               // for FunctionOfPse...
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 
 // SoftDrop includes
 #include <fastjet/contrib/SoftDrop.hh>
+#include <fastjet/contrib/RecursiveSymmetryCutBase.hh>  // for RecursiveSymm...
 
 #include <TSystem.h>
 
 // standard includes
+#include <cmath>                                        // for isfinite
 #include <iostream>
 #include <map>      // for _Rb_tree_iterator
 #include <memory>   // for allocator_traits<>::value_type
+#include <string>                                       // for operator<<
 #include <utility>  // for pair
 #include <vector>
 

--- a/simulation/g4simulation/g4jets/FastJetAlgo.cc
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.cc
@@ -4,6 +4,8 @@
 #include "Jet.h"
 #include "Jetv1.h"
 
+#include <phool/phool.h>
+
 // fastjet includes
 #include <fastjet/ClusterSequence.hh>
 #include <fastjet/JetDefinition.hh>
@@ -11,6 +13,8 @@
 
 // SoftDrop includes
 #include <fastjet/contrib/SoftDrop.hh>
+
+#include <TSystem.h>
 
 // standard includes
 #include <iostream>
@@ -20,15 +24,15 @@
 #include <vector>
 
 FastJetAlgo::FastJetAlgo(Jet::ALGO algo, float par, int verbosity)
-  : _verbosity(verbosity)
+  : m_Verbosity(verbosity)
   , _algo(algo)
-  , _par(par)
-  , _do_SD(false)
-  , _SD_beta(0)
-  , _SD_zcut(0.1)
+  , m_Par(par)
+  , m_SDFlag(false)
+  , m_SDBeta(0)
+  , m_SDZCut(0.1)
 {
   fastjet::ClusterSequence clusseq;
-  if (_verbosity > 0)
+  if (m_Verbosity > 0)
   {
     clusseq.print_banner();
   }
@@ -45,17 +49,23 @@ void FastJetAlgo::identify(std::ostream& os)
 {
   os << "   FastJetAlgo: ";
   if (_algo == Jet::ANTIKT)
-    os << "ANTIKT r=" << _par;
+  {
+    os << "ANTIKT r=" << m_Par;
+  }
   else if (_algo == Jet::KT)
-    os << "KT r=" << _par;
+  {
+    os << "KT r=" << m_Par;
+  }
   else if (_algo == Jet::CAMBRIDGE)
-    os << "CAMBRIDGE r=" << _par;
+  {
+    os << "CAMBRIDGE r=" << m_Par;
+  }
   os << std::endl;
 }
 
 std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
 {
-  if (_verbosity > 1) std::cout << "FastJetAlgo::process_event -- entered" << std::endl;
+  if (m_Verbosity > 1) std::cout << "FastJetAlgo::process_event -- entered" << std::endl;
 
   // translate to fastjet
   std::vector<fastjet::PseudoJet> pseudojets;
@@ -65,7 +75,18 @@ std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
     // (0,0,0,0) inputs, such as placeholder towers or those with
     // zero'd out energy after CS. this catch also in FastJetAlgoSub
     if (particles[ipart]->get_e() == 0.) continue;
-
+    if (! std::isfinite(particles[ipart]->get_px()) ||
+        ! std::isfinite(particles[ipart]->get_py()) ||
+        ! std::isfinite(particles[ipart]->get_pz()) ||
+	! std::isfinite(particles[ipart]->get_e()))
+    {
+      std::cout << PHWHERE << " invalid particle kinematics:"
+		<< " px: " << particles[ipart]->get_px()
+		<< " py: " << particles[ipart]->get_py()
+		<< " pz: " << particles[ipart]->get_pz()
+		<< " e: " << particles[ipart]->get_e() << std::endl;
+	gSystem->Exit(1);
+    }
     fastjet::PseudoJet pseudojet(particles[ipart]->get_px(),
                                  particles[ipart]->get_py(),
                                  particles[ipart]->get_pz(),
@@ -73,24 +94,33 @@ std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
     pseudojet.set_user_index(ipart);
     pseudojets.push_back(pseudojet);
   }
-
   // run fast jet
   fastjet::JetDefinition* jetdef = nullptr;
   if (_algo == Jet::ANTIKT)
-    jetdef = new fastjet::JetDefinition(fastjet::antikt_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+  {
+    jetdef = new fastjet::JetDefinition(fastjet::antikt_algorithm, m_Par, fastjet::E_scheme, fastjet::Best);
+  }
   else if (_algo == Jet::KT)
-    jetdef = new fastjet::JetDefinition(fastjet::kt_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+  {
+    jetdef = new fastjet::JetDefinition(fastjet::kt_algorithm, m_Par, fastjet::E_scheme, fastjet::Best);
+  }
   else if (_algo == Jet::CAMBRIDGE)
-    jetdef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+  {
+    jetdef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, m_Par, fastjet::E_scheme, fastjet::Best);
+  }
   else
+  {
     return std::vector<Jet*>();
+  }
   fastjet::ClusterSequence jetFinder(pseudojets, *jetdef);
   std::vector<fastjet::PseudoJet> fastjets = jetFinder.inclusive_jets();
   delete jetdef;
 
-  fastjet::contrib::SoftDrop sd( _SD_beta, _SD_zcut );
-  if ( _verbosity > 5 )
+  fastjet::contrib::SoftDrop sd( m_SDBeta, m_SDZCut );
+  if ( m_Verbosity > 5 )
+  {
     std::cout << "FastJetAlgo::get_jets : created SoftDrop groomer configuration : " << sd.description() << std::endl;
+  }
 
   // translate into jet output...
   std::vector<Jet*> jets;
@@ -105,11 +135,11 @@ std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
     
     // if SoftDrop enabled, and jets have > 5 GeV (do not waste time
     // on very low-pT jets), run SD and pack output into jet properties
-    if ( _do_SD && fastjets[ijet].perp() > 5 ) {
+    if ( m_SDFlag && fastjets[ijet].perp() > 5 ) {
 
       fastjet::PseudoJet sd_jet = sd( fastjets[ijet] );
             
-      if ( _verbosity > 5 ) {
+      if ( m_Verbosity > 5 ) {
 	std::cout << "original    jet: pt / eta / phi / m = " << fastjets[ijet].perp() << " / " <<  fastjets[ijet].eta() << " / " << fastjets[ijet].phi() << " / " << fastjets[ijet].m() << std::endl;
 	std::cout << "SoftDropped jet: pt / eta / phi / m = " << sd_jet.perp() << " / " <<  sd_jet.eta() << " / " << sd_jet.phi() << " / " << sd_jet.m() << std::endl;
 	
@@ -142,7 +172,7 @@ std::vector<Jet*> FastJetAlgo::get_jets(std::vector<Jet*> particles)
     jets.push_back(jet);
   }
 
-  if (_verbosity > 1) std::cout << "FastJetAlgo::process_event -- exited" << std::endl;
+  if (m_Verbosity > 1) std::cout << "FastJetAlgo::process_event -- exited" << std::endl;
 
   return jets;
 }

--- a/simulation/g4simulation/g4jets/FastJetAlgo.h
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.h
@@ -4,8 +4,8 @@
 #include "Jet.h"
 #include "JetAlgo.h"
 
-#include <iostream>   // for cout, ostream
-#include <vector>     // for vector
+#include <iostream>  // for cout, ostream
+#include <vector>    // for vector
 
 class FastJetAlgo : public JetAlgo
 {
@@ -14,26 +14,25 @@ class FastJetAlgo : public JetAlgo
   ~FastJetAlgo() override {}
 
   void identify(std::ostream& os = std::cout) override;
-  Jet::ALGO get_algo() override { return _algo; }
+  Jet::ALGO get_algo() override { return m_AlgoFlag; }
   float get_par() override { return m_Par; }
 
-  void set_do_SoftDrop( bool do_SD ) { m_SDFlag = do_SD;}
+  void set_do_SoftDrop(bool do_SD) { m_SDFlag = do_SD; }
 
-  void set_SoftDrop_beta( float beta ) { m_SDBeta = beta; }
+  void set_SoftDrop_beta(float beta) { m_SDBeta = beta; }
 
-  void set_SoftDrop_zcut( float zcut ) { m_SDZCut = zcut;  }
+  void set_SoftDrop_zcut(float zcut) { m_SDZCut = zcut; }
 
   std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
 
  private:
   int m_Verbosity = 0;
-  Jet::ALGO _algo;
+  Jet::ALGO m_AlgoFlag = Jet::NONE;
   float m_Par = NAN;
 
   bool m_SDFlag = false;
   float m_SDBeta = NAN;
   float m_SDZCut = NAN;
-
 };
 
 #endif

--- a/simulation/g4simulation/g4jets/FastJetAlgo.h
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.h
@@ -4,6 +4,7 @@
 #include "Jet.h"
 #include "JetAlgo.h"
 
+#include <cmath>     // for NAN
 #include <iostream>  // for cout, ostream
 #include <vector>    // for vector
 

--- a/simulation/g4simulation/g4jets/FastJetAlgo.h
+++ b/simulation/g4simulation/g4jets/FastJetAlgo.h
@@ -15,30 +15,24 @@ class FastJetAlgo : public JetAlgo
 
   void identify(std::ostream& os = std::cout) override;
   Jet::ALGO get_algo() override { return _algo; }
-  float get_par() override { return _par; }
+  float get_par() override { return m_Par; }
 
-  void set_do_SoftDrop( bool do_SD ) {
-    _do_SD = do_SD;
-  }
+  void set_do_SoftDrop( bool do_SD ) { m_SDFlag = do_SD;}
 
-  void set_SoftDrop_beta( float beta ) {
-    _SD_beta = beta;
-  }
+  void set_SoftDrop_beta( float beta ) { m_SDBeta = beta; }
 
-  void set_SoftDrop_zcut( float zcut ) {
-    _SD_zcut = zcut;
-  }
+  void set_SoftDrop_zcut( float zcut ) { m_SDZCut = zcut;  }
 
   std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
 
  private:
-  int _verbosity;
+  int m_Verbosity = 0;
   Jet::ALGO _algo;
-  float _par;
+  float m_Par = NAN;
 
-  bool _do_SD;
-  float _SD_beta;
-  float _SD_zcut;
+  bool m_SDFlag = false;
+  float m_SDBeta = NAN;
+  float m_SDZCut = NAN;
 
 };
 

--- a/simulation/g4simulation/g4jets/Jet.h
+++ b/simulation/g4simulation/g4jets/Jet.h
@@ -4,7 +4,7 @@
 #include <phool/PHObject.h>
 
 #include <cmath>
-#include <cstddef>          // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
 

--- a/simulation/g4simulation/g4jets/JetAlgo.h
+++ b/simulation/g4simulation/g4jets/JetAlgo.h
@@ -18,7 +18,7 @@ class JetAlgo
   virtual Jet::ALGO get_algo() { return Jet::NONE; }
   virtual float get_par() { return NAN; }
 
-  virtual std::vector<Jet*> get_jets(std::vector<Jet*>/* particles*/)
+  virtual std::vector<Jet*> get_jets(std::vector<Jet*> /* particles*/)
   {
     return std::vector<Jet*>();
   }

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.cc
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.cc
@@ -41,25 +41,15 @@
 #include <HepMC/SimpleVector.h>           // for FourVector
 #include <HepMC/Units.h>                  // for conversion_factor, GEV
 
+#include <algorithm>                      // for max
 #include <cassert>
 #include <iostream>
-
-using namespace std;
 
 JetHepMCLoader::JetHepMCLoader(const std::string &jetInputCategory)
   : SubsysReco("JetHepMCLoader_" + jetInputCategory)
   , m_jetInputCategory(jetInputCategory)
-  , m_saveQAPlots(false)
-{
-}
 
-JetHepMCLoader::~JetHepMCLoader()
 {
-}
-
-int JetHepMCLoader::Init(PHCompositeNode */*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int JetHepMCLoader::InitRun(PHCompositeNode *topNode)
@@ -77,7 +67,7 @@ int JetHepMCLoader::InitRun(PHCompositeNode *topNode)
     h->GetXaxis()->SetBinLabel(i++, "Event count");
     for (const hepmc_jet_src &src : m_jetSrc)
     {
-      h->GetXaxis()->SetBinLabel(i++, (string("SubEvent ") + src.m_name).c_str());
+      h->GetXaxis()->SetBinLabel(i++, (std::string("SubEvent ") + src.m_name).c_str());
     }
     h->GetXaxis()->LabelsOption("v");
     hm->registerHisto(h);
@@ -85,7 +75,7 @@ int JetHepMCLoader::InitRun(PHCompositeNode *topNode)
     for (const hepmc_jet_src &src : m_jetSrc)
     {
       hm->registerHisto(
-          new TH2F((string("hJetEtEta_") + src.m_name).c_str(),  //
+          new TH2F((std::string("hJetEtEta_") + src.m_name).c_str(),  //
                    ("Jet distribution from " + src.m_name + ";Jet #eta;Jet E_{T} [GeV]").c_str(),
                    40, -4., 4.,
                    100, 0, 100));
@@ -108,7 +98,7 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
     {
       once = false;
 
-      cout << "HepMCNodeReader::process_event - No PHHepMCGenEventMap node. Do not perform HepMC->Geant4 input" << endl;
+      std::cout << "HepMCNodeReader::process_event - No PHHepMCGenEventMap node. Do not perform HepMC->Geant4 input" << std::endl;
     }
 
     return Fun4AllReturnCodes::DISCARDEVENT;
@@ -132,15 +122,14 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
     jets->set_par(src.m_parameter);
     jets->insert_src(Jet::HEPMC_IMPORT);
 
-    PHHepMCGenEvent *genevt =
-        genevtmap->get(src.m_embeddingID);
+    PHHepMCGenEvent *genevt = genevtmap->get(src.m_embeddingID);
 
     if (genevt == nullptr) continue;
 
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
-      cout << PHWHERE << " no evt pointer under HEPMC Node found:";
+      std::cout << PHWHERE << " no evt pointer under HEPMC Node found:";
       genevt->identify();
       return Fun4AllReturnCodes::ABORTEVENT;
     }
@@ -155,9 +144,9 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
       assert(hm);
       TH1D *h_norm = dynamic_cast<TH1D *>(hm->getHisto("hNormalization"));
       assert(h_norm);
-      h_norm->Fill((string("SubEvent ") + src.m_name).c_str(), 1);
+      h_norm->Fill((std::string("SubEvent ") + src.m_name).c_str(), 1);
 
-      hjet = dynamic_cast<TH2F *>(hm->getHisto(string("hJetEtEta_") + src.m_name));
+      hjet = dynamic_cast<TH2F *>(hm->getHisto(std::string("hJetEtEta_") + src.m_name));
       assert(hjet);
 
     }  //   if (m_saveQAPlots)
@@ -171,7 +160,9 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
 
       assert(part);
       if (Verbosity() >= VERBOSITY_A_LOT)
+      {
         part->print();
+      }
 
       if (part->status() == src.m_tagStatus and part->pdg_id() == src.m_tagPID)
       {
@@ -205,7 +196,7 @@ int JetHepMCLoader::End(PHCompositeNode */*topNode*/)
     Fun4AllHistoManager *hm = getHistoManager();
     assert(hm);
 
-    cout << "JetHepMCLoader::End - saving QA histograms to " << Name() + ".root" << endl;
+    std::cout << "JetHepMCLoader::End - saving QA histograms to " << Name() + ".root" << std::endl;
     hm->dumpHistos(Name() + ".root", "RECREATE");
   }
 
@@ -220,7 +211,7 @@ void JetHepMCLoader::addJet(
     int tagPID,
     int tagStatus)
 {
-  string algorithmName = "Undefined_Jet_Algorithm";
+  std::string algorithmName = "Undefined_Jet_Algorithm";
 
   switch (algorithm)
   {
@@ -254,7 +245,7 @@ int JetHepMCLoader::CreateNodes(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -291,16 +282,16 @@ int JetHepMCLoader::CreateNodes(PHCompositeNode *topNode)
 Fun4AllHistoManager *
 JetHepMCLoader::getHistoManager()
 {
-  string histname(Name() + "_HISTOS");
+  std::string histname(Name() + "_HISTOS");
 
   Fun4AllServer *se = Fun4AllServer::instance();
   Fun4AllHistoManager *hm = se->getHistoManager(histname);
 
   if (not hm)
   {
-    cout
+    std::cout
         << "TPCDataStreamEmulator::get_HistoManager - Making Fun4AllHistoManager " << histname
-        << endl;
+        << std::endl;
     hm = new Fun4AllHistoManager(histname);
     se->registerHistoManager(hm);
   }

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.cc
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.cc
@@ -10,38 +10,38 @@
 
 #include "JetHepMCLoader.h"
 
-#include "JetMap.h"                       // for JetMap
+#include "JetMap.h"  // for JetMap
 #include "JetMapv1.h"
 #include "Jetv1.h"
 
 #include <phhepmc/PHHepMCGenEvent.h>
 #include <phhepmc/PHHepMCGenEventMap.h>
 
-#include <fun4all/Fun4AllBase.h>          // for Fun4AllBase::VERBOSITY_A_LOT
+#include <fun4all/Fun4AllBase.h>  // for Fun4AllBase::VERBOSITY_A_LOT
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
-#include <fun4all/SubsysReco.h>           // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                 // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>               // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                  // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
-#include <TAxis.h>                        // for TAxis
+#include <TAxis.h>  // for TAxis
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>                       // for TNamed
+#include <TNamed.h>  // for TNamed
 
-#include <HepMC/GenEvent.h>               // for GenEvent, GenEvent::particl...
-#include <HepMC/GenParticle.h>            // for GenParticle
-#include <HepMC/SimpleVector.h>           // for FourVector
-#include <HepMC/Units.h>                  // for conversion_factor, GEV
+#include <HepMC/GenEvent.h>      // for GenEvent, GenEvent::particl...
+#include <HepMC/GenParticle.h>   // for GenParticle
+#include <HepMC/SimpleVector.h>  // for FourVector
+#include <HepMC/Units.h>         // for conversion_factor, GEV
 
-#include <algorithm>                      // for max
+#include <algorithm>  // for max
 #include <cassert>
 #include <iostream>
 
@@ -189,7 +189,7 @@ int JetHepMCLoader::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int JetHepMCLoader::End(PHCompositeNode */*topNode*/)
+int JetHepMCLoader::End(PHCompositeNode * /*topNode*/)
 {
   if (m_saveQAPlots)
   {

--- a/simulation/g4simulation/g4jets/JetHepMCLoader.h
+++ b/simulation/g4simulation/g4jets/JetHepMCLoader.h
@@ -44,9 +44,8 @@ class JetHepMCLoader : public SubsysReco
  public:
   //! \param[in] jetInputCategory is the DST PHCompositeNode name that list the output jet maps, e.g. sHijing_HIJFRG for sHijing HIJFRG truth jets
   JetHepMCLoader(const std::string &jetInputCategory);
-  ~JetHepMCLoader() override;
+  ~JetHepMCLoader() override {}
 
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
@@ -78,7 +77,7 @@ class JetHepMCLoader : public SubsysReco
 
   std::string m_jetInputCategory;
 
-  bool m_saveQAPlots;
+  bool m_saveQAPlots = false;
 
   struct hepmc_jet_src
   {

--- a/simulation/g4simulation/g4jets/JetInput.h
+++ b/simulation/g4simulation/g4jets/JetInput.h
@@ -24,11 +24,14 @@ class JetInput
   {
     return std::vector<Jet*>();
   }
-  virtual int Verbosity() const {return m_Verbosity;}
-  virtual void Verbosity(int i) {m_Verbosity = i;}
+  virtual int Verbosity() const { return m_Verbosity; }
+  virtual void Verbosity(int i) { m_Verbosity = i; }
 
  protected:
-JetInput(): m_Verbosity(0) {}
+  JetInput()
+    : m_Verbosity(0)
+  {
+  }
 
  private:
   int m_Verbosity;

--- a/simulation/g4simulation/g4jets/JetMap.cc
+++ b/simulation/g4simulation/g4jets/JetMap.cc
@@ -21,7 +21,7 @@ JetMap::ConstSrcIter JetMap::find_src(Jet::SRC /*src*/) const
   return DummyJetSourceSet.end();
 }
 
-JetMap::ConstSrcIter JetMap:: end_src() const
+JetMap::ConstSrcIter JetMap::end_src() const
 {
   return DummyJetSourceSet.end();
 }

--- a/simulation/g4simulation/g4jets/JetMap.h
+++ b/simulation/g4simulation/g4jets/JetMap.h
@@ -6,7 +6,7 @@
 #include <phool/PHObject.h>
 
 #include <cmath>
-#include <cstddef>          // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
 #include <set>
@@ -23,7 +23,7 @@ class JetMap : public PHObject
   typedef std::set<Jet::SRC>::const_iterator ConstSrcIter;
   typedef std::set<Jet::SRC>::iterator SrcIter;
 
-  JetMap(){}
+  JetMap() {}
   ~JetMap() override {}
 
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4jets/JetMapv1.cc
+++ b/simulation/g4simulation/g4jets/JetMapv1.cc
@@ -10,16 +10,6 @@
 #include <ostream>   // for operator<<, endl, ostream, basic_ostream::operat...
 #include <utility>   // for pair, make_pair
 
-using namespace std;
-
-JetMapv1::JetMapv1()
-  : _algo(Jet::NONE)
-  , _par(NAN)
-  , _src()
-  , _map()
-{
-}
-
 JetMapv1::JetMapv1(const JetMap *jets)
   : _algo(jets->get_algo())
   , _par(jets->get_par())
@@ -39,7 +29,7 @@ JetMapv1::JetMapv1(const JetMap *jets)
   {
     Jet* jet = dynamic_cast<Jet *> ((iter->second)->CloneMe());
     assert(jet);
-    _map.insert(make_pair(jet->get_id(), jet));
+    _map.insert(std::make_pair(jet->get_id(), jet));
   }
 }
 
@@ -63,7 +53,7 @@ JetMapv1& JetMapv1::operator=(const JetMapv1& jets)
   {
     Jet* jet = dynamic_cast<Jet *> ((iter->second)->CloneMe());
     assert(jet);
-    _map.insert(make_pair(jet->get_id(), jet));
+    _map.insert(std::make_pair(jet->get_id(), jet));
   }
 
   return *this;
@@ -93,16 +83,16 @@ PHObject* JetMapv1::CloneMe() const
   return map;
 }
 
-void JetMapv1::identify(ostream& os) const
+void JetMapv1::identify(std::ostream& os) const
 {
-  os << "JetMapv1: size = " << _map.size() << endl;
-  os << "          par = " << _par << endl;
+  os << "JetMapv1: size = " << _map.size() << std::endl;
+  os << "          par = " << _par << std::endl;
   os << "          source = ";
   for (ConstSrcIter i = begin_src(); i != end_src(); ++i)
   {
     os << (*i) << ",";
   }
-  os << endl;
+  os << std::endl;
 
   return;
 }
@@ -125,7 +115,7 @@ Jet* JetMapv1::insert(Jet* jet)
 {
   unsigned int index = 0;
   if (!_map.empty()) index = _map.rbegin()->first + 1;
-  _map.insert(make_pair(index, jet));
+  _map.insert(std::make_pair(index, jet));
   _map[index]->set_id(index);
   return (_map[index]);
 }

--- a/simulation/g4simulation/g4jets/JetMapv1.cc
+++ b/simulation/g4simulation/g4jets/JetMapv1.cc
@@ -10,7 +10,7 @@
 #include <ostream>   // for operator<<, endl, ostream, basic_ostream::operat...
 #include <utility>   // for pair, make_pair
 
-JetMapv1::JetMapv1(const JetMap *jets)
+JetMapv1::JetMapv1(const JetMap* jets)
   : _algo(jets->get_algo())
   , _par(jets->get_par())
   , _src()
@@ -27,7 +27,7 @@ JetMapv1::JetMapv1(const JetMap *jets)
        iter != jets->end();
        ++iter)
   {
-    Jet* jet = dynamic_cast<Jet *> ((iter->second)->CloneMe());
+    Jet* jet = dynamic_cast<Jet*>((iter->second)->CloneMe());
     assert(jet);
     _map.insert(std::make_pair(jet->get_id(), jet));
   }
@@ -51,7 +51,7 @@ JetMapv1& JetMapv1::operator=(const JetMapv1& jets)
        iter != jets.end();
        ++iter)
   {
-    Jet* jet = dynamic_cast<Jet *> ((iter->second)->CloneMe());
+    Jet* jet = dynamic_cast<Jet*>((iter->second)->CloneMe());
     assert(jet);
     _map.insert(std::make_pair(jet->get_id(), jet));
   }

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -14,7 +14,7 @@ class PHObject;
 class JetMapv1 : public JetMap
 {
  public:
-  JetMapv1();
+  JetMapv1() {}
   JetMapv1(const JetMap *jets);
   JetMapv1& operator=(const JetMapv1& jets);
   ~JetMapv1() override;
@@ -68,8 +68,8 @@ class JetMapv1 : public JetMap
   Iter end() override { return _map.end(); }
 
  private:
-  Jet::ALGO _algo;          //< algorithm used to reconstruct jets
-  float _par;               //< algorithm parameter setting (e.g. radius)
+  Jet::ALGO _algo = Jet::NONE;          //< algorithm used to reconstruct jets
+  float _par = NAN;               //< algorithm parameter setting (e.g. radius)
   std::set<Jet::SRC> _src;  //< list of sources (clusters, towers, etc)
   typ_JetMap _map;          //< jet algorithm output storage
 

--- a/simulation/g4simulation/g4jets/JetMapv1.h
+++ b/simulation/g4simulation/g4jets/JetMapv1.h
@@ -5,7 +5,7 @@
 
 #include "Jet.h"
 
-#include <cstddef>          // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <set>
 
@@ -15,7 +15,7 @@ class JetMapv1 : public JetMap
 {
  public:
   JetMapv1() {}
-  JetMapv1(const JetMap *jets);
+  JetMapv1(const JetMap* jets);
   JetMapv1& operator=(const JetMapv1& jets);
   ~JetMapv1() override;
 
@@ -68,10 +68,10 @@ class JetMapv1 : public JetMap
   Iter end() override { return _map.end(); }
 
  private:
-  Jet::ALGO _algo = Jet::NONE;          //< algorithm used to reconstruct jets
-  float _par = NAN;               //< algorithm parameter setting (e.g. radius)
-  std::set<Jet::SRC> _src;  //< list of sources (clusters, towers, etc)
-  typ_JetMap _map;          //< jet algorithm output storage
+  Jet::ALGO _algo = Jet::NONE;  //< algorithm used to reconstruct jets
+  float _par = NAN;             //< algorithm parameter setting (e.g. radius)
+  std::set<Jet::SRC> _src;      //< list of sources (clusters, towers, etc)
+  typ_JetMap _map;              //< jet algorithm output storage
 
   ClassDefOverride(JetMapv1, 1);
 };

--- a/simulation/g4simulation/g4jets/JetReco.cc
+++ b/simulation/g4simulation/g4jets/JetReco.cc
@@ -9,21 +9,21 @@
 
 // PHENIX includes
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>          // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/PHTypedNodeIterator.h>
-#include <phool/PHObject.h>              // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                 // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 // standard includes
-#include <cstdlib>                      // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <memory>                        // for allocator_traits<>::value_type
+#include <memory>  // for allocator_traits<>::value_type
 #include <vector>
 
 JetReco::JetReco(const std::string &name)
@@ -33,14 +33,14 @@ JetReco::JetReco(const std::string &name)
 
 JetReco::~JetReco()
 {
-  for (unsigned int i = 0; i < _inputs.size(); ++i) 
+  for (unsigned int i = 0; i < _inputs.size(); ++i)
   {
-delete _inputs[i];
+    delete _inputs[i];
   }
   _inputs.clear();
-  for (unsigned int i = 0; i < _algos.size(); ++i) 
+  for (unsigned int i = 0; i < _algos.size(); ++i)
   {
-delete _algos[i];
+    delete _algos[i];
   }
   _algos.clear();
   _outputs.clear();
@@ -144,7 +144,7 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
 
 void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, std::vector<Jet *> jets)
 {
-  JetMap *jetmap = findNode::getClass<JetMap>(topNode,_outputs[ipos]);
+  JetMap *jetmap = findNode::getClass<JetMap>(topNode, _outputs[ipos]);
   if (!jetmap)
   {
     std::cout << PHWHERE << " ERROR: Can't find JetMap: " << _outputs[ipos] << std::endl;

--- a/simulation/g4simulation/g4jets/JetReco.cc
+++ b/simulation/g4simulation/g4jets/JetReco.cc
@@ -26,42 +26,36 @@
 #include <memory>                        // for allocator_traits<>::value_type
 #include <vector>
 
-using namespace std;
-
-JetReco::JetReco(const string &name)
+JetReco::JetReco(const std::string &name)
   : SubsysReco(name)
-  , _inputs()
-  , _algos()
-  , _algonode()
-  , _inputnode()
-  , _outputs()
 {
 }
 
 JetReco::~JetReco()
 {
-  for (unsigned int i = 0; i < _inputs.size(); ++i) delete _inputs[i];
+  for (unsigned int i = 0; i < _inputs.size(); ++i) 
+  {
+delete _inputs[i];
+  }
   _inputs.clear();
-  for (unsigned int i = 0; i < _algos.size(); ++i) delete _algos[i];
+  for (unsigned int i = 0; i < _algos.size(); ++i) 
+  {
+delete _algos[i];
+  }
   _algos.clear();
   _outputs.clear();
-}
-
-int JetReco::Init(PHCompositeNode */*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int JetReco::InitRun(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
-    cout << "========================== JetReco::InitRun() =============================" << endl;
-    cout << " Input Selections:" << endl;
+    std::cout << "========================== JetReco::InitRun() =============================" << std::endl;
+    std::cout << " Input Selections:" << std::endl;
     for (unsigned int i = 0; i < _inputs.size(); ++i) _inputs[i]->identify();
-    cout << " Algorithms:" << endl;
+    std::cout << " Algorithms:" << std::endl;
     for (unsigned int i = 0; i < _algos.size(); ++i) _algos[i]->identify();
-    cout << "===========================================================================" << endl;
+    std::cout << "===========================================================================" << std::endl;
   }
 
   return CreateNodes(topNode);
@@ -69,7 +63,7 @@ int JetReco::InitRun(PHCompositeNode *topNode)
 
 int JetReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) cout << "JetReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) std::cout << "JetReco::process_event -- entered" << std::endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -101,13 +95,8 @@ int JetReco::process_event(PHCompositeNode *topNode)
   for (unsigned int i = 0; i < inputs.size(); ++i) delete inputs[i];
   inputs.clear();
 
-  if (Verbosity() > 1) cout << "JetReco::process_event -- exited" << endl;
+  if (Verbosity() > 1) std::cout << "JetReco::process_event -- exited" << std::endl;
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int JetReco::End(PHCompositeNode */*topNode*/)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -116,26 +105,26 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
   PHNodeIterator iter(topNode);
 
   // Looking for the DST node
-  PHCompositeNode *dstNode = static_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
   // Create the AntiKt node if required
-  PHCompositeNode *AlgoNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", _algonode.c_str()));
+  PHCompositeNode *AlgoNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", _algonode));
   if (!AlgoNode)
   {
-    AlgoNode = new PHCompositeNode(_algonode.c_str());
+    AlgoNode = new PHCompositeNode(_algonode);
     dstNode->addNode(AlgoNode);
   }
 
   // Create the Input node if required
-  PHCompositeNode *InputNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", _inputnode.c_str()));
+  PHCompositeNode *InputNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", _inputnode));
   if (!InputNode)
   {
-    InputNode = new PHCompositeNode(_inputnode.c_str());
+    InputNode = new PHCompositeNode(_inputnode);
     AlgoNode->addNode(InputNode);
   }
 
@@ -145,7 +134,7 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
     if (!jets)
     {
       jets = new JetMapv1();
-      PHIODataNode<PHObject> *JetMapNode = new PHIODataNode<PHObject>(jets, _outputs[i].c_str(), "PHObject");
+      PHIODataNode<PHObject> *JetMapNode = new PHIODataNode<PHObject>(jets, _outputs[i], "PHObject");
       InputNode->addNode(JetMapNode);
     }
   }
@@ -155,17 +144,11 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
 
 void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, std::vector<Jet *> jets)
 {
-  JetMap *jetmap = nullptr;
-  PHTypedNodeIterator<JetMap> jetmapiter(topNode);
-  PHIODataNode<JetMap> *JetMapNode = jetmapiter.find(_outputs[ipos].c_str());
-  if (!JetMapNode)
+  JetMap *jetmap = findNode::getClass<JetMap>(topNode,_outputs[ipos]);
+  if (!jetmap)
   {
-    cout << PHWHERE << " ERROR: Can't find JetMap: " << _outputs[ipos] << endl;
+    std::cout << PHWHERE << " ERROR: Can't find JetMap: " << _outputs[ipos] << std::endl;
     exit(-1);
-  }
-  else
-  {
-    jetmap = dynamic_cast<JetMap *> (JetMapNode->getData());
   }
 
   jetmap->set_algo(_algos[ipos]->get_algo());

--- a/simulation/g4simulation/g4jets/JetReco.h
+++ b/simulation/g4simulation/g4jets/JetReco.h
@@ -11,7 +11,7 @@
 #include <fun4all/SubsysReco.h>
 
 // standard includes
-#include <string>                // for string
+#include <string>  // for string
 #include <vector>
 
 // forward declarations

--- a/simulation/g4simulation/g4jets/JetReco.h
+++ b/simulation/g4simulation/g4jets/JetReco.h
@@ -34,10 +34,8 @@ class JetReco : public SubsysReco
   JetReco(const std::string &name = "JetReco");
   ~JetReco() override;
 
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End(PHCompositeNode *topNode) override;
 
   void add_input(JetInput *input) { _inputs.push_back(input); }
   void add_algo(JetAlgo *algo, std::string output)

--- a/simulation/g4simulation/g4jets/Jetv1.cc
+++ b/simulation/g4simulation/g4jets/Jetv1.cc
@@ -95,7 +95,7 @@ float Jetv1::get_mass() const
   {
     return -1 * sqrt(fabs(mass2));
   }
-    return sqrt(mass2);
+  return sqrt(mass2);
 }
 
 float Jetv1::get_mass2() const
@@ -111,7 +111,7 @@ bool Jetv1::has_property(Jet::PROPERTY prop_id) const
   {
     return false;
   }
-    return true;
+  return true;
 }
 
 float Jetv1::get_property(Jet::PROPERTY prop_id) const
@@ -121,7 +121,7 @@ float Jetv1::get_property(Jet::PROPERTY prop_id) const
   {
     return NAN;
   }
-    return citer->second;
+  return citer->second;
 }
 
 void Jetv1::set_property(Jet::PROPERTY prop_id, float value)

--- a/simulation/g4simulation/g4jets/Jetv1.cc
+++ b/simulation/g4simulation/g4jets/Jetv1.cc
@@ -8,35 +8,29 @@
 
 #include "Jetv1.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 
 class PHObject;
 
-using namespace std;
-
 Jetv1::Jetv1()
-  : _id(0xFFFFFFFF)
-  , _mom()
-  , _e(NAN)
-  , _comp_ids()
-  , _property_map()
 {
-  for (int i = 0; i < 3; ++i) _mom[i] = NAN;
+  std::fill(std::begin(_mom), std::end(_mom), NAN);
 }
 
-void Jetv1::identify(ostream& os) const
+void Jetv1::identify(std::ostream& os) const
 {
-  os << "---Jet v1-----------------------" << endl;
-  os << "jetid: " << get_id() << endl;
+  os << "---Jet v1-----------------------" << std::endl;
+  os << "jetid: " << get_id() << std::endl;
   os << " (px,py,pz,e) =  (" << get_px() << ", " << get_py() << ", ";
-  os << get_pz() << ", " << get_e() << ") GeV" << endl;
+  os << get_pz() << ", " << get_e() << ") GeV" << std::endl;
   print_property(os);
   for (ConstIter citer = begin_comp(); citer != end_comp(); ++citer)
   {
-    cout << citer->first << " -> " << citer->second << endl;
+    os << citer->first << " -> " << citer->second << std::endl;
   }
-  os << "-----------------------------------------------" << endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
@@ -44,7 +38,7 @@ void Jetv1::identify(ostream& os) const
 void Jetv1::Reset()
 {
   _id = 0xFFFFFFFF;
-  for (int i = 0; i < 3; ++i) _mom[i] = NAN;
+  std::fill(std::begin(_mom), std::end(_mom), NAN);
   _e = NAN;
   _comp_ids.clear();
   _property_map.clear();
@@ -98,8 +92,9 @@ float Jetv1::get_mass() const
   // follow CLHEP convention and return negative mass if E^2 - p^2 < 0
   float mass2 = get_mass2();
   if (mass2 < 0)
+  {
     return -1 * sqrt(fabs(mass2));
-  else
+  }
     return sqrt(mass2);
 }
 
@@ -113,8 +108,9 @@ bool Jetv1::has_property(Jet::PROPERTY prop_id) const
 {
   typ_property_map::const_iterator citer = _property_map.find(prop_id);
   if (citer == _property_map.end())
+  {
     return false;
-  else
+  }
     return true;
 }
 
@@ -122,8 +118,9 @@ float Jetv1::get_property(Jet::PROPERTY prop_id) const
 {
   typ_property_map::const_iterator citer = _property_map.find(prop_id);
   if (citer == _property_map.end())
+  {
     return NAN;
-  else
+  }
     return citer->second;
 }
 
@@ -132,7 +129,7 @@ void Jetv1::set_property(Jet::PROPERTY prop_id, float value)
   _property_map[prop_id] = value;
 }
 
-void Jetv1::print_property(ostream& os) const
+void Jetv1::print_property(std::ostream& os) const
 {
   for (typ_property_map::const_iterator citer = _property_map.begin();
        citer != _property_map.end(); ++citer)
@@ -152,6 +149,6 @@ void Jetv1::print_property(ostream& os) const
       break;
     }
 
-    os << "\t= " << citer->second << endl;
+    os << "\t= " << citer->second << std::endl;
   }
 }

--- a/simulation/g4simulation/g4jets/Jetv1.h
+++ b/simulation/g4simulation/g4jets/Jetv1.h
@@ -12,6 +12,7 @@
 #include "Jet.h"
 
 #include <cstddef>  // for size_t
+#include <cmath>
 #include <iostream>
 #include <map>
 #include <utility>  // for pair, make_pair
@@ -102,13 +103,13 @@ class Jetv1 : public Jet
 
  private:
   /// unique identifier within container
-  unsigned int _id;
+  unsigned int _id = ~0x0;
 
   /// jet momentum vector (px,py,pz)
   float _mom[3];
 
   /// jet energy
-  float _e;
+  float _e = NAN;
 
   /// source id -> component id
   typ_comp_ids _comp_ids;

--- a/simulation/g4simulation/g4jets/Jetv1.h
+++ b/simulation/g4simulation/g4jets/Jetv1.h
@@ -11,10 +11,10 @@
 
 #include "Jet.h"
 
-#include <cstddef>          // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
-#include <utility>   // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class PHObject;
 

--- a/simulation/g4simulation/g4jets/TowerJetInput.cc
+++ b/simulation/g4simulation/g4jets/TowerJetInput.cc
@@ -20,8 +20,6 @@
 #include <utility>  // for pair
 #include <vector>
 
-using namespace std;
-
 TowerJetInput::TowerJetInput(Jet::SRC input)
   : _input(input)
 {
@@ -31,28 +29,40 @@ void TowerJetInput::identify(std::ostream &os)
 {
   os << "   TowerJetInput: ";
   if (_input == Jet::CEMC_TOWER)
+  {
     os << "TOWER_CEMC to Jet::CEMC_TOWER";
-  if (_input == Jet::EEMC_TOWER)
+  }
+  else if (_input == Jet::EEMC_TOWER)
+  {
     os << "TOWER_EEMC to Jet::EEMC_TOWER";
+  }
   else if (_input == Jet::HCALIN_TOWER)
+  {
     os << "TOWER_HCALIN to Jet::HCALIN_TOWER";
+  }
   else if (_input == Jet::HCALOUT_TOWER)
+  {
     os << "TOWER_HCALOUT to Jet::HCALOUT_TOWER";
+  }
   else if (_input == Jet::FEMC_TOWER)
+  {
     os << "TOWER_FEMC to Jet::FEMC_TOWER";
+  }
   else if (_input == Jet::FHCAL_TOWER)
+  {
     os << "TOWER_FHCAL to Jet::FHCAL_TOWER";
-  os << endl;
+  }
+  os << std::endl;
 }
 
 std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 0) cout << "TowerJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) std::cout << "TowerJetInput::process_event -- entered" << std::endl;
 
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
-    cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is missing. Please turn on the do_global flag in the main macro in order to reconstruct the global vertex." << endl;
+    std::cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is missing. Please turn on the do_global flag in the main macro in order to reconstruct the global vertex." << std::endl;
     assert(vertexmap);  // force quit
 
     return std::vector<Jet *>();
@@ -60,7 +70,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
   if (vertexmap->empty())
   {
-    cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << endl;
+    std::cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
     return std::vector<Jet *>();
   }
 
@@ -192,9 +202,13 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   GlobalVertex *vtx = vertexmap->begin()->second;
   float vtxz = NAN;
   if (vtx)
+  {
     vtxz = vtx->get_z();
+  }
   else
+  {
     return std::vector<Jet *>();
+  }
 
   if (isnan(vtxz))
   {
@@ -203,7 +217,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     {
       once = false;
 
-      cout << "TowerJetInput::get_input - WARNING - vertex is NAN. Drop all tower inputs (further NAN-vertex warning will be suppressed)." << endl;
+      std::cout << "TowerJetInput::get_input - WARNING - vertex is NAN. Drop all tower inputs (further NAN-vertex warning will be suppressed)." << std::endl;
     }
 
     return std::vector<Jet *>();
@@ -216,8 +230,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     RawTower *tower = rtiter->second;
 
-    RawTowerGeom *tower_geom =
-        geom->get_tower_geometry(tower->get_key());
+    RawTowerGeom *tower_geom = geom->get_tower_geometry(tower->get_key());
     assert(tower_geom);
 
     double r = tower_geom->get_center_radius();
@@ -243,7 +256,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (Verbosity() > 0) cout << "TowerJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) std::cout << "TowerJetInput::process_event -- exited" << std::endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TrackJetInput.cc
+++ b/simulation/g4simulation/g4jets/TrackJetInput.cc
@@ -10,8 +10,8 @@
 
 // standard includes
 #include <iostream>
-#include <map>                                // for _Rb_tree_const_iterator
-#include <utility>                            // for pair
+#include <map>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 #include <vector>
 
 TrackJetInput::TrackJetInput(Jet::SRC input, const std::string &nodename)

--- a/simulation/g4simulation/g4jets/TrackJetInput.cc
+++ b/simulation/g4simulation/g4jets/TrackJetInput.cc
@@ -14,9 +14,7 @@
 #include <utility>                            // for pair
 #include <vector>
 
-using namespace std;
-
-TrackJetInput::TrackJetInput(Jet::SRC input, const string &nodename)
+TrackJetInput::TrackJetInput(Jet::SRC input, const std::string &nodename)
   : m_NodeName(nodename)
   , _input(input)
 {
@@ -24,12 +22,12 @@ TrackJetInput::TrackJetInput(Jet::SRC input, const string &nodename)
 
 void TrackJetInput::identify(std::ostream &os)
 {
-  os << "   TrackJetInput: SvtxTrackMap to Jet::TRACK" << endl;
+  os << "   TrackJetInput: SvtxTrackMap to Jet::TRACK" << std::endl;
 }
 
 std::vector<Jet *> TrackJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 0) cout << "TrackJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) std::cout << "TrackJetInput::process_event -- entered" << std::endl;
 
   // Pull the reconstructed track information off the node tree...
   SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_NodeName);
@@ -54,7 +52,7 @@ std::vector<Jet *> TrackJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (Verbosity() > 0) cout << "TrackJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) std::cout << "TrackJetInput::process_event -- exited" << std::endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TrackJetInput.h
+++ b/simulation/g4simulation/g4jets/TrackJetInput.h
@@ -5,8 +5,8 @@
 
 #include "Jet.h"
 
-#include <iostream>    // for cout, ostream
-#include <string>      // for string
+#include <iostream>  // for cout, ostream
+#include <string>    // for string
 #include <vector>
 
 class PHCompositeNode;
@@ -14,7 +14,7 @@ class PHCompositeNode;
 class TrackJetInput : public JetInput
 {
  public:
-  TrackJetInput(Jet::SRC input, const std::string &name = "SvtxTrackMap");
+  TrackJetInput(Jet::SRC input, const std::string& name = "SvtxTrackMap");
   ~TrackJetInput() override {}
 
   void identify(std::ostream& os = std::cout) override;

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -8,15 +8,15 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 
 #include <phool/getClass.h>
-#include <phool/phool.h>                    // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 // standard includes
 #include <algorithm>  // std::find
-#include <cmath>                           // for asinh, sqrt
+#include <cmath>      // for asinh, sqrt
 #include <cstdlib>
 #include <iostream>
-#include <map>                              // for _Rb_tree_const_iterator
-#include <utility>                          // for pair
+#include <map>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 #include <vector>
 
 TruthJetInput::TruthJetInput(Jet::SRC input)

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -19,12 +19,8 @@
 #include <utility>                          // for pair
 #include <vector>
 
-using namespace std;
-
 TruthJetInput::TruthJetInput(Jet::SRC input)
-  : _input(input)
-  , _eta_min(-4.0)
-  , _eta_max(+4.0)
+  : m_Input(input)
 {
 }
 
@@ -34,23 +30,23 @@ void TruthJetInput::identify(std::ostream &os)
   if (use_embed_stream())
   {
     os << ". Processing embedded streams: ";
-    for (std::vector<int>::const_iterator it = _embed_id.begin(); it != _embed_id.end(); ++it)
+    for (std::vector<int>::const_iterator it = m_EmbedID.begin(); it != m_EmbedID.end(); ++it)
     {
       os << (*it) << ", ";
     }
   }
-  os << endl;
+  os << std::endl;
 }
 
 std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 0) cout << "TruthJetInput::process_event -- entered" << endl;
+  if (Verbosity() > 0) std::cout << "TruthJetInput::process_event -- entered" << std::endl;
 
   // Pull the reconstructed track information off the node tree...
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (!truthinfo)
   {
-    cerr << PHWHERE << " ERROR: Can't find G4TruthInfo" << endl;
+    std::cout << PHWHERE << " ERROR: Can't find G4TruthInfo" << std::endl;
     return std::vector<Jet *>();
   }
 
@@ -66,7 +62,7 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     {
       const int this_embed_id = truthinfo->isEmbeded(part->get_track_id());
 
-      if (std::find(_embed_id.begin(), _embed_id.end(), this_embed_id) == _embed_id.end())
+      if (std::find(m_EmbedID.begin(), m_EmbedID.end(), this_embed_id) == m_EmbedID.end())
       {
         continue;  // reject particle as it is not in the interested embedding stream.
       }
@@ -83,8 +79,8 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     // remove acceptance... _etamin,_etamax
     if ((part->get_px() == 0.0) && (part->get_py() == 0.0)) continue;  // avoid pt=0
     float eta = asinh(part->get_pz() / sqrt(pow(part->get_px(), 2) + pow(part->get_py(), 2)));
-    if (eta < _eta_min) continue;
-    if (eta > _eta_max) continue;
+    if (eta < m_EtaMin) continue;
+    if (eta > m_EtaMax) continue;
 
     Jet *jet = new Jetv1();
     jet->set_px(part->get_px());
@@ -95,7 +91,7 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     pseudojets.push_back(jet);
   }
 
-  if (Verbosity() > 0) cout << "TruthJetInput::process_event -- exited" << endl;
+  if (Verbosity() > 0) std::cout << "TruthJetInput::process_event -- exited" << std::endl;
 
   return pseudojets;
 }

--- a/simulation/g4simulation/g4jets/TruthJetInput.h
+++ b/simulation/g4simulation/g4jets/TruthJetInput.h
@@ -5,7 +5,7 @@
 
 #include "Jet.h"
 
-#include <iostream>    // for cout, ostream
+#include <iostream>  // for cout, ostream
 #include <vector>
 
 class PHCompositeNode;

--- a/simulation/g4simulation/g4jets/TruthJetInput.h
+++ b/simulation/g4simulation/g4jets/TruthJetInput.h
@@ -22,31 +22,31 @@ class TruthJetInput : public JetInput
   //! Call add_embedding_flag() multiple times to add multiple embed stream
   void add_embedding_flag(const int embed_stream_id)
   {
-    _embed_id.push_back(embed_stream_id);
+    m_EmbedID.push_back(embed_stream_id);
   }
 
   void identify(std::ostream& os = std::cout) override;
 
-  Jet::SRC get_src() override { return _input; }
+  Jet::SRC get_src() override { return m_Input; }
 
   std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
   void set_eta_range(float eta_min, float eta_max)
   {
-    _eta_min = eta_min;
-    _eta_max = eta_max;
+    m_EtaMin = eta_min;
+    m_EtaMax = eta_max;
   }
 
  private:
-  Jet::SRC _input;
-  float _eta_min;
-  float _eta_max;
+  Jet::SRC m_Input = Jet::VOID;
+  float m_EtaMin = -4.;
+  float m_EtaMax = 4.;
 
   //! if empty: process all primary particles
   //! if non-empty: only process primary particles in the selected embed stream.
-  std::vector<int> _embed_id;
+  std::vector<int> m_EmbedID;
 
-  bool use_embed_stream() { return _embed_id.size() > 0; }
+  bool use_embed_stream() { return m_EmbedID.size() > 0; }
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -374,8 +374,6 @@ void PHG4TpcDetector ::CreateCompositeMaterial(
   //takes in a list of material names known to Geant already, and thicknesses, and creates a new material called compositeName.
 
   //check that desired material name doesn't already exist
-  //note that this throws a warning.
-  std::cout << __PRETTY_FUNCTION__ << " NOTICE: Checking if material " << compositeName << " exists.  This will return a warning if it doesn't, but that is okay." << std::endl;
   G4Material *tempmat = GetDetectorMaterial(compositeName, false);
 
   if (tempmat != nullptr)

--- a/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcEndCapDetector.cc
@@ -174,8 +174,6 @@ void PHG4TpcEndCapDetector ::CreateCompositeMaterial(
   //takes in a list of material names known to Geant already, and thicknesses, and creates a new material called compositeName.
 
   //check that desired material name doesn't already exist
-  //note that this throws a warning.
-  std::cout << __PRETTY_FUNCTION__ << " NOTICE: Checking if material " << compositeName << " exists.  This will return a warning if it doesn't, but that is okay." << std::endl;
   G4Material *tempmat = GetDetectorMaterial(compositeName, false);
 
   if (tempmat != nullptr)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The hcals produced NANs as phi coordinates under certain conditions. This lead to a hard to debug problem in the jet finding with fastjet (which did not take well to px/py=NAN). Now the input values are checked via isfinite() before handed down to fastjet. The hcal tower reconstruction also makes sure the phistart value is a valid number (which was the root cause of this crash)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

