### PR TITLE
print the filename of the fieldmap where the key lookup fails

### DIFF
--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -250,7 +250,8 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
           magval = fieldmap.find(key);
           if (magval == fieldmap.end())
           {
-            std::cout << "could not locate key, x: " << xkey[i] / cm
+            std::cout << PHWHERE << " could not locate key in " << filename
+		      << " value: x: " << xkey[i] / cm
                       << ", y: " << ykey[j] / cm
                       << ", z: " << zkey[k] / cm << std::endl;
             return;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
This PR adds the filename to the printout when a key cannot be found to clarify which map is being looked at
[skip-ci]
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

