### PR TITLE
feat: Add vertex constraint to Acts KF alignment

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -34,6 +34,7 @@ namespace AlignmentDefs
     mm
   };
 
+  static constexpr int NGLVTX = 3;
   static constexpr int NGL = 6;
   static constexpr int NLC = 5;
 
@@ -50,6 +51,8 @@ namespace AlignmentDefs
      {0,1,2,3,12,13,14,15,0,0}},
     {{5,6,7,8,9,10,11,12,13,14},
      {0,1,2,3,4,15,16,17,18,19 }} };
+
+  static constexpr int glbl_vtx_label[NGLVTX] = {60000000,60000001,60000002};
 
   int getTpcRegion(int layer);
   void getMvtxGlobalLabels(Surface surf, int glbl_label[], mvtxGrp grp);

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -597,6 +597,22 @@ int HelicalFitter::process_event(PHCompositeNode*)
   
       if(use_event_vertex)
 	{	  
+	  std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
+	  
+	  std::cout << "vertex is " << event_vtx.transpose() << std::endl;
+	  std::cout << "vertex residuals " << vtx_residual.transpose() 
+		    << std::endl;
+	  std::cout << "local derivatives " << std::endl;
+	  for(int i=0; i<AlignmentDefs::NLC; i++)
+	    std::cout << lclvtx_derivativeX[i] << ", ";
+	  std::cout << std::endl;
+	  for(int i=0; i<AlignmentDefs::NLC; i++)
+	    std::cout << lclvtx_derivativeY[i] << ", ";
+	  std::cout << "global vtx derivaties " << std::endl;
+	  for(int i=0; i<3; i++) std::cout << glblvtx_derivativeX[i] << ", ";
+	  std::cout << std::endl;
+	  for(int i=0; i<3; i++) std::cout << glblvtx_derivativeY[i] << ", ";
+
 	  // add some track cuts
 	  if(fabs(newTrack.get_z() - event_vtx(2)) > 0.2) continue;  // 2 mm cut
 	  if(fabs(newTrack.get_x()) > 0.2) continue;  // 2 mm cut
@@ -1117,7 +1133,7 @@ void HelicalFitter::getGlobalDerivativesXY(Surface surf, Acts::Vector3 global, A
 
   Acts::Vector3 projX(0,0,0), projY(0,0,0);
   get_projectionXY(surf, tangent, projX, projY);
-
+  
   // translations
   glbl_derivativeX[3] = unitx.dot(projX);
   glbl_derivativeX[4] = unity.dot(projX);
@@ -1176,7 +1192,7 @@ void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 ev
   // calculate projX and projY vectors once for the optimum fit parameters
   Acts::Vector3 projX(0,0,0), projY(0,0,0);
   get_projectionVtxXY(track, event_vtx, projX, projY);
-
+  std::cout << "projx and y " << projX.transpose() << ", " << projY.transpose() << std::endl;
   // translations
   glbl_derivativeX[0] = unitx.dot(projX);
   glbl_derivativeX[1] = unity.dot(projX);
@@ -1227,17 +1243,19 @@ void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, Acts::Vector3 event_vt
 {
   Acts::Vector3 tanvec(track.get_px(),track.get_py(),track.get_pz());
   Acts::Vector3 normal(track.get_px(),track.get_py(),0); 
-
+  std::cout << "tangent and normal " << tanvec.transpose() << ", " << normal.transpose() << std::endl;
   tanvec /= tanvec.norm();
   normal /= normal.norm();
-  
+
   // get surface X and Y unit vectors in global frame
   Acts::Vector3 xloc(1.0,0.0,0.0);
   Acts::Vector3 yloc(0.0,0.0,1.0); // local y 
   Acts::Vector3 xglob = localvtxToGlobalvtx(track, event_vtx, xloc);
   Acts::Vector3 yglob = yloc + event_vtx;
+  std::cout << "xglob yglob " << xglob.transpose() << "        " << yglob.transpose() << std::endl;
   Acts::Vector3 X     = (xglob-event_vtx) / (xglob-event_vtx).norm(); // local unit vector transformed to global coordinates
   Acts::Vector3 Y     = (yglob-event_vtx) / (yglob-event_vtx).norm();
+  std::cout << "X AND Y " << X.transpose() << "        "<< Y.transpose() << std::endl;
   // see equation 31 of the ATLAS paper (and discussion) for this
   projX = X - (tanvec.dot(X) / tanvec.dot(normal)) * normal;
   projY = Y - (tanvec.dot(Y) / tanvec.dot(normal)) * normal;
@@ -1357,7 +1375,11 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
   dca3dxy = NAN;
   Acts::Vector3 track_vtx(track.get_x(),track.get_y(),track.get_z());
   Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
+  std::cout << "track vertex and mom " << std::endl << track_vtx.transpose() << "          "<< mom.transpose() << std::endl;
+  std::cout << "event vertex " << event_vertex.transpose() << std::endl;
   track_vtx -= event_vertex; // difference between track_vertex and event_vtx
+  
+  std::cout << "track vtx now " << track_vtx.transpose() << std::endl;
 
   Acts::ActsSymMatrix<3> posCov;
   for(int i = 0; i < 3; ++i)
@@ -1369,10 +1391,12 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
     }
   
   Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
+  std::cout << "r vec is " << r.transpose()<<std::endl;
   float phi       = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
   phi *= -1;
+  std::cout << "phi is " << phi << std::endl;
   rot(0,0) = cos(phi);
   rot(0,1) = -sin(phi);
   rot(0,2) = 0;
@@ -1382,11 +1406,12 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
   rot(2,0) = 0;
   rot(2,1) = 0;
   rot(2,2) = 1;
+  std::cout << "Rot is " << std::endl << rot << std::endl;
   rot_T    = rot.transpose();
 
   Acts::Vector3 pos_R           = rot * track_vtx;
   Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-
+  std::cout << "Pos r " << pos_R.transpose() << std::endl;
   dca3dxy      = pos_R(0);
   dca3dz       = pos_R(2);
   dca3dxysigma = sqrt(rotCov(0,0));
@@ -1491,8 +1516,9 @@ Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, Acts::Vector3
   rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * local;
+  std::cout << "loc to glob vtx " << pos_R.transpose() << std::endl;
   pos_R += event_vtx;
-
+  std::cout << "after vtx subt " << pos_R.transpose() << std::endl;
   if(Verbosity()>1)
     {
       std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -594,10 +594,7 @@ int HelicalFitter::process_event(PHCompositeNode*)
       float glblvtx_derivativeX[3];
       float glblvtx_derivativeY[3];
       getGlobalVtxDerivativesXY(newTrack, event_vtx, glblvtx_derivativeX, glblvtx_derivativeY);
-
-      int glbl_vtx_label[3] = {60000000,60000001,60000002};
-      int NGL_vtx           = 3;
-      
+  
       if(use_event_vertex)
 	{	  
 	  // add some track cuts
@@ -605,15 +602,13 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	  if(fabs(newTrack.get_x()) > 0.2) continue;  // 2 mm cut
 	  if(fabs(newTrack.get_y()) > 0.2) continue;  // 2 mm cut
 	  
-	     if(!isnan(vtx_residual(0)))
+	  if(!isnan(vtx_residual(0)))
 	    {
-	      //  _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeX,NGL_vtx,glblvtx_derivativeX,glbl_vtx_label,dca3dxy, vtx_sigma(0));
-	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeX,NGL_vtx,glblvtx_derivativeX,glbl_vtx_label,vtx_residual(0), vtx_sigma(0));
+	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeX,AlignmentDefs::NGLVTX,glblvtx_derivativeX,AlignmentDefs::glbl_vtx_label,vtx_residual(0), vtx_sigma(0));
 	    }    
-	     if(!isnan(vtx_residual(1)))
+	  if(!isnan(vtx_residual(1)))
 	    {  
-	      //  _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeY,NGL_vtx,glblvtx_derivativeY,glbl_vtx_label,dca3dz, vtx_sigma(1));
-	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeY,NGL_vtx,glblvtx_derivativeY,glbl_vtx_label,vtx_residual(1), vtx_sigma(1));
+	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeY,AlignmentDefs::NGLVTX,glblvtx_derivativeY,AlignmentDefs::glbl_vtx_label,vtx_residual(1), vtx_sigma(1));
 	    }
 	}
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -74,7 +74,14 @@ int MakeMilleFiles::InitRun(PHCompositeNode* topNode)
   steering_file.close();
 
   m_constraintFile.open(m_constraintFileName);
