### PR TITLE
feat: Survey geometry

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -228,19 +228,11 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::
   Eigen::AngleAxisd alpha(sensorAngles(0), Eigen::Vector3d::UnitX());
   Eigen::AngleAxisd beta(sensorAngles(1), Eigen::Vector3d::UnitY());
   Eigen::AngleAxisd gamma(sensorAngles(2), Eigen::Vector3d::UnitZ());
-  
+
   Eigen::Quaternion<double> q       = gamma*beta*alpha;
  
   Eigen::Matrix3d millepedeRotation = q.matrix();
-  if(survey)
-    {
-      //! Permute the matrix to make it match acts definition
-      Eigen::PermutationMatrix<3,3> perm;
-      perm.indices() = {0,2,1};
-      millepedeRotation = perm * millepedeRotation;
-      millepedeRotation.col(2) = millepedeRotation.col(2)* -1;
-    }
-  
+
   Acts::Transform3 mpRotationAffine;   
   mpRotationAffine.linear() = millepedeRotation;
   mpRotationAffine.translation() = nullTranslation;   
@@ -253,12 +245,12 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::
       mpTranslationAffine.translation() = millepedeTranslation;   
     }
   else
-      {
-	// offsets should now be in local frame, so (dx,dz,dy)
-	Eigen::Vector3d millepedeTranslationxzy(millepedeTranslation(0), millepedeTranslation(2), millepedeTranslation(1));
-	mpTranslationAffine.translation() = millepedeTranslationxzy;   
-      }
-
+    {
+      // offsets should now be in local frame, so (dx,dz,dy)
+      Eigen::Vector3d millepedeTranslationxzy(millepedeTranslation(0), millepedeTranslation(2), millepedeTranslation(1));
+      mpTranslationAffine.translation() = millepedeTranslationxzy;   
+    }
+  
   // get the acts transform components
   Acts::Transform3 actsTransform = surf->transform(m_tGeometry->geometry().getGeoContext());
   Eigen::Matrix3d actsRotationPart    = actsTransform.rotation();

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -91,7 +91,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
          surf                        = surfMaps.getSiliconSurface(hitsetkey);
 	 
 	 Acts::Transform3 transform;
-	 transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles);
+	 transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles, false);
 
          Acts::GeometryIdentifier id = surf->geometryId();
 	 
@@ -117,8 +117,8 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
          surf                        = surfMaps.getSiliconSurface(hitsetkey);
 	 
 	 Acts::Transform3 transform;
-	 transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles);
-         Acts::GeometryIdentifier id = surf->geometryId();
+	 transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles, use_intt_survey_geometry);
+	 Acts::GeometryIdentifier id = surf->geometryId();
 	 
 	 if(localVerbosity) 
 	   {
@@ -151,7 +151,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
              surf                        = surfMaps.getTpcSurface(hitsetkey,(unsigned int) sskey);
 	     
 	     Acts::Transform3 transform;
-	     transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles);
+	     transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles, false);
 	     Acts::GeometryIdentifier id = surf->geometryId();
 	     
 	     if(localVerbosity) 
@@ -179,7 +179,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	surf                        = surfMaps.getMMSurface(hitsetkey);
 
 	Acts::Transform3 transform;
-	transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles);
+	transform  = newMakeTransform(surf, millepedeTranslation, sensorAngles, false);
 	Acts::GeometryIdentifier id = surf->geometryId();
 
 	if(localVerbosity)
@@ -206,7 +206,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 }
 
 // currently used as the transform maker
-Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles)
+Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, bool survey)
 {
   //define null matrices
   Eigen::Vector3d nullTranslation(0,0,0);
@@ -223,18 +223,24 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::
   // If we use a local alignment translation vector (dx,dy,dz) it
   // should be converted to (dx,dz,dy) before applying the Acts transform to global
   // It seems we can just interchange the x and y coordinates for this
-  // Swapping y and z is a rotation around the x axis, resulting in a left handed coordinate system
-  // why is this not a problem???
-  // It does mean that the order of the rotations is different from (x,y,z), but they are just fitted free parameters
   //=====================================================
 
   Eigen::AngleAxisd alpha(sensorAngles(0), Eigen::Vector3d::UnitX());
   Eigen::AngleAxisd beta(sensorAngles(1), Eigen::Vector3d::UnitY());
   Eigen::AngleAxisd gamma(sensorAngles(2), Eigen::Vector3d::UnitZ());
+  
   Eigen::Quaternion<double> q       = gamma*beta*alpha;
  
   Eigen::Matrix3d millepedeRotation = q.matrix();
-
+  if(survey)
+    {
+      //! Permute the matrix to make it match acts definition
+      Eigen::PermutationMatrix<3,3> perm;
+      perm.indices() = {0,2,1};
+      millepedeRotation = perm * millepedeRotation;
+      millepedeRotation.col(2) = millepedeRotation.col(2)* -1;
+    }
+  
   Acts::Transform3 mpRotationAffine;   
   mpRotationAffine.linear() = millepedeRotation;
   mpRotationAffine.translation() = nullTranslation;   
@@ -267,18 +273,28 @@ Acts::Transform3 AlignmentTransformation::newMakeTransform(Surface surf, Eigen::
   actsTranslationAffine.translation() = actsTranslationPart;
 
   //Put them together into a combined transform
-
-
   Acts::Transform3 transform;
-  if(use_global_millepede_translations)
+  //! If we read the survey parameters direcly, that is the full transform
+  if(survey)
     {
-      // put the mp translations in the global frame
-      transform = mpTranslationAffine *  actsTranslationAffine *  mpRotationAffine * actsRotationAffine;
+      //! The millepede affines will just be what was read in, which was the 
+      //! survey information. This should (in principle) be equivalent to
+      //! the ideal position + any misalignment
+      transform = mpTranslationAffine * mpRotationAffine;
     }
+  //! Otherwise in sim we use the ideal * misalignment transforms
   else
     {
-      // put the mp translations in the local coordinate frame
-      transform =  actsTranslationAffine *  actsRotationAffine * mpTranslationAffine * mpRotationAffine;
+      if(use_global_millepede_translations)
+	{
+	  // put the mp translations in the global frame
+	  transform = mpTranslationAffine *  actsTranslationAffine *  mpRotationAffine * actsRotationAffine;
+	}
+      else
+	{
+	  // put the mp translations in the local coordinate frame
+	  transform =  actsTranslationAffine *  actsRotationAffine * mpTranslationAffine * mpRotationAffine;
+	}
     }
 
   if(localVerbosity)

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -102,7 +102,9 @@ void setTPCParams(double tpcDevs[6])
       }
   }
 
+ void verbosity() { localVerbosity = 1;}
  void misalignmentFactor(uint8_t layer, const double factor);
+ void useInttSurveyGeometry(bool sur) { use_intt_survey_geometry = sur;} 
 
  private:
 
@@ -122,8 +124,9 @@ void setTPCParams(double tpcDevs[6])
   int localVerbosity = 0;
 
   bool use_global_millepede_translations = true;
+  bool use_intt_survey_geometry = true;
 
-  Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles);
+  Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, bool survey);
 
   alignmentTransformationContainer* transformMap = NULL;
   ActsGeometry* m_tGeometry = NULL;

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -124,7 +124,7 @@ void setTPCParams(double tpcDevs[6])
   int localVerbosity = 0;
 
   bool use_global_millepede_translations = true;
-  bool use_intt_survey_geometry = true;
+  bool use_intt_survey_geometry = false;
 
   Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, bool survey);
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -172,8 +172,13 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->setGeometry(trackingGeometry);
   m_actsGeometry->setSurfMaps(surfMaps);
   m_actsGeometry->set_drift_velocity(m_drift_velocity);
-
+  alignment_transformation.useInttSurveyGeometry(m_inttSurvey);
+   if(Verbosity() > 1)
+    {
+      alignment_transformation.verbosity();
+    }
   alignment_transformation.createMap(topNode);
+ 
   for(auto& [layer, factor] : m_misalignmentFactor)
     {
       alignment_transformation.misalignmentFactor(layer, factor);

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -136,7 +136,8 @@ class MakeActsGeometry : public SubsysReco
 
   void set_nSurfPhi( unsigned int value )
   { m_nSurfPhi = value; }
-  
+  void set_intt_survey(bool surv) { m_inttSurvey = surv; }
+
  private:
   /// Main function to build all acts geometry for use in the fitting modules
   int buildAllGeometry(PHCompositeNode *topNode);
@@ -205,6 +206,8 @@ class MakeActsGeometry : public SubsysReco
   PHG4CylinderGeomContainer* m_geomContainerMicromegas = nullptr;
   PHG4TpcCylinderGeomContainer* m_geomContainerTpc = nullptr;
   TGeoManager* m_geoManager = nullptr;
+
+  bool m_inttSurvey = true;
 
   bool m_useField = true;
   std::map<uint8_t, double> m_misalignmentFactor;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -207,7 +207,7 @@ class MakeActsGeometry : public SubsysReco
   PHG4TpcCylinderGeomContainer* m_geomContainerTpc = nullptr;
   TGeoManager* m_geoManager = nullptr;
 
-  bool m_inttSurvey = true;
+  bool m_inttSurvey = false;
 
   bool m_useField = true;
   std::map<uint8_t, double> m_misalignmentFactor;


### PR DESCRIPTION
This PR allows us to bypass the simulation geometry and directly input survey geometry transformation parameters into Acts. There is an option for the INTT which already has some survey information (but is set to false by default), other detectors default to false. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

