### PR TITLE
ALICEKF cosmics compatibility changes

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -552,7 +552,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     J(5,2) = 0.; // dpz/d(sinphi)
     J(5,3) = track_pt; // dpz/d(dz/ds)
     J(5,4) = -track_pt*track_pt*track_charge*d; // dpz/d(Q/pt)
-    bool cov_rot_nan = false;
+/*    bool cov_rot_nan = false;
     for(int i=0;i<6;i++)
     {
       for(int j=0;j<5;j++)
@@ -565,7 +565,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
       }
     }
     if(cov_rot_nan) continue;
-
+*/
     // the heavy lifting happens here
     Eigen::Matrix<double,6,6> scov = J*ecov*J.transpose();
     if(!covIsPosDef(scov))


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
A check on the elements of the transformation between the local-coordinates and global-coordinates covariance matrices has been interfering with cosmics reconstruction. If there's a problem with these elements, then the offending seed is currently thrown out. Now that the covariance matrix is not included in the TrackSeed object, and is effectively discarded after the seeding stage anyway, this check is no longer necessary, both in cosmics reconstruction and in the general tracking chain. This PR removes that check.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

