### PR TITLE
fix: Remove dynamic_cast which is computationally expensive

### DIFF
--- a/offline/packages/trackbase/ClusterErrorPara.cc
+++ b/offline/packages/trackbase/ClusterErrorPara.cc
@@ -472,25 +472,25 @@ ClusterErrorPara::ClusterErrorPara()
 }
 
 //_________________________________________________________________________________
-ClusterErrorPara::error_t ClusterErrorPara::get_clusterv5_modified_error(TrkrClusterv5* clusterv5, double, TrkrDefs::cluskey key)
+ClusterErrorPara::error_t ClusterErrorPara::get_clusterv5_modified_error(TrkrCluster* cluster, double, TrkrDefs::cluskey key)
 {
 
   int layer = TrkrDefs::getLayer(key);
 
-  double phierror = clusterv5->getRPhiError();
-  double zerror = clusterv5->getZError();
+  double phierror = cluster->getRPhiError();
+  double zerror = cluster->getZError();
   if( TrkrDefs::getTrkrId( key )== TrkrDefs::tpcId){
     if(layer==7||layer==22||layer==23||layer==38||layer==39){
       phierror *= 4;
       zerror*= 4;
     }
-    if(clusterv5->getEdge()>=3)
+    if(cluster->getEdge()>=3)
       phierror *= 4;
-    if(clusterv5->getOverlap()>=2)
+    if(cluster->getOverlap()>=2)
       phierror *= 2;
-    if(clusterv5->getPhiSize()==1)
+    if(cluster->getPhiSize()==1)
       phierror *= 10;
-    if(clusterv5->getPhiSize()>=5)
+    if(cluster->getPhiSize()>=5)
       phierror *= 10;
 
     if(phierror>0.1) phierror = 0.1;

--- a/offline/packages/trackbase/ClusterErrorPara.h
+++ b/offline/packages/trackbase/ClusterErrorPara.h
@@ -55,7 +55,7 @@ class ClusterErrorPara
   
   using error_t = std::pair<double, double>;
 
-  error_t get_clusterv5_modified_error(TrkrClusterv5* clusterv5, double cluster_r, TrkrDefs::cluskey key);
+  error_t get_clusterv5_modified_error(TrkrCluster* cluster, double cluster_r, TrkrDefs::cluskey key);
   error_t get_cluster_error(TrkrCluster* cluster, double cluster_r, TrkrDefs::cluskey key, float qOverR, float slope);
   error_t get_cluster_error(TrkrCluster* cluster,  TrkrDefs::cluskey key, double alpha, double beta);
 

--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -84,8 +84,7 @@ double ALICEKF::getClusterError(TrkrCluster* c, TrkrDefs::cluskey key, Acts::Vec
 	localErr[2][2] = para_errors.second;
       }else if(m_cluster_version==5){
 	double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-	TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(c);
-	auto para_errors = _ClusErrPara->get_clusterv5_modified_error(clusterv5,clusRadius,key);
+	auto para_errors = _ClusErrPara->get_clusterv5_modified_error(c,clusRadius,key);
 
 	localErr[0][0] = 0.;
 	localErr[0][1] = 0.;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -725,8 +725,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
 	cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
       }else if(m_cluster_version==5){
 	double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-	TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-	auto para_errors = _ClusErrPara.get_clusterv5_modified_error(clusterv5,clusRadius,cluskey);
+	auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
 	cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
 	cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
 	cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1982,16 +1982,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           }
           else if (m_cluster_version == 5)
           {
-            TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5, r, cluster_key);
-            phisize = clusterv5->getPhiSize();
-            zsize = clusterv5->getZSize();
+            auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
+            phisize = cluster->getPhiSize();
+            zsize = cluster->getZSize();
             // double clusRadius = r;
             ez = sqrt(para_errors.second);
             ephi = sqrt(para_errors.first);
-            maxadc = clusterv5->getMaxAdc();
-	    pedge = clusterv5->getEdge();
-	    ovlp = clusterv5->getOverlap();
+            maxadc = cluster->getMaxAdc();
+	    pedge = cluster->getEdge();
+	    ovlp = cluster->getOverlap();
           }
 	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
 
@@ -2347,16 +2346,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           }
           else if (m_cluster_version == 5)
           {
-            TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5, r, cluster_key);
-            phisize = clusterv5->getPhiSize();
-            zsize = clusterv5->getZSize();
+            auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
+            phisize = cluster->getPhiSize();
+            zsize = cluster->getZSize();
             // double clusRadius = r;
             ez = sqrt(para_errors.second);
             ephi = sqrt(para_errors.first);
