### PR TITLE
Tpot fix bco

### DIFF
--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -132,7 +132,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
     if( !packet )
     {
       // no data
-      if( Verbosity() )
+      if( Verbosity() > 1 )
       { std::cout << "MicromegasRawDataEvaluation::process_event - packet " << packet_id << " not found." << std::endl; }
       continue;
     }
@@ -232,6 +232,9 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
           bco_matching_pair.second = lvl1_bco;
           sample.lvl1_bco = lvl1_bco;
 
+          // remove bco from running list
+          bco_list.pop_front();
+
         } else {
 
           if( Verbosity() )
@@ -265,7 +268,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
 
       // get number of samples and loop
       const unsigned short samples = packet->iValue( iwf, "SAMPLES" );
-      if( Verbosity() )
+      if( Verbosity() > 1 )
       {
         std::cout << "MicromegasRawDataEvaluation::process_event -"
           << " fee: " << sample.fee_id
@@ -332,7 +335,7 @@ int MicromegasRawDataEvaluation::End(PHCompositeNode* /*topNode*/ )
   }
 
   // print bco map
-  // if( Verbosity() )
+  if( Verbosity() )
   {
     for( const auto& [bco,nwaveforms]:m_bco_map )
     { std::cout << "MicromegasRawDataEvaluation::End - bco: " << bco << ", nwaveforms: " << nwaveforms << std::endl; }

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -124,7 +124,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
   // temporary storage for samples and waveforms, sorted by lvl1 bco
   std::multimap<uint64_t, Sample> sample_map;
   std::multimap<uint64_t, Waveform> waveform_map;
-  
+
   // loop over TPOT packets
   for( const auto& packet_id:MicromegasDefs::m_packet_ids )
   {
@@ -163,7 +163,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
       }
     }
 
-    // if( Verbosity() )
+    if( Verbosity() )
     {
       std::cout << "MicromegasRawDataEvaluation::process_event -"
         << " packet: " << packet_id
@@ -180,7 +180,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
 
     // store available bco list for each fee
     std::map<unsigned short, bco_list_t> bco_list_map;
-    
+
     for( int iwf=0; iwf<n_waveform; ++iwf )
     {
       // create running sample, assign packet, fee, layer and tile id
@@ -197,33 +197,36 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
       // beam crossing, checksum, checksum error
       sample.fee_bco = packet->iValue(iwf, "BCO");
       sample.lvl1_bco = 0;
-      
+
       // find bco matching map corresponding to fee
       auto& bco_matching_map = m_fee_bco_matching_map[sample.fee_id];
-      
+
       // find matching lvl1 bco
       auto bco_matching_iter = bco_matching_map.lower_bound(sample.fee_bco );
       if( bco_matching_iter == bco_matching_map.end() || sample.fee_bco < bco_matching_iter->first )
       {
-        
+
         // find bco list corresponding to fee
         auto bco_list_iter = bco_list_map.lower_bound( sample.fee_id );
         if( bco_list_iter == bco_list_map.end() || sample.fee_id < bco_list_iter->first )
         {
           // insert main list if not found
-          bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) ); 
+          bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) );
         }
-      
+
         // get local reference to fee's bco list
         auto& bco_list = bco_list_iter->second;
         if( !bco_list.empty() )
         {
 
-          std::cout << "MicromegasRawDataEvaluation::process_event -"
-            << " fee_id: " << sample.fee_id
-            << " fee_bco: " << sample.fee_bco
-            << " lvl1_bco: " << bco_list.front()
-            << std::endl;
+          if( Verbosity() )
+          {
+            std::cout << "MicromegasRawDataEvaluation::process_event -"
+              << " fee_id: " << sample.fee_id
+              << " fee_bco: " << sample.fee_bco
+              << " lvl1_bco: " << bco_list.front()
+              << std::endl;
+          }
 
           // fee_bco not found in list. Assume it corresponds to the first available lvl1 bco
           const auto lvl1_bco = bco_list.front();
@@ -232,21 +235,24 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
           sample.lvl1_bco = lvl1_bco;
 
         } else {
-          
-          std::cout << "MicromegasRawDataEvaluation::process_event -"
-            << " fee_id: " << sample.fee_id
-            << " fee_bco: " << sample.fee_bco
-            << " lvl1_bco: none"
-            << std::endl;
+
+          if( Verbosity() )
+          {
+            std::cout << "MicromegasRawDataEvaluation::process_event -"
+              << " fee_id: " << sample.fee_id
+              << " fee_bco: " << sample.fee_bco
+              << " lvl1_bco: none"
+              << std::endl;
+          }
 
         }
 
       } else {
-        
+
         sample.lvl1_bco = bco_matching_iter->second;
 
       }
-      
+
       sample.checksum = packet->iValue(iwf, "CHECKSUM");
       sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
 
@@ -291,7 +297,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         sample.sample = is;
         sample.adc = adc;
         sample_map.emplace( sample.lvl1_bco, sample );
-        
+
         if( sample.adc > sample_max.adc )
         { sample_max = sample; }
 
