### PR TITLE
New MvtxEventInfov2

### DIFF
--- a/offline/framework/ffarawobjects/Makefile.am
+++ b/offline/framework/ffarawobjects/Makefile.am
@@ -91,7 +91,6 @@ libffarawobjects_la_SOURCES = \
   MicromegasRawHitv1.cc \
   MvtxRawHitContainerv1.cc \
   MvtxRawHitv1.cc \
-  MvtxRawEvtHeader.cc \
   MvtxRawEvtHeaderv1.cc \
   TpcRawHitContainerv1.cc \
   TpcRawHitv1.cc

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeader.h
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeader.h
@@ -20,7 +20,13 @@ public:
   virtual void AddFeeId(const std::set<uint16_t>&) { return; }
   virtual void AddL1Trg(const std::set<uint64_t>&) { return; }
 
+  virtual std::set<uint16_t>& getMvtxFeeIdSet() { return dummySet16; };
+  virtual std::set<uint64_t>& getMvtxLvL1BCO() { return dummySet64; };
+
 private:
+  std::set<uint16_t> dummySet16;
+  std::set<uint64_t> dummySet64;
+
   ClassDefOverride(MvtxRawEvtHeader, 1)
 };
 

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeaderv1.h
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeaderv1.h
@@ -5,6 +5,8 @@
 
 #include "MvtxRawEvtHeader.h"
 
+#include <phool/PHObject.h>
+
 #include <cstdint>
 #include <set>
 
@@ -13,7 +15,7 @@ class  MvtxRawEvtHeaderv1: public MvtxRawEvtHeader
 
 public:
   MvtxRawEvtHeaderv1() = default;
-  virtual ~MvtxRawEvtHeaderv1() = default;
+  ~MvtxRawEvtHeaderv1() = default;
 
   ///Clear Event
   void Reset() override;
@@ -32,8 +34,8 @@ public:
   void AddFeeId(const std::set<uint16_t>& mvtxFeeIds) override;
   void AddL1Trg(const std::set<uint64_t>& mvtxL1TrgSet) override;
 
-  virtual std::set<uint16_t>& getMvtxFeeIdSet() { return m_MvtxFeeIdSet; };
-  virtual std::set<uint64_t>& getMvtxLvL1BCO() { return m_MvtxL1TrgSet; };
+  std::set<uint16_t>& getMvtxFeeIdSet() override { return m_MvtxFeeIdSet; };
+  std::set<uint64_t>& getMvtxLvL1BCO() override { return m_MvtxL1TrgSet; };
 
 private:
   std::set<uint16_t> m_MvtxFeeIdSet;

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -197,7 +197,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
   // Get the cluster hits verbose node, if required
   if (record_ClusHitsVerbose) {
     // get the node
-    mClusHitsVerbose = findNode::getClass<ClusHitsVerbosev1>(topNode, "Trkr_SvtxClusHitsVerbose");
+    mClusHitsVerbose = findNode::getClass<ClusHitsVerbose>(topNode, "Trkr_SvtxClusHitsVerbose");
     if (!mClusHitsVerbose)
     {
       PHNodeIterator dstiter(dstNode);

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -14,7 +14,7 @@
 #include <string>                // for string
 #include <utility>
 
-class ClusHitsVerbosev1;
+class ClusHitsVerbose;
 class PHCompositeNode;
 class TrkrHit;
 class TrkrHitSetContainer;
@@ -60,7 +60,7 @@ class MvtxClusterizer : public SubsysReco
   void set_do_hit_association(bool do_assoc){do_hit_assoc = do_assoc;}
   void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
   void set_ClusHitsVerbose(bool set=true) { record_ClusHitsVerbose = set; };
-  ClusHitsVerbosev1* mClusHitsVerbose { nullptr };
+  ClusHitsVerbose* mClusHitsVerbose { nullptr };
 
  private:
   //bool are_adjacent(const pixel lhs, const pixel rhs);

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -1,10 +1,20 @@
 /*!
  * \file MvtxCombinedRawDataDecoder.cc
- * \author Cameron Dean <cameron.dean@cern.ch@cern.ch>
+ * \author Cameron Dean <cameron.dean@cern.ch>
  * \author Jakub Kvapil <jakub.kvapil@cern.ch>
  */
 
 #include "MvtxCombinedRawDataDecoder.h"
+
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/MvtxEventInfov2.h>
+#include <trackbase/TrkrHitv2.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainerv1.h>
+
+#include <ffarawobjects/MvtxRawEvtHeader.h>
+#include <ffarawobjects/MvtxRawHit.h>
+#include <ffarawobjects/MvtxRawHitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -12,8 +22,8 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
 
-#include <trackbase/TrkrHitv2.h>
-#include <trackbase/TrkrHitSet.h>
+//#include <trackbase/TrkrHitv2.h>
+//#include <trackbase/TrkrHitSet.h>
 
 #include <algorithm>
 #include <cassert>
@@ -69,7 +79,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(mvtxNode);
     }
 
-    mvtx_event_header = findNode::getClass<MvtxEventInfov2>(mvtxNode, "MVTXEVENTHEADER");
+    mvtx_event_header = findNode::getClass<MvtxEventInfo>(mvtxNode, "MVTXEVENTHEADER");
     if (!mvtx_event_header)
     {
       mvtx_event_header = new MvtxEventInfov2();
@@ -78,7 +88,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
     }
   }
 
