### PR TITLE
add input manager for run nodes (no eventwise dst)

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -8,13 +8,13 @@
 
 /** Base class for all Fun4All Classes
  *
- *  It implements the Name, the Verbosity and the print method  
+ *  It implements the Name, the Verbosity and the print method
  */
 
 class Fun4AllBase
 {
  public:
-  /** dtor. 
+  /** dtor.
       Does nothing as this is a base class only.
   */
   virtual ~Fun4AllBase();
@@ -25,7 +25,7 @@ class Fun4AllBase
   /// Sets the name of this module.
   virtual void Name(const std::string &name) { m_ThisName = name; }
 
-  /** Print out some info about this module. 
+  /** Print out some info about this module.
       @param what can be used to specify what to print exactly.
   */
   virtual void Print(const std::string &what = "ALL") const;
@@ -66,7 +66,7 @@ class Fun4AllBase
 
  protected:
   /** ctor.
-  */
+   */
   Fun4AllBase(const std::string &name = "NONAME");
 
  private:

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -41,8 +41,8 @@ Fun4AllDstInputManager::Fun4AllDstInputManager(const std::string &name, const st
 
 Fun4AllDstInputManager::~Fun4AllDstInputManager()
 {
-  delete IManager;
-  delete runNodeSum;
+  delete m_IManager;
+  delete m_RunNodeSum;
   return;
 }
 
@@ -65,78 +65,78 @@ int Fun4AllDstInputManager::fileopen(const std::string &filenam)
   }
   // sanity check - the IManager must be nullptr when this method is executed
   // if not something is very very wrong and we must not continue
-  if (IManager)
+  if (m_IManager)
   {
-    std::cout << PHWHERE << " IManager pointer is not nullptr but " << IManager
+    std::cout << PHWHERE << " IManager pointer is not nullptr but " << m_IManager
               << std::endl;
     std::cout << "Send mail to off-l with this printout and the macro you used"
               << std::endl;
     std::cout << "Trying to execute IManager->print() to display more info"
               << std::endl;
     std::cout << "Code will probably segfault now" << std::endl;
-    IManager->print();
+    m_IManager->print();
     std::cout << "Have someone look into this problem - Exiting now" << std::endl;
     exit(1);
   }
   // first read the runnode if not disabled
   if (m_ReadRunTTree)
   {
-    IManager = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
-    if (IManager->isFunctional())
+    m_IManager = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
+    if (m_IManager->isFunctional())
     {
-      runNode = se->getNode(RunNode, TopNodeName());
-      IManager->read(runNode);
+      m_RunNode = se->getNode(RunNode, TopNodeName());
+      m_IManager->read(m_RunNode);
       // get the current run number
-      RunHeader *runheader = findNode::getClass<RunHeader>(runNode, "RunHeader");
+      RunHeader *runheader = findNode::getClass<RunHeader>(m_RunNode, "RunHeader");
       if (runheader)
       {
         SetRunNumber(runheader->get_RunNumber());
       }
       // delete our internal copy of the runnode when opening subsequent files
-      if (runNodeCopy)
+      if (m_RunNodeCopy)
       {
         std::cout << PHWHERE
                   << " The impossible happened, we have a valid copy of the run node "
-                  << runNodeCopy->getName() << " which should be a nullptr"
+                  << m_RunNodeCopy->getName() << " which should be a nullptr"
                   << std::endl;
         gSystem->Exit(1);
       }
-      runNodeCopy = new PHCompositeNode("RUNNODECOPY");
-      if (!runNodeSum)
+      m_RunNodeCopy = new PHCompositeNode("RUNNODECOPY");
+      if (!m_RunNodeSum)
       {
-        runNodeSum = new PHCompositeNode("RUNNODESUM");
+        m_RunNodeSum = new PHCompositeNode("RUNNODESUM");
       }
       PHNodeIOManager *tmpIman = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
-      tmpIman->read(runNodeCopy);
+      tmpIman->read(m_RunNodeCopy);
       delete tmpIman;
 
       PHNodeIntegrate integrate;
-      integrate.RunNode(runNode);
-      integrate.RunSumNode(runNodeSum);
+      integrate.RunNode(m_RunNode);
+      integrate.RunSumNode(m_RunNodeSum);
       // run recursively over internal run node copy and integrate objects
-      PHNodeIterator mainIter(runNodeCopy);
+      PHNodeIterator mainIter(m_RunNodeCopy);
       mainIter.forEach(integrate);
       // we do not need to keep the internal copy, keeping it would crate
       // problems in case a subsequent file does not contain all the
       // runwise objects from the previous file. Keeping this copy would then
       // integrate the missing object again with the old copy
-      delete runNodeCopy;
-      runNodeCopy = nullptr;
+      delete m_RunNodeCopy;
+      m_RunNodeCopy = nullptr;
     }
     // DLW: move the delete outside the if block to cover the case where isFunctional() fails
-    delete IManager;
+    delete m_IManager;
   }
   // now open the dst node
   dstNode = se->getNode(InputNode(), TopNodeName());
-  IManager = new PHNodeIOManager(fullfilename, PHReadOnly);
-  if (IManager->isFunctional())
+  m_IManager = new PHNodeIOManager(fullfilename, PHReadOnly);
+  if (m_IManager->isFunctional())
   {
     IsOpen(1);
     events_thisfile = 0;
     setBranches();                // set branch selections
     AddToFileOpened(FileName());  // add file to the list of files which were opened
                                   // check if our input file has a sync object or not
-    if (IManager->NodeExist(syncdefs::SYNCNODENAME))
+    if (m_IManager->NodeExist(syncdefs::SYNCNODENAME))
     {
       m_HaveSyncObject = 1;
     }
@@ -151,8 +151,8 @@ int Fun4AllDstInputManager::fileopen(const std::string &filenam)
   {
     std::cout << PHWHERE << ": " << Name() << " Could not open file "
               << FileName() << std::endl;
-    delete IManager;
-    IManager = nullptr;
+    delete m_IManager;
+    m_IManager = nullptr;
     return -1;
   }
 }
@@ -185,7 +185,7 @@ int Fun4AllDstInputManager::run(const int nevents)
 readagain:
   PHCompositeNode *dummy;
   int ncount = 0;
-  dummy = IManager->read(dstNode);
+  dummy = m_IManager->read(dstNode);
   while (dummy)
   {
     ncount++;
@@ -193,7 +193,7 @@ readagain:
     {
       break;
     }
-    dummy = IManager->read(dstNode);
+    dummy = m_IManager->read(dstNode);
   }
   if (!dummy)
   {
@@ -222,8 +222,8 @@ int Fun4AllDstInputManager::fileclose()
     std::cout << Name() << ": fileclose: No Input file open" << std::endl;
     return -1;
   }
-  delete IManager;
-  IManager = nullptr;
+  delete m_IManager;
+  m_IManager = nullptr;
   IsOpen(0);
   UpdateFileList();
   m_HaveSyncObject = 0;
@@ -372,7 +372,7 @@ int Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
       // Here the event counter and segment number and run number do agree - we found the right match
       // now read the full event (previously we only read the sync object)
       PHCompositeNode *dummy;
-      dummy = IManager->read(dstNode);
+      dummy = m_IManager->read(dstNode);
       if (!dummy)
       {
         std::cout << PHWHERE << " " << Name() << " Could not read full Event" << std::endl;
@@ -413,7 +413,7 @@ int Fun4AllDstInputManager::ReadNextEventSyncObject()
 {
 readnextsync:
   static int readfull = 0;  // for some reason all the input managers need to see the same (I think, should look at this at some point)
-  if (!IManager)            // in case the old file was exhausted and there is no new file opened
+  if (!m_IManager)            // in case the old file was exhausted and there is no new file opened
   {
     return Fun4AllReturnCodes::SYNC_FAIL;
   }
@@ -421,7 +421,7 @@ readnextsync:
   {
     readfull = 1;  // we need to read a full event to set the root branches to phool nodes right when a new file has been opened
     std::map<std::string, TBranch *>::const_iterator bIter;
-    for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
+    for (bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
     {
       if (Verbosity() > 2)
       {
@@ -448,7 +448,7 @@ readnextsync:
       std::cout << PHWHERE << "Could not locate Sync Branch" << std::endl;
       std::cout << "Please check for it in the following list of branch names and" << std::endl;
       std::cout << "PLEASE NOTIFY PHENIX-OFF-L and post the macro you used" << std::endl;
-      for (bIter = IManager->GetBranchMap()->begin(); bIter != IManager->GetBranchMap()->end(); ++bIter)
+      for (bIter = m_IManager->GetBranchMap()->begin(); bIter != m_IManager->GetBranchMap()->end(); ++bIter)
       {
         std::cout << bIter->first << std::endl;
       }
@@ -461,10 +461,10 @@ readnextsync:
   {
     // if all files are exhausted, the IManager is deleted and set to nullptr
     // so check if IManager is valid before getting a new event
-    if (IManager)
+    if (m_IManager)
     {
-      EventOnDst = IManager->getEventNumber();  // this returns the next number of the event
-      itest = IManager->readSpecific(EventOnDst, syncbranchname.c_str());
+      EventOnDst = m_IManager->getEventNumber();  // this returns the next number of the event
+      itest = m_IManager->readSpecific(EventOnDst, syncbranchname.c_str());
     }
     else
     {
@@ -477,7 +477,7 @@ readnextsync:
   }
   else
   {
-    if (IManager->read(dstNode))
+    if (m_IManager->read(dstNode))
     {
       itest = 1;
     }
@@ -503,7 +503,7 @@ readnextsync:
   if (!readfull)
   {
     EventOnDst++;
-    IManager->setEventNumber(EventOnDst);  // update event number in phool io manager
+    m_IManager->setEventNumber(EventOnDst);  // update event number in phool io manager
   }
   else
   {
@@ -556,14 +556,14 @@ int Fun4AllDstInputManager::BranchSelect(const std::string &branch, const int if
 
 int Fun4AllDstInputManager::setBranches()
 {
-  if (IManager)
+  if (m_IManager)
   {
     if (!branchread.empty())
     {
       std::map<const std::string, int>::const_iterator branchiter;
       for (branchiter = branchread.begin(); branchiter != branchread.end(); ++branchiter)
       {
-        IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
+        m_IManager->selectObjectToRead(branchiter->first.c_str(), branchiter->second);
         if (Verbosity() > 0)
         {
           std::cout << branchiter->first << " set to " << branchiter->second << std::endl;
@@ -571,7 +571,7 @@ int Fun4AllDstInputManager::setBranches()
       }
       // protection against switching off the sync variables
       // only implemented in the Sync Manager
-      setSyncBranches(IManager);
+      setSyncBranches(m_IManager);
     }
   }
   else
@@ -617,13 +617,13 @@ void Fun4AllDstInputManager::Print(const std::string &what) const
       std::cout << std::endl;
     }
   }
-  if ((what == "ALL" || what == "PHOOL") && IManager)
+  if ((what == "ALL" || what == "PHOOL") && m_IManager)
   {
     // loop over the map and print out the content (name and location in memory)
     std::cout << "--------------------------------------" << std::endl
               << std::endl;
     std::cout << "PHNodeIOManager print in Fun4AllDstInputManager " << Name() << ":" << std::endl;
-    IManager->print();
+    m_IManager->print();
   }
   Fun4AllInputManager::Print(what);
   return;
@@ -631,11 +631,11 @@ void Fun4AllDstInputManager::Print(const std::string &what) const
 
 int Fun4AllDstInputManager::PushBackEvents(const int i)
 {
-  if (IManager)
+  if (m_IManager)
   {
-    unsigned EventOnDst = IManager->getEventNumber();
+    unsigned EventOnDst = m_IManager->getEventNumber();
     EventOnDst -= static_cast<unsigned>(i);
-    IManager->setEventNumber(EventOnDst);
+    m_IManager->setEventNumber(EventOnDst);
     return 0;
   }
   std::cout << PHWHERE << Name() << ": could not push back events, Imanager is NULL"

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -413,7 +413,7 @@ int Fun4AllDstInputManager::ReadNextEventSyncObject()
 {
 readnextsync:
   static int readfull = 0;  // for some reason all the input managers need to see the same (I think, should look at this at some point)
-  if (!m_IManager)            // in case the old file was exhausted and there is no new file opened
+  if (!m_IManager)          // in case the old file was exhausted and there is no new file opened
   {
     return Fun4AllReturnCodes::SYNC_FAIL;
   }
@@ -430,7 +430,7 @@ readnextsync:
       std::string delimeters = phooldefs::branchpathdelim;  // + phooldefs::legacypathdelims;
       std::vector<std::string> splitvec;
       boost::split(splitvec, bIter->first, boost::is_any_of(delimeters));
-      for (auto & ia : splitvec)  // -1 so we skip the node name
+      for (auto &ia : splitvec)  // -1 so we skip the node name
       {
         if (ia == syncdefs::SYNCNODENAME)
         {
@@ -586,7 +586,7 @@ int Fun4AllDstInputManager::setBranches()
 int Fun4AllDstInputManager::setSyncBranches(PHNodeIOManager *IMan)
 {
   // protection against switching off the sync variables
-  for (auto & i : syncdefs::SYNCVARS)
+  for (auto &i : syncdefs::SYNCVARS)
   {
     IMan->selectObjectToRead(i, true);
   }

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -32,15 +32,15 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
  protected:
   int ReadNextEventSyncObject();
   void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
-  void IManager(PHNodeIOManager *iman) {m_IManager = iman;}
-  PHNodeIOManager *IManager() {return m_IManager;}
-  void runNode(PHCompositeNode *node) {m_RunNode = node;}
-  PHCompositeNode *runNode() {return m_RunNode;}
-  void runNodeCopy(PHCompositeNode *node) {m_RunNodeCopy = node;}
-  PHCompositeNode *runNodeCopy() {return m_RunNodeCopy;}
-  void runNodeSum(PHCompositeNode *node) {m_RunNodeSum = node;}
-  PHCompositeNode *runNodeSum() {return m_RunNodeSum;}
-  std::string RunNodeName() const {return RunNode;}
+  void IManager(PHNodeIOManager *iman) { m_IManager = iman; }
+  PHNodeIOManager *IManager() { return m_IManager; }
+  void runNode(PHCompositeNode *node) { m_RunNode = node; }
+  PHCompositeNode *runNode() { return m_RunNode; }
+  void runNodeCopy(PHCompositeNode *node) { m_RunNodeCopy = node; }
+  PHCompositeNode *runNodeCopy() { return m_RunNodeCopy; }
+  void runNodeSum(PHCompositeNode *node) { m_RunNodeSum = node; }
+  PHCompositeNode *runNodeSum() { return m_RunNodeSum; }
+  std::string RunNodeName() const { return RunNode; }
   std::string fullfilename;
 
  private:

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -24,7 +24,7 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   int SyncIt(const SyncObject *mastersync) override;
   int BranchSelect(const std::string &branch, const int iflag) override;
   int setBranches() override;
-  virtual int setSyncBranches(PHNodeIOManager *IManager);
+  virtual int setSyncBranches(PHNodeIOManager *iman);
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
   int HasSyncObject() const override;
@@ -32,6 +32,16 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
  protected:
   int ReadNextEventSyncObject();
   void ReadRunTTree(const int i) { m_ReadRunTTree = i; }
+  void IManager(PHNodeIOManager *iman) {m_IManager = iman;}
+  PHNodeIOManager *IManager() {return m_IManager;}
+  void runNode(PHCompositeNode *node) {m_RunNode = node;}
+  PHCompositeNode *runNode() {return m_RunNode;}
+  void runNodeCopy(PHCompositeNode *node) {m_RunNodeCopy = node;}
+  PHCompositeNode *runNodeCopy() {return m_RunNodeCopy;}
+  void runNodeSum(PHCompositeNode *node) {m_RunNodeSum = node;}
+  PHCompositeNode *runNodeSum() {return m_RunNodeSum;}
+  std::string RunNodeName() const {return RunNode;}
+  std::string fullfilename;
 
  private:
   int m_ReadRunTTree = 1;
@@ -39,16 +49,15 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   int events_thisfile = 0;
   int events_skipped_during_sync = 0;
   int m_HaveSyncObject = 0;
-  std::string fullfilename;
-  std::string RunNode = "RUN";
   std::map<const std::string, int> branchread;
   std::string syncbranchname;
   PHCompositeNode *dstNode = nullptr;
-  PHCompositeNode *runNode = nullptr;
-  PHCompositeNode *runNodeCopy = nullptr;
-  PHCompositeNode *runNodeSum = nullptr;
-  PHNodeIOManager *IManager = nullptr;
+  PHCompositeNode *m_RunNode = nullptr;
+  PHCompositeNode *m_RunNodeCopy = nullptr;
+  PHCompositeNode *m_RunNodeSum = nullptr;
+  PHNodeIOManager *m_IManager = nullptr;
   SyncObject *syncobject = nullptr;
+  std::string RunNode = "RUN";
 };
 
 #endif /* __FUN4ALLDSTINPUTMANAGER_H__ */

--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -175,11 +175,15 @@ bool Fun4AllHistoManager::registerHisto(const std::string &hname, TNamed *h1d, c
 
   // reset directory for TTree
   if (h1d->InheritsFrom("TTree"))
+  {
     static_cast<TTree *>(h1d)->SetDirectory(nullptr);
+  }
 
   // For histograms, enforce error calculation and propagation
   if (h1d->InheritsFrom("TH1"))
+  {
     static_cast<TH1 *>(h1d)->Sumw2();
+  }
 
   return true;
 }
@@ -285,11 +289,13 @@ void Fun4AllHistoManager::Reset()
   {
     TNamed *h = hiter->second;
     if (h->InheritsFrom("TH1"))
+    {
       (dynamic_cast<TH1 *>(h))->Reset();
-#if HAS_THNSPARSE
+    }
     else if (h->InheritsFrom("THnSparse"))
+    {
       (dynamic_cast<THnSparse *>(h))->Reset();
-#endif
+    }
   }
   return;
 }

--- a/offline/framework/fun4all/Fun4AllMemoryTracker.cc
+++ b/offline/framework/fun4all/Fun4AllMemoryTracker.cc
@@ -111,7 +111,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const std::string &name) const
     {
       std::cout << iter->first << ": ";
       std::vector<int> memvec = iter->second;
-      for (int & vit : memvec)
+      for (int &vit : memvec)
       {
         std::cout << vit << " ";
       }
@@ -125,7 +125,7 @@ void Fun4AllMemoryTracker::PrintMemoryTracker(const std::string &name) const
     {
       std::cout << "SubsysReco/OutputManager: " << iter->first << std::endl;
       std::vector<int> memvec = iter->second;
-      for (int & vit : memvec)
+      for (int &vit : memvec)
       {
         std::cout << vit << " ";
       }

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -100,7 +100,7 @@ class Fun4AllOutputManager : public Fun4AllBase
   void OutFileName(const std::string &name) { m_OutFileName = name; }
 
  protected:
-  /*! 
+  /*!
     constructor.
     is protected since we do not want the  class to be created in root macros
   */

--- a/offline/framework/fun4all/Fun4AllRunNodeInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllRunNodeInputManager.cc
@@ -1,0 +1,131 @@
+#include "Fun4AllRunNodeInputManager.h"
+
+#include "Fun4AllReturnCodes.h"
+#include "Fun4AllServer.h"
+
+#include <ffaobjects/RunHeader.h>
+
+#include <frog/FROG.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIntegrate.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE, PHReadOnly, PHRunTree
+#include <phool/phooldefs.h>
+
+#include <TSystem.h>
+
+#include <cstdlib>
+#include <iostream>
+
+Fun4AllRunNodeInputManager::Fun4AllRunNodeInputManager(const std::string &name,
+                                                           const std::string &nodename,
+                                                           const std::string &topnodename)
+  : Fun4AllDstInputManager(name, nodename, topnodename)
+{
+  return;
+}
+
+int Fun4AllRunNodeInputManager::fileopen(const std::string &filenam)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  if (IsOpen())
+  {
+    std::cout << "Closing currently open file "
+              << FileName()
+              << " and opening " << filenam << std::endl;
+    fileclose();
+  }
+  FileName(filenam);
+  FROG frog;
+  fullfilename = frog.location(FileName());
+  if (Verbosity() > 0)
+  {
+    std::cout << Name() << ": opening file " << fullfilename << std::endl;
+  }
+  // sanity check - the IManager must be nullptr when this method is executed
+  // if not something is very very wrong and we must not continue
+  if (IManager())
+  {
+    std::cout << PHWHERE << " IManager pointer is not nullptr but " << IManager()
+              << std::endl;
+    std::cout << "Send mail to off-l with this printout and the macro you used"
+              << std::endl;
+    std::cout << "Trying to execute IManager->print() to display more info"
+              << std::endl;
+    std::cout << "Code will probably segfault now" << std::endl;
+    IManager()->print();
+    std::cout << "Have someone look into this problem - Exiting now" << std::endl;
+    exit(1);
+  }
+  IManager(new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree));
+  if (IManager()->isFunctional())
+  {
+    runNode(se->getNode(RunNodeName(), TopNodeName()));
+    IManager()->read(runNode());
+    // get the current run number
+    RunHeader *runheader = findNode::getClass<RunHeader>(runNode(), "RunHeader");
+    if (runheader)
+    {
+      SetRunNumber(runheader->get_RunNumber());
+    }
+    // delete our internal copy of the runnode when opening subsequent files
+    if (runNodeCopy())
+    {
+      std::cout << PHWHERE
+		<< " The impossible happened, we have a valid copy of the run node "
+		<< runNodeCopy()->getName() << " which should be a nullptr"
+		<< std::endl;
+      gSystem->Exit(1);
+    }
+    runNodeCopy(new PHCompositeNode("RUNNODECOPY"));
+    if (!runNodeSum())
+    {
+      runNodeSum(new PHCompositeNode("RUNNODESUM"));
+    }
+    PHNodeIOManager *tmpIman = new PHNodeIOManager(fullfilename, PHReadOnly, PHRunTree);
+    tmpIman->read(runNodeCopy());
+    delete tmpIman;
+
+    PHNodeIntegrate integrate;
+    integrate.RunNode(runNode());
+    integrate.RunSumNode(runNodeSum());
+    // run recursively over internal run node copy and integrate objects
+    PHNodeIterator mainIter(runNodeCopy());
+    mainIter.forEach(integrate);
+    // we do not need to keep the internal copy, keeping it would crate
+    // problems in case a subsequent file does not contain all the
+    // runwise objects from the previous file. Keeping this copy would then
+    // integrate the missing object again with the old copy
+    delete runNodeCopy();
+    runNodeCopy(nullptr);
+  }
+  // DLW: move the delete outside the if block to cover the case where isFunctional() fails
+  delete IManager();
+  return 0;
+}
+
+int Fun4AllRunNodeInputManager::run(const int /*nevents*/)
+{
+  if (!IsOpen())
+  {
+    if (FileListEmpty())
+    {
+      if (Verbosity() > 0)
+      {
+        std::cout << Name() << ": No Input file open" << std::endl;
+      }
+      return -1;
+    }
+    else
+    {
+      if (OpenNextFile())
+      {
+        std::cout << Name() << ": No Input file from filelist opened" << std::endl;
+        return -1;
+      }
+    }
+  }
+  return 0;
+}

--- a/offline/framework/fun4all/Fun4AllRunNodeInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllRunNodeInputManager.cc
@@ -20,8 +20,8 @@
 #include <iostream>
 
 Fun4AllRunNodeInputManager::Fun4AllRunNodeInputManager(const std::string &name,
-                                                           const std::string &nodename,
-                                                           const std::string &topnodename)
+                                                       const std::string &nodename,
+                                                       const std::string &topnodename)
   : Fun4AllDstInputManager(name, nodename, topnodename)
 {
   return;
@@ -74,9 +74,9 @@ int Fun4AllRunNodeInputManager::fileopen(const std::string &filenam)
     if (runNodeCopy())
     {
       std::cout << PHWHERE
-		<< " The impossible happened, we have a valid copy of the run node "
-		<< runNodeCopy()->getName() << " which should be a nullptr"
-		<< std::endl;
+                << " The impossible happened, we have a valid copy of the run node "
+                << runNodeCopy()->getName() << " which should be a nullptr"
+                << std::endl;
       gSystem->Exit(1);
     }
     runNodeCopy(new PHCompositeNode("RUNNODECOPY"));

--- a/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
+++ b/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
@@ -1,0 +1,37 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FUN4ALL_FUN4ALLRUNNODEINPUTMANAGER_H
+#define FUN4ALL_FUN4ALLRUNNODEINPUTMANAGER_H
+
+#include "Fun4AllDstInputManager.h"
+
+#include "Fun4AllReturnCodes.h"
+
+#include <string>  // for string
+
+class PHNodeIOManager;
+class SyncObject;
+
+class Fun4AllRunNodeInputManager : public Fun4AllDstInputManager
+{
+ public:
+  Fun4AllRunNodeInputManager(const std::string& name = "DUMMY", const std::string& nodename = "DST", const std::string& topnodename = "TOP");
+
+  ~Fun4AllRunNodeInputManager() override {}
+
+  int fileopen(const std::string &filenam) override;
+  int run(const int /*nevents*/) override;
+
+  // Effectivly turn off the synchronization checking
+  //
+   int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; } 
+   int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+   int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
+  /* // no sync object we don't need to enable the sync variables */
+  int setSyncBranches(PHNodeIOManager* /*IManager*/) override { return 0; } 
+  int PushBackEvents(const int /*i*/) override {return 0;}
+  int SkipForThisManager(const int nevents) override { return PushBackEvents(nevents); }
+  int HasSyncObject() const override { return 0; }
+};
+
+#endif  // FUN4ALL_FUN4ALLRUNNODEINPUTMANAGER_H

--- a/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
+++ b/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
@@ -19,17 +19,17 @@ class Fun4AllRunNodeInputManager : public Fun4AllDstInputManager
 
   ~Fun4AllRunNodeInputManager() override {}
 
-  int fileopen(const std::string &filenam) override;
+  int fileopen(const std::string& filenam) override;
   int run(const int /*nevents*/) override;
 
   // Effectivly turn off the synchronization checking
   //
-   int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; } 
-   int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
-   int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
+  int SyncIt(const SyncObject* /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_OK; }
+  int GetSyncObject(SyncObject** /*mastersync*/) override { return Fun4AllReturnCodes::SYNC_NOOBJECT; }
+  int NoSyncPushBackEvents(const int nevt) override { return PushBackEvents(nevt); }
   /* // no sync object we don't need to enable the sync variables */
-  int setSyncBranches(PHNodeIOManager* /*IManager*/) override { return 0; } 
-  int PushBackEvents(const int /*i*/) override {return 0;}
+  int setSyncBranches(PHNodeIOManager* /*IManager*/) override { return 0; }
+  int PushBackEvents(const int /*i*/) override { return 0; }
   int SkipForThisManager(const int nevents) override { return PushBackEvents(nevents); }
   int HasSyncObject() const override { return 0; }
 };

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1480,9 +1480,13 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
       if (std::find(RetCodes.begin(),
                     RetCodes.end(),
                     static_cast<int>(Fun4AllReturnCodes::ABORTEVENT)) == RetCodes.end())
+      {
         icnt_good++;
+      }
       if (iret || (nevnts > 0 && icnt_good >= nevnts))
+      {
         break;
+      }
     }
     else if (iret || (nevnts > 0 && icnt >= nevnts))
     {

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -83,8 +83,8 @@ class Fun4AllServer : public Fun4AllBase
   //! run n events (0 means up to end of file)
   int run(const int nevnts = 0, const bool require_nevents = false);
 
-  /*! 
-    \brief skip n events (0 means up to the end of file). 
+  /*!
+    \brief skip n events (0 means up to the end of file).
     Skip means read, don't process.
   */
   int skip(const int nevnts = 0);

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -94,7 +94,7 @@ int Fun4AllSyncManager::run(const int nevnts)
     unsigned iman = 0;
     int ifirst = 0;
     int hassync = 0;
-    for (auto & iter : m_InManager)
+    for (auto &iter : m_InManager)
     {
       m_iretInManager[iman] = iter->run(1);
       iret += m_iretInManager[iman];
@@ -238,7 +238,7 @@ readerror:
     if (!resetnodetree)  // all syncing is done and no read errors --> we have a good event in memory
     {
       m_CurrentRun = 0;  // reset current run to 0
-      for (auto & iter : m_InManager)
+      for (auto &iter : m_InManager)
       {
         int runno = iter->RunNumber();
         if (Verbosity() > 2)

--- a/offline/framework/fun4all/Fun4AllSyncManager.h
+++ b/offline/framework/fun4all/Fun4AllSyncManager.h
@@ -26,8 +26,8 @@ class Fun4AllSyncManager : public Fun4AllBase
   //! run n events (0 means up to end of file
   int run(const int nevnts = 0);
 
-  /*! 
-    \brief skip n events (0 means up to the end of file). 
+  /*!
+    \brief skip n events (0 means up to the end of file).
     Skip means read, don't process.
   */
   int skip(const int nevnts = 0);
@@ -53,8 +53,8 @@ class Fun4AllSyncManager : public Fun4AllBase
   void PushBackInputMgrsEvents(const int i);
   int ResetEvent();
   const std::vector<Fun4AllInputManager *> GetInputManagers() const { return m_InManager; }
-  bool MixRunsOk() const {return m_MixRunsOkFlag;}
-  void MixRunsOk(bool b) {m_MixRunsOkFlag = b;}
+  bool MixRunsOk() const { return m_MixRunsOkFlag; }
+  void MixRunsOk(bool b) { m_MixRunsOkFlag = b; }
 
  private:
   void PrintSyncProblem() const;

--- a/offline/framework/fun4all/Makefile.am
+++ b/offline/framework/fun4all/Makefile.am
@@ -23,6 +23,7 @@ pkginclude_HEADERS = \
   Fun4AllNoSyncDstInputManager.h \
   Fun4AllOutputManager.h \
   Fun4AllReturnCodes.h \
+  Fun4AllRunNodeInputManager.h \
   Fun4AllServer.h \
   Fun4AllSyncManager.h \
   Fun4AllUtils.h \
@@ -51,6 +52,7 @@ libfun4all_la_SOURCES = \
   Fun4AllMemoryTracker.cc \
   Fun4AllNoSyncDstInputManager.cc \
   Fun4AllOutputManager.cc \
+  Fun4AllRunNodeInputManager.cc \
   Fun4AllServer.cc \
   Fun4AllSyncManager.cc \
   Fun4AllUtils.cc \

--- a/offline/framework/fun4all/PHTFileServer.cc
+++ b/offline/framework/fun4all/PHTFileServer.cc
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////
-/*! 
+/*!
   \file PHTFileServer.cc
   \brief TFile clean handling
   \author  Hugo Pereira
@@ -22,7 +22,10 @@ PHTFileServer::SafeTFile::TFileMap PHTFileServer::SafeTFile::_map;
 //_________________________________________________
 PHTFileServer::~PHTFileServer()
 {
-  if (!SafeTFile::file_map().empty()) close();
+  if (!SafeTFile::file_map().empty())
+  {
+    close();
+  }
 }
 
 //_________________________________________________
@@ -47,7 +50,10 @@ void PHTFileServer::open(const std::string& filename, const std::string& type)
 
     // create new SafeTFile; insert in map; change TDirectory
     SafeTFile* file(new SafeTFile(filename, type));
-    if (!file->IsOpen()) std::cout << ("PHTFileServer::open - error opening TFile") << std::endl;
+    if (!file->IsOpen())
+    {
+      std::cout << ("PHTFileServer::open - error opening TFile") << std::endl;
+    }
     SafeTFile::file_map().insert(make_pair(filename, file));
     file->cd();
   }
@@ -58,7 +64,9 @@ bool PHTFileServer::flush(const std::string& filename)
 {
   SafeTFile::TFileMap::iterator iter(SafeTFile::file_map().find(filename));
   if (iter != SafeTFile::file_map().end())
+  {
     iter->second->Flush();
+  }
   else
   {
     std::ostringstream what;
@@ -75,7 +83,9 @@ bool PHTFileServer::cd(const std::string& filename)
 {
   SafeTFile::TFileMap::iterator iter(SafeTFile::file_map().find(filename));
   if (iter != SafeTFile::file_map().end())
+  {
     iter->second->cd();
+  }
   else
   {
     std::ostringstream what;
@@ -132,7 +142,7 @@ void PHTFileServer::close()
 {
   // close
   //  MUTOO::TRACE( "PHTFileServer::close" );
-  for (auto & iter : SafeTFile::file_map())
+  for (auto& iter : SafeTFile::file_map())
   {
     if (iter.second->IsOpen())
     {
@@ -177,7 +187,7 @@ PHTFileServer::SafeTFile::~SafeTFile()
     Close();
   }
 
-  /* 
+  /*
   remove this filename from the make to make sure that PHTFileServer
   does not try to write/close this TFile during the destructor
   */

--- a/offline/framework/fun4all/PHTFileServer.h
+++ b/offline/framework/fun4all/PHTFileServer.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
 //////////////////////////////////////////////////////////////////
-/*! 
+/*!
   \file PHTFileServer.h
   \brief TFile clean handling
   \author  Hugo Pereira
@@ -19,10 +19,10 @@
 #include <sstream>
 #include <string>
 
-/*! 
+/*!
   \brief TFile clean handling. It allow independant classes to access
   the same TFile and write ntuple to it. TFiles get written only when as many
-  write request are achieved as open request. 
+  write request are achieved as open request.
   It get closed when the server is deleted
 */
 class PHTFileServer
@@ -38,7 +38,7 @@ class PHTFileServer
   //! destructor. All non close TFiles are closed, with a warning.
   virtual ~PHTFileServer();
 
-  /*! \brief 
+  /*! \brief
     open a SafeTFile. If filename is not found in the map, create a new TFile
     and append to the map; increment counter otherwise
   */
@@ -51,7 +51,7 @@ class PHTFileServer
   bool cd(const std::string& filename);
 
   /*! \brief
-    if TFile is found in map and counter is 0, close the TFile, 
+    if TFile is found in map and counter is 0, close the TFile,
     decrement counter otherwise
   */
   bool write(const std::string& filename);

--- a/offline/framework/fun4all/SubsysReco.h
+++ b/offline/framework/fun4all/SubsysReco.h
@@ -16,14 +16,14 @@ class PHCompositeNode;
  *  from this base class and you have to implement this class methods.
  *  None of these are strictly required as far as C++ is concerned, but as
  *  far as your job is concerned, at least process_event(), to do the
- *  job, and InitRun(), to initialize, should be implemented.  
- *  
+ *  job, and InitRun(), to initialize, should be implemented.
+ *
  */
 
 class SubsysReco : public Fun4AllBase
 {
  public:
-  /** dtor. 
+  /** dtor.
       Does nothing as this is a base class only.
   */
   ~SubsysReco() override {}

--- a/offline/framework/fun4all/TDirectoryHelper.cc
+++ b/offline/framework/fun4all/TDirectoryHelper.cc
@@ -126,7 +126,7 @@ bool TDirectoryHelper::mkpath(TDirectory* dir, const std::string& pathin)
 
   TDirectory* currentdir = dir;
 
-  for (auto & path : paths)
+  for (auto& path : paths)
   {
     currentdir->cd();
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds a new input manager to read only runwise information (needed to replace geometry node in sim DSTs)
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

