### PR TITLE
feat: determine nwrong layers per subsystem in evaluator

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -176,7 +176,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                               "trackID:px:py:pz:pt:eta:phi:deltapt:deltaeta:deltaphi:"
 			      "siqr:siphi:sithe:six0:siy0:tpqr:tpphi:tpthe:tpx0:tpy0:"
                               "charge:quality:chisq:ndf:nhits:layers:nmaps:nintt:ntpc:nmms:ntpc1:ntpc11:ntpc2:ntpc3:nlmaps:nlintt:nltpc:nlmms:"
-                              "vertexID:vx:vy:vz:dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:ntruintt:ntrutpc:ntrumms:ntrutpc1:ntrutpc11:ntrutpc2:ntrutpc3:layersfromtruth:"
+                              "vertexID:vx:vy:vz:dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:nfromtruth:nwrong:ntrumaps:nwrongmaps:ntruintt:nwrongintt:ntrutpc:nwrongtpc:ntrumms:nwrongmms:ntrutpc1:nwrongtpc1:ntrutpc11:nwrongtpc11:ntrutpc2:nwrongtpc2:ntrutpc3:nwrongtpc3:layersfromtruth:"
 			      "npedge:nredge:nbig:novlp:merr:msize:"
                               "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
   }
@@ -192,8 +192,8 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                              "gpx:gpy:gpz:gpt:geta:gphi:"
                              "gvx:gvy:gvz:gvt:"
                              "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
-                             "gembed:gprimary:nfromtruth:nwrong:ntrumaps:ntruintt:"
-                             "ntrutpc:ntrumms:ntrutpc1:ntrutpc11:ntrutpc2:ntrutpc3:layersfromtruth:"
+                             "gembed:gprimary:nfromtruth:nwrong:ntrumaps:nwrongmaps:ntruintt:nwrongintt:"
+                             "ntrutpc:nwrongtpc:ntrumms:nwrongmms:ntrutpc1:nwrongtpc1:ntrutpc11:nwrongtpc11:ntrutpc2:nwrongtpc2:ntrutpc3:nwrongtpc3:layersfromtruth:"
 			     "npedge:nredge:nbig:novlp:merr:msize:"
                              "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
   }
@@ -2952,13 +2952,21 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float nfromtruth = NAN;
         float nwrong = NAN;
         float ntrumaps = NAN;
+	float nwrongmaps = NAN;
         float ntruintt = NAN;
+	float nwrongintt = NAN;
         float ntrumms = NAN;
+	float nwrongmms = NAN;
         float ntrutpc = NAN;
+	float nwrongtpc = NAN;
         float ntrutpc1 = NAN;
+	float nwrongtpc1 = NAN;
         float ntrutpc11 = NAN;
+	float nwrongtpc11 =NAN;
         float ntrutpc2 = NAN;
+	float nwrongtpc2 = NAN;
         float ntrutpc3 = NAN;
+	float nwrongtpc3 = NAN;
         float layersfromtruth = NAN;
 	float npedge = 0;
 	float nredge = 0;
@@ -3275,7 +3283,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntrumaps = trackeval->get_layer_range_contribution(track, g4particle, 0, _nlayers_maps);
+	      auto pair = trackeval->get_layer_range_contribution(track, g4particle, 0, _nlayers_maps);
+	      ntrumaps = pair.first;
+	      nwrongmaps = pair.second;
             }
             if (_nlayers_intt == 0)
             {
@@ -3283,7 +3293,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntruintt = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps, _nlayers_maps + _nlayers_intt);
+              auto pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps, _nlayers_maps + _nlayers_intt);
+	      ntruintt = pair.first;
+	      nwrongintt = pair.second;
             }
             if (_nlayers_mms == 0)
             {
@@ -3291,14 +3303,25 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntrumms = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + _nlayers_tpc, _nlayers_maps + _nlayers_intt + _nlayers_tpc + _nlayers_mms);
+	      auto pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + _nlayers_tpc, _nlayers_maps + _nlayers_intt + _nlayers_tpc + _nlayers_mms);
+	      ntrumms = pair.first;
+	      nwrongmms = pair.second;
             }
