### PR TITLE
refactor: Remove cluster version flags

### DIFF
--- a/offline/QA/modules/QAG4SimulationIntt.cc
+++ b/offline/QA/modules/QAG4SimulationIntt.cc
@@ -263,17 +263,10 @@ void QAG4SimulationIntt::evaluate_clusters()
 
       double phi_error = 0;
       double z_error = 0;
-      if (m_cluster_version == 4)
-      {
-        auto para_errors = _ClusErrPara.get_si_cluster_error(cluster, key);
-        phi_error = sqrt(para_errors.first) / r_cluster;
-        z_error = sqrt(para_errors.second);
-      }
-      else
-      {
-        phi_error = cluster->getRPhiError() / r_cluster;
-        z_error = cluster->getZError();
-      }
+   
+      phi_error = cluster->getRPhiError() / r_cluster;
+      z_error = cluster->getZError();
+      
 
       // find associated g4hits
       const auto g4hits = find_g4hits(key);

--- a/offline/QA/modules/QAG4SimulationIntt.h
+++ b/offline/QA/modules/QAG4SimulationIntt.h
@@ -26,7 +26,6 @@ class QAG4SimulationIntt : public SubsysReco
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
-  void set_cluster_version(int value) { m_cluster_version = value; }
 
  private:
   /// common prefix for QA histograms
@@ -64,7 +63,6 @@ class QAG4SimulationIntt : public SubsysReco
   /* it is filled at Init stage. It should not change for the full run */
   std::set<int> m_layers;
   ClusterErrorPara _ClusErrPara;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/QA/modules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/modules/QAG4SimulationMicromegas.cc
@@ -434,7 +434,6 @@ void QAG4SimulationMicromegas::evaluate_clusters()
 
     // fit a circle through x,y coordinates
     const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(xy_pts);
-    const auto [slope, intercept] = TrackFitUtils::line_fit(rz_pts);
 
     // skip chain entirely if fit fails
     if (std::isnan(R)) continue;
@@ -462,27 +461,14 @@ void QAG4SimulationMicromegas::evaluate_clusters()
       // get cluster
       const auto cluster = m_cluster_map->findCluster(ckey);
       const auto global = m_tGeometry->getGlobalPosition(ckey, cluster);
-      const auto cluster_r = QAG4Util::get_r(global(0), global(1));
+
       // get segmentation type
       const auto segmentation_type = MicromegasDefs::getSegmentationType(ckey);
 
       // get relevant cluster information
-      double rphi_error = 0;
-      double z_error = 0;
-      if (m_cluster_version == 4)
-      {
-        float r = cluster_r;
-        double alpha = (r * r) / (2 * r * R);
-        double beta = slope;
-        auto para_errors = _ClusErrPara.get_cluster_error(cluster, ckey, alpha, beta);
-        rphi_error = sqrt(para_errors.first);
-        z_error = sqrt(para_errors.second);
-      }
-      else
-      {
-        rphi_error = cluster->getRPhiError();
-        z_error = cluster->getZError();
-      }
+      double rphi_error = cluster->getRPhiError();
+      double z_error = cluster->getZError();
+      
       // convert cluster position to local tile coordinates
       const TVector3 cluster_world(global(0), global(1), global(2));
       const auto cluster_local = layergeom->get_local_from_world_coords(tileid, m_tGeometry, cluster_world);

--- a/offline/QA/modules/QAG4SimulationMicromegas.h
+++ b/offline/QA/modules/QAG4SimulationMicromegas.h
@@ -31,8 +31,7 @@ class QAG4SimulationMicromegas : public SubsysReco
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+ 
  private:
   /// common prefix for QA histograms
   std::string get_histo_prefix() const;
@@ -79,7 +78,6 @@ class QAG4SimulationMicromegas : public SubsysReco
   /* it is filled at Init stage. It should not change for the full run */
   std::set<int> m_layers;
   ClusterErrorPara _ClusErrPara;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/QA/modules/QAG4SimulationMvtx.cc
+++ b/offline/QA/modules/QAG4SimulationMvtx.cc
@@ -260,20 +260,9 @@ void QAG4SimulationMvtx::evaluate_clusters()
       const auto z_cluster = global(2);
       const auto phi_cluster = (float) std::atan2(global(1), global(0));
 
-      double phi_error = 0;
-      double z_error = 0;
-      if (m_cluster_version == 4)
-      {
-        auto para_errors = _ClusErrPara.get_si_cluster_error(cluster, key);
-        phi_error = sqrt(para_errors.first) / r_cluster;
-        z_error = sqrt(para_errors.second);
-      }
-      else
-      {
-        phi_error = cluster->getRPhiError() / r_cluster;
-        z_error = cluster->getZError();
-      }
-
+      double phi_error = cluster->getRPhiError() / r_cluster;
+      double z_error = cluster->getZError();
+      
       // find associated g4hits
       const auto g4hits = find_g4hits(key);
 

--- a/offline/QA/modules/QAG4SimulationMvtx.h
+++ b/offline/QA/modules/QAG4SimulationMvtx.h
@@ -26,8 +26,7 @@ class QAG4SimulationMvtx : public SubsysReco
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+ 
  private:
   /// common prefix for QA histograms
   std::string get_histo_prefix() const;
@@ -64,7 +63,6 @@ class QAG4SimulationMvtx : public SubsysReco
   /* it is filled at Init stage. It should not change for the full run */
   std::set<int> m_layers;
   ClusterErrorPara _ClusErrPara;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/QA/modules/QAG4SimulationTpc.cc
+++ b/offline/QA/modules/QAG4SimulationTpc.cc
@@ -356,8 +356,7 @@ void QAG4SimulationTpc::evaluate_clusters()
 
     // fit a circle through x,y coordinates
     const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(xy_pts);
-    const auto [slope, intercept] = TrackFitUtils::line_fit(rz_pts);
-
+    
     // skip chain entirely if fit fails
     if (std::isnan(R)) continue;
 
@@ -401,25 +400,9 @@ void QAG4SimulationTpc::evaluate_clusters()
         const auto z_cluster = global(2);
         const auto phi_cluster = (float) std::atan2(global(1), global(0));
 
-        double phi_error = 0;
-        double z_error = 0;
-
-        if (m_cluster_version == 4)
-        {
-          float r = r_cluster;
-          double alpha = (r * r) / (2 * r * R);
-          double beta = slope;
-
-          auto para_errors = _ClusErrPara.get_cluster_error(rclus, rkey, alpha, beta);
-          phi_error = sqrt(para_errors.first) / r_cluster;
-          z_error = sqrt(para_errors.second);
-        }
-        else
-        {
-          phi_error = rclus->getRPhiError() / r_cluster;
-          z_error = rclus->getZError();
-        }
-
+	double phi_error = rclus->getRPhiError() / r_cluster;
+	double z_error = rclus->getZError();
+        
         const auto dphi = QAG4Util::delta_phi(phi_cluster, gphi);
         const auto dz = z_cluster - gz;
 

--- a/offline/QA/modules/QAG4SimulationTpc.h
+++ b/offline/QA/modules/QAG4SimulationTpc.h
@@ -32,8 +32,7 @@ class QAG4SimulationTpc : public SubsysReco
 
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+ 
  private:
   /// common prefix for QA histograms
   std::string get_histo_prefix() const;
