### PR TITLE
Alignment Tree Dump

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -8,6 +8,8 @@
 #include <trackbase/TrkrClusterContainer.h>
 
 #include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/SvtxAlignmentState.h>
+#include <trackbase_historic/SvtxAlignmentStateMap.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertex.h>
@@ -78,6 +80,32 @@ int TrackResiduals::InitRun(PHCompositeNode*)
 }
 void TrackResiduals::clearClusterStateVectors()
 {
+  m_statelxglobderivdx.clear();
+  m_statelxglobderivdy.clear();
+  m_statelxglobderivdz.clear();
+  m_statelxglobderivdalpha.clear();
+  m_statelxglobderivdbeta.clear();
+  m_statelxglobderivdgamma.clear();
+
+  m_statelxlocderivd0.clear();
+  m_statelxlocderivz0.clear();
+  m_statelxlocderivphi.clear();
+  m_statelxlocderivtheta.clear();
+  m_statelxlocderivqop.clear();
+
+  m_statelzglobderivdx.clear();
+  m_statelzglobderivdy.clear();
+  m_statelzglobderivdz.clear();
+  m_statelzglobderivdalpha.clear();
+  m_statelzglobderivdbeta.clear();
+  m_statelzglobderivdgamma.clear();
+
+  m_statelzlocderivd0.clear();
+  m_statelzlocderivz0.clear();
+  m_statelzlocderivphi.clear();
+  m_statelzlocderivtheta.clear();
+  m_statelzlocderivqop.clear();
+
   m_cluslx.clear();
   m_cluslz.clear();
   m_cluselx.clear();
@@ -106,6 +134,8 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   auto vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
+  auto alignmentmap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "SvtxAlignmentStateMap");
+
   if (!trackmap or !clustermap or !geometry or !vertexmap)
   {
     std::cout << "Missing node, can't continue" << std::endl;
@@ -214,10 +244,10 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       //! have cluster and state, fill vectors
       m_cluslx.push_back(cluster->getLocalX());
       float clusz = cluster->getLocalY();
-      if(TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
-	{
-	  clusz = convertTimeToZ(geometry,ckey, cluster);
-	}
+      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
+      {
+        clusz = convertTimeToZ(geometry, ckey, cluster);
+      }
       m_cluslz.push_back(clusz);
       m_cluselx.push_back(cluster->getRPhiError());
       m_cluselz.push_back(cluster->getZError());
@@ -271,6 +301,43 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
 
     m_nhits = m_nmaps + m_nintt + m_ntpc + m_nmms;
 
+    if (alignmentmap and alignmentmap->find(key) != alignmentmap->end())
+    {
+      auto& statevec = alignmentmap->find(key)->second;
+
+      for (auto& state : statevec)
+      {
+        auto& globderivs = state->get_global_derivative_matrix();
+        auto& locderivs = state->get_local_derivative_matrix();
+
+        m_statelxglobderivdalpha.push_back(globderivs(0, 0));
+        m_statelxglobderivdbeta.push_back(globderivs(0, 1));
+        m_statelxglobderivdgamma.push_back(globderivs(0, 2));
+        m_statelxglobderivdx.push_back(globderivs(0, 3));
+        m_statelxglobderivdy.push_back(globderivs(0, 4));
+        m_statelxglobderivdz.push_back(globderivs(0, 5));
+
+        m_statelzglobderivdalpha.push_back(globderivs(1, 0));
+        m_statelzglobderivdbeta.push_back(globderivs(1, 1));
+        m_statelzglobderivdgamma.push_back(globderivs(1, 2));
+        m_statelzglobderivdx.push_back(globderivs(1, 3));
+        m_statelzglobderivdy.push_back(globderivs(1, 4));
+        m_statelzglobderivdz.push_back(globderivs(1, 5));
+
+        m_statelxlocderivd0.push_back(locderivs(0, 0));
+        m_statelxlocderivz0.push_back(locderivs(0, 1));
+        m_statelxlocderivphi.push_back(locderivs(0, 2));
+        m_statelxlocderivtheta.push_back(locderivs(0, 3));
+        m_statelxlocderivqop.push_back(locderivs(0, 4));
+
+        m_statelzlocderivd0.push_back(locderivs(1, 0));
+        m_statelzlocderivz0.push_back(locderivs(1, 1));
+        m_statelzlocderivphi.push_back(locderivs(1, 2));
+        m_statelzlocderivtheta.push_back(locderivs(1, 3));
+        m_statelzlocderivqop.push_back(locderivs(1, 4));
+      }
+    }
+
     m_tree->Fill();
   }
 
@@ -278,18 +345,18 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-float TrackResiduals::convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster)
+float TrackResiduals::convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster)
 {
   // must convert local Y from cluster average time of arival to local cluster z position
   double drift_velocity = geometry->get_drift_velocity();
   double zdriftlength = cluster->getLocalY() * drift_velocity;
-  double surfCenterZ = 52.89; // 52.89 is where G4 thinks the surface center is
-  double zloc = surfCenterZ - zdriftlength;   // converts z drift length to local z position in the TPC in north
+  double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
+  double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
   unsigned int side = TpcDefs::getSide(cluster_key);
-  if(side == 0) zloc = -zloc;
+  if (side == 0) zloc = -zloc;
   float z = zloc;  // in cm
- 
-  return z; 
+
+  return z;
 }
 
 //____________________________________________________________________________..