-
+  if(m_useEventVertex)
+    {
+      for(int i=0; i<AlignmentDefs::NGLVTX; i++)
+	{
+	  m_constraintFile << " Constraint   0.0" << std::endl;
+	  m_constraintFile << "       " << AlignmentDefs::glbl_vtx_label[i] << "   1" << std::endl;
+	}
+    }
   // print grouping setup to log file:
   std::cout << "MakeMilleFiles::InitRun: Surface groupings are mvtx " << mvtx_group << " intt " << intt_group << " tpc " << tpc_group << " mms " << mms_group << std::endl;
 
@@ -585,34 +592,7 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
         {
           errinf = m_layerMisalignment.find(layer)->second;
         }
-        
-	if(TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::inttId)
-	  {
-	    if(m_usedConstraintGlbLbl.find(glbl_label[0]) == m_usedConstraintGlbLbl.end())
-	      {
-        
-		auto surfcent = surf->center(_tGeometry->geometry().getGeoContext());
-        
-		float sensorphi = atan2(surfcent.y(), surfcent.x());
-		m_constraintFile << " Constraint  0.0" << std::endl;
-		for(int temp =0; temp < SvtxAlignmentState::NGL; temp++)
-		  {
-		    float factor = 0.;
-		    if(temp == 3) factor = std::cos(sensorphi);
-		    else if(temp == 4) factor = std::sin(sensorphi);
-		    else continue;
-
-		    m_constraintFile << "     " << glbl_label[temp] << "   " 
-				     << factor << std::endl;
-		   
-		    
-		  }
-
-		m_usedConstraintGlbLbl.insert(glbl_label[0]);
-
-	      }
-	  }
-      
+              
       _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf * clus_sigma(i));
       }
     }

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -124,9 +124,9 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
     {
       continue;
     }
