### PR TITLE
INTT Z clustering fix

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -547,8 +547,8 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
       {
         phierror *= scalefactors_phi[2];
       }
-      // z error. All clusters have a z-size of 1.
-      const float zerror = length * invsqrt12;
+      // z error.
+      const float zerror = zbins.size() * length * invsqrt12;
 
       double cluslocaly = NAN;
       double cluslocalz = NAN;
@@ -572,7 +572,7 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
       clus->setPhiError(phierror);
       clus->setZError(zerror);
       clus->setPhiSize(phibins.size());
-      clus->setZSize(1);
+      clus->setZSize(zbins.size());
       // All silicon surfaces have a 1-1 map to hitsetkey.
       // So set subsurface key to 0
       clus->setSubSurfKey(0);
@@ -851,8 +851,8 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
       {
         phierror *= scalefactors_phi[2];
       }
-      // z error. All clusters have a z-size of 1.
-      const float zerror = length * invsqrt12;
+      // z error.
+      const float zerror = zbins.size() * length * invsqrt12;
 
       double cluslocaly = NAN;
       double cluslocalz = NAN;
@@ -875,7 +875,7 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
       clus->setPhiError(phierror);
       clus->setZError(zerror);
       clus->setPhiSize(phibins.size());
-      clus->setZSize(1);
+      clus->setZSize(zbins.size());
       // All silicon surfaces have a 1-1 map to hitsetkey.
       // So set subsurface key to 0
       clus->setSubSurfKey(0);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Enables nontrivial INTT Z clustering by switching from a hard-coded cluster Z size of 1 to the value calculated in the clusterizer. Under default running conditions, Z clustering is switched off, and there is no change to that pathway.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

