### PR TITLE
add a magic string to TFile opening to enforce binary identity

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -30,7 +30,7 @@ Fun4AllDstOutputManager::Fun4AllDstOutputManager(const std::string &myname, cons
     gSystem->Exit(1);
     exit(1);  // cppcheck does not know gSystem->Exit(1)
   }
-  dstOut->SetCompressionLevel(3);
+  dstOut->SetCompressionSetting(m_CompressionSetting);
   return;
 }
 
@@ -76,7 +76,7 @@ int Fun4AllDstOutputManager::outfileopen(const std::string &fname)
     return -1;
   }
 
-  dstOut->SetCompressionLevel(3);
+  dstOut->SetCompressionSetting(m_CompressionSetting);
   return 0;
 }
 

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -11,12 +11,17 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <filesystem>
 #include <string>
 
 Fun4AllDstOutputManager::Fun4AllDstOutputManager(const std::string &myname, const std::string &fname)
   : Fun4AllOutputManager(myname, fname)
 {
-  dstOut = new PHNodeIOManager(fname, PHWrite);
+  std::filesystem::path p = fname;
+// this adds a magic string which makes the TFiles binary identical
+// also independant of where they were written
+  m_UsedOutFileName = fname + std::string("?reproducible=") + std::string(p.filename());
+  dstOut = new PHNodeIOManager(UsedOutFileName(), PHWrite);
   if (!dstOut->isFunctional())
   {
     delete dstOut;
@@ -198,7 +203,7 @@ int Fun4AllDstOutputManager::WriteNode(PHCompositeNode *thisNode)
     dstOut = nullptr;
     return 0;
   }
-  dstOut = new PHNodeIOManager(OutFileName(), PHUpdate, PHRunTree);
+  dstOut = new PHNodeIOManager(UsedOutFileName(), PHUpdate, PHRunTree);
   Fun4AllServer *se = Fun4AllServer::instance();
   PHNodeIterator nodeiter(thisNode);
   if (saverunnodes.empty())

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -32,11 +32,13 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
 
   int Write(PHCompositeNode *startNode) override;
   int WriteNode(PHCompositeNode *thisNode) override;
+  std::string UsedOutFileName() const {return m_UsedOutFileName;}
 
  private:
   PHNodeIOManager *dstOut = nullptr;
   int m_SaveRunNodeFlag = 1;
   int m_SaveDstNodeFlag = 1;
+  std::string m_UsedOutFileName;
   std::set<std::string> savenodes;
   std::set<std::string> saverunnodes;
   std::set<std::string> stripnodes;

--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -33,11 +33,13 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   int Write(PHCompositeNode *startNode) override;
   int WriteNode(PHCompositeNode *thisNode) override;
   std::string UsedOutFileName() const {return m_UsedOutFileName;}
+  void CompressionSetting(const int i) {m_CompressionSetting = i;}
 
  private:
-  PHNodeIOManager *dstOut = nullptr;
-  int m_SaveRunNodeFlag = 1;
-  int m_SaveDstNodeFlag = 1;
+  PHNodeIOManager *dstOut {nullptr};
+  int m_SaveRunNodeFlag {1};
+  int m_SaveDstNodeFlag {1};
+  int m_CompressionSetting {505};
   std::string m_UsedOutFileName;
   std::set<std::string> savenodes;
   std::set<std::string> saverunnodes;

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -99,7 +99,7 @@ bool PHNodeIOManager::setFile(const std::string& f, const std::string& title,
     {
       return false;
     }
-    file->SetCompressionLevel(CompressionLevel);
+    file->SetCompressionSettings(m_CompressionSetting);
     tree = new TTree(TreeName.c_str(), title.c_str());
     tree->SetMaxTreeSize(900000000000LL);  // set max size to ~900 GB
     gROOT->cd(currdir.c_str());
@@ -122,7 +122,7 @@ bool PHNodeIOManager::setFile(const std::string& f, const std::string& title,
     {
       return false;
     }
-    file->SetCompressionLevel(CompressionLevel);
+    file->SetCompressionSettings(m_CompressionSetting);
     tree = new TTree(TreeName.c_str(), title.c_str());
     gROOT->cd(currdir.c_str());
     return true;
@@ -523,16 +523,16 @@ bool PHNodeIOManager::isSelected(const std::string& objectName)
   return false;
 }
 
-bool PHNodeIOManager::SetCompressionLevel(const int level)
+bool PHNodeIOManager::SetCompressionSetting(const int level)
 {
   if (level < 0)
   {
     return false;
   }
-  CompressionLevel = level;
+  m_CompressionSetting = level;
   if (file)
   {
-    file->SetCompressionLevel(CompressionLevel);
+    file->SetCompressionSettings(m_CompressionSetting);
   }
 
   return true;

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -39,7 +39,7 @@ class PHNodeIOManager : public PHIOManager
   void selectObjectToRead(const std::string &objectName, bool readit);
   bool isSelected(const std::string &objectName);
   int isFunctional() const { return isFunctionalFlag; }
-  bool SetCompressionLevel(const int level);
+  bool SetCompressionSetting(const int level);
   double GetBytesWritten();
   std::map<std::string, TBranch *> *GetBranchMap();
 
@@ -52,15 +52,15 @@ class PHNodeIOManager : public PHIOManager
   bool readEventFromFile(size_t requestedEvent);
   std::string getBranchClassName(TBranch *);
 
-  TFile *file = nullptr;
-  TTree *tree = nullptr;
-  std::string TreeName = "T";
-  int accessMode = PHReadOnly;
-  int CompressionLevel = 3;
+  TFile *file {nullptr};
+  TTree *tree {nullptr};
+  std::string TreeName {"T"};
+  int accessMode {PHReadOnly};
+  int m_CompressionSetting {505}; // ZSTD
   std::map<std::string, TBranch *> fBranches;
   std::map<std::string, bool> objectToRead;
 
-  int isFunctionalFlag = 0;  // flag to tell if that object initialized properly
+  int isFunctionalFlag {0};  // flag to tell if that object initialized properly
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds a magic string (?reproducible=filename-without-path) to the TFile name which tells root to create binary identical files (no time stamps or path to output file stored anymore) This disables the use of TRef which we don't use anyway
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

