### PR TITLE
Fix embed

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -82,12 +82,12 @@ my $production;
 my $momentum;
 # that should teach me a lesson to not give a flag an optional strign value
 # just using embed:s leads to the next ARGV to be used as argument, even if it
-# is the next option. Sadly getopt swallows the - so parsing this becomes 
+# is the next option. Sadly getopt swallows the - so parsing this becomes
 # quickly a nightmare, The only solution I see is to read the ARGV's - check for
-# the argument in question with a string compare (=~/em/) and then have a look 
+# the argument in question with a string compare (=~/em/) and then have a look
 # at the next argument (if it exists) and check if is is another option (=~/-/)
 # and if so use "auau" as default for $embed and push the modified option
-# into the new command line ARGV. It defaults to auau if -emb is set but 
+# into the new command line ARGV. It defaults to auau if -emb is set but
 # neither pau nor auau is given
 my @newargs = ();
 my $iarg = 0;
@@ -100,16 +100,14 @@ foreach my $argument (@ARGV)
 	{
 	    push(@newargs, $argument);
 	    push(@newargs,"auau");
-#   $argument = sprintf("%s auau",$argument);
-#    print "argument now: $argument\n";
 	}
 	else
 	{
 	    push(@newargs, $argument);
-if ($ARGV[$iarg+1] ne "pau" && $ARGV[$iarg+1] ne "auau")
-{
-	    push(@newargs,"auau");
-}
+	    if ($ARGV[$iarg+1] ne "pau" && $ARGV[$iarg+1] ne "auau")
+	    {
+		push(@newargs,"auau");
+	    }
 	}
     }
     else
@@ -119,9 +117,6 @@ if ($ARGV[$iarg+1] ne "pau" && $ARGV[$iarg+1] ne "auau")
     $iarg++;
 }
 
-@ARGV = @newargs;
-print "@ARGV";
-print "\n";
 GetOptions('embed:s' => \$embed, 'l:i' => \$last_segment, 'momentum:s' => \$momentum, 'n:i' => \$nEvents, "nopileup" => \$nopileup, "particle:s" => \$particle, 'pileup:i' => \$pileup, "pmin:i" => \$pmin, "pmax:i"=>\$pmax, "production:s"=>\$production, 'rand' => \$randomize, 'run:i' => \$runnumber, 's:i' => \$start_segment, 'type:i' =>\$prodtype, "verbose" =>\$verbose);
 my $filenamestring;
 my %filetypes = ();
@@ -275,7 +270,6 @@ if (defined $prodtype)
 	{
 	    if (defined $embed)
 	    {
-                print "embed is $embed\n";
 		if ($embed eq "pau")
 		{
 		    $filenamestring = sprintf("%s_sHijing_pAu_0_10fm_%s_bkg_0_10fm",$filenamestring, $pAu_pileupstring);
@@ -476,14 +470,6 @@ if (defined $embed && ! $embedok)
     print "Embedding not implemented for type $prodtype\n";
     exit(1);
 }
-
-#if (defined $embed)
-#{
-#    if ($embed ne "pau" && $embed ne "auau")
-#    {
-#	push(@ARGV,$embed);
-#    }
-#}
 
 my $filenamestring_with_runnumber = sprintf("%s\-%010d-",$filenamestring,$runnumber);
 if ($#ARGV < 0)

--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -80,6 +80,48 @@ my $pmin;
 my $pmax;
 my $production;
 my $momentum;
+# that should teach me a lesson to not give a flag an optional strign value
+# just using embed:s leads to the next ARGV to be used as argument, even if it
+# is the next option. Sadly getopt swallows the - so parsing this becomes 
+# quickly a nightmare, The only solution I see is to read the ARGV's - check for
+# the argument in question with a string compare (=~/em/) and then have a look 
+# at the next argument (if it exists) and check if is is another option (=~/-/)
+# and if so use "auau" as default for $embed and push the modified option
+# into the new command line ARGV. It defaults to auau if -emb is set but 
+# neither pau nor auau is given
+my @newargs = ();
+my $iarg = 0;
+foreach my $argument (@ARGV)
+{
+    if ($argument =~ /em/)
+    {
+	my $firstchar = substr($ARGV[$iarg+1],0,1);
+	if (! exists $ARGV[$iarg+1] || substr($ARGV[$iarg+1],0,1) eq "-")
+	{
+	    push(@newargs, $argument);
+	    push(@newargs,"auau");
+#   $argument = sprintf("%s auau",$argument);
+#    print "argument now: $argument\n";
+	}
+	else
+	{
+	    push(@newargs, $argument);
+if ($ARGV[$iarg+1] ne "pau" && $ARGV[$iarg+1] ne "auau")
+{
+	    push(@newargs,"auau");
+}
+	}
+    }
+    else
+    {
+	push(@newargs,$argument);
+    }
+    $iarg++;
+}
+
+@ARGV = @newargs;
+print "@ARGV";
+print "\n";
 GetOptions('embed:s' => \$embed, 'l:i' => \$last_segment, 'momentum:s' => \$momentum, 'n:i' => \$nEvents, "nopileup" => \$nopileup, "particle:s" => \$particle, 'pileup:i' => \$pileup, "pmin:i" => \$pmin, "pmax:i"=>\$pmax, "production:s"=>\$production, 'rand' => \$randomize, 'run:i' => \$runnumber, 's:i' => \$start_segment, 'type:i' =>\$prodtype, "verbose" =>\$verbose);
 my $filenamestring;
 my %filetypes = ();
@@ -434,13 +476,14 @@ if (defined $embed && ! $embedok)
     print "Embedding not implemented for type $prodtype\n";
     exit(1);
 }
-if (defined $embed)
-{
-    if ($embed ne "pau" && $embed ne "auau")
-    {
-	push(@ARGV,$embed);
-    }
-}
+
+#if (defined $embed)
+#{
+#    if ($embed ne "pau" && $embed ne "auau")
+#    {
+#	push(@ARGV,$embed);
+#    }
+#}
 
 my $filenamestring_with_runnumber = sprintf("%s\-%010d-",$filenamestring,$runnumber);
 if ($#ARGV < 0)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the behavior when using -embed. Previously if no parameter was given the next argument was assumed to be the dst type which didn't work if -embed was followed by more options. This lead to confusing errors like "dst type  does not exist". Now CreateFileList.pl defaults to auau if no parameter is given to the -embed. This needs a ton of gymnastics but there was just too much confusion to leave it up to the wiki to explain how this should be used
no need for jenkins which does not test this [skip-ci]


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

