### PR TITLE
New step status combination

### DIFF
--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDetector.cc
@@ -86,7 +86,7 @@ void BeamLineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
   G4LogicalVolume *magnet_mother_logic = new G4LogicalVolume(magnet_mother_solid,
                                                              GetDetectorMaterial("G4_Galactic"),
                                                              GetName(),
-                                                             0, 0, 0);
+                                                             nullptr, nullptr, nullptr);
 
   m_DisplayAction->AddVolume(magnet_mother_logic, "OFF");
   new G4PVPlacement(G4Transform3D(*rotm, origin),
@@ -174,7 +174,7 @@ void BeamLineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
   G4LogicalVolume *magnet_iron_logic = new G4LogicalVolume(magnet_iron_solid,
                                                            GetDetectorMaterial("G4_Fe"),
                                                            GetName(),
-                                                           0, 0, 0);
+                                                           nullptr, nullptr, nullptr);
   m_DisplayAction->AddVolume(magnet_iron_logic, magnettype);
 
   if (m_Params->get_double_param("skin_thickness") > 0)
@@ -195,7 +195,7 @@ void BeamLineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
     G4LogicalVolume *magnet_core_logic = new G4LogicalVolume(magnet_core_solid,
                                                              GetDetectorMaterial("G4_Fe"),
                                                              GetName(),
-                                                             0, 0, 0);
+                                                             nullptr, nullptr, nullptr);
     m_DisplayAction->AddVolume(magnet_core_logic, magnettype);
 
     magnet_core_physi = new G4PVPlacement(nullptr, G4ThreeVector(0, 0, 0),
@@ -216,7 +216,7 @@ void BeamLineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
   m_magnetFieldLogic = new G4LogicalVolume(magnet_field_solid,
                                            GetDetectorMaterial("G4_Galactic"),
                                            GetName(),
-                                           0, 0, 0);
+                                           nullptr, nullptr, nullptr);
 
   // allow installing new detector inside the magnet, magnet_field_logic
   PHG4Subsystem *mysys = GetMySubsystem();

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetDisplayAction.cc
@@ -30,7 +30,7 @@ BeamLineMagnetDisplayAction::~BeamLineMagnetDisplayAction()
 void BeamLineMagnetDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
-  for (auto it : m_LogicalVolumeMap)
+  for (const auto &it : m_LogicalVolumeMap)
   {
     G4LogicalVolume *logvol = it.first;
     if (logvol->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/BeamLineMagnetSubsystem.cc
@@ -80,7 +80,7 @@ int BeamLineMagnetSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       nodes.insert(m_AbsorberNodeName);
     }
-    for (auto node : nodes)
+    for (const auto &node : nodes)
     {
       PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, node);
       if (!g4_hits)
@@ -113,7 +113,7 @@ int BeamLineMagnetSubsystem::process_event(PHCompositeNode *topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector *BeamLineMagnetSubsystem::GetDetector(void) const
+PHG4Detector *BeamLineMagnetSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDetector.cc
@@ -313,8 +313,8 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4LogicalVolume *bbc_inner_shell_lv = new G4LogicalVolume(bbc_inner_shell, Aluminum, G4String("Bbc_Inner_Shell"));
   GetDisplayAction()->AddVolume(bbc_inner_shell_lv, "Bbc_Inner_Shell");
 
-  G4VPhysicalVolume *outer_shell_vol[2] = {0};
-  G4VPhysicalVolume *inner_shell_vol[2] = {0};
+  G4VPhysicalVolume *outer_shell_vol[2] = {nullptr};
+  G4VPhysicalVolume *inner_shell_vol[2] = {nullptr};
 
   // Place South Shells
   outer_shell_vol[0] = new G4PVPlacement(nullptr, G4ThreeVector(0, 0, (-250 + 1.0 - 11.5) * cm),
@@ -338,8 +338,8 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4LogicalVolume *bbc_plate_lv = new G4LogicalVolume(bbc_plate, Aluminum, G4String("Bbc_Cover_Plates"));
   GetDisplayAction()->AddVolume(bbc_plate_lv, "Bbc_Cover_Plates");
 
-  G4VPhysicalVolume *fplate_vol[2] = {0};  // Front Plates
-  G4VPhysicalVolume *bplate_vol[2] = {0};  // Back Plates
+  G4VPhysicalVolume *fplate_vol[2] = {nullptr};  // Front Plates
+  G4VPhysicalVolume *bplate_vol[2] = {nullptr};  // Back Plates
 
   // Place South Plates
   fplate_vol[0] = new G4PVPlacement(nullptr, G4ThreeVector(0, 0, (-250 + 1.0 + 0.5) * cm),
@@ -360,14 +360,14 @@ void PHG4BbcDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Tubs *bbc_cablecond = new G4Tubs("bbc_cablecond", 0., r_CableConductor, len_cable * 0.5, 0 * deg, 360 * deg);
 
   G4LogicalVolume *bbc_cablecond_lv = new G4LogicalVolume(bbc_cablecond, Cu, G4String("Bbc_CableCond"));
-  GetDisplayAction()->AddVolume(bbc_cablecond_lv,"Bbc_CableCond");
+  GetDisplayAction()->AddVolume(bbc_cablecond_lv, "Bbc_CableCond");
 
   const G4double rIn_CableShield = 0.302876 * cm;
   const G4double rOut_CableShield = 0.3175 * cm;
   G4Tubs *bbc_cableshield = new G4Tubs("bbc_cableshield", rIn_CableShield, rOut_CableShield, len_cable * 0.5, 0 * deg, 360 * deg);
 
   G4LogicalVolume *bbc_cableshield_lv = new G4LogicalVolume(bbc_cableshield, Cu, G4String("Bbc_CableShield"));
-  GetDisplayAction()->AddVolume(bbc_cableshield_lv,"Bbc_CableShield");
+  GetDisplayAction()->AddVolume(bbc_cableshield_lv, "Bbc_CableShield");
 
   ypos = len_cable / 2 + 5 * cm;
 

--- a/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcDisplayAction.cc
@@ -28,7 +28,7 @@ PHG4BbcDisplayAction::~PHG4BbcDisplayAction()
 void PHG4BbcDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
-  for (auto it : m_LogicalVolumeMap)
+  for (const auto &it : m_LogicalVolumeMap)
   {
     G4LogicalVolume *logvol = it.first;
     if (logvol->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/PHG4BbcSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BbcSubsystem.cc
@@ -83,7 +83,7 @@ int PHG4BbcSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       nodes.insert(m_SupportNodeName);
     }
-    for (auto nodename : nodes)
+    for (const auto &nodename : nodes)
     {
       PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)
@@ -133,7 +133,7 @@ void PHG4BbcSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4BbcSubsystem::GetDetector(void) const
+PHG4Detector *PHG4BbcSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetDetector.cc
@@ -151,7 +151,7 @@ void PHG4BeamlineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
   G4LogicalVolume *magnet_logic = new G4LogicalVolume(magnet_solid,
                                                       GetDetectorMaterial("G4_Galactic"),
                                                       GetName(),
-                                                      0, 0, 0);
+                                                      nullptr, nullptr, nullptr);
   magnet_logic->SetVisAttributes(fieldVis);
 
   /* Set field manager for logical volume */
@@ -165,7 +165,7 @@ void PHG4BeamlineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
                                                                params->get_double_param("place_z") * cm)),
                                    magnet_logic,
                                    GetName(),
-                                   logicMother, 0, false, OverlapCheck());
+                                   logicMother, false, false, OverlapCheck());
 
   /* Add volume with solid magnet material */
   G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName().append("_Solid")),
@@ -175,11 +175,11 @@ void PHG4BeamlineMagnetDetector::ConstructMe(G4LogicalVolume *logicMother)
   G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid,
                                                         TrackerMaterial,
                                                         G4String(GetName()),
-                                                        0, 0, 0);
+                                                        nullptr, nullptr, nullptr);
   cylinder_logic->SetVisAttributes(siliconVis);
 
-  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(0, 0, 0),
+  cylinder_physi = new G4PVPlacement(nullptr, G4ThreeVector(0, 0, 0),
                                      cylinder_logic,
                                      G4String(GetName().append("_Solid")),
-                                     magnet_logic, 0, false, OverlapCheck());
+                                     magnet_logic, false, false, OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BeamlineMagnetSubsystem.cc
@@ -35,7 +35,7 @@ int PHG4BeamlineMagnetSubsystem::process_event(PHCompositeNode* /*topNode*/)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4BeamlineMagnetSubsystem::GetDetector(void) const
+PHG4Detector* PHG4BeamlineMagnetSubsystem::GetDetector() const
 {
   return detector_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockCellReco.cc
@@ -292,7 +292,7 @@ int PHG4BlockCellReco::process_event(PHCompositeNode *topNode)
 
     if (cellptarray.size() < nbins)
     {
-      cellptarray.resize(nbins, 0);
+      cellptarray.resize(nbins, nullptr);
     }
 
     // ------- eta/x binning ------------------------------------------------------------------------

--- a/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockDetector.cc
@@ -105,6 +105,6 @@ void PHG4BlockDetector::ConstructMe(G4LogicalVolume *logicWorld)
   m_BlockPhysi = new G4PVPlacement(rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm),
                                    block_logic,
                                    G4String(GetName()),
-                                   logicWorld, 0, false, OverlapCheck());
+                                   logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyVolume(block_logic);
 }

--- a/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4BlockSubsystem.cc
@@ -131,7 +131,7 @@ int PHG4BlockSubsystem::process_event(PHCompositeNode *topNode)
 
 //_______________________________________________________________________
 PHG4Detector *
-PHG4BlockSubsystem::GetDetector(void) const
+PHG4BlockSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamDetector.cc
@@ -93,7 +93,7 @@ void PHG4CEmcTestBeamDetector::ConstructMe(G4LogicalVolume* logicWorld)
   recoConsts* rc = recoConsts::instance();
   G4Material* Air = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid* cemc_tub = new G4Tubs("CEmcTub", inner_radius - 2 * no_overlap, outer_radius + 2 * no_overlap, (w_dimension[2] + 2 * no_overlap) / 2., 0, cemc_angular_coverage);
-  G4LogicalVolume* cemc_log = new G4LogicalVolume(cemc_tub, Air, G4String("CEmc"), 0, 0, 0);
+  G4LogicalVolume* cemc_log = new G4LogicalVolume(cemc_tub, Air, G4String("CEmc"), nullptr, nullptr, nullptr);
 
   G4RotationMatrix cemc_rotm;
   // put our cemc at center displacement in x
@@ -103,9 +103,9 @@ void PHG4CEmcTestBeamDetector::ConstructMe(G4LogicalVolume* logicWorld)
   cemc_rotm.rotateX(x_rot);
   cemc_rotm.rotateY(y_rot);
   cemc_rotm.rotateZ(z_rot);
-  new G4PVPlacement(G4Transform3D(cemc_rotm, G4ThreeVector(place_in_x - xcenter, place_in_y - ycenter, place_in_z)), cemc_log, "CEmc", logicWorld, 0, false, OverlapCheck());
+  new G4PVPlacement(G4Transform3D(cemc_rotm, G4ThreeVector(place_in_x - xcenter, place_in_y - ycenter, place_in_z)), cemc_log, "CEmc", logicWorld, false, false, OverlapCheck());
   G4VSolid* tower_tub = new G4Tubs("TowerTub", inner_radius - no_overlap, outer_radius + no_overlap, (w_dimension[2] + no_overlap) / 2., 0, tower_angular_coverage);
-  G4LogicalVolume* tower_log = new G4LogicalVolume(tower_tub, Air, G4String("CEmcTower"), 0, 0, 0);
+  G4LogicalVolume* tower_log = new G4LogicalVolume(tower_tub, Air, G4String("CEmcTower"), nullptr, nullptr, nullptr);
   //  G4VisAttributes* towerVisAtt = new G4VisAttributes();
   // towerVisAtt->SetVisibility(true);
   // towerVisAtt->SetForceSolid(true);
@@ -119,7 +119,7 @@ void PHG4CEmcTestBeamDetector::ConstructMe(G4LogicalVolume* logicWorld)
     double phi = -i * tower_angular_coverage;
     G4RotationMatrix* tower_rotm = new G4RotationMatrix();
     tower_rotm->rotateZ(phi * rad);
-    new G4PVPlacement(tower_rotm, G4ThreeVector(0, 0, 0), tower_log, tower_vol_name.str(), cemc_log, 0, i, OverlapCheck());
+    new G4PVPlacement(tower_rotm, G4ThreeVector(0, 0, 0), tower_log, tower_vol_name.str(), cemc_log, false, i, OverlapCheck());
     tower_vol_name.str("");
   }
   ConstructTowerVolume(tower_log);
