### PR TITLE
Reaches readout short term

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -65,8 +65,8 @@ void PHG4TpcDistortion::Init()
     hDPint[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionP_posz"));
     hDZint[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionZ_negz"));
     hDZint[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hIntDistortionZ_posz"));
-    hReach[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hReachesReadout_negz"));
-    hReach[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hReachesReadout_posz"));
+   //not ready yet:   hReach[0] = dynamic_cast<TH3*>(m_static_tfile->Get("hReachesReadout_negz"));
+    //not ready yet:   hReach[1] = dynamic_cast<TH3*>(m_static_tfile->Get("hReachesReadout_posz"));
   }
 
   if (m_do_time_ordered_distortions)
@@ -96,8 +96,8 @@ void PHG4TpcDistortion::Init()
     TimeTree->SetBranchAddress("hIntDistortionP_posz", &(TimehDP[1]));
     TimeTree->SetBranchAddress("hIntDistortionZ_negz", &(TimehDZ[0]));
     TimeTree->SetBranchAddress("hIntDistortionZ_posz", &(TimehDZ[1]));
-    TimeTree->SetBranchAddress("hReachesReadout_negz", &(TimehRR[0]));
-    TimeTree->SetBranchAddress("hReachesReadout_posz", &(TimehRR[1]));
+    //not ready yet: TimeTree->SetBranchAddress("hReachesReadout_negz", &(TimehRR[0]));
+    //not ready yet: TimeTree->SetBranchAddress("hReachesReadout_posz", &(TimehRR[1]));
   }
 }
 
@@ -184,7 +184,8 @@ double PHG4TpcDistortion::get_z_distortion(double r, double phi, double z) const
 //__________________________________________________________________________________________________________
 double PHG4TpcDistortion::get_reaches_readout(double r, double phi, double z) const
 {
-  return get_distortion('R', r, phi, z);
+  return 1;
+  //not ready yet: return get_distortion('R', r, phi, z);
 }
 
 double PHG4TpcDistortion::get_distortion(char axis, double r, double phi, double z) const

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -184,6 +184,7 @@ double PHG4TpcDistortion::get_z_distortion(double r, double phi, double z) const
 //__________________________________________________________________________________________________________
 double PHG4TpcDistortion::get_reaches_readout(double r, double phi, double z) const
 {
+  if (r<1) printf("Unusual R: %f.  This line is to keep the compiler from complaining about unused parameters like %f and %f.\n",r,phi,z);
   return 1;
   //not ready yet: return get_distortion('R', r, phi, z);
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This comments out a few lines in PHG4TpcDistortion so that distortion files that lack the 'ReachesReadout' histogram can still be used. 


## TODOs (if applicable)

A more elegant fix is to check for the existence of each hist before loading, and to allow to switch off the ReachesReadout behavior itself.

## Links to other PRs in macros and calibration repositories (if applicable)

