### PR TITLE
calotowerbuilder: add new option to build towerv2 from PRDF

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -39,7 +39,8 @@ class CaloTowerBuilder : public SubsysReco
   {
     kPRDFTowerv1 = 0,
     kPRDFWaveform = 1,
-    kWaveformTowerv2 = 2
+    kWaveformTowerv2 = 2,
+    kPRDFTowerv2 = 3
   };
 
   void set_detector_type(CaloTowerBuilder::DetectorSystem dettype)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

added a new build option for `CaloTowerBuilder` that create `TowerInfov2` object from PRDF directly. Changed the waveform for empty packet from {0,0} to {-1,-1}.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

