### PR TITLE
Distortion fixes

### DIFF
--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -249,6 +249,13 @@ class PHGenFitTrkFitter : public SubsysReco
 
   //@}
 
+  /// fit only tracks with silicon+MM hits
+  void set_fit_silicon_mms( bool );
+
+  /// require micromegas in SiliconMM fits
+  void set_use_micromegas( bool value )
+  { m_use_micromegas = value; }
+
   private:
   //! Event counter
   int _event = 0;
@@ -300,7 +307,14 @@ class PHGenFitTrkFitter : public SubsysReco
   //! disabled layers
   /** clusters belonging to disabled layers are not included in track fit */
   std::set<int> _disabled_layers;
+  
+  /// Boolean to use normal tracking geometry navigator or the
+  /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
+  bool m_fit_silicon_mms = false;
 
+  /// requires micromegas present when fitting silicon-MM surfaces
+  bool m_use_micromegas = true;
+  
   //! KalmanFitterRefTrack, KalmanFitter, DafSimple, DafRef
   std::string _track_fitting_alg_name = "DafRef";
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -37,14 +37,15 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_z_search_window_lyr2(const double win){_z_search_win[1] = win;}
   void set_min_tpc_layer(const unsigned int layer){_min_tpc_layer = layer;}
   void set_test_windows_printout(const bool test){_test_windows = test;}
-  void set_sc_calib_mode(const bool mode){_sc_calib_mode = mode;}
-  void set_collision_rate(const double rate){_collision_rate = rate;}
   void SetIteration(int iter){_n_iteration = iter;}
-  //  void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
   int End(PHCompositeNode*) override;
+
+  // deprecated calls
+  inline void set_sc_calib_mode(const bool) {}
+  inline void set_collision_rate(const double) {}
   
   private:
 
@@ -76,17 +77,8 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   
   /// first micromegas layer
   /** it is reset in ::Setup using actual micromegas geometry */
-  unsigned int _min_mm_layer = 55;
-
-  //! true for initial pass with distorted tracks
-  bool _sc_calib_mode = false; 
-
-  //! input rate for phi correction
-  double _collision_rate = 50e3;  
+  unsigned int _min_mm_layer = 55; 
   
-  //! reference rate for phi correction
-  double _reference_collision_rate = 50e3;  
-
   //! internal event number
   int _event = -1;
   
@@ -108,11 +100,6 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   /// tpc distortion correction utility class
   TpcDistortionCorrection m_distortionCorrection;
-
-  //! coarse SC correction function
-  TF1 *fdrphi{nullptr};
-  double _par0 = -0.36619;
-  double _par1 = 0.00375714;
 
   //! true to printout actual residuals for testing
   bool _test_windows = false;   

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -26,6 +26,23 @@ namespace
     return x * x;
   }
 
+  // check boundaries in axis
+  /* for the interpolation to work, the value must be within the range of the provided axis, and not into the first and last bin */
+  inline bool check_boundaries( const TAxis* axis, double value )
+  {
+    const auto bin = axis->FindBin( value );
+    return( bin >= 2 && bin < axis->GetNbins() );
+  }
+  
+  // check boundaries in histogram, before interpolation
+  /* for the interpolation to work, the value must be within the range of the provided axis, and not into the first and last bin */
+  inline bool check_boundaries( const TH3* h, double r, double phi, double z )
+  {
+    return check_boundaries( h->GetXaxis(), r ) 
+      && check_boundaries( h->GetYaxis(), phi ) 
+      && check_boundaries( h->GetZaxis(), z );
+  }
+  
 }  // namespace
 
 //__________________________________________________________________________________________________________
@@ -192,7 +209,8 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
     }
     if (hdistortion)
     {
-      _distortion += hdistortion->Interpolate(phi, r, z);
+      if( check_boundaries( hdistortion, phi, r, z ) )
+      { _distortion += hdistortion->Interpolate(phi, r, z); }
     }
     else
     {
@@ -218,7 +236,8 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
     }
     if (hdistortion)
     {
-      _distortion += hdistortion->Interpolate(phi, r, z);
+      if( check_boundaries( hdistortion, phi, r, z ) )
+      { _distortion += hdistortion->Interpolate(phi, r, z); }
     }
     else
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Three fixes to the distortion code
- remove adding ad hoc corrections to the TPC-Micromegas matching when running in distortion calibration mode. This should be handled upstream by adding a first guess of the distortions corrections upfront. @adfrawley : this is what we discussed this morning
- make the genfit handling of the distortion calibration mode closer to that of acts, by adding a dedicated flag and skipping the tracks that don't have a Micromegas
- remove the ominous TH3::interpolate warnings by checking the cluster position against histogram's boundaries upfront. @pinkenburg : this should make JobA much less verbose.  

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