-  mvtx_raw_event_header = findNode::getClass<MvtxRawEvtHeaderv1>(topNode, m_MvtxRawEvtHeaderNodeName);
+  mvtx_raw_event_header = findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
   if (!mvtx_raw_event_header)
   {
     std::cout << PHWHERE << "::" << __func__ <<  ": Could not get \"" << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
@@ -92,7 +102,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
 //___________________________________________________________________________
 int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 {
-  mvtx_raw_event_header = findNode::getClass<MvtxRawEvtHeaderv1>(topNode, m_MvtxRawEvtHeaderNodeName);
+  mvtx_raw_event_header = findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
   if (Verbosity() >= VERBOSITY_MORE) mvtx_raw_event_header->identify();
 
   hit_set_container = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
@@ -117,7 +127,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 
   if (m_writeMvtxEventHeader)
   {
-    mvtx_event_header = findNode::getClass<MvtxEventInfov2>(topNode, "MVTXEVENTHEADER");
+    mvtx_event_header = findNode::getClass<MvtxEventInfo>(topNode, "MVTXEVENTHEADER");
     assert(mvtx_event_header);
   }
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -69,10 +69,10 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
       dstNode->addNode(mvtxNode);
     }
 
-    mvtx_event_header = findNode::getClass<MvtxEventInfov1>(mvtxNode, "MVTXEVENTHEADER");
+    mvtx_event_header = findNode::getClass<MvtxEventInfov2>(mvtxNode, "MVTXEVENTHEADER");
     if (!mvtx_event_header)
     {
-      mvtx_event_header = new MvtxEventInfov1();
+      mvtx_event_header = new MvtxEventInfov2();
       auto newHeader = new PHIODataNode<PHObject>(mvtx_event_header, "MVTXEVENTHEADER", "PHObject");
       mvtxNode->addNode(newHeader);
     }
@@ -117,7 +117,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 
   if (m_writeMvtxEventHeader)
   {
-    mvtx_event_header = findNode::getClass<MvtxEventInfov1>(topNode, "MVTXEVENTHEADER");
+    mvtx_event_header = findNode::getClass<MvtxEventInfov2>(topNode, "MVTXEVENTHEADER");
     assert(mvtx_event_header);
   }
 
@@ -156,6 +156,8 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   }
 
   std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
+
+  mvtx_event_header->set_strobe_BCO(strobe);
 
   if (m_writeMvtxEventHeader)
   {

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -3,24 +3,23 @@
 
 /*!
  * \file MvtxCombinedRawDataDecoder.h
+ * \author Cameron Dean <cameron.dean@cern.ch>
  * \author Jakub Kvapil <jakub.kvapil@cern.ch>
  */
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/MvtxDefs.h>
-#include <trackbase/MvtxEventInfov2.h>
-#include <trackbase/TrkrHitSetContainerv1.h>
-
-#include <ffarawobjects/MvtxRawHit.h>
-#include <ffarawobjects/MvtxRawHitContainer.h>
-#include <ffarawobjects/MvtxRawEvtHeaderv1.h>
 
 #include <memory>
 #include <string>
 #include <map>
 #include <vector>
 
+class MvtxEventInfo;
+class MvtxRawEvtHeader;
+class MvtxRawHitContainer;
+class MvtxRawHit;
 class PHCompositeNode;
+class TrkrHitSetContainer;
 
 /// mvtx raw data decoder
 class MvtxCombinedRawDataDecoder : public SubsysReco
@@ -47,13 +46,11 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
    void writeMvtxEventHeader(bool write){ m_writeMvtxEventHeader = write; }
 
-  protected:
-    void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>> &v);
-
   private:
+    void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>> &v);
     TrkrHitSetContainer* hit_set_container = nullptr;
