### PR TITLE
new towerinfo version class

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -54,8 +54,10 @@ pkginclude_HEADERS = \
   TowerInfoDefs.h \
   TowerInfo.h \
   TowerInfov1.h \
+  TowerInfov2.h \
   TowerInfoContainer.h \
-  TowerInfoContainerv1.h
+  TowerInfoContainerv1.h \
+  TowerInfoContainerv2.h
 
 ROOTDICTS = \
   RawCluster_Dict.cc \
@@ -77,8 +79,10 @@ ROOTDICTS = \
   RawTowerGeomContainer_Cylinderv1_Dict.cc \
   TowerInfo_Dict.cc \
   TowerInfov1_Dict.cc \
+  TowerInfov2_Dict.cc \
   TowerInfoContainer_Dict.cc \
-  TowerInfoContainerv1_Dict.cc
+  TowerInfoContainerv1_Dict.cc \
+  TowerInfoContainerv2_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
@@ -101,8 +105,10 @@ nobase_dist_pcm_DATA = \
   RawTowerGeomContainer_Cylinderv1_Dict_rdict.pcm \
   TowerInfo_Dict_rdict.pcm \
   TowerInfov1_Dict_rdict.pcm \
+  TowerInfov2_Dict_rdict.pcm \
   TowerInfoContainer_Dict_rdict.pcm \
-  TowerInfoContainerv1_Dict_rdict.pcm
+  TowerInfoContainerv1_Dict_rdict.pcm \
+  TowerInfoContainerv2_Dict_rdict.pcm
 
 libcalo_io_la_SOURCES = \
   $(ROOTDICTS) \
@@ -124,9 +130,11 @@ libcalo_io_la_SOURCES = \
   RawTowerGeomContainerv1.cc \
   RawTowerGeomContainer_Cylinderv1.cc \
   TowerInfov1.cc \
+  TowerInfov2.cc \  
   TowerInfoDefs.cc \
   TowerInfoContainer.cc \
-  TowerInfoContainerv1.cc
+  TowerInfoContainerv1.cc \
+  TowerInfoContainerv2.cc
 endif
 
 # Rule for generating table CINT dictionaries.

--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -137,8 +137,8 @@ libcalo_io_la_SOURCES = \
   RawTowerGeomContainerv1.cc \
   RawTowerGeomContainer_Cylinderv1.cc \
   TowerInfov1.cc \
-  TowerInfov2.cc \  
-  TowerInfov3.cc \  
+  TowerInfov2.cc \
+  TowerInfov3.cc \
   TowerInfoDefs.cc \
   TowerInfoContainer.cc \
   TowerInfoContainerv1.cc \

--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -55,9 +55,12 @@ pkginclude_HEADERS = \
   TowerInfo.h \
   TowerInfov1.h \
   TowerInfov2.h \
+  TowerInfov3.h \
   TowerInfoContainer.h \
   TowerInfoContainerv1.h \
-  TowerInfoContainerv2.h
+  TowerInfoContainerv2.h \
+  TowerInfoContainerv3.h
+  
 
 ROOTDICTS = \
   RawCluster_Dict.cc \
@@ -80,9 +83,11 @@ ROOTDICTS = \
   TowerInfo_Dict.cc \
   TowerInfov1_Dict.cc \
   TowerInfov2_Dict.cc \
+  TowerInfov3_Dict.cc \
   TowerInfoContainer_Dict.cc \
   TowerInfoContainerv1_Dict.cc \
-  TowerInfoContainerv2_Dict.cc
+  TowerInfoContainerv2_Dict.cc \
+  TowerInfoContainerv3_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
@@ -106,9 +111,11 @@ nobase_dist_pcm_DATA = \
   TowerInfo_Dict_rdict.pcm \
   TowerInfov1_Dict_rdict.pcm \
   TowerInfov2_Dict_rdict.pcm \
+  TowerInfov3_Dict_rdict.pcm \
   TowerInfoContainer_Dict_rdict.pcm \
   TowerInfoContainerv1_Dict_rdict.pcm \
-  TowerInfoContainerv2_Dict_rdict.pcm
+  TowerInfoContainerv2_Dict_rdict.pcm \
+  TowerInfoContainerv3_Dict_rdict.pcm
 
 libcalo_io_la_SOURCES = \
   $(ROOTDICTS) \
@@ -131,10 +138,12 @@ libcalo_io_la_SOURCES = \
   RawTowerGeomContainer_Cylinderv1.cc \
   TowerInfov1.cc \
   TowerInfov2.cc \  
+  TowerInfov3.cc \  
   TowerInfoDefs.cc \
   TowerInfoContainer.cc \
   TowerInfoContainerv1.cc \
-  TowerInfoContainerv2.cc
+  TowerInfoContainerv2.cc \
+  TowerInfoContainerv3.cc
 endif
 
 # Rule for generating table CINT dictionaries.

