### PR TITLE
Bbc vertex

### DIFF
--- a/simulation/g4simulation/g4bbc/BbcSimReco.cc
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.cc
@@ -116,22 +116,20 @@ namespace BBCINFO
   };
   */
 
-}  // namespace BBCINFO
-
-using namespace BBCINFO;
+}
 
 //____________________________________
 BbcSimReco::BbcSimReco(const std::string &name)
   : SubsysReco(name)
   , _tres(0.05)
 {
-  std::fill(std::begin(f_pmtq), std::end(f_pmtq), NAN);
-  std::fill(std::begin(f_pmtt0), std::end(f_pmtt0), NAN);
-  std::fill(std::begin(f_pmtt1), std::end(f_pmtt1), NAN);
+  std::fill(std::begin(f_pmtq), std::end(f_pmtq), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(f_pmtt0), std::end(f_pmtt0), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(f_pmtt1), std::end(f_pmtt1), std::numeric_limits<float>::quiet_NaN());
   std::fill(std::begin(f_bbcn), std::end(f_bbcn), 0);
-  std::fill(std::begin(f_bbcq), std::end(f_bbcq), NAN);
-  std::fill(std::begin(f_bbct), std::end(f_bbct), NAN);
-  std::fill(std::begin(f_bbcte), std::end(f_bbcte), NAN);
+  std::fill(std::begin(f_bbcq), std::end(f_bbcq), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(f_bbct), std::end(f_bbct), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(f_bbcte), std::end(f_bbcte), std::numeric_limits<float>::quiet_NaN());
   hevt_bbct[0] = nullptr;
   hevt_bbct[1] = nullptr;
   m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
@@ -194,8 +192,8 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
   f_bbct[1] = -9999.;
   f_bbcte[0] = -9999.;
   f_bbcte[1] = -9999.;
-  f_bbcz = NAN;
-  f_bbct0 = NAN;
+  f_bbcz = std::numeric_limits<float>::quiet_NaN();
+  f_bbct0 = std::numeric_limits<float>::quiet_NaN();
   hevt_bbct[0]->Reset();
   hevt_bbct[1]->Reset();
 
@@ -279,7 +277,7 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
     // get summed path length for particles that can create CKOV light
     // n.p.e. is determined from path length
     Double_t beta = v4.Beta();
-    if (beta > v_ckov && charge != 0.)
+    if (beta > BBCINFO::v_ckov && charge != 0.)
     {
       len[ch] += this_hit->get_path_length();
 
@@ -375,7 +373,7 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
     }
 
     // Now calculate zvtx, t0 from best times
-    f_bbcz = (f_bbct[0] - f_bbct[1]) * C / 2.0;
+    f_bbcz = (f_bbct[0] - f_bbct[1]) * BBCINFO::C / 2.0;
     f_bbct0 = (f_bbct[0] + f_bbct[1]) / 2.0;
 
     _bbcout->set_Vertex(f_bbcz, 0.6);

--- a/simulation/g4simulation/g4bbc/BbcSimReco.cc
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.cc
@@ -9,8 +9,6 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
-#include <ffaobjects/EventHeaderv1.h>
-
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/PHTFileServer.h>
 
@@ -185,8 +183,6 @@ int BbcSimReco::InitRun(PHCompositeNode *topNode)
 // Call user instructions for every event
 int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
 {
-  f_evt = _evtheader->get_EvtSequence();
-
   //**** Initialize Variables
 
   // Arm Data
@@ -222,7 +218,7 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
     f_vz = vtxp->get_z();
     f_vt = vtxp->get_t();
 
-    if (Verbosity() && f_evt < 20)
+    if (Verbosity())
     {
       std::cout << "VTXP "
            << "\t" << f_vx << "\t" << f_vy << "\t" << f_vz << "\t" << f_vt << std::endl;
@@ -308,7 +304,7 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
     // Fill charge and time info
     if (len[ich] > 0.)
     {
-      if (f_evt < 20 && Verbosity() != 0)
+      if (Verbosity() > 0)
       {
         std::cout << "ich " << ich << "\t" << len[ich] << "\t" << edep[ich] << std::endl;
       }
@@ -433,38 +429,35 @@ void BbcSimReco::GetNodes(PHCompositeNode *topNode)
 
   // Truth container
   _truth_container = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
-  if (!_truth_container && f_evt < 10)
+  if (!_truth_container)
   {
     std::cout << PHWHERE << " PHG4TruthInfoContainer node not found on node tree" << std::endl;
+    gSystem->Exit(1);
   }
 
   // BBC hit container
   _bbchits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_BBC");
-  if (!_bbchits && f_evt < 10)
+  if (!_bbchits)
   {
     std::cout << PHWHERE << " G4HIT_BBC node not found on node tree" << std::endl;
-  }
-
-  // Event Header info
-  _evtheader = findNode::getClass<EventHeaderv1>(topNode, "EventHeader");
-  if (!_evtheader && f_evt < 10)
-  {
-    std::cout << PHWHERE << " G4HIT_BBC node not found on node tree" << std::endl;
+    gSystem->Exit(1);
   }
 
   /** DST Objects **/
 
   // BbcOut data
   _bbcout = findNode::getClass<BbcOut>(topNode, "BbcOut");
-  if (!_bbcout && f_evt < 10)
+  if (!_bbcout)
   {
     std::cout << PHWHERE << " BbcOut node not found on node tree" << std::endl;
+    gSystem->Exit(1);
   }
 
   // BbcPmtContainer
   _bbcpmts = findNode::getClass<BbcPmtContainer>(topNode, "BbcPmtContainer");
-  if (!_bbcpmts && f_evt < 10)
+  if (!_bbcpmts)
   {
     std::cout << PHWHERE << " BbcPmtContainer node not found on node tree" << std::endl;
+    gSystem->Exit(1);
   }
 }

--- a/simulation/g4simulation/g4bbc/BbcSimReco.h
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.h
@@ -54,7 +54,6 @@ class BbcSimReco : public SubsysReco
   void CreateNodes(PHCompositeNode *topNode);  // Create all the nodes
   void GetNodes(PHCompositeNode *);            // Get all the needed nodes
 
-  Int_t f_evt = 0;
   Float_t f_vx = NAN;
   Float_t f_vy = NAN;
   Float_t f_vz = NAN;

--- a/simulation/g4simulation/g4bbc/BbcSimReco.h
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.h
@@ -83,7 +83,6 @@ class BbcSimReco : public SubsysReco
   // Input Objects from DST
   PHG4TruthInfoContainer *_truth_container = nullptr;
   PHG4HitContainer *_bbchits = nullptr;
-  EventHeader *_evtheader = nullptr;
 
   // Output to DST
   BbcOut *_bbcout = nullptr;

--- a/simulation/g4simulation/g4vertex/GlobalVertex.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.h
@@ -12,11 +12,16 @@
 class GlobalVertex : public PHObject
 {
  public:
+
+// the order matters (best vertex -> highest number), so leave some space in case we want to wedge other vertices in here
   enum VTXTYPE
   {
-    NONE = 0,
-    BBC = 1,
-    SVTX = 2
+    UNDEFINED = 0,
+    TRUTH = 100,
+    SMEARED = 200,
+    BBC = 300,
+    SVTX = 400,
+    SVTX_BBC = 500
   };
 
   typedef std::map<GlobalVertex::VTXTYPE, unsigned int>::const_iterator ConstVtxIter;

--- a/simulation/g4simulation/g4vertex/GlobalVertex.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertex.h
@@ -12,8 +12,7 @@
 class GlobalVertex : public PHObject
 {
  public:
-
-// the order matters (best vertex -> highest number), so leave some space in case we want to wedge other vertices in here
+  // the order matters (best vertex -> highest number), so leave some space in case we want to wedge other vertices in here
   enum VTXTYPE
   {
     UNDEFINED = 0,

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
@@ -68,7 +68,8 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
 
 int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) std::cout << "GlobalVertexFastSimReco::process_event -- entered" << std::endl;
+  if (Verbosity() > 1) { std::cout << "GlobalVertexFastSimReco::process_event -- entered" << std::endl;
+}
 
   //---------------------------------
   // Get Objects off of the Node Tree

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
@@ -1,30 +1,30 @@
 #include "GlobalVertexFastSimReco.h"
 
-#include "GlobalVertexMap.h"                // for GlobalVertexMap
+#include "GlobalVertex.h"     // for GlobalVertex
+#include "GlobalVertexMap.h"  // for GlobalVertexMap
 #include "GlobalVertexMapv1.h"
-#include "GlobalVertex.h"                   // for GlobalVertex
 #include "GlobalVertexv1.h"
 
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <g4main/PHG4VtxPoint.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>             // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                   // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                 // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
-#include <phool/phool.h>                    // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <gsl/gsl_randist.h>
-#include <gsl/gsl_rng.h>                    // for gsl_rng_alloc, gsl_rng_free
+#include <gsl/gsl_rng.h>  // for gsl_rng_alloc, gsl_rng_free
 
 #include <cmath>
-#include <cstdlib>                         // for exit
+#include <cstdlib>  // for exit
 #include <iostream>
 
 GlobalVertexFastSimReco::GlobalVertexFastSimReco(const std::string &name)
@@ -68,8 +68,10 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
 
 int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) { std::cout << "GlobalVertexFastSimReco::process_event -- entered" << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "GlobalVertexFastSimReco::process_event -- entered" << std::endl;
+  }
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -100,9 +102,9 @@ int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
   vertex->set_z(point->get_z());
   vertex->set_t(point->get_t());
   vertex->set_t_err(0.);
-  for (int i = 0; i<3; i++)
+  for (int i = 0; i < 3; i++)
   {
-    for (int j = 0; j<3; j++)
+    for (int j = 0; j < 3; j++)
     {
       vertex->set_error(i, j, 0.0);
     }

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.cc
@@ -27,14 +27,8 @@
 #include <cstdlib>                         // for exit
 #include <iostream>
 
-using namespace std;
-
-GlobalVertexFastSimReco::GlobalVertexFastSimReco(const string &name)
+GlobalVertexFastSimReco::GlobalVertexFastSimReco(const std::string &name)
   : SubsysReco(name)
-  , _x_smear(NAN)
-  , _y_smear(NAN)
-  , _z_smear(NAN)
-  , _t_smear(NAN)
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
 }
@@ -44,11 +38,6 @@ GlobalVertexFastSimReco::~GlobalVertexFastSimReco()
   gsl_rng_free(RandomGenerator);
 }
 
-int GlobalVertexFastSimReco::Init(PHCompositeNode */*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
 int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
 {
   if (isnan(_x_smear) ||
@@ -56,7 +45,7 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
       isnan(_z_smear) ||
       isnan(_t_smear))
   {
-    cout << PHWHERE << "::ERROR - smearing must be defined for (x,y,z,t) via set_?_smearing(float)" << endl;
+    std::cout << PHWHERE << "::ERROR - smearing must be defined for (x,y,z,t) via set_?_smearing(float)" << std::endl;
     exit(-1);
   }
 
@@ -65,13 +54,13 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
 
   if (Verbosity() > 0)
   {
-    cout << "=================== GlobalVertexFastSimReco::InitRun() ====================" << endl;
-    cout << " x smearing: " << _x_smear << " cm " << endl;
-    cout << " y smearing: " << _y_smear << " cm " << endl;
-    cout << " z smearing: " << _z_smear << " cm " << endl;
-    cout << " t smearing: " << _t_smear << " cm " << endl;
-    cout << " random seed: " << seed << endl;
-    cout << "===========================================================================" << endl;
+    std::cout << "=================== GlobalVertexFastSimReco::InitRun() ====================" << std::endl;
+    std::cout << " x smearing: " << _x_smear << " cm " << std::endl;
+    std::cout << " y smearing: " << _y_smear << " cm " << std::endl;
+    std::cout << " z smearing: " << _z_smear << " cm " << std::endl;
+    std::cout << " t smearing: " << _t_smear << " cm " << std::endl;
+    std::cout << " random seed: " << seed << std::endl;
+    std::cout << "===========================================================================" << std::endl;
   }
 
   return CreateNodes(topNode);
@@ -79,7 +68,7 @@ int GlobalVertexFastSimReco::InitRun(PHCompositeNode *topNode)
 
 int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) cout << "GlobalVertexFastSimReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) std::cout << "GlobalVertexFastSimReco::process_event -- entered" << std::endl;
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -87,14 +76,14 @@ int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
   PHG4TruthInfoContainer *truthinfo = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
   if (!truthinfo)
   {
-    cout << PHWHERE << "::ERROR - cannot find G4TruthInfo" << endl;
+    std::cout << PHWHERE << "::ERROR - cannot find G4TruthInfo" << std::endl;
     exit(-1);
   }
 
   GlobalVertexMap *vertexes = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexes)
   {
-    cout << PHWHERE << "::ERROR - cannot find GlobalVertexMap" << endl;
+    std::cout << PHWHERE << "::ERROR - cannot find GlobalVertexMap" << std::endl;
     exit(-1);
   }
 
@@ -104,7 +93,22 @@ int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
 
   PHG4VtxPoint *point = truthinfo->GetPrimaryVtx(truthinfo->GetPrimaryVertexIndex());
 
-  GlobalVertex *vertex = new GlobalVertexv1();
+  GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::TRUTH);
+  vertex->set_x(point->get_x());
+  vertex->set_y(point->get_y());
+  vertex->set_z(point->get_z());
+  vertex->set_t(point->get_t());
+  vertex->set_t_err(0.);
+  for (int i = 0; i<3; i++)
+  {
+    for (int j = 0; j<3; j++)
+    {
+      vertex->set_error(i, j, 0.0);
+    }
+  }
+  vertexes->insert(vertex);
+
+  vertex = new GlobalVertexv1(GlobalVertex::SMEARED);
 
   vertex->set_x(point->get_x() + gsl_ran_gaussian(RandomGenerator, _x_smear));
   vertex->set_y(point->get_y() + gsl_ran_gaussian(RandomGenerator, _y_smear));
@@ -130,11 +134,6 @@ int GlobalVertexFastSimReco::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int GlobalVertexFastSimReco::End(PHCompositeNode */*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
 int GlobalVertexFastSimReco::CreateNodes(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
@@ -143,7 +142,7 @@ int GlobalVertexFastSimReco::CreateNodes(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -165,7 +164,7 @@ int GlobalVertexFastSimReco::CreateNodes(PHCompositeNode *topNode)
   }
   else
   {
-    cout << PHWHERE << "::ERROR - GlobalVertexMap pre-exists, but should not if running FastSim" << endl;
+    std::cout << PHWHERE << "::ERROR - GlobalVertexMap pre-exists, but should not if running FastSim" << std::endl;
     exit(-1);
   }
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
@@ -13,6 +13,7 @@
 
 #include <gsl/gsl_rng.h>
 
+#include <limits>
 #include <string>                // for string
 
 class PHCompositeNode;
@@ -27,10 +28,8 @@ class GlobalVertexFastSimReco : public SubsysReco
   GlobalVertexFastSimReco(const std::string &name = "GlobalVertexFastSimReco");
   ~GlobalVertexFastSimReco() override;
 
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End(PHCompositeNode *topNode) override;
 
   void set_x_smearing(const float x_smear) { _x_smear = x_smear; }
   void set_y_smearing(const float y_smear) { _y_smear = y_smear; }
@@ -40,11 +39,11 @@ class GlobalVertexFastSimReco : public SubsysReco
  private:
   int CreateNodes(PHCompositeNode *topNode);
 
-  float _x_smear;
-  float _y_smear;
-  float _z_smear;
-  float _t_smear;
-  gsl_rng *RandomGenerator;
+  float _x_smear = std::numeric_limits<float>::quiet_NaN();
+  float _y_smear = std::numeric_limits<float>::quiet_NaN();
+  float _z_smear = std::numeric_limits<float>::quiet_NaN();
+  float _t_smear = std::numeric_limits<float>::quiet_NaN();
+  gsl_rng *RandomGenerator = nullptr;
 };
 
 #endif  // G4VERTEX_GLOBALVERTEXFASTSIMRECO_H

--- a/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexFastSimReco.h
@@ -14,7 +14,7 @@
 #include <gsl/gsl_rng.h>
 
 #include <limits>
-#include <string>                // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexMap.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMap.cc
@@ -31,4 +31,3 @@ GlobalVertexMap::Iter GlobalVertexMap::end()
 {
   return DummyGlobalVertexMap.end();
 }
-

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
@@ -3,8 +3,8 @@
 #include "GlobalVertex.h"
 #include "GlobalVertexMap.h"
 
-#include <iterator>           // for reverse_iterator
-#include <utility>            // for pair, make_pair
+#include <iterator>  // for reverse_iterator
+#include <utility>   // for pair, make_pair
 
 GlobalVertexMapv1::~GlobalVertexMapv1()
 {
@@ -14,7 +14,7 @@ GlobalVertexMapv1::~GlobalVertexMapv1()
 void GlobalVertexMapv1::identify(std::ostream& os) const
 {
   os << "GlobalVertexMapv1: size = " << _map.size() << std::endl;
-  for (auto &m : _map)
+  for (auto& m : _map)
   {
     m.second->identify(os);
   }
@@ -23,7 +23,7 @@ void GlobalVertexMapv1::identify(std::ostream& os) const
 
 void GlobalVertexMapv1::clear()
 {
-  for (auto & iter : _map)
+  for (const auto& iter : _map)
   {
     delete iter.second;
   }
@@ -34,16 +34,20 @@ void GlobalVertexMapv1::clear()
 const GlobalVertex* GlobalVertexMapv1::get(unsigned int id) const
 {
   ConstIter iter = _map.find(id);
-  if (iter == _map.end()) { return nullptr;
-}
+  if (iter == _map.end())
+  {
+    return nullptr;
+  }
   return iter->second;
 }
 
 GlobalVertex* GlobalVertexMapv1::get(unsigned int id)
 {
   Iter iter = _map.find(id);
-  if (iter == _map.end()) { return nullptr;
-}
+  if (iter == _map.end())
+  {
+    return nullptr;
+  }
   return iter->second;
 }
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
@@ -6,21 +6,18 @@
 #include <iterator>           // for reverse_iterator
 #include <utility>            // for pair, make_pair
 
-using namespace std;
-
-GlobalVertexMapv1::GlobalVertexMapv1()
-  : _map()
-{
-}
-
 GlobalVertexMapv1::~GlobalVertexMapv1()
 {
   clear();
 }
 
-void GlobalVertexMapv1::identify(ostream& os) const
+void GlobalVertexMapv1::identify(std::ostream& os) const
 {
-  os << "GlobalVertexMapv1: size = " << _map.size() << endl;
+  os << "GlobalVertexMapv1: size = " << _map.size() << std::endl;
+  for (auto &m : _map)
+  {
+    m.second->identify(os);
+  }
   return;
 }
 
@@ -52,9 +49,7 @@ GlobalVertex* GlobalVertexMapv1::get(unsigned int id)
 
 GlobalVertex* GlobalVertexMapv1::insert(GlobalVertex* clus)
 {
-  unsigned int index = 0;
-  if (!_map.empty()) index = _map.rbegin()->first + 1;
-  _map.insert(make_pair(index, clus));
-  _map[index]->set_id(index);
-  return _map[index];
+  unsigned int index = clus->get_id();
+  auto ret = _map.insert(std::make_pair(index, clus));
+  return ret.first->second;
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.cc
@@ -23,11 +23,9 @@ void GlobalVertexMapv1::identify(std::ostream& os) const
 
 void GlobalVertexMapv1::clear()
 {
-  for (Iter iter = _map.begin();
-       iter != _map.end();
-       ++iter)
+  for (auto & iter : _map)
   {
-    delete iter->second;
+    delete iter.second;
   }
   _map.clear();
   return;
@@ -36,14 +34,16 @@ void GlobalVertexMapv1::clear()
 const GlobalVertex* GlobalVertexMapv1::get(unsigned int id) const
 {
   ConstIter iter = _map.find(id);
-  if (iter == _map.end()) return nullptr;
+  if (iter == _map.end()) { return nullptr;
+}
   return iter->second;
 }
 
 GlobalVertex* GlobalVertexMapv1::get(unsigned int id)
 {
   Iter iter = _map.find(id);
-  if (iter == _map.end()) return nullptr;
+  if (iter == _map.end()) { return nullptr;
+}
   return iter->second;
 }
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
@@ -14,7 +14,7 @@
 class GlobalVertexMapv1 : public GlobalVertexMap
 {
  public:
-  GlobalVertexMapv1();
+  GlobalVertexMapv1() = default;
   ~GlobalVertexMapv1() override;
 
   void identify(std::ostream& os = std::cout) const override;

--- a/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexMapv1.h
@@ -7,7 +7,7 @@
 
 #include "GlobalVertex.h"
 
-#include <cstddef>        // for size_t
+#include <cstddef>  // for size_t
 #include <iostream>
 #include <map>
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
@@ -1,8 +1,8 @@
 #include "GlobalVertexReco.h"
 
+#include "GlobalVertex.h"     // for GlobalVertex, GlobalVe...
+#include "GlobalVertexMap.h"  // for GlobalVertexMap
 #include "GlobalVertexMapv1.h"
-#include "GlobalVertexMap.h"                   // for GlobalVertexMap
-#include "GlobalVertex.h"                      // for GlobalVertex, GlobalVe...
 #include "GlobalVertexv1.h"
 
 #include <g4bbc/BbcVertex.h>
@@ -14,22 +14,22 @@
 #include <trackbase_historic/SvtxVertexMap.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>                      // for PHNode
+#include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>                    // for PHObject
+#include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>                       // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <cfloat>
 #include <cmath>
-#include <cstdlib>                            // for exit
-#include <set>                                 // for _Rb_tree_const_iterator
+#include <cstdlib>  // for exit
 #include <iostream>
-#include <utility>                             // for pair
+#include <set>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 
 using namespace std;
 
@@ -51,8 +51,10 @@ int GlobalVertexReco::InitRun(PHCompositeNode *topNode)
 
 int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) { cout << "GlobalVertexReco::process_event -- entered" << endl;
-}
+  if (Verbosity() > 1)
+  {
+    cout << "GlobalVertexReco::process_event -- entered" << endl;
+  }
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -63,33 +65,35 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
     cout << PHWHERE << "::ERROR - cannot find GlobalVertexMap" << endl;
     exit(-1);
   }
-// just patch in the new bbc vertex
+  // just patch in the new bbc vertex
   BbcOut *bbcout = findNode::getClass<BbcOut>(topNode, "BbcOut");
   if (bbcout)
   {
     GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::BBC);
 
-      vertex->set_x(_xdefault);
-      vertex->set_y(_ydefault);
-      vertex->set_z(bbcout->get_VertexPoint());
+    vertex->set_x(_xdefault);
+    vertex->set_y(_ydefault);
+    vertex->set_z(bbcout->get_VertexPoint());
 
-      vertex->set_t(bbcout->get_TimeZero());
-      vertex->set_t_err(bbcout->get_dTimeZero());
+    vertex->set_t(bbcout->get_TimeZero());
+    vertex->set_t_err(bbcout->get_dTimeZero());
 
-      vertex->set_error(0, 0, _xerr * _xerr);
-      vertex->set_error(0, 1, 0.0);
-      vertex->set_error(0, 2, 0.0);
+    vertex->set_error(0, 0, _xerr * _xerr);
+    vertex->set_error(0, 1, 0.0);
+    vertex->set_error(0, 2, 0.0);
 
-      vertex->set_error(1, 1, 0.0);
-      vertex->set_error(1, 1, _yerr *_yerr);
-      vertex->set_error(1, 2, 0.0);
+    vertex->set_error(1, 1, 0.0);
+    vertex->set_error(1, 1, _yerr * _yerr);
+    vertex->set_error(1, 2, 0.0);
 
-      vertex->set_error(2, 0, 0.0);
-      vertex->set_error(2, 1, 0.0);
-      vertex->set_error(2, 2, bbcout->get_dTimeZero()*bbcout->get_dTimeZero());
-      if (Verbosity() > 1) { vertex->identify();
-}
-      globalmap->insert(vertex);
+    vertex->set_error(2, 0, 0.0);
+    vertex->set_error(2, 1, 0.0);
+    vertex->set_error(2, 2, bbcout->get_dTimeZero() * bbcout->get_dTimeZero());
+    if (Verbosity() > 1)
+    {
+      vertex->identify();
+    }
+    globalmap->insert(vertex);
   }
 
   SvtxVertexMap *svtxmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
@@ -115,8 +119,10 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
   if (svtxmap && bbcmap)
   {
-    if (Verbosity()) { cout << "GlobalVertexReco::process_event - svtxmap && bbcmap" << endl;
-}
+    if (Verbosity())
+    {
+      cout << "GlobalVertexReco::process_event - svtxmap && bbcmap" << endl;
+    }
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
          svtxiter != svtxmap->end();
@@ -141,8 +147,10 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
         }
       }
 
-      if (min_sigma > 3.0 || !bbc_best) { continue;
-}
+      if (min_sigma > 3.0 || !bbc_best)
+      {
+        continue;
+      }
 
       // we have a matching pair
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX_BBC);
@@ -169,16 +177,20 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) { vertex->identify();
-}
+      if (Verbosity() > 1)
+      {
+        vertex->identify();
+      }
     }
   }
 
   // okay now loop over all unused SVTX vertexes (2nd class)...
   if (svtxmap)
   {
-    if (Verbosity()) { cout << "GlobalVertexReco::process_event - svtxmap " << endl;
-}
+    if (Verbosity())
+    {
+      cout << "GlobalVertexReco::process_event - svtxmap " << endl;
+    }
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
          svtxiter != svtxmap->end();
@@ -186,10 +198,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
     {
       const SvtxVertex *svtx = svtxiter->second;
 
-      if (used_svtx_vtxids.find(svtx->get_id()) != used_svtx_vtxids.end()) { continue;
-}
-      if (isnan(svtx->get_z())) { continue;
-}
+      if (used_svtx_vtxids.find(svtx->get_id()) != used_svtx_vtxids.end())
+      {
+        continue;
+      }
+      if (isnan(svtx->get_z()))
+      {
+        continue;
+      }
 
       // we have a standalone SVTX vertex
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX);
@@ -215,16 +231,20 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) { vertex->identify();
-}
+      if (Verbosity() > 1)
+      {
+        vertex->identify();
+      }
     }
   }
 
   // okay now loop over all unused BBC vertexes (3rd class)...
   if (bbcmap)
   {
-    if (Verbosity()) { cout << "GlobalVertexReco::process_event -  bbcmap" << endl;
-}
+    if (Verbosity())
+    {
+      cout << "GlobalVertexReco::process_event -  bbcmap" << endl;
+    }
 
     for (BbcVertexMap::ConstIter bbciter = bbcmap->begin();
          bbciter != bbcmap->end();
@@ -232,10 +252,14 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
     {
       const BbcVertex *bbc = bbciter->second;
 
-      if (used_bbc_vtxids.find(bbc->get_id()) != used_bbc_vtxids.end()) { continue;
-}
-      if (isnan(bbc->get_z())) { continue;
-}
+      if (used_bbc_vtxids.find(bbc->get_id()) != used_bbc_vtxids.end())
+      {
+        continue;
+      }
+      if (isnan(bbc->get_z()))
+      {
+        continue;
+      }
 
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::UNDEFINED);
 
@@ -265,14 +289,16 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) { vertex->identify();
-}
+      if (Verbosity() > 1)
+      {
+        vertex->identify();
+      }
     }
   }
