### PR TITLE
Reformatting the on the fly map production of the TowerInfoContainer class

### DIFF
--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -12,10 +12,10 @@ class TowerInfo : public PHObject
   ~TowerInfo() override = default;
   void Reset() override { return; }
 
-  virtual void setTime(short /*t*/) { return; }
-  virtual short getTime() { return -1; }
-  virtual void setAmplitude(float /*amp*/) { return; }
-  virtual float getAmplitude() { return NAN; }
+  virtual void set_time(short /*t*/) { return; }
+  virtual short get_time() { return -1; }
+  virtual void set_energy(float /*energy*/) { return; }
+  virtual float get_energy() { return NAN; }
 
  private:
   ClassDefOverride(TowerInfo, 1);

--- a/offline/packages/CaloBase/TowerInfoContainer.cc
+++ b/offline/packages/CaloBase/TowerInfoContainer.cc
@@ -2,10 +2,6 @@
 
 TowerInfoContainer::TowerMap DummyTowerMap;
 
-TowerInfoContainer::TowerMap TowerInfoContainer::getTowerMap()
-{
-  return DummyTowerMap;
-}
 
 TowerInfoContainer::ConstIter TowerInfoContainer::begin() const
 {

--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -24,6 +24,11 @@ class TowerInfoContainer : public PHObject
 
   TowerInfoContainer() = default;
   ~TowerInfoContainer() override = default;
+  typedef std::map<unsigned int, TowerInfo *> Map;
+  typedef Map::iterator Iterator;
+  typedef Map::const_iterator ConstIterator;
+  typedef std::pair<ConstIterator, ConstIterator> ConstRange;
+  typedef std::pair<Iterator, Iterator> Range;
 
   virtual void Reset() override {}
   virtual void add(TowerInfo* /*ti*/, int /*pos*/) {}

--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -34,7 +34,6 @@ class TowerInfoContainer : public PHObject
   virtual void add(TowerInfo* /*ti*/, int /*pos*/) {}
   virtual TowerInfo* at(int /*pos*/) { return nullptr; }
   virtual unsigned int encode_key(unsigned int /*towerIndex*/) { return UINT_MAX; }
-  virtual TowerMap getTowerMap();
 
   virtual size_t size() { return 0; }
 

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -40,6 +40,11 @@ TowerInfoContainerv1::~TowerInfoContainerv1()
 
 void TowerInfoContainerv1::Reset()
 {
+  while (_map.begin() != _map.end())
+    {
+      delete _map.begin()->second;
+      _map.erase(_map.begin());
+    }
   _clones->Clear();
 }
 
@@ -166,6 +171,22 @@ unsigned int TowerInfoContainerv1::encode_key(unsigned int towerIndex)
 
   return key;
 }
+
+
+TowerInfoContainerv1::Range
+TowerInfoContainerv1::getTowers()
+{
+  if (_towers.empty())
+    {
+      for (unsigned int i = 0; i < size(); i++)
+	{
+	  _towers.insert(std::make_pair(encode_key(i), at(i)));
+	}
+    }
+  return make_pair(_towers.begin(), _towers.end());
+}
+
+
 
 TowerInfoContainer::TowerMap TowerInfoContainerv1::getTowerMap()
 {

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -187,18 +187,6 @@ TowerInfoContainerv1::getTowers()
 }
 
 
-
-TowerInfoContainer::TowerMap TowerInfoContainerv1::getTowerMap()
-{
-  TowerInfoContainer::TowerMap tmap;
-  for (unsigned int i = 0; i < size(); i++)
-  {
-    tmap.insert(std::make_pair(encode_key(i), at(i)));
-  }
-
-  return tmap;
-}
-
 unsigned int TowerInfoContainerv1::getTowerPhiBin(unsigned int key)
 {
   unsigned int etabin = key >> 16U;

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -13,12 +13,20 @@ class TowerInfoContainerv1 : public TowerInfoContainer
  public:
   TowerInfoContainerv1(DETECTOR detec = DETECTOR::EMCAL);
   ~TowerInfoContainerv1() override;
+   typedef std::map<unsigned int, TowerInfo *> Map;
+   typedef Map::iterator Iterator;
+  typedef Map::const_iterator ConstIterator;
+  typedef std::pair<ConstIterator, ConstIterator> ConstRange;
+  typedef std::pair<Iterator, Iterator> Range;
+
 
   void Reset() override;
   void add(TowerInfov1 *ti, int pos);
   TowerInfov1 *at(int pos) override;
   unsigned int encode_key(unsigned int towerIndex) override;
   TowerMap getTowerMap() override;
+  Range getTowers(void);
+
 
   size_t size() override { return _clones->GetEntries(); }
 
@@ -37,6 +45,7 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   TClonesArray *_clones;
   DETECTOR _detector;
   TowerMap _map;
+  Map _towers;
 
  private:
   using TowerInfoContainer::add;

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -24,7 +24,6 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   void add(TowerInfov1 *ti, int pos);
   TowerInfov1 *at(int pos) override;
   unsigned int encode_key(unsigned int towerIndex) override;
-  TowerMap getTowerMap() override;
   Range getTowers(void);
 
 

--- a/offline/packages/CaloBase/TowerInfov1.cc
+++ b/offline/packages/CaloBase/TowerInfov1.cc
@@ -3,5 +3,5 @@
 void TowerInfov1::Reset()
 {
   _time = 0;
-  _amplitude = NAN;
+  _energy = NAN;
 }

--- a/offline/packages/CaloBase/TowerInfov1.h
+++ b/offline/packages/CaloBase/TowerInfov1.h
@@ -14,14 +14,14 @@ class TowerInfov1 : public TowerInfo
   ~TowerInfov1() override {}
   void Reset() override;
 
-  void setTime(short t) override { _time = t; }
-  short getTime() override { return _time; }
-  void setAmplitude(float amp) override { _amplitude = amp; }
-  float getAmplitude() override { return _amplitude; }
+  void set_time(short t) override { _time = t; }
+  short get_time() override { return _time; }
+  void set_energy(float energy) override { _energy = energy; }
+  float get_energy() override { return _energy; }
 
  private:
   short _time = 0;
-  float _amplitude = NAN;
+  float _energy = NAN;
 
   ClassDefOverride(TowerInfov1, 1);
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR restructures the on the fly map generation to happen during the call for the iterator range rather than happen as a separate stage. Prevents the user themselves from directly accessing the map, and fixes a problem with the map not being reset between events. Additionally standardized the calls to match that of other classes

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