--- a/offline/packages/CaloBase/TowerInfoContainerv2.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv2.cc
@@ -1,0 +1,144 @@
+#include "TowerInfoContainerv2.h"
+#include "TowerInfov2.h"
+#include "TowerInfoDefs.h"
+
+#include <phool/PHObject.h>
+#include <phool/phool.h>
+
+#include <TClonesArray.h>
+
+#include <cassert>
+
+
+TowerInfoContainerv2::TowerInfoContainerv2(DETECTOR detec)
+  : _detector(detec)
+{
+  int nchannels = 744;
+  if (_detector == DETECTOR::SEPD)
+  {
+    nchannels = 744;
+  }
+  else if (_detector == DETECTOR::EMCAL)
+  {
+    nchannels = 24576;
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    nchannels = 1536;
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    nchannels = 256;
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    nchannels = 16;
+  }
+  _clones = new TClonesArray("TowerInfov2", nchannels);
+  _clones->SetOwner();
+  _clones->SetName("TowerInfoContainerv2");
+  for (int i = 0; i < nchannels; ++i)
+  {
+    // as tower numbers are fixed per event
+    // construct towers once per run, and clear the towers for first use
+    _clones->ConstructedAt(i, "C");
+  }
+}
+
+TowerInfoContainerv2::~TowerInfoContainerv2()
+{
+  delete _clones;
+}
+
+void TowerInfoContainerv2::Reset()
+{
+  // clear content of towers in the container for the next event
+
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj==nullptr)
+    {
+      std::cout<<__PRETTY_FUNCTION__<<" Fatal access error:"
+          <<" _clones->GetSize() = "<<_clones->GetSize()
+          <<" _clones->GetEntriesFast() = "<<_clones->GetEntriesFast()
+          <<" i = "<<i<<std::endl;
+      _clones->Print();
+    }
+
+    assert(obj);
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
+}
+
+TowerInfov2* TowerInfoContainerv2::get_tower_at_channel(int pos)
+{
+  return (TowerInfov2*) _clones->At(pos);
+}
+
+
+TowerInfov2* TowerInfoContainerv2::get_tower_at_key(int pos)
+{
+  int index = decode_key(pos);
+  return (TowerInfov2*) _clones->At(index);
+}
+
+unsigned int TowerInfoContainerv2::encode_key(unsigned int towerIndex)
+{
+  int key = 0;
+  if (_detector == DETECTOR::EMCAL)
+    {
+      key = TowerInfoContainer::encode_emcal(towerIndex);
+    }
+  else if (_detector == DETECTOR::HCAL)
+    {
+      key = TowerInfoContainer::encode_hcal(towerIndex);
+    }
+  else if (_detector == DETECTOR::SEPD)
+    {
+    key = TowerInfoContainer::encode_epd(towerIndex);
+    }
+  else if (_detector == DETECTOR::MBD)
+    {
+    key = TowerInfoContainer::encode_mbd(towerIndex);
+    }
+  else if (_detector == DETECTOR::ZDC)
+    {
+    key = TowerInfoContainer::encode_zdc(towerIndex);
+    }
+  return key;
+}
+
+unsigned int TowerInfoContainerv2::decode_key(unsigned int tower_key)
+{
+  int index = 0;
+
+  if (_detector == DETECTOR::EMCAL)
+  {
+    index = TowerInfoContainer::decode_emcal(tower_key);
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    index = TowerInfoContainer::decode_hcal(tower_key);
+  }
+  else if (_detector == DETECTOR::SEPD)
+  {
+    index = TowerInfoContainer::decode_epd(tower_key);
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    index = TowerInfoContainer::decode_mbd(tower_key);
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    index = TowerInfoContainer::decode_zdc(tower_key);
+  }
+  return index;
+}
+
+

