### PR TITLE
Acts::KF Alignment Overhaul

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -10,9 +10,9 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/SvtxAlignmentState.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase_historic/SvtxAlignmentState.h>
 
 #include <trackbase/TpcDefs.h>  // for side
 
@@ -102,14 +102,14 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
   if (Verbosity() > 0)
     std::cout << PHWHERE << " track map size " << _track_map->size() << std::endl;
 
-  for(auto [key, statevec] : *_state_map)
+  for (auto [key, statevec] : *_state_map)
   {
     SvtxTrack* track = _track_map->find(key)->second;
     /// Track was removed from cleaner
-    if(!track)
-      {
-	continue;
-      }
+    if (!track)
+    {
+      continue;
+    }
 
     if (Verbosity() > 0)
     {
@@ -120,13 +120,11 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
 
     // Make any desired track cuts here
     // Maybe set a lower pT limit - low pT tracks are not very sensitive to alignment
-   
-   
+
     addTrackToMilleFile(statevec);
 
     /// Finish this track
     _mille->end();
- 
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -141,7 +139,6 @@ int MakeMilleFiles::End(PHCompositeNode* /*topNode*/)
 
 int MakeMilleFiles::GetNodes(PHCompositeNode* topNode)
 {
-
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
   {
@@ -164,11 +161,11 @@ int MakeMilleFiles::GetNodes(PHCompositeNode* topNode)
   }
 
   _state_map = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
-  if(!_state_map)
-    {
-      std::cout << PHWHERE << "Error, can't find alignment state map" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  if (!_state_map)
+  {
+    std::cout << PHWHERE << "Error, can't find alignment state map" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -191,12 +188,12 @@ Acts::Vector3 MakeMilleFiles::getPCALinePoint(Acts::Vector3 global, SvtxTrackSta
 int MakeMilleFiles::getTpcRegion(int layer)
 {
   int region = 0;
-  if(layer > 23 && layer < 39)
+  if (layer > 23 && layer < 39)
     region = 1;
-  if(layer > 38 && layer < 55)
+  if (layer > 38 && layer < 55)
     region = 2;
 
-  return region;  
+  return region;
 }
 
 int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
@@ -210,78 +207,78 @@ int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
 
   // decide what level of grouping we want
   if (layer < 7)
+  {
+    if (si_group == siliconGroup::sensor)
     {
-      if(si_group == siliconGroup::sensor)
-	{
-	  // every sensor has a different label
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000 + stave*10000 + sensor*10;
-	  return label_base;
-	}
-      if(si_group == siliconGroup::stave)
-	{
-	  // layer and stave, assign all sensors to the stave number
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000 + stave*10000;
-	  return label_base;
-	}
-      if(si_group == siliconGroup::barrel)
-	{
-	  // layer only, assign all sensors to sensor 0 
-	  label_base += layer*1000000 + 0;
-      
-	  return label_base;
-	}
+      // every sensor has a different label
+      int stave = sensor / nsensors_stave[layer];
+      label_base += layer * 1000000 + stave * 10000 + sensor * 10;
+      return label_base;
     }
+    if (si_group == siliconGroup::stave)
+    {
+      // layer and stave, assign all sensors to the stave number
+      int stave = sensor / nsensors_stave[layer];
+      label_base += layer * 1000000 + stave * 10000;
+      return label_base;
+    }
+    if (si_group == siliconGroup::barrel)
+    {
+      // layer only, assign all sensors to sensor 0
+      label_base += layer * 1000000 + 0;
+
+      return label_base;
+    }
+  }
   else if (layer > 6 && layer < 55)
+  {
+    if (tpc_group == tpcGroup::hitset)
     {
-      if(tpc_group == tpcGroup::hitset)
-	{
-	  // want every hitset (layer, sector, side) to have a separate label
-	  // each group of 12 subsurfaces (sensors) is in a single hitset
-	  int hitset = sensor/12; // hitsets 0-11 on side 0, 12-23 on side 1
-	  label_base += layer*1000000 + hitset*10000;
-	  return label_base;
-	}
-      if(tpc_group == tpcGroup::sector)
-	{
-	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
-	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
-	  int sector = (sensor - side *144) / 12; 
-	  // for a given layer there are only 12 sectors x 2 sides
-	  // The following gives the sectors in the inner, mid, outer regions unique group labels
-	  int region = getTpcRegion(layer);  // inner, mid, outer
-	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
-	  //std::cout << " layer " << layer << " sensor " << sensor << " region " << region << " side " << side << " sector " << sector << " label_base " << label_base << std::endl;
-	  return label_base;
-	}
-      if(tpc_group == tpcGroup::tpc)
-	{
-	  // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
-	  label_base += 7*1000000 + 0;
-	  return label_base;
-	}
+      // want every hitset (layer, sector, side) to have a separate label
+      // each group of 12 subsurfaces (sensors) is in a single hitset
+      int hitset = sensor / 12;  // hitsets 0-11 on side 0, 12-23 on side 1
+      label_base += layer * 1000000 + hitset * 10000;
+      return label_base;
     }
+    if (tpc_group == tpcGroup::sector)
+    {
+      // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
+      int side = sensor / 144;  // 0-143 on side 0, 144-287 on side 1
+      int sector = (sensor - side * 144) / 12;
+      // for a given layer there are only 12 sectors x 2 sides
+      // The following gives the sectors in the inner, mid, outer regions unique group labels
+      int region = getTpcRegion(layer);  // inner, mid, outer
+      label_base += 7 * 1000000 + (region * 24 + side * 12 + sector) * 10000;
+      // std::cout << " layer " << layer << " sensor " << sensor << " region " << region << " side " << side << " sector " << sector << " label_base " << label_base << std::endl;
+      return label_base;
+    }
+    if (tpc_group == tpcGroup::tpc)
+    {
+      // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
+      label_base += 7 * 1000000 + 0;
+      return label_base;
+    }
+  }
   else
+  {
+    if (mms_group == mmsGroup::tile)
     {
-      if(mms_group == mmsGroup::tile)
-	{
-	  // every tile has different label
-	  int tile = sensor;
-	  label_base += layer*1000000 + tile*10000 + sensor*10;
-	  return label_base;
-	}
-      if(mms_group == mmsGroup::mms)
-	{
-	  // assign layer 55 and tile 0 to all
-	  label_base += 55*1000000 + 0;	  
-	  return label_base;
-	}
+      // every tile has different label
+      int tile = sensor;
+      label_base += layer * 1000000 + tile * 10000 + sensor * 10;
+      return label_base;
     }
+    if (mms_group == mmsGroup::mms)
+    {
+      // assign layer 55 and tile 0 to all
+      label_base += 55 * 1000000 + 0;
+      return label_base;
+    }
+  }
 
   return -1;
 }
-  
+
 void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec)
 {
   for (auto state : statevec)
@@ -289,9 +286,9 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
     TrkrDefs::cluskey ckey = state->get_cluster_key();
 
     if (Verbosity() > 2)
-      {
-	std::cout << "adding state for ckey " << ckey << std::endl;
-      }
+    {
+      std::cout << "adding state for ckey " << ckey << std::endl;
+    }
     // The global alignment parameters are given initial values of zero by default, we do not specify them
     // We identify the global alignment parameters for this surface
 
@@ -304,32 +301,31 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
     // need standard deviation of measurements
     SvtxAlignmentState::ResidualVector clus_sigma = SvtxAlignmentState::ResidualVector::Zero();
     if (_cluster_version == 3)
-      {
-        clus_sigma(2) = cluster->getZError() * Acts::UnitConstants::cm;
-        clus_sigma(0) = cluster->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-        clus_sigma(1) = cluster->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-      }
-      else if (_cluster_version == 4)
-      {
-        double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
-        auto para_errors = _ClusErrPara.get_simple_cluster_error(cluster, clusRadius, ckey);
-        float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-        float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-        clus_sigma(2) = sqrt(ez2);
-        clus_sigma(0) = sqrt(exy2 / 2.0);
-        clus_sigma(1) = sqrt(exy2 / 2.0);
-      }
+    {
+      clus_sigma(2) = cluster->getZError() * Acts::UnitConstants::cm;
+      clus_sigma(0) = cluster->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+      clus_sigma(1) = cluster->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+    }
+    else if (_cluster_version == 4)
+    {
+      double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
+      auto para_errors = _ClusErrPara.get_simple_cluster_error(cluster, clusRadius, ckey);
+      float exy2 = para_errors.first * Acts::UnitConstants::cm2;
+      float ez2 = para_errors.second * Acts::UnitConstants::cm2;
+      clus_sigma(2) = sqrt(ez2);
+      clus_sigma(0) = sqrt(exy2 / 2.0);
+      clus_sigma(1) = sqrt(exy2 / 2.0);
+    }
 
-      if (std::isnan(clus_sigma(0)) ||
-          std::isnan(clus_sigma(1)) ||
-          std::isnan(clus_sigma(2)))
-      {
-        continue;
-      }
-    
+    if (std::isnan(clus_sigma(0)) ||
+        std::isnan(clus_sigma(1)) ||
+        std::isnan(clus_sigma(2)))
+    {
+      continue;
+    }
 
-  Acts::GeometryIdentifier id = _tGeometry->maps().getSurface(ckey, cluster)->geometryId();
-  int label_base = getLabelBase(id);  // This value depends on how the surfaces are grouped
+    Acts::GeometryIdentifier id = _tGeometry->maps().getSurface(ckey, cluster)->geometryId();
+    int label_base = getLabelBase(id);  // This value depends on how the surfaces are grouped
 
     int glbl_label[SvtxAlignmentState::NGL];
     for (int i = 0; i < SvtxAlignmentState::NGL; ++i)
@@ -346,7 +342,7 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       std::cout << std::endl;
     }
 
-    /// For N residual coordinates x,y,z 
+    /// For N residual coordinates x,y,z
     for (int i = 0; i < SvtxAlignmentState::NRES; ++i)
     {
       // Add the measurement separately for each coordinate direction to Mille
@@ -355,8 +351,10 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       {
         glbl_derivative[j] = state->get_global_derivative_matrix()(i, j);
 
-	if(is_layer_fixed(layer) || is_layer_param_fixed(layer,j))
-	  {glbl_derivative[j] = 0.0;}
+        if (is_layer_fixed(layer) || is_layer_param_fixed(layer, j))
+        {
+          glbl_derivative[j] = 0.0;
+        }
       }
 
       float lcl_derivative[SvtxAlignmentState::NLOC];
@@ -368,7 +366,7 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       {
         std::cout << "coordinate " << i << " has residual " << residual(i) << " and clus_sigma " << clus_sigma(i) << std::endl
                   << "global deriv " << std::endl;
-        
+
         for (int k = 0; k < SvtxAlignmentState::NGL; k++)
         {
           std::cout << glbl_derivative[k] << ", ";
@@ -388,38 +386,38 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       }
     }
   }
- 
+
   return;
 }
 
- bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
- {
+bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
+{
   bool ret = false;
   auto it = fixed_layers.find(layer);
-  if(it != fixed_layers.end()) 
+  if (it != fixed_layers.end())
     ret = true;
 
   return ret;
- }
+}
 
- void MakeMilleFiles::set_layer_fixed(unsigned int layer)
- {
-   fixed_layers.insert(layer);
- }
- 
+void MakeMilleFiles::set_layer_fixed(unsigned int layer)
+{
+  fixed_layers.insert(layer);
+}
+
 bool MakeMilleFiles::is_layer_param_fixed(unsigned int layer, unsigned int param)
- {
+{
   bool ret = false;
   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
   auto it = fixed_layer_params.find(pair);
-  if(it != fixed_layer_params.end()) 
+  if (it != fixed_layer_params.end())
     ret = true;
 
   return ret;
- }
+}
 
 void MakeMilleFiles::set_layer_param_fixed(unsigned int layer, unsigned int param)
- {
-   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
-   fixed_layer_params.insert(pair);
- }
+{
+  std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
+  fixed_layer_params.insert(pair);
+}

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -8,17 +8,16 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
+
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxAlignmentState.h>
 
 #include <trackbase/TpcDefs.h>  // for side
 
 #include <g4detectors/PHG4TpcCylinderGeom.h>
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
-
-#include <Acts/EventData/MultiTrajectory.hpp>
-#include <Acts/EventData/MultiTrajectoryHelpers.hpp>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -51,7 +50,6 @@ namespace
 MakeMilleFiles::MakeMilleFiles(const std::string& name)
   : SubsysReco(name)
   , _mille(nullptr)
-  , _trajectories(nullptr)
 {
 }
 
@@ -104,9 +102,14 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
   if (Verbosity() > 0)
     std::cout << PHWHERE << " track map size " << _track_map->size() << std::endl;
 
-  for(auto [key, track] : *_track_map)
+  for(auto [key, statevec] : *_state_map)
   {
-    auto crossing = track->get_silicon_seed()->get_crossing();
+    SvtxTrack* track = _track_map->find(key)->second;
+    /// Track was removed from cleaner
+    if(!track)
+      {
+	continue;
+      }
 
     if (Verbosity() > 0)
     {
@@ -117,13 +120,9 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
 
     // Make any desired track cuts here
     // Maybe set a lower pT limit - low pT tracks are not very sensitive to alignment
-
-    /// Get the corresponding acts trajectory to look up the state info
-    const auto traj = _trajectories->find(key)->second;
-
-    AlignmentStateMap alignStates = getAlignmentStates(traj, track, crossing);
-
-    addTrackToMilleFile(alignStates, traj);
+   
+   
+    addTrackToMilleFile(statevec);
 
     /// Finish this track
     _mille->end();
@@ -142,12 +141,6 @@ int MakeMilleFiles::End(PHCompositeNode* /*topNode*/)
 
 int MakeMilleFiles::GetNodes(PHCompositeNode* topNode)
 {
-  _trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsTrajectories");
-  if (!_trajectories)
-  {
-    std::cout << PHWHERE << "ERROR: Can't find Acts trajectories" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
 
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
@@ -170,22 +163,12 @@ int MakeMilleFiles::GetNodes(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  // tpc distortion corrections
-  _dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerStatic");
-  if (_dcc_static)
-  {
-    std::cout << PHWHERE << "  found static TPC distortion correction container" << std::endl;
-  }
-  _dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerAverage");
-  if (_dcc_average)
-  {
-    std::cout << PHWHERE << "  found average TPC distortion correction container" << std::endl;
-  }
-  _dcc_fluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerFluctuation");
-  if (_dcc_fluctuation)
-  {
-    std::cout << PHWHERE << "  found fluctuation TPC distortion correction container" << std::endl;
-  }
+  _state_map = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+  if(!_state_map)
+    {
+      std::cout << PHWHERE << "Error, can't find alignment state map" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -203,189 +186,6 @@ Acts::Vector3 MakeMilleFiles::getPCALinePoint(Acts::Vector3 global, SvtxTrackSta
   Acts::Vector3 pca = track_base + ((global - track_base).dot(track_dir)) * track_dir;
 
   return pca;
-}
-
-std::vector<Acts::Vector3> MakeMilleFiles::getDerivativesAlignmentAngles(Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing)
-{
-  // The value of global is from the geocontext transformation
-  // we add to that transformation a small rotation around the relevant axis in the surface frame
-
-  std::vector<Acts::Vector3> derivs_vector;
-
-  // get the transformation from the geocontext
-  Acts::Transform3 transform = surface->transform(_tGeometry->geometry().getGeoContext());
-
-  // Make an additional transform that applies a small rotation angle in the surface frame
-  for (unsigned int iangle = 0; iangle < 3; ++iangle)
-  {
-    // creates transform that adds a perturbation rotation around one axis, uses it to estimate derivative wrt perturbation rotation
-
-    unsigned int trkrId = TrkrDefs::getTrkrId(cluster_key);
-    unsigned int layer = TrkrDefs::getLayer(cluster_key);
-
-    Acts::Vector3 derivs(0, 0, 0);
-    Eigen::Vector3d theseAngles(0, 0, 0);
-    theseAngles[iangle] = sensorAngles[iangle];  // set the one we want to be non-zero
-
-    Acts::Vector3 keeper(0, 0, 0);
-    for (int ip = 0; ip < 2; ++ip)
-    {
-      if (ip == 1)
-      {
-        theseAngles[iangle] *= -1;
-      }  // test both sides of zero
-
-      if (Verbosity() > 1)
-      {
-        std::cout << "     trkrId " << trkrId << " layer " << layer << " cluster_key " << cluster_key
-                  << " sensorAngles " << theseAngles[0] << "  " << theseAngles[1] << "  " << theseAngles[2] << std::endl;
-      }
-
-      Acts::Transform3 perturbationTransformation = makePerturbationTransformation(theseAngles);
-      Acts::Transform3 overallTransformation = transform * perturbationTransformation;
-
-      // transform the cluster local position to global coords with this additional rotation added
-      auto x = cluster->getLocalX() * 10;  // mm
-      auto y = cluster->getLocalY() * 10;
-      if (trkrId == TrkrDefs::tpcId)
-      {
-        y = convertTimeToZ(cluster_key, cluster);
-      }
-
-      Eigen::Vector3d clusterLocalPosition(x, y, 0);                                      // follows the convention for the acts transform of local = (x,z,y)
-      Eigen::Vector3d finalCoords = overallTransformation * clusterLocalPosition / 10.0;  // convert mm back to cm
-
-      // have to add corrections for TPC clusters after transformation to global
-      if (trkrId == TrkrDefs::tpcId)
-      {
-        makeTpcGlobalCorrections(cluster_key, crossing, global);
-      }
-
-      if (ip == 0)
-      {
-        keeper(0) = (finalCoords(0) - global(0));
-        keeper(1) = (finalCoords(1) - global(1));
-        keeper(2) = (finalCoords(2) - global(2));
-      }
-      else
-      {
-        keeper(0) -= (finalCoords(0) - global(0));
-        keeper(1) -= (finalCoords(1) - global(1));
-        keeper(2) -= (finalCoords(2) - global(2));
-      }
-
-      if (Verbosity() > 1)
-      {
-        std::cout << "        finalCoords(0) " << finalCoords(0) << " global(0) " << global(0) << " finalCoords(1) " << finalCoords(1)
-                  << " global(1) " << global(1) << " finalCoords(2) " << finalCoords(2) << " global(2) " << global(2) << std::endl;
-        std::cout << "        keeper now:  keeper(0) " << keeper(0) << " keeper(1) " << keeper(1) << " keeper(2) " << keeper(2) << std::endl;
-      }
-    }
-
-    // derivs vector contains:
-    //   (dx/dalpha,     dy/dalpha,     dz/dalpha)     (for iangle = 0)
-    //   (dx/dbeta,        dy/dbeta,        dz/dbeta)        (for iangle = 1)
-    //   (dx/dgamma, dy/dgamma, dz/dgamma) (for iangle = 2)
-
-    // Average the changes to get the estimate of the derivative
-    // Check what the sign of this should be !!!!
-    derivs(0) = keeper(0) / (2.0 * fabs(theseAngles[iangle]));
-    derivs(1) = keeper(1) / (2.0 * fabs(theseAngles[iangle]));
-    derivs(2) = keeper(2) / (2.0 * fabs(theseAngles[iangle]));
-    derivs_vector.push_back(derivs);
-
-    if (Verbosity() > 1)
-    {
-      std::cout << "        derivs(0) " << derivs(0) << " derivs(1) " << derivs(1) << " derivs(2) " << derivs(2) << std::endl;
-    }
-  }
-
-  return derivs_vector;
-}
-
-Acts::Transform3 MakeMilleFiles::makePerturbationTransformation(Acts::Vector3 angles)
-{
-  // Note: Here beta is apllied to the z axis and gamma is applied to the y axis because the geocontext transform
-  // will flip those axes when transforming to global coordinates
-  Eigen::AngleAxisd alpha(angles(0), Eigen::Vector3d::UnitX());
-  Eigen::AngleAxisd beta(angles(2), Eigen::Vector3d::UnitY());
-  Eigen::AngleAxisd gamma(angles(1), Eigen::Vector3d::UnitZ());
-  Eigen::Quaternion<double> q = gamma * beta * alpha;
-  Eigen::Matrix3d perturbationRotation = q.matrix();
-
-  // combine rotation and translation into an affine matrix
-  Eigen::Vector3d nullTranslation(0, 0, 0);
-  Acts::Transform3 perturbationTransformation;
-  perturbationTransformation.linear() = perturbationRotation;
-  perturbationTransformation.translation() = nullTranslation;
-
-  return perturbationTransformation;
-}
-
-float MakeMilleFiles::convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster)
-{
-  // must convert local Y from cluster average time of arival to local cluster z position
-  double drift_velocity = _tGeometry->get_drift_velocity();
-  double zdriftlength = cluster->getLocalY() * drift_velocity;
-  double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
-  double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
-  unsigned int side = TpcDefs::getSide(cluster_key);
-  if (side == 0) zloc = -zloc;
-  float z = zloc * 10.0;
-
-  return z;
-}
-
-void MakeMilleFiles::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global)
-{
-  // make all corrections to global position of TPC cluster
-  unsigned int side = TpcDefs::getSide(cluster_key);
-  float z = m_clusterCrossingCorrection.correctZ(global[2], side, crossing);
-  global[2] = z;
-
-  // apply distortion corrections
-  if (_dcc_static)
-  {
-    global = _distortionCorrection.get_corrected_position(global, _dcc_static);
-  }
-  if (_dcc_average)
-  {
-    global = _distortionCorrection.get_corrected_position(global, _dcc_average);
-  }
-  if (_dcc_fluctuation)
-  {
-    global = _distortionCorrection.get_corrected_position(global, _dcc_fluctuation);
-  }
-}
-
-SvtxTrack::StateIter MakeMilleFiles::getStateIter(Acts::Vector3& global, SvtxTrack* track)
-{
-  float clus_radius = sqrt(global[0] * global[0] + global[1] * global[1]);
-  auto state_iter = track->begin_states();
-  float dr_min = -1;
-  //for( auto iter = state_iter; iter != track->end_states(); ++iter )
-  for (auto iter = track->begin_states(); iter != track->end_states(); ++iter)
-  {
-    const auto dr = std::abs(clus_radius - sqrt(iter->second->get_x() * iter->second->get_x() + iter->second->get_y() * iter->second->get_y()));
-    if (dr_min < 0 || dr < dr_min)
-    {
-      state_iter = iter;
-      dr_min = dr;
-    }
-    else
-    {
-      break;
-    }
-  }
-
-  if (Verbosity() > 2)
-  {
-    std::cout << "track state for pathlength " << clus_radius << " dr_min " << dr_min << " position "
-              << state_iter->second->get_x() << "  "
-              << state_iter->second->get_y() << "  "
-              << state_iter->second->get_z() << std::endl;
-  }
-  return state_iter;
 }
 
 int MakeMilleFiles::getTpcRegion(int layer)
@@ -482,245 +282,28 @@ int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
   return -1;
 }
   
-AlignmentStateMap MakeMilleFiles::getAlignmentStates(const Trajectory& traj,
-                                                     SvtxTrack* track,
-                                                     short int crossing)
+void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec)
 {
-  const auto mj = traj.multiTrajectory();
-  const auto& tips = traj.tips();
-  const auto& trackTip = tips.front();
-  std::map<TrkrDefs::cluskey, AlignmentState> alignStates;
-
-  /// Collect the track states
-  mj.visitBackwards(trackTip, [&](const auto& state) {
-    /// Collect only track states which were used in smoothing of KF and are measurements
-    if (not state.hasSmoothed() or
-        not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag))
-    {
-      return true;
-    }
-
-    const auto& surface = state.referenceSurface();
-    const auto& sl = static_cast<const ActsExamples::IndexSourceLink&>(state.uncalibrated());
-    auto ckey = sl.cluskey();
-
-    if (Verbosity() > 2)
-    {
-      std::cout << "sl index and ckey " << sl.index() << ", "
-                << sl.cluskey() << std::endl;
-    }
-
-    auto clus = _cluster_map->findCluster(ckey);
-    const auto trkrId = TrkrDefs::getTrkrId(ckey);
-
-    if (!clus)
-    {
-      /// For some reason, the SL index and cluster key of the first state in the Acts trajectory
-      /// lose scope outside of the track fit result when the fitter is first called. They are
-      /// reset to either 0 or the largest possible value. So we have
-      /// to look up the first cluster manually
-      if (sl.index() == 0 or sl.index() > 57)
-      {
-        auto siseed = track->get_silicon_seed();
-        ckey = *(siseed->begin_cluster_keys());
-        clus = _cluster_map->findCluster(ckey);
-      }
-
-      /// if we still couldn't find it, skip it
-      if (!clus)
-      {
-        if (Verbosity() > 2)
-        {
-          std::cout << "no cluster with key " << ckey << " and index " << sl.index() << std::endl;
-        }
-
-        return true;
-      }
-    }
-
-    /// Gets the global parameters from the state
-    const Acts::FreeVector freeParams =
-        Acts::MultiTrajectoryHelpers::freeSmoothed(_tGeometry->geometry().getGeoContext(), state);
-
-    const Acts::ActsDynamicMatrix measCovariance =
-        state.effectiveCalibratedCovariance();
-
-    /// Calculate the residual in global coordinates
-    Acts::Vector3 clusGlobal = _tGeometry->getGlobalPosition(ckey, clus);
-    if (trkrId == TrkrDefs::tpcId)
-    {
-      makeTpcGlobalCorrections(ckey, crossing, clusGlobal);
-    }
-
-    /// convert to acts units
-    clusGlobal *= Acts::UnitConstants::cm;
-
-    const Acts::FreeVector globalStateParams = Acts::detail::transformBoundToFreeParameters(surface, _tGeometry->geometry().getGeoContext(), state.smoothed());
-    Acts::Vector3 stateGlobal = globalStateParams.segment<3>(Acts::eFreePos0);
-    Acts::Vector3 residual = clusGlobal - stateGlobal;
-
-    if (Verbosity() > 2)
-    {
-      Acts::Vector3 clus_sigma(0, 0, 0);
-      if (_cluster_version == 3)
-      {
-        clus_sigma(2) = clus->getZError() * Acts::UnitConstants::cm;
-        clus_sigma(0) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-        clus_sigma(1) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-      }
-      else if (_cluster_version == 4)
-      {
-        double clusRadius = sqrt(clusGlobal(0) * clusGlobal(0) + clusGlobal(1) * clusGlobal(1));
-        auto para_errors = _ClusErrPara.get_simple_cluster_error(clus, clusRadius, ckey);
-        float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-        float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-        clus_sigma(2) = sqrt(ez2);
-        clus_sigma(0) = sqrt(exy2 / 2.0);
-        clus_sigma(1) = sqrt(exy2 / 2.0);
-      }
-      std::cout << "clus global is " << clusGlobal.transpose() << std::endl
-                << "state global is " << stateGlobal.transpose() << std::endl
-                << "Residual is " << residual.transpose() << std::endl;
-      std::cout << "   clus errors are " << clus_sigma.transpose() << std::endl;
-    }
-
-    // Get the derivative of alignment (global) parameters w.r.t. measurement or residual
-    const Acts::Vector3 direction = freeParams.segment<3>(Acts::eFreeDir0);
-    // The derivative of free parameters w.r.t. path length. @note Here, we
-    // assumes a linear track model, i.e. negecting the change of track
-    // direction. Otherwise, we need to know the magnetic field at the free
-    // parameters
-    Acts::FreeVector pathDerivative = Acts::FreeVector::Zero();
-    pathDerivative.head<3>() = direction;
-
-    const Acts::ActsDynamicMatrix H = state.effectiveProjector();
-
-    /// Acts residual, in local coordinates
-    auto actslocres = state.effectiveCalibrated() - H * state.smoothed();
-
-    // Get the derivative of bound parameters w.r.t. alignment parameters
-    Acts::AlignmentToBoundMatrix d =
-        surface.alignmentToBoundDerivative(_tGeometry->geometry().getGeoContext(), freeParams, pathDerivative);
-    // Get the derivative of bound parameters wrt track parameters
-    Acts::FreeToBoundMatrix j = surface.freeToBoundJacobian(_tGeometry->geometry().getGeoContext(), freeParams);
-
-    // derivative of residual wrt track parameters
-    auto dLocResTrack = -H * j;
-    // derivative of residual wrt alignment parameters
-    auto dLocResAlignment = -H * d;
-
-    if (Verbosity() > 4)
-    {
-      std::cout << "local resids " << actslocres.transpose() << std::endl
-                << " derivative of resiudal wrt track params " << std::endl
-                << dLocResTrack << std::endl
-                << " derivative of residual wrt alignment params " << std::endl
-                << dLocResAlignment << std::endl;
-    }
-
-    /// The above matrices are in Acts local coordinates, so we need to convert them to
-    /// global coordinates with a rotation d(l0,l1)/d(x,y,z)
-
-    const double cosTheta = direction.z();
-    const double sinTheta = std::sqrt(square(direction.x()) + square(direction.y()));
-    const double invSinTheta = 1. / sinTheta;
-    const double cosPhi = direction.x() * invSinTheta;
-    const double sinPhi = direction.y() * invSinTheta;
-    Acts::ActsMatrix<3, 2> rot = Acts::ActsMatrix<3, 2>::Zero();
-    rot(0, 0) = -sinPhi;
-    rot(0, 1) = -cosPhi * cosTheta;
-    rot(1, 0) = cosPhi;
-    rot(1, 1) = -sinPhi * cosTheta;
-    rot(2, 1) = sinTheta;
-
-    /// this is a 3x6 matrix now of d(x_res,y_res,z_res)/d(dx,dy,dz,alpha,beta,gamma)
-    const auto dGlobResAlignment = rot * dLocResAlignment;
-
-    /// Acts global coordinates are (x,y,z,t,hatx,haty,hatz,q/p)
-    /// So now rotate to x,y,z, px,py,pz
-    const double p = 1. / abs(globalStateParams[Acts::eFreeQOverP]);
-    const double p2 = square(p);
-    Acts::ActsMatrix<6, 8> sphenixRot = Acts::ActsMatrix<6, 8>::Zero();
-    sphenixRot(0, 0) = 1;
-    sphenixRot(1, 1) = 1;
-    sphenixRot(2, 2) = 1;
-    sphenixRot(3, 4) = p;
-    sphenixRot(4, 5) = p;
-    sphenixRot(5, 6) = p;
-    sphenixRot(3, 7) = direction.x() * p2;
-    sphenixRot(4, 7) = direction.y() * p2;
-    sphenixRot(5, 7) = direction.z() * p2;
-
-    const auto dGlobResTrack = rot * dLocResTrack * sphenixRot.transpose();
-
-    if (Verbosity() > 3)
-    {
-      std::cout << "derivative of residual wrt alignment parameters glob " << std::endl
-                << dGlobResAlignment << std::endl;
-      std::cout << "derivative of residual wrt trakc parameters glob " << std::endl
-                << dGlobResTrack << std::endl;
-    }
-
-   
-
-    AlignmentState astate(state.index(), residual, dGlobResAlignment, dGlobResTrack, clusGlobal);
-
-    /// To switch to creating things WRT local coordinates, change 
-    /// AlignmentState::NLC to 8 and AlignmentState::NRES to 2 and 
-    /// uncomment the following
-    /// AlignmentState astate(state.index(actslocres, dLocResAlignment, dLocResTrack, clusGlobal);
-
-    if(m_useAnalytic)
-      {
-	auto surf = _tGeometry->maps().getSurface(ckey, clus);
-	auto anglederivs = getDerivativesAlignmentAngles(clusGlobal, ckey, 
-							 clus, surf, 
-							 crossing);
-	AlignmentState::GlobalMatrix analytic = AlignmentState::GlobalMatrix::Zero();
-        analytic(0,0) = 1;
-        analytic(1,1) = 1;
-        analytic(2,2) = 1;
-	for(int i=0; i<AlignmentState::NRES; ++i) 
-	  {
-	    for(int j=3; j<AlignmentState::NGL; ++j)
-	      {
-		/// convert to mm
-		analytic(i,j) = anglederivs.at(i)(j-3) * Acts::UnitConstants::cm;
-	      }
-	  }
-
-	astate.set_dResAlignmentPar(analytic);
-      }
-  
-    alignStates.insert(std::make_pair(ckey, astate));
-    
-    return true;
-    });
-
-  return alignStates;
-}
-
-void MakeMilleFiles::addTrackToMilleFile(AlignmentStateMap& alignStates, const Trajectory& traj)
-{
-  for (auto& [ckey, astate] : alignStates)
+  for (auto state : statevec)
   {
+    TrkrDefs::cluskey ckey = state->get_cluster_key();
+
     if (Verbosity() > 2)
       {
 	std::cout << "adding state for ckey " << ckey << std::endl;
       }
     // The global alignment parameters are given initial values of zero by default, we do not specify them
     // We identify the global alignment parameters for this surface
+
     const auto cluster = _cluster_map->findCluster(ckey);
     const auto layer = TrkrDefs::getLayer(ckey);
 
-    const auto residual = astate.get_residual();
-    const auto& global = astate.get_clusglob();
+    const auto residual = state->get_residual();
+    const auto& global = _tGeometry->getGlobalPosition(ckey, cluster);
 
     // need standard deviation of measurements
-    AlignmentState::ResidualVector clus_sigma = AlignmentState::ResidualVector::Zero();
-    if (AlignmentState::NRES == 3)
-    {
-      if (_cluster_version == 3)
+    SvtxAlignmentState::ResidualVector clus_sigma = SvtxAlignmentState::ResidualVector::Zero();
+    if (_cluster_version == 3)
       {
         clus_sigma(2) = cluster->getZError() * Acts::UnitConstants::cm;
         clus_sigma(0) = cluster->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
@@ -743,32 +326,13 @@ void MakeMilleFiles::addTrackToMilleFile(AlignmentStateMap& alignStates, const T
       {
         continue;
       }
-    }
-    else if (AlignmentState::NRES == 2)
-    {
-      if (_cluster_version == 3)
-      {
-        clus_sigma(1) = cluster->getZError() * Acts::UnitConstants::cm;
-        clus_sigma(0) = cluster->getRPhiError() * Acts::UnitConstants::cm;
-      }
-      else if (_cluster_version == 4)
-      {
-        double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
-        auto para_errors = _ClusErrPara.get_simple_cluster_error(cluster, clusRadius, ckey);
-        float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-        float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-        clus_sigma(1) = sqrt(ez2);
-        clus_sigma(0) = sqrt(exy2);
-      }
-    }
+    
 
-    const auto& multiTraj = traj.multiTrajectory();
-    const auto& state = multiTraj.getTrackState(astate.get_tsIndex());
-    Acts::GeometryIdentifier id = state.referenceSurface().geometryId();
-    int label_base = getLabelBase(id);  // This value depends on how the surfaces are grouped
+  Acts::GeometryIdentifier id = _tGeometry->maps().getSurface(ckey, cluster)->geometryId();
+  int label_base = getLabelBase(id);  // This value depends on how the surfaces are grouped
 
-    int glbl_label[AlignmentState::NGL];
-    for (int i = 0; i < AlignmentState::NGL; ++i)
+    int glbl_label[SvtxAlignmentState::NGL];
+    for (int i = 0; i < SvtxAlignmentState::NGL; ++i)
     {
       glbl_label[i] = label_base + i;
       if (Verbosity() > 1)
@@ -782,36 +346,36 @@ void MakeMilleFiles::addTrackToMilleFile(AlignmentStateMap& alignStates, const T
       std::cout << std::endl;
     }
 
-    /// For N residual coordinates x,y,z or local x,z
-    for (int i = 0; i < AlignmentState::NRES; ++i)
+    /// For N residual coordinates x,y,z 
+    for (int i = 0; i < SvtxAlignmentState::NRES; ++i)
     {
       // Add the measurement separately for each coordinate direction to Mille
-      float glbl_derivative[AlignmentState::NGL];
-      for (int j = 0; j < AlignmentState::NGL; ++j)
+      float glbl_derivative[SvtxAlignmentState::NGL];
+      for (int j = 0; j < SvtxAlignmentState::NGL; ++j)
       {
-        glbl_derivative[j] = astate.get_dResAlignmentPar()(i, j);
+        glbl_derivative[j] = state->get_global_derivative_matrix()(i, j);
 
 	if(is_layer_fixed(layer) || is_layer_param_fixed(layer,j))
 	  {glbl_derivative[j] = 0.0;}
       }
 
-      float lcl_derivative[AlignmentState::NLC];
-      for (int j = 0; j < AlignmentState::NLC; ++j)
+      float lcl_derivative[SvtxAlignmentState::NLOC];
+      for (int j = 0; j < SvtxAlignmentState::NLOC; ++j)
       {
-        lcl_derivative[j] = astate.get_dResTrackPar()(i, j);
+        lcl_derivative[j] = state->get_local_derivative_matrix()(i, j);
       }
       if (Verbosity() > 2)
       {
         std::cout << "coordinate " << i << " has residual " << residual(i) << " and clus_sigma " << clus_sigma(i) << std::endl
                   << "global deriv " << std::endl;
         
-        for (int k = 0; k < AlignmentState::NGL; k++)
+        for (int k = 0; k < SvtxAlignmentState::NGL; k++)
         {
           std::cout << glbl_derivative[k] << ", ";
         }
         std::cout << std::endl
                   << "local deriv " << std::endl;
-        for (int k = 0; k < AlignmentState::NLC; k++)
+        for (int k = 0; k < SvtxAlignmentState::NLOC; k++)
         {
           std::cout << lcl_derivative[k] << ", ";
         }
@@ -820,7 +384,7 @@ void MakeMilleFiles::addTrackToMilleFile(AlignmentStateMap& alignStates, const T
 
       if (clus_sigma(i) < 1.0)  // discards crazy clusters
       {
-        _mille->mille(AlignmentState::NLC, lcl_derivative, AlignmentState::NGL, glbl_derivative, glbl_label, residual(i), clus_sigma(i));
+        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), clus_sigma(i));
       }
     }
   }

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <vector>
 
-#include <trackbase/ClusterErrorPara.h>
 #include <trackbase/ActsGeometry.h>
+#include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
@@ -77,7 +77,7 @@ class MakeMilleFiles : public SubsysReco
                                                            TrkrDefs::cluskey cluster_key,
                                                            TrkrCluster* cluster,
                                                            Surface surface, int crossing);
-  
+
   int getLabelBase(Acts::GeometryIdentifier id);
   int getTpcRegion(int layer);
 
@@ -100,17 +100,17 @@ class MakeMilleFiles : public SubsysReco
   tpcGroup tpc_group = tpcGroup::hitset;
   mmsGroup mms_group = mmsGroup::tile;
 
-  int nsensors_stave[7] = {9,9,9,4,4,4,4};
+  int nsensors_stave[7] = {9, 9, 9, 4, 4, 4, 4};
 
   std::set<unsigned int> fixed_layers;
-  std::set<std::pair<unsigned int,unsigned int>> fixed_layer_params;
+  std::set<std::pair<unsigned int, unsigned int>> fixed_layer_params;
 
   std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
 
   SvtxTrackMap* _track_map{nullptr};
   SvtxAlignmentStateMap* _state_map{nullptr};
   ActsGeometry* _tGeometry{nullptr};
-  TrkrClusterContainer *_cluster_map{nullptr};
+  TrkrClusterContainer* _cluster_map{nullptr};
   ClusterErrorPara _ClusErrPara;
 };
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -15,19 +15,11 @@
 #include <string>
 #include <vector>
 
-#include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
-
-#include <trackbase_historic/SvtxTrackState_v1.h>
-
-#include <tpc/TpcClusterZCrossingCorrection.h>
-#include <tpc/TpcDistortionCorrection.h>
-#include <tpc/TpcDistortionCorrectionContainer.h>
-
-#include <ActsExamples/EventData/Track.hpp>
-#include <ActsExamples/EventData/Trajectories.hpp>
+#include <trackbase_historic/SvtxAlignmentStateMap.h>
 
 class PHCompositeNode;
 class PHG4TpcCylinderGeomContainer;
@@ -35,8 +27,6 @@ class SvtxTrack;
 class SvtxTrackMap;
 class TrkrCluster;
 class TrkrClusterContainer;
-class TpcDistortionCorrectionContainer;
-class ClusterErrorPara;
 class Mille;
 
 using Trajectory = ActsExamples::Trajectories;
@@ -58,70 +48,6 @@ enum mmsGroup
   tile,
   mms
 };
-
-/*
- * Class which contains alignment information to be written to pede, 
- * obtained from Acts::Trajectories and track states
- * Also defines all matrix and residual dimensions
- */
-class AlignmentState
-{
- public:
-  /// The number of global (alignment) parameters
-  static const int NGL = 6;
-  /// The number of local (track state) parameters
-  static const int NLC = 6;
-  /// The number of residuals per state (e.g. 2D or 3D)
-  static const int NRES = 3;
-
-  using GlobalMatrix = Acts::ActsMatrix<NRES, NGL>;
-  using LocalMatrix = Acts::ActsMatrix<NRES, NLC>;
-  using ResidualVector = Eigen::Matrix<Acts::ActsScalar, NRES, 1>;
-
-  AlignmentState(size_t index, ResidualVector res,
-                 GlobalMatrix ralign,
-                 LocalMatrix rtrack,
-                 Acts::Vector3 clusglob)
-    : m_tsIndex(index)
-    , m_residual(res)
-    , m_dResAlignmentPar(ralign)
-    , m_dResTrackPar(rtrack)
-    , m_clusglob(clusglob)
-  {
-  }
-
-  void set_residual(const ResidualVector& res) { m_residual = res; }
-  void set_dResAlignmentPar(const GlobalMatrix& d)
-  {
-    m_dResAlignmentPar = d;
-  }
-  void set_dResTrackPar(const LocalMatrix& d)
-  {
-    m_dResTrackPar = d;
-  }
-
-  const ResidualVector& get_residual() const { return m_residual; }
-  const GlobalMatrix& get_dResAlignmentPar() const
-  {
-    return m_dResAlignmentPar;
-  }
-  const LocalMatrix& get_dResTrackPar() const
-  {
-    return m_dResTrackPar;
-  }
-  void set_tsIndex(const size_t index) { m_tsIndex = index; }
-  const size_t& get_tsIndex() const { return m_tsIndex; }
-  const Acts::Vector3& get_clusglob() const { return m_clusglob; }
-
- private:
-  size_t m_tsIndex;
-  ResidualVector m_residual;
-  GlobalMatrix m_dResAlignmentPar;
-  LocalMatrix m_dResTrackPar;
-  Acts::Vector3 m_clusglob;
-};
-
-using AlignmentStateMap = std::map<TrkrDefs::cluskey, AlignmentState>;
 
 class MakeMilleFiles : public SubsysReco
 {
@@ -145,43 +71,29 @@ class MakeMilleFiles : public SubsysReco
  private:
   Mille* _mille;
 
-  std::map<const unsigned int, Trajectory>* _trajectories;
-
   int GetNodes(PHCompositeNode* topNode);
   Acts::Vector3 getPCALinePoint(Acts::Vector3 global, SvtxTrackState* state);
   std::vector<Acts::Vector3> getDerivativesAlignmentAngles(Acts::Vector3& global,
                                                            TrkrDefs::cluskey cluster_key,
                                                            TrkrCluster* cluster,
                                                            Surface surface, int crossing);
-  SvtxTrack::StateIter getStateIter(Acts::Vector3& global, SvtxTrack* track);
-  void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key,
-                                short int crossing, Acts::Vector3& global);
-  float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
-  Acts::Transform3 makePerturbationTransformation(Acts::Vector3 angles);
+  
   int getLabelBase(Acts::GeometryIdentifier id);
   int getTpcRegion(int layer);
 
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
 
-  AlignmentStateMap getAlignmentStates(const Trajectory& traj,
-                                       SvtxTrack* track, short int crossing);
-  void addTrackToMilleFile(AlignmentStateMap& alignStates, const Trajectory& traj);
+  void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec);
 
   std::map<int, float> derivativeGL;
   std::string data_outfilename = ("mille_output_data_file.bin");
   std::string steering_outfilename = ("steer.txt");
 
-  /// tpc distortion correction utility class
-  TpcDistortionCorrection _distortionCorrection;
   bool _binary = true;
-  unsigned int _cluster_version = 3;
+  unsigned int _cluster_version = 4;
 
   bool m_useAnalytic = true;
-
-  ClusterErrorPara _ClusErrPara;
-
-  float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
 
   // set default groups to lowest level
   siliconGroup si_group = siliconGroup::sensor;
@@ -196,13 +108,10 @@ class MakeMilleFiles : public SubsysReco
   std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
 
   SvtxTrackMap* _track_map{nullptr};
-  TrkrClusterContainer* _cluster_map{nullptr};
+  SvtxAlignmentStateMap* _state_map{nullptr};
   ActsGeometry* _tGeometry{nullptr};
-
-  TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
-  TpcDistortionCorrectionContainer* _dcc_static{nullptr};
-  TpcDistortionCorrectionContainer* _dcc_average{nullptr};
-  TpcDistortionCorrectionContainer* _dcc_fluctuation{nullptr};
+  TrkrClusterContainer *_cluster_map{nullptr};
+  ClusterErrorPara _ClusErrPara;
 };
 
 #endif  // MAKEMILLEFILES_H

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -40,11 +40,15 @@ pkginclude_HEADERS = \
   SvtxTrack_FastSim_v1.h \
   SvtxTrack_FastSim_v2.h \
   SvtxTrack_FastSim_v3.h \
+  SvtxAlignmentStateMap.h \
+  SvtxAlignmentStateMap_v1.h \
   SvtxTrackMap.h \
   SvtxTrackMap_v1.h \
   SvtxTrackMap_v2.h \
   SvtxTrackCaloClusterMap.h \
   SvtxTrackCaloClusterMap_v1.h \
+  SvtxAlignmentState.h \
+  SvtxAlignmentState_v1.h \
   SvtxTrackState.h \
   SvtxTrackState_v1.h \
   SvtxVertex.h \
@@ -63,6 +67,8 @@ ROOTDICTS = \
   PHG4ParticleSvtxMap_v1_Dict.cc \
   SvtxPHG4ParticleMap_Dict.cc \
   SvtxPHG4ParticleMap_v1_Dict.cc \
+  SvtxAlignmentState_Dict.cc \
+  SvtxAlignmentState_v1_Dict.cc \
   SvtxTrack_Dict.cc \
   SvtxTrackState_Dict.cc \
   SvtxTrackState_v1_Dict.cc \
@@ -74,6 +80,8 @@ ROOTDICTS = \
   SvtxTrack_FastSim_v1_Dict.cc \
   SvtxTrack_FastSim_v2_Dict.cc \
   SvtxTrack_FastSim_v3_Dict.cc \
+  SvtxAlignmentStateMap_Dict.cc \
+  SvtxAlignmentStateMap_v1_Dict.cc \
   SvtxTrackMap_Dict.cc \
   SvtxTrackMap_v1_Dict.cc \
   SvtxTrackMap_v2_Dict.cc \
@@ -96,6 +104,8 @@ nobase_dist_pcm_DATA = \
   PHG4ParticleSvtxMap_v1_Dict_rdict.pcm \
   SvtxPHG4ParticleMap_Dict_rdict.pcm \
   SvtxPHG4ParticleMap_v1_Dict_rdict.pcm \
+  SvtxAlignmentState_Dict_rdict.pcm \
+  SvtxAlignmentState_v1_Dict_rdict.pcm \
   SvtxTrack_Dict_rdict.pcm \
   SvtxTrackState_Dict_rdict.pcm \
   SvtxTrackState_v1_Dict_rdict.pcm \
@@ -107,6 +117,8 @@ nobase_dist_pcm_DATA = \
   SvtxTrack_FastSim_v1_Dict_rdict.pcm \
   SvtxTrack_FastSim_v2_Dict_rdict.pcm \
   SvtxTrack_FastSim_v3_Dict_rdict.pcm \
+  SvtxAlignmentStateMap_Dict_rdict.pcm \
+  SvtxAlignmentStateMap_v1_Dict_rdict.pcm \
   SvtxTrackMap_Dict_rdict.pcm \
   SvtxTrackMap_v1_Dict_rdict.pcm \
   SvtxTrackMap_v2_Dict_rdict.pcm \
@@ -131,6 +143,8 @@ libtrackbase_historic_io_la_SOURCES = \
   PHG4ParticleSvtxMap_v1.cc \
   SvtxPHG4ParticleMap.cc \
   SvtxPHG4ParticleMap_v1.cc \
+  SvtxAlignmentState.cc \
+  SvtxAlignmentState_v1.cc \
   SvtxTrackState_v1.cc \
   SvtxTrack.cc \
   SvtxTrack_v1.cc \
@@ -141,6 +155,8 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrack_FastSim_v1.cc \
   SvtxTrack_FastSim_v2.cc \
   SvtxTrack_FastSim_v3.cc \
+  SvtxAlignmentStateMap.cc \
+  SvtxAlignmentStateMap_v1.cc \
   SvtxTrackMap.cc \
   SvtxTrackMap_v1.cc \
   SvtxTrackMap_v2.cc \

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.cc
@@ -5,7 +5,7 @@ namespace
   SvtxAlignmentState::GlobalMatrix globalMatrix = SvtxAlignmentState::GlobalMatrix::Zero();
   SvtxAlignmentState::LocalMatrix localMatrix = SvtxAlignmentState::LocalMatrix::Zero();
   SvtxAlignmentState::ResidualVector residual = SvtxAlignmentState::ResidualVector::Zero();
-}
+}  // namespace
 
 const SvtxAlignmentState::ResidualVector& SvtxAlignmentState::get_residual() const
 {
@@ -19,5 +19,5 @@ const SvtxAlignmentState::LocalMatrix& SvtxAlignmentState::get_local_derivative_
 
 const SvtxAlignmentState::GlobalMatrix& SvtxAlignmentState::get_global_derivative_matrix() const
 {
-  return globalMatrix; 
+  return globalMatrix;
 }

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.cc
@@ -1,0 +1,23 @@
+#include "SvtxAlignmentState.h"
+
+namespace
+{
+  SvtxAlignmentState::GlobalMatrix globalMatrix = SvtxAlignmentState::GlobalMatrix::Zero();
+  SvtxAlignmentState::LocalMatrix localMatrix = SvtxAlignmentState::LocalMatrix::Zero();
+  SvtxAlignmentState::ResidualVector residual = SvtxAlignmentState::ResidualVector::Zero();
+}
+
+const SvtxAlignmentState::ResidualVector& SvtxAlignmentState::get_residual() const
+{
+  return residual;
+}
+
+const SvtxAlignmentState::LocalMatrix& SvtxAlignmentState::get_local_derivative_matrix() const
+{
+  return localMatrix;
+}
+
+const SvtxAlignmentState::GlobalMatrix& SvtxAlignmentState::get_global_derivative_matrix() const
+{
+  return globalMatrix; 
+}

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.h
@@ -1,0 +1,51 @@
+#ifndef __SVTXALIGNMENTSTATE_H__
+#define __SVTXALIGNMENTSTATE_H__
+
+#include <phool/PHObject.h>
+#include <cmath>
+#include <trackbase/TrkrDefs.h>
+#include <Acts/Definitions/Algebra.hpp>
+
+class SvtxAlignmentState : public PHObject
+{
+ public:
+  /// Number of global coordinates, where global refers to
+  /// the definition in millepede (alignment parameters)
+  const static int NGL = 6;
+  /// Number of local coordinates, where local refers to
+  /// the definition in millepede (track state parameters)
+  const static int NLOC = 6;
+  /// Number of residual parameters 
+  const static int NRES = 3;
+
+  typedef Eigen::Matrix<float, NRES, NGL> GlobalMatrix;
+  typedef Eigen::Matrix<float, NRES, NLOC> LocalMatrix;
+  typedef Eigen::Matrix<float, NRES, 1> ResidualVector;
+
+  ~SvtxAlignmentState() override {}
+
+  void identify(std::ostream &os = std::cout) const override
+  {
+    os << "SvtxAlignmentState base class" << std::endl;
+  }
+
+  int isValid() const override { return 0; }
+  PHObject *CloneMe() const override { return nullptr; }
+
+  virtual void set_residual(const ResidualVector& res) {}
+  virtual void set_local_derivative_matrix(const LocalMatrix& d) {}
+  virtual void set_global_derivative_matrix(const GlobalMatrix& d) {}
+
+  
+  virtual const ResidualVector& get_residual() const;
+  virtual const LocalMatrix& get_local_derivative_matrix() const;
+  virtual const GlobalMatrix& get_global_derivative_matrix() const;
+ 
+
+ protected:
+  SvtxAlignmentState() {}
+  ClassDefOverride(SvtxAlignmentState, 1);
+
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.h
@@ -2,9 +2,9 @@
 #define __SVTXALIGNMENTSTATE_H__
 
 #include <phool/PHObject.h>
-#include <cmath>
 #include <trackbase/TrkrDefs.h>
 #include <Acts/Definitions/Algebra.hpp>
+#include <cmath>
 
 class SvtxAlignmentState : public PHObject
 {
@@ -15,7 +15,7 @@ class SvtxAlignmentState : public PHObject
   /// Number of local coordinates, where local refers to
   /// the definition in millepede (track state parameters)
   const static int NLOC = 6;
-  /// Number of residual parameters 
+  /// Number of residual parameters
   const static int NRES = 3;
 
   typedef Eigen::Matrix<double, NRES, NGL> GlobalMatrix;
@@ -24,19 +24,19 @@ class SvtxAlignmentState : public PHObject
 
   ~SvtxAlignmentState() override {}
 
-  void identify(std::ostream &os = std::cout) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxAlignmentState base class" << std::endl;
   }
 
   int isValid() const override { return 0; }
-  PHObject *CloneMe() const override { return nullptr; }
+  PHObject* CloneMe() const override { return nullptr; }
 
   virtual void set_residual(const ResidualVector&) {}
   virtual void set_local_derivative_matrix(const LocalMatrix&) {}
   virtual void set_global_derivative_matrix(const GlobalMatrix&) {}
   virtual void set_cluster_key(TrkrDefs::cluskey) {}
-  
+
   virtual const ResidualVector& get_residual() const;
   virtual const LocalMatrix& get_local_derivative_matrix() const;
   virtual const GlobalMatrix& get_global_derivative_matrix() const;
@@ -45,7 +45,6 @@ class SvtxAlignmentState : public PHObject
  protected:
   SvtxAlignmentState() {}
   ClassDefOverride(SvtxAlignmentState, 1);
-
 };
 
 #endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.h
@@ -18,9 +18,9 @@ class SvtxAlignmentState : public PHObject
   /// Number of residual parameters 
   const static int NRES = 3;
 
-  typedef Eigen::Matrix<float, NRES, NGL> GlobalMatrix;
-  typedef Eigen::Matrix<float, NRES, NLOC> LocalMatrix;
-  typedef Eigen::Matrix<float, NRES, 1> ResidualVector;
+  typedef Eigen::Matrix<double, NRES, NGL> GlobalMatrix;
+  typedef Eigen::Matrix<double, NRES, NLOC> LocalMatrix;
+  typedef Eigen::Matrix<double, NRES, 1> ResidualVector;
 
   ~SvtxAlignmentState() override {}
 
@@ -32,9 +32,9 @@ class SvtxAlignmentState : public PHObject
   int isValid() const override { return 0; }
   PHObject *CloneMe() const override { return nullptr; }
 
-  virtual void set_residual(const ResidualVector& res) {}
-  virtual void set_local_derivative_matrix(const LocalMatrix& d) {}
-  virtual void set_global_derivative_matrix(const GlobalMatrix& d) {}
+  virtual void set_residual(const ResidualVector&) {}
+  virtual void set_local_derivative_matrix(const LocalMatrix&) {}
+  virtual void set_global_derivative_matrix(const GlobalMatrix&) {}
 
   
   virtual const ResidualVector& get_residual() const;

--- a/offline/packages/trackbase_historic/SvtxAlignmentState.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState.h
@@ -35,12 +35,12 @@ class SvtxAlignmentState : public PHObject
   virtual void set_residual(const ResidualVector&) {}
   virtual void set_local_derivative_matrix(const LocalMatrix&) {}
   virtual void set_global_derivative_matrix(const GlobalMatrix&) {}
-
+  virtual void set_cluster_key(TrkrDefs::cluskey) {}
   
   virtual const ResidualVector& get_residual() const;
   virtual const LocalMatrix& get_local_derivative_matrix() const;
   virtual const GlobalMatrix& get_global_derivative_matrix() const;
- 
+  virtual TrkrDefs::cluskey get_cluster_key() const { return UINT_MAX; }
 
  protected:
   SvtxAlignmentState() {}

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateLinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class SvtxAlignmentState+;
+#pragma link C++ class SvtxAlignmentState + ;
 
 #endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateLinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxAlignmentState+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
@@ -11,7 +11,7 @@ SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::begin() const
   return map.end();
 }
 
-SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::find(TrkrDefs::cluskey) const
+SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::find(unsigned int) const
 {
   return map.end();
 }
@@ -26,7 +26,7 @@ SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::begin()
   return map.end();
 }
 
-SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::find(TrkrDefs::cluskey)
+SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::find(unsigned int)
 {
   return map.end();
 }

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
@@ -5,7 +5,6 @@ namespace
   SvtxAlignmentStateMap::StateMap map;
 }
 
-
 SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::begin() const
 {
   return map.end();

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.cc
@@ -1,0 +1,37 @@
+#include "SvtxAlignmentStateMap.h"
+
+namespace
+{
+  SvtxAlignmentStateMap::StateMap map;
+}
+
+
+SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::begin() const
+{
+  return map.end();
+}
+
+SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::find(TrkrDefs::cluskey) const
+{
+  return map.end();
+}
+
+SvtxAlignmentStateMap::ConstIter SvtxAlignmentStateMap::end() const
+{
+  return map.end();
+}
+
+SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::begin()
+{
+  return map.end();
+}
+
+SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::find(TrkrDefs::cluskey)
+{
+  return map.end();
+}
+
+SvtxAlignmentStateMap::Iter SvtxAlignmentStateMap::end()
+{
+  return map.end();
+}

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
@@ -11,7 +11,8 @@
 class SvtxAlignmentStateMap : public PHObject
 {
  public:
-  typedef std::map<TrkrDefs::cluskey, SvtxAlignmentState*> StateMap;
+typedef std::vector<SvtxAlignmentState*> StateVec;
+  typedef std::map<unsigned int, StateVec> StateMap;
   typedef StateMap::const_iterator ConstIter;
   typedef StateMap::iterator Iter;
 
@@ -26,20 +27,20 @@ class SvtxAlignmentStateMap : public PHObject
 
   virtual bool empty() const { return true; }
   virtual std::size_t size() const { return 0; }
-  virtual std::size_t count(TrkrDefs::cluskey) const { return 0; }
+  virtual std::size_t count(unsigned int) const { return 0; }
   virtual void clear() {}
 
-  virtual const SvtxAlignmentState* get(TrkrDefs::cluskey) const { return nullptr; }
-  virtual SvtxAlignmentState* get(TrkrDefs::cluskey) { return nullptr; }
-  virtual SvtxAlignmentState* insertWithKey(TrkrDefs::cluskey, SvtxAlignmentState*) { return nullptr; }
-  virtual std::size_t erase(TrkrDefs::cluskey) { return 0; }
+virtual const StateVec get(unsigned int) const { return StateVec();}
+virtual StateVec get(unsigned int) { return StateVec(); }
+virtual StateVec insertWithKey(unsigned int, StateVec) { return StateVec(); }
+  virtual std::size_t erase(unsigned int) { return 0; }
 
   virtual ConstIter begin() const;
-  virtual ConstIter find(TrkrDefs::cluskey cluskey) const;
+  virtual ConstIter find(unsigned int) const;
   virtual ConstIter end() const;
   
   virtual Iter begin();
-  virtual Iter find(TrkrDefs::cluskey cluskey);
+  virtual Iter find(unsigned int);
   virtual Iter end();
   
  protected:

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
@@ -1,0 +1,53 @@
+#ifndef TRACKBASEHISTORIC_SVTXALIGNMENTSTATEMAP_H
+#define TRACKBASEHISTORIC_SVTXALIGNMENTSTATEMAP_H
+
+#include "SvtxAlignmentState.h"
+
+#include <trackbase/TrkrDefs.h>
+
+#include <map>
+#include <iostream>
+
+class SvtxAlignmentStateMap : public PHObject
+{
+ public:
+  typedef std::map<TrkrDefs::cluskey, SvtxAlignmentState*> StateMap;
+  typedef StateMap::const_iterator ConstIter;
+  typedef StateMap::iterator Iter;
+
+  ~SvtxAlignmentStateMap() override {}
+
+  void identify(std::ostream& os = std::cout ) const override
+  {
+    os << "SvtxAlignmentStateMap base class " << std::endl;
+  }
+  int isValid() const override { return 0; }
+  PHObject* CloneMe() const override { return nullptr; }
+
+  virtual bool empty() const { return true; }
+  virtual std::size_t size() const { return 0; }
+  virtual std::size_t count(TrkrDefs::cluskey) const { return 0; }
+  virtual void clear() {}
+
+  virtual const SvtxAlignmentState* get(TrkrDefs::cluskey) const { return nullptr; }
+  virtual SvtxAlignmentState* get(TrkrDefs::cluskey) { return nullptr; }
+  virtual SvtxAlignmentState* insertWithKey(TrkrDefs::cluskey, SvtxAlignmentState*) { return nullptr; }
+  virtual std::size_t erase(TrkrDefs::cluskey) { return 0; }
+
+  virtual ConstIter begin() const;
+  virtual ConstIter find(TrkrDefs::cluskey cluskey) const;
+  virtual ConstIter end() const;
+  
+  virtual Iter begin();
+  virtual Iter find(TrkrDefs::cluskey cluskey);
+  virtual Iter end();
+  
+ protected:
+  SvtxAlignmentStateMap() {}
+
+ private:
+  ClassDefOverride(SvtxAlignmentStateMap, 1);
+
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap.h
@@ -5,20 +5,20 @@
 
 #include <trackbase/TrkrDefs.h>
 
-#include <map>
 #include <iostream>
+#include <map>
 
 class SvtxAlignmentStateMap : public PHObject
 {
  public:
-typedef std::vector<SvtxAlignmentState*> StateVec;
+  typedef std::vector<SvtxAlignmentState*> StateVec;
   typedef std::map<unsigned int, StateVec> StateMap;
   typedef StateMap::const_iterator ConstIter;
   typedef StateMap::iterator Iter;
 
   ~SvtxAlignmentStateMap() override {}
 
-  void identify(std::ostream& os = std::cout ) const override
+  void identify(std::ostream& os = std::cout) const override
   {
     os << "SvtxAlignmentStateMap base class " << std::endl;
   }
@@ -30,25 +30,24 @@ typedef std::vector<SvtxAlignmentState*> StateVec;
   virtual std::size_t count(unsigned int) const { return 0; }
   virtual void clear() {}
 
-virtual const StateVec get(unsigned int) const { return StateVec();}
-virtual StateVec get(unsigned int) { return StateVec(); }
-virtual StateVec insertWithKey(unsigned int, StateVec) { return StateVec(); }
+  virtual const StateVec get(unsigned int) const { return StateVec(); }
+  virtual StateVec get(unsigned int) { return StateVec(); }
+  virtual StateVec insertWithKey(unsigned int, StateVec) { return StateVec(); }
   virtual std::size_t erase(unsigned int) { return 0; }
 
   virtual ConstIter begin() const;
   virtual ConstIter find(unsigned int) const;
   virtual ConstIter end() const;
-  
+
   virtual Iter begin();
   virtual Iter find(unsigned int);
   virtual Iter end();
-  
+
  protected:
   SvtxAlignmentStateMap() {}
 
  private:
   ClassDefOverride(SvtxAlignmentStateMap, 1);
-
 };
 
 #endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMapLinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMapLinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class SvtxAlignmentStateMap+;
+#pragma link C++ class SvtxAlignmentStateMap + ;
 
 #endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMapLinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxAlignmentStateMap+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
@@ -6,7 +6,8 @@
 
 SvtxAlignmentStateMap_v1::SvtxAlignmentStateMap_v1()
   : m_map()
-{}
+{
+}
 
 SvtxAlignmentStateMap_v1::~SvtxAlignmentStateMap_v1()
 {
@@ -15,30 +16,29 @@ SvtxAlignmentStateMap_v1::~SvtxAlignmentStateMap_v1()
 
 void SvtxAlignmentStateMap_v1::Reset()
 {
-  for(auto [key, statevec] : m_map)
+  for (auto [key, statevec] : m_map)
+  {
+    for (auto state : statevec)
     {
-      for(auto state : statevec)
-	{
-	  delete state;
-	}
+      delete state;
     }
- 
-  m_map.clear();
+  }
 
+  m_map.clear();
 }
 
 std::size_t SvtxAlignmentStateMap_v1::erase(unsigned int track)
 {
   auto iter = m_map.find(track);
-  if(iter != m_map.end())
+  if (iter != m_map.end())
+  {
+    auto statevec = iter->second;
+    for (auto state : statevec)
     {
-      auto statevec = iter->second;
-      for(auto state : statevec)
-	{
-	  delete state;
-	}
+      delete state;
     }
-  
+  }
+
   return m_map.erase(track);
 }
 
@@ -50,10 +50,10 @@ void SvtxAlignmentStateMap_v1::identify(std::ostream& os) const
 const SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::get(unsigned int track) const
 {
   auto iter = m_map.find(track);
-  if(iter == m_map.end()) 
-    {
-      return SvtxAlignmentStateMap::StateVec();
-    }
+  if (iter == m_map.end())
+  {
+    return SvtxAlignmentStateMap::StateVec();
+  }
 
   return iter->second;
 }
@@ -61,27 +61,26 @@ const SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::get(unsigned int
 SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::get(unsigned int track)
 {
   auto iter = m_map.find(track);
-  if(iter == m_map.end()) 
-    {
-      return SvtxAlignmentStateMap::StateVec();
-    }
+  if (iter == m_map.end())
+  {
+    return SvtxAlignmentStateMap::StateVec();
+  }
 
   return iter->second;
 }
 
 SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::insertWithKey(unsigned int track, SvtxAlignmentStateMap::StateVec states)
 {
-
   const auto result = m_map.insert(std::make_pair(track, states));
-  
-  if(!result.second)
-    {
-      std::cout <<  "SvtxAlignmentStateMap_v1::insertWithKey - duplicated key " << track << ", state not entered. " << std::endl;
-  
-      return SvtxAlignmentStateMap::StateVec();
-    }
+
+  if (!result.second)
+  {
+    std::cout << "SvtxAlignmentStateMap_v1::insertWithKey - duplicated key " << track << ", state not entered. " << std::endl;
+
+    return SvtxAlignmentStateMap::StateVec();
+  }
   else
-    {
-      return states;
-    }
+  {
+    return states;
+  }
 }

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
@@ -8,33 +8,6 @@ SvtxAlignmentStateMap_v1::SvtxAlignmentStateMap_v1()
   : m_map()
 {}
 
-SvtxAlignmentStateMap_v1::SvtxAlignmentStateMap_v1(const SvtxAlignmentStateMap_v1& map)
-  : m_map()
-{
-  for(auto [key, state] : map)
-    {
-      auto statecl = static_cast<SvtxAlignmentState*>(state->CloneMe());
-      m_map.insert(std::make_pair(key, statecl));
-    }
-}
-
-SvtxAlignmentStateMap_v1& SvtxAlignmentStateMap_v1::operator=(const SvtxAlignmentStateMap_v1& map)
-{
-  if (&map == this) 
-    {
-      return *this;
-    }
-
-  Reset();
-  for(auto [key, state] : map)
-    {
-      auto clstate = static_cast<SvtxAlignmentState*>(state->CloneMe());
-      m_map.insert(std::make_pair(key, clstate));
-    }
-
-  return *this;
-}
-
 SvtxAlignmentStateMap_v1::~SvtxAlignmentStateMap_v1()
 {
   Reset();
@@ -42,56 +15,73 @@ SvtxAlignmentStateMap_v1::~SvtxAlignmentStateMap_v1()
 
 void SvtxAlignmentStateMap_v1::Reset()
 {
-  for(auto [key, state] : m_map)
+  for(auto [key, statevec] : m_map)
     {
-      delete state;
+      for(auto state : statevec)
+	{
+	  delete state;
+	}
     }
  
   m_map.clear();
 
 }
 
+std::size_t SvtxAlignmentStateMap_v1::erase(unsigned int track)
+{
+  auto iter = m_map.find(track);
+  if(iter != m_map.end())
+    {
+      auto statevec = iter->second;
+      for(auto state : statevec)
+	{
+	  delete state;
+	}
+    }
+  
+  return m_map.erase(track);
+}
 
 void SvtxAlignmentStateMap_v1::identify(std::ostream& os) const
 {
   os << "SvtxAlignmentStateMap_v1: size = " << m_map.size() << std::endl;
 }
 
-const SvtxAlignmentState* SvtxAlignmentStateMap_v1::get(TrkrDefs::cluskey ckey) const
+const SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::get(unsigned int track) const
 {
-  auto iter = m_map.find(ckey);
+  auto iter = m_map.find(track);
   if(iter == m_map.end()) 
     {
-      return nullptr;
+      return SvtxAlignmentStateMap::StateVec();
     }
 
   return iter->second;
 }
 
-SvtxAlignmentState* SvtxAlignmentStateMap_v1::get(TrkrDefs::cluskey ckey)
+SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::get(unsigned int track)
 {
-  auto iter = m_map.find(ckey);
+  auto iter = m_map.find(track);
   if(iter == m_map.end()) 
     {
-      return nullptr;
+      return SvtxAlignmentStateMap::StateVec();
     }
 
   return iter->second;
 }
 
-SvtxAlignmentState* SvtxAlignmentStateMap_v1::insertWithKey(TrkrDefs::cluskey ckey, SvtxAlignmentState* state)
+SvtxAlignmentStateMap::StateVec SvtxAlignmentStateMap_v1::insertWithKey(unsigned int track, SvtxAlignmentStateMap::StateVec states)
 {
-  auto copy = static_cast<SvtxAlignmentState*> ( state->CloneMe());
-  const auto result = m_map.insert(std::make_pair(ckey, copy));
+
+  const auto result = m_map.insert(std::make_pair(track, states));
   
   if(!result.second)
     {
-      std::cout <<  "SvtxAlignmentStateMap_v1::insertWithKey - duplicated key, state not entered. " << std::endl;
-      delete copy;
-      return nullptr;
+      std::cout <<  "SvtxAlignmentStateMap_v1::insertWithKey - duplicated key " << track << ", state not entered. " << std::endl;
+  
+      return SvtxAlignmentStateMap::StateVec();
     }
   else
     {
-      return copy;
+      return states;
     }
 }

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
@@ -22,6 +22,7 @@ void SvtxAlignmentStateMap_v1::Reset()
     {
       delete state;
     }
+    statevec.clear();
   }
 
   m_map.clear();

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.cc
@@ -1,0 +1,97 @@
+#include "SvtxAlignmentStateMap_v1.h"
+
+#include "SvtxAlignmentState.h"
+
+#include <phool/PHObject.h>
+
+SvtxAlignmentStateMap_v1::SvtxAlignmentStateMap_v1()
+  : m_map()
+{}
+
+SvtxAlignmentStateMap_v1::SvtxAlignmentStateMap_v1(const SvtxAlignmentStateMap_v1& map)
+  : m_map()
+{
+  for(auto [key, state] : map)
+    {
+      auto statecl = static_cast<SvtxAlignmentState*>(state->CloneMe());
+      m_map.insert(std::make_pair(key, statecl));
+    }
+}
+
+SvtxAlignmentStateMap_v1& SvtxAlignmentStateMap_v1::operator=(const SvtxAlignmentStateMap_v1& map)
+{
+  if (&map == this) 
+    {
+      return *this;
+    }
+
+  Reset();
+  for(auto [key, state] : map)
+    {
+      auto clstate = static_cast<SvtxAlignmentState*>(state->CloneMe());
+      m_map.insert(std::make_pair(key, clstate));
+    }
+
+  return *this;
+}
+
+SvtxAlignmentStateMap_v1::~SvtxAlignmentStateMap_v1()
+{
+  Reset();
+}
+
+void SvtxAlignmentStateMap_v1::Reset()
+{
+  for(auto [key, state] : m_map)
+    {
+      delete state;
+    }
+ 
+  m_map.clear();
+
+}
+
+
+void SvtxAlignmentStateMap_v1::identify(std::ostream& os) const
+{
+  os << "SvtxAlignmentStateMap_v1: size = " << m_map.size() << std::endl;
+}
+
+const SvtxAlignmentState* SvtxAlignmentStateMap_v1::get(TrkrDefs::cluskey ckey) const
+{
+  auto iter = m_map.find(ckey);
+  if(iter == m_map.end()) 
+    {
+      return nullptr;
+    }
+
+  return iter->second;
+}
+
+SvtxAlignmentState* SvtxAlignmentStateMap_v1::get(TrkrDefs::cluskey ckey)
+{
+  auto iter = m_map.find(ckey);
+  if(iter == m_map.end()) 
+    {
+      return nullptr;
+    }
+
+  return iter->second;
+}
+
+SvtxAlignmentState* SvtxAlignmentStateMap_v1::insertWithKey(TrkrDefs::cluskey ckey, SvtxAlignmentState* state)
+{
+  auto copy = static_cast<SvtxAlignmentState*> ( state->CloneMe());
+  const auto result = m_map.insert(std::make_pair(ckey, copy));
+  
+  if(!result.second)
+    {
+      std::cout <<  "SvtxAlignmentStateMap_v1::insertWithKey - duplicated key, state not entered. " << std::endl;
+      delete copy;
+      return nullptr;
+    }
+  else
+    {
+      return copy;
+    }
+}

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
@@ -1,0 +1,51 @@
+#ifndef TRACKBASEHISTORIC_SVTXALIGNMENTSTATEMAP_V1_H
+#define TRACKBASEHISTORIC_SVTXALIGNMENTSTATEMAP_V1_H
+
+#include "SvtxAlignmentState.h"
+#include "SvtxAlignmentStateMap.h"
+
+class PHObject;
+
+class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
+{
+ public:
+  SvtxAlignmentStateMap_v1();
+  SvtxAlignmentStateMap_v1(const SvtxAlignmentStateMap_v1& map);
+  SvtxAlignmentStateMap_v1& operator=(const SvtxAlignmentStateMap_v1& map);
+  ~SvtxAlignmentStateMap_v1() override;
+
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override;
+  int isValid() const override { return 1; }
+  PHObject* CloneMe() const override { return new SvtxAlignmentStateMap_v1(*this); }
+  
+  bool empty() const override { return m_map.empty(); }
+  std::size_t size() const override { return m_map.size(); }
+  std::size_t count(TrkrDefs::cluskey ckey) const override { return m_map.count(ckey); }
+  void clear() override { Reset(); }
+
+  const SvtxAlignmentState* get(TrkrDefs::cluskey ckey) const override;
+  SvtxAlignmentState* get(TrkrDefs::cluskey ckey) override;
+  SvtxAlignmentState* insertWithKey(TrkrDefs::cluskey ckey, SvtxAlignmentState* state) override;
+  virtual std::size_t erase(TrkrDefs::cluskey ckey) override
+  {
+    delete m_map[ckey];
+    return m_map.erase(ckey);
+  }
+
+  ConstIter begin() const override { return m_map.begin(); }
+  ConstIter find(TrkrDefs::cluskey ckey) const override { return m_map.find(ckey); }
+  ConstIter end() const override { return m_map.end(); }
+
+  Iter begin() override { return m_map.begin(); }
+  Iter find(TrkrDefs::cluskey ckey) override { return m_map.find(ckey); }
+  Iter end() override { return m_map.end(); }
+
+ private:
+  StateMap m_map;
+
+  ClassDefOverride(SvtxAlignmentStateMap_v1, 1);
+};
+
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
@@ -10,8 +10,6 @@ class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
 {
  public:
   SvtxAlignmentStateMap_v1();
-  SvtxAlignmentStateMap_v1(const SvtxAlignmentStateMap_v1& map);
-  SvtxAlignmentStateMap_v1& operator=(const SvtxAlignmentStateMap_v1& map);
   ~SvtxAlignmentStateMap_v1() override;
 
   void identify(std::ostream& os = std::cout) const override;
@@ -21,24 +19,21 @@ class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
   
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }
-  std::size_t count(TrkrDefs::cluskey ckey) const override { return m_map.count(ckey); }
+  std::size_t count(unsigned int track) const override { return m_map.count(track); }
   void clear() override { Reset(); }
 
-  const SvtxAlignmentState* get(TrkrDefs::cluskey ckey) const override;
-  SvtxAlignmentState* get(TrkrDefs::cluskey ckey) override;
-  SvtxAlignmentState* insertWithKey(TrkrDefs::cluskey ckey, SvtxAlignmentState* state) override;
-  virtual std::size_t erase(TrkrDefs::cluskey ckey) override
-  {
-    delete m_map[ckey];
-    return m_map.erase(ckey);
-  }
+  const StateVec get(unsigned int track) const override;
+  StateVec get(unsigned int track) override;
+  StateVec insertWithKey(unsigned int track, StateVec states) override;
+  std::size_t erase(unsigned int track) override;
+
 
   ConstIter begin() const override { return m_map.begin(); }
-  ConstIter find(TrkrDefs::cluskey ckey) const override { return m_map.find(ckey); }
+  ConstIter find(unsigned int track) const override { return m_map.find(track); }
   ConstIter end() const override { return m_map.end(); }
 
   Iter begin() override { return m_map.begin(); }
-  Iter find(TrkrDefs::cluskey ckey) override { return m_map.find(ckey); }
+  Iter find(unsigned int track) override { return m_map.find(track); }
   Iter end() override { return m_map.end(); }
 
  private:

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1.h
@@ -16,7 +16,7 @@ class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
   void Reset() override;
   int isValid() const override { return 1; }
   PHObject* CloneMe() const override { return new SvtxAlignmentStateMap_v1(*this); }
-  
+
   bool empty() const override { return m_map.empty(); }
   std::size_t size() const override { return m_map.size(); }
   std::size_t count(unsigned int track) const override { return m_map.count(track); }
@@ -26,7 +26,6 @@ class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
   StateVec get(unsigned int track) override;
   StateVec insertWithKey(unsigned int track, StateVec states) override;
   std::size_t erase(unsigned int track) override;
-
 
   ConstIter begin() const override { return m_map.begin(); }
   ConstIter find(unsigned int track) const override { return m_map.find(track); }
@@ -41,6 +40,5 @@ class SvtxAlignmentStateMap_v1 : public SvtxAlignmentStateMap
 
   ClassDefOverride(SvtxAlignmentStateMap_v1, 1);
 };
-
 
 #endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentStateMap_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxAlignmentStateMap_v1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
@@ -4,11 +4,14 @@ SvtxAlignmentState_v1::SvtxAlignmentState_v1()
   : m_residual(ResidualVector::Zero())
   , m_localDeriv(LocalMatrix::Zero())
   , m_globalDeriv(GlobalMatrix::Zero())
-{}
+  , m_cluskey(UINT_MAX)
+{
+}
 
 void SvtxAlignmentState_v1::identify(std::ostream &os) const 
 {
   os << "SvtxAlignmentState_v1 identify: " << std::endl;
+  os << "state for cluskey : " << m_cluskey << std::endl;
   os << "residual : " << m_residual.transpose() << std::endl;
   os << "local derivatives : " << std::endl << m_localDeriv << std::endl;
   os << "global derivatives : " << std::endl << m_globalDeriv << std::endl;

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
@@ -8,12 +8,13 @@ SvtxAlignmentState_v1::SvtxAlignmentState_v1()
 {
 }
 
-void SvtxAlignmentState_v1::identify(std::ostream &os) const 
+void SvtxAlignmentState_v1::identify(std::ostream &os) const
 {
   os << "SvtxAlignmentState_v1 identify: " << std::endl;
   os << "state for cluskey : " << m_cluskey << std::endl;
   os << "residual : " << m_residual.transpose() << std::endl;
-  os << "local derivatives : " << std::endl << m_localDeriv << std::endl;
-  os << "global derivatives : " << std::endl << m_globalDeriv << std::endl;
-
+  os << "local derivatives : " << std::endl
+     << m_localDeriv << std::endl;
+  os << "global derivatives : " << std::endl
+     << m_globalDeriv << std::endl;
 }

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.cc
@@ -1,0 +1,16 @@
+#include "SvtxAlignmentState_v1.h"
+
+SvtxAlignmentState_v1::SvtxAlignmentState_v1()
+  : m_residual(ResidualVector::Zero())
+  , m_localDeriv(LocalMatrix::Zero())
+  , m_globalDeriv(GlobalMatrix::Zero())
+{}
+
+void SvtxAlignmentState_v1::identify(std::ostream &os) const 
+{
+  os << "SvtxAlignmentState_v1 identify: " << std::endl;
+  os << "residual : " << m_residual.transpose() << std::endl;
+  os << "local derivatives : " << std::endl << m_localDeriv << std::endl;
+  os << "global derivatives : " << std::endl << m_globalDeriv << std::endl;
+
+}

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
@@ -10,6 +10,7 @@ class PHObject;
 
 class SvtxAlignmentState_v1 : public SvtxAlignmentState
 {
+ public:
   SvtxAlignmentState_v1();
   ~SvtxAlignmentState_v1() override {}
 

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
@@ -1,0 +1,49 @@
+#ifndef TRACKBASEHISTORIC_SVTXALIGNMENTSTATE_V1_H
+#define TRACKBASEHISTORIC_SVTXALIGNMENTSTATE_V1_H
+
+#include "SvtxAlignmentState.h"
+
+#include <cmath>
+#include <iostream>
+
+class PHObject;
+
+class SvtxAlignmentState_v1 : public SvtxAlignmentState
+{
+  SvtxAlignmentState_v1();
+  ~SvtxAlignmentState_v1() override {}
+
+  void identify(std::ostream &os = std::cout) const override;
+  void Reset() override { *this = SvtxAlignmentState_v1(); }
+  int isValid() const override { return 1; }
+  PHObject *CloneMe() const override { return new SvtxAlignmentState_v1(*this); }
+
+  void set_residual(const ResidualVector& res) override 
+  {
+    m_residual = res;
+  }
+  void set_local_derivative_matrix(const LocalMatrix& d) override 
+  {
+    m_localDeriv = d;
+  }
+  void set_global_derivative_matrix(const GlobalMatrix& d) override
+  {
+    m_globalDeriv = d;
+  }
+ 
+  
+  const ResidualVector& get_residual() const override { return m_residual; }
+  const LocalMatrix& get_local_derivative_matrix() const override { return m_localDeriv; }
+  const GlobalMatrix& get_global_derivative_matrix() const override { return m_globalDeriv; }
+
+
+ private:
+
+  ResidualVector m_residual;
+  LocalMatrix m_localDeriv;
+  GlobalMatrix m_globalDeriv;
+  
+  ClassDefOverride(SvtxAlignmentState_v1, 1)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
@@ -31,19 +31,24 @@ class SvtxAlignmentState_v1 : public SvtxAlignmentState
   {
     m_globalDeriv = d;
   }
+  void set_cluster_key(const TrkrDefs::cluskey key) override
+  {
+    m_cluskey = key;
+  }
  
   
   const ResidualVector& get_residual() const override { return m_residual; }
   const LocalMatrix& get_local_derivative_matrix() const override { return m_localDeriv; }
   const GlobalMatrix& get_global_derivative_matrix() const override { return m_globalDeriv; }
-
+  TrkrDefs::cluskey get_cluster_key() const override { return m_cluskey; }
 
  private:
 
   ResidualVector m_residual;
   LocalMatrix m_localDeriv;
   GlobalMatrix m_globalDeriv;
-  
+  TrkrDefs::cluskey m_cluskey;
+
   ClassDefOverride(SvtxAlignmentState_v1, 1)
 };
 

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1.h
@@ -14,16 +14,16 @@ class SvtxAlignmentState_v1 : public SvtxAlignmentState
   SvtxAlignmentState_v1();
   ~SvtxAlignmentState_v1() override {}
 
-  void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
   void Reset() override { *this = SvtxAlignmentState_v1(); }
   int isValid() const override { return 1; }
-  PHObject *CloneMe() const override { return new SvtxAlignmentState_v1(*this); }
+  PHObject* CloneMe() const override { return new SvtxAlignmentState_v1(*this); }
 
-  void set_residual(const ResidualVector& res) override 
+  void set_residual(const ResidualVector& res) override
   {
     m_residual = res;
   }
-  void set_local_derivative_matrix(const LocalMatrix& d) override 
+  void set_local_derivative_matrix(const LocalMatrix& d) override
   {
     m_localDeriv = d;
   }
@@ -35,15 +35,13 @@ class SvtxAlignmentState_v1 : public SvtxAlignmentState
   {
     m_cluskey = key;
   }
- 
-  
+
   const ResidualVector& get_residual() const override { return m_residual; }
   const LocalMatrix& get_local_derivative_matrix() const override { return m_localDeriv; }
   const GlobalMatrix& get_global_derivative_matrix() const override { return m_globalDeriv; }
   TrkrDefs::cluskey get_cluster_key() const override { return m_cluskey; }
 
  private:
-
   ResidualVector m_residual;
   LocalMatrix m_localDeriv;
   GlobalMatrix m_globalDeriv;

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1LinkDef.h
@@ -1,5 +1,5 @@
 #ifdef __CINT__
 
-#pragma link C++ class SvtxAlignmentState_v1+;
+#pragma link C++ class SvtxAlignmentState_v1 + ;
 
 #endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxAlignmentState_v1LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxAlignmentState_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxAlignmentState_v1+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -1,0 +1,397 @@
+#include "ActsAlignmentStates.h"
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/ActsSourceLink.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TpcDefs.h>
+
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxAlignmentStateMap.h>
+#include <trackbase_historic/SvtxAlignmentState_v1.h>
+
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Definitions/Units.hpp>
+#include <Acts/EventData/MultiTrajectory.hpp>
+#include <Acts/EventData/MultiTrajectoryHelpers.hpp>
+
+namespace
+{
+  template <class T>
+  inline constexpr T square(const T& x)
+  {
+    return x * x;
+  }
+} 
+
+void ActsAlignmentStates::fillAlignmentStateMap(PHCompositeNode* topNode,
+						Trajectory traj,
+						SvtxTrack* track)
+{
+
+  auto alignmentMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+  auto clusterMap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+auto tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
+
+
+  const auto mj = traj.multiTrajectory();
+  const auto& tips = traj.tips();
+  const auto& trackTip = tips.front();
+  const auto crossing = track->get_silicon_seed()->get_crossing();
+  std::map<TrkrDefs::cluskey, SvtxAlignmentState_v1*> statemap;
+
+  mj.visitBackwards(trackTip, [&](const auto& state) {
+    /// Collect only track states which were used in smoothing of KF and are measurements
+    if (not state.hasSmoothed() or
+        not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag))
+    {
+      return true;
+    }
+
+    const auto& surface = state.referenceSurface();
+    const auto& sl = static_cast<const ActsSourceLink&>(state.uncalibrated());
+    auto ckey = sl.cluskey();
+
+    if (m_verbosity > 2)
+      {
+	std::cout << "sl index and ckey " << sl.index() << ", "
+		  << sl.cluskey() << std::endl;
+      }
+
+    auto clus = clusterMap->findCluster(ckey);
+    const auto trkrId = TrkrDefs::getTrkrId(ckey);
+
+    /// Gets the global parameters from the state
+    const Acts::FreeVector freeParams =
+        Acts::MultiTrajectoryHelpers::freeSmoothed(tGeometry->geometry().getGeoContext(), state);
+
+    const Acts::ActsDynamicMatrix measCovariance =
+        state.effectiveCalibratedCovariance();
+
+    /// Calculate the residual in global coordinates
+    Acts::Vector3 clusGlobal = tGeometry->getGlobalPosition(ckey, clus);
+    if (trkrId == TrkrDefs::tpcId)
+    {
+      makeTpcGlobalCorrections(ckey, crossing, clusGlobal, topNode);
+    }
+
+    /// convert to acts units
+    clusGlobal *= Acts::UnitConstants::cm;
+
+    const Acts::FreeVector globalStateParams = Acts::detail::transformBoundToFreeParameters(surface, tGeometry->geometry().getGeoContext(), state.smoothed());
+    Acts::Vector3 stateGlobal = globalStateParams.segment<3>(Acts::eFreePos0);
+    Acts::Vector3 residual = clusGlobal - stateGlobal;
+
+    Acts::Vector3 clus_sigma(0, 0, 0);
+      if (m_clusterVersion == 3)
+      {
+        clus_sigma(2) = clus->getZError() * Acts::UnitConstants::cm;
+        clus_sigma(0) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+        clus_sigma(1) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+      }
+      else if (m_clusterVersion == 4)
+      {
+        double clusRadius = sqrt(clusGlobal(0) * clusGlobal(0) + clusGlobal(1) * clusGlobal(1));
+        auto para_errors = m_clusErrPara.get_simple_cluster_error(clus, clusRadius, ckey);
+        float exy2 = para_errors.first * Acts::UnitConstants::cm2;
+        float ez2 = para_errors.second * Acts::UnitConstants::cm2;
+        clus_sigma(2) = sqrt(ez2);
+        clus_sigma(0) = sqrt(exy2 / 2.0);
+        clus_sigma(1) = sqrt(exy2 / 2.0);
+      }
+    if (m_verbosity > 2)
+    {
+         
+      std::cout << "clus global is " << clusGlobal.transpose() << std::endl
+                << "state global is " << stateGlobal.transpose() << std::endl
+                << "Residual is " << residual.transpose() << std::endl;
+      std::cout << "   clus errors are " << clus_sigma.transpose() << std::endl;
+    }
+
+    // Get the derivative of alignment (global) parameters w.r.t. measurement or residual
+    const Acts::Vector3 direction = freeParams.segment<3>(Acts::eFreeDir0);
+    // The derivative of free parameters w.r.t. path length. @note Here, we
+    // assumes a linear track model, i.e. negecting the change of track
+    // direction. Otherwise, we need to know the magnetic field at the free
+    // parameters
+    Acts::FreeVector pathDerivative = Acts::FreeVector::Zero();
+    pathDerivative.head<3>() = direction;
+
+    const Acts::ActsDynamicMatrix H = state.effectiveProjector();
+
+    /// Acts residual, in local coordinates
+    auto actslocres = state.effectiveCalibrated() - H * state.smoothed();
+
+    // Get the derivative of bound parameters w.r.t. alignment parameters
+    Acts::AlignmentToBoundMatrix d =
+        surface.alignmentToBoundDerivative(tGeometry->geometry().getGeoContext(), freeParams, pathDerivative);
+    // Get the derivative of bound parameters wrt track parameters
+    Acts::FreeToBoundMatrix j = surface.freeToBoundJacobian(tGeometry->geometry().getGeoContext(), freeParams);
+
+    // derivative of residual wrt track parameters
+    auto dLocResTrack = -H * j;
+    // derivative of residual wrt alignment parameters
+    auto dLocResAlignment = -H * d;
+
+    if (m_verbosity > 4)
+    {
+      std::cout << "local resids " << actslocres.transpose() << std::endl
+                << " derivative of resiudal wrt track params " << std::endl
+                << dLocResTrack << std::endl
+                << " derivative of residual wrt alignment params " << std::endl
+                << dLocResAlignment << std::endl;
+    }
+
+    /// The above matrices are in Acts local coordinates, so we need to convert them to
+    /// global coordinates with a rotation d(l0,l1)/d(x,y,z)
+
+    const double cosTheta = direction.z();
+    const double sinTheta = std::sqrt(square(direction.x()) + square(direction.y()));
+    const double invSinTheta = 1. / sinTheta;
+    const double cosPhi = direction.x() * invSinTheta;
+    const double sinPhi = direction.y() * invSinTheta;
+    Acts::ActsMatrix<3, 2> rot = Acts::ActsMatrix<3, 2>::Zero();
+    rot(0, 0) = -sinPhi;
+    rot(0, 1) = -cosPhi * cosTheta;
+    rot(1, 0) = cosPhi;
+    rot(1, 1) = -sinPhi * cosTheta;
+    rot(2, 1) = sinTheta;
+
+    /// this is a 3x6 matrix now of d(x_res,y_res,z_res)/d(dx,dy,dz,alpha,beta,gamma)
+    const auto dGlobResAlignment = rot * dLocResAlignment;
+
+    /// Acts global coordinates are (x,y,z,t,hatx,haty,hatz,q/p)
+    /// So now rotate to x,y,z, px,py,pz
+    const double p = 1. / abs(globalStateParams[Acts::eFreeQOverP]);
+    const double p2 = square(p);
+    Acts::ActsMatrix<6, 8> sphenixRot = Acts::ActsMatrix<6, 8>::Zero();
+    sphenixRot(0, 0) = 1;
+    sphenixRot(1, 1) = 1;
+    sphenixRot(2, 2) = 1;
+    sphenixRot(3, 4) = p;
+    sphenixRot(4, 5) = p;
+    sphenixRot(5, 6) = p;
+    sphenixRot(3, 7) = direction.x() * p2;
+    sphenixRot(4, 7) = direction.y() * p2;
+    sphenixRot(5, 7) = direction.z() * p2;
+
+    const auto dGlobResTrack = rot * dLocResTrack * sphenixRot.transpose();
+
+    if (m_verbosity > 3)
+    {
+      std::cout << "derivative of residual wrt alignment parameters glob " << std::endl
+                << dGlobResAlignment << std::endl;
+      std::cout << "derivative of residual wrt trakc parameters glob " << std::endl
+                << dGlobResTrack << std::endl;
+    }
+
+
+    auto svtxstate = std::make_unique<SvtxAlignmentState_v1>();
+    svtxstate->set_residual(residual);
+    svtxstate->set_local_derivative_matrix(dGlobResTrack);
+    svtxstate->set_global_derivative_matrix(dGlobResAlignment);
+
+    
+    if(m_analytic)
+      {
+	auto surf = tGeometry->maps().getSurface(ckey, clus);
+	auto anglederivs = getDerivativesAlignmentAngles(topNode, 
+							 clusGlobal, ckey, 
+							 clus, surf, 
+							 crossing);
+        SvtxAlignmentState::GlobalMatrix analytic = SvtxAlignmentState::GlobalMatrix::Zero();
+        analytic(0,0) = 1;
+        analytic(1,1) = 1;
+        analytic(2,2) = 1;
+	for(int i=0; i<SvtxAlignmentState::NRES; ++i) 
+	  {
+	    for(int j=3; j<SvtxAlignmentState::NGL; ++j)
+	      {
+		/// convert to mm
+		analytic(i,j) = anglederivs.at(i)(j-3) * Acts::UnitConstants::cm;
+	      }
+	  }
+
+	svtxstate->set_global_derivative_matrix(analytic);
+      }
+
+    statemap.insert(std::make_pair(ckey, svtxstate.get()));
+
+    return true;
+    });
+
+
+  return;
+}
+
+
+void ActsAlignmentStates::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global, PHCompositeNode *topNode)
+{
+ 
+   // tpc distortion corrections
+  auto dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerStatic");
+  
+  auto dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerAverage");
+
+  auto dcc_fluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerFluctuation");
+
+  // make all corrections to global position of TPC cluster
+  unsigned int side = TpcDefs::getSide(cluster_key);
+  float z = m_clusterCrossingCorrection.correctZ(global[2], side, crossing);
+  global[2] = z;
+  
+  // apply distortion corrections
+  if (dcc_static)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, dcc_static);
+  }
+  if (dcc_average)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, dcc_average);
+  }
+  if (dcc_fluctuation)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, dcc_fluctuation);
+  }
+}
+
+
+std::vector<Acts::Vector3> ActsAlignmentStates::getDerivativesAlignmentAngles(PHCompositeNode *topNode, Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing)
+{
+  // The value of global is from the geocontext transformation
+  // we add to that transformation a small rotation around the relevant axis in the surface frame
+  auto tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  
+  std::vector<Acts::Vector3> derivs_vector;
+
+  // get the transformation from the geocontext
+  Acts::Transform3 transform = surface->transform(tGeometry->geometry().getGeoContext());
+
+  // Make an additional transform that applies a small rotation angle in the surface frame
+  for (unsigned int iangle = 0; iangle < 3; ++iangle)
+  {
+    // creates transform that adds a perturbation rotation around one axis, uses it to estimate derivative wrt perturbation rotation
+
+    unsigned int trkrId = TrkrDefs::getTrkrId(cluster_key);
+    unsigned int layer = TrkrDefs::getLayer(cluster_key);
+
+    Acts::Vector3 derivs(0, 0, 0);
+    Eigen::Vector3d theseAngles(0, 0, 0);
+    theseAngles[iangle] = sensorAngles[iangle];  // set the one we want to be non-zero
+
+    Acts::Vector3 keeper(0, 0, 0);
+    for (int ip = 0; ip < 2; ++ip)
+    {
+      if (ip == 1)
+      {
+        theseAngles[iangle] *= -1;
+      }  // test both sides of zero
+
+      if (m_verbosity > 1)
+      {
+        std::cout << "     trkrId " << trkrId << " layer " << layer << " cluster_key " << cluster_key
+                  << " sensorAngles " << theseAngles[0] << "  " << theseAngles[1] << "  " << theseAngles[2] << std::endl;
+      }
+
+      Acts::Transform3 perturbationTransformation = makePerturbationTransformation(theseAngles);
+      Acts::Transform3 overallTransformation = transform * perturbationTransformation;
+
+      // transform the cluster local position to global coords with this additional rotation added
+      auto x = cluster->getLocalX() * 10;  // mm
+      auto y = cluster->getLocalY() * 10;
+      if (trkrId == TrkrDefs::tpcId)
+      {
+        y = convertTimeToZ(tGeometry, cluster_key, cluster);
+      }
+
+      Eigen::Vector3d clusterLocalPosition(x, y, 0);                                      // follows the convention for the acts transform of local = (x,z,y)
+      Eigen::Vector3d finalCoords = overallTransformation * clusterLocalPosition / 10.0;  // convert mm back to cm
+
+      // have to add corrections for TPC clusters after transformation to global
+      if (trkrId == TrkrDefs::tpcId)
+      {
+        makeTpcGlobalCorrections(cluster_key, crossing, global, topNode);
+      }
+
+      if (ip == 0)
+      {
+        keeper(0) = (finalCoords(0) - global(0));
+        keeper(1) = (finalCoords(1) - global(1));
+        keeper(2) = (finalCoords(2) - global(2));
+      }
+      else
+      {
+        keeper(0) -= (finalCoords(0) - global(0));
+        keeper(1) -= (finalCoords(1) - global(1));
+        keeper(2) -= (finalCoords(2) - global(2));
+      }
+
+      if (m_verbosity > 1)
+      {
+        std::cout << "        finalCoords(0) " << finalCoords(0) << " global(0) " << global(0) << " finalCoords(1) " << finalCoords(1)
+                  << " global(1) " << global(1) << " finalCoords(2) " << finalCoords(2) << " global(2) " << global(2) << std::endl;
+        std::cout << "        keeper now:  keeper(0) " << keeper(0) << " keeper(1) " << keeper(1) << " keeper(2) " << keeper(2) << std::endl;
+      }
+    }
+
+    // derivs vector contains:
+    //   (dx/dalpha,     dy/dalpha,     dz/dalpha)     (for iangle = 0)
+    //   (dx/dbeta,        dy/dbeta,        dz/dbeta)        (for iangle = 1)
+    //   (dx/dgamma, dy/dgamma, dz/dgamma) (for iangle = 2)
+
+    // Average the changes to get the estimate of the derivative
+    // Check what the sign of this should be !!!!
+    derivs(0) = keeper(0) / (2.0 * fabs(theseAngles[iangle]));
+    derivs(1) = keeper(1) / (2.0 * fabs(theseAngles[iangle]));
+    derivs(2) = keeper(2) / (2.0 * fabs(theseAngles[iangle]));
+    derivs_vector.push_back(derivs);
+
+    if (m_verbosity > 1)
+    {
+      std::cout << "        derivs(0) " << derivs(0) << " derivs(1) " << derivs(1) << " derivs(2) " << derivs(2) << std::endl;
+    }
+  }
+
+  return derivs_vector;
+}
+
+Acts::Transform3 ActsAlignmentStates::makePerturbationTransformation(Acts::Vector3 angles)
+{
+  // Note: Here beta is apllied to the z axis and gamma is applied to the y axis because the geocontext transform
+  // will flip those axes when transforming to global coordinates
+  Eigen::AngleAxisd alpha(angles(0), Eigen::Vector3d::UnitX());
+  Eigen::AngleAxisd beta(angles(2), Eigen::Vector3d::UnitY());
+  Eigen::AngleAxisd gamma(angles(1), Eigen::Vector3d::UnitZ());
+  Eigen::Quaternion<double> q = gamma * beta * alpha;
+  Eigen::Matrix3d perturbationRotation = q.matrix();
+
+  // combine rotation and translation into an affine matrix
+  Eigen::Vector3d nullTranslation(0, 0, 0);
+  Acts::Transform3 perturbationTransformation;
+  perturbationTransformation.linear() = perturbationRotation;
+  perturbationTransformation.translation() = nullTranslation;
+
+  return perturbationTransformation;
+}
+float ActsAlignmentStates::convertTimeToZ(ActsGeometry* tGeometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster)
+{
+  // must convert local Y from cluster average time of arival to local cluster z position
+  double drift_velocity = tGeometry->get_drift_velocity();
+  double zdriftlength = cluster->getLocalY() * drift_velocity;
+  double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
+  double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
+  unsigned int side = TpcDefs::getSide(cluster_key);
+  if (side == 0) zloc = -zloc;
+  float z = zloc * 10.0;
+
+  return z;
+}

