### PR TITLE
feat: Add cosmic helical propagator module

### DIFF
--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -1,11 +1,11 @@
 #include "TrackFitUtils.h"
 
-#include "ActsGeometry.h"
-#include "TrkrDefs.h"                // for cluskey, getTrkrId, tpcId
-#include "TpcDefs.h"
 #include <trackbase/MvtxDefs.h>
-#include "TrkrClusterv5.h"
+#include "ActsGeometry.h"
+#include "TpcDefs.h"
 #include "TrkrClusterContainerv4.h"
+#include "TrkrClusterv5.h"
+#include "TrkrDefs.h"  // for cluskey, getTrkrId, tpcId
 
 #include <cmath>
 
@@ -13,18 +13,21 @@ namespace
 {
 
   //! convenience square method
-  template<class T>
-    inline constexpr T square( const T& x ) { return x*x; }
-}
+  template <class T>
+  inline constexpr T square(const T& x)
+  {
+    return x * x;
+  }
+}  // namespace
 
-std::pair<Acts::Vector3, Acts::Vector3> TrackFitUtils::get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3& global) 
+std::pair<Acts::Vector3, Acts::Vector3> TrackFitUtils::get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3& global)
 {
-   // no analytic solution for the coordinates of the closest approach of a helix to a point
-  // Instead, we get the PCA in x and y to the circle, and the PCA in z to the z vs R line at the R of the PCA 
+  // no analytic solution for the coordinates of the closest approach of a helix to a point
+  // Instead, we get the PCA in x and y to the circle, and the PCA in z to the z vs R line at the R of the PCA
 
   float radius = fitpars[0];
   float x0 = fitpars[1];
-  float y0 = fitpars[2];  
+  float y0 = fitpars[2];
   float zslope = fitpars[3];
   float z0 = fitpars[4];
 
@@ -42,35 +45,33 @@ std::pair<Acts::Vector3, Acts::Vector3> TrackFitUtils::get_helix_tangent(const s
   float d_angle = 0.005;
   float newx = radius * cos(angle_pca + d_angle) + x0;
   float newy = radius * sin(angle_pca + d_angle) + y0;
-  float newz = sqrt(newx*newx+newy*newy) * zslope + z0;
+  float newz = sqrt(newx * newx + newy * newy) * zslope + z0;
   Acts::Vector3 second_point_pca(newx, newy, newz);
 
   // pca and second_point_pca define a straight line approximation to the track
-  Acts::Vector3 tangent = (second_point_pca - pca) /  (second_point_pca - pca).norm();
+  Acts::Vector3 tangent = (second_point_pca - pca) / (second_point_pca - pca).norm();
 
   // get the PCA of the cluster to that line
-// Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)   
+  // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)
 
   // The position of the closest point on the line to global is:
   // posref + projection of difference between the point and posref on the tangent vector
-  Acts::Vector3 final_pca = pca + ( (global - pca).dot(tangent) ) * tangent;
+  Acts::Vector3 final_pca = pca + ((global - pca).dot(tangent)) * tangent;
 
   auto line = std::make_pair(final_pca, tangent);
 
   return line;
-
 }
 
 //_________________________________________________________________________________
-TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const TrackFitUtils::position_vector_t& positions )
+TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin(const TrackFitUtils::position_vector_t& positions)
 {
-
   // Compute x- and y- sample means
   double meanX = 0;
   double meanY = 0;
   double weight = 0;
 
-  for( const auto& [x,y] : positions)
+  for (const auto& [x, y] : positions)
   {
     meanX += x;
     meanY += y;
@@ -88,18 +89,18 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   double Myz = 0;
   double Mzz = 0;
 
-  for (auto& [x,y] : positions)
+  for (auto& [x, y] : positions)
   {
-    double Xi = x - meanX;   //  centered x-coordinates
-    double Yi = y - meanY;   //  centered y-coordinates
+    double Xi = x - meanX;  //  centered x-coordinates
+    double Yi = y - meanY;  //  centered y-coordinates
     double Zi = square(Xi) + square(Yi);
 
-    Mxy += Xi*Yi;
-    Mxx += Xi*Xi;
-    Myy += Yi*Yi;
-    Mxz += Xi*Zi;
-    Myz += Yi*Zi;
-    Mzz += Zi*Zi;
+    Mxy += Xi * Yi;
+    Mxx += Xi * Xi;
+    Myy += Yi * Yi;
+    Mxz += Xi * Zi;
+    Myz += Yi * Zi;
+    Mzz += Zi * Zi;
   }
   Mxx /= weight;
   Myy /= weight;
@@ -111,12 +112,12 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   //  computing coefficients of the characteristic polynomial
 
   const double Mz = Mxx + Myy;
-  const double Cov_xy = Mxx*Myy - Mxy*Mxy;
-  const double Var_z = Mzz - Mz*Mz;
-  const double A3 = 4*Mz;
-  const double A2 = -3*Mz*Mz - Mzz;
-  const double A1 = Var_z*Mz + 4*Cov_xy*Mz - Mxz*Mxz - Myz*Myz;
-  const double A0 = Mxz*(Mxz*Myy - Myz*Mxy) + Myz*(Myz*Mxx - Mxz*Mxy) - Var_z*Cov_xy;
+  const double Cov_xy = Mxx * Myy - Mxy * Mxy;
+  const double Var_z = Mzz - Mz * Mz;
+  const double A3 = 4 * Mz;
+  const double A2 = -3 * Mz * Mz - Mzz;
+  const double A1 = Var_z * Mz + 4 * Cov_xy * Mz - Mxz * Mxz - Myz * Myz;
+  const double A0 = Mxz * (Mxz * Myy - Myz * Mxy) + Myz * (Myz * Mxx - Mxz * Mxy) - Var_z * Cov_xy;
   const double A22 = A2 + A2;
   const double A33 = A3 + A3 + A3;
 
@@ -128,104 +129,104 @@ TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const Tr
   double y = A0;
 
   // usually, 4-6 iterations are enough
-  for( int iter=0; iter<iter_max; ++iter)
+  for (int iter = 0; iter < iter_max; ++iter)
   {
-    const double Dy = A1 + x*(A22 + A33*x);
-    const double xnew = x - y/Dy;
-    if ((xnew == x)||(!std::isfinite(xnew))) break;
+    const double Dy = A1 + x * (A22 + A33 * x);
+    const double xnew = x - y / Dy;
+    if ((xnew == x) || (!std::isfinite(xnew))) break;
 
-    const double ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
-    if (std::abs(ynew)>=std::abs(y))  break;
+    const double ynew = A0 + xnew * (A1 + xnew * (A2 + xnew * A3));
+    if (std::abs(ynew) >= std::abs(y)) break;
 
-    x = xnew;  y = ynew;
-
+    x = xnew;
+    y = ynew;
   }
 
   //  computing parameters of the fitting circle
-  const double DET = square(x) - x*Mz + Cov_xy;
-  const double Xcenter = (Mxz*(Myy - x) - Myz*Mxy)/DET/2;
-  const double Ycenter = (Myz*(Mxx - x) - Mxz*Mxy)/DET/2;
+  const double DET = square(x) - x * Mz + Cov_xy;
+  const double Xcenter = (Mxz * (Myy - x) - Myz * Mxy) / DET / 2;
+  const double Ycenter = (Myz * (Mxx - x) - Mxz * Mxy) / DET / 2;
 
   //  assembling the output
   double X0 = Xcenter + meanX;
   double Y0 = Ycenter + meanY;
-  double R = std::sqrt( square(Xcenter) + square(Ycenter) + Mz);
-  return std::make_tuple( R, X0, Y0 );
-
+  double R = std::sqrt(square(Xcenter) + square(Ycenter) + Mz);
+  return std::make_tuple(R, X0, Y0);
 }
 
 //_________________________________________________________________________________
-TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin( const std::vector<Acts::Vector3>& positions )
+TrackFitUtils::circle_fit_output_t TrackFitUtils::circle_fit_by_taubin(const std::vector<Acts::Vector3>& positions)
 {
   position_vector_t positions_2d;
-  for( const auto& position:positions )
-  { positions_2d.emplace_back( position.x(), position.y() ); }
+  for (const auto& position : positions)
+  {
+    positions_2d.emplace_back(position.x(), position.y());
+  }
 
-  return circle_fit_by_taubin( positions_2d );
+  return circle_fit_by_taubin(positions_2d);
 }
 
 //_________________________________________________________________________________
 TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::position_vector_t& positions)
 {
-  double xsum=0;
-  double x2sum=0;
-  double ysum=0;
-  double xysum=0;
-  for( const auto& [r,z]:positions )
+  double xsum = 0;
+  double x2sum = 0;
+  double ysum = 0;
+  double xysum = 0;
+  for (const auto& [r, z] : positions)
   {
-    xsum=xsum+r;                        //calculate sigma(xi)
-    ysum=ysum+z;                        //calculate sigma(yi)
-    x2sum=x2sum+square(r);              //calculate sigma(x^2i)
-    xysum=xysum+r*z;                    //calculate sigma(xi*yi)
+    xsum = xsum + r;            // calculate sigma(xi)
+    ysum = ysum + z;            // calculate sigma(yi)
+    x2sum = x2sum + square(r);  // calculate sigma(x^2i)
+    xysum = xysum + r * z;      // calculate sigma(xi*yi)
   }
 
   const auto npts = positions.size();
-  const double denominator = (x2sum*npts-square(xsum));
-  const double a= (xysum*npts-xsum*ysum)/denominator;            //calculate slope
-  const double b= (x2sum*ysum-xsum*xysum)/denominator;           //calculate intercept
-  return std::make_tuple( a, b );
+  const double denominator = (x2sum * npts - square(xsum));
+  const double a = (xysum * npts - xsum * ysum) / denominator;   // calculate slope
+  const double b = (x2sum * ysum - xsum * xysum) / denominator;  // calculate intercept
+  return std::make_tuple(a, b);
 }
 
 //_________________________________________________________________________________
-TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit( const std::vector<Acts::Vector3>& positions )
+TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const std::vector<Acts::Vector3>& positions)
 {
   position_vector_t positions_2d;
-  for( const auto& position:positions )
-  { positions_2d.emplace_back( std::sqrt( square(position.x())+square(position.y())), position.z() ); }
+  for (const auto& position : positions)
+  {
+    positions_2d.emplace_back(std::sqrt(square(position.x()) + square(position.y())), position.z());
+  }
 
-  return line_fit( positions_2d );
+  return line_fit(positions_2d);
 }
 
 //_________________________________________________________________________________
-TrackFitUtils::circle_circle_intersection_output_t TrackFitUtils::circle_circle_intersection(double r1, double r2, double x2, double y2 )
+TrackFitUtils::circle_circle_intersection_output_t TrackFitUtils::circle_circle_intersection(double r1, double r2, double x2, double y2)
 {
-  
   const double D = square(r1) - square(r2) + square(x2) + square(y2);
-  const double a = 1.0 + square(x2/y2);
-  const double b = - D * x2/square(y2);
-  const double c = square(D/(2.*y2)) - square(r1);
-  const double delta = square(b)-4.*a*c;
-  
-  const double sqdelta = std::sqrt( delta );
-  
-  const double xplus = (-b + sqdelta ) / (2. * a);
-  const double xminus = (-b - sqdelta ) / (2. * a);
-  
-  const double yplus  = -(2*x2*xplus - D) / (2.*y2);
-  const double yminus = -(2*x2*xminus - D) / (2.*y2);
+  const double a = 1.0 + square(x2 / y2);
+  const double b = -D * x2 / square(y2);
+  const double c = square(D / (2. * y2)) - square(r1);
+  const double delta = square(b) - 4. * a * c;
 
-  
-  return std::make_tuple( xplus, yplus, xminus, yminus );
+  const double sqdelta = std::sqrt(delta);
 
+  const double xplus = (-b + sqdelta) / (2. * a);
+  const double xminus = (-b - sqdelta) / (2. * a);
+
+  const double yplus = -(2 * x2 * xplus - D) / (2. * y2);
+  const double yminus = -(2 * x2 * xminus - D) / (2. * y2);
+
+  return std::make_tuple(xplus, yplus, xminus, yminus);
 }
 
 //_________________________________________________________________________________
