### PR TITLE
Calo embed cleaning

### DIFF
--- a/offline/packages/CaloEmbedding/Makefile.am
+++ b/offline/packages/CaloEmbedding/Makefile.am
@@ -23,7 +23,7 @@ libCaloEmbedding_la_SOURCES = \
 libCaloEmbedding_la_LIBADD = \
   -lphool \
   -lSubsysReco \
-  -lfun4all
+  -lfun4all 
 
 BUILT_SOURCES = testexternals.cc
 

--- a/offline/packages/CaloEmbedding/caloTowerEmbed.cc
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.cc
@@ -1,4 +1,5 @@
 #include "caloTowerEmbed.h"
+//#include "caloreco/CaloTowerDefs.h"
 
 #include <calobase/TowerInfo.h>  // for TowerInfo
 #include <calobase/TowerInfoContainer.h>
@@ -8,8 +9,6 @@
 #include <calobase/TowerInfoDefs.h>
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
-
-#include <cdbobjects/CDBTTree.h>  // for CDBTTree
 
 #include <ffamodules/CDBInterface.h>
 
@@ -55,6 +54,27 @@ int caloTowerEmbed::InitRun(PHCompositeNode *topNode)
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
+  if (m_dettype == CaloTowerDefs::CEMC)
+    {
+      m_detector = "CEMC";
+    }
+  else if (m_dettype == CaloTowerDefs::HCALIN)
+    {
+      m_detector = "HCALIN";
+    }
+  else if (m_dettype == CaloTowerDefs::HCALOUT)
+    {
+      m_detector = "HCALOUT";
+    }
+  else if (m_dettype == CaloTowerDefs::ZDC)
+    {
+      m_detector = "ZDC";
+    }
+  else if (m_dettype == CaloTowerDefs::SEPD)
+    {
+      m_detector = "SEPD";
+    }
+  
   PHCompositeNode *simTopNode = se->topNode("TOPSim");
 
   EventHeader *evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader");
@@ -89,110 +109,73 @@ int caloTowerEmbed::process_event(PHCompositeNode* topNode)
 {
   ++m_eventNumber;
 
-  for(int caloIndex=0; caloIndex<3; caloIndex++){
+  if(Verbosity()) std::cout << "event " << m_eventNumber << " working on " << m_detector << std::endl;
+  RawTowerDefs::keytype keyData = 0;
+  RawTowerDefs::keytype keySim = 0;
+  
+  unsigned int ntowers = _data_towers->size();
+  for (unsigned int channel = 0; channel < ntowers; channel++)
+    {
+      unsigned int data_key = _data_towers->encode_key(channel);
+      unsigned int sim_key = _sim_towers->encode_key(channel);
 
-    if(Verbosity()) std::cout << "event " << m_eventNumber << " working on caloIndex " << caloIndex;
-    if(caloIndex == 0) std::cout << " CEMC" << std::endl;
-    else if(caloIndex == 1) std::cout << " HCALIN" << std::endl;
-    else if(caloIndex == 2) std::cout << " HCALOUT" << std::endl;
-    RawTowerDefs::keytype keyData = 0;
-    RawTowerDefs::keytype keySim = 0;
-
-    unsigned int ntowers = _data_towers[caloIndex]->size();
-    for (unsigned int channel = 0; channel < ntowers; channel++)
-      {
-	unsigned int data_key = _data_towers[caloIndex]->encode_key(channel);
-	unsigned int sim_key = _sim_towers[caloIndex]->encode_key(channel);
-
-	int ieta_data = _data_towers[caloIndex]->getTowerEtaBin(data_key);
-	int iphi_data = _data_towers[caloIndex]->getTowerPhiBin(data_key);
-	int ieta_sim = _sim_towers[caloIndex]->getTowerEtaBin(sim_key);
-	int iphi_sim = _sim_towers[caloIndex]->getTowerPhiBin(sim_key);
-
-	if(caloIndex == 0){
-	  if(!m_useRetower){
-	    keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, ieta_data, iphi_data);
-	    keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, ieta_sim, iphi_sim);
-	  } 
-	  else{
-	    keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_data, iphi_data);
-	    keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_sim, iphi_sim);
-	  }
-	}else if(caloIndex == 1){
+      int ieta_data = _data_towers->getTowerEtaBin(data_key);
+      int iphi_data = _data_towers->getTowerPhiBin(data_key);
+      int ieta_sim = _sim_towers->getTowerEtaBin(sim_key);
+      int iphi_sim = _sim_towers->getTowerPhiBin(sim_key);
+      
+      if(m_detector == "CEMC"){
+	if(!m_useRetower){
+	  keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, ieta_data, iphi_data);
+	  keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, ieta_sim, iphi_sim);
+	} 
+	else{
 	  keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_data, iphi_data);
 	  keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_sim, iphi_sim);
