### PR TITLE
New steppingaction for EMCal

### DIFF
--- a/simulation/g4simulation/g4detectors/LightCollectionModel.cc
+++ b/simulation/g4simulation/g4detectors/LightCollectionModel.cc
@@ -1,0 +1,126 @@
+#include "LightCollectionModel.h"
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <phool/recoConsts.h>
+
+#include <TAxis.h>  // for TAxis
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TObject.h>  // for TObject
+#include <TSystem.h>
+
+#include <cassert>
+#include <iostream>
+
+LightCollectionModel::LightCollectionModel()
+{
+  data_grid_light_guide_efficiency_verify = new TH2F("data_grid_light_guide_efficiency_verify",
+                                                     "light collection efficiency as used in LightCollectionModel;x positio fraction;y position fraction",  //
+                                                     100, 0., 1., 100, 0., 1.);
+
+  data_grid_fiber_trans_verify = new TH1F("data_grid_fiber_trans",
+                                          "SCSF-78 Fiber Transmission as used in LightCollectionModel;position in fiber (cm);Effective transmission",
+                                          100, -15, 15);
+
+  // register histograms
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  se->registerHisto(data_grid_light_guide_efficiency_verify);
+  se->registerHisto(data_grid_fiber_trans_verify);
+}
+
+LightCollectionModel::~LightCollectionModel()
+{
+  delete data_grid_light_guide_efficiency;
+  delete data_grid_fiber_trans;
+}
+
+void LightCollectionModel::load_data_from_CDB(
+    const std::string &domain,
+    const std::string &histogram_light_guide_model,
+    const std::string &histogram_fiber_model)
+{
+  recoConsts *rc = recoConsts::instance();
+  std::string url = CDBInterface::instance()->getUrl(domain);
+  if (url.empty())
+  {
+    std::cout << "No calibration for domain " << domain << " for timestamp " << rc->get_uint64Flag("TIMESTAMP") << std::endl;
+    gSystem->Exit(1);
+  }
+  TFile *fin = TFile::Open(url.c_str());
+  if (!fin)
+  {
+    std::cout << "could not open " << url << std::endl;
+    gSystem->Exit(1);
+  }
+  if (data_grid_light_guide_efficiency) delete data_grid_light_guide_efficiency;
+  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(histogram_light_guide_model.c_str()));
+  assert(data_grid_light_guide_efficiency);
+  data_grid_light_guide_efficiency->SetDirectory(nullptr);
+  if (data_grid_fiber_trans) delete data_grid_fiber_trans;
+  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(histogram_fiber_model.c_str()));
+  assert(data_grid_fiber_trans);
+  data_grid_fiber_trans->SetDirectory(nullptr);
+  delete fin;
+}
+
+void LightCollectionModel::load_data_file(
+    const std::string &input_file,
+    const std::string &histogram_light_guide_model,
+    const std::string &histogram_fiber_model)
+{
+  TFile *fin = TFile::Open(input_file.c_str());
+
+  assert(fin);
+  assert(fin->IsOpen());
+
+  if (data_grid_light_guide_efficiency) delete data_grid_light_guide_efficiency;
+  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(histogram_light_guide_model.c_str()));
+  assert(data_grid_light_guide_efficiency);
+  data_grid_light_guide_efficiency->SetDirectory(nullptr);
+
+  if (data_grid_fiber_trans) delete data_grid_fiber_trans;
+  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(histogram_fiber_model.c_str()));
+  assert(data_grid_fiber_trans);
+  data_grid_fiber_trans->SetDirectory(nullptr);
+
+  delete fin;
+}
+
+double LightCollectionModel::get_light_guide_efficiency(const double x_fraction, const double y_fraction)
+{
+  assert(data_grid_light_guide_efficiency);
+  assert(x_fraction >= 0);
+  assert(x_fraction <= 1);
+  assert(y_fraction >= 0);
+  assert(y_fraction <= 1);
+
+  const double eff = data_grid_light_guide_efficiency->Interpolate(x_fraction,
+                                                                   y_fraction);
+
+  data_grid_light_guide_efficiency_verify->SetBinContent(                        //
+      data_grid_light_guide_efficiency_verify->GetXaxis()->FindBin(x_fraction),  //
+      data_grid_light_guide_efficiency_verify->GetYaxis()->FindBin(y_fraction),  //
+      eff                                                                        //
+  );
+
+  return eff;
+}
+
+double LightCollectionModel::get_fiber_transmission(const double z_distance)
+{
+  assert(data_grid_fiber_trans);
+
+  const double eff = data_grid_fiber_trans->Interpolate(z_distance);
+
+  data_grid_fiber_trans_verify->SetBinContent(                        //
+      data_grid_fiber_trans_verify->GetXaxis()->FindBin(z_distance),  //
+      eff                                                             //
+  );
+
+  return eff;
+}

--- a/simulation/g4simulation/g4detectors/LightCollectionModel.h
+++ b/simulation/g4simulation/g4detectors/LightCollectionModel.h
@@ -1,0 +1,54 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4DETECTORS_LIGHTCOLLECTIONMODEL_H
+#define G4DETECTORS_LIGHTCOLLECTIONMODEL_H
+#include <string>
+
+class TH2;
+class TH1;
+
+class LightCollectionModel
+{
+ public:
+   LightCollectionModel();
+
+  //! delete copy ctor and assignment opertor (cppcheck)
+  explicit LightCollectionModel(const LightCollectionModel &) = delete;
+  LightCollectionModel &operator=(const LightCollectionModel &) = delete;
+
+  virtual ~LightCollectionModel();
+
+  //! input data file
+  void load_data_file(const std::string &input_file, const std::string &histogram_light_guide_model, const std::string &histogram_fiber_model);
+
+  //! load from CDB
+  void load_data_from_CDB(const std::string &domain, const std::string &histogram_light_guide_model, const std::string &histogram_fiber_model);
+
+  //! Whether use light collection model
+  bool use_light_guide_model() const { return data_grid_light_guide_efficiency != nullptr; }
+
+  //! Whether use Light Transmission Efficiency model for the fiber
+  bool use_fiber_model() const { return data_grid_fiber_trans != nullptr; }
+
+  //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+  double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
+
+  //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber. Z=0 is at the middle of the fiber
+  double get_fiber_transmission(const double z_distance);
+
+ private:
+  //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
+  TH2 *data_grid_light_guide_efficiency = nullptr;
+
+  //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to location in the fiber. Z=0 is at the middle of the fiber
+  TH1 *data_grid_fiber_trans = nullptr;
+
+  // These two histograms are handed off to Fun4All and will be deleted there
+  // this suppresses the cppcheck warning
+  // cppcheck-suppress unsafeClassCanLeak
+  TH2 *data_grid_light_guide_efficiency_verify = nullptr;
+  // cppcheck-suppress unsafeClassCanLeak
+  TH1 *data_grid_fiber_trans_verify = nullptr;
+};
+
+#endif

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -43,6 +43,7 @@ libg4detectors_la_LIBADD = \
 
 pkginclude_HEADERS = \
   BeamLineMagnetSubsystem.h \
+  LightCollectionModel.h \
   PHG4BbcSubsystem.h \
   PHG4BlockCellGeom.h \
   PHG4BlockCellGeomContainer.h \
@@ -202,6 +203,7 @@ libg4detectors_la_SOURCES = \
   BeamLineMagnetDisplayAction.cc \
   BeamLineMagnetSubsystem.cc \
   BeamLineMagnetSteppingAction.cc \
