### PR TITLE
Silicon+TPOT fit update

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -304,19 +304,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
       if(m_fitSiliconMMs)
 	{
-	  bool sil = siseed != nullptr ? true : false;
-	  bool tpot = false;
-
-	  for(auto& sl : sourceLinks)
-	    {
-	      auto key = sl.cluskey();
-	      if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
-		{
-		  tpot = true;
-		}
-	    }
-	  //if(sil && tpot)
-	  if(!sil or !tpot)
+	  if(!checkMM(sourceLinks) or !siseed)
 	    {
 	      if(Verbosity() > 3) std::cout << "no silicon+tpot measurements, skipping" << std::endl;
 	      continue; 
@@ -466,6 +454,21 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
   return;
 
+}
+
+bool PHActsTrkFitter::checkMM(SourceLinkVec& sls)
+{
+  bool tpot = false;
+  for(auto& sl : sls)
+    {
+      auto key = sl.cluskey();
+      if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
+	{
+	  tpot = true;
+	}
+    }
+
+  return tpot;
 }
 
 //___________________________________________________________________________________

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -137,6 +137,8 @@ class PHActsTrkFitter : public SubsysReco
   Acts::BoundSymMatrix setDefaultCovariance() const;
   void printTrackSeed(const ActsTrackFittingAlgorithm::TrackParameters& seed) const;
 
+  bool checkMM(SourceLinkVec& sls);
+
   /// Event counter
   int m_event = 0;
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -134,14 +134,7 @@ class PHActsTrkFitter : public SubsysReco
 	   const ActsTrackFittingAlgorithm::TrackParameters& seed,
 	   const ActsTrackFittingAlgorithm::GeneralFitterOptions& 
 	     kfOptions,
-	   const SurfacePtrVec& surfSequence,
 	   std::shared_ptr<Acts::VectorMultiTrajectory>& mtj);
-
-  /// Functions to get list of sorted surfaces for direct navigation, if
-  /// applicable
-  SourceLinkVec getSurfaceVector(const SourceLinkVec& sourceLinks, 
-				 SurfacePtrVec& surfaces) const;
-  void checkSurfaceVec(SurfacePtrVec& surfaces) const;
 
   bool getTrackFitResult(const FitResult& fitOutput, SvtxTrack* track);
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -149,7 +149,7 @@ class PHActsTrkFitter : public SubsysReco
   /// TrackMap containing SvtxTracks
   alignmentTransformationContainer *m_alignmentTransformationMap = nullptr;  // added for testing purposes
   SvtxTrackMap *m_trackMap = nullptr;
-  SvtxTrackMap *m_directedTrackMap = nullptr;
+  SvtxTrackMap *m_silmmTrackMap = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;
   TrackSeedContainer *m_seedMap = nullptr;
   TrackSeedContainer *m_tpcSeeds = nullptr;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -80,10 +80,6 @@ class PHActsTrkFitter : public SubsysReco
   void fitSiliconMMs(bool fitSiliconMMs)
        {m_fitSiliconMMs = fitSiliconMMs;}
 
-  /// require micromegas in SiliconMM fits
-  void setUseMicromegas( bool value )
-  { m_useMicromegas = value; }
-
   void setUpdateSvtxTrackStates(bool fillSvtxTrackStates)
        { m_fillSvtxTrackStates = fillSvtxTrackStates; }   
 
@@ -166,9 +162,6 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs = false;
 
-  /// requires micromegas present when fitting silicon-MM surfaces
-  bool m_useMicromegas = true;
-  
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR recovers the performance of the silicon+TPOT fit. It removes the use of the directed fitter and just uses the standard Acts::KF for the fit, which simplifies the code. The attached plot shows the performance of the silicon only fit (left) vs. silicon + TPOT fit (right) for single tracks.
[fit_tpot_silicon.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/11100983/fit_tpot_silicon.pdf)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

