### PR TITLE
More transform map speedup

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -75,8 +75,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	     Acts::Transform3 transform = makeTransform(surf, millepedeTranslation, sensorAngles);
 
              Acts::GeometryIdentifier id = surf->geometryId();
-	     if(localVerbosity) 
-	       {  std::cout << " Add transform for TPC with surface GeometryIdentifier " << id << " trkrid " << trkrId << transform.matrix() << std::endl;}
+	     if(localVerbosity > 0) 
+	       {  std::cout << " Add transform for TPC with surface GeometryIdentifier " << id << " trkrid " << trkrId << " sensor id " << id.sensitive() << std::endl;}
 
 	     transformMap->addTransform(id,transform);
 	   }
@@ -87,8 +87,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	 Acts::Transform3 transform = makeTransform(surf, millepedeTranslation, sensorAngles);
          Acts::GeometryIdentifier id = surf->geometryId();
 
-	 if(localVerbosity) 
-	   std::cout << " Add transform for Silicon with surface GeometryIdentifier " << id << " trkrid " << trkrId << " transform " << transform.matrix() << std::endl;
+	 if(localVerbosity > 0) 
+	   std::cout << " Add transform for Silicon with surface GeometryIdentifier " << id << " trkrid " << trkrId << " sensor id  " << id.sensitive() << std::endl;
 
 	 transformMap->addTransform(id, transform);
        }
@@ -98,8 +98,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	 Acts::Transform3 transform = makeTransform(surf, millepedeTranslation, sensorAngles);
          Acts::GeometryIdentifier id = surf->geometryId();
 
-	 if(localVerbosity) 
-	   std::cout << " Add transform for Micromegas with surface GeometryIdentifier " << id << " trkrid " << trkrId << std::endl;
+	 if(localVerbosity > 0) 
+	   std::cout << " Add transform for Micromegas with surface GeometryIdentifier " << id << " trkrid " << trkrId << " sensor id " << id.sensitive() << std::endl;
 
 	 transformMap->addTransform(id,transform);
       }
@@ -107,7 +107,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
        {
 	 std::cout<< "Error: Invalid Hitsetkey" << std::endl;
        }
-     if(localVerbosity)
+     if(localVerbosity > 1)
        {
 	 std::cout << i << " " <<hitsetkey << " " <<alpha<< " " <<beta<< " " <<gamma<< " " <<dx<< " " <<dy<< " " <<dz << std::endl;
        }
@@ -162,7 +162,7 @@ Eigen::Matrix3d AlignmentTransformation::rotateToGlobal(Surface surf)
 
   Eigen::Matrix3d globalRotation = fInverse * G * (fInverse.inverse()); 
 
-  if(localVerbosity == true)
+  if(localVerbosity > 2)
     {
       std::cout<< " global rotation: "<< std::endl << globalRotation <<std::endl;
     }
@@ -213,7 +213,7 @@ Acts::Transform3 AlignmentTransformation::makeTransform(Surface surf, Eigen::Vec
   Eigen::Vector3d globalTranslation = sensorCenter + millepedeTranslation;
   Acts::Transform3 transformation   = AlignmentTransformation::makeAffineMatrix(combinedRotation,globalTranslation);
 
-  if(localVerbosity == true)
+  if(localVerbosity > 2)
     {
       std::cout << "sensor center: " << sensorCenter << " millepede translation: " << millepedeTranslation <<std::endl;
       std::cout << "Transform: "<< std::endl<< transformation.matrix()  <<std::endl;

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -50,6 +50,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
  ActsSurfaceMaps surfMaps = m_tGeometry->maps();
  Surface surf;
 
+ transformMap->Reset();  // clear the existing transform map
+
  int fileLines = 1824;
  for (int i=0; i<fileLines; i++)
    {
@@ -89,6 +91,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 
 	 if(localVerbosity > 0) 
 	   std::cout << " Add transform for Silicon with surface GeometryIdentifier " << id << " trkrid " << trkrId << " sensor id  " << id.sensitive() << std::endl;
+	 if(localVerbosity > 2)
+	   std::cout << " Transform is: " << transform.matrix() << std::endl;
 
 	 transformMap->addTransform(id, transform);
        }

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -88,7 +88,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
          Acts::GeometryIdentifier id = surf->geometryId();
 
 	 if(localVerbosity) 
-	   std::cout << " Add transform for Silicon with surface GeometryIdentifier " << id << " trkrid " << trkrId << std::endl;
+	   std::cout << " Add transform for Silicon with surface GeometryIdentifier " << id << " trkrid " << trkrId << " transform " << transform.matrix() << std::endl;
 
 	 transformMap->addTransform(id, transform);
        }
@@ -113,11 +113,12 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
        }
    } 
 
+ // copy map into geoContext
  m_tGeometry->geometry().geoContext =  transformMap->getMap();
- //m_tGeometry->geometry().getGeoContext() =  transformMap->getMap();
 
  // map is created, now we can use the transforms
  alignmentTransformationContainer::use_alignment = true;
