### PR TITLE
Added MicromegasCalibrationData to online build

### DIFF
--- a/offline/packages/micromegas/Makefile.am
+++ b/offline/packages/micromegas/Makefile.am
@@ -22,15 +22,18 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 pkginclude_HEADERS = \
+  MicromegasCalibrationData.h \
   MicromegasDefs.h \
   MicromegasMapping.h
 
 # sources for io library
 libmicromegas_io_la_SOURCES = \
+  MicromegasCalibrationData.cc \
   MicromegasDefs.cc \
   MicromegasMapping.cc
 
 libmicromegas_io_la_LIBADD = \
+  -lcdbobjects \
   -ltrack_io
 
 BUILT_SOURCES = testexternals.cc


### PR DESCRIPTION
Title says it all. 
Should only depend on already available libraries/code, namely online build of track_io and cdbobjects
This is necessary for TPOT calibrations to be seemlessly used in online monitoring code

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

