### PR TITLE
Add functionality for counting number of GEM modules hit + clearing up ambiguity w/ arbitrary pointing

### DIFF
--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -28,6 +28,7 @@
 #include <TH2.h>
 #include <TH3.h>
 #include <TVector3.h>
+#include <TNtuple.h>
 
 #include <cassert>
 
@@ -186,7 +187,7 @@ int TpcDirectLaserReconstruction::End(PHCompositeNode* )
   if( m_savehistograms && m_histogramfile )
   {
     m_histogramfile->cd();
-    for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer_south,h_deltarphi_layer_north, h_deltaz_layer, h_deltar_r, h_entries,h_xy,h_xz,h_xy_pca,h_xz_pca,h_dca_path,h_zr,h_zr_pca, h_dz_z }))
+    for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer_south,h_deltarphi_layer_north, h_deltaz_layer, h_deltar_r,h_deltheta_delphi,h_entries,h_hits,h_clusters,h_origins,h_assoc_hits,h_GEMs_hit,h_xy,h_xz,h_xy_pca,h_xz_pca,h_dca_path,h_zr,h_zr_pca, h_dz_z }))
     { if( o ) o->Write(); }
     m_histogramfile->Close();
   }
@@ -265,6 +266,24 @@ void TpcDirectLaserReconstruction::create_histograms()
   h_zr->GetYaxis()->SetTitle("rad");
   h_zr_pca = new TH2F("h_zr_pca"," z vs r pca", 440,-110,110,1000,28,80);
   h_dz_z = new TH2F("h_dz_z"," dz vs z", 440,-110,110, 1000, -20, 20);
+  h_hits = new TNtuple("hits","raw hits","x:y:z");
+  h_assoc_hits = new TNtuple("assoc_hits","hits associated with tracks (dca cut)","x:y:z");
+  h_clusters = new TNtuple("clusters","associated clusters","x:y:z");
+  h_origins = new TNtuple("origins","track origins","x:y:z");
+
+  h_deltheta_delphi = new TH2F("deltheta_delphi","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and laser start points", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi->SetXTitle("#Delta#theta");
+  h_deltheta_delphi->SetYTitle("#Delta#phi");
+
+  h_GEMs_hit = new TH1F("GEMS_hit","Number of Unique GEM Modules hit for each laser",8,0,8);
+
+  char GEM_bin_label[128];
+  for(int GEMhistiter = 0; GEMhistiter < 8; GEMhistiter++)
+  {  // (pos z) laser 1 {0,60}, laser 2 {60,0}, laser 3 {0,-60}, laser 4 {-60,0}, (neg z) laser 5 {0,60}, laser 2 {60,0}, laser 3 {0,-60}, laser 4 {-60,0}
+    sprintf(GEM_bin_label,"laser %i",GEMhistiter+1);
+    h_GEMs_hit->GetXaxis()->SetBinLabel(GEMhistiter+1,GEM_bin_label);
+  }
+  h_GEMs_hit->SetYTitle("Number of Unique GEM Modules Hit");
 
   // entries vs cell grid
   /* histogram dimension and axis limits must match that of TpcSpaceChargeMatrixContainer */
@@ -298,11 +317,18 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
   const TVector3 origin( track->get_x(), track->get_y(), track->get_z() );
   const TVector3 direction( track->get_px(), track->get_py(), track->get_pz() );
 
+  if(h_origins)
+  {
+    h_origins->Fill(track->get_x(), track->get_y(), track->get_z());
+  }
+
+  const unsigned int trkid = track->get_id();
   if( Verbosity() )
   { 
     std::cout << "----------  processing track " << track->get_id() << std::endl;
     std::cout << "TpcDirectLaserReconstruction::process_track - position: " << origin << " direction: " << direction << std::endl; 
   }
+  
 
   // loop over hits
   TrkrHitSetContainer::ConstRange hitsetrange = m_hit_map->getHitSets(TrkrDefs::TrkrId::tpcId);
@@ -343,6 +369,11 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       
 	const TVector3 global(x,y,z);
 
+        if(h_hits)
+          {
+            h_hits->Fill(x,y,z);
+          }
+
 	float adc = (hitr->second->getAdc()) - m_pedestal; 
 	
 	// calculate dca
@@ -352,10 +383,39 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 	auto om = direction*t;     // vector from track origin to PCA
 	const auto dca = (oc-om).Mag();
 
+        // relative angle histogram - only fill for hits in the same quadrant as origin
+        h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+
+        //FANCIER ANGLE FINDING COMING SOON !!!
+/*
+        if(signbit(global.z()) == signbit(origin.z())){ //get things only on the same side of the central membrane
+          if( (trkid == 1 || trkid == 5) && global.y() > global.x() && global.y() > -global.x() ){ // upper lasers
+            h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+            std::cout<<"UPPER LASER"<<std::endl;
+          }
+          if( (trkid == 0 || trkid == 4) && global.y() < global.x() && global.y() > -global.x() ){ // RHS lasers
+            h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+            std::cout<<"RHS LASER"<<std::endl;
+          }
+          if( (trkid == 3 || trkid == 7) && global.y() < global.x() && global.y() < -global.x() ){ // lower lasers
+            h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+            std::cout<<"LOWER LASER"<<std::endl;
+          }
+          if( (trkid == 2 || trkid == 6) && global.y() > global.x() && global.y() < -global.x() ){ // LHS lasers
+            h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+            std::cout<<"LHS LASER"<<std::endl;
+          }
+        }
+*/
+
 	// do not associate if dca is too large
 	if( dca > m_max_dca ) continue;
 
   ++m_matched_hits;
+
+        if(h_assoc_hits){
+          h_assoc_hits->Fill( x,y,z);
+        }
 
 	// bin hits by layer
 	const auto cluspos_pair = std::make_pair(adc, global); 	
@@ -363,6 +423,8 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 	layer_bin_set.insert(layer);
       }
   }
