### PR TITLE
TPC `side` fix, try 2

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -217,7 +217,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     uint16_t sam = tpchit->get_samples();
 
     varname = "phi";// + std::to_string(key);
-    double phi = pow(-1,side)*m_cdbttree->GetDoubleValue(key,varname) + (sector - side*12)*M_PI/6;
+    double phi = pow(-1,side)*m_cdbttree->GetDoubleValue(key,varname) + (sector % 12)*M_PI/6;
     
     PHG4TpcCylinderGeom *layergeom = geom_container->GetLayerCellGeom(layer);
     unsigned int phibin = layergeom->find_phibin(phi);
@@ -238,7 +238,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     fX[n++] = sam;
     m_ntup->Fill(fX);
 
-    hit_set_key = TpcDefs::genHitSetKey(layer, (mc_sectors[sector - side*12]), side);
+    hit_set_key = TpcDefs::genHitSetKey(layer, (mc_sectors[sector % 12]), side);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
       
     float hpedestal = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Missed two lines in the last PR https://github.com/sPHENIX-Collaboration/coresoftware/pull/2406 . Giving another try. 

There is possible swap in the phi direction in the sectors, which need to be checked with cross-sector cosmic track display. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