@@ -137,7 +137,7 @@ int PHG4CEmcTestBeamDetector::ConstructTowerVolume(G4LogicalVolume* tower_log)
   G4LogicalVolume* sandwich_log = new G4LogicalVolume(sandwich_box,
                                                       Air,
                                                       G4String("CEmcSandwich"),
-                                                      0, 0, 0);
+                                                      nullptr, nullptr, nullptr);
   G4VisAttributes* sandwichVisAtt = new G4VisAttributes();
   sandwichVisAtt->SetVisibility(true);
   sandwichVisAtt->SetForceSolid(true);
@@ -191,11 +191,11 @@ int PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
   block_logic.push_back(new G4LogicalVolume(block_w,
                                             AbsorberMaterial,
                                             "Plate_log_W",
-                                            0, 0, 0));
+                                            nullptr, nullptr, nullptr));
   block_logic.push_back(new G4LogicalVolume(block_sc,
                                             ScintiMaterial,
                                             "Plate_log_Sc",
-                                            0, 0, 0));
+                                            nullptr, nullptr, nullptr));
   G4VisAttributes* matVis = new G4VisAttributes();
   G4VisAttributes* matVis1 = new G4VisAttributes();
   matVis->SetVisibility(true);
@@ -217,17 +217,17 @@ int PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
   // -w/2 -sc_a/2 -sc_p/2 -w/2 + w/2 = -w/2 -sc_a/2 -sc_p/2 = -(w+sc)/2
   // where sc_a+sc_p = sc = scintillator thickness (sc_dimension[1])
 
-  sandwich_vol[0] = new G4PVPlacement(0, G4ThreeVector(0, -(w_dimension[1] + sc_dimension[1]) / 2., 0),
+  sandwich_vol[0] = new G4PVPlacement(nullptr, G4ThreeVector(0, -(w_dimension[1] + sc_dimension[1]) / 2., 0),
                                       block_logic[0],
                                       "CEmc_W_plate_down",
-                                      sandwich, 0, 0, OverlapCheck());
+                                      sandwich, false, 0, OverlapCheck());
 
   // top of the sandwich - starting at the bottom and add the tungsten and scintillator layer and half tungsten
   // -w/2 -sc/2 -w/2 + w + sc + w/2 = +sc/2 +w/2 = (w+sc)/2
-  sandwich_vol[1] = new G4PVPlacement(0, G4ThreeVector(0, (w_dimension[1] + sc_dimension[1]) / 2., 0),
+  sandwich_vol[1] = new G4PVPlacement(nullptr, G4ThreeVector(0, (w_dimension[1] + sc_dimension[1]) / 2., 0),
                                       block_logic[0],
                                       "CEmc_W_plate_up",
-                                      sandwich, 0, 0, OverlapCheck());
+                                      sandwich, false, 0, OverlapCheck());
 
   // since we split the scintillator into an active and passive part to accomodate
   // for the scintillator fibers not occupying 100% of the volume.
@@ -237,10 +237,10 @@ int PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
   // -(w + sc_a + sc_p + w)/2, adding the w layer and half of the sc_a to get to the middle of the sc_a layer:
   // -w/2 -sc_a/2 - sc_p/2 -w/2 + w + sc_a/2 = -sc_p/2
   // if fraction of active sc is 1, sc_passive_thickness is zero
-  sandwich_vol[2] = new G4PVPlacement(0, G4ThreeVector(0, -sc_passive_thickness / 2., 0),
+  sandwich_vol[2] = new G4PVPlacement(nullptr, G4ThreeVector(0, -sc_passive_thickness / 2., 0),
                                       block_logic[1],
                                       "CEmc_Scinti_plate",
-                                      sandwich, 0, 0, OverlapCheck());
+                                      sandwich, false, 0, OverlapCheck());
 
   if (sc_passive_thickness > 0)
   {
@@ -253,15 +253,15 @@ int PHG4CEmcTestBeamDetector::ConstructSandwichVolume(G4LogicalVolume* sandwich)
     block_logic.push_back(new G4LogicalVolume(block_passive_sc,
                                               ScintiMaterial,
                                               "Plate_log_Passive_Sc",
-                                              0, 0, 0));
+                                              nullptr, nullptr, nullptr));
     block_logic[2]->SetVisAttributes(matVis2);
     // here we go again - bottome of sandwich box is
     //  -(w + sc_a + sc_p +w)/2, now add w and sc_a and half of sc_p:
     //  -w/2 -sc_a/2 - sc_p/2 -w/2 + w + sc_a + sc_p/2 = sc_a/2