--- a/offline/packages/CaloBase/TowerInfoContainerv2.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv2.h
@@ -1,0 +1,38 @@
+#ifndef TOWERINFOCONTAINERV2_H
+#define TOWERINFOCONTAINERV2_H
+
+#include "TowerInfoContainer.h"
+#include "TowerInfov2.h"
+
+#include <phool/PHObject.h>
+
+#include <TClonesArray.h>
+// this is basically a copy of TowerInfoContainerv1.h, but with TowerInfov2...
+class TowerInfoContainerv2 : public TowerInfoContainer
+{
+ public:
+  TowerInfoContainerv2(DETECTOR detec);
+
+  // default constructor for ROOT IO
+  TowerInfoContainerv2() {}
+
+  ~TowerInfoContainerv2() override;
+
+  void Reset() override;
+  TowerInfov2 *get_tower_at_channel(int pos) override;
+  TowerInfov2 *get_tower_at_key(int pos) override;
+
+  unsigned int encode_key(unsigned int towerIndex) override;
+  unsigned int decode_key(unsigned int tower_key) override;
+
+  size_t size() override { return _clones->GetEntries(); }
+
+ protected:
+  TClonesArray *_clones = nullptr;
+  DETECTOR _detector = DETECTOR_INVALID;
+
+ private:
+  ClassDefOverride(TowerInfoContainerv2, 1);
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfoContainerv2LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfoContainerv2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/TowerInfoContainerv3.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.cc
@@ -1,0 +1,144 @@
+#include "TowerInfoContainerv3.h"
+#include "TowerInfov3.h"
+#include "TowerInfoDefs.h"
+
+#include <phool/PHObject.h>
+#include <phool/phool.h>
+
+#include <TClonesArray.h>
+
+#include <cassert>
+
+
+TowerInfoContainerv3::TowerInfoContainerv3(DETECTOR detec)
+  : _detector(detec)
+{
+  int nchannels = 744;
+  if (_detector == DETECTOR::SEPD)
+  {
+    nchannels = 744;
+  }
+  else if (_detector == DETECTOR::EMCAL)
+  {
+    nchannels = 24576;
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    nchannels = 1536;
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    nchannels = 256;
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    nchannels = 16;
+  }
+  _clones = new TClonesArray("TowerInfov3", nchannels);
+  _clones->SetOwner();
+  _clones->SetName("TowerInfoContainerv3");
+  for (int i = 0; i < nchannels; ++i)
+  {
+    // as tower numbers are fixed per event
+    // construct towers once per run, and clear the towers for first use
+    _clones->ConstructedAt(i, "C");
+  }
+}
+
+TowerInfoContainerv3::~TowerInfoContainerv3()
+{
+  delete _clones;
+}
+
+void TowerInfoContainerv3::Reset()
+{
+  // clear content of towers in the container for the next event
+
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj==nullptr)
+    {
+      std::cout<<__PRETTY_FUNCTION__<<" Fatal access error:"
+          <<" _clones->GetSize() = "<<_clones->GetSize()
+          <<" _clones->GetEntriesFast() = "<<_clones->GetEntriesFast()
+          <<" i = "<<i<<std::endl;
+      _clones->Print();
+    }
+
+    assert(obj);
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
+}
+
+TowerInfov2* TowerInfoContainerv3::get_tower_at_channel(int pos)
+{
+  return (TowerInfov2*) _clones->At(pos);
+}
+
+
+TowerInfov2* TowerInfoContainerv3::get_tower_at_key(int pos)
+{
+  int index = decode_key(pos);
+  return (TowerInfov2*) _clones->At(index);
+}
+
+unsigned int TowerInfoContainerv3::encode_key(unsigned int towerIndex)
+{
+  int key = 0;
+  if (_detector == DETECTOR::EMCAL)
+    {
+      key = TowerInfoContainer::encode_emcal(towerIndex);
+    }
+  else if (_detector == DETECTOR::HCAL)
+    {
+      key = TowerInfoContainer::encode_hcal(towerIndex);
+    }
+  else if (_detector == DETECTOR::SEPD)
+    {
+    key = TowerInfoContainer::encode_epd(towerIndex);
+    }
+  else if (_detector == DETECTOR::MBD)
+    {
+    key = TowerInfoContainer::encode_mbd(towerIndex);
+    }
+  else if (_detector == DETECTOR::ZDC)
+    {
+    key = TowerInfoContainer::encode_zdc(towerIndex);
+    }
+  return key;
+}
+
+unsigned int TowerInfoContainerv3::decode_key(unsigned int tower_key)
+{
+  int index = 0;
+
+  if (_detector == DETECTOR::EMCAL)
+  {
+    index = TowerInfoContainer::decode_emcal(tower_key);
+  }
+  else if (_detector == DETECTOR::HCAL)
+  {
+    index = TowerInfoContainer::decode_hcal(tower_key);
+  }
+  else if (_detector == DETECTOR::SEPD)
+  {
+    index = TowerInfoContainer::decode_epd(tower_key);
+  }
+  else if (_detector == DETECTOR::MBD)
+  {
+    index = TowerInfoContainer::decode_mbd(tower_key);
+  }
+  else if (_detector == DETECTOR::ZDC)
+  {
+    index = TowerInfoContainer::decode_zdc(tower_key);
+  }
+  return index;
+}
+
+

--- a/offline/packages/CaloBase/TowerInfoContainerv3.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.cc
@@ -76,16 +76,16 @@ void TowerInfoContainerv3::Reset()
   }
 }
 
-TowerInfov2* TowerInfoContainerv3::get_tower_at_channel(int pos)
+TowerInfov3* TowerInfoContainerv3::get_tower_at_channel(int pos)
 {
-  return (TowerInfov2*) _clones->At(pos);
+  return (TowerInfov3*) _clones->At(pos);
 }
 
 
-TowerInfov2* TowerInfoContainerv3::get_tower_at_key(int pos)
+TowerInfov3* TowerInfoContainerv3::get_tower_at_key(int pos)
 {
   int index = decode_key(pos);
-  return (TowerInfov2*) _clones->At(index);
+  return (TowerInfov3*) _clones->At(index);
 }
 
 unsigned int TowerInfoContainerv3::encode_key(unsigned int towerIndex)

--- a/offline/packages/CaloBase/TowerInfoContainerv3.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.h
@@ -19,8 +19,8 @@ class TowerInfoContainerv3 : public TowerInfoContainer
   ~TowerInfoContainerv3() override;
 
   void Reset() override;
