### PR TITLE
afterburner that z flip the every other HEPMC event

### DIFF
--- a/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.cc
+++ b/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.cc
@@ -67,6 +67,7 @@ void HIJINGFlipAfterburner::flipZDirection(HepMC::GenEvent *event)
     HepMC::FourVector position = (*v)->position();
 
     position.setZ(-position.z());
+    position.setX(-position.x());
 
     (*v)->set_position(position);
   }
@@ -76,6 +77,7 @@ void HIJINGFlipAfterburner::flipZDirection(HepMC::GenEvent *event)
     HepMC::FourVector momentum = (*p)->momentum();
 
     momentum.setPz(-momentum.pz());
+    momentum.setPx(-momentum.px());
 
     (*p)->set_momentum(momentum);
   }

--- a/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.cc
+++ b/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.cc
@@ -1,0 +1,82 @@
+
+#include "HIJINGFlipAfterburner.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+//phhepmc
+#include <phhepmc/PHHepMCGenEvent.h>
+#include <phhepmc/PHHepMCGenEventMap.h>
+
+//hepmc
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <HepMC/GenEvent.h>
+#include <HepMC/GenParticle.h>   // for GenParticle
+#include <HepMC/GenVertex.h>     // for GenVertex, GenVertex::part...
+#include <HepMC/SimpleVector.h>
+#pragma GCC diagnostic pop
+
+
+
+#include <cassert>
+
+//____________________________________________________________________________..
+HIJINGFlipAfterburner::HIJINGFlipAfterburner(const std::string &name) : SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+HIJINGFlipAfterburner::~HIJINGFlipAfterburner()
+{
+}
+
+
+//____________________________________________________________________________..
+int HIJINGFlipAfterburner::process_event(PHCompositeNode *topNode)
+{
+  if (!doFlip)
+  {
+    doFlip = true;
+  }
+  else
+  {
+    doFlip = false;
+    PHHepMCGenEventMap *genevtmap = findNode::getClass<PHHepMCGenEventMap>(topNode, "PHHepMCGenEventMap");
+    for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter)
+    {
+      PHHepMCGenEvent *genevt = iter->second;
+      HepMC::GenEvent *evt = genevt->getEvent();
+      assert(evt);
+      flipZDirection(evt);
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+void HIJINGFlipAfterburner::flipZDirection(HepMC::GenEvent *event)
+{
+  assert(event);
+
+  for (auto v = event->vertices_begin(); v != event->vertices_end(); ++v)
+  {
+    HepMC::FourVector position = (*v)->position();
+
+    position.setZ(-position.z());
+
+    (*v)->set_position(position);
+  }
+
+  for (auto p = event->particles_begin(); p != event->particles_end(); ++p)
+  {
+    HepMC::FourVector momentum = (*p)->momentum();
+
+    momentum.setPz(-momentum.pz());
+
+    (*p)->set_momentum(momentum);
+  }
+}

--- a/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.h
+++ b/generators/HIJINGFlipAfterburner/HIJINGFlipAfterburner.h
@@ -1,0 +1,31 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef HIJINGFLIPAFTERBURNER_H
+#define HIJINGFLIPAFTERBURNER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+namespace HepMC
+{
+  class GenEvent;
+}
+
+class HIJINGFlipAfterburner : public SubsysReco
+{
+public:
+    HIJINGFlipAfterburner(const std::string &name = "HIJINGFlipAfterburner");
+
+    ~HIJINGFlipAfterburner() override;
+
+    int process_event(PHCompositeNode *topNode) override;
+
+
+private:
+    void flipZDirection(HepMC::GenEvent *event);
+    bool doFlip = true;
+};
+
+#endif // HIJINGFLIPAFTERBURNER_H

--- a/generators/HIJINGFlipAfterburner/Makefile.am
+++ b/generators/HIJINGFlipAfterburner/Makefile.am
@@ -1,0 +1,43 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+pkginclude_HEADERS = \
+  HIJINGFlipAfterburner.h
+
+lib_LTLIBRARIES = \
+  libHIJINGFlipAfterburner.la
+
+libHIJINGFlipAfterburner_la_SOURCES = \
+  HIJINGFlipAfterburner.cc
+
+libHIJINGFlipAfterburner_la_LIBADD = \
+  -lphool \
+  -lSubsysReco \
+  -lphhepmc
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libHIJINGFlipAfterburner.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/generators/HIJINGFlipAfterburner/autogen.sh
+++ b/generators/HIJINGFlipAfterburner/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/generators/HIJINGFlipAfterburner/configure.ac
+++ b/generators/HIJINGFlipAfterburner/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(hijingflipafterburner,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
 
HIJING's multiplicity is not symmetrical in +- z.

This afterburner adjusts the z-coordinates of particles and vertices, inverting their positions every other event. When aggregating data from multiple events, this method effectively balances out the asymmetry, yielding a symmetrical multiplicity distribution  for the sum of entire event set.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