-    MvtxEventInfov2* mvtx_event_header = nullptr;
-    MvtxRawEvtHeaderv1* mvtx_raw_event_header = nullptr;
+    MvtxEventInfo* mvtx_event_header = nullptr;
+    MvtxRawEvtHeader* mvtx_raw_event_header = nullptr;
     MvtxRawHitContainer* mvtx_hit_container = nullptr;
     MvtxRawHit* mvtx_hit = nullptr;
  

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -8,7 +8,7 @@
 
 #include <fun4all/SubsysReco.h>
 #include <trackbase/MvtxDefs.h>
-#include <trackbase/MvtxEventInfov1.h>
+#include <trackbase/MvtxEventInfov2.h>
 #include <trackbase/TrkrHitSetContainerv1.h>
 
 #include <ffarawobjects/MvtxRawHit.h>
@@ -52,7 +52,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   private:
     TrkrHitSetContainer* hit_set_container = nullptr;
-    MvtxEventInfov1* mvtx_event_header = nullptr;
+    MvtxEventInfov2* mvtx_event_header = nullptr;
     MvtxRawEvtHeaderv1* mvtx_raw_event_header = nullptr;
     MvtxRawHitContainer* mvtx_hit_container = nullptr;
     MvtxRawHit* mvtx_hit = nullptr;

--- a/offline/packages/trackbase/ClusHitsVerbose.h
+++ b/offline/packages/trackbase/ClusHitsVerbose.h
@@ -32,6 +32,12 @@ class ClusHitsVerbose : public PHObject
   virtual PairVector zBins_pvecIE(TrkrDefs::cluskey);
   virtual PairVector zCutBins_pvecIE(TrkrDefs::cluskey);
 
