### PR TITLE
use std::optional to detect extrapolation failures.

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -13,6 +13,7 @@
 #include <Acts/EventData/TrackParameters.hpp>
 
 #include <memory>
+#include <optional>
 
 class PHCompositeNode;
 class SvtxTrack;
@@ -106,7 +107,7 @@ class PHTpcResiduals : public SubsysReco
    * matching propagation
    * returns the path lenght and the resulting parameters
    */
-  BoundTrackParamPair propagateTrackState( const Acts::BoundTrackParameters& params, const Surface& surf ) const;
+  std::optional<BoundTrackParamPair> propagateTrackState( const Acts::BoundTrackParameters& params, const Surface& surf ) const;
 
   /// Gets distortion cell for identifying bins in TPC
   int getCell(const Acts::Vector3& loc);


### PR DESCRIPTION
The old code was crashing with latest versions of ACTS because one cannot create a BoundTrackParameter with a nullptr surface (failed assert)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

