### PR TITLE
Introducing vectorized TPC `TrkrHitSet`

### DIFF
--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -75,6 +75,7 @@ pkginclude_HEADERS = \
   TrkrHitSet.h \
   TrkrHitSetContainer.h \
   TrkrHitSetContainerv1.h \
+  TrkrHitSetContainerv2.h \
   TrkrHitSetv1.h \
   TrkrHitSetTpc.h \
   TrkrHitSetTpcv1.h \
@@ -123,6 +124,7 @@ ROOTDICTS = \
   TrkrClusterv4_Dict.cc \
   TrkrHitSetContainer_Dict.cc \
   TrkrHitSetContainerv1_Dict.cc \
+  TrkrHitSetContainerv2_Dict.cc \
   TrkrHitSet_Dict.cc \
   TrkrHitSetv1_Dict.cc \
   TrkrHitSetTpc_Dict.cc \
@@ -175,6 +177,7 @@ nobase_dist_pcm_DATA = \
   TrkrClusterv4_Dict_rdict.pcm \
   TrkrHitSetContainer_Dict_rdict.pcm \
   TrkrHitSetContainerv1_Dict_rdict.pcm \
+  TrkrHitSetContainerv2_Dict_rdict.pcm \
   TrkrHitSet_Dict_rdict.pcm \
   TrkrHitSetv1_Dict_rdict.pcm \
   TrkrHitSetTpc_Dict_rdict.pcm \
@@ -232,6 +235,7 @@ libtrack_io_la_SOURCES = \
   TrkrHitSet.cc \
   TrkrHitSetContainer.cc \
   TrkrHitSetContainerv1.cc \
+  TrkrHitSetContainerv2.cc \
   TrkrHitSetv1.cc \
   TrkrHitSetTpc.cc \
   TrkrHitSetTpcv1.cc \

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -76,6 +76,7 @@ pkginclude_HEADERS = \
   TrkrHitSetContainer.h \
   TrkrHitSetContainerv1.h \
   TrkrHitSetv1.h \
+  TrkrHitSetTpcv1.h \
   TrkrHitTruthAssoc.h \
   TrkrHitTruthAssocv1.h \
   TrkrHitv1.h \
@@ -123,6 +124,7 @@ ROOTDICTS = \
   TrkrHitSetContainerv1_Dict.cc \
   TrkrHitSet_Dict.cc \
   TrkrHitSetv1_Dict.cc \
+  TrkrHitSetTpcv1_Dict.cc \
   TrkrHitTruthAssoc_Dict.cc \
   TrkrHitTruthAssocv1_Dict.cc \
   TrkrHit_Dict.cc \
@@ -173,6 +175,7 @@ nobase_dist_pcm_DATA = \
   TrkrHitSetContainerv1_Dict_rdict.pcm \
   TrkrHitSet_Dict_rdict.pcm \
   TrkrHitSetv1_Dict_rdict.pcm \
+  TrkrHitSetTpcv1_Dict_rdict.pcm \
   TrkrHitTruthAssoc_Dict_rdict.pcm \
   TrkrHitTruthAssocv1_Dict_rdict.pcm \
   TrkrHit_Dict_rdict.pcm \
@@ -227,6 +230,7 @@ libtrack_io_la_SOURCES = \
   TrkrHitSetContainer.cc \
   TrkrHitSetContainerv1.cc \
   TrkrHitSetv1.cc \
+  TrkrHitSetTpcv1.cc \
   TrkrHitTruthAssocv1.cc \
   TrkrHitv1.cc \
   TrkrHitv2.cc \

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -76,6 +76,7 @@ pkginclude_HEADERS = \
   TrkrHitSetContainer.h \
   TrkrHitSetContainerv1.h \
   TrkrHitSetv1.h \
+  TrkrHitSetTpc.h \
   TrkrHitSetTpcv1.h \
   TrkrHitTruthAssoc.h \
   TrkrHitTruthAssocv1.h \
@@ -124,6 +125,7 @@ ROOTDICTS = \
   TrkrHitSetContainerv1_Dict.cc \
   TrkrHitSet_Dict.cc \
   TrkrHitSetv1_Dict.cc \
+  TrkrHitSetTpc_Dict.cc \
   TrkrHitSetTpcv1_Dict.cc \
   TrkrHitTruthAssoc_Dict.cc \
   TrkrHitTruthAssocv1_Dict.cc \
@@ -175,6 +177,7 @@ nobase_dist_pcm_DATA = \
   TrkrHitSetContainerv1_Dict_rdict.pcm \
   TrkrHitSet_Dict_rdict.pcm \
   TrkrHitSetv1_Dict_rdict.pcm \
+  TrkrHitSetTpc_Dict_rdict.pcm \
   TrkrHitSetTpcv1_Dict_rdict.pcm \
   TrkrHitTruthAssoc_Dict_rdict.pcm \
   TrkrHitTruthAssocv1_Dict_rdict.pcm \
