### PR TITLE
TPC Local Z fix

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -10,11 +10,15 @@
 #include <TTree.h>
 #include <string>
 
+#include <trackbase/TrkrDefs.h>
+
 #include <cmath>
 #include <iostream>
 #include <limits>
 
+class TrkrCluster;
 class PHCompositeNode;
+class ActsGeometry;
 
 class TrackResiduals : public SubsysReco
 {
@@ -32,7 +36,7 @@ class TrackResiduals : public SubsysReco
  private:
   void clearClusterStateVectors();
   void createBranches();
-
+  float convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
   std::string m_outfileName = "";
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;


### PR DESCRIPTION
This fixes the TPC local z look up in the residual ntuplizer to convert the drift time to a physical z position.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

