### PR TITLE
add 1MHz streaming selection for pileup

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -64,7 +64,8 @@ my %proddesc = (
 my %pileupdesc = (
     "1" => "50kHz for Au+Au, 3MHz for p+p (default)",
     "2" => "25kHz for Au+Au",
-    "3" => "10kHz for Au+Au"
+    "3" => "10kHz for Au+Au",
+    "4" => "1MHz for pp 100us streaming"
     );
 
 my $nEvents;
@@ -148,6 +149,11 @@ elsif ($pileup == 3)
 {
     $AuAu_pileupstring = sprintf("10kHz");
 }
+elsif ($pileup == 4)
+{
+    $pp_pileupstring = sprintf("1MHz");
+}
+
 else
 {
     print "invalid pileup option $pileup\n";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This add an option (4) to the pileup which selects 1MHz pileup for pp where the pileup window is set to 100us. Jenkins does not see this anyway [skip-ci]
## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

