### PR TITLE
add forgotten / so the online monitoring finds the csh files

### DIFF
--- a/offline/packages/tpc/TpcMap.cc
+++ b/offline/packages/tpc/TpcMap.cc
@@ -20,7 +20,7 @@ void TpcMap::setMapNames(const std::string &r1, const std::string &r2, const std
     calibrationroot = getenv("TPCCALIB");
     if (calibrationroot)
     {
-      full_path = std::string(calibrationroot);
+      full_path = std::string(calibrationroot) + "/";
     }
     else
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
The online monitoring did not find the tpc mapping. The reason was a forgotten /, so it looked in the wrong place
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

