### PR TITLE
fix: add extended readout time to tpc subsystem

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -527,7 +527,8 @@ void PHG4TpcDetector::add_geometry_node()
   const double tpc_adc_clock = m_Params->get_double_param("tpc_adc_clock");
   const double MaxZ = m_Params->get_double_param("maxdriftlength");
   const double TBinWidth = tpc_adc_clock;
-  const double MaxT = 2.0 * MaxZ / drift_velocity;  // allows for extended time readout
+  const double extended_readout_time = m_Params->get_double_param("extended_readout_time");
+  const double MaxT = extended_readout_time +  MaxZ / drift_velocity;  // allows for extended time readout
   const double MinT = 0;
   const int NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -528,7 +528,7 @@ void PHG4TpcDetector::add_geometry_node()
   const double MaxZ = m_Params->get_double_param("maxdriftlength");
   const double TBinWidth = tpc_adc_clock;
   const double extended_readout_time = m_Params->get_double_param("extended_readout_time");
-  const double MaxT = extended_readout_time +  MaxZ / drift_velocity;  // allows for extended time readout
+  const double MaxT = extended_readout_time + 2.* MaxZ / drift_velocity;  // allows for extended time readout
   const double MinT = 0;
   const int NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlane.h
@@ -26,7 +26,7 @@ class PHG4TpcPadPlane : public SubsysReco, public PHParameterInterface
   { return 0; }
 
   virtual void SetDriftVelocity(double /*vd*/) {return;}
-
+  virtual void SetReadoutTime(float) { return; }
   int InitRun(PHCompositeNode *topNode) override;
   virtual void UpdateInternalParameters() { return; }
   //  virtual void MapToPadPlane(PHG4CellContainer * /*g4cells*/, const double /*x_gem*/, const double /*y_gem*/, const double /*t_gem*/, const unsigned int /*side*/, PHG4HitContainer::ConstIterator /*hiter*/, TNtuple * /*ntpad*/, TNtuple * /*nthit*/) {}

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -175,6 +175,7 @@ void PHG4TpcPadPlaneReadout::MapToPadPlane(
     {
       // capture the layer where this electron hits the gem stack
       LayerGeom = layeriter->second;
+
       layernum = LayerGeom->get_layer();
       /* pass_data.layerGeom = LayerGeom; */
       /* pass_data.layer = layernum; */
@@ -564,7 +565,7 @@ void PHG4TpcPadPlaneReadout::populate_tbins(const double t, const std::array<dou
   int tbin = LayerGeom->get_zbin(t);
   if (tbin < 0 || tbin > LayerGeom->get_zbins())
   {
-    //std::cout << " t bin is outside range, return" << std::endl;
+    // std::cout << " t bin is outside range, return" << std::endl;
     return;
   }
 
@@ -761,16 +762,14 @@ void PHG4TpcPadPlaneReadout::UpdateInternalParameters()
 
   const double MaxZ = get_double_param("maxdriftlength");
   const double TBinWidth = tpc_adc_clock;
-  const double MaxT = 2.0 * MaxZ / drift_velocity;  // allows for extended time readout
+  const double MaxT = extended_readout_time + 2.0 * MaxZ / drift_velocity;  // allows for extended time readout
   const double MinT = 0;
   NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
-
+  
   const std::array<double, 3> SectorPhi =
-  {{
-    get_double_param("tpc_sector_phi_inner"),
-    get_double_param("tpc_sector_phi_mid"),
-    get_double_param("tpc_sector_phi_outer")
-  }};
+      {{get_double_param("tpc_sector_phi_inner"),
+        get_double_param("tpc_sector_phi_mid"),
+        get_double_param("tpc_sector_phi_outer")}};
 
   const std::array<int,3> NPhiBins = 
   {{

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.h
@@ -36,7 +36,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   void ReadGain();
 
   void SetDriftVelocity(double vd) override { drift_velocity = vd; }
-
+  void SetReadoutTime(float t) override { extended_readout_time = t; }
   // otherwise warning of inconsistent overload since only one MapToPadPlane methow is overridden
   using PHG4TpcPadPlane::MapToPadPlane;
 
@@ -68,7 +68,7 @@ class PHG4TpcPadPlaneReadout : public PHG4TpcPadPlane
   std::array<double, 2> sigmaL;
   std::array<double, 3> PhiBinWidth;
   double drift_velocity = 8.0e-03;  // default value, override from macro
-
+  float extended_readout_time = 0; //ns
   int NTBins = INT_MAX;
   int m_NHits = 0;
   // Using Gain maps is turned off by default

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -218,7 +218,8 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("tpc_maxradius_outer", 75.911);//77.0);  // from Tom
 
   set_default_double_param("maxdriftlength", 105.5);     // cm
-  set_default_double_param("tpc_adc_clock", 53.0);       // ns, for 18.8 MHz clock
+  set_default_double_param("extended_readout_time", 0.0); //ns
+  set_default_double_param("tpc_adc_clock", 53.0);  // ns, for 18.8 MHz clock
 
   set_default_double_param("tpc_sector_phi_inner", 0.5024);//2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid",   0.5087);//2 * M_PI / 12 );//sector size in phi for R2 sector


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The TPC extended readout time is currently fixed to 2x the drift time. This PR fixes this to be some extended readout time + 1 drift time, to match our envisioned streaming environment of 7+13 mus. It also allows for configuring this value when looking at the large 100 mus streamed data.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