@@ -230,6 +233,7 @@ libtrack_io_la_SOURCES = \
   TrkrHitSetContainer.cc \
   TrkrHitSetContainerv1.cc \
   TrkrHitSetv1.cc \
+  TrkrHitSetTpc.cc \
   TrkrHitSetTpcv1.cc \
   TrkrHitTruthAssocv1.cc \
   TrkrHitv1.cc \

--- a/offline/packages/trackbase/TpcDefs.h
+++ b/offline/packages/trackbase/TpcDefs.h
@@ -38,6 +38,10 @@ static const unsigned int kBitShiftTBin __attribute__((unused)) = 0;
 static const uint16_t MAXPAD __attribute__((unused)) = 1024;
 static const uint16_t MAXTBIN __attribute__((unused)) = 512;
 
+// in memory representation of TPC ADC data: 10bit ADC value as 16bit signed integer.
+// This is signed to allow pedestal subtraction when needed
+typedef int16_t ADCDataType;
+
 /**
    * @brief Get the sector id from hitsetkey
    * @param[in] hitsetkey
@@ -109,6 +113,7 @@ TrkrDefs::hitsetkey genHitSetKey(const uint8_t lyr, const uint8_t sector, const 
    * @param[out] cluskey
    */
 TrkrDefs::cluskey genClusKey(const uint8_t lyr, const uint8_t sector, const uint8_t side, const uint32_t clusid);
+
 
 }  // namespace TpcDefs
 

--- a/offline/packages/trackbase/TrkrHitSetContainer.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainer.cc
@@ -30,7 +30,7 @@ TrkrHitSetContainer::addHitSet(TrkrHitSet* /*newhit*/)
 TrkrHitSetContainer::ConstIterator
 TrkrHitSetContainer::addHitSetSpecifyKey(const TrkrDefs::hitsetkey /*key*/, TrkrHitSet* /*newhit*/)
 { return dummy_map.cbegin(); }
- 
+
 TrkrHitSetContainer::Iterator
 TrkrHitSetContainer::findOrAddHitSet(TrkrDefs::hitsetkey /*key*/)
 { return dummy_map.begin(); }

