### PR TITLE
fix: misalignment rotations

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -108,7 +108,12 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_clusgxideal;
   std::vector<float> m_clusgyideal;
   std::vector<float> m_clusgzideal;
-  
+  std::vector<float> m_idealsurfalpha;
+  std::vector<float> m_idealsurfbeta;
+  std::vector<float> m_idealsurfgamma;
+  std::vector<float> m_missurfalpha;
+  std::vector<float> m_missurfbeta;
+  std::vector<float> m_missurfgamma;
 
 
   //! states on track information

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -19,7 +19,6 @@ class ActsGeometry;
 class AlignmentTransformation {
 
  public:
-
   AlignmentTransformation() = default;
 
   ~AlignmentTransformation(){} 
@@ -124,7 +123,7 @@ void setTPCParams(double tpcDevs[6])
 
   bool use_global_millepede_translations = true;
 
-  Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d millepedeTranslation, Eigen::Vector3d sensorAngles);
+  Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles);
 
   alignmentTransformationContainer* transformMap = NULL;
   ActsGeometry* m_tGeometry = NULL;


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR fixes the applications of rotational misalignments such that they can be successfully and correctly replicated in the Acts KF alignment workflow. This means that given some input rotational misalignment, the workflow can reproduce that input before any input to pede. Now that the rotations are correctly being applied, we can test how pede interprets them.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

