### PR TITLE
updated the encode_ key classes to include a catch for packet out of range for arrays

### DIFF
--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -2,6 +2,7 @@
 #include "TowerInfov1.h"
 
 #include <phool/PHObject.h>
+#include <phool/phool.h>
 
 #include <TClonesArray.h>
 
@@ -143,6 +144,11 @@ unsigned int TowerInfoContainerv1::encode_emcal(unsigned int towerIndex)
   int etabinoffset[4] = {24,0,48,72};
   int supersectornumber = towerIndex / supersector;
   int packet = (towerIndex % supersector) / nchannelsperpacket;  // 0 = S small |eta|, 1 == S big |eta|, 2 == N small |eta|, 3 == N big |eta|
+  if (packet < 0 || packet > 3 )
+    {
+      std::cout << PHWHERE << "Attempting to access channel with invalid value in EMCal " << packet << std::endl;
+      exit(1);
+    }
   int interfaceboard = ((towerIndex % supersector) % nchannelsperpacket) / channels_per_sector;
   int interfaceboard_channel = ((towerIndex % supersector) % nchannelsperpacket) % channels_per_sector; 
   int localphibin = phimap[interfaceboard_channel];
@@ -184,6 +190,12 @@ unsigned int TowerInfoContainerv1::encode_hcal(unsigned int towerIndex)
   int phibinoffset[4] = {0,2,4,6};
   int supersectornumber = towerIndex / supersector;
   int packet = (towerIndex % supersector) / nchannelsperpacket;  // 0 = S small |eta|, 1 == S big |eta|, 2 == N small |eta|, 3 == N big |eta|
+  if (packet < 0 || packet > 3 )
+    {
+      std::cout << PHWHERE << "Attempting to access channel with invalid value ih HCAL " << packet << std::endl;
+      exit(1);
+    }
+
   int interfaceboard = ((towerIndex % supersector) % nchannelsperpacket) / channels_per_sector;
   int interfaceboard_channel = ((towerIndex % supersector) % nchannelsperpacket) % channels_per_sector;
   int localphibin = phimap[interfaceboard_channel] + phibinoffset[interfaceboard];


### PR DESCRIPTION
…range

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

trivial change to the code to add a catch for "packet < 0 || packet > 3" within the encode emcal and encode hcals in order to introduce a crash if attempting to access an array from outside its bounds.

## TODOs (if applicable)



[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

