### PR TITLE
A check on the global vertex causes KFParticle to crash

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -136,8 +136,8 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
     GlobalVertex *gvertex = iter->second;
     auto svtxv = gvertex->find_vtxids(GlobalVertex::SVTX);
     // check that it contains a track vertex
-    if(svtxv == gvertex->end_vtxids())
-      { continue; }
+    //if(svtxv == gvertex->end_vtxids())
+    //  { continue; }
 
     auto svtxvertexid = svtxv->second;
     m_dst_vertex = m_dst_vertexmap->find(svtxvertexid)->second;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -134,18 +134,23 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
   for (GlobalVertexMap::ConstIter iter = globalvertexmap->begin(); iter != globalvertexmap->end(); ++iter)
   {
     GlobalVertex *gvertex = iter->second;
-    auto svtxv = gvertex->find_vtxids(GlobalVertex::SVTX);
+    auto svtxiter = gvertex->find_vertexes(GlobalVertex::SVTX);
     // check that it contains a track vertex
-    //if(svtxv == gvertex->end_vtxids())
-    //  { continue; }
+    if(svtxiter == gvertex->end_vertexes()) { continue; }
 
-    auto svtxvertexid = svtxv->second;
-    m_dst_vertex = m_dst_vertexmap->find(svtxvertexid)->second;
+    auto svtxvertexvector = svtxiter->second;
 
-    primaryVertices.push_back(makeVertex(topNode));
-    primaryVertices[vertexID].SetId(gvertex->get_id());
-    ++vertexID;
+    for (auto& vertex : svtxvertexvector)
+    {
+      m_dst_vertex = m_dst_vertexmap->find(vertex->get_id())->second;
+
+      primaryVertices.push_back(makeVertex(topNode));
+      primaryVertices[vertexID].SetId(gvertex->get_id());
+      ++vertexID;
+    }
   }
+
+//std::cout << "The size of my KFParticle vertex vector is " << primaryVertices.size() << std::endl;
 
   return primaryVertices;
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -150,8 +150,6 @@ std::vector<KFParticle> KFParticle_Tools::makeAllPrimaryVertices(PHCompositeNode
     }
   }
 
-//std::cout << "The size of my KFParticle vertex vector is " << primaryVertices.size() << std::endl;
-
   return primaryVertices;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I was working with @chughes90 on the Lambda_c analysis when I found that KFParticle was crashing. I traced it down to there being no vertices stored as KFParticle objects so the first time it tried to access the primary vertex vector, Fun4All would crash.

Further invesitgation showed that SVTX vertices were being created and saved. KFParticle would then request SVTX vertices from the global vertex map and a check on the VTX type (400) showed this worked and there was one vertex to use. Then a check as to whether we were at the end of the vertex map was run which stopped the conversion of the SvtxVertex to a KFVertex, hence the crash. Upon removing this check, KFParticle ran with no issue.

I assume there is a good reason to have this check which caused the crash, is it because we assume to have more than one type of vertex in the global map or more than one SVTX vertex? (SVTX and MBD maybe?) I wonder if my PR is the correct fix or this will introduce some other issue further down the line. @jdosbo do you have thoughts on this?

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

