### PR TITLE
protect against crash when trying to delete event -1

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
@@ -483,13 +483,18 @@ int Fun4AllPrdfInputPoolManager::CalcDiffBclk(const int bclk1, const int bclk2)
 void Fun4AllPrdfInputPoolManager::DitchEvent(const int eventno)
 {
   std::cout << "Killing event " << eventno << std::endl;
+  m_ClockCounters.erase(eventno);
+  m_RefClockCounters.erase(eventno);
   auto pktinfoiter = m_PacketMap.find(eventno);
+  if (pktinfoiter == m_PacketMap.end())
+  {
+
+    return;
+  }
   for (auto &pktiter : pktinfoiter->second.PacketVector)
   {
     delete pktiter;
   }
-  m_ClockCounters.erase(pktinfoiter->first);
-  m_RefClockCounters.erase(pktinfoiter->first);
   m_PacketMap.erase(pktinfoiter);
   return;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
For some unknown reason event -1 makes it into the list and the pool manager crashed when trying to remove this event from its lists. This PR protects against this crash and the combiner gets over this event. Still need to figure out what's wrong here.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

