### PR TITLE
Add embed setter for QA modules

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -454,7 +454,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
     {
       //only analyze subset of particle with proper embedding IDs
       int candidate_embedding_id = trutheval->get_embed(g4particle);
-      if (candidate_embedding_id < 0) candidate_embedding_id = -1;
+      if (candidate_embedding_id <= m_embed_id_cut) candidate_embedding_id = -1;
 
       // skip if no match
       if (m_embeddingIDs.find(candidate_embedding_id) == m_embeddingIDs.end()) continue;

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -54,6 +54,8 @@ class QAG4SimulationTracking : public SubsysReco
     m_uniqueTrackingMatch = b;
   }
 
+  void set_embed_id_cut(const int id) { m_embed_id_cut = id; }
+
  private:
   /// load nodes
   int load_nodes(PHCompositeNode *);
@@ -72,6 +74,9 @@ class QAG4SimulationTracking : public SubsysReco
 
   //! only count unique truth<->reco track pair in tracking efficiency
   bool m_uniqueTrackingMatch = true;
+
+  //! cut for selecting on foreground
+  int m_embed_id_cut = 0;
 
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;

--- a/offline/QA/modules/QAG4SimulationVertex.cc
+++ b/offline/QA/modules/QAG4SimulationVertex.cc
@@ -217,7 +217,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
       ++embedvtxid_particle_count[gembed];
       PHG4Particle *g4particle = iter->second;
 
-      if (false && gembed <= 0) continue;
+      if (m_checkembed && gembed <= m_embed_id_cut) continue;
 
       std::set<TrkrDefs::cluskey> g4clusters = clustereval->all_clusters_from(g4particle);
 

--- a/offline/QA/modules/QAG4SimulationVertex.h
+++ b/offline/QA/modules/QAG4SimulationVertex.h
@@ -29,7 +29,9 @@ class QAG4SimulationVertex : public SubsysReco
   int process_event(PHCompositeNode *topNode);
 
   std::string get_histo_prefix();
-
+  
+  void check_embed() { m_checkembed = true;}
+  void embed_id_cut(const int id) { m_embed_id_cut = id; }
   void addEmbeddingID(int embeddingID);
 
   void setTrackgMapName(const std::string &name) { m_trackMapName = name; }
@@ -43,6 +45,9 @@ class QAG4SimulationVertex : public SubsysReco
   unsigned int _nlayers_maps = 3;
 
   std::unique_ptr<SvtxEvalStack> m_svtxEvalStack;
+
+  int m_embed_id_cut = 0;
+  bool m_checkembed = false;
 
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -85,9 +85,6 @@ class MakeActsGeometry : public SubsysReco
 
   void set_drift_velocity(double vd){m_drift_velocity = vd;}
 
-  void add_fake_surfaces(bool add)
-  {fake_surfaces = add;}
-
   void build_mm_surfaces( bool value )
   { m_buildMMs = value; }
     
@@ -232,7 +229,6 @@ class MakeActsGeometry : public SubsysReco
   double m_magFieldRescale = -1.;
 
   bool m_buildMMs = false;
-  bool fake_surfaces = true;
 };
 
 #endif

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -474,7 +474,9 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int
 
       if(crossing == SHRT_MAX) 
 	{
-	  std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << si_track->get_z() << " because crossing is undefined " << std::endl; 
+	  if(Verbosity() > 2) {
+	    std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << si_track->get_z() << " because crossing is undefined " << std::endl; 
+	  }
 	  continue;
 	}
 


### PR DESCRIPTION

This PR adds a setter for the embed id flag in the QA modules. It defaults to the current behavior, so the Jenkins QA should run normally but we want to be able to set it for the daily build Hijing and Pythia8 QA. 

It also cleans up unused code in MakeActsGeometry and hides a verbosity statement from the track matcher.


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

