### PR TITLE
Fix bug introduced by changing size of Jetv1

### DIFF
--- a/offline/packages/jetbase/Jetv1.cc
+++ b/offline/packages/jetbase/Jetv1.cc
@@ -162,6 +162,17 @@ std::vector<float>& Jetv1::get_property_vec() {
   return DummyJetPropVecv1;
 }
 
+size_t Jetv1::n_clustered() const {
+  not_in_v1_msg("n_clustered()");
+  return 0;
+}
+
+void Jetv1::set_n_clustered(unsigned int/**/) {
+  not_in_v1_msg("set_n_clustered()");
+  return;
+}
+
+
 // inline float Jetv1::get_prop_by_index(unsigned int /*index*/) const
 // {
 //   not_in_v1_msg("get_prop_by_index()");

--- a/offline/packages/jetbase/Jetv1.h
+++ b/offline/packages/jetbase/Jetv1.h
@@ -74,8 +74,9 @@ class Jetv1 : public Jet
   bool empty_comp() const override { return _comp_ids.empty(); }
   size_t size_comp() const override { return _comp_ids.size(); }
 
-  size_t n_clustered() const override { return _n_clustered; }
-  virtual void  set_n_clustered(unsigned int n) override { _n_clustered =n;} ;
+  // not used in Jetv1
+  size_t n_clustered() const override;
+  virtual void  set_n_clustered(unsigned int /*n*/) override;
 
   void clear_comp() override { _comp_ids.clear(); }
   size_t erase_comp(SRC source) override { return _comp_ids.erase(source); }
@@ -114,7 +115,7 @@ class Jetv1 : public Jet
 
   /// source id -> component id
   typ_comp_ids _comp_ids;
-  size_t _n_clustered {0};
+  /* size_t _n_clustered {0}; */
 
   typedef std::map<Jet::PROPERTY, float> typ_property_map;
   /// map that contains extra properties

--- a/offline/packages/jetbase/Jetv1.h
+++ b/offline/packages/jetbase/Jetv1.h
@@ -115,7 +115,6 @@ class Jetv1 : public Jet
 
   /// source id -> component id
   typ_comp_ids _comp_ids;
-  /* size_t _n_clustered {0}; */
 
   typedef std::map<Jet::PROPERTY, float> typ_property_map;
   /// map that contains extra properties


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

I added a size_t field to Jetv1 with the last PR that merged the JetContainer. This causes an error when reading Jetv1's from existing TTrees, but that wasn't checked by Jenkins. This is the fix, which just removes that member field for Jetv1.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

