### PR TITLE
Timestamp

### DIFF
--- a/calibrations/framework/oncal/OnCalServer.cc
+++ b/calibrations/framework/oncal/OnCalServer.cc
@@ -704,7 +704,6 @@ bool OnCalServer::connectDB()
 
 int OnCalServer::DisconnectDB()
 {
-  Fun4AllServer::DisconnectDB();
   delete DBconnection;
   DBconnection = nullptr;
   return 0;

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1601,11 +1601,6 @@ void Fun4AllServer::GetInputFullFileList(std::vector<std::string> &fnames) const
   return;
 }
 
-int Fun4AllServer::DisconnectDB()
-{
-  return 0;
-}
-
 unsigned
 Fun4AllServer::GetTopNodes(std::vector<std::string> &names) const
 {
@@ -1682,16 +1677,10 @@ int Fun4AllServer::setRun(const int runno)
 {
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runno);
-  PHTimeStamp *tstamp = nullptr;
-  if (!tstamp)
-  {
-    tstamp = new PHTimeStamp(0);
-    std::cout << "Fun4AllServer::setRun(): could not get timestamp for run  " << runno
-              << ", using tics(0) timestamp: ";
-    tstamp->print();
-    std::cout << std::endl;
-  }
-  delete tstamp;
+  rc->set_uint64Flag("TIMESTAMP",runno);
+  std::cout << "Fun4AllServer::setRun(): run " << runno
+	    << " uses CDB TIMESTAMP " << rc->get_uint64Flag("TIMESTAMP")
+	    << std::endl;
   FrameWorkVars->SetBinContent(RUNNUMBERBIN, (Stat_t) runno);
   return 0;
 }

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -848,21 +848,6 @@ int Fun4AllServer::BeginRun(const int runno)
     BeginRunSubsystem(std::make_pair(NewSubsystems.front().first, topNode(NewSubsystems.front().second)));
   }
   gROOT->cd(currdir.c_str());
-  // disconnect from DB to save resources on DB machine
-  // PdbCal leaves the DB connection open (PdbCal will reconnect without
-  // problem if neccessary)
-  if (!keep_db_connected)
-  {
-    DisconnectDB();
-  }
-  else
-  {
-    std::cout << "WARNING WARNING, DBs will not be disconnected" << std::endl;
-    std::cout << "This is for DB server testing purposes only" << std::endl;
-    std::cout << "If you do not test our DB servers, remove" << std::endl;
-    std::cout << "Fun4AllServer->KeepDBConnection()" << std::endl;
-    std::cout << "from your macro" << std::endl;
-  }
   // print out all node trees
   Print("NODETREE");
 #ifdef FFAMEMTRACKER
@@ -1677,7 +1662,10 @@ int Fun4AllServer::setRun(const int runno)
 {
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runno);
-  rc->set_uint64Flag("TIMESTAMP",runno);
+  if (! rc->FlagExist("TIMESTAMP"))
+  {
+    rc->set_uint64Flag("TIMESTAMP",runno);
+  }
   std::cout << "Fun4AllServer::setRun(): run " << runno
 	    << " uses CDB TIMESTAMP " << rc->get_uint64Flag("TIMESTAMP")
 	    << std::endl;

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -98,7 +98,6 @@ class Fun4AllServer : public Fun4AllBase
   int BranchSelect(const std::string &branch, int iflag);
   int setBranches(const std::string &managername);
   int setBranches();
-  virtual int DisconnectDB();
   virtual void identify(std::ostream &out = std::cout) const;
   unsigned GetTopNodes(std::vector<std::string> &names) const;
   void GetInputFullFileList(std::vector<std::string> &fnames) const;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR sets the cdb timestamp to the run number. This should work for the sims (the calibrations start at 0 to infinity, so small runnumbers are covered) and for our 2023 runs. Once the runDB has settled it will provide the cdb timestamp. But with this change we do not have to set this in the macros anymore
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

