### PR TITLE
added maximum g4hit lifetime limit to the cell reconstruction in Calorimeters

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -420,6 +420,8 @@ int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
         // checking ADC timing integration window cut
         if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
         if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
+	if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
+
 
         pair<double, double> etaphi[2];
         double phibin[2];
@@ -623,6 +625,7 @@ int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
         // checking ADC timing integration window cut
         if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
         if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
+	if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
 
         double xinout[2];
         double yinout[2];

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.cc
@@ -40,9 +40,6 @@ using namespace std;
 PHG4CylinderCellReco::PHG4CylinderCellReco(const string &name)
   : SubsysReco(name)
   , PHParameterContainerInterface(name)
-  , chkenergyconservation(0)
-  , sum_energy_before_cuts(0.)
-  , sum_energy_g4hit(0.)
 {
   SetDefaultParameters();
   memset(nbins, 0, sizeof(nbins));
@@ -75,9 +72,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
     exit(1);
   }
   PHNodeIterator runiter(runNode);
-  PHCompositeNode *RunDetNode =
-      dynamic_cast<PHCompositeNode *>(runiter.findFirst("PHCompositeNode",
-                                                        detector));
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runiter.findFirst("PHCompositeNode", detector));
   if (!RunDetNode)
   {
     RunDetNode = new PHCompositeNode(detector);
@@ -96,9 +91,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
   if (!cells)
   {
     PHNodeIterator dstiter(dstNode);
-    PHCompositeNode *DetNode =
-        dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode",
-                                                          detector));
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", detector));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode(detector);
@@ -149,6 +142,7 @@ int PHG4CylinderCellReco::InitRun(PHCompositeNode *topNode)
     implemented_detid.insert(layer);
     set_size(layer, get_double_param(layer, "size_long"), get_double_param(layer, "size_perp"));
     tmin_max.insert(std::make_pair(layer, std::make_pair(get_double_param(layer, "tmin"), get_double_param(layer, "tmax"))));
+    m_DeltaTMap.insert(std::make_pair(layer,get_double_param(layer, "delta_t")));
     double circumference = layergeom->get_radius() * 2 * M_PI;
     double length_in_z = layergeom->get_zmax() - layergeom->get_zmin();
     sizeiter = cell_size.find(layer);
@@ -420,7 +414,7 @@ int PHG4CylinderCellReco::process_event(PHCompositeNode *topNode)
         // checking ADC timing integration window cut
         if (hiter->second->get_t(0) > tmin_max[*layer].second) continue;
         if (hiter->second->get_t(1) < tmin_max[*layer].first) continue;
-	if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
+	if (hiter->second->get_t(1) - hiter->second->get_t(0) > m_DeltaTMap[*layer]) continue;
 
 
         pair<double, double> etaphi[2];
@@ -1001,5 +995,6 @@ void PHG4CylinderCellReco::SetDefaultParameters()
   set_default_double_param("size_perp", NAN);
   set_default_double_param("tmax", 60.0);
   set_default_double_param("tmin", -20.0);  // collision has a timing spread around the triggered event. Accepting negative time too.
+  set_default_double_param("delta_t", 100.);
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderCellReco.h
@@ -58,16 +58,17 @@ class PHG4CylinderCellReco : public SubsysReco, public PHParameterContainerInter
   std::string cellnodename;
   std::string geonodename;
   std::string seggeonodename;
-  std::map<int, std::pair<int, int> > n_phi_z_bins;
+  std::map<int, std::pair<int, int>> n_phi_z_bins;
   std::map<unsigned long long, PHG4Cell *> cellptmap;  // This map holds the hit cells
   std::map<unsigned long long, PHG4Cell *>::iterator it;
-  std::map<int, std::pair<double, double> > tmin_max;
+  std::map<int, std::pair<double, double>> tmin_max;
+  std::map<int, double> m_DeltaTMap;
 
   int nbins[2];
-  int chkenergyconservation;
+  int chkenergyconservation = 0;
 
-  double sum_energy_before_cuts;
-  double sum_energy_g4hit;
+  double sum_energy_before_cuts = 0.;
+  double sum_energy_g4hit = 0.;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -307,7 +307,7 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
   PutOnParNode(ParDetNode, cellgeonodename);
   tmin = get_double_param("tmin");
   tmax = get_double_param("tmax");
-
+  m_DeltaT = get_double_param("tdelta_t");
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -362,7 +362,7 @@ int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     // checking ADC timing integration window cut
     if (hiter->second->get_t(0) > tmax) continue;
     if (hiter->second->get_t(1) < tmin) continue;