@@ -74,7 +73,6 @@ class QAG4SimulationTpc : public SubsysReco
   std::set<int> m_layers;
   std::multimap<int, int> m_layer_region_map;
   ClusterErrorPara _ClusErrPara;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -970,31 +970,13 @@ Acts::Vector2 HelicalFitter::getClusterError(TrkrCluster *cluster, TrkrDefs::clu
 {
   Acts::Vector2 clus_sigma(0,0);
 
-  if(_cluster_version==3)
-    {
-      clus_sigma(1) = cluster->getZError();
-      clus_sigma(0) = cluster->getRPhiError();
-    }
-  else if(_cluster_version==4)
-    {
-      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-      auto para_errors = _ClusErrPara.get_simple_cluster_error(cluster,clusRadius,cluskey);
-      float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-      float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-      clus_sigma(1) = sqrt(ez2);
-      clus_sigma(0) = sqrt(exy2);
-    }
-  else if(_cluster_version == 5)
-    {
-      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-      TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-      auto para_errors = _ClusErrPara.get_clusterv5_modified_error(clusterv5,clusRadius,cluskey);
-      double phierror = sqrt(para_errors.first);
-      double zerror = sqrt(para_errors.second);
-      clus_sigma(1) = zerror;
-      clus_sigma(0) = phierror;
-    }
-
+  double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
+  auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
+  double phierror = sqrt(para_errors.first);
+  double zerror = sqrt(para_errors.second);
+  clus_sigma(1) = zerror;
+  clus_sigma(0) = phierror;
+  
   return clus_sigma; 
 }
 

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -70,7 +70,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_tpc_sector_fixed(unsigned int region, unsigned int sector, unsigned int side);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
-  void set_cluster_version(unsigned int v) { _cluster_version = v; }
+
   void set_fitted_subsystems(bool si, bool tpc, bool full) { fitsilicon = si; fittpc = tpc; fitfulltrack = full; }
 
   void set_error_inflation_factor(unsigned int layer, float factor) 
@@ -152,7 +152,6 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   TpcDistortionCorrectionContainer* _dcc_average{nullptr};
   TpcDistortionCorrectionContainer* _dcc_fluctuation{nullptr};
 
-  unsigned int _cluster_version = 5;
   bool test_output = false;
 
   ClusterErrorPara _ClusErrPara;

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -447,31 +447,14 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
     // need standard deviation of measurements
     SvtxAlignmentState::ResidualVector clus_sigma = SvtxAlignmentState::ResidualVector::Zero();
 
-    if (_cluster_version == 3)
-    {
-      clus_sigma(1) = cluster->getZError() * Acts::UnitConstants::cm;
-      clus_sigma(0) = cluster->getRPhiError() * Acts::UnitConstants::cm;
-    }
-    else if (_cluster_version == 4)
-    {
-      double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
-      auto para_errors = _ClusErrPara.get_simple_cluster_error(cluster, clusRadius, ckey);
-      float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-      float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-      clus_sigma(1) = sqrt(ez2);
-      clus_sigma(0) = sqrt(exy2);
-    }
-    else if (_cluster_version == 5)
-    {
-      double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
-      TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-      auto para_errors = _ClusErrPara.get_clusterv5_modified_error(clusterv5, clusRadius, ckey);
-      double phierror = sqrt(para_errors.first);
-      double zerror = sqrt(para_errors.second);
-      clus_sigma(1) = zerror * Acts::UnitConstants::cm;
-      clus_sigma(0) = phierror * Acts::UnitConstants::cm;
-    }
-
+    double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
+    auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster, clusRadius, ckey);
+    double phierror = sqrt(para_errors.first);
+    double zerror = sqrt(para_errors.second);
+    clus_sigma(1) = zerror * Acts::UnitConstants::cm;
+    clus_sigma(0) = phierror * Acts::UnitConstants::cm;
+    
+    
     if (std::isnan(clus_sigma(0)) ||
         std::isnan(clus_sigma(1)))
     {

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -58,7 +58,7 @@ class MakeMilleFiles : public SubsysReco
   void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_layer_gparam_fixed(unsigned int layer, unsigned int param);
   void set_layer_lparam_fixed(unsigned int layer, unsigned int param);
-  void set_cluster_version(unsigned int v) { _cluster_version = v; }
+  
   void set_layers_fixed(unsigned int minlayer, unsigned int maxlayer);
   void set_error_inflation_factor(unsigned int layer, float factor)
   {
@@ -108,7 +108,6 @@ class MakeMilleFiles : public SubsysReco
 
   bool m_useEventVertex = false;
   bool _binary = true;
-  unsigned int _cluster_version = 5;
 
   Acts::Vector2 m_vtxSigma = {0.1, 0.1};
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -6,7 +6,6 @@
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterv5.h>
 
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
@@ -372,8 +371,7 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   }
   m_cluslz.push_back(clusz);
 
-  TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-  auto para_errors = m_clusErrPara.get_clusterv5_modified_error(clusterv5,
+  auto para_errors = m_clusErrPara.get_clusterv5_modified_error(cluster,
 							       clusr,ckey);
   m_cluselx.push_back(sqrt(para_errors.first));
   m_cluselz.push_back(sqrt(para_errors.second));

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -3,9 +3,6 @@
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrCluster.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
-#include <trackbase/TrkrClusterv5.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSetContainer.h>
@@ -937,49 +934,16 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
           float phisize = 0;
           float zsize = 0;
           float maxadc = -999;
-          if (m_cluster_version == 3)
-          {
-            auto globerr = calculateClusterError(cluster, phi);
-            ex = sqrt(globerr[0][0]);
-            ey = sqrt(globerr[1][1]);
-            ez = cluster->getZError();
-            ephi = cluster->getRPhiError();
-          }
-          else if (m_cluster_version == 4)
-          {
-            phisize = cluster->getPhiSize();
-            zsize = cluster->getZSize();
-            TrackSeed* seed = nullptr;
-            if (track != nullptr)
-            {
-              if (layer < 7)
-              {
-                seed = track->get_silicon_seed();
-              }
-              else
-              {
-                seed = track->get_tpc_seed();
-              }
-              if (seed != nullptr)
-              {
-                auto para_errors = ClusErrPara.get_cluster_error(cluster, r, cluster_key, seed->get_qOverR(), seed->get_slope());
-                pephi = sqrt(para_errors.first * Acts::UnitConstants::cm2);
-                pez = sqrt(para_errors.second * Acts::UnitConstants::cm2);
-              }
-            }
-          }
-          else if (m_cluster_version == 5)
-          {
-            TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-	    auto para_errors = ClusErrPara.get_clusterv5_modified_error(clusterv5,r ,cluster_key);
+         
+	  auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r ,cluster_key);
 
-            phisize = clusterv5->getPhiSize();
-            zsize = clusterv5->getZSize();
-            // double clusRadius = r;
-            ez = sqrt(para_errors.second);
-            ephi = sqrt(para_errors.first);
-            maxadc = clusterv5->getMaxAdc();
-          }
+	  phisize = cluster->getPhiSize();
+	  zsize = cluster->getZSize();
+	  // double clusRadius = r;
+	  ez = sqrt(para_errors.second);
+	  ephi = sqrt(para_errors.first);
+	  maxadc = cluster->getMaxAdc();
+          
           float e = cluster->getAdc();
           float adc = cluster->getAdc();
           float layer_local = (float) TrkrDefs::getLayer(cluster_key);

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.h
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.h
@@ -62,7 +62,6 @@ class TrkrNtuplizer : public SubsysReco
   void do_tpcseed_eval(bool b) { _do_tpcseed_eval = b; }
   void do_siseed_eval(bool b) { _do_siseed_eval = b; }
 
-  void set_cluster_version(int value) { m_cluster_version = value; }
   SvtxTrack* best_track_from(TrkrDefs::cluskey cluster_key);
   std::set<SvtxTrack*> all_tracks_from(TrkrDefs::cluskey cluster_key);
   void create_cache_track_from_cluster();
@@ -119,7 +118,7 @@ class TrkrNtuplizer : public SubsysReco
   void printInputInfo(PHCompositeNode *topNode);     ///< print out the input object information (debugging upstream components)
   void printOutputInfo(PHCompositeNode *topNode);    ///< print out the ancestry information for detailed diagnosis
   double AdcClockPeriod = 53.0;                      // ns
-  int m_cluster_version = 5;
+ 
   bool _cache_track_from_cluster_exists = false;
   std::map<TrkrDefs::cluskey, std::set<SvtxTrack*> > _cache_all_tracks_from_cluster;
   std::map<TrkrDefs::cluskey, SvtxTrack*> _cache_best_track_from_cluster;

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -2,8 +2,6 @@
 #include "CylinderGeomIntt.h"
 
 #include <trackbase/TrkrClusterContainerv4.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
 #include <trackbase/TrkrClusterv5.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
@@ -551,59 +549,25 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 	    cluslocaly = ylocalsum / nhits;
 	    cluslocalz = zlocalsum / nhits;
 	  }
-	if(m_cluster_version==3){
-	  auto clus = std::make_unique<TrkrClusterv3>();
-	  // Fill the cluster fields
-	  clus->setAdc(clus_adc);
-	  
-	  if(Verbosity() > 10) clus->identify();
-	  
-	  clus->setLocalX(cluslocaly);
-	  clus->setLocalY(cluslocalz);
-	  /// silicon has a 1-1 map between hitsetkey and surfaces. So set to 
-	    /// 0
-	    clus->setSubSurfKey(0);
-	    clus->setActsLocalError(0,0, square(phierror));
-	    clus->setActsLocalError(0,1, 0.);
-	    clus->setActsLocalError(1,0, 0.);
-	    clus->setActsLocalError(1,1, square(zerror));
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	}
-	else if(m_cluster_version==4){
-	  auto clus = std::make_unique<TrkrClusterv4>();
-	  // Fill the cluster fields
-	  clus->setAdc(clus_adc);
-	  clus->setPhiSize(phibins.size());
-	  clus->setZSize(1);
 
-	  if(Verbosity() > 10) clus->identify();
-	  
-	  clus->setLocalX(cluslocaly);
-	  clus->setLocalY(cluslocalz);
-	  // silicon has a 1-1 map between hitsetkey and surfaces. So set to 
-	  // 0
-	  clus->setSubSurfKey(0);
-	  m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  
-	}else if(m_cluster_version==5){
-	  auto clus = std::make_unique<TrkrClusterv5>();
-	  clus->setAdc(clus_adc);
-	  clus->setMaxAdc(clus_maxadc);
-	  clus->setLocalX(cluslocaly);
-	  clus->setLocalY(cluslocalz);
-	  clus->setPhiError(phierror);
-	  clus->setZError(zerror);
-	  clus->setPhiSize(phibins.size());
-	  clus->setZSize(1);
-	  // All silicon surfaces have a 1-1 map to hitsetkey. 
-	  // So set subsurface key to 0
-	  clus->setSubSurfKey(0);
-	  
-	  if (Verbosity() > 2)
-	    clus->identify();
-	  
-	  m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	}
+	auto clus = std::make_unique<TrkrClusterv5>();
+	clus->setAdc(clus_adc);
+	clus->setMaxAdc(clus_maxadc);
+	clus->setLocalX(cluslocaly);
+	clus->setLocalY(cluslocalz);
+	clus->setPhiError(phierror);
+	clus->setZError(zerror);
+	clus->setPhiSize(phibins.size());
+	clus->setZSize(1);
+	// All silicon surfaces have a 1-1 map to hitsetkey. 
+	// So set subsurface key to 0
+	clus->setSubSurfKey(0);
+	
+	if (Verbosity() > 2)
+	  clus->identify();
+	
+	m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+	
       } // end loop over cluster ID's
   }  // end loop over hitsets
 
