### PR TITLE
Redesign PHSiliconHelicalPropagator for micromegas matching compatibility

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -49,6 +49,7 @@ pkginclude_HEADERS = \
   PHTrackCleaner.h \
   PHTrackSelector.h \
   PHRaveVertexing.h \
+  PHSiliconHelicalPropagator.h \
   PHSiliconSeedMerger.h \
   PHSiliconTruthTrackSeeding.h \
   PHSimpleKFProp.h \
@@ -120,6 +121,7 @@ libtrack_reco_la_SOURCES = \
   PHInitVertexing.cc \
   PHMicromegasTpcTrackMatching.cc \
   PHRaveVertexing.cc \
+  PHSiliconHelicalPropagator.cc \
   PHSiliconSeedMerger.cc \
   PHSiliconTpcTrackMatching.cc \
   PHSiliconTruthTrackSeeding.cc \
@@ -167,7 +169,8 @@ libtrack_reco_la_LIBADD = \
   -ltrack_io \
   -ltrackbase_historic_io \
   -lcalo_io \
-  -lphparameter
+  -lphparameter \
+  -ltrackeralign
 
 
 # Rule for generating table CINT dictionaries.

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
@@ -1,9 +1,12 @@
 #include "PHSiliconHelicalPropagator.h"
 
 #include <trackbase_historic/TrackSeed_v1.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/SvtxTrackSeed_v1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
 
 PHSiliconHelicalPropagator::PHSiliconHelicalPropagator(std::string name) : SubsysReco(name)
 {
@@ -31,38 +34,82 @@ int PHSiliconHelicalPropagator::InitRun(PHCompositeNode* topNode)
     std::cout << "No Acts tracking geometry, exiting." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
+  _tpc_seeds = findNode::getClass<TrackSeedContainer>(topNode,"TpcTrackSeedContainer");
+  if(!_tpc_seeds)
+  {
+    std::cout << "No TpcTrackSeedContainer, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
   _si_seeds = findNode::getClass<TrackSeedContainer>(topNode,"SiliconTrackSeedContainer");
   if(!_si_seeds)
   {
-    std::cout << "No SiliconTrackSeedContainer, exiting." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
+    std::cout << "No SiliconTrackSeedContainer, creating..." << std::endl;
+    if(createSeedContainer("SiliconTrackSeedContainer", topNode) != Fun4AllReturnCodes::EVENT_OK)
+    {
+      std::cout << "Cannot create, exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT; 
+    }
   }
-  _track_map = findNode::getClass<SvtxTrackMap>(topNode,_track_map_name);
-  if(!_track_map)
+  _svtx_seeds = findNode::getClass<TrackSeedContainer>(topNode,_track_map_name);
+  if(!_svtx_seeds)
   {
-    std::cout << "No track map found, exiting." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
+    std::cout << "No " << _track_map_name << " found, creating..." << std::endl;
+    if(createSeedContainer(_track_map_name, topNode) != Fun4AllReturnCodes::EVENT_OK)
+    {
+      std::cout << "Cannot create, exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
   }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHSiliconHelicalPropagator::createSeedContainer(std::string container_name, PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  if (!dstNode)
+  {
+    std::cerr << "DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in PHSiliconHelicalPropagator::createNodes");
+  }
+
+  PHNodeIterator dstIter(dstNode);
+  PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", "SVTX"));
+
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  TrackSeedContainer *m_seedContainer = findNode::getClass<TrackSeedContainer>(topNode, container_name);
+  if(!m_seedContainer)
+  {
+    m_seedContainer = new TrackSeedContainer_v1;
+    PHIODataNode<PHObject> *trackNode = new PHIODataNode<PHObject>(m_seedContainer, container_name, "PHObject");
+    svtxNode->addNode(trackNode);
+  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int PHSiliconHelicalPropagator::process_event(PHCompositeNode* /*topNode*/)
 {
-  for(SvtxTrackMap::Iter track_iter = _track_map->begin(); track_iter != _track_map->end(); ++track_iter)
+  for(TrackSeedContainer::ConstIter seed_iter = _tpc_seeds->begin(); seed_iter != _tpc_seeds->end(); ++seed_iter)
   {
-    SvtxTrack* track = track_iter->second;
-    if(!track) continue;
+    TrackSeed* tpcseed = *seed_iter;
+    if(!tpcseed) continue;
 
     std::vector<Acts::Vector3> clusterPositions;
     std::vector<TrkrDefs::cluskey> clusterKeys;
-    TrackSeed* tpcseed = track->get_tpc_seed();
     _fitter->getTrackletClusters(tpcseed,clusterPositions,clusterKeys);
     std::vector<float> fitparams = _fitter->fitClusters(clusterPositions,clusterKeys);
     
     std::vector<TrkrDefs::cluskey> si_clusterKeys;
     std::vector<Acts::Vector3> si_clusterPositions;
     unsigned int nSiClusters = _fitter->addSiliconClusters(fitparams,si_clusterPositions,si_clusterKeys);
-    if(Verbosity()>0) std::cout << "adding " << nSiClusters << " cluster keys" << std::endl;
     
     std::unique_ptr<TrackSeed_v1> si_seed = std::make_unique<TrackSeed_v1>();
     for(auto clusterkey : si_clusterKeys)
@@ -73,8 +120,18 @@ int PHSiliconHelicalPropagator::process_event(PHCompositeNode* /*topNode*/)
     si_seed->lineFit(_cluster_map,_tgeometry,0,8);
     
     TrackSeed* mapped_seed = _si_seeds->insert(si_seed.get());
-    
-    track->set_silicon_seed(mapped_seed);
+
+    std::unique_ptr<SvtxTrackSeed_v1> full_seed = std::make_unique<SvtxTrackSeed_v1>();
+    int tpc_seed_index = _tpc_seeds->index(seed_iter);
+    int si_seed_index = _si_seeds->find(mapped_seed);
+    if(Verbosity()>0)
+    {
+      std::cout << "inserted " << nSiClusters << " silicon clusters for tpc seed " << tpc_seed_index << std::endl;
+      std::cout << "new silicon seed index: " << si_seed_index << std::endl;
+    }
+    full_seed->set_tpc_seed_index(tpc_seed_index);
+    full_seed->set_silicon_seed_index(si_seed_index);
+    _svtx_seeds->insert(full_seed.get());
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.h
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.h
@@ -15,12 +15,18 @@ public:
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
+  int Verbosity() { return _verbosity; }
+  void Verbosity(const int v) { _verbosity = v; }
+
   void set_track_map_name(std::string name){ _track_map_name = name; }
 private:
+  int createSeedContainer(const std::string container_name, PHCompositeNode *topNode);
   ActsGeometry* _tgeometry = nullptr;
   TrackSeedContainer* _si_seeds = nullptr;
+  TrackSeedContainer* _tpc_seeds = nullptr;
+  TrackSeedContainer* _svtx_seeds = nullptr;
   HelicalFitter* _fitter = nullptr;
   TrkrClusterContainer* _cluster_map = nullptr;
-  SvtxTrackMap* _track_map = nullptr;
-  std::string _track_map_name = "SvtxTrackMap";
+  std::string _track_map_name = "SvtxTrackSeedMap";
+  int _verbosity = 0;
 };

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.h
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.h
@@ -15,18 +15,14 @@ public:
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
-  int Verbosity() { return _verbosity; }
-  void Verbosity(const int v) { _verbosity = v; }
-
   void set_track_map_name(std::string name){ _track_map_name = name; }
 private:
-  int createSeedContainer(const std::string container_name, PHCompositeNode *topNode);
+  int createSeedContainer(TrackSeedContainer*& container, const std::string container_name, PHCompositeNode *topNode);
   ActsGeometry* _tgeometry = nullptr;
   TrackSeedContainer* _si_seeds = nullptr;
   TrackSeedContainer* _tpc_seeds = nullptr;
   TrackSeedContainer* _svtx_seeds = nullptr;
   HelicalFitter* _fitter = nullptr;
   TrkrClusterContainer* _cluster_map = nullptr;
-  std::string _track_map_name = "SvtxTrackSeedMap";
-  int _verbosity = 0;
+  std::string _track_map_name = "SvtxTrackSeedContainer";
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
PHSiliconHelicalPropagator originally worked by modifying SvtxTrack objects. This made it incompatible with PHMicromegasTpcTrackMatching, which acts on SvtxTrackSeed objects. This PR converts PHSiliconHelicalPropagator into something that creates SvtxTrackSeeds, so micromegas clusters can be incorporated.

In addition, it now creates the silicon seed container if it's not found, so no silicon seeding module needs to be run beforehand.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

