### PR TITLE
shift inner Hcal scintillator row index down by 1

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -273,6 +273,9 @@ std::tuple<int, int, int> PHG4IHCalDetector::ExtractLayerTowerId(const unsigned 
   }
   int column = map_towerid(tower_id);
   int row = map_layerid(layer_id);
+  //shift row number down by one so every sector start with a row number that mod4=0
+  row--;
+  while(row<0) row+=256;
   return std::make_tuple(isector, row, column);
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Since for inner HCal the row index maps to tower phi index via twrrow = cellrow / 4 (https://sphenix-collaboration.github.io/doxygen/d8/d63/HcalRawTowerBuilder_8cc_source.html#l00451)
The row index for each sector should start with a number that mod 4 =0, otherwise one sector will map to three phi index.

![1664308737177](https://user-images.githubusercontent.com/71942661/192623624-67bc7730-d292-4e3b-b11e-a275121d5a01.png)
While running simulation with only one inner HCal sector(isector=15 in this case) built, the towers that have non zero energy deposition map to three different phi indexes before this PR, indicating the tower definition is not totally aligned with sector geometry. 


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

