### PR TITLE
Implementing plane shifting 

### DIFF
--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -63,14 +63,22 @@ class EventPlaneReco : public SubsysReco
   const char *OutFileName;
   
   CDBHistos *cdbhistosOut = nullptr;
- 
+
   std::vector<std::vector<double>> south_q;
   std::vector<std::vector<double>> north_q;
-  std::vector<std::vector<double>> south_q_subtract;
-  std::vector<std::vector<double>> north_q_subtract;
-
   std::vector<std::pair<double, double>> south_Qvec;
   std::vector<std::pair<double, double>> north_Qvec;
+    
+  //recentering utility
+  std::vector<std::vector<double>> south_q_subtract;
+  std::vector<std::vector<double>> north_q_subtract;
+    
+  //shifting utility
+  std::vector<double> tmp_south_psi;
+  std::vector<double> tmp_north_psi;
+  std::vector<double> shift_north;
+  std::vector<double> shift_south;
+    
 
   bool _mbdEpReco = false;
   bool _sepdEpReco = false;
@@ -82,6 +90,7 @@ class EventPlaneReco : public SubsysReco
   float mbd_e_north;
   float mbdQ;
 
+  //recentering histograms
   TProfile * tprof_mean_cos_north_mbd[6] = {};
   TProfile * tprof_mean_sin_north_mbd[6] = {};
   TProfile * tprof_mean_cos_south_mbd[6] = {};
@@ -91,6 +100,19 @@ class EventPlaneReco : public SubsysReco
   TProfile * tprof_mean_sin_north_mbd_input[6] = {};
   TProfile * tprof_mean_cos_south_mbd_input[6] = {};
   TProfile * tprof_mean_sin_south_mbd_input[6] = {};
+    
+  //shifting histograms
+  const int _imax = 6;
+  TProfile * tprof_cos_north_mbd_shift[6][6] = {};
+  TProfile * tprof_sin_north_mbd_shift[6][6] = {};
+  TProfile * tprof_cos_south_mbd_shift[6][6] = {};
+  TProfile * tprof_sin_south_mbd_shift[6][6] = {};
+    
+  TProfile * tprof_cos_north_mbd_shift_input[6][6] = {};
+  TProfile * tprof_sin_north_mbd_shift_input[6][6] = {};
+  TProfile * tprof_cos_south_mbd_shift_input[6][6] = {};
+  TProfile * tprof_sin_south_mbd_shift_input[6][6] = {};
+
     
 };
 

--- a/offline/packages/eventplaneinfo/Eventplaneinfo.h
+++ b/offline/packages/eventplaneinfo/Eventplaneinfo.h
@@ -21,8 +21,12 @@ class Eventplaneinfo : public PHObject
   PHObject* CloneMe() const override { return nullptr; }
 
   virtual void set_qvector(std::vector<std::pair<double, double>> /*Qvec*/) { return; }
+  virtual void set_shifted_psi(std::vector<double> /*Psi_Shifted*/) { return; }
   virtual std::pair<double, double> get_qvector(int /*order*/) const { return std::make_pair(NAN, NAN); }
   virtual double get_psi(int /*order*/) const { return NAN; }
+  virtual double get_shifted_psi(int /*order*/) const { return NAN; }
+  virtual double GetPsi(const double /*Qx*/, const double /*Qy*/, const unsigned int /*order*/) const { return NAN; }
+
 
  protected:
   Eventplaneinfo() {}

--- a/offline/packages/eventplaneinfo/Eventplaneinfov1.h
+++ b/offline/packages/eventplaneinfo/Eventplaneinfov1.h
@@ -24,12 +24,15 @@ class Eventplaneinfov1 : public Eventplaneinfo
   PHObject* CloneMe() const override { return new Eventplaneinfov1(*this); }
 
   void set_qvector(std::vector<std::pair<double, double>> Qvec) override { mQvec = Qvec; }
+  void set_shifted_psi(std::vector<double> Psi_Shifted) override { mPsi_Shifted = Psi_Shifted; }
   std::pair<double, double> get_qvector(int order) const override { return std::make_pair(mQvec[order - 1].first, mQvec[order - 1].second); }
   double get_psi(int order) const override { return GetPsi(mQvec[order - 1].first, mQvec[order - 1].second, order); }
+  double get_shifted_psi(int order) const override { return mPsi_Shifted[order - 1]; }
+  double GetPsi(const double Qx, const double Qy, const unsigned int order) const override;
 
  private:
-  double GetPsi(const double Qx, const double Qy, const unsigned int order) const;
   std::vector<std::pair<double, double>> mQvec;
+  std::vector<double> mPsi_Shifted;
   ClassDefOverride(Eventplaneinfov1, 1);
 };
 


### PR DESCRIPTION
PR implements Equation (6) of arxiv:nucl-ex/9805001. Some runs require recentering in addition to shifting. In particular some of the zero field runs. See plot for implementation result. 
<img width="1008" alt="20869" src="https://github.com/sPHENIX-Collaboration/coresoftware/assets/27926345/a780476f-1503-42a5-9ccc-e8860e5688a6">