-	}else if(caloIndex == 2){
-	  keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, ieta_data, iphi_data);
-	  keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, ieta_sim, iphi_sim);
 	}
-	
-	TowerInfo *caloinfo_data = _data_towers[caloIndex]->get_tower_at_channel(channel);
-	TowerInfo *caloinfo_sim = _sim_towers[caloIndex]->get_tower_at_channel(channel);
+      }else if(m_detector == "HCALIN"){
+	keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_data, iphi_data);
+	keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, ieta_sim, iphi_sim);
+      }else if(m_detector == "HCALOUT"){
+	keyData = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, ieta_data, iphi_data);
+	keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, ieta_sim, iphi_sim);
+      }
+      
+      TowerInfo *caloinfo_data = _data_towers->get_tower_at_channel(channel);
+      TowerInfo *caloinfo_sim = _sim_towers->get_tower_at_channel(channel);
 
-	float data_E = caloinfo_data->get_energy();
-	float sim_E = caloinfo_sim->get_energy();
-	float embed_E = data_E + sim_E;
-
-	float data_phi = 0.0;
-	float sim_phi = 0.0;
-
-	float data_eta = 0.0;
-	float sim_eta = 0.0;
-
-	if(caloIndex == 0){
-	  if(!m_useRetower){
-	    data_phi = tower_geom->get_tower_geometry(keyData)->get_phi();
-	    data_eta = tower_geom->get_tower_geometry(keyData)->get_eta();
-	    
-	    sim_phi = tower_geom->get_tower_geometry(keySim)->get_phi();
-	    sim_eta = tower_geom->get_tower_geometry(keySim)->get_eta();
-	  }else{
-	    data_phi = tower_geomIH->get_tower_geometry(keyData)->get_phi();
-	    data_eta = tower_geomIH->get_tower_geometry(keyData)->get_eta();
-	    
-	    sim_phi = tower_geomIH->get_tower_geometry(keySim)->get_phi();
-	    sim_eta = tower_geomIH->get_tower_geometry(keySim)->get_eta();
-	  }
-
-	  if(data_phi == sim_phi && data_eta == sim_eta){
-	    _data_towers[caloIndex]->get_tower_at_channel(channel)->set_energy(embed_E);
-	  }else{
-	    if(Verbosity()) std::cout << "eta and phi values in CEMC do not match between data and simulation, removing this event" << std::endl;
-	    return Fun4AllReturnCodes::ABORTEVENT;
-	  }
-
-	}else if(caloIndex == 1){
-	  data_phi = tower_geomIH->get_tower_geometry(keyData)->get_phi();
-	  data_eta = tower_geomIH->get_tower_geometry(keyData)->get_eta();
-
-	  sim_phi = tower_geomIH->get_tower_geometry(keySim)->get_phi();
-	  sim_eta = tower_geomIH->get_tower_geometry(keySim)->get_eta();
-
-	  if(data_phi == sim_phi && data_eta == sim_eta){
-	    _data_towers[caloIndex]->get_tower_at_channel(channel)->set_energy(embed_E);
-	  }else{
-	    if(Verbosity()) std::cout << "eta and phi values in HCALIN do not match between data and simulation, removing this event" << std::endl;
-	    return Fun4AllReturnCodes::ABORTEVENT;
-	  }
-
-	}else if(caloIndex == 2){
-	  data_phi = tower_geomOH->get_tower_geometry(keyData)->get_phi();
-	  data_eta = tower_geomOH->get_tower_geometry(keyData)->get_eta();
-
-	  sim_phi = tower_geomOH->get_tower_geometry(keySim)->get_phi();
-	  sim_eta = tower_geomOH->get_tower_geometry(keySim)->get_eta();
-
-	  if(data_phi == sim_phi && data_eta == sim_eta){
-	    _data_towers[caloIndex]->get_tower_at_channel(channel)->set_energy(embed_E);
-	  }else{
-	    if(Verbosity()) std::cout << "eta and phi values in HCALOUT do not match between data and simulation, removing this event" << std::endl;
-	    return Fun4AllReturnCodes::ABORTEVENT;
-	  }
-
-	}
-      }//end loop over channels
-  }//end loop over calorimeters
-
+      if(!caloinfo_data->get_isGood()){
+	_data_towers->get_tower_at_channel(channel)->set_energy(0.0);
+	_data_towers->get_tower_at_channel(channel)->set_time(-11);
+	continue;
+      }
+      
+      float data_E = caloinfo_data->get_energy();
+      float sim_E = caloinfo_sim->get_energy();
+      float embed_E = data_E + sim_E;
+      
+      float data_phi = 0.0;
+      float sim_phi = 0.0;
+      
+      float data_eta = 0.0;
+      float sim_eta = 0.0;
+      
+      data_phi = tower_geom->get_tower_geometry(keyData)->get_phi();
+      data_eta = tower_geom->get_tower_geometry(keyData)->get_eta();
+      
+      sim_phi = tower_geom->get_tower_geometry(keySim)->get_phi();
+      sim_eta = tower_geom->get_tower_geometry(keySim)->get_eta();
+      
+      if(data_phi == sim_phi && data_eta == sim_eta){
+	_data_towers->get_tower_at_channel(channel)->set_energy(embed_E);
+      }else{
+	if(Verbosity()) std::cout << "eta and phi values in " << m_detector << " do not match between data and simulation, removing this event" << std::endl;
+	return Fun4AllReturnCodes::ABORTEVENT;
+      }
+      
+      
+    }//end loop over channels
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -207,32 +190,23 @@ void caloTowerEmbed::CreateNodeTree(PHCompositeNode *topNode)
 {
   std::cout << "creating node" << std::endl;
 
+  std::string TowerNodeName = m_inputNodePrefix + m_detector;
+  std::string GeomNodeName = "TOWERGEOM_" + m_detector;
+  if(m_useRetower && m_detector == "CEMC")
+    {
+      TowerNodeName = m_inputNodePrefix + m_detector + "_RETOWER";
+      GeomNodeName = "TOWERGEOM_HCALIN";
+    }
+
   Fun4AllServer *se = Fun4AllServer::instance();
   PHCompositeNode *simTopNode = se->topNode("TOPSim");
 
-  tower_geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
+  tower_geom = findNode::getClass<RawTowerGeomContainer>(topNode, GeomNodeName);
   if(!tower_geom){
-    std::cerr << Name() << "::" << __PRETTY_FUNCTION__
-	      << "tower geom CEMC missing, doing nothing." << std::endl;
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+	      << "tower geom " << GeomNodeName << " missing, doing nothing." << std::endl;
     throw std::runtime_error(
-			     "Failed to find TOWERGEOM_CEMC node");
-  }
-
-  tower_geomIH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-  if(!tower_geomIH){
-    std::cerr << Name() << "::" << __PRETTY_FUNCTION__
-	      << "tower geom HCALIN missing, doing nothing." << std::endl;
-    throw std::runtime_error(
-			     "Failed to find TOWERGEOM_HCALIN node");
-  }
-
-
-  tower_geomOH = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
-  if(!tower_geomOH){
-    std::cerr << Name() << "::" << __PRETTY_FUNCTION__
-	      << "tower geom HCALOUT missing, doing nothing." << std::endl;
-    throw std::runtime_error(
-			     "Failed to find TOWERGEOM_HCALOUT node");
+			     "Failed to find " + GeomNodeName + " node");
   }
 
   PHNodeIterator dataIter(topNode);