-
+    
     SvtxTrack* track = iter->second;
-
+    
     if (Verbosity() > 0)
     {
       std::cout << std::endl
@@ -277,20 +277,23 @@ bool MakeMilleFiles::getLocalVtxDerivativesXY(SvtxTrack* track,
   //! innermost track state and propagate it to the vertex surface to
   //! get the jacobian at the vertex
   SvtxTrackState* firststate = (*std::next(track->begin_states(),1)).second;
+ 
   TrkrDefs::cluskey ckey = firststate->get_cluskey();
   auto cluster = _cluster_map->findCluster(ckey);
   auto surf = _tGeometry->maps().getSurface(ckey, cluster);
   ActsPropagator propagator(_tGeometry);
+  
   auto param = propagator.makeTrackParams(firststate,track->get_charge(),surf);
   auto perigee = propagator.makeVertexSurface(vertex);
-
   auto actspropagator = propagator.makePropagator();
-  Acts::Logging::Level logLevel = Acts::Logging::VERBOSE;
+
+  Acts::Logging::Level logLevel = Acts::Logging::FATAL;
   auto logger = Acts::getDefaultLogger("MakeMilleFiles", logLevel);
   Acts::PropagatorOptions<> options(_tGeometry->geometry().getGeoContext(),
 				    _tGeometry->geometry().magFieldContext,
 				    Acts::LoggerWrapper{*logger});
-  auto result = actspropagator.propagate(param, *surf, options);
+
+  auto result = actspropagator.propagate(param, *perigee, options);
 
   if(result.ok())
     {
@@ -303,8 +306,6 @@ bool MakeMilleFiles::getLocalVtxDerivativesXY(SvtxTrack* track,
       if(Verbosity() > 2)
 	{
 	  std::cout << "local vtxderiv " << std::endl << deriv << std::endl;
-	  std::cout << "original jacobian " << std::endl
-		    << jacobian << std::endl;
 	}
 
       for(int i=0; i<deriv.rows(); i++)

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -149,7 +149,7 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
 	auto dcapair = get_dca(track, eventVertex);
 	Acts::Vector2 vtx_residual(-dcapair.first, -dcapair.second);
 	vtx_residual *= Acts::UnitConstants::cm;
-	std::cout << "test event vertex"<<std::endl;
+
 	float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC];
 	bool success = getLocalVtxDerivativesXY(track, propagator,
 						eventVertex, lclvtx_derivative);

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -24,6 +24,11 @@
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
 
 #include <ActsExamples/EventData/Trajectories.hpp>
+
+
+#include <TFile.h>
+#include <TH2.h>
+
 class PHCompositeNode;
 class PHG4TpcCylinderGeomContainer;
 class SvtxTrack;
@@ -109,6 +114,9 @@ class MakeMilleFiles : public SubsysReco
   bool m_useEventVertex = false;
   bool _binary = true;
   unsigned int _cluster_version = 5;
+
+  TFile *_file = nullptr;
+  TH2 *_xyresid = nullptr, *_zresid = nullptr;
 
   Acts::Vector2 m_vtxSigma = {0.1, 0.1};
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -31,6 +31,7 @@ class SvtxTrackMap;
 class TrkrCluster;
 class TrkrClusterContainer;
 class Mille;
+class ActsPropagator;
 
 using Trajectory = ActsExamples::Trajectories;
 
@@ -92,6 +93,7 @@ class MakeMilleFiles : public SubsysReco
 				 const Acts::Vector3& vertex,
 				 float glblvtx_derivative[SvtxAlignmentState::NRES][3]);
   bool getLocalVtxDerivativesXY(SvtxTrack* track,
+				ActsPropagator& propagator,
 				const Acts::Vector3& vertex,
 				float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC]);
   Acts::Vector3 localToGlobalVertex(SvtxTrack* track,

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -22,7 +22,6 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
-#include <trackbase_historic/TrackAnalysisUtils.h>
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 class PHCompositeNode;
@@ -92,13 +91,16 @@ class MakeMilleFiles : public SubsysReco
   void getGlobalVtxDerivativesXY(SvtxTrack* track,
 				 const Acts::Vector3& vertex,
 				 float glblvtx_derivative[SvtxAlignmentState::NRES][3]);
+  bool getLocalVtxDerivativesXY(SvtxTrack* track,
+				const Acts::Vector3& vertex,
+				float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC]);
   Acts::Vector3 localToGlobalVertex(SvtxTrack* track,
 				    const Acts::Vector3& vertex,
 				    const Acts::Vector3& localx) const;
   void getProjectionVtxXY(SvtxTrack* track, const Acts::Vector3& vertex,
 			  Acts::Vector3& projx, Acts::Vector3& projy);
 
- 
+  std::pair<float, float> get_dca(SvtxTrack* track, const Acts::Vector3& vertex);
   std::string data_outfilename = ("mille_output_data_file.bin");
   std::string steering_outfilename = ("steer.txt");
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -25,10 +25,6 @@
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 
-
-#include <TFile.h>
-#include <TH2.h>
-
 class PHCompositeNode;
 class PHG4TpcCylinderGeomContainer;
 class SvtxTrack;
@@ -107,16 +103,12 @@ class MakeMilleFiles : public SubsysReco
   void getProjectionVtxXY(SvtxTrack* track, const Acts::Vector3& vertex,
 			  Acts::Vector3& projx, Acts::Vector3& projy);
 
-  std::pair<float, float> get_dca(SvtxTrack* track, const Acts::Vector3& vertex);
   std::string data_outfilename = ("mille_output_data_file.bin");
   std::string steering_outfilename = ("steer.txt");
 
   bool m_useEventVertex = false;
   bool _binary = true;
   unsigned int _cluster_version = 5;
-
-  TFile *_file = nullptr;
-  TH2 *_xyresid = nullptr, *_zresid = nullptr;
 
   Acts::Vector2 m_vtxSigma = {0.1, 0.1};
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -126,7 +126,6 @@ class MakeMilleFiles : public SubsysReco
 
   std::string m_constraintFileName = "mp2con.txt";
   std::ofstream m_constraintFile;
-  std::set<int> m_usedConstraintGlbLbl;
 
   SvtxTrackMap* _track_map{nullptr};
   SvtxAlignmentStateMap* _state_map{nullptr};

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -22,6 +22,7 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
+#include <trackbase_historic/TrackAnalysisUtils.h>
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 class PHCompositeNode;
@@ -51,7 +52,9 @@ class MakeMilleFiles : public SubsysReco
   void set_intt_grouping(int group) { intt_group = (AlignmentDefs::inttGrp) group; }
   void set_tpc_grouping(int group) { tpc_group = (AlignmentDefs::tpcGrp) group; }
   void set_mms_grouping(int group) { mms_group = (AlignmentDefs::mmsGrp) group; }
+  void use_event_vertex(bool useit) { m_useEventVertex = useit; }
   void set_layer_fixed(unsigned int layer);
+  void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_layer_gparam_fixed(unsigned int layer, unsigned int param);
   void set_layer_lparam_fixed(unsigned int layer, unsigned int param);
   void set_cluster_version(unsigned int v) { _cluster_version = v; }
@@ -67,30 +70,43 @@ class MakeMilleFiles : public SubsysReco
    unsigned int subsector = region * 24 + side * 12 + sector;
    fixed_sectors.insert(subsector);
  }
