### PR TITLE
Micromegas calibrations

### DIFF
--- a/offline/packages/micromegas/MicromegasCalibrationData.cc
+++ b/offline/packages/micromegas/MicromegasCalibrationData.cc
@@ -24,7 +24,7 @@ std::ostream& operator << (std::ostream& out, const MicromegasCalibrationData& c
 {
   out << "MicromegasCalibrationData" << std::endl;
   size_t total_entries = 0;
-  for( const auto& [fee_id, data_array] : calib_data.m_calibration_map )
+  for( const auto& [fee_id, data_array] : calib_data.m_raw_calibration_map )
   {
     total_entries += data_array.size();
     out << "fee_id: " << fee_id << " entries: " << data_array.size() << std::endl;
@@ -33,42 +33,49 @@ std::ostream& operator << (std::ostream& out, const MicromegasCalibrationData& c
       const auto& data = data_array[i];
       out << "fee_id: " << fee_id << " channel: " << i << " pedestal: " << data.m_pedestal << " rms: " << data.m_rms << std::endl;
     }
-    
+
   }
   out << "total entries: " << total_entries << std::endl;
-    
+
 
   return out;
 }
-  
+
 //________________________________________________________________________-
 void MicromegasCalibrationData::read( const std::string& filename )
 {
   std::cout << "MicromegasCalibrationData::read - filename: " << filename << std::endl;
 
   // clear existing data
-  m_calibration_map.clear();
+  m_raw_calibration_map.clear();
+  m_mapped_calibration_map.clear();
 
   // make sure file exists before loading, otherwise crashes
-  if( !std::ifstream( filename.c_str() ).good() ) 
+  if( !std::ifstream( filename.c_str() ).good() )
   {
     std::cout << "MicromegasCalibrationData::read -"
       << " filename: " << filename << " does not exist."
       << " No calibration loaded" << std::endl;
     return;
   }
-  
-  // use generic CDBTree to load 
+
+  // use generic CDBTree to load
   CDBTTree cdbttree( filename );
   cdbttree.LoadCalibrations();
-    
+
   // loop over registered fee ids
   MicromegasMapping mapping;
   for( const auto& fee:mapping.get_fee_id_list() )
-  {    
+  {
+    // get corresponding hitset key
+    const auto hitsetkey = mapping.get_hitsetkey(fee);
+
     // loop over channels
     for( int i = 0; i < m_nchannels_fee; ++i )
     {
+      // get matching strip id
+      const auto strip = mapping.get_physical_strip( fee, i );
+
       // read pedestal and rms
       int channel = fee*m_nchannels_fee + i;
       double pedestal = cdbttree.GetDoubleValue( channel, m_pedestal_key, 0 );
@@ -76,31 +83,41 @@ void MicromegasCalibrationData::read( const std::string& filename )
 
       // insert in local structure
       if( !std::isnan( rms ) )
-      { m_calibration_map[fee].at(i) = calibration_data_t( pedestal, rms ); }
+      {
+        // create calibration data
+        const calibration_data_t calibration_data( pedestal, rms );
+
+        // insert in fee,channel structure
+        m_raw_calibration_map[fee].at(i) = calibration_data;
+
+        // also insert in hitsetkey, strip structure
+        if( hitsetkey > 0 && strip >= 0 )
+        { m_mapped_calibration_map[hitsetkey].at(strip) = calibration_data; }
+      }
     }
-  }  
+  }
 }
 
 //________________________________________________________________________-
 void MicromegasCalibrationData::set_pedestal( int fee, int channel, double value )
-{ m_calibration_map[fee].at(channel).m_pedestal = value; }
+{ m_raw_calibration_map[fee].at(channel).m_pedestal = value; }
 
 //________________________________________________________________________-
 void MicromegasCalibrationData::set_rms( int fee, int channel, double value )
-{ m_calibration_map[fee].at(channel).m_rms = value; }
+{ m_raw_calibration_map[fee].at(channel).m_rms = value; }
 
 //________________________________________________________________________-
 void MicromegasCalibrationData::write( const std::string& filename ) const
 {
   std::cout << "MicromegasCalibrationData::write - filename: " << filename << std::endl;
-  if( m_calibration_map.empty() ) return;
+  if( m_raw_calibration_map.empty() ) return;
 
-  // use generic CDBTree to load 
+  // use generic CDBTree to load
   CDBTTree cdbttree( filename );
-  for( const auto& [fee,array]:m_calibration_map )
+  for( const auto& [fee,array]:m_raw_calibration_map )
   {
     for( size_t i = 0; i < array.size(); ++i )
-    { 
+    {
       int channel = fee*m_nchannels_fee + i;
       const auto& pedestal =  array[i].m_pedestal;
       const auto& rms =  array[i].m_rms;
@@ -108,22 +125,36 @@ void MicromegasCalibrationData::write( const std::string& filename ) const
       cdbttree.SetDoubleValue( channel, m_rms_key, rms );
     }
   }
-  
+
   // commit and write
   cdbttree.Commit();
-  cdbttree.WriteCDBTTree();  
+  cdbttree.WriteCDBTTree();
 }
 
 //________________________________________________________________________-
 double MicromegasCalibrationData::get_pedestal( int fee, int channel ) const
 {
-  const auto iter = m_calibration_map.find(fee);
-  return (iter != m_calibration_map.end()) ? iter->second.at(channel).m_pedestal: -1;
+  const auto iter = m_raw_calibration_map.find(fee);
+  return (iter != m_raw_calibration_map.end()) ? iter->second.at(channel).m_pedestal: -1;
 }
 
 //________________________________________________________________________-
 double MicromegasCalibrationData::get_rms( int fee, int channel ) const
 {
-  const auto iter = m_calibration_map.find(fee);
-  return (iter != m_calibration_map.end()) ? iter->second.at(channel).m_rms: -1;
+  const auto iter = m_raw_calibration_map.find(fee);
+  return (iter != m_raw_calibration_map.end()) ? iter->second.at(channel).m_rms: -1;
+}
+
+//________________________________________________________________________-
+double MicromegasCalibrationData::get_pedestal_mapped( TrkrDefs::hitsetkey hitsetkey, int strip ) const
+{
+  const auto iter = m_mapped_calibration_map.find(hitsetkey);
+  return (iter != m_mapped_calibration_map.end()) ? iter->second.at(strip).m_pedestal: -1;
+}
+
+//________________________________________________________________________-
+double MicromegasCalibrationData::get_rms_mapped( TrkrDefs::hitsetkey hitsetkey, int strip ) const
+{
+  const auto iter = m_mapped_calibration_map.find(hitsetkey);
+  return (iter != m_mapped_calibration_map.end()) ? iter->second.at(strip).m_rms: -1;
 }

--- a/offline/packages/micromegas/MicromegasCalibrationData.h
+++ b/offline/packages/micromegas/MicromegasCalibrationData.h
@@ -22,7 +22,7 @@ class MicromegasCalibrationData
 
   ///@name modifiers
   //@{
-  
+
   /// read calibration from file
   void read( const std::string& /*filename*/ );
 
@@ -31,37 +31,43 @@ class MicromegasCalibrationData
 
   /// set rms for a given channel
   void set_rms( int /*fee*/, int /*channel*/, double /*value*/ );
-  
+
   //@}
-  
+
   //!@name accessors
   //@{
-  
+
   /// write calibration to file
   void write( const std::string& /*filename*/ ) const;
-    
-  /// get pedestal for a given channel
+
+  /// get pedestal for a given feeid and channel
   double get_pedestal( int /*fee*/, int /*channel*/ ) const;
- 
-  /// get rms for a given channel
+
+  /// get rms for a given feeid and channel
   double get_rms( int /*fee*/, int /*channel*/ ) const;
-  
+
+  /// get pedestal for a given hitsetkey and strip
+  double get_pedestal_mapped( TrkrDefs::hitsetkey /*hitsetkey*/, int /*strip*/ ) const;
+
+  /// get rms for a given hitsetkey and strip
+  double get_rms_mapped( TrkrDefs::hitsetkey /*hitsetkey*/, int /*strip*/ ) const;
+
   //@}
-   
+
   private:
-   
+
   /// simple structure to store calibration data
   class calibration_data_t
   {
-    public:    
-    
+    public:
+
     calibration_data_t() = default;
-    
+
     calibration_data_t( double pedestal, double rms ):
       m_pedestal( pedestal ),
       m_rms( rms )
     {}
-    
+
     double m_pedestal = 0;
     double m_rms = 0;
   };
@@ -69,12 +75,16 @@ class MicromegasCalibrationData
   static constexpr int m_nchannels_fee = 256;
   using calibration_vector_t = std::array<calibration_data_t,m_nchannels_fee>;
 
-  /// map fee id to calibration vector
-  using calibration_map_t = std::map<int, calibration_vector_t>;
-  calibration_map_t m_calibration_map;
-    
+  /// map fee id to channel based calibration vector
+  using raw_calibration_map_t = std::map<int, calibration_vector_t>;
+  raw_calibration_map_t m_raw_calibration_map;
+
+  /// map hitset key to strip based calibration vector
+  using mapped_calibration_map_t = std::map<TrkrDefs::hitsetkey,calibration_vector_t>;
+  mapped_calibration_map_t m_mapped_calibration_map;
+
   friend std::ostream& operator << (std::ostream&, const MicromegasCalibrationData& );
-  
+
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -6,9 +6,11 @@
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
 
+#include "MicromegasCalibrationData.h"
+
 #include <fun4all/SubsysReco.h>
 
-#include <string>        
+#include <string>
 
 class PHCompositeNode;
 
@@ -20,19 +22,47 @@ class MicromegasClusterizer : public SubsysReco
   //! constructor
   MicromegasClusterizer( const std::string &name = "MicromegasClusterizer" );
 
+  /// global initialization
+  int Init(PHCompositeNode*) override;
+
   //! run initialization
   int InitRun(PHCompositeNode*) override;
 
   //! event processing
   int process_event(PHCompositeNode*) override;
 
-  //! read raw data 
-  /** not implemented for now */
-  void set_read_raw(bool read_raw){ do_read_raw = read_raw;}
+  /// set default pedestal
+  void set_default_pedestal( double value )
+  { m_default_pedestal = value; }
+
+  /// set whether default pedestal is used or not
+  void set_use_default_pedestal( bool value )
+  { m_use_default_pedestal = value; }
+
+  /// calibration file
+  void set_calibration_file( const std::string& value )
+  { m_calibration_filename = value; }
 
   private:
 
-  bool do_read_raw = false;
+  //!@name calibration filename
+  //@{
+
+  /// if true, use default pedestal to get hit charge. Relies on calibration data otherwise
+  bool m_use_default_pedestal = true;
+
+  /// default pedestal
+  double m_default_pedestal = 74.6;
+
+  /// calibration filename
+  std::string m_calibration_filename;
+
+  /// calibration data
+  MicromegasCalibrationData m_calibration_data;
+
+  //@}
+
+
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
@@ -31,6 +31,24 @@ MicromegasCombinedDataDecoder::MicromegasCombinedDataDecoder( const std::string&
 //_____________________________________________________________________
 int MicromegasCombinedDataDecoder::Init(PHCompositeNode* /*topNode*/ )
 {
+  // print configuration
+  std::cout
+    << "MicromegasCombinedDataDecoder::Init -"
+    << " m_calibration_filename: "
+    << (m_calibration_filename.empty() ? "unspecified":m_calibration_filename )
+    << std::endl;
+
+  std::cout
+    << "MicromegasCombinedDataDecoder::Init -"
+    << " m_hot_channel_map_filename: "
+    << (m_hot_channel_map_filename.empty() ? "unspecified":m_hot_channel_map_filename)
+    << std::endl;
+
+  std::cout << "MicromegasCombinedDataDecoder::Init - m_n_sigma: " << m_n_sigma << std::endl;
+  std::cout << "MicromegasCombinedDataDecoder::Init - m_min_adc: " << m_min_adc << std::endl;
+  std::cout << "MicromegasCombinedDataDecoder::Init - m_sample_min: " << m_sample_min << std::endl;
+  std::cout << "MicromegasCombinedDataDecoder::Init - m_sample_max: " << m_sample_max << std::endl;
+
   // read calibrations
   m_calibration_data.read( m_calibration_filename );
 

--- a/offline/packages/micromegas/MicromegasMapping.cc
+++ b/offline/packages/micromegas/MicromegasMapping.cc
@@ -11,42 +11,42 @@
 
 namespace
 {
-  
+
   class mec8_channel_id
   {
     public:
-    
+
     /*
-    * 0 or 1, corresponding to cable1 and cable 2 as defined by Takao in 
+    * 0 or 1, corresponding to cable1 and cable 2 as defined by Takao in
     * https://indico.bnl.gov/event/18458/contributions/73400/attachments/46043/77969/FEE_to_MEC_map_Feb17_2023.xlsx
     */
     int m_cable_id = 0;
-    
+
     /*
     * 0 or 1, corresponding to j2 or j3 in transition board drawing in
     * https://wiki.sphenix.bnl.gov/index.php/File:HDR-225938-XX.PNG.png
     * https://wiki.sphenix.bnl.gov/index.php/File:HDR-225940-XX.PNG.png
-    * and as defined by Takao in 
+    * and as defined by Takao in
     * https://indico.bnl.gov/event/18458/contributions/73400/attachments/46043/77969/FEE_to_MEC_map_Feb17_2023.xlsx
     */
     int m_connector_id = 0;
-    
+
     /*
-    * 1 to 70 as defined in 
+    * 1 to 70 as defined in
     * https://wiki.sphenix.bnl.gov/index.php/File:HDR-225938-XX.PNG.png
     * https://wiki.sphenix.bnl.gov/index.php/File:HDR-225940-XX.PNG.png
     */
     int m_channel_id = 0;
-    
+
     // constructor
     mec8_channel_id( int cable_id, int connector_id, int channel_id ):
       m_cable_id( cable_id ),
       m_connector_id( connector_id ),
       m_channel_id( channel_id )
     {}
-    
+
   };
-    
+
   // less than operator
   inline bool operator < (const mec8_channel_id& lhs, const mec8_channel_id& rhs )
   {
@@ -54,7 +54,7 @@ namespace
     if( lhs.m_connector_id != rhs.m_connector_id ) return lhs.m_connector_id < rhs.m_connector_id;
     return lhs.m_channel_id < rhs.m_channel_id;
   }
-  
+
   // print mapping
   [[maybe_unused]] void print_mapping( const std::string& name, const std::array<int, MicromegasDefs::m_nchannels_fee>& array )
   {
@@ -71,10 +71,10 @@ namespace
       std::cout << array[i];
       ++count;
     }
-    
+
     std::cout << std::endl << "};" << std::endl;
   }
-  
+
 }
 
 //____________________________________________________________________________________________________
@@ -113,22 +113,21 @@ m_detectors( {
     if(TrkrDefs::getLayer( lhs.m_hitsetkey ) != TrkrDefs::getLayer( rhs.m_hitsetkey ) ) return TrkrDefs::getLayer( lhs.m_hitsetkey ) < TrkrDefs::getLayer( rhs.m_hitsetkey );
     else return MicromegasDefs::getTileId( lhs.m_hitsetkey ) < MicromegasDefs::getTileId( rhs.m_hitsetkey );
   } );
-  
+
   // fill detector map from vector
   for( const auto& detector_id:m_detectors )
   { m_detector_map.emplace( detector_id.m_fee_id, detector_id ); }
 
   // construct channel mapping
   construct_channel_mapping();
-  
 }
 
 //____________________________________________________________________________________________________
-std::vector<int> MicromegasMapping::get_fee_id_list() const 
+std::vector<int> MicromegasMapping::get_fee_id_list() const
 {
   std::vector<int> out;
   std::transform( m_detectors.begin(), m_detectors.end(), std::back_inserter( out ), []( const DetectorId& det_id ){ return det_id.m_fee_id; } );
-  return out;  
+  return out;
 }
 
 //____________________________________________________________________________________________________
@@ -173,19 +172,19 @@ int MicromegasMapping::get_physical_strip( int fee_id, int channel_id) const
     std::cout << "MicromegasMapping::get_physical_strip - invalid channel: " << channel_id << std::endl;
     return -1;
   }
-  
+
   // get hitsetkey and orientation
   const auto hitsetkey = get_hitsetkey(fee_id);
   const auto segmentation_type = MicromegasDefs::getSegmentationType(hitsetkey);
-  switch (segmentation_type)    
+  switch (segmentation_type)
   {
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
     return m_fee_to_strip_mapping_z[channel_id];
-  
+
     case MicromegasDefs::SegmentationType::SEGMENTATION_PHI:
     return m_fee_to_strip_mapping_phi[channel_id];
   }
-  
+
   // never reached
   return -1;
 }
