### PR TITLE
Update seed converter to SvtxTrack_v4

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -3734,6 +3734,8 @@ void SvtxEvaluator::get_dca(SvtxTrack* track, SvtxVertexMap* vertexmap,
 
   auto vtxid = track->get_vertex_id();
   auto svtxVertex = vertexmap->get(vtxid);
+  if(!svtxVertex)
+    { return; }
   Acts::Vector3 vertex(svtxVertex->get_x(),
 		       svtxVertex->get_y(),
 		       svtxVertex->get_z());

--- a/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
+++ b/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
@@ -4,10 +4,8 @@
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainer.h>
 
-#include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackMap_v1.h>
-#include <trackbase_historic/SvtxTrack.h>
-#include <trackbase_historic/SvtxTrack_v3.h>
+#include <trackbase_historic/SvtxTrack_v4.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeed.h>
 
@@ -89,7 +87,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
 	    { continue; }
 	}
 
-      auto svtxtrack = std::make_unique<SvtxTrack_v3>();
+      auto svtxtrack = std::make_unique<SvtxTrack_v4>();
 
       if(Verbosity() > 0)
 	{
@@ -124,6 +122,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
 	      svtxtrack->set_y(siseed->get_y());
 	      svtxtrack->set_z(siseed->get_z());
 	      addKeys(svtxtrack, siseed);
+	      svtxtrack->set_silicon_seed(siseed);
 	    }
 
 
@@ -133,6 +132,8 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
 	  svtxtrack->set_pz(tpcseed->get_pz());
 	  
 	  addKeys(svtxtrack, tpcseed);
+	  svtxtrack->set_tpc_seed(tpcseed);
+	
 
 	}
       else
@@ -147,6 +148,16 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
 	  svtxtrack->set_pz(trackSeed->get_pz());
 	  
 	  addKeys(svtxtrack, trackSeed);
+	  if(m_trackSeedName.find("SiliconTrackSeed") != std::string::npos)
+	    {
+	      svtxtrack->set_silicon_seed(trackSeed);
+	      svtxtrack->set_tpc_seed(nullptr);
+	    }
+	  else if(m_trackSeedName.find("TpcTrackSeed") != std::string::npos)
+	    {
+	      svtxtrack->set_tpc_seed(trackSeed);
+	      svtxtrack->set_silicon_seed(nullptr);
+	    }
 	}
 
       if(Verbosity() > 0)
@@ -169,7 +180,7 @@ int TrackSeedTrackMapConverter::End(PHCompositeNode*)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void TrackSeedTrackMapConverter::addKeys(std::unique_ptr<SvtxTrack_v3>& track, TrackSeed *seed)
+void TrackSeedTrackMapConverter::addKeys(std::unique_ptr<SvtxTrack_v4>& track, TrackSeed *seed)
 {
   for(TrackSeed::ConstClusterKeyIter iter = seed->begin_cluster_keys();
       iter != seed->end_cluster_keys();

--- a/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.h
+++ b/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.h
@@ -9,7 +9,7 @@
 
 class PHCompositeNode;
 class SvtxTrackMap;
-class SvtxTrack_v3;
+class SvtxTrack_v4;
 class TrackSeed;
 class TrackSeedContainer;
 class ActsGeometry;
@@ -34,7 +34,7 @@ class TrackSeedTrackMapConverter : public SubsysReco
 
   int getNodes(PHCompositeNode *topNode);
 
-  void addKeys(std::unique_ptr<SvtxTrack_v3>& track, TrackSeed *seed);
+  void addKeys(std::unique_ptr<SvtxTrack_v4>& track, TrackSeed *seed);
   std::string m_trackMapName = "SvtxTrackMap";
   std::string m_trackSeedName = "TpcTrackSeedContainer";
 


### PR DESCRIPTION
Catch missing vertex seg fault in evaluator when running single particles

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR updates the seed converter to use `SvtxTrack_v4`. It now works on full seeds in local tests so that the seeding quantities can be evaluated.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
It should be merged with the corresponding macros PR [555](https://github.com/sPHENIX-Collaboration/macros/pull/555)