@@ -849,41 +813,24 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
 	    cluslocaly = ylocalsum / nhits;
 	    cluslocalz = zlocalsum / nhits;
 	  }
-	if(m_cluster_version==3){
-	  auto clus = std::make_unique<TrkrClusterv3>();
-	  // Fill the cluster fields
-	  clus->setAdc(clus_adc);
-	  
-	  if(Verbosity() > 10) clus->identify();
-	  
-	  clus->setLocalX(cluslocaly);
-	  clus->setLocalY(cluslocalz);
-	  /// silicon has a 1-1 map between hitsetkey and surfaces. So set to 
-	    /// 0
-	    clus->setSubSurfKey(0);
-	    clus->setActsLocalError(0,0, square(phierror));
-	    clus->setActsLocalError(0,1, 0.);
-	    clus->setActsLocalError(1,0, 0.);
-	    clus->setActsLocalError(1,1, square(zerror));
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	}
-	else if(m_cluster_version==4){
-	  auto clus = std::make_unique<TrkrClusterv4>();
-	  // Fill the cluster fields
-	  clus->setAdc(clus_adc);
-	  clus->setPhiSize(phibins.size());
-	  clus->setZSize(1);
 
-	  if(Verbosity() > 10) clus->identify();
-	  
-	  clus->setLocalX(cluslocaly);
-	  clus->setLocalY(cluslocalz);
-	  // silicon has a 1-1 map between hitsetkey and surfaces. So set to 
-	  // 0
-	  clus->setSubSurfKey(0);
-	  m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  
-	}
+	auto clus = std::make_unique<TrkrClusterv5>();
+	clus->setAdc(clus_adc);
+	clus->setLocalX(cluslocaly);
+	clus->setLocalY(cluslocalz);
+	clus->setPhiError(phierror);
+	clus->setZError(zerror);
+	clus->setPhiSize(phibins.size());
+	clus->setZSize(1);
+	// All silicon surfaces have a 1-1 map to hitsetkey. 
+	// So set subsurface key to 0
+	clus->setSubSurfKey(0);
+	
+	if (Verbosity() > 2)
+	  clus->identify();
+	
+	m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+
       } // end loop over cluster ID's
   }  // end loop over hitsets
 

--- a/offline/packages/intt/InttClusterizer.h
+++ b/offline/packages/intt/InttClusterizer.h
@@ -73,7 +73,7 @@ class InttClusterizer : public SubsysReco
     if (_make_e_weights.find(layer) == _make_e_weights.end()) return false;
     return _make_e_weights.find(layer)->second;
   }
-  void set_cluster_version(int value) { m_cluster_version = value; }
+
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
 
@@ -105,7 +105,7 @@ class InttClusterizer : public SubsysReco
   std::map<int, bool> _make_e_weights;        // layer->energy_weighting_option
   bool do_hit_assoc = true;
   bool do_read_raw = false;
-  int m_cluster_version = 4;
+
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -12,8 +12,6 @@
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrClusterContainerv4.h>        // for TrkrCluster
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
 #include <trackbase/TrkrClusterv5.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
@@ -345,77 +343,33 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       }
 
       
-      if(m_cluster_version==3)
-      {
-        auto cluster = std::make_unique<TrkrClusterv3>();
-        cluster->setAdc( adc_sum );
-        cluster->setLocalX(local_coordinates.X());
-        cluster->setLocalY(local_coordinates.Y());
-        
-        // assign errors
-        cluster->setActsLocalError(0,0, error_sq_x);
-        cluster->setActsLocalError(1,1, error_sq_y);
-        cluster->setActsLocalError(0,1, 0);
-        cluster->setActsLocalError(1,0, 0);
-
-        // add to container
-        trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-
-      } else if(m_cluster_version==4) {
-
-        auto cluster = std::make_unique<TrkrClusterv4>();
-        cluster->setAdc( adc_sum );
-        cluster->setLocalX(local_coordinates.X());
-        cluster->setLocalY(local_coordinates.Y());
-
-        // store cluster size
-        switch( segmentation_type )
+      auto cluster = std::make_unique<TrkrClusterv5>();
+      cluster->setAdc( adc_sum );
+      cluster->setMaxAdc( max_adc );
+      cluster->setLocalX(local_coordinates.X());
+      cluster->setLocalY(local_coordinates.Y());
+      cluster->setPhiError(sqrt(error_sq_x));
+      cluster->setZError(sqrt(error_sq_y));
+      // store cluster size
+      switch( segmentation_type )
         {
-          case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
+	case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
           {
             cluster->setPhiSize(strip_count);
             cluster->setZSize(1);
             break;
           }
-
-          case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
+	  
+	case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
           {
             cluster->setPhiSize(1);
             cluster->setZSize(strip_count);
             break;
           }
         }
-        // add to container
-        trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-      } else if(m_cluster_version==5) {
-
-        auto cluster = std::make_unique<TrkrClusterv5>();
-        cluster->setAdc( adc_sum );
-        cluster->setMaxAdc( max_adc );
-        cluster->setLocalX(local_coordinates.X());
-        cluster->setLocalY(local_coordinates.Y());
-        cluster->setPhiError(sqrt(error_sq_x));
-        cluster->setZError(sqrt(error_sq_y));
-        // store cluster size
-        switch( segmentation_type )
-        {
-          case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
-          {
-            cluster->setPhiSize(strip_count);
-            cluster->setZSize(1);
-            break;
-          }
-
-          case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
-          {
-            cluster->setPhiSize(1);
-            cluster->setZSize(strip_count);
-            break;
-          }
-        }
-        // add to container
-        trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-      }
+      // add to container
+      trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
+      
 
     }
 

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -26,9 +26,6 @@ class MicromegasClusterizer : public SubsysReco
   //! event processing
   int process_event(PHCompositeNode*) override;
 
-  //! cluster version
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
   //! read raw data 
   /** not implemented for now */
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
@@ -36,7 +33,6 @@ class MicromegasClusterizer : public SubsysReco
   private:
 
   bool do_read_raw = false;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -490,60 +490,24 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 		 << " local x " << locclusx << " local y " << locclusz
 		 << endl;
 	  
-	  if(m_cluster_version==3){
-	    auto clus = std::make_unique<TrkrClusterv3>();
-	    clus->setAdc(nhits);
-	    clus->setLocalX(locclusx);
-	    clus->setLocalY(locclusz);
-	    // Take the rphi and z uncertainty of the cluster
-	    clus->setActsLocalError(0,0,square(phierror));
-	    clus->setActsLocalError(0,1,0.);
-	    clus->setActsLocalError(1,0,0.);
-	    clus->setActsLocalError(1,1,square(zerror));
-	    
-	    // All silicon surfaces have a 1-1 map to hitsetkey. 
-	    // So set subsurface key to 0
-	    clus->setSubSurfKey(0);
-	    
-	    if (Verbosity() > 2)
-	      clus->identify();
-	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  }else if(m_cluster_version==4){
-	    auto clus = std::make_unique<TrkrClusterv4>();
-	    clus->setAdc(nhits);
-	    clus->setLocalX(locclusx);
-	    clus->setLocalY(locclusz);
-	    
-	    clus->setPhiSize(phibins.size());
-	    clus->setZSize(zbins.size());
-	    // All silicon surfaces have a 1-1 map to hitsetkey. 
-	    // So set subsurface key to 0
-	    clus->setSubSurfKey(0);
-	    
-	    if (Verbosity() > 2)
-	      clus->identify();
-	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  }else if(m_cluster_version==5){
-	    auto clus = std::make_unique<TrkrClusterv5>();
-	    clus->setAdc(nhits);
-	    clus->setMaxAdc(1);
-	    clus->setLocalX(locclusx);
-	    clus->setLocalY(locclusz);
-	    clus->setPhiError(phierror);
-	    clus->setZError(zerror);
-	    clus->setPhiSize(phibins.size());
-	    clus->setZSize(zbins.size());
-	    // All silicon surfaces have a 1-1 map to hitsetkey. 
-	    // So set subsurface key to 0
-	    clus->setSubSurfKey(0);
-	    
-	    if (Verbosity() > 2)
-	      clus->identify();
-	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  }
+	  auto clus = std::make_unique<TrkrClusterv5>();
+	  clus->setAdc(nhits);
+	  clus->setMaxAdc(1);
+	  clus->setLocalX(locclusx);
+	  clus->setLocalY(locclusz);
+	  clus->setPhiError(phierror);
+	  clus->setZError(zerror);
+	  clus->setPhiSize(phibins.size());
+	  clus->setZSize(zbins.size());
+	  // All silicon surfaces have a 1-1 map to hitsetkey. 
+	  // So set subsurface key to 0
+	  clus->setSubSurfKey(0);
+	  
+	  if (Verbosity() > 2)
+	    clus->identify();
+	  
+	  m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+	  
 	}  // clusitr loop
     }  // loop over hitsets
       
@@ -739,43 +703,26 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
 		 << " zbins " << zbins.size() << " length " << length << " zsize " << zsize 
 		 << " local x " << locclusx << " local y " << locclusz
 		 << endl;
+
+	  auto clus = std::make_unique<TrkrClusterv5>();
+	  clus->setAdc(nhits);
+	  clus->setMaxAdc(1);
+	  clus->setLocalX(locclusx);
+	  clus->setLocalY(locclusz);
+	  clus->setPhiError(phierror);
+	  clus->setZError(zerror);
+	  clus->setPhiSize(phibins.size());
+	  clus->setZSize(zbins.size());
+	  // All silicon surfaces have a 1-1 map to hitsetkey. 
+	  // So set subsurface key to 0
+	  clus->setSubSurfKey(0);
 	  