@@ -244,7 +218,7 @@ void caloTowerEmbed::CreateNodeTree(PHCompositeNode *topNode)
       "PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    std::cerr << Name() << "::" << __PRETTY_FUNCTION__
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
               << "DST Node missing, doing nothing." << std::endl;
     throw std::runtime_error(
         "Failed to find DST node in RawTowerCalibration::CreateNodes");
@@ -255,46 +229,32 @@ void caloTowerEmbed::CreateNodeTree(PHCompositeNode *topNode)
       "PHCompositeNode", "DST"));
   if (!dstNodeSim)
   {
-    std::cerr << Name() << "::" << __PRETTY_FUNCTION__
+    std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
               << "DSTsim Node missing, doing nothing." << std::endl;
     throw std::runtime_error(
         "Failed to find DSTsim node in RawTowerCalibration::CreateNodes");
   }
 
-  for(int i=0; i<3; i++){
-
-    std::string detector = "CEMC";
-    if(i==0 && m_useRetower) detector = "CEMC_RETOWER";
-    if(i==1) detector = "HCALIN";
-    else if(i==2) detector = "HCALOUT";
-
-    
     //data
-    std::string DataTowerNodeName = "TOWERINFO_CALIB_" + detector;
-    _data_towers[i] = findNode::getClass<TowerInfoContainer>(dstNode,
-							       DataTowerNodeName);
-    if (!_data_towers[i])
+    _data_towers = findNode::getClass<TowerInfoContainer>(dstNode,TowerNodeName);
+    if (!_data_towers)
       {
-	std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-		  << "Tower Calib Node missing, doing nothing." << std::endl;
+	std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+		  << TowerNodeName << " Node missing, doing nothing." << std::endl;
 	throw std::runtime_error(
-				 "Failed to find Calib Tower node in caloTowerEmbed::CreateNodes");
+				 "Failed to find " + TowerNodeName + " node in caloTowerEmbed::CreateNodes");
       }
 
 
     //sim
