### PR TITLE
(INTT) updated Makefile, fixed mapping conventions/conversions

### DIFF
--- a/offline/packages/intt/InttMapping.cc
+++ b/offline/packages/intt/InttMapping.cc
@@ -30,9 +30,10 @@ struct Intt::RawData_s Intt::RawFromPacket(int const _i, int const _n, Packet* _
 struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
 {
 	struct Online_s s;
+	int n_ldr = _s.lyr < 2 ? 12 : 16;
 
 	s.lyr = _s.layer - 3;
-	s.ldr = _s.ladder_phi;
+	s.ladder_phi = (_s.ldr + n_ldr / 4) % n_ldr;
 
 	s.arm = _s.ladder_z / 2;
 	switch(_s.ladder_z)
@@ -65,9 +66,10 @@ struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
 struct Intt::Offline_s Intt::ToOffline(struct Online_s const& _s)
 {
 	struct Offline_s s;
+	int n_ldr = _s.lyr < 2 ? 12 : 16;
 
 	s.layer = _s.lyr + 3;
-	s.ladder_phi = _s.ldr;
+	s.ladder_phi = (_s.ldr + 3 * n_ldr / 4) % n_ldr;
 
 	s.ladder_z = 2 * _s.arm + (_s.chp % 13 < 5);
 	switch(s.ladder_z)

--- a/offline/packages/intt/InttMapping.cc
+++ b/offline/packages/intt/InttMapping.cc
@@ -30,10 +30,10 @@ struct Intt::RawData_s Intt::RawFromPacket(int const _i, int const _n, Packet* _
 struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
 {
 	struct Online_s s;
-	int n_ldr = _s.lyr < 2 ? 12 : 16;
+	int n_ldr = _s.layer < 5 ? 12 : 16;
 
 	s.lyr = _s.layer - 3;
-	s.ladder_phi = (_s.ldr + n_ldr / 4) % n_ldr;
+	s.ldr = (_s.ladder_phi + n_ldr / 4) % n_ldr;
 
 	s.arm = _s.ladder_z / 2;
 	switch(_s.ladder_z)

--- a/offline/packages/intt/InttRawDataDecoder.cc
+++ b/offline/packages/intt/InttRawDataDecoder.cc
@@ -125,7 +125,7 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 
 			offline = Intt::ToOffline(rawdata);
 
-			hit_key = InttDefs::genHitKey(offline.strip_x, offline.strip_y);
+			hit_key = InttDefs::genHitKey(offline.strip_y, offline.strip_x); //col, row <trackbase/InttDefs.h>
 			hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);
 
 			hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -3,10 +3,6 @@
 
 AUTOMAKE_OPTIONS = foreign
 
-lib_LTLIBRARIES = \
-  libintt_io.la \
-  libintt.la 
-
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(OFFLINE_MAIN)/include  \
@@ -19,6 +15,9 @@ AM_LDFLAGS = \
 
 if USE_ONLINE
 
+lib_LTLIBRARIES = \
+  libintt.la 
+
 pkginclude_HEADERS = \
   InttFelixMap.h \
   InttMapping.h
@@ -28,6 +27,10 @@ libintt_la_SOURCES = \
   InttMapping.cc
 
 else
+
+lib_LTLIBRARIES = \
+  libintt_io.la \
+  libintt.la 
 
 pkginclude_HEADERS = \
   InttClusterizer.h \

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -17,6 +17,18 @@ AM_LDFLAGS = \
   -L$(ROOTSYS)/lib \
   -L$(OFFLINE_MAIN)/lib
 
+if USE_ONLINE
+
+pkginclude_HEADERS = \
+  InttFelixMap.h \
+  InttMapping.h
+
+libintt_la_SOURCES = \
+  InttFelixMap.cc \
+  InttMapping.cc
+
+else
+
 pkginclude_HEADERS = \
   InttClusterizer.h \
   InttDeadMapHelper.h \
@@ -62,6 +74,7 @@ libintt_io_la_LIBADD = \
   -ltrack_io \
   -ltrackbase_historic_io
 
+endif
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/intt/configure.ac
+++ b/offline/packages/intt/configure.ac
@@ -15,5 +15,15 @@ fi
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-unknown-warning-option"
 AC_SUBST(CINTDEFS)
 
+AC_ARG_ENABLE(online,
+	[ --enable-online	build using for online [default=no]],
+	[case "${enableval}" in
+		yes) online=true ;;
+		no)  online=false ;;
+		*) AC_MSG_ERROR(bad value ${enableval} for --enable-online) ;;
+		esac],
+	online=false)
+AM_CONDITIONAL(USE_ONLINE, test "x$online" = xtrue)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Added a USE_ONLINE switch to the makefile in the style of the CaloBase/Makefile.am, I will likely change INTT's OnlMon to use the InttMapping library to standardize event readouts

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