-	  if(m_cluster_version==3){
-	    auto clus = std::make_unique<TrkrClusterv3>();
-	    clus->setAdc(nhits);
-	    clus->setLocalX(locclusx);
-	    clus->setLocalY(locclusz);
-	    // Take the rphi and z uncertainty of the cluster
-	    clus->setActsLocalError(0,0,square(phierror));
-	    clus->setActsLocalError(0,1,0.);
-	    clus->setActsLocalError(1,0,0.);
-	    clus->setActsLocalError(1,1,square(zerror));
-	    
-	    // All silicon surfaces have a 1-1 map to hitsetkey. 
-	    // So set subsurface key to 0
-	    clus->setSubSurfKey(0);
-	    
-	    if (Verbosity() > 2)
-	      clus->identify();
-	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  }else if(m_cluster_version==4){
-	    auto clus = std::make_unique<TrkrClusterv4>();
-	    clus->setAdc(nhits);
-	    clus->setLocalX(locclusx);
-	    clus->setLocalY(locclusz);
-	    
-	    clus->setPhiSize(phibins.size());
-	    clus->setZSize(zbins.size());
-	    // All silicon surfaces have a 1-1 map to hitsetkey. 
-	    // So set subsurface key to 0
-	    clus->setSubSurfKey(0);
-	    
-	    if (Verbosity() > 2)
-	      clus->identify();
-	    
-	    m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
-	  }
+	  if (Verbosity() > 2)
+	    clus->identify();
+	  
+	  m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+
+
 	}  // clusitr loop
     }  // loop over hitsets
       

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -56,7 +56,7 @@ class MvtxClusterizer : public SubsysReco
   {
     return m_makeZClustering;
   }
-  void set_cluster_version(int value) { m_cluster_version = value; }
+
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
   void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
@@ -83,7 +83,6 @@ class MvtxClusterizer : public SubsysReco
   bool m_makeZClustering;  // z_clustering_option
   bool do_hit_assoc = true;
   bool do_read_raw = false;
-  int m_cluster_version = 4;
 };
 
 #endif  // MVTX_MVTXCLUSTERIZER_H

