### PR TITLE
Replacing PHG4CylinderCellGeom by PHG4TpcCylinderGeom in offline/pack…

### DIFF
--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.cc
@@ -15,8 +15,8 @@
 #include <TGraph.h>
 #include <cmath>
 
-#include <g4detectors/PHG4CylinderCellGeom.h>
-#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 /// Tracking includes
 #include <trackbase/TrkrDefs.h>
@@ -267,11 +267,11 @@ int PHTpcCentralMembraneClusterizer::process_event(PHCompositeNode *topNode)
 	      //      Use ratio of component cluster energies to estimate number of sigmas at row boundary
 	      float efrac = energy[i] / (energy[i] + energy[i_pair[i]]);
 
-	      PHG4CylinderCellGeom *layergeom1 = _geom_container->GetLayerCellGeom(layer[i]);
+	      PHG4TpcCylinderGeom *layergeom1 = _geom_container->GetLayerCellGeom(layer[i]);
 	      double rad1 = layergeom1->get_radius();
-	      PHG4CylinderCellGeom *layergeom2 = _geom_container->GetLayerCellGeom(layer[i_pair[i]]);
+	      PHG4TpcCylinderGeom *layergeom2 = _geom_container->GetLayerCellGeom(layer[i_pair[i]]);
 	      double rad2 = layergeom2->get_radius();
-	      PHG4CylinderCellGeom *layergeom0;
+	      PHG4TpcCylinderGeom *layergeom0;
 	      double layer_dr;
 	      if(layer[i] != 7 && layer[i] != 23 && layer[i] != 39)
 		{
@@ -412,7 +412,7 @@ int  PHTpcCentralMembraneClusterizer::GetNodes(PHCompositeNode* topNode)
   }
 
   _geom_container =
-      findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!_geom_container)
   {
     std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;

--- a/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneClusterizer.h
@@ -19,7 +19,7 @@ class SvtxVertexMap;
 class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class CMFlashClusterContainer;
-class  PHG4CylinderCellGeomContainer;
+class  PHG4TpcCylinderGeomContainer;
 
 class TF1;
 class TNtuple;
@@ -63,7 +63,7 @@ class PHTpcCentralMembraneClusterizer : public SubsysReco
 
   TrkrClusterContainer *_cluster_map{nullptr};
   CMFlashClusterContainer *_corrected_CMcluster_map{nullptr};
-  PHG4CylinderCellGeomContainer *_geom_container{nullptr};
+  PHG4TpcCylinderGeomContainer *_geom_container{nullptr};
  TpcDistortionCorrectionContainer* _dcc{nullptr};
 
   TH1F *henergy;

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -11,8 +11,8 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
 
-#include <g4detectors/PHG4CylinderCellGeom.h>
-#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <trackbase/ActsTrackingGeometry.h>
 #include <trackbase/ActsSurfaceMaps.h>
@@ -225,7 +225,7 @@ void TpcDirectLaserReconstruction::set_grid_dimensions( int phibins, int rbins, 
 //_____________________________________________________________________
 int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
 {
-  m_geom_container =  findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  m_geom_container =  findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   assert( m_geom_container );
 
   // acts surface map
@@ -323,7 +323,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       TrkrDefs::hitsetkey hitsetkey = hitsetitr->first;
       TrkrHitSet *hitset = hitsetitr->second;
       unsigned int layer = TrkrDefs::getLayer(hitsetkey);
-      PHG4CylinderCellGeom *layergeom = m_geom_container->GetLayerCellGeom(layer);
+      PHG4TpcCylinderGeom *layergeom = m_geom_container->GetLayerCellGeom(layer);
       const auto layer_center_radius = layergeom->get_radius();
 
     // get corresponding hits
@@ -368,7 +368,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 
   for(auto layer : layer_bin_set)
     {
-      PHG4CylinderCellGeom *layergeom = m_geom_container->GetLayerCellGeom(layer);
+      PHG4TpcCylinderGeom *layergeom = m_geom_container->GetLayerCellGeom(layer);
       const auto layer_center_radius = layergeom->get_radius();
       const auto layer_inner_radius = layer_center_radius - layergeom->get_thickness() / 2.0;
       const auto layer_outer_radius = layer_center_radius + layergeom->get_thickness() / 2.0;

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -19,7 +19,7 @@ class SvtxTrack;
 class SvtxTrackMap;
 class TpcSpaceChargeMatrixContainer;
 class TrkrHitSetContainer;
-class   PHG4CylinderCellGeomContainer;
+class   PHG4TpcCylinderGeomContainer;
 
 class TFile;
 class TH1;
@@ -123,7 +123,7 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   ///@name nodes
   //@{
 
-  PHG4CylinderCellGeomContainer *m_geom_container = nullptr;
+  PHG4TpcCylinderGeomContainer *m_geom_container = nullptr;
 
   /// Acts surface maps for surface lookup
   ActsSurfaceMaps* m_surfmaps = nullptr;

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -9,8 +9,8 @@
 #include "TpcSpaceChargeMatrixContainerv1.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <g4detectors/PHG4CylinderCellGeom.h>
-#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>


### PR DESCRIPTION
…ages/tpccalib/

[comment]: <> (This pull request changes the term PHG4CylinderCellGeom to PHG4TpcCylinderGeom in relevant files located in offline/packages/ tpccalib in order to use TPC central membrane clusterizer at https://github.com/sPHENIX-Collaboration/macros/blob/master/common/G4_TPC.C#L326  )

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

