### PR TITLE
feat: cosmic development and line fitter fix

### DIFF
--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -173,11 +173,13 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::po
   double x2sum = 0;
   double ysum = 0;
   double xysum = 0;
+  double y2sum = 0;
   for (const auto& [r, z] : positions)
   {
     xsum = xsum + r;            // calculate sigma(xi)
     ysum = ysum + z;            // calculate sigma(yi)
     x2sum = x2sum + square(r);  // calculate sigma(x^2i)
+    y2sum = y2sum + square(z);  // calculate sigma(y^2i)
     xysum = xysum + r * z;      // calculate sigma(xi*yi)
   }
 
@@ -186,7 +188,31 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::po
   const double a = (xysum * npts - xsum * ysum) / denominator;   // calculate slope
   const double b = (x2sum * ysum - xsum * xysum) / denominator;  // calculate intercept
 
-  return std::make_tuple(a, b);
+  //! The fit fails for the case where the line is close to vertical, because
+  //! there is little dependence on x and thus the denominator is very small
+  //! we can swap the x-y points to find a y-x horizontal line in this case
+  //! then check which line minimizes the sums of squares of residuals
+  //! that is the best fit, and should be returned
+  const double denominatoryx = (y2sum * npts - square(ysum));
+  const double inva = (xysum * npts - xsum * ysum) / denominatoryx;
+  const double invb = (y2sum * xsum - ysum * xysum) / denominatoryx;
+
+  //! now determine which one minimizes the sum of residuals to return
+  float sumresid = 0;
+  float suminvresid = 0;
+  for (const auto& [r, z] : positions)
+  {
+    sumresid += square(z - (a * r + b));
+    suminvresid += square(r - (inva * z + invb));
+  }
+
+  if (sumresid < suminvresid)
+  {
+    return std::make_tuple(a, b);
+  }
+
+  //! the fit is horizontal, so find the perpendicular line
+  return std::make_tuple(1. / inva, -invb / inva);
 }
 
 //_________________________________________________________________________________

--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -211,7 +211,7 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit(const TrackFitUtils::po
     return std::make_tuple(a, b);
   }
 
-  //! the fit is horizontal, so find the perpendicular line
+  //! the best fit is swapped in y-x, so find the perpendicular line
   return std::make_tuple(1. / inva, -invb / inva);
 }
 

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -250,7 +250,10 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
       int tpcind = _tpc_seeds->find(tpcseed);
       int siind = _si_seeds->find(mapped_seed);
       full_seed->set_tpc_seed_index(tpcind);
-      full_seed->set_silicon_seed_index(siind);
+      if (si_seed->size_cluster_keys() > 0)
+      {
+        full_seed->set_silicon_seed_index(siind);
+      }
       _svtx_seeds->insert(full_seed.get());
       if (Verbosity() > 3)
       {

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -94,7 +94,6 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
     unsigned int tpcid1 = track1->get_tpc_seed_index();
     unsigned int siid1 = track1->get_silicon_seed_index();
     auto tpcseed1 = m_tpcSeeds->get(tpcid1);
-    tpcseed1->identify();
     auto silseed1 = m_siliconSeeds->get(siid1);
 
     for (auto tr2it = tr1it; tr2it != m_seeds->end();
@@ -137,7 +136,7 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       unsigned int siid2 = track2->get_silicon_seed_index();
       auto tpcseed2 = m_tpcSeeds->get(tpcid2);
       auto silseed2 = m_siliconSeeds->get(siid2);
-      tpcseed2->identify();
+
       TrackFitUtils::position_vector_t tr2_rz_pts, tr2_xy_pts;
       auto globTr2 = getGlobalPositions(tpcseed2);
 

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -36,8 +36,8 @@ class PHCosmicTrackMerger : public SubsysReco
 
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);
-  void removeOutliers(TrackSeed* seed);
-  
+  void removeOutliers(TrackSeed *seed);
+
   ActsGeometry *m_geometry = nullptr;
   KeyPosMap getGlobalPositions(TrackSeed *seed);
   TrkrClusterContainer *m_clusterMap = nullptr;

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -36,6 +36,8 @@ class PHCosmicTrackMerger : public SubsysReco
 
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);
+  void removeOutliers(TrackSeed* seed);
+  
   ActsGeometry *m_geometry = nullptr;
   KeyPosMap getGlobalPositions(TrackSeed *seed);
   TrkrClusterContainer *m_clusterMap = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The line fit algorithm fails for tracks that are nearly vertical - it is a result of dividing by something close to 0. This PR does two things:
1. Performs the line fit in both x-y and y-x. Whichever line fit minimizes the residuals is the line fit that is actually returned (i.e. the determined parameters for x-y fit or the inverse parameters for y-x fit). This improves line fits for nearly vertical tracks dramatically (quite a few cosmics).
2. Tunes the seed merger to remove outlier clusters from the line fit that got picked up by some seed merging. 

The cosmic seeding now performs pretty well and doesn't create so many duplicates, I'll make a PR in macros shortly which switches from the CA seeder to a new chain.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

