### PR TITLE
Fix bbc root memory issue

### DIFF
--- a/offline/packages/bbc/BbcReconstruction.cc
+++ b/offline/packages/bbc/BbcReconstruction.cc
@@ -23,6 +23,8 @@
 BbcReconstruction::BbcReconstruction(const std::string &name)
   : SubsysReco(name)
 {
+  h_evt_bbct[0] = nullptr;
+  h_evt_bbct[1] = nullptr;
 }
 
 //____________________________________________________________________________..
@@ -35,6 +37,18 @@ int BbcReconstruction::Init(PHCompositeNode *)
 {
   m_gaussian = std::make_unique<TF1>("gaussian", "gaus", 0, 20);
   m_gaussian->FixParameter(2, m_tres);
+
+  TString name, title;
+  for (int iarm = 0; iarm < 2; iarm++)
+  {
+    //
+    name = "hevt_bbct";
+    name += iarm;
+    title = "bbc times, arm ";
+    title += iarm;
+    h_evt_bbct[iarm] = new TH1F(name, title, 200, 7.5, 11.5);
+    h_evt_bbct[iarm]->SetLineColor(4);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -54,20 +68,6 @@ int BbcReconstruction::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int BbcReconstruction::process_event(PHCompositeNode *)
 {
-  TH1 *h_evt_bbct[2]{};
-  h_evt_bbct[0] = nullptr;
-  h_evt_bbct[1] = nullptr;
-  TString name, title;
-  for (int iarm = 0; iarm < 2; iarm++)
-  {
-    //
-    name = "hevt_bbct";
-    name += iarm;
-    title = "bbc times, arm ";
-    title += iarm;
-    h_evt_bbct[iarm] = new TH1F(name, title, 200, 7.5, 11.5);
-    h_evt_bbct[iarm]->SetLineColor(4);
-  }
 
   std::vector<float> hit_times[2];
   float bbcq[2] = {0};

--- a/offline/packages/bbc/BbcReconstruction.h
+++ b/offline/packages/bbc/BbcReconstruction.h
@@ -12,6 +12,7 @@ class PHCompositeNode;
 class BbcPmtContainer;
 class BbcVertexMap;
 class TF1;
+class TH1;
 
 class BbcReconstruction : public SubsysReco
 {
@@ -31,7 +32,7 @@ class BbcReconstruction : public SubsysReco
   std::unique_ptr<TF1> m_gaussian = nullptr;
 
   float m_tres = 0.05;
-
+  TH1 *h_evt_bbct[2];
   BbcVertexMap *m_bbcvertexmap = nullptr;
   BbcPmtContainer *m_bbcpmts = nullptr;
 };


### PR DESCRIPTION
This PR fixes a bug I introduced by creating a histogram every event, which root complains about. This PR moves the histo creation to one time in Init

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