--- a/offline/packages/trackbase/TrkrHitSetContainerv2.cc
+++ b/offline/packages/trackbase/TrkrHitSetContainerv2.cc
@@ -1,0 +1,162 @@
+/**
+ * @file trackbase/TrkrHitSetContainerv2.cc
+ * @author D. McGlinchey, H. PEREIRA DA COSTA
+ * @date June 2018
+ * @brief Implementation for TrkrHitSetContainerv2
+ */
+#include "TrkrHitSetContainerv2.h"
+
+#include "TrkrDefs.h"
+#include "TrkrHitSetv1.h"
+
+#include <TClass.h>
+
+#include <cassert>
+#include <cstdlib>
+
+TrkrHitSetContainerv2::
+    TrkrHitSetContainerv2(const std::string& hitsetclass)
+  : m_hitArray(hitsetclass.c_str())
+{
+}
+
+void TrkrHitSetContainerv2::Reset()
+{
+  m_hitmap.clear();
+  //! fast clear without calling destructor
+  m_hitArray.Clear("C");
+}
+
+void TrkrHitSetContainerv2::identify(std::ostream& os) const
+{
+  syncMapArray();
+
+  os << "TrkrHitSetContainerv2 with class "
+     << m_hitArray.GetClass()->GetName()
+     << ": Number of hits: " << size() << " index map size = " << m_hitmap.size() << std::endl;
+  ConstIterator iter;
+  for (const auto& pair : m_hitmap)
+  {
+    int layer = TrkrDefs::getLayer(pair.first);
+    os << "hitsetkey " << pair.first << " layer " << layer << std::endl;
+    pair.second->identify();
+  }
+  return;
+}
+
+TrkrHitSetContainerv2::ConstIterator
+TrkrHitSetContainerv2::addHitSet(TrkrHitSet* newhit)
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : deprecated. Use findOrAddHitSet()." << std::endl;
+  return addHitSetSpecifyKey(newhit->getHitSetKey(), newhit);
+}
+
+TrkrHitSetContainerv2::ConstIterator
+TrkrHitSetContainerv2::addHitSetSpecifyKey(const TrkrDefs::hitsetkey key, TrkrHitSet* newhit)
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : deprecated. Use findOrAddHitSet()." << std::endl;
+
+  exit(1);
+
+  return TrkrHitSetContainer::addHitSetSpecifyKey(key, newhit);
+}
+
+void TrkrHitSetContainerv2::removeHitSet(TrkrDefs::hitsetkey key)
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : deprecated. This function still works but slows down operation." << std::endl;
+
+  syncMapArray();
+  auto iter = m_hitmap.find(key);
+  if (iter != m_hitmap.end())
+  {
+    TrkrHitSet* hitset = iter->second;
+    //    delete hitset;
+    m_hitArray.Remove(hitset);
+    m_hitmap.erase(iter);
+  }
+}
+
+void TrkrHitSetContainerv2::removeHitSet(TrkrHitSet* hitset)
+{
+  removeHitSet(hitset->getHitSetKey());
+}
+
+TrkrHitSetContainerv2::ConstRange
+TrkrHitSetContainerv2::getHitSets(const TrkrDefs::TrkrId trackerid) const
+{
+  syncMapArray();
+  const TrkrDefs::hitsetkey keylo = TrkrDefs::getHitSetKeyLo(trackerid);
+  const TrkrDefs::hitsetkey keyhi = TrkrDefs::getHitSetKeyHi(trackerid);
+  return std::make_pair(m_hitmap.lower_bound(keylo), m_hitmap.upper_bound(keyhi));
+}
+
+TrkrHitSetContainerv2::ConstRange
+TrkrHitSetContainerv2::getHitSets(const TrkrDefs::TrkrId trackerid, const uint8_t layer) const
+{
+  syncMapArray();
+  TrkrDefs::hitsetkey keylo = TrkrDefs::getHitSetKeyLo(trackerid, layer);
+  TrkrDefs::hitsetkey keyhi = TrkrDefs::getHitSetKeyHi(trackerid, layer);
+  return std::make_pair(m_hitmap.lower_bound(keylo), m_hitmap.upper_bound(keyhi));
+}
+
+TrkrHitSetContainerv2::ConstRange
+TrkrHitSetContainerv2::getHitSets() const
+{
+  syncMapArray();
+  return std::make_pair(m_hitmap.cbegin(), m_hitmap.cend());
+}
+
+TrkrHitSetContainerv2::Iterator
+TrkrHitSetContainerv2::findOrAddHitSet(TrkrDefs::hitsetkey key)
+{
+  syncMapArray();
+  auto it = m_hitmap.lower_bound(key);
+  if (it == m_hitmap.end() || (key < it->first))
+  {
+    TrkrHitSet* hitset = (TrkrHitSet*) m_hitArray.ConstructedAt(m_hitArray.GetSize());
+    assert(hitset);
+
+    it = m_hitmap.insert(it, std::make_pair(key, hitset));
+    it->second->setHitSetKey(key);
+  }
+  return it;
+}
+
+TrkrHitSet*
+TrkrHitSetContainerv2::findHitSet(TrkrDefs::hitsetkey key)
+{
+  syncMapArray();
+  auto it = m_hitmap.find(key);
+  if (it != m_hitmap.end())
+  {
+    return it->second;
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+void TrkrHitSetContainerv2::syncMapArray(void) const
+{
+  if (m_hitmap.size() == (size_t) m_hitArray.GetSize()) return;
+
+  if (m_hitmap.size() > 0)
+  {
+    std::cout
+        << __PRETTY_FUNCTION__ << " Error: m_hitmap and m_hitArray get out of sync, which should not happen unless DST readback. "
+        << "m_hitmap.size( ) = " << m_hitmap.size() << " m_hitArray.GetSize() = " << m_hitArray.GetSize() << std::endl;
+  }
+
+  for (int i = 0; i < m_hitArray.GetSize(); ++i)
+  {
+    TrkrHitSet* hitset = static_cast<TrkrHitSet*>(m_hitArray[i]);
+
+    assert(hitset);
+
+    m_hitmap[hitset->getHitSetKey()] = hitset;
+  }
+}

--- a/offline/packages/trackbase/TrkrHitSetContainerv2.h
+++ b/offline/packages/trackbase/TrkrHitSetContainerv2.h
@@ -1,0 +1,74 @@
+#ifndef TRACKBASE_TrkrHitSetContainerv2_H
+#define TRACKBASE_TrkrHitSetContainerv2_H
+
+#include "TrkrDefs.h"
+#include "TrkrHitSetContainer.h"
+
+#include <TClonesArray.h>
+#include <iostream>  // for cout, ostream
+#include <map>
+#include <string>   // for pair
+#include <utility>  // for pair
+
+class TrkrHitSet;
+
+/**
+ * IO and memory efficient container using TClonesArray
+ * TrkrHitSet used in this container must impliment TrkrHitSet::Clear() function for fast reset without calling ~TrkrHitSet()
+ */
+class TrkrHitSetContainerv2 final : public TrkrHitSetContainer
+{
+ private:
+  //! only used in ROOT IO
+  TrkrHitSetContainerv2() = default;
+
+ public:
+  TrkrHitSetContainerv2(const std::string& hitsetclass);
+
+  ~TrkrHitSetContainerv2() override
+  {
+  }
+
+  void Reset() override;
+
+  void identify(std::ostream& = std::cout) const override;
+
+  ConstIterator addHitSet(TrkrHitSet*) override;
+
+  ConstIterator addHitSetSpecifyKey(const TrkrDefs::hitsetkey, TrkrHitSet*) override;
+
+  //! Add a TrkrHitSet to TrkrHitSetContainerv2, return the iterater to the newly constructed TrkrHitSet
+  ConstIterator addHitSetSpecifyKey(const TrkrDefs::hitsetkey key);
+
+  void removeHitSet(TrkrDefs::hitsetkey) override;
+
+  void removeHitSet(TrkrHitSet*) override;
+
+  Iterator findOrAddHitSet(TrkrDefs::hitsetkey key) override;
+
+  ConstRange getHitSets(const TrkrDefs::TrkrId trackerid) const override;
+
+  ConstRange getHitSets(const TrkrDefs::TrkrId trackerid, const uint8_t layer) const override;
+
+  ConstRange getHitSets() const override;
+
+  TrkrHitSet* findHitSet(TrkrDefs::hitsetkey key) override;
+
+  unsigned int size() const override
+  {
+    return m_hitArray.GetSize();
+  }
+
+ private:
+  //! endure m_hitmap and m_hitArray are in sync, in particular m_hitmap need rebuild after reading back from the DST
+  void syncMapArray(void) const;
+
+  //! used for indexing only, not used in storage. syncMapArray(void) rebuilds the map after DST readback
+  mutable Map m_hitmap;  //!
+
+  TClonesArray m_hitArray;
+
+  ClassDefOverride(TrkrHitSetContainerv2, 1)
+};
+
+#endif  // TRACKBASE_TrkrHitSetContainerv2_H

--- a/offline/packages/trackbase/TrkrHitSetContainerv2LinkDef.h
+++ b/offline/packages/trackbase/TrkrHitSetContainerv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrHitSetContainerv2+;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase/TrkrHitSetTpc.cc
+++ b/offline/packages/trackbase/TrkrHitSetTpc.cc
@@ -1,0 +1,38 @@
+/**
+ * @file trackbase/TrkrHitSetTpc.cc
+ * @author D. McGlinchey
+ * @date June 2018
+ * @brief Implementation of TrkrHitSetTpc
+ */
+#include "TrkrHitSetTpc.h"
+#include "TrkrHit.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>  // for exit
+#include <iostream>
+#include <type_traits>  // for __decay_and_strip<>::__type
+
+void TrkrHitSetTpc::identify(std::ostream& os) const
+{
+  os
+      << "TrkrHitSetTpc: "
+      << "       hitsetkey " << getHitSetKey()
+      << std::endl;
+}
+
+TpcDefs::ADCDataType& TrkrHitSetTpc::getTpcADC(TrkrDefs::hitkey key)
+{
+  const uint16_t pad = TpcDefs ::getPad(key);
+  const uint16_t tbin = TpcDefs ::getTBin(key);
+
+  return getTpcADC(pad, tbin);
+}
+
+const TpcDefs::ADCDataType& TrkrHitSetTpc::getTpcADC(TrkrDefs::hitkey key) const
+{
+  const uint16_t pad = TpcDefs ::getPad(key);
+  const uint16_t tbin = TpcDefs ::getTBin(key);
+
+  return getTpcADC(pad, tbin);
+}

--- a/offline/packages/trackbase/TrkrHitSetTpc.h
+++ b/offline/packages/trackbase/TrkrHitSetTpc.h
@@ -1,0 +1,81 @@
+#ifndef TRACKBASE_TrkrHitSetTpc_H
+#define TRACKBASE_TrkrHitSetTpc_H
+
+#include "TpcDefs.h"
+#include "TrkrDefs.h"
+#include "TrkrHitSet.h"
+
+#include <utility>  // for pair
+#include <vector>
+
+// forward declaration
+class TrkrHit;
+
+//! Generalized interface class for vectorized TPC data time frame storage
+class TrkrHitSetTpc : public TrkrHitSet
+{
+ public:
+  typedef std::vector<std::vector<TpcDefs::ADCDataType> > TimeFrameADCDataType;
+
+  TrkrHitSetTpc() = default;
+
+  TrkrHitSetTpc(const unsigned int /*n_pad*/, const unsigned int /*n_tbin*/) {}
+
+  ~TrkrHitSetTpc() override
+  {
+  }
+
+  virtual void identify(std::ostream& os = std::cout) const override;
+
+  virtual void Resize(const unsigned int /*n_pad*/, const unsigned int /*n_tbin*/) {}
+
+  TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey);
+
+  const TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey) const;
+
+  virtual TpcDefs::ADCDataType& getTpcADC(const uint16_t /*pad*/, const uint16_t /*tbin*/)
+  {
+    static TpcDefs::ADCDataType v = 0;
+    return v;
+  };
+
+  virtual const TpcDefs::ADCDataType& getTpcADC(const uint16_t /*pad*/, const uint16_t /*tbin*/) const
+  {
+    static TpcDefs::ADCDataType v = 0;
+    return v;
+  };
+
+  virtual unsigned int getNPads() const
+  {
+    return 0;
+  }
+
+  virtual void setNPads(unsigned int /*nPads*/)
+  {
+  }
+
+  virtual const TimeFrameADCDataType& getTimeFrameAdcData() const
+  {
+    static TimeFrameADCDataType tmp;
+
+    return tmp;
+  }
+
+  virtual void setTimeFrameAdcData(const TimeFrameADCDataType&)
+  {
+  }
+
+  virtual unsigned int getTBins() const
+  {
+    return 0;
+  }
+
+  virtual void setTBins(unsigned int /*tBins*/)
+  {
+  }
+
+ private:
+  ClassDefOverride(TrkrHitSetTpc, 1);
+};
+
+#endif  // TRACKBASE_TrkrHitSetTpc_H

