### PR TITLE
Consistent use of Acts units

### DIFF
--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -103,7 +103,7 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
   if (result.ok())
   {
     auto finalparams = *result.value().endParameters;
-    auto pathlength = result.value().pathLength / Acts::UnitConstants::cm;
+    auto pathlength = result.value().pathLength;
     auto pair = std::make_pair(pathlength, finalparams);
 
     return Acts::Result<BoundTrackParamPair>::success(pair);
@@ -142,7 +142,7 @@ ActsPropagator::propagateTrack(const Acts::BoundTrackParameters& params,
   if (result.ok())
   {
     auto finalparams = *result.value().endParameters;
-    auto pathlength = result.value().pathLength / Acts::UnitConstants::cm;
+    auto pathlength = result.value().pathLength;
     auto pair = std::make_pair(pathlength, finalparams);
 
     return Acts::Result<BoundTrackParamPair>::success(pair);
@@ -181,7 +181,7 @@ ActsPropagator::propagateTrackFast(const Acts::BoundTrackParameters& params,
   if (result.ok())
   {
     auto finalparams = *result.value().endParameters;
-    auto pathlength = result.value().pathLength / Acts::UnitConstants::cm;
+    auto pathlength = result.value().pathLength;
     auto pair = std::make_pair(pathlength, finalparams);
 
     return Acts::Result<BoundTrackParamPair>::success(pair);

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -30,6 +30,7 @@ class ActsPropagator
 {
  public:
   using BoundTrackParam = const Acts::BoundTrackParameters;
+  /// Return type of std::pair<path length, parameters>
   using BoundTrackParamPair = std::pair<float, BoundTrackParam>;
   using BoundTrackParamResult = Acts::Result<BoundTrackParamPair>;
   using SurfacePtr = std::shared_ptr<const Acts::Surface>;
@@ -44,15 +45,20 @@ class ActsPropagator
   }
   ~ActsPropagator() {}
 
+  /// Helper functions for creating needed input for track propagation
+  /// functions below
   SurfacePtr makeVertexSurface(const SvtxVertex* vertex);
   BoundTrackParam makeTrackParams(SvtxTrack* track, SvtxVertexMap* vertexMap);
 
+  /// The return type is an Acts::Result of a std::pair, where the pair is
+  /// a path length and the track parameters at the surface in units of mm 
+  /// and GeV. For an example of how to unpack this, see 
+  /// PHActsTrackProjection::propagateTrack and 
+  /// PHActsTrackProjection::updateSvtxTrack
   BoundTrackParamResult propagateTrack(const Acts::BoundTrackParameters& params,
                                        const unsigned int sphenixLayer);
-
   BoundTrackParamResult propagateTrack(const Acts::BoundTrackParameters& params,
                                        const SurfacePtr& surface);
-
   /// The following function takes the track parameters at the vertex and
   /// propagates them in isolation to the requested surface, i.e. it does
   /// NOT stop at each layer in the sPHENIX detector on the way to the

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -140,14 +140,12 @@ int PHActsTrackProjection::projectTracks(const int caloLayer)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
-
 void PHActsTrackProjection::updateSvtxTrack(
     const ActsPropagator::BoundTrackParamPair& parameters,
     SvtxTrack* svtxTrack,
     const int caloLayer)
 {
-  float pathlength = parameters.first;
+  float pathlength = parameters.first / Acts::UnitConstants::cm;
   auto params = parameters.second;
 
   SvtxTrackState_v1 out(pathlength);

--- a/offline/packages/trackreco/PHActsTrackPropagator.cc
+++ b/offline/packages/trackreco/PHActsTrackPropagator.cc
@@ -72,7 +72,7 @@ void PHActsTrackPropagator::addTrackState(
     BoundTrackParamResult &result,
     SvtxTrack *svtxTrack)
 {
-  float pathlength = result.value().first;
+  float pathlength = result.value().first / Acts::UnitConstants::cm;
   auto params = result.value().second;
 
   SvtxTrackState_v1 out(pathlength);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR makes the propagation machinery consistently use Acts units of mm and GeV. It is noted in the comments, and is not easily modified because of the const correctness of the package. The PR also adds some comments to note this for downstream users.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