--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -1,29 +1,29 @@
 #include "ActsAlignmentStates.h"
 
 #include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHDataNode.h>
 #include <phool/PHNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/ActsSourceLink.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/ActsSourceLink.h>
-#include <trackbase/ActsGeometry.h>
-#include <trackbase/TrkrCluster.h>
-#include <trackbase/TpcDefs.h>
 
-#include <trackbase_historic/SvtxTrack.h>
-#include <trackbase_historic/SvtxAlignmentStateMap.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
+#include <trackbase_historic/SvtxAlignmentStateMap.h>
 #include <trackbase_historic/SvtxAlignmentState_v1.h>
+#include <trackbase_historic/SvtxTrack.h>
 
-#include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Definitions/Units.hpp>
 #include <Acts/EventData/MultiTrajectory.hpp>
 #include <Acts/EventData/MultiTrajectoryHelpers.hpp>
+#include <Acts/Surfaces/Surface.hpp>
 
 namespace
 {
@@ -32,10 +32,10 @@ namespace
   {
     return x * x;
   }
-} 
+}  // namespace
 
 void ActsAlignmentStates::fillAlignmentStateMap(Trajectory traj,
-						SvtxTrack* track)
+                                                SvtxTrack* track)
 {
   const auto mj = traj.multiTrajectory();
   const auto& tips = traj.tips();
@@ -43,7 +43,8 @@ void ActsAlignmentStates::fillAlignmentStateMap(Trajectory traj,
   const auto crossing = track->get_silicon_seed()->get_crossing();
   SvtxAlignmentStateMap::StateVec statevec;
 
-  mj.visitBackwards(trackTip, [&](const auto& state) {
+  mj.visitBackwards(trackTip, [&](const auto& state)
+                    {
     /// Collect only track states which were used in smoothing of KF and are measurements
     if (not state.hasSmoothed() or
         not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag))
@@ -219,29 +220,26 @@ void ActsAlignmentStates::fillAlignmentStateMap(Trajectory traj,
 
     statevec.push_back(svtxstate.release());
 
-    return true;
-    });
+    return true; });
 
-  if(m_verbosity > 2)
-    {
-      std::cout << "Inserting track " << track->get_id() << " with nstates "
-		<< statevec.size() << std::endl;
-    }
+  if (m_verbosity > 2)
+  {
+    std::cout << "Inserting track " << track->get_id() << " with nstates "
+              << statevec.size() << std::endl;
+  }
 
-  m_alignmentStateMap->insertWithKey(track->get_id(),statevec);
+  m_alignmentStateMap->insertWithKey(track->get_id(), statevec);
 
   return;
 }
 
-
 void ActsAlignmentStates::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global)
 {
- 
   // make all corrections to global position of TPC cluster
   unsigned int side = TpcDefs::getSide(cluster_key);
   float z = m_clusterCrossingCorrection.correctZ(global[2], side, crossing);
   global[2] = z;
-  
+
   // apply distortion corrections
   if (m_dcc_static)
   {
@@ -256,7 +254,6 @@ void ActsAlignmentStates::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_fluctuation);
   }
 }
