### PR TITLE
Common alignment tools

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -1,16 +1,70 @@
 #include "AlignmentDefs.h"
 
-
-void AlignmentDefs::getGlobalLabels(Surface surf, int glbl_label[])
+void AlignmentDefs::getSiliconGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::siliconGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
-  int label_base = getLabelBase(id);   // This value depends on how the surfaces are grouped
-  for(int i=0; i<NGL; i++)
+  int group = 0;
+  switch(grp) {
+  case AlignmentDefs::siliconGrp::snsr:
+    group = 0;
+    break;
+  case AlignmentDefs::siliconGrp::stv:
+    group = 1;
+    break;
+  case AlignmentDefs::siliconGrp::brrl:
+    group = 2;
+    break;
+  }
+  
+  int label_base = getLabelBase(id, group);
+  for(int i=0; i<NGL; ++i)
     {
       glbl_label[i] = label_base + i;
     }
-
 }
+
+void AlignmentDefs::getTpcGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::tpcGrp grp)
+{
+  Acts::GeometryIdentifier id = surf->geometryId();
+  int group = 0;
+  switch(grp) {
+  case AlignmentDefs::tpcGrp::htst:
+    group = 3;
+    break;
+  case AlignmentDefs::tpcGrp::sctr:
+    group = 4;
+    break;
+  case AlignmentDefs::tpcGrp::tp:
+    group = 5;
+    break;
+  }
+  
+  int label_base = getLabelBase(id, group);
+  for(int i=0; i<NGL; ++i)
+    {
+      glbl_label[i] = label_base + i;
+    }
+}
+void AlignmentDefs::getMMGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::mmsGrp grp)
+{
+  Acts::GeometryIdentifier id = surf->geometryId();
+  int group = 0;
+  switch(grp) {
+  case AlignmentDefs::mmsGrp::tl:
+    group = 6;
+    break;
+  case AlignmentDefs::mmsGrp::mm:
+    group = 7;
+    break;
+  }
+  
+  int label_base = getLabelBase(id, group);
+  for(int i=0; i<NGL; ++i)
+    {
+      glbl_label[i] = label_base + i;
+    }
+}
+
 int AlignmentDefs::getTpcRegion(int layer)
 {
   int region = 0;
@@ -21,7 +75,7 @@ int AlignmentDefs::getTpcRegion(int layer)
 
   return region;  
 }
