### PR TITLE
Slight improvements to InttRawDataDecoder, Fixed strip_x/strip_y convention in InttMapping

### DIFF
--- a/offline/packages/intt/InttMapping.cc
+++ b/offline/packages/intt/InttMapping.cc
@@ -24,26 +24,26 @@ struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
 	switch(_s.ladder_z)
 	{
 		case 1:
-		s.chp = _s.strip_x + 13 * (_s.strip_y < 128);
+		s.chp = _s.strip_y + 13 * (_s.strip_x < 128);
 		break;
 
 		case 0:
-		s.chp = _s.strip_x + 13 * (_s.strip_y < 128) + 5;
+		s.chp = _s.strip_y + 13 * (_s.strip_x < 128) + 5;
 		break;
 
 		case 2:
-		s.chp = 13 - _s.strip_x + 13 * !(_s.strip_y < 128);
+		s.chp = 13 - _s.strip_y + 13 * !(_s.strip_x < 128);
 		break;
 
 		case 3:
-		s.chp = 4 - _s.strip_x + 13 * !(_s.strip_y < 128);
+		s.chp = 4 - _s.strip_y + 13 * !(_s.strip_x < 128);
 		break;
 
 		default:
 		break;
 	}
 
-	s.chn = (_s.strip_y < 128) ? _s.strip_y : 255 - _s.strip_y;
+	s.chn = (_s.strip_x < 128) ? _s.strip_x : 255 - _s.strip_x;
 
 	return s;
 }
@@ -59,26 +59,26 @@ struct Intt::Offline_s Intt::ToOffline(struct Online_s const& _s)
 	switch(s.ladder_z)
 	{
 		case 1:
-		s.strip_x = _s.chp % 13;
+		s.strip_y = _s.chp % 13;
 		break;
 
 		case 0:
-		s.strip_x = _s.chp % 13 - 5;
+		s.strip_y = _s.chp % 13 - 5;
 		break;
 
 		case 2:
-		s.strip_x = 7 - (_s.chp % 13);
+		s.strip_y = 7 - (_s.chp % 13);
 		break;
 
 		case 3:
-		s.strip_x = 4 - (_s.chp % 13);
+		s.strip_y = 4 - (_s.chp % 13);
 		break;
 
 		default:
 		break;
 }
 
-	s.strip_y = (!_s.arm != !(_s.chp / 13)) ? _s.chn : 255 - _s.chn;
+	s.strip_x = (!_s.arm != !(_s.chp / 13)) ? _s.chn : 255 - _s.chn;
 
 	return s;
 }

--- a/offline/packages/intt/InttRawDataDecoder.cc
+++ b/offline/packages/intt/InttRawDataDecoder.cc
@@ -1,6 +1,8 @@
 #include "InttRawDataDecoder.h"
 #include "InttMapping.h"
 
+#include <cstdio>
+
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packet.h>
@@ -78,7 +80,17 @@ int InttRawDataDecoder::InitRun(PHCompositeNode* topNode)
 int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 {
 	TrkrHitSetContainer* trkr_hit_set_container = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-	if(!trkr_hit_set_container)return Fun4AllReturnCodes::DISCARDEVENT;
+	if(!trkr_hit_set_container)
+	{
+		std::cout << PHWHERE << std::endl;
+		std::cout << "InttRawDataDecoder::process_event(PHCompositeNode* topNode)" << std::endl;
+		std::cout << "Could not get \"TRKR_HITSET\" from Node Tree" << std::endl;
+		std::cout << "Exiting" << std::endl;
+		exit(1);
+
+		return Fun4AllReturnCodes::DISCARDEVENT;
+	}
+
 
 	Event* evt = findNode::getClass<Event>(topNode, "PRDF");
 	if(!evt)return Fun4AllReturnCodes::DISCARDEVENT;
@@ -119,7 +131,7 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 			offline = Intt::ToOffline(rawdata);
 
 			hit_key = InttDefs::genHitKey(offline.strip_x, offline.strip_y);
-			hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);
+			hit_set_key = InttDefs::genHitSetKey(offline.layer + 3, offline.ladder_z, offline.ladder_phi, bco);
 
 			hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
 			hit = hit_set_container_itr->second->getHit(hit_key);
@@ -131,6 +143,14 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 		}
 
 		delete p;
+	}
+
+	if(Verbosity() > 20)
+	{
+		std::cout << std::endl;
+		std::cout << "Identify():" << std::endl;
+		trkr_hit_set_container->identify();
+		std::cout << std::endl;
 	}
 
 	return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/intt/InttRawDataDecoder.cc
+++ b/offline/packages/intt/InttRawDataDecoder.cc
@@ -1,8 +1,6 @@
 #include "InttRawDataDecoder.h"
 #include "InttMapping.h"
 
-#include <cstdio>
-
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/packet.h>


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Fixes the strip_x/y convention to be consistent with tracking group's
Improved guard clause in process_event for the intt decoder (e.g., exit(1) instead of return 1)
Slightly more debugging information (behind Verbosity checks)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

