### PR TITLE
Removed line in KFParticle_Container.cc that resets track ID

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -17,7 +17,7 @@ libcalo_io_la_LIBADD = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
   RawClusterUtility.h \

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Container.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Container.cc
@@ -88,7 +88,7 @@ KFParticle* KFParticle_Container::insert(const KFParticle* particle)
   unsigned int index = 0;
   if (!m_kfpmap.empty()) index = m_kfpmap.rbegin()->first + 1;
   m_kfpmap.insert(std::make_pair(index, dynamic_cast<KFParticle*>(particle->Clone())));
-  //:ewm_kfpmap[index]->SetId(index);
+  //m_kfpmap[index]->SetId(index);
   return m_kfpmap[index];
 }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Container.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Container.cc
@@ -88,7 +88,7 @@ KFParticle* KFParticle_Container::insert(const KFParticle* particle)
   unsigned int index = 0;
   if (!m_kfpmap.empty()) index = m_kfpmap.rbegin()->first + 1;
   m_kfpmap.insert(std::make_pair(index, dynamic_cast<KFParticle*>(particle->Clone())));
-  m_kfpmap[index]->SetId(index);
+  //:ewm_kfpmap[index]->SetId(index);
   return m_kfpmap[index];
 }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -404,7 +404,7 @@ int KFParticle_sPHENIX::parseDecayDescriptor()
   }
 }
 
-bool KFParticle_sPHENIX::findParticle(std::string particle)
+bool KFParticle_sPHENIX::findParticle(const std::string &particle)
 {
   bool particleFound = true;
   if (!particleList.count(particle))

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -76,7 +76,7 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   int parseDecayDescriptor();
 
-  bool findParticle(std::string particle);
+  bool findParticle(const std::string &particle);
 
   ///Parameters for the user to vary
 

--- a/offline/packages/KFParticle_sPHENIX/Makefile.am
+++ b/offline/packages/KFParticle_sPHENIX/Makefile.am
@@ -12,7 +12,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
+  -isystem$(ROOTSYS)/include \
   -DHomogeneousField
 
 

--- a/offline/packages/NodeDump/Makefile.am
+++ b/offline/packages/NodeDump/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = libphnodedump.la
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
   Dumper.h \

--- a/offline/packages/PHGeometry/Makefile.am
+++ b/offline/packages/PHGeometry/Makefile.am
@@ -3,7 +3,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \
    libphgeom_io.la \

--- a/offline/packages/TrackerMillepedeAlignment/Makefile.am
+++ b/offline/packages/TrackerMillepedeAlignment/Makefile.am
@@ -6,8 +6,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include \
-  -I$(ROOTSYS)/include \
-  -I$(OFFLINE_MAIN)/include/eigen3
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/compressor/Makefile.am
+++ b/offline/packages/compressor/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = libcompressor.la
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include 
+  -isystem$(ROOTSYS)/include 
 
 libcompressor_la_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/micromegas/Makefile.am
+++ b/offline/packages/micromegas/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include
+  -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include \
+  -isystem$(ROOTSYS)/include \
   -I$(OPT_SPHENIX)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/vararray/Makefile.am
+++ b/offline/packages/vararray/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = libvararray.la
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
-  -I$(ROOTSYS)/include 
+  -isystem$(ROOTSYS)/include 
 
 AM_LDFLAGS = \
   -L$(libdir) \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

It was observed that the KFParticle ID gets reset when written to the KFParticle container on the DST. I removed this line so we can reassociate the reco track to the KFParticle particle.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

