### PR TITLE
Make detector specific misalignment factors possible

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -297,9 +297,9 @@ int AlignmentTransformation::getNodes(PHCompositeNode* topNode)
   return 0; 
 }
 
-void AlignmentTransformation::misalignmentFactor(const double factor)
+void AlignmentTransformation::misalignmentFactor(TrkrDefs::TrkrId id, const double factor)
 {
-  transformMap->setMisalignmentFactor(factor);
+  transformMap->setMisalignmentFactor(id, factor);
 }
 void AlignmentTransformation::createAlignmentTransformContainer(PHCompositeNode* topNode)
 {

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -103,7 +103,7 @@ void setTPCParams(double tpcDevs[6])
       }
   }
 
-  void misalignmentFactor(const double factor);
+ void misalignmentFactor(TrkrDefs::TrkrId id, const double factor);
 
  private:
 

--- a/offline/packages/trackbase/Calibrator.h
+++ b/offline/packages/trackbase/Calibrator.h
@@ -7,6 +7,7 @@
 #include <Acts/EventData/SourceLink.hpp>
 #include <ActsExamples/EventData/IndexSourceLink.hpp>
 
+#include "TrkrDefs.h"
 #include "alignmentTransformationContainer.h"
 
 class Calibrator
@@ -53,9 +54,11 @@ class Calibrator
           loc(1) = uncalibmeas.parameters()[Acts::eBoundLoc1];
 
           auto cov = uncalibmeas.covariance();
+          const auto& cluskey = sourceLink.cluskey();
+          const auto trkrid = TrkrDefs::getTrkrId(cluskey);
+          const double misalignmentFactor = gctx.get<alignmentTransformationContainer*>()->getMisalignmentFactor(trkrid);
 
           Acts::ActsSymMatrix<2> expandedCov = Acts::ActsSymMatrix<2>::Zero();
-          const double misalignmentFactor = gctx.get<alignmentTransformationContainer*>()->getMisalignmentFactor();
 
           for (int i = 0; i < cov.rows(); i++)
           {

--- a/offline/packages/trackbase/alignmentTransformationContainer.cc
+++ b/offline/packages/trackbase/alignmentTransformationContainer.cc
@@ -15,6 +15,24 @@
  
 bool alignmentTransformationContainer::use_alignment = false;
 
+alignmentTransformationContainer::alignmentTransformationContainer()
+{
+  for ( const auto id : { TrkrDefs::mvtxId, TrkrDefs::inttId, TrkrDefs::tpcId, TrkrDefs::micromegasId })
+    {
+      m_misalignmentFactor.insert(std::make_pair(id, 1.));
+    }
+}
+void alignmentTransformationContainer::setMisalignmentFactor(uint8_t id, double factor)
+{
+  auto it = m_misalignmentFactor.find(id);
+  if(it != m_misalignmentFactor.end())
+    {
+      it->second = factor;
+      return;
+    }
+  std::cout << "You provided a nonexistent TrkrDefs::TrkrId in alignmentTransformationContainer::setMisalignmentFactor..."
+	    << std::endl;
+}
 void alignmentTransformationContainer::Reset()
 { 
   if(transformVec.size() == 0) return;

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -32,7 +32,7 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   
   public:
 
-  alignmentTransformationContainer() = default;
+  alignmentTransformationContainer();
 
   virtual ~alignmentTransformationContainer(){}
 
@@ -41,8 +41,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   void addTransform(Acts::GeometryIdentifier, Acts::Transform3); 
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
   const std::vector<std::vector<Acts::Transform3>>& getMap() const;
-  void setMisalignmentFactor(const double m) { m_misalignmentFactor = m; }
-  const double& getMisalignmentFactor() const { return m_misalignmentFactor; }
+  void setMisalignmentFactor(uint8_t id, double factor);
+  const double& getMisalignmentFactor(uint8_t id) const { return m_misalignmentFactor.find(id)->second; }
   static bool use_alignment;
 
   private:
@@ -53,7 +53,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
 
   std::vector< std::vector<Acts::Transform3>> transformVec;
 
-  double m_misalignmentFactor = 1;
+  /// Map of TrkrDefs::TrkrId to misalignment factor
+  std::map<uint8_t, double> m_misalignmentFactor;
 
   ClassDef(alignmentTransformationContainer,1);
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -112,7 +112,12 @@ namespace
 
 MakeActsGeometry::MakeActsGeometry(const std::string &name)
 : SubsysReco(name)
-{}
+{
+  for ( const auto id : { TrkrDefs::mvtxId, TrkrDefs::inttId, TrkrDefs::tpcId, TrkrDefs::micromegasId })
+    {
+      m_misalignmentFactor.insert(std::make_pair(id, 1.));
+    }
+}
 
 int MakeActsGeometry::Init(PHCompositeNode */*topNode*/)
 {  
@@ -169,7 +174,10 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->set_drift_velocity(m_drift_velocity);
 
   alignment_transformation.createMap(topNode);
-  alignment_transformation.misalignmentFactor(m_misalignmentFactor);
+  for(auto& [id, factor] : m_misalignmentFactor)
+    {
+      alignment_transformation.misalignmentFactor(id, factor);
+    }
 
  // print
   if( Verbosity() )

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -128,9 +128,16 @@ class MakeActsGeometry : public SubsysReco
   }
 
 
-  void misalignmentFactor(const double misalignment)
+  void misalignmentFactor(TrkrDefs::TrkrId id, const double misalignment)
   {
-    m_misalignmentFactor = misalignment;
+    auto it = m_misalignmentFactor.find(id);
+    if(it != m_misalignmentFactor.end())
+      {
+	it->second = misalignment;
+	return;
+      }
+
+    std::cout << "Passed an unknown trkr id, misalignment factor will not be set for " << id << std::endl;
   }
 
   double getSurfStepPhi() {return m_surfStepPhi;}
@@ -215,7 +222,7 @@ class MakeActsGeometry : public SubsysReco
   TGeoManager* m_geoManager = nullptr;
 
   bool m_useField = true;
-  double m_misalignmentFactor = 1.;
+  std::map<TrkrDefs::TrkrId, double> m_misalignmentFactor;
 
   /// Acts Context decorators, which may contain e.g. calibration information
   std::vector<std::shared_ptr<ActsExamples::IContextDecorator> > 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR allows subsystem specific misalignment factors to be set, e.g. for the MVTX a 150 micron misalignment is a lot but for the TPC this is not a lot. Will improve misaligned Acts::KF fitting performance in commissioning.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