-            ntrutpc = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
-            ntrutpc1 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 16);
-            ntrutpc11 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 8);
-            ntrutpc2 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 16, _nlayers_maps + _nlayers_intt + 32);
-            ntrutpc3 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 32, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
-
+            auto pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
+	    ntrutpc = pair.first;
+	    nwrongtpc = pair.second;
+            pair  = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 16);
+	    ntrutpc1 = pair.first;
+	    nwrongtpc1 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 8);
+	    ntrutpc11 = pair.first;
+	    nwrongtpc11 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 16, _nlayers_maps + _nlayers_intt + 32);
+	    ntrutpc2 = pair.first;
+	    nwrongtpc2 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 32, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
+	    ntrutpc3 = pair.first;
+	    nwrongtpc3 = pair.first;
             layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track, g4particle);
           }
         }
@@ -3397,13 +3420,21 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                                nfromtruth,
                                nwrong,
                                ntrumaps,
+			       nwrongmaps,
                                ntruintt,
+			       nwrongintt,
                                ntrutpc,
+			       nwrongtpc,
                                ntrumms,
+			       nwrongmms,
                                ntrutpc1,
+			       nwrongtpc1,
                                ntrutpc11,
+			       nwrongtpc11,
                                ntrutpc2,
+			       nwrongtpc2,
                                ntrutpc3,
+			       nwrongtpc3,
                                layersfromtruth,
 			       npedge,
 			       nredge,
@@ -3810,13 +3841,21 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float nfromtruth = NAN;
         float nwrong = NAN;
         float ntrumaps = NAN;
+	float nwrongmaps = NAN;
         float ntruintt = NAN;
+	float nwrongintt = NAN;
         float ntrumms = NAN;
+	float nwrongmms = NAN;
         float ntrutpc = NAN;
+	float nwrongtpc = NAN;
         float ntrutpc1 = NAN;
+	float nwrongtpc1 = NAN;
         float ntrutpc11 = NAN;
+	float nwrongtpc11 = NAN;
         float ntrutpc2 = NAN;
+	float nwrongtpc2 = NAN;
         float ntrutpc3 = NAN;
+	float nwrongtpc3 = NAN;
         float layersfromtruth = NAN;
 
         if (_do_track_match)
@@ -3968,7 +4007,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntrumaps = trackeval->get_layer_range_contribution(track, g4particle, 0, _nlayers_maps);
+	      auto pair = trackeval->get_layer_range_contribution(track, g4particle, 0, _nlayers_maps);
+	      ntrumaps = pair.first;
+	      nwrongmaps = pair.second;
             }
             if (_nlayers_intt == 0)
             {
@@ -3976,7 +4017,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntruintt = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps, _nlayers_maps + _nlayers_intt);
+              auto pair =  trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps, _nlayers_maps + _nlayers_intt);
+	      ntruintt = pair.first;
+	      nwrongintt = pair.second;
             }
             if (_nlayers_mms == 0)
             {
@@ -3984,13 +4027,25 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             }
             else
             {
-              ntrumms = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + _nlayers_tpc, _nlayers_maps + _nlayers_intt + _nlayers_tpc + _nlayers_mms);
+              auto pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + _nlayers_tpc, _nlayers_maps + _nlayers_intt + _nlayers_tpc + _nlayers_mms);
+	      ntrumms = pair.first;
+	      nwrongmms = pair.second;
             }
-            ntrutpc = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
-            ntrutpc1 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 16);
-            ntrutpc11 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 8);
-            ntrutpc2 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 16, _nlayers_maps + _nlayers_intt + 32);
-            ntrutpc3 = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 32, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
+            auto pair  = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
+	    ntrutpc = pair.first;
+	    nwrongtpc = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 16);
+	    ntrutpc1 = pair.first;
+	    nwrongtpc1 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt, _nlayers_maps + _nlayers_intt + 8);
+	    ntrutpc11 = pair.first;
+	    nwrongtpc11 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 16, _nlayers_maps + _nlayers_intt + 32);
+	    ntrutpc2 = pair.first;
+	    nwrongtpc2 = pair.second;
+            pair = trackeval->get_layer_range_contribution(track, g4particle, _nlayers_maps + _nlayers_intt + 32, _nlayers_maps + _nlayers_intt + _nlayers_tpc);
+	    ntrutpc3 = pair.first;
+	    nwrongtpc3 = pair.second;
             layersfromtruth = trackeval->get_nclusters_contribution_by_layer(track, g4particle);
           }
         }
@@ -4077,13 +4132,21 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               nfromtruth,
 			      nwrong,
                               ntrumaps,
+			      nwrongmaps,
                               ntruintt,
