### PR TITLE
fix: INTT purity improvement

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -455,7 +455,13 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
   const double zProj[])
 {
   std::vector<TrkrDefs::cluskey> matchedClusters;
-
+  TrkrDefs::cluskey matchedClusterLay0;
+  Acts::Vector3 matchedGlobPosLay0;
+  TrkrDefs::cluskey matchedClusterLay1;
+  Acts::Vector3 matchedGlobPosLay1;
+  float minResidLay0 = std::numeric_limits<float>::max();
+  float minResidLay1 = std::numeric_limits<float>::max();
+  
   for(int inttlayer = 0; inttlayer < m_nInttLayers; inttlayer++)
     {
       const double projR = std::sqrt(square(xProj[inttlayer]) + square(yProj[inttlayer]));
@@ -517,16 +523,29 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	     
 	      /// Z strip spacing is the entire strip, so because we use fabs
 	      /// we divide by two
-	      if(fabs(projectionLocal[1] - cluster->getLocalX()) < m_rPhiSearchWin and
-		 fabs(projectionLocal[2] - cluster->getLocalY()) < stripZSpacing / 2.)
+	      float rphiresid = fabs(projectionLocal[1] - cluster->getLocalX());
+	      float zresid = fabs(projectionLocal[2] - cluster->getLocalY());
+	      if(rphiresid < m_rPhiSearchWin and
+		 zresid < stripZSpacing / 2.)
 		{
-	
-		  matchedClusters.push_back(cluskey);
-		  /// Cache INTT global positions with seed
+		  
 		  const auto globalPos = m_tGeometry->getGlobalPosition(
                     cluskey, cluster);
-		  clusters.push_back(globalPos);
-
+		  
+		  if(inttlayer<2 && rphiresid < minResidLay0)
+		    {
+		      matchedClusterLay0 = cluskey;
+		      /// Cache INTT global positions with seed
+		      matchedGlobPosLay0 = globalPos;
+		      minResidLay0 = rphiresid;
+		    }
+		  if(inttlayer>1 && rphiresid < minResidLay1)
+		    {
+		      matchedClusterLay1 = cluskey;
+		      matchedGlobPosLay1 = globalPos;
+		      minResidLay1 = rphiresid;
+		    }
+		    
 		 		  	      
 		  if(Verbosity() > 4)
 		    {
@@ -544,7 +563,12 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	    }
 	}  
     }
-  
+
+  matchedClusters.push_back(matchedClusterLay0);
+  matchedClusters.push_back(matchedClusterLay1);
+  clusters.push_back(matchedGlobPosLay0);
+  clusters.push_back(matchedGlobPosLay1);
+
   if(m_seedAnalysis) {
     h_nMatchedClusters->Fill(matchedClusters.size());
   }

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -564,10 +564,16 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
 	}  
     }
 
-  matchedClusters.push_back(matchedClusterLay0);
-  matchedClusters.push_back(matchedClusterLay1);
-  clusters.push_back(matchedGlobPosLay0);
-  clusters.push_back(matchedGlobPosLay1);
+  if(minResidLay0 < std::numeric_limits<float>::max())
+    {
+      matchedClusters.push_back(matchedClusterLay0);
+      clusters.push_back(matchedGlobPosLay0);
+    }
+  if(minResidLay1 < std::numeric_limits<float>::max())
+    {
+      matchedClusters.push_back(matchedClusterLay1);
+      clusters.push_back(matchedGlobPosLay1);
+    }
 
   if(m_seedAnalysis) {
     h_nMatchedClusters->Fill(matchedClusters.size());


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This improves the rate at which the correct INTT clusters are associated to a silicon seed by a factor of 2-3 by selecting only the clusters in each layer set that closest to the circle fit trajectory. This gives us a ~95% rate at which INTT clusters are associated to tracks, with <~5% having wrong measurements associated to them according to the evaluation machinery.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

