### PR TITLE
enable online build

### DIFF
--- a/offline/packages/micromegas/Makefile.am
+++ b/offline/packages/micromegas/Makefile.am
@@ -3,6 +3,47 @@
 
 AUTOMAKE_OPTIONS = foreign
 
+if USE_ONLINE
+
+### trimmed version of libmicromegas_io library, for online monitoring
+### it only contains MicromegasDefs.h and MicromegasMapping
+
+lib_LTLIBRARIES = \
+  libmicromegas_io.la
+
+## TODO: check with Chris where headers are installed (TrkrDefs.h) in "online" build
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include 
+
+## TODO: check with Chris where libraries are installed (TrkrDefs.h) in "online" build
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib
+
+pkginclude_HEADERS = \
+  MicromegasDefs.h \
+  MicromegasMapping.h
+
+# sources for io library
+libmicromegas_io_la_SOURCES = \
+  MicromegasDefs.cc \
+  MicromegasMapping.cc
+
+libmicromegas_io_la_LIBADD = \
+  -ltrack_io
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals_micromegas_io
+
+testexternals_micromegas_io_SOURCES = testexternals.cc
+testexternals_micromegas_io_LDADD = libmicromegas_io.la
+
+else
+
+### full offline version
 lib_LTLIBRARIES = \
   libmicromegas_io.la \
   libmicromegas.la
@@ -36,7 +77,6 @@ nobase_dist_pcm_DATA = \
   CylinderGeomMicromegas_Dict_rdict.pcm \
   MicromegasTile_Dict_rdict.pcm
 
-# sources for io library
 libmicromegas_io_la_SOURCES = \
   $(ROOTDICTS) \
   CylinderGeomMicromegas.cc \
@@ -52,7 +92,6 @@ libmicromegas_io_la_LIBADD = \
   -ltrack_io \
   -ltrackbase_historic_io
 
-# sources for micromegas library
 libmicromegas_la_SOURCES = \
   MicromegasClusterizer.cc \
   MicromegasRawDataCalibration.cc \
@@ -63,15 +102,10 @@ libmicromegas_la_LIBADD = \
   -lphg4hit \
   -lSubsysReco
 
-# Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h
 	rootcint -f $@ @CINTDEFS@  $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
 
-#just to get the dependency
 %_Dict_rdict.pcm: %_Dict.cc ;
-
-################################################
-# linking tests
 
 BUILT_SOURCES = testexternals.cc
 
@@ -85,14 +119,14 @@ testexternals_micromegas_io_LDADD = libmicromegas_io.la
 testexternals_micromegas_SOURCES = testexternals.cc
 testexternals_micromegas_LDADD = libmicromegas.la
 
+endif
+
 testexternals.cc:
 	echo "//*** this is a generated file. Do not commit, do not edit" > $@
 	echo "int main()" >> $@
 	echo "{" >> $@
 	echo "  return 0;" >> $@
 	echo "}" >> $@
-
-################################################
 
 clean-local:
 	rm -f *Dict* $(BUILT_SOURCES) *.pcm

--- a/offline/packages/micromegas/configure.ac
+++ b/offline/packages/micromegas/configure.ac
@@ -21,5 +21,16 @@ esac
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)
 
+### add "online" build option
+AC_ARG_ENABLE(online,
+        [  --enable-online	build using for online [default=no]],
+        [case "${enableval}" in
+                yes) online=true ;;
+                no)  online=false ;;
+                *) AC_MSG_ERROR(bad value ${enableval} for --enable-online) ;;
+                esac],
+        online=false)
+AM_CONDITIONAL(USE_ONLINE, test "x$online" = xtrue)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
title says it all. 
"online" library only includes MicromegasDefs and MicromegasMapping.
MicromegasDefs depends on TrkrDefs, and the corresponding trimmed libtrackbase_io that chris just built for online
This will avoid duplicated code in the TPOT online monitoring
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