--- a/offline/packages/trackbase/TrkrHitSetTpcLinkDef.h
+++ b/offline/packages/trackbase/TrkrHitSetTpcLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrHitSetTpc+;
+
+#endif

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.cc
@@ -24,11 +24,13 @@ void TrkrHitSetTpcv1::Reset()
 }
 void TrkrHitSetTpcv1::Resize(const unsigned int n_pad, const unsigned int n_tbin)
 {
-  m_timeFrameADCData.resize(n_pad);
+  if (n_pad != m_timeFrameADCData.size())
+    m_timeFrameADCData.resize(n_pad);
 
   for (auto& pad : m_timeFrameADCData)
   {
-    pad.resize(n_tbin);
+    if (n_tbin != pad.size())
+      pad.resize(n_tbin);
   }
 
   Reset();

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.cc
@@ -1,0 +1,145 @@
+/**
+ * @file trackbase/TrkrHitSetTpcv1.cc
+ * @author D. McGlinchey
+ * @date June 2018
+ * @brief Implementation of TrkrHitSetTpcv1
+ */
+#include "TrkrHitSetTpcv1.h"
+#include "TrkrHit.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>  // for exit
+#include <iostream>
+#include <type_traits>  // for __decay_and_strip<>::__type
+
+void TrkrHitSetTpcv1::Reset()
+{
+  m_hitSetKey = TrkrDefs::HITSETKEYMAX;
+
+  for (auto& pad : m_timeFrameADCData)
+  {
+    std::fill(pad.begin(), pad.end(), 0);
+  }
+}
+void TrkrHitSetTpcv1::Resize(const unsigned int n_pad, const unsigned int n_tbin)
+{
+  m_timeFrameADCData.resize(n_pad);
+
+  for (auto& pad : m_timeFrameADCData)
+  {
+    pad.resize(n_tbin);
+  }
+
+  Reset();
+}
+
+void TrkrHitSetTpcv1::identify(std::ostream& os) const
+{
+  const unsigned int layer = TrkrDefs::getLayer(m_hitSetKey);
+  const unsigned int trkrid = TrkrDefs::getTrkrId(m_hitSetKey);
+
+  os
+      << "TrkrHitSetTpcv1: "
+      << "       hitsetkey " << getHitSetKey()
+      << " TrkrId " << trkrid
+      << " layer " << layer
+      << " m_nPads: " << m_nPads
+      << " n_tBins: " << n_tBins
+      << std::endl;
+
+  //  for( const auto& entry : m_hits )
+  //  {
+  //    std::cout << " hitkey " << entry.first << std::endl;
+  //    (entry.second)->identify(os);
+  //  }
+
+  for (int i = 0; i < m_nPads; ++i)
+  {
+    os << "Pad " << i << ":";
+
+    for (const auto& adc : m_timeFrameADCData[i])
+    {
+      os << "\t" << adc;
+    }
+    os << std::endl;
+  }
+}
+
+TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(TrkrDefs::hitkey key)
+{
+  const uint16_t pad = TpcDefs ::getPad(key);
+  const uint16_t tbin = TpcDefs ::getTBin(key);
+
+  return getTpcADC(pad, tbin);
+}
+
+const TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(TrkrDefs::hitkey key) const
+{
+  const uint16_t pad = TpcDefs ::getPad(key);
+  const uint16_t tbin = TpcDefs ::getTBin(key);
+
+  return getTpcADC(pad, tbin);
+}
+
+TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(const uint16_t pad, const uint16_t tbin)
+{
+  assert(pad < m_nPads);
+  assert(tbin < n_tBins);
+
+  return m_timeFrameADCData[pad][tbin];
+}
+
+const TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(const uint16_t pad, const uint16_t tbin) const
+{
+  assert(pad < m_nPads);
+  assert(tbin < n_tBins);
+
+  return m_timeFrameADCData[pad][tbin];
+}
+
+void TrkrHitSetTpcv1::removeHit(TrkrDefs::hitkey key)
+{
+  getTpcADC(key) = 0;
+}
+
+TrkrHitSetTpcv1::ConstIterator
+TrkrHitSetTpcv1::addHitSpecificKey(const TrkrDefs::hitkey key, TrkrHit* hit)
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+
+  if (hit)
+  {
+    getTpcADC(key) = hit->getAdc();
+    delete hit;
+  }
+
+  return TrkrHitSet::addHitSpecificKey(key, hit);
+}
+
+TrkrHit*
+TrkrHitSetTpcv1::getHit(const TrkrDefs::hitkey key) const
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+
+  exit(1);
+  TrkrHitSetTpcv1::ConstIterator it = m_hits.find(key);
+
+  if (it != m_hits.end())
+    return it->second;
+  else
+    return nullptr;
+}
+
+TrkrHitSetTpcv1::ConstRange
+TrkrHitSetTpcv1::getHits() const
+{
+  std::cout << __PRETTY_FUNCTION__
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+
+  exit(1);
+
+  return TrkrHitSet::getHits();
+}

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.cc
@@ -95,11 +95,7 @@ TrkrHitSetTpcv1::addHitSpecificKey(const TrkrDefs::hitkey key, TrkrHit* hit)
   std::cout << __PRETTY_FUNCTION__
             << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << std::endl;
 