--- a/offline/packages/tpc/TpcClusterCleaner.cc
+++ b/offline/packages/tpc/TpcClusterCleaner.cc
@@ -50,8 +50,6 @@ int TpcClusterCleaner::InitRun(PHCompositeNode *topNode)
 int TpcClusterCleaner::process_event(PHCompositeNode *topNode)
 {
 
-  if(m_cluster_version==4) return Fun4AllReturnCodes::EVENT_OK;
-
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
   {

--- a/offline/packages/tpc/TpcClusterCleaner.h
+++ b/offline/packages/tpc/TpcClusterCleaner.h
@@ -36,8 +36,7 @@ class TpcClusterCleaner : public SubsysReco
 
   void set_new_rphi_error(double err){_new_rphi_error = err;}
   void set_new_z_error(double err){_new_z_error = err;}
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+ 
  private:
 
   void rotate_error(double erphi, double ez, double phi, double error[][3]);
@@ -50,7 +49,6 @@ class TpcClusterCleaner : public SubsysReco
 
   double _new_rphi_error = 0.05;
   double _new_z_error = 0.1;
-  int m_cluster_version = 4;
 };
 
 #endif // TPCCLUSTERCLEANER_H

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -99,7 +99,6 @@ namespace
     unsigned short maxHalfSizePhi = 0;
     double m_tdriftmax = 0;
     double sampa_tbias = 0;
-    int cluster_version = 4;
     std::vector<assoc> association_vector;
     std::vector<TrkrCluster*> cluster_vector;
     int verbosity = 0;
@@ -452,63 +451,28 @@ namespace
       
   bool b_made_cluster { false };
 
-      if(my_data.cluster_version==3){
-	//std::cout << "ver3" << std::endl;
-	// Fill in the cluster details
-	//================
-	auto clus = new TrkrClusterv3;
-	//auto clus = std::make_unique<TrkrClusterv3>();
-	clus->setAdc(adc_sum);      
-	clus->setSubSurfKey(subsurfkey);      
-	clus->setLocalX(local(0));
-	clus->setLocalY(clust);
-	clus->setActsLocalError(0,0, phi_err_square);
-	clus->setActsLocalError(1,0, 0);
-	clus->setActsLocalError(0,1, 0);
-	clus->setActsLocalError(1,1, t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2));
-	my_data.cluster_vector.push_back(clus);
-  b_made_cluster = true;
-      }else if(my_data.cluster_version==4){
-	//std::cout << "ver4" << std::endl;
-	//	std::cout << "clus num" << my_data.cluster_vector.size() << " X " << local(0) << " Y " << clust << std::endl;
-	if(sqrt(phi_err_square) > my_data.min_err_squared){
-	auto clus = new TrkrClusterv4;
-	//auto clus = std::make_unique<TrkrClusterv3>();
-	clus->setAdc(adc_sum);  
-	clus->setMaxAdc(max_adc);  
-	clus->setOverlap(ntouch);
-	clus->setEdge(nedge);
-	clus->setPhiSize(phisize);
-	clus->setZSize(tsize);
-	clus->setSubSurfKey(subsurfkey);      
-	clus->setLocalX(local(0));
-	clus->setLocalY(clust);
-	//	clus->setPhiErr(sqrt(phi_err_square));
-	//clus->setZErr(sqrt(t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2)));
-	my_data.cluster_vector.push_back(clus);
-  b_made_cluster = true;
-	}
-      }else if(my_data.cluster_version==5){
-	//std::cout << "ver5" << std::endl;
-	//	std::cout << "clus num" << my_data.cluster_vector.size() << " X " << local(0) << " Y " << clust << std::endl;
-	if(sqrt(phi_err_square) > my_data.min_err_squared){
-	auto clus = new TrkrClusterv5;
-	//auto clus = std::make_unique<TrkrClusterv3>();
-	clus->setAdc(adc_sum);  
-	clus->setMaxAdc(max_adc); 
-	clus->setEdge(nedge);
-	clus->setPhiSize(phisize);
-	clus->setZSize(tsize);
-	clus->setSubSurfKey(subsurfkey);      
-	clus->setLocalX(local(0));
-	clus->setLocalY(clust);
-	clus->setPhiError(sqrt(phi_err_square));
-	clus->setZError(sqrt(t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2)));
-	my_data.cluster_vector.push_back(clus);
-  b_made_cluster = true;
-	}
-      }
-
+  
+  //std::cout << "ver5" << std::endl;
+  //	std::cout << "clus num" << my_data.cluster_vector.size() << " X " << local(0) << " Y " << clust << std::endl;
+  if(sqrt(phi_err_square) > my_data.min_err_squared){
+    auto clus = new TrkrClusterv5;
+    //auto clus = std::make_unique<TrkrClusterv3>();
+    clus->setAdc(adc_sum);  
+    clus->setMaxAdc(max_adc); 
+    clus->setEdge(nedge);
+    clus->setPhiSize(phisize);
+    clus->setZSize(tsize);
+    clus->setSubSurfKey(subsurfkey);  
+    clus->setOverlap(ntouch);
+    clus->setLocalX(local(0));
+    clus->setLocalY(clust);
+    clus->setPhiError(sqrt(phi_err_square));
+    clus->setZError(sqrt(t_err_square * pow(my_data.tGeometry->get_drift_velocity(),2)));
+    my_data.cluster_vector.push_back(clus);
+    b_made_cluster = true;
+    
+  }
+  
       if (my_data.fillClusHitsVerbose && b_made_cluster) {
         // push the data back to 
         my_data.phivec_ClusHitsVerbose .push_back( std::vector<std::pair<int,int>> {} );
@@ -972,7 +936,6 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	thread_pair.data.maxHalfSizeT =  MaxClusterHalfSizeT;
 	thread_pair.data.maxHalfSizePhi = MaxClusterHalfSizePhi;
 	thread_pair.data.sampa_tbias = m_sampa_tbias;
-	thread_pair.data.cluster_version = cluster_version;
 	thread_pair.data.verbosity = Verbosity();
 	thread_pair.data.do_split = do_split;
 	thread_pair.data.min_err_squared = min_err_squared;
@@ -1079,7 +1042,6 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       thread_pair.data.maxHalfSizeT =  MaxClusterHalfSizeT;
       thread_pair.data.maxHalfSizePhi = MaxClusterHalfSizePhi;
       thread_pair.data.sampa_tbias = m_sampa_tbias;
-      thread_pair.data.cluster_version = cluster_version;
       thread_pair.data.verbosity = Verbosity();
 
       unsigned short NPhiBins = (unsigned short) layergeom->get_phibins();

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -49,7 +49,7 @@ class TpcClusterizer : public SubsysReco
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
   void set_max_cluster_half_size_phi(unsigned short size) { MaxClusterHalfSizePhi = size ;}
   void set_max_cluster_half_size_z(unsigned short size) { MaxClusterHalfSizeT = size ;}
-  void set_cluster_version(int value) { cluster_version = value; }
+  
   void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
   void set_rawdata_reco() {
     set_do_hit_association(false);
@@ -89,7 +89,7 @@ class TpcClusterizer : public SubsysReco
   double SectorFiducialCut = 0.5;
   unsigned short MaxClusterHalfSizePhi = 3;
   unsigned short MaxClusterHalfSizeT = 5;
-  int cluster_version = 4;
+ 
   double m_tdriftmax = 0;
   double AdcClockPeriod = 53.0;   // ns 
 

--- a/offline/packages/tpc/TpcRawWriter.cc
+++ b/offline/packages/tpc/TpcRawWriter.cc
@@ -6,8 +6,7 @@
 #include <micromegas/MicromegasDefs.h>
 
 #include <trackbase/TrkrClusterContainerv4.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
+#include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterHitAssocv3.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHit.h>

--- a/offline/packages/tpc/TpcRawWriter.h
+++ b/offline/packages/tpc/TpcRawWriter.h
@@ -41,8 +41,7 @@ class TpcRawWriter : public SubsysReco
   void set_max_cluster_half_size_phi(unsigned short size) { MaxClusterHalfSizePhi = size ;}
   void set_max_cluster_half_size_z(unsigned short size) { MaxClusterHalfSizeZ = size ;}
   void set_drift_velocity_scale(double value) { m_drift_velocity_scale = value; }
-  void set_cluster_version(int value) { cluster_version = value; }
-  
+ 
  private:
   
   TrkrHitSetContainer *m_hits = nullptr;
@@ -58,7 +57,7 @@ class TpcRawWriter : public SubsysReco
   double SectorFiducialCut = 0.5;
   unsigned short MaxClusterHalfSizePhi = 3;
   unsigned short MaxClusterHalfSizeZ = 5;
-  int cluster_version = 3;
+ 
   /// drift velocity scale factor
 
   double m_drift_velocity_scale = 1.0;

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -327,15 +327,10 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     // cluster errors
     double clusRPhiErr = 0;
     double clusZErr = 0;
-    if( m_cluster_version == 4 )
-    {
-      const auto errors_square = m_cluster_error_parametrization.get_cluster_error( cluster, clusR, cluskey, track->get_tpc_seed()->get_qOverR(), track->get_tpc_seed()->get_slope() ); 
-      clusRPhiErr = std::sqrt( errors_square.first );
-      clusZErr = std::sqrt( errors_square.second );
-    } else {
-      clusRPhiErr = cluster->getRPhiError();
-      clusZErr = cluster->getZError();
-    }
+ 
+    clusRPhiErr = cluster->getRPhiError();
+    clusZErr = cluster->getZError();
+    
     
     if(Verbosity() > 3)
     {
@@ -351,16 +346,6 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
      * as instructed by Christof, it should not be necessary to cut on small
      * cluster errors any more with clusters of version 4 or higher 
      */ 
-    if( m_cluster_version < 4 )
-    {
-      /*
-       * remove clusters with too small errors since they are likely pathological
-       * and have a large contribution to the chisquare
-       * TODO: make these cuts configurable
-       */
-      if(clusRPhiErr < 0.015) continue;
-      if(clusZErr < 0.05) continue;
-    }
     
     const auto globalStatePos = trackStateParams.position(m_tGeometry->geometry().getGeoContext());
     const auto globalStateMom = trackStateParams.momentum();

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -83,10 +83,6 @@ class PHTpcResiduals : public SubsysReco
   void setUseMicromegas( bool value )
   { m_useMicromegas = value; }
 
-  /// cluster version
-  /* Note: this could be retrived automatically using dynamic casts from TrkrCluster objects */
-  void setClusterVersion(int value) { m_cluster_version = value; }
-
   private:
 
   using BoundTrackParam = 
@@ -159,9 +155,6 @@ class PHTpcResiduals : public SubsysReco
   /// cluster error parametrisation
   ClusterErrorPara m_cluster_error_parametrization;
   
-  /// cluster version
-  int m_cluster_version = 4;
-
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
   

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -444,32 +444,13 @@ void TpcSpaceChargeReconstruction::process_track( SvtxTrack* track )
     const auto cluster_z = global_position.z();
 
     // cluster errors
-    double cluster_rphi_error = 0;
-    double cluster_z_error = 0;
-    if( m_cluster_version >= 4 )
-    {
-      const auto errors_square = m_cluster_error_parametrization.get_cluster_error(cluster, cluster_r, cluster_key, track->get_tpc_seed()->get_qOverR(), track->get_tpc_seed()->get_slope() ); 
-      cluster_rphi_error = std::sqrt( errors_square.first );
-      cluster_z_error = std::sqrt( errors_square.second );
-    } else {
-      cluster_rphi_error = cluster->getRPhiError();
-      cluster_z_error = cluster->getZError();
-    }
-
+    double cluster_rphi_error = cluster->getRPhiError();
+    double cluster_z_error = cluster->getZError();
+    
     /* 
      * as instructed by Christof, it should not be necessary to cut on small
      * cluster errors any more with clusters of version 4 or higher 
-     */ 
-    if( m_cluster_version < 4 )
-    {
-      /*
-       * remove clusters with too small errors since they are likely pathological
-       * and have a large contribution to the chisquare
-       * TODO: make these cuts configurable
-       */
-      if( cluster_rphi_error < 0.015 ) continue;
-      if( cluster_z_error < 0.05 ) continue;
-    }
+     */
     
     // find track state that is the closest to cluster
     /* this assumes that both clusters and states are sorted along r */

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.h
@@ -82,10 +82,6 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
   /// output file name for evaluation histograms
   void set_histogram_outputfile(const std::string &outputfile) {m_histogramfilename = outputfile;}
   
-  /// cluster version
-  /* Note: this could be retrived automatically using dynamic casts from TrkrCluster objects */
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
   /// output file
   /**
    * this is the file where space charge matrix container is stored
@@ -165,10 +161,7 @@ class TpcSpaceChargeReconstruction: public SubsysReco, public PHParameterInterfa
  
   /// cluster error parametrisation
   ClusterErrorPara m_cluster_error_parametrization;
-  
-  /// cluster version
-  int m_cluster_version = 4;
-  
+ 
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
 

--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -61,41 +61,20 @@ double ALICEKF::getClusterError(TrkrCluster* c, TrkrDefs::cluskey key, Acts::Vec
   else 
     {
       TMatrixF localErr(3,3);
-      if(m_cluster_version==3){
-	localErr[0][0] = 0.;
-	localErr[0][1] = 0.;
-	localErr[0][2] = 0.;
-	localErr[1][0] = 0.;
-	localErr[1][1] = c->getActsLocalError(0,0);
-	localErr[1][2] = c->getActsLocalError(0,1);
-	localErr[2][0] = 0.;
-	localErr[2][1] = c->getActsLocalError(1,0);
-	localErr[2][2] = c->getActsLocalError(2,0);
-      }else if(m_cluster_version==4){
-	std::pair<double, double> para_errors = _ClusErrPara->get_fix_tpc_cluster_error(c,key);
-	localErr[0][0] = 0.;
-	localErr[0][1] = 0.;
-	localErr[0][2] = 0.;
-	localErr[1][0] = 0.;
-	localErr[1][1] = para_errors.first;
-	localErr[1][2] = 0.;
-	localErr[2][0] = 0.;
-	localErr[2][1] = 0.;
-	localErr[2][2] = para_errors.second;
-      }else if(m_cluster_version==5){
-	double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-	auto para_errors = _ClusErrPara->get_clusterv5_modified_error(c,clusRadius,key);
-
-	localErr[0][0] = 0.;
-	localErr[0][1] = 0.;
-	localErr[0][2] = 0.;
-	localErr[1][0] = 0.;
-	localErr[1][1] = para_errors.first;
-	localErr[1][2] = 0.;
-	localErr[2][0] = 0.;
-	localErr[2][1] = 0.;
-	localErr[2][2] = para_errors.second;
-      }
+    
+      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
+      auto para_errors = _ClusErrPara->get_clusterv5_modified_error(c,clusRadius,key);
+      
+      localErr[0][0] = 0.;
+      localErr[0][1] = 0.;
+      localErr[0][2] = 0.;
+      localErr[1][0] = 0.;
+      localErr[1][1] = para_errors.first;
+      localErr[1][2] = 0.;
+      localErr[2][0] = 0.;
+      localErr[2][1] = 0.;
+      localErr[2][2] = para_errors.second;
+      
       float clusphi = atan2(global(1), global(0));
       TMatrixF ROT(3,3);
       ROT[0][0] = cos(clusphi);
@@ -354,13 +333,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     
 	float nextclusrad = std::sqrt(nextCluster_x*nextCluster_x +
 				      nextCluster_y*nextCluster_y);
-	float nextclusphierr = 0;
-	if(m_cluster_version==3){
-	  nextclusphierr = nextCluster->getRPhiError() / nextclusrad;
-	}else if(m_cluster_version==4){
-	  auto para_errors = _ClusErrPara->get_fix_tpc_cluster_error(nextCluster,*clusterkey);
-	  nextclusphierr = sqrt(para_errors.first);
-	}
+	float nextclusphierr = nextCluster->getRPhiError() / nextclusrad;;
 
 	cx.push_back(nextCluster_x);
         cy.push_back(nextCluster_y);
@@ -421,15 +394,8 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     auto lcluster = _cluster_map->findCluster(trackKeyChain.back());
     const auto& lclusterglob = globalPositions.at(trackKeyChain.back());
     const float lclusterrad = sqrt(lclusterglob(0)*lclusterglob(0) + lclusterglob(1)*lclusterglob(1));
-    double last_cluster_phierr = 0;
-//    std::cout << " lversion: "<< m_cluster_version << std::endl;
-    if(m_cluster_version==3){
-      last_cluster_phierr = lcluster->getRPhiError() / lclusterrad;
-    }else if(m_cluster_version==4){
-      //ClusterErrorPara ClusErrPara;
-      auto para_errors = _ClusErrPara->get_fix_tpc_cluster_error(lcluster,trackKeyChain.back());
-      last_cluster_phierr  = sqrt(para_errors.first);
-    }
+    double last_cluster_phierr = lcluster->getRPhiError() / lclusterrad;;
+
     // phi error assuming error in track radial coordinate is zero
     double track_phierr = sqrt(pow(last_cluster_phierr,2)+(pow(trackSeed.GetX(),2)*trackSeed.GetErr2Y()) / 
       pow(pow(trackSeed.GetX(),2)+pow(trackSeed.GetY(),2),2));

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -62,7 +62,7 @@ class ALICEKF
   std::vector<double> GetCircleClusterResiduals(const std::vector<std::pair<double,double>>& pts, double R, double X0, double Y0) const;
   std::vector<double> GetLineClusterResiduals(const std::vector<std::pair<double,double>>& pts, double A, double B) const; 
   double get_Bzconst() const { return _Bzconst; }
-  void set_cluster_version(int value) { m_cluster_version = value; }
+  
   ClusterErrorPara *_ClusErrPara;
   private:
   PHField* _B = nullptr;
@@ -79,7 +79,6 @@ class ALICEKF
   bool _use_fixed_clus_error = true;
   std::array<double,3> _fixed_clus_error = {.1,.1,.1};
 
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/packages/trackreco/ActsAlignmentStates.cc
+++ b/offline/packages/trackreco/ActsAlignmentStates.cc
@@ -129,24 +129,10 @@ void ActsAlignmentStates::fillAlignmentStateMap(const Trajectory& traj,
 
     Acts::Vector3 clus_sigma(0, 0, 0);
 
-    if (m_clusterVersion != 4)
-      {
-        clus_sigma(2) = clus->getZError() * Acts::UnitConstants::cm;
-        clus_sigma(0) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-        clus_sigma(1) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
-      }
-    else 
-      {
-        double clusRadius = sqrt(clusGlobal(0) * clusGlobal(0) + clusGlobal(1) * clusGlobal(1)) / Acts::UnitConstants::cm;
-        auto para_errors = m_clusErrPara.get_simple_cluster_error(clus, clusRadius, ckey);
-        float exy2 = para_errors.first * Acts::UnitConstants::cm2;
-        float ez2 = para_errors.second * Acts::UnitConstants::cm2;
-        clus_sigma(2) = sqrt(ez2);
-        clus_sigma(0) = sqrt(exy2 / 2.0);
-        clus_sigma(1) = sqrt(exy2 / 2.0);
-      }
-  
- 
+    clus_sigma(2) = clus->getZError() * Acts::UnitConstants::cm;
+    clus_sigma(0) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+    clus_sigma(1) = clus->getRPhiError() / sqrt(2) * Acts::UnitConstants::cm;
+           
     if (m_verbosity > 2)
     {
       std::cout << "clus global is " << clusGlobal.transpose() << std::endl

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -32,7 +32,7 @@ class ActsAlignmentStates
 
   ActsAlignmentStates() {}
   ~ActsAlignmentStates() {}
-  void clusterVersion(const int v) { m_clusterVersion = v; }
+  
   void fillAlignmentStateMap(const Trajectory& traj,
                              SvtxTrack* track,
                              const ActsTrackFittingAlgorithm::MeasurementContainer& measurements);
@@ -56,7 +56,6 @@ class ActsAlignmentStates
   SvtxAlignmentState::GlobalMatrix makeGlobalDerivatives(const Acts::Vector3& OM, const std::pair<Acts::Vector3, Acts::Vector3>& projxy);
 
   int m_verbosity = 0;
-  int m_clusterVersion = 4;
 
   float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
 

--- a/offline/packages/trackreco/PHActsGSF.cc
+++ b/offline/packages/trackreco/PHActsGSF.cc
@@ -324,37 +324,14 @@ SourceLinkVec PHActsGSF::getSourceLinks(TrackSeed* track,
     indices[0] = Acts::BoundIndices::eBoundLoc0;
     indices[1] = Acts::BoundIndices::eBoundLoc1;
     Acts::ActsSymMatrix<2> cov = Acts::ActsSymMatrix<2>::Zero();
-    if (m_cluster_version == 3)
-    {
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) =
-          cluster->getActsLocalError(0, 0) * Acts::UnitConstants::cm2;
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc1) =
-          cluster->getActsLocalError(0, 1) * Acts::UnitConstants::cm2;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc0) =
-          cluster->getActsLocalError(1, 0) * Acts::UnitConstants::cm2;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) =
-          cluster->getActsLocalError(1, 1) * Acts::UnitConstants::cm2;
-    }
-    else if (m_cluster_version == 4)
-    {
-      double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
-      auto para_errors = _ClusErrPara.get_cluster_error(cluster, clusRadius, cluskey, track->get_qOverR(), track->get_slope());
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
-    }
-    else if (m_cluster_version == 5)
-    {
-      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-      TrkrClusterv5* clusterv5 = dynamic_cast<TrkrClusterv5*>(cluster);
-      auto para_errors = _ClusErrPara.get_clusterv5_modified_error(clusterv5,clusRadius,cluskey);
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
-      cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
-      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
-    }
-
+  
+    double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
+    auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
+    cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
+    cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
+    cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
+    cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
+    
     ActsSourceLink::Index index = measurements.size();
 
     SourceLink sl(surf->geometryId(), index, cluskey);

--- a/offline/packages/trackreco/PHActsGSF.h
+++ b/offline/packages/trackreco/PHActsGSF.h
@@ -48,7 +48,7 @@ class PHActsGSF : public SubsysReco
   PHActsGSF(const std::string& name = "PHActsGSF");
 
   ~PHActsGSF() override;
-  void set_cluster_version(int version) { m_cluster_version = version; }
+  
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode* topNode) override;
   int End(PHCompositeNode* topNode) override;
@@ -83,7 +83,7 @@ class PHActsGSF : public SubsysReco
 
   std::string m_trackMapName = "SvtxTrackMap";
   unsigned int m_pHypothesis = 11;
-  int m_cluster_version = 4;
+ 
   ClusterErrorPara _ClusErrPara;
 
   ActsTrackFittingAlgorithm::Config m_fitCfg;

--- a/offline/packages/trackreco/PHActsKDTreeSeeding.cc
+++ b/offline/packages/trackreco/PHActsKDTreeSeeding.cc
@@ -384,17 +384,10 @@ SpacePointPtr PHActsKDTreeSeeding::makeSpacePoint(const Surface& surf,
 				  localPos, mom);
 
   Acts::SymMatrix2 localCov = Acts::SymMatrix2::Zero();
-  if(m_clusterVersion==3)
-    {
-      localCov(0,0) = clus->getActsLocalError(0,0) * Acts::UnitConstants::cm2;
-      localCov(1,1) = clus->getActsLocalError(1,1) * Acts::UnitConstants::cm2;
-    }
-  else if(m_clusterVersion==4)
-    {
-      auto para_errors = m_clusErrPara.get_si_cluster_error(clus,key);
-      localCov(0,0) = para_errors.first * Acts::UnitConstants::cm2;
-      localCov(1,1) = para_errors.second * Acts::UnitConstants::cm2;
-    }
+
+  localCov(0,0) = clus->getActsLocalError(0,0) * Acts::UnitConstants::cm2;
+  localCov(1,1) = clus->getActsLocalError(1,1) * Acts::UnitConstants::cm2;
+  
     
   float x = globalPos.x();
   float y = globalPos.y();

--- a/offline/packages/trackreco/PHActsKDTreeSeeding.h
+++ b/offline/packages/trackreco/PHActsKDTreeSeeding.h
@@ -37,7 +37,6 @@ class PHActsKDTreeSeeding : public SubsysReco
   int End(PHCompositeNode *topNode) override;
   
   void useTruthClusters(bool truth) { m_useTruthClusters = truth; }
-  void set_cluster_version(int ver) { m_clusterVersion = ver; }
  private:
 
   Acts::SeedFinderOrthogonalConfig<SpacePoint> configureSeedFinder();
@@ -96,7 +95,7 @@ class PHActsKDTreeSeeding : public SubsysReco
   int m_nIteration = 0;
   std::string m_trackMapName = "SiliconTrackSeedContainer";
   bool m_useTruthClusters = false;
-  int m_clusterVersion = 4;
+
   ClusterErrorPara m_clusErrPara;
   float m_uncfactor = 3.175;
   const static int m_nInttLayers = 4;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -565,17 +565,9 @@ SpacePointPtr PHActsSiliconSeeding::makeSpacePoint(
 				  localPos, mom);
 
   Acts::SymMatrix2 localCov = Acts::SymMatrix2::Zero();
-  if(m_cluster_version==3){
-    localCov(0,0) = clus->getActsLocalError(0,0) * Acts::UnitConstants::cm2;
-    localCov(1,1) = clus->getActsLocalError(1,1) * Acts::UnitConstants::cm2;
-  }else if(m_cluster_version==4){
-    auto para_errors = _ClusErrPara.get_si_cluster_error(clus,key);
-    localCov(0,0) = para_errors.first* Acts::UnitConstants::cm2;
-    localCov(1,1) = para_errors.second* Acts::UnitConstants::cm2;
-  }else if(m_cluster_version==5){
-    localCov(0,0) = pow(clus->getRPhiError(),2) * Acts::UnitConstants::cm2;
-    localCov(1,1) = pow(clus->getZError(),2) * Acts::UnitConstants::cm2;
-  }
+  localCov(0,0) = pow(clus->getRPhiError(),2) * Acts::UnitConstants::cm2;
+  localCov(1,1) = pow(clus->getZError(),2) * Acts::UnitConstants::cm2;
+  
     
   float x = globalPos.x();
   float y = globalPos.y();

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -105,7 +105,6 @@ class PHActsSiliconSeeding : public SubsysReco
 
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   void SetIteration(int iter){_n_iteration = iter;}
-  void set_cluster_version(int value) { m_cluster_version = value; }
 
  private:
 
@@ -250,7 +249,7 @@ class PHActsSiliconSeeding : public SubsysReco
   TH2 *h_projHits = nullptr;
   TH2 *h_zprojHits = nullptr;
   TH2 *h_resids = nullptr;
-  int m_cluster_version = 3;
+
 };
 
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -88,7 +88,6 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
   m_alignStates.actsGeometry(m_tGeometry);
   m_alignStates.clusters(m_clusterContainer);
   m_alignStates.stateMap(m_alignmentStateMap);
-  m_alignStates.clusterVersion(m_cluster_version);
   m_alignStates.verbosity(Verbosity());
 
   m_fitCfg.fit = ActsTrackFittingAlgorithm::makeKalmanFitterFunction(
@@ -707,31 +706,13 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       indices[1] = Acts::BoundIndices::eBoundLoc1;
       Acts::ActsSymMatrix<2> cov = Acts::ActsSymMatrix<2>::Zero();
 
-      if(m_cluster_version==3){
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = 
-	  cluster->getActsLocalError(0,0) * Acts::UnitConstants::cm2;
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc1) =
-	  cluster->getActsLocalError(0,1) * Acts::UnitConstants::cm2;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 
-	  cluster->getActsLocalError(1,0) * Acts::UnitConstants::cm2;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = 
-	  cluster->getActsLocalError(1,1) * Acts::UnitConstants::cm2;
-      }else if(m_cluster_version==4){
-	double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-	auto para_errors = _ClusErrPara.get_cluster_error(cluster,clusRadius,cluskey, track->get_qOverR(), track->get_slope());
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
-      }else if(m_cluster_version==5){
-	double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-	auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
-	cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
-	cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
-      }
-
+      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
+      auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
+      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = para_errors.first * Acts::UnitConstants::cm2;
+      cov(Acts::eBoundLoc0, Acts::eBoundLoc1) = 0;
+      cov(Acts::eBoundLoc1, Acts::eBoundLoc0) = 0;
+      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = para_errors.second * Acts::UnitConstants::cm2;
+      
       ActsSourceLink::Index index = measurements.size();
       
       SourceLink sl(surf->geometryId(), index, cluskey);

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -105,8 +105,6 @@ class PHActsTrkFitter : public SubsysReco
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
   void set_seed_track_map_name(const std::string &map_name) { _seed_track_map_name = map_name; }
 
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
 
@@ -231,7 +229,6 @@ class PHActsTrkFitter : public SubsysReco
   TH1 *h_updateTime = nullptr;
   TH1 *h_stateTime = nullptr;
   TH1 *h_rotTime = nullptr;
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1172,42 +1172,9 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
     }
     
     // get cluster errors
-    double cluster_rphi_error = 0;
-    double cluster_z_error = 0;
-    if( m_cluster_version == 4 )
-    {
-      // get error from cluster error parametrization 
-      // get cluster radius
-      const auto cluster_r = std::sqrt(square(globalPosition_acts.x()) + square(globalPosition_acts.y()));
-
-      // decide of which seed to use depending on detector id
-      switch(  TrkrDefs::getTrkrId(cluster_key) )
-      {
-        case TrkrDefs::mvtxId:
-        case TrkrDefs::inttId:
-        {
-          const auto errors_square = m_cluster_error_parametrization.get_cluster_error(cluster, cluster_r, cluster_key, intrack->get_silicon_seed()->get_qOverR(), intrack->get_silicon_seed()->get_slope() ); 
-          cluster_rphi_error = std::sqrt( errors_square.first );
-          cluster_z_error = std::sqrt( errors_square.second );
-          break;
-        }
-        
-        case TrkrDefs::micromegasId:
-        case TrkrDefs::tpcId:
-        {
-          const auto errors_square = m_cluster_error_parametrization.get_cluster_error(cluster, cluster_r, cluster_key, intrack->get_tpc_seed()->get_qOverR(), intrack->get_tpc_seed()->get_slope() ); 
-          cluster_rphi_error = std::sqrt( errors_square.first );
-          cluster_z_error = std::sqrt( errors_square.second );
-          break;
-        }
-      }
-    } else {
-      // get error directly from cluster
-      cluster_rphi_error = cluster->getRPhiError();
-      cluster_z_error = cluster->getZError();
-    }
-
-
+    double cluster_rphi_error = cluster->getRPhiError();
+    double cluster_z_error = cluster->getZError();
+    
     // create measurement
     auto meas = new PHGenFit::PlanarMeasurement(pos, n, cluster_rphi_error, cluster_z_error);
 

--- a/offline/packages/trackreco/PHGenFitTrkFitter.h
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.h
@@ -232,10 +232,6 @@ class PHGenFitTrkFitter : public SubsysReco
     _vertex_min_ndf = vertexMinPT;
   }
 
-  /// cluster version
-  /* Note: this could be retrived automatically using dynamic casts from TrkrCluster objects */
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
   //!@name disabled layers interface
   //@{
 
@@ -369,9 +365,6 @@ class PHGenFitTrkFitter : public SubsysReco
  
   /// cluster error parametrisation
   ClusterErrorPara m_cluster_error_parametrization;
-  
-  /// cluster version
-  int m_cluster_version = 4;
 
   //! Evaluation
   //! switch eval out

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -97,14 +97,12 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 				     _min_clusters_per_track,_max_sin_phi,Verbosity());
   fitter->useConstBField(_use_const_field);
   fitter->useFixedClusterError(_use_fixed_clus_err);
-  fitter->set_cluster_version( m_cluster_version );
-  std::cout << "simple kf cluster version " << m_cluster_version << std::endl;
   fitter->setFixedClusterError(0,_fixed_clus_err.at(0));
   fitter->setFixedClusterError(1,_fixed_clus_err.at(1));
   fitter->setFixedClusterError(2,_fixed_clus_err.at(2));
   //  _field_map = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
   // m_Cache = magField->makeCache(m_tGeometry->magFieldContext);
-  std::cout << "done init " << m_cluster_version << std::endl;
+ 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -58,8 +58,7 @@ class PHSimpleKFProp : public SubsysReco
   void use_truth_clusters(bool truth)
   { _use_truth_clusters = truth; }
   void SetIteration(int iter){_n_iteration = iter;}
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+ 
  private:
 
   /// tpc distortion correction utility class
@@ -154,7 +153,6 @@ class PHSimpleKFProp : public SubsysReco
   TrkrClusterIterationMapv1* _iteration_map = nullptr;
   int _n_iteration = 0;
 
-  int m_cluster_version = 4;
 };
 
 #endif

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -1957,7 +1957,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  pedge = cluster->getEdge();
 	  ovlp = cluster->getOverlap();
 	
-	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
+	  if(hitsetlayer==7||hitsetlayer==22||hitsetlayer==23||hitsetlayer==38||hitsetlayer==39) redge = 1;
 
           float e = cluster->getAdc();
           float adc = cluster->getAdc();

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -2290,14 +2290,13 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  pedge = cluster->getEdge();
 	  ovlp = cluster->getOverlap();
           
-	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
-
-          float e = cluster->getAdc();
+	  float e = cluster->getAdc();
           float adc = cluster->getAdc();
           float local_layer = (float) TrkrDefs::getLayer(cluster_key);
           float sector = TpcDefs::getSectorId(cluster_key);
           float side = TpcDefs::getSide(cluster_key);
           // count all hits for this cluster
+	  if(local_layer==7||local_layer==22||local_layer==23||local_layer==38||local_layer==39) redge = 1;
 
           // count all hits for this cluster
           TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -15,9 +15,6 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
-#include <trackbase/TrkrClusterv5.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
@@ -1949,49 +1946,17 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  float pedge = NAN;
 	  float ovlp = NAN;
 
-          if (m_cluster_version == 3)
-          {
-            auto globerr = calculateClusterError(cluster, phi);
-            ex = sqrt(globerr[0][0]);
-            ey = sqrt(globerr[1][1]);
-            ez = cluster->getZError();
-            ephi = cluster->getRPhiError();
-          }
-          else if (m_cluster_version == 4)
-          {
-            phisize = cluster->getPhiSize();
-            zsize = cluster->getZSize();
-            TrackSeed* seed = nullptr;
-            if (track != nullptr)
-            {
-              if (layer < 7)
-              {
-                seed = track->get_silicon_seed();
-              }
-              else
-              {
-                seed = track->get_tpc_seed();
-              }
-              if (seed != nullptr)
-              {
-                auto para_errors = ClusErrPara.get_cluster_error(cluster, r, cluster_key, seed->get_qOverR(), seed->get_slope());
-                pephi = sqrt(para_errors.first * Acts::UnitConstants::cm2);
-                pez = sqrt(para_errors.second * Acts::UnitConstants::cm2);
-              }
-            }
-          }
-          else if (m_cluster_version == 5)
-          {
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
-            phisize = cluster->getPhiSize();
-            zsize = cluster->getZSize();
-            // double clusRadius = r;
-            ez = sqrt(para_errors.second);
-            ephi = sqrt(para_errors.first);
-            maxadc = cluster->getMaxAdc();
-	    pedge = cluster->getEdge();
-	    ovlp = cluster->getOverlap();
-          }
+
+	  auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
+	  phisize = cluster->getPhiSize();
+	  zsize = cluster->getZSize();
+	  // double clusRadius = r;
+	  ez = sqrt(para_errors.second);
+	  ephi = sqrt(para_errors.first);
+	  maxadc = cluster->getMaxAdc();
+	  pedge = cluster->getEdge();
+	  ovlp = cluster->getOverlap();
+	
 	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
 
           float e = cluster->getAdc();
@@ -2315,47 +2280,16 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	  float pedge = NAN;
 	  float ovlp = NAN;
 
-          if (m_cluster_version == 3)
-          {
-            auto globerr = calculateClusterError(cluster, phi);
-            ex = sqrt(globerr[0][0]);
-            ey = sqrt(globerr[1][1]);
-            ez = cluster->getZError();
-            ephi = cluster->getRPhiError();
-          }
-          else if (m_cluster_version == 4)
-          {
-            phisize = cluster->getPhiSize();
-            zsize = cluster->getZSize();
-            double clusRadius = r;
-            TrackSeed* seed = nullptr;
-            if (layer < 7)
-            {
-              seed = track->get_silicon_seed();
-            }
-            else
-            {
-              seed = track->get_tpc_seed();
-            }
-            if (seed != nullptr)
-            {
-              auto para_errors = ClusErrPara.get_cluster_error(cluster, clusRadius, cluster_key, seed->get_qOverR(), seed->get_slope());
-              pephi = sqrt(para_errors.first * Acts::UnitConstants::cm2);
-              pez = sqrt(para_errors.second * Acts::UnitConstants::cm2);
-            }
-          }
-          else if (m_cluster_version == 5)
-          {
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
-            phisize = cluster->getPhiSize();
-            zsize = cluster->getZSize();
-            // double clusRadius = r;
-            ez = sqrt(para_errors.second);
-            ephi = sqrt(para_errors.first);
-            maxadc = cluster->getMaxAdc();
-	    pedge = cluster->getEdge();
-	    ovlp = cluster->getOverlap();
-          }
+	  auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster, r, cluster_key);
+	  phisize = cluster->getPhiSize();
+	  zsize = cluster->getZSize();
+	  // double clusRadius = r;
+	  ez = sqrt(para_errors.second);
+	  ephi = sqrt(para_errors.first);
+	  maxadc = cluster->getMaxAdc();
+	  pedge = cluster->getEdge();
+	  ovlp = cluster->getOverlap();
+          
 	  if(layer==7||layer==22||layer==23||layer==38||layer==39) redge = 1;
 
           float e = cluster->getAdc();
