### PR TITLE
Enabled TPC-only track fitting

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -260,21 +260,23 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	{ std::cout << "tpc and si id " << tpcid << ", " << siid << std::endl; }
 
       /// A track seed is made for every tpc seed. Not every tpc seed
-      /// has a silicon match, we skip those cases completely
-      if(siid == std::numeric_limits<unsigned int>::max()) 
+      /// has a silicon match, we skip those cases completely in pp running
+      if(m_pp_mode && siid == std::numeric_limits<unsigned int>::max()) 
 	{
-	  if(Verbosity() > 1) std::cout << "SvtxSeedTrack has no silicon match, skip it" << std::endl;
+	  if(Verbosity() > 1) std::cout << "Running in pp mode and SvtxSeedTrack has no silicon match, skip it" << std::endl;
 	  continue;
 	}
 
       // get the crossing number
       auto siseed = m_siliconSeeds->get(siid);
-      auto crossing = siseed->get_crossing();
+      short crossing = SHRT_MAX;
+      if(siseed) crossing = siseed->get_crossing();
+      else if(!m_pp_mode) crossing = 0;
 
-      // if the crossing was not determined, skip this case completely
-      if(crossing == SHRT_MAX) 
+      // if the crossing was not determined in pp running, skip this case completely
+      if(m_pp_mode && crossing == SHRT_MAX) 
 	{
-	  // Skip this in the pp case. For AuAu it should not happen
+	  // Skip this in the pp case.
 	  if(Verbosity() > 1) std::cout << "Crossing not determined, skipping track" << std::endl;
 	  continue;
 	}
@@ -287,7 +289,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
       if(Verbosity() > 0) 
 	{
-	  std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
+	  if(siseed) std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
 	  std::cout << " tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
 	}
 
@@ -296,15 +298,25 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       trackTimer.restart();
       ActsExamples::MeasurementContainer measurements;
   
-      auto sourceLinks = getSourceLinks(siseed, measurements, crossing);
+      SourceLinkVec sourceLinks;
+      if(siseed) sourceLinks = getSourceLinks(siseed, measurements, crossing);
       const auto tpcSourceLinks = getSourceLinks(tpcseed, measurements, crossing);
       sourceLinks.insert( sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end() );
 
-      // position comes from the silicon seed
+      // position comes from the silicon seed, unless there is no silicon seed
       Acts::Vector3 position(0,0,0);
-      position(0) = siseed->get_x() * Acts::UnitConstants::cm;
-      position(1) = siseed->get_y() * Acts::UnitConstants::cm;
-      position(2) = siseed->get_z() * Acts::UnitConstants::cm;
+      if(siseed)
+        {
+          position(0) = siseed->get_x() * Acts::UnitConstants::cm;
+          position(1) = siseed->get_y() * Acts::UnitConstants::cm;
+          position(2) = siseed->get_z() * Acts::UnitConstants::cm;
+        }
+      else
+        {
+          position(0) = tpcseed->get_x() * Acts::UnitConstants::cm;
+          position(1) = tpcseed->get_y() * Acts::UnitConstants::cm;
+          position(2) = tpcseed->get_z() * Acts::UnitConstants::cm;
+        }
       if( !is_valid( position ) ) continue;
 
       if(sourceLinks.empty()) { continue; }
@@ -459,7 +471,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
 
   SourceLinkVec sourcelinks;
 
-  if(crossing == SHRT_MAX) 
+  if(m_pp_mode && crossing == SHRT_MAX) 
     {
       // Need to skip this in the pp case, for AuAu it should not happen
       return sourcelinks; 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -106,6 +106,9 @@ class PHActsTrkFitter : public SubsysReco
 
   void set_cluster_version(int value) { m_cluster_version = value; }
 
+  /// Set flag for pp running
+  void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
+
  private:
 
   /// Get all the nodes
@@ -176,6 +179,9 @@ class PHActsTrkFitter : public SubsysReco
   /// A bool to use the chi2 outlier finder in the track fitting
   bool m_useOutlierFinder = false;
   ResidualOutlierFinder m_outlierFinder;
+
+  /// Flag for pp running
+  bool m_pp_mode = false;
 
   bool m_actsEvaluator = false;
   std::map<const unsigned int, Trajectory> *m_trajectories = nullptr;

--- a/offline/packages/trackreco/PHActsVertexPropagator.cc
+++ b/offline/packages/trackreco/PHActsVertexPropagator.cc
@@ -70,7 +70,6 @@ int PHActsVertexPropagator::process_event(PHCompositeNode*)
       for(const auto& trackTip : trackTips)
 	{
 	  const auto& boundParams = trajectory.trackParameters(trackTip);
-
 	  auto propresult = propagateTrack(boundParams, svtxTrack->get_vertex_id());
 	  if(propresult.ok())
 	    {
@@ -78,6 +77,10 @@ int PHActsVertexPropagator::process_event(PHCompositeNode*)
 	      auto paramsAtVertex = std::move(**propresult);
 	      updateSvtxTrack(svtxTrack,paramsAtVertex);
 	    }
+          else
+            {
+              svtxTrack->identify();
+            }
 	}
     }
   

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -51,6 +51,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   int GetNodes(PHCompositeNode* topNode);
 
   void findEtaPhiMatches( std::set<unsigned int> &tpc_matched_set,
+                            std::set<unsigned int> &tpc_unmatched_set,
 			    std::multimap<unsigned int, unsigned int> &tpc_matches );
   std::vector<short int> getInttCrossings(TrackSeed *si_track);
    void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Allows tracks which only have TPC clusters to be fitted by PHActsTrkFitter and added to the SvtxTrackMap. 

This also adds a "pp mode" switch to PHActsTrkFitter that only strictly checks for crossing info when in pp running. Since TPC-only tracks have no crossing info, their crossing in AuAu running is assumed to be 0. In pp running, TPC-only tracks are still skipped.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
https://github.com/sPHENIX-Collaboration/macros/pull/574
