### PR TITLE
Eta and phi track state calculation changed to position coords at OHCAL

### DIFF
--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -215,8 +215,8 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
 	  	  }
 	if(ohstate)
 	  {
-	    _pflow_TRK_HADproj_phi.push_back(atan2(ohstate->get_py(), ohstate->get_px()));
-	    _pflow_TRK_HADproj_eta.push_back(asinh(ohstate->get_pz()/ohstate->get_pt()));
+	    _pflow_TRK_HADproj_phi.push_back(atan2(ohstate->get_y(), ohstate->get_x()));
+	    _pflow_TRK_HADproj_eta.push_back(asinh(ohstate->get_z()/sqrt(ohstate->get_x()*ohstate->get_x() + ohstate->get_y()*ohstate->get_y())));
 	  }
 	  else {
 	  _pflow_TRK_HADproj_phi.push_back(track->get_phi());


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Change the calculation of eta and phi of track state at OHCAL position from momentum coords to position coords.



