### PR TITLE
fix error in clearing and adding builders

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -512,7 +512,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       auto pass_data = padplane->MapToPadPlane(
         single_hitsetcontainer.get(), temp_hitsetcontainer.get(), hittruthassoc, 
         x_final, y_final, t_final, side, hiter, ntpad, nthit);
-      if (is_embedded && pass_data.has_data()) layer_clusterers[pass_data.layer-1] += pass_data;
+      if (is_embedded && pass_data.has_data) layer_clusterers[pass_data.layer-1] += pass_data;
     }  // end loop over electrons for this g4hit
 
     TrkrHitSetContainer::ConstRange single_hitset_range = single_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::tpcId);
@@ -772,7 +772,7 @@ void PHG4TpcElectronDrift::registerPadPlane(PHG4TpcPadPlane *inpadplane)
 void PHG4TpcElectronDrift::buildTruthClusters(std::map<TrkrDefs::hitsetkey,unsigned int>& hitset_cnt)
 {
   for (auto& cluster_builder : layer_clusterers) {
-    if (cluster_builder.has_data()) {
+    if (cluster_builder.has_data) {
       std::pair<TrkrDefs::cluskey,TrkrCluster*> keyval = cluster_builder.build(hitset_cnt);
       current_track->addCluster(keyval.first);
       truthclustercontainer->addClusterSpecifyKey(keyval.first, keyval.second);

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -194,7 +194,7 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
 
     if (rad_gem > rad_low && rad_gem < rad_high)
     {
-      // capture the layer where this electron hits sthe gem stack
+      // capture the layer where this electron hits the gem stack
       LayerGeom = layeriter->second;
       layernum = LayerGeom->get_layer();
       pass_data.layerGeom = LayerGeom;

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -21,6 +21,7 @@ class TpcClusterBuilder
   using PairCluskeyCluster = std::pair<TrkrDefs::cluskey,TrkrCluster*>;
   public:
     PHG4TpcCylinderGeom *layerGeom { nullptr }; // unique to the layer
+    bool   has_data       { false };
     short  layer          {  SHRT_MAX };
     unsigned int side     { 0       };
     int    neff_electrons { 0       };
@@ -60,7 +61,7 @@ class TpcClusterBuilder
     void fillPhiBins  (const std::vector<int>& bins);
     void fillTimeBins (const std::vector<int>& bins);
     void reset();
-    bool has_data() const;
+    void set_has_data();
     PairCluskeyCluster build(MapHitsetkeyUInt& cluster_cnt) const;
 
     ~TpcClusterBuilder(){};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

Fix bug in the implementation for TpcClusterBuilder objects. These objects aggregate the hits in the TPC GEM layers into TrkrCluster's from GEANT4 hits from embedded truth tracks. The bug had to do properly clearing and adding together different sets of cluster hits.

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

