### PR TITLE
Make FastJetAlgoSub fill JetContainer (it wasn't)

### DIFF
--- a/offline/packages/jetbackground/FastJetAlgoSub.cc
+++ b/offline/packages/jetbackground/FastJetAlgoSub.cc
@@ -3,6 +3,7 @@
 
 #include <jetbase/Jet.h>
 #include <jetbase/Jetv2.h>
+#include <jetbase/JetContainer.h>
 
 // fastjet includes
 #include <fastjet/ClusterSequence.hh>
@@ -50,8 +51,13 @@ void FastJetAlgoSub::identify(std::ostream& os)
   os << endl;
 }
 
-std::vector<Jet*> FastJetAlgoSub::get_jets(std::vector<Jet*> particles)
+/* std::vector<Jet*> FastJetAlgoSub::get_jets(std::vector<Jet*> particles) */
+/* { }; //  deprecated by iterating from JetMap; now is JetContainer and most code moved into */
+        //  into cluster_and_fill
+
+void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer* jetcont) 
 {
+  std::cout << "FIXME I0 :: GOT JETS" << std::endl;
   if (_verbosity > 1) cout << "FastJetAlgoSub::process_event -- entered" << endl;
 
   // translate to fastjet
@@ -99,7 +105,8 @@ std::vector<Jet*> FastJetAlgoSub::get_jets(std::vector<Jet*> particles)
   else if (_algo == Jet::CAMBRIDGE)
     jetdef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, _par, fastjet::E_scheme, fastjet::Best);
   else
-    return std::vector<Jet*>();
+    return;
+
   fastjet::ClusterSequence jetFinder(pseudojets, *jetdef);
   std::vector<fastjet::PseudoJet> fastjets = jetFinder.inclusive_jets();
   delete jetdef;
@@ -108,7 +115,7 @@ std::vector<Jet*> FastJetAlgoSub::get_jets(std::vector<Jet*> particles)
   std::vector<Jet*> jets;
   for (unsigned int ijet = 0; ijet < fastjets.size(); ++ijet)
   {
-    Jet* jet = new Jetv2();
+    auto jet = jetcont->add_jet();
 
     if (_verbosity > 5 && fastjets[ijet].perp() > 15)
     {
@@ -148,11 +155,8 @@ std::vector<Jet*> FastJetAlgoSub::get_jets(std::vector<Jet*> particles)
       std::cout << " FastJetAlgoSub : jet # " << ijet << " after correcting for proper constituent kinematics, pt / eta / phi = " << jet->get_pt() << " / " << jet->get_eta() << " / " << jet->get_phi();
       std::cout << ", px / py / pz / e = " << jet->get_px() << " / " << jet->get_py() << " / " << jet->get_pz() << " / " << jet->get_e() << std::endl;
     }
-
-    jets.push_back(jet);
   }
 
   if (_verbosity > 1) cout << "FastJetAlgoSub::process_event -- exited" << endl;
-
-  return jets;
+  return;
 }

--- a/offline/packages/jetbackground/FastJetAlgoSub.h
+++ b/offline/packages/jetbackground/FastJetAlgoSub.h
@@ -17,7 +17,8 @@ class FastJetAlgoSub : public JetAlgo
   Jet::ALGO get_algo() override { return _algo; }
   float get_par() override { return _par; }
 
-  std::vector<Jet*> get_jets(std::vector<Jet*> particles) override;
+  /* std::vector<Jet*> get_jets(std::vector<Jet*> particles) override; */
+  void cluster_and_fill(std::vector<Jet*>& part_in, JetContainer* jets_out) override;
 
  private:
   int _verbosity;


### PR DESCRIPTION
FastJetAlgoSub inherits from JetAlgo (and not FastJetAlgo), and was quietly not filling the JetContainer. This is, to the best I can tell, only used in the HIJetReco package. In any case, this fix should fix all instances where it is used.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

