### PR TITLE
Update the TrkrCluster's for the truth track to use local geometry.

### DIFF
--- a/offline/packages/trackbase/EmbRecoMatchContainer.h
+++ b/offline/packages/trackbase/EmbRecoMatchContainer.h
@@ -1,0 +1,54 @@
+#ifndef TRACKBASE_EMBRECOMATCHCONTAINER_H
+#define TRACKBASE_EMBRECOMATCHCONTAINER_H
+
+/* #include "TrkrDefs.h" */
+
+#include <phool/PHObject.h>
+#include <vector>
+#include <climits>
+
+class EmbRecoMatch;
+
+class EmbRecoMatchContainer : public PHObject
+{
+  public:
+  using Vector        = std::vector<EmbRecoMatch*>;
+  using ConstIterator = Vector::const_iterator;
+  using ConstRange    = std::pair<ConstIterator, ConstIterator>;
+  /* using Iterator      = Vector::iterator; */
+  /* using Range         = std::pair<Iterator, Iterator>; */
+
+  //! reset method
+  void Reset() override {}
+
+  //! add a match set
+  virtual unsigned short nMatches()   const { return USHRT_MAX; };
+  virtual unsigned short nTruthUnmatched() const { return USHRT_MAX; };
+
+  virtual std::vector<unsigned short>& ids_TruthUnmatched(); // id's of the TrkrTruthTrack's that are not matched
+  virtual std::vector<unsigned short>  ids_TruthMatched() const { return {}; }; // id's of the TrkrTruthTrack's that are matched
+  virtual std::vector<unsigned short>  ids_RecoMatched()  const { return {}; }; // id's of the TrkrTruthTrack's that are matched
+
+  virtual ConstRange getMatchedRange() const;
+  virtual Vector&    getMatches()           ;
+
+  virtual void addMatch(EmbRecoMatch*) {};
+  virtual bool hasTruthMatch (unsigned short /*Truth Track Id*/) { return false; };
+  virtual bool hasRecoMatch  (unsigned short /*Reco  Track Id*/) { return false; };
+  virtual EmbRecoMatch* getMatchTruth (unsigned short /*idEmb*/)  { return nullptr; };
+  virtual EmbRecoMatch* getMatchReco  (unsigned short /*idReco*/) { return nullptr; };
+
+  virtual void sort() {}; // only to be used when filling the contianer. Sorts the internal vectors for the sake of using them.
+
+  // PHObject virtual overload
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "EmbREcoMatchContainer base class" << std::endl;
+  };
+
+ protected:
+  EmbRecoMatchContainer() = default;
+  ClassDefOverride(EmbRecoMatchContainer, 1)
+};
+
+#endif // TRACKBASE_EMBRECOMATCHCONTAINER_H

