### PR TITLE
remove legacy distortion gen options

### DIFF
--- a/calibrations/tpc/generator/generate_distortion_map.C
+++ b/calibrations/tpc/generator/generate_distortion_map.C
@@ -92,19 +92,8 @@ void generate_distortion_map(const char *inputname, const char* gainName, const 
   
 }
 
-
-
-void generate_distortion_map(const char *inputname, const char *outputname, const char *ibfName, const char *primName, bool hasSpacecharge=true){
-  //this is a legacy interface so that old macros can run unchanged even though I now ask for flags about the gain map
-  printf("generating single distortion map:  InputType=IBF+Primaries denominated in ions per voxel.\n");
-
-  generate_distortion_map(inputname, "", outputname, ibfName, primName, hasSpacecharge,false);
-
-  return;
-}
-
   
-void generate_distortion_map(const char * inputpattern="./evgeny_apr/Smooth*.root", const char *outputfilebase="./apr07_maps/apr07", bool hasSpacecharge, bool isDigitalCurrent, int nSteps=500){
+void generate_distortion_map(const char * inputpattern="./evgeny_apr/Smooth*.root", const char *outputfilebase="./apr07_maps/apr07", bool hasSpacecharge=true, bool isDigitalCurrent=false, int nSteps=500){
   
 
   int maxmaps=10;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This fixes an issue in the tpc distortion generator.  Default argument values were causing an ambiguous call.  The ambiguity was a legacy interface that is no longer in use, so it was removed, and default values were rearranged for convenience.
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
A minor change fixing the invocation of generate_distortion_map.  
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

