### PR TITLE
Fix vertex lookup

### DIFF
--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -295,11 +295,12 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   }
 
   /// Associate any tracks that were not assigned a track-vertex
+  
   for (const auto &[tkey, track] : *trackmap)
   {
     //! Check that the vertex hasn't already been assigned
     auto trackvtxid = track->get_vertex_id();
-    if (globalmap->find(trackvtxid)->second != nullptr)
+    if (globalmap->find(trackvtxid) != globalmap->end())
     {
       continue;
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

There are some instances (e.g. single tracks) where, despite the vertex id being unavailable, the vertex map returns a non-nullptr vertex. To fix the unassigned track to vertex association, just check if the end of the map has been reached.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