--- a/offline/packages/trackbase/EmbRecoMatchContainerv1.cc
+++ b/offline/packages/trackbase/EmbRecoMatchContainerv1.cc
@@ -1,0 +1,105 @@
+#include "EmbRecoMatchContainerv1.h"
+#include "EmbRecoMatch.h"
+#include "EmbRecoMatchv1.h"
+
+#include <algorithm>
+#include <iomanip>
+
+// WARNING to user:
+// methods depend on the internal data being sorted appropriately
+// -> BE SURE TO CALL *SORT*
+
+void EmbRecoMatchContainerv1::sort() {
+  std::sort(m_data.begin(), m_data.end(), EmbRecoMatch::Comp());
+  std::sort(m_RecoToTruth.begin(), m_RecoToTruth.end());
+  std::sort(m_idsTruthUnmatched.begin(), m_idsTruthUnmatched.end());
+}
+
+void EmbRecoMatchContainerv1::addMatch(EmbRecoMatch* match) {
+  m_data.push_back(match);
+  for (int i=0; i<=match->nMatches(); ++i) {
+    m_RecoToTruth.push_back({match->idRecoTrack(i), match->idTruthTrack()});
+  }
+}
+
+void EmbRecoMatchContainerv1::Reset() {
+  for (auto &m : m_data) delete m;
+  m_data.clear();
+  m_RecoToTruth.clear();
+  m_idsTruthUnmatched.clear();
+}
+
+std::vector<unsigned short>  EmbRecoMatchContainerv1::ids_TruthMatched() const {
+  std::vector<unsigned short> vec;
+  for (auto& id : m_data) vec.push_back(id->idTruthTrack());
+  return vec;
+}
+
+std::vector<unsigned short>  EmbRecoMatchContainerv1::ids_RecoMatched() const {
+  std::vector<unsigned short> vec;
+  for (auto& id : m_RecoToTruth) vec.push_back(id.first);
+  return vec;
+}
+
+EmbRecoMatch* EmbRecoMatchContainerv1::getMatchTruth(unsigned short idtruth) {
+  auto iter = std::lower_bound(m_data.begin(), m_data.end(), idtruth, EmbRecoMatch::Comp());
+  if (iter == m_data.end() || (*iter)->idTruthTrack() != idtruth) {
+    std::cout << "Asking for EmbTrackMatch for Embedded Track id " << idtruth 
+              << " which is not present. Returning empty match." << std::endl;
+    EmbRecoMatch* match = new EmbRecoMatchv1();
+    return match;
+  }
+  return *iter;
+}
+
+EmbRecoMatch* EmbRecoMatchContainerv1::getMatchReco(unsigned short idreco) {
+  auto iter = std::lower_bound(m_RecoToTruth.begin(), m_RecoToTruth.end(), idreco, CompShortToPair());
+  if (iter==m_RecoToTruth.end() || iter->first != idreco) {
+    std::cout << "Asking for EmbTrackMatch for reco track id ("<<idreco<<") for which there is not match." << std::endl
+              << "Returning empty match." << std::endl;
+    EmbRecoMatch* match = new EmbRecoMatchv1();
+    return match;
+  }
+  return getMatchTruth(iter->second);
+}
+
+bool EmbRecoMatchContainerv1::hasTruthMatch(unsigned short idtruth) {
+  return std::binary_search(m_data.begin(), m_data.end(), idtruth, EmbRecoMatch::Comp());
+}
+
+bool EmbRecoMatchContainerv1::hasRecoMatch(unsigned short idreco) {
+  return std::binary_search(m_RecoToTruth.begin(), m_RecoToTruth.end(), idreco, CompShortToPair());
+}
+
+void EmbRecoMatchContainerv1::identify(std::ostream& os) const {
+  os << " EmbRecoMatchContainerv1 data. N(matched emb. tracks) = " 
+     << nMatches() << ",  N(not matched) " << nTruthUnmatched() << std::endl;
+  os << " Matched track data: " << std::endl;
+  //    id-Emb  id-Reco  id-Seed  id-SvtxSeed  nClus-Emb nClus-Reco meanZClus meanPhiClus
+  os << std::setw(6) << "id-Emb " 
+     << std::setw(7) << "id-Reco " 
+     << std::setw(7) << "id-Seed "
+     << std::setw(11) << "id-SvtxSeed "
+     << std::setw(9)  << "nClus-Emb "
+     << std::setw(10) << "nClus-Reco "
+     << std::setw(12) << "nClus_Matched " << std::endl;
+  for (auto& _m : m_data) {
+    auto m = static_cast<EmbRecoMatchv1*> (_m);
+  os << std::setw(6)  << m->idTruthTrack()      << " " //id-Emb" 
+     << std::setw(7)  << m->idRecoTrack()       << " " //"id-Reco"
+     << std::setw(7)  << m->idTpcTrackSeed()    << " " //"id-Seed"
+     << std::setw(11) << m->idSvtxTrackSeed()   << " " //id-SvtxSeed"
+     << std::setw(9)  << m->nClustersTruth()    << " " //nClus-Emb"
+     << std::setw(10) << m->nClustersReco()     << " " //"nClus-Reco"
+     << std::setw(12) << m->nClustersMatched()  << std::endl; // //"nClus-Reco"
+     /* << std::setw(9)  << m->meanClusterZDiff() << " " //"meanZclus" */
+     /* << std::setw(11) << m->meanClusterPhiDiff() << std::endl; //"meanPhiclus" << std::endl; */
+
+  /* os << Form(" %7i %7i %8s %11s %11s %10s %10s %10s", */
+    /* m->idTruthTrack(), m->idRecoTrack(), m->idTrackSeed(), m->idSvtxTrackSeed(), */
+    /* m->nClustersTruth(), m->nClustersReco(), m->meanClusterZDiff(), m->meanClusterPhiDiff()) << std::endl; */
+  }
+  os << " IDs of embedded tracks that were not reconstructed: " << std::endl;
+  for (const auto n : m_idsTruthUnmatched) os << n << " ";
+  os << std::endl;
+}

