### PR TITLE
revert TowerInfov1.h change

### DIFF
--- a/offline/packages/CaloBase/TowerInfov1.h
+++ b/offline/packages/CaloBase/TowerInfov1.h
@@ -24,10 +24,8 @@ class TowerInfov1 : public TowerInfo
   float get_energy() override { return _energy; }
 
  private:
-  float _energy = 0;
-
- protected:
   short _time = 0;
+  float _energy = 0;
 
   ClassDefOverride(TowerInfov1, 1);
 };

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -7,17 +7,16 @@ class TowerInfov2 : public TowerInfov1
 {
  public:
   TowerInfov2() {}
- 
+
   ~TowerInfov2() override {}
 
   void Reset() override;
   void Clear(Option_t* = "") override;
+  void set_time(short t) override { set_time(t * 1000); }
+  short get_time() override { return get_time() / 1000; }
 
-  void set_time(short t) override { _time = t * 1000; }
-  short get_time() override { return _time / 1000; }
-
-  void set_time_float(float t) { _time = t * 1000; }
-  float get_time_float() { return _time / 1000.; }
+  void set_time_float(float t) { set_time(t * 1000); }
+  float get_time_float() { return get_time() / 1000.; }
 
   void set_chi2(float chi2) { _chi2 = chi2; }
   float get_chi2() { return _chi2; }
@@ -41,7 +40,6 @@ class TowerInfov2 : public TowerInfov1
   uint8_t get_status() const { return _status; }
 
   void set_status(uint8_t status) { _status = status; }
-
 
   void copy_tower(TowerInfov2* tower);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR reverts TowerInfov1.h to its previous state. Using access methods should allow one to have private data members

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