-  if (hit)
-  {
-    getTpcADC(key) = hit->getAdc();
-    delete hit;
-  }
+  exit(1);
 
   return TrkrHitSetTpc::addHitSpecificKey(key, hit);
 }

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.cc
@@ -54,7 +54,7 @@ void TrkrHitSetTpcv1::identify(std::ostream& os) const
   //    (entry.second)->identify(os);
   //  }
 
-  for (int i = 0; i < m_nPads; ++i)
+  for (unsigned int i = 0; i < m_nPads; ++i)
   {
     os << "Pad " << i << ":";
 
@@ -64,22 +64,6 @@ void TrkrHitSetTpcv1::identify(std::ostream& os) const
     }
     os << std::endl;
   }
-}
-
-TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(TrkrDefs::hitkey key)
-{
-  const uint16_t pad = TpcDefs ::getPad(key);
-  const uint16_t tbin = TpcDefs ::getTBin(key);
-
-  return getTpcADC(pad, tbin);
-}
-
-const TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(TrkrDefs::hitkey key) const
-{
-  const uint16_t pad = TpcDefs ::getPad(key);
-  const uint16_t tbin = TpcDefs ::getTBin(key);
-
-  return getTpcADC(pad, tbin);
 }
 
 TpcDefs::ADCDataType& TrkrHitSetTpcv1::getTpcADC(const uint16_t pad, const uint16_t tbin)
