### PR TITLE
quit if the name of a funall object is an empty string

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -6,6 +6,13 @@
 Fun4AllBase::Fun4AllBase(const std::string& name)
   : m_ThisName(name)
 {
+  if (name.empty())
+  {
+    std::cout << "Fun4AllBase::Fun4AllBase: No empty strings as Object Name" << std::endl;
+    std::cout << "You likely create a module with an empty name in your macro" << std::endl;
+    std::cout << "Since it does not have a name I cannot tell you what it is, but this message is from its ctor, so it happens when you do a new XXX() in your macro" << std::endl;
+    exit(1);
+  }
   return;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
If someone creates a module and gave it an empty string as name, it leads to a failure creating a TDirectory for this module deep in the guts of fun4all. This PR makes the Fun4AllBase ctor quit if it gets an empty string as a name

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

