### PR TITLE
TrkrNtuplizer no track protection

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -1635,6 +1635,8 @@ std::set<SvtxTrack*> TrkrNtuplizer::all_tracks_from(TrkrDefs::cluskey cluster_ke
 void TrkrNtuplizer::create_cache_track_from_cluster()
 {
 
+  if(!_trackmap) return;
+
   // loop over all SvtxTracks
   for (SvtxTrackMap::Iter iter = _trackmap->begin();
        iter != _trackmap->end();

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -120,7 +120,7 @@ int TrkrNtuplizer::Init(PHCompositeNode* /*topNode*/)
   {
     _ntp_hit = new TNtuple("ntp_hit", "svtxhit => max truth",
                            "event:seed:hitID:e:adc:layer:phielem:zelem:"
-                           "cellID:ecell:phibin:tbin:phi:z:y:z"
+                           "cellID:ecell:phibin:tbin:phi:x:y:z:"
                            "nhittpcall:nhittpcin:nhittpcmid:nhittpcout:nclusall:nclustpc:nclusintt:nclusmaps:nclusmms");
   }
 


### PR DESCRIPTION
Added protection to TrkrNtuplizer for if no tracks exist (particularly important if no tracking is being done).

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

