### PR TITLE
allow bco range for intt-gl1 bco match

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -58,6 +58,8 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   void AddMvtxL1TrgBco(uint64_t bclk, uint64_t lv1Bco);
   void AddMvtxRawHit(uint64_t bclk, MvtxRawHit *hit);
   void AddTpcRawHit(uint64_t bclk, TpcRawHit *hit);
+  void SetInttBcoRange(const unsigned int i);
+  void SetInttNegativeBco(const unsigned int value);
   void SetMicromegasBcoRange(const unsigned int i);
   void SetMicromegasNegativeBco(const unsigned int value);
   void SetMvtxBcoRange(const unsigned int i);
@@ -108,6 +110,8 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   bool m_micromegas_registered_flag{false};
   bool m_mvtx_registered_flag{false};
   bool m_tpc_registered_flag{false};
+  unsigned int m_intt_bco_range{0};
+  unsigned int m_intt_negative_bco{0};
   unsigned int m_micromegas_bco_range{0};
   unsigned int m_micromegas_negative_bco{0};
   unsigned int m_mvtx_bco_range{0};

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -341,3 +341,13 @@ void SingleInttPoolInput::CreateDSTNode(PHCompositeNode *topNode)
     detNode->addNode(newNode);
   }
 }
+//_______________________________________________________
+
+void SingleInttPoolInput::ConfigureStreamingInputManager()
+{
+  if (StreamingInputManager())
+  {
+    StreamingInputManager()->SetInttBcoRange(m_BcoRange);
+    StreamingInputManager()->SetInttNegativeBco(m_NegativeBco);
+  }
+}

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -28,9 +28,16 @@ class SingleInttPoolInput : public SingleStreamingInput
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
+  void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
+  void ConfigureStreamingInputManager() override;
+  void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
+
  private:
-  Packet **plist = nullptr;
-  unsigned int m_NumSpecialEvents = 0;
+  Packet **plist{nullptr};
+  unsigned int m_NumSpecialEvents{0};
+  unsigned int m_BcoRange{0};
+  unsigned int m_NegativeBco{0};
+
   std::array<uint64_t, 14> m_PreviousClock{};
   std::array<uint64_t, 14> m_Rollover{};
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The INTT is sometimes off by one BCO. This PR copies the bco matching mechanics from the other streaming systems, the range is configurable in a macro. This also recovers the ability to combine the intt standalone (without gl1 data) where it then provides its own reference bco

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

