### PR TITLE
Updated QA modules to use towerinfo objects

### DIFF
--- a/offline/QA/modules/QAG4SimulationCalorimeter.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeter.cc
@@ -10,8 +10,8 @@
 
 #include <calobase/RawCluster.h>
 #include <calobase/RawClusterContainer.h>
-#include <calobase/RawTower.h>
-#include <calobase/RawTowerContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
 #include <calobase/RawTowerGeomContainer.h>
 
 #include <g4eval/CaloEvalStack.h>
@@ -497,11 +497,11 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
       get_histo_prefix() + "_Normalization"));
   assert(h_norm);
 
-  std::string towernodename = "TOWER_CALIB_" + detector;
+  std::string towernodename = "TOWERINFO_CALIB_" + detector;
   // Grab the towers
-  RawTowerContainer *towers = findNode::getClass<RawTowerContainer>(topNode,
+   TowerInfoContainer *towers = findNode::getClass<TowerInfoContainerv1>(topNode,
                                                                     towernodename);
-  if (!towers)
+ if (!towers)
   {
     std::cout << PHWHERE << ": Could not find node " << towernodename
               << std::endl;
@@ -573,7 +573,9 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
               wrapphi = wrapphi - towergeom->get_phibins();
             }
 
-            RawTower *tower = towers->getTower(ieta, wrapphi);
+
+	    unsigned int towerkey =  (ieta << 16U) + wrapphi;
+            TowerInfo *tower = towers->get_tower_at_key(towerkey);
 
             if (tower)
             {

--- a/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/modules/QAG4SimulationCalorimeterSum.cc
@@ -9,8 +9,8 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 
 #include <calobase/RawCluster.h>
-#include <calobase/RawTower.h>
-#include <calobase/RawTowerContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
 #include <calobase/RawTowerGeomContainer.h>
 
 #include <trackbase_historic/SvtxTrack.h>
@@ -318,8 +318,8 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
     towergeo->identify();
   }
   // pull the towers
-  std::string towernodename = "TOWER_CALIB_" + detector;
-  RawTowerContainer *towerList = findNode::getClass<RawTowerContainer>(topNode,
+  std::string towernodename = "TOWERINFO_CALIB_" + detector;
+  TowerInfoContainer *towerList = findNode::getClass<TowerInfoContainerv1>(topNode,
                                                                        towernodename);
   assert(towerList);
 
@@ -426,7 +426,10 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
                   << wrapphi << " - [" << towergeo->get_phibounds(wrapphi).first
                   << ", " << towergeo->get_phibounds(wrapphi).second << "]" << std::endl;
 
-      RawTower *tower = towerList->getTower(ieta, wrapphi);
+
+
+      unsigned int towerkey =  (ieta << 16U) + wrapphi;
+      TowerInfo *tower = towerList->get_tower_at_key(towerkey);
       double energy = 0;
       if (tower)
       {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )
Minor change to the QA modules to switch them to look at TowerInfo objects rather than RawTower objects.

## Links to other PRs in macros and calibration repositories (if applicable)