@@ -351,4 +418,30 @@ void TrackResiduals::createBranches()
   m_tree->Branch("statepy", &m_statepy);
   m_tree->Branch("statepz", &m_statepz);
   m_tree->Branch("statepl", &m_statepl);
+
+  m_tree->Branch("statelxglobderivdx", &m_statelxglobderivdx);
+  m_tree->Branch("statelxglobderivdy", &m_statelxglobderivdy);
+  m_tree->Branch("statelxglobderivdz", &m_statelxglobderivdz);
+  m_tree->Branch("statelxglobderivdalpha", &m_statelxglobderivdalpha);
+  m_tree->Branch("statelxglobderivdbeta", &m_statelxglobderivdbeta);
+  m_tree->Branch("statelxglobderivdgamma", &m_statelxglobderivdgamma);
+
+  m_tree->Branch("statelxlocderivd0", &m_statelxlocderivd0);
+  m_tree->Branch("statelxlocderivz0", &m_statelxlocderivz0);
+  m_tree->Branch("statelxlocderivphi", &m_statelxlocderivphi);
+  m_tree->Branch("statelxlocderivtheta", &m_statelxlocderivtheta);
+  m_tree->Branch("statelxlocderivqop", &m_statelxlocderivqop);
+
+  m_tree->Branch("statelzglobderivdx", &m_statelzglobderivdx);
+  m_tree->Branch("statelzglobderivdy", &m_statelzglobderivdy);
+  m_tree->Branch("statelzglobderivdz", &m_statelzglobderivdz);
+  m_tree->Branch("statelzglobderivdalpha", &m_statelzglobderivdalpha);
+  m_tree->Branch("statelzglobderivdbeta", &m_statelzglobderivdbeta);
+  m_tree->Branch("statelzglobderivdgamma", &m_statelzglobderivdgamma);
+
+  m_tree->Branch("statelzlocderivd0", &m_statelzlocderivd0);
+  m_tree->Branch("statelzlocderivz0", &m_statelzlocderivz0);
+  m_tree->Branch("statelzlocderivphi", &m_statelzlocderivphi);
+  m_tree->Branch("statelzlocderivtheta", &m_statelzlocderivtheta);
+  m_tree->Branch("statelzlocderivqop", &m_statelzlocderivqop);
 }

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -142,8 +142,6 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  ActsTransformations transformer;
-
   if (Verbosity() > 1)
   {
     std::cout << "Track map size is " << trackmap->size() << std::endl;
@@ -198,146 +196,57 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
 
     for (const auto& ckey : get_cluster_keys(track))
     {
-      TrkrCluster* cluster = clustermap->findCluster(ckey);
-      switch (TrkrDefs::getTrkrId(ckey))
-      {
-      case TrkrDefs::mvtxId:
-        m_nmaps++;
-        break;
-      case TrkrDefs::inttId:
-        m_nintt++;
-        break;
-      case TrkrDefs::tpcId:
-        m_ntpc++;
-        break;
-      case TrkrDefs::micromegasId:
-        m_nmms++;
-        break;
-      }
-
-      Acts::Vector3 clusglob = geometry->getGlobalPosition(ckey, cluster);
-
-      auto matched_state = track->begin_states();
-      float drmin = -1;
-      float clusr = r(clusglob.x(), clusglob.y());
-
-      for (auto state_iter = track->begin_states();
-           state_iter != track->end_states();
-           ++state_iter)
-      {
-        SvtxTrackState* state = state_iter->second;
-        float stater = r(state->get_x(), state->get_y());
-        float thisdr = std::abs(clusr - stater);
-        if (drmin < 0 or thisdr < drmin)
-        {
-          matched_state = state_iter;
-          drmin = thisdr;
-        }
-        else
-        {
-          break;
-        }
-      }
-
-      SvtxTrackState* state = matched_state->second;
-
-      //! have cluster and state, fill vectors
-      m_cluslx.push_back(cluster->getLocalX());
-      float clusz = cluster->getLocalY();
-      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
-      {
-        clusz = convertTimeToZ(geometry, ckey, cluster);
-      }
-      m_cluslz.push_back(clusz);
-      m_cluselx.push_back(cluster->getRPhiError());
-      m_cluselz.push_back(cluster->getZError());
-      m_clusgx.push_back(clusglob.x());
-      m_clusgy.push_back(clusglob.y());
-      m_clusgz.push_back(clusglob.z());
-      m_cluslayer.push_back(TrkrDefs::getLayer(ckey));
-      m_clussize.push_back(cluster->getPhiSize() + cluster->getZSize());
-
-      if (Verbosity() > 1)
-      {
-        std::cout << "Track state/clus in layer "
-                  << TrkrDefs::getLayer(ckey) << std::endl;
-      }
-
-      auto surf = geometry->maps().getSurface(ckey, cluster);
-      Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
-      Acts::Vector2 stateloc;
-      auto norm = surf->normal(geometry->geometry().getGeoContext());
-      auto result = surf->globalToLocal(geometry->geometry().getGeoContext(),
-                                        stateglob * Acts::UnitConstants::cm,
-                                        norm);
-      if (result.ok())
-      {
-        stateloc = result.value() / Acts::UnitConstants::cm;
-      }
-      else
-      {
-        //! manual transform for tpc
-        Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * (stateglob * Acts::UnitConstants::cm);
-        loct /= Acts::UnitConstants::cm;
-        stateloc(0) = loct(0);
-        stateloc(1) = loct(1);
-      }
-
-      const Acts::BoundSymMatrix actscov =
-          transformer.rotateSvtxTrackCovToActs(state);
-
-      m_statelx.push_back(stateloc(0));
-      m_statelz.push_back(stateloc(1));
-      m_stateelx.push_back(std::sqrt(actscov(Acts::eBoundLoc0, Acts::eBoundLoc0)) / Acts::UnitConstants::cm);
-      m_stateelz.push_back(std::sqrt(actscov(Acts::eBoundLoc1, Acts::eBoundLoc1)) / Acts::UnitConstants::cm);
-      m_stategx.push_back(state->get_x());
-      m_stategy.push_back(state->get_y());
-      m_stategz.push_back(state->get_z());
-      m_statepx.push_back(state->get_px());
-      m_statepy.push_back(state->get_py());
-      m_statepz.push_back(state->get_pz());
-      m_statepl.push_back(state->get_pathlength());
+      fillClusterBranches(ckey, track, topNode);
     }
 
     m_nhits = m_nmaps + m_nintt + m_ntpc + m_nmms;
 
-    if (alignmentmap and alignmentmap->find(key) != alignmentmap->end())
+    if (m_doAlignment)
     {
-      auto& statevec = alignmentmap->find(key)->second;
+      /// repopulate with info that is going into alignment
+      clearClusterStateVectors();
 
-      for (auto& state : statevec)
+      if (alignmentmap and alignmentmap->find(key) != alignmentmap->end())
       {
-        auto& globderivs = state->get_global_derivative_matrix();
-        auto& locderivs = state->get_local_derivative_matrix();
+        auto& statevec = alignmentmap->find(key)->second;
 
-        m_statelxglobderivdalpha.push_back(globderivs(0, 0));
-        m_statelxglobderivdbeta.push_back(globderivs(0, 1));
-        m_statelxglobderivdgamma.push_back(globderivs(0, 2));
-        m_statelxglobderivdx.push_back(globderivs(0, 3));
-        m_statelxglobderivdy.push_back(globderivs(0, 4));
-        m_statelxglobderivdz.push_back(globderivs(0, 5));
+        for (auto& state : statevec)
+        {
+          auto ckey = state->get_cluster_key();
 
-        m_statelzglobderivdalpha.push_back(globderivs(1, 0));
-        m_statelzglobderivdbeta.push_back(globderivs(1, 1));
-        m_statelzglobderivdgamma.push_back(globderivs(1, 2));
-        m_statelzglobderivdx.push_back(globderivs(1, 3));
-        m_statelzglobderivdy.push_back(globderivs(1, 4));
-        m_statelzglobderivdz.push_back(globderivs(1, 5));
+          fillClusterBranches(ckey, track, topNode);
 
-        m_statelxlocderivd0.push_back(locderivs(0, 0));
-        m_statelxlocderivz0.push_back(locderivs(0, 1));
-        m_statelxlocderivphi.push_back(locderivs(0, 2));
-        m_statelxlocderivtheta.push_back(locderivs(0, 3));
-        m_statelxlocderivqop.push_back(locderivs(0, 4));
+          auto& globderivs = state->get_global_derivative_matrix();
+          auto& locderivs = state->get_local_derivative_matrix();
 
-        m_statelzlocderivd0.push_back(locderivs(1, 0));
-        m_statelzlocderivz0.push_back(locderivs(1, 1));
-        m_statelzlocderivphi.push_back(locderivs(1, 2));
-        m_statelzlocderivtheta.push_back(locderivs(1, 3));
-        m_statelzlocderivqop.push_back(locderivs(1, 4));
+          m_statelxglobderivdalpha.push_back(globderivs(0, 0));
+          m_statelxglobderivdbeta.push_back(globderivs(0, 1));
+          m_statelxglobderivdgamma.push_back(globderivs(0, 2));
+          m_statelxglobderivdx.push_back(globderivs(0, 3));
+          m_statelxglobderivdy.push_back(globderivs(0, 4));
+          m_statelxglobderivdz.push_back(globderivs(0, 5));
+
+          m_statelzglobderivdalpha.push_back(globderivs(1, 0));
+          m_statelzglobderivdbeta.push_back(globderivs(1, 1));
+          m_statelzglobderivdgamma.push_back(globderivs(1, 2));
+          m_statelzglobderivdx.push_back(globderivs(1, 3));
+          m_statelzglobderivdy.push_back(globderivs(1, 4));
+          m_statelzglobderivdz.push_back(globderivs(1, 5));
+
+          m_statelxlocderivd0.push_back(locderivs(0, 0));
+          m_statelxlocderivz0.push_back(locderivs(0, 1));
+          m_statelxlocderivphi.push_back(locderivs(0, 2));
+          m_statelxlocderivtheta.push_back(locderivs(0, 3));
+          m_statelxlocderivqop.push_back(locderivs(0, 4));
+
+          m_statelzlocderivd0.push_back(locderivs(1, 0));
+          m_statelzlocderivz0.push_back(locderivs(1, 1));
+          m_statelzlocderivphi.push_back(locderivs(1, 2));
+          m_statelzlocderivtheta.push_back(locderivs(1, 3));
+          m_statelzlocderivqop.push_back(locderivs(1, 4));
+        }
       }
     }
-
     m_tree->Fill();
   }
 
