### PR TITLE
Update the phi and z clustering locations

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -583,7 +583,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
       const int sector = TpcDefs::getSectorId(node_hitsetkey);
       const int side = TpcDefs::getSide(node_hitsetkey);
 
-      if (Verbosity() > 2)
+      if (Verbosity() > 8)
         std::cout << " hitsetkey " << node_hitsetkey << " layer " << layer << " sector " << sector << " side " << side << std::endl;
       // get all of the hits from the single hitset
       TrkrHitSet::ConstRange single_hit_range = single_hitset_iter->second->getHits();
@@ -679,7 +679,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
   truth_clusterer->cluster_and_reset(/*argument is if to reset hitsetkey as well*/ true);
 
-  if (Verbosity() > 2)
+  if (Verbosity() > 10)
   {
     std::cout << "From PHG4TpcElectronDrift: hitsetcontainer printout at end:" << std::endl;
     // We want all hitsets for the Tpc
@@ -728,6 +728,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
     truthtracks->identify();
   }
 
+  if (Verbosity() == 6) truth_clusterer->print(truthtracks);
   if (Verbosity()>800) {
     truth_clusterer->print(truthtracks);
     truth_clusterer->print_file(truthtracks,"drift_clusters.txt");

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -59,7 +59,7 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     TrkrHitSet *hitset             = hitsetitr->second;
     unsigned int layer             = TrkrDefs::getLayer(hitsetitr->first);
     int side                       = TpcDefs::getSide(hitsetitr->first);
-    // unsigned int sector            = TpcDefs::getSectorId(hitsetitr->first);
+    unsigned int sector            = TpcDefs::getSectorId(hitsetitr->first);
     PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
 
     //get the maximum and minimum phi and time
@@ -67,16 +67,16 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     unsigned short NPhiBinsSector = NPhiBins/12;
     unsigned short NTBins = (unsigned short)layergeom->get_zbins();
     unsigned short NTBinsSide = NTBins;
-    // unsigned short NTBinsMin = 0;
-    // unsigned short PhiOffset = NPhiBinsSector * sector;
-    // unsigned short TOffset = NTBinsMin;
+    unsigned short NTBinsMin = 0;
+    unsigned short PhiOffset = NPhiBinsSector * sector;
+    unsigned short TOffset = NTBinsMin;
 
     double m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
 
     unsigned short phibins   = NPhiBinsSector;
-    // unsigned short phioffset = PhiOffset;
+    unsigned short phioffset = PhiOffset;
     unsigned short tbins     = NTBinsSide;
-    // unsigned short toffset   = TOffset ;
+    unsigned short toffset   = TOffset ;
    
     // loop over the hits in this cluster
     double t_sum = 0.0;
@@ -97,8 +97,10 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
       unsigned int adc = iter->second->getAdc(); 
       if (adc <= 0) continue;
 
-      int iphi = TpcDefs::getPad(iter->first);
-      int it   = TpcDefs::getTBin(iter->first);
+      int iphi = TpcDefs::getPad(iter->first) - phioffset;
+      int it   = TpcDefs::getTBin(iter->first) - toffset;
+      // int iphi = TpcDefs::getPad(iter->first);
+      // int it   = TpcDefs::getTBin(iter->first);
 
       if(iphi<0 || iphi>=phibins){
         //std::cout << "WARNING phibin out of range: " << phibin << " | " << phibins << std::endl;
@@ -235,23 +237,28 @@ void TpcClusterBuilder::print(
     TrkrTruthTrackContainer* truth_tracks, int nclusprint) {
   cout << " ------------- content of TrkrTruthTrackContainer ---------- " << endl;
   auto& tracks = truth_tracks->getTruthTracks();
-  cout << " Number of tracks: " << tracks.size() << endl;
+  cout << " Number of tracks:  xyz db : " << tracks.size() << endl;
   for (auto& track : tracks) {
-    cout << " id( " << track->getTrackid() << ")  phi:eta:pt("<<
-      track->getPhi()<<":"<<track->getPseudoRapidity()<<":"<<track->getPt() << ") nclusters(" 
-      << track->getClusters().size() <<") ";
-    int nclus = 0;
-    for (auto cluskey : track->getClusters()) {
-      cout << " " 
-        << ((int) TrkrDefs::getHitSetKeyFromClusKey(cluskey)) <<":index(" <<
-        ((int)  TrkrDefs::getClusIndex(cluskey)) << ")";
-      ++nclus;
-      if (nclusprint > 0 && nclus >= nclusprint) {
-        cout << " ... "; 
-        break;
+    printf("id(%2i) phi:eta:pt(", (int)track->getTrackid());
+    cout << "phi:eta:pt(";
+    printf("%5.2f:%5.2f:%5.2f", track->getPhi(), track->getPseudoRapidity(), track->getPt());
+      /* Form("%5.2:%5.2:%5.2", track->getPhi(), track->getPseudoRapidity(), track->getPt()) */
+      //<<track->getPhi()<<":"<<track->getPseudoRapidity()<<":"<<track->getPt() 
+      cout << ") nclusters(" << track->getClusters().size() <<") ";
+    if (verbosity <= 10) { cout << endl; }
+    else {
+      int nclus = 0;
+      for (auto cluskey : track->getClusters()) {
+        cout << " " 
+          << ((int) TrkrDefs::getHitSetKeyFromClusKey(cluskey)) <<":index(" <<
+          ((int)  TrkrDefs::getClusIndex(cluskey)) << ")";
+        ++nclus;
+        if (nclusprint > 0 && nclus >= nclusprint) {
+          cout << " ... "; 
+          break;
+        }
       }
     }
-    cout << endl;
   }
   cout << " ----- end of tracks in TrkrrTruthTrackContainer ------ " << endl;
 }

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -80,8 +80,10 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
    
     // loop over the hits in this cluster
     double t_sum = 0.0;
-    double phi_sum = 0.0;
     double adc_sum = 0.0;
+
+    /* double phi_sum = 0.0; */
+    double iphi_sum = 0.0;
     // double t2_sum = 0.0;
     // double phi2_sum = 0.0;
 
@@ -99,8 +101,6 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
 
       int iphi = TpcDefs::getPad(iter->first) - phioffset;
       int it   = TpcDefs::getTBin(iter->first) - toffset;
-      // int iphi = TpcDefs::getPad(iter->first);
-      // int it   = TpcDefs::getTBin(iter->first);
 
       if(iphi<0 || iphi>=phibins){
         //std::cout << "WARNING phibin out of range: " << phibin << " | " << phibins << std::endl;
@@ -111,14 +111,18 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
         continue;
       }
 
+      iphi += phioffset;
+      it   += toffset;
+
       if (iphi > phibinhi) phibinhi = iphi;
       if (iphi < phibinlo) phibinlo = iphi;
       if (it > tbinhi) tbinhi = it;
       if (it < tbinlo) tbinlo = it;
 
       // update phi sums
-      double phi_center = layergeom->get_phicenter(iphi);
-      phi_sum += phi_center * adc;
+      /* double phi_center = layergeom->get_phicenter(iphi); */
+      /* phi_sum += phi_center * adc; */
+      iphi_sum += iphi * adc;
       // phi2_sum += square(phi_center)*adc;
 
       // update t sums
@@ -130,7 +134,9 @@ void TpcClusterBuilder::cluster_and_reset(bool clear_hitsetkey_cnt) {
     }
 
     // This is the global position
-    double clusphi = phi_sum / adc_sum;
+    double clusiphi = iphi_sum / adc_sum;
+    double clusphi  = layergeom->get_phi(clusiphi);
+    /* double clusphi = phi_sum / adc_sum; */
     float  clusx   = radius  * cos(clusphi);
     float  clusy   = radius  * sin(clusphi);
     double clust   = t_sum   / adc_sum;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [ ] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This request undoes a few lines modified in [PR 1834](https://github.com/sPHENIX-Collaboration/coresoftware/pull/1834/files) which inadvertantly place the clusters reconstruction out of bounds and therefore don't make truth clusters for many tracks. I think this re-correction is the proper way to do things but will cast a weathered eye over it tomorrow, and would appreciate any expert opinion.

Essentially what happend in PR 1834 is the offset corrections to phi and time put the clusters out of bounds for the number of possible bins (the checks at TpcClusterBuilder.cc lines 105 and 109) and therefore removes many clusters.

I left the sampa bias correction from PR 1834 in, as well as the flipping of the cluster Z location for the other side of the TPC (which I think is correct). The logic all follows from TpcClusterizer.cc, which is the work of many experts, but the logic there is not perhaps difficult, but at least highly nested.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