--- a/offline/packages/trackbase/EmbRecoMatchContainerv1.h
+++ b/offline/packages/trackbase/EmbRecoMatchContainerv1.h
@@ -1,0 +1,49 @@
+#ifndef TRACKBASE_EMBRECOMATCHCONTAINERV1_H
+#define TRACKBASE_EMBRECOMATCHCONTAINERV1_H
+
+#include "EmbRecoMatchContainer.h"
+#include <vector>
+
+class EmbRecoMatch;
+
+class EmbRecoMatchContainerv1 : public EmbRecoMatchContainer 
+{
+  public:
+  void Reset() override;
+
+  //! add a match set
+  unsigned short nMatches()   const override { return m_data.size();          };
+  unsigned short nTruthUnmatched() const override { return m_idsTruthUnmatched.size(); };
+  std::vector<unsigned short>& ids_TruthUnmatched() override { return m_idsTruthUnmatched; };
+  std::vector<unsigned short>  ids_TruthMatched() const override;
+  std::vector<unsigned short>  ids_RecoMatched()  const override;
+  ConstRange getMatchedRange() const override { return  std::make_pair(m_data.begin(), m_data.end()); };
+  Vector&    getMatches()            override { return m_data; };
+
+  void addMatch(EmbRecoMatch* match)       override;
+  bool hasTruthMatch(unsigned short idEmb) override;
+  bool hasRecoMatch(unsigned short idReco) override;
+  EmbRecoMatch* getMatchTruth(unsigned short idEmb) override;
+  EmbRecoMatch* getMatchReco (unsigned short idEmb) override;
+
+  // PHObject virtual overload
+  void identify(std::ostream& os = std::cout) const override;
+
+  struct CompShortToPair {
+    bool operator() (const unsigned short lhs, const std::pair<unsigned short, unsigned short> rhs) const
+    {return lhs < rhs.first;}
+    bool operator() (const std::pair<unsigned short, unsigned short> lhs, const unsigned short rhs) const
+    {return lhs.first < rhs;}
+  };
+
+  void sort() override;
+
+  private:
+  Vector m_data; // using Vector = std::vector<EmbRecoMatch*>;
+  std::vector<std::pair<unsigned short, unsigned short>> m_RecoToTruth;
+  std::vector<unsigned short> m_idsTruthUnmatched;
+  ClassDefOverride(EmbRecoMatchContainerv1, 1)
+};
+
+#endif // TRACKBASE_EMBRECOMATCHCONTAINERV1_H
+

--- a/offline/packages/trackbase/TrkrTruthTrack.h
+++ b/offline/packages/trackbase/TrkrTruthTrack.h
@@ -28,6 +28,10 @@ class TrkrTruthTrack : public PHObject
 
   virtual std::vector<TrkrDefs::cluskey>& getClusters();
   virtual void addCluster(TrkrDefs::cluskey){};
+
+  virtual bool has_hitsetkey(TrkrDefs::hitsetkey) const { return false; };
+  virtual bool has_hitsetkey(TrkrDefs::cluskey)   const { return false; };
+  virtual std::pair<bool, TrkrDefs::cluskey> get_cluskey(TrkrDefs::hitsetkey) const { return {false, 0}; }; // bool is if there is the key, and 
   // std::map<unsigned int /*track id*/, std::vector<TrkrDefs::cluskey>
 
   virtual void setTrackid(unsigned int){};

