### PR TITLE
Micromegas mapping

### DIFF
--- a/offline/packages/micromegas/Makefile.am
+++ b/offline/packages/micromegas/Makefile.am
@@ -21,6 +21,7 @@ pkginclude_HEADERS = \
   CylinderGeomMicromegas.h \
   MicromegasClusterizer.h \
   MicromegasDefs.h \
+  MicromegasMapping.h \
   MicromegasRawDataDecoder.h \
   MicromegasTile.h
 
@@ -37,6 +38,7 @@ nobase_dist_pcm_DATA = \
 libmicromegas_io_la_SOURCES = \
   $(ROOTDICTS) \
   CylinderGeomMicromegas.cc \
+  MicromegasMapping.cc \
   MicromegasDefs.cc
 
 libmicromegas_io_la_LIBADD = \
@@ -62,7 +64,6 @@ libmicromegas_la_LIBADD = \
 
 #just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;
-
 
 ################################################
 # linking tests

--- a/offline/packages/micromegas/MicromegasMapping.cc
+++ b/offline/packages/micromegas/MicromegasMapping.cc
@@ -1,0 +1,89 @@
+/*!
+ * \file MicromegasMapping.cc
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include "MicromegasMapping.h"
+#include "MicromegasDefs.h"
+
+//____________________________________________________________________________________________________
+MicromegasMapping::MicromegasMapping():
+m_detectors( {
+  /*
+   * fee_id (=fiber numbers) for south side correspond to that used during test noise run on March 2 2023
+   * for now, same fee_id incremented by 10, have been assigned to south side detectors, but this is arbitrary
+   * all this will be updated with final TPOT cabling
+   */
+  // Phi layer
+  {3, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 0 ), "M5P",  "SCOP" },
+  {8, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 1 ), "M8P",  "SCIP" },
+  {2, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 4 ), "M9P",  "SEIP" },
+  {7, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 6 ), "M6P",  "SWIP" },
+
+  {13, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 3 ), "M10P", "NCOP" },
+  {18, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 2 ), "M4P",  "NCIP" },
+  {12, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "M2P",  "NEIP" },
+  {17, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 7 ), "M7P",  "NWIP" },
+
+  // z layer
+  {4, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 0 ), "M5Z",  "SCOZ" },
+  {9, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 1 ), "M8Z",  "SCIZ" },
+  {1, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 4 ), "M9Z",  "SEIZ" },
+  {5, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 6 ), "M6Z",  "SWIZ" },
+
+  {14, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 3 ), "M10Z", "NCOZ" },
+  {19, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 2 ), "M4Z",  "NCIZ" },
+  {11, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 5 ), "M2Z",  "NEIZ" },
+  {15, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 7 ), "M7Z",  "NWIZ" } 
+} )
+{
+  std::cout << "MicromegasMapping::MicromegasMapping." << std::endl;
+
+  /// fill detector map from vector
+  for( const auto& detector_id:m_detectors )
+  { m_detector_map.emplace( detector_id.m_fee_id, detector_id ); }
+}
+
+//____________________________________________________________________________________________________
+TrkrDefs::hitsetkey MicromegasMapping::get_hitsetkey( int fee_id ) const
+{
+  const auto iter = m_detector_map.find( fee_id );
+  if( iter == m_detector_map.end() )
+  {
+    std::cout << "MicromegasMapping::get_hitsetkey - invalid fee_id: " << fee_id << std::endl;
+    return 0;
+  } else return iter->second.m_hitsetkey;
+}
+
+//____________________________________________________________________________________________________
+std::string MicromegasMapping::get_detname_saclay( int fee_id ) const
+{
+  const auto iter = m_detector_map.find( fee_id );
+  if( iter == m_detector_map.end() )
+  {
+    std::cout << "MicromegasMapping::get_detname_saclay - invalid fee_id: " << fee_id << std::endl;
+    return std::string();
+  } else return iter->second.m_detname_saclay;
+}
+
+//____________________________________________________________________________________________________
+std::string MicromegasMapping::get_detname_sphenix( int fee_id ) const
+{
+  const auto iter = m_detector_map.find( fee_id );
+  if( iter == m_detector_map.end() )
+  {
+    std::cout << "MicromegasMapping::get_detname_sphenix - invalid fee_id: " << fee_id << std::endl;
+    return std::string();
+  } else return iter->second.m_detname_sphenix;
+}
+
+//____________________________________________________________________________________________________
+int MicromegasMapping::get_physical_strip( int /*fee_id*/, int channel_id) const
+{
+  /* 
+   * this maps channel id (0-255) on a given FEE board, to physical strip number in the detector 
+   * Just a placeholder for now. We just return the same index. 
+   */
+  return channel_id;
+}
+