+  virtual void addPhiHit    (int /*_i*/, int /*_v*/) {};
+  virtual void addZHit      (int /*_i*/, int /*_v*/) {};
+  virtual void addPhiCutHit (int /*_i*/, int /*_v*/) {};
+  virtual void addZCutHit   (int /*_i*/, int /*_v*/) {};
+  virtual void push_hits (TrkrDefs::cluskey) {};
+
   // PHObject virtual overload
   void identify(std::ostream& os = std::cout) const override
   {

--- a/offline/packages/trackbase/ClusHitsVerbose.h
+++ b/offline/packages/trackbase/ClusHitsVerbose.h
@@ -39,12 +39,6 @@ class ClusHitsVerbose : public PHObject
   virtual void addZCutHit(int, int) {return;}
   virtual void push_hits (TrkrDefs::cluskey) {return;}
 
-  virtual void addPhiHit    (int /*_i*/, int /*_v*/) {};
-  virtual void addZHit      (int /*_i*/, int /*_v*/) {};
-  virtual void addPhiCutHit (int /*_i*/, int /*_v*/) {};
-  virtual void addZCutHit   (int /*_i*/, int /*_v*/) {};
-  virtual void push_hits (TrkrDefs::cluskey) {};
-
   // PHObject virtual overload
   void identify(std::ostream& os = std::cout) const override
   {

--- a/offline/packages/trackbase/ClusHitsVerbosev1.h
+++ b/offline/packages/trackbase/ClusHitsVerbosev1.h
@@ -28,21 +28,18 @@ class ClusHitsVerbosev1 : public ClusHitsVerbose
   Vector& zBins      (TrkrDefs::cluskey) override;
   Vector& phiCutBins (TrkrDefs::cluskey) override;
   Vector& zCutBins   (TrkrDefs::cluskey) override;
-
-
-  PairVector phiBins_pvecIE    (TrkrDefs::cluskey) override;
-  PairVector zBins_pvecIE      (TrkrDefs::cluskey) override;
-  PairVector phiCutBins_pvecIE (TrkrDefs::cluskey) override;
-  PairVector zCutBins_pvecIE   (TrkrDefs::cluskey) override;
-
-
   Map&    getMap     () override { return m_data; };
 
-  void addPhiHit    (int _i, int _v) { m_stage_phi    .push_back({_i,_v}); };
-  void addZHit      (int _i, int _v) { m_stage_z      .push_back({_i,_v}); };
-  void addPhiCutHit (int _i, int _v) { m_stage_phiCut .push_back({_i,_v}); };
-  void addZCutHit   (int _i, int _v) { m_stage_zCut   .push_back({_i,_v}); };
-  void push_hits (TrkrDefs::cluskey);
+  PairVector phiBins_pvecIE    (TrkrDefs::cluskey) override;
+  PairVector phiCutBins_pvecIE (TrkrDefs::cluskey) override;
+  PairVector zBins_pvecIE      (TrkrDefs::cluskey) override;
+  PairVector zCutBins_pvecIE   (TrkrDefs::cluskey) override;
+
+  void addPhiHit    (int _i, int _v) override { m_stage_phi    .push_back({_i,_v}); };
+  void addZHit      (int _i, int _v) override { m_stage_z      .push_back({_i,_v}); };
+  void addPhiCutHit (int _i, int _v) override { m_stage_phiCut .push_back({_i,_v}); };
+  void addZCutHit   (int _i, int _v) override { m_stage_zCut   .push_back({_i,_v}); };
+  void push_hits (TrkrDefs::cluskey) override;
 
   ClusHitsVerbosev1() = default;
 

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -58,6 +58,7 @@ pkginclude_HEADERS = \
   MvtxDefs.h \
   MvtxEventInfo.h \
   MvtxEventInfov1.h \
+  MvtxEventInfov2.h \
   RawHit.h \
   RawHitSet.h \
   RawHitSetContainer.h \
@@ -123,6 +124,7 @@ ROOTDICTS = \
   InttEventInfov1_Dict.cc \
   MvtxEventInfo_Dict.cc \
   MvtxEventInfov1_Dict.cc \
+  MvtxEventInfov2_Dict.cc \
   RawHitSetContainer_Dict.cc \
   RawHitSetContainerv1_Dict.cc \
   RawHitSet_Dict.cc \
@@ -183,6 +185,7 @@ nobase_dist_pcm_DATA = \
   InttEventInfov1_Dict_rdict.pcm \
   MvtxEventInfo_Dict_rdict.pcm \
   MvtxEventInfov1_Dict_rdict.pcm \
+  MvtxEventInfov2_Dict_rdict.pcm \
   RawHitSetContainer_Dict_rdict.pcm \
   RawHitSetContainerv1_Dict_rdict.pcm \
   RawHitSet_Dict_rdict.pcm \
@@ -246,6 +249,7 @@ libtrack_io_la_SOURCES = \
   MvtxDefs.cc \
   MvtxEventInfo.cc \
   MvtxEventInfov1.cc \
+  MvtxEventInfov2.cc \
   RawHitSet.cc \
   RawHitSetContainer.cc \
   RawHitSetContainerv1.cc \

--- a/offline/packages/trackbase/MvtxEventInfo.cc
+++ b/offline/packages/trackbase/MvtxEventInfo.cc
@@ -6,13 +6,13 @@
 
 PHObject* MvtxEventInfo::CloneMe() const
 {
-  std::cout << PHWHERE << "::" << __func__ << " is not implemented in daughter class" << std::endl;
+  std::cout << PHWHERE << "::" << __func__ << " is not implemented in base class" << std::endl;
   return nullptr;
 }
 
 void MvtxEventInfo::Reset()
 {
-  std::cout << PHWHERE << "::" << __func__ << " is not implemented in daughter class" << std::endl;
+  std::cout << PHWHERE << "::" << __func__ << " is not implemented in base class" << std::endl;
   return;
 }
 
@@ -67,7 +67,7 @@ void MvtxEventInfo::identify(std::ostream &out) const
 
 int MvtxEventInfo::isValid() const
 {
-  std::cout << PHWHERE << " isValid not implemented by daughter class" << std::endl;
+  std::cout << PHWHERE << " isValid not implemented by base class" << std::endl;
   return 0;
 }
 

--- a/offline/packages/trackbase/MvtxEventInfo.h
+++ b/offline/packages/trackbase/MvtxEventInfo.h
@@ -14,8 +14,9 @@
 
 #include <cmath>
 #include <iostream>
-#include <string>  // for string
 #include <map>
+#include <set>
+#include <string>  // for string
 
 ///
 class MvtxEventInfo : public PHObject
@@ -57,8 +58,21 @@ class MvtxEventInfo : public PHObject
   void set_stringval(const std::string & /*name*/, const std::string & /*ival*/);
   std::string get_stringval(const std::string & /*name*/) const;
 
-  /// switches off the pesky virtual warning messages
-  void NoWarning(const int i = 1);
+  virtual void set_number_HB(const int /*ival*/) {};
+  virtual int get_number_HB() const { return 0; };
+
+  virtual void set_strobe_BCO(const uint64_t /*strobe_BCO*/) {};
+
+  virtual void set_strobe_BCO_L1_BCO(const uint64_t /*strobe_BCO*/, const uint64_t /*L1_BCO*/) {};
+
+  virtual unsigned int get_number_strobes() const { return 0; };
+  virtual unsigned int get_number_L1s() const { return 0; };
+
+  virtual std::set<uint64_t> get_strobe_BCOs() const { return dummySet; };
+  virtual std::set<uint64_t> get_L1_BCOs() const { return dummySet; };
+
+  virtual std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t /*ival*/) const { return dummySet; };
+  virtual std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t /*ival*/) const { return dummySet; };
 
  protected:
   std::map<std::string, int32_t> m_IntEventProperties;
