### PR TITLE
Add negative bco range for tpc

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -717,6 +717,10 @@ int Fun4AllStreamingInputManager::FillMicromegas()
 
     m_MicromegasRawHitMap.begin()->second.MicromegasRawHitVector.clear();
     m_MicromegasRawHitMap.erase(m_MicromegasRawHitMap.begin());
+    if (m_MicromegasRawHitMap.empty())
+    {
+      break;
+    }
   }
 
   return 0;
@@ -749,7 +753,7 @@ int Fun4AllStreamingInputManager::FillTpc()
   }
   // m_TpcRawHitMap.empty() does not need to be checked here, FillTpcPool returns non zero
   // if this map is empty which is handled above
-  while (m_TpcRawHitMap.begin()->first < m_RefBCO)
+  while (m_TpcRawHitMap.begin()->first + m_tpc_negative_bco < m_RefBCO)
   {
     for (auto iter : m_TpcInputVector)
     {
@@ -764,7 +768,7 @@ int Fun4AllStreamingInputManager::FillTpc()
     }
   }
   // again m_TpcRawHitMap.empty() is handled by return of FillTpcPool()
-  while (m_TpcRawHitMap.begin()->first <= select_crossings)
+  while (m_TpcRawHitMap.begin()->first + m_tpc_negative_bco <= select_crossings)
   {
     for (auto tpchititer : m_TpcRawHitMap.begin()->second.TpcRawHitVector)
     {
@@ -780,6 +784,10 @@ int Fun4AllStreamingInputManager::FillTpc()
     }
     m_TpcRawHitMap.begin()->second.TpcRawHitVector.clear();
     m_TpcRawHitMap.erase(m_TpcRawHitMap.begin());
+    if (m_TpcRawHitMap.empty())
+    {
+      break;
+    }
   }
   // std::cout << "size  m_TpcRawHitMap: " <<  m_TpcRawHitMap.size()
   // 	    << std::endl;
@@ -804,6 +812,11 @@ void Fun4AllStreamingInputManager::SetMvtxNegativeBco(const unsigned int i)
 void Fun4AllStreamingInputManager::SetTpcBcoRange(const unsigned int i)
 {
   m_tpc_bco_range = std::max(i, m_tpc_bco_range);
+}
+
+void Fun4AllStreamingInputManager::SetTpcNegativeBco(const unsigned int i)
+{
+  m_tpc_negative_bco = std::max(i, m_tpc_negative_bco);
 }
 
 void Fun4AllStreamingInputManager::SetMvtxBcoRange(const unsigned int i)

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -63,6 +63,7 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   void SetMvtxBcoRange(const unsigned int i);
   void SetMvtxNegativeBco(const unsigned int value);
   void SetTpcBcoRange(const unsigned int i);
+  void SetTpcNegativeBco(const unsigned int value);
   int FillInttPool();
   int FillMicromegasPool();
   int FillMvtxPool();
@@ -109,9 +110,10 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   bool m_tpc_registered_flag{false};
   unsigned int m_micromegas_bco_range{0};
   unsigned int m_micromegas_negative_bco{0};
-  unsigned int m_tpc_bco_range{0};
   unsigned int m_mvtx_bco_range{0};
   unsigned int m_mvtx_negative_bco{0};
+  unsigned int m_tpc_bco_range{0};
+  unsigned int m_tpc_negative_bco{0};
   uint64_t m_RefBCO{0};
 
   std::vector<SingleStreamingInput *> m_Gl1InputVector;

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -345,6 +345,7 @@ void SingleTpcPoolInput::ConfigureStreamingInputManager()
   if (StreamingInputManager())
   {
     StreamingInputManager()->SetTpcBcoRange(m_BcoRange);
+    StreamingInputManager()->SetTpcNegativeBco(m_NegativeBco);
   }
   return;
 }

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.h
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.h
@@ -27,11 +27,13 @@ class SingleTpcPoolInput : public SingleStreamingInput
   void CreateDSTNode(PHCompositeNode *topNode) override;
   void SetBcoRange(const unsigned int i) {m_BcoRange = i;}
   void ConfigureStreamingInputManager() override;
+  void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
  private:
   Packet **plist {nullptr};
   unsigned int m_NumSpecialEvents {0};
   unsigned int m_BcoRange {0};
+  unsigned int m_NegativeBco{0};
 
   //! map bco to packet
   std::map<unsigned int, uint64_t> m_packet_bco;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds matching of earlier bco to the gl1 (just like mvtx and micromegas)
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

