### PR TITLE
fix tpc overlap

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -12,6 +12,8 @@
 #include <cmath>
 #include <iostream>
 #include <climits>
+#include <g4detectors/PHG4CylinderCellGeom.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
 
 TpcClusterMover::TpcClusterMover()
 {
@@ -31,6 +33,21 @@ TpcClusterMover::TpcClusterMover()
     {
       layer_radius[i+32] = outer_tpc_min_radius + (double) i * outer_tpc_spacing  +  0.5 * outer_tpc_spacing;
     }
+}
+
+void TpcClusterMover::initialize_geometry(PHG4CylinderCellGeomContainer* cellgeo)
+{
+  
+  int layer=0;
+  PHG4CylinderCellGeomContainer::ConstRange layerrange = cellgeo->get_begin_end();
+  for (PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
+       layeriter != layerrange.second;
+       ++layeriter)
+  {
+    layer_radius[layer] = layeriter->second->get_radius();
+    layer++;
+  }
+
 }
 
 //____________________________________________________________________________..

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -10,6 +10,8 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
 
+class PHG4CylinderCellGeomContainer;
+
 class TpcClusterMover
 {
   public:
@@ -18,8 +20,13 @@ class TpcClusterMover
   TpcClusterMover();
 
   void set_verbosity(int verb) { _verbosity = verb; }
+
   std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(std::vector<std::pair<TrkrDefs::cluskey,Acts::Vector3>> global_in );
-  
+
+  //! Updates the assumed default geometry below to that contained in the
+  //! cell geo
+  void initialize_geometry(PHG4CylinderCellGeomContainer* cellgeo);
+
   private:
   int get_circle_circle_intersection(double target_radius, double R, double X0, double Y0, double xclus, double yclus, double &x, double &y);
 
@@ -35,7 +42,7 @@ class TpcClusterMover
   double inner_tpc_min_radius = 30.0;
   double mid_tpc_min_radius = 40.0;
   double outer_tpc_min_radius = 60.0;
-  double outer_tpc_max_radius = 77.0;
+  double outer_tpc_max_radius = 76.4;
 
   double inner_tpc_spacing = 0.0;
   double mid_tpc_spacing = 0.0;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -112,12 +112,16 @@ MakeActsGeometry::MakeActsGeometry(const std::string &name)
 
 int MakeActsGeometry::Init(PHCompositeNode */*topNode*/)
 {  
-  setPlanarSurfaceDivisions();
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
 {
+    m_geomContainerTpc =
+      findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  setPlanarSurfaceDivisions();
+
   // Alignment Transformation declaration of instance - must be here to set initial alignment flag
   AlignmentTransformation alignment_transformation;
   alignment_transformation.createAlignmentTransformContainer(topNode);
@@ -1454,21 +1458,20 @@ void MakeActsGeometry::setPlanarSurfaceDivisions()
   m_moduleStepPhi = 2.0 * M_PI / 12.0;
   m_modulePhiStart = -M_PI;
   m_surfStepPhi = 2.0 * M_PI / (double) (m_nSurfPhi * m_nTpcModulesPerLayer);
-  for(unsigned int isector = 0; isector < 3; ++isector)
-    {
-      layer_thickness_sector[isector] = 
-	(m_maxRadius[isector] - m_minRadius[isector]) / 16.0;
+ 
 
-      for(unsigned int ilayer =0; ilayer < 16; ++ilayer)
-	{
-	  m_layerRadius[isector*16 + ilayer] = 
-	    m_minRadius[isector] + layer_thickness_sector[isector] * 
-	    (double) ilayer + layer_thickness_sector[isector] / 2.0;
-	  
-	  m_layerThickness[isector*16 + ilayer] = 
-	    layer_thickness_sector[isector];
-	}
-    }
+  int layer=0;
+  PHG4CylinderCellGeomContainer::ConstRange layerrange = m_geomContainerTpc->get_begin_end();
+  for (PHG4CylinderCellGeomContainer::ConstIterator layeriter = layerrange.first;
+       layeriter != layerrange.second;
+       ++layeriter)
+  {
+    m_layerRadius[layer] = layeriter->second->get_radius();
+    m_layerThickness[layer] = layeriter->second->get_thickness();
+    layer++;
+  }
+
+ 
 }
 
 int MakeActsGeometry::createNodes(PHCompositeNode *topNode)

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -196,9 +196,7 @@ class MakeActsGeometry : public SubsysReco
 
   /// TPC TGeoManager editing box surfaces subdivisions
   const static int m_nTpcSectors = 3;
-  const double m_minRadius[m_nTpcSectors] = {30.0, 40.0, 60.0};
-  const double m_maxRadius[m_nTpcSectors] = {40.0, 60.0, 76.4};
-  double layer_thickness_sector[m_nTpcSectors] = {0};
+  
   double m_layerRadius[m_nTpcLayers] = {0};
   double m_layerThickness[m_nTpcLayers] = {0};
 

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -197,7 +197,7 @@ class MakeActsGeometry : public SubsysReco
   /// TPC TGeoManager editing box surfaces subdivisions
   const static int m_nTpcSectors = 3;
   const double m_minRadius[m_nTpcSectors] = {30.0, 40.0, 60.0};
-  const double m_maxRadius[m_nTpcSectors] = {40.0, 60.0, 77.0};
+  const double m_maxRadius[m_nTpcSectors] = {40.0, 60.0, 76.4};
   double layer_thickness_sector[m_nTpcSectors] = {0};
   double m_layerRadius[m_nTpcLayers] = {0};
   double m_layerThickness[m_nTpcLayers] = {0};

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -22,6 +22,8 @@
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+
 #include <micromegas/MicromegasDefs.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -116,6 +118,14 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
       h_stateTime = new TH1F("h_stateTime", ";time [ms]",
 			     100000, 0, 1000);			     
     }		 
+
+   auto cellgeo =
+      findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+
+  if (cellgeo)
+  {
+    _clusterMover.initialize_geometry(cellgeo);
+  }
 
   if(Verbosity() > 1)
     std::cout << "Finish PHActsTrkFitter Setup" << std::endl;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -562,7 +562,7 @@ void PHG4TpcPadPlaneReadout::SetDefaultParameters()
 
   set_default_double_param("tpc_maxradius_inner", 40.0);  // cm
   set_default_double_param("tpc_maxradius_mid", 60.0);
-  set_default_double_param("tpc_maxradius_outer", 77.0);  // from Tom
+  set_default_double_param("tpc_maxradius_outer", 76.4);  // from Tom
 
   set_default_double_param("neffelectrons_threshold", 1.0);
   set_default_double_param("maxdriftlength", 105.5);     // cm


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes the TGeo TPC overlap introduced from the changes in the TPC gas volume at the G4 level. It also removes all hard coded instances of the TPC geometry from the cluster+track reconstruction and uses only the CellGeometryContainer to get the relevant pad plane readout information.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

