### PR TITLE
Acts propagator with custom aborter for sPHENIX defined layer

### DIFF
--- a/offline/packages/trackbase/ActsAborter.h
+++ b/offline/packages/trackbase/ActsAborter.h
@@ -1,0 +1,35 @@
+
+#ifndef TRACKBASE_ACTSABORTER_H
+#define TRACKBASE_ACTSTRACKFITTINGALGORITHM_H
+
+
+#include <Acts/Definitions/Algebra.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Utilities/Logger.hpp>
+
+struct ActsAborter {
+  
+  unsigned int m_abortlayer = std::numeric_limits<unsigned int>::max();
+
+  template <typename propagator_state_t, typename stepper_t>
+    bool operator()(propagator_state_t& state, const stepper_t& /*stepper*/) const {
+
+    if(state.navigation.targetReached) 
+      {
+	return true;
+      }
+    
+    auto layerno = state.navigation.currentSurface->geometryId().layer();
+    if(layerno == m_abortlayer)
+      {
+	state.navigation.targetReached = true;
+	return true;
+      }
+
+    return false;
+
+  }
+};
+
+
+#endif

--- a/offline/packages/trackbase/ActsAborter.h
+++ b/offline/packages/trackbase/ActsAborter.h
@@ -1,35 +1,43 @@
 
 #ifndef TRACKBASE_ACTSABORTER_H
-#define TRACKBASE_ACTSTRACKFITTINGALGORITHM_H
-
+#define TRACKBASE_ACTSABORTER_H
 
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Utilities/Logger.hpp>
 
