### PR TITLE
Prdf beamclock

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
@@ -82,12 +82,12 @@ int Fun4AllPrdfInputPoolManager::run(const int /*nevents*/)
     SetRunNumber(m_RunNumber);
   }
 
-  if(m_PacketMap.empty())
+  if (m_PacketMap.empty())
   {
     std::cout << "we are done" << std::endl;
     return -1;
   }
-//  std::cout << "next event is " << m_PacketMap.begin()->first << std::endl;
+  //  std::cout << "next event is " << m_PacketMap.begin()->first << std::endl;
   auto pktinfoiter = m_PacketMap.begin();
   oph->prepare_next(pktinfoiter->first, m_RunNumber);
   for (auto &pktiter : pktinfoiter->second.PacketVector)

--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -16,12 +16,15 @@ SinglePrdfInput::SinglePrdfInput(const std::string &name, Fun4AllPrdfInputPoolMa
   , m_InputMgr(inman)
 {
   plist = new Packet *[100];
+  m_PacketEventNumberOffset = new int[100]{};
+//  std::fill_n(m_PacketEventNumberOffset, 100, 0);
 }
 
 SinglePrdfInput::~SinglePrdfInput()
 {
   delete m_EventIterator;
   delete [] plist;
+  delete [] m_PacketEventNumberOffset;
 }
 
 void SinglePrdfInput::FillPool(const unsigned int nevents)
@@ -75,14 +78,17 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
         if (plist[i]->iValue(0, "EVENCHECKSUMOK") != 0 && plist[i]->iValue(0, "ODDCHECKSUMOK") != 0)
         {
           int evtno = plist[i]->iValue(0, "EVTNR");
+          unsigned int bclk = plist[i]->iValue(0, "CLOCK");
+	  std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
+		    << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
           // dummy check for the first event which is the problem for the calorimeters
           // it is the last event from the previous run, so it's event number is > 0
-          if (evtno > EventSequence)
-          {
-            delete plist[i];
-            plist[i] = nullptr;
-            continue;
-          }
+          // if (evtno > EventSequence)
+          // {
+          //   delete plist[i];
+          //   plist[i] = nullptr;
+          //   continue;
+          // }
           plist[i]->convert();
           // calculate "real" event number
           // special events are counted, so the packet event counter is never the
@@ -90,18 +96,98 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
           // also our packets are just 16bit counters, so we need to add the upper bits
           // from the event sequence
           // and our packet counters start at 0, while our events start at 1
-
-          evtno += m_EventNumberOffset + m_NumSpecialEvents + (EventSequence & 0xFFFF0000);
-          m_InputMgr->AddPacket(evtno, plist[i]);
+          evtno += m_EventNumberOffset + m_PacketEventNumberOffset[i] + m_NumSpecialEvents + (EventSequence & 0xFFFF0000);
+          m_PacketMap[bclk].push_back(plist[i]);
+          m_EvtSet.insert(evtno);
+	  std::cout << "added evtno " << evtno << " beam clock 0x" << std::hex << bclk << std::dec
+		    << ", size: " << m_EvtSet.size() << std::endl;
+          m_Event.push_back(std::make_pair(evtno,bclk));
         }
 	else
 	{
 	  delete plist[i];
 	}
       }
+// here we have all packets of a given event in our maps/vectors
+// first pass - check if beam clocks are identical
+      std::cout << "pktmap size : " << m_PacketMap.size() << std::endl;
+      std::cout << "evt set size : " << m_EvtSet.size() << std::endl;
+      int common_event_number = *(m_EvtSet.begin());
+      if (m_PacketMap.size() == 1) // all packets from the same beam clock
+      {
+	if (m_EvtSet.size() == 1)
+	{
+	  std::cout << "we are good evtno: " << *(m_EvtSet.begin())
+                    << ", clock: " << m_PacketMap.begin()->first << std::endl;
+	}
+	else
+	{
+	  std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
+		    << m_PacketMap.begin()->first << std::dec << std::endl;
+	  for (auto iter : m_EvtSet)
+	  {
+	    std::cout << "Event " << iter << std::endl;
+	  }
+          common_event_number = majority_eventnumber();
+	  std::cout << "picked event no " << common_event_number << std::endl;
+          adjust_eventnumber_offset(common_event_number);
+	}
+	for (auto iter : m_PacketMap)
+	{
+	  for (auto pktiter : iter.second)
+	  {
+          m_InputMgr->AddPacket(common_event_number, pktiter);
+	  }
+	}
+      }
+	else
+	{
+	  std::cout << "We have multiple beam clocks per event" << std::endl;
+	  std::cout << "This is not handled yet" << std::endl;
+	  // for(auto iter : m_PacketMap)
+	  // {
+	  //   std::cout << "0x" << std::hex << iter.first << std::dec << std::endl;
+	  // }
+	}
+      m_PacketMap.clear();
+      m_EvtSet.clear();
       delete evt;
   }
   
