### PR TITLE
Updated, works: verbose clusters, matching alg. update

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -14,6 +14,7 @@
 #include <trackbase/InttDefs.h>
 #include <trackbase/TpcDefs.h>
 
+#include <trackbase/ClusHitsVerbosev1.h>
 #include <trackbase/RawHit.h>
 #include <trackbase/RawHitSet.h>
 #include <trackbase/RawHitSetContainer.h>
@@ -235,6 +236,24 @@ int InttClusterizer::InitRun(PHCompositeNode* topNode)
       cout << " Energy weighting clusters in Layer #" << iter->first << " = " << boolalpha << iter->second << noboolalpha << endl;
     }
     cout << "===========================================================================" << endl;
+  }
+
+  if (record_ClusHitsVerbose) {
+    // get the node
+    mClusHitsVerbose = findNode::getClass<ClusHitsVerbosev1>(topNode, "Trkr_SvtxClusHitsVerbose");
+    if (!mClusHitsVerbose)
+    {
+      PHNodeIterator dstiter(dstNode);
+      auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+      if (!DetNode)
+      {
+        DetNode = new PHCompositeNode("TRKR");
+        dstNode->addNode(DetNode);
+      }
+      mClusHitsVerbose = new ClusHitsVerbosev1();
+      auto newNode = new PHIODataNode<PHObject>(mClusHitsVerbose, "Trkr_SvtxClusHitsVerbose", "PHObject");
+      DetNode->addNode(newNode);
+    }
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -731,15 +750,26 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
 	unsigned nhits = 0;
 
 	//std::cout << PHWHERE << " ckey " << ckey << ":" << std::endl;	
+  
+  std::map<int,unsigned int> m_phi, m_z; // hold data for 
 	for (mapiter = clusrange.first; mapiter != clusrange.second; ++mapiter)
 	  {
 	    // mapiter->second.first  is the hit key
 	    //cout << " adding hitkey " << mapiter->second.first << endl; 
+      const auto energy = (mapiter->second)->getAdc();
 	    int col = (mapiter->second)->getPhiBin();
 	    int row = (mapiter->second)->getTBin();
 	    //	    cout << " found Tbin(row) " << row << " Phibin(col) " << col << endl; 
 	    zbins.insert(col);
 	    phibins.insert(row);
+
+      if (mClusHitsVerbose) {
+        auto pnew = m_phi.try_emplace(row,energy);
+        if (!pnew.second) pnew.first->second += energy;
+
+        pnew = m_z.try_emplace(col,energy);
+        if (!pnew.second) pnew.first->second += energy;
+      }
 
 	    // mapiter->second.second is the hit
 	    unsigned int hit_adc = (mapiter->second)->getAdc();
@@ -780,6 +810,17 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
 		
 	      }
 	  }
+
+    if (mClusHitsVerbose) {
+      if (Verbosity()>10) {
+        for (auto& hit : m_phi) {
+          std::cout << " m_phi(" << hit.first <<" : " << hit.second<<") " << std::endl;
+        }
+      }
+      for (auto& hit : m_phi) mClusHitsVerbose->addPhiHit    (hit.first, (float)hit.second);
+      for (auto& hit : m_z)   mClusHitsVerbose->addZHit      (hit.first, (float)hit.second);
+      mClusHitsVerbose->push_hits(ckey);
+    }
 
 	static const float invsqrt12 = 1./sqrt(12);
 	

--- a/offline/packages/intt/InttClusterizer.h
+++ b/offline/packages/intt/InttClusterizer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+class ClusHitsVerbosev1;
 class PHCompositeNode;
 class TrkrHitSetContainer;
 class TrkrClusterContainer;
@@ -76,7 +77,12 @@ class InttClusterizer : public SubsysReco
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
 
+  // for saving verbose clusters
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
+
  private:
+  bool  record_ClusHitsVerbose { false };
   bool ladder_are_adjacent(const std::pair<TrkrDefs::hitkey, TrkrHit*> &lhs, const std::pair<TrkrDefs::hitkey, TrkrHit*> &rhs, const int layer);
   bool ladder_are_adjacent(RawHit* lhs,  RawHit* rhs, const int layer);
 

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -13,6 +13,8 @@
 
 #include <string>                // for string
 #include <utility>
+
+class ClusHitsVerbosev1;
 class PHCompositeNode;
 class TrkrHit;
 class TrkrHitSetContainer;
@@ -57,9 +59,12 @@ class MvtxClusterizer : public SubsysReco
   void set_cluster_version(int value) { m_cluster_version = value; }
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
 
  private:
   //bool are_adjacent(const pixel lhs, const pixel rhs);
+  bool  record_ClusHitsVerbose { false };
   bool are_adjacent(const std::pair<TrkrDefs::hitkey, TrkrHit*> &lhs, const std::pair<TrkrDefs::hitkey, TrkrHit*> &rhs);
   bool are_adjacent(RawHit* lhs,  RawHit* rhs);
 

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -1,5 +1,6 @@
 #include "TpcClusterizer.h"
 
+#include <trackbase/ClusHitsVerbosev1.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrClusterContainerv4.h>
 #include <trackbase/TrkrClusterv3.h>
@@ -65,6 +66,8 @@ namespace
     unsigned short edge = 0;
   };
 
+  using vec_dVerbose = std::vector<std::vector<std::pair<int,int>>>;
+
   struct thread_data 
   {
     PHG4TpcCylinderGeom *layergeom = nullptr;
@@ -95,6 +98,9 @@ namespace
     std::vector<assoc> association_vector;
     std::vector<TrkrCluster*> cluster_vector;
     int verbosity = 0;
+    bool fillClusHitsVerbose = false;
+    vec_dVerbose phivec_ClusHitsVerbose ; // only fill if fillClusHitsVerbose
+    vec_dVerbose zvec_ClusHitsVerbose   ;// only fill if fillClusHitsVerbose
   };
   
   pthread_mutex_t mythreadlock;
@@ -313,6 +319,11 @@ namespace
       if(clus_size == 1) return;
       //      std::cout << "process list" << std::endl;    
       std::vector<TrkrDefs::hitkey> hitkeyvec;
+
+      // keep track of the hit locations in a given cluster
+  std::map<int,unsigned int> m_phi {};
+  std::map<int,unsigned int> m_z   {};
+
       for(auto iter = ihit_list.begin(); iter != ihit_list.end();++iter){
 	double adc = iter->adc; 
 	
@@ -335,16 +346,24 @@ namespace
 	iphi_sum += iphi * adc;
 	iphi2_sum += square(iphi)*adc;
 
-	// update t sums
-	double t = my_data.layergeom->get_zcenter(it);
-	t_sum += t*adc;
-	t2_sum += square(t)*adc;
-	
-	adc_sum += adc;
-	
-	// capture the hitkeys for all adc values above a certain threshold
-	TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it);
-	// if(adc>5)
+  // update t sums
+  double t = my_data.layergeom->get_zcenter(it);
+  t_sum += t*adc;
+  t2_sum += square(t)*adc;
+
+  adc_sum += adc;
+
+  if (my_data.fillClusHitsVerbose) {
+    auto pnew = m_phi.try_emplace(iphi,adc);
+    if (!pnew.second) pnew.first->second += adc;
+
+    pnew = m_z.try_emplace(it,adc);
+    if (!pnew.second) pnew.first->second += adc;
+  }
+
+  // capture the hitkeys for all adc values above a certain threshold
+  TrkrDefs::hitkey hitkey = TpcDefs::genHitKey(iphi, it);
+  // if(adc>5)
 	hitkeyvec.push_back(hitkey);
       }
       //      std::cout << "done process list" << std::endl;
@@ -417,6 +436,8 @@ namespace
       //std::cout << "done transform" << std::endl;
       // we need the cluster key and all associated hit keys (note: the cluster key includes the hitset key)
       
+  bool b_made_cluster { false };
+
       if(my_data.cluster_version==3){
 	//std::cout << "ver3" << std::endl;
 	// Fill in the cluster details
@@ -432,6 +453,7 @@ namespace
 	clus->setActsLocalError(0,1, 0);
 	clus->setActsLocalError(1,1, t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2));
 	my_data.cluster_vector.push_back(clus);
+  b_made_cluster = true;
       }else if(my_data.cluster_version==4){
 	//std::cout << "ver4" << std::endl;
 	//	std::cout << "clus num" << my_data.cluster_vector.size() << " X " << local(0) << " Y " << clust << std::endl;
@@ -450,6 +472,7 @@ namespace
 	//	clus->setPhiErr(sqrt(phi_err_square));
 	//clus->setZErr(sqrt(t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2)));
 	my_data.cluster_vector.push_back(clus);
+  b_made_cluster = true;
 	}
       }else if(my_data.cluster_version==5){
 	//std::cout << "ver5" << std::endl;
@@ -468,7 +491,20 @@ namespace
 	clus->setPhiError(sqrt(phi_err_square));
 	clus->setZError(sqrt(t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2)));
 	my_data.cluster_vector.push_back(clus);
+  b_made_cluster = true;
 	}
+      }
+
+      if (my_data.fillClusHitsVerbose && b_made_cluster) {
+        // push the data back to 
+        my_data.phivec_ClusHitsVerbose .push_back( std::vector<std::pair<int,int>> {} );
+        my_data.zvec_ClusHitsVerbose   .push_back( std::vector<std::pair<int,int>> {} );
+
+        auto& vphi = my_data.phivec_ClusHitsVerbose .back();
+        auto& vz   = my_data.zvec_ClusHitsVerbose   .back();
+
+        for (auto& entry : m_phi ) vphi.push_back({entry.first, entry.second});
+        for (auto& entry : m_z   ) vz  .push_back({entry.first, entry.second});
       }
 	
       //std::cout << "end clus out" << std::endl;
@@ -761,6 +797,24 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
     DetNode->addNode(newNode);
   }
 
+  if (record_ClusHitsVerbose) {
+    // get the node
+    mClusHitsVerbose = findNode::getClass<ClusHitsVerbosev1>(topNode, "Trkr_SvtxClusHitsVerbose");
+    if (!mClusHitsVerbose)
+    {
+      PHNodeIterator dstiter(dstNode);
+      auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
+      if (!DetNode)
+      {
+        DetNode = new PHCompositeNode("TRKR");
+        dstNode->addNode(DetNode);
+      }
+      mClusHitsVerbose = new ClusHitsVerbosev1();
+      auto newNode = new PHIODataNode<PHObject>(mClusHitsVerbose, "Trkr_SvtxClusHitsVerbose", "PHObject");
+      DetNode->addNode(newNode);
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -886,6 +940,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	
 	// instanciate new thread pair, at the end of thread vector
 	thread_pair_t& thread_pair = threads.emplace_back();
+  if (mClusHitsVerbose) { thread_pair.data.fillClusHitsVerbose = true; };
 	
 	thread_pair.data.layergeom = layergeom;
 	thread_pair.data.hitset = hitset;
@@ -951,6 +1006,16 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	      
 	      // insert in map
 	      m_clusterlist->addClusterSpecifyKey(ckey, cluster);
+
+        if (mClusHitsVerbose) {
+          for (auto& hit : data.phivec_ClusHitsVerbose[index]) {
+            mClusHitsVerbose->addPhiHit (hit.first, hit.second);
+          }
+          for (auto& hit : data.zvec_ClusHitsVerbose[index]) {
+            mClusHitsVerbose->addZHit (hit.first, hit.second);
+          }
+          mClusHitsVerbose->push_hits(ckey);
+        }
 	    }
 	  
 	  // copy hit associations to map
@@ -1111,6 +1176,17 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	    // insert in map
 	    //std::cout << "X: " << cluster->getLocalX() << "Y: " << cluster->getLocalY() << std::endl;
 	    m_clusterlist->addClusterSpecifyKey(ckey, cluster);
+
+      if (mClusHitsVerbose) {
+        for (auto& hit : data.phivec_ClusHitsVerbose[index]) {
+          mClusHitsVerbose->addPhiHit (hit.first, (float)hit.second);
+        }
+        for (auto& hit : data.zvec_ClusHitsVerbose[index]) {
+          mClusHitsVerbose->addZHit (hit.first, (float)hit.second);
+        }
+        mClusHitsVerbose->push_hits(ckey);
+      }
+
 	  }
 	
 	// copy hit associations to map

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 
+class ClusHitsVerbosev1;
 class PHCompositeNode;
 class TrkrHitSet;
 class TrkrHitSetContainer;
@@ -44,10 +45,12 @@ class TpcClusterizer : public SubsysReco
   void set_max_cluster_half_size_phi(unsigned short size) { MaxClusterHalfSizePhi = size ;}
   void set_max_cluster_half_size_z(unsigned short size) { MaxClusterHalfSizeT = size ;}
   void set_cluster_version(int value) { cluster_version = value; }
-  void set_pedestal(int value) { pedestal = value; }
-
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
+  
  private:
   bool is_in_sector_boundary(int phibin, int sector, PHG4TpcCylinderGeom *layergeom) const;
+  bool record_ClusHitsVerbose { false };
 
   TrkrHitSetContainer *m_hits = nullptr;
   RawHitSetContainer *m_rawhits = nullptr;