@@ -2649,30 +2583,14 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           r = sqrt(x * x + y * y);
           phi = pos.Phi();
           eta = pos.Eta();
-          if (m_cluster_version == 3)
-          {
-            auto globerr = calculateClusterError(reco_cluster, phi);
-            ex = sqrt(globerr[0][0]);
-            ey = sqrt(globerr[1][1]);
-            ez = reco_cluster->getZError();
-            ephi = reco_cluster->getRPhiError();
-          }
-          else if (m_cluster_version == 4)
-          {
-            // std::cout << " ver v4 " <<  std::endl;
-            phisize = reco_cluster->getPhiSize();
-            zsize = reco_cluster->getZSize();
-          }
-          else if (m_cluster_version == 5)
-          {
+                 
+	  auto para_errors = ClusErrPara.get_clusterv5_modified_error(reco_cluster, r, ckey);
+	  // std::cout << " ver v4 " <<  std::endl;
+	  phisize = reco_cluster->getPhiSize();
+	  zsize = reco_cluster->getZSize();
+	  ez = sqrt(para_errors.second);
+	  ephi = sqrt(para_errors.first);
           
-            auto para_errors = ClusErrPara.get_clusterv5_modified_error(reco_cluster, r, ckey);
-            // std::cout << " ver v4 " <<  std::endl;
-            phisize = reco_cluster->getPhiSize();
-            zsize = reco_cluster->getZSize();
-            ez = sqrt(para_errors.second);
-            ephi = sqrt(para_errors.first);
-          }
 
           adc = reco_cluster->getAdc();
 