+  void set_vtx_sigma(float xysig, float zsig)
+  {
+    m_vtxSigma(0) = xysig;
+    m_vtxSigma(1) = zsig;
+  }
 
  private:
   Mille* _mille;
 
   int GetNodes(PHCompositeNode* topNode);
-  Acts::Vector3 getPCALinePoint(Acts::Vector3 global, SvtxTrackState* state);
-  std::vector<Acts::Vector3> getDerivativesAlignmentAngles(Acts::Vector3& global,
-                                                           TrkrDefs::cluskey cluster_key,
-                                                           TrkrCluster* cluster,
-                                                           Surface surface, int crossing);
+  Acts::Vector3 getEventVertex();
 
   bool is_layer_fixed(unsigned int layer);
 
   bool is_layer_param_fixed(unsigned int layer, unsigned int param, std::set<std::pair<unsigned int, unsigned int>>& param_fixed);
 
   bool is_tpc_sector_fixed(unsigned int layer, unsigned int sector, unsigned int side);
-  void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec statevec);
+  bool is_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
+  void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statevec);
+  void getGlobalVtxDerivativesXY(SvtxTrack* track,
+				 const Acts::Vector3& vertex,
+				 float glblvtx_derivative[SvtxAlignmentState::NRES][3]);
+  Acts::Vector3 localToGlobalVertex(SvtxTrack* track,
+				    const Acts::Vector3& vertex,
+				    const Acts::Vector3& localx) const;
+  void getProjectionVtxXY(SvtxTrack* track, const Acts::Vector3& vertex,
+			  Acts::Vector3& projx, Acts::Vector3& projy);
 
