### PR TITLE
Screen out empty hitmaps + hitmaps with no hits 10 ADC above pedestal + Hough Transform Method

### DIFF
--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -65,7 +65,7 @@ namespace
     const double delta = square(B)-4*A*C;
     if( delta < 0 ) return ret;
 
-    // we want the first intersection
+    // we want 1 intersection
     const double tup = (-B + std::sqrt(delta))/(2*A);
     const double tdn = (-B-sqrt(delta))/(2*A);
     // std::cout << " tup " << tup << " tdn " << tdn << std::endl;
@@ -187,10 +187,23 @@ int TpcDirectLaserReconstruction::End(PHCompositeNode* )
   if( m_savehistograms && m_histogramfile )
   {
     m_histogramfile->cd();
-    for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer_south,h_deltarphi_layer_north, h_deltaz_layer, h_deltar_r,h_deltheta_delphi,h_deltheta_delphi_1,h_deltheta_delphi_2,h_deltheta_delphi_3,h_deltheta_delphi_4,h_deltheta_delphi_5,h_deltheta_delphi_6,h_deltheta_delphi_7,h_deltheta_delphi_8, h_entries,h_hits,h_clusters,h_origins,h_assoc_hits,h_GEMs_hit,h_layers_hit,h_xy,h_xz,h_xy_pca,h_xz_pca,h_dca_path,h_zr,h_zr_pca, h_dz_z }))
+    //for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer_south,h_deltarphi_layer_north, h_deltaz_layer, h_deltar_r,h_deltheta_delphi,h_deltheta_delphi_1,h_deltheta_delphi_2,h_deltheta_delphi_3,h_deltheta_delphi_4,h_deltheta_delphi_5,h_deltheta_delphi_6,h_deltheta_delphi_7,h_deltheta_delphi_8, h_entries,h_relangle_lasrangle,h_relangle_theta_lasrangle,h_relangle_phi_lasrangle,h_GEMs_hit,h_layers_hit,h_xy,h_xz,h_xy_pca,h_xz_pca,h_dca_path,h_zr,h_zr_pca, h_dz_z }))
+
+    for(const auto& o:std::initializer_list<TObject*>({ h_dca_layer, h_deltarphi_layer_south,h_deltarphi_layer_north, h_deltaz_layer, h_deltar_r,h_deltheta_delphi,h_deltheta_delphi_1,h_deltheta_delphi_2,h_deltheta_delphi_3,h_deltheta_delphi_4,h_deltheta_delphi_5,h_deltheta_delphi_6,h_deltheta_delphi_7,h_deltheta_delphi_8, h_entries,h_hits,h_bright_hits_laser1,h_bright_hits_laser2,h_bright_hits_laser3,h_bright_hits_laser4,h_relangle_lasrangle,h_relangle_theta_lasrangle,h_relangle_phi_lasrangle,h_GEMs_hit,h_layers_hit,h_xy,h_xz,h_xy_pca,h_xz_pca,h_dca_path,h_zr,h_zr_pca, h_dz_z }))
+
     { if( o ) o->Write(); }
     m_histogramfile->Close();
   }
+
+// add these back in later !!!
+//,h_assoc_hits
+//h_hits
+//h_bright_hits_laser1
+//h_bright_hits_laser2
+//h_bright_hits_laser3
+//h_bright_hits_laser4
+//h_origins
+//h_clusters
 
   // print counters
   std::cout << "TpcDirectLaserReconstruction::End - m_total_hits: " << m_total_hits << std::endl;
@@ -266,46 +279,66 @@ void TpcDirectLaserReconstruction::create_histograms()
   h_zr->GetYaxis()->SetTitle("rad");
   h_zr_pca = new TH2F("h_zr_pca"," z vs r pca", 440,-110,110,1000,28,80);
   h_dz_z = new TH2F("h_dz_z"," dz vs z", 440,-110,110, 1000, -20, 20);
