### PR TITLE
Turn on template fits, add debugging output

### DIFF
--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -32,11 +32,13 @@ class MbdCalib : public Fun4AllBase
   float get_qgain(const int ipmt) const { return _qfit_mpv[ipmt]; }
   float get_tq0(const int ipmt) const { return _tqfit_t0mean[ipmt]; }
   int get_sampmax(const int ifeech) const { return _sampmax[ifeech]; }
-  std::vector<Double_t> get_shape(const int ifeech) const { return _shape_y[ifeech]; }
-  std::vector<Double_t> get_sherr(const int ifeech) const { return _sherr_yerr[ifeech]; }
+  std::vector<float> get_shape(const int ifeech) const { return _shape_y[ifeech]; }
+  std::vector<float> get_sherr(const int ifeech) const { return _sherr_yerr[ifeech]; }
 
   int Download_Gains(const std::string& dbfile);
   int Download_TQT0(const std::string& dbfile);
+  int Download_TTT0(const std::string& dbfile);
+  int Download_Slew(const std::string& dbfile);
   int Download_SampMax(const std::string& dbfile);
   int Download_Shapes(const std::string& dbfile);
   int Download_All();
@@ -70,26 +72,38 @@ class MbdCalib : public Fun4AllBase
   std::array<float, MbdDefs::BBC_N_PMT> _qfit_sigmaerr{};
   std::array<float, MbdDefs::BBC_N_PMT> _qfit_chi2ndf{};
 
+  // T0 offsets, time channels
+  std::array<float, MbdDefs::BBC_N_PMT> _ttfit_t0mean{};
+  std::array<float, MbdDefs::BBC_N_PMT> _ttfit_t0meanerr{};
+  std::array<float, MbdDefs::BBC_N_PMT> _ttfit_t0sigma{};
+  std::array<float, MbdDefs::BBC_N_PMT> _ttfit_t0sigmaerr{};
+
   // T0 offsets, charge channels
   std::array<float, MbdDefs::BBC_N_PMT> _tqfit_t0mean{};
   std::array<float, MbdDefs::BBC_N_PMT> _tqfit_t0meanerr{};
   std::array<float, MbdDefs::BBC_N_PMT> _tqfit_t0sigma{};
   std::array<float, MbdDefs::BBC_N_PMT> _tqfit_t0sigmaerr{};
 
+  // Slew Correction
+  std::array<int, MbdDefs::BBC_N_FEECH>   _slew_npts{};      // num points in template
+  std::array<float, MbdDefs::BBC_N_FEECH> _slew_minrange{};  // in template units (samples)
+  std::array<float, MbdDefs::BBC_N_FEECH> _slew_maxrange{};  // in template units (samples)
+  std::array<std::vector<float>, MbdDefs::BBC_N_FEECH> _slew_y{};
+
   // Peak of waveform
   std::array<int, MbdDefs::BBC_N_FEECH> _sampmax{};
 
   // Waveform Template
   int do_templatefit{0};
-  std::array<int, MbdDefs::BBC_N_FEECH> _shape_npts{};     // num points in template
-  std::array<Double_t, MbdDefs::BBC_N_FEECH> _shape_minrange{}; // in template units (samples)
-  std::array<Double_t, MbdDefs::BBC_N_FEECH> _shape_maxrange{}; // in template units (samples)
-  std::array<std::vector<Double_t>, MbdDefs::BBC_N_FEECH> _shape_y{};
+  std::array<int, MbdDefs::BBC_N_FEECH>   _shape_npts{};     // num points in template
+  std::array<float, MbdDefs::BBC_N_FEECH> _shape_minrange{}; // in template units (samples)
+  std::array<float, MbdDefs::BBC_N_FEECH> _shape_maxrange{}; // in template units (samples)
+  std::array<std::vector<float>, MbdDefs::BBC_N_FEECH> _shape_y{};
 
   std::array<int, MbdDefs::BBC_N_FEECH> _sherr_npts{};     // num points in template
