### PR TITLE
SvtxHitEval: truth matching with trkrid as an additional argument

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxHitEval.h
+++ b/simulation/g4simulation/g4eval/SvtxHitEval.h
@@ -52,9 +52,17 @@ class SvtxHitEval
   std::set<PHG4Hit*> all_truth_hits(TrkrDefs::hitkey hit_key);
   PHG4Hit* max_truth_hit_by_energy(TrkrDefs::hitkey hit_key);
 
+  // backtrace through to PHG4Hits for a specific tracker
+  std::set<PHG4Hit*> all_truth_hits(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);
+  PHG4Hit* max_truth_hit_by_energy(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);
+
   // backtrace through to PHG4Particles
   std::set<PHG4Particle*> all_truth_particles(TrkrDefs::hitkey hit_key);
   PHG4Particle* max_truth_particle_by_energy(TrkrDefs::hitkey hit_key);
+
+  // backtrace through to PHG4Particles for a specific tracker
+  std::set<PHG4Particle*> all_truth_particles(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);
+  PHG4Particle* max_truth_particle_by_energy(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);
 
   // forwardtrace through to SvtxHits
   std::set<TrkrDefs::hitkey> all_hits_from(PHG4Particle* truthparticle);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Add an additional argument to the methods `std::set<PHG4Hit*> SvtxHitEval::all_truth_hits` and `PHG4Hit* SvtxHitEval::max_truth_hit_by_energy` to specify the TrkrId to find the proper TrkrHitsets to perform matching. 

Added methods are `std::set<PHG4Hit*> all_truth_hits(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);`, `PHG4Hit* max_truth_hit_by_energy(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);`, `std::set<PHG4Particle*> all_truth_particles(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);`, and `PHG4Particle* max_truth_particle_by_energy(TrkrDefs::hitkey hit_key, const TrkrDefs::TrkrId trkrid);`. 

As a comparison, using the original methods, the G4hits matched to MVTX TrkrHits could come from other tracking detectors
<img width="1288" alt="Screen Shot 2022-10-21 at 15 35 26" src="https://user-images.githubusercontent.com/34806107/197282763-acd584fa-0d13-4b12-98a9-4c5b4c2b29b8.png">

Using the modified methods, the G4hits matched to MVTX TrkrHits only come from MVTX
![Screen Shot 2022-10-21 at 12 26 23](https://user-images.githubusercontent.com/34806107/197283107-81454e73-9d2b-4ade-99e8-19d4aa4f16ae.png)


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

