### PR TITLE
Remove verbosity

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -127,8 +127,6 @@ class MakeActsGeometry : public SubsysReco
 	it->second = misalignment;
 	return;
       }
-
-    std::cout << "Passed an unknown trkr layer, misalignment factor will not be set for " << layer << std::endl;
   }
 
   double getSurfStepPhi() {return m_surfStepPhi;}


### PR DESCRIPTION
Removes warning about misalignment that is disrupting macro processing for some in nvim, which is why this behavior hasn't shown up in any of the builds apparently

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

