### PR TITLE
Add vertex to cluster eta

### DIFF
--- a/offline/packages/trackreco/PHTrackClusterAssociator.h
+++ b/offline/packages/trackreco/PHTrackClusterAssociator.h
@@ -12,6 +12,8 @@
 
 class PHCompositeNode;
 class SvtxTrackMap;
+class SvtxVertexMap;
+class SvtxVertex;
 class RawCluster;
 class RawClusterContainer;
 class RawTowerContainer;
@@ -40,8 +42,9 @@ class PHTrackClusterAssociator : public SubsysReco
   int createNodes(PHCompositeNode* topNode);
   int getCaloNodes(PHCompositeNode* topNode, const int caloLayer);
   int matchTracks(PHCompositeNode* topNode, const int caloLayer);
-  RawCluster* getCluster(double phi, double eta);
+  RawCluster* getCluster(double phi, double eta, SvtxVertex* vertex);
   SvtxTrackMap* m_trackMap = nullptr;
+  SvtxVertexMap* m_vertexMap = nullptr;
 
   /// Objects to hold calorimeter information. There are
   /// only 3 calo layers


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes a bug in the track-cluster associator to use the track associated vertex position to determine the cluster eta when matching.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

