### PR TITLE
Add ability to get bunch crossing independent of INTT in pp

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -24,6 +24,7 @@ pkginclude_HEADERS = \
   TrackSeed.h \
   TrackSeed_v1.h \
   SvtxTrackSeed_v1.h \
+  SvtxTrackSeed_v2.h \
   TrackSeed_FastSim_v1.h \
   TrackSeedContainer.h \
   TrackSeedContainer_v1.h \
@@ -58,6 +59,7 @@ ROOTDICTS = \
   TrackSeed_Dict.cc \
   TrackSeed_v1_Dict.cc \
   SvtxTrackSeed_v1_Dict.cc \
+  SvtxTrackSeed_v2_Dict.cc \
   TrackSeed_FastSim_v1_Dict.cc \
   TrackSeedContainer_Dict.cc \
   TrackSeedContainer_v1_Dict.cc \
@@ -92,6 +94,7 @@ nobase_dist_pcm_DATA = \
   TrackSeed_Dict_rdict.pcm \
   TrackSeed_v1_Dict_rdict.pcm \
   SvtxTrackSeed_v1_Dict_rdict.pcm \
+  SvtxTrackSeed_v2_Dict_rdict.pcm \
   TrackSeed_FastSim_v1_Dict_rdict.pcm \
   TrackSeedContainer_Dict_rdict.pcm \
   TrackSeedContainer_v1_Dict_rdict.pcm \
@@ -128,6 +131,7 @@ libtrackbase_historic_io_la_SOURCES = \
   TrackSeed.cc \
   TrackSeed_v1.cc \
   SvtxTrackSeed_v1.cc \
