### PR TITLE
Distortion modified transforms

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -172,3 +172,28 @@ Acts::Transform3 ActsGeometry::makeAffineTransform(Acts::Vector3 rot, Acts::Vect
 
   return actsAffine;
 }
+
+Acts::Vector2 ActsGeometry::getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster)
+{
+  Acts::Vector2 local;
+
+  const auto trkrid = TrkrDefs::getTrkrId(key);
+  if(trkrid == TrkrDefs::tpcId)
+    {
+      double surfaceZCenter = 52.89; // this is where G4 thinks the surface center is in cm
+      double zdriftlength = cluster->getLocalY() * _drift_velocity;  // cm
+      double zloc = surfaceZCenter - zdriftlength;     // local z relative to surface center (for north side):
+      unsigned int side = TpcDefs::getSide(key);
+      if(side == 0) zloc = -zloc;
+      
+      local(0) = cluster->getLocalX();
+      local(1) = zloc;
+    }
+  else
+    {
+      local(0) = cluster->getLocalX();
+      local(1) = cluster->getLocalY();
+    }
+      
+  return local;
+}

--- a/offline/packages/trackbase/ActsGeometry.cc
+++ b/offline/packages/trackbase/ActsGeometry.cc
@@ -2,6 +2,7 @@
 #include "TrkrCluster.h"
 #include "TpcDefs.h"
 #include "alignmentTransformationContainer.h"
+#include <Acts/Definitions/Algebra.hpp>
 
 namespace
 {
@@ -155,3 +156,19 @@ Surface ActsGeometry::get_tpc_surface_from_coords(
   
 }
 
+Acts::Transform3 ActsGeometry::makeAffineTransform(Acts::Vector3 rot, Acts::Vector3 trans)
+{
+
+  Acts::Transform3 actsAffine;
+
+  Eigen::AngleAxisd alpha(rot(0), Eigen::Vector3d::UnitX());
+  Eigen::AngleAxisd beta(rot(1), Eigen::Vector3d::UnitY());
+  Eigen::AngleAxisd gamma(rot(2), Eigen::Vector3d::UnitZ());
+  Eigen::Quaternion<double> q       = gamma*beta*alpha;
+  actsAffine.linear() = q.matrix();
+  
+  Eigen::Vector3d translation(trans(0),trans(1),trans(2));
+  actsAffine.translation() = translation;
+
+  return actsAffine;
+}

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -46,6 +46,8 @@ class ActsGeometry {
 
   Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation);
 
+  Acts::Vector2 getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster);
+
  private:
   ActsTrackingGeometry m_tGeometry;
   ActsSurfaceMaps m_surfMaps;

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -44,6 +44,8 @@ class ActsGeometry {
       Acts::Vector3 world,
       TrkrDefs::subsurfkey& subsurfkey);
 
+  Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation);
+
  private:
   ActsTrackingGeometry m_tGeometry;
   ActsSurfaceMaps m_surfMaps;

--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -102,6 +102,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	     std::cout << " final mvtx transform:" << std::endl << transform.matrix() << std::endl;
 	   }
 	 transformMap->addTransform(id,transform);
+	 transformMapTransient->addTransform(id,transform);
        }
      
      else if(trkrId == TrkrDefs::inttId) 
@@ -126,6 +127,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	   }
 
 	 transformMap->addTransform(id,transform);
+	 transformMapTransient->addTransform(id,transform);
        }
 
 
@@ -165,6 +167,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 		 std::cout << "transform matrix: " << std::endl <<  transform.matrix() << std::endl;
 	       }
 	     transformMap->addTransform(id,transform);
+	     transformMapTransient->addTransform(id,transform);
 	   }
        }
      else if(trkrId == TrkrDefs::micromegasId)
@@ -188,6 +191,7 @@ void AlignmentTransformation::createMap(PHCompositeNode* topNode)
 	  }
 
 	transformMap->addTransform(id,transform);
+	transformMapTransient->addTransform(id,transform);
       }
 
      else
@@ -363,6 +367,14 @@ void AlignmentTransformation::createAlignmentTransformContainer(PHCompositeNode*
     {
       transformMap = new alignmentTransformationContainer;
       auto node    = new PHDataNode<alignmentTransformationContainer>(transformMap, "alignmentTransformationContainer");
+      dstNode->addNode(node);
+    }
+
+  transformMapTransient = findNode::getClass<alignmentTransformationContainer>(topNode, "alignmentTransformationContainerTransient");
+  if(!transformMapTransient)
+    {
+      transformMapTransient = new alignmentTransformationContainer;
+      auto node    = new PHDataNode<alignmentTransformationContainer>(transformMapTransient, "alignmentTransformationContainerTransient");
       dstNode->addNode(node);
     }
 }

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -129,6 +129,7 @@ void setTPCParams(double tpcDevs[6])
   Acts::Transform3 newMakeTransform(Surface surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, bool survey);
 
   alignmentTransformationContainer* transformMap = NULL;
