### PR TITLE
adding CaloTowerStatus setter which has a hard coded chi2 cut for now…

### DIFF
--- a/offline/packages/CaloReco/CaloTowerDefs.h
+++ b/offline/packages/CaloReco/CaloTowerDefs.h
@@ -9,7 +9,8 @@ namespace CaloTowerDefs
     HCALIN = 1,
     HCALOUT = 2,
     SEPD = 3,
-    ZDC = 4
+    ZDC = 4,
+    DETECTOR_INVALID = 99999
   };
 
   enum BuilderType

--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -1,0 +1,238 @@
+#include "CaloTowerStatus.h"
+#include "CaloTowerDefs.h"
+
+#include <calobase/TowerInfo.h>  // for TowerInfo
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfoContainerv2.h>
+#include <calobase/TowerInfov1.h>
+#include <calobase/TowerInfov2.h>
+
+#include <cdbobjects/CDBTTree.h>  // for CDBTTree
+
+#include <ffamodules/CDBInterface.h>
+
+#include <ffaobjects/EventHeader.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>  // for SubsysReco
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>        // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/recoConsts.h>
+
+#include <TSystem.h>
+
+#include <cstdlib>    // for exit
+#include <exception>  // for exception
+#include <iostream>   // for operator<<, basic_ostream
+#include <stdexcept>  // for runtime_error
+
+//____________________________________________________________________________..
+CaloTowerStatus::CaloTowerStatus(const std::string &name)
+  : SubsysReco(name)
+  , m_dettype(CaloTowerDefs::HCALOUT)
+  , m_detector("HCALOUT")
+  , m_DETECTOR(TowerInfoContainer::HCAL)
+  , m_fieldname("")
+  , m_runNumber(-1)
+{
+  if (Verbosity() > 0) std::cout << "CaloTowerStatus::CaloTowerStatus(const std::string &name) Calling ctor" << std::endl;
+}
+
+//____________________________________________________________________________..
+CaloTowerStatus::~CaloTowerStatus()
+{
+  delete cdbttree;
+  if (Verbosity() > 0) std::cout << "CaloTowerStatus::~CaloTowerStatus() Calling dtor" << std::endl;
+}
+
+//____________________________________________________________________________..
+int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
+{
+  PHNodeIterator nodeIter(topNode);
+
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    m_detector = "CEMC";
+    std::string default_time_independent_calib = "cemc_pi0_twrSlope_v1_default";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = m_detector + "_BadTowerMap";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "status";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloTowerStatus::::InitRun No EMCal deadmap found" << std::endl;
+      m_doHot = 0;
+    }
+  }
+  else if (m_dettype == CaloTowerDefs::HCALIN)
+  {
+    m_detector = "HCALIN";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = m_detector + "_BadTowerMap";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "status";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloTowerStatus::::InitRun No masking file for domain " << m_calibName << " found, not doing isHot" << std::endl;
+      m_doHot = 0;
+    }
+  }
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
+  {
+    m_detector = "HCALOUT";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = m_detector + "_BadTowerMap";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "status";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloTowerStatus::::InitRun No masking file for domain " << m_calibName << " found, not doing isHot" << std::endl;
+      m_doHot = 0;
+    }
+  }
+  else if (m_dettype == CaloTowerDefs::ZDC)
+  {
+    m_detector = "ZDC";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "noMasker";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "noMasker";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloTowerStatus::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
+    }
+  }
+
+  else if (m_dettype == CaloTowerDefs::SEPD)
+  {
+    m_detector = "SEPD";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "noCalibYet";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "noCalibYet";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloTowerStatus::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
+    }
+  }
+
+  PHNodeIterator iter(topNode);
+
+  // Looking for the DST node
+  PHCompositeNode *dstNode;
+  dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << "DST Node missing, doing nothing." << std::endl;
+    exit(1);
+  }
+  try
+  {
+    CreateNodeTree(topNode);
+  }
+  catch (std::exception &e)
+  {
+    std::cout << e.what() << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  if (Verbosity() > 0) topNode->print();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
+{
+  unsigned int ntowers = _raw_towers->size();
+  int mask_status = 0;
+  for (unsigned int channel = 0; channel < ntowers; channel++)
+  {
+    if (m_doHot) mask_status = cdbttree->GetIntValue(channel, m_fieldname);
+    float chi2 = _raw_towers->get_tower_at_channel(channel)->get_chi2();
+    if (mask_status > 1 && m_doHot)
+    {
+      _raw_towers->get_tower_at_channel(channel)->set_isHot(true);
+    }
+    if (chi2 > 3e3)
+    {
+      _raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
+    }
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloTowerStatus::CreateNodeTree(PHCompositeNode *topNode)
+{
+  RawTowerNodeName = m_inputNodePrefix + m_detector;
+  _raw_towers = findNode::getClass<TowerInfoContainer>(topNode, RawTowerNodeName);
+  if (!_raw_towers)
+  {
+    std::cout << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+              << " " << RawTowerNodeName << " Node missing, doing bail out!"
+              << std::endl;
+    throw std::runtime_error(
+        "Failed to find " + RawTowerNodeName + " node in CaloTowerStatus::CreateNodes");
+  }
+
+  return;
+}

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -51,25 +51,22 @@ class CaloTowerStatus : public SubsysReco
     return;
   }
 
-
  private:
-  CaloTowerDefs::DetectorSystem m_dettype;
+  TowerInfoContainer *m_raw_towers{nullptr};
+  CDBTTree *m_cdbttree{nullptr};
+
+  bool m_overrideCalibName{false};
+  bool m_overrideFieldName{false};
+  bool m_doHot{true};
+
+  CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
 
   std::string m_detector;
-  TowerInfoContainer::DETECTOR m_DETECTOR;
   std::string m_fieldname;
   std::string m_calibName;
-  bool m_overrideCalibName {false};
-  bool m_overrideFieldName {false};
-  std::string m_inputNodePrefix {"TOWERS_"};
-  std::string RawTowerNodeName;
+  std::string m_inputNodePrefix{"TOWERS_"};
 
-  TowerInfoContainer *_raw_towers;
 
-  bool m_doHot = 1;
-
-  CDBTTree *cdbttree = nullptr;
-  int m_runNumber;
 
 };
 

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -1,0 +1,76 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef CALOTOWERSTATUS_H
+#define CALOTOWERSTATUS_H
+
+#include "CaloTowerDefs.h"
+
+#include <calobase/TowerInfoContainer.h>  // for TowerInfoContainer, TowerIn...
+
+#include <fun4all/SubsysReco.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+class CDBTTree;
+class PHCompositeNode;
+class TowerInfoContainer;
+
+class CaloTowerStatus : public SubsysReco
+{
+ public:
+  CaloTowerStatus(const std::string &name = "CaloTowerStatus");
+
+  ~CaloTowerStatus() override;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  void CreateNodeTree(PHCompositeNode *topNode);
+
+  void set_detector_type(CaloTowerDefs::DetectorSystem dettype)
+  {
+    m_dettype = dettype;
+    return;
+  }
+  void setCalibName(const std::string &name)
+  {
+    m_calibName = name;
+    m_overrideCalibName = 1;
+    return;
+  }
+  void setFieldName(const std::string &name)
+  {
+    m_fieldname = name;
+    m_overrideFieldName = 1;
+    return;
+  }
+  void set_inputNodePrefix(const std::string &name)
+  {
+    m_inputNodePrefix = name;
+    return;
+  }
+
+
+ private:
+  CaloTowerDefs::DetectorSystem m_dettype;
+
+  std::string m_detector;
+  TowerInfoContainer::DETECTOR m_DETECTOR;
+  std::string m_fieldname;
+  std::string m_calibName;
+  bool m_overrideCalibName {false};
+  bool m_overrideFieldName {false};
+  std::string m_inputNodePrefix {"TOWERS_"};
+  std::string RawTowerNodeName;
+
+  TowerInfoContainer *_raw_towers;
+
+  bool m_doHot = 1;
+
+  CDBTTree *cdbttree = nullptr;
+  int m_runNumber;
+
+};
+
+#endif  // CALOTOWERBUILDER_H

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -49,6 +49,7 @@ pkginclude_HEADERS = \
   CaloRecoUtility.h \
   CaloTowerBuilder.h \
   CaloTowerCalib.h \
+  CaloTowerStatus.h \
   CaloTowerDefs.h \
   RawClusterBuilderGraph.h \
   RawClusterBuilderTopo.h \
@@ -78,6 +79,7 @@ libcalo_reco_la_SOURCES = \
   CaloWaveformProcessing.cc \
   CaloTowerBuilder.cc \
   CaloTowerCalib.cc \
+  CaloTowerStatus.cc \
   RawClusterBuilderGraph.cc \
   RawClusterBuilderTopo.cc \
   RawClusterBuilderTemplate.cc \


### PR DESCRIPTION
… and does hot tower masking

This sets the status bools of the TowerInfo objects.  Currently it sets the isBadChi2 and isHot.  

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

