### PR TITLE
Changed HFTrackEff defaults from 0 to numeric_limits

### DIFF
--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -408,35 +408,35 @@ void HFTrackEfficiency::initializeBranches()
 void HFTrackEfficiency::resetBranches()
 {
   m_all_tracks_reconstructed = false;
-  m_true_mother_mass = 0.;
-  m_reco_mother_mass = 0.;
-  m_true_mother_pT = 0.;
-  m_true_mother_p = 0.;
-  m_true_mother_eta = 0.;
-  m_min_true_track_pT = FLT_MAX;
-  m_min_reco_track_pT = FLT_MAX;
-  m_max_true_track_pT = -1 * FLT_MAX;
-  m_max_reco_track_pT = -1 * FLT_MAX;
+  m_true_mother_mass = std::numeric_limits<float>::quiet_NaN();
+  m_reco_mother_mass = std::numeric_limits<float>::quiet_NaN();
+  m_true_mother_pT = std::numeric_limits<float>::quiet_NaN();
+  m_true_mother_p = std::numeric_limits<float>::quiet_NaN();
+  m_true_mother_eta = std::numeric_limits<float>::quiet_NaN();
+  m_min_true_track_pT = std::numeric_limits<float>::quiet_NaN();
+  m_min_reco_track_pT = std::numeric_limits<float>::quiet_NaN();
+  m_max_true_track_pT = -1 * std::numeric_limits<float>::quiet_NaN();
+  m_max_reco_track_pT = -1 * std::numeric_limits<float>::quiet_NaN();
   for (unsigned int iTrack = 0; iTrack < m_nDaughters; ++iTrack)
   {
     m_reco_track_exists[iTrack] = false;
     m_used_truth_reco_map[iTrack] = false;
-    m_true_track_pT[iTrack] = 0.;
-    m_reco_track_pT[iTrack] = 0.;
-    m_true_track_eta[iTrack] = 0.;
-    m_reco_track_eta[iTrack] = 0.;
-    m_true_track_PID[iTrack] = 0.;
-    m_reco_track_chi2nDoF[iTrack] = 0.;
+    m_true_track_pT[iTrack] = std::numeric_limits<float>::quiet_NaN();
+    m_reco_track_pT[iTrack] = std::numeric_limits<float>::quiet_NaN();
+    m_true_track_eta[iTrack] = std::numeric_limits<float>::quiet_NaN();
+    m_reco_track_eta[iTrack] = std::numeric_limits<float>::quiet_NaN();
+    m_true_track_PID[iTrack] = std::numeric_limits<float>::quiet_NaN();
+    m_reco_track_chi2nDoF[iTrack] = std::numeric_limits<float>::quiet_NaN();
     m_reco_track_silicon_seeds[iTrack] = 0;
     m_reco_track_tpc_seeds[iTrack] = 0;
   }
 
-  m_primary_vtx_x = 0.;
-  m_primary_vtx_y = 0.;
-  m_primary_vtx_z = 0.;
-  m_secondary_vtx_x = 0.;
-  m_secondary_vtx_y = 0.;
-  m_secondary_vtx_z = 0.;
+  m_primary_vtx_x = std::numeric_limits<float>::quiet_NaN();
+  m_primary_vtx_y = std::numeric_limits<float>::quiet_NaN();
+  m_primary_vtx_z = std::numeric_limits<float>::quiet_NaN();
+  m_secondary_vtx_x = std::numeric_limits<float>::quiet_NaN();
+  m_secondary_vtx_y = std::numeric_limits<float>::quiet_NaN();
+  m_secondary_vtx_z = std::numeric_limits<float>::quiet_NaN();
 }
 
 void HFTrackEfficiency::getDecayDescriptor()

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.cc
@@ -413,10 +413,10 @@ void HFTrackEfficiency::resetBranches()
   m_true_mother_pT = std::numeric_limits<float>::quiet_NaN();
   m_true_mother_p = std::numeric_limits<float>::quiet_NaN();
   m_true_mother_eta = std::numeric_limits<float>::quiet_NaN();