-if (Verbosity()) 
-{
- globalmap->identify();
-}
+  if (Verbosity())
+  {
+    globalmap->identify();
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.cc
@@ -51,7 +51,8 @@ int GlobalVertexReco::InitRun(PHCompositeNode *topNode)
 
 int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 1) cout << "GlobalVertexReco::process_event -- entered" << endl;
+  if (Verbosity() > 1) { cout << "GlobalVertexReco::process_event -- entered" << endl;
+}
 
   //---------------------------------
   // Get Objects off of the Node Tree
@@ -86,7 +87,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       vertex->set_error(2, 0, 0.0);
       vertex->set_error(2, 1, 0.0);
       vertex->set_error(2, 2, bbcout->get_dTimeZero()*bbcout->get_dTimeZero());
-      if (Verbosity() > 1) vertex->identify();
+      if (Verbosity() > 1) { vertex->identify();
+}
       globalmap->insert(vertex);
   }
 
@@ -113,7 +115,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
   if (svtxmap && bbcmap)
   {
-    if (Verbosity()) cout << "GlobalVertexReco::process_event - svtxmap && bbcmap" << endl;
+    if (Verbosity()) { cout << "GlobalVertexReco::process_event - svtxmap && bbcmap" << endl;
+}
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
          svtxiter != svtxmap->end();
@@ -138,7 +141,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
         }
       }
 
