### PR TITLE
feat: cosmic development

### DIFF
--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -44,6 +44,7 @@
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
 #include <TDatabasePDG.h>
+#include <TVector3.h>
 
 #include <cmath>
 #include <iostream>
@@ -128,6 +129,14 @@ int PHCosmicsTrkFitter::InitRun(PHCompositeNode* topNode)
     m_evaluator->verbosity(Verbosity());
   }
 
+  if(m_seedClusAnalysis)
+    {
+      m_outfile =  std::make_unique<TFile>(m_evalname.c_str(),"RECREATE");
+      m_tree = std::make_unique<TTree>("seedclustree","Tree with cosmic seeds and their clusters");
+      makeBranches();
+      
+    }
+
   if (Verbosity() > 1)
   {
     std::cout << "Finish PHCosmicsTrkFitter Setup" << std::endl;
@@ -198,7 +207,12 @@ int PHCosmicsTrkFitter::End(PHCompositeNode* /*topNode*/)
   {
     m_evaluator->End();
   }
-
+  if( m_seedClusAnalysis)
+    {
+      m_outfile->cd();
+      m_tree->Write();
+      m_outfile->Close();
+    }
   if (Verbosity() > 0)
   {
     std::cout << "The Acts track fitter had " << m_nBadFits
@@ -323,15 +337,33 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     position *= Acts::UnitConstants::cm;
     if (!is_valid(momentum)) continue;
-
+ 
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         Acts::Vector3(0, -1 * m_vertexRadius * Acts::UnitConstants::cm, 0));
     auto actsFourPos = Acts::Vector4(position(0), position(1),
                                      position(2),
                                      10 * Acts::UnitConstants::ns);
-
+   
     Acts::BoundSquareMatrix cov = setDefaultCovariance();
-
+    if(m_seedClusAnalysis)
+      {
+	clearVectors();
+	m_seed = tpcid;
+	m_R = tpcR;
+	m_X0 = tpcx;
+	m_Y0 = tpcy;
+	m_Z0 = tpcseed->get_Z0();
+	m_slope = slope;
+	m_pcax = position(0);
+	m_pcay = position(1);
+	m_pcaz = position(2);
+	m_px = momentum(0);
+	m_py = momentum(1);
+	m_pz = momentum(2);
+	m_charge = charge;
+	fillVectors(siseed, tpcseed);
+	m_tree->Fill();
+      }
     //! Reset the track seed with the dummy covariance
     auto seed = ActsTrackFittingAlgorithm::TrackParameters::create(
                     pSurface,
@@ -341,7 +373,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
                     charge / momentum.norm(),
                     cov,
                     Acts::ParticleHypothesis::muon(), 
-		    1*Acts::UnitConstants::cm)
+		    100*Acts::UnitConstants::cm)
                     .value();
 
     if (Verbosity() > 2)
@@ -537,9 +569,10 @@ SourceLinkVec PHCosmicsTrkFitter::getSourceLinks(
     global *= Acts::UnitConstants::cm;
 
     Acts::Vector3 normal = surf->normal(m_tGeometry->geometry().getGeoContext());
+    std::cout << "test global to local"<<std::endl;
     auto local = surf->globalToLocal(m_tGeometry->geometry().getGeoContext(),
                                      global, normal);
-
+    std::cout << "is the position even tested?"<<std::endl;
     if (local.ok())
     {
       localPos = local.value() / Acts::UnitConstants::cm;
@@ -595,11 +628,13 @@ SourceLinkVec PHCosmicsTrkFitter::getSourceLinks(
                 << localPos(0) << ", " << localPos(1)
                 << std::endl;
     }
-
+    
     sourcelinks.push_back(actsSL);
+    std::cout << "push back meas"<<std::endl;
     measurements.push_back(meas);
+    std::cout << "push back meas2"<<std::endl;
   }
-
+  std::cout << "find closest cluster"<<std::endl;
   //! find the closest cluster to the outermost cluster
   float maxdr = std::numeric_limits<float>::max();
   for (int i = 0; i < global_moved.size(); i++)
@@ -615,7 +650,7 @@ SourceLinkVec PHCosmicsTrkFitter::getSourceLinks(
       globalSecondMostOuter = global_moved[i].second;
     }
   }
