### PR TITLE
Add virtual towerinfov2 and v3 methods to the base class

### DIFF
--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -16,6 +16,28 @@ class TowerInfo : public PHObject
   virtual short get_time() { return -1; }
   virtual void set_energy(float /*energy*/) { return; }
   virtual float get_energy() { return NAN; }
+  virtual void copy_tower(TowerInfo* /*tower*/) { return; }
+  // methods in v2
+  virtual void set_time_float(float /*t*/) { return; }
+  virtual float get_time_float() { return NAN; }
+  virtual void set_chi2(float /*chi2*/) { return; }
+  virtual float get_chi2() { return NAN; }
+  virtual void set_pedestal(float /*pedestal*/) { return; }
+  virtual float get_pedestal() { return NAN; }
+  virtual void set_isHot(bool /*isHot*/) { return; }
+  virtual bool get_isHot() const { return false; }
+  virtual void set_isBadTime(bool /*isBadTime*/) { return; }
+  virtual bool get_isBadTime() const { return false; }
+  virtual void set_isBadChi2(bool /*isBadChi2*/) { return; }
+  virtual bool get_isBadChi2() const { return false; }
+  virtual void set_isNotInstr(bool /*isNotInstr*/) { return; }
+  virtual bool get_isNotInstr() const { return false; }
+  virtual bool get_isGood() const { return false; }
+  virtual uint8_t get_status() const { return 0; }
+  virtual void set_status(uint8_t /*status*/) { return; }
+  // methods in v3
+  virtual int16_t get_waveform_value(int /*index*/) const {return -1;}
+  virtual void set_waveform_value(int /*index*/, int16_t /*value*/) {return;}
 
  private:
   ClassDefOverride(TowerInfo, 1);

--- a/offline/packages/CaloBase/TowerInfov1.cc
+++ b/offline/packages/CaloBase/TowerInfov1.cc
@@ -17,3 +17,9 @@ void TowerInfov1::Clear(Option_t* )
   _time = 0;
   _energy = 0;
 }
+
+void TowerInfov1::copy_tower(TowerInfo* tower)
+{
+  set_time(tower->get_time());
+  set_energy(tower->get_energy());
+}

--- a/offline/packages/CaloBase/TowerInfov1.h
+++ b/offline/packages/CaloBase/TowerInfov1.h
@@ -22,6 +22,7 @@ class TowerInfov1 : public TowerInfo
   short get_time() override { return _time; }
   void set_energy(float energy) override { _energy = energy; }
   float get_energy() override { return _energy; }
+  void copy_tower(TowerInfo* tower) override;
 
  private:
   short _time = 0;

--- a/offline/packages/CaloBase/TowerInfov2.cc
+++ b/offline/packages/CaloBase/TowerInfov2.cc
@@ -1,3 +1,4 @@
+#include "TowerInfo.h"
 #include "TowerInfov2.h"
 
 void TowerInfov2::Reset()
@@ -16,8 +17,9 @@ void TowerInfov2::Clear(Option_t* )
   _status = 0;
 }
 