@@ -70,6 +84,8 @@ class MvtxEventInfo : public PHObject
 
  private:
   void warning(const std::string &func) const;
+
+  std::set<uint64_t> dummySet;
 
   //ClassDefOverride(MvtxEventInfo, 1)
 };

--- a/offline/packages/trackbase/MvtxEventInfov1.h
+++ b/offline/packages/trackbase/MvtxEventInfov1.h
@@ -40,29 +40,25 @@ class MvtxEventInfov1 : public MvtxEventInfo
   /// isValid returns non zero if object contains valid data
   int isValid() const override;
 
-  void set_number_HB(const int /*ival*/);
-  int get_number_HB() const;
+  void set_number_HB(const int /*ival*/) override;
+  int get_number_HB() const override;
 
-  void set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO);
+  void set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO) override;
  
-  unsigned int get_number_strobes() const;
-  unsigned int get_number_L1s() const;
+  unsigned int get_number_strobes() const override;
+  unsigned int get_number_L1s() const override;
 
-  std::set<uint64_t> get_strobe_BCOs() const;
-  std::set<uint64_t> get_L1_BCOs() const;
+  std::set<uint64_t> get_strobe_BCOs() const override;
+  std::set<uint64_t> get_L1_BCOs() const override;
 
-  std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const;
-  std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t ival) const;
-
-  /// switches off the pesky virtual warning messages
-  void NoWarning(const int i = 1);
+  std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const override;
+  std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t ival) const override;
 
 protected:
   std::set<strobe_L1_pair> m_strobe_BCO_L1_BCO;
 
   std::string m_number_L1_name = "Number L1";
   std::string m_number_HB_name = "Number HB";
-
 
  private:
   void warning(const std::string &func) const;

--- a/offline/packages/trackbase/MvtxEventInfov1.h
+++ b/offline/packages/trackbase/MvtxEventInfov1.h
@@ -57,14 +57,17 @@ class MvtxEventInfov1 : public MvtxEventInfo
   /// switches off the pesky virtual warning messages
   void NoWarning(const int i = 1);
 
- private:
-  void warning(const std::string &func) const;
-
-  int m_number_HB = -1;
+protected:
   std::set<strobe_L1_pair> m_strobe_BCO_L1_BCO;
 
   std::string m_number_L1_name = "Number L1";
   std::string m_number_HB_name = "Number HB";
+
+
+ private:
+  void warning(const std::string &func) const;
+
+  int m_number_HB = -1;
 
   //ClassDefOverride(MvtxEventInfov1, 1)
 };

--- a/offline/packages/trackbase/MvtxEventInfov2.cc
+++ b/offline/packages/trackbase/MvtxEventInfov2.cc
@@ -10,6 +10,7 @@ PHObject* MvtxEventInfov2::CloneMe() const
 
 void MvtxEventInfov2::Reset()
 {
+  m_strobe_BCOs.clear();
   m_strobe_BCO_L1_BCO.clear();
   m_StringEventProperties.clear();
   m_IntEventProperties.clear();
@@ -17,10 +18,10 @@ void MvtxEventInfov2::Reset()
   m_UintEventProperties.clear();
   m_Uint64EventProperties.clear();
   m_FloatEventProperties.clear();
-  m_strobe_BCO = 0;
 
   return;
 }
+
 
 void MvtxEventInfov2::identify(std::ostream &out) const
 {
@@ -31,8 +32,13 @@ void MvtxEventInfov2::identify(std::ostream &out) const
     out << iters->first << ": " << iters->second << std::endl;
   }
   
-  out << "Strobe BCO: " << m_strobe_BCO << std::endl;
- 
+  out << "List of strobe BCOs:" << std::endl;
+  std::set<uint64_t> strobeList = get_strobe_BCOs();
+  for (auto iter = strobeList.begin(); iter != strobeList.end(); ++iter)
+  {
+    out << *iter << std::endl;
+  }
+  
   out << "Number of L1 triggers in this event" << std::endl;
   out << m_number_L1_name << ": " << get_number_L1s() << std::endl;
     
