### PR TITLE
change default rapidity range from -4,4 to -5,5 to cover sEPD

### DIFF
--- a/generators/phhepmc/HepMCFlowAfterBurner.cc
+++ b/generators/phhepmc/HepMCFlowAfterBurner.cc
@@ -38,14 +38,6 @@ set<string> algoset = {"MINBIAS", "MINBIAS_V2_ONLY", "CUSTOM"};
 // please apply the same change to generators/flowAfterburner/main.cc
 HepMCFlowAfterBurner::HepMCFlowAfterBurner(const std::string &name)
   : SubsysReco(name)
-  , algorithmName("MINBIAS")
-  , mineta(-4)
-  , maxeta(4)
-  , minpt(0.)
-  , maxpt(100.)
-  , seedset(0)
-  , seed(0)
-  , randomSeed(11793)
 {
 }
 

--- a/generators/phhepmc/HepMCFlowAfterBurner.h
+++ b/generators/phhepmc/HepMCFlowAfterBurner.h
@@ -46,17 +46,17 @@ class HepMCFlowAfterBurner : public SubsysReco
 
  protected:
   std::string config_filename;
-  std::string algorithmName;
+  std::string algorithmName = "MINBIAS";
 
-  float mineta;
-  float maxeta;
+  float mineta = -5.;
+  float maxeta = 5.;
 
-  float minpt;
-  float maxpt;
+  float minpt = 0.;
+  float maxpt = 100.;
 
-  int seedset;
-  long seed;
-  long randomSeed;
+  int seedset = 0;
+  long seed = 0;
+  long randomSeed = 11793;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR changes the rapidity range for the flow afterburner from -4,4 to -5,5 to cover the sEPD acceptance. That's been known for ~3 years but nobody though of updating this range.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

