### PR TITLE
Fix constant field in projection

### DIFF
--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -146,14 +146,17 @@ ActsPropagator::FastPropagator ActsPropagator::makeFastPropagator()
 
   if (m_constField)
   {
+    if (m_verbosity > 2)
+    {
+      std::cout << "Using const field of val " << m_fieldval << std::endl;
+    }
     Acts::Vector3 fieldVec(0, 0, m_fieldval);
     field = std::make_shared<Acts::ConstantBField>(fieldVec);
   }
 
-  auto trackingGeometry = m_geometry->geometry().tGeometry;
-  Stepper stepper(field);
+  ActsPropagator::Stepper stepper(field);
 
-  return FastPropagator(stepper);
+  return ActsPropagator::FastPropagator(stepper);
 }
 ActsPropagator::SphenixPropagator ActsPropagator::makePropagator()
 {

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -161,7 +161,7 @@ ActsPropagator::SphenixPropagator ActsPropagator::makePropagator()
 
   if (m_constField)
   {
-    Acts::Vector3 fieldVec(0, 0, 1.4 * Acts::UnitConstants::T);
+    Acts::Vector3 fieldVec(0, 0, m_fieldval);
     field = std::make_shared<Acts::ConstantBField>(fieldVec);
   }
 

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -146,7 +146,7 @@ ActsPropagator::FastPropagator ActsPropagator::makeFastPropagator()
 
   if (m_constField)
   {
-    Acts::Vector3 fieldVec(0, 0, 1.4 * Acts::UnitConstants::T);
+    Acts::Vector3 fieldVec(0, 0, m_fieldval);
     field = std::make_shared<Acts::ConstantBField>(fieldVec);
   }
 

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -57,7 +57,7 @@ class ActsPropagator
                   unsigned int& actsvolume,
                   unsigned int& actslayer);
   void verbosity(int verb) { m_verbosity = verb; }
-
+  void setConstField(float field) { m_fieldval = field; }
  private:
   SphenixPropagator makePropagator();
   FastPropagator makeFastPropagator();
@@ -68,6 +68,8 @@ class ActsPropagator
   bool m_constField = false;
 
   ActsGeometry* m_geometry = nullptr;
+
+  float m_fieldval = -1.4 * Acts::UnitConstants::T;
 };
 
 #endif

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -15,8 +15,8 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <Acts/Propagator/Propagator.hpp>
 #pragma GCC diagnostic pop
-#include <Acts/Propagator/detail/VoidPropagatorComponents.hpp>
 #include <Acts/Propagator/Navigator.hpp>
+#include <Acts/Propagator/detail/VoidPropagatorComponents.hpp>
 
 #include <Acts/Utilities/Result.hpp>
 
@@ -57,7 +57,9 @@ class ActsPropagator
                   unsigned int& actsvolume,
                   unsigned int& actslayer);
   void verbosity(int verb) { m_verbosity = verb; }
-  void setConstField(float field) { m_fieldval = field; }
+  void setConstFieldValue(float field) { m_fieldval = field; }
+  void constField() { m_constField = true; }
+
  private:
   SphenixPropagator makePropagator();
   FastPropagator makeFastPropagator();

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -71,7 +71,7 @@ class ActsPropagator
 
   ActsGeometry* m_geometry = nullptr;
 
-  float m_fieldval = -1.4 * Acts::UnitConstants::T;
+  float m_fieldval = 1.4 * Acts::UnitConstants::T;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -292,7 +292,9 @@ PHActsTrackProjection::propagateTrack(
     const SurfacePtr& targetSurf)
 {
   ActsPropagator propagator(m_tGeometry);
+  propagator.setConstField(true);
   propagator.verbosity(Verbosity());
+  std::cout << "propagating to calo layer " << caloLayer<<std::endl;
   if(caloLayer < 2)
     {
       propagator.setConstField(-1.4*Acts::UnitConstants::T);
@@ -301,6 +303,7 @@ PHActsTrackProjection::propagateTrack(
     {
       propagator.setConstField(1.4*Acts::UnitConstants::T);
     }
+
   return propagator.propagateTrackFast(params, targetSurf);
 }
 

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -129,7 +129,7 @@ int PHActsTrackProjection::projectTracks(const int caloLayer)
     auto cylSurf =
         m_caloSurfaces.find(m_caloNames.at(caloLayer))->second;
 
-    auto result = propagateTrack(params, cylSurf);
+    auto result = propagateTrack(params, caloLayer, cylSurf);
     if (result.ok())
     {
       updateSvtxTrack(result.value(), track, caloLayer);
@@ -288,10 +288,19 @@ void PHActsTrackProjection::getSquareTowerEnergies(int phiBin,
 PHActsTrackProjection::BoundTrackParamResult
 PHActsTrackProjection::propagateTrack(
     const Acts::BoundTrackParameters& params,
+    const int caloLayer,
     const SurfacePtr& targetSurf)
 {
   ActsPropagator propagator(m_tGeometry);
   propagator.verbosity(Verbosity());
+  if(caloLayer < 2)
+    {
+      propagator.setConstField(-1.4*Acts::UnitConstants::T);
+    }
+  else
+    {
+      propagator.setConstField(1.4*Acts::UnitConstants::T);
+    }
   return propagator.propagateTrackFast(params, targetSurf);
 }
 

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -288,21 +288,13 @@ void PHActsTrackProjection::getSquareTowerEnergies(int phiBin,
 PHActsTrackProjection::BoundTrackParamResult
 PHActsTrackProjection::propagateTrack(
     const Acts::BoundTrackParameters& params,
-    const int caloLayer,
+    const int /*caloLayer*/,
     const SurfacePtr& targetSurf)
 {
   ActsPropagator propagator(m_tGeometry);
-  propagator.setConstField(true);
+  propagator.constField();
   propagator.verbosity(Verbosity());
-  std::cout << "propagating to calo layer " << caloLayer<<std::endl;
-  if(caloLayer < 2)
-    {
-      propagator.setConstField(-1.4*Acts::UnitConstants::T);
-    }
-  else
-    {
-      propagator.setConstField(1.4*Acts::UnitConstants::T);
-    }
+  propagator.setConstFieldValue(1.4 * Acts::UnitConstants::T);
 
   return propagator.propagateTrackFast(params, targetSurf);
 }

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -74,6 +74,7 @@ class PHActsTrackProjection : public SubsysReco
   /// Propagate the fitted track parameters to a surface with Acts
   BoundTrackParamResult propagateTrack(
       const Acts::BoundTrackParameters &params,
+      const int caloLayer,
       const SurfacePtr &targetSurf);
 
   /// Set the particular calo nodes depending on which layer


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The track projection module was running with the default field map which only exists in the tracking volume when it should be running with a constant field. This fixes that

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

