### PR TITLE
use G4Transform3D to pass positioning of Micromegas modules to geant4

### DIFF
--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
@@ -233,23 +233,23 @@ void PHG4MicromegasDetector::construct_micromegas(G4LogicalVolume* logicWorld)
       const double tile_thickness = static_cast<G4Box*>(tile_logic->GetSolid())->GetXHalfLength()*2;
       radius = inner_radius + tile_thickness/2;
     }
-    
-    // palce tile in master volume
+
+    // place tile in master volume
     const double centerZ = tile.m_centerZ*cm;
     const double centerPhi = tile.m_centerPhi;
- 
-    // place
-    /* not completely sure why one must rotate with oposite angle as that use for the translation */
-    auto rotation = new G4RotationMatrix;
-    rotation->rotateZ( -centerPhi*radian );
 
+    G4RotationMatrix rotation;
+    rotation.rotateZ( centerPhi*radian );
+    
     const G4ThreeVector center(
       radius*std::cos(centerPhi),
       radius*std::sin(centerPhi),
       centerZ );
+
+    G4Transform3D transform( rotation, center );
     
     const auto tilename = GetName() + "_tile_" + std::to_string(tileid);
-    new G4PVPlacement( rotation, center, tile_logic, tilename+"_phys", logicWorld, false, 0, OverlapCheck() );
+    new G4PVPlacement( transform, tile_logic, tilename+"_phys", logicWorld, false, 0, OverlapCheck() );
   }
   
   // adjust active volume radius to account for world placement


### PR DESCRIPTION
this allows not to have to create a G4Rotation on the stack, than then never gets deleted

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