@@ -107,7 +91,7 @@ TrkrHitSetTpcv1::ConstIterator
 TrkrHitSetTpcv1::addHitSpecificKey(const TrkrDefs::hitkey key, TrkrHit* hit)
 {
   std::cout << __PRETTY_FUNCTION__
-            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << std::endl;
 
   if (hit)
   {
@@ -115,31 +99,27 @@ TrkrHitSetTpcv1::addHitSpecificKey(const TrkrDefs::hitkey key, TrkrHit* hit)
     delete hit;
   }
 
-  return TrkrHitSet::addHitSpecificKey(key, hit);
+  return TrkrHitSetTpc::addHitSpecificKey(key, hit);
 }
 
 TrkrHit*
 TrkrHitSetTpcv1::getHit(const TrkrDefs::hitkey key) const
 {
   std::cout << __PRETTY_FUNCTION__
-            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << std::endl;
 
   exit(1);
-  TrkrHitSetTpcv1::ConstIterator it = m_hits.find(key);
 
-  if (it != m_hits.end())
-    return it->second;
-  else
-    return nullptr;
+  return TrkrHitSetTpc::getHit(key);
 }
 
 TrkrHitSetTpcv1::ConstRange
 TrkrHitSetTpcv1::getHits() const
 {
   std::cout << __PRETTY_FUNCTION__
-            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << endl;
+            << " : This function is deprecated! Please use getTpcADC(TrkrDefs::hitkey key)" << std::endl;
 
   exit(1);
 
-  return TrkrHitSet::getHits();
+  return TrkrHitSetTpc::getHits();
 }

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.h
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.h
@@ -1,9 +1,7 @@
 #ifndef TRACKBASE_TrkrHitSetTpcv1_H
 #define TRACKBASE_TrkrHitSetTpcv1_H
 
-#include "TpcDefs.h"
-#include "TrkrDefs.h"
-#include "TrkrHitSet.h"
+#include "TrkrHitSetTpc.h"
 
 #include <utility>  // for pair
 #include <vector>
