### PR TITLE
sEPD Channel masking

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -164,6 +164,17 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
         }
         for (int channel = 0; channel < nchannels; channel++)
         {
+          //mask empty channels
+            
+          if(m_dettype == CaloTowerBuilder::EPD){
+            /*
+            if (pid > 9001) {
+              continue;
+            }*/
+            if (pid == 9001 && (channel < 64 || channel == 78 || channel == 110)) {
+              continue;
+            }
+          }
           std::vector<float> waveform;
           waveform.reserve(m_nsamples);
           for (int samp = 0; samp < m_nsamples; samp++)
@@ -177,12 +188,6 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
         {
           for (int channel = 0; channel < m_nchannels - nchannels; channel++)
           {
-            //mask empty channels
-            if (m_dettype == CaloTowerBuilder::EPD && pid == 9001 && (channel < 64 || channel == 78 || channel == 110)) {
-              continue;
-            }
-
-
             std::vector<float> waveform;
             waveform.reserve(m_nsamples);
             for (int samp = 0; samp < m_nzerosuppsamples; samp++)

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -177,6 +177,12 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
         {
           for (int channel = 0; channel < m_nchannels - nchannels; channel++)
           {
+            //mask empty channels
+            if (m_dettype == CaloTowerBuilder::EPD && pid == 9001 && (channel < 64 || channel == 78 || channel == 110)) {
+              continue;
+            }
+
+
             std::vector<float> waveform;
             waveform.reserve(m_nsamples);
             for (int samp = 0; samp < m_nzerosuppsamples; samp++)


### PR DESCRIPTION
This masks channels 0-63, 78, and 110 in the sEPD within the CaloTowerBuilder. This should prevent out of bounds errors after the number of channels was changed to 744 in commit ae7dabf . 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)



