### PR TITLE
fix: TPC subsurface lookup at phi boundary

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -119,17 +119,20 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   
   std::vector<Surface>& surf_vec = mapIter->second;
   unsigned int surf_index = 999;
-    
+
   // Predict which surface index this phi and z will correspond to
   // assumes that the vector elements are ordered positive z, -pi to pi, then negative z, -pi to pi
   double fraction =  (world_phi + M_PI) / (2.0 * M_PI);
   double rounded_nsurf = round( (double) (surf_vec.size()/2) * fraction  - 0.5);
-  unsigned int nsurf = (unsigned int) rounded_nsurf; 
+  unsigned int nsurfm = (unsigned int) rounded_nsurf;
+
   if(world_z < 0)
-    { nsurf += surf_vec.size()/2; }
+    { nsurfm += surf_vec.size()/2; }
+  
+  unsigned int nsurf = nsurfm % surf_vec.size();
 
   Surface this_surf = surf_vec[nsurf];
-      
+
   auto vec3d = this_surf->center(geometry().getGeoContext());
   std::vector<double> surf_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
   double surf_z = surf_center[2];


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes a segfault that happens if a TPC cluster is at exactly phi=2pi where the boundary condition occurs. Currently the subsurface lookup looks outside the vector, when it should look at the very beginning, which is now the case by adding modulo.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

