### PR TITLE
Adding the TPCHitTrackDisplay module

### DIFF
--- a/offline/packages/TPCHitTrackDisplay/Makefile.am
+++ b/offline/packages/TPCHitTrackDisplay/Makefile.am
@@ -1,0 +1,57 @@
+##############################################
+# please add new classes/includes/everything else in alphabetical order
+
+AUTOMAKE_OPTIONS = foreign
+
+lib_LTLIBRARIES = \
+  libTPCHitTrackDisplay.la
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(G4_MAIN)/include \
+  -I$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
+libTPCHitTrackDisplay_la_LIBADD = \
+  -lphool \
+  -lg4detectors \
+  -lepd \
+  -lcentrality_io \
+  -lphg4hit \
+  -lConstituentSubtractor \
+  -lg4jets_io \
+  -ltrackbase_historic_io \
+  -lSubsysReco \
+  -lcalo_io
+
+pkginclude_HEADERS = \
+  TPCHitTrackDisplay.h
+
+libTPCHitTrackDisplay_la_SOURCES = \
+  TPCHitTrackDisplay.cc
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = \
+  testexternals
+
+BUILT_SOURCES = testexternals.cc
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD = libTPCHitTrackDisplay.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/offline/packages/TPCHitTrackDisplay/TPCHitTrackDisplay.cc
+++ b/offline/packages/TPCHitTrackDisplay/TPCHitTrackDisplay.cc
@@ -1,0 +1,451 @@
+#include "TPCHitTrackDisplay.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/PHTFileServer.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <centrality/CentralityInfo.h>
+#include <centrality/CentralityInfov1.h>
+
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4VtxPoint.h>
+#include <g4main/PHG4Particle.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <trackbase/TrkrCluster.h>
+
+#include <phgeom/PHGeomUtility.h>
+
+#include <TTree.h>
+#include <TH2D.h>
+#include <TVector3.h>
+#include <TRandom3.h>
+#include <TMath.h>
+
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <g4jets/Jet.h>
+#include <g4jets/JetMap.h>
+#include <g4jets/JetMapv1.h>
+#include <g4main/PHG4Utils.h>
+
+#include <iostream>
+#include <cassert>
+#include <fstream>
+#include <sstream>
+#include <boost/format.hpp>
+#include <boost/math/special_functions/sign.hpp>
+
+/*************************************************************/
+/*              TPC Event Display Generator                  */
+/*         Thomas Marshall,Aditya Dash,Ejiro Umaka           */
+/*rosstom@ucla.edu,aditya55@physics.ucla.edu,eumaka1@bnl.gov */
+/*************************************************************/
+
+
+std::ofstream outfile1("TRACKS.json", std::ios::app);
+
+
+using namespace std;
+
+//----------------------------------------------------------------------------//
+//-- Constructor:
+//--  simple initialization
+//----------------------------------------------------------------------------//
+
+TPCHitTrackDisplay::TPCHitTrackDisplay(const string &name) :
+  SubsysReco(name)
+  , m_cut_ADC(200.0)
+  , m_trackless_clusters(true)
+{
+	//initialize
+	_event = 0;
+}
+
+//----------------------------------------------------------------------------//
+//-- Init():
+//--   Intialize all histograms, trees, and ntuples
+//----------------------------------------------------------------------------//
+int TPCHitTrackDisplay::Init(PHCompositeNode *topNode) {
+    
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TPCHitTrackDisplay::InitRun(PHCompositeNode *topNode)
+{
+	return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//----------------------------------------------------------------------------//
+//-- process_event():
+//--   Call user instructions for every event.
+//--   This function contains the analysis structure.
+//----------------------------------------------------------------------------//
+
+int TPCHitTrackDisplay::process_event(PHCompositeNode *topNode)
+{
+	_event++;
+	SimulationOut(topNode);
+	
+       return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//----------------------------------------------------------------------------//
+//-- End():
+//--   End method, wrap everything up
+//----------------------------------------------------------------------------//
+
+int TPCHitTrackDisplay::EndRun(PHCompositeNode *topNode)
+{
+
+    return Fun4AllReturnCodes::EVENT_OK;
+
+}
+
+//Produce json file from raw TPC csv data
+// Will adjust this soon, once TrkrHitSetContainer is updated
+/*
+void TPCHitTrackDisplay::TPCRawOut(PHCompositeNode *topNode)
+{
+
+    cout << _event << endl;
+
+    outfile1 << "\"TRACKS\": {" << endl;
+    outfile1 <<"\""<<"INNERTRACKER"<<"\": [";
+    
+    bool first = true;
+ 
+    stringstream spts;
+    float c = NAN;
+    
+    float x = 0.; float y = 0.; float z = 0.;
+    float px = 0.; float py = 0.; float pz = 0.;
+    TVector3 pos; TVector3 mom;
+
+    for 
+
+    for (SvtxTrackMap::Iter iter = trackmap->begin(); iter != trackmap->end(); ++iter)
+    {
+      SvtxTrack* track = iter->second;
+      px = track->get_px();
+      py = track->get_py();
+      pz = track->get_pz();
+      mom.SetX(px); mom.SetY(py); mom.SetZ(pz);
+      c = track->get_charge();
+
+
+      std::vector<TrkrDefs::cluskey> clusters;
+      auto siseed = track->get_silicon_seed();
+      if(siseed)
+      {
+        for (auto iter = siseed->begin_cluster_keys(); iter != siseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+                  clusters.push_back(cluster_key);
+            }
+        }
+        
+      auto tpcseed = track->get_tpc_seed();
+      if(tpcseed)
+      {
+        for (auto iter = tpcseed->begin_cluster_keys(); iter != tpcseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+                  clusters.push_back(cluster_key);
+            }
+      }
+        
+        
+     for(unsigned int iclus = 0; iclus < clusters.size(); ++iclus)
+      {
+        TrkrDefs::cluskey cluster_key = clusters[iclus];
+        TrkrCluster* cluster = clusterContainer->findCluster(cluster_key);
+        if(!cluster) continue;
+        
+        Acts::Vector3 globalClusterPosition = geometry->getGlobalPosition(cluster_key, cluster);
+        x = globalClusterPosition(0);
+        y = globalClusterPosition(1);
+        z = globalClusterPosition(2);
+        pos.SetX(x); pos.SetY(y); pos.SetZ(z);
+                
+        if (first)
+        {
+            first = false;
+        }
+                         
+        else
+        spts << ",";
+        spts << "[";
+        spts << pos.x();
+        spts << ",";
+        spts << pos.y();
+        spts << ",";
+        spts << pos.z();
+        spts << "]";
+
+        first = true;
+    }
+   
+     outfile1
+        << (boost::format(
+          "{ \"pt\": %1%, \"e\": %2%, \"p\": %3%, \"c\": %4%, \"pdgcode \": %5%, \"pts\":[ %6% ]},")
+           % mom.Pt() % mom.PseudoRapidity() % mom.Phi() % c % _pdgcode % spts.str() ) << endl;
+           spts.clear();
+           spts.str("");
+}
+  
+
+    outfile1 << "]" << endl;
+    outfile1 << "}" << endl;
+ 
+    
+    
+return;
+
+}
+*/
+
+// write json file from simulation data for silicon and tpc clusters/tracks
+void TPCHitTrackDisplay::SimulationOut(PHCompositeNode *topNode)
+{
+    cout << _event << endl;
+
+    TrkrClusterContainer *clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+
+    CentralityInfov1 *cent = findNode::getClass<CentralityInfov1>(topNode, "CentralityInfo");
+    if (!cent)
+    {
+      std::cout << " ERROR -- can't find CentralityInfo node" << std::endl;
+      return;
+    }
+
+    cent_index = cent->get_centile(CentralityInfo::PROP::bimp);
+
+
+    SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+
+    ActsGeometry *geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+    if(!geometry)
+    {
+      std::cout << PHWHERE << "No Acts geometry on node tree. Can't  continue."
+              << std::endl;
+    }
+
+    std::cout<< "This event has centrality: \t" << cent_index << std::endl;
+   
+
+    // Header information for the json file
+ 
+    outfile1 << "{\n    \"EVENT\": {\n        \"runid\": 1, \n        \"evtid\": 1, \n        \"time\": 0, \n        \"type\": \"Collision\", \n        \"s_nn\": 0, \n        \"B\": 3.0,\n        \"pv\": [0,0,0]  \n    },\n" << endl;
+
+    outfile1 << "    \"META\": {\n       \"HITS\": {\n          \"INNERTRACKER\": {\n              \"type\": \"3D\",\n              \"options\": {\n              \"size\": 5,\n              \"color\": 16777215\n              } \n          },\n" << endl;
+    outfile1 << "          \"TRACKHITS\": {\n              \"type\": \"3D\",\n              \"options\": {\n              \"size\": 5,\n              \"transparent\": 0.5,\n              \"color\": 16777215\n              } \n          },\n" << endl;
+    outfile1 << "    \"JETS\": {\n        \"type\": \"JET\",\n        \"options\": {\n            \"rmin\": 0,\n            \"rmax\": 78,\n            \"emin\": 0,\n            \"emax\": 30,\n            \"color\": 16777215,\n            \"transparent\": 0.5 \n        }\n    }\n        }\n    }\n," << endl;
+    outfile1 << "    \"HITS\": {\n        \"CEMC\":[{\"eta\": 0, \"phi\": 0, \"e\": 0}\n            ],\n        \"HCALIN\": [{\"eta\": 0, \"phi\": 0, \"e\": 0}\n            ],\n        \"HCALOUT\": [{\"eta\": 0, \"phi\": 0, \"e\": 0}\n \n            ],\n\n" << endl;
+    outfile1 << "    \"TRACKHITS\": [\n\n "; 
+
+    std::vector<TrkrDefs::cluskey> usedClusters; 
+
+    // Fill usedClusters with cluster keys that are associated with a reconstructed track
+    for (SvtxTrackMap::Iter iter = trackmap->begin(); iter != trackmap->end(); ++iter)
+    {
+      if (!m_trackless_clusters) break;
+      SvtxTrack* track = iter->second;
+      std::vector<TrkrDefs::cluskey> clusters;
+      auto siseed = track->get_silicon_seed();
+      if(siseed)
+      {
+        for (auto iter = siseed->begin_cluster_keys(); iter != siseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+ 	          usedClusters.push_back(cluster_key);
+            }
+      }
+        
+      auto tpcseed = track->get_tpc_seed();
+      if(tpcseed)
+      {
+        for (auto iter = tpcseed->begin_cluster_keys(); iter != tpcseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+	          usedClusters.push_back(cluster_key);
+            }
+      }
+    }   
+
+    bool firstClus = true;
+    int counter = 0;
+    stringstream spts;
+    float c = NAN;
+    
+    float x = 0.; float y = 0.; float z = 0.;
+    float px = 0.; float py = 0.; float pz = 0.;
+    TVector3 pos; TVector3 mom;
+   
+    // iterate over all clusters and write out only those without an associated track 
+    for(const auto& hitsetkey:clusterContainer->getHitSetKeys())
+    {
+      if (!m_trackless_clusters) break; // cut on whether or not to display trackless clusters
+      auto range = clusterContainer->getClusters(hitsetkey);
+      for( auto iter = range.first; iter != range.second; ++iter )
+      {
+        counter = counter + 1;
+        TrkrDefs::cluskey cluster_key = iter->first;
+        bool clusFromTrack = false;
+        for(unsigned int iclus = 0; iclus < usedClusters.size(); ++iclus)
+        {
+          TrkrDefs::cluskey trackClusKey = usedClusters[iclus];
+          if (trackClusKey == cluster_key) 
+          {
+            clusFromTrack = true;
+            break;
+          }
+        } 
+        if (clusFromTrack) continue;
+        TrkrCluster* cluster = iter->second;
+        if(!cluster) continue;
+
+        unsigned int clusADC = cluster->getAdc();
+        if (clusADC < m_cut_ADC) continue;      // ADC check on cluster to not over-saturate display 
+ 
+        Acts::Vector3 globalClusterPosition = geometry->getGlobalPosition(cluster_key, cluster);
+        x = globalClusterPosition(0);
+        y = globalClusterPosition(1);
+        z = globalClusterPosition(2);
+        pos.SetX(x); pos.SetY(y); pos.SetZ(z);
+               
+        if (firstClus) firstClus = false;
+        else spts << ","; 
+
+        spts << "{ \"x\": ";
+        spts << pos.x();
+        spts << ", \"y\": ";
+        spts << pos.y();
+        spts << ", \"z\": ";
+        spts << pos.z();
+        spts << ", \"e\": ";
+        spts << clusADC;
+        spts << "}";
+    
+        outfile1 << (boost::format("%1%") % spts.str());
+        spts.clear();
+        spts.str("");
+      }
+    }
+
+    outfile1 << "],\n    \"JETS\": [\n         ]\n    }," << endl;
+
+    outfile1 << "\"TRACKS\": {" << endl;
+    outfile1 <<"\""<<"INNERTRACKER"<<"\": [";   
+ 
+    firstClus = true;
+    bool firstTrack = true;
+   
+    //tracking
+
+    c = NAN;
+    
+    x = 0.; y = 0.; z = 0.;
+    px = 0.; py = 0.; pz = 0.;
+
+    // iterate over tracks and write to file all tracks and their associated clusters
+    for (SvtxTrackMap::Iter iter = trackmap->begin(); iter != trackmap->end(); ++iter)
+    {
+      SvtxTrack* track = iter->second;
+      px = track->get_px();
+      py = track->get_py();
+      pz = track->get_pz();
+      mom.SetX(px); mom.SetY(py); mom.SetZ(pz);
+      c = track->get_charge();
+
+
+      std::vector<TrkrDefs::cluskey> clusters;
+      auto siseed = track->get_silicon_seed();
+      if(siseed)
+      {
+        for (auto iter = siseed->begin_cluster_keys(); iter != siseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+                  clusters.push_back(cluster_key);
+            }
+      }
+        
+      auto tpcseed = track->get_tpc_seed();
+      if(tpcseed)
+      {
+        for (auto iter = tpcseed->begin_cluster_keys(); iter != tpcseed->end_cluster_keys(); ++iter)
+            {
+                  TrkrDefs::cluskey cluster_key = *iter;
+                  clusters.push_back(cluster_key);
+            }
+      }
+        
+        
+     for(unsigned int iclus = 0; iclus < clusters.size(); ++iclus)
+      {
+        TrkrDefs::cluskey cluster_key = clusters[iclus];
+        TrkrCluster* cluster = clusterContainer->findCluster(cluster_key);
+        if(!cluster) continue;
+   
+        Acts::Vector3 globalClusterPosition = geometry->getGlobalPosition(cluster_key, cluster);
+        x = globalClusterPosition(0);
+        y = globalClusterPosition(1);
+        z = globalClusterPosition(2);
+        pos.SetX(x); pos.SetY(y); pos.SetZ(z);
+                
+        if (firstClus)
+        {
+            firstClus = false;
+        }
+                         
+        else
+        spts << ",";
+        spts << "[";
+        spts << pos.x();
+        spts << ",";
+        spts << pos.y();
+        spts << ",";
+        spts << pos.z();
+        spts << "]";
+
+     }
+   
+     firstClus = true;
+     if (firstTrack)
+     {
+       outfile1
+        << (boost::format(
+          "{ \"pt\": %1%, \"e\": %2%, \"p\": %3%, \"c\": %4%, \"pdgcode \": %5%, \"centrality \": %6%, \"pts\":[ %7% ]}")
+           % mom.Pt() % mom.PseudoRapidity() % mom.Phi() % c % _pdgcode % cent_index % spts.str() ) << endl;
+           spts.clear();
+           spts.str("");
+           firstTrack = false;
+     }
+     else
+     {
+       outfile1
+        << (boost::format(
+          ",{ \"pt\": %1%, \"e\": %2%, \"p\": %3%, \"c\": %4%, \"pdgcode \": %5%, \"centrality \": %6%, \"pts\":[ %7% ]}")
+           % mom.Pt() % mom.PseudoRapidity() % mom.Phi() % c % _pdgcode % cent_index % spts.str() ) << endl;
+           spts.clear();
+           spts.str("");
+     }
+    }
+    
+    
+    outfile1 << "]" << endl;
+    outfile1 << "}" << endl; 
+    outfile1 << "}" << endl; 
+    
+return;
+
+}
+

--- a/offline/packages/TPCHitTrackDisplay/TPCHitTrackDisplay.h
+++ b/offline/packages/TPCHitTrackDisplay/TPCHitTrackDisplay.h
@@ -1,0 +1,75 @@
+
+
+#ifndef __TPCHitTrackDisplay_H__
+#define __TPCHitTrackDisplay_H__
+
+#include <fun4all/SubsysReco.h>
+#include <string>
+#include <vector>
+
+
+
+//Forward declerations
+class PHCompositeNode;
+class TFile; 
+class TTree;
+class RawTowerContainer;
+class RawTowerGeomContainer;
+class TH2F;
+class TProfile;
+class SvtxTrackMap;
+
+
+RawTowerContainer *cemctowers;
+RawTowerContainer *hcalotowers;
+RawTowerContainer *hcalitowers;
+
+RawTowerGeomContainer *cemctowergeom;
+RawTowerGeomContainer *hcalotowergeom;
+RawTowerGeomContainer *hcalitowergeom;
+
+// Writes json file to be used to display an event with:
+// https://www.sphenix.bnl.gov/edisplay/
+class TPCHitTrackDisplay: public SubsysReco
+{
+ public: 
+  //Default constructor
+  TPCHitTrackDisplay(const std::string &name="TPCHitTrackDisplay"/*, bool &tpcRaw=True*/);
+
+  //Initialization, called for initialization
+  int Init(PHCompositeNode *);
+
+  int InitRun(PHCompositeNode *); 
+
+  //Process Event, called for each event
+  int process_event(PHCompositeNode *);
+
+  //End, write and close files
+  int EndRun(PHCompositeNode *);
+  
+  void set_pdgcode(const int thispdgcode) { _pdgcode = thispdgcode; }
+
+  // set the ADC cut for displaying trackless clusters
+  void setCutADC(float value) { m_cut_ADC = value; }
+
+  // Boolean for whether or not to include clusters without an associted track above a certain ADC value 
+  void setIncludeTracklessClusters(float value) { m_trackless_clusters = value; }
+    
+ private:
+ 
+  float m_cut_ADC;  
+  bool m_trackless_clusters; 
+
+  //Event counter
+  int _event;
+  int _pdgcode;
+  int cent_index;
+  //bool isRawData;
+    
+  //User modules
+  void SimulationOut(PHCompositeNode*);
+  //void TPCRawOut(PHCompositeNode*);
+
+};
+
+#endif //* __TPCHitTrackDisplay_H__ *//

--- a/offline/packages/TPCHitTrackDisplay/autogen.sh
+++ b/offline/packages/TPCHitTrackDisplay/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure "$@"
+

--- a/offline/packages/TPCHitTrackDisplay/configure.ac
+++ b/offline/packages/TPCHitTrackDisplay/configure.ac
@@ -1,0 +1,21 @@
+AC_INIT(TPCHitTrackDisplay,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+AM_INIT_AUTOMAKE
+
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+case $CXX in
+ clang++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-undefined-var-template"
+ ;;
+ g++)
+  CXXFLAGS="$CXXFLAGS -Wall -Werror"
+ ;;
+esac
+
+CINTDEFS=" -noIncludePaths  -inlineInputHeader "
+AC_SUBST(CINTDEFS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Input currently only takes DSTs for tracks and clusters (adding ability to read raw TPC data soon) 
Outputs a json file to use with https://www.sphenix.bnl.gov/edisplay/ in order to display events

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

Will eventually update this to read in raw TPC data using TrkrHitSetContainer once that is finished being updated

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

