### PR TITLE
remove confusing printouts from CDBInterface

### DIFF
--- a/offline/framework/ffamodules/CDBInterface.cc
+++ b/offline/framework/ffamodules/CDBInterface.cc
@@ -15,6 +15,7 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
+#include <phool/phool.h>
 #include <phool/recoConsts.h>
 
 #include <TSystem.h>
@@ -66,7 +67,7 @@ int CDBInterface::End(PHCompositeNode *topNode)
   else
   {
     std::set<std::tuple<std::string, std::string, uint64_t>> tmp_set;
-    for (const auto & cdburl : *cdburls)
+    for (const auto &cdburl : *cdburls)
     {
       tmp_set.insert(cdburl);
     }
@@ -78,7 +79,7 @@ int CDBInterface::End(PHCompositeNode *topNode)
       {
         if (Verbosity())
         {
-          std::cout << "removing already saved: domain " << std::get<0>(*itr)
+          std::cout << PHWHERE << " removing already saved: domain " << std::get<0>(*itr)
                     << ", url: " << std::get<1>(*itr)
                     << ", timestamp: " << std::get<2>(*itr) << std::endl;
         }
@@ -94,7 +95,7 @@ int CDBInterface::End(PHCompositeNode *topNode)
   {
     cdburls->AddUrl(tuple);
   }
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     cdburls->identify();
   }
@@ -115,15 +116,15 @@ void CDBInterface::Print(const std::string & /* what */) const
 std::string CDBInterface::getUrl(const std::string &domain, const std::string &filename)
 {
   recoConsts *rc = recoConsts::instance();
-  if (! rc->FlagExist("CDB_GLOBALTAG"))
+  if (!rc->FlagExist("CDB_GLOBALTAG"))
   {
-    std::cout << "CDB_GLOBALTAG flag needs to be set via" << std::endl;
+    std::cout << PHWHERE << "CDB_GLOBALTAG flag needs to be set via" << std::endl;
     std::cout << "rc->set_StringFlag(\"CDB_GLOBALTAG\",<global tag>)" << std::endl;
     gSystem->Exit(1);
   }
-  if (! rc->FlagExist("TIMESTAMP"))
+  if (!rc->FlagExist("TIMESTAMP"))
   {
-    std::cout << "TIMESTAMP flag needs to be set via" << std::endl;
+    std::cout << PHWHERE << "TIMESTAMP flag needs to be set via" << std::endl;
     std::cout << "rc->set_uint64Flag(\"TIMESTAMP\",<64 bit timestamp>)" << std::endl;
     gSystem->Exit(1);
   }
@@ -134,11 +135,11 @@ std::string CDBInterface::getUrl(const std::string &domain, const std::string &f
   uint64_t timestamp = rc->get_uint64Flag("TIMESTAMP");
   if (Verbosity() > 0)
   {
-    std::cout << "Global Tag: " <<  rc->get_StringFlag("CDB_GLOBALTAG")
-	      << ", domain: " << domain
-	      << ", timestamp: " << timestamp;
+    std::cout << "Global Tag: " << rc->get_StringFlag("CDB_GLOBALTAG")
+              << ", domain: " << domain
+              << ", timestamp: " << timestamp;
   }
-  std::string return_url = cdbclient->getCalibration(domain,timestamp);
+  std::string return_url = cdbclient->getCalibration(domain, timestamp);
   if (Verbosity() > 0)
   {
     if (return_url.empty())
@@ -147,7 +148,7 @@ std::string CDBInterface::getUrl(const std::string &domain, const std::string &f
     }
     else
     {
-      std::cout << "... reply: " <<  return_url << std::endl;
+      std::cout << "... reply: " << return_url << std::endl;
     }
   }
   if (return_url.empty())
@@ -157,7 +158,7 @@ std::string CDBInterface::getUrl(const std::string &domain, const std::string &f
   auto pret = m_UrlVector.insert(make_tuple(domain, return_url, timestamp));
   if (!pret.second && Verbosity() > 1)
   {
-    std::cout << "duplicate entry " << domain << ", url: " << return_url
+    std::cout << PHWHERE << "not adding again " << domain << ", url: " << return_url
               << ", time stamp: " << timestamp << std::endl;
   }
   return return_url;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR reshuffles the verbositis of the CDBInterface a bit to remove confusing duplicates and clarifies messages. The verbosity is currently enabled for the calo production and the current output indicates non existing problems which is bad

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