+
  
 }
 

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -29,7 +29,7 @@ class AlignmentTransformation {
 
   std::string alignmentParamsFile = "";
 
-  bool localVerbosity = false;
+  int localVerbosity = 0;
 
   Acts::Transform3 makeTransform(Surface surf, Eigen::Vector3d millepedeTranslation, Eigen::Vector3d sensorAngles);
 

--- a/offline/packages/trackbase/alignmentTransformationContainer.cc
+++ b/offline/packages/trackbase/alignmentTransformationContainer.cc
@@ -16,7 +16,21 @@
 bool alignmentTransformationContainer::use_alignment = false;
 
 void alignmentTransformationContainer::Reset()
-{ transformVec.clear(); }
+{ 
+  if(transformVec.size() == 0) return;
+
+  // loop over the transformVec
+  for(unsigned int i=0; i< transformVec.size(); ++i)
+    {
+      transformVec[i].clear();
+      std::vector<Acts::Transform3> emptyLayerVec;
+      transformVec[i].swap(emptyLayerVec);
+    }
+
+  transformVec.clear(); 
+  std::vector<std::vector<Acts::Transform3>> emptyVec;
+  transformVec.swap(emptyVec);
+}
 
 void alignmentTransformationContainer::identify(std::ostream &os)
 {
@@ -76,29 +90,13 @@ void alignmentTransformationContainer::addTransform(const Acts::GeometryIdentifi
       }
     else
       {
+	transformVec.resize(sphlayer+1);  // pad the missing layers with empty vectors
+	// Add this transform to the last layer
 	std::vector<Acts::Transform3> newVec;
 	newVec.resize(sensor + 1, transform);
-	transformVec.resize(sphlayer+1, newVec);
+	transformVec[sphlayer] = newVec;
       }
 }
-
-/*
-void alignmentTransformationContainer::removeTransform(const Acts::GeometryIdentifier id)
-{
-  // in the fixed length vector of vectors scheme, removing a transform makes no sense
-
-  unsigned int sphlayer = getsphlayer(id);
-  unsigned int sensor = id.sensitive() - 1;  // Acts sensor numbering starts at 1
-
-  auto& layerVec = transformVec[sphlayer];
-  
-  auto transform = layerVec[sensor];
-  if(layerVec.size() > sensor)
-    {
-      return;
-    }
-}  
-*/
 
 Acts::Transform3& alignmentTransformationContainer::getTransform(const Acts::GeometryIdentifier id)
 {
@@ -128,5 +126,3 @@ unsigned int alignmentTransformationContainer::getsphlayer(Acts::GeometryIdentif
   
   return sphlayer;
 }
-
-void alignmentTransformationContainer::set(){}

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -37,19 +37,10 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   virtual ~alignmentTransformationContainer(){}
 
   void Reset(); 
-
   void identify(std::ostream &os = std::cout);  
-
   void addTransform(Acts::GeometryIdentifier, Acts::Transform3); 
-  //  void removeTransform(Acts::GeometryIdentifier id); 
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
-
-  //  const std::multimap<unsigned int, std::pair<Acts::GeometryIdentifier, Acts::Transform3>> getMap();
-  //const std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
-  //const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
   const std::vector<std::vector<Acts::Transform3>>& getMap();
-
-  void set();
 
   static bool use_alignment;
 
@@ -59,8 +50,6 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   
   std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };
 
-  //std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
-  //std::vector< std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
   std::vector< std::vector<Acts::Transform3>> transformVec;
 
   ClassDef(alignmentTransformationContainer,1);

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -41,12 +41,13 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   void identify(std::ostream &os = std::cout);  
 
   void addTransform(Acts::GeometryIdentifier, Acts::Transform3); 
-  void removeTransform(Acts::GeometryIdentifier id); 
+  //  void removeTransform(Acts::GeometryIdentifier id); 
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
 
   //  const std::multimap<unsigned int, std::pair<Acts::GeometryIdentifier, Acts::Transform3>> getMap();
   //const std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
-  const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
+  //const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
+  const std::vector<std::vector<Acts::Transform3>>& getMap();
 
   void set();
 
@@ -59,7 +60,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };
 
   //std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
-  std::vector< std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
+  //std::vector< std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
+  std::vector< std::vector<Acts::Transform3>> transformVec;
 
   ClassDef(alignmentTransformationContainer,1);
 

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -45,7 +45,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
 
   //  const std::multimap<unsigned int, std::pair<Acts::GeometryIdentifier, Acts::Transform3>> getMap();
-  const std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
+  //const std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
+  const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& getMap();
 
   void set();
 
@@ -57,7 +58,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   
   std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };
 
-  std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
+  //std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
+  std::vector< std::map<Acts::GeometryIdentifier, Acts::Transform3>> transformMap;
 
   ClassDef(alignmentTransformationContainer,1);
 

