### PR TITLE
Improve TPC Unpacker speed

### DIFF
--- a/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
@@ -41,7 +41,7 @@ int TpcRawHitContainerv1::isValid() const
 
 unsigned int TpcRawHitContainerv1::get_nhits()
 {
-  return TpcRawHitsTCArray->GetEntries();
+  return TpcRawHitsTCArray->GetEntriesFast();
 }
 
 TpcRawHit *TpcRawHitContainerv1::AddHit()

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -180,7 +180,9 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
   uint64_t bco_min = UINT64_MAX;
   uint64_t bco_max = 0;
 
-  for (unsigned int i = 0; i < tpccont->get_nhits(); i++)
+  const auto nhits = tpccont->get_nhits();
+
+  for (unsigned int i = 0; i < nhits; i++)
   {
     TpcRawHit *tpchit = tpccont->get_hit(i);
     uint64_t gtm_bco = tpchit->get_gtm_bco();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As discussed in the last online offline meeting that the TPC unpacker has been slow. The problem trace to repeated call of the `TpcRawHitContainerv1::get_nhits()`  function which trace to slow `TClonesArray::GetEntries()` call
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/7947083/6c422909-7ee0-4008-b323-6b27c77d4d7e)

Solution is two folds:
* Switch to the faster `TClonesArray::GetEntriesFast()`
* Locally cache repeatedly used variables

Speed improvement seems about one order of magnitude. 

There are plenty further opportunities to speed up this unpacker, to come later


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

