### PR TITLE
Enable silicon-only tracking and vertexing

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -82,13 +82,15 @@ void SvtxTrack_v4::identify(std::ostream& os) const
 	}
     }
   os << std::endl << "Tpc + TPOT clusters " << std::endl;
+  if(_tpc_seed)
+  {
     for(auto iter = _tpc_seed->begin_cluster_keys(); 
       iter != _tpc_seed->end_cluster_keys();
       ++iter)
     {
       std::cout << *iter << ", ";
     }
-    
+  }
   os << std::endl;
 
   return;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -2061,21 +2061,27 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
 	  std::vector<TrkrDefs::cluskey> clusters;
 	  auto siseed = track->get_silicon_seed();
-	  for (auto iter = siseed->begin_cluster_keys();
-	       iter != siseed->end_cluster_keys();
-	       ++iter)
-	    {
-	      TrkrDefs::cluskey cluster_key = *iter;
-	      clusters.push_back(cluster_key);
-	    }
+          if(siseed)
+          {
+	    for (auto iter = siseed->begin_cluster_keys();
+	         iter != siseed->end_cluster_keys();
+	         ++iter)
+	      {
+	        TrkrDefs::cluskey cluster_key = *iter;
+	        clusters.push_back(cluster_key);
+	      }
+          }
 	  auto tpcseed = track->get_tpc_seed();
-	  for (auto iter = tpcseed->begin_cluster_keys();
-	       iter != tpcseed->end_cluster_keys();
-	       ++iter)
-	    {
-	      TrkrDefs::cluskey cluster_key = *iter;
-	      clusters.push_back(cluster_key);
-	    }
+          if(tpcseed)
+          {
+	    for (auto iter = tpcseed->begin_cluster_keys();
+	         iter != tpcseed->end_cluster_keys();
+	         ++iter)
+	      {
+	        TrkrDefs::cluskey cluster_key = *iter;
+	        clusters.push_back(cluster_key);
+	      }
+          }
 
 	  // loop over all cluster keys and build ntuple
 	  for(unsigned int iclus = 0; iclus < clusters.size(); ++iclus)

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -154,7 +154,7 @@ std::set<PHG4Particle*> SvtxTrackEval::all_truth_particles(SvtxTrack* track)
     }
   }
   std::set<PHG4Particle*> truth_particles;
-  SvtxTrack_FastSim * fastsim_track = dynamic_cast<SvtxTrack_FastSim * >(track);                                                                                            
+  SvtxTrack_FastSim * fastsim_track = dynamic_cast<SvtxTrack_FastSim * >(track);
 
   if (fastsim_track)
   {
@@ -951,10 +951,13 @@ std::vector<TrkrDefs::cluskey> SvtxTrackEval::get_track_ckeys(SvtxTrack* track)
 	  ++iter)
 	{ cluster_keys.push_back(*iter); }
     }
-  for(auto iter = tpcseed->begin_cluster_keys();
-      iter!= tpcseed->end_cluster_keys();
-      ++iter)
-    { cluster_keys.push_back(*iter); }
+  if(tpcseed)
+    {
+      for(auto iter = tpcseed->begin_cluster_keys();
+          iter!= tpcseed->end_cluster_keys();
+          ++iter)
+        { cluster_keys.push_back(*iter); }
+    }
   
   return cluster_keys;
 }

--- a/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
+++ b/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
@@ -197,7 +197,8 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
             chi2 += xy_residuals[i]*xy_residuals[i]/xy_error2[i] + rz_residuals[i]*rz_residuals[i]/rz_error2[i];
           }
           svtxtrack->set_chisq(chi2);
-          svtxtrack->set_ndf(xy_residuals.size()-2);
+          // GPUTPCTrackParam initially sets NDF to -3 on first cluster and increments by 2 with every application of filter
+          svtxtrack->set_ndf(2*xy_residuals.size()-5);
 
           addKeys(svtxtrack, trackSeed);
 	  if(m_trackSeedName.find("SiliconTrackSeed") != std::string::npos)

