### PR TITLE
added Ar:CF4 60:40 gas mixture as sPHENIX_TPC_Gas_ArCF4

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1036,8 +1036,8 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   const double alt_den_G4_Ar = G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar")->GetDensity();
   const double alt_den_CF4 = CF4->GetDensity();
   const double alt_den_sphenix_tpc_gas = alt_den_G4_Ar * alt_G4_Ar_frac + alt_den_CF4 * alt_CF4_frac;
-  G4Material *alt_sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas_ArCF4", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
-  alt_sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4 * alt_CF4_frac / den_sphenix_tpc_gas);
+  G4Material *alt_sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas_ArCF4", alt_den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
+  alt_sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4 * alt_CF4_frac / alt_den_sphenix_tpc_gas);
   alt_sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), alt_den_G4_Ar * alt_G4_Ar_frac / alt_den_sphenix_tpc_gas);
 
   

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -25,6 +25,7 @@
 
 #include <g4gdml/PHG4GDMLUtility.hh>
 
+#include <phfield/PHFieldConfig.h>  // for PHFieldConfig
 #include <phfield/PHFieldConfigv1.h>
 #include <phfield/PHFieldConfigv2.h>
 #include <phfield/PHFieldUtility.h>
@@ -33,6 +34,7 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>      // for PHDataNode
@@ -56,8 +58,6 @@
 #include <Geant4/G4IonisParamMat.hh>  // for G4IonisParamMat
 #include <Geant4/G4LossTableManager.hh>
 #include <Geant4/G4Material.hh>
-#include <Geant4/G4MaterialPropertiesTable.hh>  // for G4MaterialProperties...
-#include <Geant4/G4MaterialPropertyVector.hh>   // for G4MaterialPropertyVector
 #include <Geant4/G4NistManager.hh>
 #include <Geant4/G4OpAbsorption.hh>
 #include <Geant4/G4OpBoundaryProcess.hh>
@@ -69,9 +69,6 @@
 #include <Geant4/G4ParticleTable.hh>
 #include <Geant4/G4PhotoElectricEffect.hh>  // for G4PhotoElectricEffect
 #include <Geant4/G4ProcessManager.hh>
-#include <Geant4/G4ProductionCuts.hh>  // for G4ProductionCuts
-#include <Geant4/G4Region.hh>
-#include <Geant4/G4RegionStore.hh>
 #include <Geant4/G4RunManager.hh>
 #include <Geant4/G4Scintillation.hh>
 #include <Geant4/G4StepLimiterPhysics.hh>
@@ -85,6 +82,7 @@
 #include <Geant4/G4Version.hh>
 #include <Geant4/G4VisExecutive.hh>
 #include <Geant4/G4VisManager.hh>  // for G4VisManager
+#include <Geant4/Randomize.hh>     // for G4Random
 
 // physics lists
 #include <Geant4/FTFP_BERT.hh>
@@ -98,19 +96,13 @@
 #include <Geant4/QGSP_INCLXX.hh>
 #include <Geant4/QGSP_INCLXX_HP.hh>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#include <boost/filesystem.hpp>
-#pragma GCC diagnostic pop
-
 #include <cassert>
 #include <cstdlib>
 #include <exception>  // for exception
 #include <iostream>   // for operator<<, endl
 #include <memory>
-#include <set>     // for set, _Rb_tree_const_...
-#include <vector>  // for vector, vector<>::it...
 
+class G4EmSaturation;
 class G4TrackingManager;
 class G4VPhysicalVolume;
 class PHField;
@@ -1040,402 +1032,12 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   alt_sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4 * alt_CF4_frac / alt_den_sphenix_tpc_gas);
   alt_sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), alt_den_G4_Ar * alt_G4_Ar_frac / alt_den_sphenix_tpc_gas);
 
