### PR TITLE
Small update -- remove cout of blank line in FillClusMatchTree

### DIFF
--- a/simulation/g4simulation/g4eval/FillClusMatchTree.cc
+++ b/simulation/g4simulation/g4eval/FillClusMatchTree.cc
@@ -491,8 +491,7 @@ void FillClusMatchTree::print_mvtx_diagnostics() {
   }
 
 void FillClusMatchTree::clear_clusvecs(const std::string& tag) {
-  /* cout << " banana |" << tag << "|"<<endl; */
-  if (tag != "") {
+  if (tag != "" && b_clus_x.size()>0) {
     for (auto x : b_clus_x) cout << x <<" ";
     cout << endl;
   }


### PR DESCRIPTION
When not using the verbose option on the clusters, an unnecessary blank line is sent to cout once per process_event(). This update removes that line.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