@@ -43,7 +49,6 @@ void MvtxEventInfov2::identify(std::ostream &out) const
   {
     out << "List of strobe BCOs and L1 BCOs in this event" << std::endl;
 
-    std::set<uint64_t> strobeList = get_strobe_BCOs();
     for (auto iterStrobe = strobeList.begin(); iterStrobe != strobeList.end(); ++iterStrobe)
     { 
       std::set<uint64_t> l1List = get_L1_BCO_from_strobe_BCO(*iterStrobe);
@@ -87,4 +92,102 @@ int MvtxEventInfov2::isValid() const
 {
   std::cout << PHWHERE << " isValid not implemented by daughter class" << std::endl;
   return 0;
+}
+
+void MvtxEventInfov2::set_number_HB(const int ival)
+{
+  m_number_HB = ival;
+}
+
+int MvtxEventInfov2::get_number_HB() const
+{
+  return m_number_HB;
+}
+  
+void MvtxEventInfov2::set_strobe_BCO(const uint64_t strobe_BCO)
+{
+  m_strobe_BCOs.insert(strobe_BCO);
+}
+
+void MvtxEventInfov2::set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO)
+{
+  strobe_L1_pair strobe_L1_BCO_pair(strobe_BCO, L1_BCO);
+  m_strobe_BCO_L1_BCO.insert(strobe_L1_BCO_pair);
+}
+
+unsigned int MvtxEventInfov2::get_number_strobes() const
+{
+  std::set<uint64_t> mySet;
+  std::set<strobe_L1_pair>::const_iterator iter;
+  for (iter = m_strobe_BCO_L1_BCO.begin(); iter != m_strobe_BCO_L1_BCO.end(); ++iter)
+  {
+    strobe_L1_pair myPair = *iter;
+    mySet.insert(myPair.first);
+  }
+  
+  return mySet.size();
+}
+
+unsigned int MvtxEventInfov2::get_number_L1s() const
+{
+  std::set<uint64_t> mySet;
+  std::set<strobe_L1_pair>::const_iterator iter;
+  for (iter = m_strobe_BCO_L1_BCO.begin(); iter != m_strobe_BCO_L1_BCO.end(); ++iter)
+  {
+    strobe_L1_pair myPair = *iter;
+    mySet.insert(myPair.second);
+  }
+  
+  return mySet.size();
+}
+
+std::set<uint64_t> MvtxEventInfov2::get_strobe_BCOs() const 
+{
+  std::set<uint64_t> mySet = m_strobe_BCOs;
+  return mySet;
+}
+
+std::set<uint64_t> MvtxEventInfov2::get_L1_BCOs() const
+{
+  std::set<uint64_t> mySet;
+  std::set<strobe_L1_pair>::const_iterator iter;
+  for (iter = m_strobe_BCO_L1_BCO.begin(); iter != m_strobe_BCO_L1_BCO.end(); ++iter)
+  {
+    strobe_L1_pair myPair = *iter;
+    mySet.insert(myPair.second);
+  }
+
+  return mySet;
+}
+
+std::set<uint64_t> MvtxEventInfov2::get_strobe_BCO_from_L1_BCO(const uint64_t ival) const
+{
+  std::set<uint64_t> mySet;
+  std::set<strobe_L1_pair>::const_iterator iter;
+  for (iter = m_strobe_BCO_L1_BCO.begin(); iter != m_strobe_BCO_L1_BCO.end(); ++iter)
+  { 
+    strobe_L1_pair myPair = *iter;
+    if (ival == myPair.second)
+    {
+      mySet.insert(myPair.first);
+    }
+  }
+
+  return mySet;
+}
+
+std::set<uint64_t> MvtxEventInfov2::get_L1_BCO_from_strobe_BCO(const uint64_t ival) const
+{
+  std::set<uint64_t> mySet;
+  std::set<strobe_L1_pair>::const_iterator iter;
+  for (iter = m_strobe_BCO_L1_BCO.begin(); iter != m_strobe_BCO_L1_BCO.end(); ++iter)
+  {
+    strobe_L1_pair myPair = *iter;
+    if (ival == myPair.first)
+    {
+      mySet.insert(myPair.second);
+    }
+  }
+
+  return mySet;
 }

--- a/offline/packages/trackbase/MvtxEventInfov2.cc
+++ b/offline/packages/trackbase/MvtxEventInfov2.cc
@@ -1,0 +1,90 @@
+#include "MvtxEventInfov2.h"
+
+#include <phool/phool.h>
+
+PHObject* MvtxEventInfov2::CloneMe() const
+{
+  std::cout << PHWHERE << "::" << __func__ << " is not implemented in daughter class" << std::endl;
+  return nullptr;
+}
+
+void MvtxEventInfov2::Reset()
+{
+  m_strobe_BCO_L1_BCO.clear();
+  m_StringEventProperties.clear();
+  m_IntEventProperties.clear();
+  m_Int64EventProperties.clear();
+  m_UintEventProperties.clear();
+  m_Uint64EventProperties.clear();
+  m_FloatEventProperties.clear();
+  m_strobe_BCO = 0;
+
+  return;
+}
+
+void MvtxEventInfov2::identify(std::ostream &out) const
+{
+  out << "MvtxEventInfov2 information" << std::endl;
+
+  for (auto iters = m_StringEventProperties.begin(); iters != m_StringEventProperties.end(); ++iters)
+  {
+    out << iters->first << ": " << iters->second << std::endl;
+  }
+  
+  out << "Strobe BCO: " << m_strobe_BCO << std::endl;
+ 
+  out << "Number of L1 triggers in this event" << std::endl;
+  out << m_number_L1_name << ": " << get_number_L1s() << std::endl;
+    
+  out << "Number of heart beats in this event" << std::endl;
+  out << m_number_HB_name << ": " << get_number_HB() << std::endl;
+
+  if (get_number_L1s() > 0)
+  {
+    out << "List of strobe BCOs and L1 BCOs in this event" << std::endl;
+
+    std::set<uint64_t> strobeList = get_strobe_BCOs();
+    for (auto iterStrobe = strobeList.begin(); iterStrobe != strobeList.end(); ++iterStrobe)
+    { 
+      std::set<uint64_t> l1List = get_L1_BCO_from_strobe_BCO(*iterStrobe);
+      out << "Strobe BCO: " << *iterStrobe << std::endl; 
+      for (auto iterL1 = l1List.begin(); iterL1 != l1List.end(); ++iterL1)
+      {
+        out << "L1 BCO: " << *iterL1 << std::endl; 
+      }
+      out << std::endl;
+    }
+  }
+
+  for (auto iteri = m_IntEventProperties.begin(); iteri != m_IntEventProperties.end(); ++iteri)
+  {
+    out << iteri->first << ": " << iteri->second << std::endl;
+  }
+
+  for (auto iteri64 = m_Int64EventProperties.begin(); iteri64 != m_Int64EventProperties.end(); ++iteri64)
+  {
+    out << iteri64->first << ": " << iteri64->second << std::endl;
+  }
+
+  for (auto iteru = m_UintEventProperties.begin(); iteru != m_UintEventProperties.end(); ++iteru)
+  {
+    out << iteru->first << ": " << iteru->second << std::endl;
+  }
+
+  for (auto iteru64 = m_Uint64EventProperties.begin(); iteru64 != m_Uint64EventProperties.end(); ++iteru64)
+  {
+    out << iteru64->first << ": " << iteru64->second << std::endl;
+  }
+
+  for (auto iterf = m_FloatEventProperties.begin(); iterf != m_FloatEventProperties.end(); ++iterf)
+  {
+    out << iterf->first << ": " << iterf->second << std::endl;
+  }
+  return;
+}
+
+int MvtxEventInfov2::isValid() const
+{
+  std::cout << PHWHERE << " isValid not implemented by daughter class" << std::endl;
+  return 0;
+}

--- a/offline/packages/trackbase/MvtxEventInfov2.h
+++ b/offline/packages/trackbase/MvtxEventInfov2.h
@@ -1,0 +1,58 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef MVTXEVENTINFOV2_H
+#define MVTXEVENTINFOV2_H
+
+     /***************************/
+    /* MVTX event header class */
+   /*       Cameron Dean      */
+  /*   MIT (ctdean@mit.edu)  */
+ /*          09/11/2023     */
+/***************************/
+
+#include <iostream>
+
+#include <set>
+
+#include "MvtxEventInfov1.h"
+
+typedef std::pair<uint64_t, uint64_t> strobe_L1_pair;
+
+///
+class MvtxEventInfov2 : public MvtxEventInfov1 
+{
+ public:
+  MvtxEventInfov2() = default;
+
+  /// dtor
+  virtual ~MvtxEventInfov2() = default;
+
+  PHObject *CloneMe() const override;
+
+  /// Clear Event
+  void Reset() override;
+
+  /** identify Function from PHObject
+      @param os Output Stream 
+   */
+  void identify(std::ostream &os = std::cout) const override;
+
+  /// isValid returns non zero if object contains valid data
+  int isValid() const override;
+
+  void set_strobe_BCO(const uint64_t strobe_BCO) { m_strobe_BCO = strobe_BCO; }
+
+  uint64_t get_strobe_BCO() {return  m_strobe_BCO; }
+
+  /// switches off the pesky virtual warning messages
+  void NoWarning(const int i = 1);
+
+ private:
+  void warning(const std::string &func) const;
+
+  uint64_t m_strobe_BCO = 0;
+
+  //ClassDefOverride(MvtxEventInfov2, 1)
+};
+
+#endif

--- a/offline/packages/trackbase/MvtxEventInfov2.h
+++ b/offline/packages/trackbase/MvtxEventInfov2.h
@@ -14,12 +14,12 @@
 
 #include <set>
 
-#include "MvtxEventInfov1.h"
+#include "MvtxEventInfo.h"
 
 typedef std::pair<uint64_t, uint64_t> strobe_L1_pair;
 
 ///
-class MvtxEventInfov2 : public MvtxEventInfov1 
+class MvtxEventInfov2 : public MvtxEventInfo 
 {
  public:
   MvtxEventInfov2() = default;
@@ -40,17 +40,38 @@ class MvtxEventInfov2 : public MvtxEventInfov1
   /// isValid returns non zero if object contains valid data
   int isValid() const override;
 
-  void set_strobe_BCO(const uint64_t strobe_BCO) { m_strobe_BCO = strobe_BCO; }
+  void set_number_HB(const int /*ival*/);
+  int get_number_HB() const;
 
-  uint64_t get_strobe_BCO() {return  m_strobe_BCO; }
+  void set_strobe_BCO(const uint64_t strobe_BCO);
+
+  void set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO);
+ 
+  unsigned int get_number_strobes() const;
+  unsigned int get_number_L1s() const;
+
+  //std::set<uint64_t> get_strobe_BCOs() const;
+  std::set<uint64_t> get_strobe_BCOs() const;
+  std::set<uint64_t> get_L1_BCOs() const;
+
+  std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const;
+  std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t ival) const;
 
   /// switches off the pesky virtual warning messages
   void NoWarning(const int i = 1);
 