--- a/offline/packages/trackbase/TrkrTruthTrackv1.cc
+++ b/offline/packages/trackbase/TrkrTruthTrackv1.cc
@@ -75,3 +75,18 @@ void TrkrTruthTrackv1::addCluster(TrkrDefs::cluskey key)
 {
   clusters.push_back(key);
 }
+
+
+bool TrkrTruthTrackv1::has_hitsetkey(TrkrDefs::hitsetkey key) const {
+  return std::binary_search(clusters.begin(), clusters.end(), key, CompHitSetKey() );
+}
+
+bool TrkrTruthTrackv1::has_hitsetkey(TrkrDefs::cluskey key) const {
+  return std::binary_search(clusters.begin(), clusters.end(), key, CompHitSetKey() );
+}
+
+std::pair<bool, TrkrDefs::cluskey> TrkrTruthTrackv1::get_cluskey(TrkrDefs::hitsetkey hitsetkey) const { 
+  auto lb = std::lower_bound(clusters.begin(), clusters.end(), hitsetkey, CompHitSetKey());
+  if (lb == clusters.end() || TrkrDefs::getHitSetKeyFromClusKey(*lb) != hitsetkey) return { false, 0. };
+  else                      return { true,  *lb };
+}

--- a/offline/packages/trackbase/TrkrTruthTrackv1.h
+++ b/offline/packages/trackbase/TrkrTruthTrackv1.h
@@ -33,6 +33,10 @@ class TrkrTruthTrackv1 : public TrkrTruthTrack
   std::vector<TrkrDefs::cluskey>& getClusters() override { return clusters; };
   void addCluster(TrkrDefs::cluskey) override;
 
+  bool has_hitsetkey(TrkrDefs::hitsetkey) const override; // note, only works when the data is sorted
+  bool has_hitsetkey(TrkrDefs::cluskey)   const override;
+  std::pair<bool, TrkrDefs::cluskey> get_cluskey(TrkrDefs::hitsetkey) const override; // bool is if there is the key, and 
+
   void setTrackid(unsigned int _) override { trackid = _; };
 
   void setX0(float _) override { X0 = _; };
@@ -44,6 +48,18 @@ class TrkrTruthTrackv1 : public TrkrTruthTrack
   void setPhi(float _) override { phi = _; };
 
   void identify(std::ostream& os = std::cout) const override;
+
+  struct CompHitSetKey {
+    bool operator()(const TrkrDefs::cluskey& lhs, const TrkrDefs::cluskey& rhs) {
+      return TrkrDefs::getHitSetKeyFromClusKey(lhs) < TrkrDefs::getHitSetKeyFromClusKey(rhs);
+    };
+    bool operator()(const TrkrDefs::cluskey& lhs, const TrkrDefs::hitsetkey& rhs) {
+      return TrkrDefs::getHitSetKeyFromClusKey(lhs) < rhs; 
+    };
+    bool operator()(const TrkrDefs::hitsetkey& lhs, const TrkrDefs::cluskey& rhs) {
+      return lhs < TrkrDefs::getHitSetKeyFromClusKey(rhs);
+    };
+  };
 
  protected:
   unsigned int trackid;

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -321,6 +321,14 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   }
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
+  TpcClusterBuilder::tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
+  if (!TpcClusterBuilder::tGeometry) {
+    std::cout << "ActsGeometry not found on node tree. Exiting"
+      << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   //std::cout << "g4hits size " << g4hit->size() << std::endl;
   unsigned int count_g4hits = 0;
@@ -774,8 +782,10 @@ void PHG4TpcElectronDrift::buildTruthClusters(std::map<TrkrDefs::hitsetkey,unsig
   for (auto& cluster_builder : layer_clusterers) {
     if (cluster_builder.has_data) {
       std::pair<TrkrDefs::cluskey,TrkrCluster*> keyval = cluster_builder.build(hitset_cnt);
-      current_track->addCluster(keyval.first);
-      truthclustercontainer->addClusterSpecifyKey(keyval.first, keyval.second);
+      if (keyval.second != nullptr) {
+        current_track->addCluster(keyval.first);
+        truthclustercontainer->addClusterSpecifyKey(keyval.first, keyval.second);
+      }
       cluster_builder.reset();
     }
   }

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -829,10 +829,7 @@ void PHG4TpcElectronDrift::buildTruthClusters()
 
     // add the cluster key to truth track
     current_track->addCluster(cluskey);
-
-    if (Verbosity() > 10) {
-      std::cout << " FIXME adding truth cluster to layer " << key_builder.second.layer << " now " << std::endl;
-    }
   }
+  std::sort(current_track->getClusters().begin(), current_track->getClusters().end());
   truth_cluster_builders.clear();
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -127,8 +127,9 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   double min_time = NAN;
   double max_time = NAN;
 
-  std::array<TpcClusterBuilder,55> layer_clusterers; // Generate TrkrClusterv4's for TrkrTruthTracks
-  void buildTruthClusters(std::map<TrkrDefs::hitsetkey,unsigned int>&);
+  std::map<TrkrDefs::hitsetkey,TpcClusterBuilder> truth_cluster_builders;
+  std::map<TrkrDefs::hitsetkey,unsigned int> truth_cluster_cnt; // needed for indexing the TrkrClusters into the TrkrClusterContainer
+  void buildTruthClusters();
 
   //! rng de-allocator
   class Deleter

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -404,6 +404,7 @@ TpcClusterBuilder PHG4TpcPadPlaneReadout::MapToPadPlane(
     }
 
   m_NHits++;
+  pass_data.set_has_data();
   return pass_data;
 }
 

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -1,6 +1,7 @@
 #ifndef G4TPC_TPCCLUSTERBUILDER_H
 #define G4TPC_TPCCLUSTERBUILDER_H
 
