### PR TITLE
fix: Silicon unpackers calculate crossing WRT GL1 

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -1,8 +1,8 @@
 #include "InttCombinedRawDataDecoder.h"
 #include "InttMapping.h"
-#include <set>
+
 #include <trackbase/InttDefs.h>
-#include <trackbase/TrkrDefs.h>    // for hitkey, hitsetkey
+#include <trackbase/TrkrDefs.h>  // for hitkey, hitsetkey
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
@@ -16,10 +16,10 @@
 #include <fun4all/Fun4AllReturnCodes.h>
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>      // for PHIODataNode
+#include <phool/PHIODataNode.h>  // for PHIODataNode
 #include <phool/PHNodeIterator.h>
 #include <phool/getClass.h>
-#include <phool/phool.h>             // for PHWHERE
+#include <phool/phool.h>  // for PHWHERE
 
 #include <TSystem.h>
 
@@ -118,7 +118,7 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
     exit(1);
   }
   auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
-  if(!gl1)
+  if (!gl1)
   {
     std::cout << PHWHERE << " no gl1 container, exiting" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
@@ -143,16 +143,16 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
     // uint64_t gtm_bco = intthit->get_bco();
 
     InttNameSpace::RawFromHit(raw, intthit);
-    //raw.felix_server = InttNameSpace::FelixFromPacket(intthit->get_packetid());
-    //raw.felix_channel = intthit->get_fee();
-    //raw.chip = (intthit->get_chip_id() + 25) % 26;
-    //raw.channel = intthit->get_channel_id();
+    // raw.felix_server = InttNameSpace::FelixFromPacket(intthit->get_packetid());
+    // raw.felix_channel = intthit->get_fee();
+    // raw.chip = (intthit->get_chip_id() + 25) % 26;
+    // raw.channel = intthit->get_channel_id();
     ofl = InttNameSpace::ToOffline(raw);
 
     int adc = intthit->get_adc();
     // amp = intthit->get_amplitude();
     // int bco = intthit->get_FPHX_BCO();
-    hit_key = InttDefs::genHitKey(ofl.strip_y, ofl.strip_x); //col, row <trackbase/InttDefs.h>
+    hit_key = InttDefs::genHitKey(ofl.strip_y, ofl.strip_x);  // col, row <trackbase/InttDefs.h>
     hit_set_key = InttDefs::genHitSetKey(ofl.layer, ofl.ladder_z, ofl.ladder_phi, intthit->get_bco() - gl1bco);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
     hit = hit_set_container_itr->second->getHit(hit_key);

--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -1,6 +1,6 @@
 #include "InttCombinedRawDataDecoder.h"
 #include "InttMapping.h"
-
+#include <set>
 #include <trackbase/InttDefs.h>
 #include <trackbase/TrkrDefs.h>    // for hitkey, hitsetkey
 #include <trackbase/TrkrHit.h>
@@ -9,6 +9,7 @@
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitv2.h>
 
+#include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/InttRawHit.h>
 #include <ffarawobjects/InttRawHitContainer.h>
 
@@ -116,6 +117,18 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
     gSystem->Exit(1);
     exit(1);
   }
