### PR TITLE
Enable layer misalignment in acts kf

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -310,9 +310,9 @@ int AlignmentTransformation::getNodes(PHCompositeNode* topNode)
   return 0; 
 }
 
-void AlignmentTransformation::misalignmentFactor(TrkrDefs::TrkrId id, const double factor)
+void AlignmentTransformation::misalignmentFactor(uint8_t layer, const double factor)
 {
-  transformMap->setMisalignmentFactor(id, factor);
+  transformMap->setMisalignmentFactor(layer, factor);
 }
 void AlignmentTransformation::createAlignmentTransformContainer(PHCompositeNode* topNode)
 {

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -103,7 +103,7 @@ void setTPCParams(double tpcDevs[6])
       }
   }
 
- void misalignmentFactor(TrkrDefs::TrkrId id, const double factor);
+ void misalignmentFactor(uint8_t layer, const double factor);
 
  private:
 

--- a/offline/packages/trackbase/Calibrator.h
+++ b/offline/packages/trackbase/Calibrator.h
@@ -61,8 +61,8 @@ class Calibrator
 
           auto cov = uncalibmeas.covariance();
           const auto& cluskey = sourceLink.cluskey();
-          const auto trkrid = TrkrDefs::getTrkrId(cluskey);
-          const double misalignmentFactor = gctx.get<alignmentTransformationContainer*>()->getMisalignmentFactor(trkrid);
+          const auto layer = TrkrDefs::getLayer(cluskey);
+          const double misalignmentFactor = gctx.get<alignmentTransformationContainer*>()->getMisalignmentFactor(layer);
 
           Acts::ActsSymMatrix<2> expandedCov = Acts::ActsSymMatrix<2>::Zero();
 

--- a/offline/packages/trackbase/alignmentTransformationContainer.cc
+++ b/offline/packages/trackbase/alignmentTransformationContainer.cc
@@ -17,20 +17,20 @@ bool alignmentTransformationContainer::use_alignment = false;
 
 alignmentTransformationContainer::alignmentTransformationContainer()
 {
-  for ( const auto id : { TrkrDefs::mvtxId, TrkrDefs::inttId, TrkrDefs::tpcId, TrkrDefs::micromegasId })
+  for ( uint8_t layer = 0; layer < 57; layer++)
     {
-      m_misalignmentFactor.insert(std::make_pair(id, 1.));
+      m_misalignmentFactor.insert(std::make_pair(layer, 1.));
     }
 }
-void alignmentTransformationContainer::setMisalignmentFactor(uint8_t id, double factor)
+void alignmentTransformationContainer::setMisalignmentFactor(uint8_t layer, double factor)
 {
-  auto it = m_misalignmentFactor.find(id);
+  auto it = m_misalignmentFactor.find(layer);
   if(it != m_misalignmentFactor.end())
     {
       it->second = factor;
       return;
     }
-  std::cout << "You provided a nonexistent TrkrDefs::TrkrId in alignmentTransformationContainer::setMisalignmentFactor..."
+  std::cout << "You provided a nonexistent layer in alignmentTransformationContainer::setMisalignmentFactor..."
 	    << std::endl;
 }
 void alignmentTransformationContainer::Reset()

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -41,8 +41,8 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   void addTransform(Acts::GeometryIdentifier, Acts::Transform3); 
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
   const std::vector<std::vector<Acts::Transform3>>& getMap() const;
-  void setMisalignmentFactor(uint8_t id, double factor);
-  const double& getMisalignmentFactor(uint8_t id) const { return m_misalignmentFactor.find(id)->second; }
+  void setMisalignmentFactor(uint8_t layer, double factor);
+  const double& getMisalignmentFactor(uint8_t layer) const { return m_misalignmentFactor.find(layer)->second; }
   static bool use_alignment;
 
   private:
@@ -53,7 +53,7 @@ class alignmentTransformationContainer : public Acts::GeometryContext
 
   std::vector< std::vector<Acts::Transform3>> transformVec;
 
-  /// Map of TrkrDefs::TrkrId to misalignment factor
+  /// Map of TrkrDefs::Layer to misalignment factor
   std::map<uint8_t, double> m_misalignmentFactor;
 
   ClassDef(alignmentTransformationContainer,1);

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -174,9 +174,9 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->set_drift_velocity(m_drift_velocity);
 
   alignment_transformation.createMap(topNode);
-  for(auto& [id, factor] : m_misalignmentFactor)
+  for(auto& [layer, factor] : m_misalignmentFactor)
     {
-      alignment_transformation.misalignmentFactor(id, factor);
+      alignment_transformation.misalignmentFactor(layer, factor);
     }
 
  // print

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -119,16 +119,16 @@ class MakeActsGeometry : public SubsysReco
   }
 
 
-  void misalignmentFactor(TrkrDefs::TrkrId id, const double misalignment)
+  void misalignmentFactor(uint8_t layer, const double misalignment)
   {
-    auto it = m_misalignmentFactor.find(id);
+    auto it = m_misalignmentFactor.find(layer);
     if(it != m_misalignmentFactor.end())
       {
 	it->second = misalignment;
 	return;
       }
 
-    std::cout << "Passed an unknown trkr id, misalignment factor will not be set for " << id << std::endl;
+    std::cout << "Passed an unknown trkr layer, misalignment factor will not be set for " << layer << std::endl;
   }
 
   double getSurfStepPhi() {return m_surfStepPhi;}
@@ -209,7 +209,7 @@ class MakeActsGeometry : public SubsysReco
   TGeoManager* m_geoManager = nullptr;
 
   bool m_useField = true;
-  std::map<TrkrDefs::TrkrId, double> m_misalignmentFactor;
+  std::map<uint8_t, double> m_misalignmentFactor;
 
   /// Several maps that connect Acts world to sPHENIX G4 world 
   std::map<TrkrDefs::hitsetkey, TGeoNode*> m_clusterNodeMap;


### PR DESCRIPTION
Allows certain layers to blow up measurement covariance in the KF instead of an entire subsystem.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
https://github.com/sPHENIX-Collaboration/macros/pull/636
