### PR TITLE
feat: Add num charged hadrons to tuple

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -168,7 +168,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
   if (_do_gtrack_eval)
   {
     _ntp_gtrack = new TNtuple("ntp_gtrack", "g4particle => best svtxtrack",
-                              "event:seed:gntracks:gtrackID:gflavor:gnhits:gnmaps:gnintt:gnmms:"
+                              "event:seed:gntracks:gnchghad:gtrackID:gflavor:gnhits:gnmaps:gnintt:gnmms:"
                               "gnintt1:gnintt2:gnintt3:gnintt4:"
                               "gnintt5:gnintt6:gnintt7:gnintt8:"
                               "gntpc:gnlmaps:gnlintt:gnltpc:gnlmms:"
@@ -2760,6 +2760,26 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
       }
 
       Float_t gntracks = (Float_t) truthinfo->GetNumPrimaryVertexParticles();
+      Float_t gnchghad = 0;
+      for(auto iter = range.first; iter!= range.second; ++iter)
+	{
+	   PHG4Particle* g4particle = iter->second;
+
+	   if (_scan_for_embedded)
+	     {
+	       if (trutheval->get_embed(g4particle) <= 0)
+		 {
+		   continue;
+		 }
+	     }
+
+	   float gflavor = g4particle->get_pid();
+	  if(fabs(gflavor)==211 || fabs(gflavor)==321 || fabs(gflavor)==2212)
+	    {
+	      gnchghad++;
+	    }
+	}
+
       for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
            iter != range.second;
            ++iter)
@@ -3376,6 +3396,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 
         float gtrack_data[] = {(float) _ievent, m_fSeed,
                                gntracks,
+			       gnchghad,
                                gtrackID,
                                gflavor,
                                ng4hits,


### PR DESCRIPTION
This adds the number of truth charged hadrons (pi/K/p) to the output gtuple, which can be useful for pythia analysis since pythia calls every final state particle a truth particle.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

