### PR TITLE
fix: get_position mosttracks not updated

### DIFF
--- a/offline/packages/globalvertex/GlobalVertexv2.cc
+++ b/offline/packages/globalvertex/GlobalVertexv2.cc
@@ -123,8 +123,9 @@ float GlobalVertexv2::get_position(unsigned int coor) const
     {
       if(vertex->size_tracks() > mosttracks)
 	{
-	  pos = vertex->get_position(coor);
-	}
+          mosttracks = vertex->size_tracks();
+          pos = vertex->get_position(coor);
+        }
     }
 
   return pos;
@@ -145,8 +146,9 @@ float GlobalVertexv2::get_chisq() const
     {
       if(vertex->size_tracks() > mosttracks)
 	{
-	  chisq = vertex->get_chisq();
-	}
+          mosttracks = vertex->size_tracks();
+          chisq = vertex->get_chisq();
+        }
     }
 
   return chisq;
@@ -167,8 +169,9 @@ unsigned int GlobalVertexv2::get_ndof() const
     {
       if(vertex->size_tracks() > mosttracks)
 	{
-	  ndf = vertex->get_ndof();
-	}
+          mosttracks = vertex->size_tracks();
+          ndf = vertex->get_ndof();
+        }
     }
 
   return ndf;
@@ -202,8 +205,9 @@ float GlobalVertexv2::get_error(unsigned int i, unsigned int j) const
     {
       if(vertex->size_tracks() > mosttracks)
 	{
-	  err = vertex->get_error(i, j);
-	}
+          mosttracks = vertex->size_tracks();
+          err = vertex->get_error(i, j);
+        }
     }
 
   return err;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Jakub noticed that the counter `mosttracks` was not updated in the `get_position` call of `GlobalVertexv2`. This fixes this and the other instances that existed. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