-  std::array<int, MbdDefs::BBC_N_FEECH> _sherr_minrange{}; // in template units (samples)
-  std::array<int, MbdDefs::BBC_N_FEECH> _sherr_maxrange{}; // in template units (samples)
-  std::array<std::vector<Double_t>, MbdDefs::BBC_N_FEECH> _sherr_yerr{};
+  std::array<float, MbdDefs::BBC_N_FEECH> _sherr_minrange{}; // in template units (samples)
+  std::array<float, MbdDefs::BBC_N_FEECH> _sherr_maxrange{}; // in template units (samples)
+  std::array<std::vector<float>, MbdDefs::BBC_N_FEECH> _sherr_yerr{};
 };
 
 #endif  // MBD_MBDCALIB_H

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -37,7 +37,7 @@ MbdEvent::MbdEvent()
   }
   else
   {
-    do_templatefit = 0;
+    do_templatefit = 1;
   }
 
   for (int ifeech = 0; ifeech < MbdDefs::BBC_N_FEECH; ifeech++)
@@ -74,8 +74,6 @@ MbdEvent::MbdEvent()
     iboard = -1;
   }
 
-  gaussian = nullptr;
-
   // BBCCALIB is used in offline to read in our calibrations
   const char *bbccaldir = getenv("BBCCALIB");
   if (bbccaldir)
@@ -103,6 +101,10 @@ MbdEvent::MbdEvent()
     */
   }
 
+  // Debug stuff
+  //debugintt = 1;
+  if ( debugintt ) ReadSyncFile();
+
   Clear();
 }
 
@@ -117,9 +119,11 @@ MbdEvent::~MbdEvent()
   delete h2_tmax[0];
   delete h2_tmax[1];
   delete ac;
-  delete gaussian;
+  delete gausfit[0];
+  delete gausfit[1];
   delete _mbdgeom;
   delete _mbdcal;
+  delete _syncttree;
 }
 
 int MbdEvent::InitRun()
@@ -147,7 +151,8 @@ int MbdEvent::InitRun()
     delete _mbdcal;
   }
   _mbdcal = new MbdCalib();
-  _mbdcal->Download_All();
+  std::cout << "SIMFLAG IS " << _simflag << std::endl;
+  if ( !_simflag ) _mbdcal->Download_All();
 
   // Read in template if specified
   if ( do_templatefit )
@@ -157,6 +162,7 @@ int MbdEvent::InitRun()
       if ( _mbdgeom->get_type(ifeech) == 0 ) continue;
       //std::cout << PHWHERE << "Reading template " << ifeech << std::endl;
       //std::cout << "SIZES0 " << _mbdcal->get_shape(ifeech).size() << std::endl;
+      // Should set template size automatically here
       _mbdsig[ifeech].SetTemplate( _mbdcal->get_shape(ifeech), _mbdcal->get_sherr(ifeech) );
       _mbdsig[ifeech].SetMinMaxFitTime( _mbdcal->get_sampmax(ifeech)-2-3, _mbdcal->get_sampmax(ifeech)-2+3 );
       //_mbdsig[ifeech].SetMinMaxFitTime( 0, 31 );
@@ -181,8 +187,9 @@ void MbdEvent::Clear()
     m_bbcq[iarm] = 0.;
     m_bbct[iarm] = -9999.;
     m_bbcte[iarm] = -9999.;
+    m_bbctl[iarm] = -9999.;
     hevt_bbct[iarm]->Reset();
-    hevt_bbct[1]->Reset();
+    hevt_bbct[iarm]->GetXaxis()->SetRangeUser(-50,50);
   }
 
   // Reset end product to prepare next event
@@ -296,58 +303,63 @@ int MbdEvent::SetRawData(Event *event, MbdPmtContainer *bbcpmts)
 
     if (type == 0)
     {
-      continue;
-    }
-    // Use dCFD method to get time for now in charge channels
-    // Double_t threshold = 4.0*sig->GetPed0RMS();
+      Double_t tdc = _mbdsig[ifeech].MBD( _mbdcal->get_sampmax(ifeech) );
 
-    // std::cout << "getspline " << ifeech << std::endl;
-    if ( do_templatefit )
-    {
-      _mbdsig[ifeech].FitTemplate();
- 
-      m_pmttq[pmtch] = _mbdsig[ifeech].GetTime();
-      m_ampl[ifeech] = _mbdsig[ifeech].GetAmpl();
+      if ( tdc<40 )
+      {
+        m_pmttt[pmtch] = NAN;  // no hit
+      }
+      else
+      {
+        m_pmttt[pmtch] = 26.5 - tdc*0.00189;  // simple linear correction
+      }
     }
