### PR TITLE
Check for track map rather than returning

### DIFF
--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -69,11 +69,6 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   SvtxVertexMap *svtxmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   BbcVertexMap *bbcmap = findNode::getClass<BbcVertexMap>(topNode, "BbcVertexMap");
   SvtxTrackMap *trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
-  if (!trackmap)
-  {
-    std::cout << PHWHERE << "No track map, can't continue." << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
 
   // we will make 3 different kinds of global vertexes
   //  (1) SVTX+BBC vertexes - we match SVTX vertex to the nearest BBC vertex within 3 sigma in zvertex
@@ -157,13 +152,15 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       globalmap->insert(vertex);
 
       //! Reset track ids to the new vertex object
-      for (auto iter = svtx->begin_tracks(); iter != svtx->end_tracks();
-           ++iter)
+      if (trackmap)
       {
-        auto track = trackmap->find(*iter)->second;
-        track->set_vertex_id(vertex->get_id());
+        for (auto iter = svtx->begin_tracks(); iter != svtx->end_tracks();
+             ++iter)
+        {
+          auto track = trackmap->find(*iter)->second;
+          track->set_vertex_id(vertex->get_id());
+        }
       }
-
       global_vertex_id++;
 
       if (Verbosity() > 1)
@@ -218,13 +215,15 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       used_svtx_vtxids.insert(svtx->get_id());
 
       //! Reset track ids to the new vertex object
-      for (auto iter = svtx->begin_tracks(); iter != svtx->end_tracks();
-           ++iter)
+      if (trackmap)
       {
-        auto track = trackmap->find(*iter)->second;
-        track->set_vertex_id(vertex->get_id());
+        for (auto iter = svtx->begin_tracks(); iter != svtx->end_tracks();
+             ++iter)
+        {
+          auto track = trackmap->find(*iter)->second;
+          track->set_vertex_id(vertex->get_id());
+        }
       }
-
       globalmap->insert(vertex);
 
       if (Verbosity() > 1)
@@ -295,33 +294,35 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   }
 
   /// Associate any tracks that were not assigned a track-vertex
-  
-  for (const auto &[tkey, track] : *trackmap)
+  if (trackmap)
   {
-    //! Check that the vertex hasn't already been assigned
-    auto trackvtxid = track->get_vertex_id();
-    if (globalmap->find(trackvtxid) != globalmap->end())
+    for (const auto &[tkey, track] : *trackmap)
     {
-      continue;
-    }
-
-    float maxdz = std::numeric_limits<float>::max();
-    unsigned int vtxid = std::numeric_limits<unsigned int>::max();
-
-    for (const auto &[vkey, vertex] : *globalmap)
-    {
-      float dz = track->get_z() - vertex->get_z();
-      if (fabs(dz) < maxdz)
+      //! Check that the vertex hasn't already been assigned
+      auto trackvtxid = track->get_vertex_id();
+      if (globalmap->find(trackvtxid) != globalmap->end())
       {
-        maxdz = dz;
-        vtxid = vkey;
+        continue;
       }
-    }
 
-    track->set_vertex_id(vtxid);
-    if (Verbosity())
-    {
-      std::cout << "Associated track with z " << track->get_z() << " to GlobalVertex id " << track->get_vertex_id() << std::endl;
+      float maxdz = std::numeric_limits<float>::max();
+      unsigned int vtxid = std::numeric_limits<unsigned int>::max();
+
+      for (const auto &[vkey, vertex] : *globalmap)
+      {
+        float dz = track->get_z() - vertex->get_z();
+        if (fabs(dz) < maxdz)
+        {
+          maxdz = dz;
+          vtxid = vkey;
+        }
+      }
+
+      track->set_vertex_id(vtxid);
+      if (Verbosity())
+      {
+        std::cout << "Associated track with z " << track->get_z() << " to GlobalVertex id " << track->get_vertex_id() << std::endl;
+      }
     }
   }
 


### PR DESCRIPTION
This just checks for the track map instead of returning `ABORTEVENT` so that DSTs where no track map is made can still fill the global vertex reco map

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

