### PR TITLE
Fixed bug in MvtxRawHit::identify()

### DIFF
--- a/offline/framework/ffarawobjects/MvtxRawHitv1.cc
+++ b/offline/framework/ffarawobjects/MvtxRawHitv1.cc
@@ -16,6 +16,6 @@ void MvtxRawHitv1::identify(std::ostream &os) const
 {
   os << "BCO: 0x" << std::hex << bco << std::dec << std::endl;
   os << "Strobe BC: " << strobe_bc << ", Chip BC: " << chip_bc << std::endl;
-  os << "Layer: " << layer_id << ", stave: " << stave_id << ", chip: " << chip_id << std::endl;
+  os << "Layer: " << (unsigned) layer_id << ", stave: " << (unsigned) stave_id << ", chip: " << (unsigned) chip_id << std::endl;
   os << "Row: " << row << ", column: " << col << std::endl;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

There was a bug in MvtxRawHitv1::identify(). The layer, stave and chip were stored as uint8_t which std::cout was interpreting as a char. I casted the values to unsigned's and the print outs work now

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