-            maxadc = clusterv5->getMaxAdc();
-	    pedge = clusterv5->getEdge();
-	    ovlp = clusterv5->getOverlap();
+            maxadc = cluster->getMaxAdc();
+	    pedge = cluster->getEdge();
+	    ovlp = cluster->getOverlap();
           }
 	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
 
@@ -2667,8 +2665,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           }
           else if (m_cluster_version == 5)
           {
-            TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(reco_cluster);
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5, r, ckey);
+          
+            auto para_errors = ClusErrPara.get_clusterv5_modified_error(reco_cluster, r, ckey);
             // std::cout << " ver v4 " <<  std::endl;
             phisize = reco_cluster->getPhiSize();
             zsize = reco_cluster->getZSize();
@@ -3200,14 +3198,14 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		    //zsize = clusterv4->getZSize();
 		    
 		  }else if(m_cluster_version==5){
-		    TrkrClusterv5 *clusterv5 = dynamic_cast<TrkrClusterv5 *>(cluster);
-		    gphisize = clusterv5->getPhiSize();
+		    
+		    gphisize = cluster->getPhiSize();
 		    //zsize = clusterv5->getZSize();
-		    auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5,r,cluster_key);
+		    auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
 		    //zerr = sqrt(para_errors.second);
 		    gphierr = sqrt(para_errors.first);
-		    govlp = clusterv5->getOverlap();
-		    gedge = clusterv5->getEdge();
+		    govlp = cluster->getOverlap();
+		    gedge = cluster->getEdge();
 		  } 
 		  if(gedge>0) npedge++;
 		  if(gphisize>=4) nbig++;
@@ -3715,14 +3713,14 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		//zsize = clusterv4->getZSize();
 		
 	      }else if(m_cluster_version==5){
-		TrkrClusterv5 *clusterv5 = dynamic_cast<TrkrClusterv5 *>(cluster);
-		rphisize = clusterv5->getPhiSize();
+        
+		rphisize = cluster->getPhiSize();
 		//zsize = clusterv5->getZSize();
-		auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5,r,cluster_key);
+		auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
 		//zerr = sqrt(para_errors.second);
 		rphierr = sqrt(para_errors.first);
-		rovlp = clusterv5->getOverlap();
-		pedge = clusterv5->getEdge();
+		rovlp = cluster->getOverlap();
+		pedge = cluster->getEdge();
 	      } 
 	      if(pedge>0) npedge++;
 	      if(rphisize>=4) nbig++;

--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -824,11 +824,10 @@ TrackEvaluationContainerv1::ClusterStruct TrackEvaluation::create_cluster(TrkrDe
 
     if (cluster_struct.layer >= 7)
     {
-      TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-      auto para_errors_mm = ClusErrPara.get_clusterv5_modified_error(clusterv5, r, key);
+      auto para_errors_mm = ClusErrPara.get_clusterv5_modified_error(cluster, r, key);
 
-      cluster_struct.phi_error = clusterv5->getRPhiError() / cluster_struct.r;
-      cluster_struct.z_error = clusterv5->getZError();
+      cluster_struct.phi_error = cluster->getRPhiError() / cluster_struct.r;
+      cluster_struct.z_error = cluster->getZError();
       cluster_struct.para_phi_error = sqrt(para_errors_mm.first) / cluster_struct.r;
       cluster_struct.para_z_error = sqrt(para_errors_mm.second);
       //	float R = TMath::Abs(1.0/tpc_seed->get_qOverR());


### PR DESCRIPTION
Removes dynamic cast from modified cluster errors, which is computationally expensive and slows the tracking down. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