-      if (min_sigma > 3.0 || !bbc_best) continue;
+      if (min_sigma > 3.0 || !bbc_best) { continue;
+}
 
       // we have a matching pair
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX_BBC);
@@ -165,14 +169,16 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) vertex->identify();
+      if (Verbosity() > 1) { vertex->identify();
+}
     }
   }
 
   // okay now loop over all unused SVTX vertexes (2nd class)...
   if (svtxmap)
   {
-    if (Verbosity()) cout << "GlobalVertexReco::process_event - svtxmap " << endl;
+    if (Verbosity()) { cout << "GlobalVertexReco::process_event - svtxmap " << endl;
+}
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
          svtxiter != svtxmap->end();
@@ -180,8 +186,10 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
     {
       const SvtxVertex *svtx = svtxiter->second;
 
-      if (used_svtx_vtxids.find(svtx->get_id()) != used_svtx_vtxids.end()) continue;
-      if (isnan(svtx->get_z())) continue;
+      if (used_svtx_vtxids.find(svtx->get_id()) != used_svtx_vtxids.end()) { continue;
+}
+      if (isnan(svtx->get_z())) { continue;
+}
 
       // we have a standalone SVTX vertex
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX);
@@ -207,14 +215,16 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) vertex->identify();
+      if (Verbosity() > 1) { vertex->identify();
+}
     }
   }
 
   // okay now loop over all unused BBC vertexes (3rd class)...
   if (bbcmap)
   {
-    if (Verbosity()) cout << "GlobalVertexReco::process_event -  bbcmap" << endl;
+    if (Verbosity()) { cout << "GlobalVertexReco::process_event -  bbcmap" << endl;
+}
 
     for (BbcVertexMap::ConstIter bbciter = bbcmap->begin();
          bbciter != bbcmap->end();
@@ -222,8 +232,10 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
     {
       const BbcVertex *bbc = bbciter->second;
 
-      if (used_bbc_vtxids.find(bbc->get_id()) != used_bbc_vtxids.end()) continue;
-      if (isnan(bbc->get_z())) continue;
+      if (used_bbc_vtxids.find(bbc->get_id()) != used_bbc_vtxids.end()) { continue;
+}
+      if (isnan(bbc->get_z())) { continue;
+}
 
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::UNDEFINED);
 
@@ -253,7 +265,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       globalmap->insert(vertex);
 
-      if (Verbosity() > 1) vertex->identify();
+      if (Verbosity() > 1) { vertex->identify();
+}
     }
   }
 if (Verbosity()) 

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.h
@@ -24,12 +24,10 @@ class GlobalVertexReco : public SubsysReco
 {
  public:
   GlobalVertexReco(const std::string &name = "GlobalVertexReco");
-  ~GlobalVertexReco() override;
+  ~GlobalVertexReco() override = default;
 
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End(PHCompositeNode *topNode) override;
 
   void set_x_defaults(float xdefault, float xerr)
   {
@@ -50,9 +48,12 @@ class GlobalVertexReco : public SubsysReco
  private:
   int CreateNodes(PHCompositeNode *topNode);
 
-  float _xdefault, _xerr;
-  float _ydefault, _yerr;
-  float _tdefault, _terr;
+  float _xdefault = 0.;
+  float _xerr = 0.3;
+  float _ydefault = 0.;
+  float _yerr = 0.3;
+  float _tdefault = 0.;
+  float _terr = 0.2;
 };
 
 #endif  // G4VERTEX_GLOBALVERTEXRECO_H

--- a/simulation/g4simulation/g4vertex/GlobalVertexReco.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexReco.h
@@ -12,7 +12,7 @@
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>                // for string
+#include <string>  // for string
 
 class PHCompositeNode;
 

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
@@ -72,23 +72,30 @@ void GlobalVertexv1::identify(std::ostream& os) const
 
 int GlobalVertexv1::isValid() const
 {
-  if (! std::isfinite(_t)) return 0;
-  if (! std::isfinite(_t_err)) return 0;
-  if (! std::isfinite(_chisq)) return 0;
-  if (_ndof ==  std::numeric_limits<unsigned int>::max()) return 0;
+  if (! std::isfinite(_t)) { return 0;
+}
+  if (! std::isfinite(_t_err)) { return 0;
+}
+  if (! std::isfinite(_chisq)) { return 0;
+}
+  if (_ndof ==  std::numeric_limits<unsigned int>::max()) { return 0;
+}
 
-  for (int i = 0; i < 3; ++i)
+  for (float _po : _pos)
   {
-    if (! std::isfinite(_pos[i])) return 0;
+    if (! std::isfinite(_po)) { return 0;
+}
   }
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (! std::isfinite(get_error(i, j))) return 0;
+      if (! std::isfinite(get_error(i, j))) { return 0;
+}
     }
   }
