### PR TITLE
Recover `std::cout` to previous behavior after EvtGen load

### DIFF
--- a/simulation/g4simulation/g4decayer/EvtGenExtDecayerPhysics.cc
+++ b/simulation/g4simulation/g4decayer/EvtGenExtDecayerPhysics.cc
@@ -43,6 +43,8 @@
 #include <Geant4/G4VProcess.hh>  // for G4VProcess
 #include <Geant4/G4Version.hh>
 
+#include <boost/io/ios_state.hpp>
+
 #include <cstddef>   // for size_t
 #include <iostream>  // for operator<<, endl, basic_o...
 #include <string>    // for operator<<
@@ -82,6 +84,10 @@ void EvtGenExtDecayerPhysics::ConstructParticle()
 
 void EvtGenExtDecayerPhysics::ConstructProcess()
 {
+  // EvtGen model initialization changed the behavior of std::cout float print. Recover the default float print format
+  boost::io::ios_all_saver  ias_cout( std::cout );
+  boost::io::ios_all_saver  ias_cerr( std::cerr );
+
   /// Loop over all particles instantiated and add external decayer
   /// to all decay processes if External decayer is set
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
EvtGen model initialization (carried out as class member initialization in `G4VExtDecayer`) changed the behavior of std::cout float print. Recover the default float print format

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