-  
-
-  //
-  // CF4
-  //
-  const G4int nEntries_CF4 = 50;
-
-  G4double PhotonEnergy_CF4[nEntries_CF4] =
-      {5.5 * eV, 5.6 * eV, 5.7 * eV, 5.8 * eV, 5.9 * eV,
-       6.0 * eV, 6.1 * eV, 6.2 * eV, 6.3 * eV, 6.4 * eV,
-       6.5 * eV, 6.6 * eV, 6.7 * eV, 6.8 * eV, 6.9 * eV,
-       7.0 * eV, 7.1 * eV, 7.2 * eV, 7.3 * eV, 7.4 * eV,
-       7.5 * eV, 7.6 * eV, 7.7 * eV, 7.8 * eV, 7.9 * eV,
-       8.0 * eV, 8.1 * eV, 8.2 * eV, 8.4 * eV, 8.6 * eV,
-       8.8 * eV, 9.0 * eV, 9.2 * eV, 9.4 * eV, 9.6 * eV,
-       9.8 * eV, 10.0 * eV, 10.2 * eV, 10.4 * eV, 10.6 * eV,
-       10.8 * eV, 11.0 * eV, 11.2 * eV, 11.3 * eV, 11.4 * eV,
-       11.5 * eV, 11.6 * eV, 11.7 * eV, 11.8 * eV, 11.9 * eV};
-
-  G4double RefractiveIndex_CF4[nEntries_CF4] =
-      {1.000480, 1.000482, 1.000483, 1.000485, 1.000486,
-       1.000488, 1.000490, 1.000491, 1.000493, 1.000495,
-       1.000497, 1.000498, 1.000500, 1.000502, 1.000504,
-       1.000506, 1.000508, 1.000510, 1.000512, 1.000514,
-       1.000517, 1.000519, 1.000521, 1.000524, 1.000526,
-       1.000529, 1.000531, 1.000534, 1.000539, 1.000545,
-       1.000550, 1.000557, 1.000563, 1.000570, 1.000577,
-       1.000584, 1.000592, 1.000600, 1.000608, 1.000617,
-       1.000626, 1.000636, 1.000646, 1.000652, 1.000657,
-       1.000662, 1.000667, 1.000672, 1.000677, 1.000682};
-
-  G4double Absorption_CF4[nEntries_CF4] =
-      {1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m};
-
-  G4MaterialPropertiesTable *MPT_CF4 = new G4MaterialPropertiesTable();
-
-#if G4VERSION_NUMBER >= 1100
-  MPT_CF4->AddProperty("RINDEX", PhotonEnergy_CF4, RefractiveIndex_CF4, nEntries_CF4, false, true);
-  MPT_CF4->AddProperty("ABSLENGTH", PhotonEnergy_CF4, Absorption_CF4, nEntries_CF4, false, true);
-#else
-  MPT_CF4->AddProperty("RINDEX", PhotonEnergy_CF4, RefractiveIndex_CF4, nEntries_CF4)->SetSpline(true);
-  MPT_CF4->AddProperty("ABSLENGTH", PhotonEnergy_CF4, Absorption_CF4, nEntries_CF4)->SetSpline(true);
-#endif
-  CF4->SetMaterialPropertiesTable(MPT_CF4);
-
-  //
-  // LiF
-  //
-  G4Material *g4_lif = G4NistManager::Instance()->FindOrBuildMaterial("G4_LITHIUM_FLUORIDE");
-  G4Material *LiF = new G4Material("LiF", density = 2.635 * g / cm3, ncomponents = 2);
-  LiF->AddElement(G4NistManager::Instance()->FindOrBuildElement("Li"), natoms = 1);
-  LiF->AddElement(G4NistManager::Instance()->FindOrBuildElement("F"), natoms = 1);
-
-  if (Verbosity() > 1)
-  {
-    std::cout << "g4_lif: " << g4_lif << std::endl;
-    std::cout << "LiF: " << LiF << std::endl;
-  }
-
-  const G4int nEntries_LiF = 50;
-
-  G4double PhotonEnergy_LiF[nEntries_LiF] =
-      {5.5 * eV, 5.6 * eV, 5.7 * eV, 5.8 * eV, 5.9 * eV,
-       6.0 * eV, 6.1 * eV, 6.2 * eV, 6.3 * eV, 6.4 * eV,
-       6.5 * eV, 6.6 * eV, 6.7 * eV, 6.8 * eV, 6.9 * eV,
-       7.0 * eV, 7.1 * eV, 7.2 * eV, 7.3 * eV, 7.4 * eV,
-       7.5 * eV, 7.6 * eV, 7.7 * eV, 7.8 * eV, 7.9 * eV,
-       8.0 * eV, 8.1 * eV, 8.2 * eV, 8.4 * eV, 8.6 * eV,
-       8.8 * eV, 9.0 * eV, 9.2 * eV, 9.4 * eV, 9.6 * eV,
-       9.8 * eV, 10.0 * eV, 10.2 * eV, 10.4 * eV, 10.6 * eV,
-       10.8 * eV, 11.0 * eV, 11.2 * eV, 11.3 * eV, 11.4 * eV,
-       11.5 * eV, 11.6 * eV, 11.7 * eV, 11.8 * eV, 11.9 * eV};
-
-  G4double RefractiveIndex_LiF[nEntries_LiF] =
-      {1.42709, 1.42870, 1.42998, 1.43177, 1.43368,
-       1.43520, 1.43736, 1.43907, 1.44088, 1.44279,
-       1.44481, 1.44694, 1.44920, 1.45161, 1.45329,
-       1.45595, 1.45781, 1.46077, 1.46285, 1.46503,
-       1.46849, 1.47093, 1.47349, 1.47618, 1.47901,
-       1.48198, 1.48511, 1.48841, 1.49372, 1.50152,
-       1.50799, 1.51509, 1.52290, 1.53152, 1.54108,
-       1.54805, 1.55954, 1.56799, 1.58202, 1.59243,
-       1.60382, 1.61632, 1.63010, 1.63753, 1.64536,
-       1.65363, 1.66236, 1.67159, 1.68139, 1.69178};
-
-  G4double Absorption_LiF[nEntries_LiF] =
-      {1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m,
-       1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m, 1.e4 * m};
-
-  G4MaterialPropertiesTable *MPT_LiF = new G4MaterialPropertiesTable();
-
-#if G4VERSION_NUMBER >= 1100
-  MPT_LiF->AddProperty("RINDEX", PhotonEnergy_LiF, RefractiveIndex_LiF, nEntries_LiF, false, true);
-  MPT_LiF->AddProperty("ABSLENGTH", PhotonEnergy_LiF, Absorption_LiF, nEntries_LiF, false, true);
-#else
-  MPT_LiF->AddProperty("RINDEX", PhotonEnergy_LiF, RefractiveIndex_LiF, nEntries_LiF)->SetSpline(true);
-  MPT_LiF->AddProperty("ABSLENGTH", PhotonEnergy_LiF, Absorption_LiF, nEntries_LiF)->SetSpline(true);
-#endif
-  LiF->SetMaterialPropertiesTable(MPT_LiF);
-
-  //
-  // CsI
-  //
-  const G4int nEntries_CsI = 50;
-
-  G4double PhotonEnergy_CsI[nEntries_CsI] =
-      {5.5 * eV, 5.6 * eV, 5.7 * eV, 5.8 * eV, 5.9 * eV,
-       6.0 * eV, 6.1 * eV, 6.2 * eV, 6.3 * eV, 6.4 * eV,
-       6.5 * eV, 6.6 * eV, 6.7 * eV, 6.8 * eV, 6.9 * eV,
-       7.0 * eV, 7.1 * eV, 7.2 * eV, 7.3 * eV, 7.4 * eV,
-       7.5 * eV, 7.6 * eV, 7.7 * eV, 7.8 * eV, 7.9 * eV,
-       8.0 * eV, 8.1 * eV, 8.2 * eV, 8.4 * eV, 8.6 * eV,
-       8.8 * eV, 9.0 * eV, 9.2 * eV, 9.4 * eV, 9.6 * eV,
-       9.8 * eV, 10.0 * eV, 10.2 * eV, 10.4 * eV, 10.6 * eV,
-       10.8 * eV, 11.0 * eV, 11.2 * eV, 11.3 * eV, 11.4 * eV,
-       11.5 * eV, 11.6 * eV, 11.7 * eV, 11.8 * eV, 11.9 * eV};
-
-  G4double RefractiveIndex_CsI[nEntries_CsI] =
-      {1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.,
-       1., 1., 1., 1., 1.};
-
-  G4double Absorption_CsI[nEntries_CsI] =
-      {0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m,
-       0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m, 0.0000001 * m};
-
-  G4MaterialPropertiesTable *MPT_CsI = new G4MaterialPropertiesTable();
-
-#if G4VERSION_NUMBER >= 1100
-  MPT_CsI->AddProperty("RINDEX", PhotonEnergy_CsI, RefractiveIndex_CsI, nEntries_CsI, false, true);
-  MPT_CsI->AddProperty("ABSLENGTH", PhotonEnergy_CsI, Absorption_CsI, nEntries_CsI, false, true);
-#else
-  MPT_CsI->AddProperty("RINDEX", PhotonEnergy_CsI, RefractiveIndex_CsI, nEntries_CsI)->SetSpline(true);
-  MPT_CsI->AddProperty("ABSLENGTH", PhotonEnergy_CsI, Absorption_CsI, nEntries_CsI)->SetSpline(true);
-#endif
-
-  CsI->SetMaterialPropertiesTable(MPT_CsI);
-
   // define P10 Gas which will be used for TPC Benchmarking
   G4Material *P10 =
       new G4Material("P10", density = 1.74 * mg / cm3, ncomponents = 3);  // @ 0K, 1atm
   P10->AddElement(G4NistManager::Instance()->FindOrBuildElement("Ar"), fractionmass = 0.9222);
   P10->AddElement(G4NistManager::Instance()->FindOrBuildElement("C"), fractionmass = 0.0623);
   P10->AddElement(G4NistManager::Instance()->FindOrBuildElement("H"), fractionmass = 0.0155);
