### PR TITLE
put printout behind verbosity

### DIFF
--- a/simulation/g4simulation/g4bbc/BbcSimReco.cc
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.cc
@@ -185,10 +185,7 @@ int BbcSimReco::InitRun(PHCompositeNode *topNode)
 // Call user instructions for every event
 int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
 {
-  // GetNodes(topNode);
-
   f_evt = _evtheader->get_EvtSequence();
-  // if(f_evt%100==0) std::cout << PHWHERE << "Events processed: " << f_evt << std::endl;
 
   //**** Initialize Variables
 
@@ -225,7 +222,7 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
     f_vz = vtxp->get_z();
     f_vt = vtxp->get_t();
 
-    if (f_evt < 20)
+    if (Verbosity() && f_evt < 20)
     {
       std::cout << "VTXP "
            << "\t" << f_vx << "\t" << f_vy << "\t" << f_vz << "\t" << f_vt << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR removes the vertex printout for the first 20 event, now behind Verbosity() setting
[skip-ci]
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

