### PR TITLE
change the initial parameter setting in the template fit

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -53,7 +53,6 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
   auto func = [&](std::vector<float> &v)
   {
     int size1 = v.size() - 1;
-    
     if (size1 == _nzerosuppresssamples)
       {
 	v.push_back(v.at(0) - v.at(1)); //returns peak sample - pedestal sample
@@ -92,26 +91,27 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
 	  {
 	    // std::cout << "software zero suppression happened " << std::endl;
 	    h->Delete();
-	    v.push_back(v.at(6) - pedestal);
+	    v.push_back(v.at(6) - v.at(0));
 	    v.push_back(-1);
-	    v.push_back(pedestal);		
+	    v.push_back(v.at(0));
 	  }
 	else
 	  {
-	    auto f = new TF1(Form("f_%d", (int) round(v.at(size1))), this,&CaloWaveformFitting::template_function, 0, 31, 3,"CaloWaveformFitting","template_function");
+      auto f = new TF1(Form("f_%d", (int) round(v.at(size1))), this,&CaloWaveformFitting::template_function, 0, 31, 3,"CaloWaveformFitting","template_function");
 	    ROOT::Math::WrappedMultiTF1 *fitFunction = new ROOT::Math::WrappedMultiTF1(*f, 3);
 	    ROOT::Fit::BinData data(v.size() - 1, 1);
 	    ROOT::Fit::FillData(data, h);
 	    ROOT::Fit::Chi2Function *EPChi2 = new ROOT::Fit::Chi2Function(data, *fitFunction);
 	    ROOT::Fit::Fitter *fitter = new ROOT::Fit::Fitter();
 	    fitter->Config().MinimizerOptions().SetMinimizerType("GSLMultiFit");
-	    double params[] = {static_cast<double>(maxheight), static_cast<double>(maxbin - 5), static_cast<double>(pedestal)};
+	    double params[] = {static_cast<double>(maxheight - pedestal), static_cast<double>(maxbin - 6), static_cast<double>(pedestal)};
 	    fitter->Config().SetParamsSettings(3, params);
 	    fitter->FitFCN(*EPChi2, nullptr, data.Size(), true);
 	    for (int i = 0; i < 3; i++)
 	      {
 		v.push_back(f->GetParameter(i));
 	      }
+        
 	    h->Delete();
 	    f->Delete();
 	    delete fitFunction;


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR changed the initial guess of the fit parameter closer to the actual value.

the first parameter should really be peak - ped instead of peak, also change the software ZS to be the sample 6 - sample 1.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