-    sandwich_vol[3] = new G4PVPlacement(0, G4ThreeVector(0, sc_active_thickness / 2., 0),
+    sandwich_vol[3] = new G4PVPlacement(nullptr, G4ThreeVector(0, sc_active_thickness / 2., 0),
                                         block_logic[2],
                                         "CEmc_Passive_Si_plate",
-                                        sandwich, 0, 0, OverlapCheck());
+                                        sandwich, false, 0, OverlapCheck());
   }
   else
   {

--- a/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CEmcTestBeamSubsystem.cc
@@ -27,7 +27,7 @@ using namespace std;
 //_______________________________________________________________________
 PHG4CEmcTestBeamSubsystem::PHG4CEmcTestBeamSubsystem(const std::string& name, const int lyr)
   : PHG4Subsystem(name)
-  , detector_(0)
+  , detector_(nullptr)
   , steppingAction_(nullptr)
   , eventAction_(nullptr)
   , place_in_x(0)
@@ -48,9 +48,9 @@ PHG4CEmcTestBeamSubsystem::PHG4CEmcTestBeamSubsystem(const std::string& name, co
   ostringstream nam;
   nam << name << "_" << lyr;
   Name(nam.str());
-  for (int i = 0; i < 3; i++)
+  for (double& i : dimension)
   {
-    dimension[i] = 100.0 * cm;
+    i = 100.0 * cm;
   }
 }
 
@@ -130,13 +130,13 @@ int PHG4CEmcTestBeamSubsystem::process_event(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4CEmcTestBeamSubsystem::GetDetector(void) const
+PHG4Detector* PHG4CEmcTestBeamSubsystem::GetDetector() const
 {
   return detector_;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4CEmcTestBeamSubsystem::GetSteppingAction(void) const
+PHG4SteppingAction* PHG4CEmcTestBeamSubsystem::GetSteppingAction() const
 {
   return steppingAction_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CellContainer.cc
@@ -8,9 +8,7 @@
 
 using namespace std;
 
-PHG4CellContainer::PHG4CellContainer()
-{
-}
+PHG4CellContainer::PHG4CellContainer() = default;
 
 void PHG4CellContainer::Reset()
 {
@@ -75,7 +73,7 @@ PHG4CellContainer::getCells(const unsigned short int detid) const
 }
 
 PHG4CellContainer::ConstRange
-PHG4CellContainer::getCells(void) const
+PHG4CellContainer::getCells() const
 {
   return std::make_pair(cellmap.begin(), cellmap.end());
 }
@@ -104,7 +102,7 @@ PHG4CellContainer::findCell(PHG4CellDefs::keytype key)
     return it->second;
   }
 
-  return 0;
+  return nullptr;
 }
 
 double

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.cc
@@ -58,8 +58,8 @@ float PHG4Cellv1::get_property_float(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -75,8 +75,8 @@ int PHG4Cellv1::get_property_int(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -93,8 +93,8 @@ PHG4Cellv1::get_property_uint(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -110,8 +110,8 @@ void PHG4Cellv1::add_property(const PROPERTY prop_id, const float value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   float val = value;
@@ -128,8 +128,8 @@ void PHG4Cellv1::add_property(const PROPERTY prop_id, const int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   int val = value;
@@ -146,8 +146,8 @@ void PHG4Cellv1::add_property(const PROPERTY prop_id, const unsigned int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   unsigned int val = value;
@@ -164,8 +164,8 @@ void PHG4Cellv1::set_property(const PROPERTY prop_id, const float value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -177,8 +177,8 @@ void PHG4Cellv1::set_property(const PROPERTY prop_id, const int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map[prop_id] += u_property(value).get_storage();
@@ -190,8 +190,8 @@ void PHG4Cellv1::set_property(const PROPERTY prop_id, const unsigned int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map[prop_id] += u_property(value).get_storage();
@@ -237,9 +237,9 @@ void PHG4Cellv1::identify(std::ostream& os) const
     os << "\t Shower " << pair.first << " -> " << pair.second << " GeV" << std::endl;
   }
   os << "Properties:" << std::endl;
-  for (prop_map_t::const_iterator i = prop_map.begin(); i != prop_map.end(); ++i)
+  for (auto i : prop_map)
   {
-    PROPERTY prop_id = static_cast<PROPERTY>(i->first);
+    PROPERTY prop_id = static_cast<PROPERTY>(i.first);
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
     switch (property_info.second)

--- a/simulation/g4simulation/g4detectors/PHG4Cellv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4Cellv1.h
@@ -17,7 +17,7 @@
 class PHG4Cellv1 : public PHG4Cell
 {
  public:
-  PHG4Cellv1(){}
+  PHG4Cellv1() {}
   explicit PHG4Cellv1(const PHG4CellDefs::keytype g4cellid);
   ~PHG4Cellv1() override;
 

--- a/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeDetector.cc
@@ -59,7 +59,7 @@ void PHG4ConeDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4LogicalVolume *cone_logic = new G4LogicalVolume(cone_solid,
                                                     TrackerMaterial,
                                                     GetName() + "_LOGIC",
-                                                    0, 0, 0);
+                                                    nullptr, nullptr, nullptr);
   PHG4Subsystem *mysys = GetMySubsystem();
   mysys->SetLogicalVolume(cone_logic);
 
@@ -98,6 +98,6 @@ void PHG4ConeDetector::ConstructMe(G4LogicalVolume *logicWorld)
                                                   m_Params->get_double_param("place_z") * cm),
                                     cone_logic,
                                     GetName(),
-                                    logicWorld, 0, false, OverlapCheck());
+                                    logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyVolume(cone_logic);
 }

--- a/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ConeSubsystem.cc
@@ -109,7 +109,7 @@ int PHG4ConeSubsystem::process_event(PHCompositeNode *topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4ConeSubsystem::GetDetector(void) const
+PHG4Detector *PHG4ConeSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellContainer.cc
@@ -100,7 +100,7 @@ PHG4CylinderCellContainer::getCylinderCells(const unsigned int detid) const
 }
 
 PHG4CylinderCellContainer::ConstRange
-PHG4CylinderCellContainer::getCylinderCells(void) const
+PHG4CylinderCellContainer::getCylinderCells() const
 {
   return std::make_pair(cellmap.begin(), cellmap.end());
 }
@@ -130,7 +130,7 @@ PHG4CylinderCellContainer::findCylinderCell(PHG4CylinderCellDefs::keytype key)
     return it->second;
   }
 
-  return 0;
+  return nullptr;
 }
 
 double

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellGeom_Spacalv1.cc
@@ -21,9 +21,7 @@
 
 using namespace std;
 
-PHG4CylinderCellGeom_Spacalv1::PHG4CylinderCellGeom_Spacalv1()
-{
-}
+PHG4CylinderCellGeom_Spacalv1::PHG4CylinderCellGeom_Spacalv1() = default;
 
 PHG4CylinderCellGeom_Spacalv1::~PHG4CylinderCellGeom_Spacalv1()
 {

--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -120,6 +120,6 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
                                                              m_Params->get_double_param("place_z") * cm),
                                                cylinder_logic,
                                                G4String(GetName()),
-                                               logicWorld, 0, false, OverlapCheck());
+                                               logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyVolume(cylinder_logic);
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv1.cc
@@ -127,12 +127,11 @@ void PHG4CylinderGeom_Spacalv1::Print(Option_t*) const
     cout << "\t"
          << "Containing " << sector_map.size()
          << " sector with rotation specified:" << endl;
-    for (sector_map_t::const_iterator it = sector_map.begin();
-         it != sector_map.end(); ++it)
+    for (auto it : sector_map)
     {
       cout << "\t"
            << "\t"
-           << "sector_map[" << it->first << "] = " << it->second
+           << "sector_map[" << it.first << "] = " << it.second
            << endl;
     }
   }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderGeom_Spacalv3.cc
@@ -84,12 +84,11 @@ void PHG4CylinderGeom_Spacalv3::Print(Option_t* opt) const
        << " unique towers per sector." << endl;
 
   if (get_construction_verbose() >= 2)
-    for (tower_map_t::const_iterator it = sector_tower_map.begin();
-         it != sector_tower_map.end(); ++it)
+    for (const auto& it : sector_tower_map)
     {
       cout << "\t";
       cout << "\t";
-      it->second.identify(cout);
+      it.second.identify(cout);
     }
 }
 
@@ -460,10 +459,9 @@ PHG4CylinderGeom_Spacalv3::get_max_lightguide_height() const
 {
   double max_height = 0;
 
-  for (tower_map_t::const_iterator it = sector_tower_map.begin();
-       it != sector_tower_map.end(); ++it)
+  for (const auto& it : sector_tower_map)
   {
-    const double h = it->second.LightguideHeight;
+    const double h = it.second.LightguideHeight;
     max_height = max(max_height, h);
   }
 

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -180,7 +180,7 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
 }
 
 PHG4Detector *
-PHG4CylinderSubsystem::GetDetector(void) const
+PHG4CylinderSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorGroupSubsystem.cc
@@ -215,7 +215,7 @@ void PHG4DetectorGroupSubsystem::set_double_param(const int detid, const std::st
   if (iter == m_DefaultDoubleParamsMap.end())
   {
     std::cout << "called like set_double_param(" << detid << ", \""
-         << name << "\", " << dval << ")" << std::endl;
+              << name << "\", " << dval << ")" << std::endl;
     std::cout << "detid " << detid << " not implemented" << std::endl;
     std::cout << "implemented detector ids: " << std::endl;
     for (auto &iter2 : m_DefaultDoubleParamsMap)
@@ -227,7 +227,7 @@ void PHG4DetectorGroupSubsystem::set_double_param(const int detid, const std::st
   if (iter->second.find(name) == iter->second.end())
   {
     std::cout << "double parameter " << name << " not implemented for detid "
-         << detid << std::endl;
+              << detid << std::endl;
     std::cout << "implemented double parameters are:" << std::endl;
     for (auto &iter2 : iter->second)
     {
@@ -258,7 +258,7 @@ void PHG4DetectorGroupSubsystem::set_int_param(const int detid, const std::strin
   if (iter == m_DefaultIntegerParamsMap.end())
   {
     std::cout << "called like set_int_param(" << detid << ", \""
-         << name << "\", " << ival << ")" << std::endl;
+              << name << "\", " << ival << ")" << std::endl;
     std::cout << "detid " << detid << " not implemented" << std::endl;
     std::cout << "implemented detector ids: " << std::endl;
     for (auto &iter2 : m_DefaultIntegerParamsMap)
@@ -270,7 +270,7 @@ void PHG4DetectorGroupSubsystem::set_int_param(const int detid, const std::strin
   if (iter->second.find(name) == iter->second.end())
   {
     std::cout << "int parameter " << name << " not implemented for detid"
-         << detid << std::endl;
+              << detid << std::endl;
     std::cout << "implemented int parameters are:" << std::endl;
     for (auto &iter2 : iter->second)
     {
@@ -296,7 +296,7 @@ void PHG4DetectorGroupSubsystem::set_string_param(const int detid, const std::st
   if (iter == m_DefaultStringParamsMap.end())
   {
     std::cout << "called like set_string_param(" << detid << ", \""
-         << name << "\", " << sval << ")" << std::endl;
+              << name << "\", " << sval << ")" << std::endl;
     std::cout << "detid " << detid << " not implemented" << std::endl;
     std::cout << "implemented detector ids: " << std::endl;
     for (auto &iter2 : m_DefaultStringParamsMap)
@@ -308,7 +308,7 @@ void PHG4DetectorGroupSubsystem::set_string_param(const int detid, const std::st
   if (iter->second.find(name) == iter->second.end())
   {
     std::cout << "string parameter " << name << " not implemented for detid "
-         << detid << std::endl;
+              << detid << std::endl;
     std::cout << "implemented string parameters are:" << std::endl;
     for (auto &iter2 : iter->second)
     {
@@ -385,8 +385,8 @@ void PHG4DetectorGroupSubsystem::set_default_double_param(const int detid, const
   if (ret2.second == false)
   {
     std::cout << PHWHERE << "Default double Parameter " << name
-         << " for detid " << detid << " already set to "
-         << ret.first->second[name] << " will not overwrite with " << dval << std::endl;
+              << " for detid " << detid << " already set to "
+              << ret.first->second[name] << " will not overwrite with " << dval << std::endl;
     std::cout << "Means: You are calling set_default_double_param twice for the same parameter" << std::endl;
     std::cout << "Please make up your mind and call it only once using the correct default" << std::endl;
     gSystem->Exit(1);
@@ -403,8 +403,8 @@ void PHG4DetectorGroupSubsystem::set_default_int_param(const int detid, const st
   if (ret2.second == false)
   {
     std::cout << PHWHERE << "Default integer Parameter " << name
-         << " for detid " << detid << " already set to "
-         << ret.first->second[name] << " will not overwrite with " << ival << std::endl;
+              << " for detid " << detid << " already set to "
+              << ret.first->second[name] << " will not overwrite with " << ival << std::endl;
     std::cout << "Means: You are calling set_default_int_param twice for the same parameter" << std::endl;
     std::cout << "Please make up your mind and call it only once using the correct default" << std::endl;
     gSystem->Exit(1);
@@ -421,8 +421,8 @@ void PHG4DetectorGroupSubsystem::set_default_string_param(const int detid, const
   if (ret2.second == false)
   {
     std::cout << PHWHERE << "Default String Parameter " << name
-         << " for detid " << detid << " already set to "
-         << ret.first->second[name] << " will not overwrite with " << sval << std::endl;
+              << " for detid " << detid << " already set to "
+              << ret.first->second[name] << " will not overwrite with " << sval << std::endl;
     std::cout << "Means: You are calling set_default_string_param twice for the same parameter" << std::endl;
     std::cout << "Please make up your mind and call it only once using the correct default" << std::endl;
     gSystem->Exit(1);
@@ -442,7 +442,7 @@ void PHG4DetectorGroupSubsystem::InitializeParameters()
   }
   SetDefaultParameters();  // call method from specific subsystem
   // now load those parameters to our params class
-  for (auto iter1 : m_DefaultDoubleParamsMap)
+  for (const auto &iter1 : m_DefaultDoubleParamsMap)
   {
     PHParameters *detidparams = m_ParamsContainerDefault->GetParametersToModify(iter1.first);
     if (!detidparams)
@@ -511,7 +511,7 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromDB(const std::string & /*name*/, c
   //  if (iret)
   std::cout << boost::stacktrace::stacktrace();
   std::cout << std::endl
-       << "DO NOT PANIC - this is not a segfault" << std::endl;
+            << "DO NOT PANIC - this is not a segfault" << std::endl;
   std::cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << std::endl;
   {
     std::cout << "problem reading from DB" << std::endl;
@@ -565,7 +565,7 @@ int PHG4DetectorGroupSubsystem::ReadParamsFromFile(const std::string & /*name*/,
   //  if (iret)
   std::cout << boost::stacktrace::stacktrace();
   std::cout << std::endl
-       << "DO NOT PANIC - this is not a segfault" << std::endl;
+            << "DO NOT PANIC - this is not a segfault" << std::endl;
   std::cout << "This method is a dummy, tell the offline gurus about it and give this stack trace" << std::endl;
   std::cout << "problem reading from " << extension << " file " << std::endl;
   std::cout << "problem reading from DB" << std::endl;

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeDetector.cc
@@ -83,7 +83,7 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                                 dZ / 2.,
                                                 sPhi, dPhi);
 
-  G4LogicalVolume* GarbageCollector_logical = new G4LogicalVolume(GarbageCollector_solid, material_crystal, G4String("GarbageCollector"), 0, 0, 0);
+  G4LogicalVolume* GarbageCollector_logical = new G4LogicalVolume(GarbageCollector_solid, material_crystal, G4String("GarbageCollector"), nullptr, nullptr, nullptr);
 
   G4VisAttributes* ecalVisAtt = new G4VisAttributes();
   ecalVisAtt->SetVisibility(true);
@@ -100,7 +100,7 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
                     GarbageCollector_logical,
                     "GarbageCollector",
                     logicWorld,
-                    0,
+                    false,
                     false,
                     OverlapCheck());
 
@@ -112,7 +112,7 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
                     GarbageCollector_logical,
                     "GarbageCollector_front",
                     logicWorld,
-                    0,
+                    false,
                     false,
                     OverlapCheck());
 
@@ -135,9 +135,9 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
   G4LogicalVolume* GarbageCollector_cyl_logical = new G4LogicalVolume(GarbageCollector_cyl_solid,
                                                                       material_crystal,
                                                                       G4String("GarbageCollector_cyl"),
-                                                                      0,
-                                                                      0,
-                                                                      0);
+                                                                      nullptr,
+                                                                      nullptr,
+                                                                      nullptr);
 
   GarbageCollector_cyl_logical->SetVisAttributes(ecalVisAtt);
 
@@ -145,7 +145,7 @@ void PHG4EnvelopeDetector::ConstructMe(G4LogicalVolume* logicWorld)
                     GarbageCollector_cyl_logical,
                     "GarbageCollector_cyl",
                     logicWorld,
-                    0,
+                    false,
                     false,
                     OverlapCheck());
 }

--- a/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4EnvelopeSubsystem.cc
@@ -71,13 +71,13 @@ int PHG4EnvelopeSubsystem::process_event(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4EnvelopeSubsystem::GetDetector(void) const
+PHG4Detector* PHG4EnvelopeSubsystem::GetDetector() const
 {
   return detector_;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4EnvelopeSubsystem::GetSteppingAction(void) const
+PHG4SteppingAction* PHG4EnvelopeSubsystem::GetSteppingAction() const
 {
   return steppingAction_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -165,7 +165,7 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
                       * layergeom->get_n_subtower_phi();     // subtower per block
   const double deltaphi = 2. * M_PI / nphibin;
 
-  typedef std::map<double, int> map_z_tower_z_ID_t;
+  using map_z_tower_z_ID_t = std::map<double, int>;
   map_z_tower_z_ID_t map_z_tower_z_ID;
   double phi_min = NAN;
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalDetector.cc
@@ -111,7 +111,7 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
   assert(cylinder_mat);
 
   G4LogicalVolume* sec_logic = new G4LogicalVolume(sec_solid, cylinder_mat,
-                                                   G4String(G4String(GetName() + std::string("_sec"))), 0, 0);
+                                                   G4String(G4String(GetName() + std::string("_sec"))), nullptr, nullptr);
 
   GetDisplayAction()->AddVolume(sec_logic, "Sector");
 
@@ -136,11 +136,11 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
                                     twopi / get_geom_v3()->get_azimuthal_n_sec());
 
     G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
-                                                      G4String(G4String(GetName() + std::string("_EndWall"))), 0, 0,
+                                                      G4String(G4String(GetName() + std::string("_EndWall"))), nullptr, nullptr,
                                                       nullptr);
     GetDisplayAction()->AddVolume(wall_logic, "WallProj");
 
-    typedef std::map<int, double> z_locations_t;
+    using z_locations_t = std::map<int, double>;
     z_locations_t z_locations;
     z_locations[1000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
     z_locations[1001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
@@ -180,11 +180,11 @@ PHG4FullProjSpacalDetector::Construct_AzimuthalSeg()
                                   (get_geom_v3()->get_length() / 2. - 2 * (get_geom_v3()->get_sidewall_thickness() + 2. * get_geom_v3()->get_assembly_spacing())) * cm * .5);
 
     G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
-                                                      G4String(G4String(GetName() + std::string("_SideWall"))), 0, 0,
+                                                      G4String(G4String(GetName() + std::string("_SideWall"))), nullptr, nullptr,
                                                       nullptr);
     GetDisplayAction()->AddVolume(wall_logic, "WallProj");
 
-    typedef std::map<int, std::pair<int, int> > sign_t;
+    using sign_t = std::map<int, std::pair<int, int>>;
     sign_t signs;
     signs[2000] = std::make_pair(+1, +1);
     signs[2001] = std::make_pair(+1, -1);
@@ -258,7 +258,7 @@ int PHG4FullProjSpacalDetector::Construct_Fibers_SameLengthFiberPerTower(
 
   // first check out the fibers geometry
 
-  typedef std::map<int, std::pair<G4Vector3D, G4Vector3D> > fiber_par_map;
+  using fiber_par_map = std::map<int, std::pair<G4Vector3D, G4Vector3D>>;
   fiber_par_map fiber_par;
   G4double min_fiber_length = g_tower.pDz * cm * 4;
 
@@ -512,7 +512,7 @@ PHG4FullProjSpacalDetector::Construct_Tower(
   assert(cylinder_mat);
 
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, cylinder_mat,
-                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), 0, 0,
+                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), nullptr, nullptr,
                                                      nullptr);
 
   GetDisplayAction()->AddVolume(block_logic, "Block");

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -283,7 +283,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
   assert(cylinder_mat);
 
   G4LogicalVolume* sec_logic = new G4LogicalVolume(sec_solid_place, cylinder_mat,
-                                                   G4String(G4String(GetName() + std::string("_sec"))), 0, 0, nullptr);
+                                                   G4String(G4String(GetName() + std::string("_sec"))), nullptr, nullptr, nullptr);
 
   GetDisplayAction()->AddVolume(sec_logic, "Sector");
 
@@ -318,11 +318,11 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
     G4VSolid* wall_solid_place = new G4DisplacedSolid(G4String(GetName() + std::string("_EndWall")), wall_solid, sec_solid_transform);
 
     G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid_place, wall_mat,
-                                                      G4String(G4String(GetName() + std::string("_EndWall"))), 0, 0,
+                                                      G4String(G4String(GetName() + std::string("_EndWall"))), nullptr, nullptr,
                                                       nullptr);
     GetDisplayAction()->AddVolume(wall_logic, "Wall");
 
-    typedef std::map<int, double> z_locations_t;
+    using z_locations_t = std::map<int, double>;
     z_locations_t z_locations;
     z_locations[000] = get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm;
     z_locations[001] = get_geom_v3()->get_length() * cm / 2.0 - (get_geom_v3()->get_sidewall_thickness() * cm / 2.0 + get_geom_v3()->get_assembly_spacing() * cm);
@@ -358,7 +358,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                 << " - construct side walls." << std::endl;
     }
 
-    typedef std::map<int, std::pair<int, int> > sign_t;
+    using sign_t = std::map<int, std::pair<int, int>>;
     sign_t signs;
     signs[100] = std::make_pair(+1, +1);
     signs[101] = std::make_pair(+1, -1);
@@ -391,7 +391,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                     (get_geom_v3()->get_length() / 2. - 2 * (get_geom_v3()->get_sidewall_thickness() + 2. * get_geom_v3()->get_assembly_spacing())) * cm * .5);
 
       G4LogicalVolume* wall_logic = new G4LogicalVolume(wall_solid, wall_mat,
-                                                        G4String(G4String(GetName() + G4String("_SideWall_") + std::to_string(val.first))), 0, 0,
+                                                        G4String(G4String(GetName() + G4String("_SideWall_") + std::to_string(val.first))), nullptr, nullptr,
                                                         nullptr);
       GetDisplayAction()->AddVolume(wall_logic, "Wall");
 
@@ -433,7 +433,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_AzimuthalSeg()
                                        (get_geom_v3()->get_length() / 2. - 2 * (get_geom_v3()->get_sidewall_thickness() + 2. * get_geom_v3()->get_assembly_spacing())) * cm * .5);
 
       G4LogicalVolume* wall_logic = new G4LogicalVolume(divider_solid, divider_mat,
-                                                        G4String(G4String(GetName() + G4String("_Divider_") + std::to_string(ID))), 0, 0,
+                                                        G4String(G4String(GetName() + G4String("_Divider_") + std::to_string(ID))), nullptr, nullptr,
                                                         nullptr);
       GetDisplayAction()->AddVolume(wall_logic, "Divider");
 
@@ -538,7 +538,7 @@ int PHG4FullProjTiltedSpacalDetector::Construct_Fibers_SameLengthFiberPerTower(
 
   // first check out the fibers geometry
 
-  typedef std::map<int, std::pair<G4Vector3D, G4Vector3D> > fiber_par_map;
+  using fiber_par_map = std::map<int, std::pair<G4Vector3D, G4Vector3D>>;
   fiber_par_map fiber_par;
   G4double min_fiber_length = g_tower.pDz * cm * 4;
 
@@ -790,7 +790,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_Tower(
   assert(cylinder_mat);
 
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, cylinder_mat,
-                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), 0, 0,
+                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), nullptr, nullptr,
                                                      nullptr);
 
   GetDisplayAction()->AddVolume(block_logic, "Block");
@@ -885,7 +885,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_LightGuide(
   );
 
   block_solid = new G4DisplacedSolid(G4String(GetName() + "_displaced"),
-                                     block_solid, 0,                                           //
+                                     block_solid, nullptr,                                     //
                                      G4ThreeVector(                                            //
                                          tan(g_tower.pTheta * rad) * cos(g_tower.pPhi * rad),  //
                                          tan(g_tower.pTheta * rad) * sin(g_tower.pPhi * rad),  //
@@ -900,7 +900,7 @@ PHG4FullProjTiltedSpacalDetector::Construct_LightGuide(
   assert(cylinder_mat);
 
   G4LogicalVolume* block_logic = new G4LogicalVolume(block_solid, cylinder_mat,
-                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), 0, 0,
+                                                     G4String(G4String(GetName()) + std::string("_Tower") + sTowerID), nullptr, nullptr,
                                                      nullptr);
 
   GetDisplayAction()->AddMaterial("LightGuide", g_tower.LightguideMaterial);

--- a/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLDetector.cc
@@ -64,9 +64,7 @@ PHG4GDMLDetector::PHG4GDMLDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
   }
 }
 
-PHG4GDMLDetector::~PHG4GDMLDetector()
-{
-}
+PHG4GDMLDetector::~PHG4GDMLDetector() = default;
 
 void
 

--- a/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4GDMLSubsystem.cc
@@ -25,9 +25,7 @@ PHG4GDMLSubsystem::PHG4GDMLSubsystem(const std::string &name)
   InitializeParameters();
 }
 
-PHG4GDMLSubsystem::~PHG4GDMLSubsystem()
-{
-}
+PHG4GDMLSubsystem::~PHG4GDMLSubsystem() = default;
 
 //_______________________________________________________________________
 int PHG4GDMLSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
@@ -61,7 +59,7 @@ void PHG4GDMLSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4GDMLSubsystem::GetDetector(void) const
+PHG4Detector *PHG4GDMLSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalDetector.cc
@@ -112,23 +112,23 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
   G4ThreeVector zTransneg(0, 0, -(length - cone_length + delta_len) / 2.0);
   G4ThreeVector zTranspos(0, 0, (length - cone_length + delta_len) / 2.0);
   G4SubtractionSolid* subtraction_tmp =
-      new G4SubtractionSolid("Cylinder-Cone", _cylinder_solid, cone1, 0, zTransneg);
+      new G4SubtractionSolid("Cylinder-Cone", _cylinder_solid, cone1, nullptr, zTransneg);
   G4SubtractionSolid* subtraction =
-      new G4SubtractionSolid("Cylinder-Cone-Cone", subtraction_tmp, cone2, 0, zTranspos);
+      new G4SubtractionSolid("Cylinder-Cone-Cone", subtraction_tmp, cone2, nullptr, zTranspos);
   cylinder_logic = new G4LogicalVolume(subtraction,
                                        TrackerMaterial,
                                        G4String(GetName()),
-                                       0, 0, 0);
+                                       nullptr, nullptr, nullptr);
   G4VisAttributes* VisAtt = new G4VisAttributes();
   VisAtt->SetColour(G4Colour::Grey());
   VisAtt->SetVisibility(true);
   VisAtt->SetForceSolid(true);
   cylinder_logic->SetVisAttributes(VisAtt);
 
-  cylinder_physi = new G4PVPlacement(0, G4ThreeVector(xpos, ypos, zpos),
+  cylinder_physi = new G4PVPlacement(nullptr, G4ThreeVector(xpos, ypos, zpos),
                                      cylinder_logic,
                                      G4String(GetName()),
-                                     logicWorld, 0, false, OverlapCheck());
+                                     logicWorld, false, false, OverlapCheck());
   // Figure out corners of scintillator inside the containing G4Tubs.
   // Work our way around the scintillator cross section in a counter
   // clockwise fashion: ABCD
@@ -199,12 +199,12 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4Material* boxmat = GetDetectorMaterial("G4_POLYSTYRENE");
   G4SubtractionSolid* subtractionbox_tmp =
-      new G4SubtractionSolid("Box-Cone", _box_solid, cone1, 0, zTransneg);
+      new G4SubtractionSolid("Box-Cone", _box_solid, cone1, nullptr, zTransneg);
   G4SubtractionSolid* subtractionbox =
-      new G4SubtractionSolid("Box-Cone-Cone", subtractionbox_tmp, cone2, 0, zTranspos);
+      new G4SubtractionSolid("Box-Cone-Cone", subtractionbox_tmp, cone2, nullptr, zTranspos);
   G4LogicalVolume* box_logic = new G4LogicalVolume(subtractionbox,
                                                    boxmat, G4String("BOX"),
-                                                   0, 0, 0);
+                                                   nullptr, nullptr, nullptr);
   VisAtt = new G4VisAttributes();
   PHG4Utils::SetColour(VisAtt, "G4_POLYSTYRENE");
   VisAtt->SetVisibility(true);
@@ -224,7 +224,7 @@ void PHG4HcalDetector::ConstructMe(G4LogicalVolume* logicWorld)
     G4VPhysicalVolume* box_vol_tmp = new G4PVPlacement(G4Transform3D(Rot, G4ThreeVector(myTrans)),
                                                        box_logic,
                                                        G4String(slatname.str()),
-                                                       cylinder_logic, 0, false, OverlapCheck());
+                                                       cylinder_logic, false, false, OverlapCheck());
     box_vol[box_vol_tmp] = i;
   }
   if (active)

--- a/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalSubsystem.cc
@@ -152,13 +152,13 @@ int PHG4HcalSubsystem::process_event(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4HcalSubsystem::GetDetector(void) const
+PHG4Detector* PHG4HcalSubsystem::GetDetector() const
 {
   return detector_;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction* PHG4HcalSubsystem::GetSteppingAction(void) const
+PHG4SteppingAction* PHG4HcalSubsystem::GetSteppingAction() const
 {
   return steppingAction_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalDetector.cc
@@ -56,10 +56,10 @@
 
 class PHCompositeNode;
 
-typedef CGAL::Circle_2<PHG4InnerHcalDetector::Circular_k> Circle_2;
-typedef CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k> Circular_arc_point_2;
-typedef CGAL::Line_2<PHG4InnerHcalDetector::Circular_k> Line_2;
-typedef CGAL::Segment_2<PHG4InnerHcalDetector::Circular_k> Segment_2;
+using Circle_2 = CGAL::Circle_2<PHG4InnerHcalDetector::Circular_k>;
+using Circular_arc_point_2 = CGAL::Circular_arc_point_2<PHG4InnerHcalDetector::Circular_k>;
+using Line_2 = CGAL::Line_2<PHG4InnerHcalDetector::Circular_k>;
+using Segment_2 = CGAL::Segment_2<PHG4InnerHcalDetector::Circular_k>;
 
 // there is still a minute problem for very low tilt angles where the scintillator
 // face touches the boundary instead of the corner, subtracting 1 permille from the total
@@ -421,13 +421,13 @@ void PHG4InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *Air = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("InnerHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), 0, 0, 0);
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("Hcal_envelope"), nullptr, nullptr, nullptr);
 
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);
   hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
-  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, 0, false, OverlapCheck());
+  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "InnerHcalEnvelope", logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructInnerHcal(hcal_envelope_log);
   std::vector<G4VPhysicalVolume *>::iterator it = m_ScintiMotherAssembly->GetVolumesIterator();
@@ -473,14 +473,14 @@ void PHG4InnerHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
           if (layer_id < 0 || layer_id >= m_NumScintiPlates)
           {
             std::cout << "invalid scintillator row " << layer_id
-                 << ", valid range 0 < row < " << m_NumScintiPlates << std::endl;
+                      << ", valid range 0 < row < " << m_NumScintiPlates << std::endl;
             gSystem->Exit(1);
           }
         }
         else
         {
           std::cout << PHWHERE << " Error parsing " << (*it)->GetName()
-               << " for mother volume number " << std::endl;
+                    << " for mother volume number " << std::endl;
           gSystem->Exit(1);
         }
         break;
@@ -497,7 +497,7 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
   SetTiltViaNcross();  // if number of crossings is set, use it to determine tilt
   CheckTiltAngle();    // die if the tilt angle is out of range
   G4VSolid *steel_plate = ConstructSteelPlate(hcalenvelope);
-  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, GetDetectorMaterial(m_Params->get_string_param("material")), "HcalInnerSteelPlate", 0, 0, 0);
+  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, GetDetectorMaterial(m_Params->get_string_param("material")), "HcalInnerSteelPlate", nullptr, nullptr, nullptr);
   m_DisplayAction->AddSteelVolume(steel_logical);
   m_ScintiMotherAssembly = ConstructHcalScintillatorAssembly(hcalenvelope);
   double phi = 0;
@@ -557,7 +557,7 @@ int PHG4InnerHcalDetector::ConstructInnerHcal(G4LogicalVolume *hcalenvelope)
     Rot->rotateZ(-phi * rad);
     name.str("");
     name << "InnerHcalSteel_" << i;
-    m_SteelAbsorberPhysVolSet.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str(), hcalenvelope, 0, i, OverlapCheck()));
+    m_SteelAbsorberPhysVolSet.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str(), hcalenvelope, false, i, OverlapCheck()));
     phi += deltaphi;
   }
   return 0;
@@ -774,7 +774,7 @@ int PHG4InnerHcalDetector::CheckTiltAngle() const
   if (fabs(m_TiltAngle / rad) >= M_PI)
   {
     std::cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (m_TiltAngle / deg)
-         << std::endl;
+              << std::endl;
     exit(1);
   }
 
@@ -791,7 +791,7 @@ int PHG4InnerHcalDetector::CheckTiltAngle() const
   if (res.size() == 0)
   {
     std::cout << PHWHERE << " Tilt angle " << (m_TiltAngle / deg)
-         << " too large, no intersection with inner radius" << std::endl;
+              << " too large, no intersection with inner radius" << std::endl;
     exit(1);
   }
   return 0;
@@ -803,22 +803,22 @@ int PHG4InnerHcalDetector::ConsistencyCheck() const
   if (m_InnerRadius >= m_OuterRadius)
   {
     std::cout << PHWHERE << ": Inner Radius " << m_InnerRadius / cm
-         << " cm larger than Outer Radius " << m_OuterRadius / cm
-         << " cm" << std::endl;
+              << " cm larger than Outer Radius " << m_OuterRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiTileThickness > m_ScintiInnerGap)
   {
     std::cout << PHWHERE << "Scintillator thickness " << m_ScintiTileThickness / cm
-         << " cm larger than scintillator inner gap " << m_ScintiInnerGap / cm
-         << " cm" << std::endl;
+              << " cm larger than scintillator inner gap " << m_ScintiInnerGap / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiOuterRadius <= m_InnerRadius)
   {
     std::cout << PHWHERE << "Scintillator outer radius " << m_ScintiOuterRadius / cm
-         << " cm smaller than inner radius " << m_InnerRadius / cm
-         << " cm" << std::endl;
+              << " cm smaller than inner radius " << m_InnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   return 0;
@@ -928,7 +928,7 @@ std::pair<int, int> PHG4InnerHcalDetector::GetLayerTowerId(G4VPhysicalVolume *vo
     return it->second;
   }
   std::cout << "could not locate volume " << volume->GetName()
-       << " in Inner Hcal scintillator map" << std::endl;
+            << " in Inner Hcal scintillator map" << std::endl;
   gSystem->Exit(1);
   // that's dumb but code checkers do not know that gSystem->Exit()
   // terminates, so using the standard exit() makes them happy

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSteppingAction.cc
@@ -96,7 +96,7 @@ int PHG4InnerHcalSteppingAction::Init()
       gSystem->Exit(1);
       exit(1);  // make code checkers which do not know gSystem->Exit() happy
     }
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    m_MapCorrHist->SetDirectory(nullptr);  // rootism: this needs to be set otherwise histo vanished when closing the file
     file->Close();
     delete file;
   }

--- a/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4InnerHcalSubsystem.cc
@@ -143,7 +143,7 @@ void PHG4InnerHcalSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4InnerHcalSubsystem::GetDetector(void) const
+PHG4Detector *PHG4InnerHcalSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalDetector.cc
@@ -57,10 +57,10 @@
 
 class PHCompositeNode;
 
-typedef CGAL::Circle_2<PHG4OuterHcalDetector::Circular_k> Circle_2;
-typedef CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k> Circular_arc_point_2;
-typedef CGAL::Line_2<PHG4OuterHcalDetector::Circular_k> Line_2;
-typedef CGAL::Segment_2<PHG4OuterHcalDetector::Circular_k> Segment_2;
+using Circle_2 = CGAL::Circle_2<PHG4OuterHcalDetector::Circular_k>;
+using Circular_arc_point_2 = CGAL::Circular_arc_point_2<PHG4OuterHcalDetector::Circular_k>;
+using Line_2 = CGAL::Line_2<PHG4OuterHcalDetector::Circular_k>;
+using Segment_2 = CGAL::Segment_2<PHG4OuterHcalDetector::Circular_k>;
 
 // just for debugging if you want a single layer of scintillators at the center of the world
 //#define SCINTITEST
@@ -413,12 +413,12 @@ void PHG4OuterHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *Air = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("OuterHcal_envelope_solid", m_EnvelopeInnerRadius, m_EnvelopeOuterRadius, m_EnvelopeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), 0, 0, 0);
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OuterHcal_envelope"), nullptr, nullptr, nullptr);
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);
   hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
