### PR TITLE
KFP: New truth matching method using maps

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -109,12 +109,9 @@ PHG4Particle *KFParticle_truthAndDetTools::getTruthTrack(SvtxTrack *thisTrack, P
   if (findNode)
   {
     findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("G4TruthInfo"));
-    if (findNode && m_truthinfo == nullptr)
+    if (findNode)
     {
       m_truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-    }
-    else if (findNode && m_truthinfo != nullptr)
-    {
     }
     else
     {
@@ -375,12 +372,9 @@ int KFParticle_truthAndDetTools::getHepMCInfo(PHCompositeNode *topNode, TTree * 
   if (g4particle->get_parent_id() != 0)
   {
     PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("G4TruthInfo"));
-    if (findNode && m_truthinfo == nullptr)
+    if (findNode)
     {
       m_truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-    }
-    else if (findNode && m_truthinfo != nullptr)
-    {
     }
     else
     {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -13,6 +13,7 @@
 #include <trackbase/TrkrCluster.h>             // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>    // for TrkrClusterContainer
 #include <trackbase/TrkrDefs.h>                // for getLayer, getTrkrId
+#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
 #include <trackbase_historic/SvtxTrack.h>      // for SvtxTrack, SvtxTrack::...
 #include <trackbase_historic/SvtxTrackMap.h>   // for SvtxTrackMap, SvtxTrac...
 #include <trackbase_historic/SvtxVertex.h>     // for SvtxVertex
@@ -95,20 +96,56 @@ SvtxVertex *KFParticle_truthAndDetTools::getVertex(unsigned int vertex_id, SvtxV
 
 PHG4Particle *KFParticle_truthAndDetTools::getTruthTrack(SvtxTrack *thisTrack, PHCompositeNode *topNode)
 {
-  if (!m_svtx_evalstack)
+/*
+ * There are two methods for getting the truth rack from the reco track
+ * 1. (recommended) Use the reco -> truth tables (requires SvtxPHG4ParticleMap). Introduced Summer of 2022
+ * 2. Get truth track via nClusters. Older method and will work with older DSTs 
+ */
+
+  PHG4Particle *particle = nullptr;
+
+  PHNodeIterator nodeIter(topNode);
+  PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("SvtxPHG4ParticleMap"));
+  if (findNode)
   {
-    m_svtx_evalstack = new SvtxEvalStack(topNode);
-    clustereval = m_svtx_evalstack->get_cluster_eval();
-    //hiteval = m_svtx_evalstack->get_hit_eval();
-    trackeval = m_svtx_evalstack->get_track_eval();
-    trutheval = m_svtx_evalstack->get_truth_eval();
-    vertexeval = m_svtx_evalstack->get_vertex_eval();
+    findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("G4TruthInfo"));
+    if (findNode && m_truthinfo == nullptr)
+    {
+      m_truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+    }
+    else if (findNode && m_truthinfo != nullptr)
+    {
+    }
+    else
+    {
+      std::cout << "KFParticle truth matching: G4TruthInfo does not exist" << std::endl;
+    }
+
+    SvtxPHG4ParticleMap_v1 *dst_reco_truth_map = findNode::getClass<SvtxPHG4ParticleMap_v1>(topNode, "SvtxPHG4ParticleMap");
+
+    std::map<float, std::set<int>> truth_set = dst_reco_truth_map->get(thisTrack->get_id()); 
+    const auto& best_weight = truth_set.rbegin();
+    int best_truth_id =  *best_weight->second.rbegin();
+    particle = m_truthinfo->GetParticle(best_truth_id);
   }
-
-  m_svtx_evalstack->next_event(topNode);
-
-  PHG4Particle *particle = trackeval->max_truth_particle_by_nclusters(thisTrack);
-
+  else
+  {
+    std::cout << __FILE__ << ": SvtxPHG4ParticleMap not found, reverting to max_truth_particle_by_nclusters()" << std::endl;
+  
+    if (!m_svtx_evalstack)
+    {
+      m_svtx_evalstack = new SvtxEvalStack(topNode);
+      //clustereval = m_svtx_evalstack->get_cluster_eval();
+      //hiteval = m_svtx_evalstack->get_hit_eval();
+      trackeval = m_svtx_evalstack->get_track_eval();
+      trutheval = m_svtx_evalstack->get_truth_eval();
+      vertexeval = m_svtx_evalstack->get_vertex_eval();
+    }
+  
+    m_svtx_evalstack->next_event(topNode);
+  
+    particle = trackeval->max_truth_particle_by_nclusters(thisTrack);
+  }
   return particle;
 }
 
@@ -184,6 +221,16 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
   m_true_daughter_p[daughter_id] = true_p;
   m_true_daughter_pt[daughter_id] = true_pt;
   m_true_daughter_id[daughter_id] = isParticleValid ? g4particle->get_pid() : 0;
+
+  if (!m_svtx_evalstack)
+  {
+    m_svtx_evalstack = new SvtxEvalStack(topNode);
+    //clustereval = m_svtx_evalstack->get_cluster_eval();
+    //hiteval = m_svtx_evalstack->get_hit_eval();
+    trackeval = m_svtx_evalstack->get_track_eval();
+    trutheval = m_svtx_evalstack->get_truth_eval();
+    vertexeval = m_svtx_evalstack->get_vertex_eval();
+  }
 
   if (isParticleValid)
   {
@@ -328,9 +375,12 @@ int KFParticle_truthAndDetTools::getHepMCInfo(PHCompositeNode *topNode, TTree * 
   if (g4particle->get_parent_id() != 0)
   {
     PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst("G4TruthInfo"));
-    if (findNode)
+    if (findNode && m_truthinfo == nullptr)
     {
       m_truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+    }
+    else if (findNode && m_truthinfo != nullptr)
+    {
     }
     else
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I added a new method to the truth matching in KFParticle. It now uses the new reco -> truth maps developed by the tracking team. If the maps don't exist it will revert back to the old method using association by nClusters, this will make it backwards compatible with our DSTs

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