+			      nwrongintt,
                               ntrutpc,
+			      nwrongtpc,
                               ntrumms,
+			      nwrongmms,
                               ntrutpc1,
+			      nwrongtpc1,
                               ntrutpc11,
+			      nwrongtpc11,
                               ntrutpc2,
+			      nwrongtpc2,
                               ntrutpc3,
+			      nwrongtpc3,
                               layersfromtruth,
 			      npedge,
 			      nredge,

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -867,12 +867,12 @@ unsigned int SvtxTrackEval::get_nclusters_contribution_by_layer(SvtxTrack* track
   return nclusters_by_layer;
 }
 
-unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4Particle* particle, unsigned int start_layer, unsigned int end_layer)
+std::pair<unsigned int, unsigned int> SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4Particle* particle, unsigned int start_layer, unsigned int end_layer)
 {
   if (!has_node_pointers())
   {
     ++_errors;
-    return 0;
+    return std::make_pair(0,0);
   }
 
   if (_strict)
@@ -883,16 +883,19 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
   else if (!track || !particle)
   {
     ++_errors;
-    return 0;
+    return std::make_pair(0,0);
   }
 
   unsigned int nmatches = 0;
+  unsigned int nwrong = 0;
   unsigned int nlayers = end_layer - start_layer;
 
   int layers[nlayers];
+  int layers_wrong[nlayers];
   for (unsigned int i = 0; i < nlayers; i++)
   {
     layers[i] = 0;
+    layers_wrong[i] = 0;
   }
   // loop over all clusters
   std::vector<TrkrDefs::cluskey> cluster_keys = get_track_ckeys(track);
@@ -927,6 +930,10 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
         //	nmatches |= (0x3FFFFFFF & (0x1 << cluster_layer));
         layers[cluster_layer - start_layer] = 1;
       }
+      else
+	{
+	  layers_wrong[cluster_layer - start_layer] = 1;
+	}
     }
   }
   for (unsigned int i = 0; i < nlayers; i++)
@@ -935,9 +942,14 @@ unsigned int SvtxTrackEval::get_layer_range_contribution(SvtxTrack* track, PHG4P
     {
       nmatches++;
     }
+    if(layers_wrong[i] == 1)
+      {
+	nwrong++;
+      }
   }
+  
 
-  return nmatches;
+  return std::make_pair(nmatches,nwrong);
 }
 
 void SvtxTrackEval::get_node_pointers(PHCompositeNode* topNode)

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.cc
@@ -923,18 +923,20 @@ std::pair<unsigned int, unsigned int> SvtxTrackEval::get_layer_range_contributio
 
     // loop over all particles
     std::set<PHG4Particle*> particles = _clustereval.all_truth_particles(cluster_key);
+    int matched = 0;
     for (auto candidate : particles)
     {
       if (get_truth_eval()->are_same_particle(candidate, particle))
       {
         //	nmatches |= (0x3FFFFFFF & (0x1 << cluster_layer));
         layers[cluster_layer - start_layer] = 1;
+	matched = 1;
       }
-      else
-	{
-	  layers_wrong[cluster_layer - start_layer] = 1;
-	}
     }
+    if(matched == 0)
+      {
+	layers_wrong[cluster_layer - start_layer] = 1;
+      }
   }
   for (unsigned int i = 0; i < nlayers; i++)
   {

--- a/simulation/g4simulation/g4eval/SvtxTrackEval.h
+++ b/simulation/g4simulation/g4eval/SvtxTrackEval.h
@@ -69,7 +69,7 @@ class SvtxTrackEval
   // overlap calculations
   void calc_cluster_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
   unsigned int get_nclusters_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
-  unsigned int get_layer_range_contribution(SvtxTrack* track, PHG4Particle* particle, unsigned int start_layer, unsigned int end_layer);
+  std::pair<unsigned int, unsigned int> get_layer_range_contribution(SvtxTrack* track, PHG4Particle* particle, unsigned int start_layer, unsigned int end_layer);
   unsigned int get_nclusters_contribution_by_layer(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
   unsigned int get_nwrongclusters_contribution(SvtxTrack* svtxtrack, PHG4Particle* truthparticle);
   unsigned int get_errors() { return _errors + _clustereval.get_errors(); }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Add branches and capability in the evaluation machinery to determine the number of clusters that don't match between a given truth/reco track per subsystem instead of only on the track as a whole.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

