### PR TITLE
New interpolation peak extraction method for CaloWaveformProcessing

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformProcessing.cc
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.cc
@@ -7,6 +7,7 @@
 #include <TF1.h>
 #include <TFile.h>
 #include <TProfile.h>
+#include <TSpline.h>
 
 #include <Fit/BinData.h>
 #include <Fit/Chi2FCN.h>
@@ -69,6 +70,10 @@ std::vector<std::vector<float>> CaloWaveformProcessing::process_waveform(std::ve
   if (m_processingtype == CaloWaveformProcessing::ONNX)
   {
     fitresults = CaloWaveformProcessing::calo_processing_ONNX(waveformvector);
+  }
+  if (m_processingtype == CaloWaveformProcessing::FAST)
+  {
+    fitresults = CaloWaveformProcessing::calo_processing_fast(waveformvector);
   }
   return fitresults;
 }
@@ -167,6 +172,100 @@ std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_ONNX(std
         val.at(i) = val.at(i) * 1000;
       }
     }
+    fit_values.push_back(val);
+    val.clear();
+  }
+  return fit_values;
+}
+void CaloWaveformProcessing::FastMax(float x0, float x1, float x2, float y0, float y1, float y2, float & xmax, float & ymax) {
+  int n = 3;
+  double xp[3] = {x0, x1, x2};
+  double yp[3] = {y0, y1, y2};
+  TSpline3 *sp = new TSpline3("", xp, yp, n, "b2e2", 0, 0);
+  double X, Y, B, C, D;
+  ymax = y1;
+  xmax = x1;
+  if (y0 > ymax) {
+    ymax = y0;
+    xmax = x0;
+  }
+  if (y2 > ymax) {
+    ymax = y2;
+    xmax = x2;
+  }
+  for (int i = 0; i <= 1; i++) {
+    sp->GetCoeff(i, X, Y, B, C, D);
+    if (D == 0) {
+
+      if (C < 0) {
+        //TSpline is a quadratic equation
+
+        float root = -B / (2 * C) + X;
+        if (root >= xp[i] && root <= xp[i + 1]) {
+          float yvalue = sp->Eval(root);
+          if (yvalue > ymax) {
+            ymax = yvalue;
+            xmax = root;
+          }
+        }
+      }
+    }
+    else {
+      //find x then derivative = 0
+      float root = (-2 * C + sqrt(4 * C * C - 12 * B * D)) / (6 * D) + X;
+      if (root >= xp[i] && root <= xp[i + 1]) {
+        float yvalue = sp->Eval(root);
+        if (yvalue > ymax) {
+          ymax = yvalue;
+          xmax = root;
+        }
+      }
+      root = (-2 * C - sqrt(4 * C * C - 12 * B * D)) / (6 * D) + X;
+      if (root >= xp[i] && root <= xp[i + 1]) {
+        float yvalue = sp->Eval(root);
+        if (yvalue > ymax) {
+          ymax = yvalue;
+          xmax = root;
+        }
+      }
+
+    }
+  }
+  delete sp;
+  return;
+}
+std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_fast(std::vector<std::vector<float>> chnlvector)
+{
+  std::vector<std::vector<float>> fit_values;
+  int nchnls = chnlvector.size();
+  for (int m = 0; m < nchnls; m++)
+  {
+    std::vector<float> v = chnlvector.at(m);
+    int nsamples = v.size();
+    
+    double maxy = v.at(0);
+    float amp = 0;
+    float time = 0;
+    float ped = 0;
+    if (nsamples >= 3) {
+      int maxx = 0;
+      for (int i = 0; i < nsamples; i++) {
+        if(i < 3) ped += v.at(i);
+        if(v.at(i) > maxy){
+         maxy = v.at(i);
+         maxx = i;
+        }
+      }
+      ped /= 3;
+      if(maxx == 0 || maxx == nsamples - 1){
+        amp = maxy;
+        time = maxx;
+      }
+      else{
+        FastMax(maxx - 1,maxx, maxx+1, v.at(maxx - 1), v.at(maxx), v.at(maxx + 1), time, amp);
+      }
+    }
+    std::vector<float> val = {amp, time, ped};
     fit_values.push_back(val);
     val.clear();
   }

--- a/offline/packages/CaloReco/CaloWaveformProcessing.cc
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.cc
@@ -177,6 +177,7 @@ std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_ONNX(std
   }
   return fit_values;
 }
