### PR TITLE
fix: DCA calculation and duplication

### DIFF
--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -664,7 +664,8 @@ void QAG4SimulationTracking::get_dca(SvtxTrack *track, float &dca3dxy,
   auto vtxid = track->get_vertex_id();
   auto glVertex = m_vertexMap->get(vtxid);
   if (!glVertex) return;
-  auto pair = TrackAnalysisUtils::get_dca(track,glVertex);
+  Acts::Vector3 vert(glVertex->get_x(), glVertex->get_y(), glVertex->get_z());
+  auto pair = TrackAnalysisUtils::get_dca(track,vert);
   dca3dxy = pair.first.first;
   dca3dxysigma = pair.first.second;
   dca3dz = pair.second.first;

--- a/offline/QA/modules/QAG4SimulationTracking.cc
+++ b/offline/QA/modules/QAG4SimulationTracking.cc
@@ -18,6 +18,10 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/TrackSeed.h>
+#include <trackbase_historic/TrackAnalysisUtils.h>
+
+#include <globalvertex/GlobalVertexMap.h>
+#include <globalvertex/GlobalVertex.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -56,7 +60,7 @@ int QAG4SimulationTracking::InitRun(PHCompositeNode *topNode)
     m_svtxEvalStack->set_verbosity(Verbosity());
   }
 
-  m_vertexMap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+  m_vertexMap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
 
   if (!m_trackMap or !m_vertexMap)
@@ -579,7 +583,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         float dca3dz = NAN;
         float dca3dxysigma = NAN;
         float dca3dzsigma = NAN;
