### PR TITLE
Fix error in code in storing TrkrCluster sizes for phi and time

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -678,15 +678,6 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-/* TpcClusterBuilder PHG4TpcElectronDrift::MapToPadPlane(const double x_gem, const double y_gem, const double t_gem, const unsigned int side, PHG4HitContainer::ConstIterator hiter, TNtuple *padnt, TNtuple *hitnt) */
-/* { */
-/*   return padplane->MapToPadPlane( */
-/*       single_hitsetcontainer.get(), */ 
-/*       temp_hitsetcontainer.get(), */ 
-/*       hittruthassoc, */ 
-/*       x_gem, y_gem, t_gem, side, hiter, padnt, hitnt); */
-/* } */
-
 int PHG4TpcElectronDrift::End(PHCompositeNode * /*topNode*/)
 {
   if (Verbosity() > 0)

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -213,6 +213,8 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
 
   // store phi bins and tbins upfront to avoid repetitive checks on the phi methods
   const auto phibins = LayerGeom->get_phibins();
+  pass_data.nphibins = phibins;
+
   const auto tbins   = LayerGeom->get_zbins();
 
   // Create the distribution function of charge on the pad plane around the electron position
@@ -242,10 +244,10 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
   pad_phibin.clear();
   pad_phibin_share.clear();
   populate_zigzag_phibins(layernum, phi, sigmaT, pad_phibin, pad_phibin_share);
-  if (pad_phibin.size() == 0) pass_data.neff_electrons = 0;
-  else {
-    pass_data.phi_bin_lo = pad_phibin[0];
-    pass_data.phi_bin_hi = pad_phibin[pad_phibin.size()-1];
+  if (pad_phibin.size() == 0) {
+    pass_data.neff_electrons = 0;
+  } else {
+    pass_data.fillPhiBins(pad_phibin);
   }
 
   // Normalize the shares so they add up to 1
@@ -267,10 +269,10 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
   adc_tbin.clear();
   adc_tbin_share.clear();
   populate_tbins(t_gem, sigmaL, adc_tbin, adc_tbin_share);
-  if (adc_tbin.size() == 0)  pass_data.neff_electrons = 0;
-  else {
-    pass_data.time_bin_lo = adc_tbin[0];
-    pass_data.time_bin_hi = adc_tbin[adc_tbin.size()-1];
+  if (adc_tbin.size() == 0)  {
+    pass_data.neff_electrons = 0;
+  } else {
+    pass_data.fillTimeBins(adc_tbin);
   }
 
   // Normalize the shares so that they add up to 1
@@ -304,7 +306,7 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
       float neffelectrons = nelec * (pad_share) * (adc_bin_share);
       if (neffelectrons < neffelectrons_threshold) continue;  // skip signals that will be below the noise suppression threshold
 
-      if (tbin_num >= tbins) std::cout << " Error making key: adc_tbin " << tbin_num << " ntbins " << tbins << std::endl;
+      if (tbin_num >= tbins)  std::cout << " Error making key: adc_tbin " << tbin_num << " ntbins " << tbins << std::endl;
       if (pad_num >= phibins) std::cout << " Error making key: pad_phibin " << pad_num << " nphibins " << phibins << std::endl;
 
       // collect information to do simple clustering. Checks operation of PHG4CylinderCellTpcReco, and

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -2,22 +2,54 @@
 #include <trackbase/TrkrClusterv4.h>
 #include <trackbase/TpcDefs.h>
 #include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <algorithm>
 
 class TpcClusterBuilder;
+using std::cout, std::endl;
 
 TpcClusterBuilder& TpcClusterBuilder::operator+=(const TpcClusterBuilder& rhs) {
   // layer, side, and layerGeom won't change between different additions, but they
   // but need to be set by the first addition
+  if (rhs.neff_electrons==0) return *this; 
+
   layerGeom = rhs.layerGeom;
   layer     = rhs.layer;
   side      = rhs.side;
 
+  if (rhs.hasPhiBins) {
+    if (!hasPhiBins) {
+      phi_bin_lo = rhs.phi_bin_lo;
+      phi_bin_hi = rhs.phi_bin_hi;
+    } else {
+      int rhs_phi_bin_lo = rhs.phi_bin_lo;
+      int rhs_phi_bin_hi = rhs.phi_bin_hi;
 
-  if (rhs.phi_bin_lo < phi_bin_lo) phi_bin_lo = rhs.phi_bin_lo;
-  if (rhs.phi_bin_hi > phi_bin_hi) phi_bin_hi = rhs.phi_bin_hi;
+      // if this is the case, wrap the lower values to be higher
+      if ( (phi_bin_lo - rhs_phi_bin_lo) > (nphibins/2)) {
+        rhs_phi_bin_lo += nphibins;
+        rhs_phi_bin_hi += nphibins;
+      } else if ( (rhs_phi_bin_lo - phi_bin_lo) > (nphibins/2)) {
+        phi_bin_lo += nphibins;
+        phi_bin_hi += nphibins;
+      }
 
-  if (rhs.time_bin_lo < time_bin_lo) time_bin_lo = rhs.time_bin_lo;
-  if (rhs.time_bin_hi > time_bin_hi) time_bin_hi = rhs.time_bin_hi;
+      if (rhs_phi_bin_lo < phi_bin_lo) phi_bin_lo = rhs_phi_bin_lo;
+      if (rhs_phi_bin_hi > phi_bin_hi) phi_bin_hi = rhs_phi_bin_hi;
+    }
+    hasPhiBins = true;
+  } 
+
+
+  if (rhs.hasTimeBins) {
+    if (!hasTimeBins) {
+      time_bin_lo = rhs.time_bin_lo;
+      time_bin_hi = rhs.time_bin_hi;
+    } else {
+      if (rhs.time_bin_lo < time_bin_lo) time_bin_lo = rhs.time_bin_lo;
+      if (rhs.time_bin_hi > time_bin_hi) time_bin_hi = rhs.time_bin_hi;
+    }
+    hasTimeBins = true;
+  }
 
   neff_electrons += rhs.neff_electrons;
   phi_integral   += rhs.phi_integral;
@@ -33,10 +65,13 @@ void TpcClusterBuilder::reset() {
   neff_electrons = 0;
   phi_integral   = 0.;
   time_integral  = 0.;
-  phi_bin_lo     = 0;
-  phi_bin_hi     = 0;
-  time_bin_lo    = 0;
-  time_bin_hi    = 0;
+  phi_bin_lo     = INT_MAX;
+  phi_bin_hi     = INT_MIN;
+  time_bin_lo    = INT_MAX;
+  time_bin_hi    = INT_MIN;
+  nphibins       = 0;
+  hasPhiBins     = false;
+  hasTimeBins    = false;
 }
 
 TpcClusterBuilder::PairCluskeyCluster TpcClusterBuilder::build(MapHitsetkeyUInt& cluster_cnt) const {
@@ -46,16 +81,14 @@ TpcClusterBuilder::PairCluskeyCluster TpcClusterBuilder::build(MapHitsetkeyUInt&
   TrkrClusterv4* cluster = new TrkrClusterv4();
   cluster->setPosition ( 0, phi_mean );
   cluster->setPosition ( 1, time_integral / neff_electrons);
-  cluster->setPhiSize  ( phi_bin_hi  - phi_bin_lo  +1);
-  cluster->setZSize    ( time_bin_hi - time_bin_lo +1);
+  cluster->setPhiSize  ( static_cast<char>(phi_bin_hi-phi_bin_lo+1) );
+  if (phi_bin_hi < phi_bin_lo) std::cout << " WARNING 101: phi_bin_hi<phi_bin_lo: " 
+     << phi_bin_hi << "<" << phi_bin_lo << std::endl;
+  cluster->setZSize    ( static_cast<char>(time_bin_hi-time_bin_lo+1));
   cluster->setAdc      ( neff_electrons );
 
-  // generate the hitset key at the mean phi location:
-  /* std::cout << " a0 " << std::endl; */
   const int phi_pad_number           = layerGeom->get_phibin(phi_mean);
-  /* std::cout << " a1 " << std::endl; */
   const auto phibins                 = layerGeom->get_phibins();
-  /* std::cout << " a2 " << std::endl; */
   const unsigned int pads_per_sector = phibins / 12;
   const unsigned int sector          = phi_pad_number / pads_per_sector;
   TrkrDefs::hitsetkey hitsetkey = TpcDefs::genHitSetKey(layer, sector, side);
@@ -79,3 +112,19 @@ bool TpcClusterBuilder::has_data() const {
   return neff_electrons != 0;
 }
 
+void TpcClusterBuilder::fillPhiBins(const std::vector<int>& bins) {
+  if (bins.size() == 0) return;
+  phi_bin_lo = bins[0];
+  phi_bin_hi = bins[bins.size()-1];
+  // Check if the phi_bin_hi "wrapped around" to be below phi_bin_lo; 
+  // If it did wrap it "back above" phi_bin_lo
+  if (phi_bin_hi < phi_bin_lo) phi_bin_hi += nphibins;
+  hasPhiBins = true;
+}
+
+void TpcClusterBuilder::fillTimeBins(const std::vector<int>& bins) {
+  if (bins.size() == 0) return;
+  time_bin_lo = bins[0];
+  time_bin_hi = bins[bins.size()-1];
+  hasTimeBins = true;
+}

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -81,10 +81,21 @@ TpcClusterBuilder::PairCluskeyCluster TpcClusterBuilder::build(MapHitsetkeyUInt&
   TrkrClusterv4* cluster = new TrkrClusterv4();
   cluster->setPosition ( 0, phi_mean );
   cluster->setPosition ( 1, time_integral / neff_electrons);
-  cluster->setPhiSize  ( static_cast<char>(phi_bin_hi-phi_bin_lo+1) );
-  if (phi_bin_hi < phi_bin_lo) std::cout << " WARNING 101: phi_bin_hi<phi_bin_lo: " 
-     << phi_bin_hi << "<" << phi_bin_lo << std::endl;
-  cluster->setZSize    ( static_cast<char>(time_bin_hi-time_bin_lo+1));
+  int phi_size = phi_bin_hi-phi_bin_lo+1;
+  if (phi_size > CHAR_MAX || phi_size < 0) {
+    std::cout << PHWHERE << " Error in calculating nPads in Truth Track cluster: value is " << phi_size << " but should be within [1," << CHAR_MAX << "]" << std::endl
+              <<            "   -> setting nPads to -1 (i.e. it *can't* match any other node) " << std::endl;
+    phi_size = -1;
+  }
+  cluster->setPhiSize  ( static_cast<char>(phi_size) );
+
+  int Z_size = time_bin_hi-time_bin_lo+1;
+  if (Z_size > CHAR_MAX || Z_size < 0) {
+    std::cout << PHWHERE << " Error in calculating nTimeBins in Truth Track cluster: value is " << Z_size << " but should be within [1," << CHAR_MAX << "]" << std::endl
+              <<            "   -> setting nTimeBins to -1 (i.e. it *can't* match any other node) " << std::endl;
+    Z_size = -1;
+  }
+  cluster->setZSize    ( static_cast<char>(Z_size));
   cluster->setAdc      ( neff_electrons );
 
   const int phi_pad_number           = layerGeom->get_phibin(phi_mean);

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -4,6 +4,7 @@
 #include <phool/PHObject.h>
 #include <trackbase/TrkrDefs.h>
 #include <map>
+#include <climits>
 
 class TrkrCluster;
 class PHG4TpcCylinderGeom;
@@ -19,16 +20,19 @@ class TpcClusterBuilder
   using MapHitsetkeyUInt   = std::map<TrkrDefs::hitsetkey, unsigned int>;
   using PairCluskeyCluster = std::pair<TrkrDefs::cluskey,TrkrCluster*>;
   public:
-    PHG4TpcCylinderGeom *layerGeom ; // unique to the layer
-    short  layer;
-    unsigned int side;
-    int    neff_electrons ;
-    double phi_integral   ;
-    double time_integral  ;
-    int    phi_bin_lo     ;
-    int    phi_bin_hi     ;
-    int    time_bin_lo    ;
-    int    time_bin_hi    ;
+    PHG4TpcCylinderGeom *layerGeom { nullptr }; // unique to the layer
+    short  layer          {  SHRT_MAX };
+    unsigned int side     { 0       };
+    int    neff_electrons { 0       };
+    double phi_integral   { 0.      };
+    double time_integral  { 0.      };
+    int    phi_bin_lo     { INT_MAX };
+    int    phi_bin_hi     { INT_MIN };
+    int    time_bin_lo    { INT_MAX };
+    int    time_bin_hi    { INT_MIN };
+    int    nphibins       { 0       };
+    bool   hasPhiBins     { false   };
+    bool   hasTimeBins    { false   };
 
     TpcClusterBuilder( short _layer,  unsigned int _side, 
         int _neff_electrons, double _phi_integral, 
@@ -45,14 +49,16 @@ class TpcClusterBuilder
       , time_bin_lo    { _time_bin_lo    }
       , time_bin_hi    { _time_bin_hi    }
     {};
-    TpcClusterBuilder() :
-      layerGeom {nullptr}, layer {0}, side {0}, neff_electrons {0}, 
-      phi_integral {0.}, time_integral {0.},
-      phi_bin_lo {0}, phi_bin_hi {0}, time_bin_lo {0}, time_bin_hi {0}
-    {};
-
+    TpcClusterBuilder() {};
+      /* layerGeom {nullptr}, layer {0}, side {0}, neff_electrons {0}, */ 
+      /* phi_integral {0.}, time_integral {0.}, */
+      /* phi_bin_lo {0}, phi_bin_hi {0}, time_bin_lo {0}, time_bin_hi {0}, nphibins{0} */
+    /* {}; */
 
     TpcClusterBuilder& operator+=(const TpcClusterBuilder& rhs);
+    /* void fillBinsLowHigh (int& bin_lo, int&bin_hi, std::vector<int> bins); */
+    void fillPhiBins  (const std::vector<int>& bins);
+    void fillTimeBins (const std::vector<int>& bins);
     void reset();
     bool has_data() const;
     PairCluskeyCluster build(MapHitsetkeyUInt& cluster_cnt) const;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

While working on the TrkrCluster matching for the Embedded to Reco tracks, I found a bug in my code for the arguments of  TrkrCluster->Set{Phi,Z}Size when filling the clusters for the truth tracks. This code fixes that error.

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