-void TowerInfov2::copy_tower(TowerInfov2* tower)
+void TowerInfov2::copy_tower(TowerInfo* tower)
 {
+  TowerInfov1::copy_tower(tower);
   set_time_float(tower->get_time_float());
   set_energy(tower->get_energy());
   set_chi2(tower->get_chi2());

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -1,6 +1,7 @@
 #ifndef TOWERINFOV2_H
 #define TOWERINFOV2_H
 
+#include "TowerInfo.h"
 #include "TowerInfov1.h"
 
 class TowerInfov2 : public TowerInfov1
@@ -15,33 +16,33 @@ class TowerInfov2 : public TowerInfov1
   void set_time(short t) override { TowerInfov1::set_time(t * 1000); }
   short get_time() override { return TowerInfov1::get_time() / 1000; }
 
-  void set_time_float(float t) { TowerInfov1::set_time(t * 1000); }
-  float get_time_float() { return TowerInfov1::get_time() / 1000.; }
+  void set_time_float(float t) override { TowerInfov1::set_time(t * 1000); }
+  float get_time_float() override { return TowerInfov1::get_time() / 1000.; }
 
-  void set_chi2(float chi2) { _chi2 = chi2; }
-  float get_chi2() { return _chi2; }
-  void set_pedestal(float pedestal) { _pedestal = pedestal; }
-  float get_pedestal() { return _pedestal; }
+  void set_chi2(float chi2) override { _chi2 = chi2; }
+  float get_chi2() override { return _chi2; }
+  void set_pedestal(float pedestal) override { _pedestal = pedestal; }
+  float get_pedestal() override { return _pedestal; }
 
-  void set_isHot(bool isHot) { set_status_bit(0, isHot); }
-  bool get_isHot() const { return get_status_bit(0); }
+  void set_isHot(bool isHot) override { set_status_bit(0, isHot); }
+  bool get_isHot() const override { return get_status_bit(0); }
 
-  void set_isBadTime(bool isBadTime) { set_status_bit(1, isBadTime); }
-  bool get_isBadTime() const { return get_status_bit(1); }
+  void set_isBadTime(bool isBadTime) override { set_status_bit(1, isBadTime); }
+  bool get_isBadTime() const override { return get_status_bit(1); }
 
   void set_isBadChi2(bool isBadChi2) { set_status_bit(2, isBadChi2); }
-  bool get_isBadChi2() const { return get_status_bit(2); }
+  bool get_isBadChi2() const override { return get_status_bit(2); }
 
   void set_isNotInstr(bool isNotInstr) { set_status_bit(3, isNotInstr); }
-  bool get_isNotInstr() const { return get_status_bit(3); }
+  bool get_isNotInstr() const override { return get_status_bit(3); }
 
-  bool get_isGood() const { return !((bool) _status); }
+  bool get_isGood() const override { return !((bool) _status); }
 
-  uint8_t get_status() const { return _status; }
+  uint8_t get_status() const override { return _status; }
 
-  void set_status(uint8_t status) { _status = status; }
+  void set_status(uint8_t status) override { _status = status; }
 
-  void copy_tower(TowerInfov2* tower);
+  void copy_tower(TowerInfo* tower) override;
 
  private:
   float _chi2 = 0;

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -30,10 +30,10 @@ class TowerInfov2 : public TowerInfov1
   void set_isBadTime(bool isBadTime) override { set_status_bit(1, isBadTime); }
   bool get_isBadTime() const override { return get_status_bit(1); }
 
-  void set_isBadChi2(bool isBadChi2) { set_status_bit(2, isBadChi2); }
+  void set_isBadChi2(bool isBadChi2) override { set_status_bit(2, isBadChi2); }
   bool get_isBadChi2() const override { return get_status_bit(2); }
 
-  void set_isNotInstr(bool isNotInstr) { set_status_bit(3, isNotInstr); }
+  void set_isNotInstr(bool isNotInstr) override { set_status_bit(3, isNotInstr); }
   bool get_isNotInstr() const override { return get_status_bit(3); }
 
   bool get_isGood() const override { return !((bool) _status); }

--- a/offline/packages/CaloBase/TowerInfov3.cc
+++ b/offline/packages/CaloBase/TowerInfov3.cc
@@ -1,4 +1,6 @@
+#include "TowerInfo.h"
 #include "TowerInfov3.h"
+
 
 void TowerInfov3::Reset()
 {
@@ -36,7 +38,7 @@ void TowerInfov3::set_waveform_value(int index, int16_t value)
   return;
 }
 
-void TowerInfov3::copy_tower(TowerInfov3* tower)
+void TowerInfov3::copy_tower(TowerInfo* tower)
 {
   TowerInfov2::copy_tower(tower);
   for (int i = 0; i < nsample; ++i)

--- a/offline/packages/CaloBase/TowerInfov3.h
+++ b/offline/packages/CaloBase/TowerInfov3.h
@@ -1,6 +1,7 @@
 #ifndef TOWERINFOV3_H
 #define TOWERINFOV3_H
 
+#include "TowerInfo.h"
 #include "TowerInfov2.h"
 
 #include <cstdint> // For int16_t
@@ -15,10 +16,10 @@ public:
     void Clear(Option_t* = "") override;
     
     // Getter and setter for waveform
-    int16_t get_waveform_value(int index) const;
-    void set_waveform_value(int index, int16_t value);
+    int16_t get_waveform_value(int index) const override;
+    void set_waveform_value(int index, int16_t value) override;
 
-    void copy_tower(TowerInfov3* tower);
+    void copy_tower(TowerInfo* tower) override;
     
 private:
     static const int nsample = 31;

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -276,12 +276,11 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
     for (int i = 0; i < n_channels; i++)
     {
       int n_samples = waveforms.at(i).size();
-      TowerInfov3 *raw_tower_v3 = dynamic_cast<TowerInfov3 *>(m_CaloInfoContainer->get_tower_at_channel(i));
       //right not the missing packets are treated as zero suppressed, we need to change the behavior of empty packets in the future
-      if (n_samples == m_nzerosuppsamples) raw_tower_v3->set_isNotInstr(true);
+      if (n_samples == m_nzerosuppsamples) m_CaloInfoContainer->get_tower_at_channel(i)->set_isNotInstr(true);
       for (int j = 0; j < n_samples; j++)
       {
-        raw_tower_v3->set_waveform_value(j, waveforms.at(i).at(j));
+        m_CaloInfoContainer->get_tower_at_channel(i)->set_waveform_value(j, waveforms.at(i).at(j));
       }
     }
   }
@@ -296,9 +295,8 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
       m_CaloInfoContainer->get_tower_at_channel(i)->set_energy(processed_waveforms.at(i).at(0));
       if (m_buildertype == CaloTowerBuilder::kWaveformTowerv2)
       {
-        TowerInfov2 *raw_tower_v2 = dynamic_cast<TowerInfov2 *>(m_CaloInfoContainer->get_tower_at_channel(i));
-        raw_tower_v2->set_time_float(processed_waveforms.at(i).at(1));
-        raw_tower_v2->set_status(m_CaloWaveformContainer->get_tower_at_channel(i)->get_status());
+        m_CaloInfoContainer->get_tower_at_channel(i)->set_time_float(processed_waveforms.at(i).at(1));
+        m_CaloInfoContainer->get_tower_at_channel(i)->set_status(m_CaloWaveformContainer->get_tower_at_channel(i)->get_status());
         
       }
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

define virtual functions of the methods implement in `TowerInfov3` and `TowerInfov3` to the base class so and remove the type casting in `CaloTowerBuilder`.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

