### PR TITLE
track efficiency updates

### DIFF
--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.h
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.h
@@ -88,6 +88,8 @@ class HFTrackEfficiency : public SubsysReco
   PHHepMCGenEventMap *m_geneventmap = nullptr;
   PHHepMCGenEvent *m_genevt = nullptr;
 
+  PHG4ParticleSvtxMap_v1 *m_dst_truth_reco_map = nullptr;
+
   DecayFinderContainer_v1 *m_decayMap = nullptr;
   std::string m_df_module_name;
 
@@ -121,6 +123,7 @@ class HFTrackEfficiency : public SubsysReco
 
   static const int m_maxTracks = 5;
   bool m_all_tracks_reconstructed = false;
+  float m_true_mother_mass = 0.;
   float m_reco_mother_mass = 0.;
   float m_true_mother_pT = 0.;
   float m_true_mother_eta = 0.;
@@ -129,9 +132,11 @@ class HFTrackEfficiency : public SubsysReco
   float m_max_true_track_pT = -1. * FLT_MAX;
   float m_max_reco_track_pT = -1. * FLT_MAX;
   bool m_reco_track_exists[m_maxTracks] = {false};
+  bool m_used_truth_reco_map[m_maxTracks] = {false};
   float m_true_track_pT[m_maxTracks] = {0.};
   float m_reco_track_pT[m_maxTracks] = {0.};
   float m_true_track_eta[m_maxTracks] = {0.};
+  float m_reco_track_eta[m_maxTracks] = {0.};
   float m_true_track_PID[m_maxTracks] = {0.};
   float m_reco_track_chi2nDoF[m_maxTracks] = {0.};
   int m_reco_track_silicon_seeds[m_maxTracks] = {0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As discussed in yesterdays HF&Q meeting (see minutes emailed from Jin) I have updated the HFTrackEfficiency module to:

1. Calcualte the mass of the mother particle using the truth variables of the daughters
2. Take the PID of the daughter from truth particle rather than the DecayFinder tag (in case the matching is wrong)
3. Add a new matching feature to initially try and match the truth particle to the reco. track using the PHG4ParticleSvtxMap. This should improve the low pT tagging


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

