### PR TITLE
Ohcal const field

### DIFF
--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -3,12 +3,8 @@
 //root framework
 #include <TDirectory.h>
 #include <TFile.h>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TNtuple.h>
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4SystemOfUnits.hh>
 
@@ -22,9 +18,7 @@
 #include <set>
 #include <utility>
 
-using namespace std;
-
-PHField2D::PHField2D(const string &filename, const int verb, const float magfield_rescale)
+PHField2D::PHField2D(const std::string &filename, const int verb, const float magfield_rescale)
   : PHField(verb)
   , r_index0_cache(0)
   , r_index1_cache(0)
@@ -33,19 +27,19 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
 {
   if (Verbosity() > 0)
   {
-    cout << " ------------- PHField2D::PHField2D() ------------------" << endl;
+    std::cout << " ------------- PHField2D::PHField2D() ------------------" << std::endl;
   }
   // open file
   TFile *rootinput = TFile::Open(filename.c_str());
   if (!rootinput)
   {
-    cout << " could not open " << filename << " exiting now" << endl;
+    std::cout << " could not open " << filename << " exiting now" << std::endl;
     gSystem->Exit(1);
     exit(1);
   }
   if (Verbosity() > 0)
   {
-    cout << "  Field grid file: " << filename << endl;
+    std::cout << "  Field grid file: " << filename << std::endl;
   }
   rootinput->cd();
 
@@ -62,7 +56,7 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
     field_map = (TNtuple *) gDirectory->Get("map");
     if (!field_map)
     {
-      cout << "PHField2D: could not locate ntuple of name map or fieldmap, exiting now" << endl;
+      std::cout << "PHField2D: could not locate ntuple of name map or fieldmap, exiting now" << std::endl;
       exit(1);
     }
     magfield_unit = gauss;
@@ -81,21 +75,21 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
   // run checks on entries
   if (Verbosity() > 0)
   {
-    cout << "  The field grid contained " << NENTRIES << " entries" << endl;
+    std::cout << "  The field grid contained " << NENTRIES << " entries" << std::endl;
   }
   if (Verbosity() > 1)
   {
-    cout << "\n  NENTRIES should be the same as the following values:"
+    std::cout << "\n  NENTRIES should be the same as the following values:"
          << "\n  [ Number of values r,z: "
-         << nr << " " << nz << " ]! " << endl;
+         << nr << " " << nz << " ]! " << std::endl;
   }
 
   if (nz != nr)
   {
-    cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
          << "\n The file you entered is not a \"table\" of values"
          << "\n Something very likely went oh so wrong"
-         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endl;
+         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
   }
 
   // Keep track of the unique z, r, phi values in the grid using sets
@@ -108,7 +102,7 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
   // phi.
   if (Verbosity() > 1)
   {
-    cout << "  --> Sorting Entries..." << endl;
+    std::cout << "  --> Sorting Entries..." << std::endl;
   }
   std::map<trio, trio> sorted_map;
   for (int i = 0; i < field_map->GetEntries(); i++)
@@ -122,10 +116,10 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
     r_set.insert(ROOT_R * cm);
   }
 
