### PR TITLE
Comment out removal of hit-truth association for TPC hits with ADC zero to speed it up

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -449,6 +449,7 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
   std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> delete_hitkey_list;
 
   // Clean up undigitized hits - we want all hitsets for the Tpc
+  // This loop is pretty efficient because the remove methods all take a specified hitset as input
   TrkrHitSetContainer::ConstRange hitset_range_now = trkrhitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
   for (TrkrHitSetContainer::ConstIterator hitset_iter = hitset_range_now.first;
        hitset_iter != hitset_range_now.second;
@@ -499,7 +500,7 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
         std::cout << "removed hit with hitsetkey " << delete_hitkey_list[i].first << " and hitkey " << delete_hitkey_list[i].second << std::endl;
 
     // should also delete all entries with this hitkey from the TrkrHitTruthAssoc map
-    hittruthassoc->removeAssoc(delete_hitkey_list[i].first, delete_hitkey_list[i].second);
+    //hittruthassoc->removeAssoc(delete_hitkey_list[i].first, delete_hitkey_list[i].second);   // this is slow! Commented out by ADF 9/6/2022
   }
 
   // Final hitset dump


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Commented out the line in the TPC digitizer that removes entries from the hit-truth association map for TPC hits that fall below ADC threshold. This speeds up the TPC digitizer by a factor of more than three for 1000 pion events, with no obvious effect on tracking. The speed up will be larger for events with more hits.

For 1000 pion events with fixed random seed:
  TPC digitizer time/evt = 28.2 s  before and 8.7 s after the change
  TPC clustering time/evt = 0.68 s before and 0.62 s after the change
  Evaluator time/evt = 388.2 s before and 451.2 s after the change
  Resident memory in PHActsTrkFitter = 4.8 GB before and after the change
  Reconstructed and matched tracks = 748 before and after the change 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

