### PR TITLE
Save state at calo radius

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -147,8 +147,8 @@ void PHActsTrackProjection::updateSvtxTrack(
 {
   float pathlength = parameters.first / Acts::UnitConstants::cm;
   auto params = parameters.second;
-
-  SvtxTrackState_v1 out(pathlength);
+  float calorad = m_caloRadii.find(m_caloTypes.at(caloLayer))->second;
+  SvtxTrackState_v1 out(calorad);
 
   auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
   const auto momentum = params.momentum();
@@ -162,7 +162,7 @@ void PHActsTrackProjection::updateSvtxTrack(
   if (Verbosity() > 1)
   {
     std::cout << "Adding track state for caloLayer " << caloLayer
-              << " with position " << projectionPos.transpose() << std::endl;
+              << " at pathlength " << pathlength << " with position " << projectionPos.transpose() << std::endl;
   }
 
   ActsTransformations transformer;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

State of track projections was changed to save at the pathlength which is typical for the actual track states. For the calo projections it makes it hard to look up the state info, so this changes the saving back to the calo radius.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