-
 
 std::vector<Acts::Vector3> ActsAlignmentStates::getDerivativesAlignmentAngles(Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing)
 {

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -1,0 +1,57 @@
+#ifndef TRACKRECO_ACTSALIGNMENTSTATES_H
+#define TRACKRECO_ACTSALIGNMENTSTATES_H
+
+#include <trackbase/TrkrDefs.h>
+
+#include <Acts/Definitions/Algebra.hpp>
+
+#include <ActsExamples/EventData/Trajectories.hpp>
+#include <ActsExamples/EventData/Track.hpp>
+
+#include <tpc/TpcClusterZCrossingCorrection.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
+#include <tpc/TpcDistortionCorrection.h>
+
+#include <trackbase/ClusterErrorPara.h>
+#include <trackbase/ActsGeometry.h>
+
+class PHCompositeNode;
+class SvtxTrack;
+
+
+/*
+ * Helper class that contains functionality to fill alignment state
+ * map from Acts track fitter
+ */
+class ActsAlignmentStates
+{
+ public:
+  using Trajectory = ActsExamples::Trajectories;
+
+  ActsAlignmentStates() {}
+  ~ActsAlignmentStates() {}
+  void clusterVersion(const int v) { m_clusterVersion = v; }
+  void fillAlignmentStateMap(PHCompositeNode* topNode,
+			     Trajectory traj,
+			     SvtxTrack* track);
+  void verbosity(const int verb) { m_verbosity = verb; }
+  void analyticGlobalDer(bool a) { m_analytic = a; }
+
+ private:
+  void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global, PHCompositeNode* topNode);
+  std::vector<Acts::Vector3> getDerivativesAlignmentAngles(PHCompositeNode *topNode, Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing);
+  Acts::Transform3 makePerturbationTransformation(Acts::Vector3 angles);
+  float convertTimeToZ(ActsGeometry* tGeometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
+
+  bool m_analytic = false;
+  int m_verbosity = 0;
+  int m_clusterVersion = 4;
+
+   float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
+
+  ClusterErrorPara m_clusErrPara;
+  TpcDistortionCorrection m_distortionCorrection;
+  TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
+};
+
+#endif

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -5,15 +5,15 @@
 
 #include <Acts/Definitions/Algebra.hpp>
 
-#include <ActsExamples/EventData/Trajectories.hpp>
 #include <ActsExamples/EventData/Track.hpp>
+#include <ActsExamples/EventData/Trajectories.hpp>
 
 #include <tpc/TpcClusterZCrossingCorrection.h>
-#include <tpc/TpcDistortionCorrectionContainer.h>
 #include <tpc/TpcDistortionCorrection.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
 
-#include <trackbase/ClusterErrorPara.h>
 #include <trackbase/ActsGeometry.h>
+#include <trackbase/ClusterErrorPara.h>
 
 class PHCompositeNode;
 class SvtxTrack;
@@ -34,19 +34,19 @@ class ActsAlignmentStates
   ~ActsAlignmentStates() {}
   void clusterVersion(const int v) { m_clusterVersion = v; }
   void fillAlignmentStateMap(Trajectory traj,
-			     SvtxTrack* track);
+                             SvtxTrack* track);
   void verbosity(const int verb) { m_verbosity = verb; }
   void analyticGlobalDer(bool a) { m_analytic = a; }
   void distortionContainers(TpcDistortionCorrectionContainer* stat,
-			    TpcDistortionCorrectionContainer *average,
-			    TpcDistortionCorrectionContainer *fluc)
+                            TpcDistortionCorrectionContainer* average,
+                            TpcDistortionCorrectionContainer* fluc)
   {
     m_dcc_static = stat;
     m_dcc_average = average;
     m_dcc_fluctuation = fluc;
   }
   void actsGeometry(ActsGeometry* geom) { m_tGeometry = geom; }
