### PR TITLE
Use analytic derivatives by default in MakeMilleFiles

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -70,9 +70,9 @@ class AlignmentState
   /// The number of global (alignment) parameters
   static const int NGL = 6;
   /// The number of local (track state) parameters
-  static const int NLC = 8;
+  static const int NLC = 6;
   /// The number of residuals per state (e.g. 2D or 3D)
-  static const int NRES = 2;
+  static const int NRES = 3;
 
   using GlobalMatrix = Acts::ActsMatrix<NRES, NGL>;
   using LocalMatrix = Acts::ActsMatrix<NRES, NLC>;
@@ -170,7 +170,9 @@ class MakeMilleFiles : public SubsysReco
   /// tpc distortion correction utility class
   TpcDistortionCorrection _distortionCorrection;
   bool _binary = true;
-  unsigned int _cluster_version = 3;
+  unsigned int _cluster_version = 4;
+
+  bool m_useAnalytic = true;
 
   ClusterErrorPara _ClusErrPara;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This returns the functionality to use the analytic global derivatives instead of the Acts determined ones, which assume a different rotation definition than we are using. It adds a flag to be able to continue to use the Acts definitions should they change their rotation definitions, but uses the analytic determined values by default. All values are in global coordinates and use mm since the local derivatives are still obtained from Acts.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

