### PR TITLE
fix: Clean up InttEventInfo

### DIFF
--- a/offline/packages/trackbase/InttEventInfo.h
+++ b/offline/packages/trackbase/InttEventInfo.h
@@ -18,16 +18,15 @@ class InttEventInfo : public PHObject
   InttEventInfo() = default;
   virtual ~InttEventInfo() = default;
 
-  virtual void identify(std::ostream &os = std::cout) const;
-  virtual void Reset();
+  virtual void identify(std::ostream &os = std::cout) const override;
+  virtual void Reset() override;
 
   virtual uint64_t get_bco_full() const;
   virtual void set_bco_full(uint64_t const&);
 
  protected:
 
- private:
-
+  ClassDefOverride(InttEventInfo, 1);
 };
 
 #endif//INTT_EVENT_INFO_H

--- a/offline/packages/trackbase/InttEventInfov1.h
+++ b/offline/packages/trackbase/InttEventInfov1.h
@@ -29,7 +29,7 @@ class InttEventInfov1 : public InttEventInfo
   uint64_t bco_full;
 
  private:
-  ClassDefOverride(InttEventInfo, 1)
+  ClassDefOverride(InttEventInfov1, 1)
 };
 
 #endif//INTT_EVENT_INFO_v1_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

On compiling trackbase with the new build there is a ROOT warning that appears in the compiler log but does not actually fail the compilation that is due to the fact that the `InttEventInfo` is missing a `ClassDefOverride` statement. This PR fixes that and a few other minor related things that gets the inheritance structure right.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

