### PR TITLE
Initialize `G4EmSaturation` after all materials are defined

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -246,13 +246,6 @@ int PHG4Reco::Init(PHCompositeNode *topNode)
   m_RunManager->SetUserInitialization(myphysicslist);
 
   DefineRegions();
-#if G4VERSION_NUMBER >= 1033
-  G4EmSaturation *emSaturation = G4LossTableManager::Instance()->EmSaturation();
-  if (!emSaturation)
-  {
-    std::cout << PHWHERE << "Could not initialize EmSaturation, Birks constants will fail" << std::endl;
-  }
-#endif
   // initialize registered subsystems
   for (SubsysReco *reco: m_SubsystemList)
   {
@@ -458,6 +451,14 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   // initialize
   m_RunManager->Initialize();
 
+#if G4VERSION_NUMBER >= 1033
+  G4EmSaturation *emSaturation = G4LossTableManager::Instance()->EmSaturation();
+  if (!emSaturation)
+  {
+    std::cout << PHWHERE << "Could not initialize EmSaturation, Birks constants will fail" << std::endl;
+  }
+#endif
+  
   // add cerenkov and optical photon processes
   // std::cout << std::endl << "Ignore the next message - we implemented this correctly" << std::endl;
   G4Cerenkov *theCerenkovProcess = new G4Cerenkov("Cerenkov");


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

After https://github.com/sPHENIX-Collaboration/coresoftware/pull/1665 a rare memory invalid read is observed at https://ecce-eic.github.io/doxygen/d8/d17/G4EmSaturation_8cc_source.html#l00132 , which appears related to the order of initialization between material table and `G4EmSaturation` that manages Birk constants. In particular, it fixes `G4EmSaturation::effCharges` array size to the number of material at its initialization. 

This pull request is a test, moving `G4EmSaturation` initialization to after the G4 subsystem geometry build which finalize material list. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Test it out, solve any problem. 

## Links to other PRs in macros and calibration repositories (if applicable)

