### PR TITLE
Added crossing determination to PHSiliconHelicalPropagator

### DIFF
--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.h
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.h
@@ -1,8 +1,8 @@
-#include <trackreco/PHTrackPropagating.h>
 #include <trackbase/ActsGeometry.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 #include <trackermillepedealignment/HelicalFitter.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase/TrkrClusterCrossingAssoc.h>
 
 class PHSiliconHelicalPropagator : public SubsysReco
 {
@@ -18,11 +18,14 @@ public:
   void set_track_map_name(std::string name){ _track_map_name = name; }
 private:
   int createSeedContainer(TrackSeedContainer*& container, const std::string container_name, PHCompositeNode *topNode);
+  
   ActsGeometry* _tgeometry = nullptr;
   TrackSeedContainer* _si_seeds = nullptr;
   TrackSeedContainer* _tpc_seeds = nullptr;
   TrackSeedContainer* _svtx_seeds = nullptr;
   HelicalFitter* _fitter = nullptr;
   TrkrClusterContainer* _cluster_map = nullptr;
+  TrkrClusterCrossingAssoc* _cluster_crossing_map = nullptr;
+
   std::string _track_map_name = "SvtxTrackSeedContainer";
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
In order to match TPOT clusters using current machinery, the crossing of the silicon seed paired with the TPC seed must be known. PHSiliconHelicalPropagator now does this, by choosing the most common crossing associated with the hits in any INTT clusters in the silicon seed.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