-int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
+int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, int group)
 {
   
   unsigned int volume = id.volume(); 
@@ -34,28 +88,28 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
   // decide what level of grouping we want
   if(layer < 7)
     {
-      if(si_grp == siliconGrp::snsr)
+      if(group == 0)
 	{
 	  // every sensor has a different label
 	  int stave = sensor / nsensors_stave[layer];
 	  label_base += layer*1000000  + stave*10000 + sensor*10;
 	  return label_base;
 	}
-      if(si_grp == siliconGrp::stv)
+      if(group == 1)
 	{
 	  // layer and stave, assign all sensors to the stave number
 	  int stave = sensor / nsensors_stave[layer];
 	  label_base += layer*1000000 + stave*10000;
 	  return label_base;
 	}
-      if(si_grp == siliconGrp::brrl)
+      if(group == 2)
 	// layer only, assign all sensors to sensor 0 
 	label_base += layer*1000000 + 0;
       return label_base;
     }
   else if(layer > 6 && layer < 55)
     {
-      if(tpc_grp == tpcGrp::htst)
+      if(group == 3)
 	{
 	  // want every hitset (layer, sector, side) to have a separate label
 	  // each group of 12 subsurfaces (sensors) is in a single hitset
@@ -63,7 +117,7 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
 	  label_base += layer*1000000 + hitset*10000;
 	  return label_base;
 	}
-      if(tpc_grp == tpcGrp::sctr)
+      if(group == 4)
 	{
 	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
 	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
@@ -74,7 +128,7 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
 	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
 	  return label_base;
 	}
-      if(tpc_grp == tpcGrp::tp)
+      if(group == 5)
 	{
 	  // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
 	  label_base += 7*1000000 + 0;
@@ -83,14 +137,14 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
     }
   else
     {
-      if(mms_grp == mmsGrp::tl)
+      if(group == 6)
 	{
 	  // every tile has different label
 	  int tile = sensor;
 	  label_base += layer*1000000 + tile*10000+sensor*10;
 	  return label_base;
 	}
-      if(mms_grp == mmsGrp::mm)
+      if(group == 7)
 	{
 	  // assign layer 55 and tile 0 to all
 	  label_base += 55*1000000 + 0;	  

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -1,0 +1,116 @@
+#include "AlignmentDefs.h"
+
+
+void AlignmentDefs::getGlobalLabels(Surface surf, int glbl_label[])
+{
+  Acts::GeometryIdentifier id = surf->geometryId();
+  int label_base = getLabelBase(id);   // This value depends on how the surfaces are grouped
+  for(int i=0; i<NGL; i++)
+    {
+      glbl_label[i] = label_base + i;
+    }
+
+}
+int AlignmentDefs::getTpcRegion(int layer)
+{
+  int region = 0;
+  if(layer > 23 && layer < 39)
+    region = 1;
+  if(layer > 38 && layer < 55)
+    region = 2;
+
+  return region;  
+}
+int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id)
+{
+  
+  unsigned int volume = id.volume(); 
+  unsigned int acts_layer = id.layer();
+  unsigned int layer = base_layer_map.find(volume)->second + acts_layer / 2 -1;
+  unsigned int sensor = id.sensitive() - 1;  // Acts starts at 1
+
+  int label_base = 1;  // Mille wants to start at 1
+
+  // decide what level of grouping we want
+  if(layer < 7)
+    {
+      if(si_grp == siliconGrp::snsr)
+	{
+	  // every sensor has a different label
+	  int stave = sensor / nsensors_stave[layer];
+	  label_base += layer*1000000  + stave*10000 + sensor*10;
+	  return label_base;
+	}
+      if(si_grp == siliconGrp::stv)
+	{
+	  // layer and stave, assign all sensors to the stave number
+	  int stave = sensor / nsensors_stave[layer];
+	  label_base += layer*1000000 + stave*10000;
+	  return label_base;
+	}
+      if(si_grp == siliconGrp::brrl)
+	// layer only, assign all sensors to sensor 0 
+	label_base += layer*1000000 + 0;
+      return label_base;
+    }
+  else if(layer > 6 && layer < 55)
+    {
+      if(tpc_grp == tpcGrp::htst)
+	{
+	  // want every hitset (layer, sector, side) to have a separate label
+	  // each group of 12 subsurfaces (sensors) is in a single hitset
+	  int hitset = sensor/12; // 0-11 on side 0, 12-23 on side 1
+	  label_base += layer*1000000 + hitset*10000;
+	  return label_base;
+	}
+      if(tpc_grp == tpcGrp::sctr)
+	{
+	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
+	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
+	  int sector = (sensor - side *144) / 12; 
+	  // for a given layer there are only 12 sectors x 2 sides
+	  // The following gives the sectors in the inner, mid, outer regions unique group labels
+	  int region = getTpcRegion(layer);  // inner, mid, outer
+	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
+	  return label_base;
+	}
+      if(tpc_grp == tpcGrp::tp)
+	{
+	  // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
+	  label_base += 7*1000000 + 0;
+	  return label_base;
+	}
+    }
+  else
+    {
+      if(mms_grp == mmsGrp::tl)
+	{
+	  // every tile has different label
+	  int tile = sensor;
+	  label_base += layer*1000000 + tile*10000+sensor*10;
+	  return label_base;
+	}
+      if(mms_grp == mmsGrp::mm)
+	{
+	  // assign layer 55 and tile 0 to all
+	  label_base += 55*1000000 + 0;	  
+	  return label_base;
+	}
+    }
+
+  return -1;
+}
+
+void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[])
+{
+    std::cout << " float buffer: " << " residual " << "  " << residual(index);
+  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_deriv["<< il << "] " << lcl_derivative[il] << "  ";  }
+  std::cout  << " sigma " << "  " << clus_sigma(index) << "  ";
+  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0)  std::cout << " glbl_deriv["<< ig << "] " << glbl_derivative[ig] << "  ";  }
+  std::cout << " int buffer: " << " 0 " << " 0 " << " ";  // spacer, rmeas placeholder
+  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_label["<< il << "] " << il+1 << "  ";  }
+  std::cout << " 0 " << "  ";
+  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0) std::cout << " glbl_label["<< ig << "] " << glbl_label[ig] << "  ";  }
+  std::cout << " end of meas " << std::endl;
+}
+

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -4,7 +4,8 @@ void AlignmentDefs::getSiliconGlobalLabels(Surface surf, int glbl_label[], Align
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
-  switch(grp) {
+  switch (grp)
+  {
   case AlignmentDefs::siliconGrp::snsr:
     group = 0;
     break;
@@ -15,19 +16,20 @@ void AlignmentDefs::getSiliconGlobalLabels(Surface surf, int glbl_label[], Align
     group = 2;
     break;
   }
-  
+
   int label_base = getLabelBase(id, group);
-  for(int i=0; i<NGL; ++i)
-    {
-      glbl_label[i] = label_base + i;
-    }
+  for (int i = 0; i < NGL; ++i)
+  {
+    glbl_label[i] = label_base + i;
+  }
 }
 
 void AlignmentDefs::getTpcGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::tpcGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
-  switch(grp) {
+  switch (grp)
+  {
   case AlignmentDefs::tpcGrp::htst:
     group = 3;
     break;
@@ -38,18 +40,19 @@ void AlignmentDefs::getTpcGlobalLabels(Surface surf, int glbl_label[], Alignment
     group = 5;
     break;
   }
-  
+
   int label_base = getLabelBase(id, group);
-  for(int i=0; i<NGL; ++i)
-    {
-      glbl_label[i] = label_base + i;
-    }
+  for (int i = 0; i < NGL; ++i)
+  {
+    glbl_label[i] = label_base + i;
+  }
 }
 void AlignmentDefs::getMMGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::mmsGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
-  switch(grp) {
+  switch (grp)
+  {
   case AlignmentDefs::mmsGrp::tl:
     group = 6;
     break;
@@ -57,114 +60,131 @@ void AlignmentDefs::getMMGlobalLabels(Surface surf, int glbl_label[], AlignmentD
     group = 7;
     break;
   }
-  
+
   int label_base = getLabelBase(id, group);
-  for(int i=0; i<NGL; ++i)
-    {
-      glbl_label[i] = label_base + i;
-    }
+  for (int i = 0; i < NGL; ++i)
+  {
+    glbl_label[i] = label_base + i;
+  }
 }
 
 int AlignmentDefs::getTpcRegion(int layer)
 {
   int region = 0;
-  if(layer > 23 && layer < 39)
+  if (layer > 23 && layer < 39)
     region = 1;
-  if(layer > 38 && layer < 55)
+  if (layer > 38 && layer < 55)
     region = 2;
 
-  return region;  
+  return region;
 }
 int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, int group)
 {
-  
-  unsigned int volume = id.volume(); 
+  unsigned int volume = id.volume();
   unsigned int acts_layer = id.layer();
-  unsigned int layer = base_layer_map.find(volume)->second + acts_layer / 2 -1;
+  unsigned int layer = base_layer_map.find(volume)->second + acts_layer / 2 - 1;
   unsigned int sensor = id.sensitive() - 1;  // Acts starts at 1
 
   int label_base = 1;  // Mille wants to start at 1
 
   // decide what level of grouping we want
-  if(layer < 7)
+  if (layer < 7)
+  {
+    if (group == 0)
     {
-      if(group == 0)
-	{
-	  // every sensor has a different label
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000  + stave*10000 + sensor*10;
-	  return label_base;
-	}
-      if(group == 1)
-	{
-	  // layer and stave, assign all sensors to the stave number
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000 + stave*10000;
-	  return label_base;
-	}
-      if(group == 2)
-	// layer only, assign all sensors to sensor 0 
-	label_base += layer*1000000 + 0;
+      // every sensor has a different label
+      int stave = sensor / nsensors_stave[layer];
+      label_base += layer * 1000000 + stave * 10000 + sensor * 10;
       return label_base;
     }
-  else if(layer > 6 && layer < 55)
+    if (group == 1)
     {
-      if(group == 3)
-	{
-	  // want every hitset (layer, sector, side) to have a separate label
-	  // each group of 12 subsurfaces (sensors) is in a single hitset
-	  int hitset = sensor/12; // 0-11 on side 0, 12-23 on side 1
-	  label_base += layer*1000000 + hitset*10000;
-	  return label_base;
-	}
-      if(group == 4)
-	{
-	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
-	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
-	  int sector = (sensor - side *144) / 12; 
-	  // for a given layer there are only 12 sectors x 2 sides
-	  // The following gives the sectors in the inner, mid, outer regions unique group labels
-	  int region = getTpcRegion(layer);  // inner, mid, outer
-	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
-	  return label_base;
-	}
-      if(group == 5)
-	{
-	  // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
-	  label_base += 7*1000000 + 0;
-	  return label_base;
-	}
+      // layer and stave, assign all sensors to the stave number
+      int stave = sensor / nsensors_stave[layer];
+      label_base += layer * 1000000 + stave * 10000;
+      return label_base;
     }
+    if (group == 2)
+      // layer only, assign all sensors to sensor 0
+      label_base += layer * 1000000 + 0;
+    return label_base;
+  }
+  else if (layer > 6 && layer < 55)
+  {
+    if (group == 3)
+    {
+      // want every hitset (layer, sector, side) to have a separate label
+      // each group of 12 subsurfaces (sensors) is in a single hitset
+      int hitset = sensor / 12;  // 0-11 on side 0, 12-23 on side 1
+      label_base += layer * 1000000 + hitset * 10000;
+      return label_base;
+    }
+    if (group == 4)
+    {
+      // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
+      int side = sensor / 144;  // 0-143 on side 0, 144-287 on side 1
+      int sector = (sensor - side * 144) / 12;
+      // for a given layer there are only 12 sectors x 2 sides
+      // The following gives the sectors in the inner, mid, outer regions unique group labels
+      int region = getTpcRegion(layer);  // inner, mid, outer
+      label_base += 7 * 1000000 + (region * 24 + side * 12 + sector) * 10000;
+      return label_base;
+    }
+    if (group == 5)
+    {
+      // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
+      label_base += 7 * 1000000 + 0;
+      return label_base;
+    }
+  }
   else
+  {
+    if (group == 6)
     {
-      if(group == 6)
-	{
-	  // every tile has different label
-	  int tile = sensor;
-	  label_base += layer*1000000 + tile*10000+sensor*10;
-	  return label_base;
-	}
-      if(group == 7)
-	{
-	  // assign layer 55 and tile 0 to all
-	  label_base += 55*1000000 + 0;	  
-	  return label_base;
-	}
+      // every tile has different label
+      int tile = sensor;
+      label_base += layer * 1000000 + tile * 10000 + sensor * 10;
+      return label_base;
     }
+    if (group == 7)
+    {
+      // assign layer 55 and tile 0 to all
+      label_base += 55 * 1000000 + 0;
+      return label_base;
+    }
+  }
 
   return -1;
 }
 
 void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[])
 {
-    std::cout << " float buffer: " << " residual " << "  " << residual(index);
-  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_deriv["<< il << "] " << lcl_derivative[il] << "  ";  }
-  std::cout  << " sigma " << "  " << clus_sigma(index) << "  ";
-  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0)  std::cout << " glbl_deriv["<< ig << "] " << glbl_derivative[ig] << "  ";  }
-  std::cout << " int buffer: " << " 0 " << " 0 " << " ";  // spacer, rmeas placeholder
-  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_label["<< il << "] " << il+1 << "  ";  }
-  std::cout << " 0 " << "  ";
-  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0) std::cout << " glbl_label["<< ig << "] " << glbl_label[ig] << "  ";  }
+  std::cout << " float buffer: "
+            << " residual "
+            << "  " << residual(index);
+  for (int il = 0; il < NLC; ++il)
+  {
+    if (lcl_derivative[il] != 0) std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
+  }
+  std::cout << " sigma "
+            << "  " << clus_sigma(index) << "  ";
+  for (int ig = 0; ig < NGL; ++ig)
+  {
+    if (glbl_derivative[ig] != 0) std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
+  }
+  std::cout << " int buffer: "
+            << " 0 "
+            << " 0 "
+            << " ";  // spacer, rmeas placeholder
+  for (int il = 0; il < NLC; ++il)
+  {
+    if (lcl_derivative[il] != 0) std::cout << " lcl_label[" << il << "] " << il + 1 << "  ";
+  }
+  std::cout << " 0 "
+            << "  ";
+  for (int ig = 0; ig < NGL; ++ig)
+  {
+    if (glbl_derivative[ig] != 0) std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
+  }
   std::cout << " end of meas " << std::endl;
 }