+  LightCollectionModel.cc \
   PHG4GDMLDetector.cc \
   PHG4GDMLSubsystem.cc \
   PHG4BbcDetector.cc \

--- a/simulation/g4simulation/g4detectors/Makefile.am
+++ b/simulation/g4simulation/g4detectors/Makefile.am
@@ -93,6 +93,7 @@ pkginclude_HEADERS = \
   PHG4SectorConstructor.h \
   PHG4SectorSubsystem.h \
   PHG4SpacalSubsystem.h \
+  PHG4SpacalSteppingAction.h \
   PHG4StepStatusDecode.h \
   PHG4TpcCylinderGeom.h \
   PHG4TpcCylinderGeomContainer.h \

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.cc
@@ -1,10 +1,11 @@
 #include "PHG4FullProjSpacalCellReco.h"
 
+#include "LightCollectionModel.h"
 #include "PHG4Cell.h"  // for PHG4Cell
 #include "PHG4CylinderCellGeom.h"
 #include "PHG4CylinderCellGeomContainer.h"
 #include "PHG4CylinderCellGeom_Spacalv1.h"
-#include "PHG4CylinderGeom.h"  // for PHG4CylinderGeom
+#include "PHG4CylinderGeom.h"           // for PHG4CylinderGeom
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4CylinderGeom_Spacalv1.h"  // for PHG4CylinderGeom_Spaca...
 #include "PHG4CylinderGeom_Spacalv3.h"
@@ -25,11 +26,11 @@
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNode.h>    // for PHNode
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
-#include <phool/phool.h>  // for PHWHERE
+#include <phool/phool.h>     // for PHWHERE
 #include <phool/recoConsts.h>
 
 #include <ffamodules/CDBInterface.h>
@@ -181,14 +182,14 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
 
     if (tower_ID_phi == 0)
     {
-      //assign phi min according phi bin 0
+      // assign phi min according phi bin 0
       phi_min = M_PI_2 - deltaphi * (layergeom->get_max_phi_bin_in_sec() * layergeom->get_n_subtower_phi() / 2)  // shift of first tower in sector
                 + sector_map.begin()->second;
     }
 
     if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
     {
-      //assign eta min according phi bin 0
+      // assign eta min according phi bin 0
       map_z_tower_z_ID[tower.centralZ] = tower_ID_z;
     }
     // ...
@@ -211,7 +212,7 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
   layerseggeo->set_etamin(NAN);
   layerseggeo->set_etastep(NAN);
 
-  //build eta bin maps
+  // build eta bin maps
   for (const auto &tower_pair : tower_map)
   {
     const int &tower_ID = tower_pair.first;
@@ -229,7 +230,8 @@ int PHG4FullProjSpacalCellReco::InitRun(PHCompositeNode *topNode)
       const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
       const double tower_radial = layergeom->get_tower_radial_position(tower);
 
-      auto z_to_eta = [&tower_radial](const double &z) { return -log(tan(0.5 * atan2(tower_radial, z))); };
+      auto z_to_eta = [&tower_radial](const double &z)
+      { return -log(tan(0.5 * atan2(tower_radial, z))); };
 
       const double eta_central = z_to_eta(tower.centralZ);
       // half eta-range
@@ -421,6 +423,7 @@ int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
     double light_yield = hiter->second->get_light_yield();
 
     // light yield correction from fiber attenuation:
+    
     if (light_collection_model.use_fiber_model())
     {
       const double z = 0.5 * (hiter->second->get_local_z(0) + hiter->second->get_local_z(1));
@@ -428,6 +431,7 @@ int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 
       light_yield *= light_collection_model.get_fiber_transmission(z);
     }
+  
 
     // light yield correction from light guide collection efficiency:
     if (light_collection_model.use_fiber_model())
@@ -437,7 +441,6 @@ int PHG4FullProjSpacalCellReco::process_event(PHCompositeNode *topNode)
 
       light_yield *= light_collection_model.get_light_guide_efficiency(x, y);
     }
-
     cell->add_edep(hiter->first, hiter->second->get_edep());
     cell->add_edep(hiter->second->get_edep());
     cell->add_light_yield(light_yield);
@@ -512,117 +515,6 @@ int PHG4FullProjSpacalCellReco::CheckEnergy(PHCompositeNode *topNode)
     }
   }
   return 0;
-}
-
-PHG4FullProjSpacalCellReco::LightCollectionModel::LightCollectionModel()
-{
-  data_grid_light_guide_efficiency_verify = new TH2F("data_grid_light_guide_efficiency_verify",
-                                                     "light collection efficiency as used in PHG4FullProjSpacalCellReco::LightCollectionModel;x positio fraction;y position fraction",  //
-                                                     100, 0., 1., 100, 0., 1.);
-
-  data_grid_fiber_trans_verify = new TH1F("data_grid_fiber_trans",
-                                          "SCSF-78 Fiber Transmission as used in PHG4FullProjSpacalCellReco::LightCollectionModel;position in fiber (cm);Effective transmission",
-                                          100, -15, 15);
-
-  // register histograms
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  se->registerHisto(data_grid_light_guide_efficiency_verify);
-  se->registerHisto(data_grid_fiber_trans_verify);
-}
-
-PHG4FullProjSpacalCellReco::LightCollectionModel::~LightCollectionModel()
-{
-  delete data_grid_light_guide_efficiency;
-  delete data_grid_fiber_trans;
-}
-
-void PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_from_CDB(
-    const std::string &domain,
-    const std::string &histogram_light_guide_model,
-    const std::string &histogram_fiber_model)
-{
-  recoConsts *rc = recoConsts::instance();
-  std::string url = CDBInterface::instance()->getUrl(domain);
-  if (url.empty())
-  {
-    std::cout << "No calibration for domain " << domain << " for timestamp " << rc->get_uint64Flag("TIMESTAMP") << std::endl;
-    gSystem->Exit(1);
-  }
-  TFile *fin = TFile::Open(url.c_str());
-  if (!fin)
-  {
-    std::cout << "could not open " << url << std::endl;
-    gSystem->Exit(1);
-  }
-  if (data_grid_light_guide_efficiency) delete data_grid_light_guide_efficiency;
-  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(histogram_light_guide_model.c_str()));
-  assert(data_grid_light_guide_efficiency);
-  data_grid_light_guide_efficiency->SetDirectory(nullptr);
-  if (data_grid_fiber_trans) delete data_grid_fiber_trans;
-  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(histogram_fiber_model.c_str()));
-  assert(data_grid_fiber_trans);
-  data_grid_fiber_trans->SetDirectory(nullptr);
-  delete fin;
-}
-
-void PHG4FullProjSpacalCellReco::LightCollectionModel::load_data_file(
-    const std::string &input_file,
-    const std::string &histogram_light_guide_model,
-    const std::string &histogram_fiber_model)
-{
-  TFile *fin = TFile::Open(input_file.c_str());
-
-  assert(fin);
-  assert(fin->IsOpen());
-
-  if (data_grid_light_guide_efficiency) delete data_grid_light_guide_efficiency;
-  data_grid_light_guide_efficiency = dynamic_cast<TH2 *>(fin->Get(histogram_light_guide_model.c_str()));
-  assert(data_grid_light_guide_efficiency);
-  data_grid_light_guide_efficiency->SetDirectory(nullptr);
-
-  if (data_grid_fiber_trans) delete data_grid_fiber_trans;
-  data_grid_fiber_trans = dynamic_cast<TH1 *>(fin->Get(histogram_fiber_model.c_str()));
-  assert(data_grid_fiber_trans);
-  data_grid_fiber_trans->SetDirectory(nullptr);
-
-  delete fin;
-}
-
-double
-PHG4FullProjSpacalCellReco::LightCollectionModel::get_light_guide_efficiency(const double x_fraction, const double y_fraction)
-{
-  assert(data_grid_light_guide_efficiency);
-  assert(x_fraction >= 0);
-  assert(x_fraction <= 1);
-  assert(y_fraction >= 0);
-  assert(y_fraction <= 1);
-
-  const double eff = data_grid_light_guide_efficiency->Interpolate(x_fraction,
-                                                                   y_fraction);
-
-  data_grid_light_guide_efficiency_verify->SetBinContent(                        //
-      data_grid_light_guide_efficiency_verify->GetXaxis()->FindBin(x_fraction),  //
-      data_grid_light_guide_efficiency_verify->GetYaxis()->FindBin(y_fraction),  //
-      eff                                                                        //
-  );
-
-  return eff;
-}
-
-double
-PHG4FullProjSpacalCellReco::LightCollectionModel::get_fiber_transmission(const double z_distance)
-{
-  assert(data_grid_fiber_trans);
-
-  const double eff = data_grid_fiber_trans->Interpolate(z_distance);
-
-  data_grid_fiber_trans_verify->SetBinContent(                        //
-      data_grid_fiber_trans_verify->GetXaxis()->FindBin(z_distance),  //
-      eff                                                             //
-  );
-
-  return eff;
 }
 
 void PHG4FullProjSpacalCellReco::SetDefaultParameters()