@@ -369,6 +278,115 @@ int TrackResiduals::End(PHCompositeNode*)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* track,
+                                         PHCompositeNode* topNode)
+{
+  auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+
+  ActsTransformations transformer;
+  TrkrCluster* cluster = clustermap->findCluster(ckey);
+  switch (TrkrDefs::getTrkrId(ckey))
+  {
+  case TrkrDefs::mvtxId:
+    m_nmaps++;
+    break;
+  case TrkrDefs::inttId:
+    m_nintt++;
+    break;
+  case TrkrDefs::tpcId:
+    m_ntpc++;
+    break;
+  case TrkrDefs::micromegasId:
+    m_nmms++;
+    break;
+  }
+
+  Acts::Vector3 clusglob = geometry->getGlobalPosition(ckey, cluster);
+
+  auto matched_state = track->begin_states();
+  float drmin = -1;
+  float clusr = r(clusglob.x(), clusglob.y());
+
+  for (auto state_iter = track->begin_states();
+       state_iter != track->end_states();
+       ++state_iter)
+  {
+    SvtxTrackState* state = state_iter->second;
+    float stater = r(state->get_x(), state->get_y());
+    float thisdr = std::abs(clusr - stater);
+    if (drmin < 0 or thisdr < drmin)
+    {
+      matched_state = state_iter;
+      drmin = thisdr;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  SvtxTrackState* state = matched_state->second;
+
+  //! have cluster and state, fill vectors
+  m_cluslx.push_back(cluster->getLocalX());
+  float clusz = cluster->getLocalY();
+
+  if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
+  {
+    clusz = convertTimeToZ(geometry, ckey, cluster);
+  }
+  m_cluslz.push_back(clusz);
+  m_cluselx.push_back(cluster->getRPhiError());
+  m_cluselz.push_back(cluster->getZError());
+  m_clusgx.push_back(clusglob.x());
+  m_clusgy.push_back(clusglob.y());
+  m_clusgz.push_back(clusglob.z());
+  m_cluslayer.push_back(TrkrDefs::getLayer(ckey));
+  m_clussize.push_back(cluster->getPhiSize() + cluster->getZSize());
+  m_clushitsetkey.push_back(TrkrDefs::getHitSetKeyFromClusKey(ckey));
+
+  if (Verbosity() > 1)
+  {
+    std::cout << "Track state/clus in layer "
+              << TrkrDefs::getLayer(ckey) << std::endl;
+  }
+
+  auto surf = geometry->maps().getSurface(ckey, cluster);
+  Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
+  Acts::Vector2 stateloc;
+  auto norm = surf->normal(geometry->geometry().getGeoContext());
+  auto result = surf->globalToLocal(geometry->geometry().getGeoContext(),
+                                    stateglob * Acts::UnitConstants::cm,
+                                    norm);
+  if (result.ok())
+  {
+    stateloc = result.value() / Acts::UnitConstants::cm;
+  }
+  else
+  {
+    //! manual transform for tpc
+    Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * (stateglob * Acts::UnitConstants::cm);
+    loct /= Acts::UnitConstants::cm;
+    stateloc(0) = loct(0);
+    stateloc(1) = loct(1);
+  }
+
+  const Acts::BoundSymMatrix actscov =
+      transformer.rotateSvtxTrackCovToActs(state);
+
+  m_statelx.push_back(stateloc(0));
+  m_statelz.push_back(stateloc(1));
+  m_stateelx.push_back(std::sqrt(actscov(Acts::eBoundLoc0, Acts::eBoundLoc0)) / Acts::UnitConstants::cm);
+  m_stateelz.push_back(std::sqrt(actscov(Acts::eBoundLoc1, Acts::eBoundLoc1)) / Acts::UnitConstants::cm);
+  m_stategx.push_back(state->get_x());
+  m_stategy.push_back(state->get_y());
+  m_stategz.push_back(state->get_z());
+  m_statepx.push_back(state->get_px());
+  m_statepy.push_back(state->get_py());
+  m_statepz.push_back(state->get_pz());
+  m_statepl.push_back(state->get_pathlength());
+}
 void TrackResiduals::createBranches()
 {
   m_tree = new TTree("residualtree", "A tree with track, cluster, and state info");
@@ -406,6 +424,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("clusgz", &m_clusgz);
   m_tree->Branch("cluslayer", &m_cluslayer);
   m_tree->Branch("clussize", &m_clussize);
+  m_tree->Branch("clushitsetkey", &m_clushitsetkey);
 
   m_tree->Branch("statelx", &m_statelx);
   m_tree->Branch("statelz", &m_statelz);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -36,7 +36,7 @@ class TrackResiduals : public SubsysReco
  private:
   void clearClusterStateVectors();
   void createBranches();
-  float convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
+  float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
   std::string m_outfileName = "";
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;
@@ -92,6 +92,32 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_statepy;
   std::vector<float> m_statepz;
   std::vector<float> m_statepl;
+
+  std::vector<float> m_statelxglobderivdx;
+  std::vector<float> m_statelxglobderivdy;
+  std::vector<float> m_statelxglobderivdz;
+  std::vector<float> m_statelxglobderivdalpha;
+  std::vector<float> m_statelxglobderivdbeta;
+  std::vector<float> m_statelxglobderivdgamma;
+
+  std::vector<float> m_statelxlocderivd0;
+  std::vector<float> m_statelxlocderivz0;
+  std::vector<float> m_statelxlocderivphi;
+  std::vector<float> m_statelxlocderivtheta;
+  std::vector<float> m_statelxlocderivqop;
+
+  std::vector<float> m_statelzglobderivdx;
+  std::vector<float> m_statelzglobderivdy;
+  std::vector<float> m_statelzglobderivdz;
+  std::vector<float> m_statelzglobderivdalpha;
+  std::vector<float> m_statelzglobderivdbeta;
+  std::vector<float> m_statelzglobderivdgamma;
+
+  std::vector<float> m_statelzlocderivd0;
+  std::vector<float> m_statelzlocderivz0;
+  std::vector<float> m_statelzlocderivphi;
+  std::vector<float> m_statelzlocderivtheta;
+  std::vector<float> m_statelzlocderivqop;
 };
 
 #endif  // TRACKRESIDUALS_H

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -19,6 +19,7 @@
 class TrkrCluster;
 class PHCompositeNode;
 class ActsGeometry;
+class SvtxTrack;
 
 class TrackResiduals : public SubsysReco
 {
@@ -32,14 +33,21 @@ class TrackResiduals : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   void outfileName(std::string name) { m_outfileName = name; }
+  void alignment(bool align) { m_doAlignment = align; }
 
  private:
   void clearClusterStateVectors();
   void createBranches();
   float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
+
+  void fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack *track,
+                           PHCompositeNode *topNode);
+
   std::string m_outfileName = "";
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;
+
+  bool m_doAlignment = false;
 
   int m_event = 0;
   //! Track level quantities
@@ -79,6 +87,7 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_clusgz;
   std::vector<int> m_cluslayer;
   std::vector<int> m_clussize;
+  std::vector<uint32_t> m_clushitsetkey;
 
   //! states on track information
   std::vector<float> m_statelx;


### PR DESCRIPTION
Adds an option to dump the alignment state information fed to pede into a tree instead of the raw residual information.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