-    std::string SimTowerNodeName = "TOWERINFO_CALIB_" + detector;
-    _sim_towers[i] = findNode::getClass<TowerInfoContainer>(dstNodeSim,
-                                                           SimTowerNodeName);
-    if (!_sim_towers[i])
+    _sim_towers = findNode::getClass<TowerInfoContainer>(dstNodeSim,TowerNodeName);
+    if (!_sim_towers)
       {
-	std::cerr << Name() << "::" << detector << "::" << __PRETTY_FUNCTION__
-		  << "Tower Calib Sim Node missing, doing nothing." << std::endl;
+	std::cerr << Name() << "::" << m_detector << "::" << __PRETTY_FUNCTION__
+		  << TowerNodeName << " Sim Node missing, doing nothing." << std::endl;
 	throw std::runtime_error(
-				 "Failed to find Calib Tower Sim node in caloTowerEmbed::CreateNodes");
+				 "Failed to find " + TowerNodeName + " Sim node in caloTowerEmbed::CreateNodes");
       }
-
-  }//end loop over calorimeter types
 
   return;
 }

--- a/offline/packages/CaloEmbedding/caloTowerEmbed.h
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.h
@@ -3,11 +3,8 @@
 #ifndef CALOTOWEREMBED_H
 #define CALOTOWEREMBED_H
 
-#include "caloreco/CaloTowerDefs.h"
-
-
+#include <caloreco/CaloTowerDefs.h>
 #include <calobase/TowerInfoContainer.h>  // for TowerInfoContainer, TowerIn...
-
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
 

--- a/offline/packages/CaloEmbedding/caloTowerEmbed.h
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.h
@@ -3,6 +3,9 @@
 #ifndef CALOTOWEREMBED_H
 #define CALOTOWEREMBED_H
 
+#include "caloreco/CaloTowerDefs.h"
+
+
 #include <calobase/TowerInfoContainer.h>  // for TowerInfoContainer, TowerIn...
 
 #include <calobase/RawTowerGeom.h>
@@ -35,30 +38,41 @@ class caloTowerEmbed : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   void CreateNodeTree(PHCompositeNode *topNode);
+
+  void set_detector_type(CaloTowerDefs::DetectorSystem dettype)
+  {
+    m_dettype = dettype;
+    return;
+  }
   
 
-  void set_useRetower(bool a){ m_useRetower = a; };
-
-  enum DetectorSystem
+  void set_inputNodePrefix(const std::string &name)
   {
-    CEMC = 0,
-    HCALIN = 1,
-    HCALOUT = 2,
-    EPD = 3
+    m_inputNodePrefix = name;
+    return;
+  }
+  
+  void set_useRetower(bool a)
+  {
+    m_useRetower = a;
+    return;
   };
 
  private:
-  TowerInfoContainer *_data_towers[3] = {nullptr,nullptr,nullptr};
-  TowerInfoContainer *_sim_towers[3] = {nullptr,nullptr,nullptr};
+
+
+  TowerInfoContainer *_data_towers = nullptr;
+  TowerInfoContainer *_sim_towers = nullptr;
 
   RawTowerGeomContainer *tower_geom = nullptr;
