### PR TITLE
Rphi toggle

### DIFF
--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -55,22 +55,35 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position( const Acts::Vecto
   auto phi_new=phi;
   auto r_new=r;
   auto z_new=z;
+
+  //if the phi correction hist units are cm, we must divide by r to get the dPhi in radians
+  auto divisor=r;
+  if (phi_hist_in_radians){
+    //if the phi correction hist units are radians, we must not divide by r.
+    divisor=1.0;
+  }
+    
   if (dcc->dimensions==3)
   {
-    if (dcc->m_hDPint[index] && (mask&COORD_PHI) && check_boundaries( dcc->m_hDPint[index],phi,r,z)) phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi,r,z)/r;
+    if (dcc->m_hDPint[index] && (mask&COORD_PHI) && check_boundaries( dcc->m_hDPint[index],phi,r,z)) phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi,r,z)/divisor;
     if (dcc->m_hDRint[index] && (mask&COORD_R) && check_boundaries( dcc->m_hDRint[index],phi,r,z)) r_new = r - dcc->m_hDRint[index]->Interpolate(phi,r,z);
     if (dcc->m_hDZint[index] && (mask&COORD_Z) && check_boundaries( dcc->m_hDZint[index],phi,r,z)) z_new = z - dcc->m_hDZint[index]->Interpolate(phi,r,z);
   }
   else if (dcc->dimensions==2){
     const double zterm = (1.- std::abs(z)/105.5);
-    if (dcc->m_hDPint[index] && (mask&COORD_PHI) && check_boundaries( dcc->m_hDPint[index],phi,r)) phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi,r)*zterm/r;
+    if (dcc->m_hDPint[index] && (mask&COORD_PHI) && check_boundaries( dcc->m_hDPint[index],phi,r)) phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi,r)*zterm/divisor;
     if (dcc->m_hDRint[index] && (mask&COORD_R) && check_boundaries( dcc->m_hDRint[index],phi,r)) r_new = r - dcc->m_hDRint[index]->Interpolate(phi,r)*zterm;
     if (dcc->m_hDZint[index] && (mask&COORD_Z) && check_boundaries( dcc->m_hDZint[index],phi,r)) z_new = z - dcc->m_hDZint[index]->Interpolate(phi,r)*zterm;
   }
-  
+
   // update cluster
   const auto x_new = r_new*std::cos( phi_new );
   const auto y_new = r_new*std::sin( phi_new );
 
   return {x_new, y_new, z_new};
+}
+
+void TpcDistortionCorrection::read_phi_as_radians(bool flag=true){
+  phi_hist_in_radians=flag;
+  return;
 }

--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -58,7 +58,7 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position( const Acts::Vecto
 
   //if the phi correction hist units are cm, we must divide by r to get the dPhi in radians
   auto divisor=r;
-  if (phi_hist_in_radians){
+  if (m_phi_hist_in_radians){
     //if the phi correction hist units are radians, we must not divide by r.
     divisor=1.0;
   }
@@ -81,9 +81,4 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position( const Acts::Vecto
   const auto y_new = r_new*std::sin( phi_new );
 
   return {x_new, y_new, z_new};
-}
-
-void TpcDistortionCorrection::read_phi_as_radians(bool flag=true){
-  phi_hist_in_radians=flag;
-  return;
 }

--- a/offline/packages/tpc/TpcDistortionCorrection.h
+++ b/offline/packages/tpc/TpcDistortionCorrection.h
@@ -38,6 +38,10 @@ class TpcDistortionCorrection
  Acts::Vector3 get_corrected_position( const Acts::Vector3&, const TpcDistortionCorrectionContainer*, 
 					unsigned int mask = COORD_ALL ) const;
 
+ //! set the phi histogram to be interpreted as radians.
+ void read_phi_as_radians(bool flag=true);
+ private:
+ bool phi_hist_in_radians=true;
 };
 
 #endif

--- a/offline/packages/tpc/TpcDistortionCorrection.h
+++ b/offline/packages/tpc/TpcDistortionCorrection.h
@@ -39,9 +39,12 @@ class TpcDistortionCorrection
 					unsigned int mask = COORD_ALL ) const;
 
  //! set the phi histogram to be interpreted as radians.
- void read_phi_as_radians(bool flag=true);
+ void read_phi_as_radians(bool flag=true){
+  m_phi_hist_in_radians=flag;
+  return;
+}
  private:
- bool phi_hist_in_radians=true;
+ bool m_phi_hist_in_radians=true;
 };
 
 #endif

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.cc
@@ -173,6 +173,9 @@ double PHG4TpcDistortion::get_r_distortion(double r, double phi, double z) const
 //__________________________________________________________________________________________________________
 double PHG4TpcDistortion::get_rphi_distortion(double r, double phi, double z) const
 {
+  if (m_phi_hist_in_radians) //if the hist is in radians, multiply by r to get the rphi distortion
+    return r*get_distortion('p', r, phi, z);
+
   return get_distortion('p', r, phi, z);
 }
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDistortion.h
@@ -84,6 +84,10 @@ class PHG4TpcDistortion
     m_time_ordered_distortion_filename = value;
   }
 
+  void set_read_phi_as_radians(bool flag=true){
+    m_phi_hist_in_radians=flag;
+  }
+
   //! initialize
   void Init();
 
@@ -105,6 +109,10 @@ class PHG4TpcDistortion
   //! The verbosity level. 0 means not verbose at all.
   int verbosity = 0;
 
+  //! Flag controls whether to assume the phi hist units are radians or cm.
+  bool m_phi_hist_in_radians=true;
+
+  
   //!@name static histograms
   //@{
   bool m_do_static_distortions = false;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This adds flags to the simulation and the reco that allow it to interpret phi distortions as either d(r*phi), in centimeters, or as d(phi), in radians.  The flag is set to true by default, which makes the distortion framework compatible with recent simulated distortion datasets.  This approach makes these compatible with the fewest flags.

## TODOs (if applicable)

The handling in the reconstruction is currently in TpcDistortionCorrection, but probably more correctly belongs to the TpcDistortionCorrectionContainer.  This is a minor issue that would only apply if we were swapping from current to old datasets and back.

Also, if we are deprecating the old distortion simulations, eventually we should also change PHG4TpcElectronDrift so it assumes the result will be given natively in radians, rather than multiplying by 'r' in one place only to later divide by 'r' in the other.
[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