+
+  int GEM_Mod_Arr[72] = {0};
 
   // we have all of the residuals for this track added to the map, binned by layer
   // now we calculate the centroid of the clusters in each bin
@@ -496,7 +558,17 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       const auto cluster_r = get_r(clus_centroid.x(), clus_centroid.y());
       const auto cluster_phi = std::atan2(clus_centroid.y(),clus_centroid.x());
       const auto cluster_z = clus_centroid.z();
+
+      float r2 = cluster_r;
+      float phi2 = cluster_phi;
+      float z2 = cluster_z;
+      while( phi2 < m_phimin ) phi2 += 2.*M_PI; 
+      while( phi2 >= m_phimax ) phi2 -= 2.*M_PI; 
+
+      const int locateid = Locate(r2 , phi2 , z2); //find where the cluster is 
       
+      if( z2 > m_zmin || z2 < m_zmax ) GEM_Mod_Arr[locateid-1]++; // the array ath the cluster location - counts the number of clusters in each array, (IFF its in the volume !!!)
+
       // cluster errors
       const auto cluster_rphi_error = 0.015;
       const auto cluster_z_error = 0.075;
@@ -568,6 +640,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 	  if(h_zr) h_zr->Fill(clus_centroid.z(), cluster_r);
 	  if(h_zr_pca) h_zr_pca->Fill(projection.z(), r);
 	  if(h_dz_z)h_dz_z->Fill(projection.z(), clus_centroid.z()- projection.z());
+          if(h_clusters)h_clusters->Fill(clus_centroid.x(),clus_centroid.y(),clus_centroid.z());
 	}
       
       //       // check against limits
@@ -630,6 +703,35 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       // increment number of accepted clusters
       ++m_accepted_clusters;      
     }
+
+  for(int GEMS_iter = 0; GEMS_iter < 72; GEMS_iter++)
+  {
+    if(trkid == 0 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 0
+      h_GEMs_hit->Fill(0.5);
+    }
+    if(trkid == 1 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 1
+      h_GEMs_hit->Fill(1.5);
+    }
+    if(trkid == 2 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 2
+      h_GEMs_hit->Fill(2.5);
+    }
+    if(trkid == 3 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 3
+      h_GEMs_hit->Fill(3.5);
+    }
+    if(trkid == 4 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 4
+      h_GEMs_hit->Fill(4.5);
+    }
+    if(trkid == 5 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 5
+      h_GEMs_hit->Fill(5.5);
+    }
+    if(trkid == 6 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 6
+      h_GEMs_hit->Fill(6.5);
+    }
+    if(trkid == 7 && GEM_Mod_Arr[GEMS_iter] > 0){  //laser 7
+      h_GEMs_hit->Fill(7.5);
+    }
+  }
+
 }
 
 
@@ -660,4 +762,76 @@ int TpcDirectLaserReconstruction::get_cell_index( const TVector3& global ) const
   int iz = zbins*(z-m_zmin)/(m_zmax-m_zmin);
 
   return m_matrix_container->get_cell_index( iphi, ir, iz );
