### PR TITLE
adding timing status flag, default is +/- 2 from mean of the channel …

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -47,7 +47,8 @@ CaloTowerStatus::CaloTowerStatus(const std::string &name)
 //____________________________________________________________________________..
 CaloTowerStatus::~CaloTowerStatus()
 {
-  delete m_cdbttree;
+  delete m_cdbttree_chi2;
+  delete m_cdbttree_time;
   if (Verbosity() > 0)
   {
     std::cout << "CaloTowerStatus::~CaloTowerStatus() Calling dtor" << std::endl;
@@ -62,119 +63,51 @@ int CaloTowerStatus::InitRun(PHCompositeNode *topNode)
   if (m_dettype == CaloTowerDefs::CEMC)
   {
     m_detector = "CEMC";
-    std::string default_time_independent_calib = "cemc_pi0_twrSlope_v1_default";
-
-    if (!m_overrideCalibName)
-    {
-      m_calibName = "cemc_hotTowers_fracBadChi2";
-    }
-    if (!m_overrideFieldName)
-    {
-      m_fieldname = "fraction";
-    }
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (!calibdir.empty())
-    {
-      m_cdbttree = new CDBTTree(calibdir);
-    }
-    else
-    {
-      std::cout << "CaloTowerStatus::::InitRun No EMCal deadmap found" << std::endl;
-      m_doHot = false;
-    }
   }
   else if (m_dettype == CaloTowerDefs::HCALIN)
   {
     m_detector = "HCALIN";
-
-    if (!m_overrideCalibName)
-    {
-      m_calibName ="ihcal_hotTowers_fracBadChi2";
-    }
-    if (!m_overrideFieldName)
-    {
-      m_fieldname = "fraction";
-    }
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (!calibdir.empty())
-    {
-      m_cdbttree = new CDBTTree(calibdir);
-    }
-    else
-    {
-      std::cout << "CaloTowerStatus::::InitRun No masking file for domain " << m_calibName << " found, not doing isHot" << std::endl;
-      m_doHot = false;
-    }
   }
   else if (m_dettype == CaloTowerDefs::HCALOUT)
   {
     m_detector = "HCALOUT";
-
-    if (!m_overrideCalibName)
-    {
-      m_calibName = "ohcal_hotTowers_fracBadChi2";
-    }
-    if (!m_overrideFieldName)
-    {
-      m_fieldname = "fraction";
-    }
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (!calibdir.empty())
-    {
-      m_cdbttree = new CDBTTree(calibdir);
-    }
-    else
-    {
-      std::cout << "CaloTowerStatus::::InitRun No masking file for domain " << m_calibName << " found, not doing isHot" << std::endl;
-      m_doHot = false;
-    }
   }
   else if (m_dettype == CaloTowerDefs::ZDC)
   {
     m_detector = "ZDC";
-
-    if (!m_overrideCalibName)
-    {
-      m_calibName = "noMasker";
-    }
-    if (!m_overrideFieldName)
-    {
-      m_fieldname = "noMasker";
-    }
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (!calibdir.empty())
-    {
-      m_cdbttree = new CDBTTree(calibdir);
-    }
-    else
-    {
-      std::cout << "CaloTowerStatus::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
-      exit(1);
-    }
   }
 
   else if (m_dettype == CaloTowerDefs::SEPD)
   {
     m_detector = "SEPD";
+  }
 
-    if (!m_overrideCalibName)
-    {
-      m_calibName = "noCalibYet";
-    }
-    if (!m_overrideFieldName)
-    {
-      m_fieldname = "noCalibYet";
-    }
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (!calibdir.empty())
-    {
-      m_cdbttree = new CDBTTree(calibdir);
-    }
-    else
-    {
-      std::cout << "CaloTowerStatus::::InitRun No calibration file for domain " << m_calibName << " found" << std::endl;
-      exit(1);
-    }
+  m_calibName_chi2 = m_detector + "_hotTowers_fracBadChi2";
+  m_fieldname_chi2 = "fraction";
+
+  std::string calibdir = CDBInterface::instance()->getUrl(m_calibName_chi2);
+  if (!calibdir.empty())
+  {
+    m_cdbttree_chi2 = new CDBTTree(calibdir);
+  }
+  else
+  {
+    std::cout << "CaloTowerStatus::::InitRun No masking file for domain " << m_calibName_chi2 << " found, not doing isHot" << std::endl;
+    m_doHot = false;
+  }
+
+  m_calibName_time = m_detector + "_meanTime";
+  m_fieldname_time = "time";
+
+  calibdir = CDBInterface::instance()->getUrl(m_calibName_time);
+  if (!calibdir.empty())
+  {
+    m_cdbttree_time = new CDBTTree(calibdir);
+  }
+  else
+  {
+    std::cout << "CaloTowerStatus::::InitRun no timing info, " << m_calibName_time << " not found, not doing isHot" << std::endl;
+    m_doTime = false;
   }
 
   PHNodeIterator iter(topNode);
@@ -209,17 +142,27 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
 {
   unsigned int ntowers = m_raw_towers->size();
   float fraction_badChi2 = 0;
+  float mean_time = 0;
   for (unsigned int channel = 0; channel < ntowers; channel++)
   {
     unsigned int key = m_raw_towers->encode_key(channel);
     if (m_doHot)
     {
-      fraction_badChi2 = m_cdbttree->GetFloatValue(key, m_fieldname);
+      fraction_badChi2 = m_cdbttree_chi2->GetFloatValue(key, m_fieldname_chi2);
+    }
+    if (m_doTime)
+    {
+      fraction_badChi2 = m_cdbttree_time->GetFloatValue(key, m_fieldname_time);
     }
     float chi2 = m_raw_towers->get_tower_at_channel(channel)->get_chi2();
+    float time = m_raw_towers->get_tower_at_channel(channel)->get_time_float();
     if (fraction_badChi2 > fraction_badChi2_threshold && m_doHot)
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
+    }
+    if (fabs(time-mean_time) > time_cut && m_doTime)
+    {
+      m_raw_towers->get_tower_at_channel(channel)->set_isBadTime(true);
     }
     if (chi2 > badChi2_treshold)
     {

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -33,18 +33,6 @@ class CaloTowerStatus : public SubsysReco
     m_dettype = dettype;
     return;
   }
-  void setCalibName(const std::string &name)
-  {
-    m_calibName = name;
-    m_overrideCalibName = 1;
-    return;
-  }
-  void setFieldName(const std::string &name)
-  {
-    m_fieldname = name;
-    m_overrideFieldName = 1;
-    return;
-  }
   void set_inputNodePrefix(const std::string &name)
   {
     m_inputNodePrefix = name;
@@ -60,24 +48,32 @@ class CaloTowerStatus : public SubsysReco
     fraction_badChi2_threshold = threshold;
     return;
   }
+  void set_time_cut(float threshold)
+  {
+    time_cut = threshold;
+    return;
+  }
 
  private:
   TowerInfoContainer *m_raw_towers{nullptr};
-  CDBTTree *m_cdbttree{nullptr};
+  CDBTTree *m_cdbttree_chi2{nullptr};
+  CDBTTree *m_cdbttree_time{nullptr};
 
-  bool m_overrideCalibName{false};
-  bool m_overrideFieldName{false};
   bool m_doHot{true};
+  bool m_doTime{true};
 
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
 
   std::string m_detector;
-  std::string m_fieldname;
-  std::string m_calibName;
+  std::string m_fieldname_time;
+  std::string m_calibName_time;
+  std::string m_fieldname_chi2;
+  std::string m_calibName_chi2;
   std::string m_inputNodePrefix{"TOWERS_"};
 
   float badChi2_treshold = 1e4;
   float fraction_badChi2_threshold = 0.05;
+  float time_cut = 2; // number of samples from the mean time for the channel in the run
 };
 
 #endif  // CALOTOWERBUILDER_H


### PR DESCRIPTION
…and run, but the cut is configurable from the macro.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

