### PR TITLE
accomodate new packet ids

### DIFF
--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -94,8 +94,15 @@ namespace MicromegasDefs
   uint8_t getTileId(TrkrDefs::cluskey);
 
   //! TPOT packet ids
-  static constexpr int m_npackets = 2;
-  static constexpr std::array<unsigned int,m_npackets> m_packet_ids = {5000, 5001};
+  /** 
+   * note: TPOT only uses 2 packets. 
+   * For early runs (before 07/28/2023) they are 5000 and 5001
+   * For later run, (after 07/28/2023) and because, as instructed by Martin, they are 5001 and 5002
+   * We keep all 3 values here in order to be able to read both type of runs
+   * One might need to change this in the future when 5000 becomes used by a different subsystem
+   */
+  static constexpr int m_npackets = 3;
+  static constexpr std::array<unsigned int,m_npackets> m_packet_ids = {5000, 5001, 5002};
   
   //! number of channels per fee board
   static constexpr int m_nchannels_fee = 256;

--- a/offline/packages/micromegas/MicromegasRawDataCalibration.cc
+++ b/offline/packages/micromegas/MicromegasRawDataCalibration.cc
@@ -60,7 +60,8 @@ int MicromegasRawDataCalibration::process_event(PHCompositeNode *topNode)
     if( !packet )
     {
       // no data
-      std::cout << "MicromegasRawDataCalibration::process_event - event contains no TPOT data" << std::endl;
+      if( Verbosity() )
+      { std::cout << "MicromegasRawDataCalibration::process_event - event contains no TPOT data" << std::endl; }
       continue;
     }
     

--- a/offline/packages/micromegas/MicromegasRawDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasRawDataDecoder.cc
@@ -99,7 +99,8 @@ int MicromegasRawDataDecoder::process_event(PHCompositeNode *topNode)
     if( !packet )
     {
       // no data
-      std::cout << "MicromegasRawDataDecoder::process_event - event contains no TPOT data" << std::endl;
+      if( Verbosity() )
+      { std::cout << "MicromegasRawDataDecoder::process_event - event contains no TPOT data" << std::endl; }
       continue;
     }
     

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -99,7 +99,8 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
     if( !packet )
     {
       // no data
-      std::cout << "MicromegasRawDataEvaluation::process_event - packet " << packet_id << " not found." << std::endl;
+      if( Verbosity() )
+      { std::cout << "MicromegasRawDataEvaluation::process_event - packet " << packet_id << " not found." << std::endl; }
       continue;
     }
 


### PR DESCRIPTION
Starting from July 28 2023 TPOT will use packets 5001 and 5002 instead of 5000 and 5001, following request from @mpurschke 

Register packets 5000, 5001 and 5002 for TPOT to handle the transition gracefully 
Hide complains about packet not found behind Verbosity

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