+}
+//_____________________________________________________________________
+int TpcDirectLaserReconstruction::Locate(float r , float phi , float z)
+{
+
+  ////////////////////////////////////////////////////////////////////////
+  //          North Label Conventions                                  //
+  ///////////////////////////////////////////////////////////////////////
+  //   1 - 00_R1   16 - 05_R1   31 - 10_R1    
+  //   2 - 00_R2   17 - 05_R2   32 - 10_R2   
+  //   3 - 00_R3   18 - 05_R3   33 - 10_R3 
+  //   4 - 01_R1   19 - 06_R1   34 - 11_R1
+  //   5 - 01_R2   20 - 06_R2   35 - 11_R2
+  //   6 - 01_R3   21 - 06_R3   36 - 11_R3
+  //   7 - 02_R1   22 - 07_R1
+  //   8 - 02_R2   23 - 07_R2
+  //   9 - 02_R3   24 - 07_R3
+  //  10 - 03_R1   25 - 08_R1
+  //  11 - 03_R2   26 - 08_R2
+  //  12 - 03_R3   27 - 08_R3
+  //  13 - 04_R1   28 - 09_R1
+  //  14 - 04_R2   29 - 09_R2
+  //  15 - 04_R3   30 - 09_R3
+
+  //////////////////////////////////////////////////////////////////////// 
+  //          South Label Conventions                                   //  
+  ///////////////////////////////////////////////////////////////////////  
+  //  37 - 12_R1   52 - 17_R1   67 - 22_R1    
+  //  38 - 12_R2   53 - 17_R2   68 - 22_R2   
+  //  39 - 12_R3   54 - 17_R3   69 - 22_R3 
+  //  40 - 13_R1   55 - 18_R1   70 - 23_R1
+  //  41 - 13_R2   56 - 18_R2   71 - 23_R2
+  //  42 - 13_R3   57 - 18_R3   72 - 23_R3
+  //  43 - 14_R1   58 - 19_R1
+  //  44 - 14_R2   59 - 19_R2
+  //  45 - 14_R3   60 - 19_R3
+  //  46 - 15_R1   61 - 20_R1
+  //  47 - 15_R2   62 - 20_R2
+  //  48 - 15_R3   63 - 20_R3
+  //  49 - 16_R1   64 - 21_R1
+  //  50 - 16_R2   65 - 21_R2
+  //  51 - 16_R3   66 - 21_R3
+
+
+  int GEM_Mod_ID; //integer from 1 to 72
+
+  const float Angle_Bins[13] = {23*M_PI/12,1*M_PI/12,3*M_PI/12,5*M_PI/12,7*M_PI/12,9*M_PI/12,11*M_PI/12,13*M_PI/12,15*M_PI/12,17*M_PI/12,19*M_PI/12,21*M_PI/12,23*M_PI/12}; //12 angle bins on each side
+
+  const float r_bins[4] = {30,46,62,78}; //4 r bins 
+
+  int angle_id = 0; // default to 0
+  int r_id = 0; //default to 0
+  int side_id = 0; //default to 0 (north side)
+
+  for(int r_iter = 0; r_iter < 3; r_iter++ ){
+    if( r > r_bins[r_iter] && r < r_bins[r_iter+1] )
+    {
+      r_id = r_iter+1;
+      break; //break out of the for loop if you found where the hit is in r
+    }
+  }
+
+  for(int ang_iter = 0; ang_iter < 12; ang_iter++ ){
+    if( phi > Angle_Bins[ang_iter] && phi < Angle_Bins[ang_iter+1] ) 
+    {
+      angle_id = ang_iter;
+      break; //break out the for loop if you found where the hit is in phi
+    }
+  }
+  if(z < 0)side_id=1; //(south side)
+
+  return GEM_Mod_ID = (36*side_id) + (3*angle_id) + r_id;
 }

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -25,6 +25,7 @@ class TH2;
 class TH3;
 class TH2;
 class TVector3;
+class TNtuple;
 
 class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterface
 {
@@ -88,6 +89,9 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// get relevant cell for a given hit
   int get_cell_index( const TVector3& ) const;
+
+  /// get the GEM module where cluster hit
+  int Locate(float r , float phi , float z);
 
   /// output file
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
@@ -157,6 +161,15 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
 
   /// number of entries per cell
   TH3 *h_entries = nullptr;
+  TNtuple *h_hits = nullptr;
+  TNtuple *h_origins = nullptr;
+  TNtuple *h_assoc_hits = nullptr;
+
+  /// for diagnosing separation b/w laser starting points and tpc volume hits
+  TH2 *h_deltheta_delphi = nullptr;
+
+  // for recording # of unique GEM modules hit for the clusters associated w/ each track
+  TH1 *h_GEMs_hit = nullptr;
 
   TH2* h_xy = nullptr;
   TH2* h_xz = nullptr;
@@ -166,6 +179,7 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   TH2* h_zr = nullptr;
   TH2* h_zr_pca = nullptr;
   TH2* h_dz_z = nullptr;
+  TNtuple *h_clusters = nullptr;
 
   //@}
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -269,7 +269,7 @@ int PHG4TpcDirectLaser::process_event(PHCompositeNode* topNode)
   else
   {
     // use arbitrary direction
-    AimToThetaPhi(M_PI / 180. * arbitrary_theta, M_PI / 180. * arbitrary_phi);
+    AimToThetaPhi( arbitrary_theta, arbitrary_phi);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Files Affected:

offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
offline/packages/tpccalib/TpcDirectLaserReconstruction.h 
simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc

Changes:

TpcDirectLaserReconstruction: Adds in functionality for locating clusters from laser fire hits with respect to TPC GEM Modules and counting how many clusters hit which GEMs. Also adds additional histograms useful for visualization/debugging.

PHG4TpcDirectLaser: Clears up ambiguity with angles in AimToThetaPhi (line 272) for abitrary pointing angle in process_event. User must multiply by deg_to_rad in G4_TPC.

TODO:

Need to make relative angle finding (line 390 - TpcDirectLaserReconstruction) more fancy implementation and re-adjust track to the angle found. Double check location map in Recon

