### PR TITLE
Small commit to code -- efficiency of lookup in adc value

### DIFF
--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
@@ -339,12 +339,6 @@ void PHG4InttDigitizer::set_adc_scale(const int &layer, const std::vector<double
     std::cout << "Error: vector in set_fphx_adc_scale(vector) must have eight elements." << std::endl;
     gSystem->Exit(1);
   }
-  //sort(userrange.begin(), userrange.end()); // TODO, causes GLIBC error
-
-  std::vector<double> vadcrange;
-  for (unsigned int irange = 0; irange < userrange.size(); ++irange)
-  {
-      vadcrange.push_back(userrange[irange]);
-  }
-  _max_fphx_adc.insert(std::make_pair(layer, vadcrange));
+  _max_fphx_adc.insert(std::make_pair(layer, userrange));
+  std::sort(_max_fphx_adc[layer].begin(), _max_fphx_adc[layer].end());
 }

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
@@ -264,16 +264,14 @@ void PHG4InttDigitizer::DigitizeLadderCells(PHCompositeNode *topNode)
       }
       const float mip_e = _energy_scale[layer];
 
-      std::vector<std::pair<double, double> > vadcrange = _max_fphx_adc[layer];
+      std::vector<double>& vadcrange = _max_fphx_adc[layer];
 
-      int adc = 0;
-      for (unsigned int irange = 0; irange < vadcrange.size(); ++irange)
-      {
-        if (hit->getEnergy() / TrkrDefs::InttEnergyScaleup >= vadcrange[irange].first * (double) mip_e && hit->getEnergy() / TrkrDefs::InttEnergyScaleup < vadcrange[irange].second * (double) mip_e)
-        {
-          adc = (unsigned short) irange;
-        }
-      }
+      // c++ upper_bound finds the bin location above the test value (or vadcrange.end() if there isn't one)
+      auto irange = std::upper_bound(vadcrange.begin(), vadcrange.end(), 
+          hit->getEnergy() / TrkrDefs::InttEnergyScaleup * (double) mip_e);
+      int adc = (irange-vadcrange.begin())-1;
+      if (adc == -1) adc = 0;
+
       hit->setAdc(adc);
 
       if (Verbosity() > 2)
@@ -343,17 +341,10 @@ void PHG4InttDigitizer::set_adc_scale(const int &layer, const std::vector<double
   }
   //sort(userrange.begin(), userrange.end()); // TODO, causes GLIBC error
 
-  std::vector<std::pair<double, double> > vadcrange;
+  std::vector<double> vadcrange;
   for (unsigned int irange = 0; irange < userrange.size(); ++irange)
   {
-    if (irange == userrange.size() - 1)
-    {
-      vadcrange.push_back(std::make_pair(userrange[irange], FLT_MAX));
-    }
-    else
-    {
-      vadcrange.push_back(std::make_pair(userrange[irange], userrange[irange + 1]));
-    }
+      vadcrange.push_back(userrange[irange]);
   }
   _max_fphx_adc.insert(std::make_pair(layer, vadcrange));
 }

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.cc
@@ -332,13 +332,13 @@ float PHG4InttDigitizer::added_noise()
   return noise;
 }
 
-void PHG4InttDigitizer::set_adc_scale(const int &layer, const std::vector<double> &userrange)
+void PHG4InttDigitizer::set_adc_scale(const int &layer, std::vector<double> userrange)
 {
   if (userrange.size() != nadcbins)
   {
     std::cout << "Error: vector in set_fphx_adc_scale(vector) must have eight elements." << std::endl;
     gSystem->Exit(1);
   }
+  std::sort(userrange.begin(), userrange.end());
   _max_fphx_adc.insert(std::make_pair(layer, userrange));
-  std::sort(_max_fphx_adc[layer].begin(), _max_fphx_adc[layer].end());
 }

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
@@ -33,7 +33,7 @@ class PHG4InttDigitizer : public SubsysReco, public PHParameterInterface
 
   void Detector(const std::string &d) { detector = d; }
 
-  void set_adc_scale(const int &layer, const std::vector<double> &userrange);
+  void set_adc_scale(const int &layer, std::vector<double> userrange_copy);
 
  private:
   void CalculateLadderCellADCScale(PHCompositeNode *topNode);

--- a/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
+++ b/simulation/g4simulation/g4intt/PHG4InttDigitizer.h
@@ -57,7 +57,7 @@ class PHG4InttDigitizer : public SubsysReco, public PHParameterInterface
   //SvtxHitMap *_hitmap;
 
   const unsigned int nadcbins = 8;
-  std::map<int, std::vector<std::pair<double, double> > > _max_fphx_adc;
+  std::map<int, std::vector<double>> _max_fphx_adc;
 
   unsigned int m_nCells = 0;
   unsigned int m_nDeadCells = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Small change in code for efficiency and readability. See changes in code. Swap from forced loop over 
`vector< pair<bound0, bound1>,pair<bound1,bound2>,...pair<boundN,FLT_MAX>>` to find a range to `std::upper_bound(vec.begin(), vec.end(),val)` where vec is now `bound0, bound1, ..., boundN`.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

