### PR TITLE
fix: improve silicon seed momentum resolution

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -290,7 +290,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
 	      m_nBadInitialFits++;
 	      continue;
 	    }
-        
+	 
 	  trackSeed->lineFit(positions, 0, 8);
 	  z = trackSeed->get_Z0();
 
@@ -299,21 +299,27 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
 	  fitTimer->restart();
 	  
 	  /// Project to INTT and find matches
+	  int mvtxsize = globalPositions.size();
 	  auto additionalClusters = findInttMatches(globalPositions, *trackSeed);
 
 	  /// Add possible matches to cluster list to be parsed when
 	  /// Svtx tracks are made
-	  for(auto& cluskey : additionalClusters)
-	    { 
-	      trackSeed->insert_cluster_key(cluskey); 
+	  for(int newkey = 0; newkey < additionalClusters.size(); newkey++)
+	    {
+	      trackSeed->insert_cluster_key(additionalClusters[newkey]);
+	      positions.insert(std::make_pair(additionalClusters[newkey],globalPositions[mvtxsize+newkey]));
+	      
 	      if(Verbosity() > 1)
-		{ std::cout << "adding additional intt key " << cluskey << std::endl; }
+		{ std::cout << "adding additional intt key " << additionalClusters[newkey] << std::endl; }
 	    }
 
 	  fitTimer->stop();
 	  auto addClusters = fitTimer->get_accumulated_time();
 	  fitTimer->restart();
-	  
+
+	  //! Circle fit again to take advantage of INTT lever arm
+	  trackSeed->circleFitByTaubin(positions, 0, 8);
+
 	  if(Verbosity() > 0)
 	    { std::cout << "find intt clusters time " << addClusters << std::endl; }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR improves the silicon seed track parameters by circle fitting the MVTX+INTT clusters after any INTT measurements are found. Previously only the MVTX was fit because of the poor INTT z resolution screwing up the line fit in r-z. Since we split this functionality into the track seeds, it was apparently never updated to also include the INTT clusters in the x-y fit, for which the INTT provides much needed lever arm than the MVTX has alone. Some plots to show the improvement of the track parameters in single track events, where red is the (current) version and black is after the inclusion of the INTT. Note the PCA_z resolution is unchanged because we still don't include the INTT in the r-z fit.

[silphires.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/12399688/silphires.pdf)
[silxres.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/12399689/silxres.pdf)
[silzres.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/12399690/silzres.pdf)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