-

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -8,31 +8,26 @@ namespace AlignmentDefs
   enum siliconGrp {snsr, stv, brrl};
   enum tpcGrp {htst, sctr, tp};
   enum mmsGrp {tl, mm};
-  
+
+  static constexpr int NGL = 6;
+  static constexpr int NLC = 5;
+
   //! Map relating Acts::VolumeID to sPHENIX layer 
-  std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };  
-  int nsensors_stave[7] = {9,9,9,4,4,4,4};
+  static const std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };  
+  static constexpr int nsensors_stave[7] = {9,9,9,4,4,4,4};
 
   int getTpcRegion(int layer);
-  void getGlobalLabels(Surface surf, int glbl_label[]);
-  int getLabelBase(Acts::GeometryIdentifier id);
+  void getSiliconGlobalLabels(Surface surf, int glbl_label[], siliconGrp grp);
+  void getTpcGlobalLabels(Surface surf, int glbl_label[], tpcGrp grp);
+  void getMMGlobalLabels(Surface surf, int glbl_label[], mmsGrp grp);
+  
+  int getLabelBase(Acts::GeometryIdentifier id, int group);
+ 
   void printBuffers(int index, Acts::Vector2 residual, 
 		    Acts::Vector2 clus_sigma, float lcl_derivative[], 
 		    float glbl_derivative[], int glbl_label[]);
 
