### PR TITLE
Add flag to skip noise addition for empty time bins

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.h
@@ -45,15 +45,18 @@ class PHG4TpcDigitizer : public SubsysReco
   void SetADCThreshold(const float thresh) { ADCThreshold = thresh; };
   void SetENC(const float enc) { TpcEnc = enc; };
   void set_drift_velocity(float vd) {_drift_velocity = vd;}
+  void set_skip_noise_flag(const bool skip) {skip_noise = skip;}
 
  private:
   void CalculateCylinderCellADCScale(PHCompositeNode *topNode);
   void DigitizeCylinderCells(PHCompositeNode *topNode);
   float added_noise();
-
+  float add_noise_to_bin(float signal);
+  
   unsigned int TpcMinLayer;
   unsigned int TpcNLayers;
   float ADCThreshold;
+  float ADCThreshold_mV = 0;
   float TpcEnc;
   float Pedestal;
   float ChargeToPeakVolts;
@@ -61,6 +64,8 @@ class PHG4TpcDigitizer : public SubsysReco
 
   float ADCSignalConversionGain;
   float ADCNoiseConversionGain;
+
+  bool skip_noise = false;
 
   std::vector<std::vector<TrkrHitSet::ConstIterator> > phi_sorted_hits;
   std::vector<std::vector<TrkrHitSet::ConstIterator> > t_sorted_hits;


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a flag that tells PHG4TpcDigitizer to skip adding noise to all empty time bins. If the flag is set to true, the code adds noise only to time bins that contain a g4hit, and the four time bins following a hit above threshold. This reproduces the old behavior.
The flag is intended to be used only to speed up execution for testing purposes. It reduces the time for TPC digitization in a few-track event from 10.5 s to 0.6 s. For AuAu events it makes no significant difference - adding noise to empty bins is a one-time cost per event that takes ~ 10 s.

To set the flag, in G4_TPC.C add:
digitpc->set_skip_noise_flag(true);

The default for the flag is false.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