-  TowerInfov2 *get_tower_at_channel(int pos) override;
-  TowerInfov2 *get_tower_at_key(int pos) override;
+  TowerInfov3 *get_tower_at_channel(int pos) override;
+  TowerInfov3 *get_tower_at_key(int pos) override;
 
   unsigned int encode_key(unsigned int towerIndex) override;
   unsigned int decode_key(unsigned int tower_key) override;

--- a/offline/packages/CaloBase/TowerInfoContainerv3.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.h
@@ -1,0 +1,38 @@
+#ifndef TOWERINFOCONTAINERV3_H
+#define TOWERINFOCONTAINERV3_H
+
+#include "TowerInfoContainer.h"
+#include "TowerInfov3.h"
+
+#include <phool/PHObject.h>
+
+#include <TClonesArray.h>
+
+class TowerInfoContainerv3 : public TowerInfoContainer
+{
+ public:
+  TowerInfoContainerv3(DETECTOR detec);
+
+  // default constructor for ROOT IO
+  TowerInfoContainerv3() {}
+
+  ~TowerInfoContainerv3() override;
+
+  void Reset() override;
+  TowerInfov2 *get_tower_at_channel(int pos) override;
+  TowerInfov2 *get_tower_at_key(int pos) override;
+
+  unsigned int encode_key(unsigned int towerIndex) override;
+  unsigned int decode_key(unsigned int tower_key) override;
+
+  size_t size() override { return _clones->GetEntries(); }
+
+ protected:
+  TClonesArray *_clones = nullptr;
+  DETECTOR _detector = DETECTOR_INVALID;
+
+ private:
+  ClassDefOverride(TowerInfoContainerv3, 1);
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfoContainerv3LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfoContainerv3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/TowerInfov1.h
+++ b/offline/packages/CaloBase/TowerInfov1.h
@@ -24,8 +24,10 @@ class TowerInfov1 : public TowerInfo
   float get_energy() override { return _energy; }
 
  private:
-  short _time = 0;
   float _energy = 0;
+
+ protected:
+  short _time = 0;
 
   ClassDefOverride(TowerInfov1, 1);
 };

--- a/offline/packages/CaloBase/TowerInfov2.cc
+++ b/offline/packages/CaloBase/TowerInfov2.cc
@@ -15,3 +15,13 @@ void TowerInfov2::Clear(Option_t* )
   _pedestal = 0;
   _status = 0;
 }
+
+void TowerInfov2::copy_tower(TowerInfov2* tower)
+{
+  set_time_float(tower->get_time_float());
+  set_energy(tower->get_energy());
+  set_chi2(tower->get_chi2());
+  set_pedestal(tower->get_pedestal());
+  set_status(tower->get_status());
+  return;
+}