-    if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
+    if (hiter->second->get_t(1) - hiter->second->get_t(0) > m_DeltaT) continue;
 
     sum_energy_g4hit += hiter->second->get_edep();
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -630,6 +630,7 @@ void PHG4FullProjSpacalCellReco::SetDefaultParameters()
 {
   set_default_double_param("tmax", 60.0);
   set_default_double_param("tmin", -20.0);  // collision has a timing spread around the triggered event. Accepting negative time too.
+  set_default_double_param("delta_t", 100.0);
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -52,7 +52,6 @@
 PHG4FullProjSpacalCellReco::PHG4FullProjSpacalCellReco(const std::string &name)
   : SubsysReco(name)
   , PHParameterInterface(name)
-  , light_collection_model()
 {
   InitializeParameters();
 }
@@ -307,7 +306,7 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
   PutOnParNode(ParDetNode, cellgeonodename);
   tmin = get_double_param("tmin");
   tmax = get_double_param("tmax");
-  m_DeltaT = get_double_param("tdelta_t");
+  m_DeltaT = get_double_param("delta_t");
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -362,6 +362,7 @@ int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     // checking ADC timing integration window cut
     if (hiter->second->get_t(0) > tmax) continue;
     if (hiter->second->get_t(1) < tmin) continue;
+    if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
 
     sum_energy_g4hit += hiter->second->get_edep();
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -102,7 +102,7 @@ class PHG4FullProjSpacalCellReco : public SubsysReco, public PHParameterInterfac
   //! timing window size in ns. This is for a simple simulation of the ADC integration window starting from 0ns to this value. Default to infinity, i.e. include all hits
   double tmin = NAN;
   double tmax = NAN;
-
+  double m_DeltaT = NAN;
   LightCollectionModel light_collection_model;
 };
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -106,6 +106,7 @@ int PHG4HcalCellReco::InitRun(PHCompositeNode *topNode)
   PutOnParNode(ParDetNode, geonodename);
   tmin = get_double_param("tmin");
   tmax = get_double_param("tmax");
+  m_DeltaT = get_double_param("delta_t");
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -152,7 +153,7 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
   {
     if (hiter->second->get_t(0) > tmax) continue;
     if (hiter->second->get_t(1) < tmin) continue;
-    if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
+    if (hiter->second->get_t(1) - hiter->second->get_t(0) >  m_DeltaT) continue;
 
     short icolumn = hiter->second->get_scint_id();
     int introw = (hiter->second->get_hit_id() >> PHG4HitDefs::hit_idbits);
@@ -217,11 +218,6 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHG4HcalCellReco::End(PHCompositeNode * /*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
 int PHG4HcalCellReco::CheckEnergy(PHCompositeNode *topNode)
 {
   PHG4HitContainer *g4hit = findNode::getClass<PHG4HitContainer>(topNode, hitnodename);
@@ -264,6 +260,7 @@ void PHG4HcalCellReco::SetDefaultParameters()
 {
   set_default_double_param("tmax", 60.0);
   set_default_double_param("tmin", -20.0);  // collision has a timing spread around the triggered event. Accepting negative time too.
+  set_default_double_param("delta_t", 100.);
   return;
 }
 

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.cc
@@ -152,6 +152,8 @@ int PHG4HcalCellReco::process_event(PHCompositeNode *topNode)
   {
     if (hiter->second->get_t(0) > tmax) continue;
     if (hiter->second->get_t(1) < tmin) continue;
+    if (hiter->second->get_t(1) - hiter->second->get_t(0) > 100) continue;
+
     short icolumn = hiter->second->get_scint_id();
     int introw = (hiter->second->get_hit_id() >> PHG4HitDefs::hit_idbits);
     if (introw >= ROWDIM || introw < 0)

--- a/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4HcalCellReco.h
@@ -25,9 +25,6 @@ class PHG4HcalCellReco : public SubsysReco, public PHParameterInterface
   //! event processing
   int process_event(PHCompositeNode *topNode) override;
 
-  //! end of process
-  int End(PHCompositeNode *topNode) override;
-
   void SetDefaultParameters() override;
 
   void Detector(const std::string &d) { detector = d; }
@@ -47,6 +44,7 @@ class PHG4HcalCellReco : public SubsysReco, public PHParameterInterface
 
   double tmin = NAN;
   double tmax = NAN;
+  double m_DeltaT = NAN;
   double m_FixedEnergy = NAN;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR introduces a maximal time limit to the g4hit energy depositions within the EMCal, as well as the HCal systems of 100 ns. Any g4hit that has a lifetime longer than 100 ns is not counted towards the determined tower energy. This was discussed in a software meeting on November 1st: https://indico.bnl.gov/event/17577/contributions/70185/attachments/44178/74532/Long%20time-steps%20in%20geant.pdf  

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