-  std::map<int, float> derivativeGL;
+ 
   std::string data_outfilename = ("mille_output_data_file.bin");
   std::string steering_outfilename = ("steer.txt");
 
+  bool m_useEventVertex = false;
   bool _binary = true;
   unsigned int _cluster_version = 5;
+
+  Acts::Vector2 m_vtxSigma = {0.1, 0.1};
 
   std::map<unsigned int, float> m_layerMisalignment;
   std::set<unsigned int> fixed_sectors;
@@ -101,6 +117,7 @@ class MakeMilleFiles : public SubsysReco
   AlignmentDefs::mmsGrp mms_group = AlignmentDefs::mmsGrp::tl;
 
   std::set<unsigned int> fixed_layers;
+  std::set<std::pair<unsigned int,unsigned int>> fixed_mvtx_layers;
   std::set<std::pair<unsigned int, unsigned int>> fixed_layer_gparams, fixed_layer_lparams;
 
   std::string m_constraintFileName = "mp2con.txt";

--- a/offline/packages/TrackerMillepedeAlignment/Makefile.am
+++ b/offline/packages/TrackerMillepedeAlignment/Makefile.am
@@ -26,7 +26,6 @@ libtrackeralign_la_LIBADD = \
   -ltrack_io \
   -ltrackbase_historic_io \
   -ltrack_reco \
-  -ltrack_reco_io \
   -ltpc_io
 
 pkginclude_HEADERS = \

--- a/offline/packages/TrackerMillepedeAlignment/Makefile.am
+++ b/offline/packages/TrackerMillepedeAlignment/Makefile.am
@@ -25,6 +25,8 @@ libtrackeralign_la_LIBADD = \
   -lg4detectors_io \
   -ltrack_io \
   -ltrackbase_historic_io \
+  -ltrack_reco \
+  -ltrack_reco_io \
   -ltpc_io
 
 pkginclude_HEADERS = \

--- a/offline/packages/trackbase_historic/ActsTransformations.cc
+++ b/offline/packages/trackbase_historic/ActsTransformations.cc
@@ -1,11 +1,12 @@
 #include "ActsTransformations.h"
 #include "SvtxTrack.h"
 #include "SvtxTrackState.h"