-    else
+
+    if ( type==1 )
     {
+      // Use dCFD method to get time for now in charge channels
+      // std::cout << "getspline " << ifeech << std::endl;
       _mbdsig[ifeech].GetSplineAmpl();
       Double_t threshold = 0.5;
       m_pmttq[pmtch] = _mbdsig[ifeech].dCFD(threshold);
       m_ampl[ifeech] = _mbdsig[ifeech].GetAmpl();
-    }
+      if ( do_templatefit )
+      {
+        _mbdsig[ifeech].FitTemplate();
 
-    if ( m_ampl[ifeech] < _mbdcal->get_qgain(pmtch)*0.25 )
-    {
-      // m_t0[ifeech] = -9999.;
-      m_pmttq[pmtch] = std::numeric_limits<Float_t>::quiet_NaN();
-    }
-    else
-    {
-      // if ( m_pmttq[pmtch]<-50. && ifeech==255 ) std::cout << "hit_times " << ifeech << "\t" << m_pmttq[pmtch] << std::endl;
-      // if ( arm==1 ) std::cout << "hit_times " << ifeech << "\t" << setw(10) << m_pmttq[pmtch] << "\t" << board << "\t" << TRIG_SAMP[board] << std::endl;
-      m_pmttq[pmtch] -= (_mbdcal->get_sampmax(ifeech) - 2);
-      m_pmttq[pmtch] *= 17.7623;  // convert from sample to ns (1 sample = 1/56.299 MHz)
-      m_pmttq[pmtch] = m_pmttq[pmtch] - _mbdcal->get_tq0(pmtch);
-    }
+        //m_pmttq[pmtch] = _mbdsig[ifeech].GetTime();
+        m_ampl[ifeech] = _mbdsig[ifeech].GetAmpl();
+      }
 
-    m_pmtq[pmtch] = m_ampl[ifeech] / _mbdcal->get_qgain(pmtch);
+      if ( m_ampl[ifeech] < _mbdcal->get_qgain(pmtch)*0.25 )
+      {
+        // m_t0[ifeech] = -9999.;
+        m_pmttq[pmtch] = std::numeric_limits<Float_t>::quiet_NaN();
+      }
+      else
+      {
+        // if ( m_pmttq[pmtch]<-50. && ifeech==255 ) std::cout << "hit_times " << ifeech << "\t" << m_pmttq[pmtch] << std::endl;
+        // if ( arm==1 ) std::cout << "hit_times " << ifeech << "\t" << setw(10) << m_pmttq[pmtch] << "\t" << board << "\t" << TRIG_SAMP[board] << std::endl;
+        m_pmttq[pmtch] -= (_mbdcal->get_sampmax(ifeech) - 2);
+        m_pmttq[pmtch] *= 17.7623;  // convert from sample to ns (1 sample = 1/56.299 MHz)
+        m_pmttq[pmtch] = m_pmttq[pmtch] - _mbdcal->get_tq0(pmtch);
+      }
 
-    if (m_pmtq[pmtch] < 0.25)
-    {
-      m_pmtq[pmtch] = 0.;
-      m_pmttq[pmtch] = std::numeric_limits<Float_t>::quiet_NaN();
+      m_pmtq[pmtch] = m_ampl[ifeech] / _mbdcal->get_qgain(pmtch);
+
+      if (m_pmtq[pmtch] < 0.25)
+      {
+        m_pmtq[pmtch] = 0.;
+        m_pmttq[pmtch] = std::numeric_limits<Float_t>::quiet_NaN();
+      }
+
+      /*
+      if ( m_evt<3 && ifeech==255 && m_ampl[ifeech] )
+      {
+        std::cout << "dcfdcalc " << m_evt << "\t" << ifeech << "\t" << m_pmttq[pmtch] << "\t" << m_ampl[ifeech] << std::endl;
+      }
+      */
     }
-
-    // set tt to tq for now
-    m_pmttt[pmtch] = m_pmttq[pmtch];
-
-    /*
-    if ( m_evt<3 && ifeech==255 && m_ampl[ifeech] )
-    {
-      std::cout << "dcfdcalc " << m_evt << "\t" << ifeech << "\t" << m_pmttq[pmtch] << "\t" << m_ampl[ifeech] << std::endl;
-    }
-    */
   }
 
   // bbcpmts->Reset();
