### PR TITLE
Unit conversion in propagator

### DIFF
--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -105,7 +105,7 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
     auto finalparams = *result.value().endParameters;
     auto pathlength = result.value().pathLength / Acts::UnitConstants::cm;
     auto pair = std::make_pair(pathlength, finalparams);
-
+    finalparams.position(m_geometry->geometry().getGeoContext()) /= Acts::UnitConstants::cm;
     return Acts::Result<BoundTrackParamPair>::success(pair);
   }
 

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -154,9 +154,9 @@ void PHActsTrackProjection::updateSvtxTrack(
 
   auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
   const auto momentum = params.momentum();
-  out.set_x(projectionPos.x() / Acts::UnitConstants::cm);
-  out.set_y(projectionPos.y() / Acts::UnitConstants::cm);
-  out.set_z(projectionPos.z() / Acts::UnitConstants::cm);
+  out.set_x(projectionPos.x());
+  out.set_y(projectionPos.y());
+  out.set_z(projectionPos.z());
   out.set_px(momentum.x());
   out.set_py(momentum.y());
   out.set_pz(momentum.z());

--- a/offline/packages/trackreco/PHActsTrackPropagator.cc
+++ b/offline/packages/trackreco/PHActsTrackPropagator.cc
@@ -79,9 +79,9 @@ void PHActsTrackPropagator::addTrackState(
 
   auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
   const auto momentum = params.momentum();
-  out.set_x(projectionPos.x() / Acts::UnitConstants::cm);
-  out.set_y(projectionPos.y() / Acts::UnitConstants::cm);
-  out.set_z(projectionPos.z() / Acts::UnitConstants::cm);
+  out.set_x(projectionPos.x());
+  out.set_y(projectionPos.y());
+  out.set_z(projectionPos.z());
   out.set_px(momentum.x());
   out.set_py(momentum.y());
   out.set_pz(momentum.z());

--- a/offline/packages/trackreco/PHActsVertexPropagator.cc
+++ b/offline/packages/trackreco/PHActsVertexPropagator.cc
@@ -150,9 +150,10 @@ void PHActsVertexPropagator::updateSvtxTrack(SvtxTrack* track,
               << std::endl;
   }
 
-  track->set_x(position(0) / Acts::UnitConstants::cm);
-  track->set_y(position(1) / Acts::UnitConstants::cm);
-  track->set_z(position(2) / Acts::UnitConstants::cm);
+  /// unit conversion already happened in ActsPropagator
+  track->set_x(position(0));
+  track->set_y(position(1));
+  track->set_z(position(2));
 
   ActsTransformations rotater;
   rotater.setVerbosity(Verbosity());

--- a/offline/packages/trackreco/SecondaryVertexFinder.cc
+++ b/offline/packages/trackreco/SecondaryVertexFinder.cc
@@ -522,9 +522,9 @@ bool SecondaryVertexFinder::projectTrackToPoint(SvtxTrack* track, Eigen::Vector3
       auto resultparams = result.value().second;
       auto projectionPos = resultparams.position(_tGeometry->geometry().getGeoContext());
       const auto momentum = resultparams.momentum();
-      pos(0) = projectionPos.x() / Acts::UnitConstants::cm;
-      pos(1) = projectionPos.y() / Acts::UnitConstants::cm;
-      pos(2) = projectionPos.z() / Acts::UnitConstants::cm;
+      pos(0) = projectionPos.x();
+      pos(1) = projectionPos.y();
+      pos(2) = projectionPos.z();
       
       mom(0) = momentum.x();
       mom(1) = momentum.y();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This moves the Acts unit  conversion from mm -> sPHENIX cm into the acts propagator so that outward facing users who use the propagation machinery get a consistent unit object.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

