### PR TITLE
use GetEntriesFast for TCArrays

### DIFF
--- a/offline/framework/ffarawobjects/InttRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/InttRawHitContainerv1.cc
@@ -25,7 +25,7 @@ void InttRawHitContainerv1::Reset()
 void InttRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "InttRawHitContainerv1" << std::endl;
-  os << "containing " << InttRawHitsTCArray->GetEntries() << " Intt hits" << std::endl;
+  os << "containing " << InttRawHitsTCArray->GetEntriesFast() << " Intt hits" << std::endl;
   InttRawHit *intthit = static_cast< InttRawHit *> (InttRawHitsTCArray->At(0));
   if (intthit)
    {
@@ -40,7 +40,7 @@ int InttRawHitContainerv1::isValid() const
 
 unsigned int InttRawHitContainerv1::get_nhits()
 {
-  return InttRawHitsTCArray->GetEntries();
+  return InttRawHitsTCArray->GetEntriesFast();
 }
 
 InttRawHit *InttRawHitContainerv1::AddHit()

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.cc
@@ -25,7 +25,7 @@ void MicromegasRawHitContainerv1::Reset()
 void MicromegasRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "MicromegasRawHitContainerv1" << std::endl;
-  os << "containing " << MicromegasRawHitsTCArray->GetEntries() << " Micromegas hits" << std::endl;
+  os << "containing " << MicromegasRawHitsTCArray->GetEntriesFast() << " Micromegas hits" << std::endl;
   auto hit = static_cast< MicromegasRawHit *> (MicromegasRawHitsTCArray->At(0));
   if (hit)
    {
@@ -40,7 +40,7 @@ int MicromegasRawHitContainerv1::isValid() const
 
 unsigned int MicromegasRawHitContainerv1::get_nhits()
 {
-  return MicromegasRawHitsTCArray->GetEntries();
+  return MicromegasRawHitsTCArray->GetEntriesFast();
 }
 
 MicromegasRawHit *MicromegasRawHitContainerv1::AddHit()

--- a/offline/framework/ffarawobjects/MvtxRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/MvtxRawHitContainerv1.cc
@@ -25,7 +25,7 @@ void MvtxRawHitContainerv1::Reset()
 void MvtxRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "MvtxRawHitContainerv1" << std::endl;
-  os << "containing " << MvtxRawHitsTCArray->GetEntries() << " Mvtx hits" << std::endl;
+  os << "containing " << MvtxRawHitsTCArray->GetEntriesFast() << " Mvtx hits" << std::endl;
   MvtxRawHit *mvtxhit = static_cast< MvtxRawHit *> (MvtxRawHitsTCArray->At(0));
   if (mvtxhit)
    {
@@ -40,7 +40,7 @@ int MvtxRawHitContainerv1::isValid() const
 
 unsigned int MvtxRawHitContainerv1::get_nhits()
 {
-  return MvtxRawHitsTCArray->GetEntries();
+  return MvtxRawHitsTCArray->GetEntriesFast();
 }
 
 MvtxRawHit *MvtxRawHitContainerv1::AddHit()

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
@@ -26,7 +26,7 @@ void TpcRawHitContainerv1::Reset()
 void TpcRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "TpcRawHitContainerv1" << std::endl;
-  os << "containing " << TpcRawHitsTCArray->GetEntries() << " Tpc hits" << std::endl;
+  os << "containing " << TpcRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
   TpcRawHit *tpchit = static_cast< TpcRawHit *> (TpcRawHitsTCArray->At(0));
   if (tpchit)
    {
@@ -41,7 +41,7 @@ int TpcRawHitContainerv1::isValid() const
 
 unsigned int TpcRawHitContainerv1::get_nhits()
 {
-  return TpcRawHitsTCArray->GetEntries();
+  return TpcRawHitsTCArray->GetEntriesFast();
 }
 
 TpcRawHit *TpcRawHitContainerv1::AddHit()


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Use GetEntriesFast() instead of GetEntries() for TC Array to speed up code (Thanks Jin)
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