@@ -367,9 +379,14 @@ int MbdEvent::SetRawData(Event *event, MbdPmtContainer *bbcpmts)
 ///
 int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 {
+  if ( debugintt )
+  {
+    _verbose = 100;
+  }
+  //_verbose = 100;
   if (_verbose >= 10)
   {
-    std::cout << "In MbdEvent::Calculate()" << std::endl;
+    std::cout << "In MbdEvent::Calculate() " << m_evt << std::endl;
   }
   Clear();
   if (bbcout != nullptr)
@@ -377,10 +394,23 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
     bbcout->Reset();
   }
 
-  if (!gaussian)
+  // Debug stuff
+  if ( debugintt && (bbevt[_syncevt] != (m_evt-1)) )
   {
-    gaussian = new TF1("gaussian", "gaus", 0, 20);
-    gaussian->FixParameter(2, _tres);  // set sigma to timing resolution
+    _verbose = 0;
+    return 1;
+  }
+ 
+  if (gausfit[0] == nullptr)
+  {
+    TString name;
+    for (int iarm=0; iarm<2; iarm++)
+    {
+      name = "gausfit"; name += iarm;
+      gausfit[iarm] = new TF1(name, "gaus", 0, 20);
+      gausfit[iarm]->FixParameter(2, _tres);  // set sigma to timing resolution
+      gausfit[iarm]->SetLineColor(2);
+    }
   }
 
   std::vector<float> hit_times[2];  // times of the hits in each [arm]
@@ -390,6 +420,12 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
   {
     std::cout << "Hit PMT info " << std::endl;
   }
+
+  int epmt[2] {-1,-1};        // pmt of earliest time
+  //int lpmt[2] {-1,-1};        // pmt of latest time
+  double tepmt[2] {1e9,1e9};  // earliest time
+  double tlpmt[2] {-1e9,-1e9};  // latest time
+
   for (int ipmt = 0; ipmt < MbdDefs::BBC_N_PMT; ipmt++)
   {
     MbdPmtHit *bbcpmt = bbcpmts->get_pmt(ipmt);
@@ -414,6 +450,17 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
       if (_verbose >= 10)
       {
         std::cout << ipmt << "\t" << t_pmt << "\t" << q_pmt << std::endl;
+
+        if ( t_pmt < tepmt[arm] )
+        {
+          epmt[arm] = ipmt;
+          tepmt[arm] = t_pmt;
+        }
+        if ( t_pmt > tlpmt[arm] )
+        {
+          //lpmt[arm] = ipmt;
+          tlpmt[arm] = t_pmt;
+        }
       }
     }
   }
@@ -437,14 +484,15 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
     std::sort(hit_times[iarm].begin(), hit_times[iarm].end());
     float earliest = hit_times[iarm].at(0);
+    float latest = hit_times[iarm].back();
     // std::cout << "earliest" << iarm << "\t" << earliest << std::endl;
 
-    gaussian->SetParameter(0, 5);
-    // gaussian->SetParameter(1, earliest);
-    // gaussian->SetRange(6, earliest + 5 * 0.05);
-    gaussian->SetParameter(1, hevt_bbct[iarm]->GetMean());
-    gaussian->SetParameter(2, hevt_bbct[iarm]->GetRMS());
-    gaussian->SetRange(hevt_bbct[iarm]->GetMean() - 5, hevt_bbct[iarm]->GetMean() + 5);
+    gausfit[iarm]->SetParameter(0, 5);
+    // gausfit[iarm]->SetParameter(1, earliest);
+    // gausfit[iarm]->SetRange(6, earliest + 5 * 0.05);
+    gausfit[iarm]->SetParameter(1, hevt_bbct[iarm]->GetMean());
+    gausfit[iarm]->SetParameter(2, hevt_bbct[iarm]->GetRMS());
+    gausfit[iarm]->SetRange(hevt_bbct[iarm]->GetMean() - 5, hevt_bbct[iarm]->GetMean() + 5);
 
     if (_verbose)
     {
@@ -456,17 +504,53 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
       ac->cd(iarm + 1);
     }
 