+  SvtxTrackSeed_v2.cc \
   TrackSeed_FastSim_v1.cc \
   TrackSeedContainer.cc \
   TrackSeedContainer_v1.cc \

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v1.cc
@@ -3,8 +3,9 @@
 SvtxTrackSeed_v1::SvtxTrackSeed_v1()
 {}
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrackSeed_v1::SvtxTrackSeed_v1(const SvtxTrackSeed_v1& seed)
 { SvtxTrackSeed_v1::CopyFrom( seed ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
@@ -3,8 +3,9 @@
 SvtxTrackSeed_v2::SvtxTrackSeed_v2()
 {}
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrackSeed_v2::SvtxTrackSeed_v2(const SvtxTrackSeed_v2& seed)
 { SvtxTrackSeed_v2::CopyFrom( seed ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
@@ -21,7 +21,6 @@ void SvtxTrackSeed_v2::CopyFrom( const TrackSeed& seed )
 
   m_silicon_seed = seed.get_silicon_seed_index();
   m_tpc_seed = seed.get_tpc_seed_index();
-  m_tpc_seed = seed.get_tpc_seed_index();
   m_crossing_estimate = seed.get_crossing_estimate();
 }
 

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2.cc
@@ -1,0 +1,35 @@
+#include "SvtxTrackSeed_v2.h"
+
+SvtxTrackSeed_v2::SvtxTrackSeed_v2()
+{}
+
+// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
+// cppcheck-suppress uninitMemberVar
+SvtxTrackSeed_v2::SvtxTrackSeed_v2(const SvtxTrackSeed_v2& seed)
+{ SvtxTrackSeed_v2::CopyFrom( seed ); }
+
+SvtxTrackSeed_v2& SvtxTrackSeed_v2::operator=(const SvtxTrackSeed_v2& seed)
+{ if( this != &seed ) CopyFrom( seed ); return *this; }
+
+SvtxTrackSeed_v2::~SvtxTrackSeed_v2()
+{}
+
+void SvtxTrackSeed_v2::CopyFrom( const TrackSeed& seed )
+{
+  if( this == &seed ) return;
+  TrackSeed::CopyFrom( seed );
+
+  m_silicon_seed = seed.get_silicon_seed_index();
+  m_tpc_seed = seed.get_tpc_seed_index();
+  m_tpc_seed = seed.get_tpc_seed_index();
+  m_crossing_estimate = seed.get_crossing_estimate();
+}
+
+void SvtxTrackSeed_v2::identify(std::ostream& os) const
+{
+
+  os << "SvtxTrackSeed_v2 object ";
+  os << "Silicon seed index: " << m_silicon_seed;
+  os << "tpc seed index: " << m_tpc_seed;
+  os << "crossing estimate: " << m_crossing_estimate;
+}

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2.h
@@ -1,0 +1,44 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKSEED_V2_H
+#define TRACKBASEHISTORIC_SVTXTRACKSEED_V2_H
+
+#include <phool/PHObject.h>
+
+#include "TrackSeed.h"
+
+#include <cmath>
+#include <iostream>
+
+class SvtxTrackSeed_v2 : public TrackSeed
+{
+ public: 
+  SvtxTrackSeed_v2();
+  ~SvtxTrackSeed_v2() override;
+  
+  SvtxTrackSeed_v2( const SvtxTrackSeed_v2& );
+  SvtxTrackSeed_v2& operator=(const SvtxTrackSeed_v2& seed);
+ 
+  void identify(std::ostream& os = std::cout) const override;
+  void Reset() override { *this = SvtxTrackSeed_v2(); }
+  int isValid() const override { return 1; }
+  void CopyFrom( const TrackSeed&) override;
+  void CopyFrom( TrackSeed* seed) override { CopyFrom( *seed ); }
+  PHObject* CloneMe() const override { return new SvtxTrackSeed_v2(*this); }
+
+  unsigned int get_silicon_seed_index() const override { return m_silicon_seed; }
+  unsigned int get_tpc_seed_index() const override { return m_tpc_seed; }
+  short int get_crossing_estimate() const override { return m_crossing_estimate; }
+  void set_silicon_seed_index(const unsigned int index) override { m_silicon_seed = index; }
+  void set_tpc_seed_index(const unsigned int index) override { m_tpc_seed = index; }
+  void set_crossing_estimate(const short int cross) override { m_crossing_estimate = cross; }
+
+ private:
+
+  unsigned int m_silicon_seed = std::numeric_limits<unsigned int>::max();
+  unsigned int m_tpc_seed = std::numeric_limits<unsigned int>::max();
+  short int m_crossing_estimate = SHRT_MAX;
+  
+  ClassDefOverride(SvtxTrackSeed_v2, 1);
+
+};
+
+#endif 

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v2LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrackSeed_v2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxTrack_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v1.cc
@@ -19,8 +19,9 @@ SvtxTrack_v1::SvtxTrack_v1()
 SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack& source)
 { SvtxTrack_v1::CopyFrom( source ); }
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrack_v1::SvtxTrack_v1(const SvtxTrack_v1& source)
 { SvtxTrack_v1::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v2.cc
@@ -24,8 +24,9 @@ SvtxTrack_v2::SvtxTrack_v2()
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack& source)
 { SvtxTrack_v2::CopyFrom( source ); }
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrack_v2::SvtxTrack_v2(const SvtxTrack_v2& source)
 { SvtxTrack_v2::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v3.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v3.cc
@@ -24,8 +24,9 @@ SvtxTrack_v3::SvtxTrack_v3()
 SvtxTrack_v3::SvtxTrack_v3(const SvtxTrack& source)
 { SvtxTrack_v3::CopyFrom( source ); }
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrack_v3::SvtxTrack_v3(const SvtxTrack_v3& source)
 { SvtxTrack_v3::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/SvtxTrack_v4.cc
+++ b/offline/packages/trackbase_historic/SvtxTrack_v4.cc
@@ -20,8 +20,9 @@ SvtxTrack_v4::SvtxTrack_v4()
 SvtxTrack_v4::SvtxTrack_v4(const SvtxTrack& source)
 { SvtxTrack_v4::CopyFrom( source ); }
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 SvtxTrack_v4::SvtxTrack_v4(const SvtxTrack_v4& source)
 { SvtxTrack_v4::CopyFrom( source ); }
 

--- a/offline/packages/trackbase_historic/TrackSeed.h
+++ b/offline/packages/trackbase_historic/TrackSeed.h
@@ -98,6 +98,9 @@ class TrackSeed : public PHObject
   virtual unsigned int get_silicon_seed_index() const { return 0; }
   virtual unsigned int get_tpc_seed_index() const { return 0; }
 
+  virtual void set_crossing_estimate(const short int) { }
+  virtual short int get_crossing_estimate() const { return 0; }
+
   /* ---------------------------------------------------------
    * Truth tracking interfaces
    * ---------------------------------------------------------

--- a/offline/packages/trackbase_historic/TrackSeed_v1.cc
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.cc
@@ -17,8 +17,9 @@ TrackSeed_v1::TrackSeed_v1()
 TrackSeed_v1::TrackSeed_v1(const TrackSeed& seed)
 { TrackSeed_v1::CopyFrom( seed ); }
 
-// have to suppress uninitMenberVar from cppcheck since it triggers many false positive
-// cppcheck-suppress uninitMemberVar
+// have to suppress missingMemberCopy from cppcheck, it does not
+// go down to the CopyFrom method where things are done correctly
+// cppcheck-suppress missingMemberCopy
 TrackSeed_v1::TrackSeed_v1(const TrackSeed_v1& seed)
 { TrackSeed_v1::CopyFrom( seed ); }
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -289,17 +289,18 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     unsigned int tpcid = track->get_tpc_seed_index();
     unsigned int siid = track->get_silicon_seed_index();
+    short int crossing_estimate = track->get_crossing_estimate();
 
     if (Verbosity() > 1)
     {
-      std::cout << "tpc and si id " << tpcid << ", " << siid << std::endl;
+      std::cout << "tpc and si id " << tpcid << ", " << siid << " crossing estimate " << crossing_estimate << std::endl;
     }
 
     /// A track seed is made for every tpc seed. Not every tpc seed
     /// has a silicon match, we skip those cases completely in pp running
     if (m_pp_mode && siid == std::numeric_limits<unsigned int>::max())
     {
-      if (Verbosity() > 1) std::cout << "Running in pp mode and SvtxSeedTrack has no silicon match, skip it" << std::endl;
+      if (Verbosity() > 2) std::cout << "Running in pp mode and SvtxSeedTrack has no silicon match, skip it" << std::endl;
       continue;
     }
 
@@ -312,10 +313,10 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       crossing = 0;
 
     // if the crossing was not determined in pp running, skip this case completely
-    if (m_pp_mode && crossing == SHRT_MAX)
+    if (m_pp_mode && crossing == SHRT_MAX && crossing_estimate == SHRT_MAX)
     {
       // Skip this in the pp case.
-      if (Verbosity() > 1) std::cout << "Crossing not determined, skipping track" << std::endl;
+      if (Verbosity() > 1) std::cout << "Crossing and crossing_estimate not determined, skipping track" << std::endl;
       continue;
     }
 
@@ -679,7 +680,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       }
     }
 
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
       std::cout << " zinit " << global[2] << " xinit " << global[0] << " yinit " << global[1] << " side " << side << " crossing " << crossing
                 << " cluskey " << key << " subsurfkey " << subsurfkey << std::endl;
@@ -748,7 +749,7 @@ SourceLinkVec PHActsTrkFitter::getSourceLinks(TrackSeed* track,
       localPos(1) = loct(1);
     }
 
-    if (Verbosity() > 0)
+    if (Verbosity() > 2)
     {
       std::cout << " cluster global after mover: " << global << std::endl;
       std::cout << " cluster local X " << cluster->getLocalX() << " cluster local Y " << cluster->getLocalY() << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -204,6 +204,9 @@ class PHActsTrkFitter : public SubsysReco
   /// Flag for pp running
   bool m_pp_mode = false;
 
+  // max variation of bunch crossing away from crossing_estimate
+  short int max_bunch_search = 2;
+
   bool m_actsEvaluator = false;
   std::unique_ptr<ActsEvaluator> m_evaluator = nullptr;
   std::string m_evalname = "ActsEvaluator.root";

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -100,7 +100,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
       // returns SHRT_MAX if no INTT clusters in silicon seed
       short int crossing= getCrossingIntt(_tracklet_si);
       _tracklet_si->set_crossing(crossing);
-
+      
       if(Verbosity() > 8)
 	std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta()  << " pt " << _tracklet_si->get_pt()  << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl; 
 
@@ -131,7 +131,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
       svtxseed->set_crossing_estimate(crossing_estimate);
       _svtx_seed_map->insert(svtxseed.get());
       
-      if(Verbosity() > 1) std::cout << "  combined seed id " << _svtx_seed_map->size()-1 << " si id " << si_id << " tpc id " << tpcid  << std::endl;
+      if(Verbosity() > 1) std::cout << "  combined seed id " << _svtx_seed_map->size()-1 << " si id " << si_id << " tpc id " << tpcid  << " crossing estimate " << crossing_estimate << std::endl;
     }
 
   // Also make the unmatched TPC seeds into SvtxTrackSeeds
@@ -174,17 +174,13 @@ short int  PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpc
   // this is an initial estimate of the bunch crossing based on the z-mismatch for this track
   short int crossing_estimate = (short int) getBunchCrossing(tpcid, tpc_z - si_z);
 
-  if ( abs(crossing_estimate - crossing) < 3) 
+  if(Verbosity() > 1)
     {
-      if(Verbosity() > 1)
-	{
-	  std::cout << "findCrossing: " <<   " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z 
-		    << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
-	}
-      return crossing_estimate;
+      std::cout << "findCrossing: " <<   " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z 
+		<< " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
     }
 
-  return SHRT_MAX;
+  return crossing_estimate;
   
 }
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -58,7 +58,7 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
 
   // put these in the output file
   cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta " 
-       << _eta_search_win << " _pp_mode " << _pp_mode << " _use_intt_time " << _use_intt_time << endl;
+       << _eta_search_win << " _pp_mode " << _pp_mode << " _use_intt_crossing " << _use_intt_crossing << endl;
 
 
    int ret = GetNodes(topNode);
@@ -99,7 +99,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
 
       // returns SHRT_MAX if no INTT clusters in silicon seed
       short int crossing= getCrossingIntt(_tracklet_si);
-      _tracklet_si->set_crossing(crossing);
+      if(_use_intt_crossing) { _tracklet_si->set_crossing(crossing); } // flag is for testing only, use_intt_crossing should always be true!
       
       if(Verbosity() > 8)
 	std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta()  << " pt " << _tracklet_si->get_pt()  << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl; 
@@ -171,7 +171,7 @@ short int  PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpc
   TrackSeed *tpc_track = _track_map->get(tpcid);
   double tpc_z = tpc_track->get_z();
 
-  // this is an initial estimate of the bunch crossing based on the z-mismatch for this track
+  // this is an initial estimate of the bunch crossing based on the z-mismatch of the seeds for this track
   short int crossing_estimate = (short int) getBunchCrossing(tpcid, tpc_z - si_z);
 
   if(Verbosity() > 1)
@@ -186,7 +186,9 @@ short int  PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpc
 
 double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_mismatch )
 {
-  double vdrift = 8.00;  // cm /microsecond
+  double vdrift = _tGeometry->get_drift_velocity();  // cm/ns
+  vdrift *= 1000.0;    // cm/microsecond
+  //  double vdrift = 8.00;  // cm /microsecond
   //double z_bunch_separation = 0.106 * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
   double z_bunch_separation = (crossing_period/1000.0) * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -58,9 +58,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   std::vector<short int> getInttCrossings(TrackSeed *si_track);
    void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);
    short int getCrossingIntt(TrackSeed *_tracklet_si);
+   void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
+   double getBunchCrossing(unsigned int trid, double z_mismatch);
 
    //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
-  //double getBunchCrossing(unsigned int trid, double z_mismatch);
   //double getMedian(std::vector<double> &v);
   //void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
   //void addSiliconClusters(  std::multimap<unsigned int, unsigned int> &tpc_matches);

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -58,7 +58,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   std::vector<short int> getInttCrossings(TrackSeed *si_track);
    void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);
    short int getCrossingIntt(TrackSeed *_tracklet_si);
-   void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
+   //void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
+   short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
    double getBunchCrossing(unsigned int trid, double z_mismatch);
 
    //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -35,7 +35,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   void set_test_windows_printout(const bool test){_test_windows = test ;}
   void set_pp_mode(const bool flag){_pp_mode = flag ;}
-  void set_use_intt_time(const bool flag){_use_intt_time = flag ;}
+  void set_use_intt_crossing(const bool flag){_use_intt_crossing = flag ;}
 
   int InitRun(PHCompositeNode* topNode) override;
 
@@ -121,7 +121,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   bool _test_windows = false;
   bool _pp_mode = false;
-  bool _use_intt_time = false;
+  bool _use_intt_crossing = true;  // should always be true except for testing
 
   int _n_iteration = 0;
   std::string _track_map_name = "TpcTrackSeedContainer";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR introduces redundancy in the determination of the bunch crossing during extended-readout pp running. It will prevent loss of tracking acceptance if a part of the INTT is not working. The changes are:

1) Estimate the bunch crossing in PHSiliconTPCTrackMatcher using the z offset between (otherwise) matched silicon and tpc seeds. This is accurate to +/- 2 bunch crossings.
2) Make SvtxTrackSeed_v2 and add the bunch crossing estimate to it.
3) In PHActsTrkFitter, fit any track that does not have a valid INTT bunch crossing by postulating bunch crossing values of (crossing estimate +/- 2) when calculating the TPC z positions. The best chisq/ndf is well defined, and this is chosen.

It works well, finding the correct bunch crossing in essentially all cases. It does produce about 5-10% additional false positives, those will have to be dealt with using analysis cuts. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

