### PR TITLE
Don't default to ideal geometry

### DIFF
--- a/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
+++ b/offline/packages/trackbase/sPHENIXActsDetectorElement.cc
@@ -2,6 +2,7 @@
 #include "alignmentTransformationContainer.h"
 #include "sPHENIXActsDetectorElement.h"
 
+#include <phool/phool.h>
 
 sPHENIXActsDetectorElement::~sPHENIXActsDetectorElement() = default;
 
@@ -32,10 +33,10 @@ const Acts::Transform3& sPHENIXActsDetectorElement::transform(const Acts::Geomet
 	}
       
       // if we are still here, it was not found
-      std::cout << " Alignment transform not found, for identifier " << id << " use construction transform " << std::endl;
-      const Acts::Transform3& transform = TGeoDetectorElement::transform(ctxt);  // ctxt is unused here
-      //std::cout << "           construction transform: " << std::endl << transform.matrix() << std::endl;      
-      return transform;
+      std::cout << PHWHERE << " Alignment transform not found, for identifier " << id << " continuing on with ideal geometry is not ideal so we exit" << std::endl;
+   
+      exit(1);
+   
     }
  else
     {


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

If the alignment file in the cdb is not found, currently the code just defaults to the ideal geometry. This is not good for 
1. What happened today, where the CDB went down
2. In any case, if we have real alignment parameters and we can't find them for some reason, defaulting to ideal geometry will lead to some more difficult to debug behavior. 
Now we just exit if this isn't found.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