-  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "OuterHcal", logicWorld, 0, false, OverlapCheck());
+  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "OuterHcal", logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructOuterHcal(hcal_envelope_log);
   std::vector<G4VPhysicalVolume *>::iterator it = m_ScintiMotherAssembly->GetVolumesIterator();
@@ -464,14 +464,14 @@ void PHG4OuterHcalDetector::ConstructMe(G4LogicalVolume *logicWorld)
           if (layer_id < 0 || layer_id >= m_NumScintiPlates)
           {
             std::cout << "invalid scintillator row " << layer_id
-                 << ", valid range 0 < row < " << m_NumScintiPlates << std::endl;
+                      << ", valid range 0 < row < " << m_NumScintiPlates << std::endl;
             gSystem->Exit(1);
           }
         }
         else
         {
           std::cout << PHWHERE << " Error parsing " << (*it)->GetName()
-               << " for mother volume number " << std::endl;
+                    << " for mother volume number " << std::endl;
           gSystem->Exit(1);
         }
         break;
@@ -503,7 +503,7 @@ int PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume *hcalenvelope)
 #endif
   G4VSolid *steel_plate = ConstructSteelPlate(hcalenvelope);
   //   DisplayVolume(steel_plate_4 ,hcalenvelope);
-  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, GetDetectorMaterial(m_Params->get_string_param("material")), "HcalOuterSteelPlate", 0, 0, 0);
+  G4LogicalVolume *steel_logical = new G4LogicalVolume(steel_plate, GetDetectorMaterial(m_Params->get_string_param("material")), "HcalOuterSteelPlate", nullptr, nullptr, nullptr);
   m_DisplayAction->AddSteelVolume(steel_logical);
   double phi = 0;
   double deltaphi = 2 * M_PI / m_NumScintiPlates;
