### PR TITLE
TPC seeding overhaul

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -111,11 +111,12 @@ class PHCASeeding : public PHTrackSeeding
 
   PositionMap FillTree();
   int FindSeedsWithMerger(const PositionMap&);
-  std::pair<std::vector<std::unordered_set<keylink>>,std::vector<std::unordered_set<keylink>>> CreateLinks(const std::vector<coordKey>& clusters, const PositionMap& globalPositions, int mode = skip_layers::off) const;
+  std::pair<std::vector<std::unordered_set<keylink>>,std::vector<std::unordered_set<keylink>>> CreateLinks(const std::vector<coordKey>& clusters, const PositionMap& globalPositions) const;
   std::vector<std::vector<keylink>> FindBiLinks(const std::vector<std::unordered_set<keylink>>& belowLinks, const std::vector<std::unordered_set<keylink>>& aboveLinks) const;
   std::vector<keylist> FollowBiLinks(const std::vector<std::vector<keylink>>& bidirectionalLinks, const PositionMap& globalPositions) const;
   void QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>> &rtree, double phimin, double etamin, double lmin, double phimax, double etamax, double lmax, std::vector<pointKey> &returned_values) const;
   std::vector<TrackSeed_v1> RemoveBadClusters(const std::vector<keylist>& seeds, const PositionMap& globalPositions) const;
+  double getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b, TrkrDefs::cluskey c, const PositionMap& globalPositions) const;
   
   void publishSeeds(const std::vector<TrackSeed_v1>& seeds);
 

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -83,7 +83,6 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   
   int ret = get_nodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-
   PHFieldConfigv1 fcfg;
   fcfg.set_field_config(PHFieldConfig::FieldConfigTypes::Field3DCartesian);
   auto magField = std::string(getenv("CALIBRATIONROOT")) +
@@ -101,7 +100,6 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
   fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
   fitter->setFixedClusterError(1,_fixed_clus_err.at(1));
   fitter->setFixedClusterError(2,_fixed_clus_err.at(2));
-
   //  _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
   // m_Cache = magField->makeCache(m_tGeometry->magFieldContext);
   return Fun4AllReturnCodes::EVENT_OK;