-    hevt_bbct[iarm]->Fit(gaussian, "BNQLR");
-    if (_verbose)
-    {
-      hevt_bbct[iarm]->Draw();
-    }
+    hevt_bbct[iarm]->Fit(gausfit[iarm], "BNQLR");
 
     // m_bbct[iarm] = m_bbct[iarm] / m_bbcn[iarm];
-    m_bbct[iarm] = gaussian->GetParameter(1);
+    m_bbct[iarm] = gausfit[iarm]->GetParameter(1);
     m_bbcte[iarm] = earliest;
+    m_bbctl[iarm] = latest;
 
     //_bbcout->set_arm(iarm, m_bbcn[iarm], m_bbcq[iarm], m_bbct[iarm]);
+
+    //if ( _verbose && mybbz[_syncevt]< -40. )
+    if ( _verbose )
+    {
+      hevt_bbct[iarm]->GetXaxis()->SetRangeUser( tepmt[iarm]-3., tlpmt[iarm]+3. );
+      //hevt_bbct[iarm]->GetXaxis()->SetRangeUser(-20,20);
+      hevt_bbct[iarm]->Draw();
+      gausfit[iarm]->Draw("same");
+      gPad->Modified();
+      gPad->Update();
+      if ( iarm==1 )
+      {
+        double zearly = (tepmt[0]-tepmt[1])*MbdDefs::C/2.0;
+        double znew = (m_bbct[0]-m_bbct[1])*MbdDefs::C/2.0;
+
+        if ( debugintt )
+        {
+          double intzdiff = intz[_syncevt]/10. - mybbz[_syncevt];
+          double intzediff = intz[_syncevt]/10. - zearly;
+          if ( fabs(znew-mybbz[_syncevt]) > 0.1 )
+          {
+            std::cout << "**ERR** " << znew << "\t" << mybbz[_syncevt] << std::endl;
+          }
+          std::string junk;
+          std::cout << m_evt << "\t" << bbevt[_syncevt] << "\t" << m_bbct[0] << "\t" << m_bbct[1] << std::endl;
+          std::cout << m_evt << " gmean " << gausfit[0]->GetParameter(1) << "\t" << gausfit[1]->GetParameter(1) << std::endl;
+          std::cout << m_evt << " mean " << hevt_bbct[0]->GetMean(1) << "\t" << hevt_bbct[1]->GetMean(1) << std::endl;
+          std::cout << m_evt << " gsigma " << gausfit[0]->GetParameter(2) << "\t" << gausfit[1]->GetParameter(2) << std::endl;
+          std::cout << m_evt << " rms " << hevt_bbct[0]->GetRMS() << "\t" << hevt_bbct[1]->GetRMS() << std::endl;
+          std::cout << m_evt << " te ch " << epmt[0] << "\t" << epmt[1] << "\t" << tepmt[0] << "\t" << tepmt[1] << std::endl;
+          std::cout << m_evt << " tetl " << m_bbcte[0] << "\t" << m_bbctl[0] << "\t" << m_bbcte[1] << "\t" << m_bbctl[1] << std::endl;
+          std::cout << m_evt << " bz intz " << mybbz[_syncevt] << "\t" << intz[_syncevt]/10. << "\t" << intzdiff << "\t" << intzdiff*2.0/MbdDefs::C << std::endl;
+          std::cout << m_evt << " bze " << zearly << "\t" << intzediff << std::endl;
+          std::cout << "? ";
+          std::cin >> junk;
+        }
+      }
+    }
+
   }
 
   // Get Zvertex, T0
@@ -498,9 +582,14 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
     m_bbct0 = (m_bbcte[0] + m_bbcte[1]) / 2.0;
     */
 
-    if (_verbose > 10)
+    //if (_verbose > 10)
+    //if ( _verbose && mybbz[_syncevt]< -40. )
+    if ( _verbose )
     {
       std::cout << "bbcz " << m_bbcz << std::endl;
+      std::string junk;
+      std::cout << "? ";
+      std::cin >> junk;
     }
   }
 
@@ -524,6 +613,12 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
     }
   }
 
+  if ( debugintt )
+  {
+    _syncevt++;
+    _verbose = 0;
+  }
+  _verbose = 0;
   return 1;
 }
 
