### PR TITLE
Tpc subsurface lookup speed up

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -117,7 +117,7 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   double world_phi = atan2(world[1], world[0]);
   double world_z = world[2];
   
-  std::vector<Surface> surf_vec = mapIter->second;
+  std::vector<Surface>& surf_vec = mapIter->second;
   unsigned int surf_index = 999;
     
   // Predict which surface index this phi and z will correspond to


### PR DESCRIPTION
This PR improves the lookup speed of tpc subsurfaces by a factor of 10 by passing the surface vector by reference instead of copy.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

