### PR TITLE
fix: nullptr check

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -3838,7 +3838,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
         float gembed = NAN;
         float gprimary = NAN;
 
-	float ispure = NAN;
+	int ispure = 0;
         float nfromtruth = NAN;
         float nwrong = NAN;
         float ntrumaps = NAN;
@@ -3872,13 +3872,12 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               }
             }
 	    SvtxTrack* truthrecotrk = trackeval->best_track_from(g4particle);
-	    if(truthrecotrk->get_id() == track->get_id())
+	    if(truthrecotrk)
 	      {
-		ispure = 1;
-	      }
-	    else
-	      {
-		ispure = 0;
+		if(truthrecotrk->get_id() == track->get_id())
+		  {
+		    ispure = 1;
+		  }
 	      }
             gtrackID = g4particle->get_track_id();
             gflavor = g4particle->get_pid();
@@ -4110,7 +4109,7 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
                               pcay,
                               pcaz,
                               gtrackID,
-			      ispure,
+			      (float)ispure,
                               gflavor,
                               ng4hits,
                               (float) ngmaps,


### PR DESCRIPTION
The commit from yesterday worked for low multiplicity but can segfault in AuAu. This PR fixes that mistake
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

