### PR TITLE
fall back to pythia6 decayer

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -37,6 +37,14 @@ class PHG4UIsession;
 class PHG4Reco : public SubsysReco
 {
  public:
+  enum DecayerOptions
+  {
+    kGEANTInternalDecayer = 0,
+    kPYTHIA6Decayer = 1,
+    kEvtGenDecayer = 2,
+
+  };  // Decayer Option for User to Choose: 0 - GEANT 4 Internal Decayer (with momentum conservation issues), 1, PYTHIA 6 Decayer, 2 - EvtGen Decayer
+
   //! constructor
   PHG4Reco(const std::string &name = "PHG4RECO");
 
@@ -89,13 +97,13 @@ class PHG4Reco : public SubsysReco
   //! set default scaling factor for input magnetic field map. If available, Field map setting on DST take higher priority.
   void set_field_rescale(const float rescale) { m_MagneticFieldRescale = rescale; }
 
-//  void set_decayer_active(bool b) { m_ActiveDecayerFlag = b; }
   void set_force_decay(EDecayType force_decay_type)
   {
-//    m_ActiveDecayerFlag = true;
     m_ActiveForceDecayFlag = true;
     m_ForceDecayType = force_decay_type;
   }
+
+  void set_decayer(DecayerOptions type) {m_Decayer = type;}
 
   //! export geometry to root file
   void export_geometry( bool b, const std::string& filename = "sPHENIXGeom.root" )
@@ -198,15 +206,8 @@ class PHG4Reco : public SubsysReco
   //bool m_ActiveDecayerFlag = true;     //< turn on/off decayer
   bool m_ActiveForceDecayFlag = false;  //< turn on/off force decay channels
 
-  enum DecayerOptions
-  {
-    kGEANTInternalDecayer = 0,
-    kPYTHIA6Decayer = 1,
-    kEvtGenDecayer = 2,
 
-  };  // Decayer Option for User to Choose: 0 - GEANT 4 Internal Decayer (with momentum conservation issues), 1, PYTHIA 6 Decayer, 2 - EvtGen Decayer
-
-  DecayerOptions m_Decayer = kEvtGenDecayer;  // Here we use EvtGen as default
+  DecayerOptions m_Decayer = kPYTHIA6Decayer;  // Here we use pythia6 as default
   EDecayType m_ForceDecayType = kAll;  //< forced decay channel setting
 
   bool m_SaveDstGeometryFlag = true;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
This PR reverts the default decayer back to pythia6. EvtGen modifies cout which affects all printouts, That needs to be fixed before we can go back to the EvtGen decayer. Also - now it is possible to change the decayer in a macro
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

