### PR TITLE
Fix B field NaN lookup error

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -218,6 +218,9 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     std::vector<double> zsize;
     for(auto clusterkey = std::next(trackKeyChain.begin()); clusterkey != trackKeyChain.end(); ++clusterkey)
     {
+      if(std::isnan(trackSeed.GetX()) ||
+         std::isnan(trackSeed.GetY()) ||
+         std::isnan(trackSeed.GetZ())) continue;
       LogDebug("-------------------------------------------------------------" << std::endl);
       LogDebug("cluster " << cluster_ctr << " -> " << cluster_ctr + 1 << std::endl);
       LogDebug("this cluster (x,y,z) = (" << x << "," << y << "," << z << ")" << std::endl);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Fixes error in ALICEKF where pathological track seeds still tried to look up the magnetic field values at NaN position values. Checking whether the current position is NaN, and terminating before calling the magnetic field lookup if so, eliminates this error.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