--- a/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjSpacalCellReco.h
@@ -3,6 +3,8 @@
 #ifndef G4DETECTORS_PHG4FULLPROJSPACALCELLRECO_H
 #define G4DETECTORS_PHG4FULLPROJSPACALCELLRECO_H
 
+#include "LightCollectionModel.h" 
+
 #include <phparameter/PHParameterInterface.h>
 
 #include <fun4all/SubsysReco.h>
@@ -11,6 +13,7 @@
 #include <map>
 #include <string>
 
+class LightCollectionModel;
 class PHCompositeNode;
 class PHG4Cell;
 class TH2;
@@ -40,49 +43,6 @@ class PHG4FullProjSpacalCellReco : public SubsysReco, public PHParameterInterfac
 
   void set_timing_window(const double tmin, const double tmax);
 
-  class LightCollectionModel
-  {
-   public:
-    LightCollectionModel();
-
-    //! delete copy ctor and assignment opertor (cppcheck)
-    explicit LightCollectionModel(const LightCollectionModel &) = delete;
-    LightCollectionModel &operator=(const LightCollectionModel &) = delete;
-
-    virtual ~LightCollectionModel();
-
-    //! input data file
-    void load_data_file(const std::string &input_file, const std::string &histogram_light_guide_model, const std::string &histogram_fiber_model);
-
-    //! load from CDB
-    void load_data_from_CDB(const std::string &domain, const std::string &histogram_light_guide_model, const std::string &histogram_fiber_model);
-
-    //! Whether use light collection model
-    bool use_light_guide_model() const { return data_grid_light_guide_efficiency != nullptr; }
-
-    //! Whether use Light Transmission Efficiency model for the fiber
-    bool use_fiber_model() const { return data_grid_fiber_trans != nullptr; }
-
-    //! get Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
-    double get_light_guide_efficiency(const double x_fraction, const double y_fraction);
-
-    //! get Light Transmission Efficiency for the fiber as function of z position (cm) in the fiber. Z=0 is at the middle of the fiber
-    double get_fiber_transmission(const double z_distance);
-
-   private:
-    //! 2-D data grid for Light Collection Efficiency for the light guide as function of x,y position in fraction of tower width
-    TH2 *data_grid_light_guide_efficiency = nullptr;
-
-    //! 1-D data grid for the light transmission efficiency in the fiber as function of distance to location in the fiber. Z=0 is at the middle of the fiber
-    TH1 *data_grid_fiber_trans = nullptr;
-
-    // These two histograms are handed off to Fun4All and will be deleted there
-    // this suppresses the cppcheck warning
-    // cppcheck-suppress unsafeClassCanLeak
-    TH2 *data_grid_light_guide_efficiency_verify = nullptr;
-    // cppcheck-suppress unsafeClassCanLeak
-    TH1 *data_grid_fiber_trans_verify = nullptr;
-  };
 
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.cc
@@ -15,6 +15,8 @@
 
 #include <phool/recoConsts.h>
 
+#include <phparameter/PHParameters.h>
+
 #include <Geant4/G4Box.hh>
 #include <Geant4/G4DisplacedSolid.hh>
 #include <Geant4/G4Exception.hh>          // for G4Exception
@@ -55,6 +57,7 @@ class PHCompositeNode;
 PHG4FullProjTiltedSpacalDetector::PHG4FullProjTiltedSpacalDetector(PHG4Subsystem* subsys, PHCompositeNode* Node,
                                                                    const std::string& dnam, PHParameters* parameters, const int lyr)
   : PHG4SpacalDetector(subsys, Node, dnam, parameters, lyr, false)
+  , m_Params(parameters)
 {
   assert(_geom == nullptr);
 
@@ -90,6 +93,22 @@ void PHG4FullProjTiltedSpacalDetector::ConstructMe(G4LogicalVolume* logicWorld)
     std::cout << "PHG4FullProjTiltedSpacalDetector::Construct::" << GetName()
               << " - Completed." << std::endl;
   }
+  
+  if (m_Params->get_int_param("saveg4hit")) return;
+   try
+  {
+    AddCellGeometryNode();
+    AddTowerGeometryNode();
+    
+    
+  }
+  catch (std::exception &e)
+  {
+    std::cout << e.what() << std::endl;
+    //exit(1);
+  }
+  
+  
 }
 
 std::pair<G4LogicalVolume*, G4Transform3D>

--- a/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4FullProjTiltedSpacalDetector.h
@@ -69,6 +69,7 @@ class PHG4FullProjTiltedSpacalDetector : public PHG4SpacalDetector
   }
 
  private:
+  PHParameters* m_Params = nullptr;
   //  SpacalGeom_t* _geom;
   //! get the v3 cast of the geometry object
   SpacalGeom_t*

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -70,7 +70,6 @@ PHG4SpacalDetector::PHG4SpacalDetector(PHG4Subsystem *subsys,
                                        bool init_geom)
   : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4SpacalDisplayAction *>(subsys->GetDisplayAction()))
