### PR TITLE
Add zdc calibration functionality

### DIFF
--- a/offline/packages/CaloReco/CaloTowerCalib.cc
+++ b/offline/packages/CaloReco/CaloTowerCalib.cc
@@ -136,6 +136,32 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
       exit(1);
     }
   }
+  else if (m_dettype == CaloTowerCalib::ZDC)
+  {
+    m_detector = "ZDC";
+    m_DETECTOR = TowerInfoContainer::ZDC;
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "data_driven_zdc_calib";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "zdc_calib";
+    }
+    cdb = CDBInterface::instance();
+    std::string calibdir = cdb->getUrl(m_calibName);
+    if (calibdir[0] == '/')
+    {
+      cdbttree = new CDBTTree(calibdir.c_str());
+    }
+    else
+    {
+      std::cout << "CaloTowerCalib::::InitRun No calibration file found" << std::endl;
+      exit(1);
+    }
+  }
+  
   else if (m_dettype == CaloTowerCalib::EPD)
   {
     m_detector = "EPD";

--- a/offline/packages/CaloReco/CaloTowerCalib.h
+++ b/offline/packages/CaloReco/CaloTowerCalib.h
@@ -32,7 +32,8 @@ class CaloTowerCalib : public SubsysReco
     CEMC = 0,
     HCALIN = 1,
     HCALOUT = 2,
-    EPD = 3
+    EPD = 3,
+    ZDC = 4
   };
 
   void set_detector_type(CaloTowerCalib::DetectorSystem dettype)


### PR DESCRIPTION

PR allows for the creation of ZDC calibrated towers using the Lagrange multiplier method, see slide 7 of: https://indico.bnl.gov/event/19944/contributions/78023/attachments/48370/82183/Steinberg_sPHENIX20230630.pdf

Method puts single neutron peak at 100 GeV. Weights extracted per channel numbers as follows:

channel number, weights
0, 0.825664
2, 0.670553
4, 0.723938
8, 0.69576
10, 0.615914
12, 0.631928

Distribution in S/N arm:
<img width="649" alt="zdc_calib" src="https://github.com/sPHENIX-Collaboration/coresoftware/assets/27926345/3c6408b1-536a-4941-9fd5-4d0ecefa8f87">

