### PR TITLE
make cdbobjects standalone library - only dependent on root

### DIFF
--- a/offline/database/cdbobjects/CDBHistos.cc
+++ b/offline/database/cdbobjects/CDBHistos.cc
@@ -1,7 +1,5 @@
 #include "CDBHistos.h"
 
-#include <phool/phool.h>
-
 #include <TClass.h>       // for TClass
 #include <TCollection.h>  // for TIter
 #include <TDirectory.h>   // for TDirectoryAtomicAdapter, TDirectory, gDirec...
@@ -34,7 +32,7 @@ void CDBHistos::WriteCDBHistos()
 {
   if (m_HistoMap.empty())
   {
-    std::cout << PHWHERE << " no histograms to be saved " << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " no histograms to be saved " << std::endl;
     return;
   }
   std::string currdir = gDirectory->GetPath();
@@ -53,13 +51,13 @@ void CDBHistos::LoadCalibrations()
   TFile *fin = TFile::Open(m_Filename.c_str());
   if (fin == nullptr)
   {
-    std::cout << PHWHERE << " Could not open " << m_Filename << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " Could not open " << m_Filename << std::endl;
     return;
   }
   TList *list = fin->GetListOfKeys();
   if (!list)
   {
-    std::cout << PHWHERE << " No keys found in " << m_Filename << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " No keys found in " << m_Filename << std::endl;
     fin->Close();
     gROOT->cd(currdir.c_str());  // restore previous directory
     return;
@@ -97,7 +95,7 @@ void CDBHistos::registerHisto(TH1 *h1)
   const auto iter = m_HistoMap.find(h1->GetName());
   if (iter != m_HistoMap.end())
   {
-    std::cout << PHWHERE << " Histogram " << h1->GetName() << " already registered, use a different name and try again" << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " Histogram " << h1->GetName() << " already registered, use a different name and try again" << std::endl;
     gSystem->Exit(1);
   }
   m_HistoMap.insert(std::make_pair(h1->GetName(), h1));
@@ -109,7 +107,7 @@ TH1 *CDBHistos::getHisto(const std::string &name)
   const auto iter = m_HistoMap.find(name);
   if (iter == m_HistoMap.end())
   {
-    std::cout << PHWHERE << ": Histogram " << name << " not found" << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << ": Histogram " << name << " not found" << std::endl;
     return nullptr;
   }
   return iter->second;

--- a/offline/database/cdbobjects/CDBTTree.cc
+++ b/offline/database/cdbobjects/CDBTTree.cc
@@ -1,7 +1,5 @@
 #include "CDBTTree.h"
 
-#include <phool/phool.h>
-
 #include <TBranch.h>      // for TBranch
 #include <TCollection.h>  // for TIter
 #include <TDirectory.h>   // for TDirectoryAtomicAdapter, TDirectory, gDirec...
@@ -514,7 +512,7 @@ void CDBTTree::LoadCalibrations()
       }
       else
       {
-        std::cout << PHWHERE << " data type " << DataType
+        std::cout << __PRETTY_FUNCTION__ << " data type " << DataType
                   << " in " << m_TTree[SingleEntries]->GetName()
                   << " from " << f->GetName()
                   << " not implemented" << std::endl;

--- a/offline/database/cdbobjects/Makefile.am
+++ b/offline/database/cdbobjects/Makefile.am
@@ -5,8 +5,6 @@ lib_LTLIBRARIES = \
   libcdbobjects.la
 
 AM_CPPFLAGS = \
-  -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 libcdbobjects_la_SOURCES = \
@@ -14,15 +12,7 @@ libcdbobjects_la_SOURCES = \
   CDBTTree.cc
 
 libcdbobjects_la_LDFLAGS = \
-  -L$(libdir) \
-  -L$(OFFLINE_MAIN)/lib \
-  -L$(OFFLINE_MAIN)/lib64
-
-libcdbobjects_la_LIBADD = \
-  -lboost_system \
-  -lffamodules \
-  -lphool
-
+  `root-config --libs`
 
 ##############################################
 # please add new classes in alphabetical order


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)
This PR makes the cdbobjects library a standlone lib, only dependent on ROOT so we can use it online
## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

