### PR TITLE
Distortion gen save charge hist

### DIFF
--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -1372,7 +1372,7 @@ void AnnularFieldSim::save_spacecharge(const std::string &filename){
           for (int k = 0; k < nz; k++)
             {
               float z = zmin+step.Z()*(k+0.5);
-              hsc->Fill(q->GetChargeAtPosition(r,phi,z));                                                                                                        
+              hsc->Fill(phi,r,z,q->GetChargeAtPosition(r,phi,z));                                                                                                        
 	      //old version: hsc->Fill(phi,r,z,q->Get(j,i,k));
             }
         }

--- a/calibrations/tpc/generator/AnnularFieldSim.cc
+++ b/calibrations/tpc/generator/AnnularFieldSim.cc
@@ -1359,6 +1359,29 @@ commenting this out for now, until we see if it works.
   */
 }
 
+
+void AnnularFieldSim::save_spacecharge(const std::string &filename){
+  //save a histogram giving the spacecharge in our local coordinates, as we'll be using them..                                                                                  
+  TH3F* hsc=new TH3F("hInternalSpaceCharge","Internal Charge Histogram;phi(rad);r(cm);z(cm)",nphi,0,phispan,nr,rmin,rmax,nz,zmin,zmax);
+  for (int i = 0; i < nphi; i++)
+    {
+      float phi = 0+step.Phi()*(i+0.5);
+      for (int j = 0; j < nr; j++)
+        {
+          float r = rmin + step.Perp()*(j+0.5);
+          for (int k = 0; k < nz; k++)
+            {
+              float z = zmin+step.Z()*(k+0.5);
+              hsc->Fill(q->GetChargeAtPosition(r,phi,z));                                                                                                        
+	      //old version: hsc->Fill(phi,r,z,q->Get(j,i,k));
+            }
+        }
+    }
+  hsc->SaveAs(filename.c_str());
+  return;
+}
+
+
 void AnnularFieldSim::add_testcharge(float r, float phi, float z, float coulombs)
 {
   q->AddChargeAtPosition(r, phi, z, coulombs * C);

--- a/calibrations/tpc/generator/AnnularFieldSim.h
+++ b/calibrations/tpc/generator/AnnularFieldSim.h
@@ -245,7 +245,7 @@ class AnnularFieldSim
   void load_and_resample_spacecharge(int new_nphi, int new_nr, int new_nz, const std::string &filename, const std::string &histname, float zoffset, float chargescale, float cmscale, bool isChargeDensity);
 
   void load_and_resample_spacecharge(int new_nphi, int new_nr, int new_nz, TH3 *hist, float zoffset, float chargescale, float cmscale, bool isChargeDensity);
-
+  void save_spacecharge(const std::string &filename);
   void load_analytic_spacecharge(float scalefactor);
   void add_testcharge(float r, float phi, float z, float coulombs);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This adds a new feature to the distortion generator, allowing to write out the internal representation of the charge distritbuion in the TPC for debugging purposes

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Minor mods to the AnnularFieldSim code.

## TODOs (if applicable)

It might be slightly nicer to have this handle the field sim twin for north and south together, rather than exporting only north or south's histogram.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

