### PR TITLE
Updates to Jet Tagging macros - new features, bug fixes

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -153,7 +153,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
 
 int KFParticle_sPHENIX::End(PHCompositeNode * /*topNode*/)
 {
-  std::cout << "KFParticle_sPHENIX object " << Name() << " finished. Number of canadidates: " << candidateCounter << std::endl;
+  std::cout << "KFParticle_sPHENIX object " << Name() << " finished. Number of candidates: " << candidateCounter << std::endl;
 
   if (m_save_output && candidateCounter != 0)
   {

--- a/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
+++ b/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
@@ -63,16 +63,20 @@
 #include <set>       // for set
 #include <string>
 
+#include <g4main/PHG4TruthInfoContainer.h>
+class PHG4TruthInfoContainer;
+
 /**
  * ResonanceJetTagging is a class developed to reconstruct jets containing a D-meson
  * The class can be adapted to tag jets using any kind of particle
  * Author: Antonio Silva (antonio.sphenix@gmail.com)
+ * Contributor: Jakub Kvapil (jakub.kvapil@cern.ch)
  */
 
 /**
  * Constructor of module
  */
-ResonanceJetTagging::ResonanceJetTagging(const std::string &name, const TAG tag)
+ResonanceJetTagging::ResonanceJetTagging(const std::string &name, const TAG tag, std::string KFparticle_Container_name)
   : SubsysReco(name)
   , m_particleflow_mineta(-1.1)
   , m_particleflow_maxeta(1.1)
@@ -97,29 +101,46 @@ ResonanceJetTagging::ResonanceJetTagging(const std::string &name, const TAG tag)
   , m_recomb_scheme(fastjet::pt_scheme)
   , m_dorec(true)
   , m_dotruth(false)
+  , m_nDaughters(0)
   , m_tag_particle(tag)
+  , m_KFparticle_name(KFparticle_Container_name)
 {
   switch (m_tag_particle) {
-    case TAG::D0:
+    case ResonanceJetTagging::TAG::D0:
       m_tag_pdg = 421;
+      m_nDaughters = 2;
       break;
-    case TAG::DPLUS:
+    case ResonanceJetTagging::TAG::D0TOK3PI:
+      m_tag_pdg = 421;
+      m_nDaughters = 4;
+      break;
+    case ResonanceJetTagging::TAG::DPLUS:
       m_tag_pdg = 411;
+      m_nDaughters = 3;
       break;
-    case TAG::DSTAR:
+    case ResonanceJetTagging::TAG::DSTAR:
       m_tag_pdg = 413;
+      m_nDaughters = 0;
       break;
-    case TAG::JPSY:
+    case ResonanceJetTagging::TAG::JPSY:
       m_tag_pdg = 433;
+      m_nDaughters = 0;
       break;
-    case TAG::K0:
+    case ResonanceJetTagging::TAG::K0:
       m_tag_pdg = 311;
+      m_nDaughters = 0;
       break;
-    case TAG::GAMMA:
+    case ResonanceJetTagging::TAG::GAMMA:
       m_tag_pdg = 22;
+      m_nDaughters = 0;
       break;
-    case TAG::ELECTRON:
+    case ResonanceJetTagging::TAG::ELECTRON:
       m_tag_pdg = 11;
+      m_nDaughters = 0;
+      break;
+    case ResonanceJetTagging::TAG::LAMBDAC:
+      m_tag_pdg = 4122;
+      m_nDaughters = 3;
       break;
   }
 
@@ -154,22 +175,25 @@ int ResonanceJetTagging::Init(PHCompositeNode *topNode)
  */
 int ResonanceJetTagging::process_event(PHCompositeNode *topNode)
 {
+  if(m_nDaughters == 0)
+  {
+    std::cout<<"ERROR: Number of Decay Daughters Not Set, ABORTING!";
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
 
   switch (m_tag_particle) {
-    case TAG::D0:
-      return tagD0(topNode);
+    case ResonanceJetTagging::TAG::D0:
+      [[fallthrough]];
+    case ResonanceJetTagging::TAG::D0TOK3PI:
+      [[fallthrough]];
+    case ResonanceJetTagging::TAG::DPLUS:
+      [[fallthrough]];
+    case ResonanceJetTagging::TAG::LAMBDAC:
+      return tagHFHadronic(topNode);
       break;
-    case TAG::DPLUS:
-      break;
-    case TAG::DSTAR:
-      break;
-    case TAG::JPSY:
-      break;
-    case TAG::K0:
-      break;
-    case TAG::GAMMA:
-      break;
-    case TAG::ELECTRON:
+    default:
+      std::cout<<"ERROR: Fill Tree Function Not Set, ABORTING!";
+      return Fun4AllReturnCodes::ABORTRUN;
       break;
   }
 
@@ -190,22 +214,18 @@ int ResonanceJetTagging::End(PHCompositeNode * /*topNode*/)
   return 0;
 }
 
-int ResonanceJetTagging::tagD0(PHCompositeNode *topNode)
+int ResonanceJetTagging::tagHFHadronic(PHCompositeNode *topNode)
 {
-
   if(m_dorec)
   {
-    KFParticle_Container *kfContainer = findNode::getClass<KFParticle_Container>(topNode, "reconstructedParticles_KFParticle_Container");
+    KFParticle_Container *kfContainer = findNode::getClass<KFParticle_Container>(topNode, m_KFparticle_name);
     if(!kfContainer) return Fun4AllReturnCodes::ABORTEVENT;
 
     KFParticle *TagCand = nullptr;
     PHG4Particlev2 *Cand = new PHG4Particlev2();
-
-    const int nDaughters = 2;  // TagCand->NDaughters() is returning 0, bug?
-
-    KFParticle *TagDaughters[nDaughters];
-    PHG4Particlev2 *Daughters[nDaughters];
-
+    //const int nDaughters = 2;  // TagCand->NDaughters() is returning 0, bug?
+    std::vector<KFParticle*> TagDaughters(m_nDaughters);
+    std::vector<PHG4Particlev2*> Daughters(m_nDaughters);
     m_jet_id = 0;
 
     for (unsigned int i = 0; i < kfContainer->size(); i++)
@@ -213,7 +233,7 @@ int ResonanceJetTagging::tagD0(PHCompositeNode *topNode)
       TagCand = kfContainer->get(i);
       if (std::abs(TagCand->GetPDG()) == m_tag_pdg)
       {
-        for (int idau = 0; idau < nDaughters; idau++)
+        for (int idau = 0; idau < m_nDaughters; idau++)
         {
           TagDaughters[idau] = kfContainer->get(i + idau + 1);
           Daughters[idau] = new PHG4Particlev2();
@@ -233,13 +253,16 @@ int ResonanceJetTagging::tagD0(PHCompositeNode *topNode)
         //so that later the tag particle can be recovered from jet constituent
         Cand->set_barcode(i);
 
-        findTaggedJets(topNode, Cand, Daughters, nDaughters);
+        findTaggedJets(topNode, Cand, Daughters);
+
+        for (int idau = 0; idau < m_nDaughters; idau++) delete Daughters[idau];
+
         m_jet_id++;
-        i += nDaughters;  // Go to the next D meson
+        i += m_nDaughters;  // Go to the next D meson
       }
     }
+  delete Cand;
   }
-
 
   if (m_dotruth)
   {
@@ -249,14 +272,11 @@ int ResonanceJetTagging::tagD0(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, PHG4Particlev2 *TagDecays[], int nDecays)
+void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, std::vector<PHG4Particlev2*> TagDecays)
 {
   std::unique_ptr<fastjet::JetDefinition> jetdef(new fastjet::JetDefinition(m_jetalgo, m_jetr, m_recomb_scheme, fastjet::Best));
-
   std::vector<fastjet::PseudoJet> particles;
-
   Jet *taggedJet;
-
   std::map<int, std::pair<Jet::SRC, int>> fjMap;
 
   fastjet::PseudoJet fjTag(Tag->get_px(), Tag->get_py(), Tag->get_pz(), Tag->get_e());
@@ -266,12 +286,12 @@ void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev
 
   if (m_add_particleflow)
   {
-    addParticleFlow(topNode, particles, TagDecays, nDecays, fjMap);
+    addParticleFlow(topNode, particles, TagDecays, fjMap);
   }
 
   if (m_add_tracks)
   {
-    addTracks(topNode, particles, TagDecays, nDecays, fjMap);
+    addTracks(topNode, particles, TagDecays, fjMap);
   }
 
   if (m_add_EMCal_clusters || m_add_HCal_clusters)
@@ -310,13 +330,12 @@ void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev
       taggedJet->clear_comp();
     }
   }
-
   m_taggedJetMap->insert(taggedJet);
 
   return;
 }
 
-void ResonanceJetTagging::addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, PHG4Particlev2 *TagDecays[], int nDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
+void ResonanceJetTagging::addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
 {
   ParticleFlowElementContainer *pflowContainer = findNode::getClass<ParticleFlowElementContainer>(topNode, "ParticleFlowElements");
 
@@ -354,7 +373,7 @@ void ResonanceJetTagging::addParticleFlow(PHCompositeNode *topNode, std::vector<
     track = pflow->get_track();
 
     // Remove D0 decay daughter
-    if (track && isDecay(track, TagDecays, nDecays))
+    if (track && isDecay(track, TagDecays))
     {
       continue;
     }
@@ -378,7 +397,7 @@ bool ResonanceJetTagging::isAcceptableParticleFlow(ParticleFlowElement *pfPart)
 
   return true;
 }
-void ResonanceJetTagging::addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, PHG4Particlev2 *TagDecays[], int nDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
+void ResonanceJetTagging::addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
 {
   SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
 
@@ -403,7 +422,7 @@ void ResonanceJetTagging::addTracks(PHCompositeNode *topNode, std::vector<fastje
       continue;
     }
 
-    if (isDecay(track, TagDecays, nDecays))
+    if (isDecay(track, TagDecays))
     {
       continue;
     }
@@ -633,9 +652,9 @@ bool ResonanceJetTagging::isAcceptableHCalCluster(CLHEP::Hep3Vector &E_vec_clust
   return true;
 }
 
-bool ResonanceJetTagging::isDecay(SvtxTrack *track, PHG4Particlev2 *decays[], int nDecays)
+bool ResonanceJetTagging::isDecay(SvtxTrack *track,  std::vector<PHG4Particlev2*> decays)
 {
-  for (int idecay = 0; idecay < nDecays; idecay++)
+  for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {
     if(int(track->get_id()) == decays[idecay]->get_barcode())
     {
@@ -645,9 +664,9 @@ bool ResonanceJetTagging::isDecay(SvtxTrack *track, PHG4Particlev2 *decays[], in
   return false;
 }
 
-bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, PHG4Particle *decays[], int nDecays)
+bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, std::vector<PHG4Particlev2*> decays)
 {
-  for (int idecay = 0; idecay < nDecays; idecay++)
+  for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {
     if (particle->barcode() == decays[idecay]->get_barcode())
     {
@@ -660,7 +679,6 @@ bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, PHG4Particle *de
 void ResonanceJetTagging::findMCTaggedJets(PHCompositeNode *topNode)
 {
   PHHepMCGenEventMap *hepmceventmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
-
   /// If the node was not properly put on the tree, return
   if (!hepmceventmap)
   {
@@ -687,6 +705,10 @@ void ResonanceJetTagging::findMCTaggedJets(PHCompositeNode *topNode)
   TDatabasePDG *database = TDatabasePDG::Instance();
   TParticlePDG *partPDG = nullptr;
 
+  PHG4TruthInfoContainer *m_truthinfo = nullptr;
+
+  m_truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+
   m_truth_jet_id = 0;
 
   Jet *mcTaggedJet;
@@ -703,9 +725,28 @@ void ResonanceJetTagging::findMCTaggedJets(PHCompositeNode *topNode)
       std::vector<int> decayIDs;
 
       HepMC::GenVertex *TagVertex = (*tag)->end_vertex();
-      for (HepMC::GenVertex::particle_iterator it = TagVertex->particles_begin(HepMC::descendants); it != TagVertex->particles_end(HepMC::descendants); ++it)
+      //if HEPMC vertex exists
+      if(TagVertex){
+        for (HepMC::GenVertex::particle_iterator it = TagVertex->particles_begin(HepMC::descendants); it != TagVertex->particles_end(HepMC::descendants); ++it)
+        {
+          decayIDs.push_back((*it)->barcode());
+        }
+      //if not, look into GEANT
+      } 
+      else
       {
-        decayIDs.push_back((*it)->barcode());
+        PHG4TruthInfoContainer::ConstRange range = m_truthinfo->GetParticleRange();
+        for(PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
+        {  
+          PHG4Particle* g4particle = iter->second;
+          PHG4Particle* mother = nullptr;
+          if (g4particle->get_parent_id() != 0) mother = m_truthinfo->GetParticle(g4particle->get_parent_id());
+          else continue;
+          if (mother->get_barcode() == (*tag)->barcode() && mother->get_pid() == (*tag)->pdg_id())
+          {
+            decayIDs.push_back(g4particle->get_barcode());
+          }
+        }
       }
 
       std::map<int, std::pair<Jet::SRC, int>> fjMapMC;
@@ -799,7 +840,6 @@ void ResonanceJetTagging::findMCTaggedJets(PHCompositeNode *topNode)
           mcTaggedJet->clear_comp();
         }
       }
-
       m_truth_taggedJetMap->insert(mcTaggedJet);
       m_truth_jet_id++;
     }

--- a/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
+++ b/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
@@ -235,14 +235,14 @@ int ResonanceJetTagging::tagHFHadronic(PHCompositeNode *topNode)
       {
         for (int idau = 0; idau < m_nDaughters; idau++)
         {
-          TagDaughters[idau] = kfContainer->get(i + idau + 1);
-          Daughters[idau] = new PHG4Particlev2();
-          Daughters[idau]->set_px(TagDaughters[idau]->Px());
-          Daughters[idau]->set_py(TagDaughters[idau]->Py());
-          Daughters[idau]->set_pz(TagDaughters[idau]->Pz());
+          TagDaughters.at(idau) = kfContainer->get(i + idau + 1);
+          Daughters.at(idau) = new PHG4Particlev2();
+          Daughters.at(idau)->set_px(TagDaughters.at(idau)->Px());
+          Daughters.at(idau)->set_py(TagDaughters.at(idau)->Py());
+          Daughters.at(idau)->set_pz(TagDaughters.at(idau)->Pz());
           //For daughters keep ID as the track ID, so they can be removed from the sample
           //given to fastjet
-          Daughters[idau]->set_barcode(TagDaughters[idau]->Id());
+          Daughters.at(idau)->set_barcode(TagDaughters.at(idau)->Id());
         }
 
         Cand->set_px(TagCand->Px());
@@ -255,7 +255,7 @@ int ResonanceJetTagging::tagHFHadronic(PHCompositeNode *topNode)
 
         findTaggedJets(topNode, Cand, Daughters);
 
-        for (int idau = 0; idau < m_nDaughters; idau++) delete Daughters[idau];
+        for (long unsigned int idau = 0; idau < Daughters.size(); idau++) delete Daughters.at(idau);
 
         m_jet_id++;
         i += m_nDaughters;  // Go to the next D meson
@@ -656,7 +656,7 @@ bool ResonanceJetTagging::isDecay(SvtxTrack *track,  std::vector<PHG4Particlev2*
 {
   for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {
-    if(int(track->get_id()) == decays[idecay]->get_barcode())
+    if(int(track->get_id()) == decays.at(idecay)->get_barcode())
     {
       return true;
     }
@@ -668,7 +668,7 @@ bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, std::vector<PHG4
 {
   for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {
-    if (particle->barcode() == decays[idecay]->get_barcode())
+    if (particle->barcode() == decays.at(idecay)->get_barcode())
     {
       return true;
     }

--- a/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
+++ b/offline/packages/ResonanceJetTagging/ResonanceJetTagging.cc
@@ -76,7 +76,7 @@ class PHG4TruthInfoContainer;
 /**
  * Constructor of module
  */
-ResonanceJetTagging::ResonanceJetTagging(const std::string &name, const TAG tag, std::string KFparticle_Container_name)
+ResonanceJetTagging::ResonanceJetTagging(const std::string &name, const TAG tag, const std::string &KFparticle_Container_name)
   : SubsysReco(name)
   , m_particleflow_mineta(-1.1)
   , m_particleflow_maxeta(1.1)
@@ -192,7 +192,7 @@ int ResonanceJetTagging::process_event(PHCompositeNode *topNode)
       return tagHFHadronic(topNode);
       break;
     default:
-      std::cout<<"ERROR: Fill Tree Function Not Set, ABORTING!";
+      std::cout<<"ERROR: Tag Function Not Set, ABORTING!";
       return Fun4AllReturnCodes::ABORTRUN;
       break;
   }
@@ -272,7 +272,7 @@ int ResonanceJetTagging::tagHFHadronic(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, std::vector<PHG4Particlev2*> TagDecays)
+void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, const std::vector<PHG4Particlev2*> &TagDecays)
 {
   std::unique_ptr<fastjet::JetDefinition> jetdef(new fastjet::JetDefinition(m_jetalgo, m_jetr, m_recomb_scheme, fastjet::Best));
   std::vector<fastjet::PseudoJet> particles;
@@ -335,7 +335,7 @@ void ResonanceJetTagging::findTaggedJets(PHCompositeNode *topNode, PHG4Particlev
   return;
 }
 
-void ResonanceJetTagging::addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
+void ResonanceJetTagging::addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, const std::vector<PHG4Particlev2*> &TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
 {
   ParticleFlowElementContainer *pflowContainer = findNode::getClass<ParticleFlowElementContainer>(topNode, "ParticleFlowElements");
 
@@ -397,7 +397,7 @@ bool ResonanceJetTagging::isAcceptableParticleFlow(ParticleFlowElement *pfPart)
 
   return true;
 }
-void ResonanceJetTagging::addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
+void ResonanceJetTagging::addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, const std::vector<PHG4Particlev2*> &TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap)
 {
   SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
 
@@ -652,7 +652,7 @@ bool ResonanceJetTagging::isAcceptableHCalCluster(CLHEP::Hep3Vector &E_vec_clust
   return true;
 }
 
-bool ResonanceJetTagging::isDecay(SvtxTrack *track,  std::vector<PHG4Particlev2*> decays)
+bool ResonanceJetTagging::isDecay(SvtxTrack *track,  const std::vector<PHG4Particlev2*> &decays)
 {
   for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {
@@ -664,7 +664,7 @@ bool ResonanceJetTagging::isDecay(SvtxTrack *track,  std::vector<PHG4Particlev2*
   return false;
 }
 
-bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, std::vector<PHG4Particlev2*> decays)
+bool ResonanceJetTagging::isDecay(HepMC::GenParticle *particle, const std::vector<PHG4Particlev2*> &decays)
 {
   for (long unsigned int idecay = 0; idecay < decays.size(); idecay++)
   {

--- a/offline/packages/ResonanceJetTagging/ResonanceJetTagging.h
+++ b/offline/packages/ResonanceJetTagging/ResonanceJetTagging.h
@@ -67,7 +67,7 @@ class ResonanceJetTagging : public SubsysReco
   };
 
   /// Constructor
-  ResonanceJetTagging(const std::string &name = "ResonanceJetTagging", const TAG tag = TAG::D0, std::string KFparticle_Container_name = "");
+  ResonanceJetTagging(const std::string &name = "ResonanceJetTagging", const TAG tag = TAG::D0, const std::string &KFparticle_Container_name = "");
 
   // Destructor
   virtual ~ResonanceJetTagging();
@@ -270,9 +270,9 @@ class ResonanceJetTagging : public SubsysReco
 
   /// Methods for grabbing the data
   int tagHFHadronic(PHCompositeNode *topNode);
-  void findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, std::vector<PHG4Particlev2*> TagDecays);
-  void addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
-  void addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
+  void findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, const std::vector<PHG4Particlev2*> &TagDecays);
+  void addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, const std::vector<PHG4Particlev2*> &TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
+  void addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, const std::vector<PHG4Particlev2*> &TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
   void addClusters(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
   void findMCTaggedJets(PHCompositeNode *topNode);
 
@@ -280,8 +280,8 @@ class ResonanceJetTagging : public SubsysReco
   bool isAcceptableTrack(SvtxTrack *track);
   bool isAcceptableEMCalCluster(CLHEP::Hep3Vector &E_vec_cluster);
   bool isAcceptableHCalCluster(CLHEP::Hep3Vector &E_vec_cluster);
-  bool isDecay(HepMC::GenParticle *particle, std::vector<PHG4Particlev2*> decays);
-  bool isDecay(SvtxTrack *track, std::vector<PHG4Particlev2*> decays);
+  bool isDecay(HepMC::GenParticle *particle, const std::vector<PHG4Particlev2*> &decays);
+  bool isDecay(SvtxTrack *track, const std::vector<PHG4Particlev2*> &decays);
   int createJetNode(PHCompositeNode *topNode);
 };
 

--- a/offline/packages/ResonanceJetTagging/ResonanceJetTagging.h
+++ b/offline/packages/ResonanceJetTagging/ResonanceJetTagging.h
@@ -56,16 +56,18 @@ class ResonanceJetTagging : public SubsysReco
   enum TAG
   {
     D0 = 0,
-    DPLUS = 1,
-    DSTAR = 2,
-    JPSY = 3,
-    K0 = 4,
-    GAMMA = 5,
-    ELECTRON = 6
+    D0TOK3PI = 1,
+    DPLUS = 2,
+    DSTAR = 3,
+    JPSY = 4,
+    K0 = 5,
+    GAMMA = 6,
+    ELECTRON = 7,
+    LAMBDAC = 8
   };
 
   /// Constructor
-  ResonanceJetTagging(const std::string &name = "ResonanceJetTagging", const TAG tag = TAG::D0);
+  ResonanceJetTagging(const std::string &name = "ResonanceJetTagging", const TAG tag = TAG::D0, std::string KFparticle_Container_name = "");
 
   // Destructor
   virtual ~ResonanceJetTagging();
@@ -172,10 +174,13 @@ class ResonanceJetTagging : public SubsysReco
     {
     case ALGO::ANTIKT:
       m_jetalgo = fastjet::antikt_algorithm;
+      break;
     case ALGO::KT:
       m_jetalgo = fastjet::kt_algorithm;
+      break;
     case ALGO::CAMBRIDGE:
       m_jetalgo = fastjet::cambridge_algorithm;
+      break;
     }
   }
   fastjet::JetAlgorithm getJetAlgo() { return m_jetalgo; }
@@ -185,14 +190,19 @@ class ResonanceJetTagging : public SubsysReco
     {
     case RECOMB::E_SCHEME:
       m_recomb_scheme = fastjet::E_scheme;
+      break;
     case RECOMB::PT_SCHEME:
       m_recomb_scheme = fastjet::pt_scheme;
+      break;
     case RECOMB::PT2_SCHEME:
       m_recomb_scheme = fastjet::pt2_scheme;
+      break;
     case RECOMB::ET_SCHEME:
       m_recomb_scheme = fastjet::Et_scheme;
+      break;
     case RECOMB::ET2_SCHEME:
       m_recomb_scheme = fastjet::Et2_scheme;
+      break;
     }
   }
   fastjet::RecombinationScheme getRecombScheme() { return m_recomb_scheme; }
@@ -254,13 +264,15 @@ class ResonanceJetTagging : public SubsysReco
   unsigned int m_truth_jet_id = 0;
   bool m_dorec;
   bool m_dotruth;
+  int m_nDaughters;
   TAG m_tag_particle;
+  std::string m_KFparticle_name;
 
   /// Methods for grabbing the data
-  int tagD0(PHCompositeNode *topNode);
-  void findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, PHG4Particlev2 *TagDecays[], int nDecays);
-  void addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, PHG4Particlev2 *TagDecays[], int nDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
-  void addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, PHG4Particlev2 *TagDecays[], int nDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
+  int tagHFHadronic(PHCompositeNode *topNode);
+  void findTaggedJets(PHCompositeNode *topNode, PHG4Particlev2 *Tag, std::vector<PHG4Particlev2*> TagDecays);
+  void addParticleFlow(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
+  void addTracks(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::vector<PHG4Particlev2*> TagDecays, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
   void addClusters(PHCompositeNode *topNode, std::vector<fastjet::PseudoJet> &particles, std::map<int, std::pair<Jet::SRC, int>> &fjMap);
   void findMCTaggedJets(PHCompositeNode *topNode);
 
@@ -268,8 +280,8 @@ class ResonanceJetTagging : public SubsysReco
   bool isAcceptableTrack(SvtxTrack *track);
   bool isAcceptableEMCalCluster(CLHEP::Hep3Vector &E_vec_cluster);
   bool isAcceptableHCalCluster(CLHEP::Hep3Vector &E_vec_cluster);
-  bool isDecay(HepMC::GenParticle *particle, PHG4Particle *decays[], int nDecays);
-  bool isDecay(SvtxTrack *track, PHG4Particlev2 *decays[], int nDecays);
+  bool isDecay(HepMC::GenParticle *particle, std::vector<PHG4Particlev2*> decays);
+  bool isDecay(SvtxTrack *track, std::vector<PHG4Particlev2*> decays);
   int createJetNode(PHCompositeNode *topNode);
 };
 


### PR DESCRIPTION
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
- fixed a typo in KFParticle printout
- generalized tagging code to run on the multiple HF tagged particles without the need of recompiling - a new parameter has been added as an input to the code which must be properly reflected by the analysis/macro
- removed hardcoded variables, moved from arrays to vectors
- fixed a bug to properly select jet algorithm and scheme, now it properly set them instead of using CA and Et2
- in case the HEPMC vector does not exist, it will look for GEANT vertex - this fixes crashes on ccbar data samples
- fixed memory leaks using valgrind, insure tested

## TODOs (if applicable)
while running on ccbar sample, there is an issue that the reconstructed jets does not have truth information, this need more digging. Djet sample are unaffected.

## Links to other PRs in macros and calibration repositories (if applicable)