--- a/offline/packages/micromegas/MicromegasMapping.cc
+++ b/offline/packages/micromegas/MicromegasMapping.cc
@@ -34,7 +34,7 @@ m_detectors( {
   {14, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 3 ), "M10Z", "NCOZ" },
   {19, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 2 ), "M4Z",  "NCIZ" },
   {11, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 5 ), "M2Z",  "NEIZ" },
-  {15, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 7 ), "M7Z",  "NWIZ" } 
+  {15, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z, 7 ), "M7Z",  "NWIZ" }
 } )
 {
   std::cout << "MicromegasMapping::MicromegasMapping." << std::endl;
@@ -80,9 +80,9 @@ std::string MicromegasMapping::get_detname_sphenix( int fee_id ) const
 //____________________________________________________________________________________________________
 int MicromegasMapping::get_physical_strip( int /*fee_id*/, int channel_id) const
 {
-  /* 
-   * this maps channel id (0-255) on a given FEE board, to physical strip number in the detector 
-   * Just a placeholder for now. We just return the same index. 
+  /*
+   * this maps channel id (0-255) on a given FEE board, to physical strip number in the detector
+   * Just a placeholder for now. We just return the same index.
    */
   return channel_id;
 }

--- a/offline/packages/micromegas/MicromegasMapping.h
+++ b/offline/packages/micromegas/MicromegasMapping.h
@@ -1,0 +1,81 @@
+#ifndef MICROMEGAS_MICROMEGASMAPPING_H
+#define MICROMEGAS_MICROMEGASMAPPING_H
+
+/*!
+ * \file MicromegasMapping.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ */
+
+#include <trackbase/TrkrDefs.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+//! micromegas mapping
+class MicromegasMapping
+{
+  public:
+  
+  //! constructor
+  MicromegasMapping();
+  
+  //! get hitsetkey from fiber_id (fee_id)
+  TrkrDefs::hitsetkey get_hitsetkey( int /*fee_id*/ ) const;
+  
+  //! get detector name (saclay) from fiber_id (fee_id)
+  /** saclay detector name are of type MxxP and MxxZ, with xx the module number */
+  std::string get_detname_saclay( int /*fee_id*/) const;
+  
+  //! get detector name (saclay) from fiber_id (fee_id)
+  /** sphenix detector name are of type SWP, SWZ, etc. */
+  std::string get_detname_sphenix( int /*fee_id*/) const;
+  
+  //! get physical strip number from channel_id
+  /** 
+   * physical strip number correspond to a position in the 
+   * detector's geant implementation, with increasing number corresponding to strips further away from the detector's edge, 
+   * as defined in CylinderGeomMicromegas
+   */
+  int get_physical_strip( int /*fee_id*/, int /*channel_id*/) const;
+  
+  private:
+
+  //! contains all relevant detector information
+  /** this effectively implements mapping between fee_id as defined in EDBC,    * detector names (in both Saclay and sPHENIX convention), 
+   * and hitsetkey which is the detector unique identifier 
+   */
+  class DetectorId
+  {
+    public:
+    
+    //! constructor
+    DetectorId( int fee_id, TrkrDefs::hitsetkey hitsetkey, const std::string& detname_saclay, const std::string& detname_sphenix ):
+      m_fee_id( fee_id ),
+      m_hitsetkey( hitsetkey ),
+      m_detname_saclay( detname_saclay ),
+      m_detname_sphenix( detname_sphenix )
+    {}
+    
+    //! fee_id
+    int m_fee_id = 0;
+    
+    //! hitset key
+    TrkrDefs::hitsetkey m_hitsetkey = 0;
+    
+    //! detector name
+    std::string m_detname_saclay;
+    
+    //! detector name
+    std::string m_detname_sphenix;    
+  };
+  
+  //! list of defined detectors
+  std::vector<DetectorId> m_detectors;
+
+  //! map detector_id to fee_id
+  std::map<int, DetectorId> m_detector_map;
+  
+};
+
+#endif

--- a/offline/packages/micromegas/MicromegasMapping.h
+++ b/offline/packages/micromegas/MicromegasMapping.h
@@ -16,39 +16,39 @@
 class MicromegasMapping
 {
   public:
-  
+
   //! constructor
   MicromegasMapping();
-  
+
   //! get hitsetkey from fiber_id (fee_id)
   TrkrDefs::hitsetkey get_hitsetkey( int /*fee_id*/ ) const;
-  
+
   //! get detector name (saclay) from fiber_id (fee_id)
   /** saclay detector name are of type MxxP and MxxZ, with xx the module number */
   std::string get_detname_saclay( int /*fee_id*/) const;
-  
+
   //! get detector name (saclay) from fiber_id (fee_id)
   /** sphenix detector name are of type SWP, SWZ, etc. */
   std::string get_detname_sphenix( int /*fee_id*/) const;
-  
+
   //! get physical strip number from channel_id
-  /** 
-   * physical strip number correspond to a position in the 
-   * detector's geant implementation, with increasing number corresponding to strips further away from the detector's edge, 
+  /**
+   * physical strip number correspond to a position in the
+   * detector's geant implementation, with increasing number corresponding to strips further away from the detector's edge,
    * as defined in CylinderGeomMicromegas
    */
   int get_physical_strip( int /*fee_id*/, int /*channel_id*/) const;
-  
+
   private:
 
   //! contains all relevant detector information
-  /** this effectively implements mapping between fee_id as defined in EDBC,    * detector names (in both Saclay and sPHENIX convention), 
-   * and hitsetkey which is the detector unique identifier 
+  /** this effectively implements mapping between fee_id as defined in EDBC,    * detector names (in both Saclay and sPHENIX convention),
+   * and hitsetkey which is the detector unique identifier
    */
   class DetectorId
   {
     public:
-    
+
     //! constructor
     DetectorId( int fee_id, TrkrDefs::hitsetkey hitsetkey, const std::string& detname_saclay, const std::string& detname_sphenix ):
       m_fee_id( fee_id ),
@@ -56,26 +56,26 @@ class MicromegasMapping
       m_detname_saclay( detname_saclay ),
       m_detname_sphenix( detname_sphenix )
     {}
-    
+
     //! fee_id
     int m_fee_id = 0;
-    
+
     //! hitset key
     TrkrDefs::hitsetkey m_hitsetkey = 0;
-    
+
     //! detector name
     std::string m_detname_saclay;
-    
+
     //! detector name
-    std::string m_detname_sphenix;    
+    std::string m_detname_sphenix;
   };
-  
+
   //! list of defined detectors
   std::vector<DetectorId> m_detectors;
 
   //! map detector_id to fee_id
   std::map<int, DetectorId> m_detector_map;
-  
+
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasRawDataDecoder.h
+++ b/offline/packages/micromegas/MicromegasRawDataDecoder.h
@@ -16,7 +16,7 @@ class TFile;
 class TH1;
 class TH2;
 
-//! micromegas clusterizer
+//! micromegas raw data decoder
 class MicromegasRawDataDecoder : public SubsysReco
 {
   public:

--- a/offline/packages/micromegas/MicromegasRawDataDecoder.h
+++ b/offline/packages/micromegas/MicromegasRawDataDecoder.h
@@ -9,7 +9,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <memory>
-#include <string>        
+#include <string>
 
 class PHCompositeNode;
 class TFile;
@@ -38,12 +38,12 @@ class MicromegasRawDataDecoder : public SubsysReco
 
   /// set to true to store evaluation histograms and ntuples
   void set_save_histograms( bool value ) { m_savehistograms = value; }
-    
+
   /// output file name for evaluation histograms
   void set_histogram_outputfile(const std::string &outputfile) {m_histogramfilename = outputfile;}
 
-  private:  
- 
+  private:
+
   /// create evaluation histograms
   void create_histograms();
 
@@ -51,25 +51,25 @@ class MicromegasRawDataDecoder : public SubsysReco
   static constexpr int m_nfee = 8;
   static constexpr int m_nchannels_total = m_nfee*m_nchannels_fee;
   static constexpr int m_max_adc = 1024;
-  
+
   //!@name evaluation histograms
   //@{
- 
+
   /// Output root histograms
   bool m_savehistograms = true;
 
   /// histogram output file name
   std::string m_histogramfilename = "MicromegasRawDataDecoder.root";
-  std::unique_ptr<TFile> m_histogramfile;  
- 
+  std::unique_ptr<TFile> m_histogramfile;
+
   //! Fired FEE
   TH1* m_h_fee_id = nullptr;
-  
+
   //! ADC distribution vs channel number
   TH2* m_h_adc_channel = nullptr;
-  
+
   //@}
-  
+
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This implements a small class to handle micromegas mapping, namely: 
- fiber (or fee) id mapping to hitsetkey and detector names
- channel_id (0-255) into physical strip number

For the first, hitsetkeys and detector names are mapped to reality and is hardcoded, according to diagram at https://wiki.sphenix.bnl.gov/index.php/File:ModuleMapping_hp.png

The mapping to fee_id (or fiber_id) is also hardcoded and matches noise data taken at 1008 on March 2nd 2023, but changing to read the mapping from an actual text file should be straightforward.
For the second (channel id to physical strip), right now this is only a placeholder. True implementation is ongoing work.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