-
-  //------------------------------
-  // for Modular RICH (mRICH)
-  //------------------------------
-
-  // mRICH_Air_Opt ---------------
-  const int mRICH_nEntries_Air_Opt = 2;
-
-  G4double mRICH_PhotonEnergy_Air_Opt[mRICH_nEntries_Air_Opt] = {2.034 * eV, 4.136 * eV};
-  G4double mRICH_RefractiveIndex_Air_Opt[mRICH_nEntries_Air_Opt] = {1.00, 1.00};
-
-  G4MaterialPropertiesTable *mRICH_Air_Opt_MPT = new G4MaterialPropertiesTable();
-  mRICH_Air_Opt_MPT->AddProperty("RINDEX", mRICH_PhotonEnergy_Air_Opt, mRICH_RefractiveIndex_Air_Opt, mRICH_nEntries_Air_Opt);
-
-  G4Material *mRICH_Air_Opt = new G4Material("mRICH_Air_Opt", density = 1.29 * mg / cm3, ncomponents = 2);
-  mRICH_Air_Opt->AddElement(G4NistManager::Instance()->FindOrBuildElement("N"), fractionmass = 70. * perCent);
-  mRICH_Air_Opt->AddElement(G4NistManager::Instance()->FindOrBuildElement("O"), fractionmass = 30. * perCent);
-  mRICH_Air_Opt->SetMaterialPropertiesTable(mRICH_Air_Opt_MPT);
-
-  // mRICH_Acrylic ---------------
-  const int mRICH_nEntries1 = 32;
-
-  // same photon energy array as aerogel 1
-  G4double mRICH_PhotonEnergy[mRICH_nEntries1] =
-      {2.034 * eV, 2.068 * eV, 2.103 * eV, 2.139 * eV,   // 610, 600, 590, 580, (nm)
-       2.177 * eV, 2.216 * eV, 2.256 * eV, 2.298 * eV,   // 570, 560, 550, 540,
-       2.341 * eV, 2.386 * eV, 2.433 * eV, 2.481 * eV,   // 530, 520, 510, 500,
-       2.532 * eV, 2.585 * eV, 2.640 * eV, 2.697 * eV,   // 490, 480, 470, 460,
-       2.757 * eV, 2.820 * eV, 2.885 * eV, 2.954 * eV,   // 450, 440, 430, 420,
-       3.026 * eV, 3.102 * eV, 3.181 * eV, 3.265 * eV,   // 410, 400, 390, 380,
-       3.353 * eV, 3.446 * eV, 3.545 * eV, 3.649 * eV,   // 370, 360, 350, 340,
-       3.760 * eV, 3.877 * eV, 4.002 * eV, 4.136 * eV};  // 330, 320, 310, 300.
-
-  G4double mRICH_AcRefractiveIndex[mRICH_nEntries1] =
-      {1.4902, 1.4907, 1.4913, 1.4918, 1.4924,  // 610, 600, 590, 580, 570,
-       1.4930, 1.4936, 1.4942, 1.4948, 1.4954,  // 560, 550, 540, 530, 520,  (this line is interpolated)
-       1.4960, 1.4965, 1.4971, 1.4977, 1.4983,  // 510, 500, 490, 480, 470,
-       1.4991, 1.5002, 1.5017, 1.5017, 1.5017,  // 460, 450, 440, 430, 420,
-       1.5017, 1.5017, 1.5017, 1.5017, 1.5017,  // 410,
-       1.5017, 1.5017, 1.5017, 1.5017, 1.5017,  // 360,     look up values below 435
-       1.5017, 1.5017};
-
-  G4double mRICH_AcAbsorption[mRICH_nEntries1] =
-      {25.25 * cm, 25.25 * cm, 25.25 * cm, 25.25 * cm,
-       25.25 * cm, 25.25 * cm, 25.25 * cm, 25.25 * cm,
-       25.25 * cm, 25.25 * cm, 25.25 * cm, 25.25 * cm,
-       25.25 * cm, 25.25 * cm, 25.25 * cm, 25.25 * cm,
-       25.25 * cm, 25.25 * cm, 25.25 * cm, 25.25 * cm,
-       25.25 * cm, 00.667 * cm, 00.037 * cm, 00.333 * cm,
-       00.001 * cm, 00.001 * cm, 00.001 * cm, 00.001 * cm,
-       00.001 * cm, 00.001 * cm, 00.001 * cm, 00.001 * cm};
-
-  G4MaterialPropertiesTable *mRICH_Ac_myMPT = new G4MaterialPropertiesTable();
-  mRICH_Ac_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_AcRefractiveIndex, mRICH_nEntries1);
-  mRICH_Ac_myMPT->AddProperty("ABSLENGTH", mRICH_PhotonEnergy, mRICH_AcAbsorption, mRICH_nEntries1);
-
-  G4Material *mRICH_Acrylic = new G4Material("mRICH_Acrylic", density = 1.19 * g / cm3, ncomponents = 3);
-  mRICH_Acrylic->AddElement(G4NistManager::Instance()->FindOrBuildElement("C"), natoms = 5);
-  mRICH_Acrylic->AddElement(G4NistManager::Instance()->FindOrBuildElement("H"), natoms = 8);  // molecular ratios
-  mRICH_Acrylic->AddElement(G4NistManager::Instance()->FindOrBuildElement("O"), natoms = 2);
-  mRICH_Acrylic->SetMaterialPropertiesTable(mRICH_Ac_myMPT);
-
-  // mRICH_Agel1 -----------------
-  // using same photon energy array as mRICH_Acrylic
-
-  G4double mRICH_Agel1RefractiveIndex[mRICH_nEntries1] =
-      {1.02435, 1.0244, 1.02445, 1.0245, 1.02455,
-       1.0246, 1.02465, 1.0247, 1.02475, 1.0248,
-       1.02485, 1.02492, 1.025, 1.02505, 1.0251,
-       1.02518, 1.02522, 1.02530, 1.02535, 1.0254,
-       1.02545, 1.0255, 1.02555, 1.0256, 1.02568,
-       1.02572, 1.0258, 1.02585, 1.0259, 1.02595,
-       1.026, 1.02608};
-
-  G4double mRICH_Agel1Absorption[mRICH_nEntries1] =  // from Hubert
-      {3.448 * m, 4.082 * m, 6.329 * m, 9.174 * m, 12.346 * m, 13.889 * m,
-       15.152 * m, 17.241 * m, 18.868 * m, 20.000 * m, 26.316 * m, 35.714 * m,
-       45.455 * m, 47.619 * m, 52.632 * m, 52.632 * m, 55.556 * m, 52.632 * m,
-       52.632 * m, 47.619 * m, 45.455 * m, 41.667 * m, 37.037 * m, 33.333 * m,
-       30.000 * m, 28.500 * m, 27.000 * m, 24.500 * m, 22.000 * m, 19.500 * m,
-       17.500 * m, 14.500 * m};
-
-  G4double mRICH_Agel1Rayleigh[mRICH_nEntries1];
-  // const G4double AerogelTypeAClarity = 0.00719*micrometer*micrometer*micrometer*micrometer/cm;
-  const G4double AerogelTypeAClarity = 0.0020 * micrometer * micrometer * micrometer * micrometer / cm;
-  G4double Cparam = AerogelTypeAClarity * cm / (micrometer * micrometer * micrometer * micrometer);
-  G4double PhotMomWaveConv = 1239 * eV * nm;
-
-  if (Cparam != 0.0)
-  {
-    for (int i = 0; i < mRICH_nEntries1; i++)
-    {
-      G4double ephoton = mRICH_PhotonEnergy[i];
-      // In the following the 1000 is to convert form nm to micrometer
-      G4double wphoton = (PhotMomWaveConv / ephoton) / (1000.0 * nm);
-      mRICH_Agel1Rayleigh[i] = (std::pow(wphoton, 4)) / Cparam;
-    }
-  }
-
-  G4MaterialPropertiesTable *mRICH_Agel1_myMPT = new G4MaterialPropertiesTable();
-  mRICH_Agel1_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_Agel1RefractiveIndex, mRICH_nEntries1);
-  mRICH_Agel1_myMPT->AddProperty("ABSLENGTH", mRICH_PhotonEnergy, mRICH_Agel1Absorption, mRICH_nEntries1);
-  mRICH_Agel1_myMPT->AddProperty("RAYLEIGH", mRICH_PhotonEnergy, mRICH_Agel1Rayleigh, mRICH_nEntries1);  // Need table of rayleigh Scattering!!!
-  mRICH_Agel1_myMPT->AddConstProperty("SCINTILLATIONYIELD", 0. / MeV);
-  mRICH_Agel1_myMPT->AddConstProperty("RESOLUTIONSCALE", 1.0);
-
-  G4Material *mRICH_Aerogel1 = new G4Material("mRICH_Aerogel1", density = 0.02 * g / cm3, ncomponents = 2);
-  mRICH_Aerogel1->AddElement(G4NistManager::Instance()->FindOrBuildElement("Si"), natoms = 1);
-  mRICH_Aerogel1->AddElement(G4NistManager::Instance()->FindOrBuildElement("O"), natoms = 2);
-  mRICH_Aerogel1->SetMaterialPropertiesTable(mRICH_Agel1_myMPT);
-
-  // mRICH_Agel2 -----------------
-  const int mRICH_nEntries2 = 50;
-
-  G4double mRICH_Agel2PhotonEnergy[mRICH_nEntries2] =
-      {1.87855 * eV, 1.96673 * eV, 2.05490 * eV, 2.14308 * eV, 2.23126 * eV,
-       2.31943 * eV, 2.40761 * eV, 2.49579 * eV, 2.58396 * eV, 2.67214 * eV,
-       2.76032 * eV, 2.84849 * eV, 2.93667 * eV, 3.02485 * eV, 3.11302 * eV,
-       3.20120 * eV, 3.28938 * eV, 3.37755 * eV, 3.46573 * eV, 3.55391 * eV,
-       3.64208 * eV, 3.73026 * eV, 3.81844 * eV, 3.90661 * eV, 3.99479 * eV,
-       4.08297 * eV, 4.17114 * eV, 4.25932 * eV, 4.34750 * eV, 4.43567 * eV,
-       4.52385 * eV, 4.61203 * eV, 4.70020 * eV, 4.78838 * eV, 4.87656 * eV,
-       4.96473 * eV, 5.05291 * eV, 5.14109 * eV, 5.22927 * eV, 5.31744 * eV,
-       5.40562 * eV, 5.49380 * eV, 5.58197 * eV, 5.67015 * eV, 5.75833 * eV,
-       5.84650 * eV, 5.93468 * eV, 6.02286 * eV, 6.11103 * eV, 6.19921 * eV};
-
-  G4double mRICH_Agel2RefractiveIndex[mRICH_nEntries2] =
-      {1.02825, 1.02829, 1.02834, 1.02839, 1.02844,
-       1.02849, 1.02854, 1.02860, 1.02866, 1.02872,
-       1.02878, 1.02885, 1.02892, 1.02899, 1.02906,
-       1.02914, 1.02921, 1.02929, 1.02938, 1.02946,
-       1.02955, 1.02964, 1.02974, 1.02983, 1.02993,
-       1.03003, 1.03014, 1.03025, 1.03036, 1.03047,
-       1.03059, 1.03071, 1.03084, 1.03096, 1.03109,
-       1.03123, 1.03137, 1.03151, 1.03166, 1.03181,
-       1.03196, 1.03212, 1.03228, 1.03244, 1.03261,
-       1.03279, 1.03297, 1.03315, 1.03334, 1.03354};
-
-  G4double mRICH_Agel2Absorption[mRICH_nEntries2] =  // from Marco
-      {17.5000 * cm, 17.7466 * cm, 17.9720 * cm, 18.1789 * cm, 18.3694 * cm,
-       18.5455 * cm, 18.7086 * cm, 18.8602 * cm, 19.0015 * cm, 19.1334 * cm,
-       19.2569 * cm, 19.3728 * cm, 19.4817 * cm, 19.5843 * cm, 19.6810 * cm,
-       19.7725 * cm, 19.8590 * cm, 19.9410 * cm, 20.0188 * cm, 20.0928 * cm,
-       18.4895 * cm, 16.0174 * cm, 13.9223 * cm, 12.1401 * cm, 10.6185 * cm,
-       9.3147 * cm, 8.1940 * cm, 7.2274 * cm, 6.3913 * cm, 5.6659 * cm,
-       5.0347 * cm, 4.4841 * cm, 4.0024 * cm, 3.5801 * cm, 3.2088 * cm,
-       2.8817 * cm, 2.5928 * cm, 2.3372 * cm, 2.1105 * cm, 1.9090 * cm,
-       1.7296 * cm, 1.5696 * cm, 1.4266 * cm, 1.2986 * cm, 1.1837 * cm,
-       1.0806 * cm, 0.9877 * cm, 0.9041 * cm, 0.8286 * cm, 0.7603 * cm};
-
-  G4double mRICH_Agel2Rayleigh[mRICH_nEntries2] =  // from Marco
-      {35.1384 * cm, 29.24805 * cm, 24.5418 * cm, 20.7453 * cm, 17.6553 * cm,
-       15.1197 * cm, 13.02345 * cm, 11.2782 * cm, 9.81585 * cm, 8.58285 * cm,
-       7.53765 * cm, 6.6468 * cm, 5.88375 * cm, 5.22705 * cm, 4.6596 * cm,
-       4.167 * cm, 3.73785 * cm, 3.36255 * cm, 3.03315 * cm, 2.7432 * cm,
-       2.487 * cm, 2.26005 * cm, 2.05845 * cm, 1.87875 * cm, 1.71825 * cm,
-       1.57455 * cm, 1.44555 * cm, 1.3296 * cm, 1.2249 * cm, 1.1304 * cm,
-       1.04475 * cm, 0.9672 * cm, 0.89655 * cm, 0.83235 * cm, 0.77385 * cm,
-       0.7203 * cm, 0.67125 * cm, 0.6264 * cm, 0.58515 * cm, 0.54735 * cm,
-       0.51255 * cm, 0.48045 * cm, 0.45075 * cm, 0.4233 * cm, 0.39795 * cm,
-       0.37455 * cm, 0.3528 * cm, 0.33255 * cm, 0.3138 * cm, 0.29625 * cm};
-
-  G4MaterialPropertiesTable *mRICH_Agel2MPT = new G4MaterialPropertiesTable();
-  mRICH_Agel2MPT->AddProperty("RINDEX", mRICH_Agel2PhotonEnergy, mRICH_Agel2RefractiveIndex, mRICH_nEntries2);
-  mRICH_Agel2MPT->AddProperty("ABSLENGTH", mRICH_Agel2PhotonEnergy, mRICH_Agel2Absorption, mRICH_nEntries2);
-  mRICH_Agel2MPT->AddProperty("RAYLEIGH", mRICH_Agel2PhotonEnergy, mRICH_Agel2Rayleigh, mRICH_nEntries2);
-  mRICH_Agel2MPT->AddConstProperty("SCINTILLATIONYIELD", 0. / MeV);
-  mRICH_Agel2MPT->AddConstProperty("RESOLUTIONSCALE", 1.0);
-
-  G4Material *mRICH_Aerogel2 = new G4Material("mRICH_Aerogel2", density = 0.02 * g / cm3, ncomponents = 2);
-  mRICH_Aerogel2->AddElement(G4NistManager::Instance()->FindOrBuildElement("Si"), natoms = 1);
-  mRICH_Aerogel2->AddElement(G4NistManager::Instance()->FindOrBuildElement("O"), natoms = 2);
-  mRICH_Aerogel2->SetMaterialPropertiesTable(mRICH_Agel2MPT);
-
-  // mRICH_Borosilicate ----------
-  // using the same photon energy array as mRICH_Acrylic
-
-  G4double mRICH_glassRefractiveIndex[mRICH_nEntries1] =
-      {1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47, 1.47, 1.47, 1.47,
-       1.47, 1.47};
-
-  G4double mRICH_glassAbsorption[mRICH_nEntries1] =
-      {4.25 * cm, 4.25 * cm, 4.25 * cm, 4.25 * cm,
-       4.25 * cm, 4.25 * cm, 4.25 * cm, 4.25 * cm,
-       4.25 * cm, 4.25 * cm, 4.25 * cm, 4.25 * cm,
-       4.25 * cm, 4.25 * cm, 4.25 * cm, 4.25 * cm,
-       4.25 * cm, 4.25 * cm, 4.25 * cm, 4.25 * cm,
-       4.25 * cm, 00.667 * cm, 00.037 * cm, 00.333 * cm,
-       00.001 * cm, 00.001 * cm, 00.001 * cm, 00.001 * cm,
-       00.001 * cm, 00.001 * cm, 00.001 * cm, 00.001 * cm};
-
-  G4MaterialPropertiesTable *mRICH_glass_myMPT = new G4MaterialPropertiesTable();
-  // same photon energy array as aerogel 1
-  mRICH_glass_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_glassRefractiveIndex, mRICH_nEntries1);
-  mRICH_glass_myMPT->AddProperty("ABSLENGTH", mRICH_PhotonEnergy, mRICH_glassAbsorption, mRICH_nEntries1);
-
-  const G4Material *G4_Pyrex_Glass = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
-  G4Material *mRICH_Borosilicate = new G4Material("mRICH_Borosilicate", G4_Pyrex_Glass->GetDensity(), G4_Pyrex_Glass, G4_Pyrex_Glass->GetState(), G4_Pyrex_Glass->GetTemperature(), G4_Pyrex_Glass->GetPressure());
-  mRICH_Borosilicate->SetMaterialPropertiesTable(mRICH_glass_myMPT);
-
-  // mRICH_Air ------------------
-  // using same photon energy array as mRICH_Acrylic
-
-  G4double mRICH_AirRefractiveIndex[mRICH_nEntries1] =
-      {1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00,
-       1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00,
-       1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00,
-       1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00,
-       1.00, 1.00, 1.00, 1.00};
-
-  G4MaterialPropertiesTable *mRICH_Air_myMPT = new G4MaterialPropertiesTable();
-  mRICH_Air_myMPT->AddProperty("RINDEX", mRICH_PhotonEnergy, mRICH_AirRefractiveIndex, mRICH_nEntries1);
-  const G4Material *G4_AIR = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
-  G4Material *mRICH_Air = new G4Material("mRICH_Air", G4_AIR->GetDensity(), G4_AIR, G4_AIR->GetState(), G4_AIR->GetTemperature(), G4_AIR->GetPressure());
-  mRICH_Air->SetMaterialPropertiesTable(mRICH_Air_myMPT);
 }
 
 void PHG4Reco::DefineRegions()

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -1053,6 +1053,20 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   sPHENIX_tpc_gas->AddMaterial(CF4, den_CF4_2 * CF4_frac / den_sphenix_tpc_gas);
   sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ne"), den_G4_Ne * G4_Ne_frac / den_sphenix_tpc_gas);
 
