### PR TITLE
Zdc event combiner

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputPoolManager.cc
@@ -75,7 +75,8 @@ int Fun4AllPrdfInputPoolManager::run(const int /*nevents*/)
       iter->FillPool(m_InitialPoolDepth);
       m_RunNumber = iter->RunNumber();
     }
-    CreateBclkOffsets();
+
+   CreateBclkOffsets();
     m_StartUpFlag = false;
   }
   bool event_ok = false;
@@ -373,6 +374,7 @@ SinglePrdfInput *Fun4AllPrdfInputPoolManager::AddPrdfInputFile(const std::string
 {
   SinglePrdfInput *prdfin = new SinglePrdfInput("PRDFIN_" + std::to_string(m_PrdfInputVector.size()), this);
   prdfin->AddFile(filenam);
+  prdfin->Verbosity(Verbosity());
   m_PrdfInputVector.push_back(prdfin);
   return m_PrdfInputVector.back();
 }

--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -60,6 +60,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
         return;
       }
     }
+
     m_RunNumber = evt->getRunNumber();
     if (Verbosity() > 1)
     {
@@ -71,23 +72,34 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       delete evt;
       continue;  // need handling for non data events
     }
+
     int EventSequence = evt->getEvtSequence();
     int npackets = evt->getPacketList(plist, 100);