+#include <trackbase/ActsGeometry.h>
 #include <phool/PHObject.h>
 #include <trackbase/TrkrDefs.h>
 #include <map>
@@ -17,9 +18,13 @@ class PHG4TpcCylinderGeom;
 
 class TpcClusterBuilder 
 {
+
   using MapHitsetkeyUInt   = std::map<TrkrDefs::hitsetkey, unsigned int>;
   using PairCluskeyCluster = std::pair<TrkrDefs::cluskey,TrkrCluster*>;
   public:
+    static constexpr double AdcClockPeriod = 53.0; // ns (copied from TpcClusterizer.h)
+    static ActsGeometry* tGeometry;
+
     PHG4TpcCylinderGeom *layerGeom { nullptr }; // unique to the layer
     bool   has_data       { false };
     short  layer          {  SHRT_MAX };
@@ -35,11 +40,12 @@ class TpcClusterBuilder
     bool   hasPhiBins     { false   };
     bool   hasTimeBins    { false   };
 
-    TpcClusterBuilder( short _layer,  unsigned int _side, 
+    TpcClusterBuilder( short _layer,  bool _has_data, unsigned int _side, 
         int _neff_electrons, double _phi_integral, 
         double _time_integral, int _phi_bin_lo,  int _phi_bin_hi, 
         int _time_bin_lo, int _time_bin_hi) 
       : layerGeom      { nullptr         }
+      , has_data       { _has_data       }
       , layer          { _layer          }
       , side           { _side           }
       , neff_electrons { _neff_electrons }

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -9,68 +9,44 @@
 
 class TrkrCluster;
 class PHG4TpcCylinderGeom;
-  // This is really just a structure used in simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
-  // to collect necessary statistics from simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
-  // 
-  // It could have been just std::pair< std::array<int,6>, std::pair<double,double>>, but 
-  // having the structure to name those subtypes.
-
+  // This structure collects data from PHG$TpcPadPlaneReadout for cluster data in a given layer for a given truth particle.
 
 class TpcClusterBuilder 
 {
 
-  using MapHitsetkeyUInt   = std::map<TrkrDefs::hitsetkey, unsigned int>;
   using PairCluskeyCluster = std::pair<TrkrDefs::cluskey,TrkrCluster*>;
+
   public:
-    static constexpr double AdcClockPeriod = 53.0; // ns (copied from TpcClusterizer.h)
-    static ActsGeometry* tGeometry;
+  static constexpr double AdcClockPeriod = 53.0; // ns (copied from TpcClusterizer.h)
+  static ActsGeometry* tGeometry;
 
-    PHG4TpcCylinderGeom *layerGeom { nullptr }; // unique to the layer
-    bool   has_data       { false };
-    short  layer          {  SHRT_MAX };
-    unsigned int side     { 0       };
-    int    neff_electrons { 0       };
-    double phi_integral   { 0.      };
-    double time_integral  { 0.      };
-    int    phi_bin_lo     { INT_MAX };
-    int    phi_bin_hi     { INT_MIN };
-    int    time_bin_lo    { INT_MAX };
-    int    time_bin_hi    { INT_MIN };
-    int    nphibins       { 0       };
-    bool   hasPhiBins     { false   };
-    bool   hasTimeBins    { false   };
+  TrkrDefs::hitsetkey   hitsetkey { UCHAR_MAX };
+  PHG4TpcCylinderGeom *layerGeom { nullptr }; // unique to the layer
+  bool   has_data       { false };
+  short  layer          {  SHRT_MIN };
+  unsigned int side     { UINT_MAX };
+  int    neff_electrons { 0  };
+  double phi_integral   { 0. };
+  double time_integral  { 0. };
+  int    phi_bin_lo     { INT_MAX };
+  int    phi_bin_hi     { INT_MIN };
+  int    time_bin_lo    { INT_MAX };
+  int    time_bin_hi    { INT_MIN };
+  int    nphibins       { INT_MIN };
+  bool   hasPhiBins     { false   };
+  bool   hasTimeBins    { false   };
 
-    TpcClusterBuilder( short _layer,  bool _has_data, unsigned int _side, 
-        int _neff_electrons, double _phi_integral, 
-        double _time_integral, int _phi_bin_lo,  int _phi_bin_hi, 
-        int _time_bin_lo, int _time_bin_hi) 
-      : layerGeom      { nullptr         }
-      , has_data       { _has_data       }
-      , layer          { _layer          }
-      , side           { _side           }
-      , neff_electrons { _neff_electrons }
-      , phi_integral   { _phi_integral   }
-      , time_integral  { _time_integral  }
-      , phi_bin_lo     { _phi_bin_lo     }
-      , phi_bin_hi     { _phi_bin_hi     }
-      , time_bin_lo    { _time_bin_lo    }
-      , time_bin_hi    { _time_bin_hi    }
-    {};
-    TpcClusterBuilder() {};
-      /* layerGeom {nullptr}, layer {0}, side {0}, neff_electrons {0}, */ 
-      /* phi_integral {0.}, time_integral {0.}, */
-      /* phi_bin_lo {0}, phi_bin_hi {0}, time_bin_lo {0}, time_bin_hi {0}, nphibins{0} */
-    /* {}; */
+  TpcClusterBuilder& operator+=(const TpcClusterBuilder& rhs);
 
-    TpcClusterBuilder& operator+=(const TpcClusterBuilder& rhs);
-    /* void fillBinsLowHigh (int& bin_lo, int&bin_hi, std::vector<int> bins); */
-    void fillPhiBins  (const std::vector<int>& bins);
-    void fillTimeBins (const std::vector<int>& bins);
-    void reset();
-    void set_has_data();
-    PairCluskeyCluster build(MapHitsetkeyUInt& cluster_cnt) const;
+  void fillPhiBins  (const std::vector<int>& bins);
+  void fillTimeBins (const std::vector<int>& bins);
+  void set_has_data();
 
-    ~TpcClusterBuilder(){};
+  TrkrCluster* build() const;
+
+  TpcClusterBuilder() {};
+  ~TpcClusterBuilder(){};
+
 };
 
 #endif  //TRACKBASE_PADPLANEREADOUTSTRUCT_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The Embedded ("Truth") tracks are associated with TrkrClusters that were set using global phi and time geometries. This PR modifies them to use the local geometries (in the TPC Pad Plane for each hit), such that they can be compared with the reconstructed track TrkrClusters.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

