### PR TITLE
Introduce PHSiliconHelicalPropagator

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -68,6 +68,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);
   void getTrackletClusters(TrackSeed *_track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
   Acts::Vector3 get_helix_pca(std::vector<float>& fitpars, Acts::Vector3 global);
+  unsigned int addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
  private:
 
@@ -96,7 +97,6 @@ Mille* _mille;
   void printBuffers(int index, Acts::Vector3 residual, Acts::Vector3 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[]);
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
-  unsigned int addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
   TpcDistortionCorrectionContainer* _dcc_static{nullptr};

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
@@ -1,0 +1,85 @@
+#include "PHSiliconHelicalPropagator.h"
+
+#include <trackbase_historic/TrackSeed_v1.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+PHSiliconHelicalPropagator::PHSiliconHelicalPropagator(std::string name) : SubsysReco(name)
+{
+  _fitter = new HelicalFitter();
+}
+
+PHSiliconHelicalPropagator::~PHSiliconHelicalPropagator()
+{
+  delete _fitter;
+}
+
+int PHSiliconHelicalPropagator::InitRun(PHCompositeNode* topNode)
+{
+  _fitter->InitRun(topNode);
+
+  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!_cluster_map)
+  {
+    std::cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  _tgeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if(!_tgeometry)
+  {
+    std::cout << "No Acts tracking geometry, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  _si_seeds = findNode::getClass<TrackSeedContainer>(topNode,"SiliconTrackSeedContainer");
+  if(!_si_seeds)
+  {
+    std::cout << "No SiliconTrackSeedContainer, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  _track_map = findNode::getClass<SvtxTrackMap>(topNode,_track_map_name);
+  if(!_track_map)
+  {
+    std::cout << "No track map found, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconHelicalPropagator::process_event(PHCompositeNode* /*topNode*/)
+{
+  for(SvtxTrackMap::Iter track_iter = _track_map->begin(); track_iter != _track_map->end(); ++track_iter)
+  {
+    SvtxTrack* track = track_iter->second;
+    if(!track) continue;
+
+    std::vector<Acts::Vector3> clusterPositions;
+    std::vector<TrkrDefs::cluskey> clusterKeys;
+    TrackSeed* tpcseed = track->get_tpc_seed();
+    _fitter->getTrackletClusters(tpcseed,clusterPositions,clusterKeys);
+    std::vector<float> fitparams = _fitter->fitClusters(clusterPositions,clusterKeys);
+    
+    std::vector<TrkrDefs::cluskey> si_clusterKeys;
+    std::vector<Acts::Vector3> si_clusterPositions;
+    unsigned int nSiClusters = _fitter->addSiliconClusters(fitparams,si_clusterPositions,si_clusterKeys);
+    if(Verbosity()>0) std::cout << "adding " << nSiClusters << " cluster keys" << std::endl;
+    
+    std::unique_ptr<TrackSeed_v1> si_seed = std::make_unique<TrackSeed_v1>();
+    for(auto clusterkey : si_clusterKeys)
+    {
+      si_seed->insert_cluster_key(clusterkey);
+    }
+    si_seed->circleFitByTaubin(_cluster_map,_tgeometry,0,8);
+    si_seed->lineFit(_cluster_map,_tgeometry,0,8);
+    
+    TrackSeed* mapped_seed = _si_seeds->insert(si_seed.get());
+    
+    track->set_silicon_seed(mapped_seed);
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconHelicalPropagator::End(PHCompositeNode* /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.h
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.h
@@ -1,0 +1,26 @@
+#include <trackreco/PHTrackPropagating.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackermillepedealignment/HelicalFitter.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+class PHSiliconHelicalPropagator : public SubsysReco
+{
+public:
+
+  PHSiliconHelicalPropagator(std::string name = "PHSiliconHelicalPropagator");
+  ~PHSiliconHelicalPropagator();
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+
+  void set_track_map_name(std::string name){ _track_map_name = name; }
+private:
+  ActsGeometry* _tgeometry = nullptr;
+  TrackSeedContainer* _si_seeds = nullptr;
+  HelicalFitter* _fitter = nullptr;
+  TrkrClusterContainer* _cluster_map = nullptr;
+  SvtxTrackMap* _track_map = nullptr;
+  std::string _track_map_name = "SvtxTrackMap";
+};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
For cosmics tracking, we use the HelicalFitter class to find silicon clusters associated with a given TPC seed. The module PHSiliconHelicalPropagator does this, modifying existing SvtxTracks (converted from TPC seeds) to insert a corresponding silicon seed.

This PR also makes HelicalFitter::addSiliconClusters a public method, as it's needed by this module.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

