### PR TITLE
Set the error on the template fit histogram to 1

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -105,7 +105,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
 	    ROOT::Fit::Chi2Function *EPChi2 = new ROOT::Fit::Chi2Function(data, *fitFunction);
 	    ROOT::Fit::Fitter *fitter = new ROOT::Fit::Fitter();
 	    fitter->Config().MinimizerOptions().SetMinimizerType("GSLMultiFit");
-	    double params[] = {static_cast<double>(maxheight - pedestal), static_cast<double>(maxbin - 6), static_cast<double>(pedestal)};
+	    double params[] = {static_cast<double>(maxheight - pedestal), 0, static_cast<double>(pedestal)};
 	    fitter->Config().SetParamsSettings(3, params);
 	    fitter->FitFCN(*EPChi2, nullptr, data.Size(), true);
             ROOT::Fit::FitResult fitres = fitter->Result();
@@ -252,7 +252,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_fast(std::v
       }
     }
     amp -= ped;
-    std::vector<float> val = {amp, time, ped};
+    std::vector<float> val = {amp, time, ped, 0};
     fit_values.push_back(val);
     val.clear();
   }

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -57,7 +57,8 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
       {
 	v.push_back(v.at(0) - v.at(1)); //returns peak sample - pedestal sample
 	v.push_back(-1); // set time to -1 to indicate zero suppressed 
-	v.push_back(v.at(1));    
+	v.push_back(v.at(1)); 
+	v.push_back(0);
       }
     else
       {
@@ -95,6 +96,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
 	    v.push_back(v.at(6) - v.at(0));
 	    v.push_back(-1);
 	    v.push_back(v.at(0));
+	    v.push_back(0);
 	  }
 	else
 	  {

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -67,6 +67,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
 	for (int i = 0; i < size1; i++)
 	  {
 	    h->SetBinContent(i + 1, v.at(i));
+	    h->SetBinError(i + 1, 1);
 	    if (v.at(i) > maxheight)
 	      {
 		maxheight = v.at(i);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Set the error for the waveform histogram for the template fit to 1 instead of sqrt(N), so that the bias from the non-perfect template is a constant ratio. Change the initial time parameter of the template fit to around sample 6 to reduce bias.

Also make the fast method and ZS case push back a 0 chi2 to avoid potential seg faults.


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

