### PR TITLE
add flag to override exit when mixing runs in embedding

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -527,7 +527,7 @@ int Fun4AllServer::process_event()
   }
   gROOT->cd(default_Tdirectory.c_str());
   std::string currdir = gDirectory->GetPath();
-  for (auto & Subsystem : Subsystems)
+  for (auto &Subsystem : Subsystems)
   {
     if (Verbosity() >= VERBOSITY_MORE)
     {
@@ -711,7 +711,7 @@ int Fun4AllServer::process_event()
       }
     }
   }
-  for (auto & Subsystem : Subsystems)
+  for (auto &Subsystem : Subsystems)
   {
     if (Verbosity() >= VERBOSITY_EVEN_MORE)
     {
@@ -742,7 +742,7 @@ int Fun4AllServer::ResetNodeTree()
   for (iter = topnodemap.begin(); iter != topnodemap.end(); ++iter)
   {
     PHNodeIterator mainIter((*iter).second);
-    for (const auto & nodename : ResetNodeList)
+    for (const auto &nodename : ResetNodeList)
     {
       if (mainIter.cd(nodename))
       {
@@ -803,7 +803,7 @@ int Fun4AllServer::BeginRun(const int runno)
     std::cout << "overriding BOR timestamp by ";
     beginruntimestamp->print();
     std::cout << std::endl;
-    //rc->set_TimeStamp(*beginruntimestamp);
+    // rc->set_TimeStamp(*beginruntimestamp);
   }
   if (Verbosity() >= VERBOSITY_SOME)
   {
@@ -1415,15 +1415,18 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
         {
           if (currentrun != runno)
           {
-            std::cout << "Mixing of Runs within same event is not supported" << std::endl;
-            std::cout << "Here is the list of Sync Managers and their runnumbers:" << std::endl;
-            std::vector<Fun4AllSyncManager *>::const_iterator syiter;
-            for (syiter = SyncManagers.begin(); syiter != SyncManagers.end(); ++syiter)
+            if (!(*iter)->MixRunsOk())
             {
-              std::cout << (*syiter)->Name() << " run number: " << (*syiter)->CurrentRun() << std::endl;
+              std::cout << "Mixing of Runs within same event is not supported" << std::endl;
+              std::cout << "Here is the list of Sync Managers and their runnumbers:" << std::endl;
+              std::vector<Fun4AllSyncManager *>::const_iterator syiter;
+              for (syiter = SyncManagers.begin(); syiter != SyncManagers.end(); ++syiter)
+              {
+                std::cout << (*syiter)->Name() << " run number: " << (*syiter)->CurrentRun() << std::endl;
+              }
+              std::cout << "Exiting now" << std::endl;
+              exit(1);
             }
-            std::cout << "Exiting now" << std::endl;
-            exit(1);
           }
         }
       }

--- a/offline/framework/fun4all/Fun4AllSyncManager.h
+++ b/offline/framework/fun4all/Fun4AllSyncManager.h
@@ -53,6 +53,8 @@ class Fun4AllSyncManager : public Fun4AllBase
   void PushBackInputMgrsEvents(const int i);
   int ResetEvent();
   const std::vector<Fun4AllInputManager *> GetInputManagers() const { return m_InManager; }
+  bool MixRunsOk() const {return m_MixRunsOkFlag;}
+  void MixRunsOk(bool b) {m_MixRunsOkFlag = b;}
 
  private:
   void PrintSyncProblem() const;
@@ -63,6 +65,7 @@ class Fun4AllSyncManager : public Fun4AllBase
   int m_CurrentRun = 0;
   int m_CurrentEvent = 0;
   int m_Repeat = 0;
+  bool m_MixRunsOkFlag = false;
   SyncObject *m_MasterSync = nullptr;
   std::vector<Fun4AllInputManager *> m_InManager;
   std::vector<int> m_iretInManager;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a flag which enables running different runs under other sync managers. Needed to read fake raw data while reading simulated DSTs to run the actual processing

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

