### PR TITLE
Fitted Alignment Parameters

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -83,6 +83,7 @@ class MakeMilleFiles : public SubsysReco
 
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
+  void printBuffers(int index, Acts::Vector3 residual, Acts::Vector3 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[]);
 
   void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec);
 

--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -199,19 +199,9 @@ void ActsAlignmentStates::fillAlignmentStateMap(Trajectory traj,
 							 clus, surf, 
 							 crossing);
         SvtxAlignmentState::GlobalMatrix analytic = SvtxAlignmentState::GlobalMatrix::Zero();
-        analytic(0,0) = 1;
-        analytic(1,1) = 1;
-        analytic(2,2) = 1;
-	for(int i=0; i<SvtxAlignmentState::NRES; ++i) 
-	  {
-	    for(int j=3; j<SvtxAlignmentState::NGL; ++j)
-	      {
-		/// convert to mm
-		analytic(i,j) = anglederivs.at(i)(j-3) * Acts::UnitConstants::cm;
-	      }
-	  }
 
-	svtxstate->set_global_derivative_matrix(analytic);
+	getGlobalDerivatives(anglederivs,analytic);
+       	svtxstate->set_global_derivative_matrix(analytic);
       }
 
     statevec.push_back(svtxstate.release());
@@ -227,6 +217,23 @@ void ActsAlignmentStates::fillAlignmentStateMap(Trajectory traj,
   m_alignmentStateMap->insertWithKey(track->get_id(), statevec);
 
   return;
+}
+
+void ActsAlignmentStates::getGlobalDerivatives(std::vector<Acts::Vector3>& anglederivs, SvtxAlignmentState::GlobalMatrix& analytic)
+{
+  analytic(0,0) = 1;
+  analytic(1,1) = 1;
+  analytic(2,2) = 1;
+  
+  for(int res = 0; res < SvtxAlignmentState::NRES; ++res)
+    {
+      for(int gl = 3; gl < SvtxAlignmentState::NGL; ++gl)
+	{
+	  // this is not backwards - the angle derivs is transposed
+	  analytic(res,gl) = anglederivs.at(gl-3)(res) * Acts::UnitConstants::cm;
+	}
+    }
+  
 }
 
 void ActsAlignmentStates::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global)

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -14,13 +14,13 @@
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
+#include <trackbase_historic/SvtxAlignmentState.h>
 
 class PHCompositeNode;
 class SvtxTrack;
 class SvtxAlignmentStateMap;
 class ActsGeometry;
 class TrkrClusterContainer;
-
 /*
  * Helper class that contains functionality to fill alignment state
  * map from Acts track fitter
@@ -48,14 +48,15 @@ class ActsAlignmentStates
   void actsGeometry(ActsGeometry* geom) { m_tGeometry = geom; }
   void clusters(TrkrClusterContainer* clus) { m_clusterMap = clus; }
   void stateMap(SvtxAlignmentStateMap* map) { m_alignmentStateMap = map; }
-
+  
  private:
   void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global);
   std::vector<Acts::Vector3> getDerivativesAlignmentAngles(Acts::Vector3& global, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster, Surface surface, int crossing);
+  void getGlobalDerivatives(std::vector<Acts::Vector3>& anglederivs, SvtxAlignmentState::GlobalMatrix& analytic);
   Acts::Transform3 makePerturbationTransformation(Acts::Vector3 angles);
   float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
 
-  bool m_analytic = false;
+  bool m_analytic = true;
   int m_verbosity = 0;
   int m_clusterVersion = 4;
 


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes the Acts alignment state creation to take the fully fitted tracks and produce sensible alignment parameters with millepede in the case of perfect alignment. From the full alignment workflow I can produce sub O(mrad) and O(micron) alignment residuals in the MVTX and INTT with the fully fitted tracks now with the default geometry. Need to start testing with actual misaligned surfaces.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

