### PR TITLE
shifting epd sector phi shift

### DIFF
--- a/simulation/g4simulation/g4epd/PHG4EPDDetector.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDDetector.cc
@@ -61,8 +61,20 @@ void PHG4EPDDetector::ConstructMe(G4LogicalVolume* world)
     for (int32_t k = 0; k < nsectors; ++k)
     {
       G4RotationMatrix* rotate = new G4RotationMatrix();
+      
+      //shift epd sectors so that first sector starts at phi = 0
+      double phi_shift = (k + 3) * 2 * M_PI / nsectors;
 
-      rotate->rotateZ(k * 2 * M_PI / nsectors);
+      if(phi_shift >= (2.0 * M_PI))
+      {
+         phi_shift -= (2.0 * M_PI);
+      }
+      else if (phi_shift < 0.0)
+      {
+         phi_shift += (2.0 * M_PI);
+      }
+
+      rotate->rotateZ(phi_shift);
 
       m_volumes.emplace(
           new G4PVPlacement( rotate, positive, volume, label, world, false, 2 * k + 0, OverlapCheck()),


### PR DESCRIPTION
PR rotates epd sectors so that the first sector starts a phi = 0. See attached image for details- The numbers [0-11] are the sector ids.
![epdphishift_PR](https://user-images.githubusercontent.com/27926345/213896124-ccfe9389-20ab-4be9-a09f-c628ae080a23.png)
