### PR TITLE
update to use tile by tile normalized maps

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -85,9 +85,9 @@ int PHG4IHCalSteppingAction::Init()
       gSystem->Exit(1);
     }
     std::string ihcalmapname(Calibroot);
-    ihcalmapname += "/HCALIN/tilemap/ihcalgdmlmap092022norm.root";
+    ihcalmapname += "/HCALIN/tilemap/ihcalgdmlmap09212022.root";
     TFile* file = TFile::Open(ihcalmapname.c_str());
-    file->GetObject("ihcalcombinedgdmlnorm", m_MapCorrHist);
+    file->GetObject("ihcalcombinedgdmlnormtbyt", m_MapCorrHist);
     if (!m_MapCorrHist)
     {
       std::cout << "ERROR: m_MapCorrHist is NULL" << std::endl;


### PR DESCRIPTION
This PR is as a result of a discussion at the software meeting on 9/20- A request was made to normalize the Mephi maps on a tile by tile basis rather than as a whole map.

The idea to previously normalize a whole map, rather than on a tile by tile basis was due to the fact that the old sims tiles were smaller than the Mephi maps. This led lines between tiles (creating artificial hotspots) - see page 4 of https://indico.bnl.gov/event/13165/contributions/54359/attachments/37115/61122/EjiroU_ohcal_update_091421.pdf
Normalizing the whole map suppresses the artificial hotspots on the borders of the tiles.

The new ihcal sims however are more closely matched with the Mephi maps, hence, normalizing tile by tile is not an issue in this case and is done here-  (given the need to suppress the tile by tile fluctuations of the maps currently reflected in the sim light yield).