+}
+
+void SinglePrdfInput::adjust_eventnumber_offset(const int decided_evtno)
+{
+  for (unsigned int i = 0; i< m_Event.size(); i++)
+  {
+    if (m_Event[i].first != decided_evtno)
+    {
+      std::cout << "my evtno: " << m_Event[i].first << ", decided: " << decided_evtno
+		<< ", adjustment: " << m_Event[i].first-decided_evtno << std::endl;
+      m_PacketEventNumberOffset[i] -=  (m_Event[i].first-decided_evtno);
+      std::cout << "adjusting event number offset for " << i << " to " << m_PacketEventNumberOffset[i] << std::endl;
+    }
+  }
+}
+
+int SinglePrdfInput::majority_eventnumber()
+{
+  std::map<int, int> evtcnt;
+  for (auto iter : m_Event)
+  {
+    evtcnt[iter.first]++;
+  }
+  int imax = -1;
+  int evtno = -1;
+  for (auto iter : evtcnt)
+  {
+    if (iter.second > imax)
+    {
+      evtno = iter.first;
+      imax = iter.second;
+    }
+  }
+  return evtno;
 }
 
 int SinglePrdfInput::fileopen(const std::string &filenam)

--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -17,227 +17,225 @@ SinglePrdfInput::SinglePrdfInput(const std::string &name, Fun4AllPrdfInputPoolMa
 {
   plist = new Packet *[100];
   m_PacketEventNumberOffset = new int[100]{};
-//  std::fill_n(m_PacketEventNumberOffset, 100, 0);
+  //  std::fill_n(m_PacketEventNumberOffset, 100, 0);
 }
 
 SinglePrdfInput::~SinglePrdfInput()
 {
   delete m_EventIterator;
-  delete [] plist;
-  delete [] m_PacketEventNumberOffset;
+  delete[] plist;
+  delete[] m_PacketEventNumberOffset;
 }
 
 void SinglePrdfInput::FillPool(const unsigned int nevents)
 {
-  if (AllDone()) // no more files and all events read
+  if (AllDone())  // no more files and all events read
   {
     return;
   }
-  while (m_EventIterator == nullptr) // at startup this is a null pointer
+  while (m_EventIterator == nullptr)  // at startup this is a null pointer
   {
     OpenNextFile();
   }
-  for (unsigned int ievt=0; ievt<nevents; ievt++)
+  for (unsigned int ievt = 0; ievt < nevents; ievt++)
   {
-      Event *evt = m_EventIterator->getNextEvent();
+    Event *evt = m_EventIterator->getNextEvent();
+    if (!evt)
+    {
+      fileclose();
+      if (!OpenNextFile())
+      {
+        AllDone(1);
+        return;
+      }
+      evt = m_EventIterator->getNextEvent();
       if (!evt)
       {
-        fileclose();
-        if (!OpenNextFile())
-	{
-          AllDone(1);
-	  return;
-	}
-        evt = m_EventIterator->getNextEvent();
-	if (!evt)
-	{
-	  std::cout << PHWHERE << "Event is nullptr" << std::endl;
-          AllDone(1);
-	  return;
-	}
+        std::cout << PHWHERE << "Event is nullptr" << std::endl;
+        AllDone(1);
+        return;
       }
-      m_RunNumber = evt->getRunNumber();
-      if (Verbosity() > 1)
+    }
+    m_RunNumber = evt->getRunNumber();
+    if (Verbosity() > 1)
+    {
+      evt->identify();
+    }
+    if (evt->getEvtType() != DATAEVENT)
+    {
+      m_NumSpecialEvents++;
+      delete evt;
+      continue;  // need handling for non data events
+    }
+    int EventSequence = evt->getEvtSequence();
+    int npackets = evt->getPacketList(plist, 100);
+    if (npackets == 100)
+    {
+      exit(1);
+    }
+    for (int i = 0; i < npackets; i++)
+    {
+      if (plist[i]->iValue(0, "EVENCHECKSUMOK") != 0 && plist[i]->iValue(0, "ODDCHECKSUMOK") != 0)
       {
-        evt->identify();
-      }
-      if (evt->getEvtType() != DATAEVENT)
-      {
-        m_NumSpecialEvents++;
-        delete evt;
-        continue; // need handling for non data events
-      }
-      int EventSequence = evt->getEvtSequence();
-      int npackets = evt->getPacketList(plist, 100);
-      if (npackets == 100)
-      {
-        exit(1);
-      }
-      for (int i = 0; i < npackets; i++)
-      {
-        if (plist[i]->iValue(0, "EVENCHECKSUMOK") != 0 && plist[i]->iValue(0, "ODDCHECKSUMOK") != 0)
+        int evtno = plist[i]->iValue(0, "EVTNR");
+        unsigned int bclk = plist[i]->iValue(0, "CLOCK");
+        if (Verbosity() > 1)
         {
-          int evtno = plist[i]->iValue(0, "EVTNR");
-          unsigned int bclk = plist[i]->iValue(0, "CLOCK");
-	  if (Verbosity() > 1)
-	  {
-	  std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
-		    << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
-	  }
-          // dummy check for the first event which is the problem for the calorimeters
-          // it is the last event from the previous run, so it's event number is > 0
-          // if (evtno > EventSequence)
-          // {
-          //   delete plist[i];
-          //   plist[i] = nullptr;
-          //   continue;
-          // }
-          plist[i]->convert();
-          // calculate "real" event number
-          // special events are counted, so the packet event counter is never the
-          // Event Sequence (bc the begin run event)
-          // also our packets are just 16bit counters, so we need to add the upper bits
-          // from the event sequence
-          // and our packet counters start at 0, while our events start at 1
-          evtno += m_EventNumberOffset + m_PacketEventNumberOffset[i] + m_NumSpecialEvents + (EventSequence & 0xFFFF0000);
-          m_PacketMap[bclk].push_back(plist[i]);
-          m_EvtSet.insert(evtno);
-          m_Event.push_back(std::make_pair(evtno,bclk));
+          std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
+                    << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
         }
-	else
-	{
-	  delete plist[i];
-	}
-      }
-// here we have all packets of a given event in our maps/vectors
-// first pass - check if beam clocks are identical
-      if (Verbosity() > 1)
-      {
-	std::cout << "pktmap size : " << m_PacketMap.size() << std::endl;
-	std::cout << "evt set size : " << m_EvtSet.size() << std::endl;
-      }
-      int common_event_number = *(m_EvtSet.begin());
-      if (m_PacketMap.size() == 1) // all packets from the same beam clock
-      {
-	if (m_EvtSet.size() == 1)
-	{
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "we are good evtno: " << *(m_EvtSet.begin())
-		      << ", clock: " << m_PacketMap.begin()->first << std::endl;
-	  }
-	}
-	else
-	{
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
-		      << m_PacketMap.begin()->first << std::dec << std::endl;
-	    for (auto iter : m_EvtSet)
-	    {
-	      std::cout << "Event " << iter << std::endl;
-	    }
-	  }
-          common_event_number = majority_eventnumber();
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "picked event no " << common_event_number << std::endl;
-	  }
-          adjust_eventnumber_offset(common_event_number);
-	}
-	for (auto iter : m_PacketMap)
-	{
-	  for (auto pktiter : iter.second)
-	  {
-	    m_InputMgr->AddPacket(common_event_number, pktiter);
-	  }
-	}
+        // dummy check for the first event which is the problem for the calorimeters
+        // it is the last event from the previous run, so it's event number is > 0
+        // if (evtno > EventSequence)
+        // {
+        //   delete plist[i];
+        //   plist[i] = nullptr;
+        //   continue;
+        // }
+        plist[i]->convert();
+        // calculate "real" event number
+        // special events are counted, so the packet event counter is never the
+        // Event Sequence (bc the begin run event)
+        // also our packets are just 16bit counters, so we need to add the upper bits
+        // from the event sequence
+        // and our packet counters start at 0, while our events start at 1
+        evtno += m_EventNumberOffset + m_PacketEventNumberOffset[i] + m_NumSpecialEvents + (EventSequence & 0xFFFF0000);
+        m_PacketMap[bclk].push_back(plist[i]);
+        m_EvtSet.insert(evtno);
+        m_Event.push_back(std::make_pair(evtno, bclk));
       }
       else
       {
-
-	if (Verbosity() > 1)
-	{
-	std::cout << "We have multiple beam clocks per event" << std::endl;
-	}
-	if (m_EvtSet.size() == 1)
-	{
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "we are good evtno: " << *(m_EvtSet.begin())
-		      << ", clock: " << m_PacketMap.begin()->first << std::endl;
-	  }
-	}
-	else
-	{
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
-		      << m_PacketMap.begin()->first << std::dec << std::endl;
-	    for (auto iter : m_EvtSet)
-	    {
-	      std::cout << "Event " << iter << std::endl;
-	    }
-	  }
-          common_event_number = majority_eventnumber();
-	  if (Verbosity() > 1)
-	  {
-	    std::cout << "picked event no " << common_event_number << std::endl;
-	  }
-          adjust_eventnumber_offset(common_event_number);
-	}
-	int common_beam_clock =  majority_beamclock();
-	if (Verbosity() > 1)
-	{
-        std::cout << "picked bclk: " << std::hex << common_beam_clock << std::dec << std::endl;
-	}
-// for time being clean out packets which do not match
-	for (auto iter : m_PacketMap)
-	{
-	  for (auto pktiter : iter.second)
-	  {
-	    if (pktiter->iValue(0, "CLOCK") == common_beam_clock)
-	    {
-	      if (Verbosity() > 1)
-	      {
-		std::cout << "adding packet " << pktiter->getIdentifier() << " beam clock "
-			  << std::hex << pktiter->iValue(0, "CLOCK") << std::dec << std::endl;
-	      }
-	      m_InputMgr->AddPacket(common_event_number, pktiter);
-	    }
-	    else
-	    {
-	      if (Verbosity() > 1)
-	      {
-		std::cout << "Deleting packet " << pktiter->getIdentifier() << " beam clock "
-			  << std::hex << pktiter->iValue(0, "CLOCK") << " common bclk: "
-			  << common_beam_clock << std::dec << std::endl;
-	      }
-	      delete pktiter;
-	    }
-	  }
-	}
+        delete plist[i];
       }
