### PR TITLE
Disable GDML/TGeo geometry export for new HCal

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -12,6 +12,8 @@
 
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
+#include <g4gdml/PHG4GDMLConfig.hh>
+#include <g4gdml/PHG4GDMLUtility.hh>
 
 #include <TSystem.h>
 
@@ -60,6 +62,8 @@ PHG4IHCalDetector::PHG4IHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
   , m_AbsorberActive(m_Params->get_int_param("absorberactive"))
   , m_GDMPath(m_Params->get_string_param("GDMPath"))
 {
+  gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
+  assert(gdml_config);
 }
 
 PHG4IHCalDetector::~PHG4IHCalDetector()
@@ -105,6 +109,12 @@ void PHG4IHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "IHCalEnvelope", logicWorld, 0, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructIHCal(hcal_envelope_log);
+
+  // disable GDML export for HCal geometries for memory saving and compatibility issues
+  assert(gdml_config);
+  gdml_config->exclude_physical_vol(mothervol);
+  gdml_config->exclude_logical_vol (hcal_envelope_log);
+
   return;
 }
 

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.h
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.h
@@ -19,6 +19,7 @@ class PHCompositeNode;
 class PHG4IHCalDisplayAction;
 class PHParameters;
 class PHG4Subsystem;
+class PHG4GDMLConfig;
 
 class PHG4IHCalDetector : public PHG4Detector
 {
@@ -75,6 +76,9 @@ class PHG4IHCalDetector : public PHG4Detector
   std::set<G4LogicalVolume *> m_ScintiTileLogVolSet;
   std::map<G4VPhysicalVolume *, std::tuple<int, int, int>> m_ScintiTilePhysVolMap;
   std::map<G4VPhysicalVolume *, int> m_AbsorberPhysVolMap;
+
+  //! registry for volumes that should not be exported
+  PHG4GDMLConfig* gdml_config = nullptr;
 
   std::string m_GDMPath;
 };

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -14,6 +14,9 @@
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
 
+#include <g4gdml/PHG4GDMLConfig.hh>
+#include <g4gdml/PHG4GDMLUtility.hh>
+
 #include <TSystem.h>
 
 #include <Geant4/G4AssemblyVolume.hh>
@@ -38,6 +41,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -62,6 +66,8 @@ PHG4OHCalDetector::PHG4OHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
   , m_AbsorberActiveFlag(m_Params->get_int_param("absorberactive"))
   , m_GDMPath(m_Params->get_string_param("GDMPath"))
 {
+  gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
+  assert(gdml_config);
 }
 
 PHG4OHCalDetector::~PHG4OHCalDetector()
@@ -106,6 +112,12 @@ void PHG4OHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "OHCal", logicWorld, 0, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructOHCal(hcal_envelope_log);
+
+  // disable GDML export for HCal geometries for memory saving and compatibility issues
+  assert(gdml_config);
+  gdml_config->exclude_physical_vol(mothervol);
+  gdml_config->exclude_logical_vol (hcal_envelope_log);
+
   return;
 }
 

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
@@ -19,6 +19,7 @@ class PHG4OHCalDisplayAction;
 class PHG4OHCalFieldSetup;
 class PHParameters;
 class PHG4Subsystem;
+class PHG4GDMLConfig;
 
 class PHG4OHCalDetector : public PHG4Detector
 {
@@ -72,6 +73,9 @@ class PHG4OHCalDetector : public PHG4Detector
   std::set<G4LogicalVolume *> m_SteelAbsorberLogVolSet;
   std::set<G4LogicalVolume *> m_ScintiTileLogVolSet;
   std::map<G4VPhysicalVolume *, std::tuple<int, int, int>> m_ScintiTilePhysVolMap;
+
+  //! registry for volumes that should not be exported, i.e. fibers
+  PHG4GDMLConfig* gdml_config = nullptr;
 
   std::string m_GDMPath;
 };

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
@@ -74,7 +74,7 @@ class PHG4OHCalDetector : public PHG4Detector
   std::set<G4LogicalVolume *> m_ScintiTileLogVolSet;
   std::map<G4VPhysicalVolume *, std::tuple<int, int, int>> m_ScintiTilePhysVolMap;
 
-  //! registry for volumes that should not be exported, i.e. fibers
+  //! registry for volumes that should not be exported
   PHG4GDMLConfig* gdml_config = nullptr;
 
   std::string m_GDMPath;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR disables the GDML/TGeo geometry export for new HCal, which is aimed to solve two issues since the introduction of the new HCal: 
* The exported geometry has a compatibility issue that lead to large amount of overlap errors in the exported sPHENIX geometry in TGeo: [example error message in CI geometry checks](https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-overlap-check-pipeline/1687/artifact/macros/detectors/sPHENIX/Fun4All_G4_sPHENIX.log/*view*/). This geometry copy is later used in downstream tracking reconstruction and saved in DST. As the current tracking code do not read HCal geometry, we can simply choose to disable Hcal export for now. 
* Help reducing memory foot print. The exported geometry clone all the detailed HCal features in a second copy in memory and disabling the export help simulation run-time memory. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Full test in CI

## Links to other PRs in macros and calibration repositories (if applicable)

