### PR TITLE
Distortion correction fixes

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -82,11 +82,13 @@ namespace
 
 }
 
+//___________________________________________________________________________________
 PHTpcResiduals::PHTpcResiduals(const std::string &name)
   : SubsysReco(name)
   , m_matrix_container( new TpcSpaceChargeMatrixContainerv1 )
 {}
 
+//___________________________________________________________________________________
 int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
 {
   if( m_savehistograms ) makeHistograms();
@@ -101,38 +103,28 @@ int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//___________________________________________________________________________________
 int PHTpcResiduals::InitRun(PHCompositeNode *topNode)
 {
   if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    return Fun4AllReturnCodes::ABORTEVENT;
+  { return Fun4AllReturnCodes::ABORTEVENT; }
 
   if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-    return Fun4AllReturnCodes::ABORTEVENT;
+  { return Fun4AllReturnCodes::ABORTEVENT; }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//___________________________________________________________________________________
 int PHTpcResiduals::process_event(PHCompositeNode *topNode)
 {
-  if(Verbosity() > 1)
-    std::cout <<"Starting PHTpcResiduals event " 
-	      << m_event << std::endl;
-
-  if(m_event % 1000 == 0)
-    std::cout << "PHTpcResiduals processed " << m_event 
-	      << " events" << std::endl;
-
-  int returnVal = processTracks(topNode);
-
-  if(Verbosity() > 1)
-    std::cout <<"Finished PHTpcResiduals event " 
-	      << m_event << std::endl;
-  
-  m_event++;
+  const auto returnVal = processTracks(topNode);  
+  ++m_event;
 
   return returnVal;
 }
 
+//___________________________________________________________________________________
 int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
 {
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
@@ -181,7 +173,7 @@ int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
+//___________________________________________________________________________________
 int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
 {
 
@@ -191,7 +183,7 @@ int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
   for(const auto &[trackKey, track] : *m_trackMap)
   {
     if(Verbosity() > 1) 
-    { std::cout << "Processing track key " << trackKey << std::endl; }
+    { std::cout << "PHTpcResiduals::processTracks - Processing track key " << trackKey << std::endl; }
     
     ++m_total_tracks;
     if(checkTrack(track))
@@ -204,14 +196,14 @@ int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//___________________________________________________________________________________
 bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
 {
+  if(Verbosity() > 2)
+  { std::cout << "PHTpcResiduals::checkTrack - pt: " << track->get_pt() << std::endl; }
  
   if(track->get_pt() < 0.5)
     return false;
-
-  if(Verbosity() > 2)
-    std::cout << "Track has pt " << track->get_pt() << std::endl;
 
   int nMvtxHits = 0;
   int nInttHits = 0;
@@ -226,18 +218,20 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
   }
 
   if(Verbosity() > 2)
-    std::cout << "Number of mvtx/intt/MM hits "
-	      << nMvtxHits << "/" << nInttHits << "/" 
-	      << nMMHits << std::endl;
-
+  {
+    std::cout << "PHTpcResiduals::checkTrack -"
+      << " nMvtxHits: " << nMvtxHits 
+      << " nInttHits: " << nInttHits 
+      << " nMMHits: "  << nMMHits 
+      << std::endl;
+  }
+    
   // Require at least 2 hits in each detector
   if( m_useMicromegas )
   {
-    if(nMvtxHits<2 || nInttHits<2 || nMMHits<2)
-    return false;
+    if(nMvtxHits<2 || nInttHits<2 || nMMHits<2) return false;
   } else {
-    if(nMvtxHits<2 || nInttHits<2 )
-    return false;
+    if(nMvtxHits<2 || nInttHits<2 ) return false;
   }
 
   return true;
@@ -252,20 +246,11 @@ Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track) con
 			  track->get_pz());
   double trackQ = track->get_charge() * Acts::UnitConstants::e;
   double p = track->get_p();
-  
-  Acts::BoundSymMatrix cov;
-  for(int i =0; i<6; i++)
-    for(int j =0; j<6; j++)
-  { cov(i,j) = track->get_acts_covariance(i, j); }
 
-  /* convert from track parameters */
-  const auto cov2 = m_transformer.rotateSvtxTrackCovToActs( track );
+  /* get acts covariance matrix from track parameters */
+  const auto cov = m_transformer.rotateSvtxTrackCovToActs( track );
   
-  // compare
-  for( int i = 0; i < 6; ++i )
-    for( int j = 0; j < 6; ++j )
-  { std::cout << "PHTpcResiduals::makeTrackParams - (" << i << ", " << j << ") cov: " << cov(i,j) << " cov2: " << cov2(i,j) << std::endl; }
-  
+  /* get position from  track parameters */
   const Acts::Vector3 position(track->get_x() * Acts::UnitConstants::cm,
     track->get_y() * Acts::UnitConstants::cm,
     track->get_z() * Acts::UnitConstants::cm);
@@ -283,12 +268,14 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 {
 
   if(Verbosity() > 1)
-    std::cout << "Propagating silicon+MM fit params momentum: " 
-	      << track->get_p() << " and position " 
-	      << track->get_x() << ", " << track->get_y() 
-	      << ", " << track->get_z() << " cm "
-	      << std::endl;
-
+  {
+    std::cout << "PHTpcResiduals::processTrack -" 
+      << " track momentum: " << track->get_p() 
+      << " position: (" << track->get_x() << ", " << track->get_y() << ", " << track->get_z() << ")"
+      << std::endl;
+  }
+  
+  // create ACTS parameters from track parameters at origin
   auto trackParams = makeTrackParams(track);
 
   int initNBadProps = m_nBadProps;
@@ -345,14 +332,13 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
         
 }
 
-PHTpcResiduals::ExtrapolationResult PHTpcResiduals::propagateTrackState(
-			   const Acts::BoundTrackParameters& params,
-			   const Surface& surf) const
+//__________________________________________________________________________________________________________________________________________
+PHTpcResiduals::ExtrapolationResult PHTpcResiduals::propagateTrackState( const Acts::BoundTrackParameters& params, const Surface& surf) const
 {
  
 
-  using Stepper            = Acts::EigenStepper<>;
-  using Propagator         = Acts::Propagator<Stepper, Acts::Navigator>;
+  using Stepper = Acts::EigenStepper<>;
+  using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
 
   Stepper stepper(m_tGeometry->geometry().magField);
   Acts::Navigator::Config cfg{m_tGeometry->geometry().tGeometry};
@@ -371,21 +357,21 @@ PHTpcResiduals::ExtrapolationResult PHTpcResiduals::propagateTrackState(
      
   auto result = propagator.propagate(params, *surf, options);
    
-        
   if(result.ok())
-    {
-      // return both path length and extrapolated parameters
-      return std::make_pair( (*result).pathLength/Acts::UnitConstants::cm, std::move((*result).endParameters) );
-    } else {
+  {
+    // return both path length and extrapolated parameters
+    return std::make_pair( (*result).pathLength/Acts::UnitConstants::cm, std::move((*result).endParameters) );
+  } else {
     return result.error();
   }
 }
 
+//_______________________________________________________________________________________________________
 void PHTpcResiduals::addTrackState( SvtxTrack* track, float pathlength, const Acts::BoundTrackParameters& params )
 {
 
   /* this is essentially a copy of the code from trackbase_historic/ActsTransformations::fillSvtxTrackStates */
-
+  
   // create track state
   SvtxTrackState_v1 state( pathlength );
 
@@ -410,10 +396,8 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, float pathlength, const Ac
   track->insert_state(&state);
 }
 
-void PHTpcResiduals::calculateTpcResiduals(
-  const Acts::BoundTrackParameters &params,
-  TrkrDefs::cluskey key,
-  TrkrCluster* cluster)
+//_______________________________________________________________________________________________________
+void PHTpcResiduals::calculateTpcResiduals( const Acts::BoundTrackParameters &params, TrkrDefs::cluskey key, TrkrCluster* cluster)
 {
   
   // store cluster key in ntuple
@@ -429,33 +413,29 @@ void PHTpcResiduals::calculateTpcResiduals(
   clusZErr = cluster->getZError();
  
   if(Verbosity() > 3)
-    {
-      std::cout << "cluster key is " << cluskey <<std::endl;
-      std::cout << "Cluster r phi and z " << clusR << "  " 
-		<< clusPhi << "+/-" << clusRPhiErr
-		<<" and " << clusZ << "+/-" << clusZErr << std::endl;
-    }
-  
-  if(clusRPhiErr < 0.015)
-    return;
-  if(clusZErr < 0.05)
-    return;
+  {
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -"
+      << " cluskey: " << cluskey
+      << " clusR: " << clusR 
+      << " clusPhi: " << clusPhi << "+/-" << clusRPhiErr
+      << " clusZ: " << clusZ << "+/-" << clusZErr
+      << std::endl;
+  }
+      
+  if(clusRPhiErr < 0.015) return;
+  if(clusZErr < 0.05) return;
 
   const auto globalStatePos = params.position(m_tGeometry->geometry().geoContext);
   const auto globalStateMom = params.momentum();
   const auto globalStateCov = *params.covariance();
 
-  stateRPhiErr = sqrt(globalStateCov(Acts::eBoundLoc0,
-				     Acts::eBoundLoc0))
-    / Acts::UnitConstants::cm;
-  stateZErr = sqrt(globalStateCov(Acts::eBoundLoc1,
-				  Acts::eBoundLoc1))
-    / Acts::UnitConstants::cm;
- 
-  stateZ = globalStatePos.z() / Acts::UnitConstants::cm;
+  stateRPhiErr = std::sqrt(globalStateCov(Acts::eBoundLoc0, Acts::eBoundLoc0))/Acts::UnitConstants::cm;
+  stateZErr = sqrt(globalStateCov(Acts::eBoundLoc1, Acts::eBoundLoc1))/Acts::UnitConstants::cm;
+  
+  stateZ = globalStatePos.z()/Acts::UnitConstants::cm;
 
-  const auto globStateX = globalStatePos.x() / Acts::UnitConstants::cm;
-  const auto globStateY = globalStatePos.y() / Acts::UnitConstants::cm;
+  const auto globStateX = globalStatePos.x()/Acts::UnitConstants::cm;
+  const auto globStateY = globalStatePos.y()/Acts::UnitConstants::cm;
   const auto globStateZ = stateZ;
 
   stateR = std::sqrt(square(globStateX) + square(globStateY));
@@ -472,21 +452,28 @@ void PHTpcResiduals::calculateTpcResiduals(
   const auto trackZ = globStateZ + dr * trackDzDr;
   
   if(Verbosity() > 2)
-    std::cout << "State Calculations: " << stateR << ", " 
-	      << dr << ", " << trackDrDt << ", " << trackDxDr
-	      << ", " << trackDyDr << ", " << trackDzDr
-	      <<" , " << trackX << ", " << trackY << ", "
-	      << trackZ << std::endl;
+  {
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -"
+      << " stateR: " << stateR 
+      << " dr: " << dr 
+      << " trackDrDt: " << trackDrDt 
+      << " trackDxDr: " << trackDxDr
+      << " trackDyDr: " << trackDyDr 
+      << " trackDzDr: " << trackDzDr
+      << " track position: (" << trackX << ", " << trackY << ", " << trackZ  << ")"
+      << std::endl;
+  }
 
   statePhi = std::atan2(trackY, trackX);
   stateZ = trackZ;
 
   if(Verbosity() > 3)
   {
-    std::cout << "State r phi and z " 
-      << stateR
-      << "   " << statePhi << "+/-" << stateRPhiErr
-      << " and " << stateZ << "+/-" << stateZErr << std::endl;
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -" 
+      << " stateR: " << stateR
+      << " statePhi: " << statePhi << "+/-" << stateRPhiErr
+      << " stateZ: " << stateZ << "+/-" << stateZErr 
+      << std::endl;
   }
 
   const auto erp = square(clusRPhiErr) + square(stateRPhiErr);
@@ -497,27 +484,37 @@ void PHTpcResiduals::calculateTpcResiduals(
   dz  = clusZ - stateZ;
 
   if(Verbosity() > 3)
-    std::cout << "TPC residuals " << drphi << "   " << dz << std::endl;
+  {
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -"
+      << " drphi: " << drphi 
+      << " dz: " << dz 
+      << std::endl;
+  }
   
-  const auto trackEta 
-    = std::atanh(params.momentum().z() / params.absoluteMomentum());
+  const auto trackEta = std::atanh(params.momentum().z() / params.absoluteMomentum());
   const auto clusEta = std::atanh(clusZ / std::sqrt(
     square(globClusPos(0)) +
     square(globClusPos(1)) +
     square(globClusPos(2))));
 
-  const auto trackPPhi = -params.momentum()(0) * std::sin(statePhi) +
-    params.momentum()(1) * std::cos(statePhi);
-  const auto trackPR = params.momentum()(0) * std::cos(statePhi) +
-    params.momentum()(1) * std::sin(statePhi);
-  const auto trackPZ    = params.momentum()(2);
+  const auto trackPPhi = -params.momentum()(0) * std::sin(statePhi) + params.momentum()(1) * std::cos(statePhi);
+  const auto trackPR = params.momentum()(0) * std::cos(statePhi) + params.momentum()(1) * std::sin(statePhi);
+  const auto trackPZ = params.momentum()(2);
+  
   const auto trackAlpha = -trackPPhi / trackPR;
-  const auto trackBeta  = -trackPZ / trackPR;
+  const auto trackBeta = -trackPZ / trackPR;
 
   if(Verbosity() > 3)
-    std::cout << "Track angles " << trackPPhi << ", " << trackPR
-	      << ", " << trackPZ << ", " << trackAlpha << ", " << trackBeta
-	      << std::endl;
+  {
+    std::cout 
+      << "PHTpcResiduals::calculateTpcResiduals -"
+      << " trackPPhi: " << trackPPhi 
+      << " trackPR: " << trackPR
+      << " trackPZ: " << trackPZ 
+      << " trackAlpha: " << trackAlpha 
+      << " trackBeta: " << trackBeta
+      << std::endl;
+  }
     
   tanBeta = trackBeta;
   tanAlpha = trackAlpha;
@@ -528,6 +525,22 @@ void PHTpcResiduals::calculateTpcResiduals(
   { std::cout << "Bin index found is " << index << std::endl; }
   
   if(index < 0 ) return;
+
+  if(Verbosity() > 3)
+  {
+    std::cout << "PHTpcResiduals::calculateTpcResiduals - layer: " << (int) TrkrDefs::getLayer(key) << std::endl;
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -"
+      << " cluster: (" << clusR << ", " << clusR*clusPhi << ", " << clusZ << ")"
+      << " (" << clusRPhiErr << ", " << clusZErr << ")"
+      << std::endl;
+
+    std::cout << "PHTpcResiduals::calculateTpcResiduals -"
+      << " track: (" << stateR << ", " << clusR*statePhi << ", " << stateZ << ")"
+      << " (" << tanAlpha << ", " << tanBeta << ")"
+      << " (" << stateRPhiErr << ", " << stateZErr << ")"
+      << std::endl;
+    std::cout << std::endl;
+  }
 
   if( m_savehistograms )
   {
@@ -553,13 +566,11 @@ void PHTpcResiduals::calculateTpcResiduals(
   }
   
   // check track angles and residuals agains cuts
-  if(std::abs(trackAlpha) > m_maxTAlpha
-     or std::abs(drphi) > m_maxResidualDrphi)
-    return;
+  if(std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
+  { return; }
 
-  if(std::abs(trackBeta) > m_maxTBeta
-     or std::abs(dz) > m_maxResidualDz)
-    return;
+  if(std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
+  { return; }
   
   // Fill distortion matrices
   m_matrix_container->add_to_lhs(index, 0, 0, 1./erp );
@@ -587,6 +598,7 @@ void PHTpcResiduals::calculateTpcResiduals(
   return;
 }
 
+//_______________________________________________________________________________
 int PHTpcResiduals::getCell(const Acts::Vector3& loc)
 {
 
@@ -617,45 +629,38 @@ int PHTpcResiduals::getCell(const Acts::Vector3& loc)
 
 }
 
+//_______________________________________________________________________________
 int PHTpcResiduals::createNodes(PHCompositeNode */*topNode*/)
-{
+{ return Fun4AllReturnCodes::EVENT_OK; }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
+//_______________________________________________________________________________
 int PHTpcResiduals::getNodes(PHCompositeNode *topNode)
 {
-  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,
-								"TRKR_CLUSTER");
+  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"TRKR_CLUSTER");
   if(!m_clusterContainer)
-    {
-      std::cout << PHWHERE << "No TRKR_CLUSTER node on node tree. Exiting."
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    std::cout << PHWHERE << "No TRKR_CLUSTER node on node tree. Exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   if(!m_tGeometry)
-    {
-      std::cout << "ActsTrackingGeometry not on node tree. Exiting."
-		<< std::endl;
-      
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    std::cout << "ActsTrackingGeometry not on node tree. Exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");
-  
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");  
   if (!m_trackMap)
-    {
-      std::cout << PHWHERE << "SvtxSiliconMMTrackMap not on node tree. Exiting."
-		<< std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  
+  {
+    std::cout << PHWHERE << "SvtxSiliconMMTrackMap not on node tree. Exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//_______________________________________________________________________________
 void PHTpcResiduals::makeHistograms()
 {  
   
@@ -666,17 +671,11 @@ void PHTpcResiduals::makeHistograms()
   h_beta = new TH2F("betadz",";tan#beta; #Deltaz [cm]",100,-0.5,0.5,100,-0.5,0.5);
   h_alpha = new TH2F("alphardphi",";tan#alpha; r#Delta#phi [cm]", 100,-0.5,0.5,100,-0.5,0.5);
   h_index = new TH1F("index",";index",total_bins, 0, total_bins);
-  h_rphiResid = new TH2F("rphiResid", ";r [cm]; #Deltar#phi [cm]",
-			 60, 20, 80, 500, -2, 2);
-  h_zResid = new TH2F("zResid", ";z [cm]; #Deltaz [cm]",
-		      200, -100, 100, 1000, -2, 2);
-  h_etaResid = new TH2F("etaResid", ";#eta;#Delta#eta",
-			20, -1, 1, 500, -0.2, 0.2);
-  h_etaResidLayer = new TH2F("etaResidLayer", ";r [cm]; #Delta#eta",
-			     60, 20, 80, 500, -0.2, 0.2);
-  h_zResidLayer = new TH2F("zResidLayer", ";r [cm]; #Deltaz [cm]",
-			   60, 20, 80, 1000, -2, 2);
-
+  h_rphiResid = new TH2F("rphiResid", ";r [cm]; #Deltar#phi [cm]", 60, 20, 80, 500, -2, 2);
+  h_zResid = new TH2F("zResid", ";z [cm]; #Deltaz [cm]", 200, -100, 100, 1000, -2, 2);
+  h_etaResid = new TH2F("etaResid", ";#eta;#Delta#eta",	20, -1, 1, 500, -0.2, 0.2);
+  h_etaResidLayer = new TH2F("etaResidLayer", ";r [cm]; #Delta#eta", 60, 20, 80, 500, -0.2, 0.2);
+  h_zResidLayer = new TH2F("zResidLayer", ";r [cm]; #Deltaz [cm]", 60, 20, 80, 1000, -2, 2);
   h_deltarphi_layer = new TH2F( "deltarphi_layer", ";layer; r.#Delta#phi_{track-cluster} (cm)", 57, 0, 57, 500, -2, 2 );
   h_deltaz_layer = new TH2F( "deltaz_layer", ";layer; #Deltaz_{track-cluster} (cm)", 57, 0, 57, 100, -2, 2 );
 
@@ -742,13 +741,11 @@ void PHTpcResiduals::makeHistograms()
     
   }
   
-  
   residTup = new TTree("residTree","tpc residual info");
   residTup->Branch("tanAlpha",&tanAlpha,"tanAlpha/D");
   residTup->Branch("tanBeta",&tanBeta,"tanBeta/D");
   residTup->Branch("drphi",&drphi,"drphi/D");
   residTup->Branch("dz",&dz,"dz/D");
-//   residTup->Branch("cell",&cell,"cell/I");
   residTup->Branch("clusR",&clusR,"clusR/D");
   residTup->Branch("clusPhi",&clusPhi,"clusPhi/D");
   residTup->Branch("clusZ",&clusZ,"clusZ/D");
@@ -759,9 +756,6 @@ void PHTpcResiduals::makeHistograms()
   residTup->Branch("stateZErr",&stateZErr,"stateZErr/D");
   residTup->Branch("clusRPhiErr",&clusRPhiErr,"clusRPhiErr/D");
   residTup->Branch("clusZErr",&clusZErr,"clusZErr/D");
-//   residTup->Branch("ir",&ir,"ir/I");
-//   residTup->Branch("iz",&iz,"iz/I");
-//   residTup->Branch("iphi",&iphi,"iphi/I");
   residTup->Branch("cluskey",&cluskey,"cluskey/l");
   residTup->Branch("event",&m_event,"event/I");
 

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -534,17 +534,17 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
     if( std::abs( drp ) > m_max_drphi ) continue;
     if( std::abs( dz ) > m_max_dz ) continue;
 
-    std::cout << "TpcSpaceChargeReconstruction::process_track - layer: " << (int) TrkrDefs::getLayer(cluster->getClusKey()) << std::endl;
-    std::cout << "TpcSpaceChargeReconstruction::process_track -"
-      << " cluster: (" << cluster_r << ", " << cluster_r*cluster_phi << ", " << cluster_z << ")"
-      << " (" << cluster_rphi_error << ", " << cluster_z_error << ")" 
-      << std::endl;
-    std::cout << "TpcSpaceChargeReconstruction::process_track -"
-      << " track: (" << track_r << ", " << cluster_r*track_phi << ", " << track_z << ")"
-      << " (" << talpha << ", " << tbeta << ")"
-      << " (" << track_rphi_error << ", " << track_z_error << ")"
-      << std::endl;
-    std::cout << std::endl;
+//     std::cout << "TpcSpaceChargeReconstruction::process_track - layer: " << (int) TrkrDefs::getLayer(cluster->getClusKey()) << std::endl;
+//     std::cout << "TpcSpaceChargeReconstruction::process_track -"
+//       << " cluster: (" << cluster_r << ", " << cluster_r*cluster_phi << ", " << cluster_z << ")"
+//       << " (" << cluster_rphi_error << ", " << cluster_z_error << ")" 
+//       << std::endl;
+//     std::cout << "TpcSpaceChargeReconstruction::process_track -"
+//       << " track: (" << track_r << ", " << cluster_r*track_phi << ", " << track_z << ")"
+//       << " (" << talpha << ", " << tbeta << ")"
+//       << " (" << track_rphi_error << ", " << track_z_error << ")"
+//       << std::endl;
+//     std::cout << std::endl;
 
     // update matrices
     // see https://indico.bnl.gov/event/7440/contributions/43328/attachments/31334/49446/talk.pdf for details

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -534,6 +534,18 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
     if( std::abs( drp ) > m_max_drphi ) continue;
     if( std::abs( dz ) > m_max_dz ) continue;
 
+    std::cout << "TpcSpaceChargeReconstruction::process_track - layer: " << (int) TrkrDefs::getLayer(cluster->getClusKey()) << std::endl;
+    std::cout << "TpcSpaceChargeReconstruction::process_track -"
+      << " cluster: (" << cluster_r << ", " << cluster_r*cluster_phi << ", " << cluster_z << ")"
+      << " (" << cluster_rphi_error << ", " << cluster_z_error << ")" 
+      << std::endl;
+    std::cout << "TpcSpaceChargeReconstruction::process_track -"
+      << " track: (" << track_r << ", " << cluster_r*track_phi << ", " << track_z << ")"
+      << " (" << talpha << ", " << tbeta << ")"
+      << " (" << track_rphi_error << ", " << track_z_error << ")"
+      << std::endl;
+    std::cout << std::endl;
+
     // update matrices
     // see https://indico.bnl.gov/event/7440/contributions/43328/attachments/31334/49446/talk.pdf for details
     m_matrix_container->add_to_lhs(i, 0, 0, 1./erp );

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -24,6 +24,8 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 
 #include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
 
 #include <cassert>
 #include <memory>
@@ -53,6 +55,15 @@ namespace
     return std::count_if( track->begin_cluster_keys(), track->end_cluster_keys(),
       []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == type; } );
   }
+  
+  /// get sector median angle associated to a given index
+  /** this assumes that sector 0 is centered on phi=0, then numbered along increasing phi */
+  inline constexpr double get_sector_phi( int isec ) 
+  { return isec*M_PI/6; }
+
+  // specify bins for which one will save histograms
+  static const std::vector<float> phi_rec = { get_sector_phi(9) };
+  static const std::vector<float> z_rec = { 5. };
 
   // phi range
   static constexpr float m_phimin = 0;
@@ -91,6 +102,9 @@ int TpcSpaceChargeReconstruction::Init(PHCompositeNode* /*topNode*/ )
 
   m_total_clusters = 0;
   m_accepted_clusters = 0;
+
+  // histogram evaluation
+  if( m_savehistograms ) create_histograms();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -155,6 +169,17 @@ int TpcSpaceChargeReconstruction::End(PHCompositeNode* /*topNode*/ )
     outputfile->cd();
     m_matrix_container->Write( "TpcSpaceChargeMatrixContainer" );
   }
+  
+  // save histograms
+  if( m_savehistograms && m_histogramfile )
+  {
+    m_histogramfile->cd();    
+    for( const auto& [cell,h]:m_h_drphi ) { if(h) h->Write(); }
+    for( const auto& [cell,h]:m_h_dz ) { if(h) h->Write(); }
+    for( const auto& [cell,h]:m_h_drphi_alpha ) { if(h) h->Write(); }
+    for( const auto& [cell,h]:m_h_dz_beta ) { if(h) h->Write(); }
+    m_histogramfile->Close();
+  }
 
   // print counters
   std::cout
@@ -211,6 +236,72 @@ int TpcSpaceChargeReconstruction::load_nodes( PHCompositeNode* topNode )
 
   assert( m_cluster_map );
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+void TpcSpaceChargeReconstruction::create_histograms()
+{
+  std::cout << "TpcSpaceChargeReconstruction::create_histograms - writing evaluation histograms to: " << m_histogramfilename << std::endl;
+  m_histogramfile.reset( new TFile(m_histogramfilename.c_str(), "RECREATE") );
+  m_histogramfile->cd();
+
+  // get grid dimensions from matrix container
+  int phibins = 0;
+  int rbins = 0;
+  int zbins = 0;
+  m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
+  
+  // get bins corresponding to selected angles
+  std::set<int> phibin_rec;
+  std::transform( phi_rec.begin(), phi_rec.end(), std::inserter( phibin_rec, phibin_rec.end() ), [&]( const float& phi ) { return phibins*(phi-m_phimin)/(m_phimax-m_phimin); } );
+  
+  std::set<int> zbin_rec;
+  std::transform( z_rec.begin(), z_rec.end(), std::inserter( zbin_rec, zbin_rec.end() ), [&]( const float& z ) { return zbins*(z-m_zmin)/(m_zmax-m_zmin); } );
+  
+  // keep track of all cell ids that match selected histograms
+  for( int iphi = 0; iphi < phibins; ++iphi )
+    for( int ir = 0; ir < rbins; ++ir )
+    for( int iz = 0; iz < zbins; ++iz )
+  {
+    
+    if( phibin_rec.find( iphi ) == phibin_rec.end() || zbin_rec.find( iz ) == zbin_rec.end() ) continue;
+    const auto icell = m_matrix_container->get_cell_index( iphi, ir, iz );
+    
+    {
+      // rphi residuals
+      const auto hname = Form( "residual_drphi_p%i_r%i_z%i", iphi, ir, iz );
+      auto h = new TH1F( hname, hname, 100, -m_max_drphi, +m_max_drphi );
+      h->GetXaxis()->SetTitle( "r.#Delta#phi_{cluster-track} (cm)" );
+      m_h_drphi.insert( std::make_pair( icell, h ) );
+    }
+    
+    {
+      // 2D histograms
+      const auto hname = Form( "residual_2d_drphi_p%i_r%i_z%i", iphi, ir, iz );
+      auto h = new TH2F( hname, hname, 100, -m_max_talpha, m_max_talpha, 100, -m_max_drphi, +m_max_drphi );
+      h->GetXaxis()->SetTitle( "tan#alpha" );
+      h->GetYaxis()->SetTitle( "r.#Delta#phi_{cluster-track} (cm)" );
+      m_h_drphi_alpha.insert( std::make_pair( icell, h ) );
+    }
+    
+    {
+      // z residuals
+      const auto hname = Form( "residual_dz_p%i_r%i_z%i", iphi, ir, iz );
+      auto h = new TH1F( hname, hname, 100, -m_max_dz, +m_max_dz );
+      h->GetXaxis()->SetTitle( "#Deltaz_{cluster-track} (cm)" );
+      m_h_dz.insert( std::make_pair( icell, h ) );
+    }
+    
+    {
+      // 2D histograms
+      static constexpr double max_tbeta = 0.5;
+      const auto hname = Form( "residual_2d_dz_p%i_r%i_z%i", iphi, ir, iz );
+      auto h = new TH2F( hname, hname, 100, -max_tbeta, max_tbeta, 100, -m_max_dz, +m_max_dz );
+      h->GetXaxis()->SetTitle( "tan#beta" );
+      h->GetYaxis()->SetTitle( "#Deltaz_{cluster-track} (cm)" );
+      m_h_dz_beta.insert( std::make_pair( icell, h ) );
+    }     
+  }  
 }
 
 //_________________________________________________________________________________
@@ -380,10 +471,6 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
       continue;
     }
 
-    // check against limits
-    if( std::abs( talpha ) > m_max_talpha ) continue;
-    if( std::abs( tbeta ) > m_max_tbeta ) continue;
-
     // track errors
     const auto track_rphi_error = state->get_rphi_error();
     const auto track_z_error = state->get_z_error();
@@ -404,10 +491,6 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
       std::cout << "TpcSpaceChargeReconstruction::process_track - dz is nan" << std::endl;
       continue;
     }
-
-    // check against limits
-    if( std::abs( drp ) > m_max_drphi ) continue;
-    if( std::abs( dz ) > m_max_dz ) continue;
 
     // residual errors squared
     const auto erp = square(track_rphi_error) + square(cluster_rphi_error);
@@ -434,6 +517,22 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
       std::cout << "TpcSpaceChargeReconstruction::process_track - invalid cell index" << std::endl;
       continue;
     }
+    
+    if( m_savehistograms )
+    {      
+      { const auto iter = m_h_drphi.find( i ); if( iter != m_h_drphi.end() ) iter->second->Fill( drp ); }
+      { const auto iter = m_h_drphi_alpha.find( i ); if( iter != m_h_drphi_alpha.end() ) iter->second->Fill( talpha, drp ); }
+      { const auto iter = m_h_dz.find( i ); if( iter != m_h_dz.end() ) iter->second->Fill( dz ); }
+      { const auto iter = m_h_dz_beta.find( i ); if( iter != m_h_dz_beta.end() ) iter->second->Fill( tbeta, dz ); }
+    }
+    
+    // check against limits
+    if( std::abs( talpha ) > m_max_talpha ) continue;
+    if( std::abs( tbeta ) > m_max_tbeta ) continue;
+
+    // check against limits
+    if( std::abs( drp ) > m_max_drphi ) continue;
+    if( std::abs( dz ) > m_max_dz ) continue;
 
     // update matrices
     // see https://indico.bnl.gov/event/7440/contributions/43328/attachments/31334/49446/talk.pdf for details

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -47,14 +47,6 @@ namespace
 
   /// radius
   template<class T> T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
-
-  /// return number of clusters of a given type that belong to a tracks
-  template<int type>
-    int count_clusters( const std::vector<TrkrDefs::cluskey>& keys )
-  {
-    return std::count_if( keys.begin(), keys.end(),
-      []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == type; } );
-  }
   
   /// get sector median angle associated to a given index
   /** this assumes that sector 0 is centered on phi=0, then numbered along increasing phi */
@@ -88,6 +80,14 @@ namespace
       { std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::back_inserter( out ) ); }
     }
     return out;
+  }
+
+  /// return number of clusters of a given type that belong to a tracks
+  template<int type>
+    int count_clusters( const std::vector<TrkrDefs::cluskey>& keys )
+  {
+    return std::count_if( keys.begin(), keys.end(),
+      []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == type; } );
   }
   
 }
@@ -133,21 +133,16 @@ int TpcSpaceChargeReconstruction::InitRun(PHCompositeNode* )
   m_max_dz = get_double_param( "spacecharge_max_dz" );
 
   // print
-  if( Verbosity() )
-  {
-    std::cout
-      << "TpcSpaceChargeReconstruction::InitRun\n"
-      << " m_outputfile: " << m_outputfile << "\n"
-      << " m_use_micromegas: " << std::boolalpha <<  m_use_micromegas << "\n"
-      << " m_max_talpha: " << m_max_talpha << "\n"
-      << " m_max_drphi: " << m_max_drphi << "\n"
-      << " m_max_tbeta: " << m_max_tbeta << "\n"
-      << " m_max_dz: " << m_max_dz << "\n"
-      << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_outputfile: " << m_outputfile << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_use_micromegas: " << std::boolalpha <<  m_use_micromegas << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_max_talpha: " << m_max_talpha << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_max_drphi: " << m_max_drphi << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_max_tbeta: " << m_max_tbeta << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_max_dz: " << m_max_dz << std::endl;
+  std::cout << "TpcSpaceChargeReconstruction::InitRun - m_min_pt: " << m_min_pt << " GeV/c" << std::endl;
 
-    // also identify the matrix container
-    m_matrix_container->identify();
-  }
+  // also identify the matrix container
+  m_matrix_container->identify();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -357,9 +352,10 @@ void TpcSpaceChargeReconstruction::process_tracks()
 //_____________________________________________________________________
 bool TpcSpaceChargeReconstruction::accept_track( SvtxTrack* track ) const
 {
-  // ignore tracks whose transverse momentum is too small
-  const auto pt = std::sqrt( square( track->get_px() ) + square( track->get_py() ) );
-  if( pt < 0.5 ) return false;
+
+  // track pt
+  if(track->get_pt() < m_min_pt)
+  { return false; }
 
   // ignore tracks with too few mvtx, intt and micromegas hits
   const auto cluster_keys( get_cluster_keys( track ) );

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -30,6 +30,10 @@ class TpcSpaceChargeMatrixContainer;
 class TrkrCluster;
 class TrkrClusterContainer;
 
+class TFile;
+class TH1;
+class TH2;
+
 /**
  * \class TpcSpaceChargeReconstruction
  * \brief performs space charge distortion reconstruction using tracks
@@ -65,6 +69,13 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   */
   void set_grid_dimensions( int phibins, int rbins, int zbins );
 
+
+  /// set to true to store evaluation histograms and ntuples
+  void set_save_histograms( bool value ) { m_savehistograms = value; }
+    
+  /// output file name for evaluation histograms
+  void set_histogram_outputfile(const std::string &outputfile) {m_histogramfilename = outputfile;}
+
   /// output file
   /**
    * this is the file where space charge matrix container is stored
@@ -93,6 +104,9 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// load nodes
   int load_nodes( PHCompositeNode* );
+  
+  /// create evaluation histograms
+  void create_histograms();
 
   /// get global position for a given cluster
   /**
@@ -152,6 +166,25 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   int m_accepted_clusters = 0;
   //@}
 
+  
+  ///@name evaluation histograms
+  //@{
+  /// Output root histograms
+  bool m_savehistograms = false;
+
+  /// histogram output file name
+  std::string m_histogramfilename = "TpcSpaceChargeReconstruction.root";
+  std::unique_ptr<TFile> m_histogramfile;  
+  
+  using TH1_map_t = std::map<int,TH1*>;
+  using TH2_map_t = std::map<int,TH2*>;
+  
+  TH1_map_t m_h_drphi;
+  TH1_map_t m_h_dz;
+  TH2_map_t m_h_drphi_alpha;
+  TH2_map_t m_h_dz_beta;
+  //@}
+  
   ///@name nodes
   //@{
   SvtxTrackMap* m_track_map = nullptr;

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -62,6 +62,10 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   void set_use_micromegas( bool value )
   { m_use_micromegas = value; }
 
+  /// track min pT 
+  void set_min_pt( double value ) 
+  { m_min_pt = value; }
+  
   /// set grid dimensions
   /**
   \param phibins the number of bins in the azimuth direction
@@ -135,6 +139,9 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// true if only tracks with micromegas must be used
   bool m_use_micromegas = true;
+
+  /// minimum pT required for track to be considered in residuals calculation (GeV/c)
+  double m_min_pt = 0.5;
 
   /// acts geometry
   ActsGeometry *m_tgeometry = nullptr;


### PR DESCRIPTION
- remove use of now obsolete get_acts_covariance()
- cleanup

This fixes getting Nan for all reconstructed distortion corrections
Also adapts the Genfit version of the distortion corrections to new track interface, and make acts/genfit distortion reconstruction more consistent. 

We still need the genfit path in order to be able to compare with acts in detail.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

