### PR TITLE
Acts fit fixes

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrackMap_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackMap_v2.cc
@@ -9,9 +9,6 @@
 #include <ostream>      // for operator<<, endl, ostream, basic_ostream, bas...
 #include <utility>      // for pair, make_pair
 
-using namespace std;
-
-
 SvtxTrackMap_v2::SvtxTrackMap_v2()
   : _map()
 {
@@ -24,20 +21,24 @@ SvtxTrackMap_v2::SvtxTrackMap_v2(const SvtxTrackMap_v2& trackmap)
        iter != trackmap.end();
        ++iter)
   {
-    SvtxTrack* track = dynamic_cast<SvtxTrack*> (iter->second->CloneMe());
-    _map.insert(make_pair(track->get_id(), track));
+    auto track = static_cast<SvtxTrack*> (iter->second->CloneMe());
+    _map.insert(std::make_pair(track->get_id(), track));
   }
 }
 
 SvtxTrackMap_v2& SvtxTrackMap_v2::operator=(const SvtxTrackMap_v2& trackmap)
 {
+  
+  // do nothing if same  copying map onto itself
+  if( &trackmap == this ) return *this;
+  
   Reset();
   for (ConstIter iter = trackmap.begin();
        iter != trackmap.end();
        ++iter)
   {
-    SvtxTrack* track = dynamic_cast<SvtxTrack*> (iter->second->CloneMe());
-    _map.insert(make_pair(track->get_id(), track));
+    auto track = static_cast<SvtxTrack*> (iter->second->CloneMe());
+    _map.insert(std::make_pair(track->get_id(), track));
   }
   return *this;
 }
@@ -59,9 +60,9 @@ void SvtxTrackMap_v2::Reset()
   _map.clear();
 }
 
-void SvtxTrackMap_v2::identify(ostream& os) const
+void SvtxTrackMap_v2::identify(std::ostream& os) const
 {
-  os << "SvtxTrackMap_v2: size = " << _map.size() << endl;
+  os << "SvtxTrackMap_v2: size = " << _map.size() << std::endl;
   return;
 }
 
@@ -83,14 +84,31 @@ SvtxTrack* SvtxTrackMap_v2::insert(const SvtxTrack* track)
 {
   unsigned int index = 0;
   if (!_map.empty()) index = _map.rbegin()->first + 1;
-  _map.insert(make_pair(index, dynamic_cast<SvtxTrack*> (track->CloneMe())));
-  _map[index]->set_id(index);
-  return _map[index];
+  auto copy = static_cast<SvtxTrack*>( track->CloneMe() );
+  copy->set_id(index);
+
+  const auto result = _map.insert(std::make_pair(index, copy ));
+  if( !result.second ) 
+  {
+    std::cout << "SvtxTrackMap_v2::insert - duplicated key. track not inserted" << std::endl; 
+    delete copy;
+    return nullptr;
+  } else {
+    return copy;
+  }
 }
 
 SvtxTrack* SvtxTrackMap_v2::insertWithKey(const SvtxTrack* track, unsigned int index)
 {
-  _map.insert(make_pair(index, dynamic_cast<SvtxTrack*> (track->CloneMe())));
-  _map[index]->set_id(index);
-  return _map[index];
+  auto copy = static_cast<SvtxTrack*>( track->CloneMe() );
+  copy->set_id(index);
+  const auto result = _map.insert(std::make_pair(index, copy ));
+  if( !result.second ) 
+  {
+    std::cout << "SvtxTrackMap_v2::insertWithKey - duplicated key. track not inserted" << std::endl; 
+    delete copy;
+    return nullptr;
+  } else {
+    return copy;
+  }
 }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -80,8 +80,7 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
     m_tGeometry->geometry().tGeometry,
     m_tGeometry->geometry().magField);
 
