### PR TITLE
add MBD event plane recentering histograms

### DIFF
--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -42,6 +42,7 @@
 
 EventPlaneReco::EventPlaneReco(const std::string &name)
   : SubsysReco(name)
+  , OutFileName("eventplane_correction_histograms")
 {
  
   south_q.resize(m_MaxOrder);

--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -16,6 +16,8 @@
 #include <mbd/MbdPmtContainer.h>
 #include <mbd/MbdPmtHit.h>
 
+#include <cdbobjects/CDBHistos.h>
+
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/SubsysReco.h>  // for SubsysReco
 
@@ -35,13 +37,17 @@
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 #include <vector>   // for vector
+#include <TProfile.h>
+
 
 EventPlaneReco::EventPlaneReco(const std::string &name)
   : SubsysReco(name)
-  , m_MaxOrder(3)
 {
+ 
   south_q.resize(m_MaxOrder);
   north_q.resize(m_MaxOrder);
+  south_q_subtract.resize(m_MaxOrder);
+  north_q_subtract.resize(m_MaxOrder);
 
   for (auto &vec : south_q)
   {
@@ -52,6 +58,69 @@ EventPlaneReco::EventPlaneReco(const std::string &name)
   {
     vec.resize(2);
   }
+    
+ for (auto &vec : south_q_subtract)
+ {
+    vec.resize(2);
+ }
+
+ for (auto &vec : north_q_subtract)
+ {
+    vec.resize(2);
+ }
+    
+}
+
+int EventPlaneReco::Init(PHCompositeNode *topNode)
+{
+ 
+    OutFileName = Form("eventplane_correction_histograms_run_%d.root", m_runNo);
+
+    //load calibration histograms
+    CDBHistos *cdbhistosIn = new CDBHistos(OutFileName);
+    cdbhistosIn->LoadCalibrations();
+
+    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    {
+      if(!(cdbhistosIn->getHisto(Form("tprof_mean_cos_south_mbd_order_%d",order))))
+      {
+          if(order == m_MaxOrder) std::cout<< "Correction Histograms Not Found in DataBase, Output Are Raw Qs and EPs" << std::endl;
+          tprof_mean_cos_south_mbd_input[order - 1] = NULL;
+          tprof_mean_sin_south_mbd_input[order - 1] =  NULL;
+          tprof_mean_cos_north_mbd_input[order - 1] =  NULL;
+          tprof_mean_sin_north_mbd_input[order - 1] =  NULL;
+      }
+      else
+      {
+          tprof_mean_cos_south_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(Form("tprof_mean_cos_south_mbd_order_%d",order)));
+          tprof_mean_sin_south_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(Form("tprof_mean_sin_south_mbd_order_%d",order)));
+          tprof_mean_cos_north_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(Form("tprof_mean_cos_north_mbd_order_%d",order)));
+          tprof_mean_sin_north_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(Form("tprof_mean_sin_north_mbd_order_%d",order)));
+      }
+    }
+    
+    cdbhistosIn->Print();
+    
+    
+    //create correction histograms
+    cdbhistosOut = new CDBHistos(OutFileName);
+    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    {
+        tprof_mean_cos_south_mbd[order - 1] =  new TProfile(Form("tprof_mean_cos_south_mbd_order_%d", order), "", 125*4, 0, 2500, -1e10, 1e10);
+        tprof_mean_sin_south_mbd[order - 1] =  new TProfile(Form("tprof_mean_sin_south_mbd_order_%d", order), "", 125*4, 0, 2500, -1e10, 1e10);
+        tprof_mean_cos_north_mbd[order - 1] =  new TProfile(Form("tprof_mean_cos_north_mbd_order_%d", order), "", 125*4, 0, 2500, -1e10, 1e10);
+        tprof_mean_sin_north_mbd[order - 1] =  new TProfile(Form("tprof_mean_sin_north_mbd_order_%d", order), "", 125*4, 0, 2500, -1e10, 1e10);
+       
+        //register histos
+        cdbhistosOut->registerHisto(tprof_mean_cos_south_mbd[order - 1]);
+        cdbhistosOut->registerHisto(tprof_mean_sin_south_mbd[order - 1]);
+        cdbhistosOut->registerHisto(tprof_mean_cos_north_mbd[order - 1]);
+        cdbhistosOut->registerHisto(tprof_mean_sin_north_mbd[order - 1]);
+    }
+    
+ 
+   return CreateNodes(topNode);
+    
 }
 
 int EventPlaneReco::InitRun(PHCompositeNode *topNode)