-  std::map<unsigned int, float> m_layerMisalignment;
-
-  void setLayerUncInflation(const unsigned int layer, 
-			    const float unc)
-  {
-    m_layerMisalignment.insert(std::make_pair(layer, unc));
-  }
-
-  static const int NGL = 6;
-  static const int NLC = 5;
-  siliconGrp si_grp = siliconGrp::snsr;
-  tpcGrp tpc_grp = tpcGrp::htst;
-  mmsGrp mms_grp = mmsGrp::tl;
+  static std::map<unsigned int, float> layerMisalignment;
 
 
 }

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -1,0 +1,39 @@
+#ifndef ALIGNMENTDEFS_H
+#define ALIGNMENTDEFS_H
+
+#include <trackbase/ActsGeometry.h>
+
+namespace AlignmentDefs
+{
+  enum siliconGrp {snsr, stv, brrl};
+  enum tpcGrp {htst, sctr, tp};
+  enum mmsGrp {tl, mm};
+  
+  //! Map relating Acts::VolumeID to sPHENIX layer 
+  std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };  
+  int nsensors_stave[7] = {9,9,9,4,4,4,4};
+
+  int getTpcRegion(int layer);
+  void getGlobalLabels(Surface surf, int glbl_label[]);
+  int getLabelBase(Acts::GeometryIdentifier id);
+  void printBuffers(int index, Acts::Vector2 residual, 
+		    Acts::Vector2 clus_sigma, float lcl_derivative[], 
+		    float glbl_derivative[], int glbl_label[]);
+
+  std::map<unsigned int, float> m_layerMisalignment;
+
+  void setLayerUncInflation(const unsigned int layer, 
+			    const float unc)
+  {
+    m_layerMisalignment.insert(std::make_pair(layer, unc));
+  }
+
+  static const int NGL = 6;
+  static const int NLC = 5;
+  siliconGrp si_grp = siliconGrp::snsr;
+  tpcGrp tpc_grp = tpcGrp::htst;
+  mmsGrp mms_grp = mmsGrp::tl;
+
+
+}
+#endif

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -5,27 +5,41 @@
 
 namespace AlignmentDefs
 {
-  enum siliconGrp {snsr, stv, brrl};
-  enum tpcGrp {htst, sctr, tp};
-  enum mmsGrp {tl, mm};
+  enum siliconGrp
+  {
+    snsr,
+    stv,
+    brrl
+  };
+  enum tpcGrp
+  {
+    htst,
+    sctr,
+    tp
+  };
+  enum mmsGrp
+  {
+    tl,
+    mm
+  };
 
   static constexpr int NGL = 6;
   static constexpr int NLC = 5;
 
-  //! Map relating Acts::VolumeID to sPHENIX layer 
-  static const std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };  
-  static constexpr int nsensors_stave[7] = {9,9,9,4,4,4,4};
+  //! Map relating Acts::VolumeID to sPHENIX layer
+  static const std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
+  static constexpr int nsensors_stave[7] = {9, 9, 9, 4, 4, 4, 4};
 
   int getTpcRegion(int layer);
   void getSiliconGlobalLabels(Surface surf, int glbl_label[], siliconGrp grp);
   void getTpcGlobalLabels(Surface surf, int glbl_label[], tpcGrp grp);
   void getMMGlobalLabels(Surface surf, int glbl_label[], mmsGrp grp);
-  
-  int getLabelBase(Acts::GeometryIdentifier id, int group);
- 
-  void printBuffers(int index, Acts::Vector2 residual, 
-		    Acts::Vector2 clus_sigma, float lcl_derivative[], 
-		    float glbl_derivative[], int glbl_label[]);
 
-}
+  int getLabelBase(Acts::GeometryIdentifier id, int group);
+
+  void printBuffers(int index, Acts::Vector2 residual,
+                    Acts::Vector2 clus_sigma, float lcl_derivative[],
+                    float glbl_derivative[], int glbl_label[]);
+
+}  // namespace AlignmentDefs
 #endif

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -204,23 +204,34 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	  Acts::Vector2 clus_sigma = getClusterError(cluster, cluskey, global);
 	  if(isnan(clus_sigma(0)) || isnan(clus_sigma(1)))  { continue; }
 
-	  int glbl_label[NGL];
-	  getGlobalLabels(surf, glbl_label);  // these depend on the sensor grouping
+	  int glbl_label[AlignmentDefs::NGL];
+	  if(layer < 7)
+	    {
+	      AlignmentDefs::getSiliconGlobalLabels(surf, glbl_label, si_grp);
+	    }
+	  else if (layer < 55)
+	    {
+	      AlignmentDefs::getTpcGlobalLabels(surf, glbl_label, tpc_grp);
+	    }
+	  else if (layer < 57)
+	    {
+	      AlignmentDefs::getMMGlobalLabels(surf, glbl_label, mms_grp);
+	    }
 
 	  // These derivatives are for the local parameters
 	  // The angleDerivs dimensions are [alpha/beta/gamma](x/y/z)
 	  //std::vector<Acts::Vector3> angleDerivs = getDerivativesAlignmentAngles(global, cluskey, cluster); 
 	  //std::vector<Acts::Vector3> translDerivs = getDerivativesAlignmentTranslations(global, cluskey, cluster);
 
-	  float lcl_derivativeX[NLC];
-	  float lcl_derivativeY[NLC];
+	  float lcl_derivativeX[AlignmentDefs::NLC];
+	  float lcl_derivativeY[AlignmentDefs::NLC];
 	  getLocalDerivativesXY(surf, global, fitpars, lcl_derivativeX, lcl_derivativeY, layer);
 
-	  float glbl_derivativeX[NGL];
-	  float glbl_derivativeY[NGL];
+	  float glbl_derivativeX[AlignmentDefs::NGL];
+	  float glbl_derivativeY[AlignmentDefs::NGL];
 	  getGlobalDerivativesXY(surf, global, fitpoint, fitpars, glbl_derivativeX, glbl_derivativeY, layer);
 
-	  for(unsigned int i = 0; i < NGL; ++i) 
+	  for(unsigned int i = 0; i < AlignmentDefs::NGL; ++i) 
 	    {
 	      if(is_layer_param_fixed(layer, i) || is_layer_fixed(layer)) 
 		{
@@ -263,7 +274,15 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	    }	  
     
 	  if( !isnan(residual(0)) && clus_sigma(0) < 1.0)  // discards crazy clusters
-	    { _mille->mille(NLC, lcl_derivativeX, NGL, glbl_derivativeX, glbl_label, residual(0), _error_inflation*clus_sigma(0));}
+	    { 
+	      float errinf = 1.0;
+	      if(AlignmentDefs::layerMisalignment.find(layer) != AlignmentDefs::layerMisalignment.end())
+		{
+		  errinf = AlignmentDefs::layerMisalignment.find(layer)->second;
+		}
+	      
+	      _mille->mille(AlignmentDefs::NLC, lcl_derivativeX, AlignmentDefs::NGL, glbl_derivativeX, glbl_label, residual(0), errinf*clus_sigma(0));
+	    }
 	  
 	  // provides output that can be grep'ed to make plots of input to mille
 	  if(Verbosity() > 1)
@@ -294,7 +313,14 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	    }
 
 	  if(!isnan(residual(1)) && clus_sigma(1) < 1.0 && trkrid != TrkrDefs::inttId)