@@ -3192,21 +3110,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 		float govlp = 0 ;
 		float gedge = 0;
 		if(cluster!=nullptr){
-		  if(m_cluster_version==4){
-		    TrkrClusterv4 *clusterv4 = dynamic_cast<TrkrClusterv4 *>(cluster);
-		    gphisize = clusterv4->getPhiSize();
-		    //zsize = clusterv4->getZSize();
-		    
-		  }else if(m_cluster_version==5){
-		    
-		    gphisize = cluster->getPhiSize();
-		    //zsize = clusterv5->getZSize();
-		    auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
-		    //zerr = sqrt(para_errors.second);
-		    gphierr = sqrt(para_errors.first);
-		    govlp = cluster->getOverlap();
-		    gedge = cluster->getEdge();
-		  } 
+        
+		  gphisize = cluster->getPhiSize();
+		  //zsize = clusterv5->getZSize();
+		  auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
+		  //zerr = sqrt(para_errors.second);
+		  gphierr = sqrt(para_errors.first);
+		  govlp = cluster->getOverlap();
+		  gedge = cluster->getEdge();
+		 
 		  if(gedge>0) npedge++;
 		  if(gphisize>=4) nbig++;
 		  if(govlp>=2) novlp++;
@@ -3707,21 +3619,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
 	    float rovlp = 0 ;
 	    float pedge = 0;
 	    if(cluster!=nullptr){
-	      if(m_cluster_version==4){
-		TrkrClusterv4 *clusterv4 = dynamic_cast<TrkrClusterv4 *>(cluster);
-		rphisize = clusterv4->getPhiSize();
-		//zsize = clusterv4->getZSize();
-		
-	      }else if(m_cluster_version==5){
-        
-		rphisize = cluster->getPhiSize();
-		//zsize = clusterv5->getZSize();
-		auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
-		//zerr = sqrt(para_errors.second);
-		rphierr = sqrt(para_errors.first);
-		rovlp = cluster->getOverlap();
-		pedge = cluster->getEdge();
-	      } 
+	     
+	      rphisize = cluster->getPhiSize();
+	      //zsize = clusterv5->getZSize();
+	      auto para_errors = ClusErrPara.get_clusterv5_modified_error(cluster,r,cluster_key);
+	      //zerr = sqrt(para_errors.second);
+	      rphierr = sqrt(para_errors.first);
+	      rovlp = cluster->getOverlap();
+	      pedge = cluster->getEdge();
+	       
 	      if(pedge>0) npedge++;
 	      if(rphisize>=4) nbig++;
 	      if(rovlp>=2) novlp++;

--- a/simulation/g4simulation/g4eval/SvtxEvaluator.h
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.h
@@ -72,8 +72,7 @@ class SvtxEvaluator : public SubsysReco
   void do_vtx_eval_light(bool b) { _do_vtx_eval_light = b; }
   void scan_for_embedded(bool b) { _scan_for_embedded = b; }
   void scan_for_primaries(bool b) { _scan_for_primaries = b; }
-  void set_cluster_version(int value) { m_cluster_version = value; }
-
+  
  private:
   unsigned int _ievent = 0;
   unsigned int _iseed = 0;
@@ -140,7 +139,7 @@ class SvtxEvaluator : public SubsysReco
   void fillOutputNtuples(PHCompositeNode *topNode);  ///< dump the evaluator information into ntuple for external analysis
   void printInputInfo(PHCompositeNode *topNode);     ///< print out the input object information (debugging upstream components)
   void printOutputInfo(PHCompositeNode *topNode);    ///< print out the ancestry information for detailed diagnosis
-  int m_cluster_version = 4;
+ 
 };
 
 #endif  // G4EVAL_SVTXEVALUATOR_H

--- a/simulation/g4simulation/g4eval/TrackEvaluation.cc
+++ b/simulation/g4simulation/g4eval/TrackEvaluation.cc
@@ -27,8 +27,6 @@
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
-#include <trackbase/TrkrClusterv4.h>
-#include <trackbase/TrkrClusterv5.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
@@ -236,14 +234,13 @@ namespace
   //! number of hits associated to cluster
   void add_cluster_size(TrackEvaluationContainerv1::ClusterStruct& cluster, TrkrCluster* trk_clus)
   {
-    TrkrClusterv5* trk_clusv5 = dynamic_cast<TrkrClusterv5*>(trk_clus);
-    cluster.size = trk_clusv5->getSize();
-    cluster.phi_size = trk_clusv5->getPhiSize();
-    cluster.z_size = trk_clusv5->getZSize();
-    cluster.ovlp = trk_clusv5->getOverlap();
-    cluster.edge = trk_clusv5->getEdge();
-    cluster.adc = trk_clusv5->getAdc();
-    cluster.max_adc = trk_clusv5->getMaxAdc();
+    cluster.size = trk_clus->getSize();
+    cluster.phi_size = trk_clus->getPhiSize();
+    cluster.z_size = trk_clus->getZSize();
+    cluster.ovlp = trk_clus->getOverlap();
+    cluster.edge = trk_clus->getEdge();
+    cluster.adc = trk_clus->getAdc();
+    cluster.max_adc = trk_clus->getMaxAdc();
   }
 
   //! hit energy for a given cluster


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR removes the cluster version flag from the macros and coresoftware, which opens us up to possible mistakes or places in the code where the correct version is not used in some weird way (e.g. as I found in ALICEKF.cc). In any case it creates a lot of extra code bloat that is not needed. Now that the base class is properly implemented there is no need for dynamic_casting anything and if a particular component does not exist in the implemented version it will be called from the base class.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
Requires https://github.com/sPHENIX-Collaboration/macros/pull/661
