### PR TITLE
fix: Correct strobe index

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -139,7 +139,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   auto mvtxbco = *l1BCOs.begin();
   if (Verbosity() > 0)
   {
-    std::cout << "mvtx bco " << mvtxbco << " and gl1 bco " << gl1bco << std::endl;
+    std::cout << "mvtx header bco " << mvtxbco << " and gl1 bco " << gl1bco << std::endl;
   }
 
   if (m_writeMvtxEventHeader)
@@ -158,9 +158,13 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     row = mvtx_hit->get_row();
     col = mvtx_hit->get_col();
 
+    uint64_t bcodiff = gl1bco - strobe;
+    double timeElapsed = bcodiff * 0.106; // 106 ns rhic clock
+    int index = std::floor(timeElapsed / m_strobeWidth);
+    
     if (Verbosity() >= VERBOSITY_A_LOT) mvtx_hit->identify();
 
-    const TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, mvtxbco - gl1bco);
+    const TrkrDefs::hitsetkey hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, index);
     if (!hitsetkey) continue;
 
     // get matching hitset

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -56,7 +56,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
  
     std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
     std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
-
+    float m_strobeWidth = 89.; //!microseconds
     bool m_writeMvtxEventHeader = true;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes the unpacking (really this time, after more discussion) to be the relative strobe to the gl1 bco for each hit in the trigger frame.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