-	    {_mille->mille(NLC, lcl_derivativeY, NGL, glbl_derivativeY, glbl_label, residual(1), _error_inflation*clus_sigma(1));}
+	    {
+	      float errinf = 1.0;
+	      if(AlignmentDefs::layerMisalignment.find(layer) != AlignmentDefs::layerMisalignment.end())
+		{
+		  errinf = AlignmentDefs::layerMisalignment.find(layer)->second;
+		}
+	      _mille->mille(AlignmentDefs::NLC, lcl_derivativeY, AlignmentDefs::NGL, glbl_derivativeY, glbl_label, residual(1), errinf*clus_sigma(1));
+	    }
 	}
 
       // close out this track
@@ -514,109 +540,8 @@ void HelicalFitter::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, shor
   if(_dcc_fluctuation) { global = _distortionCorrection.get_corrected_position( global, _dcc_fluctuation ); }
 }
 
-void HelicalFitter::getGlobalLabels(Surface surf, int glbl_label[])
-{
-  // identify the global alignment parameters for this surface
-  Acts::GeometryIdentifier id = surf->geometryId();
-  int label_base = getLabelBase(id);   // This value depends on how the surfaces are grouped	  
-  for(int i=0;i<NGL;++i) 
-    {
-      glbl_label[i] = label_base + i;
-      if(Verbosity() > 1)
-	{ std::cout << "    glbl " << i << " label " << glbl_label[i] << " "; }
-    }
-  if(Verbosity() > 1) { std::cout << std::endl; }
-}
 
-int HelicalFitter::getTpcRegion(int layer)
-{
-  int region = 0;
-  if(layer > 23 && layer < 39)
-    region = 1;
-  if(layer > 38 && layer < 55)
-    region = 2;
 
-  return region;  
-}
-
-int HelicalFitter::getLabelBase(Acts::GeometryIdentifier id)
-{
-  unsigned int volume = id.volume(); 
-  unsigned int acts_layer = id.layer();
-  unsigned int layer = base_layer_map.find(volume)->second + acts_layer / 2 -1;
-  unsigned int sensor = id.sensitive() - 1;  // Acts starts at 1
-
-  int label_base = 1;  // Mille wants to start at 1
-
-  // decide what level of grouping we want
-  if(layer < 7)
-    {
-      if(si_grp == siliconGrp::snsr)
-	{
-	  // every sensor has a different label
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000  + stave*10000 + sensor*10;
-	  return label_base;
-	}
-      if(si_grp == siliconGrp::stv)
-	{
-	  // layer and stave, assign all sensors to the stave number
-	  int stave = sensor / nsensors_stave[layer];
-	  label_base += layer*1000000 + stave*10000;
-	  return label_base;
-	}
-      if(si_grp == siliconGrp::brrl)
-	// layer only, assign all sensors to sensor 0 
-	label_base += layer*1000000 + 0;
-      return label_base;
-    }
-  else if(layer > 6 && layer < 55)
-    {
-      if(tpc_grp == tpcGrp::htst)
-	{
-	  // want every hitset (layer, sector, side) to have a separate label
-	  // each group of 12 subsurfaces (sensors) is in a single hitset
-	  int hitset = sensor/12; // 0-11 on side 0, 12-23 on side 1
-	  label_base += layer*1000000 + hitset*10000;
-	  return label_base;
-	}
-      if(tpc_grp == tpcGrp::sctr)
-	{
-	  // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
-	  int side = sensor / 144; // 0-143 on side 0, 144-287 on side 1
-	  int sector = (sensor - side *144) / 12; 
-	  // for a given layer there are only 12 sectors x 2 sides
-	  // The following gives the sectors in the inner, mid, outer regions unique group labels
-	  int region = getTpcRegion(layer);  // inner, mid, outer
-	  label_base += 7*1000000 + (region * 24 + side*12 + sector) *10000; 
-	  return label_base;
-	}
-      if(tpc_grp == tpcGrp::tp)
-	{
-	  // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
-	  label_base += 7*1000000 + 0;
-	  return label_base;
-	}
-    }
-  else
-    {
-      if(mms_grp == mmsGrp::tl)
-	{
-	  // every tile has different label
-	  int tile = sensor;
-	  label_base += layer*1000000 + tile*10000+sensor*10;
-	  return label_base;
-	}
-      if(mms_grp == mmsGrp::mm)
-	{
-	  // assign layer 55 and tile 0 to all
-	  label_base += 55*1000000 + 0;	  
-	  return label_base;
-	}
-    }
-
-  return -1;
-}
 
 // this method to be replaced by calls to TrackFitUtils
 void HelicalFitter::getTrackletClusters(TrackSeed *tracklet, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec)
@@ -828,18 +753,6 @@ void HelicalFitter::get_projectionXY(Surface surf, std::pair<Acts::Vector3, Acts
   return;
 }
 
-void HelicalFitter::printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[])
-{
-  std::cout << " float buffer: " << " residual " << "  " << residual(index);
-  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_deriv["<< il << "] " << lcl_derivative[il] << "  ";  }
-  std::cout  << " sigma " << "  " << _error_inflation*clus_sigma(index) << "  ";
-  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0)  std::cout << " glbl_deriv["<< ig << "] " << glbl_derivative[ig] << "  ";  }
-  std::cout << " int buffer: " << " 0 " << " 0 " << " ";  // spacer, rmeas placeholder
-  for (int il=0;il<NLC;++il) { if(lcl_derivative[il] != 0) std::cout << " lcl_label["<< il << "] " << il+1 << "  ";  }
-  std::cout << " 0 " << "  ";
-  for (int ig=0;ig<NGL;++ig) { if(glbl_derivative[ig] != 0) std::cout << " glbl_label["<< ig << "] " << glbl_label[ig] << "  ";  }
-  std::cout << " end of meas " << std::endl;		    
-}
 
 unsigned int HelicalFitter::addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -145,7 +145,6 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   bool fitfulltrack = false;
 
   float dca_cut = 0.1;  // 1 mm
-  float _error_inflation[4] = {1,1,1,1};
 
   std::string _field;
   int _fieldDir = -1;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -3,6 +3,8 @@
 #ifndef HELICALFITTER_H
 #define HELICALFITTER_H
 
+#include "AlignmentDefs.h"
+
 #include <fun4all/SubsysReco.h>
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrackFitUtils.h>
@@ -23,10 +25,6 @@ class TF1;
 class TpcDistortionCorrectionContainer;
 class Mille;
 class SvtxTrackSeed;
