### PR TITLE
fixed the need for the template functions to be static in CaloWaveformFitting

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -19,9 +19,6 @@
 #include <iostream>
 #include <string>
 
-// Define some items that must be defined globally in the .cc file
-TProfile *CaloWaveformFitting::h_template = nullptr;
-
 double CaloWaveformFitting::template_function(double *x, double *par)
 {
   Double_t v1 = par[0] * h_template->Interpolate(x[0] - par[1]) + par[2];
@@ -79,8 +76,10 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
     {
       pedestal = 0.5 * (v.at(size1 - 3) + v.at(size1 - 2));
     }
-    auto f = new TF1(Form("f_%d", (int) round(v.at(size1))), template_function, 0, 31, 3);
-    ROOT::Math::WrappedMultiTF1 *fitFunction = new ROOT::Math::WrappedMultiTF1(*f, 3);
+
+
+    auto f = new TF1(Form("f_%d", (int) round(v.at(size1))), this,&CaloWaveformFitting::template_function, 0, 31, 3,"CaloWaveformFitting","template_function");
+   ROOT::Math::WrappedMultiTF1 *fitFunction = new ROOT::Math::WrappedMultiTF1(*f, 3);
     ROOT::Fit::BinData data(v.size() - 1, 1);
     ROOT::Fit::FillData(data, h);
     ROOT::Fit::Chi2Function *EPChi2 = new ROOT::Fit::Chi2Function(data, *fitFunction);

--- a/offline/packages/CaloReco/CaloWaveformFitting.h
+++ b/offline/packages/CaloReco/CaloWaveformFitting.h
@@ -37,8 +37,8 @@ class CaloWaveformFitting
 
  private:
   void FastMax(float x0, float x1, float x2, float y0, float y1, float y2, float &xmax, float &ymax);
-  static TProfile *h_template;
-  static double template_function(double *x, double *par);
+  TProfile *h_template;
+  double template_function(double *x, double *par);
   int _nthreads = 1;
   std::string m_template_input_file;
   std::string url_template;

--- a/offline/packages/CaloReco/CaloWaveformFitting.h
+++ b/offline/packages/CaloReco/CaloWaveformFitting.h
@@ -37,7 +37,7 @@ class CaloWaveformFitting
 
  private:
   void FastMax(float x0, float x1, float x2, float y0, float y1, float y2, float &xmax, float &ymax);
-  TProfile *h_template;
+  TProfile *h_template = nullptr;
   double template_function(double *x, double *par);
   int _nthreads = 1;
   std::string m_template_input_file;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Resolved the need for the template fit function being a static in the CaloWaveformFitting code. This introduced issues when processing multiple calorimeter systems in the same job. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

