### PR TITLE
feat: update TrackResiduals to output more O2O debug info

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -614,12 +614,20 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         m_hitpad = TpcDefs::getPad(hitkey);
         m_hittbin = TpcDefs::getTBin(hitkey);
 
-        auto local_GeoLayer = tpcGeom->GetLayerCellGeom(m_hitlayer);
-        auto phi = local_GeoLayer->get_phicenter(m_hitpad);
-        auto radius = local_GeoLayer->get_radius();
+        auto geoLayer = tpcGeom->GetLayerCellGeom(m_hitlayer);
+        auto phi = geoLayer->get_phicenter(m_hitpad);
+        auto radius = geoLayer->get_radius();
+        float AdcClockPeriod = 53.0;  // ns (?)
+        double zdriftlength = m_hittbin * geometry->get_drift_velocity() * AdcClockPeriod;
+        unsigned short NTBins = (unsigned short) geoLayer->get_zbins();
+        double tdriftmax = AdcClockPeriod * NTBins / 2.0;
+        m_hitgz = (tdriftmax * geometry->get_drift_velocity()) - zdriftlength;
+        if (m_side == 0)
+        {
+          m_hitgz *= -1;
+        }
         m_hitgx = radius * std::cos(phi);
         m_hitgy = radius * std::sin(phi);
-        m_hitgz = local_GeoLayer->get_zcenter(m_hittbin);
         break;
       }
       case TrkrDefs::TrkrId::micromegasId:

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -176,10 +176,13 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   if (gl1)
   {
     m_bco = gl1->get_bco();
+    auto lbshift = m_bco << 24;
+    m_bcotr = lbshift >> 24;
   }
   else
   {
     m_bco = std::numeric_limits<uint64_t>::quiet_NaN();
+    m_bcotr = std::numeric_limits<uint64_t>::quiet_NaN();
   }
   if (Verbosity() > 1)
   {
@@ -596,6 +599,7 @@ void TrackResiduals::createBranches()
   m_clustree = new TTree("clustertree", "A tree with all clusters");
   m_clustree->Branch("event", &m_event, "m_event/I");
   m_clustree->Branch("gl1bco", &m_bco, "m_bco/l");
+  m_clustree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_clustree->Branch("lx", &m_scluslx, "m_scluslx/F");
   m_clustree->Branch("lz", &m_scluslz, "m_scluslz/F");
   m_clustree->Branch("gx", &m_sclusgx, "m_sclusgx/F");
@@ -626,6 +630,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("event", &m_event, "m_event/I");
   m_tree->Branch("trackid", &m_trackid, "m_trackid/I");
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
+  m_tree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
   m_tree->Branch("px", &m_px, "m_px/F");
   m_tree->Branch("py", &m_py, "m_py/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -462,11 +462,6 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
       break;
     }
   }
-  if (!state)
-  {
-    //! skip clusters that don't have an associated track state
-    return;
-  }
 
   m_cluskeys.push_back(ckey);
 
@@ -499,7 +494,12 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     std::cout << "Track state/clus in layer "
               << TrkrDefs::getLayer(ckey) << std::endl;
   }
-
+  if (!state)
+  {
+    //! skip filling the state information if a state is not there
+    //! or we just ran the seeding
+    return;
+  }
   auto surf = geometry->maps().getSurface(ckey, cluster);
   Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
   Acts::Vector2 stateloc;