@@ -225,7 +224,7 @@ void MicromegasMapping::construct_channel_mapping()
    * the other 64 channels are signals
    */
   // source: https://indico.bnl.gov/event/18458/contributions/73400/attachments/46043/77969/FEE_to_MEC_map_Feb17_2023.xlsx
-  std::array<mec8_channel_id, MicromegasDefs::m_nchannels_fee> fee_to_mec8_mapping = 
+  std::array<mec8_channel_id, MicromegasDefs::m_nchannels_fee> fee_to_mec8_mapping =
   {{
     {0,0,34}, {0,0,33}, {0,0,32}, {0,0,31}, {0,0,30}, {0,0,29}, {0,0,28}, {0,0,27},
     {0,0,26}, {0,0,25}, {0,0,24}, {0,0,23}, {0,0,22}, {0,0,21}, {0,0,20}, {0,0,19},
@@ -331,7 +330,7 @@ void MicromegasMapping::construct_channel_mapping()
     {41,21}, {42,53}, {43,22}, {44,54}, {45,23}, {46,55}, {47,24}, {48,56},
     {49,25}, {50,57}, {51,26}, {52,58}, {53,27}, {54,59}, {55,28}, {56,60},
     {57,29}, {58,61}, {59,30}, {60,62}, {61,31}, {62,63}, {63,32}, {64,64},
-    
+
     {65,65}, {66,97}, {67,66}, {68,98}, {69,67}, {70,99}, {71,68}, {72,100},
     {73,69}, {74,101}, {75,70}, {76,102}, {77,71}, {78,103}, {79,72}, {80,104},
     {81,73}, {82,105}, {83,74}, {84,106}, {85,75}, {86,107}, {87,76}, {88,108},
@@ -340,7 +339,7 @@ void MicromegasMapping::construct_channel_mapping()
     {105,85}, {106,117}, {107,86}, {108,118}, {109,87}, {110,119}, {111,88}, {112,120},
     {113,89}, {114,121}, {115,90}, {116,122}, {117,91}, {118,123}, {119,92}, {120,124},
     {121,93}, {122,125}, {123,94}, {124,126}, {125,95}, {126,127}, {127,96}, {128,128},
-    
+
     {129,129}, {130,161}, {131,130}, {132,162}, {133,131}, {134,163}, {135,132}, {136,164},
     {137,133}, {138,165}, {139,134}, {140,166}, {141,135}, {142,167}, {143,136}, {144,168},
     {145,137}, {146,169}, {147,138}, {148,170}, {149,139}, {150,171}, {151,140}, {152,172},
@@ -349,7 +348,7 @@ void MicromegasMapping::construct_channel_mapping()
     {169,149}, {170,181}, {171,150}, {172,182}, {173,151}, {174,183}, {175,152}, {176,184},
     {177,153}, {178,185}, {179,154}, {180,186}, {181,155}, {182,187}, {183,156}, {184,188},
     {185,157}, {186,189}, {187,158}, {188,190}, {189,159}, {190,191}, {191,160}, {192,192},
-    
+
     {193,193}, {194,225}, {195,194}, {196,226}, {197,195}, {198,227}, {199,196}, {200,228},
     {201,197}, {202,229}, {203,198}, {204,230}, {205,199}, {206,231}, {207,200}, {208,232},
     {209,201}, {210,233}, {211,202}, {212,234}, {213,203}, {214,235}, {215,204}, {216,236},
@@ -397,7 +396,7 @@ void MicromegasMapping::construct_channel_mapping()
   }
 
   // print_mapping( "m_fee_to_strip_mapping_z", m_fee_to_strip_mapping_z );
-  
+
   // map mec8 channel id (1-70) to mec8 signal id on detector as defined by audrey in phi views
   /* sources:
    * https://wiki.sphenix.bnl.gov/index.php/File:HDR-225938-XX.PNG.png
@@ -486,5 +485,5 @@ void MicromegasMapping::construct_channel_mapping()
   }
 
   // print_mapping( "m_fee_to_strip_mapping_phi", m_fee_to_strip_mapping_phi );
-  
+
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR allows to read calibrations in the micromegas clusterizer. This is necessary to subtract the correct pedestal from the hits ADC before calculating the cluster ADC weighted centroid.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

