### PR TITLE
Add ability to fill TowerInfoContainer based on physical location

### DIFF
--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -34,6 +34,7 @@ class TowerInfoContainer : public PHObject
   virtual void add(TowerInfo* /*ti*/, int /*pos*/) {}
   virtual TowerInfo* at(int /*pos*/) { return nullptr; }
   virtual unsigned int encode_key(unsigned int /*towerIndex*/) { return UINT_MAX; }
+  virtual unsigned int decode_key(unsigned int /*towerIndex*/) { return UINT_MAX; }
 
   virtual size_t size() { return 0; }
 

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -28,7 +28,18 @@ int hcaladc[8][2] = {
 TowerInfoContainerv1::TowerInfoContainerv1(DETECTOR detec)
   : _detector(detec)
 {
-  _clones = new TClonesArray("TowerInfov1", 50);
+  if (_detector == DETECTOR::SEPD)
+    {
+      _clones = new TClonesArray("TowerInfov1", 744);
+    }
+  else if (_detector == DETECTOR::EMCAL)
+    {
+      _clones = new TClonesArray("TowerInfov1", 24576);
+    }
+  else if (_detector == DETECTOR::HCAL)
+    {
+      _clones = new TClonesArray("TowerInfov1", 1536);
+    }
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv1");
 }
@@ -171,6 +182,157 @@ unsigned int TowerInfoContainerv1::encode_key(unsigned int towerIndex)
 
   return key;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+unsigned int TowerInfoContainerv1::decode_key(unsigned int tower_key)
+{
+  int channels_per_sector = -1;
+  int supersector = -1;
+  int nchannelsperpacket = -1;
+  int maxphibin = -1;
+  int maxetabin = -1;
+  int etabinoffset[4] = {0};
+  int phibinoffset[4] = {0};
+  int etabinmap[4] = {0};
+
+  if (_detector == DETECTOR::SEPD)
+    {
+      channels_per_sector = 31;
+      supersector = channels_per_sector*12;
+      int ns_sector = tower_key >> 20U;
+      int rbin = (tower_key - (ns_sector << 20U)) >> 10U; 
+      int phibin = tower_key - (ns_sector << 20U) - (rbin << 10U);
+      int epdchnlmap[16][2] = {    0, 0,    1,2,    3,4,    5,6,    7,8,    9,10,    11,12,    13,14,    15,16,    17,18,    19,20,    21,22,    23,24,    25,26,    27,28,    29,30};
+      int sector = phibin/2;
+      int channel = 0;
+      if (rbin > 0)
+	{
+	  channel = epdchnlmap[rbin][phibin-2*sector];
+	}  
+      else
+	{
+	  channel = 0;
+	}
+      unsigned int index = 0;
+      index = ns_sector * supersector + sector*channels_per_sector+channel;
+      return index;
+    }
+
+
+  if (_detector == DETECTOR::EMCAL)
+  {
+    channels_per_sector = 64;
+    supersector = 64 * 12;
+    nchannelsperpacket = 64 * 3;
+    maxphibin = 7;
+    maxetabin = 23;
+    etabinoffset[0] = 24;
+    etabinoffset[1] = 0;
+    etabinoffset[2] = 48;
+    etabinoffset[3] = 72;
+    phibinoffset[0] = 0;
+    phibinoffset[1] = 0;
+    phibinoffset[2] = 0;
+    phibinoffset[3] = 0;
+    etabinmap[0] = 1;
+    etabinmap[1] = 0;
+    etabinmap[2] = 2;
+    etabinmap[3] = 3;
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    channels_per_sector = 16;
+    supersector = 16 * 4 * 3;
+    nchannelsperpacket = channels_per_sector * 4;
+    maxphibin = 7;
+    maxetabin = 23;
+    etabinoffset[0] = 0;
+    etabinoffset[1] = 8;
+    etabinoffset[2] = 16;
+    etabinoffset[3] = 0;
+    phibinoffset[0] = 0;
+    phibinoffset[1] = 2;
+    phibinoffset[2] = 4;
+    phibinoffset[3] = 6;
+    etabinmap[0] = 0;
+    etabinmap[1] = 1;
+    etabinmap[2] = 2;
+    etabinmap[3] = 3;
+  }
+
+
+  int etabin = tower_key >> 16U;
+  int phibin = tower_key - (etabin << 16U);
+  int packet = 0;
+  if (_detector == DETECTOR::HCAL)
+    {
+      packet =etabin/8;
+    }
+  else
+    {
+      packet = etabinmap[(int)etabin/24];
+    }
+  int localetabin = etabin - etabinoffset[packet];
+  int localphibin = phibin%8;
+  int supersectornumber = phibin/8;
+
+  int ib = 0;
+  if (_detector == DETECTOR::HCAL)
+    {
+      ib = localphibin/2;
+    }
+  else
+    {
+      if (packet == 0 || packet == 1)
+	{
+	  localetabin = maxetabin - localetabin;
+	}  
+      ib = localetabin/8;
+    }
+  unsigned int index = 0;
+  if (_detector == DETECTOR::HCAL)
+    {
+      localphibin = localphibin - phibinoffset[ib];
+    }
+  else 
+    {
+      if (packet == 0 || packet == 1)
+	{
+	  localphibin = maxphibin - localphibin;
+	}
+      localetabin = localetabin%8;
+    }
+
+unsigned int localindex;
+  if (_detector == DETECTOR::HCAL)
+    {
+      localindex= hcaladc[localetabin][localphibin];
+    }
+  else
+    {
+      localindex = emcadc[localetabin][localphibin];
+    }
+  index = localindex+channels_per_sector* ib + packet*nchannelsperpacket + supersector*supersectornumber;
+  return index;
+}
+
+
+
+
+
+
+
+
 
 
 TowerInfoContainerv1::Range

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -29,17 +29,17 @@ TowerInfoContainerv1::TowerInfoContainerv1(DETECTOR detec)
   : _detector(detec)
 {
   if (_detector == DETECTOR::SEPD)
-    {
-      _clones = new TClonesArray("TowerInfov1", 744);
-    }
+  {
+    _clones = new TClonesArray("TowerInfov1", 744);
+  }
   else if (_detector == DETECTOR::EMCAL)
-    {
-      _clones = new TClonesArray("TowerInfov1", 24576);
-    }
+  {
+    _clones = new TClonesArray("TowerInfov1", 24576);
+  }
   else if (_detector == DETECTOR::HCAL)
-    {
-      _clones = new TClonesArray("TowerInfov1", 1536);
-    }
+  {
+    _clones = new TClonesArray("TowerInfov1", 1536);
+  }
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv1");
 }
@@ -52,10 +52,10 @@ TowerInfoContainerv1::~TowerInfoContainerv1()
 void TowerInfoContainerv1::Reset()
 {
   while (_map.begin() != _map.end())
-    {
-      delete _map.begin()->second;
-      _map.erase(_map.begin());
-    }
+  {
+    delete _map.begin()->second;
+    _map.erase(_map.begin());
+  }
   _clones->Clear();
 }
 
@@ -183,17 +183,6 @@ unsigned int TowerInfoContainerv1::encode_key(unsigned int towerIndex)
   return key;
 }
 