-        get_dca(track, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
+	get_dca(track, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
 
         double px = track->get_px();
         double py = track->get_py();
@@ -656,56 +660,15 @@ void QAG4SimulationTracking::get_dca(SvtxTrack *track, float &dca3dxy,
                                      float &dca3dz, float &dca3dxysigma,
                                      float &dca3dzsigma)
 {
-  Acts::Vector3 pos(track->get_x(),
-                    track->get_y(),
-                    track->get_z());
-  Acts::Vector3 mom(track->get_px(),
-                    track->get_py(),
-                    track->get_pz());
-
+  
   auto vtxid = track->get_vertex_id();
-  auto svtxVertex = m_vertexMap->get(vtxid);
-  if (!svtxVertex) return;
-
-  Acts::Vector3 vertex(svtxVertex->get_x(),
-                       svtxVertex->get_y(),
-                       svtxVertex->get_z());
-
-  pos -= vertex;
-
-  Acts::ActsSymMatrix<3> posCov;
-  for (int i = 0; i < 3; ++i)
-  {
-    for (int j = 0; j < 3; ++j)
-    {
-      posCov(i, j) = track->get_error(i, j);
-    }
-  }
-
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
-  float phi = atan2(r(1), r(0));
-
-  Acts::RotationMatrix3 rot;
-  Acts::RotationMatrix3 rot_T;
-  rot(0, 0) = cos(phi);
-  rot(0, 1) = -sin(phi);
-  rot(0, 2) = 0;
-  rot(1, 0) = sin(phi);
-  rot(1, 1) = cos(phi);
-  rot(1, 2) = 0;
-  rot(2, 0) = 0;
-  rot(2, 1) = 0;
-  rot(2, 2) = 1;
-
-  rot_T = rot.transpose();
-
-  Acts::Vector3 pos_R = rot * pos;
-  Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-
-  dca3dxy = pos_R(0);
-  dca3dz = pos_R(2);
-  dca3dxysigma = sqrt(rotCov(0, 0));
-  dca3dzsigma = sqrt(rotCov(2, 2));
+  auto glVertex = m_vertexMap->get(vtxid);
+  if (!glVertex) return;
+  auto pair = TrackAnalysisUtils::get_dca(track,glVertex);
+  dca3dxy = pair.first.first;
+  dca3dxysigma = pair.first.second;
+  dca3dz = pair.second.first;
+  dca3dzsigma = pair.second.second;
 
   return;
 }

--- a/offline/QA/modules/QAG4SimulationTracking.h
+++ b/offline/QA/modules/QAG4SimulationTracking.h
@@ -21,6 +21,7 @@ class TrkrClusterContainer;
 class TrkrClusterHitAssoc;
 class TrkrHitTruthAssoc;
 class SvtxVertexMap;
+class GlobalVertexMap;
 
 /// \class QAG4SimulationTracking
 class QAG4SimulationTracking : public SubsysReco
@@ -80,7 +81,7 @@ class QAG4SimulationTracking : public SubsysReco
 
   PHG4TruthInfoContainer *m_truthContainer = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
-  SvtxVertexMap *m_vertexMap = nullptr;
+  GlobalVertexMap *m_vertexMap = nullptr;
 
   TrkrClusterContainer *m_cluster_map = nullptr;
   TrkrClusterHitAssoc *m_cluster_hit_map = nullptr;

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -17,6 +17,10 @@
 #include <trackbase/TrkrClusterIterationMapv1.h>
 #include <trackbase/TrkrHitSet.h>
 
+#include <globalvertex/GlobalVertex.h>
+#include <globalvertex/GlobalVertexMap.h>
+
+#include <trackbase_historic/TrackAnalysisUtils.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
@@ -1080,7 +1084,7 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
 
     // need things off of the DST...
 
-    SvtxVertexMap* vertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
+    GlobalVertexMap* vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
 
     if (_trackmap)
     {
@@ -1295,7 +1299,7 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
         float dca2d = NAN, dca2dsigma = NAN;
 
         int vertexID = track->get_vertex_id();
-        SvtxVertex* vertex = vertexmap->get(vertexID);
+        GlobalVertex* vertex = vertexmap->get(vertexID);
         float vx = NAN;
         float vy = NAN;
         float vz = NAN;
@@ -1305,8 +1309,11 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
           vy = vertex->get_y();
           vz = vertex->get_z();
 
-          get_dca(track, vertexmap, dca3dxy, dca3dz,
-                  dca3dxysigma, dca3dzsigma);
+          auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+	  dca3dxy = dcapair.first.first;
+	  dca3dxysigma = dcapair.first.second;
+	  dca3dz = dcapair.second.first;
+	  dca3dzsigma = dcapair.second.second;
         }
         float px = track->get_px();
         float py = track->get_py();
@@ -1589,62 +1596,4 @@ TMatrixF TrkrNtuplizer::calculateClusterError(TrkrCluster* c, float& clusphi)
   TMatrixF err(3, 3);
   err = ROT * localErr * ROT_T;
   return err;
-}
-
-void TrkrNtuplizer::get_dca(SvtxTrack* track, SvtxVertexMap* vertexmap,
-                            float& dca3dxy, float& dca3dz,
-                            float& dca3dxysigma, float& dca3dzsigma)
-{
-  Acts::Vector3 pos(track->get_x(),
-                    track->get_y(),
-                    track->get_z());
-  Acts::Vector3 mom(track->get_px(),
-                    track->get_py(),
-                    track->get_pz());
-
-  auto vtxid = track->get_vertex_id();
-  auto svtxVertex = vertexmap->get(vtxid);
-  if (!svtxVertex)
-  {
-    return;
-  }
-  Acts::Vector3 vertex(svtxVertex->get_x(),
-                       svtxVertex->get_y(),
-                       svtxVertex->get_z());
-
-  pos -= vertex;
-
-  Acts::ActsSymMatrix<3> posCov;
-  for (int i = 0; i < 3; ++i)
-  {
-    for (int j = 0; j < 3; ++j)
-    {
-      posCov(i, j) = track->get_error(i, j);
-    }
-  }
-
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
-  float phi = atan2(r(1), r(0));
-
-  Acts::RotationMatrix3 rot;
-  Acts::RotationMatrix3 rot_T;
-  rot(0, 0) = cos(phi);
-  rot(0, 1) = -sin(phi);
-  rot(0, 2) = 0;
-  rot(1, 0) = sin(phi);
-  rot(1, 1) = cos(phi);
-  rot(1, 2) = 0;
-  rot(2, 0) = 0;
-  rot(2, 1) = 0;
-  rot(2, 2) = 1;
-
-  rot_T = rot.transpose();
-
-  Acts::Vector3 pos_R = rot * pos;
-  Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-
-  dca3dxy = pos_R(0);
-  dca3dz = pos_R(2);
-  dca3dxysigma = sqrt(rotCov(0, 0));
-  dca3dzsigma = sqrt(rotCov(2, 2));
 }

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -1308,8 +1308,8 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
           vx = vertex->get_x();
           vy = vertex->get_y();
           vz = vertex->get_z();
-
-          auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+	  Acts::Vector3 vert(vx,vy,vz);
+          auto dcapair = TrackAnalysisUtils::get_dca(track, vert);
 	  dca3dxy = dcapair.first.first;
 	  dca3dxysigma = dcapair.first.second;
 	  dca3dz = dcapair.second.first;

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -177,8 +177,7 @@ libtrackbase_historic_io_la_LDFLAGS = \
 libtrackbase_historic_io_la_LIBADD = \
   -lphool \
   -lActsCore \
-  -ltrack_io \
-  -lglobalvertex_io
+  -ltrack_io
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -177,7 +177,8 @@ libtrackbase_historic_io_la_LDFLAGS = \
 libtrackbase_historic_io_la_LIBADD = \
   -lphool \
   -lActsCore \
-  -ltrack_io
+  -ltrack_io \
+  -lglobalvertex_io
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -1,15 +1,14 @@
 #include "TrackAnalysisUtils.h"
 #include "SvtxTrack.h"
-#include <globalvertex/GlobalVertex.h>
 
 namespace TrackAnalysisUtils
 {
 
 TrackAnalysisUtils::DCAPair get_dca(SvtxTrack* track,
-				    GlobalVertex* gvertex)
+				    Acts::Vector3& vertex)
 {
   TrackAnalysisUtils::DCAPair pair;
-  if (!track or !gvertex)
+  if (!track)
   {
     std::cout << "You passed a nullptr, can't calculate DCA" << std::endl;
     return pair;
@@ -21,10 +20,6 @@ TrackAnalysisUtils::DCAPair get_dca(SvtxTrack* track,
   Acts::Vector3 mom(track->get_px(),
                     track->get_py(),
                     track->get_pz());
-
-  Acts::Vector3 vertex(gvertex->get_x(),
-                       gvertex->get_y(),
-                       gvertex->get_z());
 
   pos -= vertex;
 

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -1,12 +1,15 @@
 #include "TrackAnalysisUtils.h"
 #include "SvtxTrack.h"
-#include "SvtxVertex.h"
+#include <globalvertex/GlobalVertex.h>
 
-TrackAnalysisUtils::DCAPair TrackAnalysisUtils::get_dca(SvtxTrack* track,
-                                                        SvtxVertex* svtxVertex)
+namespace TrackAnalysisUtils
+{
+
+TrackAnalysisUtils::DCAPair get_dca(SvtxTrack* track,
+				    GlobalVertex* gvertex)
 {
   TrackAnalysisUtils::DCAPair pair;
-  if (!track or !svtxVertex)
+  if (!track or !gvertex)
   {
     std::cout << "You passed a nullptr, can't calculate DCA" << std::endl;
     return pair;
@@ -19,9 +22,9 @@ TrackAnalysisUtils::DCAPair TrackAnalysisUtils::get_dca(SvtxTrack* track,
                     track->get_py(),
                     track->get_pz());
 
-  Acts::Vector3 vertex(svtxVertex->get_x(),
-                       svtxVertex->get_y(),
-                       svtxVertex->get_z());
+  Acts::Vector3 vertex(gvertex->get_x(),
+                       gvertex->get_y(),
+                       gvertex->get_z());
 
   pos -= vertex;
 
@@ -36,7 +39,7 @@ TrackAnalysisUtils::DCAPair TrackAnalysisUtils::get_dca(SvtxTrack* track,
 
   Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
   float phi = atan2(r(1), r(0));
-
+  phi*= -1;
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
   rot(0, 0) = cos(phi);
@@ -53,7 +56,6 @@ TrackAnalysisUtils::DCAPair TrackAnalysisUtils::get_dca(SvtxTrack* track,
 
   Acts::Vector3 pos_R = rot * pos;
   Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-
   //! First pair is DCA_xy +/- DCA_xy_err
   pair.first.first = pos_R(0);
   pair.first.second = sqrt(rotCov(0, 0));
@@ -63,4 +65,5 @@ TrackAnalysisUtils::DCAPair TrackAnalysisUtils::get_dca(SvtxTrack* track,
   pair.second.second = sqrt(rotCov(2, 2));
 
   return pair;
+}
 }

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -4,20 +4,16 @@
 #include <utility>
 
 class SvtxTrack;
-class SvtxVertex;
+class GlobalVertex;
 
-class TrackAnalysisUtils
+namespace TrackAnalysisUtils
 {
- public:
+  /// Returns DCA as .first and uncertainty on DCA as .second
   using DCA = std::pair<float, float>;
   using DCAPair = std::pair<DCA, DCA>;
 
-  TrackAnalysisUtils() = default;
-  ~TrackAnalysisUtils() {}
+  DCAPair get_dca(SvtxTrack* track, GlobalVertex* svtxVertex);
 
-  DCAPair get_dca(SvtxTrack* track, SvtxVertex* svtxVertex);
-
- private:
 };
 
 #endif

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.h
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.h
@@ -2,9 +2,9 @@
 #define _TRACKBASEHISTORIC_TRACKANALYSISUTILS_H
 
 #include <utility>
+#include <Acts/Definitions/Algebra.hpp>
 
 class SvtxTrack;
-class GlobalVertex;
 
 namespace TrackAnalysisUtils
 {
@@ -12,7 +12,7 @@ namespace TrackAnalysisUtils
   using DCA = std::pair<float, float>;
   using DCAPair = std::pair<DCA, DCA>;
 
-  DCAPair get_dca(SvtxTrack* track, GlobalVertex* svtxVertex);
+  DCAPair get_dca(SvtxTrack* track, Acts::Vector3& vertex);
 
 };
 

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -3204,8 +3204,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               vx = vertex->get_x();
               vy = vertex->get_y();
               vz = vertex->get_z();
-	      
-	      auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+	      Acts::Vector3 vert(vx,vy,vz);
+	      auto dcapair = TrackAnalysisUtils::get_dca(track, vert);
 	      dca3dxy = dcapair.first.first;
 	      dca3dxysigma = dcapair.first.second;
 	      dca3dz = dcapair.second.first;
@@ -3623,8 +3623,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           vx = vertex->get_x();
           vy = vertex->get_y();
           vz = vertex->get_z();
+	  Acts::Vector3 vert(vx,vy,vz);
 
-          auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+          auto dcapair = TrackAnalysisUtils::get_dca(track, vert);
 	  dca3dxy = dcapair.first.first;
 	  dca3dxysigma = dcapair.first.second;
 	  dca3dz = dcapair.second.first;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -29,6 +29,7 @@
 #include <trackbase_historic/SvtxVertex.h>
 #include <trackbase_historic/SvtxVertexMap.h>
 #include <trackbase_historic/TrackSeed.h>
+#include <trackbase_historic/TrackAnalysisUtils.h>
 
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
@@ -3203,8 +3204,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               vx = vertex->get_x();
               vy = vertex->get_y();
               vz = vertex->get_z();
-
-              get_dca(track, gvertexmap, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
+	      
+	      auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+	      dca3dxy = dcapair.first.first;
+	      dca3dxysigma = dcapair.first.second;
+	      dca3dz = dcapair.second.first;
+	      dca3dzsigma = dcapair.second.second;
             }
 
             px = track->get_px();
@@ -3619,8 +3624,11 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           vy = vertex->get_y();
           vz = vertex->get_z();
 
-          get_dca(track, gvertexmap, dca3dxy, dca3dz,
-                  dca3dxysigma, dca3dzsigma);
+          auto dcapair = TrackAnalysisUtils::get_dca(track, vertex);
+	  dca3dxy = dcapair.first.first;
+	  dca3dxysigma = dcapair.first.second;
+	  dca3dz = dcapair.second.first;
+	  dca3dzsigma = dcapair.second.second;
         }
         float px = track->get_px();
         float py = track->get_py();
@@ -4150,62 +4158,4 @@ TMatrixF SvtxEvaluator::calculateClusterError(TrkrCluster* c, float& clusphi)
   TMatrixF err(3, 3);
   err = ROT * localErr * ROT_T;
   return err;
-}
-
-void SvtxEvaluator::get_dca(SvtxTrack* track, GlobalVertexMap* vertexmap,
-                            float& dca3dxy, float& dca3dz,
-                            float& dca3dxysigma, float& dca3dzsigma)
-{
-  Acts::Vector3 pos(track->get_x(),
-                    track->get_y(),
-                    track->get_z());
-  Acts::Vector3 mom(track->get_px(),
-                    track->get_py(),
-                    track->get_pz());
-
-  auto vtxid = track->get_vertex_id();
-  auto svtxVertex = vertexmap->get(vtxid);
-  if (!svtxVertex)
-  {
-    return;
-  }
-  Acts::Vector3 vertex(svtxVertex->get_x(),
-                       svtxVertex->get_y(),
-                       svtxVertex->get_z());
-
-  pos -= vertex;
-
-  Acts::ActsSymMatrix<3> posCov;
-  for (int i = 0; i < 3; ++i)
-  {
-    for (int j = 0; j < 3; ++j)
-    {
-      posCov(i, j) = track->get_error(i, j);
-    }
-  }
-
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
-  float phi = atan2(r(1), r(0));
-
-  Acts::RotationMatrix3 rot;
-  Acts::RotationMatrix3 rot_T;
-  rot(0, 0) = cos(phi);
-  rot(0, 1) = -sin(phi);
-  rot(0, 2) = 0;
-  rot(1, 0) = sin(phi);
-  rot(1, 1) = cos(phi);
-  rot(1, 2) = 0;
-  rot(2, 0) = 0;
-  rot(2, 1) = 0;
-  rot(2, 2) = 1;
-
-  rot_T = rot.transpose();
-
-  Acts::Vector3 pos_R = rot * pos;
-  Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-
-  dca3dxy = pos_R(0);
-  dca3dz = pos_R(2);
-  dca3dxysigma = sqrt(rotCov(0, 0));
-  dca3dzsigma = sqrt(rotCov(2, 2));
 }


### PR DESCRIPTION
This removes a lot of duplicated DCA calculation code and consolidates it to use a single function in track analysis utilities. It also corrects a bug Tony found that rotates the vector clockwise rather than counter clockwise to make the y component of the 3D DCA 0.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