-  m_min_true_track_pT = std::numeric_limits<float>::quiet_NaN();
-  m_min_reco_track_pT = std::numeric_limits<float>::quiet_NaN();
-  m_max_true_track_pT = -1 * std::numeric_limits<float>::quiet_NaN();
-  m_max_reco_track_pT = -1 * std::numeric_limits<float>::quiet_NaN();
+  m_min_true_track_pT = std::numeric_limits<float>::max();
+  m_min_reco_track_pT = std::numeric_limits<float>::max();
+  m_max_true_track_pT = -1 * std::numeric_limits<float>::max();
+  m_max_reco_track_pT = -1 * std::numeric_limits<float>::max();
   for (unsigned int iTrack = 0; iTrack < m_nDaughters; ++iTrack)
   {
     m_reco_track_exists[iTrack] = false;

--- a/offline/packages/HFTrackEfficiency/HFTrackEfficiency.h
+++ b/offline/packages/HFTrackEfficiency/HFTrackEfficiency.h
@@ -123,31 +123,31 @@ class HFTrackEfficiency : public SubsysReco
 
   static const int m_maxTracks = 5;
   bool m_all_tracks_reconstructed = false;
-  float m_true_mother_mass = 0.;
-  float m_reco_mother_mass = 0.;
-  float m_true_mother_pT = 0.;
-  float m_true_mother_p = 0.;
-  float m_true_mother_eta = 0.;
-  float m_min_true_track_pT = FLT_MAX;
-  float m_min_reco_track_pT = FLT_MAX;
-  float m_max_true_track_pT = -1. * FLT_MAX;
-  float m_max_reco_track_pT = -1. * FLT_MAX;
+  float m_true_mother_mass = std::numeric_limits<float>::quiet_NaN();
+  float m_reco_mother_mass = std::numeric_limits<float>::quiet_NaN();
+  float m_true_mother_pT = std::numeric_limits<float>::quiet_NaN();
+  float m_true_mother_p = std::numeric_limits<float>::quiet_NaN();
+  float m_true_mother_eta = std::numeric_limits<float>::quiet_NaN();
+  float m_min_true_track_pT = std::numeric_limits<float>::max();
+  float m_min_reco_track_pT = std::numeric_limits<float>::max();
+  float m_max_true_track_pT = -1. * std::numeric_limits<float>::max(); //Apparently min() is still a +ve value
+  float m_max_reco_track_pT = -1. * std::numeric_limits<float>::max();
   bool m_reco_track_exists[m_maxTracks] = {false};
   bool m_used_truth_reco_map[m_maxTracks] = {false};
-  float m_true_track_pT[m_maxTracks] = {0.};
-  float m_reco_track_pT[m_maxTracks] = {0.};
-  float m_true_track_eta[m_maxTracks] = {0.};
-  float m_reco_track_eta[m_maxTracks] = {0.};
-  float m_true_track_PID[m_maxTracks] = {0.};
-  float m_reco_track_chi2nDoF[m_maxTracks] = {0.};
+  float m_true_track_pT[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_reco_track_pT[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_true_track_eta[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_reco_track_eta[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_true_track_PID[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_reco_track_chi2nDoF[m_maxTracks] = {std::numeric_limits<float>::quiet_NaN()};
   int m_reco_track_silicon_seeds[m_maxTracks] = {0};
   int m_reco_track_tpc_seeds[m_maxTracks] = {0};
-  float m_primary_vtx_x = 0.;
-  float m_primary_vtx_y = 0.;
-  float m_primary_vtx_z = 0.;
-  float m_secondary_vtx_x = 0.;
-  float m_secondary_vtx_y = 0.;
-  float m_secondary_vtx_z = 0.;
+  float m_primary_vtx_x = std::numeric_limits<float>::quiet_NaN();
+  float m_primary_vtx_y = std::numeric_limits<float>::quiet_NaN();
+  float m_primary_vtx_z = std::numeric_limits<float>::quiet_NaN();
+  float m_secondary_vtx_x = std::numeric_limits<float>::quiet_NaN();
+  float m_secondary_vtx_y = std::numeric_limits<float>::quiet_NaN();
+  float m_secondary_vtx_z = std::numeric_limits<float>::quiet_NaN();
 };
 
 #endif  // HFTRACKEFFICIENCY_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

At today's HF&Q meeting, Charles showed some reconstructed eta plot which had a cross structure around 0. This is due to the default value of each track being 0 so if the reco track doesn't exist, this isn't updated. I changed the default values to use numeric limits

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

[Link to Charles' presentation](https://indico.bnl.gov/event/22058/contributions/86161/attachments/52265/89385/20240124_Joint_HF_Quarkonia_Meeting_Charles.pdf)