--- a/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
+++ b/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
@@ -17,10 +17,10 @@ const Acts::Transform3& sPHENIXActsDetectorElement::transform(const Acts::Geomet
       unsigned int sphlayer = base_layer_map.find(volume)->second + layer / 2 -1;
       unsigned int sensor = id.sensitive() - 1;  // Acts sensor ID starts at 1
 
-      const std::vector<std::vector<Acts::Transform3>>& transformMap 
+      const std::vector<std::vector<Acts::Transform3>>& transformVec 
 	= ctxt.get<std::vector<std::vector<Acts::Transform3>>&>();
             
-      auto& layerVec = transformMap[sphlayer];    // get the vector of transforms for this layer
+      auto& layerVec = transformVec[sphlayer];    // get the vector of transforms for this layer
       if(layerVec.size() > sensor)
 	{
 	  //std::cout << "sPHENIXActsDetectorElement: return transform:  volume " << volume <<" Acts  layer " << layer << " sensor " << sensor

--- a/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
+++ b/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
@@ -14,19 +14,20 @@ const Acts::Transform3& sPHENIXActsDetectorElement::transform(const Acts::Geomet
 
       unsigned int layer = id.layer(); 
       unsigned int volume = id.volume(); 
+      //unsigned int sensor = id.sensitive();  // sensor ID
       unsigned int sphlayer = base_layer_map.find(volume)->second + layer / 2 -1;
 
-      const std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>& transformMap 
-	= ctxt.get<std::map<unsigned int, std::map<Acts::GeometryIdentifier, Acts::Transform3>>&>();
+      const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& transformMap 
+	= ctxt.get<std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>&>();
             
-      auto it = transformMap.find(sphlayer);    // get an iterator to the map for this layer
-      if(it != transformMap.end())
+      auto& layerMap = transformMap[sphlayer];    // get the map for this layer
+      if(!layerMap.empty())
 	{
-	  //std::cout << "sPHENIXActsDetectorElement: return transform for volume " << volume <<"  layer " << layer 
-	  //	    << " sphenix layer " << sphlayer << " layer map size " << it->second.size() << std::endl;
+	  // std::cout << "sPHENIXActsDetectorElement: return transform for volume " << volume <<"  layer " << layer << " sensor " << sensor
+	  //	    << " sphenix layer " << sphlayer << " layer map size " << layerMap.size() << std::endl;
 	
-	  auto lyr_mapit = it->second.find(id);     //iterator to the map entry for this surface
-	  if(lyr_mapit != it->second.end())
+	  auto lyr_mapit = layerMap.find(id);     //iterator to the map entry for this surface
+	  if(lyr_mapit != layerMap.end())
 	    {
 	      return lyr_mapit->second;
 	    }

--- a/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
+++ b/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
@@ -12,25 +12,21 @@ const Acts::Transform3& sPHENIXActsDetectorElement::transform(const Acts::Geomet
     {
       Acts::GeometryIdentifier id = surface().geometryId();
 
-      unsigned int layer = id.layer(); 
       unsigned int volume = id.volume(); 
-      //unsigned int sensor = id.sensitive();  // sensor ID
+      unsigned int layer = id.layer(); 
       unsigned int sphlayer = base_layer_map.find(volume)->second + layer / 2 -1;
+      unsigned int sensor = id.sensitive() - 1;  // Acts sensor ID starts at 1
 
-      const std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>& transformMap 
-	= ctxt.get<std::vector<std::map<Acts::GeometryIdentifier, Acts::Transform3>>&>();
+      const std::vector<std::vector<Acts::Transform3>>& transformMap 
+	= ctxt.get<std::vector<std::vector<Acts::Transform3>>&>();
             
-      auto& layerMap = transformMap[sphlayer];    // get the map for this layer
-      if(!layerMap.empty())
+      auto& layerVec = transformMap[sphlayer];    // get the vector of transforms for this layer
+      if(layerVec.size() > sensor)
 	{
-	  // std::cout << "sPHENIXActsDetectorElement: return transform for volume " << volume <<"  layer " << layer << " sensor " << sensor
-	  //	    << " sphenix layer " << sphlayer << " layer map size " << layerMap.size() << std::endl;
+	  //std::cout << "sPHENIXActsDetectorElement: return transform:  volume " << volume <<" Acts  layer " << layer << " sensor " << sensor
+	  //	  	    << " sphenix layer " << sphlayer << " layerVec size " << layerVec.size() << std::endl;
 	
-	  auto lyr_mapit = layerMap.find(id);     //iterator to the map entry for this surface
-	  if(lyr_mapit != layerMap.end())
-	    {
-	      return lyr_mapit->second;
-	    }
+	  return layerVec[sensor];
 	}
       
       // if we are still here, it was not found


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR converts the alignment transformation map from a map of all transformations with a key of Acts::GeometryId to a vector of vectors, where the index of the main vector is layer number and the index of the sub vectors is sensor number. The purpose is to minimize the time required to locate a local/global transformation for a given surface. After the change, the execution times for 500 pion events for modules that use Acts transformations are indistinguishable from when the default simulation geometry was being fetched from the detector element base class. The improvement in speed over the current repository version is small, only ~ 5%. But this PR essentially eliminates the transformation lookup time. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