-  , m_Params(parameters)
   , layer(lyr)
 {
   if (init_geom)

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -6,13 +6,23 @@
  * \date $$Date: 2015/02/10 15:39:26 $$
  */
 #include "PHG4SpacalDetector.h"
+#include "PHG4CylinderGeom_Spacalv3.h"
 
+#include "PHG4CylinderCellGeom_Spacalv1.h"
+#include "PHG4CylinderGeom_Spacalv1.h"  // for PHG4CylinderGeom_Spaca...
+
+#include "PHG4CellDefs.h"
+#include "PHG4CylinderCellGeom.h"
+#include "PHG4CylinderCellGeomContainer.h"
 #include "PHG4CylinderGeomContainer.h"
 #include "PHG4SpacalDisplayAction.h"
 
 #include <g4main/PHG4Detector.h>       // for PHG4Detector
 #include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
 #include <g4main/PHG4Subsystem.h>
+#include <g4main/PHG4Utils.h>
+
+#include <phparameter/PHParameters.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -25,18 +35,24 @@
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
 
+#include <calobase/RawTowerDefs.h>           // for convert_name_...
+#include <calobase/RawTowerGeom.h>           // for RawTowerGeom
+#include <calobase/RawTowerGeomContainer.h>  // for RawTowerGeomC...
+#include <calobase/RawTowerGeomContainer_Cylinderv1.h>
+#include <calobase/RawTowerGeomv1.h>
+
 #include <TSystem.h>
 
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4PVPlacement.hh>
 #include <Geant4/G4PhysicalConstants.hh>
-#include <Geant4/G4String.hh>  // for G4String
+#include <Geant4/G4String.hh>       // for G4String
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4ThreeVector.hh>  // for G4ThreeVector
 #include <Geant4/G4Transform3D.hh>  // for G4Transform3D, G4RotateZ3D
 #include <Geant4/G4Tubs.hh>
-#include <Geant4/G4Types.hh>  // for G4double
+#include <Geant4/G4Types.hh>        // for G4double
 #include <Geant4/G4UserLimits.hh>
 
 #include <cassert>
@@ -47,7 +63,7 @@
 class PHG4CylinderGeom;
 
 //_______________________________________________________________
-//note this inactive thickness is ~1.5% of a radiation length
+// note this inactive thickness is ~1.5% of a radiation length
 PHG4SpacalDetector::PHG4SpacalDetector(PHG4Subsystem *subsys,
                                        PHCompositeNode *Node,
                                        const std::string &dnam,
@@ -56,6 +72,7 @@ PHG4SpacalDetector::PHG4SpacalDetector(PHG4Subsystem *subsys,
                                        bool init_geom)
   : PHG4Detector(subsys, Node, dnam)
   , m_DisplayAction(dynamic_cast<PHG4SpacalDisplayAction *>(subsys->GetDisplayAction()))
+  , m_Params(parameters)
   , layer(lyr)
 {
   if (init_geom)
@@ -118,7 +135,6 @@ int PHG4SpacalDetector::IsInCylinderActive(const G4VPhysicalVolume *volume)
 void PHG4SpacalDetector::ConstructMe(G4LogicalVolume *logicWorld)
 {
   assert(_geom);
-
   fiber_core_step_limits = new G4UserLimits(_geom->get_fiber_core_step_size() * cm);
 
   Verbosity(_geom->get_construction_verbose());
@@ -320,13 +336,7 @@ PHG4SpacalDetector::Construct_AzimuthalSeg()
               << "_geom->get_fiber_distance() = " << _geom->get_fiber_distance()
               << std::endl;
     std::cout << "\t"
-              << "fiber_length = " << fiber_length / cm << std::endl;
-    std::cout << "\t"
-              << "z_step = " << z_step << std::endl;
-    std::cout << "\t"
-              << "_geom->get_azimuthal_bin() = " << _geom->get_azimuthal_n_sec()
-              << std::endl;
-    std::cout << "\t"
+              << "fiber_length = " << fiber_length
               << "_geom->get_azimuthal_distance() = "
               << _geom->get_azimuthal_distance() << std::endl;
     std::cout << "\t"
@@ -383,5 +393,545 @@ void PHG4SpacalDetector::Print(const std::string & /*what*/) const
   std::cout << "PHG4SpacalDetector::Print::" << GetName() << " - Print Geometry:" << std::endl;
   _geom->Print();
 
+  return;
+}
+// This is dulplicated code, we can get rid of it when we have the code to make towergeom for real data reco.
+void PHG4SpacalDetector::AddTowerGeometryNode()
+{
+  PHNodeIterator iter(topNode());
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode)
+  {
+    std::cout << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error("Failed to find Run node in PHG4SpacalDetector::AddGeometryNode");
+  }
+
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", superdetector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(superdetector);
+    runNode->addNode(RunDetNode);
+  }
+
+  const RawTowerDefs::CalorimeterId caloid = RawTowerDefs::convert_name_to_caloid(superdetector);
+
+  // get the cell geometry and build up the tower geometry object
+  std::string geonodename = "CYLINDERCELLGEOM_" + superdetector;
+  PHG4CylinderCellGeomContainer *cellgeos = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode(), geonodename);
+  if (!cellgeos)
+  {
+    std::cout << PHWHERE << " " << geonodename
+              << " Node missing, doing nothing." << std::endl;
+    throw std::runtime_error(
+        "Failed to find " + geonodename + " node in PHG4SpacalDetector::AddGeometryNode");
+  }
+  m_TowerGeomNodeName = "TOWERGEOM_" + superdetector;
+  m_RawTowerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode(), m_TowerGeomNodeName);
+  if (!m_RawTowerGeomContainer)
+  {
+    m_RawTowerGeomContainer = new RawTowerGeomContainer_Cylinderv1(caloid);
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(m_RawTowerGeomContainer, m_TowerGeomNodeName, "PHObject");
+    RunDetNode->addNode(newNode);
+  }
+  // fill the number of layers in the calorimeter
+  m_NumLayers = cellgeos->get_NLayers();
+
+  // Create the tower nodes on the tree
+  PHG4CylinderCellGeomContainer::ConstIterator miter;
+  PHG4CylinderCellGeomContainer::ConstRange begin_end =
+      cellgeos->get_begin_end();
+  int ifirst = 1;
+  int first_layer = -1;
+  PHG4CylinderCellGeom *first_cellgeo = nullptr;
+  double inner_radius = 0;
+  double thickness = 0;
+  for (miter = begin_end.first; miter != begin_end.second; ++miter)
+  {
+    PHG4CylinderCellGeom *cellgeo = miter->second;
+
+    if (Verbosity())
+    {
+      cellgeo->identify();
+    }
+    thickness += cellgeo->get_thickness();
+    if (ifirst)
+    {
+      first_cellgeo = miter->second;
+      m_CellBinning = cellgeo->get_binning();
+      m_NumPhiBins = cellgeo->get_phibins();
+      m_PhiMin = cellgeo->get_phimin();
+      m_PhiStep = cellgeo->get_phistep();
+      if (m_CellBinning == PHG4CellDefs::etaphibinning || m_CellBinning == PHG4CellDefs::etaslatbinning)
+      {
+        m_NumEtaBins = cellgeo->get_etabins();
+        m_EtaMin = cellgeo->get_etamin();
+        m_EtaStep = cellgeo->get_etastep();
+      }
+      else if (m_CellBinning == PHG4CellDefs::sizebinning)
+      {
+        m_NumEtaBins = cellgeo->get_zbins();  // bin eta in the same number of z bins
+      }
+      else if (m_CellBinning == PHG4CellDefs::spacalbinning)
+      {
+        // use eta definiton for each row of towers
+        m_NumEtaBins = cellgeo->get_etabins();
+      }
+      else
+      {
+        std::cout << "PHG4SpacalDetector::AddGeometryNode::" << GetName()
+                  << " - Fatal Error - unsupported cell binning method "
+                  << m_CellBinning << std::endl;
+      }
+      inner_radius = cellgeo->get_radius();
+      first_layer = cellgeo->get_layer();
+      ifirst = 0;
+    }
+    else
+    {
+      if (m_CellBinning != cellgeo->get_binning())
+      {
+        std::cout << "inconsistent binning method from " << m_CellBinning
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_binning() << std::endl;
+        exit(1);
+      }
+      if (inner_radius > cellgeo->get_radius())
+      {
+        std::cout << "radius of layer " << cellgeo->get_layer() << " is "
+                  << cellgeo->get_radius() << " which smaller than radius "
+                  << inner_radius << " of first layer in list " << first_layer
+                  << std::endl;
+      }
+      if (m_NumPhiBins != cellgeo->get_phibins())
+      {
+        std::cout << "mixing number of phibins, fisrt layer: " << m_NumPhiBins
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_phibins() << std::endl;
+        exit(1);
+      }
+      if (m_PhiMin != cellgeo->get_phimin())
+      {
+        std::cout << "mixing number of phimin, fisrt layer: " << m_PhiMin
+                  << " layer " << cellgeo->get_layer() << ": "
+                  << cellgeo->get_phimin() << std::endl;
+        exit(1);
+      }
+      if (m_PhiStep != cellgeo->get_phistep())
+      {
+        std::cout << "mixing phisteps first layer: " << m_PhiStep << " layer "
+                  << cellgeo->get_layer() << ": " << cellgeo->get_phistep()
+                  << " diff: " << m_PhiStep - cellgeo->get_phistep() << std::endl;
+        exit(1);
+      }
+      if (m_CellBinning == PHG4CellDefs::etaphibinning || m_CellBinning == PHG4CellDefs::etaslatbinning)
+      {
+        if (m_NumEtaBins != cellgeo->get_etabins())
+        {
+          std::cout << "mixing number of EtaBins , first layer: "
+                    << m_NumEtaBins << " layer " << cellgeo->get_layer() << ": "
+                    << cellgeo->get_etabins() << std::endl;
+          exit(1);
+        }
+        if (fabs(m_EtaMin - cellgeo->get_etamin()) > 1e-9)
+        {
+          std::cout << "mixing etamin, fisrt layer: " << m_EtaMin << " layer "
+                    << cellgeo->get_layer() << ": " << cellgeo->get_etamin()
+                    << " diff: " << m_EtaMin - cellgeo->get_etamin() << std::endl;
+          exit(1);
+        }
+        if (fabs(m_EtaStep - cellgeo->get_etastep()) > 1e-9)
+        {
+          std::cout << "mixing eta steps first layer: " << m_EtaStep
+                    << " layer " << cellgeo->get_layer() << ": "
+                    << cellgeo->get_etastep() << " diff: "
+                    << m_EtaStep - cellgeo->get_etastep() << std::endl;
+          exit(1);
+        }
+      }
+
+      else if (m_CellBinning == PHG4CellDefs::sizebinning)
+      {
+        if (m_NumEtaBins != cellgeo->get_zbins())
+        {
+          std::cout << "mixing number of z bins , first layer: " << m_NumEtaBins
+                    << " layer " << cellgeo->get_layer() << ": "
+                    << cellgeo->get_zbins() << std::endl;
+          exit(1);
+        }
+      }
+    }
+  }
+  m_RawTowerGeomContainer->set_radius(inner_radius);
+  m_RawTowerGeomContainer->set_thickness(thickness);
+  m_RawTowerGeomContainer->set_phibins(m_NumPhiBins);
+  //  m_RawTowerGeomContainer->set_phistep(m_PhiStep);
+  //  m_RawTowerGeomContainer->set_phimin(m_PhiMin);
+  m_RawTowerGeomContainer->set_etabins(m_NumEtaBins);
+
+  if (!first_cellgeo)
+  {
+    std::cout << "PHG4SpacalDetector::AddGeometryNode - ERROR - can not find first layer of cells "
+              << std::endl;
+
+    exit(1);
+  }
+
+  for (int ibin = 0; ibin < first_cellgeo->get_phibins(); ibin++)
+  {
+    const std::pair<double, double> range = first_cellgeo->get_phibounds(ibin);
+
+    m_RawTowerGeomContainer->set_phibounds(ibin, range);
+  }
+
+  if (m_CellBinning == PHG4CellDefs::etaphibinning || m_CellBinning == PHG4CellDefs::etaslatbinning || m_CellBinning == PHG4CellDefs::spacalbinning)
+  {
+    const double r = inner_radius;
+
+    for (int ibin = 0; ibin < first_cellgeo->get_etabins(); ibin++)
+    {
+      const std::pair<double, double> range = first_cellgeo->get_etabounds(ibin);
+
+      m_RawTowerGeomContainer->set_etabounds(ibin, range);
+    }
+
+    // setup location of all towers
+    for (int iphi = 0; iphi < m_RawTowerGeomContainer->get_phibins(); iphi++)
+    {
+      for (int ieta = 0; ieta < m_RawTowerGeomContainer->get_etabins(); ieta++)
+      {
+        const RawTowerDefs::keytype key =
+            RawTowerDefs::encode_towerid(caloid, ieta, iphi);
+
+        const double x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double z(r / tan(PHG4Utils::get_theta(m_RawTowerGeomContainer->get_etacenter(ieta))));
+
+        RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
+        if (tg)
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Tower geometry " << key << " already exists" << std::endl;
+          }
+
+          if (fabs(tg->get_center_x() - x) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+                      << std::endl;
+
+            exit(1);
+          }
+          if (fabs(tg->get_center_y() - y) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+                      << std::endl;
+            exit(1);
+          }
+          if (fabs(tg->get_center_z() - z) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+                      << std::endl;
+            exit(1);
+          }
+        }
+        else
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - building tower geometry " << key << "" << std::endl;
+          }
+
+          tg = new RawTowerGeomv1(key);
+
+          tg->set_center_x(x);
+          tg->set_center_y(y);
+          tg->set_center_z(z);
+          m_RawTowerGeomContainer->add_tower_geometry(tg);
+        }
+      }
+    }
+  }
+  else if (m_CellBinning == PHG4CellDefs::sizebinning)
+  {
+    const double r = inner_radius;
+
+    for (int ibin = 0; ibin < first_cellgeo->get_zbins(); ibin++)
+    {
+      const std::pair<double, double> z_range = first_cellgeo->get_zbounds(ibin);
+      //          const double r = first_cellgeo->get_radius();
+      const double eta1 = -log(tan(atan2(r, z_range.first) / 2.));
+      const double eta2 = -log(tan(atan2(r, z_range.second) / 2.));
+      m_RawTowerGeomContainer->set_etabounds(ibin, std::make_pair(eta1, eta2));
+    }
+
+    // setup location of all towers
+    for (int iphi = 0; iphi < m_RawTowerGeomContainer->get_phibins(); iphi++)
+    {
+      for (int ibin = 0; ibin < first_cellgeo->get_zbins(); ibin++)
+      {
+        const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(caloid, ibin, iphi);
+
+        const double x(r * cos(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double y(r * sin(m_RawTowerGeomContainer->get_phicenter(iphi)));
+        const double z(first_cellgeo->get_zcenter(ibin));
+
+        RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
+        if (tg)
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Tower geometry " << key << " already exists" << std::endl;
+          }
+
+          if (fabs(tg->get_center_x() - x) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+                      << std::endl;
+
+            exit(1);
+          }
+          if (fabs(tg->get_center_y() - y) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+                      << std::endl;
+            exit(1);
+          }
+          if (fabs(tg->get_center_z() - z) > 1e-4)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+                      << std::endl;
+            exit(1);
+          }
+        }
+        else
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << "PHG4SpacalDetector::AddGeometryNode - building tower geometry " << key << "" << std::endl;
+          }
+
+          tg = new RawTowerGeomv1(key);
+
+          tg->set_center_x(x);
+          tg->set_center_y(y);
+          tg->set_center_z(z);
+          m_RawTowerGeomContainer->add_tower_geometry(tg);
+        }
+      }
+    }
+  }
+  else
+  {
+    std::cout << "PHG4SpacalDetector::AddGeometryNode - ERROR - unsupported cell geometry "
+              << m_CellBinning << std::endl;
+    exit(1);
+  }
+
+  if (Verbosity() >= 1)
+  {
+    m_RawTowerGeomContainer->identify();
+  }
+  
+  return;
+}
+
+void PHG4SpacalDetector::AddCellGeometryNode()
+{
+  PHNodeIterator iter(topNode());
+  std::string detector = superdetector;
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
+
+  std::string geonodename = "CYLINDERGEOM_" + detector;
+  PHG4CylinderGeomContainer *geo = findNode::getClass<PHG4CylinderGeomContainer>(topNode(), geonodename);
+  if (!geo)
+  {
+    std::cout << "PHG4SpacalDetector::AddCellGeometryNode - Could not locate geometry node "
+              << geonodename << std::endl;
+    topNode()->print();
+    exit(1);
+  }
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHG4SpacalDetector::AddCellGeometryNode- incoming geometry:"
+              << std::endl;
+    geo->identify();
+  }
+  std::string seggeonodename = "CYLINDERCELLGEOM_" + detector;
+  PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode(), seggeonodename);
+  if (!seggeo)
+  {
+    seggeo = new PHG4CylinderCellGeomContainer();
+    PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(seggeo, seggeonodename, "PHObject");
+    runNode->addNode(newNode);
+  }
+
+  const PHG4CylinderGeom *layergeom_raw = geo->GetFirstLayerGeom();
+  assert(layergeom_raw);
+
+  // a special implimentation of PHG4CylinderGeom is required here.
+  const PHG4CylinderGeom_Spacalv3 *layergeom =
+      dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
+
+  if (!layergeom)
+  {
+    std::cout << "PHG4SpacalDetector::AddCellGeometryNode- Fatal Error -"
+              << " require to work with a version of SPACAL geometry of PHG4CylinderGeom_Spacalv3 or higher. "
+              << "However the incoming geometry has version "
+              << layergeom_raw->ClassName() << std::endl;
+    exit(1);
+  }
+  if (Verbosity() > 1)
+  {
+    layergeom->identify();
+  }
+
+  layergeom->subtower_consistency_check();
+
+  //      int layer = layergeom->get_layer();
+
+  // create geo object and fill with variables common to all binning methods
+  PHG4CylinderCellGeom_Spacalv1 *layerseggeo = new PHG4CylinderCellGeom_Spacalv1();
+  layerseggeo->set_layer(layergeom->get_layer());
+  layerseggeo->set_radius(layergeom->get_radius());
+  layerseggeo->set_thickness(layergeom->get_thickness());
+  layerseggeo->set_binning(PHG4CellDefs::spacalbinning);
+
+  // construct a map to convert tower_ID into the older eta bins.
+
+  const PHG4CylinderGeom_Spacalv3::tower_map_t &tower_map = layergeom->get_sector_tower_map();
+  const PHG4CylinderGeom_Spacalv3::sector_map_t &sector_map = layergeom->get_sector_map();
+  const int nphibin = layergeom->get_azimuthal_n_sec()       // sector
+                      * layergeom->get_max_phi_bin_in_sec()  // blocks per sector
+                      * layergeom->get_n_subtower_phi();     // subtower per block
+  const double deltaphi = 2. * M_PI / nphibin;
+
+  using map_z_tower_z_ID_t = std::map<double, int>;
+  map_z_tower_z_ID_t map_z_tower_z_ID;
+  double phi_min = NAN;
+
+  for (const auto &tower_pair : tower_map)
+  {
+    const int &tower_ID = tower_pair.first;
+    const PHG4CylinderGeom_Spacalv3::geom_tower &tower = tower_pair.second;
+
+    // inspect index in sector 0
+    std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
+
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+
+    if (tower_ID_phi == 0)
+    {
+      // assign phi min according phi bin 0
+      phi_min = M_PI_2 - deltaphi * (layergeom->get_max_phi_bin_in_sec() * layergeom->get_n_subtower_phi() / 2)  // shift of first tower in sector
+                + sector_map.begin()->second;
+    }
+
+    if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
+    {
+      // assign eta min according phi bin 0
+      map_z_tower_z_ID[tower.centralZ] = tower_ID_z;
+    }
+    // ...
+  }  //       const auto &tower_pair: tower_map
+
+  assert(!std::isnan(phi_min));
+  layerseggeo->set_phimin(phi_min);
+  layerseggeo->set_phistep(deltaphi);
+  layerseggeo->set_phibins(nphibin);
+
+  PHG4CylinderCellGeom_Spacalv1::tower_z_ID_eta_bin_map_t tower_z_ID_eta_bin_map;
+  int eta_bin = 0;
+  for (auto &z_tower_z_ID : map_z_tower_z_ID)
+  {
+    tower_z_ID_eta_bin_map[z_tower_z_ID.second] = eta_bin;
+    eta_bin++;
+  }
+  layerseggeo->set_tower_z_ID_eta_bin_map(tower_z_ID_eta_bin_map);
+  layerseggeo->set_etabins(eta_bin * layergeom->get_n_subtower_eta());
+  layerseggeo->set_etamin(NAN);
+  layerseggeo->set_etastep(NAN);
+
+  // build eta bin maps
+  for (const auto &tower_pair : tower_map)
+  {
+    const int &tower_ID = tower_pair.first;
+    const PHG4CylinderGeom_Spacalv3::geom_tower &tower = tower_pair.second;
+
+    // inspect index in sector 0
+    std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(tower_ID, 0);
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+    const int &etabin = tower_z_ID_eta_bin_map[tower_ID_z];
+
+    if (tower_ID_phi == layergeom->get_max_phi_bin_in_sec() / 2)
+    {
+      // half z-range
+      const double dz = fabs(0.5 * (tower.pDy1 + tower.pDy2) / sin(tower.pRotationAngleX));
+      const double tower_radial = layergeom->get_tower_radial_position(tower);
+
+      auto z_to_eta = [&tower_radial](const double &z)
+      { return -log(tan(0.5 * atan2(tower_radial, z))); };
+
+      const double eta_central = z_to_eta(tower.centralZ);
+      // half eta-range
+      const double deta = (z_to_eta(tower.centralZ + dz) - z_to_eta(tower.centralZ - dz)) / 2;
+      assert(deta > 0);
+
+      for (int sub_tower_ID_y = 0; sub_tower_ID_y < tower.NSubtowerY;
+           ++sub_tower_ID_y)
+      {
+        assert(tower.NSubtowerY <= layergeom->get_n_subtower_eta());
+        // do not overlap to the next bin.
+        const int sub_tower_etabin = etabin * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
+
+        const std::pair<double, double> etabounds(eta_central - deta + sub_tower_ID_y * 2 * deta / tower.NSubtowerY,
+                                                  eta_central - deta + (sub_tower_ID_y + 1) * 2 * deta / tower.NSubtowerY);
+
+        const std::pair<double, double> zbounds(tower.centralZ - dz + sub_tower_ID_y * 2 * dz / tower.NSubtowerY,
+                                                tower.centralZ - dz + (sub_tower_ID_y + 1) * 2 * dz / tower.NSubtowerY);
+
+        layerseggeo->set_etabounds(sub_tower_etabin, etabounds);
+        layerseggeo->set_zbounds(sub_tower_etabin, zbounds);
+      }
+    }
+    // ...
+  }  //       const auto &tower_pair: tower_map
+
+  // add geo object filled by different binning methods
+  seggeo->AddLayerCellGeom(layerseggeo);
+  // save this to the run wise tree to store on DST
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  //PHCompositeNode *parNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "PAR"));
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", detector));
+  if (!RunDetNode)
+  {
+    RunDetNode = new PHCompositeNode(detector);
+    runNode->addNode(RunDetNode);
+  }
+  /*
+  std::string paramnodename = "G4CELLPARAM_" + detector;
+  SaveToNodeTree(RunDetNode, paramnodename);
+  save this to the parNode for use
+  PHNodeIterator parIter(parNode);
+   PHCompositeNode *ParDetNode = dynamic_cast<PHCompositeNode *>(parIter.findFirst("PHCompositeNode", detector));
+   if (!ParDetNode)
+   {
+     ParDetNode = new PHCompositeNode(detector);
+     parNode->addNode(ParDetNode);
+   }
+   std::string cellgeonodename = "G4CELLGEO_" + detector;
+   PutOnParNode(ParDetNode, cellgeonodename);
+    */
   return;
 }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.cc