@@ -654,3 +749,38 @@ int MbdEvent::Read_TT_CLK_Offsets(const std::string &t0cal_fname)
   return 1;
 }
 
+
+void MbdEvent::ReadSyncFile(const char *fname)
+{
+  Int_t    f_evt {0};
+  UShort_t f_femclk {0};          
+  Float_t  f_bz {0.};
+  Long64_t bco_full {0};
+  Double_t ES_zvtx {0.};
+  Double_t mbd_bz {0.};
+
+  _synctfile = std::make_unique<TFile>(fname,"READ");
+  _syncttree = (TTree*)_synctfile->Get("t2");
+  _syncttree->SetBranchAddress("evt", &f_evt);
+  _syncttree->SetBranchAddress("femclk", &f_femclk);
+  _syncttree->SetBranchAddress("bz", &f_bz);
+  _syncttree->SetBranchAddress("bco_full", &bco_full);
+  _syncttree->SetBranchAddress("ES_zvtx", &ES_zvtx);
+  _syncttree->SetBranchAddress("mbd_bz", &mbd_bz);
+
+  Stat_t nentries = _syncttree->GetEntries();
+  for (int ientry=0; ientry<nentries; ientry++)
+  {
+    _syncttree->GetEntry( ientry );
+
+    bbevt.push_back( f_evt );
+    bbclk.push_back( f_femclk );
+    mybbz.push_back( f_bz );
+    bco.push_back( bco_full );
+    intz.push_back( ES_zvtx );
+    bbz.push_back( mbd_bz );
+  }
+
+  std::cout << "Read in " << bbevt.size() << " INTT sync events" << std::endl;
+
+}

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -5,6 +5,9 @@
 #include "MbdSig.h"
 
 #include <fun4all/Fun4AllBase.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <vector>
 
 class PHCompositeNode;
 class Event;
@@ -28,6 +31,8 @@ class MbdEvent : public Fun4AllBase
   int InitRun();
   void Clear();
 
+  void SetSim(const int s) { _simflag = s; }
+
   float get_bbcz() { return m_bbcz; }
   float get_bbczerr() { return m_bbczerr; }
   float get_bbct0() { return m_bbct0; }
@@ -42,10 +47,9 @@ class MbdEvent : public Fun4AllBase
   float get_pmttt(const int ipmt) { return m_pmttt[ipmt]; }
   float get_pmttq(const int ipmt) { return m_pmttq[ipmt]; }
 
-  int get_EventNumber(void) const
-  {
-    return m_evt;
-  }
+  int get_EventNumber(void) const { return m_evt; }
+
+  void set_debugintt(const int d) { debugintt = d; }
 
   MbdSig *GetSig(const int ipmt) { return &_mbdsig[ipmt]; }
 
@@ -61,6 +65,9 @@ class MbdEvent : public Fun4AllBase
   int Read_TT_CLK_Offsets(const std::string &calfname);
   int DoQuickClockOffsetCalib();
 
+  int debugintt{0};
+  void ReadSyncFile(const char *fname = "SYNC_INTTMBD.root");
+
   float gaincorr[MbdDefs::MBD_N_PMT]{};       // gain corrections
   float tq_t0_offsets[MbdDefs::MBD_N_PMT]{};  // t0 offsets in charge channels
   float tq_clk_offsets[MbdDefs::MBD_N_PMT]{};
@@ -70,6 +77,7 @@ class MbdEvent : public Fun4AllBase
 
   int _verbose{0};
   int _runnum{0};
+  int _simflag{0};
   Packet *p[2]{nullptr, nullptr};
 
   // alignment data
@@ -95,6 +103,7 @@ class MbdEvent : public Fun4AllBase
   Float_t m_bbcq[2]{};                                            // total charge (currently npe) in each arm
   Float_t m_bbct[2]{};                                            // time in arm
   Float_t m_bbcte[2]{};                                           // earliest hit time in arm
+  Float_t m_bbctl[2]{};                                           // latest hit time in arm
   Float_t m_bbcz{std::numeric_limits<Float_t>::quiet_NaN()};      // z-vertex
   Float_t m_bbczerr{std::numeric_limits<Float_t>::quiet_NaN()};   // z-vertex error
   Float_t m_bbct0{std::numeric_limits<Float_t>::quiet_NaN()};     // start time
