### PR TITLE
fix: cosmic track seeding

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -282,15 +282,15 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
           keys.push_back(ckey);
         }
       }
-      if (m_zeroField) 
-        {
-          lineFitClusters(keys, geometry, clustermap);
-        }
-        for (const auto& ckey : get_cluster_keys(track))
-        {
-          fillClusterBranches(ckey, track, topNode);
-        }
+      if (m_zeroField)
+      {
+        lineFitClusters(keys, geometry, clustermap);
       }
+      for (const auto& ckey : get_cluster_keys(track))
+      {
+        fillClusterBranches(ckey, track, topNode);
+      }
+    }
     m_nhits = m_nmaps + m_nintt + m_ntpc + m_nmms;
 
     if (m_doAlignment)
@@ -769,7 +769,7 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   }
   if (!state)
   {
-    if(m_zeroField)
+    if (m_zeroField)
     {
       fillStatesWithLineFit(ckey, cluster, geometry);
     }
@@ -895,8 +895,8 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   m_statepz.push_back(state->get_pz());
   m_statepl.push_back(state->get_pathlength());
 }
-void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key, 
-  TrkrCluster* cluster, ActsGeometry* geometry)
+void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
+                                           TrkrCluster* cluster, ActsGeometry* geometry)
 {
   auto surf = geometry->maps().getSurface(key, cluster);
 
@@ -907,7 +907,7 @@ void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
   float x2 = 5;
   float y1 = m_xyslope * x1 + m_xyint;
   float y2 = m_xyslope * x2 + m_xyint;
-  
+
   //! slope/int for r-z is calculated with z as "x" variable, r as "y" variable
   //! so swap them around
   float r1 = r(x1, y1);
@@ -917,13 +917,13 @@ void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
   float z1 = (r1 - m_rzint) / m_rzslope;
   float z2 = (r2 - m_rzint) / m_rzslope;
   Acts::Vector3 v1(x1, y1, z1), v2(x2, y2, z2);
- 
+
   Acts::Vector3 surfcenter = surf->center(geometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;
   Acts::Vector3 surfnorm = surf->normal(geometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;
 
   Acts::Vector3 u = v2 - v1;
   float dot = surfnorm.dot(u);
-  if(abs(dot) > 1e-6)
+  if (abs(dot) > 1e-6)
   {
     Acts::Vector3 w = v1 - surfcenter;
     float fac = -surfnorm.dot(w) / dot;
@@ -933,13 +933,14 @@ void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
     auto locstateres = surf->globalToLocal(geometry->geometry().getGeoContext(),
                                            intersection * Acts::UnitConstants::cm,
                                            surfnorm);
-    if(locstateres.ok())                    
+    if (locstateres.ok())
     {
       Acts::Vector2 loc = locstateres.value() / Acts::UnitConstants::cm;
       m_statelx.push_back(loc(0));
       m_statelz.push_back(loc(1));
     }
-    else{
+    else
+    {
       Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * (intersection * Acts::UnitConstants::cm);
       loct /= Acts::UnitConstants::cm;
       m_statelx.push_back(loct(0));
@@ -948,11 +949,10 @@ void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
     m_stategx.push_back(intersection.x());
     m_stategy.push_back(intersection.y());
     m_stategz.push_back(intersection.z());
-
   }
   else
   {
-    //! otherwise the line is parallel to the surface, should not happen if 
+    //! otherwise the line is parallel to the surface, should not happen if
     //! we have a cluster on the surface but just fill the state vecs with nan
     m_statelx.push_back(NAN);
     m_statelz.push_back(NAN);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1,7 +1,6 @@
 
 #include "TrackResiduals.h"
 
-#include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
@@ -276,20 +275,22 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     if (!m_doAlignment)
     {
       std::vector<TrkrDefs::cluskey> keys;
-
       for (const auto& ckey : get_cluster_keys(track))
       {
         if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
         {
           keys.push_back(ckey);
         }
-        fillClusterBranches(ckey, track, topNode);
       }
-      if (m_zeroField)
-      {
-        lineFitClusters(keys, geometry, clustermap);
+      if (m_zeroField) 
+        {
+          lineFitClusters(keys, geometry, clustermap);
+        }
+        for (const auto& ckey : get_cluster_keys(track))
+        {
+          fillClusterBranches(ckey, track, topNode);
+        }
       }
-    }
     m_nhits = m_nmaps + m_nintt + m_ntpc + m_nmms;
 
     if (m_doAlignment)
@@ -768,6 +769,10 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   }
   if (!state)
   {
+    if(m_zeroField)
+    {
+      fillStatesWithLineFit(ckey, cluster, geometry);
+    }
     //! skip filling the state information if a state is not there
     //! or we just ran the seeding. Fill with Nans to maintain the
     //! 1-to-1 mapping between cluster/state vectors
@@ -792,13 +797,6 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     m_clusgxideal.push_back(NAN);
     m_clusgyideal.push_back(NAN);
     m_clusgzideal.push_back(NAN);
-    m_statelx.push_back(NAN);
-    m_statelz.push_back(NAN);
-    m_stateelx.push_back(NAN);
-    m_stateelz.push_back(NAN);
-    m_stategx.push_back(NAN);
-    m_stategy.push_back(NAN);
-    m_stategz.push_back(NAN);
     m_statepx.push_back(NAN);
     m_statepy.push_back(NAN);
     m_statepz.push_back(NAN);
@@ -896,6 +894,72 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   m_statepy.push_back(state->get_py());
   m_statepz.push_back(state->get_pz());
   m_statepl.push_back(state->get_pathlength());
+}
+void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key, 
+  TrkrCluster* cluster, ActsGeometry* geometry)
+{
+  auto surf = geometry->maps().getSurface(key, cluster);
+
+  //! The slope/intercept params for x-y and r-z are already filled. Take
+  //! two random x points and calculate y and z on the line to find 2
+  //! 3D points with which to calculate the 3D line
+  float x1 = -1;
+  float x2 = 5;
+  float y1 = m_xyslope * x1 + m_xyint;
+  float y2 = m_xyslope * x2 + m_xyint;
+  
+  //! slope/int for r-z is calculated with z as "x" variable, r as "y" variable
+  //! so swap them around
+  float r1 = r(x1, y1);
+  float r2 = r(x2, y2);
+  if (y1 < 0) r1 *= -1;
+  if (y2 < 0) r2 *= -1;
+  float z1 = (r1 - m_rzint) / m_rzslope;
+  float z2 = (r2 - m_rzint) / m_rzslope;
+  Acts::Vector3 v1(x1, y1, z1), v2(x2, y2, z2);
+ 
+  Acts::Vector3 surfcenter = surf->center(geometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;
+  Acts::Vector3 surfnorm = surf->normal(geometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;
+
+  Acts::Vector3 u = v2 - v1;
+  float dot = surfnorm.dot(u);
+  if(abs(dot) > 1e-6)
+  {
+    Acts::Vector3 w = v1 - surfcenter;
+    float fac = -surfnorm.dot(w) / dot;
+    u *= fac;
+    Acts::Vector3 intersection = v1 + u;
+
+    auto locstateres = surf->globalToLocal(geometry->geometry().getGeoContext(),
+                                           intersection * Acts::UnitConstants::cm,
+                                           surfnorm);
+    if(locstateres.ok())                    
+    {
+      Acts::Vector2 loc = locstateres.value() / Acts::UnitConstants::cm;
+      m_statelx.push_back(loc(0));
+      m_statelz.push_back(loc(1));
+    }
+    else{
+      Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * (intersection * Acts::UnitConstants::cm);
+      loct /= Acts::UnitConstants::cm;
+      m_statelx.push_back(loct(0));
+      m_statelz.push_back(loct(1));
+    }
+    m_stategx.push_back(intersection.x());
+    m_stategy.push_back(intersection.y());
+    m_stategz.push_back(intersection.z());
+
+  }
+  else
+  {
+    //! otherwise the line is parallel to the surface, should not happen if 
+    //! we have a cluster on the surface but just fill the state vecs with nan
+    m_statelx.push_back(NAN);
+    m_statelz.push_back(NAN);
+    m_stategx.push_back(NAN);
+    m_stategy.push_back(NAN);
+    m_stategz.push_back(NAN);
+  }
 }
 void TrackResiduals::createBranches()
 {

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -10,6 +10,7 @@
 #include <TTree.h>
 #include <string>
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrDefs.h>
 
@@ -45,6 +46,8 @@ class TrackResiduals : public SubsysReco
   void zeroField() { m_zeroField = true; }
 
  private:
+  void fillStatesWithLineFit(const TrkrDefs::cluskey& ckey, 
+    TrkrCluster *cluster, ActsGeometry* geometry);
   void clearClusterStateVectors();
   void createBranches();
   float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -46,8 +46,8 @@ class TrackResiduals : public SubsysReco
   void zeroField() { m_zeroField = true; }
 
  private:
-  void fillStatesWithLineFit(const TrkrDefs::cluskey& ckey, 
-    TrkrCluster *cluster, ActsGeometry* geometry);
+  void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
+                             TrkrCluster *cluster, ActsGeometry *geometry);
   void clearClusterStateVectors();
   void createBranches();
   float convertTimeToZ(ActsGeometry *geometry, TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -166,6 +166,22 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
       }
       std::set_intersection(newClusKeysxy.begin(), newClusKeysxy.end(),
                             newClusKeysrz.begin(), newClusKeysrz.end(), std::back_inserter(newClusKeys));
+      if(m_resetContainer)
+      {
+        for(auto& keys : {newClusKeysxy, newClusKeysrz})
+        {
+          for(auto& key : keys)
+          {
+            if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
+            {
+              std::cout << "pushingb back key " << key << std::endl;
+              newClusKeys.push_back(key);
+            }
+          }
+        }
+      }
+
+      std::cout << "checking clusters" << std::endl;
       if (Verbosity() > 3)
       {
         for (auto key : newClusKeysxy)
@@ -179,7 +195,7 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
         {
           auto cluster = _cluster_map->findCluster(key);
           auto clusglob = _tgeometry->getGlobalPosition(key, cluster);
-          std::cout << "Found key for rz cosmic in layer " << (unsigned int) TrkrDefs::getLayer(key)
+          std::cout << "Found key " << key << " for rz cosmic in layer " << (unsigned int) TrkrDefs::getLayer(key)
                     << " with pos " << clusglob.transpose() << std::endl;
         }
       }

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -166,22 +166,20 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
       }
       std::set_intersection(newClusKeysxy.begin(), newClusKeysxy.end(),
                             newClusKeysrz.begin(), newClusKeysrz.end(), std::back_inserter(newClusKeys));
-      if(m_resetContainer)
+      if (m_resetContainer)
       {
-        for(auto& keys : {newClusKeysxy, newClusKeysrz})
+        for (auto& keys : {newClusKeysxy, newClusKeysrz})
         {
-          for(auto& key : keys)
+          for (auto& key : keys)
           {
-            if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
+            if (TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::micromegasId)
             {
-              std::cout << "pushingb back key " << key << std::endl;
               newClusKeys.push_back(key);
             }
           }
         }
       }
 
-      std::cout << "checking clusters" << std::endl;
       if (Verbosity() > 3)
       {
         for (auto key : newClusKeysxy)

--- a/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
+++ b/offline/packages/trackreco/PHCosmicSiliconPropagator.cc
@@ -241,14 +241,6 @@ int PHCosmicSiliconPropagator::process_event(PHCompositeNode*)
         }
         if (!isTpcKey)
         {
-          if (TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::mvtxId)
-          {
-            auto clus = _cluster_map->findCluster(key);
-            if (clus->getSize() < 2)
-            {
-              continue;
-            }
-          }
           si_seed->insert_cluster_key(key);
         }
         else

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -142,7 +142,9 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
 
       for (auto &pos : globTr2.second)
       {
-        tr2_rz_pts.push_back(std::make_pair(pos.z(), r(pos.x(), pos.y())));
+        float clusr = r(pos.x(), pos.y());
+        if (pos.y() < 0) clusr *= -1;
+        tr2_rz_pts.push_back(std::make_pair(pos.z(), clusr));
         tr2_xy_pts.push_back(std::make_pair(pos.x(), pos.y()));
       }
 

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -137,6 +137,9 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       auto tpcseed2 = m_tpcSeeds->get(tpcid2);
       auto silseed2 = m_siliconSeeds->get(siid2);
 
+      std::cout << "identifying seeds" << std::endl;
+      tpcseed1->identify();
+      tpcseed2->identify();
       TrackFitUtils::position_vector_t tr2_rz_pts, tr2_xy_pts;
       auto globTr2 = getGlobalPositions(tpcseed2);
 
@@ -199,7 +202,8 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
 
     //! remove any obvious outlier clusters from the track that were mistakenly
     //! picked up by the seeder
-    removeOutliers(tpcseed1);
+     removeOutliers(tpcseed1);
+    
   }
   if (Verbosity() > 3)
   {
@@ -237,6 +241,8 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
   {
     float clusr = r(pos.x(), pos.y());
     if (pos.y() < 0) clusr *= -1;
+    // skip tpot clusters, as they are always bad in 1D due to 1D resolution
+    if (fabs(clusr) > 80.) continue;
     tr_rz_pts.push_back(std::make_pair(pos.z(), clusr));
     tr_xy_pts.push_back(std::make_pair(pos.x(), pos.y()));
   }
@@ -249,6 +255,8 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
     auto &pos = glob.second[i];
     float clusr = r(pos.x(), pos.y());
     if (pos.y() < 0) clusr *= -1;
+    // skip tpot clusters, as they are always bad in 1D due to 1D resolution
+    if (fabs(clusr) > 80.) continue;
     float perpxyslope = -1. / std::get<0>(xyParams);
     float perpxyint = pos.y() - perpxyslope * pos.x();
     float perprzslope = -1. / std::get<0>(rzParams);

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -137,9 +137,6 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       auto tpcseed2 = m_tpcSeeds->get(tpcid2);
       auto silseed2 = m_siliconSeeds->get(siid2);
 
-      std::cout << "identifying seeds" << std::endl;
-      tpcseed1->identify();
-      tpcseed2->identify();
       TrackFitUtils::position_vector_t tr2_rz_pts, tr2_xy_pts;
       auto globTr2 = getGlobalPositions(tpcseed2);
 
@@ -202,8 +199,7 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
 
     //! remove any obvious outlier clusters from the track that were mistakenly
     //! picked up by the seeder
-     removeOutliers(tpcseed1);
-    
+    removeOutliers(tpcseed1);
   }
   if (Verbosity() > 3)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a few things
1. Fixes a bug in the r-z fit for seed 2 when combining seeds
2. Ensures TPOT clusters are treated differently since they are 1D in nature and thus don't satisfy a 2D DCA line cut
3. Removes the MVTX cluster size cut since the MVTX hot/dead map is now applied
4. Adds a line-surface intersection algorithm to determine a "track state" for a line fit to the clusters on track in `TrackResiduals`

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

