### PR TITLE
update new gdml based ihcal light yield with maps

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -77,7 +77,7 @@ int PHG4IHCalSteppingAction::Init()
 {
   if (m_LightScintModelFlag)
   {
-    /*
+    
     const char* Calibroot = getenv("CALIBRATIONROOT");
     if (!Calibroot)
     {
@@ -85,9 +85,9 @@ int PHG4IHCalSteppingAction::Init()
       gSystem->Exit(1);
     }
     std::string ihcalmapname(Calibroot);
-    ihcalmapname += "/HCALIN/tilemap/iHCALMapsNorm020922.root";
+    ihcalmapname += "/HCALIN/tilemap/ihcalgdmlmap092022norm.root";
     TFile* file = TFile::Open(ihcalmapname.c_str());
-    file->GetObject("ihcalmapcombined", m_MapCorrHist);
+    file->GetObject("ihcalcombinedgdmlnorm", m_MapCorrHist);
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;
@@ -96,7 +96,7 @@ int PHG4IHCalSteppingAction::Init()
     m_MapCorrHist->SetDirectory(0);  // rootism: this needs to be set otherwise histo vanished when closing the file
     file->Close();
     delete file;
-*/
+
   }
   return 0;
 }
@@ -316,16 +316,16 @@ bool PHG4IHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
           const G4ThreeVector& worldPosition = postPoint->GetPosition();
           G4ThreeVector localPosition = theTouchable->GetHistory()->GetTopTransform().TransformPoint(worldPosition);
           float lx = (localPosition.x() / cm);
-          float lz = fabs(localPosition.z() / cm);
+          float ly = (localPosition.y() / cm);
 
           //adjust to tilemap coordinates
-          int lcz = (int) (5.0 * lz) + 1;
-          int lcx = (int) (5.0 * (lx + 12.1)) + 1;
+          int lcx = (int) (5.0 * lx) + 1;
+          int lcy = (int) (5.0 * (ly + 2.0)) + 1;
 
-          if ((lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsY()) &&
-              (lcz >= 1) && (lcz <= m_MapCorrHist->GetNbinsX()))
+          if ((lcy >= 1) && (lcy <= m_MapCorrHist->GetNbinsY()) &&
+              (lcx >= 1) && (lcx <= m_MapCorrHist->GetNbinsX()))
           {
-            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcz, lcx));
+            light_yield *= (double) (m_MapCorrHist->GetBinContent(lcx, lcy));
           }
           else
           {
@@ -434,3 +434,4 @@ void PHG4IHCalSteppingAction::SetHitNodeName(const std::string& type, const std:
   gSystem->Exit(1);
   return;
 }
+


### PR DESCRIPTION
This PR updates the new gdml based ihcal light yield with ihcal Mephi maps. See attached pdf.
[newihcal.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/9558470/newihcal.pdf)