+protected:
+  std::set<strobe_L1_pair> m_strobe_BCO_L1_BCO;
+  std::set<uint64_t> m_strobe_BCOs;
+
+  std::string m_number_L1_name = "Number L1";
+  std::string m_number_HB_name = "Number HB";
+
+
  private:
   void warning(const std::string &func) const;
 
-  uint64_t m_strobe_BCO = 0;
+  int m_number_HB = -1;
 
   //ClassDefOverride(MvtxEventInfov2, 1)
 };

--- a/offline/packages/trackbase/MvtxEventInfov2.h
+++ b/offline/packages/trackbase/MvtxEventInfov2.h
@@ -40,25 +40,22 @@ class MvtxEventInfov2 : public MvtxEventInfo
   /// isValid returns non zero if object contains valid data
   int isValid() const override;
 
-  void set_number_HB(const int /*ival*/);
-  int get_number_HB() const;
+  void set_number_HB(const int /*ival*/) override;
+  int get_number_HB() const override;
 
-  void set_strobe_BCO(const uint64_t strobe_BCO);
+  void set_strobe_BCO(const uint64_t strobe_BCO) override;
 
-  void set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO);
+  void set_strobe_BCO_L1_BCO(const uint64_t strobe_BCO, const uint64_t L1_BCO) override;
  
