### PR TITLE
patch for crash in begin run event, ignore special events

### DIFF
--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -61,6 +61,8 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       if (evt->getEvtType() != DATAEVENT)
       {
         m_NumSpecialEvents++;
+        delete evt;
+        continue; // need handling for non data events
       }
       int EventSequence = evt->getEvtSequence();
       int npackets = evt->getPacketList(plist, 100);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Some BOR packets crash in the decoder. This patch just ignores non data events (and doesn't pass them on). That needs to be taken care off later [skip-ci]
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