@@ -316,7 +322,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
 
   for( auto&& [lvl1_bco, waveform]:waveform_map )
   { m_container->waveforms.push_back(std::move(waveform)); }
-  
+
   // fill evaluation tree
   m_evaluation_tree->Fill();
 

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -191,28 +191,25 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
       sample.layer = TrkrDefs::getLayer( hitsetkey );
       sample.tile = MicromegasDefs::getTileId( hitsetkey );
 
-      // for now only focus on fee_id == 0
-      // if( sample.fee_id != 0 ) continue;
-
       // beam crossing, checksum, checksum error
       sample.fee_bco = packet->iValue(iwf, "BCO");
       sample.lvl1_bco = 0;
 
       // find bco matching map corresponding to fee
-      auto& bco_matching_map = m_fee_bco_matching_map[sample.fee_id];
+      auto& bco_matching_pair = m_fee_bco_matching_map[sample.fee_id];
 
       // find matching lvl1 bco
-      auto bco_matching_iter = bco_matching_map.lower_bound(sample.fee_bco );
-      if( bco_matching_iter == bco_matching_map.end() || sample.fee_bco < bco_matching_iter->first )
+      if( bco_matching_pair.first == sample.fee_bco )
       {
 
-        // find bco list corresponding to fee
+        sample.lvl1_bco = bco_matching_pair.second;
+
+      } else {
+
+        // find bco list corresponding to fee, insert main list if not found
         auto bco_list_iter = bco_list_map.lower_bound( sample.fee_id );
         if( bco_list_iter == bco_list_map.end() || sample.fee_id < bco_list_iter->first )
-        {
-          // insert main list if not found
-          bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) );
-        }
+        { bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) ); }
 
         // get local reference to fee's bco list
         auto& bco_list = bco_list_iter->second;
@@ -228,10 +225,11 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
               << std::endl;
           }
 
-          // fee_bco not found in list. Assume it corresponds to the first available lvl1 bco
+          // fee_bco is new. Assume it corresponds to the first available lvl1 bco
+          // update running fee_bco and lvl1_bco pair accordingly
           const auto lvl1_bco = bco_list.front();
-          bco_matching_iter = bco_matching_map.insert( bco_matching_iter, std::make_pair( sample.fee_bco, lvl1_bco ) );
-          bco_list.pop_front();
+          bco_matching_pair.first = sample.fee_bco;
+          bco_matching_pair.second = lvl1_bco;
           sample.lvl1_bco = lvl1_bco;
 
         } else {
@@ -244,13 +242,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
               << " lvl1_bco: none"
               << std::endl;
           }
-
         }
-
-      } else {
-
-        sample.lvl1_bco = bco_matching_iter->second;
-
       }
 
       sample.checksum = packet->iValue(iwf, "CHECKSUM");

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -195,10 +195,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
       sample.lvl1_bco = 0;
       
       // find bco matching map corresponding to fee
-      auto bco_matching_map_iter = m_fee_bco_matching_map.lower_bound( sample.fee_id );
-      if( bco_matching_map_iter == m_fee_bco_matching_map.end() || sample.fee_id < bco_matching_map_iter->first )
-      { bco_matching_map_iter = m_fee_bco_matching_map.insert( bco_matching_map_iter, std::make_pair( sample.fee_id, bco_matching_map_t() ) ); }
-      auto& bco_matching_map = bco_matching_map_iter->second;
+      auto& bco_matching_map = m_fee_bco_matching_map[sample.fee_id];
       
       // find matching lvl1 bco
       auto bco_matching_iter = bco_matching_map.lower_bound(sample.fee_bco );
@@ -219,6 +216,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         {
 
           std::cout << "MicromegasRawDataEvaluation::process_event -"
+            << " fee_id: " << sample.fee_id
             << " fee_bco: " << sample.fee_bco
             << " lvl1_bco: " << bco_list.front()
             << std::endl;
@@ -230,11 +228,13 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
           sample.lvl1_bco = lvl1_bco;
 
         } else {
+          
           std::cout << "MicromegasRawDataEvaluation::process_event -"
             << " fee_id: " << sample.fee_id
             << " fee_bco: " << sample.fee_bco
             << " lvl1_bco: none"
             << std::endl;
+
         }
 
       } else {

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -121,6 +121,10 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
 
   m_container->Reset();
 
+  // temporary storage for samples and waveforms, sorted by lvl1 bco
+  std::multimap<uint64_t, Sample> sample_map;
+  std::multimap<uint64_t, Waveform> waveform_map;
+  
   // loop over TPOT packets
   for( const auto& packet_id:MicromegasDefs::m_packet_ids )
   {
@@ -286,8 +290,8 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         unsigned short adc = packet->iValue(iwf,is);
         sample.sample = is;
         sample.adc = adc;
-        m_container->samples.push_back( sample );
-
+        sample_map.emplace( sample.lvl1_bco, sample );
+        
         if( sample.adc > sample_max.adc )
         { sample_max = sample; }
 
@@ -302,20 +306,19 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         waveform.sample_max < m_sample_max &&
         waveform.adc_max > pedestal+m_n_sigma * rms;
 
-      m_container->waveforms.push_back( waveform );
-
+      waveform_map.emplace( waveform.lvl1_bco, waveform );
     }
   }
 
