### PR TITLE
removed spurious line bug added in previous pr

### DIFF
--- a/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.cc
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.cc
@@ -289,7 +289,6 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
       _clusterPts[jCs] = tt_clus_pt;
       _clusterEtas[jCs] = tt_clus_eta;
       _clusterPhis[jCs] = tt_clus_phi;
-      _nClusters = savCs[jCs]->getNTowers();
 
       if (tt_clus_pt > 1.0 ) 
 	{


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

bug fix which removed spurious extra line that was added in last pr (no one nows how it got added) that sneakily reduced the number of clusters saved in the output and therefore available for iterating in the later iterations.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

