### PR TITLE
Update PHG4EPDDetector.cc

### DIFF
--- a/simulation/g4simulation/g4epd/PHG4EPDDetector.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDDetector.cc
@@ -77,11 +77,11 @@ void PHG4EPDDetector::ConstructMe(G4LogicalVolume* world)
       rotate->rotateZ(-1*phi_shift);
 
       m_volumes.emplace(
-          new G4PVPlacement( rotate, positive, volume, label, world, false, 2 * k + 0, OverlapCheck()),
+          new G4PVPlacement( rotate, negative, volume, label, world, false, 2 * k + 0, OverlapCheck()),
           module_id_for(i, k, 0));
 
       m_volumes.emplace(
-          new G4PVPlacement( rotate, negative, volume, label, world, false, 2 * k + 1, OverlapCheck()),
+          new G4PVPlacement( rotate, positive, volume, label, world, false, 2 * k + 1, OverlapCheck()),
           module_id_for(i, k, 1));
     }
   }


### PR DESCRIPTION
This PR assigns arm = 0 as the negative wheel, i.e. the south wheel. And arm = 1 as the positive wheel, i.e. the north wheel (see attached pdf).

The reason is to match the sim to the channel mapping scheme of TowerInfoContainer: https://github.com/sPHENIX-Collaboration/coresoftware/blob/master/offline/packages/CaloBase/TowerInfoContainerv1.cc#L101

where that mapping scheme decodes arm = 0 as the south and thus, channels ranging from 0-371; and arm = 1 as the north with channels ranging from 372-743.

[epd_arm_index.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/10563497/epd_arm_index.pdf)
