### PR TITLE
add option to process simulated waveforms

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -68,8 +68,10 @@ class CaloTowerBuilder : public SubsysReco
   }
 
  private:
+  int process_sim();
   CaloWaveformProcessing *WaveformProcessing {nullptr};
   TowerInfoContainer *m_CaloInfoContainer {nullptr};  //! Calo info
+  TowerInfoContainer *m_CalowaveformContainer {nullptr};  //waveform from simulation
   bool m_isdata {true};
   bool _bdosoftwarezerosuppression {false};
   int m_packet_low {std::numeric_limits<int>::min()};
@@ -82,6 +84,7 @@ class CaloTowerBuilder : public SubsysReco
   CaloTowerDefs::BuilderType m_buildertype {CaloTowerDefs::kPRDFTowerv1};
   CaloWaveformProcessing::process _processingtype {CaloWaveformProcessing::NONE};
   std::string m_detector {"CEMC"};
+  std::string m_inputNodePrefix {"WAVEFORM_"};
   std::string m_outputNodePrefix {"TOWERS_"};
   std::string TowerNodeName;
 };

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -1,0 +1,379 @@
+
+#include "CaloWaveformSim.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4HitDefs.h> // for hit_idbits
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <cdbobjects/CDBTTree.h>  // for CDBTTree
+
+#include <ffamodules/CDBInterface.h>
+
+#include <ffaobjects/EventHeader.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/PHRandomSeed.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoContainerv3.h>
+
+#include <g4detectors/PHG4CylinderGeomContainer.h>
+#include <g4detectors/PHG4CylinderGeom_Spacalv1.h>  // for PHG4CylinderGeom_Spaca...
+#include <g4detectors/PHG4CylinderGeom_Spacalv3.h>
+#include <g4detectors/PHG4CylinderCellGeomContainer.h>
+#include <g4detectors/PHG4CylinderCellGeom_Spacalv1.h>
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TProfile.h>
+#include <TSystem.h>
+#include <cassert>
+#include <sstream>
+#include <string>
+
+double CaloWaveformSim::template_function(double *x, double *par)
+{
+  Double_t v1 = par[0] * h_template->Interpolate(x[0] - par[1]) + par[2];
+  return v1;
+}
+
+CaloWaveformSim::CaloWaveformSim(const std::string &name) : SubsysReco(name)
+{
+}
+
+CaloWaveformSim::~CaloWaveformSim()
+{
+}
+
+int CaloWaveformSim::Init(PHCompositeNode *topNode)
+{
+  m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
+  unsigned int seed = PHRandomSeed();  // fixed seed handled in PHRandomSeed()
+  gsl_rng_set(m_RandomGenerator, seed);
+  // get the template
+
+  TFile *ft = new TFile(m_templatefile.c_str());
+  assert(ft);
+  assert(ft->IsOpen());
+  h_template = (TProfile *)ft->Get("hpwaveform");
+  // get the decalibration from the CDB
+  PHNodeIterator nodeIter(topNode);
+
+  EventHeader *evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader");
+
+  if (evtHeader)
+  {
+    m_runNumber = evtHeader->get_RunNumber();
+  }
+  else
+  {
+    m_runNumber = -1;
+  }
+  if (Verbosity() > 0)
+  {
+    std::cout << "CaloWaveformSim::Init(PHCompositeNode *topNode) Run Number: " << evtHeader->get_RunNumber() << std::endl;
+    std::cout << "CaloWaveformSim getting calibration" << std::endl;
+  }
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    m_detector = "CEMC";
+    encode_tower = TowerInfoDefs::encode_emcal;
+    decode_tower = TowerInfoDefs::decode_emcal;
+    m_sampling_fraction = 2e-02;
+    m_nchannels = 24576;
+    m_noisetree_name = "/sphenix/user/shuhangli/noisetree/macro/noiseout_emcalout.root";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "cemc_pi0_twrSlope_v1";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "Femc_datadriven_qm1_correction";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloWaveformSim::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
+    }
+  }
+  else if (m_dettype == CaloTowerDefs::HCALIN)
+  {
+    m_detector = "HCALIN";
+    encode_tower = TowerInfoDefs::encode_hcal;
+    decode_tower = TowerInfoDefs::decode_hcal;
+    m_sampling_fraction = 0.162166;
+    m_nchannels = 1536;
+    m_noisetree_name = "/sphenix/user/shuhangli/noisetree/macro/noiseout_ihcalout.root";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "ihcal_abscalib_cosmic";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "ihcal_abscalib_mip";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloWaveformSim::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
+    }
+  }
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
+  {
+    m_detector = "HCALOUT";
+    encode_tower = TowerInfoDefs::encode_hcal;
+    decode_tower = TowerInfoDefs::decode_hcal;
+    m_sampling_fraction = 3.38021e-02;
+    m_nchannels = 1536;
+    m_noisetree_name = "/sphenix/user/shuhangli/noisetree/macro/noiseout_ohcalout.root";
+
+    if (!m_overrideCalibName)
+    {
+      m_calibName = "ohcal_abscalib_cosmic";
+    }
+    if (!m_overrideFieldName)
+    {
+      m_fieldname = "ohcal_abscalib_mip";
+    }
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+    if (!calibdir.empty())
+    {
+      cdbttree = new CDBTTree(calibdir);
+    }
+    else
+    {
+      std::cout << "CaloWaveformSim:::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
+      exit(1);
+    }
+  }
+  m_waveforms.resize(m_nchannels);
+  for (auto &waveform : m_waveforms)
+  {
+    waveform.resize(m_nsamples);
+  }
+
+  // get the noise from calibration dir
+  TFile *fn = new TFile(m_noisetree_name.c_str());
+  m_noisetree = (TTree *)fn->Get("T");
+  m_noisetree->SetBranchAddress("pedestal", &m_pedestal);
+  CreateNodeTree(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int CaloWaveformSim::process_event(PHCompositeNode *topNode)
+{
+  if (Verbosity() > 0)
+  {
+    std::cout << "CaloWaveformSim::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  }
+  // initialize the waveform
+  for (auto &waveform : m_waveforms)
+  {
+    for (auto &sample : waveform)
+    {
+      sample = 0.;
+    }
+  }
+  // waveform TH1
+  TF1 *f_fit = new TF1("f_fit", [this](double *x, double *par) {
+    return this->template_function(x, par);
+}, 0, m_nsamples, 3);
+  f_fit->SetParameter(0, 1.0);
+  float shift_of_shift = gsl_rng_uniform(m_RandomGenerator);
+
+  float _shiftval = 4 + shift_of_shift - f_fit->GetMaximumX();
+  f_fit->SetParameters(1, _shiftval, 0);
+
+  // get G4Hits
+  std::string nodename = "G4HIT_" + m_detector;
+  PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, nodename);
+  if (!hits)
+  {
+    std::cout << PHWHERE << " " << nodename << " Node missing, doing nothing." << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+
+  // loop over hits
+  for (PHG4HitContainer::ConstIterator hititer = hits->getHits().first; hititer != hits->getHits().second; hititer++)
+  {
+    PHG4Hit *hit = hititer->second;
+    // get eta phi bin
+    unsigned short etabin = 0;
+    unsigned short phibin = 0;
+    maphitetaphi(hit, etabin, phibin);
+    unsigned int key = encode_tower(etabin, phibin);
+    float calibconst = cdbttree->GetFloatValue(key, m_fieldname);
+    float e_vis = hit->get_light_yield();
+    float e_dep = e_vis / m_sampling_fraction;
+    float ADC = e_dep / calibconst;
+    float t0 = hit->get_t(0) / m_sampletime;
+    unsigned int tower_index = decode_tower(key);
+    f_fit->SetParameters(ADC, _shiftval + t0, 0.);
+    for (int i = 0; i < m_nsamples; i++)
+    {
+      m_waveforms.at(tower_index).at(i) += f_fit->Eval(i);
+    }
+  }
+  //do noise here and add to waveform
+  int n_noise_events = m_noisetree->GetEntries();
+  int random_noise_event = gsl_rng_uniform_int(m_RandomGenerator, n_noise_events);
+  m_noisetree->GetEntry(random_noise_event);
+  for (int i = 0; i < m_nchannels; i++)
+  {
+    for (int j = 0; j < m_nsamples; j++)
+    {
+      m_waveforms.at(i).at(j) += (j < (int)m_pedestal->at(i).size()) ? m_pedestal->at(i).at(j) : m_pedestal->at(i).back();
+      m_CaloWaveformContainer->get_tower_at_channel(i)->set_waveform_value(j, m_waveforms.at(i).at(j));
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloWaveformSim::maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsigned short &phibin)
+{
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    int scint_id = g4hit->get_scint_id();
+    PHG4CylinderGeom_Spacalv3::scint_id_coder decoder(scint_id);
+    std::pair<int, int> tower_z_phi_ID = layergeom->get_tower_z_phi_ID(decoder.tower_ID, decoder.sector_ID);
+    const int &tower_ID_z = tower_z_phi_ID.first;
+    const int &tower_ID_phi = tower_z_phi_ID.second;
+
+    PHG4CylinderGeom_Spacalv3::tower_map_t::const_iterator it_tower =
+        layergeom->get_sector_tower_map().find(decoder.tower_ID);
+    assert(it_tower != layergeom->get_sector_tower_map().end());
+
+    const int etabin_cell = geo->get_etabin_block(tower_ID_z); // block eta bin
+    const int sub_tower_ID_x = it_tower->second.get_sub_tower_ID_x(decoder.fiber_ID);
+    const int sub_tower_ID_y = it_tower->second.get_sub_tower_ID_y(decoder.fiber_ID);
+    unsigned short etabinshort = etabin_cell * layergeom->get_n_subtower_eta() + sub_tower_ID_y;
+    unsigned short phibin_cell = tower_ID_phi * layergeom->get_n_subtower_phi() + sub_tower_ID_x;
+    etabin = etabinshort;
+    phibin = phibin_cell;
+  }
+  else if (m_dettype == CaloTowerDefs::HCALIN)
+  {
+    //int layer = (g4hit->get_hit_id() >> PHG4HitDefs::hit_idbits);
+    unsigned int iphi = (unsigned int)(g4hit->get_hit_id() >> PHG4HitDefs::hit_idbits) / 4;
+    unsigned int ieta = g4hit->get_scint_id();
+
+    etabin = ieta;
+    phibin = iphi;
+  }
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
+  {
+    //int layer = (g4hit->get_hit_id() >> PHG4HitDefs::hit_idbits);
+    unsigned int iphi = (unsigned int)(g4hit->get_hit_id() >> PHG4HitDefs::hit_idbits) / 5;
+    unsigned int ieta = g4hit->get_scint_id();
+
+    etabin = ieta;
+    phibin = iphi;
+  }
+  else
+  {
+    std::cout << PHWHERE << " Invalid detector type " << m_dettype << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+}
+
+//____________________________________________________________________________..
+int CaloWaveformSim::End(PHCompositeNode *topNode)
+{
+  std::cout << "CaloWaveformSim::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloWaveformSim::CreateNodeTree(PHCompositeNode *topNode)
+{
+  // if CEMC get the geom
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    PHG4CylinderGeomContainer *layergeo = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_CEMC");
+    if (!layergeo)
+    {
+      std::cout << PHWHERE << " CYLINDERGEOM_CEMC Node missing, doing nothing." << std::endl;
+      gSystem->Exit(1);
+      exit(1);
+    }
+    const PHG4CylinderGeom *layergeom_raw = layergeo->GetFirstLayerGeom();
+    assert(layergeom_raw);
+
+    layergeom = dynamic_cast<const PHG4CylinderGeom_Spacalv3 *>(layergeom_raw);
+    assert(layergeom);
+
+    PHG4CylinderCellGeomContainer *seggeo = findNode::getClass<PHG4CylinderCellGeomContainer>(topNode, "CYLINDERCELLGEOM_CEMC");
+    PHG4CylinderCellGeom *geo_raw = seggeo->GetFirstLayerCellGeom();
+    geo = dynamic_cast<PHG4CylinderCellGeom_Spacalv1 *>(geo_raw);
+  }
+
+  PHNodeIterator topNodeItr(topNode);
+  // DST node
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(topNodeItr.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode)
+  {
+    std::cout << "PHComposite node created: DST" << std::endl;
+    dstNode = new PHCompositeNode("DST");
+    topNode->addNode(dstNode);
+  }
+  PHNodeIterator nodeItr(dstNode);
+  PHCompositeNode *DetNode;
+  // enum CaloTowerDefs::DetectorSystem and TowerInfoContainer::DETECTOR are different!!!!
+  TowerInfoContainer::DETECTOR DetectorEnum = TowerInfoContainer::DETECTOR::DETECTOR_INVALID;
+  std::string DetectorNodeName;
+
+  if (m_dettype == CaloTowerDefs::CEMC)
+  {
+    DetectorEnum = TowerInfoContainer::DETECTOR::EMCAL;
+    DetectorNodeName = "CEMC";
+  }
+  else if (m_dettype == CaloTowerDefs::HCALIN)
+  {
+    DetectorEnum = TowerInfoContainer::DETECTOR::HCAL;
+    DetectorNodeName = "HCALIN";
+  }
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
+  {
+    DetectorEnum = TowerInfoContainer::DETECTOR::HCAL;
+    DetectorNodeName = "HCALOUT";
+  }
+  else
+  {
+    std::cout << PHWHERE << " Invalid detector type " << m_dettype << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
+  DetNode = dynamic_cast<PHCompositeNode *>(nodeItr.findFirst("PHCompositeNode", DetectorNodeName));
+  if (!DetNode)
+  {
+    DetNode = new PHCompositeNode(DetectorNodeName);
+    dstNode->addNode(DetNode);
+  }
+  m_CaloWaveformContainer = new TowerInfoContainerv3(DetectorEnum);
+
+  PHIODataNode<PHObject> *newTowerNode = new PHIODataNode<PHObject>(m_CaloWaveformContainer, "WAVEFORM_" + m_detector, "PHObject");
+  DetNode->addNode(newTowerNode);
+}

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -251,6 +251,11 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
   for (PHG4HitContainer::ConstIterator hititer = hits->getHits().first; hititer != hits->getHits().second; hititer++)
   {
     PHG4Hit *hit = hititer->second;
+    if (hit->get_t(1) - hit->get_t(0) >  m_deltaT) continue;
+
+
+    //timing cut 
+    
     // get eta phi bin
     unsigned short etabin = 0;
     unsigned short phibin = 0;

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -1,0 +1,118 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef CALOWAVEFORMSIM_H
+#define CALOWAVEFORMSIM_H
+
+#include <fun4all/SubsysReco.h>
+#include <caloreco/CaloTowerDefs.h>
+#include <calobase/TowerInfoDefs.h>
+
+#include <gsl/gsl_rng.h>
+
+#include <string>
+#include <vector>
+
+class PHCompositeNode;
+class TProfile;
+class PHG4Hit;
+class PHG4CylinderCellGeom_Spacalv1;
+class PHG4CylinderGeom_Spacalv3;
+class TRandom3;
+class TTree;
+class CDBTTree;
+class TowerInfoContainer;
+
+class CaloWaveformSim : public SubsysReco
+{
+public:
+    CaloWaveformSim(const std::string &name = "CaloWaveformSim");
+
+    ~CaloWaveformSim() override;
+
+    int Init(PHCompositeNode *topNode) override;
+
+    /** Called for each event.
+        This is where you do the real work.
+     */
+    int process_event(PHCompositeNode *topNode) override;
+
+    /// Called at the end of all processing.
+    int End(PHCompositeNode *topNode) override;
+
+    void set_detector_type(CaloTowerDefs::DetectorSystem dettype)
+    {
+        m_dettype = dettype;
+        return;
+    }
+    void set_detector(const std::string &detector)
+    {
+        m_detector = detector;
+        return;
+    }
+    void set_fieldname(const std::string &fieldname)
+    {
+        m_fieldname = fieldname;
+        return;
+    }
+    void set_calibName(const std::string &calibName)
+    {
+        m_calibName = calibName;
+        m_overrideCalibName = true;
+        return;
+    }
+    void set_overrideCalibName(bool overrideCalibName)
+    {
+        m_overrideCalibName = overrideCalibName;
+        return;
+    }
+    void set_overrideFieldName(bool overrideFieldName)
+    {
+        m_overrideFieldName = overrideFieldName;
+        return;
+    }
+    void set_templatefile(const std::string &templatefile)
+    {
+        m_templatefile = templatefile;
+        return;
+    }
+    void set_nsamples(int _nsamples)
+    {
+        m_nsamples = _nsamples;
+        return;
+    }
+
+
+private:
+    CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::CEMC};
+    std::string m_detector{"CEMC"};
+    std::string m_fieldname{"Femc_datadriven_qm1_correction"};
+    std::string m_calibName{"cemc_pi0_twrSlope_v1"};
+    std::string m_noisetree_name{"/sphenix/user/shuhangli/noisetree/macro/noiseout_emcalout.root"};
+    bool m_overrideCalibName{false};
+    bool m_overrideFieldName{false};
+    CDBTTree *cdbttree{nullptr};
+    std::string m_templatefile{"/sphenix/user/shuhangli/cosmicreco/macro/waveformtemptempohcalcosmic.root"};
+    TProfile *h_template{nullptr};
+    TTree *m_noisetree{nullptr};
+    TowerInfoContainer *m_CaloWaveformContainer{nullptr};
+
+    std::vector<std::vector<float>> m_waveforms = {{}};
+    std::vector<std::vector<int>> *m_pedestal = nullptr;
+    int m_runNumber{0};
+    int m_nsamples{31};
+    int m_nchannels{24576};
+    float m_sampletime{50. / 3.};
+    gsl_rng *m_RandomGenerator{nullptr};
+
+    PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
+    const PHG4CylinderGeom_Spacalv3 *layergeom{nullptr};
+    float m_sampling_fraction = {1.0};
+    void maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsigned short &phibin);
+    unsigned int (*encode_tower)(const unsigned int etabin, const unsigned int phibin){TowerInfoDefs::encode_emcal};
+    unsigned int (*decode_tower)(const unsigned int tower_key){TowerInfoDefs::decode_emcal};
+    double template_function(double *x, double *par);
+    void CreateNodeTree(PHCompositeNode *topNode);
+
+};
+
+#endif // CALOWAVEFORMSIM_H

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -7,6 +7,8 @@
 #include <caloreco/CaloTowerDefs.h>
 #include <calobase/TowerInfoDefs.h>
 
+#include <g4detectors/LightCollectionModel.h> 
+
 #include <gsl/gsl_rng.h>
 
 #include <string>
@@ -80,6 +82,8 @@ public:
         m_nsamples = _nsamples;
         return;
     }
+    //for CEMC light yield correction
+    LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
 
 private:
@@ -107,11 +111,13 @@ private:
     PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
     const PHG4CylinderGeom_Spacalv3 *layergeom{nullptr};
     float m_sampling_fraction = {1.0};
-    void maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsigned short &phibin);
+    void maphitetaphi(PHG4Hit *g4hit, unsigned short &etabin, unsigned short &phibin, float &correction);
     unsigned int (*encode_tower)(const unsigned int etabin, const unsigned int phibin){TowerInfoDefs::encode_emcal};
     unsigned int (*decode_tower)(const unsigned int tower_key){TowerInfoDefs::decode_emcal};
     double template_function(double *x, double *par);
     void CreateNodeTree(PHCompositeNode *topNode);
+
+    LightCollectionModel light_collection_model;
 
 };
 

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -10,6 +10,7 @@
 #include <g4detectors/LightCollectionModel.h> 
 
 #include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
 
 #include <string>
 #include <vector>
@@ -30,6 +31,13 @@ public:
     CaloWaveformSim(const std::string &name = "CaloWaveformSim");
 
     ~CaloWaveformSim() override;
+
+    enum NoiseType{
+        NOISE_NONE = 0,
+        NOISE_GAUSSIAN = 1,
+        NOISE_TREE = 2
+    };
+    
 
     int Init(PHCompositeNode *topNode) override;
 
@@ -82,6 +90,21 @@ public:
         m_nsamples = _nsamples;
         return;
     }
