### PR TITLE
Add fastjet::contrib::ConstituentSubtractor to FastJetAlgo

### DIFF
--- a/offline/packages/jetbase/FastJetAlgo.cc
+++ b/offline/packages/jetbase/FastJetAlgo.cc
@@ -12,14 +12,18 @@
 // fastjet includes
 #include <fastjet/AreaDefinition.hh>
 #include <fastjet/ClusterSequenceArea.hh>
+#include <fastjet/Selector.hh>
 #include <fastjet/tools/BackgroundEstimatorBase.hh>
 #include <fastjet/tools/JetMedianBackgroundEstimator.hh>
+#include <fastjet/tools/GridMedianBackgroundEstimator.hh>
 #include <fastjet/ClusterSequence.hh>
 #include <fastjet/FunctionOfPseudoJet.hh>  // for FunctionOfPse...
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/contrib/RecursiveSymmetryCutBase.hh>  // for RecursiveSymm...
 #include <fastjet/contrib/SoftDrop.hh>
+#include <fastjet/contrib/ConstituentSubtractor.hh>
+
 
 // standard includes
 #include <cmath>  // for isfinite
@@ -206,6 +210,23 @@ void FastJetAlgo::first_call_init(JetContainer* jetcont) {
     m_area_index = jetcont->property_index(Jet::PROPERTY::prop_area);
   }
 
+  if (m_opt.cs_calc_constsub) {
+    cs_bge_rho =  new fastjet::GridMedianBackgroundEstimator(m_opt.cs_max_eta, 0.5);
+    cs_subtractor = new fastjet::contrib::ConstituentSubtractor();
+	  cs_subtractor->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); 
+	  cs_subtractor->set_max_distance(m_opt.cs_max_dist); // free parameter for the maximal allowed distance between particle i and ghost k
+	  cs_subtractor->set_alpha(m_opt.cs_alpha);  // free parameter for the distance measure (the exponent of particle pt). The larger the parameter alpha, the more are favoured the lower pt particles in the subtraction process
+	  cs_subtractor->set_ghost_area(m_opt.cs_ghost_area); // free parameter for the density of ghosts. 
+	  cs_subtractor->set_max_eta(m_opt.cs_max_eta); // parameter for the maximal eta cut
+	  cs_subtractor->set_background_estimator(cs_bge_rho); // specify the background estimator to estimate rho.
+    if (m_opt.cs_max_pt > 0) {
+      cs_sel_max_pt = new fastjet::Selector(fastjet::SelectorPtMax(m_opt.cs_max_pt));
+      cs_subtractor->set_particle_selector(cs_sel_max_pt);
+    }
+    cs_subtractor->initialize();
+    if (m_opt.verbosity > 1) std::cout << cs_subtractor->description() << std::endl;
+  }
+
   jetcont->set_algo(m_opt.algo);
   jetcont->set_jetpar_R(m_opt.jet_R);
 }
