### PR TITLE
fix: Updates for Actsv30.3.0

### DIFF
--- a/offline/packages/trackreco/ActsPropagator.cc
+++ b/offline/packages/trackreco/ActsPropagator.cc
@@ -91,7 +91,8 @@ ActsPropagator::makeTrackParams(SvtxTrack* track,
                                                             actsFourPos, momentum,
                                                             track->get_charge() / track->get_p(),
                                                             cov,
-                                                            Acts::ParticleHypothesis::pion());
+                                                            Acts::ParticleHypothesis::pion(),
+							    1*Acts::UnitConstants::cm);
 }
 
 ActsPropagator::BTPPairResult

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -620,7 +620,7 @@ MakeActsGeometry::build(const boost::program_options::variables_map& vm,
       Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
       // Set up the json-based decorator
       matDeco = std::make_shared<const Acts::JsonMaterialDecorator>(
-	   jsonGeoConvConfig, fileName, Acts::Logging::INFO);
+	   jsonGeoConvConfig, fileName, Acts::Logging::FATAL);
     } 
   else
     {
@@ -632,6 +632,10 @@ MakeActsGeometry::build(const boost::program_options::variables_map& vm,
   config.elementFactory = sPHENIXElementFactory;
 
   config.fileName = vm["geo-tgeo-filename"].as<std::string>();
+
+  config.surfaceLogLevel = Acts::Logging::FATAL;
+  config.layerLogLevel = Acts::Logging::FATAL;
+  config.volumeLogLevel = Acts::Logging::FATAL;
 
   const auto path = vm["geo-tgeo-jsonconfig"].template as<std::string>();
 

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -340,7 +340,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
                     momentum,
                     charge / momentum.norm(),
                     cov,
-                    Acts::ParticleHypothesis::muon())
+                    Acts::ParticleHypothesis::muon(), 
+		    1*Acts::UnitConstants::cm)
                     .value();
 
     if (Verbosity() > 2)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes a bug from Actsv30 which only allowed you to create track parameters on a perigee surface if they were within 0.1 micron tolerance, and reverts back to the previous behavior of (effectively) any tolerance to the perigee.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

