### PR TITLE
Fix TpcDirectLaserReconstruction

### DIFF
--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -15,7 +15,6 @@
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <trackbase/ActsTrackingGeometry.h>
-#include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
@@ -228,16 +227,9 @@ int TpcDirectLaserReconstruction::load_nodes( PHCompositeNode* topNode )
   m_geom_container =  findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   assert( m_geom_container );
 
-  // acts surface map
-  m_surfmaps = findNode::getClass<ActsSurfaceMaps>(topNode, "ActsSurfaceMaps");
-  assert( m_surfmaps );
-
   // acts geometry
   m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   assert( m_tGeometry );
-
-  //  m_tGeometry = findNode::getClass<ActsTrackingGeometry>(topNode, "ActsTrackingGeometry");
-  // assert( m_tGeometry );
 
   // tracks
   m_track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -13,13 +13,11 @@
 
 #include <memory>
 
-struct ActsSurfaceMaps;
-struct ActsTrackingGeometry;
 class SvtxTrack;
 class SvtxTrackMap;
 class TpcSpaceChargeMatrixContainer;
 class TrkrHitSetContainer;
-class   PHG4TpcCylinderGeomContainer;
+class PHG4TpcCylinderGeomContainer;
 
 class TFile;
 class TH1;
@@ -125,11 +123,7 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
 
   PHG4TpcCylinderGeomContainer *m_geom_container = nullptr;
 
-  /// Acts surface maps for surface lookup
-  ActsSurfaceMaps* m_surfmaps = nullptr;
-
-  /// Acts tracking geometry for surface lookup
-  //  ActsTrackingGeometry* m_tGeometry = nullptr;
+  /// Acts geometry
   ActsGeometry *m_tGeometry = nullptr;
 
   /// acts transformation


### PR DESCRIPTION
remove looking up ActsSurfaceMap from node tree: it is both obsolete and unused in the code
This fixes a crash (assert) when running the direct laser reconstruction

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

