### PR TITLE
Fixed phi and z bin number and added sampa_tbias

### DIFF
--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -58,8 +58,8 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     TrkrDefs::hitsetkey hitsetkey  = hitsetitr->first;
     TrkrHitSet *hitset             = hitsetitr->second;
     unsigned int layer             = TrkrDefs::getLayer(hitsetitr->first);
-    /* int side                       = TpcDefs::getSide(hitsetitr->first); */
-    unsigned int sector            = TpcDefs::getSectorId(hitsetitr->first);
+    int side                       = TpcDefs::getSide(hitsetitr->first);
+    // unsigned int sector            = TpcDefs::getSectorId(hitsetitr->first);
     PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
 
     //get the maximum and minimum phi and time
@@ -67,16 +67,16 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     unsigned short NPhiBinsSector = NPhiBins/12;
     unsigned short NTBins = (unsigned short)layergeom->get_zbins();
     unsigned short NTBinsSide = NTBins;
-    unsigned short NTBinsMin = 0;
-    unsigned short PhiOffset = NPhiBinsSector * sector;
-    unsigned short TOffset = NTBinsMin;
+    // unsigned short NTBinsMin = 0;
+    // unsigned short PhiOffset = NPhiBinsSector * sector;
+    // unsigned short TOffset = NTBinsMin;
 
     double m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
 
     unsigned short phibins   = NPhiBinsSector;
-    unsigned short phioffset = PhiOffset;
+    // unsigned short phioffset = PhiOffset;
     unsigned short tbins     = NTBinsSide;
-    unsigned short toffset   = TOffset ;
+    // unsigned short toffset   = TOffset ;
    
     // loop over the hits in this cluster
     double t_sum = 0.0;
@@ -97,8 +97,8 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
       unsigned int adc = iter->second->getAdc(); 
       if (adc <= 0) continue;
 
-      int iphi = TpcDefs::getPad(iter->first) - phioffset;
-      int it   = TpcDefs::getTBin(iter->first) - toffset;
+      int iphi = TpcDefs::getPad(iter->first);
+      int it   = TpcDefs::getTBin(iter->first);
 
       if(iphi<0 || iphi>=phibins){
         //std::cout << "WARNING phibin out of range: " << phibin << " | " << phibins << std::endl;
@@ -135,6 +135,7 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     double zdriftlength = clust * m_tGeometry->get_drift_velocity();
     // convert z drift length to z position in the TPC
     double clusz = m_tdriftmax * m_tGeometry->get_drift_velocity() - zdriftlength;
+    if(side == 0) clusz = -clusz;
     /* const double phi_cov = phi2_sum/adc_sum - square(clusphi); */
 
     char tsize = tbinhi - tbinlo + 1;
@@ -151,6 +152,9 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
       if (verbosity) std::cout << "Can't find the surface! with hitsetkey " << ((int)hitsetkey) << std::endl;
       continue;
     }
+
+    // SAMPA shaping bias correction
+    clust = clust + m_sampa_tbias;
 
     global *= Acts::UnitConstants::cm;
 

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -82,7 +82,7 @@ class TpcClusterBuilder {
 
   // TPC shaping offset correction parameter
   // From Tony Frawley July 5, 2022
-  /* double m_sampa_tbias = 39.6;  // ns */  
+  double m_sampa_tbias = 39.6;  // ns
 
   void reset(bool clear_hitsetkey_cnt);
 };


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Function cluster_and_reset in TpcClusterBuilder copied from TpcClusterizer but missing:
if(side == 0) clusz = -clusz;
clust = clust + m_sampa_tbias;
Also, iphi and iz wrongly used a relative bin number.
This fixed all the issues.