### PR TITLE
Modified TPC sector grouping to be by region and sector

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -439,6 +439,17 @@ void HelicalFitter::getGlobalLabels(Surface surf, int glbl_label[])
   if(Verbosity() > 1) { std::cout << std::endl; }
 }
 
+int HelicalFitter::getTpcRegion(int layer)
+{
+  int region = 0;
+  if(layer > 23 && layer < 39)
+    region = 1;
+  if(layer > 38 && layer < 55)
+    region = 2;
+
+  return region;  
+}
+
 int HelicalFitter::getLabelBase(Acts::GeometryIdentifier id)
 {
   unsigned int volume = id.volume(); 
@@ -482,10 +493,13 @@ int HelicalFitter::getLabelBase(Acts::GeometryIdentifier id)
 	}
       if(tpc_grp == tpcGrp::sctr)
 	{
-	  // all tpc layers, assign layer 7 and side and sector number to all layers and subsurfaces
+	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
 	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
 	  int sector = (sensor - side *144) / 12; 
-	  label_base += 7*1000000 + (side*12 + sector) *10000; 
+	  // for a given layer there are only 12 sectors x 2 sides
+	  // The following gives the sectors in the inner, mid, outer regions unique group labels
+	  int region = getTpcRegion(layer);  // inner, mid, outer
+	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
 	  return label_base;
 	}
       if(tpc_grp == tpcGrp::tp)

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -76,6 +76,7 @@ Mille* _mille;
   std::vector<Acts::Vector3> getDerivativesAlignmentAngles(Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing);
   float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
   void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global);
+  int getTpcRegion(int layer);
 
   void getTrackletClusters(TrackSeed *_track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
   std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -391,6 +391,17 @@ SvtxTrack::StateIter MakeMilleFiles::getStateIter(Acts::Vector3& global, SvtxTra
   return state_iter;
 }
 
+int MakeMilleFiles::getTpcRegion(int layer)
+{
+  int region = 0;
+  if(layer > 23 && layer < 39)
+    region = 1;
+  if(layer > 38 && layer < 55)
+    region = 2;
+
+  return region;  
+}
+
 int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
 {
   unsigned int volume = id.volume();
@@ -437,10 +448,14 @@ int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
 	}
       if(tpc_group == tpcGroup::sector)
 	{
-	  // grouop all tpc layers in sector, assign layer 7 and side and sector number to all layers and hitsets
+	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
 	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
 	  int sector = (sensor - side *144) / 12; 
-	  label_base += 7*1000000 + (side*12 + sector) *10000; 
+	  // for a given layer there are only 12 sectors x 2 sides
+	  // The following gives the sectors in the inner, mid, outer regions unique group labels
+	  int region = getTpcRegion(layer);  // inner, mid, outer
+	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
+	  std::cout << " layer " << layer << " sensor " << sensor << " region " << region << " side " << side << " sector " << sector << " label_base " << label_base << std::endl;
 	  return label_base;
 	}
       if(tpc_group == tpcGroup::tpc)

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -157,6 +157,7 @@ class MakeMilleFiles : public SubsysReco
   float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
   Acts::Transform3 makePerturbationTransformation(Acts::Vector3 angles);
   int getLabelBase(Acts::GeometryIdentifier id);
+  int getTpcRegion(int layer);
 
   AlignmentStateMap getAlignmentStates(const Trajectory& traj,
                                        SvtxTrack* track, short int crossing);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The optional grouping of hitsets into sectors during alignment is modified so that the grouping is by sector and region (inner, mid, outer) to better match how the TPC is constructed.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

