### PR TITLE
Added TowerInfov2 selections to towers being clusterized

### DIFF
--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -370,7 +370,7 @@ int RawClusterBuilderTemplate::process_event(PHCompositeNode *topNode)
       RawTower *tower = itr->second;
       //      std::cout << "  Tower e = " << tower->get_energy()
       //           << " (" << _min_tower_e << ")" << std::endl;
-      if (tower->get_energy() > _min_tower_e)
+      if (IsAcceptableTower(tower))
       {
         // std::cout << "(" << tower->get_column() << "," << tower->get_row()
         //      << ")  (" << tower->get_binphi() << "," << tower->get_bineta()
@@ -407,7 +407,7 @@ int RawClusterBuilderTemplate::process_event(PHCompositeNode *topNode)
 
       //      std::cout << "  Tower e = " << tower->get_energy()
       //           << " (" << _min_tower_e << ")" << std::endl;
-      if (tower_info->get_energy() > _min_tower_e)
+      if (IsAcceptableTower(tower_info))
       {
         unsigned int towerkey = calib_towerinfos->encode_key(channel);
         int ieta = calib_towerinfos->getTowerEtaBin(towerkey);
@@ -639,4 +639,47 @@ void RawClusterBuilderTemplate::CreateNodes(PHCompositeNode *topNode)
 
   PHIODataNode<PHObject> *clusterNode = new PHIODataNode<PHObject>(_clusters, ClusterNodeName, "PHObject");
   cemcNode->addNode(clusterNode);
+}
+
+bool RawClusterBuilderTemplate::IsAcceptableTower(TowerInfo *tower)
+{
+  if(tower->get_energy() < _min_tower_e)
+  {
+    return false;
+  }
+
+  if(m_do_tower_selection)
+  {
+    if(tower->get_isBadTime())
+    {
+      return false;
+    }
+
+    if(tower->get_isHot())
+    {
+      return false;
+    }
+
+    if(tower->get_isBadChi2())
+    {
+      return false;
+    }
+
+    if(tower->get_isNotInstr())
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool RawClusterBuilderTemplate::IsAcceptableTower(RawTower *tower)
+{
+  if(tower->get_energy() < _min_tower_e)
+  {
+    return false;
+  }
+
+  return true;
 }

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -670,7 +670,6 @@ bool RawClusterBuilderTemplate::IsAcceptableTower(TowerInfo *tower)
       return false;
     }
   }
-
   return true;
 }
 
@@ -680,6 +679,5 @@ bool RawClusterBuilderTemplate::IsAcceptableTower(RawTower *tower)
   {
     return false;
   }
-
   return true;
 }

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -9,6 +9,8 @@ class PHCompositeNode;
 class RawClusterContainer;
 class RawTowerGeomContainer;
 class BEmcRec;
+class TowerInfo;
+class RawTower;
 
 class RawClusterBuilderTemplate : public SubsysReco
 {
@@ -37,6 +39,11 @@ class RawClusterBuilderTemplate : public SubsysReco
     m_UseTowerInfo = useMode;
   }
 
+  void set_ApplyTowerSelection(bool b)
+  {
+    m_do_tower_selection = b;
+  }
+
   void set_UseAltZVertex(const int useAltZMode)
   {  // 0 use global vtx, 1 only bbcout bbczvtx , 2 use NO zvtx[set to 0]
     m_UseAltZVertex = useAltZMode;
@@ -57,6 +64,8 @@ class RawClusterBuilderTemplate : public SubsysReco
  private:
   void CreateNodes(PHCompositeNode* topNode);
   bool Cell2Abs(RawTowerGeomContainer* towergeom, float phiC, float etaC, float& phi, float& eta);
+  bool IsAcceptableTower(TowerInfo *tower);
+  bool IsAcceptableTower(RawTower *tower);
 
   RawClusterContainer* _clusters = nullptr;
   //  BEmcProfile *_emcprof;
@@ -80,6 +89,8 @@ class RawClusterBuilderTemplate : public SubsysReco
   float fProbNoiseParam = 0.04;
 
   int m_UseTowerInfo = 0;  // 0 only old tower, 1 only new (TowerInfo based),
+
+  bool m_do_tower_selection = true;
 
   std::string m_towerInfo_nodename;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Applies TowerInfov2 selections to the pool of towers given to the clusterizer. The selections can be turned off at macro level by setting RawClusterBuilderTemplate::set_ApplyTowerSelection(false). 

This change was done during the Calo workfest (Dec 14 and 15) and discussed on mattermost (https://chat.sdcc.bnl.gov/sphenix/pl/a7wx93eraffr9ymn356dgjteua)