@@ -22,8 +22,6 @@
 #include <g4main/PHG4Subsystem.h>
 #include <g4main/PHG4Utils.h>
 
-#include <phparameter/PHParameters.h>
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHNode.h>          // for PHNode

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -121,7 +121,6 @@ class PHG4SpacalDetector : public PHG4Detector
 
  private:
   PHG4SpacalDisplayAction* m_DisplayAction = nullptr;
-  PHParameters* m_Params = nullptr;
 
  protected:
   void AddTowerGeometryNode();

--- a/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalDetector.h
@@ -12,6 +12,7 @@
 #ifndef G4DETECTORS_PHG4SPACALDETECTOR_H
 #define G4DETECTORS_PHG4SPACALDETECTOR_H
 
+#include "PHG4CellDefs.h"
 #include "PHG4CylinderGeom_Spacalv1.h"
 
 #include <g4main/PHG4Detector.h>
@@ -32,6 +33,7 @@ class PHG4GDMLConfig;
 class PHG4SpacalDisplayAction;
 class PHParameters;
 class PHG4Subsystem;
+class RawTowerGeomContainer;
 
 class PHG4SpacalDetector : public PHG4Detector
 {
@@ -119,8 +121,11 @@ class PHG4SpacalDetector : public PHG4Detector
 
  private:
   PHG4SpacalDisplayAction* m_DisplayAction = nullptr;
+  PHParameters* m_Params = nullptr;
 
  protected:
+  void AddTowerGeometryNode();
+  void AddCellGeometryNode();
   std::map<const G4VPhysicalVolume*, int> fiber_core_vol;
 
   //! map for G4VPhysicalVolume -> fiber ID
@@ -136,6 +141,15 @@ class PHG4SpacalDetector : public PHG4Detector
   int absorberactive = 0;
   int layer = -9999;
   int m_CosmicSetupFlag = 0;
+  int m_CellBinning = PHG4CellDefs::undefined;
+  int m_NumLayers = -1;
+  int m_NumPhiBins = -1;
+  int m_NumEtaBins = -1;
+  double m_Emin = 1e-6;
+  double m_EtaMin = NAN;
+  double m_PhiMin = NAN;
+  double m_EtaStep = NAN;
+  double m_PhiStep = NAN;
   std::string detector_type;
   std::string superdetector;
 
@@ -145,9 +159,12 @@ class PHG4SpacalDetector : public PHG4Detector
 
   //! registry for volumes that should not be exported, i.e. fibers
   PHG4GDMLConfig* gdml_config = nullptr;
-  //private:
+  // private:
 
   SpacalGeom_t* _geom = nullptr;
+
+  RawTowerGeomContainer* m_RawTowerGeomContainer = nullptr;
+  std::string m_TowerGeomNodeName;
 };
 
 #endif

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -13,8 +13,6 @@
 
 #include "LightCollectionModel.h"
 
