### PR TITLE
set epd channel number back to 744

### DIFF
--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -16,7 +16,7 @@ TowerInfoContainerv1::TowerInfoContainerv1(DETECTOR detec)
   int nchannels = 744;
   if (_detector == DETECTOR::SEPD)
   {
-    nchannels = 768;
+    nchannels = 744;
   }
   else if (_detector == DETECTOR::EMCAL)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR sets the number of epd channels back to 744 which is the real number of channels. This avoids filling our disks with empty channels
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

