### PR TITLE
fix seeding speed and purity

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -197,10 +197,8 @@ GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
 
   /// variable middle SP radial region of interest
   const Acts::Range1D<float> rMiddleSPRange(
-      std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 +
-          1.5,
-      std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 -
-          1.5);
+	 std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 + 1.5, 
+	 std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 - 1.5);
 
   GridSeeds seedVector;
   auto groupIt = spGroup.begin();
@@ -697,7 +695,12 @@ Acts::SeedFilterConfig PHActsSiliconSeeding::configureSeedFilter()
 Acts::SeedFinderConfig<SpacePoint> PHActsSiliconSeeding::configureSeeder()
 {
   Acts::SeedFinderConfig<SpacePoint> config;
-  
+  /// these are default values that used to be set in Acts
+  config.deltaRMinTopSP = 5 * Acts::UnitConstants::mm;
+  config.deltaRMaxTopSP = 270 * Acts::UnitConstants::mm;
+  config.deltaRMinBottomSP = 5 * Acts::UnitConstants::mm;
+  config.deltaRMaxBottomSP = 270 * Acts::UnitConstants::mm;
+
   /// Limiting location of measurements (e.g. detector constraints)
   config.rMax = m_rMax;
   config.rMin = m_rMin;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes the Acts seeding speed and purity after updating to Actsv21, which did not show up in the low occupancy QA. There were several configuration parameters in the Acts seeder that had default values (which we were using) that were changed to default values of `nan` in between v19 and v21... I have no idea how this did not yield undefined behavior from the seeder even in low occupancy and am discussing it with the developers, but in any case... this returns the seeding performance to that of ana334 in my local tests.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