-  RawTowerGeomContainer *tower_geomIH = nullptr;
-  RawTowerGeomContainer *tower_geomOH = nullptr;
 
   bool m_useRetower = false;
 
-  //  CDBInterface *cdb = nullptr;
-  //CDBTTree *cdbttree = nullptr;
+  CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
+
+  std::string m_detector;
+  std::string m_inputNodePrefix{"TOWERINFO_CALIB_"};
+
   int m_runNumber;
   int m_eventNumber;
 

--- a/offline/packages/CaloEmbedding/caloTowerEmbed.h
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.h
@@ -51,7 +51,13 @@ class caloTowerEmbed : public SubsysReco
   {
     m_useRetower = a;
     return;
-  };
+  }
+
+  void set_removeBadTowers(bool a)
+  {
+    m_removeBadTowers = a;
+    return;
+  }
 
  private:
 
@@ -59,9 +65,13 @@ class caloTowerEmbed : public SubsysReco
   TowerInfoContainer *_data_towers {nullptr};
   TowerInfoContainer *_sim_towers {nullptr};
 
+  TowerInfoContainer *_embed_towers_out {nullptr};
+  TowerInfoContainer *_sim_towers_out {nullptr};
+
   RawTowerGeomContainer *tower_geom {nullptr};
 
   bool m_useRetower {false};
+  bool m_removeBadTowers {false};
 
   CaloTowerDefs::DetectorSystem m_dettype{CaloTowerDefs::DETECTOR_INVALID};
 

--- a/offline/packages/jetbase/Jet.h
+++ b/offline/packages/jetbase/Jet.h
@@ -105,6 +105,12 @@ class Jet : public PHObject
     CEMC_TOWERINFO_SUB1 = 29,
     HCALIN_TOWERINFO_SUB1 = 30,
     HCALOUT_TOWERINFO_SUB1 = 31, /* needed for HI jet reco */
+    CEMC_TOWERINFO_EMBED = 32, /* needed for embedding */
+    CEMC_TOWERINFO_SIM = 33,
+    HCALIN_TOWERINFO_EMBED = 34,
+    HCALIN_TOWERINFO_SIM = 35,
+    HCALOUT_TOWERINFO_EMBED = 36,
+    HCALOUT_TOWERINFO_SIM = 37,
   };
 
   enum PROPERTY

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -123,6 +123,28 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	return std::vector<Jet *>();
       }
   }
+  else if (m_input == Jet::CEMC_TOWERINFO_EMBED)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_CEMC");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
+    geocaloid = RawTowerDefs::CalorimeterId::CEMC;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
+  else if (m_input == Jet::CEMC_TOWERINFO_SIM)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_CEMC");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
+    geocaloid = RawTowerDefs::CalorimeterId::CEMC;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
   else if (m_input == Jet::EEMC_TOWER)
     {
       towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_EEMC");
@@ -152,6 +174,28 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  return std::vector<Jet *>();
 	}
     }
+  else if (m_input == Jet::HCALIN_TOWERINFO_EMBED)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_HCALIN");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
+  else if (m_input == Jet::HCALIN_TOWERINFO_SIM)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_HCALIN");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
   else if (m_input == Jet::HCALOUT_TOWER)
     {
       towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
@@ -172,6 +216,29 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  return std::vector<Jet *>();
 	}
     }
+  else if (m_input == Jet::HCALOUT_TOWERINFO_EMBED)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_HCALOUT");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
+  else if (m_input == Jet::HCALOUT_TOWERINFO_SIM)
+  {
+    m_use_towerinfo = true;
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_HCALOUT");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
+    if ((!towerinfos) || !geom)
+      {
+	return std::vector<Jet *>();
+      }
+  }
+
 
   else if (m_input == Jet::FEMC_TOWER)
     {
@@ -341,6 +408,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	{
 	  TowerInfo *tower = towerinfos->get_tower_at_channel(channel);
 	  assert(tower);
+
 	  unsigned int calokey = towerinfos->encode_key(channel);
 	  int ieta = towerinfos->getTowerEtaBin(calokey);
 	  int iphi = towerinfos->getTowerPhiBin(calokey);


### PR DESCRIPTION
[comment]: <> Changed embedding to only run over the passed calorimeter, will need to be loaded separately for each calorimeter
Data towers are no longer overwritten by embedding, new containers for each calorimeter tower are added to the node tree for embedding and sim
New sources in Jet.h and TowerJetInput.cc to use these new containers

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

