### PR TITLE
default run = 7, update filetypes for CreateFileList.pl

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -70,7 +70,7 @@ my $start_segment;
 my $last_segment;
 my $randomize;
 my $prodtype;
-my $runnumber = 6;
+my $runnumber = 7;
 my $verbose;
 my $nopileup;
 my $embed;
@@ -754,30 +754,31 @@ $dbh->disconnect;
 
 sub commonfiletypes
 {
+# for no pileup pass(X) --> pass(X-1)
 # pass1
     $filetypes{"G4Hits"} = "G4 Hits";
-    $filetypes{"G4HitsOld"} = "Old G4 Hits";
+#    $filetypes{"G4HitsOld"} = "Old G4 Hits";
 # pass2
     $filetypes{"DST_BBC_G4HIT"} = "Pileup BBC/MBD, EPD G4Hits";
     $filetypes{"DST_CALO_G4HIT"} = "Pileup Calorimeter G4Hits";
     $filetypes{"DST_TRKR_G4HIT"} = "Pileup Tracking Detector G4 Hits";
     $filetypes{"DST_TRUTH_G4HIT"} = "temporary Pileup Truth info, use DST_TRUTH";
-    $filetypes{"DST_VERTEX"} = "Pileup Simulated Smeared Vertex";
-# pass3 calo
-    $filetypes{"DST_CALO_CLUSTER"} = "Reconstructed Calorimeter Towers and Clusters";
-# pass3 global
-    $filetypes{"DST_GLOBAL"} = "Old Reconstructed Global Detectors (Bbc, Epd)";
 # pass3 bbcepd
     $filetypes{"DST_BBC_EPD"} = "Reconstructed Bbc, Epd";
+# pass3 calo
+    $filetypes{"DST_CALO_CLUSTER"} = "Reconstructed Calorimeter Towers and Clusters";
 #pass3 trk
     $filetypes{"DST_TRKR_HIT"} = "TPC and Silicon Hits";
     $filetypes{"DST_TRUTH"} = "Truth Info (updated with Clusters)";
+#pass4 truth jets
+    $filetypes{"DST_TRUTH_JET"} = "Truth Jets";
 #pass4 tracks
     $filetypes{"DST_TRKR_CLUSTER"} = "pass0 output: tpc clusters";
     $filetypes{"DST_TRACKSEEDS"} = "passA output: track seeds";
     $filetypes{"DST_TRACKS"} = "passC output: Reconstructed Tracks";
-#analysis pass
-    $filetypes{"DST_TRUTH_JET"} = "Truth Jets";
+#pass5 tracks/clusters
+    $filetypes{"DST_GLOBAL"} = "Global Info (MBD, sEPD, Vertex)";
+    $filetypes{"DST_TRUTH_RECO"} = "digested track truth info";
 }
 
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
run 6 is superseeded and should not be used at least for calorimeter analysis, CreateFileList.pl now defaults to run 7. Also updated the file types (removed obsolete DST_VERTEX, added DST_GLOBAL with new content, added DST_TRUTH_RECO for the digested track truth info
It is just the script which does not get tested by jenkins, skip jenkins: [skip-ci]
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