@@ -102,13 +111,25 @@ class MbdEvent : public Fun4AllBase
   Float_t _tres = std::numeric_limits<Float_t>::quiet_NaN();      // time resolution of one channel
 
   TH1 *hevt_bbct[2]{};  // time in each bbc, per event
-  TF1 *gaussian{nullptr};
+  TF1 *gausfit[2] {nullptr,nullptr};
 
   TH2 *h2_tmax[2] = {};  // [0 == time ch, 1 == chg ch], max sample in evt vs ch
 
   float TRIG_SAMP[16]{};  // [board]
 
   TCanvas *ac{nullptr};  // for plots used during debugging
+
+  // debug stuff
+  std::unique_ptr<TFile> _synctfile { nullptr };
+  TTree *_syncttree { nullptr };
+  int _syncevt {0};
+  std::vector<Int_t>    bbevt;
+  std::vector<UShort_t> bbclk;
+  std::vector<Float_t>  mybbz;
+  std::vector<Long64_t> bco;
+  std::vector<Double_t> intz;
+  std::vector<Double_t> bbz;
+
 };
 
 #endif /* MBD_MBDEVENT_H */

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -56,9 +56,11 @@ int MbdReco::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
+  int ret = getNodes(topNode);
+
+  m_mbdevent->SetSim( _simflag );
   m_mbdevent->InitRun();
 
-  int ret = getNodes(topNode);
   return ret;
 }
 
@@ -187,6 +189,8 @@ int MbdReco::getNodes(PHCompositeNode *topNode)
 
   if ( m_event==nullptr )
   {
+    _simflag = 1;
+
     static int counter = 0;
     if ( counter < 1 )
     {

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -1,7 +1,7 @@
 #include "MbdReco.h"
 #include "MbdEvent.h"
 #include "MbdPmtContainerV1.h"
-#include "MbdOutV1.h"
+#include "MbdOutV2.h"
 #include "MbdGeomV1.h"
 
 
@@ -147,7 +147,7 @@ int MbdReco::createNodes(PHCompositeNode *topNode)
   m_mbdout = findNode::getClass<MbdOut>(bbcNode, "MbdOut");
   if (!m_mbdout)
   {
-    m_mbdout = new MbdOutV1();
+    m_mbdout = new MbdOutV2();
     PHIODataNode<PHObject> *MbdOutNode = new PHIODataNode<PHObject>(m_mbdout, "MbdOut", "PHObject");
     bbcNode->addNode(MbdOutNode);
   }

--- a/offline/packages/mbd/MbdReco.h
+++ b/offline/packages/mbd/MbdReco.h
@@ -31,6 +31,7 @@ class MbdReco : public SubsysReco
  private:
   int createNodes(PHCompositeNode *topNode);
   int getNodes(PHCompositeNode *topNode);
+  int _simflag {0};
 
   float m_tres = 0.05;
   std::unique_ptr<TF1> m_gaussian = nullptr;

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -87,7 +87,7 @@ void MbdSig::Init()
   hPed0 = new TH1F(name,name,16384,-0.5,16383.5);
   //hPed0 = new TH1F(name,name,10000,1,0); // automatically determine the range
 
-  SetTemplateSize(300,300,-10.,20.);
+  SetTemplateSize(900,1000,-10.,20.);
   //SetTemplateSize(300,300,0.,15.);
 }
 
@@ -519,19 +519,19 @@ Double_t MbdSig::MBD(const Int_t max_samp)
   Double_t *y = gSubPulse->GetY();
 
   if ( y==0 ) { 
-    cout << "ERROR y == 0" << endl; 
-    return 0;
+    std::cout << "ERROR y == 0" << std::endl; 
+    return NAN;
   }
 
   // SHOULD INCLUDE TIME CALIBRATION HERE
-  Double_t t0 = y[max_samp];
+  f_time = y[max_samp];
 
   // Get max amplitude, and set it if it hasn't already been set
   int n = gSubPulse->GetN();
   Double_t ymax = TMath::MaxElement(n,y);
   if ( f_ampl == -9999. ) f_ampl = ymax;
 
-  return t0;
+  return f_time;
 }
 
 Double_t MbdSig::Integral(const Double_t xmin, const Double_t xmax)