-  m_fitCfg.dFit = ActsExamples::TrackFittingAlgorithm::makeKalmanFitterFunction(
-    m_tGeometry->geometry().magField);
+  m_fitCfg.dFit = ActsExamples::TrackFittingAlgorithm::makeKalmanFitterFunction(m_tGeometry->geometry().magField);
 
   m_outlierFinder.verbosity = Verbosity();
   std::map<long unsigned int, float> chi2Cuts;
@@ -241,7 +240,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	}
 
       // get the crossing number
-      TrackSeed *siseed = m_siliconSeeds->get(siid);
+      auto siseed = m_siliconSeeds->get(siid);
       auto crossing = siseed->get_crossing();
 
       // if the crossing was not determined, skip this case completely
@@ -252,7 +251,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	  continue;
 	}
 
-      TrackSeed *tpcseed = m_tpcSeeds->get(tpcid);
+      auto tpcseed = m_tpcSeeds->get(tpcid);
 
       /// Need to also check that the tpc seed wasn't removed by the ghost finder
       if(!tpcseed)
@@ -267,12 +266,10 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       trackTimer.stop();
       trackTimer.restart();
       ActsExamples::MeasurementContainer measurements;
-     
-      auto sourceLinks = getSourceLinks(tpcseed, measurements, crossing);
   
-      auto siSourceLinks = getSourceLinks(siseed, measurements, crossing);
-      for(auto& siSL : siSourceLinks)
-	{ sourceLinks.push_back(siSL); }
+      auto sourceLinks = getSourceLinks(siseed, measurements, crossing);
+      const auto tpcSourceLinks = getSourceLinks(tpcseed, measurements, crossing);
+      sourceLinks.insert( sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end() );
 
       // position comes from the silicon seed
       Acts::Vector3 position(0,0,0);
@@ -281,7 +278,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       position(2) = siseed->get_z() * Acts::UnitConstants::cm;
       if( !is_valid( position ) ) continue;
 
-      if(sourceLinks.size() == 0) { continue; }
+      if(sourceLinks.empty()) { continue; }
 
       /// If using directed navigation, collect surface list to navigate
       SurfacePtrVec surfaces;
@@ -321,19 +318,19 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       /// access correct
       std::vector<std::reference_wrapper<const SourceLink>>  wrappedSls;
       for(const auto& sl : sourceLinks)
-	{ wrappedSls.push_back(std::cref(sl)); }
+      { wrappedSls.push_back(std::cref(sl)); }
            
       /// Reset the track seed with the dummy covariance
       auto seed = ActsExamples::TrackParameters::create(
         pSurface,
-	m_tGeometry->geometry().geoContext,
-	actsFourPos,
-	momentum,
-	charge / momentum.norm(),
-	cov).value();
+        m_tGeometry->geometry().geoContext,
+        actsFourPos,
+        momentum,
+        charge / momentum.norm(),
+        cov).value();
       
       if(Verbosity() > 2)
-	{ printTrackSeed(seed); }
+      { printTrackSeed(seed); }
 
       /// Set host of propagator options for Acts to do e.g. material integration
       Acts::PropagatorPlainOptions ppPlainOptions;
@@ -348,77 +345,79 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       auto calibcontext = m_tGeometry->geometry().calibContext;
 
       ActsExamples::TrackFittingAlgorithm::GeneralFitterOptions 
-	kfOptions{geocontext,
-		  magcontext,
-	          calibcontext,
-		  calibrator,
-		  &(*pSurface),
-	  Acts::LoggerWrapper(*logger),ppPlainOptions};
+        kfOptions{geocontext,
+        magcontext,
+        calibcontext,
+        calibrator,
+        &(*pSurface),
+        Acts::LoggerWrapper(*logger),ppPlainOptions};
       
       PHTimer fitTimer("FitTimer");
       fitTimer.stop();
       fitTimer.restart();
-      auto result = fitTrack(wrappedSls, seed, kfOptions,
-			     surfaces);
+      auto result = fitTrack(wrappedSls, seed, kfOptions, surfaces);
       fitTimer.stop();
       auto fitTime = fitTimer.get_accumulated_time();
