### PR TITLE
Updated decay finder to not require the HepMC record

### DIFF
--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -304,7 +304,56 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
   if (!m_geneventmap)
   {
     std::cout << "DecayFinder: Missing node PHHepMCGenEventMap" << std::endl;
-    return 0;
+  }
+
+  if (m_truthinfo && !m_geneventmap) //This should use the truth info container if we have no HepMC record
+  {
+    if (Verbosity() >= VERBOSITY_SOME)
+    {
+    	std::cout << "You have a valid G4TruthInfo but no PHHepMCGenEventMap container" << std::endl;
+    	std::cout << "You are probably using a particle gun" << std::endl;
+    }
+  
+    PHG4TruthInfoContainer::ConstRange range = m_truthinfo->GetParticleRange();
+    for(PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
+    {
+      PHG4Particle* g4particle = iter->second;
+      int this_pid = m_getChargeConjugate ? abs(g4particle->get_pid()) : g4particle->get_pid();
+      if (this_pid == m_mother_ID)
+      {
+        if (Verbosity() >= VERBOSITY_MAX) std::cout << "parent->pdg_id(): " << g4particle->get_pid() << std::endl;
+  
+        bool breakOut = false;
+        correctMotherProducts.clear();
+        decayChain.clear();
+        decayChain.push_back(std::make_pair(g4particle->get_barcode(), g4particle->get_pid()));
+  
+        searchGeant4Record(g4particle->get_barcode(), g4particle->get_pid(), positive_motherDecayProducts, breakOut, aMotherHasPhoton, aMotherHasPi0, aTrackFailedPT, aTrackFailedETA, correctMotherProducts);
+  
+        if (breakOut) continue;    
+  
+        decayWasFound = compareDecays(m_motherDecayProducts, correctMotherProducts);     
+  
+        if (decayWasFound)
+        {
+          m_counter += 1;
+          if (aTrackFailedPT && !aTrackFailedETA) m_nCandFail_pT += 1;
+          else if (!aTrackFailedPT && aTrackFailedETA) m_nCandFail_eta += 1;
+          else if (aTrackFailedPT && aTrackFailedETA) m_nCandFail_pT_and_eta += 1;
+          else
+          {
+            m_nCandReconstructable += 1;
+            reconstructableDecayWasFound = true;
+            if (m_save_dst) fillDecayNode(topNode, decayChain);
+            if (aMotherHasPhoton && !aMotherHasPi0) m_nCandHas_Photon += 1;
+            else if (!aMotherHasPhoton && aMotherHasPi0) m_nCandHas_Pi0 += 1;
+            else if (aMotherHasPhoton && aMotherHasPi0) m_nCandHas_Photon_and_Pi0 += 1;
+            else m_nCandHas_noPhoton_and_noPi0 += 1;
+          }
+        }
+      }
+    }
+    return reconstructableDecayWasFound;
   }
 
 
@@ -760,7 +809,7 @@ int DecayFinder::deleteElement(int arr[], int n, int x)
   return n;
 }
 
-bool DecayFinder::findParticle(std::string particle)
+bool DecayFinder::findParticle(const std::string particle)
 {
   bool particleFound = true;
   if (!TDatabasePDG::Instance()->GetParticle(particle.c_str()))
@@ -782,7 +831,7 @@ void DecayFinder::multiplyVectorByScalarAndSort(std::vector<int>& v, int k)
   std::sort(v.begin(), v.end());
 }
 
-int DecayFinder::get_pdgcode(std::string name)
+int DecayFinder::get_pdgcode(const std::string name)
 {
   if (findParticle(name))
     return TDatabasePDG::Instance()->GetParticle(name.c_str())->PdgCode();
@@ -790,7 +839,7 @@ int DecayFinder::get_pdgcode(std::string name)
     return 0;
 }
 
-int DecayFinder::get_charge(std::string name)
+int DecayFinder::get_charge(const std::string name)
 {
   if (findParticle(name))
     return TDatabasePDG::Instance()->GetParticle(name.c_str())->Charge()/3;

--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -306,6 +306,13 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
     std::cout << "DecayFinder: Missing node PHHepMCGenEventMap" << std::endl;
   }
 
+  if (!m_truthinfo && !m_geneventmap)
+  {
+    std::cout << "You have neither the PHHepMCGenEventMap or G4TruthInfo nodes" << std::endl;
+    std::cout << "DecayFinder will crash, exiting now!" << std::endl;
+    exit(1);
+  }
+
   if (m_truthinfo && !m_geneventmap) //This should use the truth info container if we have no HepMC record
   {
     if (Verbosity() >= VERBOSITY_SOME)

--- a/offline/packages/decayfinder/DecayFinder.h
+++ b/offline/packages/decayfinder/DecayFinder.h
@@ -39,7 +39,7 @@ class DecayFinder : public SubsysReco
 
   bool findDecay(PHCompositeNode *topNode);
 
-  bool findParticle(std::string particle);
+  bool findParticle(const std::string particle);
 
   void searchHepMCRecord(HepMC::GenParticle* particle, std::vector<int> decayProducts, 
                          bool &breakLoop, bool &hasPhoton, bool &hasPi0, bool &failedPT, bool &failedETA, 
@@ -59,9 +59,9 @@ class DecayFinder : public SubsysReco
 
   void multiplyVectorByScalarAndSort(std::vector<int> &v, int k);
 
-  int get_pdgcode(std::string name);
+  int get_pdgcode(const std::string name);
 
-  int get_charge(std::string name);
+  int get_charge(const std::string name);
 
   bool isInRange(float min, float value, float max);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Zhaozhong requested an update to DecayFinder so it doesn't require the HepMC record to run. He's using particle guns which only write to the truth info container. This should allow him to run DecayFinder and use the truth info QA code

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Zhaozhong should check if this works with his particle gun

## Links to other PRs in macros and calibration repositories (if applicable)