-struct ActsAborter {
-  
-  unsigned int m_abortlayer = std::numeric_limits<unsigned int>::max();
+struct ActsAborter
+{
+  unsigned int abortlayer = std::numeric_limits<unsigned int>::max();
+  unsigned int abortvolume = std::numeric_limits<unsigned int>::max();
 
   template <typename propagator_state_t, typename stepper_t>
-    bool operator()(propagator_state_t& state, const stepper_t& /*stepper*/) const {
+  bool operator()(propagator_state_t& state, const stepper_t& /*stepper*/) const
+  {
+    if (state.navigation.targetReached)
+    {
+      return true;
+    }
 
-    if(state.navigation.targetReached) 
-      {
-	return true;
-      }
-    
+    if (!state.navigation.currentSurface)
+    {
+      return false;
+    }
+
+    auto volumeno = state.navigation.currentSurface->geometryId().volume();
     auto layerno = state.navigation.currentSurface->geometryId().layer();
-    if(layerno == m_abortlayer)
-      {
-	state.navigation.targetReached = true;
-	return true;
-      }
+    auto sensitive = state.navigation.currentSurface->geometryId().sensitive();
+
+    /// Check that we are in the proper layer and that we've also reached
+    /// a sensitive surface
+    if (layerno == abortlayer and volumeno == abortvolume and sensitive != 0)
+    {
+      state.navigation.targetReached = true;
+      return true;
+    }
 
     return false;
-
   }
 };
-
 
 #endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -19,6 +19,7 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
+  ActsAborter.h \
   ActsGeometry.h \
   ActsGsfTrackFittingAlgorithm.h \
   ActsSourceLink.h \

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -36,6 +36,7 @@ pkginclude_HEADERS = \
   PHActsVertexPropagator.h \
   PHActsTrkFitter.h \
   PHActsTrackProjection.h \
+  PHActsTrackPropagator.h \
   PHCASeeding.h \
   PHGenFitTrackProjection.h \
   PHGenFitTrkFitter.h \
@@ -89,7 +90,8 @@ ACTS_SOURCES = \
   PHActsSiliconSeeding.cc \
   PHActsTrkFitter.cc \
   PHActsVertexPropagator.cc \
-  PHActsTrackProjection.cc
+  PHActsTrackProjection.cc \
+  PHActsTrackPropagator.cc
 
 $OFFLINE_MAIN/share:
 dist_data_DATA = \

--- a/offline/packages/trackreco/PHActsTrackPropagator.cc
+++ b/offline/packages/trackreco/PHActsTrackPropagator.cc
@@ -1,0 +1,217 @@
+
+#include "PHActsTrackPropagator.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+
+#include <trackbase/ActsTrackFittingAlgorithm.h>
+#include <trackbase/ActsAborter.h>
+
+#include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackState.h>
+#include <trackbase_historic/SvtxTrackState_v1.h>
+#include <trackbase_historic/SvtxVertex.h>
+#include <trackbase_historic/SvtxVertexMap.h>
+
+#include <Acts/Geometry/GeometryIdentifier.hpp>
+#include <Acts/MagneticField/ConstantBField.hpp>
+#include <Acts/MagneticField/MagneticFieldProvider.hpp>
+#include <Acts/Propagator/EigenStepper.hpp>
+#include <Acts/Surfaces/PerigeeSurface.hpp>
+#include <Acts/Propagator/Navigator.hpp>
+
+//____________________________________________________________________________..
+PHActsTrackPropagator::PHActsTrackPropagator(const std::string &name):
+ SubsysReco(name)
+{
+
+}
+
+//____________________________________________________________________________..
+PHActsTrackPropagator::~PHActsTrackPropagator()
+{
+
+}
+
+//____________________________________________________________________________..
+int PHActsTrackPropagator::Init(PHCompositeNode*)
+{
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHActsTrackPropagator::InitRun(PHCompositeNode *topNode)
+{
+
+  int ret = getNodes(topNode);
+
+  return ret;
+}
+
+//____________________________________________________________________________..
+int PHActsTrackPropagator::process_event(PHCompositeNode*)
+{
+ 
+  for(auto &[key, track] : *m_trackMap)
+    {
+      const auto params = makeTrackParams(track); 
+
+      auto result = propagateTrack(params);
+    }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+PHActsTrackPropagator::BoundTrackParamResult
+PHActsTrackPropagator::propagateTrack(const Acts::BoundTrackParameters& params)
+{
+  if (Verbosity() > 1)
+    {
+      std::cout << "Propagating final track fit with momentum: "
+		<< params.momentum() << " and position "
+		<< params.position(m_tGeometry->geometry().getGeoContext())
+		<< std::endl
+		<< "track fit phi/eta "
+		<< atan2(params.momentum()(1),
+			 params.momentum()(0))
+		<< " and "
+		<< atanh(params.momentum()(2) / params.momentum().norm())
+		<< std::endl;
+    }
+  
+  using Stepper = Acts::EigenStepper<>;
+  using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
+
+  auto field = m_tGeometry->geometry().magField;
+  auto trackingGeometry = m_tGeometry->geometry().tGeometry;
+  Stepper stepper(field);
+  Acts::Navigator::Config cfg{trackingGeometry};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Acts::Navigator navigator(cfg);
+
+  Propagator propagator(stepper, navigator);
+
+  Acts::Logging::Level logLevel = Acts::Logging::INFO;
+  if (Verbosity() > 3)
+  {
+    logLevel = Acts::Logging::VERBOSE;
+  }
+  
+  auto logger = Acts::getDefaultLogger("PHActsTrackPropagator",
+                                       logLevel);
+  using Actors = Acts::ActionList<>;
+  using Aborter = ActsAborter;
+  using Aborters = Acts::AbortList<ActsAborter>;
+  using abortlist = Acts::AbortList<>;
+  Acts::PropagatorOptions<Actors, Aborters> options(
+     m_tGeometry->geometry().getGeoContext(),
+     m_tGeometry->geometry().magFieldContext,
+     Acts::LoggerWrapper{*logger});
+
+  auto result = propagator.propagate(params, options);
+  if(result.ok())
+    {
+      return Acts::Result<BoundTrackParam>::success(std::move((*result).endParameters.value()));
+    }
+
+  return result.error();
+
+}
+
+Acts::BoundTrackParameters
+PHActsTrackPropagator::makeTrackParams(SvtxTrack* track)
+{
+  Acts::Vector3 momentum(track->get_px(),
+                         track->get_py(),
+                         track->get_pz());
+
+  auto actsVertex = getVertex(track);
+  auto perigee =
+      Acts::Surface::makeShared<Acts::PerigeeSurface>(actsVertex);
+  auto actsFourPos =
+      Acts::Vector4(track->get_x() * Acts::UnitConstants::cm,
+                    track->get_y() * Acts::UnitConstants::cm,
+                    track->get_z() * Acts::UnitConstants::cm,
+                    10 * Acts::UnitConstants::ns);
+
+  ActsTransformations transformer;
+
+  Acts::BoundSymMatrix cov = transformer.rotateSvtxTrackCovToActs(track);
+
+  return ActsTrackFittingAlgorithm::TrackParameters::create(perigee, 
+     m_tGeometry->geometry().getGeoContext(),
+     actsFourPos, momentum,
+     track->get_charge() / track->get_p(),
+     cov).value();
+}
+Acts::Vector3 PHActsTrackPropagator::getVertex(SvtxTrack* track)
+{
+  auto vertexId = track->get_vertex_id();
+  const SvtxVertex* svtxVertex = m_vertexMap->get(vertexId);
+  Acts::Vector3 vertex = Acts::Vector3::Zero();
+  if (svtxVertex)
+  {
+    vertex(0) = svtxVertex->get_x() * Acts::UnitConstants::cm;
+    vertex(1) = svtxVertex->get_y() * Acts::UnitConstants::cm;
+    vertex(2) = svtxVertex->get_z() * Acts::UnitConstants::cm;
+  }
+
+  return vertex;
+}
+
+//____________________________________________________________________________..
+int PHActsTrackPropagator::End(PHCompositeNode*)
+{
+ 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+void PHActsTrackPropagator::Print(const std::string &what) const
+{
+  std::cout << "PHActsTrackPropagator:: " << what << std::endl;
+}
+
+int PHActsTrackPropagator::getNodes(PHCompositeNode *topNode)
+{
+   m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  if (!m_vertexMap)
+  {
+    std::cout << PHWHERE << "No vertex map on node tree, bailing."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  m_tGeometry = findNode::getClass<ActsGeometry>(
+      topNode, "ActsGeometry");
+  if (!m_tGeometry)
+  {
+    std::cout << "ActsTrackingGeometry not on node tree. Exiting."
+              << std::endl;
+
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!m_trackMap)
+  {
+    std::cout << PHWHERE << "No SvtxTrackMap on node tree. Bailing."
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHActsTrackPropagator.cc
+++ b/offline/packages/trackreco/PHActsTrackPropagator.cc
@@ -11,9 +11,8 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-
-#include <trackbase/ActsTrackFittingAlgorithm.h>
 #include <trackbase/ActsAborter.h>
+#include <trackbase/ActsTrackFittingAlgorithm.h>
 
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -23,73 +22,114 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/Propagator/EigenStepper.hpp>
-#include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Surfaces/PerigeeSurface.hpp>
 
 //____________________________________________________________________________..
-PHActsTrackPropagator::PHActsTrackPropagator(const std::string &name):
- SubsysReco(name)
+PHActsTrackPropagator::PHActsTrackPropagator(const std::string &name)
+  : SubsysReco(name)
 {
-
 }
 
 //____________________________________________________________________________..
 PHActsTrackPropagator::~PHActsTrackPropagator()
 {
-
 }
 
 //____________________________________________________________________________..
-int PHActsTrackPropagator::Init(PHCompositeNode*)
+int PHActsTrackPropagator::Init(PHCompositeNode *)
 {
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int PHActsTrackPropagator::InitRun(PHCompositeNode *topNode)
 {
-
   int ret = getNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
+
+  ret = checkLayer();
 
   return ret;
 }
 
 //____________________________________________________________________________..
-int PHActsTrackPropagator::process_event(PHCompositeNode*)
+int PHActsTrackPropagator::process_event(PHCompositeNode *)
 {
- 
-  for(auto &[key, track] : *m_trackMap)
-    {
-      const auto params = makeTrackParams(track); 
+  for (auto &[key, track] : *m_trackMap)
+  {
+    const auto params = makeTrackParams(track);
 
-      auto result = propagateTrack(params);
+    auto result = propagateTrack(params);
+    if (!std::isnan(result.first))
+    {
+      addTrackState(result, track);
     }
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void PHActsTrackPropagator::addTrackState(
+    const BoundTrackParamResult &result,
+    SvtxTrack *svtxTrack)
+{
+  float pathlength = result.first;
+  auto params = result.second;
+
+  SvtxTrackState_v1 out(pathlength);
+
+  auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
+  const auto momentum = params.momentum();
+  out.set_x(projectionPos.x() / Acts::UnitConstants::cm);
+  out.set_y(projectionPos.y() / Acts::UnitConstants::cm);
+  out.set_z(projectionPos.z() / Acts::UnitConstants::cm);
+  out.set_px(momentum.x());
+  out.set_py(momentum.y());
+  out.set_pz(momentum.z());
+
+  if (Verbosity() > 1)
+  {
+    std::cout << "Adding track state for layer " << m_sphenixLayer
+              << " with path length " << pathlength << " with position "
+              << projectionPos.transpose() << std::endl;
+  }
+
+  ActsTransformations transformer;
+  const auto globalCov = transformer.rotateActsCovToSvtxTrack(params);
+  for (int i = 0; i < 6; ++i)
+  {
+    for (int j = 0; j < 6; ++j)
+    {
+      out.set_error(i, j, globalCov(i, j));
+    }
+  }
+
+  svtxTrack->insert_state(&out);
+}
 
 PHActsTrackPropagator::BoundTrackParamResult
-PHActsTrackPropagator::propagateTrack(const Acts::BoundTrackParameters& params)
+PHActsTrackPropagator::propagateTrack(const Acts::BoundTrackParameters &params)
 {
   if (Verbosity() > 1)
-    {
-      std::cout << "Propagating final track fit with momentum: "
-		<< params.momentum() << " and position "
-		<< params.position(m_tGeometry->geometry().getGeoContext())
-		<< std::endl
-		<< "track fit phi/eta "
-		<< atan2(params.momentum()(1),
-			 params.momentum()(0))
-		<< " and "
-		<< atanh(params.momentum()(2) / params.momentum().norm())
-		<< std::endl;
-    }
-  
+  {
+    std::cout << "Propagating final track fit with momentum: "
+              << params.momentum() << " and position "
+              << params.position(m_tGeometry->geometry().getGeoContext())
+              << std::endl
+              << "track fit phi/eta "
+              << atan2(params.momentum()(1),
+                       params.momentum()(0))
+              << " and "
+              << atanh(params.momentum()(2) / params.momentum().norm())
+              << std::endl;
+  }
+
   using Stepper = Acts::EigenStepper<>;
   using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
 
@@ -109,30 +149,34 @@ PHActsTrackPropagator::propagateTrack(const Acts::BoundTrackParameters& params)
   {
     logLevel = Acts::Logging::VERBOSE;
   }
-  
+
   auto logger = Acts::getDefaultLogger("PHActsTrackPropagator",
                                        logLevel);
   using Actors = Acts::ActionList<>;
-  using Aborter = ActsAborter;
   using Aborters = Acts::AbortList<ActsAborter>;
-  using abortlist = Acts::AbortList<>;
+
   Acts::PropagatorOptions<Actors, Aborters> options(
-     m_tGeometry->geometry().getGeoContext(),
-     m_tGeometry->geometry().magFieldContext,
-     Acts::LoggerWrapper{*logger});
+      m_tGeometry->geometry().getGeoContext(),
+      m_tGeometry->geometry().magFieldContext,
+      Acts::LoggerWrapper{*logger});
+
+  options.abortList.get<ActsAborter>().abortlayer = m_actslayer;
+  options.abortList.get<ActsAborter>().abortvolume = m_actsvolume;
 
   auto result = propagator.propagate(params, options);
-  if(result.ok())
-    {
-      return Acts::Result<BoundTrackParam>::success(std::move((*result).endParameters.value()));
-    }
 
-  return result.error();
+  if (result.ok())
+  {
+    auto params = *result.value().endParameters;
+    double pathlength = result.value().pathLength / Acts::UnitConstants::cm;
+    return std::make_pair(pathlength, params);
+  }
 
+  return std::make_pair(NAN, Acts::BoundTrackParameters(nullptr, Acts::BoundVector::Zero(), -1));
 }
 
 Acts::BoundTrackParameters
-PHActsTrackPropagator::makeTrackParams(SvtxTrack* track)
+PHActsTrackPropagator::makeTrackParams(SvtxTrack *track)
 {
   Acts::Vector3 momentum(track->get_px(),
                          track->get_py(),
@@ -151,16 +195,17 @@ PHActsTrackPropagator::makeTrackParams(SvtxTrack* track)
 
   Acts::BoundSymMatrix cov = transformer.rotateSvtxTrackCovToActs(track);
 
-  return ActsTrackFittingAlgorithm::TrackParameters::create(perigee, 
-     m_tGeometry->geometry().getGeoContext(),
-     actsFourPos, momentum,
-     track->get_charge() / track->get_p(),
-     cov).value();
+  return ActsTrackFittingAlgorithm::TrackParameters::create(perigee,
+                                                            m_tGeometry->geometry().getGeoContext(),
+                                                            actsFourPos, momentum,
+                                                            track->get_charge() / track->get_p(),
+                                                            cov)
+      .value();
 }
-Acts::Vector3 PHActsTrackPropagator::getVertex(SvtxTrack* track)
+Acts::Vector3 PHActsTrackPropagator::getVertex(SvtxTrack *track)
 {
   auto vertexId = track->get_vertex_id();
-  const SvtxVertex* svtxVertex = m_vertexMap->get(vertexId);
+  const SvtxVertex *svtxVertex = m_vertexMap->get(vertexId);
   Acts::Vector3 vertex = Acts::Vector3::Zero();
   if (svtxVertex)
   {
@@ -173,9 +218,8 @@ Acts::Vector3 PHActsTrackPropagator::getVertex(SvtxTrack* track)
 }
 
 //____________________________________________________________________________..
-int PHActsTrackPropagator::End(PHCompositeNode*)
+int PHActsTrackPropagator::End(PHCompositeNode *)
 {
- 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -187,7 +231,7 @@ void PHActsTrackPropagator::Print(const std::string &what) const
 
 int PHActsTrackPropagator::getNodes(PHCompositeNode *topNode)
 {
-   m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   if (!m_vertexMap)
   {
     std::cout << PHWHERE << "No vertex map on node tree, bailing."
@@ -211,6 +255,75 @@ int PHActsTrackPropagator::getNodes(PHCompositeNode *topNode)
     std::cout << PHWHERE << "No SvtxTrackMap on node tree. Bailing."
               << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHActsTrackPropagator::checkLayer()
+{
+  /*
+   * Acts geometry is defined in terms of volumes and layers. Within a volume
+   * layers always begin at 2 and iterate in 2s, i.e. the MVTX is defined as a
+   * volume and the 3 layers are identifiable as 2, 4, and 6.
+   * So we convert the sPHENIX layer number here to the Acts volume and
+   * layer number that can interpret where to navigate to in the propagation.
+   * The only exception is the TPOT, which is interpreted as a single layer.
+   */
+
+  /// mvtx
+  if (m_sphenixLayer < 3)
+  {
+    m_actsvolume = 10;
+    m_actslayer = (m_sphenixLayer + 1) * 2;
+  }
+
+  /// intt
+  else if (m_sphenixLayer < 7)
+  {
+    m_actsvolume = 12;
+    m_actslayer = ((m_sphenixLayer - 3) + 1) * 2;
+  }
+
+  /// tpc
+  else if (m_sphenixLayer < 55)
+  {
+    m_actsvolume = 14;
+    m_actslayer = ((m_sphenixLayer - 7) + 1) * 2;
+  }
+  /// tpot only has one layer in Acts geometry
+  else
+  {
+    m_actsvolume = 16;
+    m_actslayer = 2;
+  }
+
+  /// Test to make sure the found volume and layer exist
+  auto tgeometry = m_tGeometry->geometry().tGeometry;
+
+  bool foundlayer = false;
+  bool foundvolume = false;
+
+  tgeometry->visitSurfaces([&](const Acts::Surface *srf)
+                           {
+    if (srf != nullptr) {
+      auto layer = srf->geometryId().layer();
+      auto volume = srf->geometryId().volume();
+      if(volume == m_actsvolume and layer == m_actslayer)
+	{
+	  foundlayer = true;
+	  foundvolume = true;
+	  return;
+	}
+    } });
+
+  if (!foundlayer or !foundvolume)
+  {
+    std::cout << PHWHERE
+              << "Could not identify Acts volume and layer to propagate to. Can't continue. "
+              << std::endl;
+
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/trackreco/PHActsTrackPropagator.h
+++ b/offline/packages/trackreco/PHActsTrackPropagator.h
@@ -32,8 +32,8 @@ class PHActsTrackPropagator : public SubsysReco
 {
  public:
   using BoundTrackParam =
-    const Acts::BoundTrackParameters;
-  using BoundTrackParamResult = Acts::Result<BoundTrackParam>;
+      const Acts::BoundTrackParameters;
+  using BoundTrackParamResult = std::pair<float, BoundTrackParam>;
   using SurfacePtr = std::shared_ptr<const Acts::Surface>;
   using Trajectory = ActsExamples::Trajectories;
 
@@ -52,12 +52,16 @@ class PHActsTrackPropagator : public SubsysReco
   void setPropagationLayer(unsigned int layer) { m_sphenixLayer = layer; }
 
  private:
-
   int getNodes(PHCompositeNode *topNode);
-  Acts::BoundTrackParameters makeTrackParams(SvtxTrack* track);
-  Acts::Vector3 getVertex(SvtxTrack* track);
+  Acts::BoundTrackParameters makeTrackParams(SvtxTrack *track);
+  Acts::Vector3 getVertex(SvtxTrack *track);
   BoundTrackParamResult propagateTrack(
       const Acts::BoundTrackParameters &params);
+  int checkLayer();
+  void convertsPHENIXLayerToActsLayer(unsigned int &actsvolume,
+                                      unsigned int &actslayer);
+  void addTrackState(const BoundTrackParamResult &params,
+                     SvtxTrack *svtxTrack);
 
   /// Objects containing the Acts track fit results
   ActsGeometry *m_tGeometry = nullptr;
@@ -66,6 +70,8 @@ class PHActsTrackPropagator : public SubsysReco
 
   unsigned int m_sphenixLayer = std::numeric_limits<unsigned int>::max();
 
+  unsigned int m_actslayer = std::numeric_limits<unsigned int>::max();
+  unsigned int m_actsvolume = std::numeric_limits<unsigned int>::max();
 };
 
-#endif // PHACTSTRACKPROPAGATOR_H
+#endif  // PHACTSTRACKPROPAGATOR_H

--- a/offline/packages/trackreco/PHActsTrackPropagator.h
+++ b/offline/packages/trackreco/PHActsTrackPropagator.h
@@ -1,0 +1,71 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHACTSTRACKPROPAGATOR_H
+#define PHACTSTRACKPROPAGATOR_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/SvtxTrack.h>
+
+#include <trackbase/ActsGeometry.h>
+
+#include <Acts/Definitions/Algebra.hpp>
+#include <Acts/EventData/TrackParameters.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <Acts/Propagator/Propagator.hpp>
+#pragma GCC diagnostic pop
+
+#include <Acts/Utilities/Result.hpp>
+
+#include <ActsExamples/EventData/Trajectories.hpp>
+
+#include <string>
+
+class PHCompositeNode;
+class SvtxTrackMap;
+class ActsGeometry;
+class SvtxVertexMap;
+
+class PHActsTrackPropagator : public SubsysReco
+{
+ public:
+  using BoundTrackParam =
+    const Acts::BoundTrackParameters;
+  using BoundTrackParamResult = Acts::Result<BoundTrackParam>;
+  using SurfacePtr = std::shared_ptr<const Acts::Surface>;
+  using Trajectory = ActsExamples::Trajectories;
+
+  PHActsTrackPropagator(const std::string &name = "PHActsTrackPropagator");
+
+  ~PHActsTrackPropagator() override;
+
+  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
+
+  int process_event(PHCompositeNode *topNode) override;
+
+  int End(PHCompositeNode *topNode) override;
+
+  void Print(const std::string &what = "ALL") const override;
+  void setPropagationLayer(unsigned int layer) { m_sphenixLayer = layer; }
+
+ private:
+
+  int getNodes(PHCompositeNode *topNode);
+  Acts::BoundTrackParameters makeTrackParams(SvtxTrack* track);
+  Acts::Vector3 getVertex(SvtxTrack* track);
+  BoundTrackParamResult propagateTrack(
+      const Acts::BoundTrackParameters &params);
+
+  /// Objects containing the Acts track fit results
+  ActsGeometry *m_tGeometry = nullptr;
+  SvtxTrackMap *m_trackMap = nullptr;
+  SvtxVertexMap *m_vertexMap = nullptr;
+
+  unsigned int m_sphenixLayer = std::numeric_limits<unsigned int>::max();
+
+};
+
+#endif // PHACTSTRACKPROPAGATOR_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This adds a module that uses the Acts propagator to propagate the track map to an arbitrary chosen user defined layer in sPHENIX coordinates. It adds an Acts::Aborter that tells the propagator to abort propagation at the sensitive surfaces of the provided layer. It can also act as a template for other Acts propagation modules which need custom defined aborters (e.g. those envisioned for iterative tracking to propagate TPC tracks back to the silicon).

You can add it to your macro and select the layer like the following:
```
auto prop = new PHActsTrackPropagator;
prop->setPropagationLayer(someLayer);
se->registerSubsystem(prop);
```
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