-      
+            
       if(Verbosity() > 1)
-	std::cout << "PHActsTrkFitter Acts fit time "
-		  << fitTime << std::endl;
+      { std::cout << "PHActsTrkFitter Acts fit time " << fitTime << std::endl; }
 
       /// Check that the track fit result did not return an error
       if (result.ok())
-	{  
-	  const FitResult& fitOutput = result.value();
+      {  
+        const FitResult& fitOutput = result.value();
+        if(m_timeAnalysis)
+        {
+          h_fitTime->Fill(fitOutput.fittedParameters.value()
+            .transverseMomentum(), 
+            fitTime);
+        }
 	  
-	  if(m_timeAnalysis)
-	    {
-	      h_fitTime->Fill(fitOutput.fittedParameters.value()
-			      .transverseMomentum(), 
-			      fitTime);
-	    }
-	  
-	  if(m_fitSiliconMMs)
-	    {
+        if(m_fitSiliconMMs)
+        {
+          
+          auto newTrack = std::make_unique<SvtxTrack_v4>();
+          unsigned int trid = m_directedTrackMap->size();
+          newTrack->set_id(trid);
+          newTrack->set_tpc_seed(tpcseed);
+          newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
+          newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
 
-	      std::unique_ptr<SvtxTrack_v4> newTrack( static_cast<SvtxTrack_v4*>(track->CloneMe()) );
-	      if( getTrackFitResult(fitOutput, newTrack.get()) )
-        { m_directedTrackMap->insert(newTrack.get()); } 
-	      
-	    }
-	  else
-	    {
-	      auto newTrack = std::make_unique<SvtxTrack_v4>();
-	      unsigned int trid = m_trackMap->size();
-	      newTrack->set_id(trid);
-	      newTrack->set_tpc_seed(tpcseed);
-	      newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
-	      newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
+          if( getTrackFitResult(fitOutput, newTrack.get()) )
+          { m_directedTrackMap->insertWithKey(newTrack.get(), trid); }
+          
+        } else {
+          
+          auto newTrack = std::make_unique<SvtxTrack_v4>();
+          unsigned int trid = m_trackMap->size();
+          newTrack->set_id(trid);
+          newTrack->set_tpc_seed(tpcseed);
+          newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
+          newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
 	
-	      if( getTrackFitResult(fitOutput, newTrack.get()))
-		{ m_trackMap->insertWithKey(newTrack.get(), trid); }
-	    }
-	}
-      else if (!m_fitSiliconMMs)
-	{
-	  /// Track fit failed, get rid of the track from the map
-	  m_nBadFits++;
-	  if(Verbosity() > 1)
-	    { 
-	      std::cout << "Track fit failed for track " << m_seedMap->find(track) 
-			<< " with Acts error message " 
-			<< result.error() << ", " << result.error().message()
-			<< std::endl;
-	    }
-	}
+          if( getTrackFitResult(fitOutput, newTrack.get()))
+          { m_trackMap->insertWithKey(newTrack.get(), trid); }
+        
+        }
+        
+      } else if (!m_fitSiliconMMs) {
+
+        /// Track fit failed, get rid of the track from the map
+        m_nBadFits++;
+        if(Verbosity() > 1)
+        { 
+          std::cout << "Track fit failed for track " << m_seedMap->find(track) 
+            << " with Acts error message " 
+            << result.error() << ", " << result.error().message()
+            << std::endl;
+        }
+      }
 
       trackTimer.stop();
       auto trackTime = trackTimer.get_accumulated_time();
       
       if(Verbosity() > 1)
-	std::cout << "PHActsTrkFitter total single track time "
-		  << trackTime << std::endl;
+      { std::cout << "PHActsTrkFitter total single track time " << trackTime << std::endl; }
     
     }
 
