### PR TITLE
fix: reverts af75741

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -181,11 +181,6 @@ double PHG4TpcDistortion::get_z_distortion(double r, double phi, double z) const
 {
   return get_distortion('z', r, phi, z);
 }
-//__________________________________________________________________________________________________________
-double PHG4TpcDistortion::get_reaches_readout(double r, double phi, double z) const
-{
-  return get_distortion('R', r, phi, z);
-}
 
 double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double z) const
 {
@@ -194,14 +189,14 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
 
   TH3* hdistortion = nullptr;
 
-  if (axis != 'r' && axis != 'p' && axis != 'z'&& axis != 'R')
+  if (axis != 'r' && axis != 'p' && axis != 'z')
   {
     std::cout << "Distortion Requested along axis " << axis << " which is invalid.  Exiting.\n"
               << std::endl;
     exit(1);
   }
 
-  double _distortion = 0.;     
+  double _distortion = 0.;
 
   //select the appropriate histogram:
   if (m_do_static_distortions)
@@ -217,10 +212,6 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
     else if (axis == 'z')
     {
       hdistortion = hDZint[zpart];
-    }
-    else if (axis == 'R')
-    {
-      hdistortion = hReach[zpart];
     }
     if (hdistortion)
     {
@@ -248,10 +239,6 @@ double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double
     else if (axis == 'z')
     {
       hdistortion = TimehDZ[zpart];
-    }
-    else if (axis == 'R')
-    {
-      hdistortion = TimehRR[zpart];
     }
     if (hdistortion)
     {

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -45,9 +45,6 @@ class PHG4TpcDistortion
 
   //! z distortion for a given cylindrical truth location of the primary ionization
   double get_z_distortion(double r, double phi, double z) const;
-  
-  //The ReachesReadout serves as a fourth axis in the distortion histogram
-  double get_reaches_readout(double r, double phi, double z) const;
 
   //! Gets the verbosity of this module.
   int Verbosity() const

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -535,12 +535,6 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 
       if (m_distortionMap)
       {
-      	//zhangcanyu
-      	const double reaches = m_distortionMap->get_reaches_readout(radstart, phistart, z_start);
-		  if (reaches < thresholdforreachesreadout)
-		  {
-		   continue;
-		  }
 	        
         const double r_distortion = m_distortionMap->get_r_distortion(radstart, phistart, z_start);
         const double phi_distortion = m_distortionMap->get_rphi_distortion(radstart, phistart, z_start) / radstart;

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -541,7 +541,7 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
 		  {
 		   continue;
 		  }
-		
+	        
         const double r_distortion = m_distortionMap->get_r_distortion(radstart, phistart, z_start);
         const double phi_distortion = m_distortionMap->get_rphi_distortion(radstart, phistart, z_start) / radstart;
         const double z_distortion = m_distortionMap->get_z_distortion(radstart, phistart, z_start);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Per request from @adfrawley and Ross, this reverts [this](https://github.com/sPHENIX-Collaboration/coresoftware/commit/6d763803bec6b6235ea8b2e2e79bcd7b562ae564) commit which apparently breaks the distortion reading machinery.

Let me know if this is not as intended

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