--- a/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
+++ b/simulation/g4simulation/g4eval/TrackSeedTrackMapConverter.cc
@@ -3,6 +3,7 @@
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
 
 #include <trackbase_historic/SvtxTrackMap_v1.h>
 #include <trackbase_historic/SvtxTrack_v4.h>
@@ -139,6 +140,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
       else
 	{
 	  /// Otherwise we are using an individual subdetectors container
+
 	  svtxtrack->set_x(trackSeed->get_x());
 	  svtxtrack->set_y(trackSeed->get_y());
 	  svtxtrack->set_z(trackSeed->get_z());
@@ -146,8 +148,58 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode*)
 	  svtxtrack->set_px(trackSeed->get_px(m_clusters,m_tGeometry));
 	  svtxtrack->set_py(trackSeed->get_py(m_clusters,m_tGeometry));
 	  svtxtrack->set_pz(trackSeed->get_pz());
-	  
-	  addKeys(svtxtrack, trackSeed);
+
+          // calculate chisq and ndf
+          double R = 1./fabs(trackSeed->get_qOverR());
+          double X0 = trackSeed->get_X0();
+          double Y0 = trackSeed->get_Y0();
+          double Z0 = trackSeed->get_Z0();
+          double slope = trackSeed->get_slope();
+          std::vector<double> xy_error2;
+          std::vector<double> rz_error2;
+          std::vector<double> xy_residuals;
+          std::vector<double> rz_residuals;
+          std::vector<double> x_circle;
+          std::vector<double> y_circle;
+          std::vector<double> z_line;
+          for(auto c_iter = trackSeed->begin_cluster_keys();
+              c_iter != trackSeed->end_cluster_keys();
+              ++c_iter)
+          {
+            TrkrCluster* c = m_clusters->findCluster(*c_iter);
+            Acts::Vector3 pos = m_tGeometry->getGlobalPosition(*c_iter,c);
+            double x = pos(0);
+            double y = pos(1);
+            double z = pos(2);
+            double r = sqrt(x*x+y*y);
+            double dx = x-X0;
+            double dy = y-Y0;
+            double xy_centerdist = sqrt(dx*dx+dy*dy);
+            // method lifted from ALICEKF::GetCircleClusterResiduals
+            xy_residuals.push_back(xy_centerdist-R);
+            // method lifted from ALICEKF::GetLineClusterResiduals
+            rz_residuals.push_back(fabs(-slope*r+z-Z0)/sqrt(slope*slope+1));
+
+            // ignoring covariance for simplicity
+            xy_error2.push_back(c->getActsLocalError(0,0)+c->getActsLocalError(1,1));
+            rz_error2.push_back(c->getActsLocalError(2,2));
+            double phi = atan2(dy,dx);
+            x_circle.push_back(R*cos(phi)+X0);
+            y_circle.push_back(R*sin(phi)+Y0);
+            z_line.push_back(R*slope+Z0);
+          }
+          double chi2 = 0.;
+          for(unsigned int i=0; i<xy_residuals.size(); i++)
+          {
+            if(std::isnan(xy_error2[i])) xy_error2[i] = 0.01;
+            if(std::isnan(rz_error2[i])) rz_error2[i] = 0.01;
+            // method lifted from GPUTPCTrackParam::Filter
+            chi2 += xy_residuals[i]*xy_residuals[i]/xy_error2[i] + rz_residuals[i]*rz_residuals[i]/rz_error2[i];
+          }
+          svtxtrack->set_chisq(chi2);
+          svtxtrack->set_ndf(xy_residuals.size()-2);
+
+          addKeys(svtxtrack, trackSeed);
 	  if(m_trackSeedName.find("SiliconTrackSeed") != std::string::npos)
 	    {
 	      svtxtrack->set_silicon_seed(trackSeed);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Enables the relevant parts of the tracking chain and vertexing to be run with only the silicon tracking detectors active. Specifically, fixes crashes in SvtxTrackv4::Identify, SvtxTrackEval, and SvtxEvaluator resulting from the absence of a TPC seed, and implements a simple chi2 and ndf calculation in TrackSeedTrackMapConverter that enables PHSimpleVertexFinder to work with silicon-only tracks.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

