### PR TITLE
Updated sEPD packet ranges and channel numbers

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -94,8 +94,8 @@ int CaloTowerBuilder::InitRun(PHCompositeNode *topNode)
   {
     m_detector = "EPD";
     m_packet_low = 9001;
-    m_packet_high = 9005;
-    m_nchannels = 186;
+    m_packet_high = 9006;
+    m_nchannels = 128;
     if (_processingtype == CaloWaveformProcessing::NONE)
     {
       WaveformProcessing->set_processing_type(CaloWaveformProcessing::FAST);  // default the EPD to fast processing


### PR DESCRIPTION
This updates the packet ranges and channel numbers in the EPD section of the CaloTowerBuilder initialization, which fixes the error message ```Error in <TClonesArray::At>: index 768 out of bounds (size: 768, this: 0x7274270)```. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