@@ -200,9 +198,10 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   if(Verbosity()>0) std::cout << "prepared KD trees" << std::endl;
 
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
-  std::vector<TrackSeed> unused_tracks;
+  std::vector<TrackSeed_v1> unused_tracks;
   for(int track_it = 0; track_it != _track_map->size(); ++track_it )
   {
+    if(Verbosity()>0) std::cout << "TPC seed " << track_it << std::endl;
     // if not a TPC track, ignore
     TrackSeed* track = _track_map->get(track_it);
     const bool is_tpc = std::any_of(
@@ -258,7 +257,40 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       timer.stop();
       timer.restart();
 
-      new_chains.push_back(PropagateTrack(track, seedpair.second.at(0), 
+      if(Verbosity()>0) std::cout << "propagate first round" << std::endl;
+      auto preseed = PropagateTrack(track,seedpair.second.at(0),globalPositions);
+
+      if(Verbosity()>0) std::cout << "preseed size " << preseed.size() << std::endl;
+
+      if(preseed.size()>40){
+        new_chains.push_back(preseed);
+        continue;
+      }
+
+      std::vector<std::vector<TrkrDefs::cluskey>> kl;
+      kl.push_back(preseed);
+
+      if(Verbosity()>0) std::cout << "kl size " << kl.size() << std::endl;
+      std::vector<float> pretrackChi2;
+      auto prepair = fitter->ALICEKalmanFilter(kl,false,globalPositions,pretrackChi2);
+      if(prepair.first.size()==0 || prepair.second.size()==0) continue;
+
+      auto pretrack = prepair.first.at(0);
+      std::vector<TrkrDefs::cluskey> dumvec2;
+      std::map<TrkrDefs::cluskey, Acts::Vector3> pretrackClusPositions;
+      for(TrackSeed::ConstClusterKeyIter iter = pretrack.begin_cluster_keys();
+          iter != pretrack.end_cluster_keys();
+          ++iter)
+        {
+          dumvec2.push_back(*iter);
+          auto pos = globalPositions.at(*iter);
+          pretrackClusPositions.insert(std::make_pair(*iter,pos));
+        }
+
+      pretrack.circleFitByTaubin(pretrackClusPositions, 7, 55);
+      pretrack.lineFit(pretrackClusPositions, 7, 55);
+
+      new_chains.push_back(PropagateTrack(&pretrack, prepair.second.at(0),
 					  globalPositions));
       timer.stop();
       auto propagatetime = timer.elapsed();
@@ -410,13 +442,17 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   double track_y = track->get_y();
   double track_z = track->get_z();
 
+  if(Verbosity()>0) std::cout << "track (x,y,z) = (" << track_x << ", " << track_y << ", " << track_z << ")" << std::endl;
+
   double track_px = track->get_px(_cluster_map,_tgeometry);
   double track_py = track->get_py(_cluster_map,_tgeometry);
   double track_pz = track->get_pz();
 
-  /// Move to first tpc cluster layer if necessary
-  if(sqrt(track_x*track_x+track_y*track_y)<10.)
-    {
+  if(Verbosity()>0) std::cout << "track (px,py,pz) = (" << track_px << ", " << track_py << ", " << track_pz << ")" << std::endl;
+
+  // Move to first tpc cluster layer if necessary
+//  if(sqrt(track_x*track_x+track_y*track_y)<10.)
+//    {
       if(Verbosity()>0) std::cout << "WARNING: moving track into TPC" << std::endl;
       std::vector<Acts::Vector3> trkGlobPos;
       for(const auto& ckey : ckeys)
@@ -463,15 +499,21 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       track_y = trkGlobPos.at(0)(1);
       track_z = trkGlobPos.at(0)(2);
 
-    }
+      if(Verbosity()>0) std::cout << "new track (x,y,z) = " << track_x << ", " << track_y << ", " << track_z << ")" << std::endl;
+      if(Verbosity()>0) std::cout << "new track (px,py,pz) = " << track_px << ", " << track_py << ", " << track_pz << ")" << std::endl;
+
+//    }
 
   double track_pt = sqrt(track_px*track_px + track_py*track_py);
+  if(Verbosity()>0) std::cout << "track pt: " << track_pt << std::endl;
 
   // get track parameters
   GPUTPCTrackParam kftrack;
   kftrack.InitParam();
-  float track_phi = atan2(track_py,track_px);
+  float track_phi = atan2(track_y,track_x);
+  if(Verbosity()>0) std::cout << "track phi: " << track_phi << std::endl;
   kftrack.SetQPt(track->get_charge()/track_pt);
+
   float track_pX = track_px*cos(track_phi)+track_py*sin(track_phi);
   float track_pY = -track_px * sin(track_phi) + track_py * cos(track_phi);
 
@@ -543,6 +585,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   kftrack.SetX(track_x*cos(track_phi)+track_y*sin(track_phi));
   kftrack.SetY(-track_x*sin(track_phi)+track_y*cos(track_phi));
   kftrack.SetZ(track_z);
+
   if(Verbosity()>0)
   {
     std::cout << "initial track params:" << std::endl;
@@ -558,19 +601,20 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 
   }
 
-
-  GPUTPCTrackLinearisation kfline(kftrack);
-
   // get layer for each cluster
   std::vector<unsigned int> layers;
-  if(Verbosity()>0) std::cout << "cluster layers:" << std::endl;
   std::transform( ckeys.begin(), ckeys.end(), std::back_inserter( layers ), []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getLayer(key); } );
 
   double old_phi = track_phi;
   unsigned int old_layer = TrkrDefs::getLayer(ckeys[0]);
   if(Verbosity()>0) std::cout << "first layer: " << old_layer << std::endl;
-
+  if(Verbosity()>0) std::cout << "cluster (x,y,z) = (" << globalPositions.at(ckeys[0])(0) << ", " << globalPositions.at(ckeys[0])(1) << ", " << globalPositions.at(ckeys[0])(2) << ")" << std::endl;
   propagated_track.push_back(ckeys[0]);
+
+  GPUTPCTrackLinearisation kfline(kftrack);
+  GPUTPCTrackParam::GPUTPCTrackFitParam fp;
+  kftrack.CalculateFitParameters(fp);
+
   // first, propagate downward
   for(unsigned int l=old_layer+1;l<=54;l++)
   {
@@ -614,8 +658,11 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 //      GPUTPCTrackParam::GPUTPCTrackFitParam fp;
 //      kftrack.CalculateFitParameters(fp);
       if(Verbosity()>0) std::cout << "track position: (" << tx << ", " << ty << ", " << tz << ")" << std::endl;
-      kftrack.Rotate(alpha,kfline,10.);
-      kftrack.TransportToX(cx*cos(cphi)+cy*sin(cphi),kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      double newX = cx*cos(cphi)+cy*sin(cphi);
+      kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial(cx*cos(cphi)+cy*sin(cphi),kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
       if(std::isnan(kftrack.GetX()) ||
        std::isnan(kftrack.GetY()) ||
        std::isnan(kftrack.GetZ())) continue;
@@ -633,24 +680,24 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       if(Verbosity()>0) std::cout << "new track position: (" << kftrack.GetX()*cos(cphi)-kftrack.GetY()*sin(cphi) << ", " << kftrack.GetX()*sin(cphi)+kftrack.GetY()*cos(cphi) << ", " << kftrack.GetZ() << ")" << std::endl;
       if(Verbosity()>0) std::cout << "track position errors: (" << txerr << ", " << tyerr << ", " << tzerr << ")" << std::endl;
       if(Verbosity()>0) std::cout << "distance: " << sqrt(square(kftrack.GetX()*cos(cphi)-kftrack.GetY()*sin(cphi)-cx)+square(kftrack.GetX()*sin(cphi)+kftrack.GetY()*cos(cphi)-cy)+square(kftrack.GetZ()-cz)) << std::endl;
-      if(fabs(tx-cx)<_max_dist*sqrt(txerr*txerr+cxerr*cxerr) &&
-         fabs(ty-cy)<_max_dist*sqrt(tyerr*tyerr+cyerr*cyerr) &&
-         fabs(tz-cz)<_max_dist*sqrt(tzerr*tzerr+czerr*czerr))
+      if(1)//fabs(tx-cx)<_max_dist*sqrt(txerr*txerr+cxerr*cxerr) &&
+         //fabs(ty-cy)<_max_dist*sqrt(tyerr*tyerr+cyerr*cyerr) &&
+         //fabs(tz-cz)<_max_dist*sqrt(tzerr*tzerr+czerr*czerr))
       {
         if(Verbosity()>0) std::cout << "Kept cluster" << std::endl;
         propagated_track.push_back(next_ckey);
-//      kftrack.SetX(cx*cos(cphi)+cy*sin(cphi));
-//      kftrack.SetY(-cx*sin(cphi)+cy*cos(cphi));
-//      kftrack.SetZ(cz);
+//        kftrack.SetX(cx*cos(cphi)+cy*sin(cphi));
+//        kftrack.SetY(-cx*sin(cphi)+cy*cos(cphi));
+//        kftrack.SetZ(cz);
       }
       else
       {
         if(Verbosity()>0)
         {
           std::cout << "Rejected cluster" << std::endl;
-          std::cout << "x: " << fabs(tx-cx) << " vs. " << _max_dist*sqrt(txerr*txerr+cxerr*cxerr) << std::endl;
-          std::cout << "y: " << fabs(ty-cy) << " vs. " << _max_dist*sqrt(tyerr*tyerr+cyerr*cyerr) << std::endl;
-          std::cout << "z: " << fabs(tz-cz) << " vs. " << _max_dist*sqrt(tzerr*tzerr+czerr*czerr) << std::endl;
+          std::cout << "dx: " << fabs(tx-cx) << " when max = " << _max_dist*sqrt(txerr*txerr+cxerr*cxerr) << std::endl;
+          std::cout << "dy: " << fabs(ty-cy) << " when max = " << _max_dist*sqrt(tyerr*tyerr+cyerr*cyerr) << std::endl;
+          std::cout << "dz: " << fabs(tz-cz) << " when max = " << _max_dist*sqrt(tzerr*tzerr+czerr*czerr) << std::endl;
         }
         kftrack.SetNDF(kftrack.GetNDF()-2);
         //ckeys.erase(std::remove(ckeys.begin(),ckeys.end(),next_ckey),ckeys.end());
@@ -669,7 +716,12 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       double tz = kftrack.GetZ();
 //      GPUTPCTrackParam::GPUTPCTrackFitParam fp;
 //      kftrack.CalculateFitParameters(fp);
-      kftrack.TransportToX(radii[l-7],kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+      double newX = radii[l-7];
+      double alpha = atan2(ty,tx)-old_phi;
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial(radii[l-7],kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
       if(std::isnan(kftrack.GetX()) ||
        std::isnan(kftrack.GetY()) ||
        std::isnan(kftrack.GetZ())) continue;
@@ -702,7 +754,12 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 	  if(Verbosity() > 2) 
 	    std::cout << " call transport again for layer " << l  << " x " << proj_pt[0] << " y " << proj_pt[1] << " z " << proj_pt[2] 
 		      << " radius " << radius << std::endl;
-	  kftrack.TransportToX(radius,kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+          double newX = radius;
+          double alpha = atan2(ty,tx)-old_phi;
+          kftrack.Rotate(alpha/2.,kfline,10.);
+          kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+          kftrack.Rotate(alpha/2.,kfline,10.);
+	  kftrack.TransportToXWithMaterial(radius,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
 	  if(std::isnan(kftrack.GetX()) ||
 	     std::isnan(kftrack.GetY()) ||
 	     std::isnan(kftrack.GetZ())) continue;
@@ -870,9 +927,12 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       double ty = tX*sin(old_phi)+tY*cos(old_phi);
       double tz = kftrack.GetZ();
 //      GPUTPCTrackParam::GPUTPCTrackFitParam fp;
-//      kftrack_up.CalculateFitParameters(fp);
-      kftrack.Rotate(alpha,kfline,10.);
-      kftrack.TransportToX(cx*cos(cphi)+cy*sin(cphi),kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+//      kftrack.CalculateFitParameters(fp);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      double newX = cx*cos(cphi)+cy*sin(cphi);
+      kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial(cx*cos(cphi)+cy*sin(cphi),kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
       if(std::isnan(kftrack.GetX()) ||
        std::isnan(kftrack.GetY()) ||
        std::isnan(kftrack.GetZ())) continue;
@@ -895,8 +955,13 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       double ty = tX*sin(old_phi)+tY*cos(old_phi);
       double tz = kftrack.GetZ();
 //      GPUTPCTrackParam::GPUTPCTrackFitParam fp;
-//      kftrack_up.CalculateFitParameters(fp);
-      kftrack.TransportToX(radii[l-7],kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+//      kftrack.CalculateFitParameters(fp);
+      double newX = radii[l-7];
+      double alpha = atan2(ty,tx)-old_phi;
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+      kftrack.Rotate(alpha/2.,kfline,10.);
+      kftrack.TransportToXWithMaterial(radii[l-7],kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
       if(std::isnan(kftrack.GetX()) ||
        std::isnan(kftrack.GetY()) ||
        std::isnan(kftrack.GetZ())) continue;
@@ -929,7 +994,12 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 	  if(Verbosity() > 2)
 	    std::cout << " call transport again for layer " << l  << " x " << proj_pt[0] << " y " << proj_pt[1] << " z " << proj_pt[2] 
 		      << " radius " << radius << std::endl;
-	  kftrack.TransportToX(radius,kfline,_Bzconst*get_Bz(tx,ty,tz),10.);
+          double newX = radius;
+          double alpha = atan2(ty,tx)-old_phi;
+          kftrack.Rotate(alpha/2.,kfline,10.);
+          kftrack.TransportToXWithMaterial((tX+newX)/2.,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
+          kftrack.Rotate(alpha/2.,kfline,10.);
+	  kftrack.TransportToXWithMaterial(radius,kfline,fp,_Bzconst*get_Bz(tx,ty,tz),10.);
 	  if(std::isnan(kftrack.GetX()) ||
 	     std::isnan(kftrack.GetY()) ||
 	     std::isnan(kftrack.GetZ())) continue;
@@ -1017,7 +1087,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
       double ccphi = atan2(ccY,ccX);
       if(Verbosity()>0) std::cout << "cluster position errors: (" << cxerr << ", " << cyerr << ", " << czerr << ")" << std::endl;
       if(Verbosity()>0) std::cout << "cluster X: " << ccX*cos(ccphi)+ccY*sin(ccphi) << std::endl;
-      double alpha = ccphi-old_phi;
+      double alpha2 = ccphi-old_phi;
       if(fabs(tx-ccX)<_max_dist*sqrt(txerr*txerr+cxerr*cxerr) &&
          fabs(ty-ccY)<_max_dist*sqrt(tyerr*tyerr+cyerr*cyerr) &&
          fabs(tz-ccZ)<_max_dist*sqrt(tzerr*tzerr+czerr*czerr))
@@ -1034,7 +1104,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
         double ccphi = atan2(ccy,ccx);
         double alpha = ccphi-old_phi;
 */
-        kftrack.Rotate(alpha,kfline,10.);
+        kftrack.Rotate(alpha2,kfline,10.);
         double ccaY = -ccX*sin(ccphi)+ccY*cos(ccphi);
         double ccerrY = fitter->getClusterError(cc,closest_ckey,ccglob2,0,0)*sin(ccphi)*sin(ccphi)+fitter->getClusterError(cc,closest_ckey,ccglob2,1,0)*sin(ccphi)*cos(ccphi)+fitter->getClusterError(cc,closest_ckey,ccglob2,1,1)*cos(ccphi)*cos(ccphi);
         double ccerrZ = fitter->getClusterError(cc,closest_ckey,ccglob2,2,2);
@@ -1084,7 +1154,7 @@ std::vector<keylist> PHSimpleKFProp::RemoveBadClusters(const std::vector<keylist
     
     for(size_t i=0;i<chain.size();i++)
     {
-      if(xy_resid[i]>_xy_outlier_threshold) continue;
+      //if(xy_resid[i]>_xy_outlier_threshold) continue;
       clean_chain.push_back(chain[i]);
     }
     clean_chains.push_back(clean_chain);
@@ -1101,7 +1171,6 @@ void PHSimpleKFProp::publishSeeds(std::vector<TrackSeed_v1>& seeds, PositionMap&
   { 
     /// The ALICEKF gives a better charge determination at high pT
     int q = seed.get_charge();
-
     seed.circleFitByTaubin(positions,7,55);
     seed.lineFit(positions,7,55);
     seed.set_qOverR(fabs(seed.get_qOverR()) * q);
@@ -1110,7 +1179,7 @@ void PHSimpleKFProp::publishSeeds(std::vector<TrackSeed_v1>& seeds, PositionMap&
   }
 }
 
-void PHSimpleKFProp::publishSeeds(const std::vector<TrackSeed>& seeds)
+void PHSimpleKFProp::publishSeeds(const std::vector<TrackSeed_v1>& seeds)
 {
   for( const auto& seed:seeds )
   { _track_map->insert(&seed); }

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -80,7 +80,7 @@ class PHSimpleKFProp : public SubsysReco
   double _Bzconst = 10*0.000299792458f;
   //double _Bz = 1.4*_Bzconst;
   double _max_dist = .05;
-  size_t _min_clusters_per_track = 20;
+  size_t _min_clusters_per_track = 3;
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   double _rz_outlier_threshold = .1;
@@ -145,7 +145,7 @@ class PHSimpleKFProp : public SubsysReco
   std::unique_ptr<ALICEKF> fitter;
   double get_Bz(double x, double y, double z) const;
   void publishSeeds(std::vector<TrackSeed_v1>& seeds, PositionMap &positions);
-  void publishSeeds(const std::vector<TrackSeed>&);
+  void publishSeeds(const std::vector<TrackSeed_v1>&);
 //   void MoveToVertex();
 
   bool _use_const_field = false;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)https://github.com/sPHENIX-Collaboration/macros/pull/556

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Rewrites PHCASeeding, ALICEKF, and PHSimpleKFProp to be more efficient, especially at lower pT and in pp data.
- Switches from eta-phi search window to z-phi search window
- Builds multiple cluster chains if multiple compatible clusters are found
- Propagates and filters using energy loss corrections
- Propagates with double previous resolution

Note that the change to a z-phi window involves a significant change to the G4_Tracking.C settings for PHCASeeding: https://github.com/sPHENIX-Collaboration/macros/pull/556.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/macros/pull/556.