-#include <phparameter/PHParameterInterface.h>
-
 #include <g4main/PHG4SteppingAction.h>
 
 class G4Step;
@@ -31,7 +29,7 @@ class PHG4Shower;
 class PHParameters;
 class TowerInfoContainer;
 
-class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterInterface
+class PHG4SpacalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! ctor
@@ -53,8 +51,6 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterIn
   double get_zmax() const;
 
   void SetHitNodeName(const std::string &type, const std::string &name) override;
-
-  void SetDefaultParameters() override;
 
   int SetUpGeomNode(PHCompositeNode *topNode);
 

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -11,16 +11,27 @@
 #ifndef G4DETECTORS_PHG4SPACALSTEPPINGACTION_H
 #define G4DETECTORS_PHG4SPACALSTEPPINGACTION_H
 
+#include "LightCollectionModel.h"
+
+#include <phparameter/PHParameterInterface.h>
+
 #include <g4main/PHG4SteppingAction.h>
 
 class G4Step;
+class LightCollectionModel;
 class PHCompositeNode;
+class PHG4CylinderCellGeomContainer;
+class PHG4CylinderCellGeom_Spacalv1;
+class PHG4CylinderGeomContainer;
+class PHG4CylinderGeom_Spacalv3;
 class PHG4SpacalDetector;
 class PHG4Hit;
 class PHG4HitContainer;
 class PHG4Shower;
