### PR TITLE
disable mephi maps if light_scint_model >= 10 for testing

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -75,7 +75,7 @@ PHG4IHCalSteppingAction::~PHG4IHCalSteppingAction()
 //____________________________________________________________________________..
 int PHG4IHCalSteppingAction::Init()
 {
-  if (m_LightScintModelFlag)
+  if (m_LightScintModelFlag < 10)
   {
     
     const char* Calibroot = getenv("CALIBRATIONROOT");

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -94,7 +94,7 @@ int PHG4OHCalSteppingAction::Init()
 {
   m_EnableFieldCheckerFlag = m_Params->get_int_param("field_check");
 
-  if (m_LightScintModelFlag)
+  if (m_LightScintModelFlag < 10)
   {
     /*
     const char* Calibroot = getenv("CALIBRATIONROOT");


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR enables keeping the light correction in G4 but disabling the application of the MEPHI maps. Set the  light_scint_model flag which defaults to 1 to larger- equal 10
e.g.
G4HCALIN::light_scint_model = 20;
G4HCALOUT::light_scint_model = 20;
does the trick

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