@@ -220,6 +241,40 @@ void FastJetAlgo::cluster_and_fill(std::vector<Jet*>& particles, JetContainer* j
 
   // translate input jets to input fastjets
   auto pseudojets = jets_to_pseudojets(particles);
+
+  // if using constituent subtraction, oberve maximum eta and subtract the constituents
+  if (m_opt.cs_calc_constsub) {
+    if (m_opt.verbosity > 100) {
+      std::cout << " Before Constituent Subtraction: " << std::endl;
+      int i = 0;
+      double sumpt = 0.;
+      for (auto c : pseudojets) {
+        sumpt += c.perp();
+        if (i<100) std::cout << Form(" jet[%2i] %8.4f  sum %8.4f", i, c.perp(), sumpt) << std::endl;
+        i++;
+      }
+      auto _c = pseudojets.back();
+      std::cout << Form(" jet[%2i] %8.4f  sum %8.4f", i++, _c.perp(), sumpt) << std::endl << std::endl;
+    }
+
+    pseudojets = fastjet::SelectorAbsEtaMax(m_opt.cs_max_eta)(pseudojets);
+    cs_bge_rho->set_particles(pseudojets);
+    auto subtracted_pseudojets = cs_subtractor->subtract_event(pseudojets);
+    pseudojets = std::move(subtracted_pseudojets);
+    
+    if (m_opt.verbosity > 100) {
+      std::cout << " After Constituent Subtraction: " << std::endl;
+      int i = 0;
+      double sumpt = 0.;
+      for (auto c : pseudojets) {
+        sumpt += c.perp();
+        if (i<100) std::cout << Form(" jet[%2i] %8.4f  sum %8.4f", i, c.perp(), sumpt) << std::endl;
+        i++;
+      }
+      auto _c = pseudojets.back();
+      std::cout << Form(" jet[%2i] %8.4f  sum %8.4f", i++, _c.perp(), sumpt) << std::endl << std::endl;
+    }
+  }
 
   if (m_opt.calc_jetmedbkgdens) jetcont->set_rho_median(calc_rhomeddens(pseudojets));
 

--- a/offline/packages/jetbase/FastJetAlgo.h
+++ b/offline/packages/jetbase/FastJetAlgo.h
@@ -7,6 +7,8 @@
 
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/JetDefinition.hh>
+/* #include <fastjet/tools/GridMedianBackgroundEstimator.hh> */
+/* #include <fastjet/contrib/ConstituentSubtractor.hh> */
 
 #include <cmath>     // for NAN
 #include <climits>     // for NAN
@@ -16,8 +18,17 @@
 
 namespace fastjet {
   class PseudoJet;
+  class GridMedianBackgroundEstimator;
+  class SelectorPtMax;
+  namespace contrib {
+    class ConstituentSubtractor;
+  }
 }
+
 class JetContainer;
+/* class ConstituentSubtractor; */
+/* using fastjet::GridMedianBackgroundEstimator; */
+/* class GridMedianBackgroundEstimator; */
 
 class FastJetAlgo : public JetAlgo
 {
@@ -61,6 +72,12 @@ class FastJetAlgo : public JetAlgo
   fastjet::JetDefinition get_fastjet_definition();
   fastjet::Selector get_selector();
   void first_call_init(JetContainer*_=nullptr);
+
+  // private members
+  fastjet::contrib::ConstituentSubtractor* cs_subtractor = nullptr;
+  fastjet::GridMedianBackgroundEstimator*  cs_bge_rho    = nullptr;
+  fastjet::Selector*                       cs_sel_max_pt = nullptr;
+
 
   fastjet::ClusterSequence* m_cluseq {nullptr};
   fastjet::ClusterSequence* m_cluseqarea {nullptr};

--- a/offline/packages/jetbase/FastJetOptions.cc
+++ b/offline/packages/jetbase/FastJetOptions.cc
@@ -81,6 +81,34 @@ FastJetOptions& FastJetOptions::update(std::vector<FastJetOptItem> input)
       {
         nhardestcut_jetmedbkgdens = static_cast<int>(next_val(i, input));
       }
+      else if (item.opt == FJCS_doConstSub)
+      {
+        cs_calc_constsub = true;
+      }
+      else if (item.opt == FJCS_max_eta)
+      {
+        cs_max_eta = static_cast<float>(next_val(i, input));
+      }
+      else if (item.opt == FJCS_GridMedBkgEst_Size)
+      {
+        cs_gridmedestsize = static_cast<float>(next_val(i, input));
+      }
+      else if (item.opt == FJCS_max_dist)
+      {
+        cs_max_dist = static_cast<float>(next_val(i, input));
+      }
+      else if (item.opt == FJCS_alpha)
+      {
+        cs_alpha = static_cast<float>(next_val(i, input));
+      }
+      else if (item.opt == FJCS_max_pt)
+      {
+        cs_max_pt = static_cast<float>(next_val(i, input));
+      }
+      else if (item.opt == FJCS_ghost_area)
+      {
+        cs_ghost_area = static_cast<float>(next_val(i, input));
+      }
       else if (item.opt == VERBOSITY)
       {
         verbosity = static_cast<int>(next_val(i, input));
@@ -151,6 +179,10 @@ void FastJetOptions::print(std::ostream& os)
   {
     os << " - calculate jet median background estimator density with cutting "
        << nhardestcut_jetmedbkgdens << " hardest jets within |eta|<" << etahardestcut_jetmedbkgdens << std::endl;
+  }
+  
+  if (cs_calc_constsub) {
+    os << " - calculate jet background constituent subtractor " << std::endl;
   }
 }
 

--- a/offline/packages/jetbase/FastJetOptions.h
+++ b/offline/packages/jetbase/FastJetOptions.h
@@ -36,6 +36,14 @@ enum FastJetOptEnum
   , CUT_RhoMedNHardest // optional; default 2
   , NONE 
 
+  , FJCS_doConstSub   // FastJet Constituent Subtraction. Optional. Default: false
+  , FJCS_max_eta      // defaults to 1.1
+  , FJCS_GridMedBkgEst_Size // defaults to 0.5, may want smaller value, see http://fastjet.fr/repo/fastjet-doc-3.4.2.pdf
+  , FJCS_max_dist   // add to vector of max dist; can add multiple times. If not added at all, defualts to { .1, 0.15}
+  , FJCS_alpha      // same as above, but for alpha. Defaults to {{0., 0.}} if no entries
+  , FJCS_max_pt     // max pt for constituents to be adjusted -- defaults to -1. (i.e. doesn't use selector)
+  , FJCS_ghost_area // max pt for constituents to be adjusted -- defaults to -1. (i.e. doesn't use selector)
+
   , SAVE_JET_COMPONENTS      // optional; default true (I think this is what is hitting the e- spectra)
   , DONT_SAVE_JET_COMPONENTS // set save_jet_components to false
 
@@ -90,19 +98,30 @@ struct FastJetOptions
 
   bool  save_jet_components    = true;
 
+  // softdrop
   bool  doSoftDrop                  = false;
   float SD_beta                     = 0;
   float SD_zcut                     = 0;
   float SD_jet_min_pt               = 5.;
 
+  // calculate area
   bool  calc_area                   = false;
   float ghost_area                  = 0.01;
   float ghost_max_rap               = 0; // will default to min(jet_max_eta+Jet_R., 5)
 
+  // calculate jet median background density
   bool  calc_jetmedbkgdens          = false;
   float nhardestcut_jetmedbkgdens   = 2;
   float etahardestcut_jetmedbkgdens = 0.; // will default to jet_max_eta or ghost_max_rap
-  /* float rhoMedEtaNHardCut           = 0.; */
+
+  // calculate constituent subtraction
+  bool  cs_calc_constsub = false;
+  float cs_max_eta = 1.1;
+  float cs_max_pt = -1.; // max pt of which constituents are corrected
+  float cs_gridmedestsize = 0.5;
+  float cs_max_dist = 0.3;
+  float cs_alpha = 1.;
+  float cs_ghost_area = 0.01;
 
   int   verbosity                   = 0;
 

--- a/offline/packages/jetbase/Makefile.am
+++ b/offline/packages/jetbase/Makefile.am
@@ -21,7 +21,8 @@ libjetbase_io_la_LIBADD = \
 libjetbase_la_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  `fastjet-config --libs`
+  `fastjet-config --libs` \
+  -lConstituentSubtractor
 
 libjetbase_la_LIBADD = \
   libjetbase_io.la \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Presented to the JS-Topical Group on 1/17 and was ok'd. This is an option on jet reconstruction and doesn't change any default behaviors of the system.

Add's FastJet 3's default Constituent Background Subtractor option to FastJetAlgo.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