+    std::cout << " Event SEquence " << EventSequence << " packet size: "<<npackets<<std::endl;
     if (npackets == 100)
     {
       exit(1);
     }
     for (int i = 0; i < npackets; i++)
     {
+      bool useFEMInfo =  (plist[i]->getIdentifier() / 1000 == 12);  
+
       if (plist[i]->iValue(0, "EVENCHECKSUMOK") != 0 && plist[i]->iValue(0, "ODDCHECKSUMOK") != 0)
       {
         int evtno = plist[i]->iValue(0, "EVTNR");
         unsigned int bclk = plist[i]->iValue(0, "CLOCK");
-        if (Verbosity() > 1)
-        {
+
+	if (useFEMInfo)
+	  {
+	    std::cout << " packet " << plist[i]->getIdentifier() << " Using FEMINFO" <<std::endl;
+	    evtno = plist[i]->iValue(0, "FEMEVTNR")  - 1;
+	    bclk = plist[i]->iValue(0, "FEMCLOCK");
+	  }
+	//        if (Verbosity() > 1)
+	//        {
           std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
                     << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
-        }
+	  // }
         // dummy check for the first event which is the problem for the calorimeters
         // it is the last event from the previous run, so it's event number is > 0
         // if (evtno > EventSequence)
@@ -126,7 +138,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
     {
       if (m_EvtSet.size() == 1)
       {
-        if (Verbosity() > 1)
+	//        if (Verbosity() > 1)
         {
           std::cout << "we are good evtno: " << *(m_EvtSet.begin())
                     << ", clock: " << m_PacketMap.begin()->first << std::endl;
@@ -134,7 +146,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       }
       else
       {
-        if (Verbosity() > 1)
+	//        if (Verbosity() > 1)
         {
           std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
                     << m_PacketMap.begin()->first << std::dec << std::endl;
@@ -144,7 +156,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
           }
         }
         common_event_number = majority_eventnumber();
-        if (Verbosity() > 1)
+	//        if (Verbosity() > 1)
         {
           std::cout << "picked event no " << common_event_number << std::endl;
         }
@@ -160,13 +172,13 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
     }
     else
     {
-      if (Verbosity() > 1)
+      //      if (Verbosity() > 1)
       {
         std::cout << "We have multiple beam clocks per event" << std::endl;
       }
       if (m_EvtSet.size() == 1)
       {
-        if (Verbosity() > 1)
+        //if (Verbosity() > 1)
         {
           std::cout << "we are good evtno: " << *(m_EvtSet.begin())
                     << ", clock: " << m_PacketMap.begin()->first << std::endl;
@@ -174,7 +186,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       }
       else
       {
-        if (Verbosity() > 1)
+	//      if (Verbosity() > 1)
         {
           std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
                     << m_PacketMap.begin()->first << std::dec << std::endl;
@@ -184,14 +196,14 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
           }
         }
         common_event_number = majority_eventnumber();
-        if (Verbosity() > 1)
+	//        if (Verbosity() > 1)
         {
           std::cout << "picked event no " << common_event_number << std::endl;
         }
         adjust_eventnumber_offset(common_event_number);
       }
       common_beam_clock = majority_beamclock();
-      if (Verbosity() > 1)
+      //      if (Verbosity() > 1)
       {
         std::cout << "picked bclk: " << std::hex << common_beam_clock << std::dec << std::endl;
       }

--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -75,7 +75,6 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
 
     int EventSequence = evt->getEvtSequence();
     int npackets = evt->getPacketList(plist, 100);
-    std::cout << " Event SEquence " << EventSequence << " packet size: "<<npackets<<std::endl;
     if (npackets == 100)
     {
       exit(1);
@@ -86,20 +85,20 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
 
       if (plist[i]->iValue(0, "EVENCHECKSUMOK") != 0 && plist[i]->iValue(0, "ODDCHECKSUMOK") != 0)
       {
-        int evtno = plist[i]->iValue(0, "EVTNR");
+        unsigned int evtno = plist[i]->iValue(0, "EVTNR");
         unsigned int bclk = plist[i]->iValue(0, "CLOCK");
 
 	if (useFEMInfo)
 	  {
-	    std::cout << " packet " << plist[i]->getIdentifier() << " Using FEMINFO" <<std::endl;
-	    evtno = plist[i]->iValue(0, "FEMEVTNR")  - 1;
-	    bclk = plist[i]->iValue(0, "FEMCLOCK");
+	    if (Verbosity() > 1) std::cout << " packet " << plist[i]->getIdentifier() << " Using FEMINFO" <<std::endl;
+	    evtno = (( plist[i]->iValue(0, "FEMEVTNR")  - 1 ) & 0xffff); // hard coded since FEM event starts at 1 and packet event starts at 0
+	    bclk = (( plist[i]->iValue(0, "FEMCLOCK") + 30 ) & 0xffff); // hardcoded since level 1 delay for ZDC is 30 beam clocks.
 	  }
-	//        if (Verbosity() > 1)
-	//        {
-          std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
-                    << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
-	  // }
+	if (Verbosity() > 1)
+	  {
+	    std::cout << "packet " << plist[i]->getIdentifier() << " evt: " << evtno
+		      << std::hex << " clock: 0x" << bclk << std::dec << std::endl;
+	  }
         // dummy check for the first event which is the problem for the calorimeters
         // it is the last event from the previous run, so it's event number is > 0
         // if (evtno > EventSequence)
@@ -138,7 +137,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
     {
       if (m_EvtSet.size() == 1)
       {
-	//        if (Verbosity() > 1)
+	if (Verbosity() > 1)
         {
           std::cout << "we are good evtno: " << *(m_EvtSet.begin())
                     << ", clock: " << m_PacketMap.begin()->first << std::endl;
@@ -146,7 +145,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       }
       else
       {
-	//        if (Verbosity() > 1)
+	if (Verbosity() > 1)
         {
           std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
                     << m_PacketMap.begin()->first << std::dec << std::endl;
@@ -156,7 +155,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
           }
         }
         common_event_number = majority_eventnumber();
-	//        if (Verbosity() > 1)
+	if (Verbosity() > 1)
         {
           std::cout << "picked event no " << common_event_number << std::endl;
         }
@@ -172,13 +171,13 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
     }
     else
     {
-      //      if (Verbosity() > 1)
+      if (Verbosity() > 1)
       {
         std::cout << "We have multiple beam clocks per event" << std::endl;
       }
       if (m_EvtSet.size() == 1)
       {
-        //if (Verbosity() > 1)
+        if (Verbosity() > 1)
         {
           std::cout << "we are good evtno: " << *(m_EvtSet.begin())
                     << ", clock: " << m_PacketMap.begin()->first << std::endl;
@@ -186,7 +185,7 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
       }
       else
       {
-	//      if (Verbosity() > 1)
+	if (Verbosity() > 1)
         {
           std::cout << "We have multiple event numbers for bclk: 0x" << std::hex
                     << m_PacketMap.begin()->first << std::dec << std::endl;
@@ -196,14 +195,14 @@ void SinglePrdfInput::FillPool(const unsigned int nevents)
           }
         }
         common_event_number = majority_eventnumber();
-	//        if (Verbosity() > 1)
+	if (Verbosity() > 1)
         {
           std::cout << "picked event no " << common_event_number << std::endl;
         }
         adjust_eventnumber_offset(common_event_number);
       }
       common_beam_clock = majority_beamclock();
-      //      if (Verbosity() > 1)
+      if (Verbosity() > 1)
       {
         std::cout << "picked bclk: " << std::hex << common_beam_clock << std::dec << std::endl;
       }

--- a/offline/framework/fun4allraw/SinglePrdfInput.h
+++ b/offline/framework/fun4allraw/SinglePrdfInput.h
@@ -46,6 +46,7 @@ class SinglePrdfInput : public Fun4AllBase, public InputFileHandler
   unsigned int m_NumSpecialEvents = 0;
   int m_EventNumberOffset = 1;               // packet event counters start at 0 but we start with event number 1
   int *m_PacketEventNumberOffset = nullptr;  // packet event counters start at 0 but we start with event number 1
+  int *m_useFEMInfo = nullptr;  // packet event counters start at 0 but we start with event number 1
   int m_RunNumber = 0;
   int m_EventsThisFile = 0;
   int m_AllDone = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR adds a hard coded boolean in the SinglePrdfInput class that checks if the packet ID is the ZDC packet ID and if the packet event number does not match the Event Sequence. If both of these pass, then the FEM info is used. If, not, the packet Info is still kept.

This does not change the event combining for runs that have succeeded in the past, but instead, adds runs where the ZDC data could not be combined.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

This is a draft pull request.

## Links to other PRs in macros and calibration repositories (if applicable)

[runlist_and_zdcrecovery-lis-20231128.pdf](https://github.com/sPHENIX-Collaboration/coresoftware/files/13505714/runlist_and_zdcrecovery-lis-20231128.pdf)
