### PR TITLE
try compile g4micromegas with dwarf4 to make valgrind happy

### DIFF
--- a/simulation/g4simulation/g4micromegas/configure.ac
+++ b/simulation/g4simulation/g4micromegas/configure.ac
@@ -6,7 +6,7 @@ AC_PROG_CXX(CC g++)
 
 LT_INIT([disable-static])
 
-CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
+CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow -gdwarf-4"
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR tells gcc 12 to create dwarf 4 debug info in the hope that the libg4micromegas plays nicely with valgrind
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