-  if (_vtx_ids.empty()) return 0;
+  if (_vtx_ids.empty()) { return 0;
+}
   return 1;
 }
 
@@ -105,6 +112,7 @@ float GlobalVertexv1::get_error(unsigned int i, unsigned int j) const
 
 unsigned int GlobalVertexv1::covar_index(unsigned int i, unsigned int j) const
 {
-  if (i > j) std::swap(i, j);
+  if (i > j) { std::swap(i, j);
+}
   return i + 1 + (j + 1) * (j) / 2 - 1;
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
@@ -2,85 +2,90 @@
 
 #include <cmath>
 
-using namespace std;
-
-GlobalVertexv1::GlobalVertexv1()
-  : _id(0xFFFFFFFF)
-  , _t(NAN)
-  , _t_err(NAN)
-  , _pos()
-  , _chisq(NAN)
-  , _ndof(0xFFFFFFFF)
-  , _err()
-  , _vtx_ids()
+GlobalVertexv1::GlobalVertexv1(const GlobalVertex::VTXTYPE id)
+  : _id(id)
 {
-  for (int i = 0; i < 3; ++i) _pos[i] = NAN;
-
-  for (int j = 0; j < 3; ++j)
-  {
-    for (int i = j; i < 3; ++i)
-    {
-      set_error(i, j, NAN);
-    }
-  }
+  std::fill(std::begin(_pos), std::end(_pos), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(_err),std::end(_err), std::numeric_limits<float>::quiet_NaN());
 }
 
-GlobalVertexv1::~GlobalVertexv1() {}
-
-void GlobalVertexv1::identify(ostream& os) const
+void GlobalVertexv1::identify(std::ostream& os) const
 {
-  os << "---GlobalVertexv1-----------------------" << endl;
-  os << "vertexid: " << get_id() << endl;
+  os << "---GlobalVertexv1-----------------------" << std::endl;
+  os << "vertexid: " << get_id();
+  switch(get_id())
+  {
+  case GlobalVertex::UNDEFINED:
+    os << ", type GlobalVertex::UNDEFINED" << std::endl;
+    break;
+  case GlobalVertex::TRUTH:
+    os << ", type GlobalVertex::TRUTH" << std::endl;
+    break;
+  case GlobalVertex::SMEARED:
+    os << ", type GlobalVertex::SMEARED" << std::endl;
+    break;
+  case GlobalVertex::BBC:
+    os << ", type GlobalVertex::BBC" << std::endl;
+    break;
+  case GlobalVertex::SVTX:
+    os << ", type GlobalVertex::SVTX" << std::endl;
+    break;
+  case GlobalVertex::SVTX_BBC:
+    os << ", type GlobalVertex::SVTX_BBC" << std::endl;
+    break;
+  default:
+    os << "unknown type of GlobalVertex:" << get_id() << std::endl;
+    break;
+  }
 
-  os << " t = " << get_t() << endl;
+  os << " t = " << get_t() << std::endl;
 
   os << " (x,y,z) =  (" << get_position(0);
   os << ", " << get_position(1) << ", ";
-  os << get_position(2) << ") cm" << endl;
+  os << get_position(2) << ") cm" << std::endl;
 
   os << " chisq = " << get_chisq() << ", ";
-  os << " ndof = " << get_ndof() << endl;
+  os << " ndof = " << get_ndof() << std::endl;
 
   os << "         ( ";
   os << get_error(0, 0) << " , ";
   os << get_error(0, 1) << " , ";
-  os << get_error(0, 2) << " )" << endl;
+  os << get_error(0, 2) << " )" << std::endl;
   os << "  err  = ( ";
   os << get_error(1, 0) << " , ";
   os << get_error(1, 1) << " , ";
-  os << get_error(1, 2) << " )" << endl;
+  os << get_error(1, 2) << " )" << std::endl;
   os << "         ( ";
   os << get_error(2, 0) << " , ";
   os << get_error(2, 1) << " , ";
-  os << get_error(2, 2) << " )" << endl;
+  os << get_error(2, 2) << " )" << std::endl;
 
-  os << " list of vtx ids: " << endl;
+  os << " list of vtx ids: " << std::endl;
   for (ConstVtxIter iter = begin_vtxids(); iter != end_vtxids(); ++iter)
   {
-    os << "  " << iter->first << " => " << iter->second << endl;
+    os << "  " << iter->first << " => " << iter->second << std::endl;
   }
-  os << "-----------------------------------------------" << endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
 
 int GlobalVertexv1::isValid() const
 {
-  if (_id == 0xFFFFFFFF) return 0;
-  if (isnan(_t)) return 0;
-  if (isnan(_t_err)) return 0;
-  if (isnan(_chisq)) return 0;
-  if (_ndof == 0xFFFFFFFF) return 0;
+  if (! std::isfinite(_t)) return 0;
+  if (! std::isfinite(_t_err)) return 0;
+  if (! std::isfinite(_chisq)) return 0;
+  if (_ndof ==  std::numeric_limits<unsigned int>::max()) return 0;
 
   for (int i = 0; i < 3; ++i)
   {
-    if (isnan(_pos[i])) return 0;
+    if (! std::isfinite(_pos[i])) return 0;
   }
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (isnan(get_error(i, j))) return 0;
+      if (! std::isfinite(get_error(i, j))) return 0;
     }
   }
   if (_vtx_ids.empty()) return 0;

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.cc
@@ -6,14 +6,14 @@ GlobalVertexv1::GlobalVertexv1(const GlobalVertex::VTXTYPE id)
   : _id(id)
 {
   std::fill(std::begin(_pos), std::end(_pos), std::numeric_limits<float>::quiet_NaN());
-  std::fill(std::begin(_err),std::end(_err), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(_err), std::end(_err), std::numeric_limits<float>::quiet_NaN());
 }
 
 void GlobalVertexv1::identify(std::ostream& os) const
 {
   os << "---GlobalVertexv1-----------------------" << std::endl;
   os << "vertexid: " << get_id();
-  switch(get_id())
+  switch (get_id())
   {
   case GlobalVertex::UNDEFINED:
     os << ", type GlobalVertex::UNDEFINED" << std::endl;
@@ -72,30 +72,44 @@ void GlobalVertexv1::identify(std::ostream& os) const
 
 int GlobalVertexv1::isValid() const
 {
-  if (! std::isfinite(_t)) { return 0;
-}
-  if (! std::isfinite(_t_err)) { return 0;
-}
-  if (! std::isfinite(_chisq)) { return 0;
-}
-  if (_ndof ==  std::numeric_limits<unsigned int>::max()) { return 0;
-}
+  if (!std::isfinite(_t))
+  {
+    return 0;
+  }
+  if (!std::isfinite(_t_err))
+  {
+    return 0;
+  }
+  if (!std::isfinite(_chisq))
+  {
+    return 0;
+  }
+  if (_ndof == std::numeric_limits<unsigned int>::max())
+  {
+    return 0;
+  }
 
   for (float _po : _pos)
   {
-    if (! std::isfinite(_po)) { return 0;
-}
+    if (!std::isfinite(_po))
+    {
+      return 0;
+    }
   }
   for (int j = 0; j < 3; ++j)
   {
     for (int i = j; i < 3; ++i)
     {
-      if (! std::isfinite(get_error(i, j))) { return 0;
-}
+      if (!std::isfinite(get_error(i, j)))
+      {
+        return 0;
+      }
     }
   }
-  if (_vtx_ids.empty()) { return 0;
-}
+  if (_vtx_ids.empty())
+  {
+    return 0;
+  }
   return 1;
 }
 
@@ -112,7 +126,9 @@ float GlobalVertexv1::get_error(unsigned int i, unsigned int j) const
 
 unsigned int GlobalVertexv1::covar_index(unsigned int i, unsigned int j) const
 {
-  if (i > j) { std::swap(i, j);
-}
+  if (i > j)
+  {
+    std::swap(i, j);
+  }
   return i + 1 + (j + 1) * (j) / 2 - 1;
 }

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.h
@@ -5,18 +5,18 @@
 
 #include "GlobalVertex.h"
 
-#include <cstddef>        // for size_t
-#include <limits>
+#include <cstddef>  // for size_t
 #include <iostream>
+#include <limits>
 #include <map>
-#include <utility>         // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 class PHObject;
 
 class GlobalVertexv1 : public GlobalVertex
 {
  public:
-  GlobalVertexv1(const GlobalVertex::VTXTYPE id=GlobalVertex::UNDEFINED);
+  GlobalVertexv1(const GlobalVertex::VTXTYPE id = GlobalVertex::UNDEFINED);
   ~GlobalVertexv1() override = default;
 
   // PHObject virtual overloads
@@ -83,13 +83,13 @@ class GlobalVertexv1 : public GlobalVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id = std::numeric_limits<unsigned int>::max();                                        //< unique identifier within container
-  float _t = std::numeric_limits<float>::quiet_NaN();                                                //< collision time
-  float _t_err = std::numeric_limits<float>::quiet_NaN();                                            //< collision time uncertainty
+  unsigned int _id = std::numeric_limits<unsigned int>::max();  //< unique identifier within container
+  float _t = std::numeric_limits<float>::quiet_NaN();           //< collision time
+  float _t_err = std::numeric_limits<float>::quiet_NaN();       //< collision time uncertainty
   float _pos[3] = {};                                           //< collision position x,y,z
-  float _chisq = std::numeric_limits<float>::quiet_NaN();                                            //< vertex fit chisq
+  float _chisq = std::numeric_limits<float>::quiet_NaN();       //< vertex fit chisq
   unsigned int _ndof = std::numeric_limits<unsigned int>::max();
-  float _err[6] = {};                                           //< error covariance matrix (+/- cm^2)
+  float _err[6] = {};                                      //< error covariance matrix (+/- cm^2)
   std::map<GlobalVertex::VTXTYPE, unsigned int> _vtx_ids;  //< list of vtx ids
 
   ClassDefOverride(GlobalVertexv1, 1);

--- a/simulation/g4simulation/g4vertex/GlobalVertexv1.h
+++ b/simulation/g4simulation/g4vertex/GlobalVertexv1.h
@@ -6,6 +6,7 @@
 #include "GlobalVertex.h"
 
 #include <cstddef>        // for size_t
+#include <limits>
 #include <iostream>
 #include <map>
 #include <utility>         // for pair, make_pair
@@ -15,8 +16,8 @@ class PHObject;
 class GlobalVertexv1 : public GlobalVertex
 {
  public:
-  GlobalVertexv1();
-  ~GlobalVertexv1() override;
+  GlobalVertexv1(const GlobalVertex::VTXTYPE id=GlobalVertex::UNDEFINED);
+  ~GlobalVertexv1() override = default;
 
   // PHObject virtual overloads
 
@@ -82,13 +83,13 @@ class GlobalVertexv1 : public GlobalVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id;                                        //< unique identifier within container
-  float _t;                                                //< collision time
-  float _t_err;                                            //< collision time uncertainty
-  float _pos[3];                                           //< collision position x,y,z
-  float _chisq;                                            //< vertex fit chisq
-  unsigned int _ndof;                                      //< degrees of freedom
-  float _err[6];                                           //< error covariance matrix (+/- cm^2)
+  unsigned int _id = std::numeric_limits<unsigned int>::max();                                        //< unique identifier within container
+  float _t = std::numeric_limits<float>::quiet_NaN();                                                //< collision time
+  float _t_err = std::numeric_limits<float>::quiet_NaN();                                            //< collision time uncertainty
+  float _pos[3] = {};                                           //< collision position x,y,z
+  float _chisq = std::numeric_limits<float>::quiet_NaN();                                            //< vertex fit chisq
+  unsigned int _ndof = std::numeric_limits<unsigned int>::max();
+  float _err[6] = {};                                           //< error covariance matrix (+/- cm^2)
   std::map<GlobalVertex::VTXTYPE, unsigned int> _vtx_ids;  //< list of vtx ids
 
   ClassDefOverride(GlobalVertexv1, 1);

--- a/simulation/g4simulation/g4vertex/Makefile.am
+++ b/simulation/g4simulation/g4vertex/Makefile.am
@@ -18,11 +18,12 @@ libg4vertex_io_la_LIBADD = \
   -ltrackbase_historic_io
 
 libg4vertex_la_LIBADD = \
+  libg4vertex_io.la \
+  -lbbc_io \
   -lg4detectors \
   -lfun4all \
   -lg4bbc_io \
-  -ltrackbase_historic_io \
-  libg4vertex_io.la
+  -ltrackbase_historic_io
 
 pkginclude_HEADERS = \
   GlobalVertex.h \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds the new Bbc Vertex to our global vertices. Major rewrite - now vertices are added via an enum which dtermines the order of precedence, not just the order in which vertices are added which allows now to have multiple modues adding vertices independently. Still needs a lot of work - the Bbc currently produces two vertex objects, the global reco for the svtx vertex needs the old bbc vertex map which is not provided anymore. Also no consistency between old smeared t0 and bbc reconstructed t0 (~8ns offset)  
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