@@ -12,12 +10,16 @@
 class TrkrHit;
 
 //! Vectorized TPC data time frame storage
-class TrkrHitSetTpcv1 : public TrkrHitSet
+class TrkrHitSetTpcv1 final : public TrkrHitSetTpc
 {
  public:
   TrkrHitSetTpcv1() = default;
 
-  TrkrHitSetTpcv1(const unsigned int n_pad, const unsigned int n_tbin) { Resize(n_pad, n_tbin); }
+  TrkrHitSetTpcv1(const unsigned int n_pad, const unsigned int n_tbin)
+    : TrkrHitSetTpc(n_pad, n_tbin)
+  {
+    Resize(n_pad, n_tbin);
+  }
 
   ~TrkrHitSetTpcv1() override
   {
@@ -25,7 +27,10 @@ class TrkrHitSetTpcv1 : public TrkrHitSet
 
   void identify(std::ostream& os = std::cout) const override;
 
-  void Resize(const unsigned int n_pad, const unsigned int n_tbin);
+  void Resize(const unsigned int n_pad, const unsigned int n_tbin) override;
+
+  //! For ROOT TClonesArray end of event Operation
+  void Clear(Option_t* /*option*/ = "") override { Reset(); }
 
   void Reset() override;
 
@@ -39,13 +44,12 @@ class TrkrHitSetTpcv1 : public TrkrHitSet
     return m_hitSetKey;
   }
 
-  TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey);
+  // legacy TrkrDefs::hitkey accesses
+  using TrkrHitSetTpc::getTpcADC;
 
-  const TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey) const;
+  TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin) override;
 
-  TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin);
-
-  const TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin) const;
+  const TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin) const override;
 
   ConstIterator addHitSpecificKey(const TrkrDefs::hitkey, TrkrHit*) override;
 
@@ -57,35 +61,35 @@ class TrkrHitSetTpcv1 : public TrkrHitSet
 
   unsigned int size() const override
   {
-    return m_hits.size();
+    return m_nPads * n_tBins;
   }
 
-  unsigned int getNPads() const
+  unsigned int getNPads() const override
   {
     return m_nPads;
   }
 
-  void setNPads(unsigned int nPads = 0)
+  void setNPads(unsigned int nPads = 0) override
   {
     m_nPads = nPads;
   }
 
-  const std::vector<std::vector<TpcDefs::ADCDataType> >& getTimeFrameAdcData() const
+  const TimeFrameADCDataType& getTimeFrameAdcData() const override
   {
     return m_timeFrameADCData;
   }
 
-  void setTimeFrameAdcData(const std::vector<std::vector<TpcDefs::ADCDataType> >& timeFrameAdcData)
+  void setTimeFrameAdcData(const TimeFrameADCDataType& timeFrameAdcData) override
   {
     m_timeFrameADCData = timeFrameAdcData;
   }
 
-  unsigned int getTBins() const
+  unsigned int getTBins() const override
   {
     return n_tBins;
   }
 
-  void setTBins(unsigned int tBins = 0)
+  void setTBins(unsigned int tBins = 0) override
   {
     n_tBins = tBins;
   }
@@ -97,7 +101,7 @@ class TrkrHitSetTpcv1 : public TrkrHitSet
   /// vector storage of TPC timeframe without zero suppression
   // Top level indexes are vectors of pads
   // Lower level indexes are vectors of time bin
-  std::vector<std::vector<TpcDefs::ADCDataType> > m_timeFrameADCData;
+  TimeFrameADCDataType m_timeFrameADCData;
 
   unsigned int m_nPads = 0;
   unsigned int n_tBins = 0;

