### PR TITLE
c arrays need extern declaration

### DIFF
--- a/simulation/g4simulation/g4decayer/pythia6_common_address.c
+++ b/simulation/g4simulation/g4decayer/pythia6_common_address.c
@@ -49,9 +49,9 @@
 # define type_of_call _stdcall
 #endif
 
-int pyjets[2+5*4000+2*2*5*4000];
-int pydat1[200+2*200+200+2*200];
-int pydat3[3*500+2*8000+2*8000+5*8000];  /* KNDCAY=8000 */
+extern int pyjets[2+5*4000+2*2*5*4000];
+extern int pydat1[200+2*200+200+2*200];
+extern int pydat3[3*500+2*8000+2*8000+5*8000];  /* KNDCAY=8000 */
 
 
 void *pythia6_common_address(const char* name)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR should fix the pythia6 decayer. THe mapping of c style arrays with fortran common blocks seems to have changed - it now needs an extern declaration. This seems to work also for gcc 8.3, we'll see what jenkins says
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