-      m_PacketMap.clear();
-      m_EvtSet.clear();
-      m_Event.clear();
-      delete evt;
+    }
+    // here we have all packets of a given event in our maps/vectors
+    // first pass - check if beam clocks are identical
+    if (Verbosity() > 1)
+    {
+      std::cout << "pktmap size : " << m_PacketMap.size() << std::endl;
+      std::cout << "evt set size : " << m_EvtSet.size() << std::endl;
+    }
+    int common_event_number = *(m_EvtSet.begin());
+    if (m_PacketMap.size() == 1)  // all packets from the same beam clock
+    {
+      if (m_EvtSet.size() == 1)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "we are good evtno: " << *(m_EvtSet.begin())
+                    << ", clock: " << m_PacketMap.begin()->first << std::endl;
+        }
+      }
+      else
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
+                    << m_PacketMap.begin()->first << std::dec << std::endl;
+          for (auto iter : m_EvtSet)
+          {
+            std::cout << "Event " << iter << std::endl;
+          }
+        }
+        common_event_number = majority_eventnumber();
+        if (Verbosity() > 1)
+        {
+          std::cout << "picked event no " << common_event_number << std::endl;
+        }
+        adjust_eventnumber_offset(common_event_number);
+      }
+      for (auto iter : m_PacketMap)
+      {
+        for (auto pktiter : iter.second)
+        {
+          m_InputMgr->AddPacket(common_event_number, pktiter);
+        }
+      }
+    }
+    else
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << "We have multiple beam clocks per event" << std::endl;
+      }
+      if (m_EvtSet.size() == 1)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "we are good evtno: " << *(m_EvtSet.begin())
+                    << ", clock: " << m_PacketMap.begin()->first << std::endl;
+        }
+      }
+      else
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
+                    << m_PacketMap.begin()->first << std::dec << std::endl;
+          for (auto iter : m_EvtSet)
+          {
+            std::cout << "Event " << iter << std::endl;
+          }
+        }
+        common_event_number = majority_eventnumber();
+        if (Verbosity() > 1)
+        {
+          std::cout << "picked event no " << common_event_number << std::endl;
+        }
+        adjust_eventnumber_offset(common_event_number);
+      }
+      int common_beam_clock = majority_beamclock();
+      if (Verbosity() > 1)
+      {
+        std::cout << "picked bclk: " << std::hex << common_beam_clock << std::dec << std::endl;
+      }
+      // for time being clean out packets which do not match
+      for (auto iter : m_PacketMap)
+      {
+        for (auto pktiter : iter.second)
+        {
+          if (pktiter->iValue(0, "CLOCK") == common_beam_clock)
+          {
+            if (Verbosity() > 1)
+            {
+              std::cout << "adding packet " << pktiter->getIdentifier() << " beam clock "
+                        << std::hex << pktiter->iValue(0, "CLOCK") << std::dec << std::endl;
+            }
+            m_InputMgr->AddPacket(common_event_number, pktiter);
+          }
+          else
+          {
+            if (Verbosity() > 1)
+            {
+              std::cout << "Deleting packet " << pktiter->getIdentifier() << " beam clock "
+                        << std::hex << pktiter->iValue(0, "CLOCK") << " common bclk: "
+                        << common_beam_clock << std::dec << std::endl;
+            }
+            delete pktiter;
+          }
+        }
+      }
+    }
+    m_PacketMap.clear();
+    m_EvtSet.clear();
+    m_Event.clear();
+    delete evt;
   }
