### PR TITLE
updating jet code to use generic TowerInfo objects instead of v1

### DIFF
--- a/offline/packages/jetbackground/CopyAndSubtractJets.cc
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.cc
@@ -7,8 +7,8 @@
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
 
-#include <calobase/TowerInfov1.h>
-#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 
 
 #include <jetbase/Jet.h>
@@ -61,9 +61,9 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosOH3 = nullptr;
   if (m_use_towerinfo)
     {
-      towerinfosEM3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-      towerinfosIH3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN");
-      towerinfosOH3 =  findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT");
+      towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+      towerinfosOH3 =  findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
     }
   else
     {

--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -8,8 +8,8 @@
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
 
-#include <calobase/TowerInfov1.h>
-#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 
 #include <jetbase/Jet.h>
 #include <jetbase/JetMap.h>
@@ -88,9 +88,9 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosOH3 = nullptr;
   if (m_use_towerinfo)
     {
-      towerinfosEM3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-      towerinfosIH3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN");
-      towerinfosOH3 =  findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT");
+      towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+      towerinfosOH3 =  findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
     }
   else
     {
@@ -731,7 +731,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
           if (layer == 2) total_E += _OHCAL_E[eta][phi] / (1 + 2 * _v2 * cos(2 * (this_phi - _Psi2)));
           total_tower++;  // towers in this eta range & layer
           _nTowers++;     // towers in entire calorimeter
-        }
+	}
         else
         {
           if (Verbosity() > 10) std::cout << " tower at eta / phi = " << this_eta << " / " << this_phi << " with E = " << total_E << " excluded due to seed " << std::endl;
@@ -744,6 +744,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float deta = etabounds.second - etabounds.first;
       float dphi = phibounds.second - phibounds.first;
       float total_area = total_tower * deta * dphi;
+
       _UE[layer].at(eta) = total_E / total_tower;
 
       if (Verbosity() > 3)

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -7,8 +7,8 @@
 #include <calobase/RawTowerGeomContainer.h>
 #include <calobase/RawTowerv1.h>
 
-#include <calobase/TowerInfov1.h>
-#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>
@@ -52,7 +52,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosEM3 = nullptr; 
   if (m_use_towerinfo)
     {
-      towerinfosEM3= findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC");
+      towerinfosEM3= findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC");
 
     }
   else
@@ -219,7 +219,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 
  if (m_use_towerinfo)
    {
-     TowerInfoContainerv1 *emcal_retower =  findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+     TowerInfoContainer *emcal_retower =  findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
      if (Verbosity() > 0) std::cout << "RetowerCEMC::process_event: filling TOWERINFO_CALIB_CEMC_RETOWER node" << std::endl;
   // create new towers
      for (int eta = 0; eta < _NETA; eta++)
@@ -281,11 +281,12 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
   if (m_use_towerinfo)
     {
       TowerInfoContainer *test_emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
       if (!test_emcal_retower)
 	{
 	  if (Verbosity() > 0) std::cout << "RetowerCEMC::CreateNode : creating TOWERINFO_CALIB_CEMC_RETOWER node " << std::endl;
 	  
-	  TowerInfoContainerv1 *emcal_retower = new TowerInfoContainerv1(TowerInfoContainerv1::DETECTOR::HCAL);
+	  TowerInfoContainer *emcal_retower = dynamic_cast<TowerInfoContainer *> (hcal_towers->CloneMe());
 	  PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_retower, "TOWERINFO_CALIB_CEMC_RETOWER", "PHObject");
 	  emcalNode->addNode(emcalTowerNode);
 	}

--- a/offline/packages/jetbackground/SubtractTowers.cc
+++ b/offline/packages/jetbackground/SubtractTowers.cc
@@ -10,6 +10,8 @@
 #include <calobase/RawTowerGeomContainer.h>
 #include <calobase/RawTowerv1.h>
 
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfov1.h>
 #include <calobase/TowerInfoContainerv1.h>
 
@@ -60,9 +62,16 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
  if (m_use_towerinfo)
     {
-      towerinfosEM3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-      towerinfosIH3 = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN");
-      towerinfosOH3 =  findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT");
+      towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+      towerinfosOH3 =  findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+    
+      if (Verbosity() > 0)
+        {
+	  std::cout << "SubtractTowers::process_event: " << towerinfosEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: " << towerinfosIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: " << towerinfosOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
+        }
     }
   else
     {
@@ -72,9 +81,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
       
       if (Verbosity() > 0)
 	{
-	  std::cout << "DetermineTowerBackground::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
-	  std::cout << "DetermineTowerBackground::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
-	  std::cout << "DetermineTowerBackground::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: " << towersEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: " << towersIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: " << towersOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
 	}
     }
 
@@ -92,10 +101,17 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *ohcal_towerinfos = nullptr;
   if (m_use_towerinfo)
     {
-      emcal_towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
-      ihcal_towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
-      ohcal_towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+      emcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
+      ihcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
+      ohcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
     }
+  if (Verbosity() > 0)
+    {
+      std::cout << "SubtractTowers::process_event: starting with " << emcal_towerinfos->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: starting with " << ihcal_towerinfos->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: starting with " << ohcal_towerinfos->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+    }
+
   else
     {
       emcal_towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER_SUB1");
@@ -148,6 +164,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	  
 	  emcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  emcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
+	
+	  if (Verbosity() > 5)
+	    std::cout << " SubtractTowers::process_event : EMCal tower at ieta / iphi = " << ieta << " / " << iphi<< ", pre-sub / after-sub E = " << raw_energy << " / " << new_energy << std::endl;
 	}
     }
   else
@@ -195,7 +214,7 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	  if( raw_energy == 0 ) new_energy = 0;
 	  tower->set_energy(new_energy);
 	  if (Verbosity() > 5)
-	    std::cout << " SubtractTowers::process_event : EMCal tower at eta / phi = " << tower->get_bineta() << " / " << tower->get_binphi() << ", pre-sub / after-sub E = " << raw_energy << " / " << tower->get_energy() << std::endl;
+	    std::cout << "SubtractTowers::process_event : EMCal tower at eta / phi = " << tower->get_bineta() << " / " << tower->get_binphi() << ", pre-sub / after-sub E = " << raw_energy << " / " << tower->get_energy() << std::endl;
 	}
     }
   // IHCal