-  // couts for assurance
+  // std::couts for assurance
   if (Verbosity() > 4)
   {
-    map<trio, trio>::iterator it = sorted_map.begin();
+    std::map<trio, trio>::iterator it = sorted_map.begin();
     print_map(it);
     float last_z = it->first.get<0>();
     for (it = sorted_map.begin(); it != sorted_map.end(); ++it)
@@ -140,7 +134,7 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
 
   if (Verbosity() > 1)
   {
-    cout << "  --> Putting entries into containers... " << endl;
+    std::cout << "  --> Putting entries into containers... " << std::endl;
   }
 
   // grab the minimum and maximum z values
@@ -159,12 +153,12 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
   std::copy(r_set.begin(), r_set.end(), r_map_.begin());
 
   // initialize the field map vectors to the correct sizes
-  BFieldR_.resize(nz, vector<float>(nr, 0));
-  BFieldZ_.resize(nz, vector<float>(nr, 0));
+  BFieldR_.resize(nz, std::vector<float>(nr, 0));
+  BFieldZ_.resize(nz, std::vector<float>(nr, 0));
 
   // all of this assumes that  z_prev < z , i.e. the table is ordered (as of right now)
   unsigned int ir = 0, iz = 0;  // useful indexes to keep track of
-  map<trio, trio>::iterator iter = sorted_map.begin();
+  std::map<trio, trio>::iterator iter = sorted_map.begin();
   for (; iter != sorted_map.end(); ++iter)
   {
     // equivalent to ->GetEntry(iter)
@@ -196,7 +190,7 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
     // shouldn't happen
     if (iz > 0 && z < z_map_[iz - 1])
     {
-      cout << "!!!!!!!!! Your map isn't ordered.... z: " << z << " zprev: " << z_map_[iz - 1] << endl;
+      std::cout << "!!!!!!!!! Your map isn't ordered.... z: " << z << " zprev: " << z_map_[iz - 1] << std::endl;
     }
 
     BFieldR_[iz][ir] = Br * magfield_rescale;
@@ -204,16 +198,16 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
 
     // you can change this to check table values for correctness
     // print_map prints the values in the root table, and the
-    // couts print the values entered into the vectors
+    // std::couts print the values entered into the vectors
     if (fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
     {
       print_map(iter);
 
-      cout << " B("
+      std::cout << " B("
            << r_map_[ir] << ", "
            << z_map_[iz] << "):  ("
            << BFieldR_[iz][ir] << ", "
-           << BFieldZ_[iz][ir] << ")" << endl;
+           << BFieldZ_[iz][ir] << ")" << std::endl;
     }
 
   }  // end loop over root field map file
@@ -222,16 +216,16 @@ PHField2D::PHField2D(const string &filename, const int verb, const float magfiel
 
   if (Verbosity() > 0)
   {
-    cout << "  Mag field z boundaries (min,max): (" << minz_ / cm << ", " << maxz_ / cm << ") cm" << endl;
+    std::cout << "  Mag field z boundaries (min,max): (" << minz_ / cm << ", " << maxz_ / cm << ") cm" << std::endl;
   }
   if (Verbosity() > 0)
   {
-    cout << "  Mag field r max boundary: " << r_map_.back() / cm << " cm" << endl;
+    std::cout << "  Mag field r max boundary: " << r_map_.back() / cm << " cm" << std::endl;
   }
 
   if (Verbosity() > 0)
   {
-    cout << " -----------------------------------------------------------" << endl;
+    std::cout << " -----------------------------------------------------------" << std::endl;
   }
 }
 
@@ -239,7 +233,7 @@ void PHField2D::GetFieldValue(const double point[4], double *Bfield) const
 {
   if (Verbosity() > 2)
   {
-    cout << "\nPHField2D::GetFieldValue" << endl;
+    std::cout << "\nPHField2D::GetFieldValue" << std::endl;
   }
   double x = point[0];
   double y = point[1];
@@ -277,15 +271,15 @@ void PHField2D::GetFieldValue(const double point[4], double *Bfield) const
     Bfield[2] = 0.0;
     if (Verbosity() > 2)
     {
-      cout << "!!!!!!!!!! Field point not in defined region (outside of z bounds)" << endl;
+      std::cout << "!!!!!!!!!! Field point not in defined region (outside of z bounds)" << std::endl;
     }
   }
 
   if (Verbosity() > 2)
   {
-    cout << "END PHField2D::GetFieldValue\n"
+    std::cout << "END PHField2D::GetFieldValue\n"
          << "  --->  {Bx, By, Bz} : "
-         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << endl;
+         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
   }
 
   return;
@@ -302,14 +296,14 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
 
   if (Verbosity() > 2)
   {
-    cout << "GetFieldCyl@ <z,r>: {" << z << "," << r << "}" << endl;
+    std::cout << "GetFieldCyl@ <z,r>: {" << z << "," << r << "}" << std::endl;
   }
 
   if (z < z_map_[0] || z > z_map_[z_map_.size() - 1])
   {
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
     }
     return;
   }
@@ -324,13 +318,13 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
   if (!((r > r_map_[r_index0]) && (r < r_map_[r_index1])))
   {
     // if miss cached r values, search through the lookup table
-    vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
+    std::vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
     r_index0 = distance(r_map_.begin(), riter) - 1;
     if (r_index0 >= r_map_.size())
     {
       if (Verbosity() > 2)
       {
-        cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+        std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
       }
       return;
     }
@@ -340,7 +334,7 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
     {
       if (Verbosity() > 2)
       {
-        cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+        std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
       }
       return;
     }
@@ -356,14 +350,14 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
   if (!((z > z_map_[z_index0]) && (z < z_map_[z_index1])))
   {
     // if miss cached z values, search through the lookup table
-    vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
+    std::vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
     z_index0 = distance(z_map_.begin(), ziter) - 1;
     z_index1 = z_index0 + 1;
     if (z_index1 >= z_map_.size())
     {
       if (Verbosity() > 2)
       {
-        cout << "!!!! Point not in defined region (z too large in specific r-plane)" << endl;
+        std::cout << "!!!! Point not in defined region (z too large in specific r-plane)" << std::endl;
       }
       return;
     }
@@ -410,22 +404,22 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
 
   if (Verbosity() > 2)
   {
-    cout << "End GFCyl Call: <bz,br,bphi> : {"
+    std::cout << "End GFCyl Call: <bz,br,bphi> : {"
          << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
-         << endl;
+         << std::endl;
   }
 
   return;
 }
 
 // debug function to print key/value pairs in map
-void PHField2D::print_map(map<trio, trio>::iterator &it) const
+void PHField2D::print_map(std::map<trio, trio>::iterator &it) const
 {
-  cout << "    Key: <"
+  std::cout << "    Key: <"
        << it->first.get<0>() / cm << ","
        << it->first.get<1>() / cm << ">"
 
        << " Value: <"
        << it->second.get<0>() / magfield_unit << ","
-       << it->second.get<1>() / magfield_unit << ">\n";
+	    << it->second.get<1>() / magfield_unit << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -8,8 +8,6 @@
 
 #include <Geant4/G4SystemOfUnits.hh>
 
-#include <boost/tuple/tuple_comparison.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -121,12 +119,12 @@ PHField2D::PHField2D(const std::string &filename, const int verb, const float ma
   {
     std::map<trio, trio>::iterator it = sorted_map.begin();
     print_map(it);
-    float last_z = it->first.get<0>();
+    float last_z = std::get<0>(it->first);
     for (it = sorted_map.begin(); it != sorted_map.end(); ++it)
     {
-      if (it->first.get<0>() != last_z)
+      if (std::get<0>(it->first) != last_z)
       {
-        last_z = it->first.get<0>();
+        last_z = std::get<0>(it->first);
         print_map(it);
       }
     }
@@ -162,10 +160,10 @@ PHField2D::PHField2D(const std::string &filename, const int verb, const float ma
   for (; iter != sorted_map.end(); ++iter)
   {
     // equivalent to ->GetEntry(iter)
-    float z = iter->first.get<0>() * cm;
-    float r = iter->first.get<1>() * cm;
-    float Bz = iter->second.get<0>() * magfield_unit;
-    float Br = iter->second.get<1>() * magfield_unit;
+    float z = std::get<0>(iter->first) * cm;
+    float r = std::get<1>(iter->first) * cm;
+    float Bz = std::get<0>(iter->second) * magfield_unit;
+    float Br = std::get<1>(iter->second) * magfield_unit;
 
     if (z > maxz_)
     {
@@ -416,10 +414,10 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
 void PHField2D::print_map(std::map<trio, trio>::iterator &it) const
 {
   std::cout << "    Key: <"
-       << it->first.get<0>() / cm << ","
-       << it->first.get<1>() / cm << ">"
+       << std::get<0>(it->first) / cm << ","
+       << std::get<1>(it->first) / cm << ">"
 
        << " Value: <"
-       << it->second.get<0>() / magfield_unit << ","
-	    << it->second.get<1>() / magfield_unit << ">" << std::endl;
+       << std::get<0>(it->second) / magfield_unit << ","
+	    << std::get<1>(it->second) / magfield_unit << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -199,7 +199,7 @@ PHField2D::PHField2D(const std::string &filename, const int verb, const float ma
     // you can change this to check table values for correctness
     // print_map prints the values in the root table, and the
     // std::couts print the values entered into the vectors
-    if (fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
+    if (std::fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
     {
       print_map(iter);
 

--- a/offline/packages/PHField/PHField2D.cc
+++ b/offline/packages/PHField/PHField2D.cc
@@ -1,6 +1,6 @@
 #include "PHField2D.h"
 
-//root framework
+// root framework
 #include <TDirectory.h>
 #include <TFile.h>
 #include <TNtuple.h>
@@ -78,16 +78,16 @@ PHField2D::PHField2D(const std::string &filename, const int verb, const float ma
   if (Verbosity() > 1)
   {
     std::cout << "\n  NENTRIES should be the same as the following values:"
-         << "\n  [ Number of values r,z: "
-         << nr << " " << nz << " ]! " << std::endl;
+              << "\n  [ Number of values r,z: "
+              << nr << " " << nz << " ]! " << std::endl;
   }
 
   if (nz != nr)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-         << "\n The file you entered is not a \"table\" of values"
-         << "\n Something very likely went oh so wrong"
-         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+              << "\n The file you entered is not a \"table\" of values"
+              << "\n Something very likely went oh so wrong"
+              << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
   }
 
   // Keep track of the unique z, r, phi values in the grid using sets
@@ -202,10 +202,10 @@ PHField2D::PHField2D(const std::string &filename, const int verb, const float ma
       print_map(iter);
 
       std::cout << " B("
-           << r_map_[ir] << ", "
-           << z_map_[iz] << "):  ("
-           << BFieldR_[iz][ir] << ", "
-           << BFieldZ_[iz][ir] << ")" << std::endl;
+                << r_map_[ir] << ", "
+                << z_map_[iz] << "):  ("
+                << BFieldR_[iz][ir] << ", "
+                << BFieldZ_[iz][ir] << ")" << std::endl;
     }
 
   }  // end loop over root field map file
@@ -276,8 +276,8 @@ void PHField2D::GetFieldValue(const double point[4], double *Bfield) const
   if (Verbosity() > 2)
   {
     std::cout << "END PHField2D::GetFieldValue\n"
-         << "  --->  {Bx, By, Bz} : "
-         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
+              << "  --->  {Bx, By, Bz} : "
+              << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
   }
 
   return;
@@ -403,8 +403,8 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
   if (Verbosity() > 2)
   {
     std::cout << "End GFCyl Call: <bz,br,bphi> : {"
-         << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
-         << std::endl;
+              << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
+              << std::endl;
   }
 
   return;
@@ -414,10 +414,10 @@ void PHField2D::GetFieldCyl(const double CylPoint[4], double *BfieldCyl) const
 void PHField2D::print_map(std::map<trio, trio>::iterator &it) const
 {
   std::cout << "    Key: <"
-       << std::get<0>(it->first) / cm << ","
-       << std::get<1>(it->first) / cm << ">"
+            << std::get<0>(it->first) / cm << ","
+            << std::get<1>(it->first) / cm << ">"
 
-       << " Value: <"
-       << std::get<0>(it->second) / magfield_unit << ","
-	    << std::get<1>(it->second) / magfield_unit << ">" << std::endl;
+            << " Value: <"
+            << std::get<0>(it->second) / magfield_unit << ","
+            << std::get<1>(it->second) / magfield_unit << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField2D.h
+++ b/offline/packages/PHField/PHField2D.h
@@ -4,15 +4,14 @@
 
 #include "PHField.h"
 
-#include <boost/tuple/tuple.hpp>
-
 #include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 class PHField2D : public PHField
 {
-  typedef boost::tuple<float, float> trio;
+  typedef std::tuple<float, float> trio;
 
  public:
   PHField2D(const std::string &filename, const int verb = 0, const float magfield_rescale = 1.0);

--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -4,12 +4,8 @@
 
 #include <TDirectory.h>  // for TDirectory, gDirectory
 #include <TFile.h>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TNtuple.h>
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4SystemOfUnits.hh>
 

--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -234,7 +234,7 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
     ykey_save = ykey[0];
     zkey_save = zkey[0];
 
-    std::map<boost::tuple<float, float, float>, boost::tuple<float, float, float> >::const_iterator magval;
+    std::map<std::tuple<float, float, float>, std::tuple<float, float, float> >::const_iterator magval;
     trio key;
     for (int i = 0; i < 2; i++)
     {
@@ -242,7 +242,7 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
       {
         for (int k = 0; k < 2; k++)
         {
-          key = boost::make_tuple(xkey[i], ykey[j], zkey[k]);
+          key = std::make_tuple(xkey[i], ykey[j], zkey[k]);
           magval = fieldmap.find(key);
           if (magval == fieldmap.end())
           {
@@ -252,12 +252,12 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
                       << ", z: " << zkey[k] / cm << std::endl;
             return;
           }
-          xyz[i][j][k][0] = (magval->first).get<0>();
-          xyz[i][j][k][1] = (magval->first).get<1>();
-          xyz[i][j][k][2] = (magval->first).get<2>();
-          bf[i][j][k][0] = (magval->second).get<0>();
-          bf[i][j][k][1] = (magval->second).get<1>();
-          bf[i][j][k][2] = (magval->second).get<2>();
+          xyz[i][j][k][0] = std::get<0>(magval->first);
+          xyz[i][j][k][1] = std::get<1>(magval->first);
+          xyz[i][j][k][2] = std::get<2>(magval->first);
+          bf[i][j][k][0] = std::get<0>(magval->second);
+          bf[i][j][k][1] = std::get<1>(magval->second);
+          bf[i][j][k][2] = std::get<2>(magval->second);
           if (Verbosity() > 0)
           {
             std::cout << "read x/y/z: " << xyz[i][j][k][0] / cm << "/"

--- a/offline/packages/PHField/PHField3DCartesian.cc
+++ b/offline/packages/PHField/PHField3DCartesian.cc
@@ -23,7 +23,6 @@
 #include <set>
 #include <utility>
 
-
 PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float magfield_rescale, const float innerradius, const float outerradius, const float size_z)
   : filename(fname)
 {
@@ -64,7 +63,7 @@ PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float mag
   if (field_map == nullptr)
   {
     std::cout << PHWHERE << " Could not load fieldmap ntuple from "
-	      << filename << " exiting now" << std::endl;
+              << filename << " exiting now" << std::endl;
     gSystem->Exit(1);
     exit(1);
   }
@@ -85,8 +84,8 @@ PHField3DCartesian::PHField3DCartesian(const std::string &fname, const float mag
     yvals.insert(ROOT_Y * cm);
     zvals.insert(ROOT_Z * cm);
     if ((std::sqrt(ROOT_X * cm * ROOT_X * cm + ROOT_Y * cm * ROOT_Y * cm) >= innerradius &&
-	 std::sqrt(ROOT_X * cm * ROOT_X * cm + ROOT_Y * cm * ROOT_Y * cm) <= outerradius) ||
-	std::abs(ROOT_Z * cm) > size_z )
+         std::sqrt(ROOT_X * cm * ROOT_X * cm + ROOT_Y * cm * ROOT_Y * cm) <= outerradius) ||
+        std::abs(ROOT_Z * cm) > size_z)
     {
       fieldmap[coord_key] = field_val;
     }
@@ -247,7 +246,7 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
           if (magval == fieldmap.end())
           {
             std::cout << PHWHERE << " could not locate key in " << filename
-		      << " value: x: " << xkey[i] / cm
+                      << " value: x: " << xkey[i] / cm
                       << ", y: " << ykey[j] / cm
                       << ", z: " << zkey[k] / cm << std::endl;
             return;
@@ -293,15 +292,15 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
 
   // linear extrapolation in cube:
 
-  //Vxyz =
-  //V000 * x * y * z +
-  //V100 * (1 - x) * y * z +
-  //V010 * x * (1 - y) * z +
-  //V001 * x y * (1 - z) +
-  //V101 * (1 - x) * y * (1 - z) +
-  //V011 * x * (1 - y) * (1 - z) +
-  //V110 * (1 - x) * (1 - y) * z +
-  //V111 * (1 - x) * (1 - y) * (1 - z)
+  // Vxyz =
+  // V000 * x * y * z +
+  // V100 * (1 - x) * y * z +
+  // V010 * x * (1 - y) * z +
+  // V001 * x y * (1 - z) +
+  // V101 * (1 - x) * y * (1 - z) +
+  // V011 * x * (1 - y) * (1 - z) +
+  // V110 * (1 - x) * (1 - y) * z +
+  // V111 * (1 - x) * (1 - y) * (1 - z)
 
   for (int i = 0; i < 3; i++)
   {

--- a/offline/packages/PHField/PHField3DCartesian.h
+++ b/offline/packages/PHField/PHField3DCartesian.h
@@ -3,13 +3,11 @@
 
 #include "PHField.h"
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
-
 #include <cmath>
 #include <map>
 #include <set>
 #include <string>
+#include <tuple>
 
 class PHField3DCartesian : public PHField
 {
@@ -44,8 +42,8 @@ explicit PHField3DCartesian(const std::string &fname, const float magfield_resca
   mutable int cache_hits = 0;
   mutable int cache_misses = 0;
 
-  typedef boost::tuple<float, float, float> trio;
-  std::map<boost::tuple<float, float, float>, boost::tuple<float, float, float> > fieldmap;
+  typedef std::tuple<float, float, float> trio;
+  std::map<std::tuple<float, float, float>, std::tuple<float, float, float> > fieldmap;
   std::set<float> xvals;
   std::set<float> yvals;
   std::set<float> zvals;

--- a/offline/packages/PHField/PHField3DCartesian.h
+++ b/offline/packages/PHField/PHField3DCartesian.h
@@ -12,7 +12,7 @@
 class PHField3DCartesian : public PHField
 {
  public:
-explicit PHField3DCartesian(const std::string &fname, const float magfield_rescale = 1.0, const float innerradius = 0, const float outerradius = 1.e10, const float size_z = 1.e10);
+  explicit PHField3DCartesian(const std::string &fname, const float magfield_rescale = 1.0, const float innerradius = 0, const float outerradius = 1.e10, const float size_z = 1.e10);
   ~PHField3DCartesian() override;
 
   //! access field value

--- a/offline/packages/PHField/PHField3DCylindrical.cc
+++ b/offline/packages/PHField/PHField3DCylindrical.cc
@@ -20,8 +20,8 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
 {
   std::cout << "\n================ Begin Construct Mag Field =====================" << std::endl;
   std::cout << "\n-----------------------------------------------------------"
-       << "\n      Magnetic field Module - Verbosity:" << Verbosity()
-       << "\n-----------------------------------------------------------";
+            << "\n      Magnetic field Module - Verbosity:" << Verbosity()
+            << "\n-----------------------------------------------------------";
 
   // open file
   TFile *rootinput = TFile::Open(filename.c_str());
@@ -31,8 +31,8 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
     exit(1);
   }
   std::cout << "\n ---> "
-          "Reading the field grid from "
-       << filename << " ... " << std::endl;
+               "Reading the field grid from "
+            << filename << " ... " << std::endl;
   rootinput->cd();
 
   //  get root NTuple objects
@@ -58,16 +58,16 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
   if (Verbosity() > 0)
   {
     std::cout << "\n  NENTRIES should be the same as the following values:"
-         << "\n  [ Number of values r,phi,z: "
-         << nr << " " << nphi << " " << nz << " ]! " << std::endl;
+              << "\n  [ Number of values r,phi,z: "
+              << nr << " " << nphi << " " << nz << " ]! " << std::endl;
   }
 
   if (nz != nr || nz != nphi || nr != nphi)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-         << "\n The file you entered is not a \"table\" of values"
-         << "\n Something very likely went oh so wrong"
-         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+              << "\n The file you entered is not a \"table\" of values"
+              << "\n Something very likely went oh so wrong"
+              << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
   }
 
   // Keep track of the unique z, r, phi values in the grid using sets
@@ -196,12 +196,12 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
       print_map(iter);
 
       std::cout << " B("
-           << r_map_[ir] << ", "
-           << phi_map_[iphi] << ", "
-           << z_map_[iz] << "):  ("
-           << BFieldR_[iz][ir][iphi] << ", "
-           << BFieldPHI_[iz][ir][iphi] << ", "
-           << BFieldZ_[iz][ir][iphi] << ")" << std::endl;
+                << r_map_[ir] << ", "
+                << phi_map_[iphi] << ", "
+                << z_map_[iz] << "):  ("
+                << BFieldR_[iz][ir][iphi] << ", "
+                << BFieldPHI_[iz][ir][iphi] << ", "
+                << BFieldZ_[iz][ir][iphi] << ")" << std::endl;
     }
 
   }  // end loop over root field map file
@@ -209,11 +209,11 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
   rootinput->Close();
 
   std::cout << "\n ---> ... read file successfully "
-       << "\n ---> Z Boundaries ~ zlow, zhigh: "
-       << minz_ / cm << "," << maxz_ / cm << " cm " << std::endl;
+            << "\n ---> Z Boundaries ~ zlow, zhigh: "
+            << minz_ / cm << "," << maxz_ / cm << " cm " << std::endl;
 
   std::cout << "\n================= End Construct Mag Field ======================\n"
-       << std::endl;
+            << std::endl;
 }
 
 void PHField3DCylindrical::GetFieldValue(const double point[4], double *Bfield) const
@@ -273,8 +273,8 @@ void PHField3DCylindrical::GetFieldValue(const double point[4], double *Bfield) 
   if (Verbosity() > 2)
   {
     std::cout << "END PHField3DCylindrical::GetFieldValue\n"
-         << "  --->  {Bx, By, Bz} : "
-         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
+              << "  --->  {Bx, By, Bz} : "
+              << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
   }
 
   return;
@@ -444,8 +444,8 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   if (Verbosity() > 2)
   {
     std::cout << "End GFCyl Call: <bz,br,bphi> : {"
-         << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
-         << std::endl;
+              << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
+              << std::endl;
   }
 
   return;
@@ -482,12 +482,12 @@ bool PHField3DCylindrical::bin_search(const std::vector<float> &vec, unsigned st
 void PHField3DCylindrical::print_map(std::map<trio, trio>::iterator &it) const
 {
   std::cout << "    Key: <"
-       << std::get<0>(it->first) * cm << ","
-       << std::get<1>(it->first) * cm << ","
-       << std::get<2>(it->first) * deg << ">"
+            << std::get<0>(it->first) * cm << ","
+            << std::get<1>(it->first) * cm << ","
+            << std::get<2>(it->first) * deg << ">"
 
-       << " Value: <"
-       << std::get<0>(it->second) * gauss << ","
-	    << std::get<1>(it->second) * gauss << ","
-	    << std::get<2>(it->second) * gauss << ">" << std::endl;
+            << " Value: <"
+            << std::get<0>(it->second) * gauss << ","
+            << std::get<1>(it->second) * gauss << ","
+            << std::get<2>(it->second) * gauss << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField3DCylindrical.cc
+++ b/offline/packages/PHField/PHField3DCylindrical.cc
@@ -6,8 +6,6 @@
 
 #include <Geant4/G4SystemOfUnits.hh>
 
-#include <boost/tuple/tuple_comparison.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -102,12 +100,12 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
   {
     std::map<trio, trio>::iterator it = sorted_map.begin();
     print_map(it);
-    float last_z = it->first.get<0>();
+    float last_z = std::get<0>(it->first);
     for (it = sorted_map.begin(); it != sorted_map.end(); ++it)
     {
-      if (it->first.get<0>() != last_z)
+      if (std::get<0>(it->first) != last_z)
       {
-        last_z = it->first.get<0>();
+        last_z = std::get<0>(it->first);
         print_map(it);
       }
     }
@@ -147,12 +145,12 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
   for (; iter != sorted_map.end(); ++iter)
   {
     // equivalent to ->GetEntry(iter)
-    float z = iter->first.get<0>() * cm;
-    float r = iter->first.get<1>() * cm;
-    float phi = iter->first.get<2>() * deg;
-    float Bz = iter->second.get<0>() * gauss;
-    float Br = iter->second.get<1>() * gauss;
-    float Bphi = iter->second.get<2>() * gauss;
+    float z = std::get<0>(iter->first) * cm;
+    float r = std::get<1>(iter->first) * cm;
+    float phi = std::get<2>(iter->first) * deg;
+    float Bz = std::get<0>(iter->second) * gauss;
+    float Br = std::get<1>(iter->second) * gauss;
+    float Bphi = std::get<2>(iter->second) * gauss;
 
     if (z > maxz_)
     {
@@ -484,12 +482,12 @@ bool PHField3DCylindrical::bin_search(const std::vector<float> &vec, unsigned st
 void PHField3DCylindrical::print_map(std::map<trio, trio>::iterator &it) const
 {
   std::cout << "    Key: <"
-       << it->first.get<0>() * cm << ","
-       << it->first.get<1>() * cm << ","
-       << it->first.get<2>() * deg << ">"
+       << std::get<0>(it->first) * cm << ","
+       << std::get<1>(it->first) * cm << ","
+       << std::get<2>(it->first) * deg << ">"
 
        << " Value: <"
-       << it->second.get<0>() * gauss << ","
-       << it->second.get<1>() * gauss << ","
-	    << it->second.get<2>() * gauss << ">" << std::endl;
+       << std::get<0>(it->second) * gauss << ","
+	    << std::get<1>(it->second) * gauss << ","
+	    << std::get<2>(it->second) * gauss << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField3DCylindrical.cc
+++ b/offline/packages/PHField/PHField3DCylindrical.cc
@@ -2,11 +2,7 @@
 
 #include <TDirectory.h>  // for TDirectory, gDirectory
 #include <TFile.h>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TNtuple.h>
-#pragma GCC diagnostic pop
 
 #include <Geant4/G4SystemOfUnits.hh>
 
@@ -21,13 +17,11 @@
 #include <set>
 #include <utility>
 
-using namespace std;
-
-PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int verb, const float magfield_rescale)
+PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const int verb, const float magfield_rescale)
   : PHField(verb)
 {
-  cout << "\n================ Begin Construct Mag Field =====================" << endl;
-  cout << "\n-----------------------------------------------------------"
+  std::cout << "\n================ Begin Construct Mag Field =====================" << std::endl;
+  std::cout << "\n-----------------------------------------------------------"
        << "\n      Magnetic field Module - Verbosity:" << Verbosity()
        << "\n-----------------------------------------------------------";
 
@@ -35,12 +29,12 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
   TFile *rootinput = TFile::Open(filename.c_str());
   if (!rootinput)
   {
-    cout << "\n could not open " << filename << " exiting now" << endl;
+    std::cout << "\n could not open " << filename << " exiting now" << std::endl;
     exit(1);
   }
-  cout << "\n ---> "
+  std::cout << "\n ---> "
           "Reading the field grid from "
-       << filename << " ... " << endl;
+       << filename << " ... " << std::endl;
   rootinput->cd();
 
   //  get root NTuple objects
@@ -62,20 +56,20 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
   static const int NENTRIES = field_map->GetEntries();
 
   // run checks on entries
-  cout << " ---> The field grid contained " << NENTRIES << " entries" << endl;
+  std::cout << " ---> The field grid contained " << NENTRIES << " entries" << std::endl;
   if (Verbosity() > 0)
   {
-    cout << "\n  NENTRIES should be the same as the following values:"
+    std::cout << "\n  NENTRIES should be the same as the following values:"
          << "\n  [ Number of values r,phi,z: "
-         << nr << " " << nphi << " " << nz << " ]! " << endl;
+         << nr << " " << nphi << " " << nz << " ]! " << std::endl;
   }
 
   if (nz != nr || nz != nphi || nr != nphi)
   {
-    cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
          << "\n The file you entered is not a \"table\" of values"
          << "\n Something very likely went oh so wrong"
-         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << endl;
+         << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
   }
 
   // Keep track of the unique z, r, phi values in the grid using sets
@@ -88,7 +82,7 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
   // phi.
   if (Verbosity() > 0)
   {
-    cout << "  --> Sorting Entries..." << endl;
+    std::cout << "  --> Sorting Entries..." << std::endl;
   }
   std::map<trio, trio> sorted_map;
   for (int i = 0; i < field_map->GetEntries(); i++)
@@ -103,10 +97,10 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
     phi_set.insert(ROOT_PHI * deg);
   }
 
-  // couts for assurance
+  // std::couts for assurance
   if (Verbosity() > 4)
   {
-    map<trio, trio>::iterator it = sorted_map.begin();
+    std::map<trio, trio>::iterator it = sorted_map.begin();
     print_map(it);
     float last_z = it->first.get<0>();
     for (it = sorted_map.begin(); it != sorted_map.end(); ++it)
@@ -121,7 +115,7 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
 
   if (Verbosity() > 0)
   {
-    cout << "  --> Putting entries into containers... " << endl;
+    std::cout << "  --> Putting entries into containers... " << std::endl;
   }
 
   // grab the minimum and maximum z values
@@ -143,13 +137,13 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
   std::copy(r_set.begin(), r_set.end(), r_map_.begin());
 
   // initialize the field map vectors to the correct sizes
-  BFieldR_.resize(nz, vector<vector<float> >(nr, vector<float>(nphi, 0)));
-  BFieldPHI_.resize(nz, vector<vector<float> >(nr, vector<float>(nphi, 0)));
-  BFieldZ_.resize(nz, vector<vector<float> >(nr, vector<float>(nphi, 0)));
+  BFieldR_.resize(nz, std::vector<std::vector<float> >(nr, std::vector<float>(nphi, 0)));
+  BFieldPHI_.resize(nz, std::vector<std::vector<float> >(nr, std::vector<float>(nphi, 0)));
+  BFieldZ_.resize(nz, std::vector<std::vector<float> >(nr, std::vector<float>(nphi, 0)));
 
   // all of this assumes that  z_prev < z , i.e. the table is ordered (as of right now)
   unsigned int ir = 0, iphi = 0, iz = 0;  // useful indexes to keep track of
-  map<trio, trio>::iterator iter = sorted_map.begin();
+  std::map<trio, trio>::iterator iter = sorted_map.begin();
   for (; iter != sorted_map.end(); ++iter)
   {
     // equivalent to ->GetEntry(iter)
@@ -189,7 +183,7 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
     // shouldn't happen
     if (iz > 0 && z < z_map_[iz - 1])
     {
-      cout << "!!!!!!!!! Your map isn't ordered.... z: " << z << " zprev: " << z_map_[iz - 1] << endl;
+      std::cout << "!!!!!!!!! Your map isn't ordered.... z: " << z << " zprev: " << z_map_[iz - 1] << std::endl;
     }
 
     BFieldR_[iz][ir][iphi] = Br * magfield_rescale;
@@ -198,37 +192,37 @@ PHField3DCylindrical::PHField3DCylindrical(const string &filename, const int ver
 
     // you can change this to check table values for correctness
     // print_map prints the values in the root table, and the
-    // couts print the values entered into the vectors
+    // std::couts print the values entered into the vectors
     if (fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
     {
       print_map(iter);
 
-      cout << " B("
+      std::cout << " B("
            << r_map_[ir] << ", "
            << phi_map_[iphi] << ", "
            << z_map_[iz] << "):  ("
            << BFieldR_[iz][ir][iphi] << ", "
            << BFieldPHI_[iz][ir][iphi] << ", "
-           << BFieldZ_[iz][ir][iphi] << ")" << endl;
+           << BFieldZ_[iz][ir][iphi] << ")" << std::endl;
     }
 
   }  // end loop over root field map file
 
   rootinput->Close();
 
-  cout << "\n ---> ... read file successfully "
+  std::cout << "\n ---> ... read file successfully "
        << "\n ---> Z Boundaries ~ zlow, zhigh: "
-       << minz_ / cm << "," << maxz_ / cm << " cm " << endl;
+       << minz_ / cm << "," << maxz_ / cm << " cm " << std::endl;
 
-  cout << "\n================= End Construct Mag Field ======================\n"
-       << endl;
+  std::cout << "\n================= End Construct Mag Field ======================\n"
+       << std::endl;
 }
 
 void PHField3DCylindrical::GetFieldValue(const double point[4], double *Bfield) const
 {
   if (Verbosity() > 2)
   {
-    cout << "\nPHField3DCylindrical::GetFieldValue" << endl;
+    std::cout << "\nPHField3DCylindrical::GetFieldValue" << std::endl;
   }
   double x = point[0];
   double y = point[1];
@@ -274,15 +268,15 @@ void PHField3DCylindrical::GetFieldValue(const double point[4], double *Bfield) 
     Bfield[2] = 0.0;
     if (Verbosity() > 2)
     {
-      cout << "!!!!!!!!!! Field point not in defined region (outside of z bounds)" << endl;
+      std::cout << "!!!!!!!!!! Field point not in defined region (outside of z bounds)" << std::endl;
     }
   }
 
   if (Verbosity() > 2)
   {
-    cout << "END PHField3DCylindrical::GetFieldValue\n"
+    std::cout << "END PHField3DCylindrical::GetFieldValue\n"
          << "  --->  {Bx, By, Bz} : "
-         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << endl;
+         << "< " << Bfield[0] << ", " << Bfield[1] << ", " << Bfield[2] << " >" << std::endl;
   }
 
   return;
@@ -300,14 +294,14 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
 
   if (Verbosity() > 2)
   {
-    cout << "GetFieldCyl@ <z,r,phi>: {" << z << "," << r << "," << phi << "}" << endl;
+    std::cout << "GetFieldCyl@ <z,r,phi>: {" << z << "," << r << "," << phi << "}" << std::endl;
   }
 
   if (z <= z_map_[0] || z >= z_map_[z_map_.size() - 1])
   {
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (|z| too large)" << endl;
+      std::cout << "!!!! Point not in defined region (|z| too large)" << std::endl;
     }
     return;
   }
@@ -316,7 +310,7 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
     r = r_map_[0];
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (radius too small in specific z-plane). Use min radius" << endl;
+      std::cout << "!!!! Point not in defined region (radius too small in specific z-plane). Use min radius" << std::endl;
     }
     //    return;
   }
@@ -324,12 +318,12 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   {
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
     }
     return;
   }
 
-  vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
+  std::vector<float>::const_iterator ziter = upper_bound(z_map_.begin(), z_map_.end(), z);
   int z_index0 = distance(z_map_.begin(), ziter) - 1;
   int z_index1 = z_index0 + 1;
 
@@ -338,13 +332,13 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   assert(z_index0 < (int) z_map_.size());
   assert(z_index1 < (int) z_map_.size());
 
-  vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
+  std::vector<float>::const_iterator riter = upper_bound(r_map_.begin(), r_map_.end(), r);
   int r_index0 = distance(r_map_.begin(), riter) - 1;
   if (r_index0 >= (int) r_map_.size())
   {
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
     }
     return;
   }
@@ -354,7 +348,7 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   {
     if (Verbosity() > 2)
     {
-      cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << endl;
+      std::cout << "!!!! Point not in defined region (radius too large in specific z-plane)" << std::endl;
     }
     return;
   }
@@ -362,7 +356,7 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
   assert(r_index0 >= 0);
   assert(r_index1 >= 0);
 
-  vector<float>::const_iterator phiiter = upper_bound(phi_map_.begin(), phi_map_.end(), phi);
+  std::vector<float>::const_iterator phiiter = upper_bound(phi_map_.begin(), phi_map_.end(), phi);
   int phi_index0 = distance(phi_map_.begin(), phiiter) - 1;
   int phi_index1 = phi_index0 + 1;
   if (phi_index1 >= (int) phi_map_.size())
@@ -438,22 +432,22 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
       zweight * ((1 - rweight) * ((1 - phiweight) * Bphi100 + phiweight * Bphi101) +
                  rweight * ((1 - phiweight) * Bphi110 + phiweight * Bphi111));
 
-  //     cout << "wr: " << rweight << " wz: " << zweight << " wphi: " << phiweight << endl;
-  //     cout << "Bz000: " << Bz000 << endl
-  //          << "Bz001: " << Bz001 << endl
-  //          << "Bz010: " << Bz010 << endl
-  //          << "Bz011: " << Bz011 << endl
-  //          << "Bz100: " << Bz100 << endl
-  //          << "Bz101: " << Bz101 << endl
-  //          << "Bz110: " << Bz110 << endl
-  //          << "Bz111: " << Bz111 << endl
-  //          << "Bz:    " << BfieldCyl[0] << endl << endl;
+  //     std::cout << "wr: " << rweight << " wz: " << zweight << " wphi: " << phiweight << std::endl;
+  //     std::cout << "Bz000: " << Bz000 << std::endl
+  //          << "Bz001: " << Bz001 << std::endl
+  //          << "Bz010: " << Bz010 << std::endl
+  //          << "Bz011: " << Bz011 << std::endl
+  //          << "Bz100: " << Bz100 << std::endl
+  //          << "Bz101: " << Bz101 << std::endl
+  //          << "Bz110: " << Bz110 << std::endl
+  //          << "Bz111: " << Bz111 << std::endl
+  //          << "Bz:    " << BfieldCyl[0] << std::endl << std::endl;
 
   if (Verbosity() > 2)
   {
-    cout << "End GFCyl Call: <bz,br,bphi> : {"
+    std::cout << "End GFCyl Call: <bz,br,bphi> : {"
          << BfieldCyl[0] / gauss << "," << BfieldCyl[1] / gauss << "," << BfieldCyl[2] / gauss << "}"
-         << endl;
+         << std::endl;
   }
 
   return;
@@ -461,7 +455,7 @@ void PHField3DCylindrical::GetFieldCyl(const double CylPoint[4], double *BfieldC
 
 // a binary search algorithm that puts the location that "key" would be, into index...
 // it returns true if key was found, and false if not.
-bool PHField3DCylindrical::bin_search(const vector<float> &vec, unsigned start, unsigned end, const float &key, unsigned &index) const
+bool PHField3DCylindrical::bin_search(const std::vector<float> &vec, unsigned start, unsigned end, const float &key, unsigned &index) const
 {
   // Termination condition: start index greater than end index
   if (start > end)
@@ -487,9 +481,9 @@ bool PHField3DCylindrical::bin_search(const vector<float> &vec, unsigned start, 
 }
 
 // debug function to print key/value pairs in map
-void PHField3DCylindrical::print_map(map<trio, trio>::iterator &it) const
+void PHField3DCylindrical::print_map(std::map<trio, trio>::iterator &it) const
 {
-  cout << "    Key: <"
+  std::cout << "    Key: <"
        << it->first.get<0>() * cm << ","
        << it->first.get<1>() * cm << ","
        << it->first.get<2>() * deg << ">"
@@ -497,5 +491,5 @@ void PHField3DCylindrical::print_map(map<trio, trio>::iterator &it) const
        << " Value: <"
        << it->second.get<0>() * gauss << ","
        << it->second.get<1>() * gauss << ","
-       << it->second.get<2>() * gauss << ">\n";
+	    << it->second.get<2>() * gauss << ">" << std::endl;
 }

--- a/offline/packages/PHField/PHField3DCylindrical.cc
+++ b/offline/packages/PHField/PHField3DCylindrical.cc
@@ -193,7 +193,7 @@ PHField3DCylindrical::PHField3DCylindrical(const std::string &filename, const in
     // you can change this to check table values for correctness
     // print_map prints the values in the root table, and the
     // std::couts print the values entered into the vectors
-    if (fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
+    if (std::fabs(z) < 10 && ir < 10 /*&& iphi==2*/ && Verbosity() > 3)
     {
       print_map(iter);
 

--- a/offline/packages/PHField/PHField3DCylindrical.h
+++ b/offline/packages/PHField/PHField3DCylindrical.h
@@ -22,15 +22,14 @@
 
 #include "PHField.h"
 
-#include <boost/tuple/tuple.hpp>
-
 #include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 class PHField3DCylindrical : public PHField
 {
-  typedef boost::tuple<float, float, float> trio;
+  typedef std::tuple<float, float, float> trio;
 
  public:
   PHField3DCylindrical(const std::string& filename, int verb = 0, const float magfield_rescale = 1.0);

--- a/offline/packages/PHField/PHFieldConfig.cc
+++ b/offline/packages/PHField/PHFieldConfig.cc
@@ -1,7 +1,7 @@
 
 /*!
  * \file PHFieldConfig.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $

--- a/offline/packages/PHField/PHFieldConfig.h
+++ b/offline/packages/PHField/PHFieldConfig.h
@@ -1,6 +1,6 @@
 /*!
  * \file PHFieldConfig.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $

--- a/offline/packages/PHField/PHFieldConfigv1.cc
+++ b/offline/packages/PHField/PHFieldConfigv1.cc
@@ -2,7 +2,7 @@
 
 /*!
  * \file PHFieldConfigv1.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $

--- a/offline/packages/PHField/PHFieldConfigv1.h
+++ b/offline/packages/PHField/PHFieldConfigv1.h
@@ -2,7 +2,7 @@
 
 /*!
  * \file PHFieldConfig_v1.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -49,8 +49,7 @@ class PHFieldConfigv1 : public PHFieldConfig
   void Reset() override {}
 
   /// isValid returns non zero if object contains vailid data
-  int
-  isValid() const override;
+  int isValid() const override;
 
   FieldConfigTypes get_field_config() const override
   {

--- a/offline/packages/PHField/PHFieldConfigv2.cc
+++ b/offline/packages/PHField/PHFieldConfigv2.cc
@@ -2,7 +2,7 @@
 
 /*!
  * \file PHFieldConfigv2.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $

--- a/offline/packages/PHField/PHFieldConfigv2.h
+++ b/offline/packages/PHField/PHFieldConfigv2.h
@@ -2,7 +2,7 @@
 
 /*!
  * \file PHFieldConfigv2.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -49,8 +49,7 @@ class PHFieldConfigv2 : public PHFieldConfig
   void Reset() override {}
 
   /// isValid returns non zero if object contains vailid data
-  int
-  isValid() const override { return 3; }
+  int isValid() const override { return 3; }
 
   FieldConfigTypes get_field_config() const override
   {

--- a/offline/packages/PHField/PHFieldUniform.cc
+++ b/offline/packages/PHField/PHFieldUniform.cc
@@ -12,7 +12,7 @@ PHFieldUniform::PHFieldUniform(
 {
 }
 
-void PHFieldUniform::GetFieldValue(const double /*point*/ [4], double *Bfield) const
+void PHFieldUniform::GetFieldValue(const double /*point*/[4], double *Bfield) const
 {
   Bfield[0] = field_mag_x_;
   Bfield[1] = field_mag_y_;

--- a/offline/packages/PHField/PHFieldUtility.cc
+++ b/offline/packages/PHField/PHFieldUtility.cc
@@ -69,8 +69,8 @@ PHFieldUtility::BuildFieldMap(const PHFieldConfig *field_config, float inner_rad
     field = new PHField3DCartesian(
         field_config->get_filename(),
         field_config->get_magfield_rescale(),
-	inner_radius,
-	outer_radius,
+        inner_radius,
+        outer_radius,
         size_z);
     break;
 

--- a/offline/packages/PHField/PHFieldUtility.cc
+++ b/offline/packages/PHField/PHFieldUtility.cc
@@ -18,10 +18,7 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <TSystem.h>
-#pragma GCC diagnostic pop
 
 #include <cassert>
 #include <cstdlib>  // for getenv

--- a/offline/packages/PHField/PHFieldUtility.h
+++ b/offline/packages/PHField/PHFieldUtility.h
@@ -31,7 +31,7 @@ class PHFieldUtility
 
   //! Build or build field map with a configuration object
   static PHField *
-    BuildFieldMap(const PHFieldConfig *field_config, float inner_radius = 0., float outer_radius = 1.e10, float size_z = 1.e10, const int verbosity = 0);
+  BuildFieldMap(const PHFieldConfig *field_config, float inner_radius = 0., float outer_radius = 1.e10, float size_z = 1.e10, const int verbosity = 0);
 
   //! DST node name for RunTime field map object
   static std::string

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -11,8 +11,8 @@
 #include <g4main/PHG4DisplayAction.h>
 #include <g4main/PHG4Subsystem.h>
 
-#include <phfield/PHFieldUtility.h>
 #include <phfield/PHFieldConfig.h>
+#include <phfield/PHFieldUtility.h>
 
 #include <phool/getClass.h>
 #include <phool/phool.h>
@@ -50,9 +50,9 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <memory>       // for unique_ptr
-#include <utility>      // for pair, make_pair
-#include <vector>       // for vector, vector<>::iter...
+#include <memory>   // for unique_ptr
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector, vector<>::iter...
 
 class PHCompositeNode;
 
@@ -73,12 +73,12 @@ PHG4OHCalDetector::PHG4OHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
   PHFieldConfig *fieldconf = findNode::getClass<PHFieldConfig>(Node, PHFieldUtility::GetDSTConfigNodeName());
   if (fieldconf->get_field_config() != PHFieldConfig::kFieldUniform)
   {
-  m_FieldSetup =
-    new PHG4OHCalFieldSetup(
-      m_Params->get_string_param("IronFieldMapPath"), m_Params->get_double_param("IronFieldMapScale"),
-      m_InnerRadius - 10*cm, // subtract 10 cm to make sure fieldmap with 2x2 grid covers it
-      m_OuterRadius + 10*cm, // add 10 cm to make sure fieldmap with 2x2 grid covers it
-      m_SizeZ/2. + 10*cm // div by 2 bc G4 convention
+    m_FieldSetup =
+        new PHG4OHCalFieldSetup(
+            m_Params->get_string_param("IronFieldMapPath"), m_Params->get_double_param("IronFieldMapScale"),
+            m_InnerRadius - 10 * cm,  // subtract 10 cm to make sure fieldmap with 2x2 grid covers it
+            m_OuterRadius + 10 * cm,  // add 10 cm to make sure fieldmap with 2x2 grid covers it
+            m_SizeZ / 2. + 10 * cm    // div by 2 bc G4 convention
         );
   }
 }
@@ -126,9 +126,9 @@ void PHG4OHCalDetector::ConstructMe(G4LogicalVolume *logicWorld)
   m_DisplayAction->SetMyTopVolume(mothervol);
   ConstructOHCal(hcal_envelope_log);
 
-  // allow installing new G4 subsystem installed inside the HCal envelope via macros, in particular its support rings. 
+  // allow installing new G4 subsystem installed inside the HCal envelope via macros, in particular its support rings.
   PHG4Subsystem *mysys = GetMySubsystem();
-  if (mysys) 
+  if (mysys)
   {
     mysys->SetLogicalVolume(hcal_envelope_log);
   }
@@ -162,8 +162,8 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
   gdmlParser.SetOverlapCheck(OverlapCheck());
   gdmlParser.Read(m_GDMPath, false);
 
-  G4AssemblyVolume *abs_asym = reader->GetAssembly("sector");         //absorber
-  m_ScintiMotherAssembly = reader->GetAssembly("tileAssembly24_90");  //tiles
+  G4AssemblyVolume *abs_asym = reader->GetAssembly("sector");         // absorber
+  m_ScintiMotherAssembly = reader->GetAssembly("tileAssembly24_90");  // tiles
 
   // this loop is inefficient but the assignment of the scintillator id's is much simpler when having the hcal sector
   std::vector<G4VPhysicalVolume *>::iterator it1 = abs_asym->GetVolumesIterator();
@@ -194,8 +194,8 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
     ++it1;
   }
   // Chimney assemblies
-  G4AssemblyVolume *chimAbs_asym = reader->GetAssembly("sectorChimney");         //absorber
-  m_ChimScintiMotherAssembly = reader->GetAssembly("tileAssembly24chimney_90");  //chimney tiles
+  G4AssemblyVolume *chimAbs_asym = reader->GetAssembly("sectorChimney");         // absorber
+  m_ChimScintiMotherAssembly = reader->GetAssembly("tileAssembly24chimney_90");  // chimney tiles
 
   std::vector<G4VPhysicalVolume *>::iterator it2 = chimAbs_asym->GetVolumesIterator();
   //	order sector 30,31,29
@@ -230,17 +230,17 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
     ++it2;
   }
 
-  for (auto & logical_vol : m_SteelAbsorberLogVolSet)
+  for (auto &logical_vol : m_SteelAbsorberLogVolSet)
   {
-    if (m_FieldSetup) // only if we have a field defined for the steel absorber
+    if (m_FieldSetup)  // only if we have a field defined for the steel absorber
     {
       logical_vol->SetFieldManager(m_FieldSetup->get_Field_Manager_Iron(), true);
 
-    if (m_Params->get_int_param("field_check"))
-    {
-      std::cout <<__PRETTY_FUNCTION__<<" : setup Field_Manager_Iron for LV "
-          <<logical_vol->GetName()<<" w/ # of daughter "<< logical_vol->GetNoDaughters()<<std::endl;
-    }
+      if (m_Params->get_int_param("field_check"))
+      {
+        std::cout << __PRETTY_FUNCTION__ << " : setup Field_Manager_Iron for LV "
+                  << logical_vol->GetName() << " w/ # of daughter " << logical_vol->GetNoDaughters() << std::endl;
+      }
     }
   }
 
@@ -458,7 +458,7 @@ int PHG4OHCalDetector::map_layerid(const unsigned int isector, const int layer_i
   {
     rowid = layer_id + 95;
   }
-  else  /* if (layer_id >= 225) */
+  else /* if (layer_id >= 225) */
   {
     rowid = layer_id - 225;
   }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.cc
@@ -14,6 +14,7 @@
 
 #include <phfield/PHFieldUtility.h>
 #include <phfield/PHFieldConfigv1.h>
+#include <phfield/PHFieldConfig.h>           // for PHFieldConfig, PHFieldCo...
 
 #include <Geant4/G4ChordFinder.hh>
 #include <Geant4/G4ClassicalRK4.hh>
@@ -23,9 +24,9 @@
 #include <Geant4/G4Mag_UsualEqRhs.hh>
 #include <Geant4/G4MagneticField.hh>
 #include <Geant4/G4SystemOfUnits.hh>
+#include <Geant4/G4Types.hh>                        // for G4int
 
 #include <cassert>
-#include <iostream>
 
 PHG4OHCalFieldSetup::PHG4OHCalFieldSetup(const std::string &iron_fieldmap_path, const double scale, const double inner_radius, const double outer_radius, const double size_z)
   : fMinStep(0.005 * mm)

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.cc
@@ -2,7 +2,7 @@
 
 /*!
  * \file PHG4OHCalFieldSetup.cc
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -12,9 +12,9 @@
 
 #include <g4main/PHG4MagneticField.h>
 
-#include <phfield/PHFieldUtility.h>
+#include <phfield/PHFieldConfig.h>  // for PHFieldConfig, PHFieldCo...
 #include <phfield/PHFieldConfigv1.h>
-#include <phfield/PHFieldConfig.h>           // for PHFieldConfig, PHFieldCo...
+#include <phfield/PHFieldUtility.h>
 
 #include <Geant4/G4ChordFinder.hh>
 #include <Geant4/G4ClassicalRK4.hh>
@@ -24,7 +24,7 @@
 #include <Geant4/G4Mag_UsualEqRhs.hh>
 #include <Geant4/G4MagneticField.hh>
 #include <Geant4/G4SystemOfUnits.hh>
-#include <Geant4/G4Types.hh>                        // for G4int
+#include <Geant4/G4Types.hh>  // for G4int
 
 #include <cassert>
 
@@ -34,7 +34,7 @@ PHG4OHCalFieldSetup::PHG4OHCalFieldSetup(const std::string &iron_fieldmap_path, 
   static const G4int nvar = 8;
 
   // the new HCal expect 3D magnetic field
-  PHFieldConfigv1 field_config (PHFieldConfig::Field3DCartesian, iron_fieldmap_path, scale);
+  PHFieldConfigv1 field_config(PHFieldConfig::Field3DCartesian, iron_fieldmap_path, scale);
 
   fEMfieldIron = new PHG4MagneticField(PHFieldUtility::BuildFieldMap(&field_config, inner_radius, outer_radius, size_z));
   assert(fEMfieldIron);

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.h
@@ -15,6 +15,7 @@
 
 #include <Geant4/G4Types.hh>  // for G4double, G4int
 
+#include <limits>             // for numeric_limits
 #include <string>
 
 class G4ChordFinder;
@@ -67,7 +68,7 @@ class PHG4OHCalFieldSetup
   G4ChordFinder* fChordFinderIron = nullptr;
   G4MagneticField* fEMfieldIron = nullptr;
   G4MagIntegratorStepper* fStepperIron = nullptr;
-  G4double fMinStep = NAN;
+  G4double fMinStep = std::numeric_limits<float>::quiet_NaN();
 };
 
 #endif /* G4OHCAL_PHG4OHCALFIELDSETUP_H */

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalFieldSetup.h
@@ -4,7 +4,7 @@
 
 /*!
  * \file PHG4OHCalFieldSetup.h
- * \brief 
+ * \brief
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
  * \date $Date: $
@@ -15,7 +15,7 @@
 
 #include <Geant4/G4Types.hh>  // for G4double, G4int
 
-#include <limits>             // for numeric_limits
+#include <limits>  // for numeric_limits
 #include <string>
 
 class G4ChordFinder;
@@ -30,7 +30,7 @@ class G4MagneticField;
 class PHG4OHCalFieldSetup
 {
  public:
-  PHG4OHCalFieldSetup(const std::string & iron_fieldmap_path, const double scale = 1., const double inner_radius = 0., const double outer_radius = 1.e10, const double size_z = 1.e10);
+  PHG4OHCalFieldSetup(const std::string& iron_fieldmap_path, const double scale = 1., const double inner_radius = 0., const double outer_radius = 1.e10, const double size_z = 1.e10);
 
   // delete copy ctor and assignment opertor (cppcheck)
   explicit PHG4OHCalFieldSetup(const PHG4OHCalFieldSetup&) = delete;

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -33,7 +33,7 @@
 #include <Geant4/G4AffineTransform.hh>  // for G4AffineTransform
 #include <Geant4/G4Field.hh>
 #include <Geant4/G4FieldManager.hh>
-#include <Geant4/G4LogicalVolume.hh>                  // for G4LogicalVolume
+#include <Geant4/G4LogicalVolume.hh>       // for G4LogicalVolume
 #include <Geant4/G4NavigationHistory.hh>   // for G4NavigationHistory
 #include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4PropagatorInField.hh>
@@ -272,17 +272,17 @@ bool PHG4OHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
       {
         m_Hit = new PHG4Hitv1();
       }
-      //here we set the entrance values in cm
+      // here we set the entrance values in cm
       m_Hit->set_x(0, prePoint->GetPosition().x() / cm);
       m_Hit->set_y(0, prePoint->GetPosition().y() / cm);
       m_Hit->set_z(0, prePoint->GetPosition().z() / cm);
 
       // time in ns
       m_Hit->set_t(0, prePoint->GetGlobalTime() / nanosecond);
-      //set the track ID
+      // set the track ID
       m_Hit->set_trkid(aTrack->GetTrackID());
       m_SaveTrackId = aTrack->GetTrackID();
-      //set the initial energy deposit
+      // set the initial energy deposit
       m_Hit->set_edep(0);
       if (whichactive > 0)  // return of IsInOHCalDetector, > 0 hit in scintillator, < 0 hit in absorber
       {
@@ -351,7 +351,7 @@ bool PHG4OHCalSteppingAction::UserSteppingAction(const G4Step* aStep, bool /*was
 
     m_Hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
 
-    //sum up the energy to get total deposited
+    // sum up the energy to get total deposited
     m_Hit->set_edep(m_Hit->get_edep() + edep);
 
     if (whichactive > 0)
@@ -493,7 +493,7 @@ void PHG4OHCalSteppingAction::FieldChecker(const G4Step* aStep)
 
   static const std::string h_field_name = "hOHCalField";
 
-  if (! se->isHistoRegistered(h_field_name))
+  if (!se->isHistoRegistered(h_field_name))
   {
     TH2F* h = new TH2F(h_field_name.c_str(), "Magnetic field (Tesla) in HCal;X (cm);Y (cm)", 2400,
                        -300, 300, 2400, -300, 300);

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -1,5 +1,3 @@
-
-// local headers in quotes (that is important when using include subdirs!)
 #include "PHG4OHCalSteppingAction.h"
 
 #include "PHG4OHCalDetector.h"
@@ -11,8 +9,6 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <fun4all/Fun4AllServer.h>
-
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
@@ -20,7 +16,10 @@
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
 
+#include <fun4all/Fun4AllServer.h>
+
 #include <phool/getClass.h>
+#include <phool/phool.h>
 
 // Root headers
 #include <TAxis.h>  // for TAxis
@@ -34,6 +33,7 @@
 #include <Geant4/G4AffineTransform.hh>  // for G4AffineTransform
 #include <Geant4/G4Field.hh>
 #include <Geant4/G4FieldManager.hh>
+#include <Geant4/G4LogicalVolume.hh>                  // for G4LogicalVolume
 #include <Geant4/G4NavigationHistory.hh>   // for G4NavigationHistory
 #include <Geant4/G4ParticleDefinition.hh>  // for G4ParticleDefinition
 #include <Geant4/G4PropagatorInField.hh>
@@ -56,7 +56,6 @@
 // finally system headers
 #include <cassert>
 #include <cmath>  // for isfinite, sqrt
-#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <string>  // for operator<<, string
@@ -494,7 +493,7 @@ void PHG4OHCalSteppingAction::FieldChecker(const G4Step* aStep)
 
   static const std::string h_field_name = "hOHCalField";
 
-  if (not se->isHistoRegistered(h_field_name))
+  if (! se->isHistoRegistered(h_field_name))
   {
     TH2F* h = new TH2F(h_field_name.c_str(), "Magnetic field (Tesla) in HCal;X (cm);Y (cm)", 2400,
                        -300, 300, 2400, -300, 300);
@@ -531,12 +530,10 @@ void PHG4OHCalSteppingAction::FieldChecker(const G4Step* aStep)
   if (h->GetBinContent(binx, binx) == 0)
   {  // only fille unfilled bins
 
-    G4TransportationManager* transportMgr =
-        G4TransportationManager::GetTransportationManager();
+    G4TransportationManager* transportMgr = G4TransportationManager::GetTransportationManager();
     assert(transportMgr);
 
-    G4PropagatorInField* fFieldPropagator =
-        transportMgr->GetPropagatorInField();
+    G4PropagatorInField* fFieldPropagator = transportMgr->GetPropagatorInField();
     assert(fFieldPropagator);
 
     G4FieldManager* fieldMgr = fFieldPropagator->FindAndSetFieldManager(volume);

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
@@ -21,9 +21,9 @@
 #include <phool/getClass.h>
 
 #include <cmath>     // for NAN
+#include <cstdlib>   // for getenv
 #include <iostream>  // for operator<<, basic_ostream
 #include <set>       // for set
-#include <cstdlib> // for getenv
 class PHG4Detector;
 
 //_______________________________________________________________________
@@ -48,12 +48,11 @@ int PHG4OHCalSubsystem::InitRunSubsystem(PHCompositeNode *topNode)
   // create display settings before detector
   m_DisplayAction = new PHG4OHCalDisplayAction(Name());
 
-  if (get_string_param("IronFieldMapPath") == "DefaultParameters-InvadPath" )
+  if (get_string_param("IronFieldMapPath") == "DefaultParameters-InvadPath")
   {
-    std::cout <<__PRETTY_FUNCTION__<<": invalid string parameter IronFieldMapPath, where we expect a 3D field map"<<std::endl;
-    exit (1);
+    std::cout << __PRETTY_FUNCTION__ << ": invalid string parameter IronFieldMapPath, where we expect a 3D field map" << std::endl;
+    exit(1);
   }
-
 
   // create detector
   m_Detector = new PHG4OHCalDetector(this, topNode, GetParams(), Name());
@@ -155,12 +154,12 @@ void PHG4OHCalSubsystem::SetLightCorrection(const double inner_radius, const dou
 
 void PHG4OHCalSubsystem::SetDefaultParameters()
 {
-  set_default_double_param("inner_radius", 182.423  - 5);
+  set_default_double_param("inner_radius", 182.423 - 5);
   set_default_double_param("light_balance_inner_corr", NAN);
   set_default_double_param("light_balance_inner_radius", NAN);
   set_default_double_param("light_balance_outer_corr", NAN);
   set_default_double_param("light_balance_outer_radius", NAN);
-  set_default_double_param("outer_radius", 269.317  + 5 );
+  set_default_double_param("outer_radius", 269.317 + 5);
   set_default_double_param("place_x", 0.);
   set_default_double_param("place_y", 0.);
   set_default_double_param("place_z", 0.);
@@ -178,21 +177,20 @@ void PHG4OHCalSubsystem::SetDefaultParameters()
 
   set_default_string_param("GDMPath", "DefaultParameters-InvadPath");
   std::string defaultmapfilename;
-  const char* Calibroot = getenv("CALIBRATIONROOT");
+  const char *Calibroot = getenv("CALIBRATIONROOT");
   if (Calibroot)
-   {
-     defaultmapfilename = Calibroot;
-     defaultmapfilename += "/HCALOUT/tilemap/ohcalgdmlmapfiles102022.root";
-   }
+  {
+    defaultmapfilename = Calibroot;
+    defaultmapfilename += "/HCALOUT/tilemap/ohcalgdmlmapfiles102022.root";
+  }
   set_default_string_param("MapFileName", defaultmapfilename);
   set_default_string_param("MapHistoName", "ohcal_mephi_map_towerid_");
-  
+
   if (!Calibroot)
   {
-    std::cout<<__PRETTY_FUNCTION__ << ": no CALIBRATIONROOT environment variable" << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << ": no CALIBRATIONROOT environment variable" << std::endl;
     exit(1);
   }
-  set_default_string_param("IronFieldMapPath", std::string(Calibroot) + "/Field/Map/sphenix3dbigmapxyz_steel_rebuild.root" );
+  set_default_string_param("IronFieldMapPath", std::string(Calibroot) + "/Field/Map/sphenix3dbigmapxyz_steel_rebuild.root");
   set_default_double_param("IronFieldMapScale", 1.);
-  
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.h
@@ -49,7 +49,7 @@ class PHG4OHCalSubsystem : public PHG4DetectorSubsystem
   // Subsystems which can be mothervolume need to implement this
   // and return true
   bool CanBeMotherSubsystem() const override { return true; }
-  
+
  private:
   void SetDefaultParameters() override;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR finally allows to run sPHENIX with a uniform field instead of fieldmaps. Needed for zero field (for real sims) and quick tests since the fieldmap takes time and tons of memory. For a uniform field the outer hcal does not load it's absorber map which crashed things before.
Replaced the old boost::tuples by std::tuples in our fieldmaps
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

