### PR TITLE
removed check on has_mm

### DIFF
--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -478,17 +478,18 @@ void TrackEvaluation::evaluate_clusters()
 //_____________________________________________________________________
 void TrackEvaluation::evaluate_tracks()
 {
-  if( !( m_track_map && m_cluster_map && m_container ) ) return;
 
+  if( !( m_track_map && m_cluster_map && m_container ) ) 
+  { return; }
+      
   // clear array
   m_container->clearTracks();
 
-  for( const auto& trackpair:*m_track_map )
+  for( const auto& [track_id,track]:*m_track_map )
   {
-
-    const auto track = trackpair.second;
+    
     auto track_struct = create_track( track );
-    bool has_mm = false;
+    
     // truth information
     const auto [id,contributors] = get_max_contributor( track );
     track_struct.contributors = contributors;
@@ -521,7 +522,6 @@ void TrackEvaluation::evaluate_tracks()
       const bool is_micromegas( TrkrDefs::getTrkrId(cluster_key) == TrkrDefs::micromegasId );
       if( is_micromegas )
       {
-	has_mm = true;
         const int tileid = MicromegasDefs::getTileId(cluster_key);
         add_truth_information_micromegas( cluster_struct, tileid, g4hits );
       } else {
@@ -554,8 +554,7 @@ void TrackEvaluation::evaluate_tracks()
       // add to track
       track_struct.clusters.push_back( cluster_struct );
     }
-    if(has_mm)
-      m_container->addTrack( track_struct );
+    m_container->addTrack( track_struct );
   }
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This fills track evaluation structure in the output disregarding whether the track has Micromegas clusters or not. 
One can always select tracks with micromegas offline using a cut like "m_tracks.nclusters_micromegas > 0"

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