-  void clusters(TrkrClusterContainer *clus) { m_clusterMap = clus; }
+  void clusters(TrkrClusterContainer* clus) { m_clusterMap = clus; }
   void stateMap(SvtxAlignmentStateMap* map) { m_alignmentStateMap = map; }
 
  private:
@@ -59,19 +59,18 @@ class ActsAlignmentStates
   int m_verbosity = 0;
   int m_clusterVersion = 4;
 
-   float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
+  float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
 
   ClusterErrorPara m_clusErrPara;
   TpcDistortionCorrection m_distortionCorrection;
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
 
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
-  TrkrClusterContainer *m_clusterMap = nullptr;
-  ActsGeometry *m_tGeometry = nullptr;
-  TpcDistortionCorrectionContainer *m_dcc_static = nullptr;
-  TpcDistortionCorrectionContainer *m_dcc_average = nullptr;
-  TpcDistortionCorrectionContainer *m_dcc_fluctuation = nullptr;
-
+  TrkrClusterContainer* m_clusterMap = nullptr;
+  ActsGeometry* m_tGeometry = nullptr;
+  TpcDistortionCorrectionContainer* m_dcc_static = nullptr;
+  TpcDistortionCorrectionContainer* m_dcc_average = nullptr;
+  TpcDistortionCorrectionContainer* m_dcc_fluctuation = nullptr;
 };
 
 #endif

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -17,7 +17,9 @@
 
 class PHCompositeNode;
 class SvtxTrack;
