### PR TITLE
Updating sEPD geometry with TowerInfoDefs

### DIFF
--- a/offline/packages/epd/EpdGeom.h
+++ b/offline/packages/epd/EpdGeom.h
@@ -1,12 +1,18 @@
+/*
+ Originated by Tristan Protzman 12/15/22
+ Re-written by Ejiro Umaka 03/28/23
+*/
+
 #ifndef EPD_GEOM_H
 #define EPD_GEOM_H
+
+#include <phool/PHObject.h>
 
 #include <vector>
 #include <utility>
 #include <tuple>
 #include <iostream>
-
-#include <phool/PHObject.h>
+#include <cmath>
 
 class EpdGeom : public PHObject
 {
@@ -14,25 +20,13 @@ class EpdGeom : public PHObject
     EpdGeom() = default;
     ~EpdGeom() override {};
 
-    virtual unsigned int side_r_phi_to_id(unsigned int /*side*/, unsigned int /*r_index*/, unsigned int /*phi_index*/) {return 999;};
-    virtual unsigned int side_sector_tile_to_id(unsigned int /*side*/, unsigned int /*sector*/, unsigned int /*tile*/) {return 999;};
-    virtual std::tuple<unsigned int, unsigned int, unsigned int> id_to_side_r_phi(unsigned int /*id*/) {return {0, 0, 0};};
-    virtual std::tuple<unsigned int, unsigned int, unsigned int> id_to_side_sector_tile(unsigned int /*id*/) {return {0, 0, 0};};
-    virtual float r(unsigned int /*id*/) {return -999;};
-    virtual float r_from_key(unsigned int /*key*/) {return -999;};
-    virtual float r_from_side_r_phi(unsigned int /*side*/, unsigned int /*r_index*/, unsigned int /*phi_index*/) {return -999;};
-    virtual float r_from_side_sector_tile(unsigned int /*side*/, unsigned int /*sector*/, unsigned int /*tile*/) {return -999;};
-    virtual float phi(unsigned int /*id*/) {return -999;};
-    virtual float phi_from_key(unsigned int /*key*/) {return -999;};
-    virtual float phi_from_side_r_phi(unsigned int /*side*/, unsigned int /*r_index*/, unsigned int /*phi_index*/) {return -999;};
-    virtual float phi_from_side_sector_tile(unsigned int /*side*/, unsigned int /*sector*/, unsigned int /*tile*/) {return -999;};
-    virtual float z(unsigned int /*id*/) {return -999;};
-    virtual float z_from_key(unsigned int /*key*/) {return -999;};
-    virtual float z_from_side_r_phi(unsigned int /*side*/, unsigned int /*r_inxed*/, unsigned int /*phi_index*/) {return -999;};
-    virtual float z_from_side_sector_tile(unsigned int /*side*/, unsigned int /*sector*/, unsigned int /*tile*/) {return -999;};
-    virtual unsigned int decode_epd(unsigned int /*tower_key*/) {return 999;};
-
-    virtual void Reset() override {return;}; // Reset doesn't need to do anything
+    virtual void set_z(unsigned int /*key*/, float /*z*/) {return;}
+    virtual void set_r(unsigned int /*key*/, float /*r*/) {return;}
+    virtual void set_phi(unsigned int /*key*/, float /*f*/) {return;}
+    virtual void set_phi0(unsigned int /*key*/, float /*f*/) {return;} 
+    virtual float get_r(unsigned int /*key*/) const {return NAN;};
+    virtual float get_z(unsigned int /*key*/) const {return NAN;};
+    virtual float get_phi(unsigned int /*key*/) const {return NAN;};
 
   private:
     ClassDefOverride(EpdGeom, 1);

--- a/offline/packages/epd/EpdGeom.h
+++ b/offline/packages/epd/EpdGeom.h
@@ -23,7 +23,7 @@ class EpdGeom : public PHObject
     virtual void set_z(unsigned int /*key*/, float /*z*/) {return;}
     virtual void set_r(unsigned int /*key*/, float /*r*/) {return;}
     virtual void set_phi(unsigned int /*key*/, float /*f*/) {return;}
-    virtual void set_phi0(unsigned int /*key*/, float /*f*/) {return;} 
+    virtual void set_phi0(unsigned int /*key*/, float /*f0*/) {return;} 
     virtual float get_r(unsigned int /*key*/) const {return NAN;};
     virtual float get_z(unsigned int /*key*/) const {return NAN;};
     virtual float get_phi(unsigned int /*key*/) const {return NAN;};

--- a/offline/packages/epd/EpdGeomV1.cc
+++ b/offline/packages/epd/EpdGeomV1.cc
@@ -1,5 +1,9 @@
 #include "EpdGeomV1.h"
 
+#include <calobase/TowerInfoDefs.h>
+
+#include <phool/PHObject.h>
+
 #include <map>
 #include <utility>
 #include <tuple>
@@ -7,217 +11,48 @@
 #include <fstream>
 #include <sstream>
 
-// Initializes the EPD Geometry
-EpdGeomV1::EpdGeomV1() {
-  build_lookup();
+
+float EpdGeomV1::get_r(unsigned int key) const
+{
+  return tile_r[TowerInfoDefs::get_epd_rbin(key)];
 }
 
-// Cleanup
-EpdGeomV1::~EpdGeomV1() {};
-
-
-// Calculates the appropriate tower id from a given side/r/phi index
-unsigned int EpdGeomV1::side_r_phi_to_id(unsigned int side, unsigned int r_index, unsigned int phi_index) {
-  unsigned int id = 0x0;
-  id = id | (side << 20);
-  id = id | (r_index << 10);
-  id = id | phi_index;
-  return id;
-};
-
-// Calculates the appropriate tower id from a given side/sector/tile index
-unsigned int EpdGeomV1::side_sector_tile_to_id(unsigned int side, unsigned int sector, unsigned int tile) {
-  int rmap[31] = {0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15};
-  int phimap[31] = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
-  unsigned int phi = phimap[tile] + (sector * 2);
-  return side_r_phi_to_id(side, rmap[tile], phi);    
+float EpdGeomV1::get_z(unsigned int key) const
+{
+  return tile_z[TowerInfoDefs::get_epd_arm(key)];
 }
 
-// Calculates the appropriate side/r/phi index from a tower ID
-std::tuple<unsigned int, unsigned int, unsigned int> EpdGeomV1::id_to_side_r_phi(unsigned int id) {
-  unsigned int side, r_index, phi_index;
-  side = (id >> 20) & 0x1;
-  r_index = (id >> 10) & 0x3ff;
-  phi_index = id & 0x3ff;
-  return std::tuple<unsigned int, unsigned int, unsigned int>(side, r_index, phi_index);
-};
+float EpdGeomV1::get_phi(unsigned int key) const
+{
 
-// Calculates the appropriate side/sector/tile from a tower ID
-std::tuple<unsigned int, unsigned int, unsigned int> EpdGeomV1::id_to_side_sector_tile(unsigned int id) {
-  unsigned int side, r_index, phi_index;
-  std::tie(side, r_index, phi_index) = id_to_side_r_phi(id);
-  unsigned int sector = phi_index / 2; 
-  unsigned int tile = r_index * 2;
-  if (r_index && (phi_index % 2 == 0)) {
-    tile --;
+  if(TowerInfoDefs::get_epd_rbin(key) == 0)
+  {
+    return tile_phi0[TowerInfoDefs::get_epd_phibin(key)];
   }
-  return std::tuple<unsigned int, unsigned int, unsigned int>(side, sector, tile);
-}
-
-float EpdGeomV1::r(unsigned int id) {
-  return r_lookup[id];
-}
-
-// Returns the r location of the specified tile.
-// Arguments: 
-// int id: The tile's ID
-// Returns:
-// float: the tile's location in r/phi space
-float EpdGeomV1::r_from_key(unsigned int key) {
-  return r(decode_epd(key));
-};
-
-// Returns the r location of the specified tile.
-// Arguments: 
-// int r_index: The r index of the desired tile
-// int phi_index: The phi index of the desired tile
-// Returns:
-// float: the tile's location in r/phi space
-float EpdGeomV1::r_from_side_r_phi(unsigned int side, unsigned int r_index, unsigned int phi_index) {
-  unsigned int key;
-  key = side_r_phi_to_id(side, r_index, phi_index);
-  return r_from_key(key);
-};
-
-
-float EpdGeomV1::r_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) {
-  unsigned int key = side_sector_tile_to_id(side, sector, tile);
-  return r_from_key(key);
-}
-
-float EpdGeomV1::phi(unsigned int id) {
-  return phi_lookup[id];
-}
-
-// Returns the phi location of the specified tile.
-// Arguments: 
-// int id: The tile's ID
-// Returns:
-// float: the tile's location in r/phi space
-float EpdGeomV1::phi_from_key(unsigned int key) {
-  return phi(decode_epd(key));
-};
-
-// Returns the phi location of the specified tile.
-// Arguments: 
-// int r_index: The r index of the desired tile
-// int phi_index: The phi index of the desired tile
-// Returns:
-// float: the tile's location in r/phi space
-float EpdGeomV1::phi_from_side_r_phi(unsigned int side, unsigned int r_index, unsigned int phi_index) {
-  unsigned int key;
-  key = side_r_phi_to_id(side, r_index, phi_index);
-  return phi_from_key(key);
-};
-
-float EpdGeomV1::phi_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) {
-  unsigned int key = side_sector_tile_to_id(side, sector, tile);
-  return phi_from_key(key);
-}
-
-float EpdGeomV1::z(unsigned int id) {
-  return z_lookup[id];
-}
-
-float EpdGeomV1::z_from_key(unsigned int key) {
-  return z(decode_epd(key));
-}
-
-float EpdGeomV1::z_from_side_r_phi(unsigned int side, unsigned int r_index, unsigned int phi_index) {
-  unsigned int key = side_r_phi_to_id(side, r_index, phi_index);
-  return z_from_key(key);
-}
-
-float EpdGeomV1::z_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) {
-  unsigned int key = side_sector_tile_to_id(side, sector, tile);
-  return z_from_key(key);
-}
-
-unsigned int EpdGeomV1::decode_epd(unsigned int tower_key) {
-  int channels_per_sector = 31;
-  int supersector = channels_per_sector * 12;
-  unsigned int ns_sector = tower_key >> 20U;
-  unsigned int rbin = (tower_key - (ns_sector << 20U)) >> 10U;
-  unsigned int phibin = tower_key - (ns_sector << 20U) - (rbin << 10U);
-  int epdchnlmap[16][2] = {{0, 0}, {1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}, {15, 16}, {17, 18}, {19, 20}, {21, 22}, {23, 24}, {25, 26}, {27, 28}, {29, 30}};
-  int sector = phibin / 2;
-  int channel = 0;
-  if (rbin > 0)
-    {
-      channel = epdchnlmap[rbin][phibin - 2 * sector];
-    }
   else
-    {
-      channel = 0;
-    }
-  unsigned int index = 0;
-  index = ns_sector * supersector + sector * channels_per_sector + channel;
-  return index;
+  {
+    return tile_phi[TowerInfoDefs::get_epd_phibin(key)];
+  }
+
+}
+ 
+void EpdGeomV1::set_z(unsigned int key, float z)
+{
+  tile_z[TowerInfoDefs::get_epd_arm(key)] = z;
 }
 
-
-// Generates the maps returning the r and phi for a particular tile
-void EpdGeomV1::build_lookup() {
-  r_lookup = std::vector<float>(NUM_TOWERS, -999);
-  phi_lookup = std::vector<float>(NUM_TOWERS, -999);
-  z_lookup = std::vector<float>(NUM_TOWERS, -999);
-  std::string epd_geom_file_path("epd_geometry.tsv");
-  std::ifstream epd_geom_file(epd_geom_file_path);
-  if (!epd_geom_file.is_open()) {
-    std::cerr << "Could not read EPD Geometry file: " << epd_geom_file_path << std::endl;
-    return; // Should this throw an error?  Not sure what the sPHENIX way to do things like that is
-  }
-  std::string line;
-  uint filled = 0;
-  while(std::getline(epd_geom_file, line)) {
-    std::stringstream tokens(line);
-    int tower;
-    tokens >> tower;  // Read the first column into the tower name;
-    float r, phi, z;
-    tokens >> r;
-    tokens >> phi;
-    tokens >> z;  // This could all use error checking
-    r_lookup[tower] = r;
-    phi_lookup[tower] = phi;
-    z_lookup[tower] = z;
-    filled++;
-  }
-  if (filled != NUM_TOWERS) {
-    std::cerr << "Did not find geometry values for all EPD towers!" << std::endl;
-  }
-  // for (uint i = 0; i < NUM_TOWERS; i++) {
-  //   printf("%d\t%f\t%f\t%f\n", i, r_lookup[i], phi_lookup[i], z_lookup[i]);
-  // }
+void EpdGeomV1::set_r(unsigned int key, float r)
+{
+  tile_r[TowerInfoDefs::get_epd_rbin(key)] = r;
 }
 
-bool EpdGeomV1::test_id_mapping() {
-  bool pass = true;
-  for (unsigned int side = 0; side < 2; side++) {
-    for (unsigned int r_index = 0; r_index < 16; r_index++) {
-      for (unsigned int phi_index = 0; phi_index < 24; phi_index++) {
-        if (r_index == 0 && (phi_index & 0x1)) {
-          continue;
-        }
-        std::cout << "side: " << side << "\tr: " << r_index << "\tphi: " << phi_index << std::endl;
-        unsigned int id_from_r_phi = side_r_phi_to_id(side, r_index, phi_index);  // side r phi to id
-        std::cout << "id 1: " << id_from_r_phi << std::endl;
-        unsigned int temp_side, sector, tile;
-        std::tie(temp_side, sector, tile) = id_to_side_sector_tile(id_from_r_phi);  // id to side sector tile
-        std::cout << "side: " << side << "\tsector: " << sector << "\ttile: " << tile << std::endl;
-        unsigned int id_from_sector_tile = side_sector_tile_to_id(temp_side, sector, tile); // side sector tile to id
-        std::cout << "id 2: " << id_from_sector_tile << std::endl;
-        unsigned int final_side, final_r_index, final_phi_index;
-        std::tie(final_side, final_r_index, final_phi_index) = id_to_side_r_phi(id_from_sector_tile); /// id to side r phi
-        std::cout << "side: " << final_side << "\tr: " << final_r_index << "\tphi: " << final_phi_index << std::endl;
-        if (side != final_side || r_index != final_r_index || phi_index != final_phi_index) {
-          pass = false;
-          std::cout << "COORDINATE FAILED" << std::endl;
-        } else{
-          std::cout << "coordinate passed" << std::endl;
-        }
-        std::cout << "\n\n" << std::endl;
-      }
-    }
-  }
-  return pass;
+void EpdGeomV1::set_phi(unsigned int key, float f)
+{
+  tile_phi[TowerInfoDefs::get_epd_phibin(key)] = f;
 }
+
+void EpdGeomV1::set_phi0(unsigned int key, float f0)
+{
+  tile_phi0[TowerInfoDefs::get_epd_phibin(key)] = f0;
+}
+

--- a/offline/packages/epd/EpdGeomV1.h
+++ b/offline/packages/epd/EpdGeomV1.h
@@ -1,90 +1,35 @@
-/*
-sEPD Geometry class
-
-Tristan Protzman
-tlprotzman@gmail.com
-December 15, 2022
-
-Converts from r/phi index to location in r/phi space
-
-Key format:
-100000000000000000000_2
-211111111110000000000
-098765432109876543210
-*/
-
 #ifndef EPD_GEOM_V1_H
 #define EPD_GEOM_V1_H
 
 #include "EpdGeom.h"
-#include "EpdGeomV1.h"
 
-#include <vector>
 #include <utility>
 #include <tuple>
 #include <iostream>
 
-#include <phool/PHObject.h>
 
-
-// sEPD geometry class
 class EpdGeomV1 : public EpdGeom {
 
 public:
-  EpdGeomV1();
-  ~EpdGeomV1() override;
-
-  unsigned int side_r_phi_to_id(unsigned int side, unsigned int r_index, unsigned int phi_index) override;
-  unsigned int side_sector_tile_to_id(unsigned int side, unsigned int sector, unsigned int tile) override;
-  std::tuple<unsigned int, unsigned int, unsigned int> id_to_side_r_phi(unsigned int id) override;
-  std::tuple<unsigned int, unsigned int, unsigned int> id_to_side_sector_tile(unsigned int id) override;
-  float r(unsigned int id) override;
-  float r_from_key(unsigned int key) override;
-  float r_from_side_r_phi(unsigned int side, unsigned int r_index, unsigned int phi_index) override;
-  float r_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) override;
-  float phi(unsigned int id) override;
-  float phi_from_key(unsigned int key) override;
-  float phi_from_side_r_phi(unsigned int side, unsigned int r_index, unsigned int phi_index) override;
-  float phi_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) override;
-  float z(unsigned int id) override;
-  float z_from_key(unsigned int key) override;
-  float z_from_side_r_phi(unsigned int side, unsigned int r_inxed, unsigned int phi_index) override;
-  float z_from_side_sector_tile(unsigned int side, unsigned int sector, unsigned int tile) override;
-  unsigned int decode_epd(unsigned int tower_key) override;
+  EpdGeomV1() = default;
+  ~EpdGeomV1() override = default;
   
-  
+  float get_r(unsigned int key) const override;
+  float get_z(unsigned int key) const override;
+  float get_phi(unsigned int key) const override;
+  void set_z(unsigned int key, float z) override;
+  void set_r(unsigned int key, float r) override;
+  void set_phi(unsigned int key, float f) override;
+  void set_phi0(unsigned int key, float f0) override;
 
-  void Reset() override {return;}; // Reset doesn't need to do anything
 
 private:
-  const unsigned int NUM_TOWERS = 744;
-  const unsigned int MAX_R = 16;
-  const unsigned int MAX_PHI = 24;
-  const unsigned int NUM_SECTORS = 12;
-  const unsigned int NUM_TILES = 31;
-
-  std::vector<float> r_lookup;
-  std::vector<float> phi_lookup;
-  std::vector<float> z_lookup;
-  bool test_id_mapping();
-
-  // const float NAIVE_R_INDEX[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-  const float NAIVE_R_LOC[16] = {6.8, 11.2, 15.6, 20.565, 26.095, 31.625, 37.155, 42.685, 48.215, 53.745, 59.275, 64.805, 70.335, 75.865, 81.395, 86.925};
   
-  const float NAIVE_PHI_LOC_RING_0[12] = {0.26179939, 0.78539816, 1.30899694, 1.83259571, 2.35619449,
-                                          2.87979327, 3.40339204, 3.92699082, 4.45058959, 4.97418837,
-                                          5.49778714, 6.02138592};
+  float tile_r[16] = {};
+  float tile_z[2] = {};
+  float tile_phi[24] = {};
+  float tile_phi0[12] = {};
 
-  const float NAIVE_PHI_LOC[24] = {0.13089969, 0.39269908, 0.65449847, 0.91629786, 1.17809725,
-                                   1.43989663, 1.70169602, 1.96349541, 2.2252948 , 2.48709418,
-                                   2.74889357, 3.01069296, 3.27249235, 3.53429174, 3.79609112,
-                                   4.05789051, 4.3196899 , 4.58148929, 4.84328867, 5.10508806,
-                                   5.36688745, 5.62868684, 5.89048623, 6.15228561};
-
-  const float NAIVE_Z_MAP[2] = {-316, 316};
-
-  void build_lookup();
-  
   ClassDefOverride(EpdGeomV1, 1)
 
 };

--- a/offline/packages/epd/Makefile.am
+++ b/offline/packages/epd/Makefile.am
@@ -20,7 +20,8 @@ AM_LDFLAGS = \
   -L$(ROOTSYS)/lib
 
 libepd_io_la_LIBADD = \
-  -lphool
+  -lphool \
+  -lcalo_io
 
 libepd_la_LIBADD = \
   libepd_io.la \

--- a/simulation/g4simulation/g4epd/PHG4EPDModuleReco.cc
+++ b/simulation/g4simulation/g4epd/PHG4EPDModuleReco.cc
@@ -1,9 +1,10 @@
-
 #include "PHG4EPDModuleReco.h"
 
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoContainerv1.h>
+
+#include <calobase/TowerInfoDefs.h>
 
 #include <epd/EPDDefs.h>
 #include <epd/EpdGeomV1.h>
@@ -62,6 +63,24 @@ int PHG4EPDModuleReco::InitRun(PHCompositeNode *topNode)
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(epdGeom, "TOWERGEOM_EPD", "PHObject");
     runNode->addNode(newNode);
   }
+ 
+  //fill epd geometry
+  unsigned int epdchannels = 744;
+  for (unsigned int ch = 0; ch < epdchannels; ch++)
+  {
+    unsigned int thiskey = TowerInfoDefs::encode_epd(ch);
+    epdGeom->set_z(thiskey, GetTileZ(TowerInfoDefs::get_epd_arm(thiskey)));
+    epdGeom->set_r(thiskey, GetTileR(TowerInfoDefs::get_epd_rbin(thiskey)));
+    if(TowerInfoDefs::get_epd_rbin(thiskey) == 0)
+    {
+      epdGeom->set_phi0(thiskey, GetTilePhi0(TowerInfoDefs::get_epd_phibin(thiskey)));
+    }
+    else
+    {
+      epdGeom->set_phi(thiskey, GetTilePhi(TowerInfoDefs::get_epd_phibin(thiskey)));
+    }
+  }
+    
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -155,16 +174,40 @@ void PHG4EPDModuleReco::set_timing_window(const double tmi, const double tma)
 
 int PHG4EPDModuleReco::Getrmap(int rindex)
 {
-  int rmap[31] = {0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15};
+  static const int rmap[31] = {0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15};
 
   return rmap[rindex];
 }
 
 int PHG4EPDModuleReco::Getphimap(int phiindex)
 {
-  int phimap[31] = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  static const int phimap[31] = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
 
   return phimap[phiindex];
+}
+
+float PHG4EPDModuleReco::GetTilePhi(int thisphi)
+{
+  static const float tilephi[24] = {0.13089969, 0.39269908, 0.65449847, 0.91629786, 1.17809725,1.43989663, 1.70169602, 1.96349541, 2.2252948 , 2.48709418, 2.74889357, 3.01069296, 3.27249235, 3.53429174, 3.79609112, 4.05789051, 4.3196899 , 4.58148929, 4.84328867, 5.10508806, 5.36688745, 5.62868684, 5.89048623, 6.15228561};
+  return tilephi[thisphi];
+} 
+
+float PHG4EPDModuleReco::GetTilePhi0(int thisphi0)
+{
+  static const float tilephi0[12] = {0.26179939, 0.78539816, 1.30899694, 1.83259571, 2.35619449, 2.87979327, 3.40339204, 3.92699082, 4.45058959, 4.97418837, 5.49778714, 6.02138592};
+  return tilephi0[thisphi0];
+} 
+
+float PHG4EPDModuleReco::GetTileR(int thisr)
+{
+  static const float tileR[16] = {6.8, 11.2, 15.6, 20.565, 26.095, 31.625, 37.155, 42.685, 48.215, 53.745, 59.275, 64.805, 70.335, 75.865, 81.395, 86.925};
+  return tileR[thisr];
+}
+
+float PHG4EPDModuleReco::GetTileZ(int thisz)
+{
+  static const float tileZ[2] = {-316.0, 316.0};
+  return tileZ[thisz];
 }
 
 void PHG4EPDModuleReco::CreateNodes(PHCompositeNode *topNode)

--- a/simulation/g4simulation/g4epd/PHG4EPDModuleReco.h
+++ b/simulation/g4simulation/g4epd/PHG4EPDModuleReco.h
@@ -62,6 +62,10 @@ class PHG4EPDModuleReco : public SubsysReco, public PHParameterInterface
  private:
   int Getrmap(int rindex);
   int Getphimap(int phiindex);
+  float GetTilePhi(int thisphi);
+  float GetTilePhi0(int thisphi0);
+  float GetTileR(int thisr);
+  float GetTileZ(int thisz);
   void CreateNodes(PHCompositeNode *topNode);
 
   std::string m_Detector;


### PR DESCRIPTION
This PR adds sEPD geometry using TowerInfoDefs keys and fills in the geometry in the tile reconstruction