@@ -67,6 +136,7 @@ int EventPlaneReco::InitRun(PHCompositeNode *topNode)
 
 int EventPlaneReco::process_event(PHCompositeNode *topNode)
 {
+ 
   if (Verbosity() > 1)
   {
     std::cout << "EventPlaneReco::process_event -- entered" << std::endl;
@@ -116,7 +186,7 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         }
         float tile_phi = _epdgeom->get_phi(key);
         int arm = TowerInfoDefs::get_epd_arm(key);
-        float truncated_e = (epd_e < _e) ? epd_e : _e;
+        float truncated_e = (epd_e < _epd_e) ? epd_e : _epd_e;
         if (arm == 0)
         {
           for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
@@ -181,6 +251,7 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
       exit(-1);
     }
 
+   
     if (mbdpmts)
     {
       if (Verbosity())
@@ -188,17 +259,27 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         std::cout << "EventPlaneReco::process_event -  mbdpmts" << std::endl;
       }
 
-      for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++)
+      mbd_e_south = 0.;
+      mbd_e_north = 0.;
+      mbdQ = 0.;
+   
+     for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++)
+      {
+         float mbd_q = mbdpmts->get_pmt(ipmt)->get_q();
+         mbdQ += mbd_q;
+      }
+
+     for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++)
       {
         float mbd_q = mbdpmts->get_pmt(ipmt)->get_q();
         float phi = mbdgeom->get_phi(ipmt);
-        int arm = mbdgeom->get_arm(ipmt);
-        if (mbd_q < 0.0)
-        {
-          continue;
-        }
+        int arm = mbdgeom->get_arm(ipmt); 
+ 
+        if(mbdQ < _mbd_e) continue; 
+
         if (arm == 0)
         {
+          mbd_e_south += mbd_q;
           for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
           {
             double Cosine = cos(phi * (double) order);
@@ -209,6 +290,7 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         }
         else if (arm == 1)
         {
+          mbd_e_north += mbd_q;
           for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
           {
             double Cosine = cos(phi * (double) order);
@@ -219,14 +301,55 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         }
       }
     }
+
+  
     for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
     {
-      south_Qvec.emplace_back(south_q[order - 1][0], south_q[order - 1][1]);
-      north_Qvec.emplace_back(north_q[order - 1][0], north_q[order - 1][1]);
+        //fill recentering histograms by order
+        tprof_mean_cos_south_mbd[order - 1]->Fill(mbd_e_south,south_q[order - 1][0]/mbd_e_south);
+        tprof_mean_sin_south_mbd[order - 1]->Fill(mbd_e_south,south_q[order - 1][1]/mbd_e_south);
+        tprof_mean_cos_north_mbd[order - 1]->Fill(mbd_e_north,north_q[order - 1][0]/mbd_e_north);
+        tprof_mean_sin_north_mbd[order - 1]->Fill(mbd_e_north,north_q[order - 1][1]/mbd_e_north);   
     }
 
-    if (mbdpmts)
+
+      //get recentering histograms and do recentering
+      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      {
+          if (tprof_mean_cos_south_mbd_input[order-1])
+          {
+              //south
+              int bin_south = tprof_mean_cos_south_mbd_input[order - 1]->FindBin(mbd_e_south);
+              double event_ave_cos_south = tprof_mean_cos_south_mbd_input[order - 1]->GetBinContent(bin_south);
+              double event_ave_sin_south = tprof_mean_sin_south_mbd_input[order - 1]->GetBinContent(bin_south);
+              south_q_subtract[order - 1][0] = mbd_e_south*event_ave_cos_south;
+              south_q_subtract[order - 1][1] = mbd_e_south*event_ave_sin_south;
+              south_q[order - 1][0] -= south_q_subtract[order - 1][0];
+              south_q[order - 1][1] -= south_q_subtract[order - 1][1];
+
+              //north
+              int bin_north = tprof_mean_cos_north_mbd_input[order - 1]->FindBin(mbd_e_north);
+              double event_ave_cos_north = tprof_mean_cos_north_mbd_input[order - 1]->GetBinContent(bin_north);
+              double event_ave_sin_north = tprof_mean_sin_north_mbd_input[order - 1]->GetBinContent(bin_north);
+              north_q_subtract[order - 1][0] = mbd_e_north*event_ave_cos_north;
+              north_q_subtract[order - 1][1] = mbd_e_north*event_ave_sin_north;
+              north_q[order - 1][0] -= north_q_subtract[order - 1][0];
+              north_q[order - 1][1] -= north_q_subtract[order - 1][1];
+          }
+          
+      }
+
+ 
+     
+    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
     {
+         south_Qvec.emplace_back(south_q[order - 1][0], south_q[order - 1][1]);
+         north_Qvec.emplace_back(north_q[order - 1][0], north_q[order - 1][1]);
+    }
+                                                                                                    
+
+    if (mbdpmts)
+    { 
       Eventplaneinfo *mbds = new Eventplaneinfov1();
       mbds->set_qvector(south_Qvec);
       epmap->insert(mbds, EventplaneinfoMap::MBDS);
@@ -241,8 +364,10 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         mbdn->identify();
       }
     }