-  
 }
 
 void SinglePrdfInput::adjust_eventnumber_offset(const int decided_evtno)
 {
-  for (unsigned int i = 0; i< m_Event.size(); i++)
+  for (unsigned int i = 0; i < m_Event.size(); i++)
   {
     if (m_Event[i].first != decided_evtno)
     {
-      m_PacketEventNumberOffset[i] -=  (m_Event[i].first-decided_evtno);
+      m_PacketEventNumberOffset[i] -= (m_Event[i].first - decided_evtno);
       if (Verbosity() > 1)
       {
-      std::cout << "my evtno: " << m_Event[i].first << ", decided: " << decided_evtno
-		<< ", adjustment: " << m_Event[i].first-decided_evtno << std::endl;
-      std::cout << "adjusting event number offset for " << i << " to " << m_PacketEventNumberOffset[i] << std::endl;
+        std::cout << "my evtno: " << m_Event[i].first << ", decided: " << decided_evtno
+                  << ", adjustment: " << m_Event[i].first - decided_evtno << std::endl;
+        std::cout << "adjusting event number offset for " << i << " to " << m_PacketEventNumberOffset[i] << std::endl;
       }
     }
   }
@@ -271,8 +269,8 @@ int SinglePrdfInput::majority_beamclock()
     evtcnt[iter.second]++;
     if (Verbosity() > 1)
     {
-    std::cout << "adding clk: " << std::hex << iter.second << std::dec
-	      << " current counter: "  << evtcnt[iter.second] << std::endl;
+      std::cout << "adding clk: " << std::hex << iter.second << std::dec
+                << " current counter: " << evtcnt[iter.second] << std::endl;
     }
   }
   int imax = -1;
