### PR TITLE
put print statement behind a `if (Verbosity()>5)` to remove excessive output

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -672,7 +672,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode *topNode)
   }
 
   // spit out the truth clusters
-  m_truth_clusterer->print_clusters();
+  if (Verbosity() > 5) m_truth_clusterer->print_clusters();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
This is a bug fix.