### PR TITLE
KFParticle update, gluon records

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -66,17 +66,17 @@ KFParticle_Tools::KFParticle_Tools()
   , m_max_decayTime(FLT_MAX)
   , m_min_decayLength(-1 * FLT_MAX)
   , m_max_decayLength(FLT_MAX)
-  , m_track_pt(0.25)
+  , m_track_pt(0.2)
   , m_track_ptchi2(FLT_MAX)
   , m_track_ip(-1.)
-  , m_track_ipchi2(10.)
+  , m_track_ipchi2(0.)
   , m_track_chi2ndof(4.)
   , m_nMVTXHits(3)
   , m_nTPCHits(20)
   , m_comb_DCA(0.05)
   , m_vertex_chi2ndof(15.)
-  , m_fdchi2(50.)
-  , m_dira_min(0.95)
+  , m_fdchi2(0.)
+  , m_dira_min(0.90)
   , m_dira_max(1.01)
   , m_mother_pt(0.)
   , m_mother_ipchi2(FLT_MAX)
@@ -577,9 +577,11 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   float max_mass = isIntermediate ? m_intermediate_mass_range[intermediateNumber].second : m_max_mass;
   float min_pt = isIntermediate ? m_intermediate_min_pt[intermediateNumber] : m_mother_pt;
 
+  float max_vertex_volume = isIntermediate ? m_intermediate_vertex_volume[intermediateNumber] : m_mother_vertex_volume; 
+
   bool goodCandidate = false;
   if (calculated_mass >= min_mass && calculated_mass <= max_mass &&
-      calculated_pt >= min_pt && daughterMassCheck && chargeCheck)
+      calculated_pt >= min_pt && daughterMassCheck && chargeCheck && calculateEllipsoidVolume(mother) <= max_vertex_volume)
     goodCandidate = true;
 
   // Check the requirements of an intermediate states against this mother and re-do goodCandidate

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -121,6 +121,7 @@ class KFParticle_Tools : protected KFParticle_MVA
   std::vector<float> m_intermediate_max_ip;
   std::vector<float> m_intermediate_min_ipchi2;
   std::vector<float> m_intermediate_max_ipchi2;
+  std::vector<float> m_intermediate_vertex_volume;
 
   float m_min_mass = -1;
 
@@ -161,6 +162,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   float m_mother_pt = -1;
 
   float m_mother_ipchi2 = FLT_MAX;
+
+  float m_mother_vertex_volume = FLT_MAX;
 
   float m_mva_cut_value = -1;
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -190,6 +190,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMotherIPchi2(float mother_ipchi2) { m_mother_ipchi2 = mother_ipchi2; }
 
+  void setMaximumMotherVertexVolume(float vertexvol) { m_mother_vertex_volume = vertexvol; }
+
   void constrainToPrimaryVertex(bool constrain_to_vertex)
   {
     m_constrain_to_vertex = constrain_to_vertex;
@@ -255,6 +257,11 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void setIntermediateMinFDchi2(const std::vector<float> &intermediate_min_FDchi2)
   {
     for (unsigned int i = 0; i < intermediate_min_FDchi2.size(); ++i) m_intermediate_min_fdchi2.push_back(intermediate_min_FDchi2[i]);
+  }
+
+  void setIntermediateMaxVertexVolume(const std::vector<float> &intermediate_max_vertexvol)
+  {
+    for (unsigned int i = 0; i < intermediate_max_vertexvol.size(); ++i) m_intermediate_vertex_volume.push_back(intermediate_max_vertexvol[i]);
   }
 
   void useMVA(bool require_mva) { m_require_mva = require_mva; }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -400,7 +400,8 @@ int KFParticle_truthAndDetTools::getHepMCInfo(PHCompositeNode *topNode, TTree * 
   HepMC::GenEvent *theEvent = m_genevt->getEvent();
   HepMC::GenParticle *prevParticle = nullptr;
 
-  int forbiddenPDGIDs[] = {21, 22};  //Stop tracing history when we reach quarks, gluons and photons
+  //int forbiddenPDGIDs[] = {21, 22};  //Stop tracing history when we reach quarks, gluons and photons
+  int forbiddenPDGIDs[] = {0};  //20230921 - Request made to have gluon information to see about gluon-splitting
 
   for (HepMC::GenEvent::particle_const_iterator p = theEvent->particles_begin(); p != theEvent->particles_end(); ++p)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

From yesterdays HF&Q meeting. Tony has asked for gluon information in the truth tracing branch of the output nTuple. This will allow him and Reese to tag events from gluon splitting.

I used the opportunity to also add a new selection on the secondary vertex volume and change some default values to be less restrictive (the track IP chisq and the mother flight distance chisq)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