-
-enum siliconGrp {snsr, stv, brrl};
-enum tpcGrp {htst, sctr, tp};
-enum mmsGrp {tl, mm};
 
 class HelicalFitter : public SubsysReco, public PHParameterInterface
 {
@@ -57,16 +55,19 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
  void set_datafile_name(const std::string& file) { data_outfilename = file;}
   void set_steeringfile_name(const std::string& file) { steering_outfilename = file;}
-  void set_silicon_grouping(int group) {si_grp = (siliconGrp) group;}
-  void set_tpc_grouping(int group) {tpc_grp = (tpcGrp) group;}
-  void set_mms_grouping(int group) {mms_grp = (mmsGrp) group;}
+  void set_silicon_grouping(int group) {si_grp = (AlignmentDefs::siliconGrp) group;}
+  void set_tpc_grouping(int group) {tpc_grp = (AlignmentDefs::tpcGrp) group;}
+  void set_mms_grouping(int group) {mms_grp = (AlignmentDefs::mmsGrp) group;}
   void set_test_output(bool test) {test_output = test;}
   void set_layer_fixed(unsigned int layer);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
   void set_cluster_version(unsigned int v) { _cluster_version = v; }
   void set_fitted_subsystems(bool si, bool tpc, bool full) { fitsilicon = si; fittpc = tpc; fitfulltrack = full; }
-  void set_error_inflation_factor(float factor) {_error_inflation = factor;}
-
+  void set_error_inflation_factor(unsigned int layer, float factor) 
+  {
+    AlignmentDefs::layerMisalignment.insert(std::make_pair(layer,factor));
+  }
+  
   // utility functions for analysis modules
   std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);
   void getTrackletClusters(TrackSeed *_track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
@@ -89,16 +90,14 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   std::pair<Acts::Vector3, Acts::Vector3> get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3 global);
   Acts::Vector3 get_helix_surface_intersection(Surface surf, std::vector<float>& fitpars, Acts::Vector3 global);
 
-  int getLabelBase(Acts::GeometryIdentifier id);
 
   float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
   void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global);
   int getTpcRegion(int layer);
 
   Acts::Vector2 getClusterError(TrkrCluster *cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global);
-  void getGlobalLabels(Surface surf, int glbl_label[]);
 
-  void printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[]);
+  
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
 
@@ -122,13 +121,10 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   std::set<std::pair<unsigned int,unsigned int>> fixed_layer_params;
 
   // set default groups to lowest level
-  siliconGrp si_grp = siliconGrp::snsr;
-  tpcGrp tpc_grp = tpcGrp::htst;
-  mmsGrp mms_grp = mmsGrp::tl;
+  AlignmentDefs::siliconGrp si_grp = AlignmentDefs::siliconGrp::snsr;
+  AlignmentDefs::tpcGrp tpc_grp = AlignmentDefs::tpcGrp::htst;
+  AlignmentDefs::mmsGrp mms_grp = AlignmentDefs::mmsGrp::tl;
 
-  int nsensors_stave[7] = {9,9,9,4,4,4,4};
-
-  std::map<unsigned int, unsigned int> base_layer_map = { {10, 0}, {12,3}, {14,7}, {16,55} };
 
  /// tpc distortion correction utility class
   TpcDistortionCorrection _distortionCorrection;
@@ -141,9 +137,6 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
   std::string  data_outfilename = ("mille_helical_output_data_file.bin");  
   std::string  steering_outfilename = ("steer_helical.txt");  
-
-  static const int NLC = 5;
-  static const int NGL = 6;
 
   bool fitsilicon = true;
   bool fittpc = false;

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -194,7 +194,6 @@ Acts::Vector3 MakeMilleFiles::getPCALinePoint(Acts::Vector3 global, SvtxTrackSta
   return pca;
 }
 
-
 void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec)
 {
   for (auto state : statevec)
@@ -249,20 +248,20 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
     }
 
     auto surf = _tGeometry->maps().getSurface(ckey, cluster);
-    
+
     int glbl_label[SvtxAlignmentState::NGL];
-    if(layer < 7)
-      {
-	AlignmentDefs::getSiliconGlobalLabels(surf, glbl_label,si_group);
-      }
-    else if( layer < 55)
+    if (layer < 7)
+    {
+      AlignmentDefs::getSiliconGlobalLabels(surf, glbl_label, si_group);
+    }
+    else if (layer < 55)
     {
       AlignmentDefs::getTpcGlobalLabels(surf, glbl_label, tpc_group);
     }
     else if (layer < 57)
-      {
-	AlignmentDefs::getMMGlobalLabels(surf, glbl_label, mms_group);
-      }
+    {
+      AlignmentDefs::getMMGlobalLabels(surf, glbl_label, mms_group);
+    }
 
     if (Verbosity() > 1)
     {
@@ -296,8 +295,8 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
 
         for (int k = 0; k < SvtxAlignmentState::NGL; k++)
         {
-	  if(glbl_derivative[k] > 0 || glbl_derivative[k] < 0)
-	    std::cout << "NONZERO GLOBAL DERIVATIVE"<<std::endl;
+          if (glbl_derivative[k] > 0 || glbl_derivative[k] < 0)
+            std::cout << "NONZERO GLOBAL DERIVATIVE" << std::endl;
           std::cout << glbl_derivative[k] << ", ";
         }
         std::cout << std::endl
@@ -314,15 +313,15 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
         if (Verbosity() > 3)
         {
           std::cout << "ckey " << ckey << " and layer " << layer << " buffers:" << std::endl;
-	  AlignmentDefs::printBuffers(i, residual, clus_sigma, lcl_derivative, glbl_derivative, glbl_label);
+          AlignmentDefs::printBuffers(i, residual, clus_sigma, lcl_derivative, glbl_derivative, glbl_label);
         }
-	float errinf = 1.0;
-	if(m_layerMisalignment.find(layer) != m_layerMisalignment.end())
-	  {
-	    errinf = m_layerMisalignment.find(layer)->second;
-	  }
-	
-        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf*clus_sigma(i));
+        float errinf = 1.0;
+        if (m_layerMisalignment.find(layer) != m_layerMisalignment.end())
+        {
+          errinf = m_layerMisalignment.find(layer)->second;
+        }
+
+        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf * clus_sigma(i));
       }
     }
   }