+    void set_noise_type(NoiseType noiseType)
+    {
+        m_noiseType = noiseType;
+        return;
+    }
+    void set_fixpedestal(int _fixpedestal)
+    {
+        m_fixpedestal = _fixpedestal;
+        return;
+    }
+    void set_gaussian_noise(int _gaussian_noise)
+    {
+        m_gaussian_noise = _gaussian_noise;
+        return;
+    }
     //for CEMC light yield correction
     LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
@@ -106,6 +129,8 @@ private:
     int m_nsamples{31};
     int m_nchannels{24576};
     float m_sampletime{50. / 3.};
+    int m_fixpedestal{1500};
+    int m_gaussian_noise{3};
     gsl_rng *m_RandomGenerator{nullptr};
 
     PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};
@@ -118,6 +143,9 @@ private:
     void CreateNodeTree(PHCompositeNode *topNode);
 
     LightCollectionModel light_collection_model;
+
+    NoiseType m_noiseType{NOISE_TREE};
+
 
 };
 

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -105,6 +105,11 @@ public:
         m_gaussian_noise = _gaussian_noise;
         return;
     }
+    void set_deltaT(float _deltaT)
+    {
+        m_deltaT = _deltaT;
+        return;
+    }
     //for CEMC light yield correction
     LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
@@ -131,6 +136,7 @@ private:
     float m_sampletime{50. / 3.};
     int m_fixpedestal{1500};
     int m_gaussian_noise{3};
