### PR TITLE
Increase mille buffer size to 10K words. Add setting of HF_ntuple pat…

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -98,7 +98,8 @@ int HelicalFitter::InitRun(PHCompositeNode *topNode)
 
   if(make_ntuple)
     {
-      fout = new TFile("HF_ntuple.root","recreate");
+      //fout = new TFile("HF_ntuple.root","recreate");
+      fout = new TFile(ntuple_outfilename.c_str(),"recreate");
       ntp  = new TNtuple("ntp","HF ntuple","event:trkid:layer:nsilicon:ntpc:nclus:trkrid:sector:side:subsurf:phi:glbl0:glbl1:glbl2:glbl3:glbl4:glbl5:sensx:sensy:sensz:normx:normy:normz:sensxideal:sensyideal:senszideal:normxideal:normyideal:normzideal:xglobideal:yglobideal:zglobideal:R:X0:Y0:Zs:Z0:xglob:yglob:zglob:xfit:yfit:zfit:pcax:pcay:pcaz:tangx:tangy:tangz:X:Y:fitX:fitY:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdalpha:dXdbeta:dXdgamma:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdalpha:dYdbeta:dYdgamma:dYdx:dYdy:dYdz");
 
       track_ntp = new TNtuple("track_ntp","HF track ntuple","track_id:residual_x:residual_y:residualxsigma:residualysigma:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdx:dYdy:dYdz:xvtx:yvtx:zvtx:event_zvtx:track_phi:perigee_phi");
@@ -479,10 +480,8 @@ int HelicalFitter::process_event(PHCompositeNode*)
 		{
 		  unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);	  
 		  unsigned int side   = TpcDefs::getSide(cluskey_vec[ivec]);	  
-		  std::cout << " Testing layer " << layer << " param " << i << std::endl;
 		  if(is_layer_param_fixed(layer, i) || is_tpc_sector_fixed(layer, sector, side))
 		    {
-		      std::cout << "     layer " << layer << " param " << i << " fixed " << std::endl;
 		      glbl_derivativeX[i] = 0;
 		      glbl_derivativeY[i] = 0;
 		    }
@@ -597,21 +596,24 @@ int HelicalFitter::process_event(PHCompositeNode*)
   
       if(use_event_vertex)
 	{	  
-	  std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
-	  
-	  std::cout << "vertex is " << event_vtx.transpose() << std::endl;
-	  std::cout << "vertex residuals " << vtx_residual.transpose() 
-		    << std::endl;
-	  std::cout << "local derivatives " << std::endl;
-	  for(int i=0; i<AlignmentDefs::NLC; i++)
-	    std::cout << lclvtx_derivativeX[i] << ", ";
-	  std::cout << std::endl;
-	  for(int i=0; i<AlignmentDefs::NLC; i++)
-	    std::cout << lclvtx_derivativeY[i] << ", ";
-	  std::cout << "global vtx derivaties " << std::endl;
-	  for(int i=0; i<3; i++) std::cout << glblvtx_derivativeX[i] << ", ";
-	  std::cout << std::endl;
-	  for(int i=0; i<3; i++) std::cout << glblvtx_derivativeY[i] << ", ";
+	  if(Verbosity() > 3)
+	    {
+	      std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
+	      
+	      std::cout << "vertex is " << event_vtx.transpose() << std::endl;
+	      std::cout << "vertex residuals " << vtx_residual.transpose() 
+			<< std::endl;
+	      std::cout << "local derivatives " << std::endl;
+	      for(int i=0; i<AlignmentDefs::NLC; i++)
+		std::cout << lclvtx_derivativeX[i] << ", ";
+	      std::cout << std::endl;
+	      for(int i=0; i<AlignmentDefs::NLC; i++)
+		std::cout << lclvtx_derivativeY[i] << ", ";
+	      std::cout << "global vtx derivaties " << std::endl;
+	      for(int i=0; i<3; i++) std::cout << glblvtx_derivativeX[i] << ", ";
+	      std::cout << std::endl;
+	      for(int i=0; i<3; i++) std::cout << glblvtx_derivativeY[i] << ", ";
+	    }
 
 	  // add some track cuts
 	  if(fabs(newTrack.get_z() - event_vtx(2)) > 0.2) continue;  // 2 mm cut
@@ -1174,7 +1176,7 @@ void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 ev
   // calculate projX and projY vectors once for the optimum fit parameters
   Acts::Vector3 projX(0,0,0), projY(0,0,0);
   get_projectionVtxXY(track, event_vtx, projX, projY);
-  std::cout << "projx and y " << projX.transpose() << ", " << projY.transpose() << std::endl;
+
   // translations
   glbl_derivativeX[0] = unitx.dot(projX);
   glbl_derivativeX[1] = unity.dot(projX);
@@ -1225,7 +1227,7 @@ void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, Acts::Vector3 event_vt
 {
   Acts::Vector3 tanvec(track.get_px(),track.get_py(),track.get_pz());
   Acts::Vector3 normal(track.get_px(),track.get_py(),0); 
-  std::cout << "tangent and normal " << tanvec.transpose() << ", " << normal.transpose() << std::endl;
+
   tanvec /= tanvec.norm();
   normal /= normal.norm();
 
@@ -1234,10 +1236,9 @@ void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, Acts::Vector3 event_vt
   Acts::Vector3 yloc(0.0,0.0,1.0); // local y 
   Acts::Vector3 xglob = localvtxToGlobalvtx(track, event_vtx, xloc);
   Acts::Vector3 yglob = yloc + event_vtx;
-  std::cout << "xglob yglob " << xglob.transpose() << "        " << yglob.transpose() << std::endl;
   Acts::Vector3 X     = (xglob-event_vtx) / (xglob-event_vtx).norm(); // local unit vector transformed to global coordinates
   Acts::Vector3 Y     = (yglob-event_vtx) / (yglob-event_vtx).norm();
-  std::cout << "X AND Y " << X.transpose() << "        "<< Y.transpose() << std::endl;
+
   // see equation 31 of the ATLAS paper (and discussion) for this
   projX = X - (tanvec.dot(X) / tanvec.dot(normal)) * normal;
   projY = Y - (tanvec.dot(Y) / tanvec.dot(normal)) * normal;
@@ -1357,12 +1358,9 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
   dca3dxy = NAN;
   Acts::Vector3 track_vtx(track.get_x(),track.get_y(),track.get_z());
   Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
-  std::cout << "track vertex and mom " << std::endl << track_vtx.transpose() << "          "<< mom.transpose() << std::endl;
-  std::cout << "event vertex " << event_vertex.transpose() << std::endl;
+
   track_vtx -= event_vertex; // difference between track_vertex and event_vtx
   
-  std::cout << "track vtx now " << track_vtx.transpose() << std::endl;
-
   Acts::ActsSymMatrix<3> posCov;
   for(int i = 0; i < 3; ++i)
     {
@@ -1373,12 +1371,11 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
     }
   
   Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
-  std::cout << "r vec is " << r.transpose()<<std::endl;
+
   float phi       = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
   phi *= -1;
-  std::cout << "phi is " << phi << std::endl;
   rot(0,0) = cos(phi);
   rot(0,1) = -sin(phi);
   rot(0,2) = 0;
@@ -1388,12 +1385,10 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
   rot(2,0) = 0;
   rot(2,1) = 0;
   rot(2,2) = 1;
-  std::cout << "Rot is " << std::endl << rot << std::endl;
   rot_T    = rot.transpose();
 
   Acts::Vector3 pos_R           = rot * track_vtx;
   Acts::ActsSymMatrix<3> rotCov = rot * posCov * rot_T;
-  std::cout << "Pos r " << pos_R.transpose() << std::endl;
   dca3dxy      = pos_R(0);
   dca3dz       = pos_R(2);
   dca3dxysigma = sqrt(rotCov(0,0));
@@ -1498,9 +1493,7 @@ Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, Acts::Vector3
   rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * local;
-  std::cout << "loc to glob vtx " << pos_R.transpose() << std::endl;
   pos_R += event_vtx;
-  std::cout << "after vtx subt " << pos_R.transpose() << std::endl;
   if(Verbosity()>1)
     {
       std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -70,6 +70,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_tpc_sector_fixed(unsigned int region, unsigned int sector, unsigned int side);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
+  void set_ntuplefile_name(const std::string& file) { ntuple_outfilename = file;}
 
   void set_fitted_subsystems(bool si, bool tpc, bool full) { fitsilicon = si; fittpc = tpc; fitfulltrack = full; }
 
@@ -178,6 +179,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
   std::string data_outfilename = ("mille_helical_output_data_file.bin");  
   std::string steering_outfilename = ("steer_helical.txt");  
+  std::string ntuple_outfilename = ("HF_ntuple.root"); 
 
   bool fitsilicon = true;
   bool fittpc = false;

--- a/offline/packages/TrackerMillepedeAlignment/Mille.h
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.h
@@ -68,7 +68,7 @@ class Mille
   bool myAsBinary;         ///< if false output as text
   bool myWriteZero;        ///< if true also write out derivatives/labels ==0
   /// buffer size for ints and floats
-  enum {myBufferSize = 5000};  ///< buffer size for ints and floats
+  enum {myBufferSize = 10000};  ///< buffer size for ints and floats
   int   myBufferInt[myBufferSize];   ///< to collect labels etc.
   float myBufferFloat[myBufferSize]; ///< to collect derivatives etc.
   int   myBufferPos; ///< position in buffer


### PR DESCRIPTION
…h from macro. Remove unguarded diagnostic output.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The mille buffer size of 5K words per track was being exceeded sometimes, with consequent loss of entries. It has been increased to 10K words per track. 
The HF_ntuple name in HelicalFitter can now be set from the macro. It defaults to the previous behavior.
Removed a group of diagnostic output lines that were accidentally left in the repository version of HelicalFitter.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