-  h_hits = new TNtuple("hits","raw hits","x:y:z");
-  h_assoc_hits = new TNtuple("assoc_hits","hits associated with tracks (dca cut)","x:y:z");
-  h_clusters = new TNtuple("clusters","associated clusters","x:y:z");
-  h_origins = new TNtuple("origins","track origins","x:y:z");
 
-  h_deltheta_delphi = new TH2F("deltheta_delphi","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and ALL laser start points", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_hits = new TNtuple("hits","raw hits","x:y:z:adc");
+  h_bright_hits_laser1 = new TNtuple("bright_hits_laser1","bright hits relative to laser 1","x:y:z:deltheta:delphi");
+  h_bright_hits_laser2 = new TNtuple("bright_hits_laser2","bright hits relative to laser 2","x:y:z:deltheta:delphi");
+  h_bright_hits_laser3 = new TNtuple("bright_hits_laser3","bright hits relative to laser 3","x:y:z:deltheta:delphi");
+  h_bright_hits_laser4 = new TNtuple("bright_hits_laser4","bright hits relative to laser 4","x:y:z:deltheta:delphi");
+
+  //h_assoc_hits = new TNtuple("assoc_hits","hits associated with tracks (dca cut)","x:y:z");
+  //h_clusters = new TNtuple("clusters","associated clusters","x:y:z");
+  //h_origins = new TNtuple("origins","track origins","x:y:z");
+
+  //h_relangle_lasrangle = new TH2F("relangle_lasrangle","Difference in pointing angle from laser and relative angle histogram for ALL lasers",51,-25.5,25.5,51,-25.5,25.5);
+  h_relangle_lasrangle = new TH2F("relangle_lasrangle","Difference in pointing angle from laser and relative angle histogram for ALL lasers",102,-25.5,25.5,102,-25.5,25.5);
+  h_relangle_lasrangle->SetXTitle("#delta#theta (deg.)");
+  h_relangle_lasrangle->SetYTitle("#delta#phi (deg.)");
+
+  h_relangle_theta_lasrangle = new TH2F("relangle_theta_lasrangle","#delta#theta from laser and relative angle histogram for LASER 1 ONLY, ",91,-0.5,90.5,361,-0.5,360.5);
+  h_relangle_theta_lasrangle->SetXTitle("#theta_{laser} (deg.)");
+  h_relangle_theta_lasrangle->SetYTitle("#phi_{laser} (deg.)");
+
+  h_relangle_phi_lasrangle = new TH2F("relangle_phi_lasrangle","#delta#phi from laser and relative angle histogram for LASER 1 ONLY",91,-0.5,90.5,361,-0.5,360.5);
+  h_relangle_phi_lasrangle->SetXTitle("#theta_{laser} (deg.)");
+  h_relangle_phi_lasrangle->SetYTitle("#phi_{laser} (deg.)");
+
+  h_deltheta_delphi = new TH2F("deltheta_delphi","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and ALL laser start points", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi->SetXTitle("#Delta#theta");
   h_deltheta_delphi->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_1 = new TH2F("deltheta_delphi_1","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 0 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_1 = new TH2F("deltheta_delphi_1","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 1 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_1->SetXTitle("#Delta#theta");
   h_deltheta_delphi_1->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_2 = new TH2F("deltheta_delphi_2","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 1 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_2 = new TH2F("deltheta_delphi_2","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 2 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_2->SetXTitle("#Delta#theta");
   h_deltheta_delphi_2->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_3 = new TH2F("deltheta_delphi_3","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 2 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_3 = new TH2F("deltheta_delphi_3","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 3 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_3->SetXTitle("#Delta#theta");
   h_deltheta_delphi_3->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_4 = new TH2F("deltheta_delphi_4","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 3 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_4 = new TH2F("deltheta_delphi_4","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 4 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_4->SetXTitle("#Delta#theta");
   h_deltheta_delphi_4->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_5 = new TH2F("deltheta_delphi_5","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 4 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_5 = new TH2F("deltheta_delphi_5","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 5 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_5->SetXTitle("#Delta#theta");
   h_deltheta_delphi_5->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_6 = new TH2F("deltheta_delphi_6","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 5 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_6 = new TH2F("deltheta_delphi_6","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 6 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_6->SetXTitle("#Delta#theta");
   h_deltheta_delphi_6->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_7 = new TH2F("deltheta_delphi_7","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 6 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_7 = new TH2F("deltheta_delphi_7","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 7 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_7->SetXTitle("#Delta#theta");
   h_deltheta_delphi_7->SetYTitle("#Delta#phi");
 
-  h_deltheta_delphi_8 = new TH2F("deltheta_delphi_8","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 7 only", 181, -10.5,180.5,361, -180.5, 180.5);
+  h_deltheta_delphi_8 = new TH2F("deltheta_delphi_8","#Delta#theta, #Delta#phi for separation b/w TPC volume hits and LASER 8 only", 181, -0.5,180.5,361,-0.5,360.5);
   h_deltheta_delphi_8->SetXTitle("#Delta#theta");
   h_deltheta_delphi_8->SetYTitle("#Delta#phi");
+
 
   h_GEMs_hit = new TH1F("GEMS_hit","Number of Unique GEM Modules hit for each laser",8,0,8);
   h_layers_hit = new TH1F("layers_hit","Number of Unique Layers hit for each laser",8,8,8);
@@ -351,23 +384,52 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
   // get track parameters
   const TVector3 origin( track->get_x(), track->get_y(), track->get_z() );
   const TVector3 direction( track->get_px(), track->get_py(), track->get_pz() );
+  TVector3 direction2( track->get_px(), track->get_py(), track->get_pz() );
 
+/*
   if(h_origins)
   {
     h_origins->Fill(track->get_x(), track->get_y(), track->get_z());
   }
-
+*/
   const unsigned int trkid = track->get_id();
-  if( Verbosity() )
-  { 
+
+  const float theta_orig = origin.Theta();
+  const float phi_orig = origin.Phi();
+
+  float theta_trk = direction.Theta();
+  direction2.RotateZ(-phi_orig);
+  float   phi_trk = direction2.Phi();
+
+  if(theta_trk > M_PI/2.) theta_trk = M_PI - theta_trk;
+
+  //if(  phi_trk < 0) phi_trk*=-1;
+
+  while( phi_trk < m_phimin ) phi_trk += 2.*M_PI; 
+  while( phi_trk >= m_phimax ) phi_trk -= 2.*M_PI; 
+
+  //const double xo = track->get_x();
+  //const double yo = track->get_y();
+  //const double zo = track->get_z();
+
+  //if( phi_orig < 0 )phi_orig += 2.*M_PI;
+
+  if( track->get_id() > 3 ){ phi_trk = (2 * M_PI) - phi_trk;}
+
+  //if( Verbosity() )
+  //{ 
     std::cout << "----------  processing track " << track->get_id() << std::endl;
     std::cout << "TpcDirectLaserReconstruction::process_track - position: " << origin << " direction: " << direction << std::endl; 
-  }
+    std::cout << "Position Orientation - Theta: " << theta_orig*(180./M_PI) << ", Phi: " << phi_orig*(180./M_PI) << std::endl;
+    std::cout << "Track Angle Direction - Theta: " << theta_trk*(180./M_PI) << ", Phi: " << phi_trk*(180./M_PI) << std::endl;
+  //}
   
   int GEM_Mod_Arr[72] = {0};
 
   // loop over hits
   TrkrHitSetContainer::ConstRange hitsetrange = m_hit_map->getHitSets(TrkrDefs::TrkrId::tpcId);
+
+  float max_adc = 0.;
 
   for(auto hitsetitr = hitsetrange.first; hitsetitr != hitsetrange.second; ++hitsetitr)
   {
@@ -405,12 +467,14 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       
 	const TVector3 global(x,y,z);
 
-        if(h_hits)
-          {
-            h_hits->Fill(x,y,z);
-          }
-
 	float adc = (hitr->second->getAdc()) - m_pedestal; 
+/*
+        if(h_hits && trkid == 0)
+          {
+            h_hits->Fill(x,y,z,adc);
+          }
+*/
+        if( adc > max_adc ){ max_adc = adc; }
 	
 	// calculate dca
 	// origin is track origin, direction is track direction
@@ -419,59 +483,146 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 	auto om = direction*t;     // vector from track origin to PCA
 	const auto dca = (oc-om).Mag();
 
-        // relative angle histogram - only fill for hits in the same quadrant as origin
-        h_deltheta_delphi->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+        //rotate displacement vector by the rotation of the coordinates:
+        //oc2.RotateY(-theta_orig * trkzdir); //undoing rotation in PHG4TpcDirectLaser 
 
-        if( trkid == 0) //only fill for the first laser !!!
+        //global2.RotateZ(-phi_orig);
+        //origin2.RotateZ(-phi_orig);
+
+        TVector3 oc2( global.x()-origin.x(), global.y()-origin.y(), global.z()-origin.z()  );  // vector from track origin to cluster
+        //const double xt = x-xo;
+        //const double yt = y-yo;
+        //const double zt = z-zo;
+        oc2.RotateZ(-phi_orig);
+   
+
+        //auto theta1 = origin.Theta()*(180./M_PI);
+        //auto theta2 = global.Theta()*(180./M_PI);
+
+        //auto phi1 = origin.Phi()*(180./M_PI);
+        //auto phi2 = global.Phi()*(180./M_PI);
+
+        //float deltheta = GetRelTheta( origin.x() , origin.y(), origin.z(), global.x() , global.y() , global.z() , origin.Theta(), origin.Phi()) *(180./M_PI); 
+        //float delphi = GetRelPhi(origin.x() , origin.y() , global.x() , global.y() , origin.Phi()) *(180./M_PI);
+
+        float deltheta = oc2.Theta();
+        float delphi = oc2.Phi();
+
+        if (deltheta > M_PI/2.) deltheta = M_PI - deltheta;
+
+        while( delphi < m_phimin ) delphi += 2.*M_PI; 
+        while( delphi >= m_phimax ) delphi -= 2.*M_PI; 
+
+        if( track->get_id() > 3 ){ delphi = (2 * M_PI) - delphi;}
+
+        //if (delphi < 0) delphi*=-1;  
+
+        deltheta *= (180./M_PI);
+        delphi   *= (180./M_PI);
+
+/*
+        if( trkid < 4)
         {
-          h_deltheta_delphi_1->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+          deltheta = 180 - theta2;    
+          if ( trkid == 1) delphi = fabs(phi2 - phi);
+          else delphi = phi2 - phi1;
         }
-        if( trkid == 1) //only fill for the first laser !!!
+        else
         {
-          h_deltheta_delphi_2->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+          deltheta = theta2;
+          if (trkid == 7 ) delphi = 360. - fabs(phi2 - phi1);
+          else delphi = fabs(phi2 - phi1);
         }
-        if( trkid == 2) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_3->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
-        }
-        if( trkid == 3) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_4->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
-        }
-        if( trkid == 4) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_5->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
-        }
-        if( trkid == 5) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_6->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
-        }
-        if( trkid == 6) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_7->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
-        }
-        if( trkid == 7) //only fill for the first laser !!!
-        {
-          h_deltheta_delphi_8->Fill(oc.Theta()*(180./M_PI), oc.Phi()*(180./M_PI)) ;
+*/
+
+        bool sameside = sameSign(global.z(),origin.z());
+        // relative angle histogram - only fill for hits in the same side as origin
+
+        if(sameside){
+         
+          //std::cout<<"Trk ID = "<<trkid<<std::endl;
+
+          h_deltheta_delphi->Fill(deltheta, delphi);
+
+          if(track->get_id() == 0) //only fill for 1 laser !!!
+          {
+            //std::cout<<"Trk ID = "<<trkid<<std::endl; 
+            h_deltheta_delphi_1->Fill(deltheta, delphi) ;
+/*
+            //if( h_bright_hits && deltheta > 80 && deltheta < 95 && delphi > 130 && delphi < 150)
+            //filling bright_hits for theta = 75, phi = 80 (simple debugging only - to be removed)
+            if( h_bright_hits_laser1 )
+            {   
+              h_bright_hits_laser1->Fill(x,y,z,deltheta,delphi);
+            } 
+*/
+          }
+          if(trkid == 1) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_2->Fill(deltheta, delphi) ;
+/*
+            if( h_bright_hits_laser2 )
+            {   
+              h_bright_hits_laser2->Fill(x,y,z,deltheta,delphi);
+            } 
+*/
+          }
+          if(trkid == 2) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_3->Fill(deltheta, delphi) ;
+/*
+            if( h_bright_hits_laser3 )
+            {   
+              h_bright_hits_laser3->Fill(x,y,z,deltheta,delphi);
+            } 
+*/
+          }
+          if(trkid == 3) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_4->Fill(deltheta, delphi) ;
+/*
+            if( h_bright_hits_laser4 )
+            {   
+              h_bright_hits_laser4->Fill(x,y,z,deltheta,delphi);
+            } 
+*/
+          }
+          if(trkid == 4) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_5->Fill(deltheta, delphi) ;
+          }
+          if(trkid == 5) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_6->Fill(deltheta, delphi) ;
+          }
+          if(trkid == 6) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_7->Fill(deltheta, delphi) ;
+          }
+          if(trkid == 7) //only fill for 1 laser !!!
+          {
+            h_deltheta_delphi_8->Fill(deltheta, delphi) ;
+          }
+
         }
 
 	// do not associate if dca is too large
-	if( dca > m_max_dca ) continue;
+	if( dca > m_max_dca ) continue; 
 
   ++m_matched_hits;
-
+/*
         if(h_assoc_hits){
           h_assoc_hits->Fill( x,y,z);
         }
-
+*/
         //for locating the associated hits   
         float r2 = std::sqrt((x*x) + (y*y));
-        float phi2 = phi;
+        float phi3 = phi;
         float z2 = z;
-        while( phi2 < m_phimin ) phi2 += 2.*M_PI; 
-        while( phi2 >= m_phimax ) phi2 -= 2.*M_PI; 
+        while( phi3 < m_phimin ) phi3 += 2.*M_PI; 
+        while( phi3 >= m_phimax ) phi3 -= 2.*M_PI; 
 
-        const int locateid = Locate(r2 , phi2 , z2); //find where the cluster is 
+        const int locateid = Locate(r2 , phi3 , z2); //find where the cluster is 
       
         if( z2 > m_zmin || z2 < m_zmax ) GEM_Mod_Arr[locateid-1]++; // the array ath the cluster location - counts the number of clusters in each array, (IFF its in the volume !!!)
 
@@ -482,12 +633,164 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       }
   }
 
+  int maxbin;
+  int deltheta_max, delphi_max, dummy_z;
+
+
+  if( (trkid == 0 && h_deltheta_delphi_1->GetEntries() > 0) && max_adc > 10)
+  {
+    h_deltheta_delphi_1->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_1->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_1->GetMaximumBin();
+
+    h_deltheta_delphi_1->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" naieve deltheta max: "<< h_deltheta_delphi_1->GetXaxis()->GetBinCenter(deltheta_max) <<", naieve delphi max: "<< h_deltheta_delphi_1->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_1->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_1->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_1->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_1->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 1 && h_deltheta_delphi_2->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_2->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_2->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_2->GetMaximumBin();
+
+    h_deltheta_delphi_2->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" naieve deltheta max: "<< h_deltheta_delphi_2->GetXaxis()->GetBinCenter(deltheta_max) <<", naive delphi max: "<< h_deltheta_delphi_2->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_2->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_2->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_2->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_2->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 2 && h_deltheta_delphi_3->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_3->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_3->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_3->GetMaximumBin();
+
+    h_deltheta_delphi_3->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" naieve deltheta max: "<< h_deltheta_delphi_3->GetXaxis()->GetBinCenter(deltheta_max) <<", naive delphi max: "<< h_deltheta_delphi_3->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_3->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_3->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_3->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_3->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 3 && h_deltheta_delphi_4->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_4->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_4->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_4->GetMaximumBin();
+
+    h_deltheta_delphi_4->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" naieve deltheta max: "<< h_deltheta_delphi_4->GetXaxis()->GetBinCenter(deltheta_max) <<", naieve delphi max: "<< h_deltheta_delphi_4->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_4->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_4->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_4->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_4->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 4 && h_deltheta_delphi_5->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_5->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_5->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_5->GetMaximumBin();
+
+    h_deltheta_delphi_5->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" deltheta max: "<< h_deltheta_delphi_5->GetXaxis()->GetBinCenter(deltheta_max) <<", delphi max: "<< h_deltheta_delphi_5->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_5->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_5->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_5->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_5->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 5 && h_deltheta_delphi_6->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_6->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_6->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_6->GetMaximumBin();
+
+    h_deltheta_delphi_6->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" deltheta max: "<< h_deltheta_delphi_6->GetXaxis()->GetBinCenter(deltheta_max) <<", delphi max: "<< h_deltheta_delphi_6->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_6->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_6->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_6->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_6->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 6 && h_deltheta_delphi_7->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_7->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_7->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_7->GetMaximumBin();
+
+    h_deltheta_delphi_7->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" deltheta max: "<< h_deltheta_delphi_7->GetXaxis()->GetBinCenter(deltheta_max) <<", delphi max: "<< h_deltheta_delphi_7->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_7->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_7->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_7->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_7->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+  else if( (trkid == 7 && h_deltheta_delphi_8->GetEntries() > 0) && max_adc > 10 )
+  {
+    h_deltheta_delphi_8->GetXaxis()->SetRangeUser(-5+(theta_trk*(180./M_PI)),5+(theta_trk*(180./M_PI)));
+    h_deltheta_delphi_8->GetYaxis()->SetRangeUser(-5+(phi_trk*(180./M_PI)),5+(phi_trk*(180./M_PI)));
+
+    maxbin= h_deltheta_delphi_8->GetMaximumBin();
+
+    h_deltheta_delphi_8->GetBinXYZ(maxbin, deltheta_max, delphi_max, dummy_z);
+
+    std::cout << "Laser # "<<(trkid+1)<<" deltheta max: "<< h_deltheta_delphi_8->GetXaxis()->GetBinCenter(deltheta_max) <<", delphi max: "<< h_deltheta_delphi_8->GetYaxis()->GetBinCenter(delphi_max) << std::endl;
+
+    h_relangle_lasrangle->Fill(h_deltheta_delphi_8->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)),h_deltheta_delphi_8->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)));
+
+    //h_relangle_theta_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_8->GetXaxis()->GetBinCenter(deltheta_max)-(theta_trk*(180./M_PI)) );
+    //h_relangle_phi_lasrangle->Fill(theta_trk*(180./M_PI),phi_trk*(180./M_PI),h_deltheta_delphi_8->GetYaxis()->GetBinCenter(delphi_max)-(phi_trk*(180./M_PI)) );
+  }
+
+
+
   for(int GEMS_iter = 0; GEMS_iter < 72; GEMS_iter++)
   {
     if(GEM_Mod_Arr[GEMS_iter] > 0){  //laser 0
       h_GEMs_hit->Fill(trkid + 0.5);
     }
   }
