### PR TITLE
Couple of fixes on event combiner

### DIFF
--- a/offline/framework/fun4allraw/SingleInttInput.cc
+++ b/offline/framework/fun4allraw/SingleInttInput.cc
@@ -124,14 +124,7 @@ void SingleInttInput::FillPool(const unsigned int /*nbclks*/)
 	}
 //          plist[i]->convert();
 	if (InputManager())
-	{
-	  InputManager()->AddInttRawHit(gtm_bco, newhit);
-	}
-	if (m_InttRawHitMap.find(gtm_bco) == m_InttRawHitMap.end())
-	{
-	  std::vector<InttRawHit *> intthitvector;
-	  m_InttRawHitMap[gtm_bco] = intthitvector;
-	}
+	{ InputManager()->AddInttRawHit(gtm_bco, newhit); }
 	m_InttRawHitMap[gtm_bco].push_back(newhit);
 	m_BclkStack.insert(gtm_bco);
       }

--- a/offline/framework/fun4allraw/SingleInttInput.cc
+++ b/offline/framework/fun4allraw/SingleInttInput.cc
@@ -109,7 +109,7 @@ void SingleInttInput::FillPool(const unsigned int /*nbclks*/)
 	if (gtm_bco < m_PreviousClock[FEE])
 	{
 	  m_Rollover[FEE] += 0x10000000000;
-	  gtm_bco += m_Rollover[FEE];  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
+	  gtm_bco += 0x10000000000;  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
 	}
 	m_PreviousClock[FEE] = gtm_bco;
 	m_BeamClockFEE[gtm_bco].insert(FEE);

--- a/offline/framework/fun4allraw/SingleTpcInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcInput.cc
@@ -287,7 +287,7 @@ void SingleTpcInput::CreateDSTNode(PHCompositeNode *topNode)
 PHCompositeNode *detNode = dynamic_cast<PHCompositeNode *>(iterDst.findFirst("PHCompositeNode", "TPC"));
 if (!detNode)
 {
-  detNode = new PHCompositeNode("INTT");
+  detNode = new PHCompositeNode("TPC");
   dstNode->addNode(detNode);
 }
   TpcRawHitContainer *tpchitcont = findNode::getClass<TpcRawHitContainer>(detNode,"TPCRAWHIT");

--- a/offline/framework/fun4allraw/SingleTpcInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcInput.cc
@@ -137,11 +137,6 @@ uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
       {
 	InputManager()->AddTpcRawHit(gtm_bco, newhit);
       }
-      if (m_TpcRawHitMap.find(gtm_bco) == m_TpcRawHitMap.end())
-      {
-	std::vector<TpcRawHit *> intthitvector;
-	m_TpcRawHitMap[gtm_bco] = intthitvector;
-      }
       m_TpcRawHitMap[gtm_bco].push_back(newhit);
       m_BclkStack.insert(gtm_bco);
     }

--- a/offline/framework/fun4allraw/SingleTpcInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcInput.cc
@@ -97,7 +97,7 @@ uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
 	if (gtm_bco < m_PreviousClock[0])
 	{
 	  m_Rollover[0] += 0x10000000000;
-	  gtm_bco += m_Rollover[0];  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
+	  gtm_bco += 0x10000000000;  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
 	}
 /*
        m_tagger_type = (uint16_t) (p->lValue(t, "TAGGER_TYPE"));


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
While working on Micromegas (TPOT) event combiner, I stumbled on a few inconsistencies/typos in the existing code for INTT and TPC:
1/ fixed a typo on the master node to be created for the TPC (code creates INTT while looking for TPC node ...)
2/ removed some unnecessary code when accessing a map. Calling map[XXX] when element XXX does not exist, automatically creates that element with default constructor (https://en.cppreference.com/w/cpp/container/map/operator_at) so there is no need to do that pre-emptively
3/ Fix, I think a bug with handling of the roll-over for GTM BCO:My understanding of the code is that m_Rollover[FEE] was actually added twice in case current BCO is < previous BCO, whereas one should only add the value of the max counter.   @pinkenburg can you double check ? 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

