### PR TITLE
Generalize ignore layer in track fit

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -627,7 +627,8 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       TrkrDefs::cluskey cluskey = global_moved[i].first;
       Acts::Vector3 global = global_moved[i].second;
    
-      if(TrkrDefs::getLayer(cluskey) == m_ignoreLayer)
+      if(std::find(m_ignoreLayer.begin(), m_ignoreLayer.end(), 
+		   TrkrDefs::getLayer(cluskey)) != m_ignoreLayer.end())
 	{
 	  if(Verbosity() > 3)
 	    {

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -627,8 +627,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       TrkrDefs::cluskey cluskey = global_moved[i].first;
       Acts::Vector3 global = global_moved[i].second;
    
-      if(std::find(m_ignoreLayer.begin(), m_ignoreLayer.end(), 
-		   TrkrDefs::getLayer(cluskey)) != m_ignoreLayer.end())
+      if(m_ignoreLayer.find(TrkrDefs::getLayer(cluskey)) != m_ignoreLayer.end())
 	{
 	  if(Verbosity() > 3)
 	    {

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -109,7 +109,7 @@ class PHActsTrkFitter : public SubsysReco
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
 
-  void ignoreLayer(int layer) { m_ignoreLayer = layer; }
+  void ignoreLayer(int layer) { m_ignoreLayer.insert(layer); }
 
  private:
 
@@ -202,8 +202,8 @@ class PHActsTrkFitter : public SubsysReco
   TpcClusterMover _clusterMover;
   ClusterErrorPara _ClusErrPara;
 
-  int m_ignoreLayer = std::numeric_limits<int>::max();
-
+  std::set<int> m_ignoreLayer;
+ 
   std::string m_fieldMap = "";
 
   int _n_iteration = 0;


### PR DESCRIPTION
Updates the skip layer feature of the track fit to use multiple layers if desired (e.g. for silicon-TPOT fitting)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

