### PR TITLE
Revert "Silicon+TPOT fit update"

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -193,6 +193,7 @@ int PHActsTrkFitter::process_event(PHCompositeNode */*topNode*/)
     {
       std::cout << " SvtxTrackMap size is now " << m_trackMap->size() 
 	      << std::endl;
+
     }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -286,7 +287,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       if(!tpcseed)
 	{ std::cout << "no tpc seed"<<std::endl; continue; }
 
-      if(Verbosity() > 1) 
+      if(Verbosity() > 0) 
 	{
 	  if(siseed) std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
 	  std::cout << " tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
@@ -301,15 +302,6 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       if(siseed) sourceLinks = getSourceLinks(siseed, measurements, crossing);
       const auto tpcSourceLinks = getSourceLinks(tpcseed, measurements, crossing);
       sourceLinks.insert( sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end() );
-
-      if(m_fitSiliconMMs)
-	{
-	  if(!checkMM(sourceLinks) or !siseed)
-	    {
-	      if(Verbosity() > 3) std::cout << "no silicon+tpot measurements, skipping" << std::endl;
-	      continue; 
-	    }
-	}
 
       // position comes from the silicon seed, unless there is no silicon seed
       Acts::Vector3 position(0,0,0);
@@ -328,6 +320,22 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       if( !is_valid( position ) ) continue;
 
       if(sourceLinks.empty()) { continue; }
+
+      /// If using directed navigation, collect surface list to navigate
+      SurfacePtrVec surfaces;
+      if(m_fitSiliconMMs)
+      {
+        sourceLinks = getSurfaceVector(sourceLinks, surfaces);
+        
+        // skip if there is no surfaces
+        if( surfaces.empty() ) continue;
+        
+        // make sure micromegas are in the tracks, if required
+        if( m_useMicromegas &&
+          std::none_of( surfaces.begin(), surfaces.end(), [this]( const auto& surface )
+          { return m_tGeometry->maps().isMicromegasSurface( surface ); } ) )
+        { continue; }
+      }
 
       Acts::Vector3 momentum(
 	       tpcseed->get_px(m_clusterContainer, m_tGeometry), 
@@ -389,7 +397,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       fitTimer.stop();
       fitTimer.restart();
       auto mtj = std::make_shared<Acts::VectorMultiTrajectory>();
-      auto result = fitTrack(wrappedSls, seed, kfOptions, mtj);
+      auto result = fitTrack(wrappedSls, seed, kfOptions, surfaces,mtj);
       fitTimer.stop();
       auto fitTime = fitTimer.get_accumulated_time();
    
@@ -415,11 +423,12 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
         if(m_fitSiliconMMs)
         {
-	  unsigned int trid = m_silmmTrackMap->size();
+          
+          unsigned int trid = m_directedTrackMap->size();
           newTrack.set_id(trid);
 
           if( getTrackFitResult(fitOutput, &newTrack) )
-	    { m_silmmTrackMap->insertWithKey(&newTrack, trid); }
+          { m_directedTrackMap->insertWithKey(&newTrack, trid); }
           
         } else {
           
@@ -456,26 +465,10 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
 }
 
-bool PHActsTrkFitter::checkMM(SourceLinkVec& sls)
-{
-  bool tpot = false;
-  for(auto& sl : sls)
-    {
-      auto key = sl.cluskey();
-      if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
-	{
-	  tpot = true;
-	}
-    }
-
-  return tpot;
-}
-
 //___________________________________________________________________________________
-SourceLinkVec PHActsTrkFitter::getSourceLinks(
-    TrackSeed* track,
-    ActsTrackFittingAlgorithm::MeasurementContainer& measurements,
-    short int crossing )
+SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
+					      ActsTrackFittingAlgorithm::MeasurementContainer& measurements,
+				   short int crossing )
 {
 
   SourceLinkVec sourcelinks;
@@ -502,7 +495,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(
       if(!cluster)
 	{
 	  if(Verbosity() > 0) std::cout << "Failed to get cluster with key " << key << " for track " << m_seedMap->find(track) << std::endl;
-	  else std::cout<< "PHActsTrkFitter :: Key: "<< key << " for track " << m_seedMap->find(track) <<std::endl;
+    else std::cout<< "PHActsTrkFitter :: Key: "<< key << " for track " << m_seedMap->find(track) <<std::endl;
 	  continue;
 	}
 
@@ -614,6 +607,12 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(
 	  if(_dcc_fluctuation) { global = _distortionCorrection.get_corrected_position( global, _dcc_fluctuation ); }
 	}
    
+      if(Verbosity() > 0)
+	{
+	  std::cout << " zinit " << global[2] << " xinit " << global[0] << " yinit " << global[1] << " side " << side << " crossing " << crossing 
+		    << " cluskey " << key << " subsurfkey " << subsurfkey << std::endl;
+	}
+
       // add the global positions to a vector to give to the cluster mover
       global_raw.push_back(std::make_pair(key, global));
       
@@ -628,9 +627,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(
       TrkrDefs::cluskey cluskey = global_moved[i].first;
       Acts::Vector3 global = global_moved[i].second;
    
-      if(m_ignoreLayer.find(TrkrDefs::getLayer(cluskey)) != m_ignoreLayer.end()
-	 or
-	 (m_fitSiliconMMs && TrkrDefs::getTrkrId(cluskey) == TrkrDefs::TrkrId::tpcId))
+      if(m_ignoreLayer.find(TrkrDefs::getLayer(cluskey)) != m_ignoreLayer.end())
 	{
 	  if(Verbosity() > 3)
 	    {
@@ -675,7 +672,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(
 	  localPos(1) = loct(1);
 	}
       
-      if(Verbosity() > 1)
+      if(Verbosity() > 0)
 	{
 	  std::cout << " cluster global after mover: " << global << std::endl; 
 	  std::cout << " cluster local X " << cluster->getLocalX() << " cluster local Y " << cluster->getLocalY() << std::endl;
@@ -734,10 +731,9 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(
 		    << std::endl;
 	}
       
-      
-         sourcelinks.push_back(sl);
-	 measurements.push_back(meas);
-	
+      sourcelinks.push_back(sl);
+      measurements.push_back(meas);
+ 
     }
   
   SLTrackTimer.stop();
@@ -825,10 +821,108 @@ bool PHActsTrkFitter::getTrackFitResult(const FitResult &fitOutput, SvtxTrack* t
 ActsTrackFittingAlgorithm::TrackFitterResult PHActsTrkFitter::fitTrack(
     const std::vector<std::reference_wrapper<const SourceLink>>& sourceLinks, 
     const ActsTrackFittingAlgorithm::TrackParameters& seed,
-    const ActsTrackFittingAlgorithm::GeneralFitterOptions& kfOptions,
+    const ActsTrackFittingAlgorithm::GeneralFitterOptions& kfOptions, 
+    const SurfacePtrVec& surfSequence,
     std::shared_ptr<Acts::VectorMultiTrajectory>& mtj)
 {
-  return (*m_fitCfg.fit)(sourceLinks, seed, kfOptions, mtj);   
+  if(m_fitSiliconMMs) 
+  { 
+    return (*m_fitCfg.dFit)(sourceLinks, seed, kfOptions, surfSequence, mtj); 
+  } else {
+    return (*m_fitCfg.fit)(sourceLinks, seed, kfOptions, mtj); 
+  }
+}
+
+SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks,
+						SurfacePtrVec& surfaces) const
+{
+  SourceLinkVec siliconMMSls;
+
+//   if(Verbosity() > 1)
+//     std::cout << "Sorting " << sourceLinks.size() << " SLs" << std::endl;
+  
+  for(const auto& sl : sourceLinks)
+  {
+    if(Verbosity() > 1)
+    { std::cout << "SL available on : " << sl.geometryId() << std::endl; }
+      
+    const auto surf = m_tGeometry->geometry().tGeometry->findSurface(sl.geometryId());
+    // skip TPC surfaces
+    if( m_tGeometry->maps().isTpcSurface( surf ) ) continue;
+    
+    // also skip micromegas surfaces if not used
+    if( m_tGeometry->maps().isMicromegasSurface( surf ) && !m_useMicromegas ) continue;
+    
+    // update vectors
+    siliconMMSls.push_back(sl);
+    surfaces.push_back(surf);
+  }
+      
+  /// Surfaces need to be sorted in order, i.e. from smallest to
+  /// largest radius extending from target surface
+  /// Add a check to ensure this
+  if(!surfaces.empty())
+  { checkSurfaceVec(surfaces); }
+
+  if(Verbosity() > 1)
+    {
+      for(const auto& surf : surfaces)
+	{
+	  std::cout << "Surface vector : " << surf->geometryId() << std::endl;
+	}
+    }
+
+  return siliconMMSls;
+}
+
+void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec &surfaces) const
+{
+  for(int i = 0; i < surfaces.size() - 1; i++)
+  {
+    const auto& surface = surfaces.at(i);
+    const auto thisVolume = surface->geometryId().volume();
+    const auto thisLayer  = surface->geometryId().layer();
+      
+    const auto nextSurface = surfaces.at(i+1);
+    const auto nextVolume = nextSurface->geometryId().volume();
+    const auto nextLayer = nextSurface->geometryId().layer();
+    
+    /// Implement a check to ensure surfaces are sorted
+    if(nextVolume == thisVolume) 
+    {
+      if(nextLayer < thisLayer)
+      {
+        std::cout 
+          << "PHActsTrkFitter::checkSurfaceVec - " 
+          << "Surface not in order... removing surface" 
+          << surface->geometryId() << std::endl;
+        
+        surfaces.erase(surfaces.begin() + i);
+	      
+        /// Subtract one so we don't skip a surface
+	      --i;
+	      continue;
+	    }
+      
+    } else {
+
+      if(nextVolume < thisVolume)
+      {
+        std::cout 
+          << "PHActsTrkFitter::checkSurfaceVec - " 
+          << "Volume not in order... removing surface" 
+          << surface->geometryId() << std::endl;
+        
+        surfaces.erase(surfaces.begin() + i);
+
+        /// Subtract one so we don't skip a surface
+	      --i;
+	      continue;
+      
+      }
+    }
+  } 
+
 }
 
 void PHActsTrkFitter::updateSvtxTrack(Trajectory traj, SvtxTrack* track)
@@ -1009,6 +1103,20 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
     dstNode->addNode(svtxNode);
   }
 
+  if(m_fitSiliconMMs)
+    {
+      m_directedTrackMap = findNode::getClass<SvtxTrackMap>(topNode,
+							    "SvtxSiliconMMTrackMap");
+      if(!m_directedTrackMap)
+	{
+	  /// Copy this trackmap, then use it for the rest of processing
+	  m_directedTrackMap = new SvtxTrackMap_v2;
+
+	  PHIODataNode<PHObject> *trackNode = 
+	    new PHIODataNode<PHObject>(m_directedTrackMap,"SvtxSiliconMMTrackMap","PHObject");
+	  svtxNode->addNode(trackNode);
+	} 
+    }
 
   m_trajectories = findNode::getClass<std::map<const unsigned int, Trajectory>>(topNode, "ActsTrajectories");
   if(!m_trajectories)
@@ -1035,24 +1143,6 @@ int PHActsTrkFitter::createNodes(PHCompositeNode* topNode)
       m_alignmentStateMap = new SvtxAlignmentStateMap_v1;
       auto node = new PHDataNode<SvtxAlignmentStateMap>(m_alignmentStateMap,"SvtxAlignmentStateMap","PHObject");
       svtxNode->addNode(node);
-    }
-
-  if(m_fitSiliconMMs)
-    {
-      m_silmmTrackMap = findNode::getClass<SvtxTrackMap>(topNode,
-							 "SvtxSiliconMMTrackMap");
-      
-      if(!m_silmmTrackMap)
-	{
-	  /// Copy this trackmap, then use it for the rest of processing
-	  m_silmmTrackMap = new SvtxTrackMap_v2;
-        
-	  PHIODataNode<PHObject> *trackNode = 
-	    new PHIODataNode<PHObject>(m_silmmTrackMap,
-				       "SvtxSiliconMMTrackMap",
-				       "PHObject");
-	  svtxNode->addNode(trackNode);
-	} 
     }
 
   if(m_actsEvaluator)

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -80,6 +80,10 @@ class PHActsTrkFitter : public SubsysReco
   void fitSiliconMMs(bool fitSiliconMMs)
        {m_fitSiliconMMs = fitSiliconMMs;}
 
+  /// require micromegas in SiliconMM fits
+  void setUseMicromegas( bool value )
+  { m_useMicromegas = value; }
+
   void setUpdateSvtxTrackStates(bool fillSvtxTrackStates)
        { m_fillSvtxTrackStates = fillSvtxTrackStates; }   
 
@@ -130,14 +134,19 @@ class PHActsTrkFitter : public SubsysReco
 	   const ActsTrackFittingAlgorithm::TrackParameters& seed,
 	   const ActsTrackFittingAlgorithm::GeneralFitterOptions& 
 	     kfOptions,
+	   const SurfacePtrVec& surfSequence,
 	   std::shared_ptr<Acts::VectorMultiTrajectory>& mtj);
+
+  /// Functions to get list of sorted surfaces for direct navigation, if
+  /// applicable
+  SourceLinkVec getSurfaceVector(const SourceLinkVec& sourceLinks, 
+				 SurfacePtrVec& surfaces) const;
+  void checkSurfaceVec(SurfacePtrVec& surfaces) const;
 
   bool getTrackFitResult(const FitResult& fitOutput, SvtxTrack* track);
 
   Acts::BoundSymMatrix setDefaultCovariance() const;
   void printTrackSeed(const ActsTrackFittingAlgorithm::TrackParameters& seed) const;
-
-  bool checkMM(SourceLinkVec& sls);
 
   /// Event counter
   int m_event = 0;
@@ -151,7 +160,7 @@ class PHActsTrkFitter : public SubsysReco
   /// TrackMap containing SvtxTracks
   alignmentTransformationContainer *m_alignmentTransformationMap = nullptr;  // added for testing purposes
   SvtxTrackMap *m_trackMap = nullptr;
-  SvtxTrackMap *m_silmmTrackMap = nullptr;
+  SvtxTrackMap *m_directedTrackMap = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;
   TrackSeedContainer *m_seedMap = nullptr;
   TrackSeedContainer *m_tpcSeeds = nullptr;
@@ -164,6 +173,9 @@ class PHActsTrkFitter : public SubsysReco
   /// Acts::DirectedNavigator with a list of sorted silicon+MM surfaces
   bool m_fitSiliconMMs = false;
 
+  /// requires micromegas present when fitting silicon-MM surfaces
+  bool m_useMicromegas = true;
+  
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
 


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/coresoftware#1917

This reverts the above PR. Interestingly the performance with the full fit seems to neglect the TPOT measurement in the residual calculations, despite it explicitly being added and propagated to by Acts when performing the Kalman Filter. Even more strangely, the fit performance with the TPOT measurement is improved substantially as one would expect. So somehow this keeps similar performance in the actual fit but worsens the residuals. Reverting this for now until more debugging can be performed.