--- a/offline/packages/CaloBase/TowerInfov2.cc
+++ b/offline/packages/CaloBase/TowerInfov2.cc
@@ -1,0 +1,17 @@
+#include "TowerInfov2.h"
+
+void TowerInfov2::Reset()
+{
+  TowerInfov1::Reset();
+  _chi2 = 0;
+  _pedestal = 0;
+  _status = 0;
+}
+
+void TowerInfov2::Clear(Option_t* )
+{
+  TowerInfov1::Clear();
+  _chi2 = 0;
+  _pedestal = 0;
+  _status = 0;
+}

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -7,10 +7,7 @@ class TowerInfov2 : public TowerInfov1
 {
  public:
   TowerInfov2() {}
-  TowerInfov2(TowerInfo& tower)
-    : TowerInfov1(tower)
-  {
-  }
+ 
   ~TowerInfov2() override {}
 
   void Reset() override;
@@ -44,6 +41,9 @@ class TowerInfov2 : public TowerInfov1
   uint8_t get_status() const { return _status; }
 
   void set_status(uint8_t status) { _status = status; }
+
+
+  void copy_tower(TowerInfov2* tower);
 
  private:
   float _chi2 = 0;

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -1,0 +1,75 @@
+#ifndef TOWERINFOV2_H
+#define TOWERINFOV2_H
+
+#include "TowerInfov1.h"
+
+class TowerInfov2 : public TowerInfov1
+{
+ public:
+  TowerInfov2() {}
+  TowerInfov2(TowerInfo& tower)
+    : TowerInfov1(tower)
+  {
+  }
+  ~TowerInfov2() override {}
+
+  void Reset() override;
+  void Clear(Option_t* = "") override;
+
+  void set_time(short t) override { _time = t * 1000; }
+  short get_time() override { return _time / 1000; }
+
+  void set_time_float(float t) { _time = t * 1000; }
+  float get_time_float() { return _time / 1000.; }
+
+  void set_chi2(float chi2) { _chi2 = chi2; }
+  float get_chi2() { return _chi2; }
+  void set_pedestal(float pedestal) { _pedestal = pedestal; }
+  float get_pedestal() { return _pedestal; }
+
+  void set_isHot(bool isHot) { set_status_bit(0, isHot); }
+  bool get_isHot() const { return get_status_bit(0); }
+
+  void set_isBadTime(bool isBadTime) { set_status_bit(1, isBadTime); }
+  bool get_isBadTime() const { return get_status_bit(1); }
+
+  void set_isBadChi2(bool isBadChi2) { set_status_bit(2, isBadChi2); }
+  bool get_isBadChi2() const { return get_status_bit(2); }
+
+  void set_isNotInstr(bool isNotInstr) { set_status_bit(3, isNotInstr); }
+  bool get_isNotInstr() const { return get_status_bit(3); }
+
+  bool get_isGood() const { return !((bool) _status); }
+
+  uint8_t get_status() const { return _status; }
+
+  void set_status(uint8_t status) { _status = status; }
+
+ private:
+  float _chi2 = 0;
+  float _pedestal = 0;
+  uint8_t _status = 0;
+
+  void set_status_bit(int bit, bool value)
+  {
+    if (bit < 0 || bit > 7)
+    {
+      return;
+    }
+    _status &= ~((uint8_t) 1 << bit);
+    _status |= (uint8_t) value << bit;
+  }
+
+  bool get_status_bit(int bit) const
+  {
+    if (bit < 0 || bit > 7)
+    {
+      return false;  // default behavior
+    }
+    return (_status & ((uint8_t) 1 << bit)) != 0;
+  }
+
+  // Inherit other methods and properties from TowerInfov1
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfov2LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfov2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfov2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloBase/TowerInfov3.cc
+++ b/offline/packages/CaloBase/TowerInfov3.cc
@@ -1,0 +1,47 @@
+#include "TowerInfov3.h"
+
+void TowerInfov3::Reset()
+{
+  TowerInfov2::Reset();  
+  for (int i = 0; i < nsample; ++i)
+  {
+    _waveform[i] = 0;
+  }
+}
+
+void TowerInfov3::Clear(Option_t *)
+{
+  TowerInfov2::Clear();  
+  for (int i = 0; i < nsample; ++i)
+  {
+    _waveform[i] = 0;
+  }
+}
+
+int16_t TowerInfov3::get_waveform_value(int index) const
+{
+  if (index >= 0 && index < nsample)
+  {
+    return _waveform[index];
+  }
+  return 0;
+}
+
+void TowerInfov3::set_waveform_value(int index, int16_t value)
+{
+  if (index >= 0 && index < nsample)
+  {
+    _waveform[index] = value;
+  }
+  return;
+}
+
+void TowerInfov3::copy_tower(TowerInfov3* tower)
+{
+  TowerInfov2::copy_tower(tower);
+  for (int i = 0; i < nsample; ++i)
+  {
+    set_waveform_value(i, tower->get_waveform_value(i));
+  }
+  return;
+}

--- a/offline/packages/CaloBase/TowerInfov3.h
+++ b/offline/packages/CaloBase/TowerInfov3.h
@@ -1,0 +1,30 @@
+#ifndef TOWERINFOV3_H
+#define TOWERINFOV3_H
+
+#include "TowerInfov2.h"
+
+#include <cstdint> // For int16_t
+
+class TowerInfov3: public TowerInfov2
+{
+public:
+    TowerInfov3() {}
+    ~TowerInfov3() override {}
+    
+    void Reset() override;
+    void Clear(Option_t* = "") override;
+    
+    // Getter and setter for waveform
+    int16_t get_waveform_value(int index) const;
+    void set_waveform_value(int index, int16_t value);
+
+    void copy_tower(TowerInfov3* tower);
+    
+private:
+    static const int nsample = 31;
+    int16_t _waveform[nsample] = {0}; // Initializes the entire array to zero
+
+    // Inherit other methods and properties from TowerInfov2
+};
+
+#endif

--- a/offline/packages/CaloBase/TowerInfov3LinkDef.h
+++ b/offline/packages/CaloBase/TowerInfov3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TowerInfov3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -3,6 +3,8 @@
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfoContainerv2.h>
+#include <calobase/TowerInfoContainerv3.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
@@ -27,7 +29,9 @@ CaloTowerBuilder::CaloTowerBuilder(const std::string &name)
   : SubsysReco(name)
   , WaveformProcessing(nullptr)
   , m_dettype(CaloTowerBuilder::CEMC)
+  , m_buildertype(CaloTowerBuilder::kPRDFTowerv1)
   , m_CaloInfoContainer(nullptr)
+  , m_CaloWaveformContainer(nullptr)
   , m_detector("CEMC")
   , m_packet_low(INT_MIN)
   , m_packet_high(INT_MIN)
@@ -134,72 +138,100 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
   std::vector<std::vector<float>> waveforms;
   if (m_isdata)
   {
-    Event *_event = findNode::getClass<Event>(topNode, "PRDF");
-    if (_event == nullptr)
+    // if we are going from prdf
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1 || m_buildertype == CaloTowerBuilder::kPRDFWaveform)
     {
-      std::cout << "CaloUnpackPRDF::Process_Event - Event not found" << std::endl;
-      return -1;
-    }
-    if (_event->getEvtType() >= 8)  /// special event where we do not read out the calorimeters
-    {
-      return Fun4AllReturnCodes::DISCARDEVENT;
-    }
-    for (int pid = m_packet_low; pid <= m_packet_high; pid++)
-    {
-      Packet *packet = _event->getPacket(pid);
-      if (packet)
+      Event *_event = findNode::getClass<Event>(topNode, "PRDF");
+      if (_event == nullptr)
       {
-        int nchannels = packet->iValue(0, "CHANNELS");
-        if (m_dettype == CaloTowerBuilder::ZDC)
-        {  // special condition during zdc commisioning
-          if (nchannels < m_nchannels)
+        std::cout << "CaloUnpackPRDF::Process_Event - Event not found" << std::endl;
+        return -1;
+      }
+      if (_event->getEvtType() >= 8)  /// special event where we do not read out the calorimeters
+      {
+        return Fun4AllReturnCodes::DISCARDEVENT;
+      }
+      for (int pid = m_packet_low; pid <= m_packet_high; pid++)
+      {
+        Packet *packet = _event->getPacket(pid);
+        if (packet)
+        {
+          int nchannels = packet->iValue(0, "CHANNELS");
+          if (m_dettype == CaloTowerBuilder::ZDC)
+          {  // special condition during zdc commisioning
+            if (nchannels < m_nchannels)
+            {
+              return Fun4AllReturnCodes::DISCARDEVENT;
+            }
+            nchannels = m_nchannels;
+          }
+          if (nchannels > m_nchannels)  // packet is corrupted and reports too many channels
           {
             return Fun4AllReturnCodes::DISCARDEVENT;
           }
-          nchannels = m_nchannels;
-        }
-        if (nchannels > m_nchannels)  // packet is corrupted and reports too many channels
-        {
-          return Fun4AllReturnCodes::DISCARDEVENT;
-        }
-        //int sector = 0;
-        
-        for (int channel = 0; channel < nchannels; channel++)
-        {
-          //mask empty channels
-          
-          if(m_dettype == CaloTowerBuilder::EPD){
-            int sector = ((channel + 1)/ 32);
-            if (channel == (14 + 32*sector)) {
-              continue;
-            }
-            
-            
-          }
-          std::vector<float> waveform;
-          waveform.reserve(m_nsamples);
-          for (int samp = 0; samp < m_nsamples; samp++)
-          {
-            waveform.push_back(packet->iValue(samp, channel));
-          }
-          waveforms.push_back(waveform);
-          waveform.clear();
-        }
-        if (nchannels < m_nchannels)
-        {
-          for (int channel = 0; channel < m_nchannels - nchannels; channel++)
-          {
+          // int sector = 0;
 
-            if(m_dettype == CaloTowerBuilder::EPD){
+          for (int channel = 0; channel < nchannels; channel++)
+          {
+            // mask empty channels
+
+            if (m_dettype == CaloTowerBuilder::EPD)
+            {
               int sector = ((channel + 1) / 32);
-              
-              if (channel == (14 + 32*sector)) {
+              if (channel == (14 + 32 * sector))
+              {
                 continue;
               }
             }
             std::vector<float> waveform;
             waveform.reserve(m_nsamples);
-            
+            for (int samp = 0; samp < m_nsamples; samp++)
+            {
+              waveform.push_back(packet->iValue(samp, channel));
+            }
+            waveforms.push_back(waveform);
+            waveform.clear();
+          }
+          if (nchannels < m_nchannels)
+          {
+            for (int channel = 0; channel < m_nchannels - nchannels; channel++)
+            {
+              if (m_dettype == CaloTowerBuilder::EPD)
+              {
+                int sector = ((channel + 1) / 32);
+
+                if (channel == (14 + 32 * sector))
+                {
+                  continue;
+                }
+              }
+              std::vector<float> waveform;
+              waveform.reserve(m_nsamples);
+
+              for (int samp = 0; samp < m_nzerosuppsamples; samp++)
+              {
+                waveform.push_back(0);
+              }
+              waveforms.push_back(waveform);
+              waveform.clear();
+            }
+          }
+          delete packet;
+        }
+        else  // if the packet is missing treat constitutent channels as zero suppressed
+        {
+          for (int channel = 0; channel < m_nchannels; channel++)
+          {
+            if (m_dettype == CaloTowerBuilder::EPD)
+            {
+              int sector = ((channel + 1) / 32);
+              if (channel == (14 + 32 * sector))
+              {
+                continue;
+              }
+            }
+            std::vector<float> waveform;
+            waveform.reserve(2);
             for (int samp = 0; samp < m_nzerosuppsamples; samp++)
             {
               waveform.push_back(0);
@@ -208,27 +240,28 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
             waveform.clear();
           }
         }
-        delete packet;
       }
-      else  // if the packet is missing treat constitutent channels as zero suppressed
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      unsigned int n_channels = m_CaloWaveformContainer->size();
+      for (unsigned int channel = 0; channel < n_channels; channel++)
       {
-        for (int channel = 0; channel < m_nchannels; channel++)
+        TowerInfov3 *calowaveform = m_CaloWaveformContainer->get_tower_at_channel(channel);
+        bool isNotInstr = calowaveform->get_isNotInstr();
+        std::vector<float> waveform;
+        int waveformsamples = m_nsamples;
+        if (isNotInstr)
         {
-          if(m_dettype == CaloTowerBuilder::EPD){
-            int sector = ((channel + 1)/ 32);
-            if (channel == (14 + 32*sector)) {
-              continue;
-            }  
-          }
-          std::vector<float> waveform;
-          waveform.reserve(2);
-          for (int samp = 0; samp < m_nzerosuppsamples; samp++)
-          {
-            waveform.push_back(0);
-          }
-          waveforms.push_back(waveform);
-          waveform.clear();
+          waveformsamples = m_nzerosuppsamples;
         }
+        waveform.reserve(waveformsamples);
+        for (int samp = 0; samp < waveformsamples; samp++)
+        {
+          waveform.push_back(calowaveform->get_waveform_value(samp));
+        }
+        waveforms.push_back(waveform);
+        waveform.clear();
       }
     }
   }
@@ -236,16 +269,35 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
   {
     return Fun4AllReturnCodes::EVENT_OK;
   }
-
-  std::vector<std::vector<float>> processed_waveforms = WaveformProcessing->process_waveform(waveforms);
-  int n_channels = processed_waveforms.size();
-  for (int i = 0; i < n_channels; i++)
+  // fill the waveform node
+  if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
   {
-    
-    m_CaloInfoContainer->get_tower_at_channel(i)->set_time(processed_waveforms.at(i).at(1));
-    m_CaloInfoContainer->get_tower_at_channel(i)->set_energy(processed_waveforms.at(i).at(0));
+    int n_channels = waveforms.size();
+    for (int i = 0; i < n_channels; i++)
+    {
+      int n_samples = waveforms.at(i).size();
+      for (int j = 0; j < n_samples; j++)
+      {
+        m_CaloWaveformContainer->get_tower_at_channel(i)->set_waveform_value(j, waveforms.at(i).at(j));
+      }
+    }
   }
 
+  if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1 || m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+  {
+    std::vector<std::vector<float>> processed_waveforms = WaveformProcessing->process_waveform(waveforms);
+    int n_channels = processed_waveforms.size();
+    for (int i = 0; i < n_channels; i++)
+    {
+      m_CaloInfoContainer->get_tower_at_channel(i)->set_time(processed_waveforms.at(i).at(1));
+      m_CaloInfoContainer->get_tower_at_channel(i)->set_energy(processed_waveforms.at(i).at(0));
+      if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+      {
+        TowerInfov2 *raw_tower_v2 = dynamic_cast<TowerInfov2 *>(m_CaloInfoContainer->get_tower_at_channel(i));
+        raw_tower_v2->set_status(m_CaloWaveformContainer->get_tower_at_channel(i)->get_status());
+      }
+    }
+  }
   waveforms.clear();
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -265,6 +317,13 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
   // towers
   PHNodeIterator nodeItr(dstNode);
   PHCompositeNode *DetNode;
+  // get the waveform node if we are building towers from waveforms
+  if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+  {
+    // get the waveform container
+    std::string WaveformNodeName = "WAVEFORMS_" + m_detector;
+    m_CaloWaveformContainer = findNode::getClass<TowerInfoContainerv3>(topNode, WaveformNodeName);
+  }
 
   if (m_dettype == CaloTowerBuilder::CEMC)
   {
@@ -273,7 +332,18 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     {
       DetNode = new PHCompositeNode("CEMC");
     }
-    m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::EMCAL);
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::EMCAL);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::EMCAL);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::EMCAL);
+    }
   }
   else if (m_dettype == EPD)
   {
@@ -282,7 +352,18 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     {
       DetNode = new PHCompositeNode("EPD");
     }
-    m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::SEPD);
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::SEPD);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::SEPD);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::SEPD);
+    }
   }
   else if (m_dettype == MBD)
   {
@@ -291,7 +372,18 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     {
       DetNode = new PHCompositeNode("MBD");
     }
-    m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::MBD);
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::MBD);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::MBD);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::MBD);
+    }
   }
   else if (m_dettype == ZDC)
   {
@@ -300,7 +392,18 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     {
       DetNode = new PHCompositeNode("ZDC");
     }
-    m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::ZDC);
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::ZDC);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::ZDC);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::ZDC);
+    }
   }
   else
   {
@@ -320,10 +423,33 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
         DetNode = new PHCompositeNode("HCALOUT");
       }
     }