-#include "SvtxTrackState_v1.h"
+#include "SvtxTrackState_v2.h"
 
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
+#include <trackbase/ActsSourceLink.h>
 
 namespace
 {
@@ -275,7 +276,7 @@ void ActsTransformations::fillSvtxTrackStates(const Acts::MultiTrajectory<Acts::
 
       // create svtx state vector with relevant pathlength
       const float pathlength = state.pathLength() / Acts::UnitConstants::cm;  
-      SvtxTrackState_v1 out( pathlength );
+      SvtxTrackState_v2 out( pathlength );
     
       // get smoothed fitted parameters
       const Acts::BoundTrackParameters params(state.referenceSurface().getSharedPtr(),
@@ -293,6 +294,8 @@ void ActsTransformations::fillSvtxTrackStates(const Acts::MultiTrajectory<Acts::
       out.set_px(momentum.x());
       out.set_py(momentum.y());
       out.set_pz(momentum.z());
+      const auto& sourceLink = static_cast<const ActsSourceLink&>(state.uncalibrated());
+      out.set_cluskey(sourceLink.cluskey());
       
       /// covariance    
       const auto globalCov = rotateActsCovToSvtxTrack(params);

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -51,6 +51,7 @@ pkginclude_HEADERS = \
   SvtxAlignmentState_v1.h \
   SvtxTrackState.h \
   SvtxTrackState_v1.h \
+  SvtxTrackState_v2.h \
   SvtxVertex.h \
   SvtxVertex_v1.h \
   SvtxVertexMap.h \
@@ -73,6 +74,7 @@ ROOTDICTS = \
   SvtxTrack_Dict.cc \
   SvtxTrackState_Dict.cc \
   SvtxTrackState_v1_Dict.cc \
+  SvtxTrackState_v2_Dict.cc \
   SvtxTrack_v1_Dict.cc \
   SvtxTrack_v2_Dict.cc \
   SvtxTrack_v3_Dict.cc \
@@ -110,6 +112,7 @@ nobase_dist_pcm_DATA = \
   SvtxTrack_Dict_rdict.pcm \
   SvtxTrackState_Dict_rdict.pcm \
   SvtxTrackState_v1_Dict_rdict.pcm \
+  SvtxTrackState_v2_Dict_rdict.pcm \
   SvtxTrack_v1_Dict_rdict.pcm \
   SvtxTrack_v2_Dict_rdict.pcm \
   SvtxTrack_v3_Dict_rdict.pcm \
@@ -147,6 +150,7 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxAlignmentState.cc \
   SvtxAlignmentState_v1.cc \
   SvtxTrackState_v1.cc \
+  SvtxTrackState_v2.cc \
   SvtxTrack.cc \
   SvtxTrack_v1.cc \
   SvtxTrack_v2.cc \

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -2,6 +2,8 @@
 #define __SVTXTRACKSTATE_H__
 
 #include <phool/PHObject.h>
+#include <trackbase/TrkrDefs.h>
+
 #include <cmath>
 
 class SvtxTrackState : public PHObject
@@ -49,6 +51,9 @@ class SvtxTrackState : public PHObject
   virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
   virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
 
+  virtual TrkrDefs::cluskey get_cluskey() const { return UINT32_MAX; }
+  virtual void set_cluskey(TrkrDefs::cluskey) {}
+  
   virtual std::string get_name() const { return ""; }
   virtual void set_name(const std::string &/*name*/) {}
 

--- a/offline/packages/trackbase_historic/SvtxTrackState_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v2.cc
@@ -1,0 +1,82 @@
+#include "SvtxTrackState_v2.h"
+
+#include <iostream>
+#include <utility>   // for swap
+
+
+using namespace std;
+
+namespace
+{
+
+  // square convenience function
+  template<class T> inline constexpr T square( const T& x ) { return x*x; }
+
+  // get unique index in cov. matrix array from i and j
+  inline unsigned int covar_index(unsigned int i, unsigned int j)
+  {
+    if (i > j) std::swap(i, j);
+    return i + 1 + (j + 1) * (j) / 2 - 1;
+  }
+
+}
+
+SvtxTrackState_v2::SvtxTrackState_v2(float pathlength)
+  : _pathlength(pathlength)
+{
+  for (int i = 0; i < 3; ++i) _pos[i] = 0.0;
+  for (int i = 0; i < 3; ++i) _mom[i] = NAN;
+  for (int i = 0; i < 6; ++i)
+  {
+    for (int j = i; j < 6; ++j)
+    {
+      set_error(i, j, 0.0);
+    }
+  }
+  state_name = "UNKNOWN";
+}
+
+void SvtxTrackState_v2::identify(std::ostream &os) const
+{
+  os << "---SvtxTrackState_v2-------------" << endl;
+  os << "pathlength: " << get_pathlength() << endl;
+  os << "(px,py,pz) = ("
+     << get_px() << ","
+     << get_py() << ","
+     << get_pz() << ")" << endl;
+
+  os << "(x,y,z) = (" << get_x() << "," << get_y() << "," << get_z() << ")" << endl;
+  os << "---------------------------------" << endl;
+}
+
+float SvtxTrackState_v2::get_error(unsigned int i, unsigned int j) const
+{
+  return _covar[covar_index(i, j)];
+}
+
+void SvtxTrackState_v2::set_error(unsigned int i, unsigned int j, float value)
+{
+  _covar[covar_index(i, j)] = value;
+  return;
+}
+
+float SvtxTrackState_v2::get_phi_error() const
+{
+  const float r = std::sqrt( square(_pos[0]) + square(_pos[1]));
+  if (r > 0) return get_rphi_error() / r;
+  return 0;
+}
+
+float SvtxTrackState_v2::get_rphi_error() const
+{
+  const auto phi = -std::atan2(_pos[1], _pos[0] );
+  const auto cosphi = std::cos(phi);
+  const auto sinphi = std::sin(phi);
+  return std::sqrt(
+    square(sinphi)*get_error(0,0) +
+    square(cosphi)*get_error(1,1) +
+    2.*cosphi*sinphi*get_error(0,1));
+}
+
+float SvtxTrackState_v2::get_z_error() const
+{ return std::sqrt(get_error(2, 2)); }

--- a/offline/packages/trackbase_historic/SvtxTrackState_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v2.h
@@ -1,0 +1,79 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKSTATEV2_H
+#define TRACKBASEHISTORIC_SVTXTRACKSTATEV2_H
+
+#include "SvtxTrackState.h"
+
+#include <cmath>
+#include <iostream>
+#include <string>  // for string, basic_string
+
+class PHObject;
+
+class SvtxTrackState_v2 : public SvtxTrackState
+{
+ public:
+  SvtxTrackState_v2(float pathlength = 0.0);
+  ~SvtxTrackState_v2() override {}
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream &os = std::cout) const override;
+  void Reset() override { *this = SvtxTrackState_v2(0.0); }
+  int isValid() const override { return 1; }
+  PHObject *CloneMe() const override { return new SvtxTrackState_v2(*this); }
+
+  float get_pathlength() const override { return _pathlength; }
+
+  float get_x() const override { return _pos[0]; }
+  void set_x(float x) override { _pos[0] = x; }
+
+  float get_y() const override { return _pos[1]; }
+  void set_y(float y) override { _pos[1] = y; }
+
+  float get_z() const override { return _pos[2]; }
+  void set_z(float z) override { _pos[2] = z; }
+
+  float get_pos(unsigned int i) const override { return _pos[i]; }
+
+  float get_px() const override { return _mom[0]; }
+  void set_px(float px) override { _mom[0] = px; }
+
+  float get_py() const override { return _mom[1]; }
+  void set_py(float py) override { _mom[1] = py; }
+
+  float get_pz() const override { return _mom[2]; }
+  void set_pz(float pz) override { _mom[2] = pz; }
+
+  float get_mom(unsigned int i) const override { return _mom[i]; }
+
+  float get_p() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2) + pow(get_pz(), 2)); }
+  float get_pt() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2)); }
+  float get_eta() const override { return asinh(get_pz() / get_pt()); }
+  float get_phi() const override { return atan2(get_py(), get_px()); }
+
+  float get_error(unsigned int i, unsigned int j) const override;
+  void set_error(unsigned int i, unsigned int j, float value) override;
+
+  TrkrDefs::cluskey get_cluskey() const override { return _ckey; }
+  void set_cluskey(TrkrDefs::cluskey ckey) { _ckey = ckey; }
+
+  std::string get_name() const override { return state_name; }
+  void set_name(const std::string &name) override { state_name = name; }
+
+  float get_rphi_error() const override;
+  float get_phi_error() const override;
+  float get_z_error() const override;
+
+  //@}
+
+ private:
+  float _pathlength;
+  float _pos[3];
+  float _mom[3];
+  float _covar[21];  //  6x6 triangular packed storage
+  TrkrDefs::cluskey _ckey; // clusterkey that is associated with this state
+  std::string state_name;
+
+  ClassDefOverride(SvtxTrackState_v2, 1)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrackState_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v2.h
@@ -54,7 +54,7 @@ class SvtxTrackState_v2 : public SvtxTrackState
   void set_error(unsigned int i, unsigned int j, float value) override;
 
   TrkrDefs::cluskey get_cluskey() const override { return _ckey; }