+
+  h_deltheta_delphi_1->Reset("ICESM");
+  h_deltheta_delphi_2->Reset("ICESM");
+  h_deltheta_delphi_3->Reset("ICESM");
+  h_deltheta_delphi_4->Reset("ICESM");
+  h_deltheta_delphi_5->Reset("ICESM");
+  h_deltheta_delphi_6->Reset("ICESM");
+  h_deltheta_delphi_7->Reset("ICESM");
+  h_deltheta_delphi_8->Reset("ICESM");
+
 
   
   // We will bring this back here when we fix the clustering
@@ -529,7 +832,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       tupdn = line_circle_intersection(origin, direction, layer_center_radius);
       double tup = tupdn.first;
       double tdn = tupdn.second;
-      // take the first one if there are two intersections
+      // take 1 one if there are two intersections
       double t = tup;
       if(tdn > 0 && tdn < tup) t = tdn;
       if( t < 0 )
@@ -579,7 +882,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
       double zrange =  zmax-zmin;
       if(zrange > m_max_zrange)
 	{
-	  std::cout << "    exeeded  max zrange:  zrange " << zrange << " max zrange " << m_max_zrange << std::endl; 
+	  std::cout << "    exceeded  max zrange:  zrange " << zrange << " max zrange " << m_max_zrange << std::endl; 
 	  continue;
 	}
 