@@ -569,7 +569,7 @@ int PHG4OuterHcalDetector::ConstructOuterHcal(G4LogicalVolume *hcalenvelope)
     Rot->rotateZ(-phi * rad);
     name.str("");
     name << "OuterHcalSteel_" << i;
-    m_SteelAbsorberVec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str(), hcalenvelope, 0, i, OverlapCheck()));
+    m_SteelAbsorberVec.insert(new G4PVPlacement(Rot, G4ThreeVector(0, 0, 0), steel_logical, name.str(), hcalenvelope, false, i, OverlapCheck()));
     phi += deltaphi;
   }
   hcalenvelope->SetFieldManager(m_FieldSetup->get_Field_Manager_Gap(), false);
@@ -792,50 +792,50 @@ int PHG4OuterHcalDetector::ConsistencyCheck() const
   if (m_InnerRadius >= m_OuterRadius)
   {
     std::cout << PHWHERE << ": Inner Radius " << m_InnerRadius / cm
-         << " cm larger than Outer Radius " << m_OuterRadius / cm
-         << " cm" << std::endl;
+              << " cm larger than Outer Radius " << m_OuterRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiTileThickness > m_ScintiGap)
   {
     std::cout << PHWHERE << "Scintillator thickness " << m_ScintiTileThickness / cm
-         << " cm larger than scintillator gap " << m_ScintiGap / cm
-         << " cm" << std::endl;
+              << " cm larger than scintillator gap " << m_ScintiGap / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiOuterRadius <= m_ScintiInnerRadius)
   {
     std::cout << PHWHERE << "Scintillator outer radius " << m_ScintiOuterRadius / cm
-         << " cm smaller than scintillator inner radius " << m_ScintiInnerRadius / cm
-         << " cm" << std::endl;
+              << " cm smaller than scintillator inner radius " << m_ScintiInnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiOuterRadius <= m_InnerRadius)
   {
     std::cout << PHWHERE << "Scintillator outer radius " << m_ScintiOuterRadius / cm
-         << " cm smaller than inner radius " << m_InnerRadius / cm
-         << " cm" << std::endl;
+              << " cm smaller than inner radius " << m_InnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_ScintiInnerRadius >= m_OuterRadius)
   {
     std::cout << PHWHERE << "Scintillator inner radius " << m_ScintiInnerRadius / cm
-         << " cm larger than inner radius " << m_InnerRadius / cm
-         << " cm" << std::endl;
+              << " cm larger than inner radius " << m_InnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_Params->get_double_param("magnet_cutout_scinti_radius") * cm < m_ScintiInnerRadius)
   {
     std::cout << PHWHERE << "Magnet scintillator cutout radius " << m_Params->get_double_param("magnet_cutout_scinti_radius")
-         << " cm smaller than inner scintillator radius " << m_ScintiInnerRadius / cm
-         << " cm" << std::endl;
+              << " cm smaller than inner scintillator radius " << m_ScintiInnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
   if (m_Params->get_double_param("magnet_cutout_radius") * cm < m_InnerRadius)
   {
     std::cout << PHWHERE << "Magnet steel cutout radius " << m_Params->get_double_param("magnet_cutout_radius")
-         << " cm smaller than inner radius " << m_InnerRadius / cm
-         << " cm" << std::endl;
+              << " cm smaller than inner radius " << m_InnerRadius / cm
+              << " cm" << std::endl;
     gSystem->Exit(1);
   }
 
@@ -928,7 +928,7 @@ int PHG4OuterHcalDetector::CheckTiltAngle() const
   if (fabs(m_TiltAngle) >= M_PI)
   {
     std::cout << PHWHERE << "invalid tilt angle, abs(tilt) >= 90 deg: " << (m_TiltAngle / deg)
-         << std::endl;
+              << std::endl;
     exit(1);
   }
 
@@ -945,7 +945,7 @@ int PHG4OuterHcalDetector::CheckTiltAngle() const
   if (res.size() == 0)
   {
     std::cout << PHWHERE << " Tilt angle " << (m_TiltAngle / deg)
-         << " too large, no intersection with inner radius" << std::endl;
+              << " too large, no intersection with inner radius" << std::endl;
     exit(1);
   }
   return 0;
@@ -972,7 +972,7 @@ std::pair<int, int> PHG4OuterHcalDetector::GetLayerTowerId(G4VPhysicalVolume *vo
     return it->second;
   }
   std::cout << "could not locate volume " << volume->GetName()
-       << " in Inner Hcal scintillator map" << std::endl;
+            << " in Inner Hcal scintillator map" << std::endl;
   gSystem->Exit(1);
   // that's dumb but code checkers do not know that gSystem->Exit()
   // terminates, so using the standard exit() makes them happy

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSteppingAction.cc
@@ -111,7 +111,7 @@ int PHG4OuterHcalSteppingAction::Init()
       gSystem->Exit(1);
       exit(1);  // make code checkers which do not know gSystem->Exit() happy
     }
-    m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
+    m_MapCorrHist->SetDirectory(nullptr);  // rootism: this needs to be set otherwise histo vanished when closing the file
     file->Close();
     delete file;
   }

--- a/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4OuterHcalSubsystem.cc
@@ -136,7 +136,7 @@ void PHG4OuterHcalSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4OuterHcalSubsystem::GetDetector(void) const
+PHG4Detector *PHG4OuterHcalSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFDetector.cc
@@ -53,7 +53,7 @@ void PHG4PSTOFDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *Glass = GetDetectorMaterial("G4_GLASS_PLATE");
   G4Box *pstof_box = new G4Box("pstof_box", 0.8 * cm, 6 * cm, 5 * cm);
 