-    m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::HCAL);
+    if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv1(TowerInfoContainer::DETECTOR::HCAL);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::HCAL);
+    }
+    else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+    {
+      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::HCAL);
+    }
   }
   dstNode->addNode(DetNode);
-
-  PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, "TOWERS_" + m_detector, "PHObject");
-  DetNode->addNode(newTowerNode);
+  if (m_buildertype == CaloTowerBuilder::kPRDFTowerv1)
+  {
+    PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, "TOWERS_" + m_detector, "PHObject");
+    DetNode->addNode(newTowerNode);
+  }
+  else if (m_buildertype == CaloTowerBuilder::kPRDFWaveform)
+  {
+    PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, "WAVEFORMS_" + m_detector, "PHObject");
+    DetNode->addNode(newTowerNode);
+  }
+  else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
+  {
+    PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, "TOWERSV2_" + m_detector, "PHObject");
+    DetNode->addNode(newTowerNode);
+  }
 }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -342,7 +342,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     }
     else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
     {
-      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::EMCAL);
+      m_CaloInfoContainer = new TowerInfoContainerv2(TowerInfoContainer::DETECTOR::EMCAL);
     }
   }
   else if (m_dettype == EPD)
@@ -362,7 +362,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     }
     else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
     {
-      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::SEPD);
+      m_CaloInfoContainer = new TowerInfoContainerv2(TowerInfoContainer::DETECTOR::SEPD);
     }
   }
   else if (m_dettype == MBD)