--- a/offline/packages/trackbase/TrkrHitSetTpcv1.h
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1.h
@@ -1,0 +1,108 @@
+#ifndef TRACKBASE_TrkrHitSetTpcv1_H
+#define TRACKBASE_TrkrHitSetTpcv1_H
+
+#include "TpcDefs.h"
+#include "TrkrDefs.h"
+#include "TrkrHitSet.h"
+
+#include <utility>  // for pair
+#include <vector>
+
+// forward declaration
+class TrkrHit;
+
+//! Vectorized TPC data time frame storage
+class TrkrHitSetTpcv1 : public TrkrHitSet
+{
+ public:
+  TrkrHitSetTpcv1() = default;
+
+  TrkrHitSetTpcv1(const unsigned int n_pad, const unsigned int n_tbin) { Resize(n_pad, n_tbin); }
+
+  ~TrkrHitSetTpcv1() override
+  {
+  }
+
+  void identify(std::ostream& os = std::cout) const override;
+
+  void Resize(const unsigned int n_pad, const unsigned int n_tbin);
+
+  void Reset() override;
+
+  void setHitSetKey(const TrkrDefs::hitsetkey key) override
+  {
+    m_hitSetKey = key;
+  }
+
+  TrkrDefs::hitsetkey getHitSetKey() const override
+  {
+    return m_hitSetKey;
+  }
+
+  TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey);
+
+  const TpcDefs::ADCDataType& getTpcADC(const TrkrDefs::hitkey) const;
+
+  TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin);
+
+  const TpcDefs::ADCDataType& getTpcADC(const uint16_t pad, const uint16_t tbin) const;
+
+  ConstIterator addHitSpecificKey(const TrkrDefs::hitkey, TrkrHit*) override;
+
+  void removeHit(TrkrDefs::hitkey) override;
+
+  TrkrHit* getHit(const TrkrDefs::hitkey) const override;
+
+  ConstRange getHits() const override;
+
+  unsigned int size() const override
+  {
+    return m_hits.size();
+  }
+
+  unsigned int getNPads() const
+  {
+    return m_nPads;
+  }
+
+  void setNPads(unsigned int nPads = 0)
+  {
+    m_nPads = nPads;
+  }
+
+  const std::vector<std::vector<TpcDefs::ADCDataType> >& getTimeFrameAdcData() const
+  {
+    return m_timeFrameADCData;
+  }
+
+  void setTimeFrameAdcData(const std::vector<std::vector<TpcDefs::ADCDataType> >& timeFrameAdcData)
+  {
+    m_timeFrameADCData = timeFrameAdcData;
+  }
+
+  unsigned int getTBins() const
+  {
+    return n_tBins;
+  }
+
+  void setTBins(unsigned int tBins = 0)
+  {
+    n_tBins = tBins;
+  }
+
+ private:
+  /// unique key for this object
+  TrkrDefs::hitsetkey m_hitSetKey = TrkrDefs::HITSETKEYMAX;
+
+  /// vector storage of TPC timeframe without zero suppression
+  // Top level indexes are vectors of pads
+  // Lower level indexes are vectors of time bin
+  std::vector<std::vector<TpcDefs::ADCDataType> > m_timeFrameADCData;
+
+  unsigned int m_nPads = 0;
+  unsigned int n_tBins = 0;
+
+  ClassDefOverride(TrkrHitSetTpcv1, 1);
+};
+
+#endif  // TRACKBASE_TrkrHitSetTpcv1_H

--- a/offline/packages/trackbase/TrkrHitSetTpcv1LinkDef.h
+++ b/offline/packages/trackbase/TrkrHitSetTpcv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrHitSetTpcv1+;
+
+#endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As [discussed with the tracking group ](https://indico.bnl.gov/event/18555/#1-tpc-signal-processing), there are multiple problems of using `TrkrHitSet` to represent TPC data, which uses `stl::map` of `TrkrHit *` for sparse encoding. It may fit silicon tracker well, but for TPC, it is dramatically wasteful for storage (uses 10x memory to store 2-byte ADC number) and slow for operation (`log(n)` for insertion/access, and calls allocation/deallocation). It also potentially leads to memory fragmentation with millions `new`/`delete` of `TrkrHitv2` per event.

This pull request introduce a concept to use static objects to store TPC data: 
* at `TrkrHitSet` level, `TrkrHitSetTpc` and `TrkrHitSetTpcv1` is introduced to use 2D nested `stl::vector` to store a non-zero suppressed TPC time frame, avoiding the use of `TrkrHit` for TPC
* At `TrkrHitSetContainer` level,  `TrkrHitSetContainerv2` use a `TClonesArray` backend for `TrkrHitSet` storage, which optimize for ROOT IO and AVOIDs allocation/ctor/dtor calls for `TrkrHitSetTpc`. The `stl::map` based assess interface is preserved with automatic map rebuild at DST readback.

This approach is aimed to deliver multiple advantage over the current treatment of the TPC data: 
* Reflect what TPC data attempt to represent: pad-time 2D array of ADC time-frame per layer of pads
* Fast hit access with array at `O(1)` speed
* 82MB fixed size memory for AuAu TPC hit data
* No map/TObject/allocator overhead associated with `TrkrHit`
* No memory fragmentation with repeated `new`/`delete` on heap
* It is also [easier to use with digitizer code](https://github.com/sPHENIX-Collaboration/coresoftware/commit/da9ddfea9e30672696b93442af1838c0365c06a5#diff-9d26dd1e18b714726a0505dc6bee180009859671e25ebec17153096823b633b1R647) and better fit clusterizer (which decode hits into 2D arrays anyway)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

**Discuss, test, debug and optimize**

In particular, integration with the digitizer and clusterizer code. We potentially would benifit from a redefine of pad and tbin for `TrkrHitSetTpc` that represent the relative position within the `TrkrHitSet` rather than global index. @adfrawley @bogui56 

Also the TPC sector test data, which is represented as time frames, can be easily ported to this structure: 
https://github.com/sPHENIX-Collaboration/calibrations/pull/117 

## Links to other PRs in macros and calibration repositories (if applicable)