-  void set_cluskey(TrkrDefs::cluskey ckey) { _ckey = ckey; }
+  void set_cluskey(TrkrDefs::cluskey ckey) override { _ckey = ckey; }
 
   std::string get_name() const override { return state_name; }
   void set_name(const std::string &name) override { state_name = name; }

--- a/offline/packages/trackbase_historic/SvtxTrackState_v2LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrackState_v2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -34,6 +34,10 @@ namespace
   {
     return x * x;
   }
+  template <class T> inline constexpr T get_r(const T& x, const T& y)
+  {
+    return std::sqrt(square(x) + square(y));
+  }
 }  // namespace
 
 void ActsAlignmentStates::fillAlignmentStateMap(const Trajectory& traj,
@@ -71,6 +75,11 @@ void ActsAlignmentStates::fillAlignmentStateMap(const Trajectory& traj,
     }
 
   if(nmaps < 2 or nintt < 2) 
+    { return; }
+ 
+  //! make sure the track was fully fit through the mvtx
+  SvtxTrackState* firststate = (*std::next(track->begin_states(),1)).second;
+  if(get_r(firststate->get_x(), firststate->get_y()) > 5.)
     { return; }
 
   mj.visitBackwards(trackTip, [&](const auto& state)

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -23,6 +23,13 @@ ActsPropagator::makeVertexSurface(const SvtxVertex* vertex)
 		   vertex->get_y() * Acts::UnitConstants::cm,
 		   vertex->get_z() * Acts::UnitConstants::cm));
 }
