### PR TITLE
deal with negative diffs to get the hcal on board

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
@@ -435,7 +435,8 @@ void Fun4AllPrdfInputPoolManager::CreateBclkOffsets()
     {
       int diffclk = CalcDiffBclk(veciter.first, refclock);
       std::cout << "diffclk for " << veciter.second->Name() << ": " << std::hex
-                << diffclk << std::dec << std::endl;
+                << diffclk << ", clk: 0x" << veciter.first
+		<< ", refclk: 0x" << refclock << std::dec << std::endl;
       auto clkiter = clockcounters.find(veciter.second);
       if (clkiter == clockcounters.end())
       {
@@ -471,12 +472,7 @@ void Fun4AllPrdfInputPoolManager::CreateBclkOffsets()
 
 int Fun4AllPrdfInputPoolManager::CalcDiffBclk(const int bclk1, const int bclk2)
 {
-  int diffclk = bclk1 - bclk2;
-  if (abs(diffclk) > 0xFFF0)
-  {
-    std::cout << "large beam clock diff: 0x" << std::hex << diffclk << ", clk1: 0x" << bclk1
-              << ", clk2: 0x" << bclk2 << std::dec << std::endl;
-  }
+  int diffclk = (bclk1 - bclk2) & 0xFFFF;
   return diffclk;
 }
 

--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.h
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.h
@@ -47,7 +47,7 @@ class Fun4AllPrdfInputPoolManager : public Fun4AllInputManager
   void DitchEvent(const int eventno);
   void Resynchronize();
   void ClearAllEvents();
-  void SetPoolDepth(unsigned int d) {m_PoolDepth = p;}
+  void SetPoolDepth(unsigned int d) {m_PoolDepth = d;}
 
  private:
   struct PacketInfo
@@ -63,7 +63,7 @@ class Fun4AllPrdfInputPoolManager : public Fun4AllInputManager
 
   bool m_StartUpFlag = true;
   int m_RunNumber = 0;
-  unsigned int m_PoolDepth = 150;
+  unsigned int m_PoolDepth = 100;
   unsigned int m_InitialPoolDepth = 20;
   std::vector<SinglePrdfInput *> m_PrdfInputVector;
   SyncObject *m_SyncObject = nullptr;

--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.h
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.h
@@ -47,6 +47,7 @@ class Fun4AllPrdfInputPoolManager : public Fun4AllInputManager
   void DitchEvent(const int eventno);
   void Resynchronize();
   void ClearAllEvents();
+  void SetPoolDepth(unsigned int d) {m_PoolDepth = p;}
 
  private:
   struct PacketInfo
@@ -62,7 +63,7 @@ class Fun4AllPrdfInputPoolManager : public Fun4AllInputManager
 
   bool m_StartUpFlag = true;
   int m_RunNumber = 0;
-  unsigned int m_PoolDepth = 100;
+  unsigned int m_PoolDepth = 150;
   unsigned int m_InitialPoolDepth = 20;
   std::vector<SinglePrdfInput *> m_PrdfInputVector;
   SyncObject *m_SyncObject = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
With this PR the pool input manager can now deal with larger differences to the reference beam clock (previously the diff being negative because of rollovers wasn't handled). This gets the hcal on board. Also increased the pool depth to 150 to see if we can process all of run 20508.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