-unsigned int TrackFitUtils::addSiliconClusters(std::vector<float>& fitpars, 
-					       double dca_cut,
-					       ActsGeometry* _tGeometry, 
-					       TrkrClusterContainer * _cluster_map,
-					       std::vector<Acts::Vector3>& global_vec,  
-					       std::vector<TrkrDefs::cluskey>& cluskey_vec)
+unsigned int TrackFitUtils::addSiliconClusters(std::vector<float>& fitpars,
+                                               double dca_cut,
+                                               ActsGeometry* _tGeometry,
+                                               TrkrClusterContainer* _cluster_map,
+                                               std::vector<Acts::Vector3>& global_vec,
+                                               std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {
   // project the fit of the TPC clusters to each silicon layer, and find the nearest silicon cluster
   // iterate over the cluster map and find silicon clusters that match this track fit
@@ -238,64 +239,60 @@ unsigned int TrackFitUtils::addSiliconClusters(std::vector<float>& fitpars,
   std::vector<TrkrDefs::cluskey> best_layer_cluskey;
   best_layer_cluskey.assign(7, 0);
 
-  for(const auto& det : {TrkrDefs::TrkrId::mvtxId, TrkrDefs::TrkrId::inttId})
-{
-  for(const auto& hitsetkey:_cluster_map->getHitSetKeys(det))
+  for (const auto& det : {TrkrDefs::TrkrId::mvtxId, TrkrDefs::TrkrId::inttId})
+  {
+    for (const auto& hitsetkey : _cluster_map->getHitSetKeys(det))
     {
       auto range = _cluster_map->getClusters(hitsetkey);
-      for( auto clusIter = range.first; clusIter != range.second; ++clusIter )
-	{
-	  TrkrDefs::cluskey cluskey = clusIter->first;
-	  unsigned int layer = TrkrDefs::getLayer(cluskey);
-	
-	
-	  TrkrCluster* cluster = clusIter->second;
-	  auto global = _tGeometry->getGlobalPosition(cluskey, cluster);
+      for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
+      {
+        TrkrDefs::cluskey cluskey = clusIter->first;
+        unsigned int layer = TrkrDefs::getLayer(cluskey);
 
-	  Acts::Vector3 pca = get_helix_pca(fitpars, global);
-	  float dca = (pca - global).norm();
-	  
-	  Acts::Vector2 global_xy(global(0), global(1));
-	  Acts::Vector2 pca_xy(pca(0), pca(1));
-	  Acts::Vector2 pca_xy_residual = pca_xy - global_xy;
-	  dca = pca_xy_residual.norm();
-	    
+        TrkrCluster* cluster = clusIter->second;
+        auto global = _tGeometry->getGlobalPosition(cluskey, cluster);
 
-	  if(dca < best_layer_dca[layer])
-	    {
-	      best_layer_dca[layer] = dca;
-	      best_layer_cluskey[layer] = cluskey;
-	    }
-	}  // end cluster iteration
-    } // end hitsetkey iteration
-}
-  for(unsigned int layer = 0; layer < 7; ++layer)
+        Acts::Vector3 pca = get_helix_pca(fitpars, global);
+        float dca = (pca - global).norm();
+
+        Acts::Vector2 global_xy(global(0), global(1));
+        Acts::Vector2 pca_xy(pca(0), pca(1));
+        Acts::Vector2 pca_xy_residual = pca_xy - global_xy;
+        dca = pca_xy_residual.norm();
+
+        if (dca < best_layer_dca[layer])
+        {
+          best_layer_dca[layer] = dca;
+          best_layer_cluskey[layer] = cluskey;
+        }
+      }  // end cluster iteration
+    }    // end hitsetkey iteration
+  }
+  for (unsigned int layer = 0; layer < 7; ++layer)
+  {
+    if (best_layer_dca[layer] < dca_cut)
     {
-      if(best_layer_dca[layer] < dca_cut)
-	{
-	 
-            cluskey_vec.push_back(best_layer_cluskey[layer]);
-	    auto clus =  _cluster_map->findCluster(best_layer_cluskey[layer]);
-	    auto global = _tGeometry->getGlobalPosition(best_layer_cluskey[layer], clus);
-	    global_vec.push_back(global);
-	    nsilicon++;
-          
-	}
+      cluskey_vec.push_back(best_layer_cluskey[layer]);
+      auto clus = _cluster_map->findCluster(best_layer_cluskey[layer]);
+      auto global = _tGeometry->getGlobalPosition(best_layer_cluskey[layer], clus);
+      global_vec.push_back(global);
+      nsilicon++;
     }
+  }
 
   return nsilicon;
 }
 
 //_________________________________________________________________________________
-Acts::Vector3 TrackFitUtils::get_helix_pca(std::vector<float>& fitpars, 
-					   Acts::Vector3 global)
+Acts::Vector3 TrackFitUtils::get_helix_pca(std::vector<float>& fitpars,
+                                           Acts::Vector3 global)
 {
   // no analytic solution for the coordinates of the closest approach of a helix to a point
-  // Instead, we get the PCA in x and y to the circle, and the PCA in z to the z vs R line at the R of the PCA 
+  // Instead, we get the PCA in x and y to the circle, and the PCA in z to the z vs R line at the R of the PCA
 
   float radius = fitpars[0];
   float x0 = fitpars[1];
-  float y0 = fitpars[2];  
+  float y0 = fitpars[2];
   float zslope = fitpars[3];
   float z0 = fitpars[4];
 
@@ -307,17 +304,17 @@ Acts::Vector3 TrackFitUtils::get_helix_pca(std::vector<float>& fitpars,
   Acts::Vector3 pca(pca_circle(0), pca_circle(1), pca_z);
 
   // now we want a second point on the helix so we can get a local straight line approximation to the track
-  // project the circle PCA vector an additional small amount and find the helix PCA to that point 
+  // project the circle PCA vector an additional small amount and find the helix PCA to that point
   float projection = 0.25;  // cm
-  Acts::Vector3 second_point = pca + projection * pca/pca.norm();
+  Acts::Vector3 second_point = pca + projection * pca / pca.norm();
   Acts::Vector2 second_point_pca_circle = get_circle_point_pca(radius, x0, y0, second_point);
   float second_point_pca_z = pca_circle_radius * zslope + z0;
   Acts::Vector3 second_point_pca(second_point_pca_circle(0), second_point_pca_circle(1), second_point_pca_z);
 
   // pca and second_point_pca define a straight line approximation to the track
-  Acts::Vector3 tangent = (second_point_pca - pca) /  (second_point_pca - pca).norm();
+  Acts::Vector3 tangent = (second_point_pca - pca) / (second_point_pca - pca).norm();
 
- // get the PCA of the cluster to that line
+  // get the PCA of the cluster to that line
   Acts::Vector3 final_pca = getPCALinePoint(global, tangent, pca);
 
   return final_pca;
@@ -328,7 +325,7 @@ Acts::Vector2 TrackFitUtils::get_circle_point_pca(float radius, float x0, float 
 {
   // get the PCA of a cluster (x,y) position to a circle
   // draw a line from the origin of the circle to the point
-  // the intersection of the line with the circle is at the distance radius from the origin along that line 
+  // the intersection of the line with the circle is at the distance radius from the origin along that line
 
   Acts::Vector2 origin(x0, y0);
   Acts::Vector2 point(global(0), global(1));
@@ -339,85 +336,87 @@ Acts::Vector2 TrackFitUtils::get_circle_point_pca(float radius, float x0, float 
 }
 
 //_________________________________________________________________________________
-std::vector<float> TrackFitUtils::fitClusters(std::vector<Acts::Vector3>& global_vec, 
-					      std::vector<TrkrDefs::cluskey> cluskey_vec)
+std::vector<float> TrackFitUtils::fitClusters(std::vector<Acts::Vector3>& global_vec,
+                                              std::vector<TrkrDefs::cluskey> cluskey_vec)
 {
-     std::vector<float> fitpars;
+  std::vector<float> fitpars;
 
-      // make the helical fit using TrackFitUtils
-      if(global_vec.size() < 3)  
-	{ return fitpars; }
-      std::tuple<double, double, double> circle_fit_pars = TrackFitUtils::circle_fit_by_taubin(global_vec);
+  // make the helical fit using TrackFitUtils
+  if (global_vec.size() < 3)
+  {
+    return fitpars;
+  }
+  std::tuple<double, double, double> circle_fit_pars = TrackFitUtils::circle_fit_by_taubin(global_vec);
 
-      // It is problematic that the large errors on the INTT strip z values are not allowed for - drop the INTT from the z line fit
-      std::vector<Acts::Vector3> global_vec_noINTT;
-      for(unsigned int ivec=0;ivec<global_vec.size(); ++ivec)
-	{
-	  
-	  unsigned int trkrid = TrkrDefs::getTrkrId(cluskey_vec[ivec]);
-	  
-	  if(trkrid != TrkrDefs::inttId and cluskey_vec[ivec] != 0)
-	    {
-	      global_vec_noINTT.push_back(global_vec[ivec]); 
-	    }
+  // It is problematic that the large errors on the INTT strip z values are not allowed for - drop the INTT from the z line fit
+  std::vector<Acts::Vector3> global_vec_noINTT;
+  for (unsigned int ivec = 0; ivec < global_vec.size(); ++ivec)
+  {
+    unsigned int trkrid = TrkrDefs::getTrkrId(cluskey_vec[ivec]);
 
-	}
-      
-      if(global_vec_noINTT.size() < 3) 
-	{ return fitpars; }
-      std::tuple<double,double> line_fit_pars = TrackFitUtils::line_fit(global_vec_noINTT);
-      
-      fitpars.push_back( std::get<0>(circle_fit_pars));
-      fitpars.push_back( std::get<1>(circle_fit_pars));
-      fitpars.push_back( std::get<2>(circle_fit_pars));
-      fitpars.push_back( std::get<0>(line_fit_pars));
-      fitpars.push_back( std::get<1>(line_fit_pars));
-      
-      return fitpars; 
+    if (trkrid != TrkrDefs::inttId and cluskey_vec[ivec] != 0)
+    {
+      global_vec_noINTT.push_back(global_vec[ivec]);
+    }
+  }
+
+  if (global_vec_noINTT.size() < 3)
+  {
+    return fitpars;
+  }
+  std::tuple<double, double> line_fit_pars = TrackFitUtils::line_fit(global_vec_noINTT);
+
+  fitpars.push_back(std::get<0>(circle_fit_pars));
+  fitpars.push_back(std::get<1>(circle_fit_pars));
+  fitpars.push_back(std::get<2>(circle_fit_pars));
+  fitpars.push_back(std::get<0>(line_fit_pars));
+  fitpars.push_back(std::get<1>(line_fit_pars));
+
+  return fitpars;
 }
 
 //_________________________________________________________________________________
-void TrackFitUtils::getTrackletClusters( ActsGeometry * _tGeometry, 
-					TrkrClusterContainer * _cluster_map,
-					std::vector<Acts::Vector3>& global_vec, 
-					std::vector<TrkrDefs::cluskey>& cluskey_vec)
+void TrackFitUtils::getTrackletClusters(ActsGeometry* _tGeometry,
+                                        TrkrClusterContainer* _cluster_map,
+                                        std::vector<Acts::Vector3>& global_vec,
+                                        std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {
-  for (unsigned int iclus=0;  iclus < cluskey_vec.size(); ++iclus)
+  for (unsigned int iclus = 0; iclus < cluskey_vec.size(); ++iclus)
+  {
+    auto key = cluskey_vec[iclus];
+    auto cluster = _cluster_map->findCluster(key);
+    if (!cluster)
     {
-      auto key = cluskey_vec[iclus];
-      auto cluster = _cluster_map->findCluster(key);
-      if(!cluster)
-	{
-	  std::cout << "Failed to get cluster with key " << key << std::endl;
-	  continue;
-	}	  
-            
-      Acts::Vector3 global  = _tGeometry->getGlobalPosition(key, cluster);	  
-      
-      /*
-      const unsigned int trkrId = TrkrDefs::getTrkrId(key);	  
-      // have to add corrections for TPC clusters after transformation to global
-      if(trkrId == TrkrDefs::tpcId) 
-	{  
-	  int crossing = 0;  // for now
-	  makeTpcGlobalCorrections(key, crossing, global); 
-	}
-      */
-      
-      // add the global positions to a vector to return
-      global_vec.push_back(global);
-      
-    } // end loop over clusters for this track 
+      std::cout << "Failed to get cluster with key " << key << std::endl;
+      continue;
+    }
+
+    Acts::Vector3 global = _tGeometry->getGlobalPosition(key, cluster);
+
+    /*
+    const unsigned int trkrId = TrkrDefs::getTrkrId(key);
+    // have to add corrections for TPC clusters after transformation to global
+    if(trkrId == TrkrDefs::tpcId)
+      {
+        int crossing = 0;  // for now
+        makeTpcGlobalCorrections(key, crossing, global);
+      }
+    */
+
+    // add the global positions to a vector to return
+    global_vec.push_back(global);
+
+  }  // end loop over clusters for this track
 }
 
 //_________________________________________________________________________________
 Acts::Vector3 TrackFitUtils::getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref)
 {
-  // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)   
+  // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)
 
   // The position of the closest point on the line to global is:
   // posref + projection of difference between the point and posref on the tangent vector
-  Acts::Vector3 pca = posref + ( (global - posref).dot(tangent) ) * tangent;
+  Acts::Vector3 pca = posref + ((global - posref).dot(tangent)) * tangent;
   /*
   if( (pca-posref).norm() > 0.001)
     {
@@ -433,11 +432,10 @@ Acts::Vector3 TrackFitUtils::getPCALinePoint(Acts::Vector3 global, Acts::Vector3
 std::vector<double> TrackFitUtils::getLineClusterResiduals(TrackFitUtils::position_vector_t& rz_pts, float slope, float intercept)
 {
   std::vector<double> residuals;
-   // calculate cluster residuals from the fitted circle
-  std::transform( rz_pts.begin(), rz_pts.end(), 
-		  std::back_inserter(residuals), [slope,intercept]( 
-				     const std::pair<double,double>& point )
-  {
+  // calculate cluster residuals from the fitted circle
+  std::transform(rz_pts.begin(), rz_pts.end(),
+                 std::back_inserter(residuals), [slope, intercept](const std::pair<double, double>& point)
+                 {
     double r = point.first;
     double z = point.second;
     
@@ -446,24 +444,21 @@ std::vector<double> TrackFitUtils::getLineClusterResiduals(TrackFitUtils::positi
     double a = -slope;
     double b = 1.0;
     double c = -intercept;
-    return std::abs(a*r+b*z+c)/sqrt(square(a)+square(b));
-  });
+    return std::abs(a*r+b*z+c)/sqrt(square(a)+square(b)); });
   return residuals;
 }
 
 std::vector<double> TrackFitUtils::getCircleClusterResiduals(TrackFitUtils::position_vector_t& xy_pts, float R, float X0, float Y0)
 {
   std::vector<double> residuals;
-  std::transform(xy_pts.begin(), xy_pts.end(), 
-		 std::back_inserter(residuals), [R,X0,Y0]( 
-				    const std::pair<double,double>& point )
-  {
+  std::transform(xy_pts.begin(), xy_pts.end(),
+                 std::back_inserter(residuals), [R, X0, Y0](const std::pair<double, double>& point)
+                 {
     double x = point.first;
     double y = point.second;
 
     // The shortest distance of a point from a circle is along the radial; line from the circle center to the point
-    return std::sqrt( square(x-X0) + square(y-Y0) )  -  R;  
-  } );
- 
+    return std::sqrt( square(x-X0) + square(y-Y0) )  -  R; });
+
   return residuals;
 }

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -14,15 +14,13 @@ class TrkrClusterContainer;
 
 class TrackFitUtils
 {
-
-  public:
-
+ public:
   using position_t = std::pair<double, double>;
   using position_vector_t = std::vector<position_t>;
 
   /// circle fit output [R, x0, y0]
   using circle_fit_output_t = std::tuple<double, double, double>;
-  
+
   /**
    * Circle fit to a given set of data points (in 2D)
    * This is an algebraic fit, due to Taubin, based on the journal article
@@ -38,10 +36,10 @@ class TrackFitUtils
   static circle_fit_output_t circle_fit_by_taubin(const position_vector_t&);
 
   /// convenient overload
-  static circle_fit_output_t circle_fit_by_taubin(const std::vector<Acts::Vector3>& );
+  static circle_fit_output_t circle_fit_by_taubin(const std::vector<Acts::Vector3>&);
 
   /// line fit output [slope, intercept]
-  using line_fit_output_t = std::tuple<double,double>;
+  using line_fit_output_t = std::tuple<double, double>;
 
   /// line_fit
   /**
@@ -51,12 +49,11 @@ class TrackFitUtils
   static line_fit_output_t line_fit(const position_vector_t&);
 
   /// convenient overload
-  static line_fit_output_t line_fit(const std::vector<Acts::Vector3>& );
+  static line_fit_output_t line_fit(const std::vector<Acts::Vector3>&);
 
   /// circle-circle intersection output. (xplus, yplus, xminus, yminus)
   using circle_circle_intersection_output_t = std::tuple<double, double, double, double>;
 
-  
   /**
    * r1 is radius of sPHENIX layer
    * r2, x2 and y2 are parameters of circle fitted to TPC clusters
@@ -70,29 +67,29 @@ class TrackFitUtils
    * iy = - (2*x2*x - D) / 2*y2,
    * then substitute for y in equation of circle 1
    */
-  static circle_circle_intersection_output_t circle_circle_intersection( double r1, double r2, double x2, double y2 );  
+  static circle_circle_intersection_output_t circle_circle_intersection(double r1, double r2, double x2, double y2);
 
-  static unsigned int addSiliconClusters(std::vector<float>& fitpars, 
-					 double dca_cut,
-					 ActsGeometry* _tGeometry,
-					 TrkrClusterContainer * _cluster_map,
-					 std::vector<Acts::Vector3>& global_vec,  
-					 std::vector<TrkrDefs::cluskey>& cluskey_vec);
+  static unsigned int addSiliconClusters(std::vector<float>& fitpars,
+                                         double dca_cut,
+                                         ActsGeometry* _tGeometry,
+                                         TrkrClusterContainer* _cluster_map,
+                                         std::vector<Acts::Vector3>& global_vec,
+                                         std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
-    static std::pair<Acts::Vector3, Acts::Vector3> get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3& global);
+  static std::pair<Acts::Vector3, Acts::Vector3> get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3& global);
 
   static Acts::Vector3 get_helix_pca(std::vector<float>& fitpars, Acts::Vector3 global);
 
   static Acts::Vector2 get_circle_point_pca(float radius, float x0, float y0, Acts::Vector3 global);
 
-  static std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, 
-						       std::vector<TrkrDefs::cluskey> cluskey_vec);
-  static void getTrackletClusters( ActsGeometry * _tGeometry, 
-				  TrkrClusterContainer * _cluster_map,
-				  std::vector<Acts::Vector3>& global_vec, 
-				  std::vector<TrkrDefs::cluskey>& cluskey_vec);
+  static std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec,
+                                        std::vector<TrkrDefs::cluskey> cluskey_vec);
+  static void getTrackletClusters(ActsGeometry* _tGeometry,
+                                  TrkrClusterContainer* _cluster_map,
+                                  std::vector<Acts::Vector3>& global_vec,
+                                  std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
-  static Acts::Vector3 getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref); 
+  static Acts::Vector3 getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref);
 
   static std::vector<double> getLineClusterResiduals(position_vector_t& rz_pts, float slope, float intercept);
   static std::vector<double> getCircleClusterResiduals(position_vector_t& xy_pts, float R, float X0, float Y0);

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -18,6 +18,7 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
+  -L$(MYINSTALL)/lib64 \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
@@ -42,6 +43,7 @@ pkginclude_HEADERS = \
   PHCASeeding.h \
   PHCosmicsTrkFitter.h \
   PHCosmicSeedCombiner.h \
+  PHCosmicSiliconPropagator.h \
   PHGenFitTrackProjection.h \
   PHGenFitTrkFitter.h \
   PHGhostRejection.h \
@@ -121,6 +123,7 @@ libtrack_reco_la_SOURCES = \
   PH3DVertexing.cc \
   PHCASeeding.cc \
   PHCosmicSeedCombiner.cc \
+  PHCosmicSiliconPropagator.cc \
   PHGenFitTrackProjection.cc \
   PHGenFitTrkFitter.cc \
   PHGhostRejection.cc \

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -115,7 +115,8 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
         auto clusglob = _tgeometry->getGlobalPosition(sickey, cluster);
         auto pca = TrackFitUtils::get_helix_pca(fitparams, clusglob);
         float dcaz = (pca - clusglob).z();
-        if (dcaz < _dca_z_cut)
+       
+        if (fabs(dcaz) < _dca_z_cut)
         {
           si_seed->insert_cluster_key(sickey);
         }

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -1,0 +1,186 @@
+
+#include "PHCosmicSiliconPropagator.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrackFitUtils.h>
+#include <trackbase/TrkrClusterCrossingAssoc.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/SvtxTrackSeed_v1.h>
+#include <trackbase_historic/TrackSeedContainer.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeed_v1.h>
+//____________________________________________________________________________..
+PHCosmicSiliconPropagator::PHCosmicSiliconPropagator(const std::string& name)
+  : SubsysReco(name)
+{
+}
+
+//____________________________________________________________________________..
+PHCosmicSiliconPropagator::~PHCosmicSiliconPropagator()
+{
+}
+
+//____________________________________________________________________________..
+int PHCosmicSiliconPropagator::Init(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHCosmicSiliconPropagator::InitRun(PHCompositeNode* topNode)
+{
+  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!_cluster_map)
+  {
+    std::cerr << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _tgeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!_tgeometry)
+  {
+    std::cout << "No Acts tracking geometry, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  _tpc_seeds = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  if (!_tpc_seeds)
+  {
+    std::cout << "No TpcTrackSeedContainer, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  _si_seeds = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
+  if (!_si_seeds)
+  {
+    std::cout << "No SiliconTrackSeedContainer, creating..." << std::endl;
+    if (createSeedContainer(_si_seeds, "SiliconTrackSeedContainer", topNode) != Fun4AllReturnCodes::EVENT_OK)
+    {
+      std::cout << "Cannot create, exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+  _svtx_seeds = findNode::getClass<TrackSeedContainer>(topNode, _track_map_name);
+  if (!_svtx_seeds)
+  {
+    std::cout << "No " << _track_map_name << " found, creating..." << std::endl;
+    if (createSeedContainer(_svtx_seeds, _track_map_name, topNode) != Fun4AllReturnCodes::EVENT_OK)
+    {
+      std::cout << "Cannot create, exiting." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
+{
+  for (auto& tpcseed : *_tpc_seeds)
+  {
+    if (!tpcseed)
+    {
+      continue;
+    }
+    std::vector<Acts::Vector3> tpcClusPos;
+    std::vector<TrkrDefs::cluskey> tpcClusKeys;
+
+    std::copy(tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys(),
+              std::back_inserter(tpcClusKeys));
+
+    TrackFitUtils::getTrackletClusters(_tgeometry, _cluster_map,
+                                       tpcClusPos, tpcClusKeys);
+    std::vector<float> fitparams = TrackFitUtils::fitClusters(tpcClusPos, tpcClusKeys);
+    //! There weren't enough clusters to fit
+    if (fitparams.size() == 0)
+    {
+      continue;
+    }
+
+    std::vector<TrkrDefs::cluskey> silClusKeys;
+    std::vector<Acts::Vector3> silClusPos;
+
+    unsigned int nSiClusters = TrackFitUtils::addSiliconClusters(fitparams, 100., _tgeometry, _cluster_map, silClusPos, silClusKeys);
+
+    if (nSiClusters > 0)
+    {
+      std::unique_ptr<TrackSeed_v1> si_seed = std::make_unique<TrackSeed_v1>();
+      for (auto& sickey : silClusKeys)
+      {
+        auto cluster = _cluster_map->findCluster(sickey);
+        auto clusglob = _tgeometry->getGlobalPosition(sickey, cluster);
+        auto pca = TrackFitUtils::get_helix_pca(fitparams, clusglob);
+        float dcaz = (pca - clusglob).z();
+        if (dcaz < _dca_z_cut)
+        {
+          si_seed->insert_cluster_key(sickey);
+        }
+      }
+      si_seed->circleFitByTaubin(_cluster_map, _tgeometry, 0, 8);
+      si_seed->lineFit(_cluster_map, _tgeometry, 0, 8);
+      TrackSeed* mapped_seed = _si_seeds->insert(si_seed.get());
+      std::unique_ptr<SvtxTrackSeed_v1> full_seed = std::make_unique<SvtxTrackSeed_v1>();
+      int tpcind = _tpc_seeds->find(tpcseed);
+      int siind = _si_seeds->find(mapped_seed);
+      full_seed->set_tpc_seed_index(tpcind);
+      full_seed->set_silicon_seed_index(siind);
+      _svtx_seeds->insert(full_seed.get());
+    }
+    else
+    {
+      // no Si clusters found, put TPC-only seed in SvtxTrackSeedContainer
+      std::unique_ptr<SvtxTrackSeed_v1> partial_seed = std::make_unique<SvtxTrackSeed_v1>();
+      int tpc_seed_index = _tpc_seeds->find(tpcseed);
+      partial_seed->set_tpc_seed_index(tpc_seed_index);
+      _svtx_seeds->insert(partial_seed.get());
+    }
+  }
+
+  if (Verbosity() > 2)
+  {
+    std::cout << "svtx seed map size is " << _svtx_seeds->size() << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int PHCosmicSiliconPropagator::End(PHCompositeNode*)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PHCosmicSiliconPropagator::createSeedContainer(TrackSeedContainer*& container, std::string container_name, PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  if (!dstNode)
+  {
+    std::cerr << "DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in PHSiliconHelicalPropagator::createNodes");
+  }
+
+  PHNodeIterator dstIter(dstNode);
+  PHCompositeNode* svtxNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode", "SVTX"));
+
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  container = findNode::getClass<TrackSeedContainer>(topNode, container_name);
+  if (!container)
+  {
+    container = new TrackSeedContainer_v1;
+    PHIODataNode<PHObject>* trackNode = new PHIODataNode<PHObject>(container, container_name, "PHObject");
+    svtxNode->addNode(trackNode);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -104,7 +104,7 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
     std::vector<TrkrDefs::cluskey> silClusKeys;
     std::vector<Acts::Vector3> silClusPos;
 
-    unsigned int nSiClusters = TrackFitUtils::addSiliconClusters(fitparams, 100., _tgeometry, _cluster_map, silClusPos, silClusKeys);
+    unsigned int nSiClusters = TrackFitUtils::addSiliconClusters(fitparams, _dca_xy_cut, _tgeometry, _cluster_map, silClusPos, silClusKeys);
 
     if (nSiClusters > 0)
     {

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.h
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.h
@@ -1,0 +1,42 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHCOSMICSILICONPROPAGATOR_H
+#define PHCOSMICSILICONPROPAGATOR_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class ActsGeometry;
+class TrackSeedContainer;
+class TrkrClusterContainer;
+
+class PHCosmicSiliconPropagator : public SubsysReco
+{
+ public:
+  PHCosmicSiliconPropagator(const std::string& name = "PHCosmicSiliconPropagator");
+
+  ~PHCosmicSiliconPropagator() override;
+
+  int Init(PHCompositeNode* topNode) override;
+  int InitRun(PHCompositeNode* topNode) override;
+  int process_event(PHCompositeNode* topNode) override;
+  int End(PHCompositeNode* topNode) override;
+  void set_track_map_name(std::string name) { _track_map_name = name; }
+  void set_dca_z_cut(float z) { _dca_z_cut = z; }
+
+ private:
+  int createSeedContainer(TrackSeedContainer*& container, const std::string container_name, PHCompositeNode* topNode);
+
+  ActsGeometry* _tgeometry = nullptr;
+  TrackSeedContainer* _si_seeds = nullptr;
+  TrackSeedContainer* _tpc_seeds = nullptr;
+  TrackSeedContainer* _svtx_seeds = nullptr;
+  TrkrClusterContainer* _cluster_map = nullptr;
+
+  float _dca_z_cut = 5.;
+  std::string _track_map_name = "SvtxTrackSeedContainer";
+};
+
+#endif  // PHCOSMICSILICONPROPAGATOR_H

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.h
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.h
@@ -25,6 +25,7 @@ class PHCosmicSiliconPropagator : public SubsysReco
   int End(PHCompositeNode* topNode) override;
   void set_track_map_name(std::string name) { _track_map_name = name; }
   void set_dca_z_cut(float z) { _dca_z_cut = z; }
+  void set_dca_xy_cut(float xy) { _dca_xy_cut = xy; }
 
  private:
   int createSeedContainer(TrackSeedContainer*& container, const std::string container_name, PHCompositeNode* topNode);
@@ -36,6 +37,7 @@ class PHCosmicSiliconPropagator : public SubsysReco
   TrkrClusterContainer* _cluster_map = nullptr;
 
   float _dca_z_cut = 5.;
+  float _dca_xy_cut = 100.;
   std::string _track_map_name = "SvtxTrackSeedContainer";
 };
 

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -373,12 +373,17 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
                     charge / momentum.norm(),
                     cov,
                     Acts::ParticleHypothesis::muon(), 
-		    100*Acts::UnitConstants::cm)
-                    .value();
+		    100*Acts::UnitConstants::cm);
+    if(!seed.ok())
+      { 
+	      std::cout << "Could not create track params, skipping track" << std::endl;
+	      continue;
+      }
+    
 
     if (Verbosity() > 2)
     {
-      printTrackSeed(seed);
+      printTrackSeed(seed.value());
     }
 
     //! Set host of propagator options for Acts to do e.g. material integration
@@ -404,7 +409,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         std::make_shared<Acts::VectorMultiTrajectory>();
     ActsTrackFittingAlgorithm::TrackContainer
         tracks(trackContainer, trackStateContainer);
-    auto result = fitTrack(sourceLinks, seed, kfOptions, calibrator, tracks);
+    auto result = fitTrack(sourceLinks, seed.value(), kfOptions, 
+			   calibrator, tracks);
 
     /// Check that the track fit result did not return an error
     if (result.ok())


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Adds a new module that is less restrictive than the current helicalpropagator module. The new module only propagates to the silicon and checks for clusters within some configurable dca xy and z cut. It also makes no restriction on the quadrant, which the previous module does as it was intended to be used in beam like conditions.

The PR also cleans up the `TrackFitUtils::addSiliconClusters` function by only iterating over silicon hitsetkeys and not making any requirement on the silicon layer, which there previously was (I'm guessing due to some copy paste error...)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

