### PR TITLE
TPC Distortions on runNode

### DIFF
--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -53,22 +53,14 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
   // look for distortion calibration object
   PHNodeIterator iter(topNode);
  
-  /// Get the DST node and check
-  auto dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
-  if (!dstNode)
+  /// Get the RUN node and check
+  auto runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode)
   {
-    std::cout << "TpcLoadDistortionCorrection::InitRun - DST Node missing, quitting" << std::endl;
+    std::cout << "TpcLoadDistortionCorrection::InitRun - RUN Node missing, quitting" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
  
-  // Get the tracking subnode and create if not found
-  auto svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
-  if (!svtxNode)
-  {
-    svtxNode = new PHCompositeNode("SVTX");
-    dstNode->addNode(svtxNode);
-  }
-
   //create and populate the nodes for each distortion, if present:
   for (int i=0;i<3;i++){
 
@@ -81,7 +73,7 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
 	std::cout << "TpcLoadDistortionCorrection::InitRun - creating TpcDistortionCorrectionContainer in node " << m_node_name[i] << std::endl;
 	distortion_correction_object = new TpcDistortionCorrectionContainer;
 	auto node = new PHDataNode<TpcDistortionCorrectionContainer>(distortion_correction_object, m_node_name[i]);
-	svtxNode->addNode(node);
+	runNode->addNode(node);
       }
 
     std::cout << "TpcLoadDistortionCorrection::InitRun - reading corrections from " << m_correction_filename[i] << std::endl;

--- a/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.cc
+++ b/offline/packages/tpccalib/PHTpcCentralMembraneMatcher.cc
@@ -16,7 +16,6 @@
 #include <trackbase/CMFlashDifferencev1.h>
 #include <trackbase/CMFlashDifferenceContainerv1.h>
 
-#include <TCanvas.h>
 #include <TFile.h>
 #include <TGraph.h>
 #include <TH1F.h>
@@ -184,8 +183,8 @@ double PHTpcCentralMembraneMatcher::getPhiRotation_smoothed(TH1D *hitHist, TH1D 
 
   clustHist->Fit("f1","IQ");
 
-  clustHist->Draw();
-  f1->Draw("same");
+  //  clustHist->Draw();
+  //f1->Draw("same");
 
   return f1->GetParameter(1);
 }
@@ -383,8 +382,8 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
 
   // reset output distortion correction container histograms
   for( const auto& harray:{m_dcc_out->m_hDRint, m_dcc_out->m_hDPint, m_dcc_out->m_hDZint, m_dcc_out->m_hentries} )
-  { for( const auto& h:harray ) { h->Reset(); } }
-
+  { 
+    
   clust_r_phi_pos->Reset();
   clust_r_phi_neg->Reset();
 
@@ -392,6 +391,8 @@ int PHTpcCentralMembraneMatcher::process_event(PHCompositeNode * /*topNode*/)
     m_event_index++;
     return Fun4AllReturnCodes::EVENT_OK;
   }
+  
+  for( const auto& h:harray ) { h->Reset(); } }
 
   // read the reconstructed CM clusters
   auto clusrange = m_corrected_CMcluster_map->getClusters();
@@ -887,36 +888,28 @@ int  PHTpcCentralMembraneMatcher::GetNodes(PHCompositeNode* topNode)
     
   //// output tpc fluctuation distortion container
   //// this one is filled on the fly on a per-CM-event basis, and applied in the tracking chain
-  //const std::string dcc_out_node_name = "TpcDistortionCorrectionContainerFluctuation";
-  //m_dcc_out = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,dcc_out_node_name);
-  //if( !m_dcc_out )
-  //{ 
+  const std::string dcc_out_node_name = "TpcDistortionCorrectionContainerFluctuation";
+  m_dcc_out = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,dcc_out_node_name);
+  if( !m_dcc_out )
+  { 
    
-  //   /// Get the DST node and check
-  //   auto dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
-  //   if (!dstNode)
-  //   {
-  //     std::cout << "PHTpcCentralMembraneMatcher::InitRun - DST Node missing, quitting" << std::endl;
-  //     return Fun4AllReturnCodes::ABORTRUN;
-  //   }
+     /// Get the RUN node and check
+     auto runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+     if (!runNode)
+     {
+       std::cout << "PHTpcCentralMembraneMatcher::InitRun - RUN Node missing, quitting" << std::endl;
+       return Fun4AllReturnCodes::ABORTRUN;
+     }
      
-  //   // Get the tracking subnode and create if not found
-  //   auto svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
-  //   if (!svtxNode)
-  //   {
-  //     svtxNode = new PHCompositeNode("SVTX");
-  //     dstNode->addNode(svtxNode);
-  //   }
- 
-  //   std::cout << "PHTpcCentralMembraneMatcher::GetNodes - creating TpcDistortionCorrectionContainer in node " << dcc_out_node_name << std::endl;
-  //   m_dcc_out = new TpcDistortionCorrectionContainer;
-  //   auto node = new PHDataNode<TpcDistortionCorrectionContainer>(m_dcc_out, dcc_out_node_name);
-  //   svtxNode->addNode(node);
-  // }
+     std::cout << "PHTpcCentralMembraneMatcher::GetNodes - creating TpcDistortionCorrectionContainer in node " << dcc_out_node_name << std::endl;
+     m_dcc_out = new TpcDistortionCorrectionContainer;
+     auto node = new PHDataNode<TpcDistortionCorrectionContainer>(m_dcc_out, dcc_out_node_name);
+     runNode->addNode(node);
+   }
   
 
   // create per event distortions. Do not put on the node tree
-  m_dcc_out = new TpcDistortionCorrectionContainer;
+  //m_dcc_out = new TpcDistortionCorrectionContainer;
 
   // also prepare the local distortion container, used to aggregate multple events 
   m_dcc_out_aggregated.reset( new TpcDistortionCorrectionContainer );


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Moved the TPC distortions to be stored on the runNode rather than the dstNode. This allows them to persist across events until they are overwritten, which is essential for the fluctuation corrections.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

