### PR TITLE
Fix scan build error

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -545,7 +545,9 @@ void MakeActsGeometry::setMaterialResponseFile(std::string& responseFile,
       std::cout << materialFile 
 		<< " not found locally, use repo version" 
 		<< std::endl;
-      materialFile = std::string(getenv("CALIBRATIONROOT")) +
+      const char* calibrationroot = getenv("CALIBRATIONROOT");
+      assert(calibrationroot);
+      materialFile = std::string(calibrationroot) +
 	("/ACTS/sphenix-mm-material.json");
     }
   

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -231,7 +231,10 @@ void PHCASeeding::QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>> &rtre
 
 PositionMap PHCASeeding::FillTree()
 { 
-  std::cout << "fill tree..." << std::endl;
+  if(Verbosity()>1)
+    {
+      std::cout << "fill tree..." << std::endl;
+    }
   t_fill->stop();
   int n_dupli = 0;
   int nlayer[60];
@@ -298,7 +301,10 @@ PositionMap PHCASeeding::FillTree()
 
 int PHCASeeding::Process(PHCompositeNode */*topNode*/)
 {
-  std::cout << " Process...  " << std::endl;
+  if(Verbosity() > 1)
+    {
+      std::cout << " Process...  " << std::endl;
+    }
 //  TFile fpara("CA_para.root", "RECREATE");
   if(_n_iteration>0){
     if (!_iteration_map){


### PR DESCRIPTION
Remove print out from CASeeder

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Fixes the scan build error introduced by me and somehow not caught by jenkins on the initial PR and also removes some verbosity from tpc seeding.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