@@ -595,7 +595,7 @@ void TrackResiduals::createBranches()
 {
   m_clustree = new TTree("clustertree", "A tree with all clusters");
   m_clustree->Branch("event", &m_event, "m_event/I");
-  m_clustree->Branch("gl1bco", &m_bco, "m_bco");
+  m_clustree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_clustree->Branch("lx", &m_scluslx, "m_scluslx/F");
   m_clustree->Branch("lz", &m_scluslz, "m_scluslz/F");
   m_clustree->Branch("gx", &m_sclusgx, "m_sclusgx/F");
@@ -625,7 +625,7 @@ void TrackResiduals::createBranches()
   m_tree = new TTree("residualtree", "A tree with track, cluster, and state info");
   m_tree->Branch("event", &m_event, "m_event/I");
   m_tree->Branch("trackid", &m_trackid, "m_trackid/I");
-  m_tree->Branch("gl1bco", &m_bco, "m_bco");
+  m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
   m_tree->Branch("px", &m_px, "m_px/F");
   m_tree->Branch("py", &m_py, "m_py/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -206,8 +206,15 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     std::cout << "Track map size is " << trackmap->size() << std::endl;
   }
 
-  fillHitTree(hitmap, geometry, tpcGeom, mvtxGeom, inttGeom, mmGeom);
-  fillClusterTree(clustermap, geometry);
+  if (m_doHits)
+  {
+    fillHitTree(hitmap, geometry, tpcGeom, mvtxGeom, inttGeom, mmGeom);
+  }
+
+  if (m_doClusters)
+  {
+    fillClusterTree(clustermap, geometry);
+  }
 
   for (const auto& [key, track] : *trackmap)
   {
@@ -437,8 +444,14 @@ int TrackResiduals::End(PHCompositeNode*)
 {
   m_outfile->cd();
   m_tree->Write();
-  m_clustree->Write();
-  m_hittree->Write();
+  if (m_doClusters)
+  {
+    m_clustree->Write();
+  }
+  if (m_doHits)
+  {
+    m_hittree->Write();
+  }
   m_outfile->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -708,9 +721,43 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   if (!state)
   {
     //! skip filling the state information if a state is not there
-    //! or we just ran the seeding
+    //! or we just ran the seeding. Fill with Nans to maintain the
+    //! 1-to-1 mapping between cluster/state vectors
+    m_idealsurfalpha.push_back(NAN);
+    m_idealsurfbeta.push_back(NAN);
+    m_idealsurfgamma.push_back(NAN);
+    m_missurfalpha.push_back(NAN);
+    m_missurfbeta.push_back(NAN);
+    m_missurfgamma.push_back(NAN);
+    m_idealsurfcenterx.push_back(NAN);
+    m_idealsurfcentery.push_back(NAN);
+    m_idealsurfcenterz.push_back(NAN);
+    m_idealsurfnormx.push_back(NAN);
+    m_idealsurfnormy.push_back(NAN);
+    m_idealsurfnormz.push_back(NAN);
+    m_missurfcenterx.push_back(NAN);
+    m_missurfcentery.push_back(NAN);
+    m_missurfcenterz.push_back(NAN);
+    m_missurfnormx.push_back(NAN);
+    m_missurfnormy.push_back(NAN);
+    m_missurfnormz.push_back(NAN);
+    m_clusgxideal.push_back(NAN);
+    m_clusgyideal.push_back(NAN);
+    m_clusgzideal.push_back(NAN);
+    m_statelx.push_back(NAN);
+    m_statelz.push_back(NAN);
+    m_stateelx.push_back(NAN);
+    m_stateelz.push_back(NAN);
+    m_stategx.push_back(NAN);
+    m_stategy.push_back(NAN);
+    m_stategz.push_back(NAN);
+    m_statepx.push_back(NAN);
+    m_statepy.push_back(NAN);
+    m_statepz.push_back(NAN);
+    m_statepl.push_back(NAN);
     return;
   }
+
   auto surf = geometry->maps().getSurface(ckey, cluster);
   Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
   Acts::Vector2 stateloc;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -61,6 +61,7 @@ class TrackResiduals : public SubsysReco
   int m_event = 0;
   //! Track level quantities
   uint64_t m_bco = std::numeric_limits<uint64_t>::quiet_NaN();
+  uint64_t m_bcotr = std::numeric_limits<uint64_t>::quiet_NaN();
   unsigned int m_trackid = std::numeric_limits<unsigned int>::quiet_NaN();
   unsigned int m_crossing = std::numeric_limits<unsigned int>::quiet_NaN();
   float m_px = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -22,7 +22,9 @@ class PHCompositeNode;
 class ActsGeometry;
 class SvtxTrack;
 class TrkrClusterContainer;
-
+class TrkrHitSetContainer;
+class PHG4TpcCylinderGeomContainer;
+class PHG4CylinderGeomContainer;
 class TrackResiduals : public SubsysReco
 {
  public:
@@ -44,7 +46,9 @@ class TrackResiduals : public SubsysReco
   void createBranches();
   float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
   void fillClusterTree(TrkrClusterContainer *clusters, ActsGeometry *geometry);
-  void fillHitTree(TrkrHitSetContainer *hitmap, PHG4TpcCylinderGeomContainer* tpcGeom);
+  void fillHitTree(TrkrHitSetContainer *hitmap, ActsGeometry *geometry,
+                   PHG4TpcCylinderGeomContainer *tpcGeom, PHG4CylinderGeomContainer *mvtxGeom,
+                   PHG4CylinderGeomContainer *inttGeom, PHG4CylinderGeomContainer *mmGeom);
   void fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack *track,
                            PHCompositeNode *topNode);
 
@@ -90,13 +94,8 @@ class TrackResiduals : public SubsysReco
   float m_pcay = std::numeric_limits<float>::quiet_NaN();
   float m_pcaz = std::numeric_limits<float>::quiet_NaN();
 
-
   //! hit tree info
   uint32_t m_hitsetkey = std::numeric_limits<uint32_t>::quiet_NaN();
-  float m_adc = std::numeric_limits<float>::quiet_NaN();
-  float m_hitgx = std::numeric_limits<float>::quiet_NaN();
-  float m_hitgy = std::numeric_limits<float>::quiet_NaN();
-  float m_hitgz = std::numeric_limits<float>::quiet_NaN();
   float m_hitgx = std::numeric_limits<float>::quiet_NaN();
   float m_hitgy = std::numeric_limits<float>::quiet_NaN();
   float m_hitgz = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -44,6 +44,7 @@ class TrackResiduals : public SubsysReco
   void createBranches();
   float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
   void fillClusterTree(TrkrClusterContainer *clusters, ActsGeometry *geometry);
+  void fillHitTree(TrkrHitSetContainer *hitmap, PHG4TpcCylinderGeomContainer* tpcGeom);
   void fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack *track,
                            PHCompositeNode *topNode);
 
@@ -51,6 +52,7 @@ class TrackResiduals : public SubsysReco
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;
   TTree *m_clustree = nullptr;
+  TTree *m_hittree = nullptr;
 
   ClusterErrorPara m_clusErrPara;
   std::string m_alignmentMapName = "SvtxAlignmentStateMap";
@@ -87,6 +89,24 @@ class TrackResiduals : public SubsysReco
   float m_pcax = std::numeric_limits<float>::quiet_NaN();
   float m_pcay = std::numeric_limits<float>::quiet_NaN();
   float m_pcaz = std::numeric_limits<float>::quiet_NaN();
+
+
+  //! hit tree info
+  uint32_t m_hitsetkey = std::numeric_limits<uint32_t>::quiet_NaN();
+  float m_adc = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgx = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgy = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgz = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgx = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgy = std::numeric_limits<float>::quiet_NaN();
+  float m_hitgz = std::numeric_limits<float>::quiet_NaN();
+  int m_hitlayer = std::numeric_limits<int>::quiet_NaN();
+  int m_sector = std::numeric_limits<int>::quiet_NaN();
+  int m_hitpad = std::numeric_limits<int>::quiet_NaN();
+  int m_hittbin = std::numeric_limits<int>::quiet_NaN();
+  int m_col = std::numeric_limits<int>::quiet_NaN();
+  int m_row = std::numeric_limits<int>::quiet_NaN();
+  int m_strip = std::numeric_limits<int>::quiet_NaN();
 
   //! cluster tree info
   float m_sclusgr = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -40,6 +40,8 @@ class TrackResiduals : public SubsysReco
   void alignment(bool align) { m_doAlignment = align; }
   void alignmentmapName(const std::string &name) { m_alignmentMapName = name; }
   void trackmapName(const std::string &name) { m_trackMapName = name; }
+  void clusterTree() { m_doClusters = true; }
+  void hitTree() { m_doHits = true; }
 
  private:
   void clearClusterStateVectors();
@@ -57,6 +59,8 @@ class TrackResiduals : public SubsysReco
   TTree *m_tree = nullptr;
   TTree *m_clustree = nullptr;
   TTree *m_hittree = nullptr;
+  bool m_doClusters = false;
+  bool m_doHits = false;
 
   ClusterErrorPara m_clusErrPara;
   std::string m_alignmentMapName = "SvtxAlignmentStateMap";

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -254,7 +254,6 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::chainSeeds(PHCosmicSeeder::SeedVector
       }
     }
   }
-  std::cout << "Deleting " << seedsToDelete.size() << " seeds in chainer" << std::endl;
   for (int i = 0; i < initialSeeds.size(); ++i)
   {
     if (seedsToDelete.find(i) != seedsToDelete.end())


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Before the great SDCC outage of December 2023, this PR adds some useful diagnostic tools to one of the ntuplizing modules for cosmic and/or real data analysis.
1. Adds the full 64 bit GL1 BCO and the 40 bit shifted tracker BCOs, so that we can do direct comparisons to the preliminary plots that were hand stitched together. Useful for validating the full O2O workflow.
2. Adds a hit tree and capability to fill the clusters associated to tracks and/or track seeds if the track state is not present (e.g. in the event the fitter is not run). The hits and clusters are saved with their specific subsystem information (e.g. sector/stave/ladder/tile/whatever).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

