### PR TITLE
fix: Blow up cluster uncertainties at TPC sector boundaries

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <trackbase/TrkrDefs.h>
+#include <trackbase/ClusterErrorPara.h>
 
 #include <cmath>
 #include <iostream>
@@ -49,6 +50,7 @@ class TrackResiduals : public SubsysReco
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;
 
+  ClusterErrorPara m_clusErrPara;
   std::string m_alignmentMapName = "SvtxAlignmentStateMap";
   std::string m_trackMapName = "SvtxTrackMap";
 
@@ -92,6 +94,8 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_clusgz;
   std::vector<int> m_cluslayer;
   std::vector<int> m_clussize;
+  std::vector<int> m_clusedge;
+  std::vector<int> m_clusoverlap;
   std::vector<uint32_t> m_clushitsetkey;
   std::vector<float> m_idealsurfcenterx;
   std::vector<float> m_idealsurfcentery;

--- a/offline/packages/trackbase/ClusterErrorPara.cc
+++ b/offline/packages/trackbase/ClusterErrorPara.cc
@@ -493,7 +493,7 @@ ClusterErrorPara::error_t ClusterErrorPara::get_clusterv5_modified_error(TrkrClu
     if(clusterv5->getPhiSize()>=5)
       phierror *= 10;
 
-    if(phierror>0.1) phierror = 0.1;
+    if(phierror>0.1 && clusterv5->getEdge()<=3) phierror = 0.1;
     if(phierror<0.0005) phierror = 0.1;
   }
   return std::make_pair(square(phierror),square(zerror)); 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR removes the upper limit for rphi cluster uncertainties for TPC clusters that exist on sector boundaries. It substantially improves the fit quality for tracks that cross azimuthal sector boundaries or completely exist on sector boundaries.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