-
+  std::cout << "determining charge"<<std::endl;
   //! we have to calculate phi WRT the vertex position outside the detector,
   //! not at (0,0)
   Acts::Vector3 vertex(0, -1 * m_vertexRadius, 0);
@@ -643,7 +678,7 @@ SourceLinkVec PHCosmicsTrkFitter::getSourceLinks(
   float r2 = std::sqrt(square(globalSecondMostOuter.x()) + square(globalSecondMostOuter.y()));
   float z1 = globalMostOuter.z();
   float z2 = globalSecondMostOuter.z();
-
+  std::cout << "determining charge"<<std::endl;
   cosmicslope = (r2 - r1) / (z2 - z1);
 
   return sourcelinks;
@@ -967,4 +1002,100 @@ int PHCosmicsTrkFitter::getNodes(PHCompositeNode* topNode)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+void PHCosmicsTrkFitter::makeBranches()
+{
+  m_tree->Branch("seed",&m_seed,"m_seed/I");
+  m_tree->Branch("event",&m_event,"m_event/I");
+  m_tree->Branch("R",&m_R,"m_R/F");
+  m_tree->Branch("X0",&m_X0,"m_X0/F");
+  m_tree->Branch("Y0",&m_Y0,"m_Y0/F");
+  m_tree->Branch("Z0",&m_Z0,"m_Z0/F");
+  m_tree->Branch("slope",&m_slope,"m_slope/F");
+  m_tree->Branch("pcax",&m_pcax,"m_pcax/F");
+  m_tree->Branch("pcay",&m_pcay,"m_pcay/F");
+  m_tree->Branch("pcaz",&m_pcaz,"m_pcaz/F");
+  m_tree->Branch("px",&m_px,"m_px/F");
+  m_tree->Branch("py",&m_py,"m_py/F");
+  m_tree->Branch("pz",&m_pz,"m_pz/F");
+  m_tree->Branch("charge",&m_charge,"m_charge/I");
+  m_tree->Branch("nmaps",&m_nmaps,"m_nmaps/I");
+  m_tree->Branch("nintt",&m_nintt,"m_nintt/I");
+  m_tree->Branch("ntpc",&m_ntpc,"m_ntpc/I");
+  m_tree->Branch("nmm",&m_nmm,"m_nmm/I");
+  m_tree->Branch("locx",&m_locx);
+  m_tree->Branch("locy",&m_locy);
+  m_tree->Branch("x",&m_x);
+  m_tree->Branch("y",&m_y);
+  m_tree->Branch("z",&m_z);
+  m_tree->Branch("r",&m_r);
+  m_tree->Branch("layer",&m_layer);
+  m_tree->Branch("phi",&m_phi);
+  m_tree->Branch("eta",&m_eta);
+  m_tree->Branch("phisize",&m_phisize);
+  m_tree->Branch("zsize",&m_zsize);
+  m_tree->Branch("ephi",&m_ephi);
+  m_tree->Branch("ez",&m_ez);
+
+
+
+}
+void PHCosmicsTrkFitter::fillVectors(TrackSeed *tpcseed, TrackSeed* siseed)
+{
+  for(auto seed : {tpcseed, siseed})
+    {
+      for(auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys();
+	  ++it)
+	{
+	  auto key = *it;
+	  auto cluster = m_clusterContainer->findCluster(key);
+	  m_locx.push_back(cluster->getLocalX());
+	  float ly = cluster->getLocalY();
+	  if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::tpcId)
+	    {
+	      double drift_velocity = m_tGeometry->get_drift_velocity();
+	      double zdriftlength = cluster->getLocalY() * drift_velocity;
+	      double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
+	      double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
+	      unsigned int side = TpcDefs::getSide(key);
+	      if (side == 0) zloc = -zloc;
+	      ly = zloc * 10;  
+	    }
+	  m_locy.push_back(ly);
+	  auto glob = m_tGeometry->getGlobalPosition(key, cluster);
+	  m_x.push_back(glob.x());
+	  m_y.push_back(glob.y());
+	  m_z.push_back(glob.z());
+	  float r = std::sqrt(glob.x()*glob.x()+glob.y()*glob.y());
+	  m_r.push_back(r);
+	  TVector3 globt(glob.x(), glob.y(), glob.z());
+	  m_phi.push_back(globt.Phi());
+	  m_eta.push_back(globt.Eta());
+	  m_phisize.push_back(cluster->getPhiSize());
+	  m_zsize.push_back(cluster->getZSize());
+	  auto para_errors = 
+	    m_clusErrPara.get_clusterv5_modified_error(cluster,r , key);
+
+	  m_ephi.push_back(std::sqrt(para_errors.first));
+	  m_ez.push_back(std::sqrt(para_errors.second));
+	}
+    }
+}
+void PHCosmicsTrkFitter::clearVectors()
+{
+  m_locx.clear();
+  m_locy.clear();
+  m_x.clear();
+  m_y.clear();
+  m_z.clear();
+  m_layer.clear();
+  m_r.clear();
+  m_phi.clear();
+  m_eta.clear();
+  m_phisize.clear();
+  m_zsize.clear();
+  m_ephi.clear();
+  m_ez.clear();
 }

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -27,6 +27,9 @@
 #include <memory>
 #include <string>
 