+ActsPropagator::SurfacePtr
+ActsPropagator::makeVertexSurface(const Acts::Vector3& vertex)
+{
+  return Acts::Surface::makeShared<Acts::PerigeeSurface>(
+         vertex * Acts::UnitConstants::cm);
+							 
+}
 ActsPropagator::BoundTrackParam
 ActsPropagator::makeTrackParams(SvtxTrackState* state,
 				int trackCharge,
@@ -38,7 +45,7 @@ ActsPropagator::makeTrackParams(SvtxTrackState* state,
   
   ActsTransformations transformer;
   Acts::BoundSymMatrix cov = transformer.rotateSvtxTrackCovToActs(state);
-
+  
   return ActsTrackFittingAlgorithm::TrackParameters::create(
          surf,
 	 m_geometry->geometry().getGeoContext(),

--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -23,7 +23,30 @@ ActsPropagator::makeVertexSurface(const SvtxVertex* vertex)
 		   vertex->get_y() * Acts::UnitConstants::cm,
 		   vertex->get_z() * Acts::UnitConstants::cm));
 }
+ActsPropagator::BoundTrackParam
+ActsPropagator::makeTrackParams(SvtxTrackState* state,
+				int trackCharge,
+				ActsPropagator::SurfacePtr surf)
+{
+  Acts::Vector3 momentum(state->get_px(),
+			 state->get_py(),
+			 state->get_pz());
+  Acts::Vector4 actsFourPos = Acts::Vector4(state->get_x() * Acts::UnitConstants::cm,
+					    state->get_y() * Acts::UnitConstants::cm,
+					    state->get_z() * Acts::UnitConstants::cm,
+					    10 * Acts::UnitConstants::ns);
+  
+  ActsTransformations transformer;
+  Acts::BoundSymMatrix cov = transformer.rotateSvtxTrackCovToActs(state);
 
+  return ActsTrackFittingAlgorithm::TrackParameters::create(
+         surf,
+	 m_geometry->geometry().getGeoContext(),
+	 actsFourPos, momentum,
+	 trackCharge / momentum.norm(),
+	 cov)
+    .value();
+}
 ActsPropagator::BoundTrackParam
 ActsPropagator::makeTrackParams(SvtxTrack* track,
 				SvtxVertexMap* vertexMap)

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -25,6 +25,7 @@
 class SvtxTrack;
 class SvtxVertex;
 class SvtxVertexMap;
+class SvtxTrackState;
 
 class ActsPropagator
 {
@@ -49,6 +50,8 @@ class ActsPropagator
   /// functions below
   SurfacePtr makeVertexSurface(const SvtxVertex* vertex);
   BoundTrackParam makeTrackParams(SvtxTrack* track, SvtxVertexMap* vertexMap);
+  BoundTrackParam makeTrackParams(SvtxTrackState* state, int trackCharge,
+				  SurfacePtr surf);
 
   /// The return type is an Acts::Result of a std::pair, where the pair is
   /// a path length and the track parameters at the surface in units of mm 

--- a/offline/packages/trackreco/ActsPropagator.h
+++ b/offline/packages/trackreco/ActsPropagator.h
@@ -49,6 +49,7 @@ class ActsPropagator
   /// Helper functions for creating needed input for track propagation
   /// functions below
   SurfacePtr makeVertexSurface(const SvtxVertex* vertex);
+  SurfacePtr makeVertexSurface(const Acts::Vector3& vertex);
   BoundTrackParam makeTrackParams(SvtxTrack* track, SvtxVertexMap* vertexMap);
   BoundTrackParam makeTrackParams(SvtxTrackState* state, int trackCharge,
 				  SurfacePtr surf);
@@ -76,9 +77,10 @@ class ActsPropagator
   void setConstFieldValue(float field) { m_fieldval = field; }
   void constField() { m_constField = true; }
 
- private:
   SphenixPropagator makePropagator();
   FastPropagator makeFastPropagator();
+
+ private:
   void printTrackParams(const Acts::BoundTrackParameters& params);
 
   int m_verbosity = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR :
1. Adds additional propagation helper methods in the ActsPropagator class, which are then used in the alignment scheme.
2. Adds a new track state version which contains a cluster key, allowing for better cluster-state association rather than just matching by minimum radius.
3. Adds a vertex constraint option to the Acts KF alignment scheme. The vertex position can be added in the alignment as an external constraint applicable to all tracks in an event.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

