### PR TITLE
fix name clash in Intt namespace with sims - rename Intt to InttDefs

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataConverter.cc
+++ b/offline/packages/intt/InttCombinedRawDataConverter.cc
@@ -181,19 +181,19 @@ int InttCombinedRawDataConverter::process_event(PHCompositeNode* topNode)
   for (auto& itr : branches_l)itr.second->clear();
   for (auto& itr : branches_d)itr.second->clear();
 
-  InttDefs::RawData_s raw;
-  InttDefs::Online_s onl;
+  InttNameSpace::RawData_s raw;
+  InttNameSpace::Online_s onl;
   std::map<std::tuple<int, int, int, int, int>, char> hits;
   for (unsigned int i = 0; i < inttcont->get_nhits(); i++)
   {
     InttRawHit* intthit = inttcont->get_hit(i);
 
-    InttDefs::RawFromHit(raw, intthit);
-    //raw.felix_server = InttDefs::FelixFromPacket(intthit->get_packetid());
+    InttNameSpace::RawFromHit(raw, intthit);
+    //raw.felix_server = InttNameSpace::FelixFromPacket(intthit->get_packetid());
     //raw.felix_channel = intthit->get_fee();
     //raw.chip = (intthit->get_chip_id() + 25) % 26;
     //raw.channel = intthit->get_channel_id();
-    onl = InttDefs::ToOnline(raw);
+    onl = InttNameSpace::ToOnline(raw);
 
     std::tuple<int, int, int, int, int> tpl;
     std::get<0>(tpl) = onl.lyr;

--- a/offline/packages/intt/InttCombinedRawDataConverter.cc
+++ b/offline/packages/intt/InttCombinedRawDataConverter.cc
@@ -181,19 +181,19 @@ int InttCombinedRawDataConverter::process_event(PHCompositeNode* topNode)
   for (auto& itr : branches_l)itr.second->clear();
   for (auto& itr : branches_d)itr.second->clear();
 
-  Intt::RawData_s raw;
-  Intt::Online_s onl;
+  InttDefs::RawData_s raw;
+  InttDefs::Online_s onl;
   std::map<std::tuple<int, int, int, int, int>, char> hits;
   for (unsigned int i = 0; i < inttcont->get_nhits(); i++)
   {
     InttRawHit* intthit = inttcont->get_hit(i);
 
-    Intt::RawFromHit(raw, intthit);
-    //raw.felix_server = Intt::FelixFromPacket(intthit->get_packetid());
+    InttDefs::RawFromHit(raw, intthit);
+    //raw.felix_server = InttDefs::FelixFromPacket(intthit->get_packetid());
     //raw.felix_channel = intthit->get_fee();
     //raw.chip = (intthit->get_chip_id() + 25) % 26;
     //raw.channel = intthit->get_channel_id();
-    onl = Intt::ToOnline(raw);
+    onl = InttDefs::ToOnline(raw);
 
     std::tuple<int, int, int, int, int> tpl;
     std::get<0>(tpl) = onl.lyr;

--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -122,19 +122,19 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
   TrkrHitSetContainer::Iterator hit_set_container_itr;
   TrkrHit* hit = nullptr;
 
-  Intt::RawData_s raw;
-  Intt::Offline_s ofl;
+  InttDefs::RawData_s raw;
+  InttDefs::Offline_s ofl;
   for (unsigned int i = 0; i < inttcont->get_nhits(); i++)
   {
     InttRawHit* intthit = inttcont->get_hit(i);
     // uint64_t gtm_bco = intthit->get_bco();
 
-    Intt::RawFromHit(raw, intthit);
-    //raw.felix_server = Intt::FelixFromPacket(intthit->get_packetid());
+    InttDefs::RawFromHit(raw, intthit);
+    //raw.felix_server = InttDefs::FelixFromPacket(intthit->get_packetid());
     //raw.felix_channel = intthit->get_fee();
     //raw.chip = (intthit->get_chip_id() + 25) % 26;
     //raw.channel = intthit->get_channel_id();
-    ofl = Intt::ToOffline(raw);
+    ofl = InttDefs::ToOffline(raw);
 
     int adc = intthit->get_adc();
     // amp = intthit->get_amplitude();
@@ -169,13 +169,13 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
 
         for(int n = 0; n < N; ++n)
         {
-        rawdata = Intt::RawFromPacket(itr->second, n, p);
+        rawdata = InttDefs::RawFromPacket(itr->second, n, p);
 
         adc = p->iValue(n, "ADC");
         //amp = p->iValue(n, "AMPLITUE");
         bco = p->iValue(n, "FPHX_BCO");
 
-        offline = Intt::ToOffline(rawdata);
+        offline = InttDefs::ToOffline(rawdata);
 
         hit_key = InttDefs::genHitKey(offline.strip_y, offline.strip_x); //col, row <trackbase/InttDefs.h>
         hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);

--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -122,19 +122,19 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
   TrkrHitSetContainer::Iterator hit_set_container_itr;
   TrkrHit* hit = nullptr;
 
-  InttDefs::RawData_s raw;
-  InttDefs::Offline_s ofl;
+  InttNameSpace::RawData_s raw;
+  InttNameSpace::Offline_s ofl;
   for (unsigned int i = 0; i < inttcont->get_nhits(); i++)
   {
     InttRawHit* intthit = inttcont->get_hit(i);
     // uint64_t gtm_bco = intthit->get_bco();
 
-    InttDefs::RawFromHit(raw, intthit);
-    //raw.felix_server = InttDefs::FelixFromPacket(intthit->get_packetid());
+    InttNameSpace::RawFromHit(raw, intthit);
+    //raw.felix_server = InttNameSpace::FelixFromPacket(intthit->get_packetid());
     //raw.felix_channel = intthit->get_fee();
     //raw.chip = (intthit->get_chip_id() + 25) % 26;
     //raw.channel = intthit->get_channel_id();
-    ofl = InttDefs::ToOffline(raw);
+    ofl = InttNameSpace::ToOffline(raw);
 
     int adc = intthit->get_adc();
     // amp = intthit->get_amplitude();
@@ -169,16 +169,16 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
 
         for(int n = 0; n < N; ++n)
         {
-        rawdata = InttDefs::RawFromPacket(itr->second, n, p);
+        rawdata = InttNameSpace::RawFromPacket(itr->second, n, p);
 
         adc = p->iValue(n, "ADC");
         //amp = p->iValue(n, "AMPLITUE");
         bco = p->iValue(n, "FPHX_BCO");
 
-        offline = InttDefs::ToOffline(rawdata);
+        offline = InttNameSpace::ToOffline(rawdata);
 
         hit_key = InttDefs::genHitKey(offline.strip_y, offline.strip_x); //col, row <trackbase/InttDefs.h>
-        hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);
+        hit_set_key = InttNameSpace::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);
 
         hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
         hit = hit_set_container_itr->second->getHit(hit_key);

--- a/offline/packages/intt/InttDeadMapHelper.cc
+++ b/offline/packages/intt/InttDeadMapHelper.cc
@@ -85,9 +85,9 @@ InttDeadMapHelper& InttDeadMapHelper::operator=(InttDeadMapHelper const& _o)
 	return *this;
 }
 
-InttDeadMapHelper::InttDeadMapHelper(InttDeadMap_Long_t const& _N, InttDeadMap_Double_t const& _n_z, InttDeadMap_Double_t const& _n_t)
+InttDeadMapHelper::InttDeadMapHelper(InttDeadMap_Long_t const& npoints, InttDeadMap_Double_t const& _n_z, InttDeadMap_Double_t const& _n_t)
 {
-	N = _N;
+	N = npoints;
 	points = new struct InttDeadMap_Point_s[N];
 
 	n_z = _n_z;

--- a/offline/packages/intt/InttFelixMap.cc
+++ b/offline/packages/intt/InttFelixMap.cc
@@ -2,7 +2,7 @@
 
 #include "InttMapping.h"
 
-int InttFelix::RawDataToOnline(struct Intt::RawData_s const& raw, struct Intt::Online_s& onl)
+int InttFelix::RawDataToOnline(struct InttDefs::RawData_s const& raw, struct InttDefs::Online_s& onl)
 {
 	switch(raw.felix_server) {
 		case  0:
@@ -276,7 +276,7 @@ int InttFelix::RawDataToOnline(struct Intt::RawData_s const& raw, struct Intt::O
 	return 1;
 }
 
-int InttFelix::OnlineToRawData(struct Intt::Online_s const& onl, struct Intt::RawData_s& raw)
+int InttFelix::OnlineToRawData(struct InttDefs::Online_s const& onl, struct InttDefs::RawData_s& raw)
 {
 	switch(onl.lyr) {
 		case  0:

--- a/offline/packages/intt/InttFelixMap.cc
+++ b/offline/packages/intt/InttFelixMap.cc
@@ -2,7 +2,7 @@
 
 #include "InttMapping.h"
 
-int InttFelix::RawDataToOnline(struct InttDefs::RawData_s const& raw, struct InttDefs::Online_s& onl)
+int InttFelix::RawDataToOnline(struct InttNameSpace::RawData_s const& raw, struct InttNameSpace::Online_s& onl)
 {
 	switch(raw.felix_server) {
 		case  0:
@@ -276,7 +276,7 @@ int InttFelix::RawDataToOnline(struct InttDefs::RawData_s const& raw, struct Int
 	return 1;
 }
 
-int InttFelix::OnlineToRawData(struct InttDefs::Online_s const& onl, struct InttDefs::RawData_s& raw)
+int InttFelix::OnlineToRawData(struct InttNameSpace::Online_s const& onl, struct InttNameSpace::RawData_s& raw)
 {
 	switch(onl.lyr) {
 		case  0:

--- a/offline/packages/intt/InttFelixMap.h
+++ b/offline/packages/intt/InttFelixMap.h
@@ -1,13 +1,13 @@
 #ifndef INTT_FELIX_MAP_H
 #define INTT_FELIX_MAP_H
 
-namespace Intt { struct Online_s; }
-namespace Intt { struct RawData_s; }
+namespace InttDefs { struct Online_s; }
+namespace InttDefs { struct RawData_s; }
 
 namespace InttFelix
 {
-	int RawDataToOnline(struct Intt::RawData_s const&, struct Intt::Online_s&);
-	int OnlineToRawData(struct Intt::Online_s const&, struct Intt::RawData_s&);
+	int RawDataToOnline(struct InttDefs::RawData_s const&, struct InttDefs::Online_s&);
+	int OnlineToRawData(struct InttDefs::Online_s const&, struct InttDefs::RawData_s&);
 };
 
 #endif//INTT_FELIX_MAP_H

--- a/offline/packages/intt/InttFelixMap.h
+++ b/offline/packages/intt/InttFelixMap.h
@@ -1,13 +1,13 @@
 #ifndef INTT_FELIX_MAP_H
 #define INTT_FELIX_MAP_H
 
-namespace InttDefs { struct Online_s; }
-namespace InttDefs { struct RawData_s; }
+namespace InttNameSpace { struct Online_s; }
+namespace InttNameSpace { struct RawData_s; }
 
 namespace InttFelix
 {
-	int RawDataToOnline(struct InttDefs::RawData_s const&, struct InttDefs::Online_s&);
-	int OnlineToRawData(struct InttDefs::Online_s const&, struct InttDefs::RawData_s&);
+	int RawDataToOnline(struct InttNameSpace::RawData_s const&, struct InttNameSpace::Online_s&);
+	int OnlineToRawData(struct InttNameSpace::Online_s const&, struct InttNameSpace::RawData_s&);
 };
 
 #endif//INTT_FELIX_MAP_H

--- a/offline/packages/intt/InttMapping.cc
+++ b/offline/packages/intt/InttMapping.cc
@@ -8,7 +8,7 @@
 
 #include <utility>   // for pair
 
-const std::map<int, int> InttDefs::Packet_Id =
+const std::map<int, int> InttNameSpace::Packet_Id =
 {
 	{3001, 0},
 	{3002, 1},
@@ -20,7 +20,7 @@ const std::map<int, int> InttDefs::Packet_Id =
 	{3008, 7},
 };
 
-int InttDefs::FelixFromPacket(int packetid)
+int InttNameSpace::FelixFromPacket(int packetid)
 {
 	packetid -= 3001;
 
@@ -30,7 +30,7 @@ int InttDefs::FelixFromPacket(int packetid)
 	return packetid;
 }
 
-struct InttDefs::RawData_s InttDefs::RawFromPacket(int const _i, int const _n, Packet* _p)
+struct InttNameSpace::RawData_s InttNameSpace::RawFromPacket(int const _i, int const _n, Packet* _p)
 {
 	struct RawData_s s;
 
@@ -46,15 +46,15 @@ struct InttDefs::RawData_s InttDefs::RawFromPacket(int const _i, int const _n, P
 	return s;
 }
 
-void InttDefs::RawFromHit(struct InttDefs::RawData_s& s, InttRawHit* h)
+void InttNameSpace::RawFromHit(struct InttNameSpace::RawData_s& s, InttRawHit* h)
 {
-	s.felix_server = InttDefs::FelixFromPacket(h->get_packetid());
+	s.felix_server = InttNameSpace::FelixFromPacket(h->get_packetid());
 	s.felix_channel = h->get_fee();
 	s.chip = (h->get_chip_id() + 25) % 26;
 	s.channel = h->get_channel_id();
 }
 
-struct InttDefs::Online_s InttDefs::ToOnline(struct Offline_s const& _s)
+struct InttNameSpace::Online_s InttNameSpace::ToOnline(struct Offline_s const& _s)
 {
 	struct Online_s s;
 	int n_ldr = _s.layer < 5 ? 12 : 16;
@@ -90,7 +90,7 @@ struct InttDefs::Online_s InttDefs::ToOnline(struct Offline_s const& _s)
 	return s;
 }
 
-struct InttDefs::Offline_s InttDefs::ToOffline(struct Online_s const& _s)
+struct InttNameSpace::Offline_s InttNameSpace::ToOffline(struct Online_s const& _s)
 {
 	struct Offline_s s;
 	int n_ldr = _s.lyr < 2 ? 12 : 16;
@@ -126,7 +126,7 @@ struct InttDefs::Offline_s InttDefs::ToOffline(struct Online_s const& _s)
 	return s;
 }
 
-struct InttDefs::RawData_s InttDefs::ToRawData(struct Online_s const& _s)
+struct InttNameSpace::RawData_s InttNameSpace::ToRawData(struct Online_s const& _s)
 {
 	struct RawData_s s;
 
@@ -137,7 +137,7 @@ struct InttDefs::RawData_s InttDefs::ToRawData(struct Online_s const& _s)
 	return s;
 }
 
-struct InttDefs::Online_s InttDefs::ToOnline(struct RawData_s const& _s)
+struct InttNameSpace::Online_s InttNameSpace::ToOnline(struct RawData_s const& _s)
 {
 	struct Online_s s;
 
@@ -148,17 +148,17 @@ struct InttDefs::Online_s InttDefs::ToOnline(struct RawData_s const& _s)
 	return s;
 }
 
-struct InttDefs::RawData_s InttDefs::ToRawData(struct Offline_s const& _s)
+struct InttNameSpace::RawData_s InttNameSpace::ToRawData(struct Offline_s const& _s)
 {
 	return ToRawData(ToOnline(_s));
 }
 
-struct InttDefs::Offline_s InttDefs::ToOffline(struct RawData_s const& _s)
+struct InttNameSpace::Offline_s InttNameSpace::ToOffline(struct RawData_s const& _s)
 {
 	return ToOffline(ToOnline(_s));
 }
 
-//Eigen::Affine3d InttDefs::GetTransform(TTree* tree, struct InttDefs::Offline_s const& _s)
+//Eigen::Affine3d InttNameSpace::GetTransform(TTree* tree, struct InttNameSpace::Offline_s const& _s)
 //{
 //	Eigen::Affine3d t;
 //
@@ -211,7 +211,7 @@ struct InttDefs::Offline_s InttDefs::ToOffline(struct RawData_s const& _s)
 //	return t;
 //}
 //
-//Eigen::Vector4d InttDefs::GetLocalPos(struct InttDefs::Offline_s const& _s)
+//Eigen::Vector4d InttNameSpace::GetLocalPos(struct InttNameSpace::Offline_s const& _s)
 //{
 //	Eigen::Vector4d u = {0.0, 0.0, 0.0, 1.0};
 //
@@ -229,7 +229,7 @@ struct InttDefs::Offline_s InttDefs::ToOffline(struct RawData_s const& _s)
 //	return u;
 //}
 
-bool operator==(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator==(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	if(lhs.felix_server != rhs.felix_server)return false;
 	if(lhs.felix_channel != rhs.felix_channel)return false;
@@ -239,7 +239,7 @@ bool operator==(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_
 	return true;
 }
 
-bool operator==(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator==(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	if(lhs.lyr != rhs.lyr)return false;
 	if(lhs.ldr != rhs.ldr)return false;
@@ -250,7 +250,7 @@ bool operator==(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s 
 	return true;
 }
 
-bool operator==(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator==(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	if(lhs.layer != rhs.layer)return false;
 	if(lhs.ladder_phi != rhs.ladder_phi)return false;
@@ -261,22 +261,22 @@ bool operator==(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_
 	return true;
 }
 
-bool operator!=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator!=(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator!=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator!=(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator!=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator!=(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator<(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator<(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	if(lhs.felix_server != rhs.felix_server)return lhs.felix_server < rhs.felix_server;
 	if(lhs.felix_channel != rhs.felix_channel)return lhs.felix_channel < rhs.felix_channel;
@@ -286,7 +286,7 @@ bool operator<(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s
 	return false;
 }
 
-bool operator<(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator<(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	if(lhs.lyr != rhs.lyr)return lhs.lyr < rhs.lyr;
 	if(lhs.ldr != rhs.ldr)return lhs.ldr < rhs.ldr;
@@ -297,7 +297,7 @@ bool operator<(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s c
 	return false;
 }
 
-bool operator<(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator<(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	if(lhs.layer != rhs.layer)return lhs.layer < rhs.layer;
 	if(lhs.ladder_phi != rhs.ladder_phi)return lhs.ladder_phi < rhs.ladder_phi;
@@ -308,47 +308,47 @@ bool operator<(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s
 	return false;
 }
 
-bool operator>(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator>(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator>(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator>(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator>=(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator>=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator>=(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator>=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator>=(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator<=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
+bool operator<=(struct InttNameSpace::RawData_s const& lhs, struct InttNameSpace::RawData_s const& rhs)
 {
 	return !(lhs > rhs);
 }
 
-bool operator<=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
+bool operator<=(struct InttNameSpace::Online_s const& lhs, struct InttNameSpace::Online_s const& rhs)
 {
 	return !(lhs > rhs);
 }
 
-bool operator<=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
+bool operator<=(struct InttNameSpace::Offline_s const& lhs, struct InttNameSpace::Offline_s const& rhs)
 {
 	return !(lhs > rhs);
 }

--- a/offline/packages/intt/InttMapping.cc
+++ b/offline/packages/intt/InttMapping.cc
@@ -8,7 +8,7 @@
 
 #include <utility>   // for pair
 
-const std::map<int, int> Intt::Packet_Id =
+const std::map<int, int> InttDefs::Packet_Id =
 {
 	{3001, 0},
 	{3002, 1},
@@ -20,7 +20,7 @@ const std::map<int, int> Intt::Packet_Id =
 	{3008, 7},
 };
 
-int Intt::FelixFromPacket(int packetid)
+int InttDefs::FelixFromPacket(int packetid)
 {
 	packetid -= 3001;
 
@@ -30,7 +30,7 @@ int Intt::FelixFromPacket(int packetid)
 	return packetid;
 }
 
-struct Intt::RawData_s Intt::RawFromPacket(int const _i, int const _n, Packet* _p)
+struct InttDefs::RawData_s InttDefs::RawFromPacket(int const _i, int const _n, Packet* _p)
 {
 	struct RawData_s s;
 
@@ -46,15 +46,15 @@ struct Intt::RawData_s Intt::RawFromPacket(int const _i, int const _n, Packet* _
 	return s;
 }
 
-void Intt::RawFromHit(struct Intt::RawData_s& s, InttRawHit* h)
+void InttDefs::RawFromHit(struct InttDefs::RawData_s& s, InttRawHit* h)
 {
-	s.felix_server = Intt::FelixFromPacket(h->get_packetid());
+	s.felix_server = InttDefs::FelixFromPacket(h->get_packetid());
 	s.felix_channel = h->get_fee();
 	s.chip = (h->get_chip_id() + 25) % 26;
 	s.channel = h->get_channel_id();
 }
 
-struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
+struct InttDefs::Online_s InttDefs::ToOnline(struct Offline_s const& _s)
 {
 	struct Online_s s;
 	int n_ldr = _s.layer < 5 ? 12 : 16;
@@ -90,7 +90,7 @@ struct Intt::Online_s Intt::ToOnline(struct Offline_s const& _s)
 	return s;
 }
 
-struct Intt::Offline_s Intt::ToOffline(struct Online_s const& _s)
+struct InttDefs::Offline_s InttDefs::ToOffline(struct Online_s const& _s)
 {
 	struct Offline_s s;
 	int n_ldr = _s.lyr < 2 ? 12 : 16;
@@ -126,7 +126,7 @@ struct Intt::Offline_s Intt::ToOffline(struct Online_s const& _s)
 	return s;
 }
 
-struct Intt::RawData_s Intt::ToRawData(struct Online_s const& _s)
+struct InttDefs::RawData_s InttDefs::ToRawData(struct Online_s const& _s)
 {
 	struct RawData_s s;
 
@@ -137,7 +137,7 @@ struct Intt::RawData_s Intt::ToRawData(struct Online_s const& _s)
 	return s;
 }
 
-struct Intt::Online_s Intt::ToOnline(struct RawData_s const& _s)
+struct InttDefs::Online_s InttDefs::ToOnline(struct RawData_s const& _s)
 {
 	struct Online_s s;
 
@@ -148,17 +148,17 @@ struct Intt::Online_s Intt::ToOnline(struct RawData_s const& _s)
 	return s;
 }
 
-struct Intt::RawData_s Intt::ToRawData(struct Offline_s const& _s)
+struct InttDefs::RawData_s InttDefs::ToRawData(struct Offline_s const& _s)
 {
 	return ToRawData(ToOnline(_s));
 }
 
-struct Intt::Offline_s Intt::ToOffline(struct RawData_s const& _s)
+struct InttDefs::Offline_s InttDefs::ToOffline(struct RawData_s const& _s)
 {
 	return ToOffline(ToOnline(_s));
 }
 
-//Eigen::Affine3d Intt::GetTransform(TTree* tree, struct Intt::Offline_s const& _s)
+//Eigen::Affine3d InttDefs::GetTransform(TTree* tree, struct InttDefs::Offline_s const& _s)
 //{
 //	Eigen::Affine3d t;
 //
@@ -211,7 +211,7 @@ struct Intt::Offline_s Intt::ToOffline(struct RawData_s const& _s)
 //	return t;
 //}
 //
-//Eigen::Vector4d Intt::GetLocalPos(struct Intt::Offline_s const& _s)
+//Eigen::Vector4d InttDefs::GetLocalPos(struct InttDefs::Offline_s const& _s)
 //{
 //	Eigen::Vector4d u = {0.0, 0.0, 0.0, 1.0};
 //
@@ -229,7 +229,7 @@ struct Intt::Offline_s Intt::ToOffline(struct RawData_s const& _s)
 //	return u;
 //}
 
-bool operator==(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator==(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	if(lhs.felix_server != rhs.felix_server)return false;
 	if(lhs.felix_channel != rhs.felix_channel)return false;
@@ -239,7 +239,7 @@ bool operator==(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const&
 	return true;
 }
 
-bool operator==(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator==(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	if(lhs.lyr != rhs.lyr)return false;
 	if(lhs.ldr != rhs.ldr)return false;
@@ -250,7 +250,7 @@ bool operator==(struct Intt::Online_s const& lhs, struct Intt::Online_s const& r
 	return true;
 }
 
-bool operator==(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator==(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	if(lhs.layer != rhs.layer)return false;
 	if(lhs.ladder_phi != rhs.ladder_phi)return false;
@@ -261,22 +261,22 @@ bool operator==(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const&
 	return true;
 }
 
-bool operator!=(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator!=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator!=(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator!=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator!=(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator!=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	return !(lhs == rhs);
 }
 
-bool operator<(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator<(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	if(lhs.felix_server != rhs.felix_server)return lhs.felix_server < rhs.felix_server;
 	if(lhs.felix_channel != rhs.felix_channel)return lhs.felix_channel < rhs.felix_channel;
@@ -286,7 +286,7 @@ bool operator<(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& 
 	return false;
 }
 
-bool operator<(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator<(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	if(lhs.lyr != rhs.lyr)return lhs.lyr < rhs.lyr;
 	if(lhs.ldr != rhs.ldr)return lhs.ldr < rhs.ldr;
@@ -297,7 +297,7 @@ bool operator<(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rh
 	return false;
 }
 
-bool operator<(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator<(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	if(lhs.layer != rhs.layer)return lhs.layer < rhs.layer;
 	if(lhs.ladder_phi != rhs.ladder_phi)return lhs.ladder_phi < rhs.ladder_phi;
@@ -308,47 +308,47 @@ bool operator<(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& 
 	return false;
 }
 
-bool operator>(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator>(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator>(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator>(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	return rhs < lhs;
 }
 
-bool operator>=(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator>=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator>=(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator>=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator>=(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator>=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	return !(lhs < rhs);
 }
 
-bool operator<=(struct Intt::RawData_s const& lhs, struct Intt::RawData_s const& rhs)
+bool operator<=(struct InttDefs::RawData_s const& lhs, struct InttDefs::RawData_s const& rhs)
 {
 	return !(lhs > rhs);
 }
 
-bool operator<=(struct Intt::Online_s const& lhs, struct Intt::Online_s const& rhs)
+bool operator<=(struct InttDefs::Online_s const& lhs, struct InttDefs::Online_s const& rhs)
 {
 	return !(lhs > rhs);
 }
 
-bool operator<=(struct Intt::Offline_s const& lhs, struct Intt::Offline_s const& rhs)
+bool operator<=(struct InttDefs::Offline_s const& lhs, struct InttDefs::Offline_s const& rhs)
 {
 	return !(lhs > rhs);
 }

--- a/offline/packages/intt/InttMapping.h
+++ b/offline/packages/intt/InttMapping.h
@@ -6,7 +6,7 @@
 class Packet;
 class InttRawHit;
 
-namespace Intt
+namespace InttDefs
 {
 	extern const std::map<int, int> Packet_Id;
 	int FelixFromPacket(int);
@@ -37,8 +37,8 @@ namespace Intt
 		int strip_y = 0;
 	};
 
-	struct Intt::RawData_s RawFromPacket(int const, int const, Packet*);
-	void RawFromHit(struct Intt::RawData_s&, InttRawHit*);
+	struct InttDefs::RawData_s RawFromPacket(int const, int const, Packet*);
+	void RawFromHit(struct InttDefs::RawData_s&, InttRawHit*);
 
 	//nontrivial
 	struct Online_s ToOnline(struct Offline_s const&);
@@ -55,29 +55,29 @@ namespace Intt
 	//Eigen::Vector4d GetLocalPos(struct Offline_s const&);
 };
 
-bool operator==(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator==(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator==(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator==(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator==(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator==(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
-bool operator!=(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator!=(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator!=(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator!=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator!=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator!=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
-bool operator<(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator<(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator<(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator<(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator<(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator<(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
-bool operator>(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator>(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator>(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator>(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator>(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator>(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
-bool operator<=(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator<=(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator<=(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator<=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator<=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator<=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
-bool operator>=(struct Intt::RawData_s const&, struct Intt::RawData_s const&);
-bool operator>=(struct Intt::Online_s const&, struct Intt::Online_s const&);
-bool operator>=(struct Intt::Offline_s const&, struct Intt::Offline_s const&);
+bool operator>=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
+bool operator>=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
+bool operator>=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
 
 #endif//INTT_MAPPING_H
 

--- a/offline/packages/intt/InttMapping.h
+++ b/offline/packages/intt/InttMapping.h
@@ -6,7 +6,7 @@
 class Packet;
 class InttRawHit;
 
-namespace InttDefs
+namespace InttNameSpace
 {
 	extern const std::map<int, int> Packet_Id;
 	int FelixFromPacket(int);
@@ -37,8 +37,8 @@ namespace InttDefs
 		int strip_y = 0;
 	};
 
-	struct InttDefs::RawData_s RawFromPacket(int const, int const, Packet*);
-	void RawFromHit(struct InttDefs::RawData_s&, InttRawHit*);
+	struct InttNameSpace::RawData_s RawFromPacket(int const, int const, Packet*);
+	void RawFromHit(struct InttNameSpace::RawData_s&, InttRawHit*);
 
 	//nontrivial
 	struct Online_s ToOnline(struct Offline_s const&);
@@ -55,29 +55,29 @@ namespace InttDefs
 	//Eigen::Vector4d GetLocalPos(struct Offline_s const&);
 };
 
-bool operator==(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator==(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator==(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator==(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator==(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator==(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
-bool operator!=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator!=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator!=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator!=(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator!=(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator!=(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
-bool operator<(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator<(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator<(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator<(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator<(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator<(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
-bool operator>(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator>(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator>(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator>(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator>(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator>(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
-bool operator<=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator<=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator<=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator<=(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator<=(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator<=(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
-bool operator>=(struct InttDefs::RawData_s const&, struct InttDefs::RawData_s const&);
-bool operator>=(struct InttDefs::Online_s const&, struct InttDefs::Online_s const&);
-bool operator>=(struct InttDefs::Offline_s const&, struct InttDefs::Offline_s const&);
+bool operator>=(struct InttNameSpace::RawData_s const&, struct InttNameSpace::RawData_s const&);
+bool operator>=(struct InttNameSpace::Online_s const&, struct InttNameSpace::Online_s const&);
+bool operator>=(struct InttNameSpace::Offline_s const&, struct InttNameSpace::Offline_s const&);
 
 #endif//INTT_MAPPING_H
 

--- a/offline/packages/intt/InttRawDataConverter.cc
+++ b/offline/packages/intt/InttRawDataConverter.cc
@@ -118,7 +118,7 @@ int InttRawDataConverter::process_event(PHCompositeNode* topNode)
 	Event* evt = findNode::getClass<Event>(topNode, "PRDF");
 	if(!evt)return Fun4AllReturnCodes::DISCARDEVENT;
 
-	for(std::map<int, int>::const_iterator pkt_itr = Intt::Packet_Id.begin(); pkt_itr != Intt::Packet_Id.end(); ++pkt_itr)
+	for(std::map<int, int>::const_iterator pkt_itr = InttDefs::Packet_Id.begin(); pkt_itr != InttDefs::Packet_Id.end(); ++pkt_itr)
 	{
 		Packet* pkt = evt->getPacket(pkt_itr->first);
 		if(!pkt)continue;
@@ -139,10 +139,10 @@ int InttRawDataConverter::process_event(PHCompositeNode* topNode)
 	
 		for(int n = 0; n < num_hits; ++n)
 		{
-			raw = Intt::RawFromPacket(pkt_itr->second, n, pkt);
+			raw = InttDefs::RawFromPacket(pkt_itr->second, n, pkt);
 			branches["flx_chn"][n] = raw.felix_channel;
 
-			onl = Intt::ToOnline(raw);
+			onl = InttDefs::ToOnline(raw);
 			branches["lyr"][n] = onl.lyr;
 			branches["ldr"][n] = onl.ldr;
 			branches["arm"][n] = onl.arm;

--- a/offline/packages/intt/InttRawDataConverter.cc
+++ b/offline/packages/intt/InttRawDataConverter.cc
@@ -118,7 +118,7 @@ int InttRawDataConverter::process_event(PHCompositeNode* topNode)
 	Event* evt = findNode::getClass<Event>(topNode, "PRDF");
 	if(!evt)return Fun4AllReturnCodes::DISCARDEVENT;
 
-	for(std::map<int, int>::const_iterator pkt_itr = InttDefs::Packet_Id.begin(); pkt_itr != InttDefs::Packet_Id.end(); ++pkt_itr)
+	for(std::map<int, int>::const_iterator pkt_itr = InttNameSpace::Packet_Id.begin(); pkt_itr != InttNameSpace::Packet_Id.end(); ++pkt_itr)
 	{
 		Packet* pkt = evt->getPacket(pkt_itr->first);
 		if(!pkt)continue;
@@ -139,10 +139,10 @@ int InttRawDataConverter::process_event(PHCompositeNode* topNode)
 	
 		for(int n = 0; n < num_hits; ++n)
 		{
-			raw = InttDefs::RawFromPacket(pkt_itr->second, n, pkt);
+			raw = InttNameSpace::RawFromPacket(pkt_itr->second, n, pkt);
 			branches["flx_chn"][n] = raw.felix_channel;
 
-			onl = InttDefs::ToOnline(raw);
+			onl = InttNameSpace::ToOnline(raw);
 			branches["lyr"][n] = onl.lyr;
 			branches["ldr"][n] = onl.ldr;
 			branches["arm"][n] = onl.arm;

--- a/offline/packages/intt/InttRawDataConverter.h
+++ b/offline/packages/intt/InttRawDataConverter.h
@@ -36,8 +36,8 @@ private:
 	Long64_t gtm_bco = 0;
 	Int_t flx_svr = 0;
 
-	InttDefs::RawData_s raw;
-	InttDefs::Online_s onl;
+	InttNameSpace::RawData_s raw;
+	InttNameSpace::Online_s onl;
 
 	typedef std::map<std::string, Int_t*> Branches_t;
 	Branches_t branches;

--- a/offline/packages/intt/InttRawDataConverter.h
+++ b/offline/packages/intt/InttRawDataConverter.h
@@ -36,8 +36,8 @@ private:
 	Long64_t gtm_bco = 0;
 	Int_t flx_svr = 0;
 
-	Intt::RawData_s raw;
-	Intt::Online_s onl;
+	InttDefs::RawData_s raw;
+	InttDefs::Online_s onl;
 
 	typedef std::map<std::string, Int_t*> Branches_t;
 	Branches_t branches;

--- a/offline/packages/intt/InttRawDataDecoder.cc
+++ b/offline/packages/intt/InttRawDataDecoder.cc
@@ -100,8 +100,8 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 	Event* evt = findNode::getClass<Event>(topNode, "PRDF");
 	if(!evt)return Fun4AllReturnCodes::DISCARDEVENT;
 
-	struct Intt::RawData_s rawdata;
-	struct Intt::Offline_s offline;
+	struct InttDefs::RawData_s rawdata;
+	struct InttDefs::Offline_s offline;
 
 	int adc = 0;
 	//int amp = 0;
@@ -112,7 +112,7 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 	TrkrHitSetContainer::Iterator hit_set_container_itr;
 	TrkrHit* hit = nullptr;
 
-	for(std::map<int, int>::const_iterator itr = Intt::Packet_Id.begin(); itr != Intt::Packet_Id.end(); ++itr)
+	for(std::map<int, int>::const_iterator itr = InttDefs::Packet_Id.begin(); itr != InttDefs::Packet_Id.end(); ++itr)
 	{
 		Packet* p = evt->getPacket(itr->first);
 		if(!p)continue;
@@ -124,13 +124,13 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 
 		for(int n = 0; n < N; ++n)
 		{
-			rawdata = Intt::RawFromPacket(itr->second, n, p);
+			rawdata = InttDefs::RawFromPacket(itr->second, n, p);
 
 			adc = p->iValue(n, "ADC");
 			//amp = p->iValue(n, "AMPLITUE");
 			bco = p->iValue(n, "FPHX_BCO");
 
-			offline = Intt::ToOffline(rawdata);
+			offline = InttDefs::ToOffline(rawdata);
 
 			hit_key = InttDefs::genHitKey(offline.strip_y, offline.strip_x); //col, row <trackbase/InttDefs.h>
 			hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);

--- a/offline/packages/intt/InttRawDataDecoder.cc
+++ b/offline/packages/intt/InttRawDataDecoder.cc
@@ -100,8 +100,8 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 	Event* evt = findNode::getClass<Event>(topNode, "PRDF");
 	if(!evt)return Fun4AllReturnCodes::DISCARDEVENT;
 
-	struct InttDefs::RawData_s rawdata;
-	struct InttDefs::Offline_s offline;
+	struct InttNameSpace::RawData_s rawdata;
+	struct InttNameSpace::Offline_s offline;
 
 	int adc = 0;
 	//int amp = 0;
@@ -112,7 +112,7 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 	TrkrHitSetContainer::Iterator hit_set_container_itr;
 	TrkrHit* hit = nullptr;
 
-	for(std::map<int, int>::const_iterator itr = InttDefs::Packet_Id.begin(); itr != InttDefs::Packet_Id.end(); ++itr)
+	for(std::map<int, int>::const_iterator itr = InttNameSpace::Packet_Id.begin(); itr != InttNameSpace::Packet_Id.end(); ++itr)
 	{
 		Packet* p = evt->getPacket(itr->first);
 		if(!p)continue;
@@ -124,13 +124,13 @@ int InttRawDataDecoder::process_event(PHCompositeNode* topNode)
 
 		for(int n = 0; n < N; ++n)
 		{
-			rawdata = InttDefs::RawFromPacket(itr->second, n, p);
+			rawdata = InttNameSpace::RawFromPacket(itr->second, n, p);
 
 			adc = p->iValue(n, "ADC");
 			//amp = p->iValue(n, "AMPLITUE");
 			bco = p->iValue(n, "FPHX_BCO");
 
-			offline = InttDefs::ToOffline(rawdata);
+			offline = InttNameSpace::ToOffline(rawdata);
 
 			hit_key = InttDefs::genHitKey(offline.strip_y, offline.strip_x); //col, row <trackbase/InttDefs.h>
 			hit_set_key = InttDefs::genHitSetKey(offline.layer, offline.ladder_z, offline.ladder_phi, bco);

--- a/offline/packages/intt/InttVertexFinder.cc
+++ b/offline/packages/intt/InttVertexFinder.cc
@@ -171,8 +171,8 @@ double InttVertexFinder::calculateZvertex(
         const auto cluskey = clusIter->first;
         const auto cluster = clusIter->second;
         const auto globalPos = m_tGeometry->getGlobalPosition(cluskey, cluster);
-        //int ladder_z   = InttDefs::getLadderZId(cluskey);
-        //int ladder_phi = InttDefs::getLadderPhiId(cluskey);
+        //int ladder_z   = InttNameSpace::getLadderZId(cluskey);
+        //int ladder_phi = InttNameSpace::getLadderPhiId(cluskey);
         //int size       = cluster->getSize();
 
         //--if(nCluster<5) {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR fixes a name clash of the Intt namespace with the Intt() function in the G4_TrkrSimulations.C macro. A change in the macro requires everybody to update their macros, changing the namespace name is less intrusive
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