@@ -712,7 +1015,7 @@ void TpcDirectLaserReconstruction::process_track( SvtxTrack* track )
 	  if(h_zr) h_zr->Fill(clus_centroid.z(), cluster_r);
 	  if(h_zr_pca) h_zr_pca->Fill(projection.z(), r);
 	  if(h_dz_z)h_dz_z->Fill(projection.z(), clus_centroid.z()- projection.z());
-          if(h_clusters)h_clusters->Fill(clus_centroid.x(),clus_centroid.y(),clus_centroid.z());
+          //if(h_clusters)h_clusters->Fill(clus_centroid.x(),clus_centroid.y(),clus_centroid.z());
 	}
       
       //       // check against limits
@@ -889,3 +1192,74 @@ int TpcDirectLaserReconstruction::Locate(float r , float phi , float z)
 
   return GEM_Mod_ID = (36*side_id) + (3*angle_id) + r_id;
 }
+
+float TpcDirectLaserReconstruction::GetRelPhi( float xorig, float yorig, float x, float y, float phiorig ) 
+{
+// getting the relative phi in the frame rotated to the ith laser origin
+//
+// inputs: 
+//	xorig = x coordinate of ith laser origin
+//      yorig = y coordinate of ith laser origin
+//          x = x coordinate of arbitrary point in TPC volume
+//          y = y coordinate of arbitrary point in TPC volume
+//    phiorig = phi (from + x axis) of ith laser origin 
+//   
+// output:
+//     relphi = azimuthal displacement of arbitrary point in TPC volume from ith laser origin
+
+  if (phiorig < 0) phiorig += 2. * M_PI;
+  else if (phiorig > 2.*M_PI) phiorig -= 2. * M_PI;
+
+  float dx = x - xorig;
+  float dy = y - yorig;
+  float relphi = atan2(dy, dx) - phiorig;
+  if (relphi < 0) relphi += 2. * M_PI;
+  else if (relphi > 2.*M_PI) relphi -= 2. * M_PI;
+
+  return relphi;
+}
+
+float TpcDirectLaserReconstruction::GetRelTheta( float xorig, float yorig, float zorig, float x, float y, float z, float thetaorig, float phiorig )
+{
+// getting the relative theta in the frame rotated to the ith laser origin
+//
+// inputs: 
+//	xorig = x coordinate of ith laser origin
+//      yorig = y coordinate of ith laser origin
+//      zorig = z cooridante of ith laser origin
+//          x = x coordinate of arbitrary point in TPC volume
+//          y = y coordinate of arbitrary point in TPC volume
+//          z = z coordinate of arbitrary point in TPC volume
+//  thetaorig = theta (from + y axis?) of ithe laser origin
+//    phiorig = phi (from + x axis) of ith laser origin 
+//   
+// output:
+//     reltheta = polar displacement of arbitrary point in TPC volume from ith laser origin
+
+  if (phiorig < 0) phiorig += 2. * M_PI;
+  else if (phiorig > 2.*M_PI) phiorig -= 2. * M_PI;
+
+  if (thetaorig < 0) thetaorig += 2. * M_PI;
+  else if (thetaorig > 2.*M_PI) thetaorig -= 2. * M_PI;
+
+
+  float dx = x - xorig;
+  float dy = y - yorig;
+  float dz = z - zorig;
+  float r = sqrt(dx*dx + dy*dy + dz*dz);
+
+  float cos_beta = (dx*cos(phiorig) + dy*sin(phiorig))/r;
+  float sin_beta = dz/r;
+
+  float reltheta = acos(cos_beta*cos(thetaorig) + sin_beta*sin(thetaorig)) - M_PI/2.;
+  if (reltheta < 0) reltheta += 2. * M_PI;
+  else if (reltheta > 2.*M_PI) reltheta -= 2. * M_PI;
+
+  return reltheta;
+}
+
+bool TpcDirectLaserReconstruction::sameSign(float num1, float num2)
+{
+    return (num1 >= 0 && num2 >= 0) || (num1 < 0 && num2 < 0);
+}
+

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.h
@@ -93,6 +93,12 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   /// get the GEM module where cluster hit
   int Locate(float r , float phi , float z);
 
