### PR TITLE
fix: hard coded tpc time bin limit

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -601,17 +601,17 @@ namespace
     std::multimap<unsigned short, ihit> all_hit_map;
     std::vector<ihit> hit_vect;
 
-    int tbinmax = 498;
+    int tbinmax = tbins;
     int tbinmin = 0;
     if(my_data->do_wedge_emulation){
       if(layer>=7 && layer <22){
-	int etacut = 249 - ((50+(layer-7))/105.5)*249;
-	tbinmin = etacut;
+        int etacut = (tbins / 2.) - ((50 + (layer - 7)) / 105.5) * (tbins / 2.);
+        tbinmin = etacut;
 	tbinmax -= etacut;
       }
       if(layer>=22 && layer <=48){
-	int etacut = 249 - ((65+((40.5/26)*(layer-22)))/105.5)*249;
-	tbinmin = etacut;
+        int etacut = (tbins / 2.) - ((65 + ((40.5 / 26) * (layer - 22))) / 105.5) * (tbins / 2.);
+        tbinmin = etacut;
 	tbinmax -= etacut;
       }
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This fixes a hard coded time bin maximum that was in the clusterizer, preventing clusters from being produced at later times. We never noticed because the nominal time is 26 mus which covers our nominal hybrid streaming case.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