@@ -335,4 +333,3 @@ int SinglePrdfInput::fileclose()
   UpdateFileList();
   return 0;
 }
-

--- a/offline/framework/fun4allraw/SinglePrdfInput.h
+++ b/offline/framework/fun4allraw/SinglePrdfInput.h
@@ -6,6 +6,7 @@
 
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -25,16 +26,28 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
   int fileclose() override;
   int AllDone() const {return m_AllDone;}
   void AllDone(const int i) {m_AllDone = i;}
+  void EventNumberOffset(const int i) {m_EventNumberOffset = i;} // if beam clk are out of sync, tweak this one
 
  private:
+  int majority_eventnumber();
+  void adjust_eventnumber_offset(const int decided_evtno);
+  struct PacketInfo
+  {
+    std::vector<Packet *> PacketVector;
+    unsigned int EventFoundCounter = 0;
+  };
   Eventiterator *m_EventIterator = nullptr;
   Fun4AllPrdfInputPoolManager *m_InputMgr = nullptr;
   Packet **plist = nullptr;
   unsigned int m_NumSpecialEvents = 0;
-  unsigned int m_EventNumberOffset = 1;  // packet event counters start at 0 but we start with event number 1
+  int m_EventNumberOffset = 1;  // packet event counters start at 0 but we start with event number 1
+  int *m_PacketEventNumberOffset = nullptr;  // packet event counters start at 0 but we start with event number 1
   int m_RunNumber = 0;
   int m_EventsThisFile = 0;
   int m_AllDone = 0;