+  alignmentTransformationContainer* transformMapTransient = NULL;
   ActsGeometry* m_tGeometry = NULL;
   
   int getNodes(PHCompositeNode* topNode);

--- a/offline/packages/trackbase/alignmentTransformationContainer.cc
+++ b/offline/packages/trackbase/alignmentTransformationContainer.cc
@@ -131,6 +131,22 @@ Acts::Transform3& alignmentTransformationContainer::getTransform(const Acts::Geo
   exit(1); 
 }
 
+void alignmentTransformationContainer::replaceTransform(const Acts::GeometryIdentifier id, Acts::Transform3 transform)
+{
+  unsigned int sphlayer = getsphlayer(id);
+  unsigned int sensor = id.sensitive() - 1;  // Acts sensor numbering starts at 1
+
+  auto& layerVec = transformVec[sphlayer];
+  if(layerVec.size() > sensor)
+    {
+      layerVec[sensor] = transform;
+      return;
+    }
+  
+  std::cout << "Unable to find Acts Id: "<< id<<  " in alignmentTransformationContainer" << std::endl;
+  exit(1); 
+}
+
 const std::vector<std::vector<Acts::Transform3>>& alignmentTransformationContainer::getMap() const
 {
   return transformVec;

--- a/offline/packages/trackbase/alignmentTransformationContainer.h
+++ b/offline/packages/trackbase/alignmentTransformationContainer.h
@@ -40,6 +40,7 @@ class alignmentTransformationContainer : public Acts::GeometryContext
   void identify(std::ostream &os = std::cout);  
   void addTransform(Acts::GeometryIdentifier, Acts::Transform3); 
   Acts::Transform3& getTransform(Acts::GeometryIdentifier id);
+  void replaceTransform(const Acts::GeometryIdentifier id, Acts::Transform3 transform);
   const std::vector<std::vector<Acts::Transform3>>& getMap() const;
   void setMisalignmentFactor(uint8_t layer, double factor);
   const double& getMisalignmentFactor(uint8_t layer) const { return m_misalignmentFactor.find(layer)->second; }

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -143,14 +143,6 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
                            100000, 0, 1000);
   }
 
-  auto cellgeo =
-      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-
-  if (cellgeo)
-  {
-    _clusterMover.initialize_geometry(cellgeo);
-  }
-
   if (m_actsEvaluator)
   {
     m_evaluator = std::make_unique<ActsEvaluator>(m_evalname);

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -19,7 +19,6 @@
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/alignmentTransformationContainer.h>
 
-#include <tpc/TpcClusterMover.h>
 #include <tpc/TpcClusterZCrossingCorrection.h>
 #include <tpc/TpcDistortionCorrection.h>
 

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -225,8 +225,6 @@ class PHActsTrkFitter : public SubsysReco
   /// tpc distortion correction utility class
   TpcDistortionCorrection _distortionCorrection;
 
-  // cluster mover utility class
-  TpcClusterMover _clusterMover;
   ClusterErrorPara _ClusErrPara;
 
   std::set<int> m_ignoreLayer;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -177,6 +177,9 @@ class PHActsTrkFitter : public SubsysReco
 
   /// TrackMap containing SvtxTracks
   alignmentTransformationContainer* m_alignmentTransformationMap = nullptr;  // added for testing purposes
+  alignmentTransformationContainer* m_alignmentTransformationMapTransient = nullptr;  
+  std::set< Acts::GeometryIdentifier> m_transient_id_set;
+  Acts::GeometryContext m_transient_geocontext;
   SvtxTrackMap* m_trackMap = nullptr;
   SvtxTrackMap* m_directedTrackMap = nullptr;
   TrkrClusterContainer* m_clusterContainer = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR modifies the way that TPC crossing and distortion corrections are applied in PHActsTrkFitter.

Previously this was done by applying the distortion corrections to the ideal global position, projecting the corrected cluster global position back to the surface, then transforming the global position to local coordinates on the surface. 

Now the correction to the global position is calculated and made into an affine transform, which is then used to modify the ideal geometry transform for that cluster. The cluster local coordinates are not changed. The modified transform is placed in a temporary copy of the transformation container that is made for each track, a new GeometryContext is set equal to the temporary transformation container, and Acts uses that when it fits the track. 

This is more in line with the Acts philosophy that the measurement is local to the surface and all corrections are applied to the surface position. This makes the crossing and distortion correction like a track-by-track alignment correction.

Tested with Pythia pileup events, where the crossing correction can be 10's of cm. Seems to work well. Let's see what the QA looks like.

Not tested yet with distortion corrections, but these are small compared with crossing corrections. This change will be applied also to PHCosmicsTrkFitter and PHActsGSF, once we evaluate it for a while.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