-  unsigned int get_number_strobes() const;
-  unsigned int get_number_L1s() const;
+  unsigned int get_number_strobes() const override;
+  unsigned int get_number_L1s() const override;
 
   //std::set<uint64_t> get_strobe_BCOs() const;
-  std::set<uint64_t> get_strobe_BCOs() const;
-  std::set<uint64_t> get_L1_BCOs() const;
+  std::set<uint64_t> get_strobe_BCOs() const override;
+  std::set<uint64_t> get_L1_BCOs() const override;
 
-  std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const;
-  std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t ival) const;
-
-  /// switches off the pesky virtual warning messages
-  void NoWarning(const int i = 1);
+  std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t ival) const override;
+  std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t ival) const override;
 
 protected:
   std::set<strobe_L1_pair> m_strobe_BCO_L1_BCO;
@@ -66,7 +63,6 @@ protected:
 
   std::string m_number_L1_name = "Number L1";
   std::string m_number_HB_name = "Number HB";
-
 
  private:
   void warning(const std::string &func) const;

--- a/offline/packages/trackbase/MvtxEventInfov2LinkDef.h
+++ b/offline/packages/trackbase/MvtxEventInfov2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class MvtxEventInfov2+;
+
+#endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I just noticed that the MVTX event header can only store strobe BCOs when there is an associated L1 trigger BCO seen in the event. I made a new version that inherits from v1 so the strobe BCO is saved for every event, irregardless of whether there is a L1 BCO

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

