### PR TITLE
Fixerd rotation direction in get_DCA.

### DIFF
--- a/offline/packages/trackreco/SecondaryVertexFinder.cc
+++ b/offline/packages/trackreco/SecondaryVertexFinder.cc
@@ -147,6 +147,12 @@ int SecondaryVertexFinder::process_event(PHCompositeNode */*topNode*/)
 
       auto vertexId = tr1->get_vertex_id();
       const SvtxVertex* svtxVertex = _svtx_vertex_map->get(vertexId);
+      if(!svtxVertex)
+	{
+	  if(Verbosity() > 1)
+	    { std::cout << PHWHERE << " Failed to find vertex id " << vertexId << " skip this track " << std::endl; }
+	  continue;
+	}
       if(svtxVertex->size_tracks() == 0) continue;  // event did not have a reconstructed vertex, vertex is bogus 
 
       // Reverse or remove this to consider TPC-only tracks too
@@ -634,6 +640,7 @@ void SecondaryVertexFinder::get_dca(SvtxTrack* track,
   
   Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
   float phi = atan2(r(1), r(0));
+  phi *= -1.0;  // rotates vector clockwise to x axis
   
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
@@ -656,7 +663,6 @@ void SecondaryVertexFinder::get_dca(SvtxTrack* track,
   dca3dz = pos_R(2);
   dca3dxysigma = sqrt(rotCov(0,0));
   dca3dzsigma = sqrt(rotCov(2,2));
-  
 }
 
 void SecondaryVertexFinder::findPcaTwoLines(Eigen::Vector3d pos1, Eigen::Vector3d mom1, Eigen::Vector3d pos2, Eigen::Vector3d mom2,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Found that the rotation direction was wrong in the get_DCA method of SecondaryVertexFinder. The rotation should be clockwise. This may be wrong elsewhere that the track DCA is calculated.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