-
+class SvtxAlignmentStateMap;
+class ActsGeometry;
+class TrkrClusterContainer;
 
 /*
  * Helper class that contains functionality to fill alignment state
@@ -31,17 +33,27 @@ class ActsAlignmentStates
   ActsAlignmentStates() {}
   ~ActsAlignmentStates() {}
   void clusterVersion(const int v) { m_clusterVersion = v; }
-  void fillAlignmentStateMap(PHCompositeNode* topNode,
-			     Trajectory traj,
+  void fillAlignmentStateMap(Trajectory traj,
 			     SvtxTrack* track);
   void verbosity(const int verb) { m_verbosity = verb; }
   void analyticGlobalDer(bool a) { m_analytic = a; }
+  void distortionContainers(TpcDistortionCorrectionContainer* stat,
+			    TpcDistortionCorrectionContainer *average,
+			    TpcDistortionCorrectionContainer *fluc)
+  {
+    m_dcc_static = stat;
+    m_dcc_average = average;
+    m_dcc_fluctuation = fluc;
+  }
+  void actsGeometry(ActsGeometry* geom) { m_tGeometry = geom; }
+  void clusters(TrkrClusterContainer *clus) { m_clusterMap = clus; }
+  void stateMap(SvtxAlignmentStateMap* map) { m_alignmentStateMap = map; }
 
  private:
-  void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global, PHCompositeNode* topNode);
-  std::vector<Acts::Vector3> getDerivativesAlignmentAngles(PHCompositeNode *topNode, Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing);
+  void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global);
+  std::vector<Acts::Vector3> getDerivativesAlignmentAngles(Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing);
   Acts::Transform3 makePerturbationTransformation(Acts::Vector3 angles);
-  float convertTimeToZ(ActsGeometry* tGeometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
+  float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
 
   bool m_analytic = false;
   int m_verbosity = 0;
@@ -52,6 +64,14 @@ class ActsAlignmentStates
   ClusterErrorPara m_clusErrPara;
   TpcDistortionCorrection m_distortionCorrection;
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
+
+  SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
+  TrkrClusterContainer *m_clusterMap = nullptr;
+  ActsGeometry *m_tGeometry = nullptr;
+  TpcDistortionCorrectionContainer *m_dcc_static = nullptr;
+  TpcDistortionCorrectionContainer *m_dcc_average = nullptr;
+  TpcDistortionCorrectionContainer *m_dcc_fluctuation = nullptr;
+
 };
 
 #endif

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -22,6 +22,7 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   ActsEvaluator.h \
+  ActsAlignmentStates.h \
   ALICEKF.h \
   AssocInfoContainer.h \
   AssocInfoContainerv1.h \
@@ -80,6 +81,7 @@ libtrack_reco_io_la_SOURCES = \
   GPUTPCTrackParam.cxx
 
 ACTS_SOURCES = \
+  ActsAlignmentStates.cc \
   ActsEvaluator.cc \
   MakeActsGeometry.cc \
   PHActsGSF.cc \

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -89,7 +89,7 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
   m_alignStates.actsGeometry(m_tGeometry);
   m_alignStates.clusters(m_clusterContainer);
   m_alignStates.stateMap(m_alignmentStateMap);
-  m_alignStates.verbosity(Verbosity()+10);
+  m_alignStates.verbosity(Verbosity());
 
   m_fitCfg.fit = ActsTrackFittingAlgorithm::makeKalmanFitterFunction(
     m_tGeometry->geometry().tGeometry,

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -22,6 +22,7 @@
 #include <trackbase_historic/SvtxTrackMap_v2.h>
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/SvtxAlignmentStateMap_v1.h>
 
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
@@ -1090,6 +1091,14 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
     {
       m_trackMap = new SvtxTrackMap_v2;
       PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_trackMap,_track_map_name,"PHObject");
+      svtxNode->addNode(node);
+    }
+
+  m_alignmentStateMap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+  if(!m_alignmentStateMap)
+    {
+      m_alignmentStateMap = new SvtxAlignmentStateMap_v1;
+      auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap,"SvtxAlignmentStateMap");
       svtxNode->addNode(node);
     }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1109,7 +1109,7 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
   if(!m_alignmentStateMap)
     {
       m_alignmentStateMap = new SvtxAlignmentStateMap_v1;
-      auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap,"SvtxAlignmentStateMap");
+      auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap,"SvtxAlignmentStateMap","PHObject");
       svtxNode->addNode(node);
     }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -8,6 +8,7 @@
 #ifndef TRACKRECO_ACTSTRKFITTER_H
 #define TRACKRECO_ACTSTRKFITTER_H
 
+#include "ActsAlignmentStates.h"
 
 #include <fun4all/SubsysReco.h>
 
@@ -94,6 +95,8 @@ class PHActsTrkFitter : public SubsysReco
 
   void setAbsPdgHypothesis(unsigned int pHypothesis)
   { m_pHypothesis = pHypothesis; }
+
+  void commissioning(bool com) { m_commissioning = com; }
 
   void useOutlierFinder(bool outlier) { m_useOutlierFinder = outlier; }
 
@@ -200,6 +203,8 @@ class PHActsTrkFitter : public SubsysReco
   unsigned int m_pHypothesis = 211;
 
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
+  ActsAlignmentStates m_alignStates;
+  bool m_commissioning = false;
 
   /// Variables for doing event time execution analysis
   bool m_timeAnalysis = false;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -25,7 +25,6 @@
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
-
 #include <ActsExamples/EventData/Trajectories.hpp>
 #include <ActsExamples/EventData/Track.hpp>
 
@@ -34,7 +33,6 @@
 #include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
-
 
 #include <trackbase/alignmentTransformationContainer.h>
 
@@ -45,6 +43,7 @@ class TrackSeed;
 class TrackSeedContainer;
 class TrkrClusterContainer;
 class TpcDistortionCorrectionContainer;
+class SvtxAlignmentStateMap;
 
 using SourceLink = ActsSourceLink;
 using FitResult = Acts::KalmanFitterResult;
@@ -199,6 +198,8 @@ class PHActsTrkFitter : public SubsysReco
 
   /// Default particle assumption to pion
   unsigned int m_pHypothesis = 211;
+
+  SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
 
   /// Variables for doing event time execution analysis
   bool m_timeAnalysis = false;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR is a major overhaul of the Acts Kalman Filter fit based alignment workflow. There is currently a bug that causes the iteration through Acts::Trajectory::States to look up the wrong  cluster key. The reason is that the Acts source link only stores the address to it's internal information, which means the cluster key is lost when looking in different Fun4All modules since we create cluster keys on the fly (thus, their addresses change). Therefore, currently the alignment state preparation compares the wrong cluster to the track state.

This PR fixes this problem by adding a new map object that stores the Acts alignment information in an `SvtxAlignmentState` object and putting the relevant information on the node tree.  The information is then read in by `MakeMilleFiles` to produce the steering file for pede. This map is only created in "commissioning mode," since the alignment information is several matrices which could cause large memory consumption in typical AuAu environments. Tests with perfect alignment show that the alignment parameters are determined within a few microns to be 0.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

