### PR TITLE
add towerinfo capability to default cemc clustering and updated pi0 c…

### DIFF
--- a/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.cc
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.cc
@@ -6,6 +6,11 @@
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerGeomContainer.h>
+#include <calobase/RawTowerGeom.h>
+
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfov1.h>
+
 
 #include <g4vertex/GlobalVertex.h>
 #include <g4vertex/GlobalVertexMap.h>
@@ -38,6 +43,7 @@
 #include <map>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 #include <vector>   // for vector
+#include <string>   // for string
 
 //using namespace std;
 
@@ -148,7 +154,8 @@ int CaloCalibEmc_Pi0::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
 {
-  if (m_ievent % 50 == 0)
+  //  if (m_ievent % 50 == 0)
+  if (true)
   {
     std::cout << std::endl;
     std::cout << "Beginning of the event " << m_ievent << std::endl;
@@ -157,8 +164,20 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
 
   _eventNumber = m_ievent++;
 
+
+  std::string clusnodename = "CLUSTER_POS_COR_CEMC";
+  if (m_UseTowerInfo)
+    clusnodename = "CLUSTERINFO_POS_COR_CEMC";
+    
+  /*
+  std::string clusnodename = "CLUSTER_CEMC";
+  if (m_UseTowerInfo)
+    clusnodename = "CLUSTERINFO_CEMC";
+  */
+
   // create a cluster object
-  RawClusterContainer *recal_clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_POS_COR_CEMC");
+  RawClusterContainer *recal_clusters = findNode::getClass<RawClusterContainer>(topNode,clusnodename.c_str());
+
 
   if (!recal_clusters)
     {
@@ -176,11 +195,21 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
   // create a tower geometry object
   std::string towergeomnode = "TOWERGEOM_" + _caloname;
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnode.c_str());
-  if (!towergeom)
+  if (!towergeom && m_UseTowerInfo < 1)
   {
     std::cout << PHWHERE << ": Could not find node " << towergeomnode << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+
+  //if using towerinfo
+  // create a tower object
+  towernode = "TOWERINFO_CALIB_" + _caloname;
+  TowerInfoContainerv1 *_towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, towernode.c_str());
+  if (!_towerinfos && m_UseTowerInfo > 0)
+    {
+      std::cout << PHWHERE << " ERROR: Can't find " << towernode << std::endl;
+    }
+
 
   // Get Vertex
   float vx = 0;
@@ -219,6 +248,8 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
     RawCluster *t_recalcluster = t_rclusiter->second;
 
     float cluse = t_recalcluster->get_ecore();
+    //    std::cout << "clus " << cluse << std::endl;
+
     if (cluse > 0.1) inCs++;
 
     if (cluse > 0.6) savCs[iCs++] = t_recalcluster;
@@ -243,6 +274,9 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
     std::vector<int> toweretas;
     std::vector<int> towerphis;
     std::vector<float> towerenergies;
+
+    RawTower * tower;
+    TowerInfov1 * towinfo;
     
     // loop over the towers from the outer loop cluster
     // and find the max tower location and save the 
@@ -254,16 +288,48 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
     
     for (toweriter = towers.first; toweriter != towers.second; ++toweriter)
       {
-	RawTower *tower = _towers->getTower(toweriter->first);
 	
-	int towereta = tower->get_bineta();
-	int towerphi = tower->get_binphi();
-	double towerenergy = tower->get_energy();
+	if (m_UseTowerInfo < 1)
+	  {
+
+	    tower = _towers->getTower(toweriter->first);
+	    
+	    int towereta = tower->get_bineta();
+	    int towerphi = tower->get_binphi();
+	    double towerenergy = tower->get_energy();
+	    
+	    // put the eta, phi, energy into corresponding vectors
+	    toweretas.push_back(towereta);
+	    towerphis.push_back(towerphi);
+	    towerenergies.push_back(towerenergy);				
+	    
+	  }
+	else
+	  {
+	    
+	    
+	    //RawTowerGeom *tower_geom_instance = geom->get_tower_geometry(toweriter->first);
+	    //
+	    //	     unsigned int towerindex = _towerinfos->decode_key(toweriter->first);
+	    
+	    
+	    int iphi = RawTowerDefs::decode_index2(toweriter->first);  // index2 is phi in CYL
+	    int ieta = RawTowerDefs::decode_index1(toweriter->first);  // index1 is eta in CYL	    
+	    unsigned int towerkey = iphi + (ieta << 16U);
+	    unsigned int towerindex =  _towerinfos->decode_key(towerkey);
+	    
+	    towinfo = _towerinfos->at(towerindex);
+	    
+	    double towerenergy = towinfo->get_energy();
+	    
+	    // put the eta, phi, energy into corresponding vectors
+	    toweretas.push_back(ieta);
+	    towerphis.push_back(iphi);
+	    towerenergies.push_back(towerenergy);				
+	    
+	    
+	  }
 	
-	// put the eta, phi, energy into corresponding vectors
-	toweretas.push_back(towereta);
-	towerphis.push_back(towerphi);
-	towerenergies.push_back(towerenergy);				
       }
     
     // cout << endl;
@@ -272,6 +338,7 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
     // cout << "Total number of towers size(toweretas): " << toweretas.size() << endl;
     // float maxTowerEnergy = *max_element(towerenergies.begin(), towerenergies.end());
     // cout << "The maxTowerEnergy: " << maxTowerEnergy << endl;
+
     int maxTowerIndex = max_element(towerenergies.begin(), towerenergies.end()) - towerenergies.begin();
     maxTowerEta = toweretas[maxTowerIndex];
     maxTowerPhi = towerphis[maxTowerIndex];
@@ -285,12 +352,30 @@ int CaloCalibEmc_Pi0::process_event(PHCompositeNode *topNode)
       float tt_clus_pt = E_vec_cluster.perp();
       float tt_clus_phi = E_vec_cluster.getPhi();
 
+      // if (tt_clus_energy > 0.029)
+      // 	{
+	  
+      // 	if (m_UseTowerInfo < 1)
+      // 	  std::cout <<  "rawtJF clus " << jCs << " " << tt_clus_energy <<  " phi: " 
+      // 		    << tt_clus_phi << " eta: " << tt_clus_eta <<  " ieta  "
+      // 		    << maxTowerEta << " iphi " << maxTowerPhi 
+      // 		    << " towsize " << towerenergies.size() << std::endl;
+      // 	else
+      // 	  std::cout <<  "infoJF clus " << jCs << " " << tt_clus_energy <<  " phi: " 
+      // 		    << tt_clus_phi << " eta: " << tt_clus_eta <<  " ieta  "
+      // 		    << maxTowerEta << " iphi " << maxTowerPhi 
+      // 		    << " towsize " << towerenergies.size() << std::endl;
+
+
+      // 	}
+	
+
       _clusterEnergies[jCs] = tt_clus_energy;
       _clusterPts[jCs] = tt_clus_pt;
       _clusterEtas[jCs] = tt_clus_eta;
       _clusterPhis[jCs] = tt_clus_phi;
 
-      if (tt_clus_pt > 1.0 ) 
+      if (tt_clus_pt > 0.9 ) 
 	{
 				
 	  // another loop to go into the saved cluster

--- a/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.h
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/CaloCalibEmc_Pi0.h
@@ -57,6 +57,14 @@ class CaloCalibEmc_Pi0 : public SubsysReco
   
   void Get_Histos(const char * infile, const char * outfile);
 
+
+
+  void set_UseTowerInfo(const int useMode)
+  {  // 0 only old tower, 1 only new (TowerInfo based), 
+    m_UseTowerInfo = useMode;
+  }
+
+
  private:
   int m_ievent = 0;
   std::string m_Filename;
@@ -101,6 +109,8 @@ class CaloCalibEmc_Pi0 : public SubsysReco
   /* float corr_val; */
   
   TFile * f_temp;
+  
+  int m_UseTowerInfo = 0;  // 0 only old tower, 1 only new (TowerInfo based), 
   
 
 };

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -32,6 +32,12 @@ class RawClusterBuilderTemplate : public SubsysReco
   void checkenergy(const int i = 1) { chkenergyconservation = i; }
   void LoadProfile(const std::string& fname);
 
+  void set_UseTowerInfo(const int useMode)
+  {  // 0 only old tower, 1 only new (TowerInfo based), 
+    m_UseTowerInfo = useMode;
+  }
+
+
  private:
   void CreateNodes(PHCompositeNode* topNode);
   bool Cell2Abs(RawTowerGeomContainer* towergeom, float phiC, float etaC, float& phi, float& eta);
@@ -56,6 +62,12 @@ class RawClusterBuilderTemplate : public SubsysReco
   bool bPrintGeom = false;
   bool bProfProb = false;
   float fProbNoiseParam = 0.04;
+
+  int m_UseTowerInfo = 0;  // 0 only old tower, 1 only new (TowerInfo based), 
+  
+  std::string m_towerInfo_nodename;
+
+
 };
 
 #endif /* RawClusterBuilderTemplate_H__ */

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.cc
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.cc
@@ -6,6 +6,11 @@
 #include <calobase/RawTowerContainer.h>
 #include <calobase/RawTowerGeomContainer.h>
 
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfov1.h>
+
 #include <phparameter/PHParameters.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -108,20 +113,45 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
   {
     std::cout << "Processing a NEW EVENT" << std::endl;
   }
-
-  RawClusterContainer *rawclusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_" + _det_name);
+  
+  std::string rawClusNodeName = "CLUSTER_" + _det_name;
+  if (m_UseTowerInfo)
+    rawClusNodeName = "CLUSTERINFO_" + _det_name;
+  
+  RawClusterContainer *rawclusters = findNode::getClass<RawClusterContainer>(topNode, rawClusNodeName.c_str());
   if (!rawclusters)
-  {
-    std::cout << "No " << _det_name << " Cluster Container found while in RawClusterPositionCorrection, can't proceed!!!" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
+    {
+      std::cout << "No " << _det_name << " Cluster Container found while in RawClusterPositionCorrection, can't proceed!!!" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
-  RawTowerContainer *_towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_" + _det_name);
-  if (!_towers)
-  {
-    std::cout << "No calibrated " << _det_name << " tower info found while in RawClusterPositionCorrection, can't proceed!!!" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
+  RawTowerContainer *_towers = 0;
+  TowerInfoContainerv1 *  _towerinfos = 0;
+
+  if (!m_UseTowerInfo)
+    {
+    _towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_" + _det_name);
+     if (!_towers)
+     {
+       std::cout << "No calibrated " << _det_name << " tower info found while in RawClusterPositionCorrection, can't proceed!!!" << std::endl;
+       return Fun4AllReturnCodes::ABORTEVENT;
+     }
+    }
+  else
+    {
+      std::string towerinfoNodename = "TOWERINFO_CALIB_" + _det_name;
+
+      _towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, towerinfoNodename);
+      if (!_towerinfos)
+	{
+	  std::cerr << Name() << "::" << _det_name << "::" << __PRETTY_FUNCTION__
+		    << " " << towerinfoNodename << " Node missing, doing bail out!"
+		    << std::endl;
+
+	  return Fun4AllReturnCodes::DISCARDEVENT;
+	}
+    }
+
 
   std::string towergeomnodename = "TOWERGEOM_" + _det_name;
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(topNode, towergeomnodename);
@@ -132,60 +162,91 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
   }
   const int nphibin = towergeom->get_phibins();
 
+
   //loop over the clusters
   RawClusterContainer::ConstRange begin_end = rawclusters->getClusters();
   RawClusterContainer::ConstIterator iter;
+
 
   for (iter = begin_end.first; iter != begin_end.second; ++iter)
   {
     //    RawClusterDefs::keytype key = iter->first;
     RawCluster *cluster = iter->second;
-
+        
     float clus_energy = cluster->get_energy();
-
+    
     std::vector<float> toweretas;
     std::vector<float> towerphis;
     std::vector<float> towerenergies;
-
+    
     //loop over the towers in the cluster
     RawCluster::TowerConstRange towers = cluster->get_towers();
     RawCluster::TowerConstIterator toweriter;
-
     for (toweriter = towers.first;
          toweriter != towers.second;
          ++toweriter)
-    {
-      RawTower *tower = _towers->getTower(toweriter->first);
+      {
+	
+	if (!m_UseTowerInfo)
+	  {
+	    
+	    RawTower *tower = _towers->getTower(toweriter->first);	  
+	    
+	    int towereta = tower->get_bineta();
+	    int towerphi = tower->get_binphi();
+	    double towerenergy = tower->get_energy();
+	    
+	    //put the etabin, phibin, and energy into the corresponding vectors
+	    toweretas.push_back(towereta);
+	    towerphis.push_back(towerphi);
+	    towerenergies.push_back(towerenergy);
+	    
+	    
+	  }
+	else
+	  {
+	    
+	    //std::cout << "clus " << iter->first << " tow key " << toweriter->first << " decoded to " << towerindex << std::endl;
+	    
+	    int iphi = RawTowerDefs::decode_index2(toweriter->first);  // index2 is phi in CYL
+	    int ieta = RawTowerDefs::decode_index1(toweriter->first);  // index1 is eta in CYL	    
+	    unsigned int towerkey = iphi + (ieta << 16U);
+	    
+	    unsigned int towerindex = _towerinfos->decode_key(towerkey);
+	    
+	    TowerInfo * towinfo = _towerinfos->at(towerindex);
 
-      int towereta = tower->get_bineta();
-      int towerphi = tower->get_binphi();
-      double towerenergy = tower->get_energy();
-
-      //put the etabin, phibin, and energy into the corresponding vectors
-      toweretas.push_back(towereta);
-      towerphis.push_back(towerphi);
-      towerenergies.push_back(towerenergy);
-    }
-
+	    double towerenergy = towinfo->get_energy();
+	    
+	// put the eta, phi, energy into corresponding vectors
+	    toweretas.push_back(ieta);
+	    towerphis.push_back(iphi);
+	    towerenergies.push_back(towerenergy);				
+	    
+	    
+	  }
+      }
+    
     int ntowers = toweretas.size();
+    //    std::cout << "jf " <<  ntowers << std::endl;
     assert(ntowers >= 1);
-
+    
     //loop over the towers to determine the energy
     //weighted eta and phi position of the cluster
-
+    
     float etamult = 0;
     float etasum = 0;
     float phimult = 0;
     float phisum = 0;
-
+    
     for (int j = 0; j < ntowers; j++)
     {
       float energymult = towerenergies.at(j) * toweretas.at(j);
       etamult += energymult;
       etasum += towerenergies.at(j);
-
+      
       int phibin = towerphis.at(j);
-
+      
       if (phibin - towerphis.at(0) < -nphibin / 2.0)
         phibin += nphibin;
       else if (phibin - towerphis.at(0) > +nphibin / 2.0)
@@ -199,7 +260,7 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
 
     float avgphi = phimult / phisum;
     float avgeta = etamult / etasum;
-
+    
     if (avgphi < 0) avgphi += nphibin;
 
     //this determines the position of the cluster in the 2x2 block
@@ -214,7 +275,7 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
     for (int j = 0; j < bins - 1; j++)
       if (fmodphi >= binvals.at(j) && fmodphi <= binvals.at(j + 1))
         phibin = j;
-
+    
     for (int j = 0; j < bins - 1; j++)
       if (fmodeta >= binvals.at(j) && fmodeta <= binvals.at(j + 1))
         etabin = j;
@@ -228,18 +289,20 @@ int RawClusterPositionCorrection::process_event(PHCompositeNode *topNode)
     float eclus_recalib_val = 1;
     float ecore_recalib_val = 1;
     if (phibin > -1 && etabin > -1)
-    {
-      eclus_recalib_val = eclus_calib_constants.at(etabin).at(phibin);
-      ecore_recalib_val = ecore_calib_constants.at(etabin).at(phibin);
+      {
+	eclus_recalib_val = eclus_calib_constants.at(etabin).at(phibin);
+	ecore_recalib_val = ecore_calib_constants.at(etabin).at(phibin);
     }
     RawCluster *recalibcluster = dynamic_cast<RawCluster *>(cluster->CloneMe());
     assert(recalibcluster);
+    //    if (m_UseTowerInfo)
+    //  std::cout << "and here" << std::endl;
     recalibcluster->set_energy(clus_energy / eclus_recalib_val);
     recalibcluster->set_ecore(cluster->get_ecore() / ecore_recalib_val);
     _recalib_clusters->AddCluster(recalibcluster);
-
+    
     if (Verbosity() && clus_energy > 1)
-    {
+      {
       std::cout << "Input eclus cluster energy: " << clus_energy << std::endl;
       std::cout << "Recalib value: " << eclus_recalib_val << std::endl;
       std::cout << "Recalibrated eclus cluster energy: "
@@ -281,22 +344,37 @@ void RawClusterPositionCorrection::CreateNodeTree(PHCompositeNode *topNode)
 
   //Check to see if the cluster recalib node is on the nodetree
   _recalib_clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_RECALIB_" + _det_name);
+  std::string ClusterCorrNodeName = "CLUSTER_POS_COR_" + _det_name;;
 
   //If not, make it and add it to the _det_name subnode
   if (!_recalib_clusters)
-  {
-    _recalib_clusters = new RawClusterContainer();
-    PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_recalib_clusters, "CLUSTER_POS_COR_" + _det_name, "PHObject");
-    cemcNode->addNode(clusterNode);
-  }
+    { 
+      _recalib_clusters = new RawClusterContainer();
+      if (m_UseTowerInfo)
+	ClusterCorrNodeName = "CLUSTERINFO_POS_COR_" + _det_name;
+      
+      PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_recalib_clusters, ClusterCorrNodeName.c_str(), "PHObject");
+      cemcNode->addNode(clusterNode);
+    }
 
   //put the recalib parameters on the node tree
   PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   assert(parNode);
-  const std::string paramNodeName = std::string("eclus_Recalibration_" + _det_name);
+
+
+  std::string paramNodeName = std::string("eclus_Recalibration_" + _det_name);
+  std::string paramNodeName2 = std::string("ecore_Recalibration_" + _det_name);
+
+  if (m_UseTowerInfo)
+    {
+       paramNodeName = std::string("eclus_RecalibrationInfo_" + _det_name);       
+       paramNodeName2 = std::string("ecore_RecalibrationInfo_" + _det_name);
+    }
+  
   _eclus_calib_params.SaveToNodeTree(parNode, paramNodeName);
-  const std::string paramNodeName2 = std::string("ecore_Recalibration_" + _det_name);
   _ecore_calib_params.SaveToNodeTree(parNode, paramNodeName2);
+  
+
 }
 int RawClusterPositionCorrection::End(PHCompositeNode * /*topNode*/)
 {

--- a/offline/packages/CaloReco/RawClusterPositionCorrection.h
+++ b/offline/packages/CaloReco/RawClusterPositionCorrection.h
@@ -48,6 +48,14 @@ class RawClusterPositionCorrection : public SubsysReco
     _ecore_calib_params = calib_params;
   }
 
+
+  void set_UseTowerInfo(const int useMode)
+  {  // 0 only old tower, 1 only new (TowerInfo based), 
+    m_UseTowerInfo = useMode;
+  }
+
+
+
  private:
   PHParameters _eclus_calib_params;
   PHParameters _ecore_calib_params;
@@ -60,6 +68,10 @@ class RawClusterPositionCorrection : public SubsysReco
   std::vector<float> binvals;
   std::vector<std::vector<double> > eclus_calib_constants;
   std::vector<std::vector<double> > ecore_calib_constants;
+
+  int m_UseTowerInfo = 0;  // 0 only old tower, 1 only new (TowerInfo based), 
+
+
 };
 
 #endif


### PR DESCRIPTION
…alib code to also be capable to use this version

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

adds capability to use towerfinfo new tower data structs in default Template emcal clustering cluster position correction tool, and also in calibration pi0 TbT code [which then uses the new cluster version] although the cluster data structures didn't change, the links to the towers they hold in the version using towinfo are implied to be tower info objects rather than raw tower].  In all three cases, turn on with set_UseTowerInfo flag-- unlike some other of Tim's commits, this flag can only be used in modes 0 (don't use tower info) and 1 (use tower info) not in Tim's mode 2 (do both simultaneously).  Corresponding example macros to use this can be found in macros/calibrations/calo/emc_pi0_tbt/towInfoClustering/


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