@@ -382,7 +382,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     }
     else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
     {
-      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::MBD);
+      m_CaloInfoContainer = new TowerInfoContainerv2(TowerInfoContainer::DETECTOR::MBD);
     }
   }
   else if (m_dettype == ZDC)
@@ -402,7 +402,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     }
     else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
     {
-      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::ZDC);
+      m_CaloInfoContainer = new TowerInfoContainerv2(TowerInfoContainer::DETECTOR::ZDC);
     }
   }
   else
@@ -433,7 +433,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     }
     else if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
     {
-      m_CaloInfoContainer = new TowerInfoContainerv3(TowerInfoContainer::DETECTOR::HCAL);
+      m_CaloInfoContainer = new TowerInfoContainerv2(TowerInfoContainer::DETECTOR::HCAL);
     }
   }
   dstNode->addNode(DetNode);

--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -12,6 +12,8 @@
 class CaloWaveformProcessing;
 class PHCompositeNode;
 class TowerInfoContainer;
+class TowerInfoContainerv3;
+
 
 class CaloTowerBuilder : public SubsysReco
 {
@@ -33,9 +35,22 @@ class CaloTowerBuilder : public SubsysReco
     ZDC = 5
   };
 
+  enum BuilderType
+  {
+    kPRDFTowerv1 = 0,
+    kPRDFWaveform = 1,
+    kWaveformTowerv2 = 2
+  };
+
   void set_detector_type(CaloTowerBuilder::DetectorSystem dettype)
   {
     m_dettype = dettype;
+    return;
+  }
+
+  void set_builder_type(CaloTowerBuilder::BuilderType buildertype)
+  {
+    m_buildertype = buildertype;
     return;
   }
 