+#include <TFile.h>
+#include <TTree.h>
+
 #include <trackbase/alignmentTransformationContainer.h>
 
 class MakeActsGeometry;
@@ -85,7 +88,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   {
     m_pHypothesis = pHypothesis;
   }
-
+  void seedAnalysis() { m_seedClusAnalysis = true; }
   void commissioning(bool com) { m_commissioning = com; }
 
   void useOutlierFinder(bool outlier) { m_useOutlierFinder = outlier; }
@@ -134,6 +137,7 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   Acts::BoundSquareMatrix setDefaultCovariance() const;
   void printTrackSeed(const ActsTrackFittingAlgorithm::TrackParameters& seed) const;
+  void makeBranches();
 
   /// Event counter
   int m_event = 0;
@@ -191,6 +195,7 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   std::string m_fieldMap = "";
 
+
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
   std::string _seed_track_map_name = "SeedTrackMap";
@@ -200,6 +205,34 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
   ActsAlignmentStates m_alignStates;
+
+
+  //! for diagnosing seed param + clusters
+  bool m_seedClusAnalysis = false;
+  std::unique_ptr<TFile> m_outfile = nullptr;
+  std::unique_ptr<TTree> m_tree = nullptr;
+  int m_seed = std::numeric_limits<int>::max();
+  float m_R = NAN;
+  float m_X0 = NAN;
+  float m_Y0 = NAN;
+  float m_Z0 = NAN;
+  float m_slope = NAN;
+  float m_pcax = NAN;
+  float m_pcay = NAN;
+  float m_pcaz = NAN;
+  float m_px = NAN;
+  float m_py = NAN;
+  float m_pz = NAN;
+  int m_charge = std::numeric_limits<int>::max();
+  int m_nmaps = std::numeric_limits<int>::max();
+  int m_nintt = std::numeric_limits<int>::max();
+  int m_ntpc = std::numeric_limits<int>::max();
+  int m_nmm = std::numeric_limits<int>::max();
+  std::vector<float> m_locx, m_locy, m_x, m_y, m_z, m_r, m_layer,m_phi, m_eta, 
+    m_phisize, m_zsize, m_ephi, m_ez;
+  void clearVectors();
+  void fillVectors(TrackSeed* tpcseed, TrackSeed *siseed);
+  ClusterErrorPara m_clusErrPara;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

1. The target surface is moved from the negative y edge of the TPC to the positive y edge to better match the data
2. State-cluster relations in track residuals are now determined by the cluster key stored in the state rather than by dr, which can lead to misleading results by associating a cluster and state on different layers.
3. A diagnostic tuple is added to the cosmic track fitter to look at the seed parameter determination for testing why Acts fits fail

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

