### PR TITLE
YCM rename gdml file for end_wheels

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -214,8 +214,8 @@ void PHG4MvtxSubsystem::SetDefaultParameters()
 
   set_default_string_param(GLOBAL, "stave_geometry_file", "ITS.gdml");  // default - almost nothing
   char *calibrationsroot = getenv("CALIBRATIONROOT");
-  std::string end_wheels_sideS = "ITS_ibEndWheelSideA_mod_PEEK.gdml";
-  std::string end_wheels_sideN = "ITS_ibEndWheelSideC_PEEK.gdml";
+  std::string end_wheels_sideS = "ITS_ibEndWheelSideA.gdml";
+  std::string end_wheels_sideN = "ITS_ibEndWheelSideC.gdml";
   if (calibrationsroot != nullptr)
   {
     end_wheels_sideS =  string(calibrationsroot) + string("/Tracking/geometry/") + end_wheels_sideS;


### PR DESCRIPTION
point to a symbolic link file with proper material

[comment]: <> (Please tell us something about this pull request)
This PR change the filename for the gdml file used to create the MVTX end_wheel geometry with right material (Al)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