+  float GetRelPhi( float xorig, float yorig, float x, float y, float phiorig );
+
+  float GetRelTheta( float xorig, float yorig, float zorig, float x, float y, float z, float thetaorig, float phiorig );
+
+  bool sameSign(float num1, float num2);
+
   /// output file
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
 
@@ -162,8 +168,12 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   /// number of entries per cell
   TH3 *h_entries = nullptr;
   TNtuple *h_hits = nullptr;
-  TNtuple *h_origins = nullptr;
-  TNtuple *h_assoc_hits = nullptr;
+  //TNtuple *h_origins = nullptr;
+  //TNtuple *h_assoc_hits = nullptr;
+  TNtuple *h_bright_hits_laser1 = nullptr;
+  TNtuple *h_bright_hits_laser2 = nullptr;
+  TNtuple *h_bright_hits_laser3 = nullptr;
+  TNtuple *h_bright_hits_laser4 = nullptr;
 
   /// for diagnosing separation b/w laser starting points and tpc volume hits
   TH2 *h_deltheta_delphi = nullptr;
@@ -180,6 +190,10 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   TH1 *h_GEMs_hit = nullptr;
   TH1 *h_layers_hit = nullptr;
 
+  TH2 *h_relangle_lasrangle = nullptr;
+  TH2 *h_relangle_theta_lasrangle = nullptr;
+  TH2 *h_relangle_phi_lasrangle = nullptr;
+
   TH2* h_xy = nullptr;
   TH2* h_xz = nullptr;
   TH2* h_xy_pca = nullptr;
@@ -188,7 +202,7 @@ class TpcDirectLaserReconstruction: public SubsysReco, public PHParameterInterfa
   TH2* h_zr = nullptr;
   TH2* h_zr_pca = nullptr;
   TH2* h_dz_z = nullptr;
-  TNtuple *h_clusters = nullptr;
+  //TNtuple *h_clusters = nullptr;
 
   //@}
 


### PR DESCRIPTION
**Files Affected:**

    - offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
    - offline/packages/tpccalib/TpcDirectLaserReconstruction.h

**Changes:**

    - Added functionality to apply Hough Transform to hits event by event and store in TH2 for each laser (and reset for new event)
    - Added functionality to find Hough Transform maximum within +/- 5 degrees of fire direction in theta/phi
    - Added histogram to store reconstructed laser angle residuals as a function of laser theta/phi (true - reco) for laser 1 only
    - Added histogram to store reconstructed laser angle residuals (true - reco) for all lasers
    - Added functionality to screen out empty hitmaps and hitmaps with no hits > 10 ADC above pedestal 

**TODO:**

    - Add functionality to calculate ADC spectra of associated hits (assuming direction = true fire direction)
    - Add functionality to calculate ADC spectra of associated hits (assuming direction = reco. fire direction)

