### PR TITLE
Add set prefix option to CaloTowerBuilder DST node name

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -316,6 +316,7 @@ void CaloTowerBuilder::CreateNodeTree(PHCompositeNode *topNode)
     gSystem->Exit(1);
     exit(1);
   }
-  PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, "TOWERS_" + m_detector, "PHObject");
+  TowerNodeName = m_outputNodePrefix + m_detector;
+  PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloInfoContainer, TowerNodeName, "PHObject");
   DetNode->addNode(newTowerNode);
 }

--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -61,6 +61,12 @@ class CaloTowerBuilder : public SubsysReco
     _bdosoftwarezerosuppression = usezerosuppression;
   }
 
+  void set_outputNodePrefix(const std::string &name)
+  {
+    m_outputNodePrefix = name;
+    return;
+  }
+
  private:
   CaloWaveformProcessing *WaveformProcessing {nullptr};
   TowerInfoContainer *m_CaloInfoContainer {nullptr};  //! Calo info
@@ -76,6 +82,8 @@ class CaloTowerBuilder : public SubsysReco
   CaloTowerDefs::BuilderType m_buildertype {CaloTowerDefs::kPRDFTowerv1};
   CaloWaveformProcessing::process _processingtype {CaloWaveformProcessing::NONE};
   std::string m_detector {"CEMC"};
+  std::string m_outputNodePrefix {"TOWERS_"};
+  std::string TowerNodeName;
 };
 
 #endif  // CALOTOWERBUILDER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Adds set_outputNodePrefix function to CaloTowerBuilder to allow for user defined prefix for DST node name of calorimeter towers.

## TODOs (if applicable)

## Links to other PRs in macros and calibration repositories (if applicable)