@@ -674,10 +673,15 @@ ActsExamples::TrackFittingAlgorithm::TrackFitterResult PHActsTrkFitter::fitTrack
     const SurfacePtrVec& surfSequence)
 {
 
+  std::cout << "PHActsTrkFitter::fitTrack - fitting track" << std::endl;
   if(m_fitSiliconMMs) 
-    { return (*m_fitCfg.dFit)(sourceLinks, seed, kfOptions, surfSequence); }
-
-  return (*m_fitCfg.fit)(sourceLinks, seed, kfOptions); 
+  { 
+    std::cout << "PHActsTrkFitter::fitTrack - using direct fit" << std::endl;
+    return (*m_fitCfg.dFit)(sourceLinks, seed, kfOptions, surfSequence); 
+  } else {
+    std::cout << "PHActsTrkFitter::fitTrack - using normal fit" << std::endl;
+    return (*m_fitCfg.fit)(sourceLinks, seed, kfOptions); 
+  }
 }
 
 SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks,
@@ -685,26 +689,26 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 {
   SourceLinkVec siliconMMSls;
 
-  if(Verbosity() > 1)
-    std::cout << "Sorting " << sourceLinks.size() << " SLs" << std::endl;
+//   if(Verbosity() > 1)
+//     std::cout << "Sorting " << sourceLinks.size() << " SLs" << std::endl;
   
   for(const auto& sl : sourceLinks)
-    {
-      if(Verbosity() > 1)
-	{ std::cout << "SL available on : " << sl.geometryId() << std::endl; }
+  {
+    if(Verbosity() > 1)
+    { std::cout << "SL available on : " << sl.geometryId() << std::endl; }
       
-      const auto surf = m_tGeometry->geometry().tGeometry->findSurface(sl.geometryId());
-      // skip TPC surfaces
-      if( m_tGeometry->maps().isTpcSurface( surf ) ) continue;
+    const auto surf = m_tGeometry->geometry().tGeometry->findSurface(sl.geometryId());
+    // skip TPC surfaces
+    if( m_tGeometry->maps().isTpcSurface( surf ) ) continue;
+    
+    // also skip micromegas surfaces if not used
+    if( m_tGeometry->maps().isMicromegasSurface( surf ) && !m_useMicromegas ) continue;
+    
+    // update vectors
+    siliconMMSls.push_back(sl);
+    surfaces.push_back(surf);
+  }
       
-      // also skip micromegas surfaces if not used
-      if( m_tGeometry->maps().isMicromegasSurface( surf ) && !m_useMicromegas ) continue;
-
-      // update vectors
-      siliconMMSls.push_back(sl);
-      surfaces.push_back(surf);
-    }
-
   /// Surfaces need to be sorted in order, i.e. from smallest to
   /// largest radius extending from target surface
   /// Add a check to ensure this
@@ -725,45 +729,50 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces) const
 {
   for(int i = 0; i < surfaces.size() - 1; i++)
+  {
+    const auto& surface = surfaces.at(i);
+    const auto thisVolume = surface->geometryId().volume();
+    const auto thisLayer  = surface->geometryId().layer();
+      
+    const auto nextSurface = surfaces.at(i+1);
+    const auto nextVolume = nextSurface->geometryId().volume();
+    const auto nextLayer = nextSurface->geometryId().layer();
+    
+    /// Implement a check to ensure surfaces are sorted
+    if(nextVolume == thisVolume) 
     {
-      auto surface = surfaces.at(i);
-      auto thisVolume = surface->geometryId().volume();
-      auto thisLayer  = surface->geometryId().layer();
-      
-      auto nextSurface = surfaces.at(i+1);
-      auto nextVolume = nextSurface->geometryId().volume();
-      auto nextLayer = nextSurface->geometryId().layer();
-      
-      /// Implement a check to ensure surfaces are sorted
-      if(nextVolume == thisVolume) 
-	{
-	  if(nextLayer < thisLayer)
-	    {
-	      if(Verbosity() > 2)
-		std::cout << PHWHERE 
-			  << "Surface not in order... removing surface" 
-			  << surface->geometryId() << std::endl;
-	      surfaces.erase(surfaces.begin() + i);
-	      /// Subtract one so we don't skip a surface
-	      i--;
+      if(nextLayer < thisLayer)
+      {
+        std::cout 
+          << "PHActsTrkFitter::checkSurfaceVec - " 
+          << "Surface not in order... removing surface" 
+          << surface->geometryId() << std::endl;
+        
+        surfaces.erase(surfaces.begin() + i);
+	      
+        /// Subtract one so we don't skip a surface
+	      --i;
 	      continue;
 	    }
-	}
-      else 
-	{
-	  if(nextVolume < thisVolume)
-	    {
-	      if(Verbosity() > 2)
-		std::cout << PHWHERE 
-			  << "Volume not in order... removing surface" 
-			  << surface->geometryId() << std::endl;
-	      surfaces.erase(surfaces.begin() + i);
-	      /// Subtract one so we don't skip a surface
-	      i--;
+      
+    } else {
+
+      if(nextVolume < thisVolume)
+      {
+        std::cout 
+          << "PHActsTrkFitter::checkSurfaceVec - " 
+          << "Volume not in order... removing surface" 
+          << surface->geometryId() << std::endl;
+        
+        surfaces.erase(surfaces.begin() + i);
+
+        /// Subtract one so we don't skip a surface
+	      --i;
 	      continue;
-	    }
-	}
-    } 
+      
+      }
+    }
+  } 
 
 }
 
