### PR TITLE
fix: GlobalVertex ID 

### DIFF
--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -126,7 +126,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       }
 
       // we have a matching pair
-      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX_BBC);
+      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::VTXTYPE::SVTX_BBC);
 
       for (unsigned int i = 0; i < 3; ++i)
       {
@@ -194,7 +194,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       }
 
       // we have a standalone SVTX vertex
-      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::SVTX);
+      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::VTXTYPE::SVTX);
 
       vertex->set_id(global_vertex_id);
       global_vertex_id++;
@@ -256,7 +256,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
         continue;
       }
 
-      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::UNDEFINED);
+      GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::VTXTYPE::BBC);
       vertex->set_id(global_vertex_id);
       global_vertex_id++;
 

--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -88,8 +88,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
   std::set<unsigned int> used_svtx_vtxids;
   std::set<unsigned int> used_bbc_vtxids;
-  int global_vertex_id = 0;
-
+ 
   if (svtxmap && bbcmap)
   {
     if (Verbosity())
@@ -147,7 +146,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       used_svtx_vtxids.insert(svtx->get_id());
       vertex->insert_vtxids(GlobalVertex::BBC, bbc_best->get_id());
       used_bbc_vtxids.insert(bbc_best->get_id());
-      vertex->set_id(global_vertex_id);
+      vertex->set_id(globalmap->size());
 
       globalmap->insert(vertex);
 
@@ -161,7 +160,6 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
           track->set_vertex_id(vertex->get_id());
         }
       }
-      global_vertex_id++;
 
       if (Verbosity() > 1)
       {
@@ -196,8 +194,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       // we have a standalone SVTX vertex
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::VTXTYPE::SVTX);
 
-      vertex->set_id(global_vertex_id);
-      global_vertex_id++;
+      vertex->set_id(globalmap->size());
 
       for (unsigned int i = 0; i < 3; ++i)
       {
@@ -232,7 +229,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       }
     }
   }
-
+ 
   // okay now loop over all unused BBC vertexes (3rd class)...
   if (bbcmap)
   {
@@ -257,8 +254,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       }
 
       GlobalVertex *vertex = new GlobalVertexv1(GlobalVertex::VTXTYPE::BBC);
-      vertex->set_id(global_vertex_id);
-      global_vertex_id++;
+      vertex->set_id(globalmap->size());
 
       // nominal beam location
       // could be replaced with a beam spot some day
@@ -292,7 +288,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       }
     }
   }
-
+ 
   /// Associate any tracks that were not assigned a track-vertex
   if (trackmap)
   {

--- a/offline/packages/globalvertex/GlobalVertexv1.cc
+++ b/offline/packages/globalvertex/GlobalVertexv1.cc
@@ -13,31 +13,7 @@ void GlobalVertexv1::identify(std::ostream& os) const
 {
   os << "---GlobalVertexv1-----------------------" << std::endl;
   os << "vertexid: " << get_id();
-  switch (get_id())
-  {
-  case GlobalVertex::UNDEFINED:
-    os << ", type GlobalVertex::UNDEFINED" << std::endl;
-    break;
-  case GlobalVertex::TRUTH:
-    os << ", type GlobalVertex::TRUTH" << std::endl;
-    break;
-  case GlobalVertex::SMEARED:
-    os << ", type GlobalVertex::SMEARED" << std::endl;
-    break;
-  case GlobalVertex::BBC:
-    os << ", type GlobalVertex::BBC" << std::endl;
-    break;
-  case GlobalVertex::SVTX:
-    os << ", type GlobalVertex::SVTX" << std::endl;
-    break;
-  case GlobalVertex::SVTX_BBC:
-    os << ", type GlobalVertex::SVTX_BBC" << std::endl;
-    break;
-  default:
-    os << "unknown type of GlobalVertex:" << get_id() << std::endl;
-    break;
-  }
-
+ 
   os << " t = " << get_t() << std::endl;
 
   os << " (x,y,z) =  (" << get_position(0);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR removes print out that is just wrong from the GlobalVertexv1::identify function and adds global vertices to the map based on the current map size. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