@@ -340,12 +339,12 @@ bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
   return ret;
 }
 void MakeMilleFiles::set_layers_fixed(unsigned int minlayer,
-				      unsigned int maxlayer)
+                                      unsigned int maxlayer)
 {
-  for(unsigned int i=minlayer; i<maxlayer; i++)
-    {
-      fixed_layers.insert(i);
-    }
+  for (unsigned int i = minlayer; i < maxlayer; i++)
+  {
+    fixed_layers.insert(i);
+  }
 }
 void MakeMilleFiles::set_layer_fixed(unsigned int layer)
 {

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -194,99 +194,6 @@ Acts::Vector3 MakeMilleFiles::getPCALinePoint(Acts::Vector3 global, SvtxTrackSta
   return pca;
 }
 
-int MakeMilleFiles::getTpcRegion(int layer)
-{
-  int region = 0;
-  if (layer > 23 && layer < 39)
-    region = 1;
-  if (layer > 38 && layer < 55)
-    region = 2;
-
-  return region;
-}
-
-int MakeMilleFiles::getLabelBase(Acts::GeometryIdentifier id)
-{
-  unsigned int volume = id.volume();
-  unsigned int acts_layer = id.layer();
-  unsigned int layer = base_layer_map.find(volume)->second + acts_layer / 2 - 1;
-  unsigned int sensor = id.sensitive() - 1;  // Acts starts at 1
-
-  int label_base = 1;  // Mille wants to start at 1
-
-  // decide what level of grouping we want
-  if (layer < 7)
-  {
-    if (si_group == siliconGroup::sensor)
-    {
-      // every sensor has a different label
-      int stave = sensor / nsensors_stave[layer];
-      label_base += layer * 1000000 + stave * 10000 + sensor * 10;
-      return label_base;
-    }
-    if (si_group == siliconGroup::stave)
-    {
-      // layer and stave, assign all sensors to the stave number
-      int stave = sensor / nsensors_stave[layer];
-      label_base += layer * 1000000 + stave * 10000;
-      return label_base;
-    }
-    if (si_group == siliconGroup::barrel)
-    {
-      // layer only, assign all sensors to sensor 0
-      label_base += layer * 1000000 + 0;
-
-      return label_base;
-    }
-  }
-  else if (layer > 6 && layer < 55)
-  {
-    if (tpc_group == tpcGroup::hitset)
-    {
-      // want every hitset (layer, sector, side) to have a separate label
-      // each group of 12 subsurfaces (sensors) is in a single hitset
-      int hitset = sensor / 12;  // hitsets 0-11 on side 0, 12-23 on side 1
-      label_base += layer * 1000000 + hitset * 10000;
-      return label_base;
-    }
-    if (tpc_group == tpcGroup::sector)
-    {
-      // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
-      int side = sensor / 144;  // 0-143 on side 0, 144-287 on side 1
-      int sector = (sensor - side * 144) / 12;
-      // for a given layer there are only 12 sectors x 2 sides
-      // The following gives the sectors in the inner, mid, outer regions unique group labels
-      int region = getTpcRegion(layer);  // inner, mid, outer
-      label_base += 7 * 1000000 + (region * 24 + side * 12 + sector) * 10000;
-      // std::cout << " layer " << layer << " sensor " << sensor << " region " << region << " side " << side << " sector " << sector << " label_base " << label_base << std::endl;
-      return label_base;
-    }
-    if (tpc_group == tpcGroup::tpc)
-    {
-      // all tpc layers and all sectors, assign layer 7 and sensor 0 to all layers and sensors
-      label_base += 7 * 1000000 + 0;
-      return label_base;
-    }
-  }
-  else
-  {
-    if (mms_group == mmsGroup::tile)
-    {
-      // every tile has different label
-      int tile = sensor;
-      label_base += layer * 1000000 + tile * 10000 + sensor * 10;
-      return label_base;
-    }
-    if (mms_group == mmsGroup::mms)
-    {
-      // assign layer 55 and tile 0 to all
-      label_base += 55 * 1000000 + 0;
-      return label_base;
-    }
-  }
-
-  return -1;
-}
 
 void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec)
 {
@@ -341,18 +248,21 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       continue;
     }
 
-    Acts::GeometryIdentifier id = _tGeometry->maps().getSurface(ckey, cluster)->geometryId();
-    int label_base = getLabelBase(id);  // This value depends on how the surfaces are grouped
-
+    auto surf = _tGeometry->maps().getSurface(ckey, cluster);
+    
     int glbl_label[SvtxAlignmentState::NGL];
-    for (int i = 0; i < SvtxAlignmentState::NGL; ++i)
-    {
-      glbl_label[i] = label_base + i;
-      if (Verbosity() > 1)
+    if(layer < 7)
       {
-        std::cout << "  glbl " << i << " label " << glbl_label[i] << " ";
+	AlignmentDefs::getSiliconGlobalLabels(surf, glbl_label,si_group);
       }
+    else if( layer < 55)
+    {
+      AlignmentDefs::getTpcGlobalLabels(surf, glbl_label, tpc_group);
     }
+    else if (layer < 57)
+      {
+	AlignmentDefs::getMMGlobalLabels(surf, glbl_label, mms_group);
+      }
 
     if (Verbosity() > 1)
     {
@@ -366,7 +276,6 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
       float glbl_derivative[SvtxAlignmentState::NGL];
       for (int j = 0; j < SvtxAlignmentState::NGL; ++j)
       {
-        /// swap the order to match what is expected from the workflow
         glbl_derivative[j] = state->get_global_derivative_matrix()(i, j);
 
         if (is_layer_fixed(layer) || is_layer_param_fixed(layer, j))
@@ -405,10 +314,14 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
         if (Verbosity() > 3)
         {
           std::cout << "ckey " << ckey << " and layer " << layer << " buffers:" << std::endl;
-          printBuffers(i, residual, clus_sigma, lcl_derivative, glbl_derivative, glbl_label);
+	  AlignmentDefs::printBuffers(i, residual, clus_sigma, lcl_derivative, glbl_derivative, glbl_label);
         }
-
-        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), clus_sigma(i));
+	float errinf = 1.0;
+	if(AlignmentDefs::layerMisalignment.find(layer) != AlignmentDefs::layerMisalignment.end())
+	  {
+	    errinf = AlignmentDefs::layerMisalignment.find(layer)->second;
+	  }
+        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf*clus_sigma(i));
       }
     }
   }
@@ -416,36 +329,6 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec stateve
   return;
 }
 