+class PHParameters;
+class TowerInfoContainer;
 
-class PHG4SpacalSteppingAction : public PHG4SteppingAction
+class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterInterface
 {
  public:
   //! ctor
@@ -32,6 +43,8 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction
   //! stepping action
   bool UserSteppingAction(const G4Step *, bool) override;
 
+  int InitWithNode(PHCompositeNode *topNode) override;
+
   //! reimplemented from base class
   void SetInterfacePointers(PHCompositeNode *) override;
 
@@ -41,7 +54,12 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction
 
   void SetHitNodeName(const std::string &type, const std::string &name) override;
 
+  void SetDefaultParameters() override;
+
+  LightCollectionModel &get_light_collection_model() { return light_collection_model; }
+
  private:
+  bool NoHitSteppingAction(const G4Step *aStep);
   //! pointer to the detector
   PHG4SpacalDetector *m_Detector = nullptr;
 
@@ -51,11 +69,31 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction
   PHG4Hit *m_Hit = nullptr;
   PHG4HitContainer *m_CurrentHitContainer = nullptr;
   PHG4Shower *m_CurrentShower = nullptr;
+  const PHParameters *m_Params = nullptr;
   int m_SaveTrackid = -1;
   int m_SavePostStepStatus = -1;
+  bool m_doG4Hit = true;
+  double m_tmin = -20.;
+  double m_tmax = 60.;
+  double m_dt = 100.;
 
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
+  std::string detector;
+  std::string geonodename;
+  std::string seggeonodename;
+
+  TowerInfoContainer *m_CaloInfoContainer = nullptr;
+
+  PHG4CylinderCellGeomContainer *_seggeo = nullptr;
+
+  PHG4CylinderGeomContainer *_layergeo = nullptr;
+
+  PHG4CylinderCellGeom_Spacalv1 *_geo = nullptr;
+
+  const PHG4CylinderGeom_Spacalv3 *_layergeom = nullptr;
+
+  LightCollectionModel light_collection_model;
 };
 
 #endif  // PHG4VHcalSteppingAction_h

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSteppingAction.h
@@ -35,7 +35,7 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterIn
 {
  public:
   //! ctor
-  explicit PHG4SpacalSteppingAction(PHG4SpacalDetector *);
+  explicit PHG4SpacalSteppingAction(PHG4SpacalDetector *, const PHParameters *parameters);
 
   //! dtor
   ~PHG4SpacalSteppingAction() override;
@@ -56,6 +56,8 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterIn
 
   void SetDefaultParameters() override;
 
+  int SetUpGeomNode(PHCompositeNode *topNode);
+
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
  private:
@@ -73,6 +75,7 @@ class PHG4SpacalSteppingAction : public PHG4SteppingAction, public PHParameterIn
   int m_SaveTrackid = -1;
   int m_SavePostStepStatus = -1;
   bool m_doG4Hit = true;
+  bool m_geomsetup = false;
   double m_tmin = -20.;
   double m_tmax = 60.;
   double m_dt = 100.;

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <iostream>  // for operator<<, basic_ostream
 #include <sstream>
+#include <cassert>
 
 class PHG4Detector;
 
@@ -140,9 +141,11 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
 
     steppingAction_ = new PHG4SpacalSteppingAction(detector_, GetParams());
     steppingAction_->InitWithNode(topNode);
+    const char* calibrationRoot = getenv("CALIBRATIONROOT");
+    assert(calibrationRoot != nullptr && "Environment variable CALIBRATIONROOT is not set");
+    std::string filePath = std::string(calibrationRoot) + "/CEMC/LightCollection/Prototype3Module.xml";
     steppingAction_->get_light_collection_model().load_data_file(
-        std::string(getenv("CALIBRATIONROOT")) + std::string("/CEMC/LightCollection/Prototype3Module.xml"),
-        "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
+    filePath, "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
     steppingAction_->SetHitNodeName("G4HIT", m_HitNodeName);
     steppingAction_->SetHitNodeName("G4HIT_ABSORBER", m_AbsorberNodeName);
   }

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -16,7 +16,7 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4DisplayAction.h>  // for PHG4DisplayAction
+#include <g4main/PHG4DisplayAction.h>   // for PHG4DisplayAction
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 
@@ -29,6 +29,7 @@
 
 #include <TSystem.h>
 
+#include <cstdlib>
 #include <iostream>  // for operator<<, basic_ostream
 #include <sstream>
 
@@ -138,8 +139,13 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
     }
 
     steppingAction_ = new PHG4SpacalSteppingAction(detector_);