@@ -64,7 +79,9 @@ class CaloTowerBuilder : public SubsysReco
  private:
   CaloWaveformProcessing *WaveformProcessing;
   CaloTowerBuilder::DetectorSystem m_dettype;
+  CaloTowerBuilder::BuilderType m_buildertype;
   TowerInfoContainer *m_CaloInfoContainer;  //! Calo info
+  TowerInfoContainerv3 *m_CaloWaveformContainer; 
   std::string m_detector;
   int m_packet_low;
   int m_packet_high;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? 
This PR introduces two new derived classes of `TowerInfo` along with corresponding downstream changes.

- **`TowerInfov2`**: 
  - Derived from `TowerInfov1`.
  - Contains three additional fields: `pedestal`, `chi2`, and `status`.
  - The `status` is an 8-bit int that includes information like whether the tower is a hot tower and if the tower is instrumented.
  - The peak time of this class can be stored with three more significant figures compared to `v1` (which uses a `short`).

- **`TowerInfov3`**: 
  - Derived from `TowerInfov2`.
  - Contains an additional field for waveform information. 
  - This is primarily utilized to create a waveform node on the DST.

- **`CaloTowerBuilder`**:
  - Updated to support three build options.
  - The default option (`kPRDFTowerv1`) continues to construct the `TowerInfov1` object from the PRDF node.
  - Two new options introduced:
    - `kPRDFWaveform` builds the `TowerInfov3` object that includes waveform data.
    - `kWaveformTowerv2` uses an existing waveform node to construct the `TowerInfov2` object with added commissioning details.

It should be noted that these new `TowerInfo` classes are designated for commissioning purposes and are not intended to be saved in the final DST production.

Also this PR shouldn't have any effect on the default reconstruction chain.

## TODOs (if applicable):
1. Validate the new options in `CaloTowerBuilder`.
2. Implement necessary updates in further downstream reconstruction code (e.g., `CaloTowerCalib`).
3. Design a module that processes the waveform node to identify and rectify problematic towers (e.g., bit flip).


## Links to other PRs in macros and calibration repositories (if applicable)

