### PR TITLE
fix copy ctors - add forgotten _detector

### DIFF
--- a/offline/packages/CaloBase/TowerInfoContainer.h
+++ b/offline/packages/CaloBase/TowerInfoContainer.h
@@ -52,6 +52,8 @@ class TowerInfoContainer : public PHObject
   virtual unsigned int getTowerPhiBin(unsigned int /*towerIndex*/);
   virtual unsigned int getTowerEtaBin(unsigned int /*towerIndex*/);
 
+  virtual DETECTOR get_detectorid() const {return DETECTOR_INVALID;}
+
  private:
   ClassDefOverride(TowerInfoContainer, 1);
 };

--- a/offline/packages/CaloBase/TowerInfoContainerv1.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.cc
@@ -51,6 +51,7 @@ TowerInfoContainerv1::~TowerInfoContainerv1()
 
 TowerInfoContainerv1::TowerInfoContainerv1(const TowerInfoContainerv1& source)
 {
+  _detector = source.get_detectorid();
   _clones = new TClonesArray("TowerInfov1", source.size());
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv1");

--- a/offline/packages/CaloBase/TowerInfoContainerv1.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv1.h
@@ -30,6 +30,7 @@ class TowerInfoContainerv1 : public TowerInfoContainer
   unsigned int decode_key(unsigned int tower_key) override;
 
   size_t size() const override { return _clones->GetEntries(); }
+  DETECTOR get_detectorid() const override {return _detector;}
 
  protected:
   TClonesArray *_clones = nullptr;

--- a/offline/packages/CaloBase/TowerInfoContainerv2.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv2.cc
@@ -46,6 +46,7 @@ TowerInfoContainerv2::TowerInfoContainerv2(DETECTOR detec)
 
 TowerInfoContainerv2::TowerInfoContainerv2(const TowerInfoContainerv2& source)
 {
+  _detector = source.get_detectorid();
   _clones = new TClonesArray("TowerInfov2", source.size());
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv2");

--- a/offline/packages/CaloBase/TowerInfoContainerv2.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv2.h
@@ -30,6 +30,7 @@ class TowerInfoContainerv2 : public TowerInfoContainer
   unsigned int decode_key(unsigned int tower_key) override;
 
   size_t size() const override { return _clones->GetEntries(); }
+  DETECTOR get_detectorid() const override {return _detector;}
 
  protected:
   TClonesArray *_clones = nullptr;

--- a/offline/packages/CaloBase/TowerInfoContainerv3.cc
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.cc
@@ -46,6 +46,7 @@ TowerInfoContainerv3::TowerInfoContainerv3(DETECTOR detec)
 
 TowerInfoContainerv3::TowerInfoContainerv3(const TowerInfoContainerv3& source)
 {
+  _detector = source.get_detectorid();
   _clones = new TClonesArray("TowerInfov3", source.size());
   _clones->SetOwner();
   _clones->SetName("TowerInfoContainerv3");

--- a/offline/packages/CaloBase/TowerInfoContainerv3.h
+++ b/offline/packages/CaloBase/TowerInfoContainerv3.h
@@ -30,6 +30,7 @@ class TowerInfoContainerv3 : public TowerInfoContainer
   unsigned int decode_key(unsigned int tower_key) override;
 
   size_t size() const override { return _clones->GetEntries(); }
+  DETECTOR get_detectorid() const override {return _detector;}
 
  protected:
   TClonesArray *_clones = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The CaloTowerContainer copy ctor didn't copy the _detector enum which then killed the calibration
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

