### PR TITLE
Fixed bug in INTT index calculation for new INTT ladder offsets.

### DIFF
--- a/offline/packages/intt/CylinderGeomIntt.cc
+++ b/offline/packages/intt/CylinderGeomIntt.cc
@@ -93,7 +93,7 @@ void CylinderGeomIntt::find_indices_from_world_location(int &segment_z_bin, int 
 {
   double signz = (location[2] > 0)? 1.  : -1;
   double phi = atan2(location[1], location[0]);
-  if(phi < 0) phi += 2.0*M_PI;
+  if(fabs(phi - m_OffsetPhi) > 0.01 && phi < 0) phi += 2.0*M_PI;
   double segment_phi_bin_tmp = (phi - m_OffsetPhi)/m_dPhi;
   segment_phi_bin = round(segment_phi_bin_tmp);
 
@@ -116,9 +116,11 @@ void CylinderGeomIntt::find_indices_from_segment_center(int &segment_z_bin, int 
 {
   double signz = (location[2] > 0)? 1.  : -1;
   double phi = atan2(location[1], location[0]);
-  if(phi < 0) phi += 2.0*M_PI;
+  if(fabs(phi - m_OffsetPhi) > 0.01 && phi < 0) phi += 2.0*M_PI;
   double segment_phi_bin_tmp = (phi - m_OffsetPhi)/m_dPhi;
   segment_phi_bin = lround(segment_phi_bin_tmp);
+
+  //  std::cout << "     phi " <<phi << " segment_phi_bin_tmp " <<  segment_phi_bin_tmp << " segment_phi_bin " << segment_phi_bin << " location " << location[0] << "  " << location[1] << "  " << location[2] << std::endl;
 
   double z_tmp = location[2]  / signz;
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -906,7 +906,7 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
         unsigned int ladderPhi = InttDefs::getLadderPhiId(hitsetkey);
         unsigned int ladderZ = InttDefs::getLadderZId(hitsetkey);
 
-        std::cout << "Layer radius " << layer_rad << " layer " << layer << " ladderPhi " << ladderPhi << " ladderZ " << ladderZ
+        std::cout << "Layer radius " << layer_rad << " layer " << layer << " ladderPhi " << ladderPhi << " ladderZ " << ladderZ << " hitsetkey " << hitsetkey 
                   << " recover surface from m_clusterSurfaceMapSilicon " << std::endl;
         std::cout << " surface type " << surf->type() << std::endl;
         auto assoc_layer = surf->associatedLayer();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The new INTT ladder geometry had the first ladder at a negative phi value in two of the layers. This was not anticipated in the algorithm that calculates the hitsetkeys. This PR fixes the algorithm so that it works with the new geometry.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