-  G4LogicalVolume *pstof_log_vol = new G4LogicalVolume(pstof_box, Glass, G4String("PSTOF_box"), 0, 0, 0);
+  G4LogicalVolume *pstof_log_vol = new G4LogicalVolume(pstof_box, Glass, G4String("PSTOF_box"), nullptr, nullptr, nullptr);
   G4VisAttributes *pstofVisAtt = new G4VisAttributes();
   pstofVisAtt->SetVisibility(true);
   pstofVisAtt->SetForceSolid(true);

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSteppingAction.cc
@@ -94,8 +94,8 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
   if (layer_id != whichactive)
   {
     std::cout << PHWHERE << " inconsistency between G4 copy number: "
-         << layer_id << " and module id from detector: "
-         << whichactive << std::endl;
+              << layer_id << " and module id from detector: "
+              << whichactive << std::endl;
     gSystem->Exit(1);
   }
 
@@ -110,15 +110,15 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
     {
       std::cout << GetName() << ": New Hit for  " << std::endl;
       std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-           << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-           << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-           << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << std::endl;
+                << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+                << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << std::endl;
       std::cout << "last track: " << savetrackid
-           << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+                << ", current trackid: " << aTrack->GetTrackID() << std::endl;
       std::cout << "phys pre vol: " << volume->GetName()
-           << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+                << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
       std::cout << " previous phys pre vol: " << savevolpre->GetName()
-           << " previous phys post vol: " << savevolpost->GetName() << std::endl;
+                << " previous phys post vol: " << savevolpost->GetName() << std::endl;
     }
     [[fallthrough]];
   case fGeomBoundary:
@@ -177,15 +177,15 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
   {
     std::cout << GetName() << ": hit was not created" << std::endl;
     std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-         << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-         << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-         << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << std::endl;
+              << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+              << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+              << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << std::endl;
     std::cout << "last track: " << savetrackid
-         << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+              << ", current trackid: " << aTrack->GetTrackID() << std::endl;
     std::cout << "phys pre vol: " << volume->GetName()
-         << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+              << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
     std::cout << " previous phys pre vol: " << savevolpre->GetName()
-         << " previous phys post vol: " << savevolpost->GetName() << std::endl;
+              << " previous phys post vol: " << savevolpost->GetName() << std::endl;
     gSystem->Exit(1);
   }
   // check if track id matches the initial one when the hit was created
@@ -193,10 +193,10 @@ bool PHG4PSTOFSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
   {
     std::cout << GetName() << ": hits do not belong to the same track" << std::endl;
     std::cout << "saved track: " << savetrackid
-         << ", current trackid: " << aTrack->GetTrackID()
-         << ", prestep status: " << prePoint->GetStepStatus()
-         << ", previous post step status: " << savepoststepstatus
-         << std::endl;
+              << ", current trackid: " << aTrack->GetTrackID()
+              << ", prestep status: " << prePoint->GetStepStatus()
+              << ", previous post step status: " << savepoststepstatus
+              << std::endl;
 
     gSystem->Exit(1);
   }

--- a/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4PSTOFSubsystem.cc
@@ -113,13 +113,13 @@ void PHG4PSTOFSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4PSTOFSubsystem::GetDetector(void) const
+PHG4Detector *PHG4PSTOFSubsystem::GetDetector() const
 {
   return detector_;
 }
 
 //_______________________________________________________________________
-PHG4SteppingAction *PHG4PSTOFSubsystem::GetSteppingAction(void) const
+PHG4SteppingAction *PHG4PSTOFSubsystem::GetSteppingAction() const
 {
   return steppingAction_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatContainer.cc
@@ -60,7 +60,7 @@ PHG4ScintillatorSlatContainer::getScintillatorSlats(const short icolumn) const
 }
 
 PHG4ScintillatorSlatContainer::ConstRange
-PHG4ScintillatorSlatContainer::getScintillatorSlats(void) const
+PHG4ScintillatorSlatContainer::getScintillatorSlats() const
 {
   return std::make_pair(slatmap.begin(), slatmap.end());
 }