+    steppingAction_->set_int_param("saveg4hit", GetParams()->get_int_param("saveg4hit"));
+    steppingAction_->get_light_collection_model().load_data_file(
+        std::string(getenv("CALIBRATIONROOT")) + std::string("/CEMC/LightCollection/Prototype3Module.xml"),
+        "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
     steppingAction_->SetHitNodeName("G4HIT", m_HitNodeName);
     steppingAction_->SetHitNodeName("G4HIT_ABSORBER", m_AbsorberNodeName);
+    steppingAction_->InitWithNode(topNode);
   }
   return 0;
 }
@@ -185,6 +191,7 @@ void PHG4SpacalSubsystem::SetDefaultParameters()
   set_default_int_param("azimuthal_seg_visible", 0.);
   set_default_int_param("virualize_fiber", 0.);
   set_default_int_param("config", static_cast<int>(PHG4CylinderGeom_Spacalv1::kNonProjective));
+  set_default_int_param("saveg4hit", 1);
 
   set_default_double_param("divider_width", 0);       // radial size of the divider between blocks. <=0 means no dividers
   set_default_string_param("divider_mat", "G4_AIR");  // materials of the divider. G4_AIR is equivalent to not installing one in the term of material distribution

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.cc
@@ -138,14 +138,13 @@ int PHG4SpacalSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
       g4_hits->AddLayer(GetLayer());
     }
 
-    steppingAction_ = new PHG4SpacalSteppingAction(detector_);
-    steppingAction_->set_int_param("saveg4hit", GetParams()->get_int_param("saveg4hit"));
+    steppingAction_ = new PHG4SpacalSteppingAction(detector_, GetParams());
+    steppingAction_->InitWithNode(topNode);
     steppingAction_->get_light_collection_model().load_data_file(
         std::string(getenv("CALIBRATIONROOT")) + std::string("/CEMC/LightCollection/Prototype3Module.xml"),
         "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
     steppingAction_->SetHitNodeName("G4HIT", m_HitNodeName);
     steppingAction_->SetHitNodeName("G4HIT_ABSORBER", m_AbsorberNodeName);
-    steppingAction_->InitWithNode(topNode);
   }
   return 0;
 }
@@ -157,6 +156,7 @@ int PHG4SpacalSubsystem::process_event(PHCompositeNode* topNode)
   // relevant nodes needed internally
   if (steppingAction_)
   {
+    
     steppingAction_->SetInterfacePointers(topNode);
   }
   return 0;
@@ -185,6 +185,9 @@ void PHG4SpacalSubsystem::SetDefaultParameters()
   set_default_double_param("radius", 90.);
   set_default_double_param("zmin", -149.470000);
   set_default_double_param("zmax", 149.470000);
+  set_default_double_param("tmin", -20.);
+  set_default_double_param("tmax", 60.);
+  set_default_double_param("dt", 100.);
   set_default_int_param("azimuthal_n_sec", 256);
 
   set_default_int_param("construction_verbose", 0.);

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
@@ -12,6 +12,7 @@
 #define G4DETECTORS_PHG4SPACALSUBSYSTEM_H
 
 #include "PHG4DetectorSubsystem.h"
+#include "PHG4SpacalSteppingAction.h"
 
 #include <string>  // for string
 
@@ -19,7 +20,6 @@ class PHCompositeNode;
 class PHG4Detector;
 class PHG4DisplayAction;
 class PHG4SpacalDetector;
-class PHG4SteppingAction;
 
 class PHG4SpacalSubsystem : public PHG4DetectorSubsystem
 {
@@ -69,7 +69,7 @@ class PHG4SpacalSubsystem : public PHG4DetectorSubsystem
 
   //! particle tracking "stepping" action
   /*! derives from PHG4SteppingActions */
-  PHG4SteppingAction *steppingAction_ = nullptr;
+  PHG4SpacalSteppingAction *steppingAction_ = nullptr;
 
   //! display attribute setting
   /*! derives from PHG4DisplayAction */

--- a/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4SpacalSubsystem.h
@@ -20,6 +20,7 @@ class PHCompositeNode;
 class PHG4Detector;
 class PHG4DisplayAction;
 class PHG4SpacalDetector;
+class PHG4SpacalSteppingAction;
 
 class PHG4SpacalSubsystem : public PHG4DetectorSubsystem
 {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
a continuation from [PR1998](https://github.com/sPHENIX-Collaboration/coresoftware/pull/1998), this PR introduce a new stepping  action for EMCAL that skips creating G4Hits and directly add energy to TowerInfo.

![f6e52fea945e9a728e79e9ded4999d1](https://github.com/sPHENIX-Collaboration/coresoftware/assets/71942661/19ca0020-b681-4ca4-afa2-805d0732793f)
The tower energy from the same HIJING event using two different stepping action agrees within 3%, the difference is coming from applying the fiber transmission efficiency is applied on the G4Step level instead of G4Hit level. While only using the light guide efficiency correction(as shown in the plot below), the tower energy mostly agrees.

![b06c412d9a6ec099eb9c63e96d7995b](https://github.com/sPHENIX-Collaboration/coresoftware/assets/71942661/96b3ea40-7384-4ba5-962f-e6e143829583)

Running the default full sim(with the absorberactive = false) the new stepping action for the calorimeter system reduce the overall resident memory by 1GB.

The related macro PR: https://github.com/sPHENIX-Collaboration/macros/pull/635
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)



## Links to other PRs in macros and calibration repositories (if applicable)

