### PR TITLE
Add track state removing module

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -61,6 +61,7 @@ void SvtxTrack_v4::identify(std::ostream& os) const
   os << "vertex id: " << get_vertex_id() << " ";
   os << "charge: " << get_charge() << " ";
   os << "chisq: " << get_chisq() << " ndf:" << get_ndf() << " ";
+  os << "nstates: " << _states.size() << " ";
   os << std::endl;
 
   os << "(px,py,pz) = ("

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -72,6 +72,7 @@ pkginclude_HEADERS = \
   PHTruthTrackSeeding.h \
   PHTruthSiliconAssociation.h \
   PHTruthVertexing.h \
+  SvtxTrackStateRemoval.h \
   VertexFitter.h
 
 ROOTDICTS = \
@@ -168,7 +169,8 @@ libtrack_reco_la_SOURCES = \
   PHTruthClustering.cc \
   PHTruthTrackSeeding.cc \
   PHTruthVertexing.cc \
-  PHTruthSiliconAssociation.cc
+  PHTruthSiliconAssociation.cc \
+  SvtxTrackStateRemoval.cc
 
 libtrack_reco_io_la_LIBADD = \
   -lphool \

--- a/offline/packages/trackreco/SvtxTrackStateRemoval.cc
+++ b/offline/packages/trackreco/SvtxTrackStateRemoval.cc
@@ -1,0 +1,100 @@
+
+#include "SvtxTrackStateRemoval.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <g4detectors/PHG4CylinderGeom.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackState.h>
+
+//____________________________________________________________________________..
+SvtxTrackStateRemoval::SvtxTrackStateRemoval(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+SvtxTrackStateRemoval::~SvtxTrackStateRemoval()
+{
+}
+
+//____________________________________________________________________________..
+int SvtxTrackStateRemoval::Init(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTrackStateRemoval::InitRun(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTrackStateRemoval::process_event(PHCompositeNode* topNode)
+{
+  auto trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!trackmap)
+  {
+    std::cout << PHWHERE << "No track map on node tree, can't continue."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  auto tpotgeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
+  if (!tpotgeom)
+  {
+    std::cout << PHWHERE << "No micromegas geometry, can't continue."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  /// get the last tracking layer
+  auto layergeom = tpotgeom->GetLayerGeom(56);
+
+  const float lastradius = layergeom->get_radius();
+  const float lastthickness = layergeom->get_thickness();
+  const float lasttrackingradius = lastradius + lastthickness / 2.;
+
+  for (auto& [key, track] : *trackmap)
+  {
+    for (auto iter = track->begin_states(); iter != track->end_states(); ++iter)
+    {
+      /// Don't erase the PCA state information
+      if (iter == track->begin_states())
+      {
+        continue;
+      }
+
+      float pathlength = iter->second->get_pathlength();
+      if (pathlength < lasttrackingradius)
+      {
+        track->erase_state(pathlength);
+      }
+    }
+
+    if (Verbosity() > 1)
+    {
+      track->identify();
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int SvtxTrackStateRemoval::End(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/SvtxTrackStateRemoval.h
+++ b/offline/packages/trackreco/SvtxTrackStateRemoval.h
@@ -1,0 +1,27 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef SVTXTRACKSTATEREMOVAL_H
+#define SVTXTRACKSTATEREMOVAL_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+
+class SvtxTrackStateRemoval : public SubsysReco
+{
+ public:
+  SvtxTrackStateRemoval(const std::string &name = "SvtxTrackStateRemoval");
+
+  ~SvtxTrackStateRemoval() override;
+
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+ private:
+};
+
+#endif  // SVTXTRACKSTATEREMOVAL_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a module that strips SvtxTracks of all the state information except that at the PCA and in the calorimeters. It should lead to an order of magnitude reduction in DST size when run as it takes the number of states of the average track from ~50 to ~5. It  can be run in any macro by just adding to the Fun4AllServer, e.g.
```
auto remover = new SvtxTrackStateRemoval;
se->registerSubsystem(remover);
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