-
+      
+   
     ResetMe();
+      
   }
 
   if (Verbosity())
@@ -292,7 +417,25 @@ void EventPlaneReco::ResetMe()
   {
     std::fill(vec.begin(), vec.end(), 0.);
   }
+    
+  for (auto &vec : south_q_subtract)
+  {
+    std::fill(vec.begin(), vec.end(), 0.);
+  }
+
+  for (auto &vec : north_q_subtract)
+  {
+    std::fill(vec.begin(), vec.end(), 0.);
+  }
 
   south_Qvec.clear();
   north_Qvec.clear();
+}
+
+int EventPlaneReco::End(PHCompositeNode * /*topNode*/)
+{
+  cdbhistosOut->WriteCDBHistos();
+  delete cdbhistosOut;
+  std::cout << " EventPlaneReco::End() " << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -45,6 +45,9 @@ EventPlaneReco::EventPlaneReco(const std::string &name)
   , OutFileName("eventplane_correction_histograms")
 {
  
+  mbd_e_south = 0.;
+  mbd_e_north = 0.;
+  mbdQ = 0.;
   south_q.resize(m_MaxOrder);
   north_q.resize(m_MaxOrder);
   south_q_subtract.resize(m_MaxOrder);
@@ -260,9 +263,9 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         std::cout << "EventPlaneReco::process_event -  mbdpmts" << std::endl;
       }
 
-      float mbd_e_south = 0.;
-      float mbd_e_north = 0.;
-      float mbdQ = 0.;
+     mbd_e_south = 0.;
+     mbd_e_north = 0.;
+     mbdQ = 0.;
    
      for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++)
       {

--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -260,9 +260,9 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         std::cout << "EventPlaneReco::process_event -  mbdpmts" << std::endl;
       }
 
