### PR TITLE
fix: All global label functions

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -289,7 +289,6 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, TrkrDefs::cluskey c
 
 std::vector<int> AlignmentDefs::getAllMvtxGlobalLabels(int grp)
 {
-  std::vector<int> labels;
   std::vector<int> label_base;
 
   if(grp == mvtxGrp::clamshl)
@@ -337,20 +336,13 @@ std::vector<int> AlignmentDefs::getAllMvtxGlobalLabels(int grp)
 	}	
     }
 
-  for (unsigned int ilbl = 0; ilbl < label_base.size(); ++ilbl)
-    {
-      for(int ipar = 3; ipar < 6;++ipar)
-	{
-	  int label_plus = label_base[ilbl] + ipar;
-	  labels.push_back(label_plus);
-	}
-    }
+  auto labels = makeLabelsFromBase(label_base);
+
   return labels;
 }
 
 std::vector<int> AlignmentDefs::getAllInttGlobalLabels(int grp)
 {
-  std::vector<int> labels;
   std::vector<int> label_base;
 
   if(grp == inttGrp::inttbrl)
@@ -392,20 +384,13 @@ std::vector<int> AlignmentDefs::getAllInttGlobalLabels(int grp)
 	}	
     }
 
-  for (unsigned int ilbl = 0; ilbl < label_base.size(); ++ilbl)
-    {
-      for(int ipar = 3; ipar < 6;++ipar)
-	{
-	  int label_plus = label_base[ilbl] + ipar;
-	  labels.push_back(label_plus);
-	}
-    }
+  auto labels = makeLabelsFromBase(label_base);
+
   return labels;
 }
 
 std::vector<int> AlignmentDefs::getAllTpcGlobalLabels(int grp)
 {
-  std::vector<int> labels;
   std::vector<int> label_base;
 
   if(grp == tpcGrp::sctr)
@@ -417,14 +402,23 @@ std::vector<int> AlignmentDefs::getAllTpcGlobalLabels(int grp)
 	}
     }
 
-  for (unsigned int ilbl = 0; ilbl < label_base.size(); ++ilbl)
+  auto labels = makeLabelsFromBase(label_base);
+
+  return labels;
+}
+
+std::vector<int> AlignmentDefs::makeLabelsFromBase(std::vector<int>& label_base)
+{
+  std::vector<int> labels;
+  for(unsigned int ilbl = 0; ilbl < label_base.size(); ++ilbl)
     {
-      for(int ipar = 3; ipar < 6;++ipar)
+      for(int ipar=0; ipar < 6; ++ipar)
 	{
 	  int label_plus = label_base[ilbl] + ipar;
 	  labels.push_back(label_plus);
 	}
     }
+
   return labels;
 }
 

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -61,6 +61,7 @@ namespace AlignmentDefs
   std::vector<int> getAllMvtxGlobalLabels(int grp);
   std::vector<int> getAllInttGlobalLabels(int grp);
   std::vector<int> getAllTpcGlobalLabels(int grp);
+  std::vector<int> makeLabelsFromBase(std::vector<int>& label_base);
 
   int getLabelBase(Acts::GeometryIdentifier id, TrkrDefs::cluskey cluskey, int group);
 


### PR DESCRIPTION
The functions which return all global labels for a given grouping only returned the translation labels. They now return all labels, including rotations.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

