### PR TITLE
Adding reco track vertex association info to SvtxEvaluator ntuples

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -129,7 +129,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_vertex_eval) _ntp_vertex = new TNtuple("ntp_vertex", "vertex => max truth",
-						 "event:seed:vx:vy:vz:ntracks:chi2:ndof:"
+						 "event:seed:vertexID:vx:vy:vz:ntracks:chi2:ndof:"
 						 "gvx:gvy:gvz:gvt:gembed:gntracks:gntracksmaps:"
 						 "gnembed:nfromtruth:"
 						 "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
@@ -188,13 +188,13 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                                                  "gembed:gprimary:"
                                                  "trackID:px:py:pz:pt:eta:phi:deltapt:deltaeta:deltaphi:"
                                                  "charge:quality:chisq:ndf:nhits:layers:nmaps:nintt:ntpc:nmms:ntpc1:ntpc11:ntpc2:ntpc3:nlmaps:nlintt:nltpc:nlmms:"
-                                                 "dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:ntrumms:ntrutpc1:ntrutpc11:ntrutpc2:ntrutpc3:layersfromtruth:"
+                                                 "vertexID:vx:vy:vz:dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:ntrumms:ntrutpc1:ntrutpc11:ntrutpc2:ntrutpc3:layersfromtruth:"
                                                  "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
 
   if (_do_track_eval) _ntp_track = new TNtuple("ntp_track", "svtxtrack => max truth",
                                                "event:seed:trackID:crossing:px:py:pz:pt:eta:phi:deltapt:deltaeta:deltaphi:charge:"
                                                "quality:chisq:ndf:nhits:nmaps:nintt:ntpc:nmms:ntpc1:ntpc11:ntpc2:ntpc3:nlmaps:nlintt:nltpc:nlmms:layers:"
-                                               "dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
+                                               "vertexID:vx:vy:vz:dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
 					       "gtrackID:gflavor:gnhits:gnmaps:gnintt:gntpc:gnmms:gnlmaps:gnlintt:gnltpc:gnlmms:"
                                                "gpx:gpy:gpz:gpt:geta:gphi:"
                                                "gvx:gvy:gvz:gvt:"
@@ -1093,6 +1093,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
        {
         SvtxVertex* vertex = iter->second;
         PHG4VtxPoint* point = vertexeval->max_truth_point_by_ntracks(vertex);
+        int vertexID = vertex->get_id();
         float vx = vertex->get_x();
         float vy = vertex->get_y();
         float vz = vertex->get_z();
@@ -1125,6 +1126,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         }
 	
         float vertex_data[] = {(float) _ievent,m_fSeed,
+                               (float) vertexID,
                                vx,
                                vy,
                                vz,
@@ -2688,6 +2690,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float nltpc = 0;
         float nlmms = 0;
         unsigned int layers = 0x0;
+        int vertexID = -1;
+        float vx = NAN;
+        float vy = NAN;
+        float vz = NAN;
         float dca2d = NAN;
         float dca2dsigma = NAN;
         float dca3dxy = NAN;
@@ -2883,7 +2889,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		 << " nltpc  " << nltpc
 		 << endl;
 	    */
-	  
+
+            vertexID = track->get_vertex_id();
+            SvtxVertex* vertex = vertexmap->get(vertexID);
+            vx = vertex->get_x();
+            vy = vertex->get_y();
+            vz = vertex->get_z();
+
 	    get_dca(track, vertexmap, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
 	    
             px = track->get_px();
@@ -3010,6 +3022,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                nlintt,
                                nltpc,
 			       nlmms,
+                               (float) vertexID,
+                               vx,
+                               vy,
+                               vz,
                                dca2d,
                                dca2dsigma,
                                dca3dxy,
@@ -3236,6 +3252,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	float dca3dxy = NAN, dca3dz = NAN,
 	  dca3dxysigma = NAN, dca3dzsigma = NAN;
 	float dca2d = NAN, dca2dsigma = NAN;
+
+        int vertexID = track->get_vertex_id();
+        SvtxVertex* vertex = vertexmap->get(vertexID);
+        float vx = vertex->get_x();
+        float vy = vertex->get_y();
+        float vz = vertex->get_z();
+
 	get_dca(track, vertexmap, dca3dxy, dca3dz,
 		dca3dxysigma, dca3dzsigma);
 
@@ -3453,6 +3476,10 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 			      ntpc1,ntpc11,ntpc2,ntpc3,
 			      nlmaps, nlintt, nltpc,nlmms,
                               (float) layers,
+                              (float) vertexID,
+                              vx,
+                              vy,
+                              vz,
                               dca2d,
                               dca2dsigma,
                               dca3dxy,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adds reco vertex ID and reco vertex position to ntp_track and ntp_gtrack, and adds vertex ID to ntp_vertex.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