+
 void CaloWaveformProcessing::FastMax(float x0, float x1, float x2, float y0, float y1, float y2, float & xmax, float & ymax) {
   int n = 3;
   double xp[3] = {x0, x1, x2};
@@ -211,7 +212,7 @@ void CaloWaveformProcessing::FastMax(float x0, float x1, float x2, float y0, flo
       }
     }
     else {
-      //find x then derivative = 0
+      //find x when derivative = 0
       float root = (-2 * C + sqrt(4 * C * C - 12 * B * D)) / (6 * D) + X;
       if (root >= xp[i] && root <= xp[i + 1]) {
         float yvalue = sp->Eval(root);
@@ -242,7 +243,7 @@ std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_fast(std
   {
     std::vector<float> v = chnlvector.at(m);
     int nsamples = v.size();
-    
+
     double maxy = v.at(0);
     float amp = 0;
     float time = 0;
@@ -250,21 +251,23 @@ std::vector<std::vector<float>> CaloWaveformProcessing::calo_processing_fast(std
     if (nsamples >= 3) {
       int maxx = 0;
       for (int i = 0; i < nsamples; i++) {
-        if(i < 3) ped += v.at(i);
-        if(v.at(i) > maxy){
-         maxy = v.at(i);
-         maxx = i;
+        if (i < 3) ped += v.at(i);
+        if (v.at(i) > maxy) {
+          maxy = v.at(i);
+          maxx = i;
         }
       }
       ped /= 3;
-      if(maxx == 0 || maxx == nsamples - 1){
+      if (maxx == 0 || maxx == nsamples - 1) {
         amp = maxy;
         time = maxx;
       }
-      else{
-        FastMax(maxx - 1,maxx, maxx+1, v.at(maxx - 1), v.at(maxx), v.at(maxx + 1), time, amp);
+      else {
+        FastMax(maxx - 1, maxx, maxx + 1, v.at(maxx - 1), v.at(maxx), v.at(maxx + 1), time, amp);
+
       }
     }
+    amp -= ped;
     std::vector<float> val = {amp, time, ped};
     fit_values.push_back(val);
     val.clear();

--- a/offline/packages/CaloReco/CaloWaveformProcessing.h
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.h
@@ -15,6 +15,7 @@ class CaloWaveformProcessing : public SubsysReco
     NONE = 0,
     TEMPLATE = 1,
     ONNX = 2,
+    FAST = 3,
   };
 
   CaloWaveformProcessing()
@@ -59,6 +60,7 @@ class CaloWaveformProcessing : public SubsysReco
   std::vector<std::vector<float>>  process_waveform(std::vector<std::vector<float>> waveformvector);
   std::vector<std::vector<float>>  calo_processing_ONNX(std::vector<std::vector<float>> chnlvector);
   std::vector<std::vector<float>>  calo_processing_templatefit(std::vector<std::vector<float>> chnlvector);
+  std::vector<std::vector<float>>  calo_processing_fast(std::vector<std::vector<float>> chnlvector);
 
 
   void initialize_processing(); 
@@ -76,6 +78,6 @@ class CaloWaveformProcessing : public SubsysReco
 
   std::string url_onnx;
   std::string m_model_name;
-
+  void FastMax(float x0, float x1, float x2, float y0, float y1, float y2, float & xmax, float & ymax);
 };
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR introduce a new waveform processing option that use a cubic spline to interpolate three samples around the maximum sample, and then solve for the local maximum analytically(see the calculation for the derivative [here](https://root.cern.ch/doc/master/TSpline_8h_source.html#l00134)) giving a peak ADC and time, the pedestal is calculated as the average of the first three samples. The processing speed of this method is fast, during the benchmarking it takes 6 ms per event for 3072 calorimeter channels(in comparison it takes on average 360 ms per event for the template fit).
This could serve as a fast alternative method for the situations such as online monitoring.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

