### PR TITLE
Updating UE subtraction/tower jet inputs to account for masked towers

### DIFF
--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -61,6 +61,10 @@ class DetermineTowerBackground : public SubsysReco
   std::vector<std::vector<float> > _IHCAL_E;
   std::vector<std::vector<float> > _OHCAL_E;
 
+  std::vector<std::vector<int> > _EMCAL_T;
+  std::vector<std::vector<int> > _IHCAL_T;
+  std::vector<std::vector<int> > _OHCAL_T;
+
   // 1-D energies vs. phi (integrated over eta strips with complete
   // phi coverage, and all layers)
   std::vector<float> _FULLCALOFLOW_PHI_E;

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -78,6 +78,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
     _NPHI = geomIH->get_phibins();
 
     _EMCAL_RETOWER_E.resize(_NETA, std::vector<float>(_NPHI, 0));
+    _EMCAL_RETOWER_T.resize(_NETA, std::vector<int>(_NPHI, 0));
   }
 
   for (int eta = 0; eta < _NETA; eta++)
@@ -85,6 +86,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
     for (int phi = 0; phi < _NPHI; phi++)
     {
       _EMCAL_RETOWER_E[eta][phi] = 0;
+      _EMCAL_RETOWER_T[eta][phi] = 0;
     }
   }
 
@@ -142,11 +144,16 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 	  
 	  int this_IHphibin = geomIH->get_phibin(tower_geom->get_phi());
 	  float this_E = tower->get_energy();
-	  
+	  int this_T = tower->get_time();
 	  for (int etabin_iter = -1 ; etabin_iter <= 1;etabin_iter++)
 	    {
 	      if (this_IHetabin+etabin_iter < 0 || this_IHetabin+etabin_iter >= _NETA){continue;}
 	      _EMCAL_RETOWER_E[this_IHetabin+etabin_iter][this_IHphibin] += this_E * fractionalcontribution[etabin_iter+1];
+	      if(this_T == -10 || this_T == -11) //if a tower in this retower is masked, mask the retower as well. Masking is noted by time = -10 or -11
+		{
+		  //currently just set the retowered tower to -10 even if the original tower was -11
+		  _EMCAL_RETOWER_T[this_IHetabin+etabin_iter][this_IHphibin] = -10;
+		}
 	    }
 	}
       
@@ -223,6 +230,8 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 	     unsigned int towerindex = emcal_retower->decode_key(towerkey);
 	     TowerInfo *towerinfo = emcal_retower->get_tower_at_channel(towerindex);
 	     towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi]);
+	     if(_EMCAL_RETOWER_T[eta][phi] == -10) towerinfo->set_energy(0);
+	     towerinfo->set_time(_EMCAL_RETOWER_T[eta][phi]);
 	   }
        }
    }

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -43,6 +43,7 @@ class RetowerCEMC : public SubsysReco
   int _NPHI;
   bool m_use_towerinfo = false;
   std::vector<std::vector<float> > _EMCAL_RETOWER_E;
+  std::vector<std::vector<int> > _EMCAL_RETOWER_T;
 };
 
 #endif

--- a/offline/packages/jetbackground/SubtractTowers.cc
+++ b/offline/packages/jetbackground/SubtractTowers.cc
@@ -143,7 +143,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
-
+	  //if a tower has time = -10 or -11 it is masked, leave it at zero
+	  if( tower->get_time() == -10 || tower->get_time() == -11 ) new_energy = 0;
+	  
 	  emcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  emcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
 	}
@@ -190,6 +192,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
+	  if( raw_energy == 0 ) new_energy = 0;
 	  tower->set_energy(new_energy);
 	  if (Verbosity() > 5)
 	    std::cout << " SubtractTowers::process_event : EMCal tower at eta / phi = " << tower->get_bineta() << " / " << tower->get_binphi() << ", pre-sub / after-sub E = " << raw_energy << " / " << tower->get_energy() << std::endl;
@@ -216,6 +219,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
+	  //if a tower has time = -10 or -11 it is masked, leave it at zero
+          if( tower->get_time() == -10 || tower->get_time() == -11 ) new_energy = 0;
+
 	  ihcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  ihcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
 	}
@@ -264,6 +270,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
+	  if( raw_energy == 0 ) new_energy = 0;
 	  tower->set_energy(new_energy);
 	}
     }
@@ -288,6 +295,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
+	  //if a tower has time = -10 or -11 it is masked, leave it at zero
+          if( tower->get_time() == -10 || tower->get_time() == -11 ) new_energy = 0;
+
 	  ohcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  ohcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
 	}
@@ -335,6 +345,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	      UE = UE * (1 + 2 * background_v2 * cos(2 * (tower_phi - background_Psi2)));
 	    }
 	  float new_energy = raw_energy - UE;
+	  if( raw_energy == 0 ) new_energy = 0;
 	  tower->set_energy(new_energy);
 	}
     }

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -325,6 +325,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  int ieta = towerinfos->getTowerEtaBin(calokey);
 	  int iphi = towerinfos->getTowerPhiBin(calokey);
 	  const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(geocaloid, ieta, iphi);
+	  //skip masked towers
+	  if (tower->get_time()==-10 || tower->get_time()==-11) continue;
 	  RawTowerGeom *tower_geom = geom->get_tower_geometry(key);
 	  assert(tower_geom);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR adds the ability for the UE subtraction to ignore towers in data which have been masked due to being hot/cold/dead. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the ability for the UE subtraction to ignore towers in data which have been masked due to being hot/cold/dead. The masking relies on the time for the tower being set to -10 (hot) or -11 (cold). This should have no effect on simulation, only data.

## TODOs (if applicable)
More detailed validation ongoing.

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