-
-
-
-
-
-
-
-
-
-
-
 unsigned int TowerInfoContainerv1::decode_key(unsigned int tower_key)
 {
   int channels_per_sector = -1;
@@ -206,28 +195,27 @@ unsigned int TowerInfoContainerv1::decode_key(unsigned int tower_key)
   int etabinmap[4] = {0};
 
   if (_detector == DETECTOR::SEPD)
+  {
+    channels_per_sector = 31;
+    supersector = channels_per_sector * 12;
+    unsigned int ns_sector = tower_key >> 20U;
+    unsigned int rbin = (tower_key - (ns_sector << 20U)) >> 10U;
+    unsigned int phibin = tower_key - (ns_sector << 20U) - (rbin << 10U);
+    int epdchnlmap[16][2] = {{0, 0}, {1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}, {15, 16}, {17, 18}, {19, 20}, {21, 22}, {23, 24}, {25, 26}, {27, 28}, {29, 30}};
+    int sector = phibin / 2;
+    int channel = 0;
+    if (rbin > 0)
     {
-      channels_per_sector = 31;
-      supersector = channels_per_sector*12;
-      int ns_sector = tower_key >> 20U;
-      int rbin = (tower_key - (ns_sector << 20U)) >> 10U; 
-      int phibin = tower_key - (ns_sector << 20U) - (rbin << 10U);
-      int epdchnlmap[16][2] = {    0, 0,    1,2,    3,4,    5,6,    7,8,    9,10,    11,12,    13,14,    15,16,    17,18,    19,20,    21,22,    23,24,    25,26,    27,28,    29,30};
-      int sector = phibin/2;
-      int channel = 0;
-      if (rbin > 0)
-	{
-	  channel = epdchnlmap[rbin][phibin-2*sector];
-	}  
-      else
-	{
-	  channel = 0;
-	}
-      unsigned int index = 0;
-      index = ns_sector * supersector + sector*channels_per_sector+channel;
-      return index;
+      channel = epdchnlmap[rbin][phibin - 2 * sector];
     }
-
+    else
+    {
+      channel = 0;
+    }
+    unsigned int index = 0;
+    index = ns_sector * supersector + sector * channels_per_sector + channel;
+    return index;
+  }
 
   if (_detector == DETECTOR::EMCAL)
   {
@@ -270,84 +258,73 @@ unsigned int TowerInfoContainerv1::decode_key(unsigned int tower_key)
     etabinmap[3] = 3;
   }
 
-
-  int etabin = tower_key >> 16U;
-  int phibin = tower_key - (etabin << 16U);
+  unsigned int etabin = tower_key >> 16U;
+  unsigned int phibin = tower_key - (etabin << 16U);
   int packet = 0;
   if (_detector == DETECTOR::HCAL)
-    {
-      packet =etabin/8;
-    }
+  {
+    packet = etabin / 8;
+  }
   else
-    {
-      packet = etabinmap[(int)etabin/24];
-    }
+  {
+    packet = etabinmap[(int) etabin / 24];
+  }
   int localetabin = etabin - etabinoffset[packet];
-  int localphibin = phibin%8;
-  int supersectornumber = phibin/8;
+  int localphibin = phibin % 8;
+  int supersectornumber = phibin / 8;
 
   int ib = 0;
   if (_detector == DETECTOR::HCAL)
-    {
-      ib = localphibin/2;
-    }
+  {
+    ib = localphibin / 2;
+  }
   else
+  {
+    if (packet == 0 || packet == 1)
     {
-      if (packet == 0 || packet == 1)
-	{
-	  localetabin = maxetabin - localetabin;
-	}  
-      ib = localetabin/8;
+      localetabin = maxetabin - localetabin;
     }
+    ib = localetabin / 8;
+  }
   unsigned int index = 0;
   if (_detector == DETECTOR::HCAL)
-    {
-      localphibin = localphibin - phibinoffset[ib];
-    }
-  else 
-    {
-      if (packet == 0 || packet == 1)
-	{
-	  localphibin = maxphibin - localphibin;
-	}
-      localetabin = localetabin%8;
-    }
-
-unsigned int localindex;
-  if (_detector == DETECTOR::HCAL)
-    {
-      localindex= hcaladc[localetabin][localphibin];
-    }
+  {
+    localphibin = localphibin - phibinoffset[ib];
+  }
   else
+  {
+    if (packet == 0 || packet == 1)
     {
-      localindex = emcadc[localetabin][localphibin];
+      localphibin = maxphibin - localphibin;
     }
-  index = localindex+channels_per_sector* ib + packet*nchannelsperpacket + supersector*supersectornumber;
+    localetabin = localetabin % 8;
+  }
+
+  unsigned int localindex;
+  if (_detector == DETECTOR::HCAL)
+  {
+    localindex = hcaladc[localetabin][localphibin];
+  }
+  else
+  {
+    localindex = emcadc[localetabin][localphibin];
+  }
+  index = localindex + channels_per_sector * ib + packet * nchannelsperpacket + supersector * supersectornumber;
   return index;
 }
-
-
-
-
-
-
-
-
-
 
 TowerInfoContainerv1::Range
 TowerInfoContainerv1::getTowers()
 {
   if (_towers.empty())
+  {
+    for (unsigned int i = 0; i < size(); i++)
     {
-      for (unsigned int i = 0; i < size(); i++)
-	{
-	  _towers.insert(std::make_pair(encode_key(i), at(i)));
-	}
+      _towers.insert(std::make_pair(encode_key(i), at(i)));
     }
+  }
   return make_pair(_towers.begin(), _towers.end());
 }
-
 
 unsigned int TowerInfoContainerv1::getTowerPhiBin(unsigned int key)
 {

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -24,6 +24,7 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   void add(TowerInfov1 *ti, int pos);
   TowerInfov1 *at(int pos) override;
   unsigned int encode_key(unsigned int towerIndex) override;
+  unsigned int decode_key(unsigned int tower_key) override;
   Range getTowers(void);
 
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the ability for the CaloInfoContainer to decode key values (I.E. etabin phi bin coordinates) into the corresponding tower index. This combined with the pre-allocation of the TowerInfoContainer size enables the user to write towers to the object in any order (key for implementation into the simulations without a significant rewrite).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