+  auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+  if(!gl1)
+  {
+    std::cout << PHWHERE << " no gl1 container, exiting" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  uint64_t gl1rawhitbco = gl1->get_bco();
+  // get the last 40 bits by bit shifting left then right to match
+  // to the mvtx bco
+  auto lbshift = gl1rawhitbco << 24;
+  auto gl1bco = lbshift >> 24;
 
   TrkrDefs::hitsetkey hit_set_key = 0;
   TrkrDefs::hitkey hit_key = 0;
@@ -139,10 +152,8 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
     int adc = intthit->get_adc();
     // amp = intthit->get_amplitude();
     // int bco = intthit->get_FPHX_BCO();
-
     hit_key = InttDefs::genHitKey(ofl.strip_y, ofl.strip_x); //col, row <trackbase/InttDefs.h>
-    hit_set_key = InttDefs::genHitSetKey(ofl.layer, ofl.ladder_z, ofl.ladder_phi, (intthit->get_bco()) & 0x3ff);
-
+    hit_set_key = InttDefs::genHitSetKey(ofl.layer, ofl.ladder_z, ofl.ladder_phi, intthit->get_bco() - gl1bco);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
     hit = hit_set_container_itr->second->getHit(hit_key);
     if (hit)

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -8,9 +8,9 @@
 
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/MvtxEventInfov2.h>
-#include <trackbase/TrkrHitv2.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainerv1.h>
+#include <trackbase/TrkrHitv2.h>
 
 #include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/MvtxRawEvtHeader.h>
@@ -19,22 +19,23 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
-#include <phool/getClass.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
+#include <phool/getClass.h>
 
 #include <algorithm>
 #include <cassert>
 
 //_________________________________________________________
-MvtxCombinedRawDataDecoder::MvtxCombinedRawDataDecoder( const std::string& name ):
-  SubsysReco( name )
-{}
+MvtxCombinedRawDataDecoder::MvtxCombinedRawDataDecoder(const std::string &name)
+  : SubsysReco(name)
+{
+}
 
 //_____________________________________________________________________
-int MvtxCombinedRawDataDecoder::Init(PHCompositeNode* /*topNode*/ )
-{ 
-  return Fun4AllReturnCodes::EVENT_OK; 
+int MvtxCombinedRawDataDecoder::Init(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
@@ -42,7 +43,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
 {
   // get dst node
   PHNodeIterator iter(topNode);
-  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
     std::cout << "MvtxCombinedRawDataDecoder::InitRun - DST Node missing, doing nothing." << std::endl;
@@ -67,7 +68,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
     trkrNode->addNode(newNode);
   }
 
-  //Check if MVTX event header already exists
+  // Check if MVTX event header already exists
   if (m_writeMvtxEventHeader)
   {
     auto mvtxNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "MVTX"));
@@ -89,7 +90,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   mvtx_raw_event_header = findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
   if (!mvtx_raw_event_header)
   {
-    std::cout << PHWHERE << "::" << __func__ <<  ": Could not get \"" << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
+    std::cout << PHWHERE << "::" << __func__ << ": Could not get \"" << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
     std::cout << "Have you built this yet?" << std::endl;
     exit(1);
   }
@@ -109,12 +110,12 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 
   if (!mvtx_hit_container)
   {
-    std::cout << PHWHERE << "::" << __func__ <<  ": Could not get \"" << m_MvtxRawHitNodeName << "\" from Node Tree" << std::endl;
+    std::cout << PHWHERE << "::" << __func__ << ": Could not get \"" << m_MvtxRawHitNodeName << "\" from Node Tree" << std::endl;
     std::cout << "Have you built this yet?" << std::endl;
     exit(1);
   }
-  auto gl1 = findNode::getClass<Gl1RawHit>(topNode,"GL1RAWHIT");
-  if(!gl1)
+  auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+  if (!gl1)
   {
     std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
@@ -127,8 +128,8 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 
   if (Verbosity() >= VERBOSITY_MORE) mvtx_hit_container->identify();
 
-  uint64_t strobe = -1; //Initialise to -1 for debugging
-  uint8_t layer = 0; 
+  uint64_t strobe = -1;  // Initialise to -1 for debugging
+  uint8_t layer = 0;
   uint8_t stave = 0;
   uint8_t chip = 0;
   uint16_t row = 0;
@@ -136,11 +137,11 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   std::vector<std::pair<uint64_t, uint32_t>> strobe_bc_pairs;
   std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
   auto mvtxbco = *l1BCOs.begin();
-  if(Verbosity() > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "mvtx bco " << mvtxbco << " and gl1 bco " << gl1bco << std::endl;
   }
-  
+
   if (m_writeMvtxEventHeader)
   {
     mvtx_event_header = findNode::getClass<MvtxEventInfo>(topNode, "MVTXEVENTHEADER");
@@ -157,20 +158,21 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     row = mvtx_hit->get_row();
     col = mvtx_hit->get_col();
 
-    if( Verbosity() >= VERBOSITY_A_LOT ) mvtx_hit->identify();
-        
-    const TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, mvtxbco-gl1bco); 
-    if( !hitsetkey ) continue;
+    if (Verbosity() >= VERBOSITY_A_LOT) mvtx_hit->identify();
+
+    const TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, mvtxbco - gl1bco);
+    if (!hitsetkey) continue;
 
     // get matching hitset
     const auto hitset_it = hit_set_container->findOrAddHitSet(hitsetkey);
 
     // generate hit key
-    const TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(col,row);
-    
+    const TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(col, row);
+
     // find existing hit, or create
     auto hit = hitset_it->second->getHit(hitkey);
-    if( hit ){
+    if (hit)
+    {
       std::cout << PHWHERE << "::" << __func__ << " - duplicated hit, hitsetkey: " << hitsetkey << " hitkey: " << hitkey << std::endl;
       continue;
     }
@@ -181,22 +183,21 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   }
 
   mvtx_event_header->set_strobe_BCO(strobe);
-   if (m_writeMvtxEventHeader)
+  if (m_writeMvtxEventHeader)
+  {
+    std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
+    for (auto iter = l1BCOs.begin(); iter != l1BCOs.end(); iter++)
     {
-      std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
-      for (auto iter = l1BCOs.begin(); iter != l1BCOs.end(); iter++)
-      {
-        mvtx_event_header->set_strobe_BCO_L1_BCO(strobe, *iter);
-      }
-      if (Verbosity() >= VERBOSITY_EVEN_MORE) mvtx_event_header->identify();
-  } 
-  
-  return Fun4AllReturnCodes::EVENT_OK;
+      mvtx_event_header->set_strobe_BCO_L1_BCO(strobe, *iter);
+    }
+    if (Verbosity() >= VERBOSITY_EVEN_MORE) mvtx_event_header->identify();
+  }
 
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_____________________________________________________________________
-int MvtxCombinedRawDataDecoder::End(PHCompositeNode* /*topNode*/ )
+int MvtxCombinedRawDataDecoder::End(PHCompositeNode * /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The silicon hitsetkeys were not filled properly WRT the timing information. They now get the gl1 bco, bit shift by 24 bits to compare to the raw hit bcos, and then fill the hitsets with the relative difference between the gl1 bco and the hit bco.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