--- a/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
+++ b/simulation/g4simulation/g4detectors/PHG4ScintillatorSlatv1.h
@@ -16,7 +16,7 @@
 class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
 {
  public:
-  PHG4ScintillatorSlatv1(){}
+  PHG4ScintillatorSlatv1() {}
   ~PHG4ScintillatorSlatv1() override {}
 
   void identify(std::ostream& os = std::cout) const override;
@@ -42,7 +42,7 @@ class PHG4ScintillatorSlatv1 : public PHG4ScintillatorSlat
 
  protected:
   PHG4ScintillatorSlatDefs::keytype key = ~0x0;
-  double edep =0.;
+  double edep = 0.;
   double eion = 0.;
   double light_yield = 0.;
   std::set<PHG4HitDefs::keytype> hit_id;

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.cc
@@ -120,7 +120,7 @@ void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *World
                                           geom.get_max_R(), (sph_min_polar_size + sph_max_polar_size) / 2,
                                           geom.get_total_thickness());
     G4VSolid *BoxBoundary_Det_Place = new G4DisplacedSolid(
-        "BoxBoundary_Det_Place", BoxBoundary_Det, 0,
+        "BoxBoundary_Det_Place", BoxBoundary_Det, nullptr,
         G4ThreeVector(0, (sph_max_polar_size - sph_min_polar_size) / 2, 0));
 
     Boundary_Det = new G4IntersectionSolid("Boundary_Det",
@@ -148,12 +148,8 @@ void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *World
   // construct layers
   double z_start = -geom.get_total_thickness() / 2;
 
-  for (Sector_Geometry::t_layer_list::const_iterator it =
-           geom.layer_list.begin();
-       it != geom.layer_list.end(); ++it)
+  for (const auto &l : geom.layer_list)
   {
-    const Layer &l = (*it);
-
     if (l.percentage_filled > 100. || l.percentage_filled < 0)
     {
       std::ostringstream strstr;
@@ -175,7 +171,7 @@ void PHG4Sector::PHG4SectorConstructor::Construct_Sectors(G4LogicalVolume *World
     RegisterLogicalVolume(LayerLog_Det);
 
     RegisterPhysicalVolume(
-        new G4PVPlacement(0, G4ThreeVector(), LayerLog_Det,
+        new G4PVPlacement(nullptr, G4ThreeVector(), LayerLog_Det,
                           layer_name + "_Physical", DetectorLog_Det, false, 0, overlapcheck_sector),
         l.active);
 
@@ -226,7 +222,7 @@ PHG4Sector::PHG4SectorConstructor::Construct_Sectors_Plane(  //
                                  2 * pi             //      G4double pDPhi
   );
 
-  G4VSolid *Sol_Place = new G4DisplacedSolid(name + "_Place", Sol_Raw, 0,
+  G4VSolid *Sol_Place = new G4DisplacedSolid(name + "_Place", Sol_Raw, nullptr,
                                              G4ThreeVector(0, 0, start_z + thickness / 2));
 
   G4VSolid *Sol = new G4IntersectionSolid(name, Sol_Place,
@@ -312,10 +308,9 @@ double
 PHG4Sector::Sector_Geometry::get_total_thickness() const
 {
   double sum = 0;
-  for (t_layer_list::const_iterator it = layer_list.begin();
-       it != layer_list.end(); ++it)
+  for (const auto &it : layer_list)
   {
-    sum += (*it).depth;
+    sum += it.depth;
   }
   return sum;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
+++ b/simulation/g4simulation/g4detectors/PHG4SectorConstructor.h
@@ -233,8 +233,8 @@ namespace PHG4Sector
 
     void
     AddLayer(                            //
-        const std::string &_name,               //! name base for this layer
-        const std::string &_material,           //! material name in G4
+        const std::string &_name,        //! name base for this layer
+        const std::string &_material,    //! material name in G4
         double _depth,                   //! depth in G4 units
         bool _active = false,            //! active detector element for sensitive detector?
         double _percentage_filled = 100  //! percentage filled//

--- a/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDetector.cc
@@ -45,13 +45,12 @@ void PHG4SectorDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   Construct_Sectors(logicWorld);
 
-  for (map_log_vol_t::iterator it = map_log_vol.begin(); it != map_log_vol.end();
-       ++it)
+  for (auto &it : map_log_vol)
   {
-    if ((*it).first != G4String(name_base + "_Log"))
+    if (it.first != G4String(name_base + "_Log"))
     {
       // sub layers
-      m_DisplayAction->AddVolume((*it).second, "SectorDetector");
+      m_DisplayAction->AddVolume(it.second, "SectorDetector");
     }
   }
 }

--- a/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorDisplayAction.cc
@@ -31,7 +31,7 @@ PHG4SectorDisplayAction::~PHG4SectorDisplayAction()
 void PHG4SectorDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
-  for (auto it : m_LogicalVolumeMap)
+  for (const auto &it : m_LogicalVolumeMap)
   {
     G4LogicalVolume *logvol = it.first;
     if (logvol->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SectorSubsystem.cc
@@ -82,7 +82,7 @@ int PHG4SectorSubsystem::process_event(PHCompositeNode* topNode)
 
 //_______________________________________________________________________
 PHG4Detector*
-PHG4SectorSubsystem::GetDetector(void) const
+PHG4SectorSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -77,7 +77,7 @@ PHG4SpacalDetector::PHG4SpacalDetector(PHG4Subsystem *subsys,
   assert(gdml_config);
 }
 
-PHG4SpacalDetector::~PHG4SpacalDetector(void)
+PHG4SpacalDetector::~PHG4SpacalDetector()
 {
   // deleting nullptr pointers is allowed (results in NOOP)
   // so checking for not null before deleting is not needed
@@ -151,11 +151,11 @@ void PHG4SpacalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *cylinder_mat = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   assert(cylinder_mat);
 
-  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat, GetName(), 0, 0, 0);
+  G4LogicalVolume *cylinder_logic = new G4LogicalVolume(cylinder_solid, cylinder_mat, GetName(), nullptr, nullptr, nullptr);
   GetDisplayAction()->AddVolume(cylinder_logic, "SpacalCylinder");
   if (!m_CosmicSetupFlag)
   {
-    new G4PVPlacement(0, G4ThreeVector(_geom->get_xpos() * cm, _geom->get_ypos() * cm, _geom->get_zpos() * cm),
+    new G4PVPlacement(nullptr, G4ThreeVector(_geom->get_xpos() * cm, _geom->get_ypos() * cm, _geom->get_zpos() * cm),
                       cylinder_logic, GetName(),
                       logicWorld, false, 0, OverlapCheck());
   }
@@ -188,7 +188,7 @@ void PHG4SpacalDetector::ConstructMe(G4LogicalVolume *logicWorld)
     G4PVPlacement *calo_phys = nullptr;
     if (m_CosmicSetupFlag)
     {
-      calo_phys = new G4PVPlacement(0, G4ThreeVector(0, -(_geom->get_radius()) * cm, 0), sec_logic,
+      calo_phys = new G4PVPlacement(nullptr, G4ThreeVector(0, -(_geom->get_radius()) * cm, 0), sec_logic,
                                     G4String(name.str()), logicWorld, false, sec,
                                     OverlapCheck());
     }
@@ -280,7 +280,7 @@ PHG4SpacalDetector::Construct_AzimuthalSeg()
   assert(cylinder_mat);
 
   G4LogicalVolume *sec_logic = new G4LogicalVolume(sec_solid, cylinder_mat,
-                                                   G4String(G4String(GetName() + std::string("_sec"))), 0, 0, nullptr);
+                                                   G4String(G4String(GetName() + std::string("_sec"))), nullptr, nullptr, nullptr);
 
   GetDisplayAction()->AddVolume(sec_logic, "AzimuthSegment");
 
@@ -347,7 +347,7 @@ PHG4SpacalDetector::Construct_Fiber(const G4double length, const std::string &id
   assert(clading_mat);
 
   G4LogicalVolume *fiber_logic = new G4LogicalVolume(fiber_solid, clading_mat,
-                                                     G4String(G4String(GetName() + std::string("_fiber") + id)), 0, 0,
+                                                     G4String(G4String(GetName() + std::string("_fiber") + id)), nullptr, nullptr,
                                                      nullptr);
 
   {
@@ -362,7 +362,7 @@ PHG4SpacalDetector::Construct_Fiber(const G4double length, const std::string &id
   assert(core_mat);
 
   G4LogicalVolume *core_logic = new G4LogicalVolume(core_solid, core_mat,
-                                                    G4String(G4String(GetName() + std::string("_fiber_core") + id)), 0, 0,
+                                                    G4String(G4String(GetName() + std::string("_fiber_core") + id)), nullptr, nullptr,
                                                     fiber_core_step_limits);
 
   {
@@ -370,7 +370,7 @@ PHG4SpacalDetector::Construct_Fiber(const G4double length, const std::string &id
   }
 
   const bool overlapcheck_fiber = OverlapCheck() and (Verbosity() >= 3);
-  G4PVPlacement *core_physi = new G4PVPlacement(0, G4ThreeVector(), core_logic,
+  G4PVPlacement *core_physi = new G4PVPlacement(nullptr, G4ThreeVector(), core_logic,
                                                 G4String(G4String(GetName() + std::string("_fiber_core") + id)), fiber_logic,
                                                 false, 0, overlapcheck_fiber);
   fiber_core_vol[core_physi] = 0;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDisplayAction.cc
@@ -31,7 +31,7 @@ PHG4SpacalDisplayAction::~PHG4SpacalDisplayAction()
 void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
-  for (auto it : m_LogicalVolumeMap)
+  for (const auto &it : m_LogicalVolumeMap)
   {
     G4LogicalVolume *logvol = it.first;
     if (logvol->GetVisAttributes())
@@ -54,7 +54,7 @@ void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/
     {
       visatt->SetColor(.3, .3, .3, .3);
       visatt->SetVisibility(m_Geom->is_azimuthal_seg_visible() or m_Geom->is_virualize_fiber());
-      visatt->SetForceSolid(! m_Geom->is_virualize_fiber());
+      visatt->SetForceSolid(!m_Geom->is_virualize_fiber());
     }
     else if (it.second == "Divider")
     {
@@ -78,7 +78,7 @@ void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/
       PHG4Utils::SetColour(visatt, m_MaterialMap["LightGuide"]);
       visatt->SetColor(.8, 1, .8, .3);
       visatt->SetVisibility(m_Geom->is_azimuthal_seg_visible() or m_Geom->is_virualize_fiber());
-      visatt->SetForceSolid(! m_Geom->is_virualize_fiber());
+      visatt->SetForceSolid(!m_Geom->is_virualize_fiber());
     }
     else if (it.second == "Sector")
     {
@@ -90,7 +90,7 @@ void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/
     else if (it.second == "SpacalCylinder")
     {
       PHG4Utils::SetColour(visatt, "W_Epoxy");
-      visatt->SetForceSolid((! m_Geom->is_virualize_fiber()) && (! m_Geom->is_azimuthal_seg_visible()));
+      visatt->SetForceSolid((!m_Geom->is_virualize_fiber()) && (!m_Geom->is_azimuthal_seg_visible()));
     }
     else if (it.second == "Wall")
     {
@@ -100,12 +100,12 @@ void PHG4SpacalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/
     else if (it.second == "WallProj")
     {
       visatt->SetColor(.5, .9, .5, .2);
-      visatt->SetVisibility(m_Geom->is_azimuthal_seg_visible() && (! m_Geom->is_virualize_fiber()));
+      visatt->SetVisibility(m_Geom->is_azimuthal_seg_visible() && (!m_Geom->is_virualize_fiber()));
     }
     else
     {
       std::cout << "did not assing color to " << it.first->GetName()
-           << " under " << it.second << std::endl;
+                << " under " << it.second << std::endl;
       gSystem->Exit(1);
     }
     logvol->SetVisAttributes(visatt);

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -126,7 +126,7 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     {
       nodes.insert(m_AbsorberNodeName);
     }
-    for (auto nodename : nodes)
+    for (const auto& nodename : nodes)
     {
       PHG4HitContainer* g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)
@@ -157,7 +157,7 @@ int PHG4SpacalSubsystem::process_event(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4SpacalSubsystem::GetDetector(void) const
+PHG4Detector* PHG4SpacalSubsystem::GetDetector() const
 {
   return detector_;
 }

--- a/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
+++ b/simulation/g4simulation/g4detectors/PHG4StepStatusDecode.cc
@@ -13,7 +13,7 @@ std::string PHG4StepStatusDecode::GetStepStatus(const int istatus)
 {
   if (stepstatus.empty())
   {
-    std::cout << "filling stepstatus map" << std::endl;
+    //    std::cout << "filling stepstatus map" << std::endl;
     stepstatus[fWorldBoundary] = "fWorldBoundary";
     stepstatus[fGeomBoundary] = "fGeomBoundary";
     stepstatus[fAtRestDoItProc] = "fAtRestDoItProc";

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDetector.cc
@@ -146,11 +146,11 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
 
   G4VSolid* Hole_solid = new G4Tubs(G4String("Hole_solid"),
                                     0.0, m_RHole, 2 * m_TWin, 0.0, CLHEP::twopi);
-  G4VSolid* ExitWindow_1cut_solid = new G4SubtractionSolid("ExitWindow_1cut_solid", ExitWindow_nocut_solid, Hole_solid, 0, G4ThreeVector(m_PlaceHole, 0, 0));
+  G4VSolid* ExitWindow_1cut_solid = new G4SubtractionSolid("ExitWindow_1cut_solid", ExitWindow_nocut_solid, Hole_solid, nullptr, G4ThreeVector(m_PlaceHole, 0, 0));
 
-  G4VSolid* ExitWindow_2cut_solid = new G4SubtractionSolid("ExitWindow_2cut_solid", ExitWindow_1cut_solid, Hole_solid, 0, G4ThreeVector(-m_PlaceHole, 0, 0));
+  G4VSolid* ExitWindow_2cut_solid = new G4SubtractionSolid("ExitWindow_2cut_solid", ExitWindow_1cut_solid, Hole_solid, nullptr, G4ThreeVector(-m_PlaceHole, 0, 0));
 
-  G4LogicalVolume* ExitWindow_log = new G4LogicalVolume(ExitWindow_2cut_solid, GetDetectorMaterial("G4_STAINLESS-STEEL"), G4String("ExitWindow_log"), 0, 0, 0);
+  G4LogicalVolume* ExitWindow_log = new G4LogicalVolume(ExitWindow_2cut_solid, GetDetectorMaterial("G4_STAINLESS-STEEL"), G4String("ExitWindow_log"), nullptr, nullptr, nullptr);
 
   GetDisplayAction()->AddVolume(ExitWindow_log, "Window");
   m_SupportLogicalVolSet.insert(ExitWindow_log);
@@ -162,13 +162,13 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
   if (m_Layer == PHG4ZDCDefs::NORTH)
   {
     new G4PVPlacement(G4Transform3D(Window_rotm, G4ThreeVector(m_Pxwin, m_Pywin, m_Params->get_double_param("place_z") * cm - m_Pzwin)),
-                      ExitWindow_log, "Window_North", logicWorld, 0, PHG4ZDCDefs::NORTH, OverlapCheck());
+                      ExitWindow_log, "Window_North", logicWorld, false, PHG4ZDCDefs::NORTH, OverlapCheck());
   }
 
   else if (m_Layer == PHG4ZDCDefs::SOUTH)
   {
     new G4PVPlacement(G4Transform3D(Window_rotm, G4ThreeVector(m_Pxwin, m_Pywin, -m_Params->get_double_param("place_z") * cm + m_Pzwin)),
-                      ExitWindow_log, "Window_South", logicWorld, 0, PHG4ZDCDefs::SOUTH, OverlapCheck());
+                      ExitWindow_log, "Window_South", logicWorld, false, PHG4ZDCDefs::SOUTH, OverlapCheck());
   }
   /* ZDC detector here */
   /* Create the box envelope = 'world volume' for ZDC */
@@ -181,7 +181,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                            Mother_Y,
                                            Mother_Z);
 
-  G4LogicalVolume* ZDC_envelope_log = new G4LogicalVolume(ZDC_envelope_solid, WorldMaterial, G4String("ZDC_envelope_log"), 0, 0, 0);
+  G4LogicalVolume* ZDC_envelope_log = new G4LogicalVolume(ZDC_envelope_solid, WorldMaterial, G4String("ZDC_envelope_log"), nullptr, nullptr, nullptr);
 
   /* Define visualization attributes */
   GetDisplayAction()->AddVolume(ZDC_envelope_log, "Envelope");
@@ -198,7 +198,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                           m_HFiber / 2.,
                                           TGap / 2.);
 
-  G4LogicalVolume* fiber_plate_log = new G4LogicalVolume(fiber_plate_solid, WorldMaterial, G4String("fiber_plate_log"), 0, 0, 0);
+  G4LogicalVolume* fiber_plate_log = new G4LogicalVolume(fiber_plate_solid, WorldMaterial, G4String("fiber_plate_log"), nullptr, nullptr, nullptr);
   GetDisplayAction()->AddVolume(fiber_plate_log, "fiber_plate_air");
   /*  front and back plate */
   G4VSolid* fb_plate_solid = new G4Box(G4String("fb_plate_solid"),
@@ -206,7 +206,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                        m_HPlate / 2.,
                                        m_TPlate / 2.);
 
-  G4LogicalVolume* fb_plate_log = new G4LogicalVolume(fb_plate_solid, Fe, G4String("fb_plate_log"), 0, 0, 0);
+  G4LogicalVolume* fb_plate_log = new G4LogicalVolume(fb_plate_solid, Fe, G4String("fb_plate_log"), nullptr, nullptr, nullptr);
   m_SupportLogicalVolSet.insert(fb_plate_log);
   GetDisplayAction()->AddVolume(fb_plate_log, "FrontBackPlate");
 
@@ -216,7 +216,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                        m_HAbsorber / 2.,
                                        m_TAbsorber / 2.);
 
-  G4LogicalVolume* absorber_log = new G4LogicalVolume(absorber_solid, W, G4String("absorber_log"), 0, 0, 0);
+  G4LogicalVolume* absorber_log = new G4LogicalVolume(absorber_solid, W, G4String("absorber_log"), nullptr, nullptr, nullptr);
   m_AbsorberLogicalVolSet.insert(absorber_log);
   GetDisplayAction()->AddVolume(absorber_log, "Absorber");
 
@@ -227,7 +227,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                   m_HSMD / 2.,
                                   m_TSMD / 2.);
 
-  G4LogicalVolume* SMD_log = new G4LogicalVolume(SMD_solid, WorldMaterial, G4String("SMD_log"), 0, 0, 0);
+  G4LogicalVolume* SMD_log = new G4LogicalVolume(SMD_solid, WorldMaterial, G4String("SMD_log"), nullptr, nullptr, nullptr);
   GetDisplayAction()->AddVolume(SMD_log, "SMD");
   // small scintillators block
   G4double scintx = 15 * mm;
@@ -237,7 +237,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                                     scinty / 2.,
                                     m_TSMD / 2.);
 
-  G4LogicalVolume* Scint_log = new G4LogicalVolume(Scint_solid, Scint, G4String("Scint_log"), 0, 0, 0);
+  G4LogicalVolume* Scint_log = new G4LogicalVolume(Scint_solid, Scint, G4String("Scint_log"), nullptr, nullptr, nullptr);
   m_ScintiLogicalVolSet.insert(Scint_log);
   GetDisplayAction()->AddVolume(Scint_log, "Scint_solid");
 
@@ -261,7 +261,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                         Scint_log,
                         "single_scint",
                         SMD_log,
-                        0, copyno, OverlapCheck());
+                        false, copyno, OverlapCheck());
 
       scint_YPos += scint_Ystep;
     }
@@ -272,7 +272,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
   G4VSolid* single_fiber_solid = new G4Tubs(G4String("single_fiber_solid"),
                                             0.0, (m_DFiber / 2.) - m_GFiber, (m_HFiber / 2.), 0.0, CLHEP::twopi);
 
-  G4LogicalVolume* single_fiber_log = new G4LogicalVolume(single_fiber_solid, PMMA, G4String("single_fiber_log"), 0, 0, 0);
+  G4LogicalVolume* single_fiber_log = new G4LogicalVolume(single_fiber_solid, PMMA, G4String("single_fiber_log"), nullptr, nullptr, nullptr);
   m_FiberLogicalVolSet.insert(single_fiber_log);
   GetDisplayAction()->AddVolume(single_fiber_log, "Fiber");
 
@@ -294,7 +294,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                       single_fiber_log,
                       G4String("single_fiber_scint"),
                       fiber_plate_log,
-                      0, copyno, OverlapCheck());
+                      false, copyno, OverlapCheck());
     fiber_XPos += fiber_step;
   }
 
@@ -330,7 +330,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                         SMD_log,
                         G4String("SMD"),
                         ZDC_envelope_log,
-                        0, 0, OverlapCheck());  //using copy number for now, need to find a better way
+                        false, 0, OverlapCheck());  //using copy number for now, need to find a better way
       ZPos += (SMD_Step / 2.);
     }
     /* place the front plate */
@@ -339,7 +339,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                       fb_plate_log,
                       G4String("front_plate"),
                       ZDC_envelope_log,
-                      0, copyno_plate, OverlapCheck());
+                      false, copyno_plate, OverlapCheck());
     ZPos += (Plate_Step / 2.);
     copyno_plate++;
     for (int j = 0; j < m_NLay; j++)
@@ -350,7 +350,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                         absorber_log,
                         G4String("single_absorber"),
                         ZDC_envelope_log,
-                        0, i * 100 + j, OverlapCheck());
+                        false, i * 100 + j, OverlapCheck());
       ZPos += (Absorber_Step / 2.);
 
       /* place the fiber plate */
@@ -361,7 +361,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                         fiber_plate_log,
                         name_fiber_plate,
                         ZDC_envelope_log,
-                        0, copyno, OverlapCheck());
+                        false, copyno, OverlapCheck());
       ZPos += (Gap_Step / 2.);
     }
     /* place the back plate */