+    float m_deltaT{100.};
     gsl_rng *m_RandomGenerator{nullptr};
 
     PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};

--- a/simulation/g4simulation/g4waveformsim/Makefile.am
+++ b/simulation/g4simulation/g4waveformsim/Makefile.am
@@ -1,0 +1,51 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+pkginclude_HEADERS = \
+  CaloWaveformSim.h
+
+lib_LTLIBRARIES = \
+  libCaloWaveformSim.la
+
+libCaloWaveformSim_la_SOURCES = \
+  CaloWaveformSim.cc
+
+libCaloWaveformSim_la_LIBADD = \
+  -lphool \
+  -lSubsysReco \
+  -lcalo_io \
+  -lfun4all \
+  -lg4detectors_io \
+  -lg4detectors \
+  -lsph_onnx \
+  -lcalo_reco \
+  -lcalo_io \
+  -lcdbobjects \
+  -lphg4hit
+
+BUILT_SOURCES = testexternals.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.cc
+testexternals_LDADD   = libCaloWaveformSim.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/simulation/g4simulation/g4waveformsim/autogen.sh
+++ b/simulation/g4simulation/g4waveformsim/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure  "$@"

--- a/simulation/g4simulation/g4waveformsim/configure.ac
+++ b/simulation/g4simulation/g4waveformsim/configure.ac
@@ -1,0 +1,16 @@
+AC_INIT(calowaveformsim,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+
+LT_INIT([disable-static])
+
+dnl   no point in suppressing warnings people should 
+dnl   at least see them, so here we go for g++: -Wall
+if test $ac_cv_prog_gxx = yes; then
+   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The CaloWaveFormSim module takes in the G4Hits and produce towerinfov3 object that contains the simulated waveform.
Added a new option(when `m_isdata == false`) to processed the simulated waveform(a towerinfov3 object) generated by calowaveformsim module from G4Hits.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)
Need to apply the fiber efficiency for EMCal

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

