### PR TITLE
feat: add a purity flag to track tree

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -188,7 +188,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
                              "siqr:siphi:sithe:six0:siy0:tpqr:tpphi:tpthe:tpx0:tpy0:"
 			     "charge:quality:chisq:ndf:nhits:nmaps:nintt:ntpc:nmms:ntpc1:ntpc11:ntpc2:ntpc3:nlmaps:nlintt:nltpc:nlmms:layers:"
                              "vertexID:vx:vy:vz:dca2d:dca2dsigma:dca3dxy:dca3dxysigma:dca3dz:dca3dzsigma:pcax:pcay:pcaz:"
-                             "gtrackID:gflavor:gnhits:gnmaps:gnintt:gntpc:gnmms:gnlmaps:gnlintt:gnltpc:gnlmms:"
+                             "gtrackID:singlematch:gflavor:gnhits:gnmaps:gnintt:gntpc:gnmms:gnlmaps:gnlintt:gnltpc:gnlmms:"
                              "gpx:gpy:gpz:gpt:geta:gphi:"
                              "gvx:gvy:gvz:gvt:"
                              "gfpx:gfpy:gfpz:gfx:gfy:gfz:"
@@ -3838,6 +3838,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float gembed = NAN;
         float gprimary = NAN;
 
+	float ispure = NAN;
         float nfromtruth = NAN;
         float nwrong = NAN;
         float ntrumaps = NAN;
@@ -3870,7 +3871,15 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                 continue;
               }
             }
-
+	    SvtxTrack* truthrecotrk = trackeval->best_track_from(g4particle);
+	    if(truthrecotrk->get_id() == track->get_id())
+	      {
+		ispure = 1;
+	      }
+	    else
+	      {
+		ispure = 0;
+	      }
             gtrackID = g4particle->get_track_id();
             gflavor = g4particle->get_pid();
 
@@ -4101,6 +4110,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               pcay,
                               pcaz,
                               gtrackID,
+			      ispure,
                               gflavor,
                               ng4hits,
                               (float) ngmaps,


### PR DESCRIPTION
Adds a flag to the reconstructed track tree to indicate whether or not the associated truth track also points back to that same reconstructed track, i.e. whether or not there is a one-to-one match
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

