### PR TITLE
Added event number tracking and modulo to CM hit generation

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
@@ -148,6 +148,8 @@ int PHG4TpcCentralMembrane::InitRun(PHCompositeNode* /* topNode */)
       }
     }
   }
+
+  m_eventNum = 0;
   
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -155,6 +157,14 @@ int PHG4TpcCentralMembrane::InitRun(PHCompositeNode* /* topNode */)
 //_____________________________________________________________
 int PHG4TpcCentralMembrane::process_event(PHCompositeNode* topNode)
 {
+  
+  if(m_eventNum % m_eventModulo != 0)
+  {
+    if(Verbosity()) std::cout << "Event " << m_eventNum << " will not generate CM hits" << std::endl;
+    m_eventNum++;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   // load g4hit container
   auto g4hitcontainer = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
   if (!g4hitcontainer)
@@ -169,6 +179,8 @@ int PHG4TpcCentralMembrane::process_event(PHCompositeNode* topNode)
     auto copy = new PHG4Hitv1(hit);
     g4hitcontainer->AddHit(detId, copy);
   }
+
+  m_eventNum++;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.h
@@ -49,6 +49,9 @@ class PHG4TpcCentralMembrane : public SubsysReco, public PHParameterInterface
   /// adjust central membrane hits delay with respect to trigger time
   void setCentralMembraneDelay(int ns) { m_centralMembraneDelay = ns; };
 
+  /// set modulo for events in which to generate CM hits
+  void setCentralMembraneEventModulo(int mod) { m_eventModulo = mod; };
+
  private:
   /// detector name
   std::string detector = "TPC";
@@ -56,6 +59,9 @@ class PHG4TpcCentralMembrane : public SubsysReco, public PHParameterInterface
   /// g4hitnode name
   std::string hitnodename = "G4HIT_TPC";
   std::vector<PHG4Hit*> PHG4Hits;
+
+  int m_eventModulo = 10;
+  int m_eventNum = 0;
 
   static constexpr double mm = 1.0;
   static constexpr double cm = 10.0;


### PR DESCRIPTION
Added event number counter to CM hit generation and a modulo so that hits will only be generated every Nth event (event%modulo != 0 will increment event number and return). Default modulo is 10. Also added function to change modulo in macro and added corresponding function to macro.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
feature: only generate CM hits every Nth event
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
https://github.com/sPHENIX-Collaboration/macros/pull/586
