### PR TITLE
Fix TPC side mapping: north sector 00..11->side 1

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -200,11 +200,11 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     if(FEE_R[fee]==2) feeM += 6;
     if(FEE_R[fee]==3) feeM += 14;
 
-    int side = 0;
+    int side = 1;
     int32_t packet_id = tpchit->get_packetid();
     int ep = (packet_id - 4000) % 10;
     int sector = (packet_id - 4000 - ep) / 10;
-    if (sector>11) side = 1;
+    if (sector>11) side = 0;
 
     unsigned int key = 256 * (feeM) + channel;
     std::string varname = "layer";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

As just mentioned in the software meeting, there is a z-flip in the TPC unpacker which translate the detector naming convention to offline naming conversion on the sectors and sides. 

This PR fixes the z flip, but watch out for other inconsistencies between detector and offline indexing. Let me know if any problem and I can help check. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