-      mbd_e_south = 0.;
-      mbd_e_north = 0.;
-      mbdQ = 0.;
+      float mbd_e_south = 0.;
+      float mbd_e_north = 0.;
+      float mbdQ = 0.;
    
      for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++)
       {

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -77,10 +77,7 @@ class EventPlaneReco : public SubsysReco
     
   float _epd_e  = 6.0;
   float _mbd_e = 10.0;
-  float mbd_e_north;
-  float mbd_e_south;
-  float mbdQ;
- 
+
   TProfile * tprof_mean_cos_north_mbd[6] = {};
   TProfile * tprof_mean_sin_north_mbd[6] = {};
   TProfile * tprof_mean_cos_south_mbd[6] = {};

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -13,15 +13,19 @@
 #include <vector>  // for vector
 
 class PHCompositeNode;
+class CDBHistos;
+class TProfile;
 
 class EventPlaneReco : public SubsysReco
 {
  public:
   EventPlaneReco(const std::string &name = "EventPlaneReco");
   ~EventPlaneReco() override = default;
-
+  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
+  int End (PHCompositeNode * /*topNode*/) override;
+
   void ResetMe();
   void set_sepd_epreco(bool sepdEpReco)
   {
@@ -33,21 +37,62 @@ class EventPlaneReco : public SubsysReco
   }
   void set_sEPD_Mip_cut(const float &e)
   {
-    _e = e;
+    _epd_e = e;
   }
-
- private:
+  void set_MBD_Min_Qcut(const float &f)
+  {
+    _mbd_e = f;
+  }
+  void set_Ep_orders(const unsigned int &n)
+  {
+    m_MaxOrder = n;
+  }
+  void set_run_number(const unsigned int &r)
+  {
+    m_runNo = r;
+  }
+ 
+  private:
+    
   int CreateNodes(PHCompositeNode *topNode);
-  unsigned int m_MaxOrder = 0;
+   
+  unsigned int m_MaxOrder = 3;
 
+  unsigned  int m_runNo = 21813;
+ 
+  const char *OutFileName;
+
+  int _event;
+  
+  CDBHistos *cdbhistosOut = nullptr;
+ 
   std::vector<std::vector<double>> south_q;
   std::vector<std::vector<double>> north_q;
+  std::vector<std::vector<double>> south_q_subtract;
+  std::vector<std::vector<double>> north_q_subtract;
 
   std::vector<std::pair<double, double>> south_Qvec;
   std::vector<std::pair<double, double>> north_Qvec;
+
   bool _mbdEpReco = false;
   bool _sepdEpReco = false;
-  float _e = 6.0;
+    
+  float _epd_e  = 6.0;
+  float _mbd_e = 10.0;
+  float mbd_e_north;
+  float mbd_e_south;
+  float mbdQ;
+ 
+  TProfile * tprof_mean_cos_north_mbd[6] = {};
+  TProfile * tprof_mean_sin_north_mbd[6] = {};
+  TProfile * tprof_mean_cos_south_mbd[6] = {};
+  TProfile * tprof_mean_sin_south_mbd[6] = {};
+    
+  TProfile * tprof_mean_cos_north_mbd_input[6] = {};
+  TProfile * tprof_mean_sin_north_mbd_input[6] = {};
+  TProfile * tprof_mean_cos_south_mbd_input[6] = {};
+  TProfile * tprof_mean_sin_south_mbd_input[6] = {};
+    
 };
 
 #endif  // EVENTPLANERECO_H

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -77,6 +77,10 @@ class EventPlaneReco : public SubsysReco
     
   float _epd_e  = 6.0;
   float _mbd_e = 10.0;
+    
+  float mbd_e_south;
+  float mbd_e_north;
+  float mbdQ;
 
   TProfile * tprof_mean_cos_north_mbd[6] = {};
   TProfile * tprof_mean_sin_north_mbd[6] = {};

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -61,8 +61,6 @@ class EventPlaneReco : public SubsysReco
   unsigned  int m_runNo = 21813;
  
   const char *OutFileName;
-
-  int _event;
   
   CDBHistos *cdbhistosOut = nullptr;
  

--- a/offline/packages/eventplaneinfo/Makefile.am
+++ b/offline/packages/eventplaneinfo/Makefile.am
@@ -21,6 +21,7 @@ libeventplaneinfo_la_LIBADD = \
   -lepd_io \
   -lmbd_io \
   -lfun4all \
+  -lcdbobjects \
   -ltrackbase_historic_io
 
 pkginclude_HEADERS = \


### PR DESCRIPTION
Recentering histograms are filled by the module during first run. On second run, these histograms are used for MBD event plane calibration. Currently uses the MBD total charge instead of centrality.