### PR TITLE
Fix cdbttree

### DIFF
--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -102,7 +102,10 @@ void CDBTTree::SetUInt64Value(int channel, const std::string &name, uint64_t val
 void CDBTTree::Commit()
 {
   m_Locked[MultipleEntries] = true;
-  // create ntuple string
+}
+
+void CDBTTree::WriteMultipleCDBTTree()
+{
   m_TTree[MultipleEntries] = new TTree(m_TTreeName[MultipleEntries].c_str(), m_TTreeName[MultipleEntries].c_str());
   std::set<int> id_set;
   std::map<std::string, float> floatmap;
@@ -293,6 +296,11 @@ void CDBTTree::SetSingleUInt64Value(const std::string &name, uint64_t value)
 void CDBTTree::CommitSingle()
 {
   m_Locked[SingleEntries] = true;
+  return;
+}
+
+void CDBTTree::WriteSingleCDBTTree()
+{
   m_TTree[SingleEntries] = new TTree(m_TTreeName[SingleEntries].c_str(), m_TTreeName[SingleEntries].c_str());
   for (auto &field : m_SingleFloatEntryMap)
   {
@@ -431,18 +439,41 @@ void CDBTTree::Print()
 
 void CDBTTree::WriteCDBTTree()
 {
-  std::string currdir = gDirectory->GetPath();
-  TFile *f = TFile::Open(m_Filename.c_str(), "RECREATE");
-  for (auto ttree : m_TTree)
+  bool empty_single = m_SingleFloatEntryMap.empty() && m_SingleDoubleEntryMap.empty() &&
+    m_SingleIntEntryMap.empty() && m_SingleUInt64EntryMap.empty();
+  if (!empty_single &&  !m_Locked[SingleEntries])
   {
-    if (ttree != nullptr)
-    {
-      ttree->Write();
-    }
-    delete ttree;
-    ttree = nullptr;
+    std::cout << "You need to call CDBTTree::CommitSingle() before writing" << std::endl;
+    return;
+  }
+  bool empty_multiple = m_FloatEntryMap.empty() && m_DoubleEntryMap.empty() &&
+    m_IntEntryMap.empty() && m_UInt64EntryMap.empty();
+  if (!empty_multiple &&  !m_Locked[MultipleEntries])
+  {
+    std::cout << "You need to call CDBTTree::Commit() before writing" << std::endl;
+    return;
+  }
+  if (empty_single && empty_multiple)
+  {
+    std::cout << "no values to be saved" << std::endl;
+    return;
+  }
+
+  std::string currdir = gDirectory->GetPath();
+
+  TFile *f = TFile::Open(m_Filename.c_str(), "RECREATE");
+  if (!empty_single)
+  {
+    WriteSingleCDBTTree();
+    m_TTree[SingleEntries]->Write();
+  }
+  if (! empty_multiple)
+  {
+    WriteMultipleCDBTTree();
+    m_TTree[MultipleEntries]->Write();
   }
   f->Close();
+
   gROOT->cd(currdir.c_str());  // restore previous directory
 }
 

--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -440,15 +440,15 @@ void CDBTTree::Print()
 void CDBTTree::WriteCDBTTree()
 {
   bool empty_single = m_SingleFloatEntryMap.empty() && m_SingleDoubleEntryMap.empty() &&
-    m_SingleIntEntryMap.empty() && m_SingleUInt64EntryMap.empty();
-  if (!empty_single &&  !m_Locked[SingleEntries])
+                      m_SingleIntEntryMap.empty() && m_SingleUInt64EntryMap.empty();
+  if (!empty_single && !m_Locked[SingleEntries])
   {
     std::cout << "You need to call CDBTTree::CommitSingle() before writing" << std::endl;
     return;
   }
   bool empty_multiple = m_FloatEntryMap.empty() && m_DoubleEntryMap.empty() &&
-    m_IntEntryMap.empty() && m_UInt64EntryMap.empty();
-  if (!empty_multiple &&  !m_Locked[MultipleEntries])
+                        m_IntEntryMap.empty() && m_UInt64EntryMap.empty();
+  if (!empty_multiple && !m_Locked[MultipleEntries])
   {
     std::cout << "You need to call CDBTTree::Commit() before writing" << std::endl;
     return;
@@ -467,7 +467,7 @@ void CDBTTree::WriteCDBTTree()
     WriteSingleCDBTTree();
     m_TTree[SingleEntries]->Write();
   }
-  if (! empty_multiple)
+  if (!empty_multiple)
   {
     WriteMultipleCDBTTree();
     m_TTree[MultipleEntries]->Write();

--- a/offline/database/cdbobjects/CDBTTree.h
+++ b/offline/database/cdbobjects/CDBTTree.h
@@ -24,6 +24,8 @@ class CDBTTree
   void SetSingleUInt64Value(const std::string &name, uint64_t value);
   void CommitSingle();
   void WriteCDBTTree();
+  void WriteSingleCDBTTree();
+  void WriteMultipleCDBTTree();
   void Print();
   void LoadCalibrations();
   float GetSingleFloatValue(const std::string &name, int verbose = 1);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
The CDBTTree was not saved properly if it had more than a handful of entries. The reason was that you have to open a TFile before creating the TTree. Just writing a memory resident TTree to a file doesn't seem to work
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

