### PR TITLE
Masked 15th channel in each sector

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -162,18 +162,19 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
         {
           return Fun4AllReturnCodes::DISCARDEVENT;
         }
+        //int sector = 0;
+        
         for (int channel = 0; channel < nchannels; channel++)
         {
           //mask empty channels
-            
+          
           if(m_dettype == CaloTowerBuilder::EPD){
-            /*
-            if (pid > 9001) {
-              continue;
-            }*/
-            if (pid == 9001 && (channel < 64 || channel == 78 || channel == 110)) {
+            int sector = ((channel + 1)/ 32);
+            if (channel == (14 + 32*sector)) {
               continue;
             }
+            
+            
           }
           std::vector<float> waveform;
           waveform.reserve(m_nsamples);
@@ -188,8 +189,17 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
         {
           for (int channel = 0; channel < m_nchannels - nchannels; channel++)
           {
+
+            if(m_dettype == CaloTowerBuilder::EPD){
+              int sector = ((channel + 1) / 32);
+              
+              if (channel == (14 + 32*sector)) {
+                continue;
+              }
+            }
             std::vector<float> waveform;
             waveform.reserve(m_nsamples);
+            
             for (int samp = 0; samp < m_nzerosuppsamples; samp++)
             {
               waveform.push_back(0);
@@ -204,6 +214,12 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
       {
         for (int channel = 0; channel < m_nchannels; channel++)
         {
+          if(m_dettype == CaloTowerBuilder::EPD){
+            int sector = ((channel + 1)/ 32);
+            if (channel == (14 + 32*sector)) {
+              continue;
+            }  
+          }
           std::vector<float> waveform;
           waveform.reserve(2);
           for (int samp = 0; samp < m_nzerosuppsamples; samp++)
@@ -225,6 +241,7 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
   int n_channels = processed_waveforms.size();
   for (int i = 0; i < n_channels; i++)
   {
+    
     m_CaloInfoContainer->get_tower_at_channel(i)->set_time(processed_waveforms.at(i).at(1));
     m_CaloInfoContainer->get_tower_at_channel(i)->set_energy(processed_waveforms.at(i).at(0));
   }


### PR DESCRIPTION
This will mask the 15th channel in every sector, regardless of whether a packet has been received or not.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

