### PR TITLE
Update to handle pre-QM bad tower map loader

### DIFF
--- a/offline/packages/CaloReco/DeadHotMapLoader.cc
+++ b/offline/packages/CaloReco/DeadHotMapLoader.cc
@@ -74,10 +74,9 @@ int DeadHotMapLoader::InitRun(PHCompositeNode *topNode)
     DetNode->addNode(towerNode);
   }
 
-  assert(m_deadmap);
+  // assert(m_deadmap);
 
-  std::string url = CDBInterface::instance()->getUrl(m_detector + "DEADMAP");
-
+  std::string url = CDBInterface::instance()->getUrl(m_detector + "BadTowerMap");
   if(url.empty())
   {
     std::cout << PHWHERE << " Could not get Dead Map for CDB. Detector: " << m_detector << std::endl;
@@ -96,41 +95,42 @@ int DeadHotMapLoader::InitRun(PHCompositeNode *topNode)
   int phibins;
 
   if (m_detector.c_str()[0] == 'H')
-  {
-    etabins = 24;
-    phibins = 64;
+    {//HCal towers
+      etabins = 24;
+      phibins = 64;
 
-    for(int ieta = 0; ieta < etabins; ieta++)
-    {
-      for(int iphi = 0; iphi < phibins; iphi++)
-      {
-        unsigned int key = TowerInfoDefs::encode_hcal(ieta, iphi);
-        int isDead = m_CDBTTree->GetIntValue(key,"status");
-        if(isDead > 0)
-        {
-          m_deadmap->addDeadTower(ieta, iphi);
-        }
-      }
+     
+      for(int i = 0; i < etabins*phibins; i++)
+	{
+	  int isDead = m_CDBTTree->GetIntValue(i,"status");
+	  if(isDead > 0)
+	    {
+	      unsigned int key = TowerInfoDefs::encode_hcal(i);
+	      int ieta = TowerInfoDefs::getCaloTowerEtaBin(key);
+	      int iphi = TowerInfoDefs::getCaloTowerPhiBin(key);
+	      m_deadmap->addDeadTower(ieta, iphi);
+	    }
+	}
     }
-  }
+  
   else if(m_detector.c_str()[0] == 'C')
-  {
-    etabins = 96;
-    phibins = 256;
-
-    for(int ieta = 0; ieta < etabins; ieta++)
     {
-      for(int iphi = 0; iphi < phibins; iphi++)
-      {
-        unsigned int key = TowerInfoDefs::encode_emcal(ieta, iphi);
-        int isDead = m_CDBTTree->GetIntValue(key,"status");
-        if(isDead > 0)
-        {
-          m_deadmap->addDeadTower(ieta, iphi);
-        }
-      }
+      etabins = 96;
+      phibins = 256;
+
+      for(int i = 0; i < 96*256; i++)
+	{
+	  int isDead = m_CDBTTree->GetIntValue(i,"status");
+	  if(isDead > 0)
+	    {
+	      unsigned int key = TowerInfoDefs::encode_emcal(i);
+	      int ieta = TowerInfoDefs::getCaloTowerEtaBin(key);
+	      int iphi = TowerInfoDefs::getCaloTowerPhiBin(key);
+	      m_deadmap->addDeadTower(ieta, iphi);
+	    }
+	}
     }
-  }
+  
 
   if (Verbosity())
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Two primary updates: 
1) Changes deadmap name to "BadTowerMap" to reflect CDB payload name
2) The Maps/CDBTTrees are 1-dimensional, so the tower-by-tower loop has been collapsed by one layer to go through the towers sequentially. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