@@ -370,7 +370,7 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
                       fb_plate_log,
                       G4String("back_plate"),
                       ZDC_envelope_log,
-                      0, copyno_plate, OverlapCheck());
+                      false, copyno_plate, OverlapCheck());
     copyno_plate++;
     ZPos += (Plate_Step / 2.);
   }
@@ -380,13 +380,13 @@ void PHG4ZDCDetector::ConstructMe(G4LogicalVolume* logicWorld)
   if (m_Layer == PHG4ZDCDefs::NORTH)
   {
     new G4PVPlacement(G4Transform3D(ZDC_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)),
-                      ZDC_envelope_log, "ZDC_Envelope_North", logicWorld, 0, PHG4ZDCDefs::NORTH, OverlapCheck());
+                      ZDC_envelope_log, "ZDC_Envelope_North", logicWorld, false, PHG4ZDCDefs::NORTH, OverlapCheck());
   }
   else if (m_Layer == PHG4ZDCDefs::SOUTH)
   {
     ZDC_rotm.rotateY(180 * deg);
     new G4PVPlacement(G4Transform3D(ZDC_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, -m_Params->get_double_param("place_z") * cm)),
-                      ZDC_envelope_log, "ZDC_Envelope_South", logicWorld, 0, PHG4ZDCDefs::SOUTH, OverlapCheck());
+                      ZDC_envelope_log, "ZDC_Envelope_South", logicWorld, false, PHG4ZDCDefs::SOUTH, OverlapCheck());
   }
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCDisplayAction.cc
@@ -28,7 +28,7 @@ PHG4ZDCDisplayAction::~PHG4ZDCDisplayAction()
 void PHG4ZDCDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
 {
   // check if vis attributes exist, if so someone else has set them and we do nothing
-  for (auto it : m_LogicalVolumeMap)
+  for (const auto &it : m_LogicalVolumeMap)
   {
     G4LogicalVolume *logvol = it.first;
     if (logvol->GetVisAttributes())

--- a/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ZDCSubsystem.cc
@@ -87,7 +87,7 @@ int PHG4ZDCSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       nodes.insert(m_SupportNodeName);
     }
 
-    for (auto nodename : nodes)
+    for (const auto& nodename : nodes)
     {
       PHG4HitContainer* g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)
@@ -122,7 +122,7 @@ int PHG4ZDCSubsystem::process_event(PHCompositeNode* topNode)
 }
 
 //_______________________________________________________________________
-PHG4Detector* PHG4ZDCSubsystem::GetDetector(void) const
+PHG4Detector* PHG4ZDCSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -113,7 +113,7 @@ void PHG4IHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   // disable GDML export for HCal geometries for memory saving and compatibility issues
   assert(gdml_config);
   gdml_config->exclude_physical_vol(mothervol);
-  gdml_config->exclude_logical_vol (hcal_envelope_log);
+  gdml_config->exclude_logical_vol(hcal_envelope_log);
 
   return;
 }

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -100,13 +100,13 @@ void PHG4IHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *worldmat = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("IHCal_envelope_solid", m_InnerRadius, m_OuterRadius, m_SizeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, worldmat, "Hcal_envelope", 0, 0, 0);
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, worldmat, "Hcal_envelope", nullptr, nullptr, nullptr);
 
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);
   hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
-  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "IHCalEnvelope", logicWorld, 0, false, OverlapCheck());
+  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "IHCalEnvelope", logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructIHCal(hcal_envelope_log);
 

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.h
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.h
@@ -78,7 +78,7 @@ class PHG4IHCalDetector : public PHG4Detector
   std::map<G4VPhysicalVolume *, int> m_AbsorberPhysVolMap;
 
   //! registry for volumes that should not be exported
-  PHG4GDMLConfig* gdml_config = nullptr;
+  PHG4GDMLConfig *gdml_config = nullptr;
 
   std::string m_GDMPath;
 };

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -174,28 +174,28 @@ bool PHG4IHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fPostStepDoItProc:
       if (m_SavePostStepStatus != fGeomBoundary)
       {
-	if (m_SavePostStepStatus != fAtRestDoItProc)
-	{
+        if (m_SavePostStepStatus != fAtRestDoItProc)
+        {
           break;
-	}
-	else
-	{
-	  if (aTrack->GetTrackID() == m_SaveTrackId)
-	  {
-	    std::cout << GetName() << ": Bad step status combination for the same track " << std::endl;
-	    std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-		      << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-		      << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
-		      << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
-	    std::cout << "last track: " << m_SaveTrackId
-		      << ", current trackid: " << aTrack->GetTrackID() << std::endl;
-	    std::cout << "phys pre vol: " << volume->GetName()
-		      << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
-	    std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
-		      << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
-	    gSystem->Exit(1);
-	  }
-	}
+        }
+        else
+        {
+          if (aTrack->GetTrackID() == m_SaveTrackId)
+          {
+            std::cout << GetName() << ": Bad step status combination for the same track " << std::endl;
+            std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+                      << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                      << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                      << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+            std::cout << "last track: " << m_SaveTrackId
+                      << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+            std::cout << "phys pre vol: " << volume->GetName()
+                      << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+            std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+                      << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+            gSystem->Exit(1);
+          }
+        }
       }
       else
       {

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -174,7 +174,28 @@ bool PHG4IHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fPostStepDoItProc:
       if (m_SavePostStepStatus != fGeomBoundary)
       {
-        break;
+	if (m_SavePostStepStatus != fAtRestDoItProc)
+	{
+          break;
+	}
+	else
+	{
+	  if (aTrack->GetTrackID() == m_SaveTrackId)
+	  {
+	    std::cout << GetName() << ": Bad step status combination for the same track " << std::endl;
+	    std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+		      << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+		      << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+		      << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+	    std::cout << "last track: " << m_SaveTrackId
+		      << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+	    std::cout << "phys pre vol: " << volume->GetName()
+		      << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+	    std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+		      << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+	    gSystem->Exit(1);
+	  }
+	}
       }
       else
       {

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
@@ -81,7 +81,7 @@ int PHG4IHCalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       nodes.insert(m_AbsorberNodeName);
     }
-    for (auto nodename : nodes)
+    for (const auto& nodename : nodes)
     {
       PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)
@@ -138,7 +138,7 @@ void PHG4IHCalSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4IHCalSubsystem::GetDetector(void) const
+PHG4Detector *PHG4IHCalSubsystem::GetDetector() const
 {
   return m_Detector;
 }

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
@@ -81,7 +81,7 @@ int PHG4IHCalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       nodes.insert(m_AbsorberNodeName);
     }
-    for (const auto& nodename : nodes)
+    for (const auto &nodename : nodes)
     {
       PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -104,19 +104,19 @@ void PHG4OHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4Material *Air = GetDetectorMaterial(rc->get_StringFlag("WorldMaterial"));
   G4VSolid *hcal_envelope_cylinder = new G4Tubs("OHCal_envelope_solid", m_InnerRadius, m_OuterRadius, m_SizeZ / 2., 0, 2 * M_PI);
   m_VolumeEnvelope = hcal_envelope_cylinder->GetCubicVolume();
-  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OHCal_envelope"), 0, 0, 0);
+  G4LogicalVolume *hcal_envelope_log = new G4LogicalVolume(hcal_envelope_cylinder, Air, G4String("OHCal_envelope"), nullptr, nullptr, nullptr);
   G4RotationMatrix hcal_rotm;
   hcal_rotm.rotateX(m_Params->get_double_param("rot_x") * deg);
   hcal_rotm.rotateY(m_Params->get_double_param("rot_y") * deg);
   hcal_rotm.rotateZ(m_Params->get_double_param("rot_z") * deg);
-  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "OHCal", logicWorld, 0, false, OverlapCheck());
+  G4VPhysicalVolume *mothervol = new G4PVPlacement(G4Transform3D(hcal_rotm, G4ThreeVector(m_Params->get_double_param("place_x") * cm, m_Params->get_double_param("place_y") * cm, m_Params->get_double_param("place_z") * cm)), hcal_envelope_log, "OHCal", logicWorld, false, false, OverlapCheck());
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructOHCal(hcal_envelope_log);
 
   // disable GDML export for HCal geometries for memory saving and compatibility issues
   assert(gdml_config);
   gdml_config->exclude_physical_vol(mothervol);
-  gdml_config->exclude_logical_vol (hcal_envelope_log);
+  gdml_config->exclude_logical_vol(hcal_envelope_log);
 
   return;
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.h
@@ -75,7 +75,7 @@ class PHG4OHCalDetector : public PHG4Detector
   std::map<G4VPhysicalVolume *, std::tuple<int, int, int>> m_ScintiTilePhysVolMap;
 
   //! registry for volumes that should not be exported
-  PHG4GDMLConfig* gdml_config = nullptr;
+  PHG4GDMLConfig *gdml_config = nullptr;
 
   std::string m_GDMPath;
 };

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -200,7 +200,28 @@ bool PHG4OHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     case fPostStepDoItProc:
       if (m_SavePostStepStatus != fGeomBoundary)
       {
-        break;
+        if (m_SavePostStepStatus != fAtRestDoItProc)
+        {
+          break;
+        }
+        else
+        {
+          if (aTrack->GetTrackID() == m_SaveTrackId)
+          {
+            std::cout << GetName() << ": Bad step status combination for the same track " << std::endl;
+            std::cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+                      << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+                      << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePreStepStatus)
+                      << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(m_SavePostStepStatus) << std::endl;
+            std::cout << "last track: " << m_SaveTrackId
+                      << ", current trackid: " << aTrack->GetTrackID() << std::endl;
+            std::cout << "phys pre vol: " << volume->GetName()
+                      << " post vol : " << touchpost->GetVolume()->GetName() << std::endl;
+            std::cout << " previous phys pre vol: " << m_SaveVolPre->GetName()
+                      << " previous phys post vol: " << m_SaveVolPost->GetName() << std::endl;
+            gSystem->Exit(1);
+          }
+        }
       }
       else
       {

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
@@ -81,7 +81,7 @@ int PHG4OHCalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
     {
       nodes.insert(m_AbsorberNodeName);
     }
-    for (auto nodename : nodes)
+    for (const auto &nodename : nodes)
     {
       PHG4HitContainer *g4_hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
       if (!g4_hits)
@@ -132,7 +132,7 @@ void PHG4OHCalSubsystem::Print(const std::string &what) const
 }
 
 //_______________________________________________________________________
-PHG4Detector *PHG4OHCalSubsystem::GetDetector(void) const
+PHG4Detector *PHG4OHCalSubsystem::GetDetector() const
 {
   return m_Detector;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR fixes a small hole in the step status check before generating a new hit, leading to this error:
https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-default-detector-pipeline/4699/artifact/macros/detectors/sPHENIX/Fun4All_G4_sPHENIX.log/*view*/
What wasn't handled was a previous step ending with fAtRestDoItProc, but the current step starting with fPostStepDoItProc (sounds like a decay right at the volume boundary). The signature here was that the track id changed. This fix is only applied to the new hcals. Other detectors will still bomb out.

Also clang-tidy for g4detectors which should give a bit of a speedup

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