--- a/offline/packages/trackbase/ClusHitsVerbose.cc
+++ b/offline/packages/trackbase/ClusHitsVerbose.cc
@@ -1,0 +1,50 @@
+#include "ClusHitsVerbose.h"
+
+namespace
+{
+  ClusHitsVerbose::Vector     dummy_vec;
+  ClusHitsVerbose::Map        dummy_map;
+  ClusHitsVerbose::PairVector dummy_pairvec;
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbose::phiBins(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_vec;
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbose::zBins(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_vec;
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbose::phiCutBins(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_vec;
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbose::zCutBins(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_vec;
+}
+
+ClusHitsVerbose::Map& ClusHitsVerbose::getMap()
+{
+  return dummy_map;
+}
+
+ClusHitsVerbose::PairVector ClusHitsVerbose::phiBins_pvecIE(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_pairvec;
+}
+ClusHitsVerbose::PairVector ClusHitsVerbose::phiCutBins_pvecIE(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_pairvec;
+}
+ClusHitsVerbose::PairVector ClusHitsVerbose::zBins_pvecIE(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_pairvec;
+}
+ClusHitsVerbose::PairVector ClusHitsVerbose::zCutBins_pvecIE(TrkrDefs::cluskey /*this key*/)
+{
+  return dummy_pairvec;
+}

--- a/offline/packages/trackbase/ClusHitsVerbose.h
+++ b/offline/packages/trackbase/ClusHitsVerbose.h
@@ -1,7 +1,7 @@
-#ifndef G4TRACKING_CLUSHITSVERBOSE_H
-#define G4TRACKING_CLUSHITSVERBOSE_H
+#ifndef CLUSHITSVERBOSE__H
+#define CLUSHITSVERBOSE__H
 
-#include <trackbase/TrkrDefs.h>
+#include "TrkrDefs.h"
 #include <phool/PHObject.h>
 #include <map>
 #include <vector>

--- a/offline/packages/trackbase/ClusHitsVerbose.h
+++ b/offline/packages/trackbase/ClusHitsVerbose.h
@@ -1,0 +1,46 @@
+#ifndef G4TRACKING_CLUSHITSVERBOSE_H
+#define G4TRACKING_CLUSHITSVERBOSE_H
+
+#include <trackbase/TrkrDefs.h>
+#include <phool/PHObject.h>
+#include <map>
+#include <vector>
+#include <array>
+
+class ClusHitsVerbose : public PHObject
+{
+ public:
+  using BinData = std::pair<int,int>;  // index + energy for a given bin (MVTX, INTT, or TPC)
+  using Vector  = std::vector<BinData>;// listing in phi and z (will need two of them)
+  using Map     = std::map<TrkrDefs::cluskey, std::array<Vector,4>>;
+  // ^ what is stored:: first: Phi data,  Z data, cut Phi data, cut Z data */
+  void Reset() override {}
+
+  virtual bool hasClusKey (TrkrDefs::cluskey) const { return false; };
+  virtual Vector& phiBins    (TrkrDefs::cluskey);
+  virtual Vector& zBins      (TrkrDefs::cluskey);
+  virtual Vector& phiCutBins (TrkrDefs::cluskey);
+  virtual Vector& zCutBins   (TrkrDefs::cluskey);
+  virtual Map& getMap();
+
+  // convenience classes; 
+  // ROOT's default library has vector<vector<int>> but not vec<vec<pair<int,int>>>
+  using VecInt   = std::vector<int>;
+  using PairVector = std::pair<VecInt,VecInt>;//
+  virtual PairVector phiBins_pvecIE(TrkrDefs::cluskey); // IE for integer-energy
+  virtual PairVector phiCutBins_pvecIE(TrkrDefs::cluskey);
+  virtual PairVector zBins_pvecIE(TrkrDefs::cluskey);
+  virtual PairVector zCutBins_pvecIE(TrkrDefs::cluskey);
+
+  // PHObject virtual overload
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "ClusHitsVerbose base class" << std::endl;
+  };
+
+ protected:
+  ClusHitsVerbose() = default;
+  ClassDefOverride(ClusHitsVerbose, 1)
+};
+
+#endif  // G4TRACKING_CLUSHITSVERBOSE_H

--- a/offline/packages/trackbase/ClusHitsVerboseLinkDef.h
+++ b/offline/packages/trackbase/ClusHitsVerboseLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class ClusHitsVerbose + ;
+
+#endif

--- a/offline/packages/trackbase/ClusHitsVerbosev1.cc
+++ b/offline/packages/trackbase/ClusHitsVerbosev1.cc
@@ -1,0 +1,78 @@
+#include "ClusHitsVerbosev1.h"
+
+#include <algorithm>
+#include <iostream>
+#include <phool/phool.h>
+
+using std::endl;
+using std::cout;
+
+namespace
+{
+  ClusHitsVerbose::Vector dummy_vec;
+  ClusHitsVerbose::PairVector dummy_pairvec;
+}
+
+void ClusHitsVerbosev1::Reset()
+{
+  m_data.clear();
+  m_stage_phi    .clear();
+  m_stage_z      .clear();
+  m_stage_phiCut .clear();
+  m_stage_zCut   .clear();
+}
+
+bool ClusHitsVerbosev1::hasClusKey(TrkrDefs::cluskey key) const {
+  return m_data.find(key) != m_data.end();
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbosev1::vecBins(TrkrDefs::cluskey key, int which) {
+  if (!hasClusKey(key)) return dummy_vec;
+  else return m_data[key][which];
+}
+
+ClusHitsVerbose::Vector& ClusHitsVerbosev1::phiBins(TrkrDefs::cluskey key)
+{ return vecBins(key, 0); }
+
+ClusHitsVerbose::Vector& ClusHitsVerbosev1::zBins(TrkrDefs::cluskey key)
+{ return vecBins(key, 1); }
+
+ClusHitsVerbose::Vector& ClusHitsVerbosev1::phiCutBins(TrkrDefs::cluskey key)
+{ return vecBins(key, 2); }
+
+ClusHitsVerbose::Vector& ClusHitsVerbosev1::zCutBins(TrkrDefs::cluskey key)
+{ return vecBins(key, 3); }
+
+ClusHitsVerbose::PairVector ClusHitsVerbosev1::pvecIE(TrkrDefs::cluskey key, int which)
+{
+  if (!hasClusKey(key)) return dummy_pairvec;
+
+  // unzip the vector<pair<int,int>> into two vectors: vector<int> vector<int>
+  std::vector<int> vecI{};
+  std::vector<int> vecE {};
+  for (auto& entry : m_data[key][which]) {
+    vecI.push_back(entry.first);
+    vecE.push_back(entry.second);
+  }
+  return {vecI, vecE};
+}
+
+ClusHitsVerbose::PairVector ClusHitsVerbosev1::phiBins_pvecIE(TrkrDefs::cluskey key)
+{ return pvecIE(key, 0); }
+
+ClusHitsVerbose::PairVector ClusHitsVerbosev1::zBins_pvecIE(TrkrDefs::cluskey key)
+{ return pvecIE(key, 1); }
+
+ClusHitsVerbose::PairVector ClusHitsVerbosev1::phiCutBins_pvecIE(TrkrDefs::cluskey key)
+{ return pvecIE(key, 2); }
+
+ClusHitsVerbose::PairVector ClusHitsVerbosev1::zCutBins_pvecIE(TrkrDefs::cluskey key)
+{ return pvecIE(key, 3); }
+
+void ClusHitsVerbosev1::push_hits(TrkrDefs::cluskey key) {
+  m_data[key] = { m_stage_phi, m_stage_z, m_stage_phiCut, m_stage_zCut };
+  m_stage_phi    .clear();
+  m_stage_z      .clear();
+  m_stage_phiCut .clear();
+  m_stage_zCut   .clear();
+}

--- a/offline/packages/trackbase/ClusHitsVerbosev1.h
+++ b/offline/packages/trackbase/ClusHitsVerbosev1.h
@@ -1,0 +1,65 @@
+#ifndef G4TRACKING_CLUSHITSVERBOSEV1_H
+#define G4TRACKING_CLUSHITSVERBOSEV1_H
+
+/**
+ * @file trackbase/ClusHitsVerbosev1.h
+ * @author D. Stewart
+ * @date May 2023
+ * @brief Ojbect to show hit locations in given clusters
+ */
+
+#include "ClusHitsVerbose.h"
+
+/**
+ * @brief Cluster container object
+ */
+class ClusHitsVerbosev1 : public ClusHitsVerbose
+{
+ public:
+  void Reset() override;
+
+ private:
+  PairVector pvecIE  (TrkrDefs::cluskey, int which);
+  Vector&    vecBins (TrkrDefs::cluskey, int which);
+
+ public:
+  bool    hasClusKey (TrkrDefs::cluskey) const    override;
+  Vector& phiBins    (TrkrDefs::cluskey) override;
+  Vector& zBins      (TrkrDefs::cluskey) override;
+  Vector& phiCutBins (TrkrDefs::cluskey) override;
+  Vector& zCutBins   (TrkrDefs::cluskey) override;
+
+
+  PairVector phiBins_pvecIE    (TrkrDefs::cluskey) override;
+  PairVector zBins_pvecIE      (TrkrDefs::cluskey) override;
+  PairVector phiCutBins_pvecIE (TrkrDefs::cluskey) override;
+  PairVector zCutBins_pvecIE   (TrkrDefs::cluskey) override;
+
+
+  Map&    getMap     () override { return m_data; };
+
+  void addPhiHit    (int _i, int _v) { m_stage_phi    .push_back({_i,_v}); };
+  void addZHit      (int _i, int _v) { m_stage_z      .push_back({_i,_v}); };
+  void addPhiCutHit (int _i, int _v) { m_stage_phiCut .push_back({_i,_v}); };
+  void addZCutHit   (int _i, int _v) { m_stage_zCut   .push_back({_i,_v}); };
+  void push_hits (TrkrDefs::cluskey);
+
+  ClusHitsVerbosev1() = default;
+
+  void identify(std::ostream& os = std::cout) const override
+  {
+    os << "ClusHitsVerbose base class" << std::endl;
+  };
+
+ private:
+  // the data
+  Map m_data {};
+  Vector m_stage_phi    {};
+  Vector m_stage_z      {};
+  Vector m_stage_phiCut {};
+  Vector m_stage_zCut   {};
+
+  ClassDefOverride(ClusHitsVerbosev1, 1)
+};
+
+#endif  // G4TRACKING_CLUSHITSVERBOSEV1_H

--- a/offline/packages/trackbase/ClusHitsVerbosev1LinkDef.h
+++ b/offline/packages/trackbase/ClusHitsVerbosev1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class ClusHitsVerbosev1 + ;
+
+#endif

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -49,6 +49,8 @@ pkginclude_HEADERS = \
   CMFlashDifferenceContainerv1.h \
   CMFlashDifferencev1.h \
   Calibrator.h \
+  ClusHitsVerbose.h \
+  ClusHitsVerbosev1.h \
   ClusterErrorPara.h \
   InttDefs.h \
   MvtxDefs.h \
@@ -109,6 +111,8 @@ ROOTDICTS = \
   CMFlashDifferenceContainerv1_Dict.cc \
   CMFlashDifference_Dict.cc \
   CMFlashDifferencev1_Dict.cc \
+  ClusHitsVerbose_Dict.cc \
+  ClusHitsVerbosev1_Dict.cc \
   RawHitSetContainer_Dict.cc \
   RawHitSetContainerv1_Dict.cc \
   RawHitSet_Dict.cc \
@@ -161,6 +165,8 @@ nobase_dist_pcm_DATA = \
   CMFlashDifferenceContainerv1_Dict_rdict.pcm \
   CMFlashDifference_Dict_rdict.pcm \
   CMFlashDifferencev1_Dict_rdict.pcm \
+  ClusHitsVerbose_Dict_rdict.pcm \
+  ClusHitsVerbosev1_Dict_rdict.pcm \
   RawHitSetContainer_Dict_rdict.pcm \
   RawHitSetContainerv1_Dict_rdict.pcm \
   RawHitSet_Dict_rdict.pcm \
@@ -213,6 +219,8 @@ libtrack_io_la_SOURCES = \
   CMFlashDifferenceContainerv1.cc \
   CMFlashDifferencev1.cc \
   ClusterErrorPara.cc \
+  ClusHitsVerbose.cc \
+  ClusHitsVerbosev1.cc \
   InttDefs.cc \
   MvtxDefs.cc \
   RawHitSet.cc \

--- a/simulation/g4simulation/g4eval/ClusKeyIter.cc
+++ b/simulation/g4simulation/g4eval/ClusKeyIter.cc
@@ -1,0 +1,52 @@
+#include "ClusKeyIter.h"
+
+#include <trackbase_historic/SvtxTrack.h>
+
+ClusKeyIter::ClusKeyIter(SvtxTrack* _track) :
+  track {_track}
+  , in_silicon { _track->get_silicon_seed()!=nullptr }
+  , has_tpc    { _track->get_tpc_seed()!=nullptr }
+  , no_data    { !in_silicon && !has_tpc }
+{
+}
+
+ClusKeyIter ClusKeyIter::begin() {
+  ClusKeyIter iter0 { track }; 
+  if (iter0.no_data) return iter0;
+  if (iter0.in_silicon) {
+    iter0.iter = track->get_silicon_seed()->begin_cluster_keys();
+    iter0.iter_end_silicon = track->get_silicon_seed()->end_cluster_keys();
+  } else if (has_tpc) {
+    iter0.iter = track->get_tpc_seed()->begin_cluster_keys();
+  } 
+  return iter0;
+}
+
+ClusKeyIter ClusKeyIter::end() {
+  ClusKeyIter iter0 { track }; 
+  if (iter0.no_data) return iter0;
+  if (has_tpc) {
+    iter0.iter = track->get_tpc_seed()->end_cluster_keys();
+  } else if (in_silicon) {
+    iter0.iter = track->get_silicon_seed()->end_cluster_keys();
+  } 
+  return iter0;
+}
+
+void ClusKeyIter::operator++() {
+  if (no_data) return;
+  ++iter;
+  if (in_silicon && has_tpc && iter == iter_end_silicon) {
+    in_silicon = false;
+    iter = track->get_tpc_seed()->begin_cluster_keys();
+  }
+}
+
+bool ClusKeyIter::operator!=(const ClusKeyIter& rhs) {
+  if (no_data) return false;
+  return iter != rhs.iter;
+}
+
+TrkrDefs::cluskey ClusKeyIter::operator*() {
+  return *iter;
+}

--- a/simulation/g4simulation/g4eval/ClusKeyIter.h
+++ b/simulation/g4simulation/g4eval/ClusKeyIter.h
@@ -1,0 +1,33 @@
+#ifndef CLUSKEYITER__H
+#define CLUSKEYITER__H
+
+// an iterator to loop over all the TrkrClusters for a given track
+#include <set>
+#include <trackbase/TrkrDefs.h>
+
+class SvtxTrack;
+
+struct ClusKeyIter {
+  typedef std::set<TrkrDefs::cluskey> ClusterKeySet;
+  typedef ClusterKeySet::iterator ClusterKeyIter;
+
+  ClusKeyIter(SvtxTrack* _track);
+  // data
+  SvtxTrack* track;
+  bool in_silicon;
+  bool has_tpc;
+  bool no_data; // neither a tpc nor a silicon seed
+  ClusterKeyIter iter             { };
+  ClusterKeyIter iter_end_silicon { };
+
+  ClusKeyIter begin();
+  ClusKeyIter end();
+
+  void operator++();
+  TrkrDefs::cluskey operator*();
+  bool operator!=(const ClusKeyIter& rhs);
+};
+
+
+
+#endif

--- a/simulation/g4simulation/g4eval/FillClusMatchTree.cc
+++ b/simulation/g4simulation/g4eval/FillClusMatchTree.cc
@@ -490,7 +490,7 @@ void FillClusMatchTree::print_mvtx_diagnostics() {
     return Fun4AllReturnCodes::EVENT_OK;
   }
 
-void FillClusMatchTree::clear_clusvecs(std::string tag) {
+void FillClusMatchTree::clear_clusvecs(const std::string& tag) {
   /* cout << " banana |" << tag << "|"<<endl; */
   if (tag != "") {
     for (auto x : b_clus_x) cout << x <<" ";

--- a/simulation/g4simulation/g4eval/FillClusMatchTree.cc
+++ b/simulation/g4simulation/g4eval/FillClusMatchTree.cc
@@ -1,0 +1,578 @@
+#include "FillClusMatchTree.h"
+#include "TrkrClusterIsMatcher.h"
+#include "g4evalfn.h"
+
+#include <TFile.h>
+#include <TTree.h>
+#include <fun4all/PHTFileServer.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4tracking/EmbRecoMatch.h>
+#include <g4tracking/EmbRecoMatchContainer.h>
+#include <g4tracking/TrkrTruthTrack.h>
+#include <g4tracking/TrkrTruthTrackContainer.h>
+#include <iostream>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+#include <trackbase/ClusHitsVerbose.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <TH2D.h>
+#include <trackbase/TrkrCluster.h>
+
+using std::cout;
+using std::endl;
+//____________________________________________________________________________..
+FillClusMatchTree::FillClusMatchTree(
+     TrkrClusterIsMatcher* _ismatcher
+    , const std::string& _outfile_name
+    , bool _fill_clusters
+    , bool _fill_clusverbose
+    , bool _fill_SvUnMatched
+    )
+    : m_ismatcher        { _ismatcher        }
+    , m_outfile_name     { _outfile_name     }
+    , m_fill_clusters    { _fill_clusters    }
+    , m_fill_clusverbose { _fill_clusverbose }
+    , m_fill_SvUnmatched  { _fill_SvUnMatched }
+{
+  m_TCEval.ismatcher = m_ismatcher;
+
+  PHTFileServer::get().open(m_outfile_name, "RECREATE");
+
+  h2_G4_nPixelsPhi = new TH2D("G4_nPixelsPhi", "PHG4 Emb Tracks; cluster pixel width Phi; layer",
+      100, -0.5, 99.5, 56, -0.5, 55.5);
+  h2_G4_nPixelsZ = new TH2D("G4_nPixelsZ", "PHG4 Emb Tracks; cluster pixel width Z; layer",
+      100, -0.5, 99.5, 56, -0.5, 55.5);
+  h2_Sv_nPixelsPhi = new TH2D("Sv_nPixelsPhi", "Svtx Reco Tracks; cluster pixel width Phi; layer",
+      100, -0.5, 99.5, 56, -0.5, 55.5);
+  h2_Sv_nPixelsZ = new TH2D("Sv_nPixelsZ", "Svtx Reco Tracks; cluster pixel width Z; layer",
+      100, -0.5, 99.5, 56, -0.5, 55.5);
+
+  m_ttree = new TTree("T", "Tracks (and sometimes clusters)");
+
+  m_ttree->Branch("event",                  &nevent);
+  m_ttree->Branch("nphg4_part",             &nphg4_part);
+  m_ttree->Branch("centrality",             &centrality);
+  m_ttree->Branch("ntrackmatches",          &ntrackmatches);
+  m_ttree->Branch("nphg4",                  &nphg4);
+  m_ttree->Branch("nsvtx",                  &nsvtx);
+
+  m_ttree ->Branch("trackid"    , &b_trackid    );
+  m_ttree  ->Branch("is_G4track" , &b_is_g4track );
+  m_ttree  ->Branch("is_Svtrack" , &b_is_Svtrack );
+  m_ttree  ->Branch("is_matched" , &b_is_matched );
+
+  m_ttree ->Branch("trkpt"  , &b_trkpt  );
+  m_ttree ->Branch("trketa" , &b_trketa );
+  m_ttree ->Branch("trkphi" , &b_trkphi );
+
+  m_ttree  ->Branch("nclus"         , &b_nclus         );
+  m_ttree  ->Branch("nclustpc"      , &b_nclustpc      );
+  m_ttree  ->Branch("nclusmvtx"     , &b_nclusmvtx     );
+  m_ttree  ->Branch("nclusintt"     , &b_nclusintt     );
+  m_ttree  ->Branch("matchrat"      , &b_matchrat      );
+  m_ttree  ->Branch("matchrat_intt" , &b_matchrat_intt );
+  m_ttree  ->Branch("matchrat_mvtx" , &b_matchrat_mvtx );
+  m_ttree  ->Branch("matchrat_tpc"  , &b_matchrat_tpc  );
+
+  if (m_fill_clusters) {
+    m_ttree ->Branch("clus_match"   , &b_clusmatch     );
+    m_ttree ->Branch("clus_x"       , &b_clus_x        );
+    m_ttree ->Branch("clus_y"       , &b_clus_y        );
+    m_ttree ->Branch("clus_z"       , &b_clus_z        );
+    m_ttree ->Branch("clus_r"       , &b_clus_r        );
+    m_ttree ->Branch("clus_layer"   , &b_clus_layer    );
+    /* m_ttree ->Branch("nphibins"     , &b_clus_nphibins ); */
+    /* m_ttree ->Branch("nzbins"       , &b_clus_ntbins   ); */
+
+    m_ttree ->Branch("clus_lphi"     , &b_clus_lphi     );
+    m_ttree ->Branch("clus_lphisize" , &b_clus_lphisize );
+    m_ttree ->Branch("clus_lz"       , &b_clus_lz       );
+    m_ttree ->Branch("clus_lzsize"   , &b_clus_lzsize   );
+    
+    if (m_fill_clusverbose) {
+      m_ttree ->Branch("phibins"     , &b_phibins     );
+      m_ttree ->Branch("phibins_cut" , &b_phibins_cut );
+      m_ttree ->Branch("zbins"       , &b_zbins     );
+      m_ttree ->Branch("zbins_cut"   , &b_zbins_cut );
+
+      m_ttree ->Branch("phibinsE"     , &b_phibinsE     );
+      m_ttree ->Branch("phibinsE_cut" , &b_phibinsE_cut );
+      m_ttree ->Branch("zbinsE"       , &b_zbinsE     );
+      m_ttree ->Branch("zbinsE_cut"   , &b_zbinsE_cut );
+    }
+  }
+}
+
+//____________________________________________________________________________..
+FillClusMatchTree::~FillClusMatchTree()
+{
+}
+
+//____________________________________________________________________________..
+int FillClusMatchTree::Init(PHCompositeNode *topNode)
+{
+  if (Verbosity()>1) {
+    std::cout << " Beginning FillClusMatchTree " << std::endl;
+    topNode->print();
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int FillClusMatchTree::InitRun(PHCompositeNode *topNode)
+{
+  /* auto init_status = m_cluster_comp.init(topNode); */
+  auto init_status = m_ismatcher->init(topNode);
+  if (init_status == Fun4AllReturnCodes::ABORTRUN) return init_status;
+
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FillClusMatchTree::createNodes(PHCompositeNode *topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+
+  if (!dstNode)
+  {
+    std::cout << PHWHERE << " DST node is missing, quitting" << std::endl;
+    std::cerr << PHWHERE << " DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in FillClusMatchTree::createNodes");
+  }
+  topNode->print();
+
+  m_PHG4ClusHitVerb = findNode::getClass<ClusHitsVerbose>(topNode,"Trkr_TruthClusHitsVerbose");
+  if (m_PHG4ClusHitVerb) {
+    std::cout << " Found truth cluster hits verbose " << std::endl;
+  } else {
+    std::cout << " Did not find truth cluster hits verbose " << std::endl;
+  }
+
+  m_SvtxClusHitVerb = findNode::getClass<ClusHitsVerbose>(topNode,"Trkr_SvtxClusHitsVerbose");
+  if (m_SvtxClusHitVerb) {
+    std::cout << " Found Svtx cluster hits verbose " << std::endl;
+  } else {
+    std::cout << " Did not find Svtx cluster hits verbose " << std::endl;
+  }
+
+  m_EmbRecoMatchContainer = findNode::getClass<EmbRecoMatchContainer>(topNode,"TRKR_EMBRECOMATCHCONTAINER");
+  if (!m_EmbRecoMatchContainer) {
+    std::cout << PHWHERE << " Cannot find node TRKR_EMBRECOMATCHCONTAINER on node tree; quitting " << std::endl;
+    std::cerr << PHWHERE << " Cannot find node TRKR_EMBRECOMATCHCONTAINER on node tree; quitting " << std::endl;
+    throw std::runtime_error(" Cannot find node TRKR_EMBRECOMATCHCONTAINER on node tree; quitting");
+  }
+
+  PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "SVTX"));
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  m_PHG4TruthInfoContainer = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!m_PHG4TruthInfoContainer)
+  {
+    std::cout << "Could not locate G4TruthInfo node when running " 
+      << "\"TruthRecoTrackMatching\" module." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  m_SvtxTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!m_SvtxTrackMap)
+  {
+    std::cout << "Could not locate SvtxTrackMap node when running "
+      <<"\"TruthRecoTrackMatching\" module." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  m_TrkrTruthTrackContainer = findNode::getClass<TrkrTruthTrackContainer>(topNode, 
+      "TRKR_TRUTHTRACKCONTAINER");
+  if (!m_TrkrTruthTrackContainer)
+  {
+    std::cout << "Could not locate TRKR_TRUTHTRACKCONTAINER node when running "
+      << "\"TruthRecoTrackMatching\" module." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FillClusMatchTree::process_event(PHCompositeNode * /*topNode*/)
+{
+  // We know that the data is in there and exists... why isn't it being transferred?
+
+  if (Verbosity()>5) cout << " FillClusMatchTree::process_event() " << endl;
+
+  // fill in the event data
+  ++nevent; 
+  nphg4 = m_TrkrTruthTrackContainer ->getMap().size();
+  nsvtx = m_SvtxTrackMap            ->size();
+  ntrackmatches = m_EmbRecoMatchContainer->getMatches().size();
+  // get centrality later...
+
+  // fill in pixel widths on truth tracks
+  for (auto hitsetkey : m_TCEval.get_PHG4_clusters()->getHitSetKeys()) {
+    float layer = (float) TrkrDefs::getLayer(hitsetkey);
+    auto range = m_TCEval.get_PHG4_clusters()->getClusters(hitsetkey);
+    for (auto iter = range.first; iter != range.second; ++iter) {
+      auto& cluster = iter->second;
+      h2_G4_nPixelsPhi ->Fill( (float)cluster->getPhiSize(), layer );
+      h2_G4_nPixelsZ   ->Fill( (float)cluster->getZSize(),   layer );
+    }
+  }
+  // fill in pixel widths on reco tracks
+  for (auto hitsetkey : m_TCEval.get_SVTX_clusters()->getHitSetKeys()) {
+    float layer = (float) TrkrDefs::getLayer(hitsetkey);
+    auto range = m_TCEval.get_SVTX_clusters()->getClusters(hitsetkey);
+    for (auto iter = range.first; iter != range.second; ++iter) {
+      auto& cluster = iter->second;
+      h2_Sv_nPixelsPhi ->Fill( (float)cluster->getPhiSize(), layer );
+      h2_Sv_nPixelsZ   ->Fill( (float)cluster->getZSize(), layer );
+    }
+  }
+
+  nphg4_part = 0;
+  const auto range = m_PHG4TruthInfoContainer->GetPrimaryParticleRange();
+  for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
+      iter != range.second; ++iter)
+  { nphg4_part++; }
+
+  // unmatched tracks are only entered once
+  // matches can repeat a given svtx or phg4 track, depending on the 
+  // parameters in teh matching in FillClusMatchTree
+  //
+  // (1) fill unmatched phg4
+  // (2) fill unmatched svtx
+  // (3) fill matched phg4 and svtx
+  clear_clusvecs(" nothing "); 
+
+  if (Verbosity() > 2) std::cout << " getting " << (int) m_EmbRecoMatchContainer->getMatches().size() << std::endl;
+  for (auto& match : m_EmbRecoMatchContainer->getMatches()) {
+    unsigned int g4_trkid = match->idTruthTrack();
+    int sv_trkid = match->idRecoTrack();
+
+    auto g4trk = m_TrkrTruthTrackContainer->getTruthTrack(g4_trkid);
+    auto svtrk = m_SvtxTrackMap->get(sv_trkid);
+
+    m_TCEval.addClusKeys( g4trk );
+    m_TCEval.addClusKeys( svtrk );
+    m_TCEval.find_matches();
+
+
+    // <- <- <- <- G4 Matched Tracks
+    b_is_matched = true;
+    b_is_g4track = true;
+    b_is_Svtrack = false;
+
+    b_trackid    = g4_trkid;
+    b_trkpt      = g4trk->getPt();
+    b_trketa     = g4trk->getPseudoRapidity();
+    b_trkphi     = g4trk->getPhi();
+
+    auto cnt = m_TCEval.phg4_cntclus();
+    auto cnt_match = m_TCEval.phg4_cnt_matchedclus();
+
+    b_nclus     = cnt[4] ;
+    b_nclusmvtx = cnt[0] ;
+    b_nclusintt = cnt[1] ;
+    b_nclustpc  = cnt[2] ;
+
+    b_matchrat      = (float)cnt_match[4] / cnt[4] ;
+    b_matchrat_mvtx = (float)cnt_match[0] / cnt[0] ;
+    b_matchrat_intt = (float)cnt_match[1] / cnt[1] ;
+    b_matchrat_tpc  = (float)cnt_match[2] / cnt[2] ;
+
+    if (m_fill_clusters) {
+      // - - - - UNMATCHED PHG4 hits in matched track
+      auto clusters = m_TCEval.phg4_clusloc_unmatched();
+      for (auto& clus : clusters) {
+          b_clusmatch     .push_back(false);
+          fill_cluster_branches(clus, true);
+      }
+
+      // - - - - MATCHED PHG4 hits in matched track
+      clusters = m_TCEval.clusloc_matched();
+      for (auto& clus : clusters) {
+        b_clusmatch     .push_back(true);
+        fill_cluster_branches(clus, true);
+      }
+    }
+    m_ttree->Fill();
+    clear_clusvecs();
+    /* clear_clusvecs("apple0 g4_matched"); */
+
+    // <- <- <- <- Svtx Matched Tracks
+    b_is_g4track = false;
+    b_is_Svtrack = true;
+    b_trackid    = sv_trkid;
+    b_trkpt      = svtrk->get_pt();
+    b_trketa     = svtrk->get_eta();
+    b_trkphi     = svtrk->get_phi();
+
+    cnt = m_TCEval.svtx_cntclus();
+    b_nclus     = cnt[4] ;
+    b_nclusmvtx = cnt[0] ;
+    b_nclusintt = cnt[1] ;
+    b_nclustpc  = cnt[2] ;
+
+    b_matchrat      = (float)cnt_match[4] / cnt[4] ;
+    b_matchrat_mvtx = (float)cnt_match[0] / cnt[0] ;
+    b_matchrat_intt = (float)cnt_match[1] / cnt[1] ;
+    b_matchrat_tpc  = (float)cnt_match[2] / cnt[2] ;
+
+    /* int _ = 0; */
+    if (m_fill_clusters) {
+      auto clusters = m_TCEval.svtx_clusloc_unmatched();
+      for (auto& clus : clusters) {
+        b_clusmatch     .push_back(false);
+        fill_cluster_branches(clus, false);
+      }
+
+      clusters = m_TCEval.clusloc_matched();
+      for (auto& clus : clusters) {
+        b_clusmatch     .push_back(true);
+        fill_cluster_branches(clus, false);
+      }
+    }
+    m_ttree->Fill();
+    clear_clusvecs();
+  }
+
+  // <- <- <- <- G4 un-matched Tracks
+  b_is_matched = false;
+  b_is_g4track = true;
+  b_is_Svtrack = false;
+  for (auto& g4_trkid : m_EmbRecoMatchContainer->ids_TruthUnmatched()) {
+    auto g4trk = m_TrkrTruthTrackContainer->getTruthTrack(g4_trkid);
+    m_TCEval.addClusKeys( g4trk );
+
+    b_trackid  = g4_trkid;
+    b_trkpt    = g4trk->getPt();
+    b_trketa   = g4trk->getPseudoRapidity();
+    b_trkphi   = g4trk->getPhi();
+
+    auto cnt = m_TCEval.phg4_cntclus();
+    b_nclus     = cnt[4];
+    b_nclusmvtx = cnt[0];
+    b_nclusintt = cnt[1];
+    b_nclustpc  = cnt[2];
+
+    if (m_fill_clusters) {
+      for (auto& clus : m_TCEval.phg4_clusloc_all()) {
+        b_clusmatch     .push_back(false);
+        fill_cluster_branches(clus, true);
+      }
+      //this is an unmatched track, so there are no matched clusters
+    }
+    m_ttree->Fill();
+    clear_clusvecs();
+  }
+
+  // <- <- <- <- Svtx un-matched Tracks
+  b_is_matched = false;
+  b_is_matched = false;
+  b_is_g4track = false;
+  b_is_Svtrack = true;
+
+  // put in all unmatched svtx tracks, too
+  if (m_fill_SvUnmatched) {
+    for (auto sv_trkid : g4evalfn::unmatchedSvtxTrkIds(m_EmbRecoMatchContainer, m_SvtxTrackMap)) {
+      auto svtrk = m_SvtxTrackMap->get(sv_trkid);
+      m_TCEval.addClusKeys( svtrk );
+      b_trackid  = sv_trkid;
+      b_trkpt    = svtrk->get_pt();
+      b_trketa   = svtrk->get_eta();
+      b_trkphi   = svtrk->get_phi();
+
+      auto cnt = m_TCEval.svtx_cntclus();
+      b_nclus     = cnt[4] ;
+      b_nclusmvtx = cnt[0] ;
+      b_nclusintt = cnt[1] ;
+      b_nclustpc  = cnt[2] ;
+
+      if (m_fill_clusters) {
+        for (auto &clus : m_TCEval.svtx_clusloc_all()) {
+            fill_cluster_branches(clus, false);
+          }
+      }
+      m_ttree->Fill();
+      clear_clusvecs();
+    }
+  }
+
+  if (Verbosity()>100) print_mvtx_diagnostics();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void FillClusMatchTree::print_mvtx_diagnostics() {
+  std::cout << "To do: "
+    << " (1)  number of truth tracks and total number of mvtx and ratio " << std::endl
+    << " (2)  ditto for reco tracks " << std::endl;
+
+  double n_PHG4_tracks = m_TrkrTruthTrackContainer->getMap().size();
+  // count how many mvtx clusters in the phg4 tracks
+  double n_in_PHG4_tracks {0.};
+  for (auto& pair : m_TrkrTruthTrackContainer->getMap()) {
+    m_TCEval.addClusKeys( pair.second );
+    n_in_PHG4_tracks += m_TCEval.phg4_cntclus()[0];
+  }
+  // count how mant mvtx clusters in truth container (should be the same)
+  double n_in_PHG4_clusters {0.};
+  for (auto hitsetkey : m_TCEval.get_PHG4_clusters()->getHitSetKeys()) {
+    if (TrkrDefs::getLayer(hitsetkey) > 2) continue;
+    auto range = m_TCEval.get_PHG4_clusters()->getClusters(hitsetkey);
+    for (auto r = range.first; r != range.second; ++r)  {
+      n_in_PHG4_clusters += 1.;
+    }
+  }
+
+  // count how many svtx tracks
+  double n_SVTX_tracks = m_SvtxTrackMap->size();
+  // count how many mvtx clusters in svtx tracks
+  double n_in_SVTX_tracks {0.};
+  for (auto entry = m_SvtxTrackMap->begin(); entry != m_SvtxTrackMap->end(); ++entry) {
+    m_TCEval.addClusKeys(entry->second);
+    n_in_SVTX_tracks += m_TCEval.svtx_cntclus()[0];
+  }
+  // count how many mvtx are total in the container
+  double n_in_SVTX_clusters {0.};
+  for (auto hitsetkey : m_TCEval.get_SVTX_clusters()->getHitSetKeys()) {
+    if (TrkrDefs::getLayer(hitsetkey) > 2) continue;
+    auto range = m_TCEval.get_SVTX_clusters()->getClusters(hitsetkey);
+    for (auto r = range.first; r != range.second; ++r)  {
+      n_in_SVTX_clusters += 1.;
+    }
+  }
+
+  std::cout << Form("MVTX"
+      "\nPHG4:  Tracks(%.0f)   Clusters In tracks(%.0f)   Total (%.0f)"
+      "\n       ave. per track: %6.3f   ratio in all tracks: %6.2f"
+      , n_PHG4_tracks, n_in_PHG4_tracks, n_in_PHG4_clusters
+      , (n_in_PHG4_tracks/n_PHG4_tracks), (n_in_PHG4_tracks/n_in_PHG4_clusters))
+    << std::endl;
+  std::cout << Form(
+      "\nSVTX:  Tracks(%.0f)   Clusters In tracks(%.0f)   Total (%.0f)"
+      "\n       ave. per track: %6.3f   ratio in all tracks: %6.2f"
+      , n_SVTX_tracks, n_in_SVTX_tracks, n_in_SVTX_clusters
+      , (n_in_SVTX_tracks/n_SVTX_tracks), (n_in_SVTX_tracks/n_in_SVTX_clusters))
+    << std::endl;
+
+}
+
+  int FillClusMatchTree::End(PHCompositeNode *)
+  {
+    if (Verbosity()>2) std::cout << PHWHERE << ": ending FillClusMatchTree" << std::endl;
+    PHTFileServer::get().cd(m_outfile_name);
+
+    h2_G4_nPixelsPhi ->Write();
+    h2_G4_nPixelsZ   ->Write();
+    h2_Sv_nPixelsPhi ->Write();
+    h2_Sv_nPixelsZ   ->Write();
+
+    m_ttree->Write();
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+void FillClusMatchTree::clear_clusvecs(std::string tag) {
+  /* cout << " banana |" << tag << "|"<<endl; */
+  if (tag != "") {
+    for (auto x : b_clus_x) cout << x <<" ";
+    cout << endl;
+  }
+
+  // Tracks and clustes
+  if (m_fill_clusters) {
+    b_clusmatch     .clear();
+    b_clus_x        .clear();
+    b_clus_y        .clear();
+    b_clus_z        .clear();
+    b_clus_r        .clear();
+    b_clus_layer    .clear();
+
+    b_clus_lphi      .clear();
+    b_clus_lphisize  .clear();
+    b_clus_lz        .clear();
+    b_clus_lzsize    .clear();
+
+    if (m_fill_clusverbose) {
+      b_phibins     .clear();
+      b_phibins_cut .clear();
+      b_zbins       .clear();
+      b_zbins_cut   .clear();
+
+      b_phibinsE     .clear();
+      b_phibinsE_cut .clear();
+      b_zbinsE       .clear();
+      b_zbinsE_cut   .clear();
+    }
+  }
+}
+
+void FillClusMatchTree::fill_cluster_branches(
+    TrkrClusLoc& clus, bool isPHG4) 
+{
+  auto x = clus.gloc[0];//std::get<1>(loc)[0];
+  auto y = clus.gloc[1];
+  auto r = pow(x*x+y*y,0.5);
+  b_clus_layer    .push_back(clus.layer);
+  b_clus_x        .push_back(x);
+  b_clus_y        .push_back(y);
+  b_clus_z        .push_back(clus.gloc[2]);
+  b_clus_r        .push_back(r);
+  b_clus_lz       .push_back(clus.z);
+  b_clus_lzsize   .push_back(clus.zsize);
+  b_clus_lphi     .push_back(clus.phi);
+  b_clus_lphisize .push_back(clus.phisize);
+  if (!m_fill_clusverbose) return;
+
+  ClusHitsVerbose* data = (isPHG4) ? m_PHG4ClusHitVerb : m_SvtxClusHitVerb;
+
+  auto& key = clus.ckey;
+  if (data->hasClusKey(key)) {
+    auto phidat = data->phiBins_pvecIE(key);
+    b_phibins  .push_back(phidat.first);
+    b_phibinsE .push_back(phidat.second);
+
+    auto zdat = data->zBins_pvecIE(key);
+    b_zbins  .push_back(zdat.first);
+    b_zbinsE .push_back(zdat.second);
+
+    auto phicut = data->phiCutBins_pvecIE(key);
+    b_phibins_cut  .push_back(phicut.first);
+    b_phibinsE_cut .push_back(phicut.second);
+
+    auto zcut = data->zCutBins_pvecIE(key);
+    b_zbins_cut  .push_back(zcut.first);
+    b_zbinsE_cut .push_back(zcut.second);
+  } else {
+    b_phibins  .push_back({});
+    b_phibinsE .push_back({});
+
+    b_zbins  .push_back({});
+    b_zbinsE .push_back({});
+
+    b_phibins_cut  .push_back({});
+    b_phibinsE_cut .push_back({});
+
+    b_zbins_cut  .push_back({});
+    b_zbinsE_cut .push_back({});
+  }
+}
+

--- a/simulation/g4simulation/g4eval/FillClusMatchTree.h
+++ b/simulation/g4simulation/g4eval/FillClusMatchTree.h
@@ -89,7 +89,7 @@ class FillClusMatchTree : public SubsysReco
   int process_event(PHCompositeNode * /*topNode*/) override;
   int End(PHCompositeNode *topNode) override;
 
-  void clear_clusvecs(std::string tag="");
+  void clear_clusvecs(const std::string& tag="");
 
   void print_mvtx_diagnostics();
 

--- a/simulation/g4simulation/g4eval/FillClusMatchTree.h
+++ b/simulation/g4simulation/g4eval/FillClusMatchTree.h
@@ -1,0 +1,199 @@
+#ifndef FILLCLUSMATCHTREE__H
+#define FILLCLUSMATCHTREE__H
+
+/**
+ * @file trackbase/TrkrMatchDefs.h
+ * @author D. Stewart
+ * @date February 2023
+ * @brief Write a TFile with a TTree with the matched tracks and (optionall) clusters
+ *   This module takes the matching done in TruthRecoTrackMatching in the 
+ *   EmbRecoMatchContainer objects, and writes out the tracks kinematics to TTree
+ *   in a TFile.
+ *    The following data is always written out:
+ *      For each track type:
+ *          G4M : PHG4 matched
+ *          G4U : PHG4 unmatched
+ *          SvM : Svtx (reco) matched
+ *          SvU : SVtx (reco) unmatched
+ *      The following is stored:
+ *          trackid, nclus, nclus{mvtx,intt,tpc}, pt, phi, eta
+ *      For matched tracks (G4M and SvM):
+ *           nclus_matchrat, nclus{mvtx,intt,tpc}_matchrat
+ *      For matched tracks, the numbers of matched clusters (these are shared by G4M and SvM):
+ *           nclusM, nclusM_{mvtx,intt,tpc}
+ *      
+ *    If the option is passed to save clusteres (default is on), then the cluster
+ *    locations are saved too, as unmatched clusters (in all types of tracks),
+ *    and the mutually matched clusters (shared by the G4M and SvM tracks):
+ *      {G4U,G4M,SvU,SvM}_clusU_{i0,i1,x,y,z,r}
+ *    For matche clusters, these are simply:
+ *      clusM_{i0,i1,x,y,z,r,layer}
+ *    The vectors of x,y,z,r are stoped in each branch with each tracks' data sequentially
+ *    following the last. The branch i0 and i1 index where the one starts and the other stops.
+ *    for each track.
+ *
+ *    Data for matched tracks positionally align with each other (i.e. 1st entry in each
+ *    correlate, then the 2nd, etc...)
+ *
+ *    A track is only an unmatched track is it has no matches (the options in 
+ *    TruthRecoTrackMatching can allow multiply matches for the same track...)
+ *
+ *    options:
+ *      save cluster locations = true
+ *      save un-matched Svtx tracks = false
+ */
+
+#include "TrkrClusLoc.h"
+#include "TrackClusEvaluator.h"
+
+#include <fun4all/SubsysReco.h> 
+#include <vector>
+#include <string>
+
+class EmbRecoMatchContainer;
+class PHCompositeNode;
+class PHG4ParticleSvtxMap;
+class SvtxPHG4ParticleMap;
+class EmbRecoMatchContainer;
+class PHCompositeNode;
+class PHG4TpcCylinderGeom;
+class PHG4TpcCylinderGeomContainer;
+class PHG4TruthInfoContainer;
+class SvtxTrack;
+class SvtxTrackMap;
+class TrackSeedContainer;
+class TrkrCluster;
+/* class TrkrClusterContainer; */
+class TrkrTruthTrack;
+class TrkrTruthTrackContainer;
+class TTree;
+class TH2D;
+class ClusHitsVerbose;
+class TrkrClusterIsMatcher;
+
+class FillClusMatchTree : public SubsysReco
+{
+ public:
+  FillClusMatchTree(
+        TrkrClusterIsMatcher* _ismatcher
+      , const std::string& tfile_name="trackclusmatch.root"
+      , bool  _fill_clusters      = true
+      , bool  _fill_clusverbose   = true
+      , bool  _fill_svtxnomatch   = false
+  );
+
+  virtual ~FillClusMatchTree();
+
+  int Init(PHCompositeNode *) override;
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode * /*topNode*/) override;
+  int End(PHCompositeNode *topNode) override;
+
+  void clear_clusvecs(std::string tag="");
+
+  void print_mvtx_diagnostics();
+
+   TrkrClusterIsMatcher* m_ismatcher;
+ private:
+
+   int createNodes(PHCompositeNode *topNode);
+   TrackClusEvaluator m_TCEval;
+
+   // contianer used to fill the other track matches
+   EmbRecoMatchContainer   *m_EmbRecoMatchContainer   {nullptr};
+   PHG4TruthInfoContainer  *m_PHG4TruthInfoContainer  {nullptr};
+   SvtxTrackMap            *m_SvtxTrackMap            {nullptr};
+   TrkrTruthTrackContainer *m_TrkrTruthTrackContainer {nullptr};
+   ClusHitsVerbose         *m_PHG4ClusHitVerb         {nullptr};
+   ClusHitsVerbose         *m_SvtxClusHitVerb         {nullptr};
+   /* TrkrClusterContainer         *m_TruthClusterContainer        {nullptr}; */
+   /* TrkrClusterContainer         *m_RecoClusterContainer         {nullptr}; */
+   /* PHG4TpcCylinderGeomContainer *m_PHG4TpcCylinderGeomContainer {nullptr}; */
+
+
+   TTree* m_ttree;
+   std::string m_outfile_name;
+ public:
+   bool   m_fill_clusters;
+   bool   m_fill_clusverbose; // unmatched Svtx tracks
+   bool   m_fill_SvUnmatched; // unmatched Svtx tracks
+ private:
+
+  // Tree Branch members:
+    int   nevent       {-1};
+    int   nphg4        {0};
+    int   nsvtx        {0};
+    int   ntrackmatches {0};
+    int   nphg4_part   {0};
+    float centrality   {0.};
+
+    // Tracks and clustes
+    //
+    // lables:
+    //  tracks:
+    //    g4 : phg4track matched
+    //    sv : svtx_track matched
+    //    gU : phg4track not-matched
+    //    sU : svtx_track not-matched
+    //  clusters:
+    //    M : matched
+    //    U : unmatched
+    TH2D* h2_G4_nPixelsPhi;
+    TH2D* h2_G4_nPixelsZ;
+    TH2D* h2_Sv_nPixelsPhi;
+    TH2D* h2_Sv_nPixelsZ;
+    
+    // Track tree
+    int  b_trackid;
+    bool b_is_g4track;
+    bool b_is_Svtrack;
+    bool b_is_matched;
+
+    float b_trkpt;
+    float b_trkphi;
+    float b_trketa;
+
+    int   b_nclus         {};
+    int   b_nclustpc      {};
+    int   b_nclusmvtx     {};
+    int   b_nclusintt     {};
+
+    float b_matchrat      {};
+    float b_matchrat_intt {};
+    float b_matchrat_mvtx {};
+    float b_matchrat_tpc  {};
+
+    std::vector<bool>  b_clusmatch  {};
+    std::vector<float> b_clus_x     {};
+    std::vector<float> b_clus_y     {};
+    std::vector<float> b_clus_z     {};
+    std::vector<float> b_clus_r     {};
+    std::vector<int>   b_clus_layer {};
+    /* std::vector<int>   b_clus_nphibins   {}; */
+    /* std::vector<int>   b_clus_ntbins     {}; */
+
+    std::vector<float> b_clus_lphi     {}; // l for local surface
+    std::vector<float> b_clus_lphisize {}; // phi scaled by dphi
+    std::vector<float> b_clus_lz       {};
+    std::vector<float> b_clus_lzsize   {};
+
+    // Maps of hits within clusters
+    /* using BinData = std::pair<int,float>;  // index + energy for a given bin (MVTX, INTT, or TPC) */
+    using VecVecInt   = std::vector<std::vector<int>>;
+    /* using VecVecFloat = std::vector<std::vector<float>>; */
+    VecVecInt b_phibins;
+    VecVecInt b_phibins_cut;
+    VecVecInt b_zbins;
+    VecVecInt b_zbins_cut;
+
+    VecVecInt b_phibinsE;
+    VecVecInt b_phibinsE_cut;
+    VecVecInt b_zbinsE;
+    VecVecInt b_zbinsE_cut;
+
+    void fill_cluster_branches(TrkrClusLoc&, bool isPHG4=true);
+    /* void pushback_verb_bins(TrkrDefs::cluskey, bool isPHG4=true); */
+    
+};
+
+#endif  // FILLTRUTHRECOMATCHTREE_H

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -48,8 +48,7 @@ pkginclude_HEADERS = \
   DSTEmulator.h \
   EventEvaluator.h \
   FillTruthRecoMatchMap.h \
-  FillTruthRecoMatchTree.h \
-  g4evaltools.h \
+  FillClusMatchTree.h \
   JetEvalStack.h \
   JetEvaluator.h \
   JetRecoEval.h \
@@ -65,6 +64,11 @@ pkginclude_HEADERS = \
   SvtxTruthEval.h \
   SvtxTruthRecoTableEval.h \
   SvtxVertexEval.h \
+  g4evalfn.h \
+  ClusKeyIter.h \
+  TrackClusEvaluator.h \
+  TrkrClusterIsMatcher.h \
+	TrkrClusLoc.h \
   TrackEvaluation.h \
   TrackEvaluationContainer.h \
   TrackEvaluationContainerv1.h  \
@@ -96,8 +100,7 @@ libg4eval_la_SOURCES = \
   DSTEmulator.cc \
   EventEvaluator.cc \
   FillTruthRecoMatchMap.cc \
-  FillTruthRecoMatchTree.cc \
-  g4evaltools.cc \
+  FillClusMatchTree.cc \
   JetEvalStack.cc \
   JetEvaluator.cc \
   JetRecoEval.cc \
@@ -113,6 +116,10 @@ libg4eval_la_SOURCES = \
   SvtxTruthEval.cc \
   SvtxTruthRecoTableEval.cc \
   SvtxVertexEval.cc \
+  g4evalfn.cc \
+  ClusKeyIter.cc \
+  TrackClusEvaluator.cc \
+  TrkrClusterIsMatcher.cc \
   TrackEvaluation.cc \
   TrackSeedTrackMapConverter.cc \
   TruthRecoTrackMatching.cc

--- a/simulation/g4simulation/g4eval/TrackClusEvaluator.cc
+++ b/simulation/g4simulation/g4eval/TrackClusEvaluator.cc
@@ -1,0 +1,191 @@
+#include "TrackClusEvaluator.h"
+#include "TrkrClusterIsMatcher.h"
+#include "ClusKeyIter.h"
+#include "g4evalfn.h"
+
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <g4tracking/TrkrTruthTrack.h>
+#include <phool/phool.h>  // for PHWHERE
+
+TrkrClusterContainer* TrackClusEvaluator::get_PHG4_clusters() {
+  if (ismatcher == nullptr) return nullptr;
+  else return ismatcher->m_TruthClusters;
+}
+
+TrkrClusterContainer* TrackClusEvaluator::get_SVTX_clusters() {
+  if (ismatcher == nullptr) return nullptr;
+  else return ismatcher->m_RecoClusters;
+}
+
+  std::array<int,5> TrackClusEvaluator::cntclus(Vector& keys) {
+    std::array<int,5> cnt { 0, 0, 0, 0, 0 };
+    for (auto& it : keys) {
+      cnt[g4evalfn::trklayer_det(it.first)] += 1;
+    }
+    for (int i=0;i<4;++i) cnt[4] += cnt[i];
+    return cnt;
+  }
+
+  int TrackClusEvaluator::addClusKeys(SvtxTrack* track) {
+    svtx_keys.clear();
+    for (auto ckey : ClusKeyIter(track)) {
+      svtx_keys.push_back( {TrkrDefs::getHitSetKeyFromClusKey(ckey), ckey} );
+    }
+    std::sort(svtx_keys.begin(), svtx_keys.end());
+    return svtx_keys.size();
+  }
+
+  std::array<int,5> TrackClusEvaluator::cnt_matchedclus
+    (Vector& keys, std::vector<bool>& matches)
+  {
+    std::array<int,5> cnt { 0, 0, 0, 0, 0 };
+    if (keys.size() != matches.size()) {
+      std::cout << PHWHERE << " matching and key vector not the same size. " 
+        << std::endl << " run find_matches() first." << std::endl;
+      return cnt;
+    }
+    for (unsigned int i=0; i<keys.size(); ++i) {
+      if (matches[i]) {
+        cnt[g4evalfn::trklayer_det(keys[i].first)] += 1;
+      }
+    }
+    for (int i=0;i<4;++i) cnt[4] += cnt[i];
+    return cnt;
+  }
+
+  int TrackClusEvaluator::addClusKeys(TrkrTruthTrack* track) {
+    phg4_keys.clear();
+    for (auto ckey : track->getClusters()) {
+      phg4_keys.push_back( {TrkrDefs::getHitSetKeyFromClusKey(ckey), ckey} );
+    }
+    std::sort(phg4_keys.begin(), phg4_keys.end());
+    return phg4_keys.size();
+  }
+
+  void TrackClusEvaluator::reset() {
+    phg4_keys.clear();
+    phg4_matches.clear();
+    svtx_keys.clear();
+    svtx_matches.clear();
+  }
+
+  std::array<int,3> TrackClusEvaluator::find_matches() {
+    if (ismatcher == nullptr) {
+      std::cout << PHWHERE 
+        << " Won't compare tracks because of missing TrkrClusterIsMatcher" << std::endl;
+      return {0,0,0};
+    }
+    // find the matches between the svtx_keys and phg4_keys
+    // also keep track of the sum of the comparison between then
+
+    // ---------------------------------
+    // set aliases for notation cleaness
+    // use A for PHG4 and B for SVTX
+    auto& vA = phg4_keys;
+    auto& vB = svtx_keys;
+
+    auto& matchesA = phg4_matches;
+    auto& matchesB = svtx_matches;
+
+    match_stat = 0.; // DEPRECATED
+
+    // matches will say, cluster by cluster, which clusters are matched
+    matchesA = std::vector<bool>(vA.size(),false);
+    matchesB = std::vector<bool>(vB.size(),false);
+   
+    // user iterators to access the vectors
+    auto iA0 = vA.begin();
+    auto iA1 = vA.end();
+
+    auto iB0 = vB.begin();
+    auto iB1 = vB.end();
+
+    auto iA = iA0;
+    auto iB = iB0;
+
+    int n_match {0};
+
+    while (iA != iA1 && iB != iB1) {
+      if (iA->first == iB->first) {
+        auto hitset = iA->first;
+
+        // must compare ALL sets of iA and iB with this same hitset
+        auto sAend = iA+1; // search A end
+        while (sAend != iA1 && sAend->first == hitset) ++sAend;
+
+        auto sBend = iB+1; // search B end
+        while (sBend != iB1 && sBend->first == hitset) ++sBend;
+
+        for (auto _A = iA; _A!=sAend; ++_A) {
+          for (auto _B = iB; _B!=sBend; ++_B) {
+            auto is_match = ismatcher->operator()(_A->second,_B->second);
+            if (is_match) {
+              matchesA[_A-iA0] = true;
+              matchesB[_B-iB0] = true;
+              if (collect_match_statistic) match_stat += g4evalfn::calc_match_statistic(ismatcher, _A->second, _B->second);
+              ++n_match;
+            }
+          }}
+        iA = sAend;
+        iB = sBend;
+      } else if (iA->first < iB->first) {
+        ++iA;
+      } else {
+        ++iB;
+      }
+    }
+    return { n_match, (int)phg4_keys.size(), (int)svtx_keys.size() };
+  }
+
+  std::array<int,3> TrackClusEvaluator::find_matches(TrkrTruthTrack* g4_track, SvtxTrack* sv_track) {
+    addClusKeys(sv_track);
+    addClusKeys(g4_track);
+    return find_matches();
+  }
+
+  int TrackClusEvaluator::phg4_n_matched() { 
+    return std::accumulate(phg4_matches.begin(), phg4_matches.end(), 0); }
+
+  int TrackClusEvaluator::svtx_n_matched() { 
+    return std::accumulate(svtx_matches.begin(), svtx_matches.end(), 0); }
+
+  std::vector<TrkrClusLoc> TrackClusEvaluator::phg4_clusloc_all() {
+    std::vector<TrkrClusLoc> vec{};
+    for (auto& cluspair : phg4_keys) vec.push_back(g4evalfn::clusloc_PHG4(ismatcher,cluspair.second));
+    return vec;
+  }
+
+  std::vector<TrkrClusLoc> TrackClusEvaluator::phg4_clusloc_unmatched() {
+    std::vector<TrkrClusLoc> vec{};
+    auto cnt = phg4_keys.size();
+    for (unsigned int i = 0; i<cnt; ++i) {
+      if (!phg4_matches[i]) vec.push_back(g4evalfn::clusloc_PHG4(ismatcher,phg4_keys[i].second));
+    }
+    return vec;
+  }
+
+  std::vector<TrkrClusLoc> TrackClusEvaluator::svtx_clusloc_all() {
+    std::vector<TrkrClusLoc> vec{};
+    for (auto& cluspair : svtx_keys) vec.push_back(g4evalfn::clusloc_SVTX(ismatcher,cluspair.second));
+    return vec;
+  }
+
+  std::vector<TrkrClusLoc> TrackClusEvaluator::svtx_clusloc_unmatched() {
+    std::vector<TrkrClusLoc> vec{};
+    auto cnt = svtx_keys.size();
+    for (unsigned int i = 0; i<cnt; ++i) {
+      if (!svtx_matches[i]) vec.push_back(g4evalfn::clusloc_SVTX(ismatcher,svtx_keys[i].second));
+    }
+    return vec;
+  }
+
+  std::vector<TrkrClusLoc> TrackClusEvaluator::clusloc_matched() {
+    std::vector<TrkrClusLoc> vec{};
+    auto cnt = phg4_keys.size();
+    for (unsigned int i = 0; i<cnt; ++i) {
+      if (phg4_matches[i]) vec.push_back(g4evalfn::clusloc_PHG4(ismatcher,phg4_keys[i].second));
+    }
+    return vec;
+  }

--- a/simulation/g4simulation/g4eval/TrackClusEvaluator.h
+++ b/simulation/g4simulation/g4eval/TrackClusEvaluator.h
@@ -1,0 +1,74 @@
+#ifndef TRACKCLUSEVALUATOR_H
+#define TRACKCLUSEVALUATOR_H
+// A class that will collect the clusters for SVTX and PHG$ tracks and compare them.
+// The actual comparison, cluster to cluster, is from a pointer to a user provided TrkrClusterIsMatcher
+#include "TrkrClusLoc.h"
+
+#include <vector>
+#include <array>
+#include <trackbase/TrkrDefs.h>
+
+class TrkrClusterIsMatcher;
+class SvtxTrack;
+class TrkrTruthTrack;
+class TrkrClusterContainer;
+
+class TrackClusEvaluator {
+  private:
+    using Vector = std::vector<std::pair<TrkrDefs::hitsetkey,TrkrDefs::cluskey>>;
+
+    using Iter = Vector::iterator;
+
+    /* TrkrClusterComparer*  comp      {nullptr}; // DEPRECATED */
+
+    std::array<int,5> cntclus(Vector& keys); // nclusters MVTX, INTT, TPC, TPOT, TOTAL
+    std::array<int,5> cnt_matchedclus(Vector& keys, std::vector<bool>& matches); // same but number matched
+
+  public:
+
+    TrkrClusterIsMatcher* ismatcher {nullptr}; 
+    /* void set_ismatcher(TrkrClusterIsMatcher* _ismatcher) { ismatcher = _ismatcher; }; */
+    TrackClusEvaluator(TrkrClusterIsMatcher*_ =nullptr) : ismatcher {_} {};
+
+    TrkrClusterContainer* get_PHG4_clusters();
+    TrkrClusterContainer* get_SVTX_clusters();
+
+    Vector svtx_keys {};
+    Vector phg4_keys {};
+
+    bool collect_match_statistic = false;
+    double match_stat {0};
+
+    void reset();
+    std::array<int,3> find_matches();// populated matches_{svtx,phg4}; 
+                                     // return's {n-matched, n-phg4, n-svtx}
+    std::array<int,3> find_matches(TrkrTruthTrack* g4_track, SvtxTrack* sv_track);
+
+    int phg4_n_matched(); // also same as phg4_cnt_matchedclus()[4]
+    int svtx_n_matched(); // should be almost always the same
+                          // which is ALMOST guaranteed to be same as svtx_cnt_matchedclus()[4]
+    int phg4_nclus() { return (int) phg4_keys.size(); }
+    int svtx_nclus() { return (int) svtx_keys.size(); }
+
+    std::vector<bool> svtx_matches;
+    std::vector<bool> phg4_matches;
+
+    int addClusKeys(SvtxTrack*); // return number of clusters
+    int addClusKeys(TrkrTruthTrack*); // return number of clusters
+
+    std::array<int,5> svtx_cntclus() { return cntclus(svtx_keys); }; // Mvtx Intt Tpc TPOT Sum
+    std::array<int,5> phg4_cntclus() { return cntclus(phg4_keys); };
+
+    std::array<int,5> svtx_cnt_matchedclus() {return cnt_matchedclus(svtx_keys, svtx_matches); };
+    std::array<int,5> phg4_cnt_matchedclus() {return cnt_matchedclus(phg4_keys, phg4_matches); };
+
+    //Convenience functions, asking for cluster locations
+    std::vector<TrkrClusLoc> phg4_clusloc_all       ();
+    std::vector<TrkrClusLoc> phg4_clusloc_unmatched ();
+    std::vector<TrkrClusLoc> svtx_clusloc_all       ();
+    std::vector<TrkrClusLoc> svtx_clusloc_unmatched ();
+    std::vector<TrkrClusLoc> clusloc_matched        ();
+
+};
+
+#endif

--- a/simulation/g4simulation/g4eval/TrkrClusLoc.h
+++ b/simulation/g4simulation/g4eval/TrkrClusLoc.h
@@ -1,0 +1,19 @@
+#ifndef TRKRCLUSLOC__H
+#define TRKRCLUSLOC__H
+// A few simple structures that are used in the evaluation and matching of clusters
+// Plus a few functions for working with clusters
+
+#include <trackbase/TrkrDefs.h>
+#include <Eigen/Core>
+
+struct TrkrClusLoc {
+  int layer{0};
+  Eigen::Vector3d gloc{};
+  float phi{0};
+  float phisize{0};
+  float z{0};
+  float zsize{0};
+  TrkrDefs::cluskey ckey{};
+};
+
+#endif

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
@@ -1,0 +1,195 @@
+#include "TrkrClusterIsMatcher.h"
+#include "g4evalfn.h"
+
+#include <mvtx/CylinderGeom_Mvtx.h>
+#include <intt/CylinderGeomIntt.h>
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
+
+#include <phool/getClass.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/phool.h>  // for PHWHERE
+#include <phool/PHCompositeNode.h>
+#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+int TrkrClusterIsMatcher::init(
+    PHCompositeNode* topNode,
+    const std::string& name_phg4_clusters,
+    const std::string& name_reco_clusters)
+{
+  // ------ MVTX data ------
+  PHG4CylinderGeomContainer* geom_container_mvtx 
+    = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+  if (!geom_container_mvtx) {
+    std::cout << PHWHERE << " Could not locate CYLINDERGEOM_MVTX " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  for (int i=0; i<3; ++i) {
+    auto layergeom = dynamic_cast<CylinderGeom_Mvtx *>
+      (geom_container_mvtx->GetLayerGeom(i));
+    pitch_phi[i] = layergeom->get_pixel_x();
+    if (i == 0) pitch_z_MVTX = layergeom->get_pixel_z();
+  }
+
+  // ------ INTT data ------
+  PHG4CylinderGeomContainer* geom_container_intt 
+    = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  if (!geom_container_intt) {
+    std::cout << PHWHERE << " Could not locate CYLINDERGEOM_INTT " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  // get phi and Z steps for intt
+  for (int i=3; i<7; ++i) {
+    CylinderGeomIntt* geom = 
+      dynamic_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(i));
+    pitch_phi[i] = geom->get_strip_y_spacing();
+  }
+
+  // ------ TPC data ------
+  auto geom_tpc =
+    findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom_tpc)
+  {
+    std::cout << PHWHERE << " Could not locate CYLINDERCELLGEOM_SVTX node " << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  for (int i=7; i<55; ++i) {
+    PHG4TpcCylinderGeom *layergeom = geom_tpc->GetLayerCellGeom(i);
+    if (i==7) step_t_TPC = layergeom->get_zstep();
+    pitch_phi[i] = layergeom->get_phistep() * layergeom->get_radius();
+  }
+
+  m_TruthClusters = 
+    findNode::getClass<TrkrClusterContainer>(topNode, name_phg4_clusters.c_str());
+  if (!m_TruthClusters)
+  {
+    std::cout << PHWHERE << " Could not locate " << name_phg4_clusters << " node" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_RecoClusters = 
+    findNode::getClass<TrkrClusterContainer>(topNode, name_reco_clusters.c_str());
+  if (!m_TruthClusters)
+  {
+    std::cout << PHWHERE << " Could not locate " << name_reco_clusters << " node" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_ActsGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!m_ActsGeometry)
+  {
+    std::cout << PHWHERE << " Could not locate ActsGeometry node" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  set_tol_z_MVTX   (tol_z_MVTX);
+  set_tol_phi_MVTX (tol_phi_MVTX);
+
+  set_tol_phi_INTT (tol_phi_INTT);
+
+  set_tol_t_TPC   (tol_t_TPC);
+  set_tol_phi_TPC (tol_phi_TPC);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void TrkrClusterIsMatcher::set_tol_phi_MVTX(float _val) {
+  tol_phi_MVTX = _val;
+  for (int i=0; i<3; ++i) {
+    tol_pitch_phi[i] = tol_phi_MVTX * pitch_phi[i];
+  }
+}
+
+void TrkrClusterIsMatcher::set_tol_z_MVTX(float _val) {
+  tol_z_MVTX = _val;
+  tol_pitch_z_MVTX = tol_z_MVTX * pitch_z_MVTX;
+}
+
+
+void TrkrClusterIsMatcher::set_tol_phi_INTT(float _val) {
+  tol_phi_INTT = _val;
+  for (int i=3; i<7; ++i) {
+    tol_pitch_phi[i] = tol_phi_INTT * pitch_phi[i];
+  }
+}
+
+void TrkrClusterIsMatcher::set_tol_phi_TPC(float _val) {
+  tol_phi_TPC = _val;
+  for (int i=7; i<55; ++i) {
+    tol_pitch_phi[i] = tol_phi_TPC * pitch_phi[i];
+  }
+}
+
+void TrkrClusterIsMatcher::set_tol_t_TPC(float _val) {
+  tol_t_TPC = _val;
+  tol_step_t_TPC = tol_t_TPC * step_t_TPC;
+}
+
+  bool TrkrClusterIsMatcher::operator()
+(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R)
+{
+  // note: can use returned values, or just pull from these values
+  layer = TrkrDefs::getLayer(key_T);
+  if (layer > 55) {
+    std::cout << " Error! Trying to compar cluster in layer > 55, "
+      << "which is not programmed yet!" << std::endl;
+    return false;
+  }
+
+  clus_T = m_TruthClusters ->findCluster(key_T);
+  clus_R = m_RecoClusters  ->findCluster(key_R);
+
+  det_0123 = g4evalfn::trklayer_det(layer);
+  dphi = g4evalfn::abs_dphi(clus_T->getPosition(0),clus_R->getPosition(0));
+  switch (det_0123) {
+    case g4evalfn::DET::MVTX : {
+              if (single_pixel_phi_MVTX) {
+                if (dphi > tol_pitch_phi[layer])  return false;
+              } else {
+                if (dphi > tol_pitch_phi[layer]*std::max(clus_T->getPhiSize(),clus_R->getPhiSize())) return false;
+              }
+              const float delta_z = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
+              if (single_pixel_z_MVTX) {
+                if (delta_z > tol_pitch_z_MVTX) return false;
+              } else {
+                if (delta_z > tol_pitch_z_MVTX*std::max(clus_T->getZSize(), clus_R->getZSize())) return false;
+              }
+              return true;
+            } break;
+
+    case g4evalfn::DET::INTT: { 
+              if (single_pixel_phi_INTT) {
+                if (dphi > tol_pitch_phi[layer])  return false;
+              } else {
+                if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize())) return false;
+              }
+              return true;
+            } break;
+
+    case g4evalfn::DET::TPC: {
+              if (single_bin_phi_TPC) {
+                if (dphi > tol_pitch_phi[layer])  return false;
+              } else {
+                if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize())) return false;
+              }
+              const float delta_t = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
+              if (single_bin_t_TPC) {
+                if (delta_t > tol_step_t_TPC) return false;
+              } else {
+                if (delta_t > tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize())) return false;
+              }
+              return true;
+            } break;
+
+    case g4evalfn::DET::TPOT: { // TPOT
+              return false; // no info for matching TPOT at this time
+            } break;
+  }
+  return false; // code shouldn't arrive here; just for completeness for compiler
+}
+

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
@@ -18,7 +18,7 @@ class PHCompositeNode;
 class TrkrClusterContainer;
 class TrackClusEvaluator;
 
-struct TrkrClusterIsMatcher {
+class TrkrClusterIsMatcher {
   public:
     TrkrClusterIsMatcher() {};
 

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
@@ -56,12 +56,12 @@ struct TrkrClusterIsMatcher {
 
     //multipliers for pixels and bins to cm and times
     std::array<float, 56> pitch_phi {0.}; // the phistep squared
-    float pitch_z_MVTX; // pixel width for MVTX
-    float step_t_TPC;   // time bin width for PTC
+    float pitch_z_MVTX {0.}; // pixel width for MVTX
+    float step_t_TPC {0.};   // time bin width for PTC
 
     std::array<float, 56> tol_pitch_phi {0.}; // pitched times tol_phi_{MVTX,INTT,TPC}
-    float tol_pitch_z_MVTX; // tol * pixel width for MVTX
-    float tol_step_t_TPC;   // tol * time bin width for PTC
+    float tol_pitch_z_MVTX {0.}; // tol * pixel width for MVTX
+    float tol_step_t_TPC {0.};   // tol * time bin width for PTC
 
     // containers to get the clusters from
     TrkrClusterContainer* m_TruthClusters {nullptr};

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
@@ -1,0 +1,87 @@
+#ifndef TRKRCLUSTERISMATCHER__H
+#define TRKRCLUSTERISMATCHER__H
+// Principle use:
+//   Does comparison of two clusters
+//   For now, does comparison by relative separation in T and RxPhi space
+//   Option to compare by a relative number of bins|pixels, or by relative
+//   overall size of the clusters (using the largest clustersize).
+//
+
+#include <string>
+#include <array>
+
+#include <trackbase/TrkrDefs.h>
+
+class ActsGeometry;
+class TrkrCluster;
+class PHCompositeNode;
+class TrkrClusterContainer;
+class TrackClusEvaluator;
+
+struct TrkrClusterIsMatcher {
+  public:
+    TrkrClusterIsMatcher() {};
+
+    bool operator()(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R);
+
+    int init(PHCompositeNode* topNode, 
+        const std::string& name_truth_clusters="TRKR_TRUTHCLUSTERCONTAINER", 
+        const std::string& name_reco_clusters="TRKR_CLUSTER");
+
+    void set_tol_phi_MVTX (float _val);
+    void set_tol_phi_INTT (float _val);
+    void set_tol_phi_TPC  (float _val);
+
+    void set_tol_z_MVTX   (float _val);
+    void set_tol_t_TPC    (float _val);
+
+    // options for if tolerance is multipled by width of one pixel|bin, or by total number of pixel|bin's 
+    // in the larger of two clusters compared
+    bool  single_pixel_phi_MVTX { false }; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
+    bool  single_pixel_phi_INTT { false }; // ... same as for MVTX
+    bool  single_bin_phi_TPC    { true };  // default to pitch*tol_TPC
+
+    bool  single_pixel_z_MVTX { false }; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
+    bool  single_pixel_z_INTT { false }; // ... same as for MVTX
+    bool  single_bin_t_TPC    { true  };  // default to pitch*tol_TPC
+
+    // For efficiency and convenience, hang on to minimal information about most recent comparison: 
+    // --------------------------------------------------------------------------------------------
+    TrkrCluster* clus_T { nullptr }; // _T for truth cluster
+    TrkrCluster* clus_R { nullptr }; // _R for reco  cluster
+    int   layer    {0};
+    int   det_0123 {0};
+    bool  is_match {false}; // also the return value of operator()
+    float dphi     {0.};
+
+    //multipliers for pixels and bins to cm and times
+    std::array<float, 56> pitch_phi {0.}; // the phistep squared
+    float pitch_z_MVTX; // pixel width for MVTX
+    float step_t_TPC;   // time bin width for PTC
+
+    std::array<float, 56> tol_pitch_phi {0.}; // pitched times tol_phi_{MVTX,INTT,TPC}
+    float tol_pitch_z_MVTX; // tol * pixel width for MVTX
+    float tol_step_t_TPC;   // tol * time bin width for PTC
+
+    // containers to get the clusters from
+    TrkrClusterContainer* m_TruthClusters {nullptr};
+    TrkrClusterContainer* m_RecoClusters  {nullptr};
+    ActsGeometry* m_ActsGeometry{nullptr};
+
+  /* public: */
+    /* TrkrClusterContainer* get_TruthClusters() { return m_TruthClusters; }; */
+    /* TrkrClusterContainer* get_RecoClusters () { return m_RecoClusters; }; */
+    /* ActsGeometry* get_ActsGeometry () { return m_ActsGeometry; }; */
+  /* private: */
+
+    // tolerances for comparison in MVTX, INTT, TPC, and TPOT
+    float tol_phi_MVTX {0.5};
+    float tol_phi_INTT {0.5};
+    float tol_phi_TPC  {1.0};
+
+    float tol_z_MVTX {0.5};
+    float tol_t_TPC  {1.0};
+
+};
+
+#endif

--- a/simulation/g4simulation/g4eval/TruthRecoTrackMatching.h
+++ b/simulation/g4simulation/g4eval/TruthRecoTrackMatching.h
@@ -1,7 +1,6 @@
 #ifndef TRUTHTRKMATCHER__H
 #define TRUTHTRKMATCHER__H
-
-#include "g4evaltools.h"  // has some G4Eval tools (TrkrClusterComparer)
+#include "TrackClusEvaluator.h"
 
 #include <fun4all/SubsysReco.h>
 
@@ -29,6 +28,7 @@ class TrkrCluster;
 class TrkrClusterContainer;
 class TrkrTruthTrack;
 class TrkrTruthTrackContainer;
+class TrkrClusterIsMatcher;
 class TTree;
 class TFile;
 
@@ -38,21 +38,29 @@ class TruthRecoTrackMatching : public SubsysReco
   // Standard public interface
   //--------------------------------------------------
  public:
-  TruthRecoTrackMatching(                                                                                                                                                                                                                                                                                                                                                           // Criteria to match a TrkrClusterContainer and track
-                                                                                                                                                                                                                                                                                                                                                                                    /*-----------------------------------------------------------------------------------
-                                                                                                                                                                                                                                                                                                                                                                                     * Input criteria for Truth Track (with nT clusters) to reco track (with nR clusters) :
-                                                                                                                                                                                                                                                                                                                                                                                     *  - nmin_match  : minimum number of clusters in Truth and Reco track that must
-                                                                                                                                                                                                                                                                                                                                                                                     *                  match for tracks to match
-                                                                                                                                                                                                                                                                                                                                                                                     *  - cutoff_dphi : maximum distance out in |phi_truth-phi_reco| for a matched track
-                                                                                                                                                                                                                                                                                                                                                                                     *  - same_dphi   : within this distance, all tracks must be checked
-                                                                                                                                                                                                                                                                                                                                                                                     *  - cutoff_deta :   like cutoff_dphi but for eta
-                                                                                                                                                                                                                                                                                                                                                                                     *  - same_deta   :   like same_dphi but for eta
-                                                                                                                                                                                                                                                                                                                                                                                     *  - cluster_nzwidths   : z-distance allowed for the truth center to be from
-                                                                                                                                                                                                                                                                                                                                                                                     *                         reco-cluster center:
-                                                                                                                                                                                                                                                                                                                                                                                     *                         |z_true-z_reco| must be <= dz_reco * cluster_nzwidths
-                                                                                                                                                                                                                                                                                                                                                                                     *  - cluster_nphiwidths : like cluster_nzwidths for phi
-                                                                                                                                                                                                                                                                                                                                                                                     *--------------------------------------------------------*/
-      const unsigned short _nmin_match = 4, const float _nmin_ratio = 0., const float _cutoff_dphi = 0.3, const float _same_dphi = 0.05, const float _cutoff_deta = 0.3, const float _same_deta = 0.05, const float _cluster_nzwidths = 0.5, const float _cluster_nphiwidths = 0.5, const unsigned short _max_nreco_per_truth = 4, const unsigned short _max_ntruth_per_reco = 4);  // for some output kinematis
+  TruthRecoTrackMatching( // Criteria to match a TrkrClusterContainer and track
+      /*-----------------------------------------------------------------------------------
+      * Input criteria for Truth Track (with nT clusters) to reco track (with nR clusters) :
+      *  - nmin_match  : minimum number of clusters in Truth and Reco track that must
+      *                  match for tracks to match
+      *  - cutoff_dphi : maximum distance out in |phi_truth-phi_reco| for a matched track
+      *  - same_dphi   : within this distance, all tracks must be checked
+      *  - cutoff_deta :   like cutoff_dphi but for eta
+      *  - same_deta   :   like same_dphi but for eta
+      *  - cluster_nzwidths   : z-distance allowed for the truth center to be from
+      *                         reco-cluster center:
+      *                         |z_true-z_reco| must be <= dz_reco * cluster_nzwidths
+      *  - cluster_nphiwidths : like cluster_nzwidths for phi
+      *--------------------------------------------------------*/
+        TrkrClusterIsMatcher* _ismatcher 
+      , const unsigned short _nmin_match = 4
+      , const float _nmin_ratio          = 0.
+      , const float _cutoff_dphi         = 0.3
+      , const float _same_dphi           = 0.05
+      , const float _cutoff_deta         = 0.3
+      , const float _same_deta           = 0.05
+      , const unsigned short _max_nreco_per_truth = 4
+      , const unsigned short _max_ntruth_per_reco = 4);  // for some output kinematis
 
   ~TruthRecoTrackMatching() override = default;
   int Init(PHCompositeNode*) override { return 0; };
@@ -60,18 +68,18 @@ class TruthRecoTrackMatching : public SubsysReco
   int process_event(PHCompositeNode*) override;  //`
   int End(PHCompositeNode*) override;
 
-  G4Eval::TrkrClusterComparer m_cluster_comp;
-  G4Eval::ClusCntr m_cluscntr;
+  TrackClusEvaluator    m_TCEval   ;
+  TrkrClusterIsMatcher* m_ismatcher {nullptr};
 
   int createNodes(PHCompositeNode* topNode);
 
-  void set_cluster_nphiwidths(float val) { m_cluster_comp.set_nphi_widths(val); };
-  void set_cluster_nzwidths(float val) { m_cluster_comp.set_nz_widths(val); };
-  void set_cutoff_deta(float val) { m_cutoff_deta = val; };
-  void set_cutoff_dphi(float val) { m_cutoff_dphi = val; };
-  void set_nmin_truth_cluster_ratio(float val) { m_nmincluster_ratio = val; };
-  void set_smallsearch_deta(float val) { m_same_deta = val; };
-  void set_smallsearch_dphi(float val) { m_same_dphi = val; };
+  void set_min_cl_match             (unsigned short val) { m_nmincluster_match = val; };
+  void set_min_cl_ratio             (float val) { m_nmincluster_ratio  = val  ; };
+  void set_cutoff_deta              (float val) { m_cutoff_deta        = val; };
+  void set_cutoff_dphi              (float val) { m_cutoff_dphi        = val; };
+  void set_nmin_truth_cluster_ratio (float val) { m_nmincluster_ratio  = val; };
+  void set_smallsearch_deta         (float val) { m_same_deta          = val; };
+  void set_smallsearch_dphi         (float val) { m_same_dphi          = val; };
 
   void set_max_nreco_per_truth(unsigned short val) { m_max_nreco_per_truth = val; };
   void set_max_ntruth_per_reco(unsigned short val) { m_max_ntruth_per_reco = val; };
@@ -86,7 +94,7 @@ class TruthRecoTrackMatching : public SubsysReco
   //--------------------------------------------------
 
   unsigned short m_nmincluster_match;  // minimum of matched clustered to keep a truth to emb match
-  float m_nmincluster_ratio;           // minimum ratio of truth clustered that must be matched in reconstructed track
+  float          m_nmincluster_ratio;           // minimum ratio of truth clustered that must be matched in reconstructed track
 
   double m_cutoff_dphi;  // how far in |phi_truth-phi_reco| to match
   double m_same_dphi;    // |phi_truth-phi_reco| to auto-evaluate (is < _m_cutoff_dphi)

--- a/simulation/g4simulation/g4eval/g4evalfn.cc
+++ b/simulation/g4simulation/g4eval/g4evalfn.cc
@@ -1,0 +1,115 @@
+#include <g4tracking/EmbRecoMatchContainer.h>
+
+#include "g4evalfn.h"
+#include "TrkrClusLoc.h"
+#include "TrkrClusterIsMatcher.h"
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase/TrkrCluster.h>
+
+#include <algorithm>
+#include <set>
+
+
+namespace g4evalfn {
+
+  int trklayer_det(int layer) {
+    if (layer < 3)  return DET::MVTX;
+    if (layer < 7)  return DET::INTT;
+    if (layer < 55) return DET::TPC;
+    return DET::TPOT;
+  }
+
+  int trklayer_det(TrkrDefs::hitsetkey key) {
+    return trklayer_det(TrkrDefs::getLayer(key));
+  }
+
+  int trklayer_det(TrkrDefs::cluskey key) {
+    return trklayer_det(TrkrDefs::getLayer(key));
+  }
+
+
+  std::vector<int> unmatchedSvtxTrkIds(EmbRecoMatchContainer* matches, SvtxTrackMap* m_SvtxTrackMap) {
+    std::set<unsigned int> ids_matched{};
+    for (auto trkid : matches->ids_RecoMatched()) {
+      ids_matched.insert(trkid); 
+    }
+
+    std::set<int> ids_unmatched;
+    for (auto reco = m_SvtxTrackMap->begin(); reco != m_SvtxTrackMap->end(); ++reco) {
+      auto trkid = reco->first;
+      if (ids_matched.count(trkid)==0) ids_unmatched.insert(trkid);
+    }
+    std::vector<int> ids_vec;
+    for (auto id : ids_unmatched) ids_vec.push_back((int)id);
+    std::sort(ids_vec.begin(), ids_vec.end());
+    return ids_vec;
+  }
+
+  TrkrClusLoc clusloc_PHG4(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key)
+  {
+    auto cluster = ismatcher->m_TruthClusters->findCluster(key);
+    Eigen::Vector3d gloc = ismatcher->m_ActsGeometry->getGlobalPosition(key, cluster);
+    return {TrkrDefs::getLayer(key), gloc,
+            cluster->getPosition(0), cluster->getPhiSize(), cluster->getPosition(1), cluster->getZSize(), key};
+  }
+
+  TrkrClusLoc clusloc_SVTX(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key)
+  {
+    auto cluster = ismatcher->m_RecoClusters->findCluster(key);
+    Eigen::Vector3d gloc = ismatcher->m_ActsGeometry->getGlobalPosition(key, cluster);
+    return {TrkrDefs::getLayer(key), gloc,
+            cluster->getPosition(0), cluster->getPhiSize(), cluster->getPosition(1), cluster->getZSize(), key};
+  }
+
+  float calc_match_statistic(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key_A, TrkrDefs::cluskey key_B) {
+    int layer = TrkrDefs::getLayer(key_A);
+    auto det_0123 = trklayer_det(layer);
+    auto clus_T = ismatcher->m_TruthClusters ->findCluster(key_A);
+    auto clus_R = ismatcher->m_RecoClusters  ->findCluster(key_B);
+    auto dphi = abs_dphi(clus_T->getPosition(0),clus_R->getPosition(0));
+
+    float stat = 0.;
+    switch (det_0123) {
+      case 0: { // MVTX
+        if (ismatcher->single_pixel_phi_MVTX) {
+          stat += dphi / ismatcher->tol_pitch_phi[layer];
+        } else {
+          stat += dphi / (ismatcher->tol_pitch_phi[layer] *std::max(clus_T->getPhiSize(),clus_R->getPhiSize()));
+        }
+        const float delta_z = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
+        if (ismatcher->single_pixel_z_MVTX) {
+          stat += delta_z / ismatcher->tol_pitch_z_MVTX;
+        } else {
+          stat += delta_z / (ismatcher->tol_pitch_z_MVTX * std::max(clus_T->getZSize(), clus_R->getZSize()));
+        }
+      } break;
+      case 1: {
+        if (ismatcher->single_pixel_phi_INTT) {
+          stat += dphi / ismatcher->tol_pitch_phi[layer];
+        } else {
+          stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
+        }
+      } break;
+      case 2: { // TPC
+        if (ismatcher->single_bin_phi_TPC) {
+          stat += dphi / ismatcher->tol_pitch_phi[layer];
+        } else {
+          stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
+        }
+        const float delta_t = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
+        if (ismatcher->single_bin_t_TPC) {
+          stat += delta_t / ismatcher->tol_step_t_TPC;
+        } else {
+          stat += delta_t / (ismatcher->tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize()));
+        }
+      } break;
+      case 3: // TPOT
+        break;
+      default:
+        break;
+    }
+    return stat;
+  }
+
+
+}

--- a/simulation/g4simulation/g4eval/g4evalfn.h
+++ b/simulation/g4simulation/g4eval/g4evalfn.h
@@ -1,0 +1,32 @@
+#ifndef G4EVALFN__H
+#define G4EVALFN__H
+
+#include "TrkrClusLoc.h"
+
+class TrkrClusterIsMatcher;
+class EmbRecoMatchContainer;
+class SvtxTrackMap;
+
+namespace g4evalfn {
+
+  enum DET { MVTX=0, INTT=1, TPC=2, TPOT=3 }; // 
+
+  int trklayer_det(TrkrDefs::hitsetkey); // 0:MVTX 1:INTt 2:TPC 3:TPOT and beyond
+  int trklayer_det(TrkrDefs::cluskey);   
+  int trklayer_det(int layer);          
+
+  TrkrClusLoc clusloc_PHG4(TrkrClusterIsMatcher*, TrkrDefs::cluskey);
+  TrkrClusLoc clusloc_SVTX(TrkrClusterIsMatcher*, TrkrDefs::cluskey);
+
+  inline float abs_dphi (float aphi, float bphi) {
+    float phi_delta = fabs(aphi-bphi);
+    while (phi_delta > M_PI) phi_delta = fabs(phi_delta-2*M_PI);
+    return phi_delta;
+  }
+
+  std::vector<int> unmatchedSvtxTrkIds(EmbRecoMatchContainer*, SvtxTrackMap*);
+
+  float calc_match_statistic(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key_A, TrkrDefs::cluskey key_B);
+}
+
+#endif

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -15,6 +15,7 @@
 
 class PHCompositeNode;
 
+class ClusHitsVerbosev1;
 class PHG4Hit;
 class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
@@ -74,9 +75,14 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
 
   double m_pixel_thresholdrat { 0.01 };
   float  max_g4hitstep        { 2.0  };
+  bool  record_ClusHitsVerbose { false };
+
   public:
   void set_pixel_thresholdrat (double val) { m_pixel_thresholdrat =   val; };
   void set_max_g4hitstep      (float  _)   { max_g4hitstep        =_; };
+
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
 
 };
 

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -12,13 +12,14 @@
 #include <memory>  // for unique_ptr
 #include <string>
 
+class ClusHitsVerbosev1;
 class PHCompositeNode;
+class PHG4Hit;
 class PHG4TruthInfoContainer;
 class TrkrClusterContainer;
 class TrkrHitSetContainer;
 class TrkrTruthTrack;
 class TrkrTruthTrackContainer;
-class PHG4Hit;
 
 class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
 {
@@ -94,8 +95,13 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
 
   double m_pixel_thresholdrat { 0.01 };
   float  max_g4hitstep        { 3.5  };
+  bool  record_ClusHitsVerbose { false };
+
   public:
   void set_pixel_thresholdrat (double val) { m_pixel_thresholdrat = val; };
+
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.h
@@ -31,6 +31,7 @@ class TrkrTruthTrack;
 class DistortedTrackContainer;
 class TpcClusterBuilder;
 class PHG4TpcCylinderGeomContainer;
+class ClusHitsVerbose;
 
 class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
 {
@@ -69,9 +70,13 @@ class PHG4TpcElectronDrift : public SubsysReco, public PHParameterInterface
   TpcClusterBuilder truth_clusterer {};
   void set_pixel_thresholdrat (double val) { truth_clusterer.set_pixel_thresholdrat(val); };
   void set_max_g4hitstep (float _) { max_g4hitstep =_; };
+  void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
+
 
  private:
   float max_g4hitstep { 7. };
+  bool  record_ClusHitsVerbose { false };
   //! map a given x,y,z coordinates to plane hits
   /* TpcClusterBuilder MapToPadPlane(const double x, const double y, const */
   /*     double z, const unsigned int side, PHG4HitContainer::ConstIterator hiter, */

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -1,5 +1,7 @@
 #include "TpcClusterBuilder.h"
-#include <trackbase/TrkrClusterv5.h>
+/* #include <trackbase/TrkrClusterv3.h> */
+#include <trackbase/ClusHitsVerbosev1.h>
+#include <trackbase/TrkrClusterv4.h>
 #include <trackbase/TpcDefs.h>
 #include <g4detectors/PHG4TpcCylinderGeom.h>
 #include <g4tracking/TrkrTruthTrack.h>
@@ -38,7 +40,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
   //-----------------------------------------------------
   // from TpcClusterizer.cc ~line: 837
   //-----------------------------------------------------
- 
+
   for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
       hitsetitr != hitsetrange.second;
       ++hitsetitr)
@@ -50,7 +52,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     int side                       = TpcDefs::getSide(hitsetitr->first);
     unsigned int sector            = TpcDefs::getSectorId(hitsetitr->first);
     PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
-    
+
     //get the maximum and minimum phi and time
     unsigned short NPhiBins = (unsigned short) layergeom->get_phibins();
     unsigned short NPhiBinsSector = NPhiBins/12;
@@ -66,7 +68,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     unsigned short phioffset = PhiOffset;
     unsigned short tbins     = NTBinsSide;
     unsigned short toffset   = TOffset ;
-
+   
     // loop over the hits in this cluster
     double t_sum = 0.0;
     double adc_sum = 0.0;
@@ -77,7 +79,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     // double phi2_sum = 0.0;
 
     double radius = layergeom->get_radius();  // returns center of layer
-    
+
     int phibinhi = -1;
     int phibinlo = INT_MAX;
     int tbinhi = -1;
@@ -85,74 +87,62 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
 
     auto ihit_list = hitset->getHits();
 
-    double sum_energy { 0. }; // energy = 4 * adc at this point
-  
-    for(auto ihit = ihit_list.first; ihit != ihit_list.second; ++ihit){
-      int e = ihit->second->getEnergy();
-      int adc = ihit->second->getAdc();
-      if (adc*4 != e) {
-	if(verbosity > 1) 
-	  {
-	    cout << " FIXME: energy: " << ihit->second->getEnergy() << " vs adc " << ihit->second->getAdc() << endl;
-	  }
-      }
-      sum_energy += ihit->second->getEnergy();
+    const int iphi_max = phioffset+phibins;
+    const int it_max   = toffset+tbins;
+
+    double sum_adc { 0. }; // energy = 4 * adc at this point
+                           //
+    // accumulate energy from all hits that are not out of range
+    for(auto iter = ihit_list.first; iter != ihit_list.second; ++iter){
+      int iphi = TpcDefs::getPad(iter->first) ;//- phioffset;
+      int it   = TpcDefs::getTBin(iter->first);// - toffset;
+      if (iphi < phioffset || iphi > iphi_max || it < toffset || it > it_max) continue;
+      sum_adc += iter->second->getAdc();
     }
-    const double threshold = sum_energy * m_pixel_thresholdrat;
+    const double threshold = sum_adc * m_pixel_thresholdrat;
   
     // FIXME -- see why the hits are so scattered
     std::set<int> v_iphi, v_it;              // FIXME
-    std::map<int,unsigned int> m_iphi, m_it; // FIXME
-    
-    for(auto iter = ihit_list.first; iter != ihit_list.second; ++iter){
+    std::map<int,unsigned int> m_iphi, m_it, m_iphiCut, m_itCut; // FIXME
+    for(auto iter = ihit_list.first; iter != ihit_list.second; ++iter)
+    {
       unsigned int adc = iter->second->getAdc(); 
       if (adc <= 0) continue;
-
-      if (iter->second->getEnergy()<threshold) {
-        /* cout << "FIXME cutting " << iter->second->getEnergy() << " is below " << threshold << endl; */
+      int iphi = TpcDefs::getPad(iter->first) ;//- phioffset;
+      int it   = TpcDefs::getTBin(iter->first);// - toffset;
+      if (iphi < phioffset || iphi > iphi_max) {
+        std::cout << "WARNING phibin out of range: " << iphi << " | " << phibins << std::endl;
+        continue;
       }
+      if (it < toffset || it > it_max) {
+        std::cout << "WARNING z bin out of range: " << it << " | " << tbins << std::endl;
+        continue;
+      }
+      if (adc<threshold) {
+        if (mClusHitsVerbose) {
+          auto pnew = m_iphiCut.try_emplace(iphi,adc);
+          if (!pnew.second) pnew.first->second += adc;
 
-      if (iter->second->getEnergy()<threshold) continue;
+          pnew = m_itCut.try_emplace(it,adc);
+          if (!pnew.second) pnew.first->second += adc;
+        }
+        continue;
+      } 
 
-      int iphi = TpcDefs::getPad(iter->first) - phioffset;
-      int it   = TpcDefs::getTBin(iter->first) - toffset;
-
-      //FIXME
       v_iphi.insert(iphi);
       v_it.insert(it);
-      m_iphi.try_emplace(iphi,0);
-      m_it.try_emplace(it,0);
 
-      m_iphi[iphi] += adc;
-      m_it[it] += adc;
-
-      if(iphi<0 || iphi>=phibins){
-      //FIXME
-	if(verbosity > 1)
-	  {
-	    std::cout << "WARNING phibin out of range: " << iphi << " | " << phibins << std::endl;
-	  }
-        continue;
-      }
-      if(it<0 || it>=tbins){
-      //FIXME
-	if(verbosity > 1) {
-	  std::cout << "WARNING z bin out of range: " << it << " | " << tbins << std::endl;
-	}
-        continue;
-      }
-
-      iphi += phioffset;
-      it   += toffset;
+      // fill m_iphi
+      auto pnew = m_iphi.try_emplace(iphi,adc);
+      if (!pnew.second) pnew.first->second += adc;
+      pnew = m_it.try_emplace(it,adc);
+      if (!pnew.second) pnew.first->second += adc;
 
       if (iphi > phibinhi) phibinhi = iphi;
       if (iphi < phibinlo) phibinlo = iphi;
       if (it > tbinhi) tbinhi = it;
       if (it < tbinlo) tbinlo = it;
 
-      // update phi sums
-      /* double phi_center = layergeom->get_phicenter(iphi); */
-      /* phi_sum += phi_center * adc; */
       iphi_sum += iphi * adc;
       // phi2_sum += square(phi_center)*adc;
 
@@ -163,17 +153,24 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
 
       adc_sum += adc;
     }
-   
-    if (false) { // FIXME 
-      int _phi_sum = 0;
-      for (auto _ : m_iphi) _phi_sum += _.second;
-      if (_phi_sum != adc_sum && verbosity > 1) std::cout << " FIXME z1 " << adc_sum << " delta phi: " << (adc_sum - _phi_sum) << std::endl;
-
-      int _t_sum = 0;
-      for (auto _ : m_it) _t_sum += _.second;
-      if (_t_sum != adc_sum && verbosity > 1) std::cout << " FIXME z1 " << adc_sum << " delta phi: " << (adc_sum - _phi_sum) << std::endl;
+    if (mClusHitsVerbose) {
+      if (verbosity>10) {
+        for (auto& hit : m_iphi) {
+          cout << " m_phi(" << hit.first <<" : " << hit.second<<") ";
+        }
+      }
+      /* cout << " MELON 0 m_iphi "; */
+      /* for (auto& hit : m_iphi)   cout  << hit.first << "|" << hit.second << " "; */
+      /* cout << endl; */
+      /* cout << " MELON 1 m_it   "; */
+      /* for (auto& hit : m_it) cout    << hit.first << "|" << hit.second << " "; */
+      /* cout << endl; */
+      for (auto& hit : m_iphi)    mClusHitsVerbose->addPhiHit    (hit.first, hit.second);
+      for (auto& hit : m_it)      mClusHitsVerbose->addZHit      (hit.first, hit.second);
+      for (auto& hit : m_iphiCut) mClusHitsVerbose->addPhiCutHit (hit.first, hit.second);
+      for (auto& hit : m_itCut)   mClusHitsVerbose->addZCutHit   (hit.first, hit.second);
     }
-      
+    
     // This is the global position
     double clusiphi = iphi_sum / adc_sum;
     double clusphi  = layergeom->get_phi(clusiphi);
@@ -189,7 +186,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     char tsize = tbinhi - tbinlo + 1;
     char phisize = phibinhi - phibinlo + 1;
 
-    if (tsize < 0 && verbosity > 1) std::cout << " FIXME z4 tsize: " << ((int)tsize) << " " << tbinlo << " to " << tbinhi << std::endl;
+    if (tsize < 0) cout << " FIXME z4 tsize: " << ((int)tsize) << " " << tbinlo << " to " << tbinhi << endl;
     
     // -------------------------------------------------
     // -------------------------------------------------
@@ -257,17 +254,18 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
         }
         cout << endl;
       }
-    }
-    
+    } // end debug printing
+
     // get the global vector3 to then get the surface local phi and z
     Acts::Vector3 global(clusx, clusy, clusz);
     TrkrDefs::subsurfkey subsurfkey = 0;
 
     Surface surface = m_tGeometry->get_tpc_surface_from_coords(
       hitsetkey, global, subsurfkey);
-  
+
     if (!surface) {
       if (verbosity) std::cout << "Can't find the surface! with hitsetkey " << ((int)hitsetkey) << std::endl;
+      /* if (mClusHitsVerbose) mClusHitsVerbose->Reset(); */
       continue;
     }
 
@@ -275,11 +273,11 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     clust = clust + m_sampa_tbias;
 
     global *= Acts::UnitConstants::cm;
-   
+
     Acts::Vector3 local=surface->transform(m_tGeometry->geometry().getGeoContext()).inverse() * global;
     local /= Acts::UnitConstants::cm;     
-    
-    auto cluster = new TrkrClusterv5; // 
+
+    auto cluster = new TrkrClusterv4; // 
     cluster->setAdc(adc_sum);  
     /* cluster->setOverlap(ntouch); */
     /* cluster->setEdge(nedge); */
@@ -288,13 +286,18 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track) {
     cluster->setSubSurfKey(subsurfkey);      
     cluster->setLocalX(local(0));
     cluster->setLocalY(clust);
-    
+
     // add the clusterkey
     auto empl = hitsetkey_cnt.try_emplace(hitsetkey,0);
     if (!empl.second) empl.first->second += 1;
     TrkrDefs::cluskey cluskey = TrkrDefs::genClusKey(hitsetkey, hitsetkey_cnt[hitsetkey]);
     m_clusterlist->addClusterSpecifyKey(cluskey, cluster);
+
     track->addCluster(cluskey);
+    if (mClusHitsVerbose) {
+      mClusHitsVerbose->push_hits(cluskey);
+      /* cout << " FIXME z1 ClusHitsVerbose.size: " << mClusHitsVerbose->getMap().size() << endl; */
+    }
   }
   m_hits->Reset();
 }
@@ -401,10 +404,12 @@ void TpcClusterBuilder::set_input_nodes(
       TrkrClusterContainer* _truth_cluster_container
     , ActsGeometry*                 _ActsGeometry
     , PHG4TpcCylinderGeomContainer* _geom_container
+    , ClusHitsVerbosev1*            _clushitsverbose
 ) {
-  m_clusterlist   = _truth_cluster_container;
-  m_tGeometry     = _ActsGeometry;
-  geom_container  = _geom_container;
+  m_clusterlist     = _truth_cluster_container;
+  m_tGeometry       = _ActsGeometry;
+  geom_container    = _geom_container;
+  mClusHitsVerbose  = _clushitsverbose;
   needs_input_nodes = false;
 };
 

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.h
@@ -36,6 +36,7 @@ class TrkrClusterContainer;
 class TrkrHitSetContainer;
 class TrkrTruthTrack;
 class TrkrTruthTrackContainer;
+class ClusHitsVerbosev1;
 
 // This is the basic data for each set of TrkrHits from each TrkrHitsSet 
 // to be used in tpc/TpcClusterizer.cc
@@ -97,6 +98,8 @@ class TpcClusterBuilder {
   // for pixel thresholds
   private:
   double m_pixel_thresholdrat { 0.01 };
+  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
+
   public:
   void clear_hitsetkey_cnt();
   void set_pixel_thresholdrat (double val) { m_pixel_thresholdrat = val; };
@@ -105,6 +108,7 @@ class TpcClusterBuilder {
       TrkrClusterContainer* _truth_cluster_container
     , ActsGeometry*                 _ActsGeometry
     , PHG4TpcCylinderGeomContainer* _geom_container
+    , ClusHitsVerbosev1*            _clushitsverbose
   );
 };
 

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackv1.cc
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackv1.cc
@@ -88,5 +88,5 @@ bool TrkrTruthTrackv1::has_hitsetkey(TrkrDefs::cluskey key) const {
 std::pair<bool, TrkrDefs::cluskey> TrkrTruthTrackv1::get_cluskey(TrkrDefs::hitsetkey hitsetkey) const { 
   auto lb = std::lower_bound(clusters.begin(), clusters.end(), hitsetkey, CompHitSetKey());
   if (lb == clusters.end() || TrkrDefs::getHitSetKeyFromClusKey(*lb) != hitsetkey) return { false, 0. };
-  else                      return { true,  *lb };
+  else return { true,  *lb };
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

 - Add an option to keep pixel (in MVTX and INTT) and bin (in TPC) information about each cluster.
 - Fix cluster sizes in cluster matching (was only in phi, now is phi x R)
 - Add finer tuning for user selection on cluster matching criteria

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