-  m_evaluation_tree->Fill();
+  // copy all samples and waveform to container
+  for( auto&& [lvl_bco, sample]:sample_map )
+  { m_container->samples.push_back(std::move(sample)); }
 
-//   for( const auto& [fee, bco]: fee_bco_map )
-//   {
-//     std::cout << "MicromegasRawDataEvaluation::process_event -"
-//       << " fee: " << fee
-//       << " bco: " << bco
-//       << std::endl;
-//   }
+  for( auto&& [lvl1_bco, waveform]:waveform_map )
+  { m_container->waveforms.push_back(std::move(waveform)); }
+  
+  // fill evaluation tree
+  m_evaluation_tree->Fill();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -218,10 +218,14 @@ class MicromegasRawDataEvaluation : public SubsysReco
   Container* m_container = nullptr;
   
   //! map fee bco to lvl1 bco
-  using fee_lvl1_bco_map_t = std::map<unsigned int, uint64_t>;
-  fee_lvl1_bco_map_t m_fee_lvl1_bco_map;
+  using bco_matching_map_t = std::map<unsigned int, uint64_t>;
 
-  // map waveforms to bco
+  //! map fee_id to bco maps
+  using fee_bco_matching_map_t = std::map<unsigned short, bco_matching_map_t>;
+  fee_bco_matching_map_t m_fee_bco_matching_map;
+  
+  /// map waveforms to bco
+  /** this is used to count how many waveforms are found for a given lvl1 bco */
   using bco_map_t = std::map<uint64_t,unsigned int>;
   bco_map_t m_bco_map;
 

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 class PHCompositeNode;
 class TFile;
@@ -218,10 +219,10 @@ class MicromegasRawDataEvaluation : public SubsysReco
   Container* m_container = nullptr;
   
   //! map fee bco to lvl1 bco
-  using bco_matching_map_t = std::map<unsigned int, uint64_t>;
+  using bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
 
   //! map fee_id to bco maps
-  using fee_bco_matching_map_t = std::map<unsigned short, bco_matching_map_t>;
+  using fee_bco_matching_map_t = std::map<unsigned short, bco_matching_pair_t>;
   fee_bco_matching_map_t m_fee_bco_matching_map;
   
   /// map waveforms to bco

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -60,9 +60,6 @@ class MicromegasRawDataEvaluation : public SubsysReco
   /// set min sample for noise estimation
   void set_sample_max( int value ) { m_sample_max = value; }
 
-  /// max number  of waveforms allowed
-  void set_max_waveforms( int value ) { m_max_waveforms = value; }
-
   /// output file name for evaluation histograms
   void set_evaluation_outputfile(const std::string &outputfile) {m_evaluation_filename = outputfile;}
 
@@ -210,9 +207,6 @@ class MicromegasRawDataEvaluation : public SubsysReco
   /// max sample for signal
   int m_sample_max = 100;
 
-  /// max waveforms allowed in a given event
-  int m_max_waveforms = 0;
-
   //! evaluation output filename
   std::string m_evaluation_filename = "MicromegasRawDataEvaluation.root";
   std::unique_ptr<TFile> m_evaluation_file;
@@ -222,14 +216,12 @@ class MicromegasRawDataEvaluation : public SubsysReco
 
   //! main branch
   Container* m_container = nullptr;
+  
+  //! map fee bco to lvl1 bco
+  using fee_lvl1_bco_map_t = std::map<unsigned int, uint64_t>;
+  fee_lvl1_bco_map_t m_fee_lvl1_bco_map;
 
-  //! map bco to packet
-  std::map<unsigned int, uint64_t> m_packet_bco_map;
-
-  //! lvl1 counter bco to packet
-  std::map<unsigned int, uint32_t> m_packet_lvl1_count_map;
-
-  // map bco to waveforms
+  // map waveforms to bco
   using bco_map_t = std::map<uint64_t,unsigned int>;
   bco_map_t m_bco_map;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR implements more robust association between waveforms and level1 full (64 bits) BCO counter. 
Unlike before, it supports previous BCO leaking into the next (RCDAQ) event, and RCDAQ events containing multiple lvl1_bco taggers. 

The association is performed using the 16bits waveform BCO as an indication for jumping from one trigger to the other. 
This is done on a per-FEE_ID basis, because the waveform BCO counter vary from FEE to FEE, in a non predictable way. 

So far this is used only  for assembling full events offline in an evaluation tree, but could be used as a basis to perform full event assembly "on the fly" within fun4all. 

Only known case of failure is when waveforms for a given lvl1 trigger are sent before the corresponding lvl1 tagger, and when the former happens to belong to the next RCDAQ event.  This could be fixed if using Martin's "sliding window" to process the raw data.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