+  std::map<unsigned int, std::vector<Packet *>> m_PacketMap;
+  std::set<int> m_EvtSet;
+  std::vector<std::pair<int,int>> m_Event;
 };
 
 #endif

--- a/offline/framework/fun4allraw/SinglePrdfInput.h
+++ b/offline/framework/fun4allraw/SinglePrdfInput.h
@@ -24,9 +24,9 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
   int RunNumber() const { return m_RunNumber; }
   int fileopen(const std::string &filename) override;
   int fileclose() override;
-  int AllDone() const {return m_AllDone;}
-  void AllDone(const int i) {m_AllDone = i;}
-  void EventNumberOffset(const int i) {m_EventNumberOffset = i;} // if beam clk are out of sync, tweak this one
+  int AllDone() const { return m_AllDone; }
+  void AllDone(const int i) { m_AllDone = i; }
+  void EventNumberOffset(const int i) { m_EventNumberOffset = i; }  // if beam clk are out of sync, tweak this one
 
  private:
   int majority_eventnumber();
@@ -41,14 +41,14 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
   Fun4AllPrdfInputPoolManager *m_InputMgr = nullptr;
   Packet **plist = nullptr;
   unsigned int m_NumSpecialEvents = 0;
-  int m_EventNumberOffset = 1;  // packet event counters start at 0 but we start with event number 1
+  int m_EventNumberOffset = 1;               // packet event counters start at 0 but we start with event number 1
   int *m_PacketEventNumberOffset = nullptr;  // packet event counters start at 0 but we start with event number 1
   int m_RunNumber = 0;
   int m_EventsThisFile = 0;
   int m_AllDone = 0;
   std::map<int, std::vector<Packet *>> m_PacketMap;
   std::set<int> m_EvtSet;
-  std::vector<std::pair<int,int>> m_Event;
+  std::vector<std::pair<int, int>> m_Event;
 };
 
 #endif

--- a/offline/framework/fun4allraw/SinglePrdfInput.h
+++ b/offline/framework/fun4allraw/SinglePrdfInput.h
@@ -30,6 +30,7 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
 
  private:
   int majority_eventnumber();
+  int majority_beamclock();
   void adjust_eventnumber_offset(const int decided_evtno);
   struct PacketInfo
   {
@@ -45,7 +46,7 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
   int m_RunNumber = 0;
   int m_EventsThisFile = 0;
   int m_AllDone = 0;
-  std::map<unsigned int, std::vector<Packet *>> m_PacketMap;
+  std::map<int, std::vector<Packet *>> m_PacketMap;
   std::set<int> m_EvtSet;
   std::vector<std::pair<int,int>> m_Event;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The previous pool combiner just went for the event number. The beam clock counter is much more reliable, some packets start with a non zero event counter but their beam clock indicates they belong to a given event.
The code now collects all packets from a given beam clock counter and discards all packets which disagree (the ones I found were really pathological, though one seems to have stuck bits). This approach should prevent event mixing. Older files have more serious problems, for those this needs more work
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

