### PR TITLE
Tdirectory fix

### DIFF
--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -30,7 +30,6 @@
 #include <TSystem.h>
 
 #include <algorithm>
-#include <cmath>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -139,7 +138,6 @@ void Fun4AllServer::InitAll()
   SyncManagers.push_back(defaultSyncManager);
   TopNode = new PHCompositeNode("TOP");
   topnodemap["TOP"] = TopNode;
-  default_Tdirectory = gDirectory->GetPath();
   InitNodeTree(TopNode);
   return;
 }

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -151,7 +151,7 @@ class Fun4AllServer : public Fun4AllBase
   std::vector<TDirectory *> TDirCollection;
   std::vector<Fun4AllHistoManager *> HistoManager;
   std::map<std::string, PHCompositeNode *> topnodemap;
-  std::string default_Tdirectory;
+  std::string default_Tdirectory = "Rint:/";
   std::vector<Fun4AllSyncManager *> SyncManagers;
   std::map<int, int> retcodesmap;
   std::map<const std::string, PHTimer> timer_map;

--- a/offline/framework/fun4all/InputFileHandler.cc
+++ b/offline/framework/fun4all/InputFileHandler.cc
@@ -104,7 +104,7 @@ int InputFileHandler::OpenNextFile()
 void InputFileHandler::Print(const std::string &/* what */) const
 {
   std::cout << "file list: " << std::endl;
-  for (auto iter : m_FileList)
+  for (const auto& iter : m_FileList)
   {
     std::cout << iter << std::endl;
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR fixes the behavior when a TFile is opened before an instance of the Fun4AllServer is created. Doing this set the default directory used by Fun4All to set up its TDirectory structure to the file which resulted in quitting with this strange error message:

/home/phnxbld/sPHENIX/gcc-12.1.0/ana/source/coresoftware/offline/framework/fun4all/Fun4AllServer.cc:871: Unexpected TDirectory Problem cd'ing to TOP - send e-mail to off-l with your macro
## TODOs (if applicable)

Now the default is hardcoded to be in memory (Rint:/) and opening TFiles (for whatever reason) before creating a Fun4AllServer instance is okay

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