@@ -909,10 +918,16 @@ Acts::BoundSymMatrix PHActsTrkFitter::setDefaultCovariance() const
 
 void PHActsTrkFitter::printTrackSeed(const ActsExamples::TrackParameters& seed) const
 {
-  std::cout << PHWHERE << " Processing proto track:"
-	    << std::endl;  
-  std::cout << "position: " << seed.position(m_tGeometry->geometry().geoContext).transpose() << std::endl
-	    << "momentum: " << seed.momentum().transpose() << std::endl;
+  std::cout 
+    << PHWHERE 
+    << " Processing proto track:"
+    << std::endl;  
+
+  std::cout 
+    << "position: " << seed.position(m_tGeometry->geometry().geoContext).transpose() 
+    << std::endl
+    << "momentum: " << seed.momentum().transpose()
+    << std::endl;
 
   std::cout << "charge : " << seed.charge() << std::endl;
   std::cout << "absolutemom : " << seed.absoluteMomentum() << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -373,30 +373,27 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
             fitTime);
         }
 	  
+        SvtxTrack_v4 newTrack;
+        newTrack.set_tpc_seed(tpcseed);
+        newTrack.set_crossing(crossing);
+        newTrack.set_silicon_seed(siseed);
+        
         if(m_fitSiliconMMs)
         {
           
-          auto newTrack = std::make_unique<SvtxTrack_v4>();
           unsigned int trid = m_directedTrackMap->size();
-          newTrack->set_id(trid);
-          newTrack->set_tpc_seed(tpcseed);
-          newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
-          newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
+          newTrack.set_id(trid);
 
-          if( getTrackFitResult(fitOutput, newTrack.get()) )
-          { m_directedTrackMap->insertWithKey(newTrack.get(), trid); }
+          if( getTrackFitResult(fitOutput, &newTrack) )
+          { m_directedTrackMap->insertWithKey(&newTrack, trid); }
           
         } else {
           
-          auto newTrack = std::make_unique<SvtxTrack_v4>();
           unsigned int trid = m_trackMap->size();
-          newTrack->set_id(trid);
-          newTrack->set_tpc_seed(tpcseed);
-          newTrack->set_crossing(m_siliconSeeds->get(siid)->get_crossing());
-          newTrack->set_silicon_seed(m_siliconSeeds->get(siid));
+          newTrack.set_id(trid);
 	
-          if( getTrackFitResult(fitOutput, newTrack.get()))
-          { m_trackMap->insertWithKey(newTrack.get(), trid); }
+          if( getTrackFitResult(fitOutput, &newTrack))
+          { m_trackMap->insertWithKey(&newTrack, trid); }
         
         }
         

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -673,13 +673,10 @@ ActsExamples::TrackFittingAlgorithm::TrackFitterResult PHActsTrkFitter::fitTrack
     const SurfacePtrVec& surfSequence)
 {
 
-  std::cout << "PHActsTrkFitter::fitTrack - fitting track" << std::endl;
   if(m_fitSiliconMMs) 
   { 
-    std::cout << "PHActsTrkFitter::fitTrack - using direct fit" << std::endl;
     return (*m_fitCfg.dFit)(sourceLinks, seed, kfOptions, surfSequence); 
   } else {
-    std::cout << "PHActsTrkFitter::fitTrack - using normal fit" << std::endl;
     return (*m_fitCfg.fit)(sourceLinks, seed, kfOptions); 
   }
 }

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -321,19 +321,19 @@ int PHGenFitTrkFitter::process_event(PHCompositeNode* topNode)
     // rf_phgf_track stands for Refit_PHGenFit_Track
     std::shared_ptr<PHGenFit::Track> rf_phgf_track = ReFitTrack(topNode, svtx_track);
     if (rf_phgf_track)