@@ -785,7 +785,7 @@ int MbdSig::FitTemplate()
   return 1;
 }
 
-int MbdSig::SetTemplate(const std::vector<Double_t>& shape, const std::vector<Double_t>& sherr)
+int MbdSig::SetTemplate(const std::vector<float>& shape, const std::vector<float>& sherr)
 {
   template_y = shape;
   template_yrms = sherr;
@@ -808,7 +808,7 @@ int MbdSig::SetTemplate(const std::vector<Double_t>& shape, const std::vector<Do
     //template_fcn = new TF1(name,this,&MbdSig::TemplateFcn,-10,20,2,"MbdSig","TemplateFcn");
     template_fcn = new TF1(name,this,&MbdSig::TemplateFcn,0,nsamples,2,"MbdSig","TemplateFcn");
     template_fcn->SetParameters(1,10);
-    SetTemplateSize(300,300,-10.,20.);
+    SetTemplateSize(900,1000,-10.,20.);
 
     if ( verbose )
     {

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -96,7 +96,7 @@ public:
 
   /** Make template waveforms for later fits */
   void  SetTemplateSize(const Int_t nptsx, const Int_t nptsy, const Double_t begt, const Double_t endt);
-  Int_t SetTemplate(const std::vector<Double_t>& shape, const std::vector<Double_t>& sherr);
+  Int_t SetTemplate(const std::vector<float>& shape, const std::vector<float>& sherr);
 
   //Double_t FitPulse();
   void     SetTimeOffset(const Double_t o) { f_time_offset = o; }
@@ -161,8 +161,8 @@ private:
   //Double_t template_max_good_amplitude;  //! for template, in original units of waveform data
   //Double_t template_min_xrange;          //! for template, in original units of waveform data
   //Double_t template_max_xrange;          //! for template, in original units of waveform data
-  std::vector<Double_t> template_y;
-  std::vector<Double_t> template_yrms;
+  std::vector<float> template_y;
+  std::vector<float> template_yrms;
   TF1     *template_fcn;
   Double_t fit_min_time;                 //! min time for fit, in original units of waveform data
   Double_t fit_max_time;                 //! max time for fit, in original units of waveform data

--- a/simulation/g4simulation/g4bbc/MbdDigitization.cc
+++ b/simulation/g4simulation/g4bbc/MbdDigitization.cc
@@ -60,7 +60,7 @@ MbdDigitization::~MbdDigitization()
 //___________________________________
 int MbdDigitization::Init(PHCompositeNode *topNode)
 {
-  // std::cout << PHWHERE << std::endl;
+  if ( Verbosity() ) std::cout << PHWHERE << std::endl;
   CreateNodes(topNode);
 
   _pdg = new TDatabasePDG();  // database of PDG info on particles
@@ -83,6 +83,7 @@ int MbdDigitization::InitRun(PHCompositeNode *topNode)
 // Call user instructions for every event
 int MbdDigitization::process_event(PHCompositeNode * /*topNode*/)
 {
+  if ( Verbosity() ) std::cout << PHWHERE << std::endl;
   //**** Initialize Variables
 
   // PMT data
@@ -112,6 +113,7 @@ int MbdDigitization::process_event(PHCompositeNode * /*topNode*/)
   }
 
   // Go through BBC G4 hits
+  if ( Verbosity()>10 ) std::cout << "Processing BBC G4 Hits" << std::endl;
 
   TLorentzVector v4;
   unsigned int nhits = 0;
@@ -173,6 +175,12 @@ int MbdDigitization::process_event(PHCompositeNode * /*topNode*/)
     }
 
     nhits++;
+  }
+
+  if ( Verbosity()>10 )
+  {
+    std::cout << "Found " << nhits << " MBD hits" << std::endl;
+    std::cout << "Calculating response and storing in MbdPmtHits" << std::endl;
   }
 
   for (int ipmt = 0; ipmt < MbdDefs::MBD_N_PMT; ipmt++)


### PR DESCRIPTION
[comment]: Enabled template fit to waveforms.  Also added debug code to evaluate z-vertex reconstruction.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: From now on, the default is to use template fits.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