+  // Due to supply issues, we are now expecting to use Ar CF4.
+  // The fractions are tuned to produce very similar drift speed
+  // and other parameters as the original NeCF4 mixture.
+  double alt_G4_Ar_frac = 0.6;
+  double alt_CF4_frac = 0.4;
+  const double alt_den_G4_Ar = G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar")->GetDensity();
+  const double alt_den_CF4 = CF4->GetDensity();
+  const double alt_den_sphenix_tpc_gas = alt_den_G4_Ar * alt_G4_Ar_frac + alt_den_CF4 * alt_CF4_frac;
+  G4Material *sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas_ArCF4", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
+  sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4_2 * alt_CF4_frac / den_sphenix_tpc_gas);
+  sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), alt_den_G4_Ar * alt_G4_Ar_frac / alt_den_sphenix_tpc_gas);
+
+  
+
   // LHCb aerogel
   //    double density = 2.200 * g / cm3;
   G4Material *SiO2AerogelQuartz = new G4Material("ePHENIX_AerogelQuartz",

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -840,15 +840,6 @@ void PHG4Reco::DefineMaterials()
   cf30_peek70->AddMaterial(cf, fractionmass = 0.34468085);
   cf30_peek70->AddMaterial(peek, fractionmass = 0.65531915);
 
-  // gas mixture for the MuID in fsPHENIX. CLS 02-25-14
-  G4Material *IsoButane = new G4Material("Isobutane", 0.00265 * g / cm3, 2);
-  IsoButane->AddElement(G4NistManager::Instance()->FindOrBuildElement("C"), 4);
-  IsoButane->AddElement(G4NistManager::Instance()->FindOrBuildElement("H"), 10);
-
-  G4Material *MuIDgas = new G4Material("MuIDgas", density = (1.977e-3 * 0.92 + 0.00265 * 0.08) * g / cm3, ncomponents = 2);
-  MuIDgas->AddMaterial(IsoButane, fractionmass = 0.08);
-  MuIDgas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_CARBON_DIOXIDE"), fractionmass = 0.92);
-
   // that seems to be the composition of 304 Stainless steel
   G4Material *StainlessSteel =
       new G4Material("SS304", density = 7.9 * g / cm3, ncomponents = 8);
@@ -1027,22 +1018,6 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   SilverEpoxyGlue_INTT->AddMaterial(Epoxy, fractionmass = 0.79);
   SilverEpoxyGlue_INTT->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ag"), fractionmass = 0.21);
 
-  //! ePHENIX TPC - Jin Huang <jhuang@bnl.gov>
-  //! Ref: B. Yu et al. A gem based tpc for the legs experiment. In Nuclear Science Symposium
-  //! Conference Record, 2005 IEEE, volume 2, pages 924-928, 2005. doi:10.1109/NSSMIC.2005.1596405.
-
-  const double den_CF4 = CF4->GetDensity() * .1;
-  const double den_G4_Ar = G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar")->GetDensity() * .8;
-  const double den_G4_CARBON_DIOXIDE = G4NistManager::Instance()->FindOrBuildMaterial("G4_CARBON_DIOXIDE")->GetDensity() * .1;
-  const double den = den_CF4 + den_G4_Ar + den_G4_CARBON_DIOXIDE;
-
-  G4Material *ePHEINX_TPC_Gas = new G4Material("ePHEINX_TPC_Gas", den,
-                                               ncomponents = 3, kStateGas);
-  ePHEINX_TPC_Gas->AddMaterial(CF4, den_CF4 / den);
-  ePHEINX_TPC_Gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), den_G4_Ar / den);
-  ePHEINX_TPC_Gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_CARBON_DIOXIDE"),
-                               den_G4_CARBON_DIOXIDE / den);
-  // cross checked with original implementation made up of Ne,C,F
   // this here is very close but makes more sense since it uses Ne and CF4
   double G4_Ne_frac = 0.5;
   double CF4_frac = 0.5;