-	{
-	  svtxtrack_genfittrack_map[svtx_track->get_id()] =  rf_phgf_tracks.size();
-	  rf_phgf_tracks.push_back(rf_phgf_track);
-	  if (rf_phgf_track->get_ndf() > _vertex_min_ndf)
-	    rf_gf_tracks.push_back(rf_phgf_track->getGenFitTrack());
-	  if(Verbosity() > 10) cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " <<   rf_phgf_tracks.size() << endl;
-	}
-      else{
-	if(Verbosity() >= 1) 
-	  cout << "failed refitting input track# " << iter->first << endl;
-      }
-      
+    {
+      svtxtrack_genfittrack_map[svtx_track->get_id()] =  rf_phgf_tracks.size();
+      rf_phgf_tracks.push_back(rf_phgf_track);
+      if (rf_phgf_track->get_ndf() > _vertex_min_ndf)
+        rf_gf_tracks.push_back(rf_phgf_track->getGenFitTrack());
+      if(Verbosity() > 10) cout << "Done refitting input track" << svtx_track->get_id() << " or rf_phgf_track " <<   rf_phgf_tracks.size() << endl;
     }
+    else{
+      if(Verbosity() >= 1)
+        cout << "failed refitting input track# " << iter->first << endl;
+    }
+      
+  }
 
   /*
    * add tracks to event display
@@ -965,8 +965,7 @@ Acts::Vector3 PHGenFitTrkFitter::getGlobalPosition( TrkrDefs::cluskey key, TrkrC
  * \param invertex Input Vertex, if fit track as a primary vertex
  */
 //PHGenFit::Track* PHGenFitTrkFitter::ReFitTrack(PHCompositeNode *topNode, const SvtxTrack* intrack,
-std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* topNode, const SvtxTrack* intrack,
-                                                               const SvtxVertex* invertex)
+std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* topNode, const SvtxTrack* intrack, const SvtxVertex* invertex)
 {
   //std::shared_ptr<PHGenFit::Track> empty_track(nullptr);
   if (!intrack)
@@ -1027,8 +1026,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
 
     if (is_vertex_cov_sane)
     {
-      PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(
-          pos, cov);
+      auto meas = new PHGenFit::SpacepointMeasurement( pos, cov);
       measurements.push_back(meas);
       if(Verbosity() >= 2)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR: 
- cleans up GenFit trackfit
- fixes the sourcelink order in Acts Trackfit. This is necessary because the SVTX+MM fit check this order and arbitrarily remove surfaces if it is not met
- fix crash in SVTX+MM fit, due to incorrect insertion of the fitted track in the map. 
- improves (speed up) track insertion in the maps, print a warning (and fixes a memory leak) in case of duplicated keys.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

