### PR TITLE
fill bbcns with -999999 if arm has no signal to avoid crashes

### DIFF
--- a/simulation/g4simulation/g4bbc/BbcSimReco.cc
+++ b/simulation/g4simulation/g4bbc/BbcSimReco.cc
@@ -370,6 +370,14 @@ int BbcSimReco::process_event(PHCompositeNode * /*topNode*/)
 
           _bbcout->AddBbcNS(iarm, f_bbcn[iarm], f_bbcq[iarm], f_bbct[iarm]);
         }
+        else
+        {
+          _bbcout->AddBbcNS(iarm, 0, -99999., -99999.);
+        }
+      }
+      else
+      {
+        _bbcout->AddBbcNS(iarm, 0, -99999., -99999.);
       }
     }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The BbcSimReco kept crashing. The reason was that arm 0 of the BbcNS TClonesArray has to be filled if arm 1 is set. Otherwise this crashes during writing in TTree->Write(). If there is no signal in the arm it's now filled with -99999. We should later replace this with nan but then we have competing bbc output objects 
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