-void MakeMilleFiles::printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[])
-{
-  std::cout << " float buffer: "
-            << " residual "
-            << "  " << residual(index);
-  for (int il = 0; il < SvtxAlignmentState::NLOC; ++il)
-  {
-    if (lcl_derivative[il] != 0) std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
-  }
-  std::cout << " sigma "
-            << "  " << clus_sigma(index) << "  ";
-  for (int ig = 0; ig < SvtxAlignmentState::NGL; ++ig)
-  {
-    if (glbl_derivative[ig] != 0) std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
-  }
-  std::cout << " int buffer: "
-            << " 0 "
-            << "  ";
-  for (int il = 0; il < SvtxAlignmentState::NLOC; ++il)
-  {
-    if (lcl_derivative[il] != 0) std::cout << " lcl_label[" << il << "] " << il << "  ";
-  }
-  std::cout << " 0 "
-            << "  ";
-  for (int ig = 0; ig < SvtxAlignmentState::NGL; ++ig)
-  {
-    if (glbl_derivative[ig] != 0) std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
-  }
-  std::cout << " end of meas " << std::endl;
-}
 bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
 {
   bool ret = false;

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -10,6 +10,8 @@
 #ifndef MAKEMILLEFILES_H
 #define MAKEMILLEFILES_H
 
+#include "AlignmentDefs.h"
+
 #include <fun4all/SubsysReco.h>
 
 #include <string>
@@ -32,24 +34,6 @@ class Mille;
 
 using Trajectory = ActsExamples::Trajectories;
 
-enum siliconGroup
-{
-  sensor,
-  stave,
-  barrel
-};
-enum tpcGroup
-{
-  hitset,
-  sector,
-  tpc
-};
-enum mmsGroup
-{
-  tile,
-  mms
-};
-
 class MakeMilleFiles : public SubsysReco
 {
  public:
@@ -63,13 +47,17 @@ class MakeMilleFiles : public SubsysReco
 
   void set_datafile_name(const std::string& file) { data_outfilename = file; }
   void set_steeringfile_name(const std::string& file) { steering_outfilename = file; }
-  void set_silicon_grouping(int group) { si_group = (siliconGroup) group; }
-  void set_tpc_grouping(int group) { tpc_group = (tpcGroup) group; }
-  void set_mms_grouping(int group) { mms_group = (mmsGroup) group; }
+  void set_silicon_grouping(int group) { si_group = (AlignmentDefs::siliconGrp) group; }
+  void set_tpc_grouping(int group) { tpc_group = (AlignmentDefs::tpcGrp) group; }
+  void set_mms_grouping(int group) { mms_group = (AlignmentDefs::mmsGrp) group; }
   void set_layer_fixed(unsigned int layer);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
   void set_cluster_version(unsigned int v) { _cluster_version = v; }
   void set_layers_fixed(unsigned int minlayer, unsigned int maxlayer);
+  void set_error_inflation_factor(unsigned int layer, float factor) 
+  {
+    AlignmentDefs::layerMisalignment.insert(std::make_pair(layer,factor));
+  }
 
  private:
   Mille* _mille;
@@ -81,13 +69,9 @@ class MakeMilleFiles : public SubsysReco
                                                            TrkrCluster* cluster,
                                                            Surface surface, int crossing);
 
-  int getLabelBase(Acts::GeometryIdentifier id);
-  int getTpcRegion(int layer);
-
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
-  void printBuffers(int index, Acts::Vector2 residual, Acts::Vector2 clus_sigma, float lcl_derivative[], float glbl_derivative[], int glbl_label[]);
-
+ 
   void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec);
 
   std::map<int, float> derivativeGL;
@@ -100,16 +84,12 @@ class MakeMilleFiles : public SubsysReco
   bool m_useAnalytic = true;
 
   // set default groups to lowest level
-  siliconGroup si_group = siliconGroup::sensor;
-  tpcGroup tpc_group = tpcGroup::hitset;
-  mmsGroup mms_group = mmsGroup::tile;
-
-  int nsensors_stave[7] = {9, 9, 9, 4, 4, 4, 4};
+  AlignmentDefs::siliconGrp si_group = AlignmentDefs::siliconGrp::snsr;
+  AlignmentDefs::tpcGrp tpc_group = AlignmentDefs::tpcGrp::htst;
+  AlignmentDefs::mmsGrp mms_group = AlignmentDefs::mmsGrp::tl;
 
   std::set<unsigned int> fixed_layers;
   std::set<std::pair<unsigned int, unsigned int>> fixed_layer_params;
-
-  std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
 
   SvtxTrackMap* _track_map{nullptr};
   SvtxAlignmentStateMap* _state_map{nullptr};

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -54,9 +54,9 @@ class MakeMilleFiles : public SubsysReco
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
   void set_cluster_version(unsigned int v) { _cluster_version = v; }
   void set_layers_fixed(unsigned int minlayer, unsigned int maxlayer);
-  void set_error_inflation_factor(unsigned int layer, float factor) 
+  void set_error_inflation_factor(unsigned int layer, float factor)
   {
-    m_layerMisalignment.insert(std::make_pair(layer,factor));
+    m_layerMisalignment.insert(std::make_pair(layer, factor));
   }
 
  private:
@@ -71,7 +71,7 @@ class MakeMilleFiles : public SubsysReco
 
   bool is_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
- 
+
   void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec);
 
   std::map<int, float> derivativeGL;

--- a/offline/packages/TrackerMillepedeAlignment/Makefile.am
+++ b/offline/packages/TrackerMillepedeAlignment/Makefile.am
@@ -28,6 +28,7 @@ libtrackeralign_la_LIBADD = \
   -ltpc_io
 
 pkginclude_HEADERS = \
+  AlignmentDefs.h \
   MakeMilleFiles.h \
   Mille.h \
   HelicalFitter.h
@@ -35,6 +36,7 @@ pkginclude_HEADERS = \
 pcmdir = $(libdir)
 
 libtrackeralign_la_SOURCES = \
+  AlignmentDefs.cc \
   MakeMilleFiles.cc \
   Mille.cc \
   HelicalFitter.cc


### PR DESCRIPTION
This PR condenses duplicate code into an `AlignmentDefs` class which both the helical and acts based fitter can access. This simplifies the code and makes sure we have consistent labeling schemes for both methods. It also adds a scheme by which each layer can have an error inflation factor applied to it, to artificially blow up the measurement uncertainties on a layer by layer basis since pede only has the ability to increase all errors in the same way.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