@@ -224,6 +243,8 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
 	  ihcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  ihcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
+	  if (Verbosity() > 5)
+	    std::cout << "SubtractTowers::process_event : IHCal tower at ieta / iphi = " << ieta << " / " << iphi<< ", pre-sub / after-sub E = " << raw_energy << " / " << new_energy << std::endl;
 	}
     }
   else
@@ -300,6 +321,8 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
 	  ohcal_towerinfos->get_tower_at_channel(channel)->set_time(tower->get_time());
 	  ohcal_towerinfos->get_tower_at_channel(channel)->set_energy(new_energy);
+	  if (Verbosity() > 5)
+	    std::cout << "SubtractTowers::process_event : OHCal tower at ieta / iphi = " << ieta << " / " << iphi<< ", pre-sub / after-sub E = " << raw_energy << " / " << new_energy << std::endl;
 	}
     }
   else
@@ -358,6 +381,12 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 	  std::cout << "SubtractTowers::process_event: ending with " << ihcal_towers->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
 	  std::cout << "SubtractTowers::process_event: ending with " << ohcal_towers->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
 	}
+      else
+	{
+	  std::cout << "SubtractTowers::process_event: ending with " << emcal_towerinfos->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: ending with " << ihcal_towerinfos->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
+	  std::cout << "SubtractTowers::process_event: ending with " << ohcal_towerinfos->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+	}
     }
 
   if (Verbosity() > 0) std::cout << "SubtractTowers::process_event: exiting" << std::endl;
@@ -377,6 +406,13 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+  if(m_use_towerinfo && !hcal_towers)
+    {
+      std::cout << PHWHERE << "Cannot find TOWERINFO_CALIB_HCALIN for creating new tower containers. Exiting" << std::endl;
+      exit(1);
+    }      
+
   // store the new EMCal towers
    
   PHCompositeNode *emcalNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "CEMC"));
@@ -386,12 +422,12 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
     }
   if (m_use_towerinfo)
     {
-      TowerInfoContainer *test_emcal_tower = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
+      TowerInfoContainer *test_emcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
       if (!test_emcal_tower)
 	{
 	  if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_CEMC_RETOWER_SUB1 node " << std::endl;
 	  
-	  TowerInfoContainer *emcal_towers = new TowerInfoContainerv1(TowerInfoContainerv1::DETECTOR::HCAL);
+	  TowerInfoContainer *emcal_towers = dynamic_cast<TowerInfoContainer *> (hcal_towers->CloneMe());
 	  PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_towers, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1", "PHObject");
 	  emcalNode->addNode(emcalTowerNode);
 	}
@@ -426,12 +462,12 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   }
   if (m_use_towerinfo)
     {
-      TowerInfoContainer *test_ihcal_tower = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
+      TowerInfoContainer *test_ihcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
       if (!test_ihcal_tower)
 	{
 	  if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_HCALIN_SUB1 node " << std::endl;
 	  
-	  TowerInfoContainer *ihcal_towers = new TowerInfoContainerv1(TowerInfoContainerv1::DETECTOR::HCAL);
+	  TowerInfoContainer *ihcal_towers = dynamic_cast<TowerInfoContainer *> (hcal_towers->CloneMe());
 	  PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(ihcal_towers, "TOWERINFO_CALIB_HCALIN_SUB1", "PHObject");
 	  ihcalNode->addNode(ihcalTowerNode);
 	}
@@ -467,12 +503,12 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   }
   if (m_use_towerinfo)
     {
-      TowerInfoContainer *test_ohcal_tower = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+      TowerInfoContainer *test_ohcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
       if (!test_ohcal_tower)
 	{
 	  if (Verbosity() > 0) std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_HCALOUT_SUB1 node " << std::endl;
 	  
-	  TowerInfoContainer *ohcal_towers = new TowerInfoContainerv1(TowerInfoContainerv1::DETECTOR::HCAL);
+	  TowerInfoContainer *ohcal_towers = dynamic_cast<TowerInfoContainer *> (hcal_towers->CloneMe());
 	  PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(ohcal_towers, "TOWERINFO_CALIB_HCALOUT_SUB1", "PHObject");
 	  ohcalNode->addNode(ohcalTowerNode);
 	}

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -5,8 +5,8 @@
 
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerContainer.h>
-#include <calobase/TowerInfov1.h>
-#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 #include <calobase/RawTowerDefs.h>           // for encode_towerid
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
@@ -115,7 +115,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC");
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC");
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
@@ -144,7 +144,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -164,7 +164,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
       geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
       if ((!towerinfos) || !geom)
@@ -203,7 +203,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_RETOWER)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -223,7 +223,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -243,7 +243,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -263,7 +263,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainerv1>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
       geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
       if ((!towerinfos) || !geom)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Updating jetbackground and jetbase code that was using TowerInfov1 and TowerInfoContainerv1 instead of the generic versions. Also updated so that when we create retowered EMCal towers and subtracted versions of towers, those objects inherit the version that was used in the original input towers.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

