### PR TITLE
Kf particle

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -144,6 +144,10 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_track_chi2ndof = FLT_MAX;
 
+  int m_nMVTXHits = 3;
+
+  int m_nTPCHits = 20;
+
   float m_comb_DCA = FLT_MAX;
 
   float m_vertex_chi2ndof = FLT_MAX;
@@ -161,6 +165,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   float m_mva_cut_value = -1;
 
   bool m_get_charge_conjugate = true;
+
+  bool m_extrapolateTracksToSV = true;
 
   bool m_allowZeroMassTracks = false;
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -170,9 +170,9 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumTrackchi2nDOF(float trackchi2ndof) { m_track_chi2ndof = trackchi2ndof; }
 
-  void setMinMVTXclusters(int nHits) { m_nMVTXHits = nHits; }
+  void setMinMVTXhits(int nHits) { m_nMVTXHits = nHits; }
 
-  void setMinTPCclusters(int nHits) { m_nTPCHits = nHits; }
+  void setMinTPChits(int nHits) { m_nTPCHits = nHits; }
 
   void setMaximumDaughterDCA(float dca) { m_comb_DCA = dca; }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -170,6 +170,10 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumTrackchi2nDOF(float trackchi2ndof) { m_track_chi2ndof = trackchi2ndof; }
 
+  void setMinMVTXclusters(int nHits) { m_nMVTXHits = nHits; }
+
+  void setMinTPCclusters(int nHits) { m_nTPCHits = nHits; }
+
   void setMaximumDaughterDCA(float dca) { m_comb_DCA = dca; }
 
   void setMaximumVertexchi2nDOF(float vertexchi2nDOF) { m_vertex_chi2ndof = vertexchi2nDOF; }
@@ -194,6 +198,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void useFakePrimaryVertex(bool use_fake) { m_use_fake_pv = use_fake; }
 
   void allowZeroMassTracks(bool allow) { m_allowZeroMassTracks = allow; }
+
+  void extraolateTracksToSV(bool extrapolate) { m_extrapolateTracksToSV = extrapolate; }
 
   void constrainIntermediateMasses(bool constrain_int_mass) { m_constrain_int_mass = constrain_int_mass; }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

After discussions in the HF/Q TG meeting on 3/24/23, I've added the ability to select tracks with a minimum umber of MVTX or TPC hits. This is defautlted to 3 and 20 respectively. The user can set this in their macro with:

```c++
  void setMinMVTXhits(int nHits) { m_nMVTXHits = nHits; }

  void setMinTPChits(int nHits) { m_nTPCHits = nHits; }
```

Also, I added a flag so you can disable the extrapolation of tracks to their secondary vertices. This was found to cause issues in K-short resonstuction. This flag is defaulted to true (whcih covers most use scenarios).

```c++
  void extraolateTracksToSV(bool extrapolate) { m_extrapolateTracksToSV = extrapolate; }
```

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

