### PR TITLE
fixing hcal tower phi mapping

### DIFF
--- a/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
+++ b/simulation/g4simulation/g4calo/HcalRawTowerBuilder.cc
@@ -156,7 +156,7 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   m_RawTowerGeom->set_phibins(get_int_param(PHG4HcalDefs::n_towers));
   m_RawTowerGeom->set_etabins(get_int_param("etabins"));
   double geom_ref_radius = innerrad + thickness / 2.;
-  double phistart = get_double_param("phistart");
+  double phistart = get_double_param("phistart") - M_PI;
   if (!std::isfinite(phistart))
   {
     std::cout << PHWHERE << " phistart is not finite: " << phistart
@@ -165,7 +165,7 @@ int HcalRawTowerBuilder::InitRun(PHCompositeNode *topNode)
   }
   for (int i = 0; i < get_int_param(PHG4HcalDefs::n_towers); i++)
   {
-    double phiend = phistart - 2. * M_PI / get_int_param(PHG4HcalDefs::n_towers);
+    double phiend = phistart + 2. * M_PI / get_int_param(PHG4HcalDefs::n_towers);
     std::pair<double, double> range = std::make_pair(phiend, phistart);
     phistart = phiend;
     m_RawTowerGeom->set_phibounds(i, range);

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -276,6 +276,7 @@ std::tuple<int, int, int> PHG4IHCalDetector::ExtractLayerTowerId(const unsigned 
   //shift row number down by one so every sector start with a row number that mod4=0
   row--;
   while(row<0) row+=256;
+  while(row>255) row-=256;
   return std::make_tuple(isector, row, column);
 }
 
@@ -416,5 +417,9 @@ int PHG4IHCalDetector::map_layerid(const int layer_id)
   {
     rowid = 255 - layer_id + 61;
   }
+
+  //fix for rotating the detector
+  rowid = 259 - rowid;
+
   return rowid;
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -480,6 +480,13 @@ int PHG4OHCalDetector::map_layerid(const unsigned int isector, const int layer_i
       }
     }
   }
+
+  //fix for rotating the detector
+  rowid = 321 - rowid;
+  while(rowid > 319)
+    {
+      rowid -= 320;
+    }
   if (rowid < 0 || rowid > 319)
   {
     std::cout << "bad rowid for sector " << isector << ", layer_id " << layer_id << std::endl;


### PR DESCRIPTION
fixing HCal scintillator mapping after rotating detector

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This fixes the HCal tower mapping in phi after the rotation of the detector.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
Will need this change to the macros to reset the phi start of HCal towers to zero: https://github.com/sPHENIX-Collaboration/macros/pull/572
