### PR TITLE
Enabling `CanBeMotherSubsystem()` and allowing PHG4CylinderSubsystem to cover partial azimuth

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderDetector.cc
@@ -60,6 +60,10 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
   double radius = m_Params->get_double_param("radius") * cm;
   double thickness = m_Params->get_double_param("thickness") * cm;
   double length = m_Params->get_double_param("length") * cm;
+
+  double start_phi_rad = m_Params->get_double_param("start_phi_rad") * rad;
+  double delta_phi_rad = m_Params->get_double_param("delta_phi_rad") * rad;
+
   if (!isfinite(radius) || !isfinite(thickness) || !isfinite(length))
   {
     cout << PHWHERE << ": Bad Parameters for " << GetName() << endl;
@@ -71,7 +75,7 @@ void PHG4CylinderDetector::ConstructMe(G4LogicalVolume *logicWorld)
   G4VSolid *cylinder_solid = new G4Tubs(G4String(GetName()),
                                         radius,
                                         radius + thickness,
-                                        length / 2., 0, twopi);
+                                        length / 2., start_phi_rad, delta_phi_rad);
   double steplimits = m_Params->get_double_param("steplimits") * cm;
   G4UserLimits *g4userlimits = nullptr;
   if (isfinite(steplimits))

--- a/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4CylinderSubsystem.cc
@@ -171,6 +171,8 @@ void PHG4CylinderSubsystem::SetDefaultParameters()
   set_default_double_param("rot_x", 0.);
   set_default_double_param("rot_y", 0.);
   set_default_double_param("rot_z", 0.);
+  set_default_double_param("start_phi_rad", 0.);
+  set_default_double_param("delta_phi_rad", M_PI * 2);
   set_default_int_param("lengthviarapidity", 1);
   set_default_int_param("lightyield", 0);
   set_default_int_param("use_g4steps", 0);

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.h
@@ -45,6 +45,11 @@ class PHG4OHCalSubsystem : public PHG4DetectorSubsystem
 
   void SetLightCorrection(const double inner_radius, const double inner_corr, const double outer_radius, const double outer_corr);
 
+  // this method is used to check if it can be used as mothervolume
+  // Subsystems which can be mothervolume need to implement this
+  // and return true
+  bool CanBeMotherSubsystem() const override { return true; }
+  
  private:
   void SetDefaultParameters() override;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

1. Enabling `CanBeMotherSubsystem()` for outer HCal for support ring installation, which was missed in https://github.com/sPHENIX-Collaboration/coresoftware/pull/1811 
2. Allow [`PHG4CylinderSubsystem`](https://github.com/sPHENIX-Collaboration/coresoftware/compare/master...blackcathj-ohcal-try2?quick_pull=1#diff-61dfe0fd92407a82134dc0182c34afe81d22a83a27b5807e1e907add0af7bd61) to cover partial azimuth, configurable from macro, e.g.: 
```c++
    PHG4CylinderSubsystem * cyl = new PHG4CylinderSubsystem("TestCylinder");
    cyl->set_double_param("start_phi_rad", M_PI/2); // y-axis
    cyl->set_double_param("delta_phi_rad", M_PI); // half circle coverage
    g4Reco->registerSubsystem(cyl);
```

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Virginia is implementing HCal support rings on the macros side

## Links to other PRs in macros and calibration repositories (if applicable)