@@ -1061,22 +1036,11 @@ PMMA      -3  12.01 1.008 15.99  6.  1.  8.  1.19  3.6  5.7  1.4
   const double alt_den_G4_Ar = G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar")->GetDensity();
   const double alt_den_CF4 = CF4->GetDensity();
   const double alt_den_sphenix_tpc_gas = alt_den_G4_Ar * alt_G4_Ar_frac + alt_den_CF4 * alt_CF4_frac;
-  G4Material *sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas_ArCF4", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
-  sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4_2 * alt_CF4_frac / den_sphenix_tpc_gas);
-  sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), alt_den_G4_Ar * alt_G4_Ar_frac / alt_den_sphenix_tpc_gas);
+  G4Material *alt_sPHENIX_tpc_gas = new G4Material("sPHENIX_TPC_Gas_ArCF4", den_sphenix_tpc_gas, ncomponents = 2, kStateGas);
+  alt_sPHENIX_tpc_gas->AddMaterial(CF4, alt_den_CF4 * alt_CF4_frac / den_sphenix_tpc_gas);
+  alt_sPHENIX_tpc_gas->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("G4_Ar"), alt_den_G4_Ar * alt_G4_Ar_frac / alt_den_sphenix_tpc_gas);
 
   
-
-  // LHCb aerogel
-  //    double density = 2.200 * g / cm3;
-  G4Material *SiO2AerogelQuartz = new G4Material("ePHENIX_AerogelQuartz",
-                                                 2.200 * g / cm3, 2);
-  SiO2AerogelQuartz->AddElement(G4NistManager::Instance()->FindOrBuildElement("Si"), 1);
-  SiO2AerogelQuartz->AddElement(G4NistManager::Instance()->FindOrBuildElement("O"), 2);
-
-  G4Material *AerogTypeA = new G4Material("ePHENIX_AeroGel", 0.200 * g / cm3, 1);
-  AerogTypeA->AddMaterial(G4NistManager::Instance()->FindOrBuildMaterial("ePHENIX_AerogelQuartz"),
-                          100.0 * perCent);
 
   //
   // CF4


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Adds a new gas mixture in PHG4Reco.cc that matches the TPC gas mixture selected when Neon became too difficult to acquire.   ArCF4 60:40 has very similar properties for amplification and drift as the original mix, and is labeled as "sPHENIX_TPC_Gas_ArCF4"
/
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

