### PR TITLE
Update Jetv1 method to Jetv2 method in jetbackground

### DIFF
--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -125,6 +125,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     if (Verbosity() > 1)
       std::cout << "DetermineTowerBackground::process_event: examining possible seeds (1st iteration) ... " << std::endl;
 
+    _index_SeedD = reco2_jets->property_index(Jet::PROPERTY::prop_SeedD);
+    _index_SeedItr = reco2_jets->property_index(Jet::PROPERTY::prop_SeedItr);
     for (auto this_jet : *reco2_jets) {
 
       float this_pt = this_jet->get_pt();
@@ -134,8 +136,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       if (this_jet->get_pt() < 5)
       {
         // mark that this jet was not selected as a seed (and did not have D determined)
-        this_jet->set_property(Jet::PROPERTY::prop_SeedD, 0);
-        this_jet->set_property(Jet::PROPERTY::prop_SeedItr, 0);
+        this_jet->set_property(_index_SeedD, 0);
+        this_jet->set_property(_index_SeedItr, 0);
 
         continue;
       }
@@ -260,7 +262,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       float seed_D = constituent_max_ET / mean_constituent_ET;
 
       // store D value as property for offline analysis / debugging
-      this_jet->set_property(Jet::PROPERTY::prop_SeedD, seed_D);
+      this_jet->set_property(_index_SeedD, seed_D);
 
       if (Verbosity() > 3)
         std::cout << "DetermineTowerBackground::process_event: --> jet has < ET > = " << constituent_sum_ET << " / " << nconstituents << " = " << mean_constituent_ET << ", max-ET = " << constituent_max_ET << ", and D = " << seed_D << std::endl;
@@ -271,7 +273,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
         _seed_phi.push_back(this_phi);
 
         // set first iteration seed property
-        this_jet->set_property(Jet::PROPERTY::prop_SeedItr, 1.0);
+        this_jet->set_property(_index_SeedItr, 1.0);
 
         if (Verbosity() > 1)
           std::cout << "DetermineTowerBackground::process_event: --> adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
@@ -279,13 +281,14 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       else
       {
         // mark that this jet was considered but not used as a seed
-        this_jet->set_property(Jet::PROPERTY::prop_SeedItr, 0.0);
+        this_jet->set_property(_index_SeedItr, 0.0);
 
         if (Verbosity() > 3)
           std::cout << "DetermineTowerBackground::process_event: --> discarding potential seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << ", D = " << seed_D << " ) " << std::endl;
       }
     }
   }
+
 
   // seed type 1 is the set of those jets above which, when their
   // kinematics are updated for the first background subtraction, have
@@ -304,6 +307,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
     if (Verbosity() > 1)
       std::cout << "DetermineTowerBackground::process_event: examining possible seeds (2nd iteration) ... " << std::endl;
 
+    _index_SeedD = reco2_jets->property_index(Jet::PROPERTY::prop_SeedD);
+    _index_SeedItr = reco2_jets->property_index(Jet::PROPERTY::prop_SeedItr);
     for (auto this_jet : *reco2_jets) 
     {
       float this_pt = this_jet->get_pt();
@@ -313,7 +318,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       if (this_jet->get_pt() < _seed_jet_pt)
       {
         // mark that this jet was considered but not used as a seed
-        this_jet->set_property(Jet::PROPERTY::prop_SeedItr, 0.0);
+        this_jet->set_property(_index_SeedItr, 0.0);
 
         continue;
       }
@@ -322,7 +327,7 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
       _seed_phi.push_back(this_phi);
 
       // set second iteration seed property
-      this_jet->set_property(Jet::PROPERTY::prop_SeedItr, 2.0);
+      this_jet->set_property(_index_SeedItr, 2.0);
 
       if (Verbosity() > 1)
         std::cout << "DetermineTowerBackground::process_event: --> adding seed at eta / phi = " << this_eta << " / " << this_phi << " ( R=0.2 jet with pt = " << this_pt << " ) " << std::endl;

--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -12,6 +12,7 @@
 // system includes
 #include <string>
 #include <vector>
+#include <jetbase/Jet.h>
 
 // forward declarations
 class PHCompositeNode;
@@ -78,6 +79,9 @@ class DetermineTowerBackground : public SubsysReco
 
   std::vector<float> _seed_eta;
   std::vector<float> _seed_phi;
+
+  Jet::PROPERTY _index_SeedD;
+  Jet::PROPERTY _index_SeedItr;
 
   bool m_use_towerinfo = false;
 

--- a/offline/packages/jetbase/JetContainerv1.cc
+++ b/offline/packages/jetbase/JetContainerv1.cc
@@ -140,17 +140,8 @@ size_t JetContainerv1::add_property(std::set<Jet::PROPERTY> props)
 // get the index for a given property
 Jet::PROPERTY JetContainerv1::property_index(Jet::PROPERTY prop)
 {
-  if (has_property(prop))
-  {
-    return m_pindex[prop];
-  }
-  else
-  {
-     std::cout << "JetContainerv1::poperty_index - ERROR - property "
-            << prop << "(" << str_Jet_PROPERTY(prop) << ") not found." << std::endl;
-    std::cout << " Returning 1000" << std::endl;
-    return static_cast<Jet::PROPERTY>(1000);
-  }
+  if (!has_property(prop)) add_property(prop);
+  return m_pindex[prop];
 }
 
 Jet::IterJetTCA JetContainerv1::begin()


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Update to DetermineJetBackground module to use the method's for adding jet properties in the 
Jetv2 paradigm instead of the Jetv1 paradigm. This is a bug fix that Jenkins didn't test for in the migration to JetContainer and was initially overlooked.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

