### PR TITLE
fix end iov (exclude ts = end iov), add delete methods

### DIFF
--- a/offline/database/sphenixnpc/CDBUtils.cc
+++ b/offline/database/sphenixnpc/CDBUtils.cc
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 
 #include <iostream>
+#include <stdexcept>  // for out_of_range
 
 CDBUtils::CDBUtils()
   : cdbclient(new SphenixClient())
@@ -199,4 +200,39 @@ void CDBUtils::Verbosity(int i)
     cdbclient->Verbosity(i);
   }
   m_Verbosity = i;
+}
+
+int CDBUtils::deletePayloadIOV(const std::string &pl_type, uint64_t iov_start)
+{
+  nlohmann::json resp = cdbclient->deletePayloadIOV(pl_type, iov_start);
+  int iret = resp["code"];
+  if (iret != 0)
+  {
+    std::cout << "Error deleting payload iov, type " << pl_type
+              << ", iov_start: " << iov_start
+              << ", msg: " << resp["msg"] << std::endl;
+  }
+  else
+  {
+    std::cout << resp["msg"] << std::endl;
+  }
+  return iret;
+}
+
+int CDBUtils::deletePayloadIOV(const std::string &pl_type, uint64_t iov_start, uint64_t iov_end)
+{
+  nlohmann::json resp = cdbclient->deletePayloadIOV(pl_type, iov_start, iov_end);
+  int iret = resp["code"];
+  if (iret != 0)
+  {
+    std::cout << "Error deleting payload iov, type " << pl_type
+              << ", iov_start: " << iov_start
+              << ", iov_end: " << iov_end
+              << ", msg: " << resp["msg"] << std::endl;
+  }
+  else
+  {
+    std::cout << resp["msg"] << std::endl;
+  }
+  return iret;
 }

--- a/offline/database/sphenixnpc/CDBUtils.h
+++ b/offline/database/sphenixnpc/CDBUtils.h
@@ -1,6 +1,7 @@
 #ifndef SPHENIXNPC_CDBUTILS_H
 #define SPHENIXNPC_CDBUTILS_H
 
+#include <cstdint>  // for uint64_t
 #include <set>
 #include <string>
 
@@ -35,6 +36,8 @@ class CDBUtils
   bool isGlobalTagSet();
   void Verbosity(int i);
   int Verbosity() const { return m_Verbosity; }
+  int deletePayloadIOV(const std::string &pl_type, uint64_t iov_start);
+  int deletePayloadIOV(const std::string &pl_type, uint64_t iov_start, uint64_t iov_end);
 
  private:
   int m_Verbosity = 0;

--- a/offline/database/sphenixnpc/SphenixClient.cc
+++ b/offline/database/sphenixnpc/SphenixClient.cc
@@ -1,5 +1,6 @@
 #include "SphenixClient.h"
 
+#include <nopayloadclient/exception.hpp>  // for DataBaseException
 #include <nopayloadclient/nopayloadclient.hpp>
 
 #include <nlohmann/json.hpp>
@@ -31,7 +32,15 @@ nlohmann::json SphenixClient::getUrl(const std::string& pl_type, long long iov)
     return nopayloadclient::DataBaseException("No valid payload with type " + pl_type).jsonify();
   }
   nlohmann::json payload_iov = payload_iovs[pl_type];
-  if (payload_iov["minor_iov_end"] < iov)
+  if (m_Verbosity > 0)
+  {
+    std::cout << "pl_type: " << pl_type
+              << ", iov: " << iov
+              << ", minor_iov_start: " << payload_iov["minor_iov_start"]
+              << ", minor_iov_end: " << payload_iov["minor_iov_end"]
+              << std::endl;
+  }
+  if (payload_iov["minor_iov_end"] <= iov)
   {
     return nopayloadclient::DataBaseException("No valid payload with type " + pl_type).jsonify();
   }
@@ -41,7 +50,10 @@ nlohmann::json SphenixClient::getUrl(const std::string& pl_type, long long iov)
 nlohmann::json SphenixClient::getUrlDict(long long iov)
 {
   nlohmann::json resp = getPayloadIOVs(iov);
-  if (resp["code"] != 0) return resp;
+  if (resp["code"] != 0)
+  {
+    return resp;
+  }
   for (auto it = resp["msg"].begin(); it != resp["msg"].end();)
   {
     if (it.value()["minor_iov_end"] < iov)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The end of validity time stamp should be excluded from the validity range but the selection included it. The CDB does not allow begin validity = end validity, so for single time stamps validity ranges like our run numbers we use begin = ts, end = ts+1. With the old client asking for the next run (ts+1) returned the calibration of ts if the calibration for that run did not exist. We only have a few runs where this might play a role but they all have calibrations so this is just an issue for testing and I don't see a need to push this immediately

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

