### PR TITLE
Check Fun4All names

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.cc
+++ b/offline/framework/fun4all/Fun4AllBase.cc
@@ -1,5 +1,7 @@
 #include "Fun4AllBase.h"
 
+#include <phool/phool.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -12,6 +14,23 @@ Fun4AllBase::Fun4AllBase(const std::string& name)
     std::cout << "Fun4AllBase::Fun4AllBase: No empty strings as Object Name" << std::endl;
     std::cout << "You likely create a module with an empty name in your macro" << std::endl;
     std::cout << "Since it does not have a name I cannot tell you what it is, but this message is from its ctor, so it happens when you do a new XXX() in your macro" << std::endl;
+    exit(1);
+  }
+  std::string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+  std::string badChars;
+  for (char ch : name)
+  {
+    // Check if the character is not in the validChars string
+    if (validChars.find(ch) == std::string::npos)
+    {
+      // Character is invalid, print it
+      badChars += std::string("\"") + ch + std::string("\" ");
+    }
+  }
+  if (!badChars.empty())
+  {
+    std::cout << PHWHERE << " Bad characters in modulename: " << badChars << std::endl;
+    std::cout << "Change them to valid characters from this list: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-" << std::endl;
     exit(1);
   }
   return;

--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -3,7 +3,7 @@
 #ifndef FUN4ALL_FUN4ALLBASE_H
 #define FUN4ALL_FUN4ALLBASE_H
 
-#include <climits>  // std::numeric_limits
+#include <limits>  // std::numeric_limits
 #include <string>
 
 /** Base class for all Fun4All Classes
@@ -51,7 +51,7 @@ class Fun4AllBase
     // ... use your imagination ...
 
     //! Show all messages. Useful for step-by-step debugging
-    VERBOSITY_MAX = INT_MAX - 10
+    VERBOSITY_MAX = std::numeric_limits<int>::max() - 10
 
   };
 

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -200,6 +200,7 @@ readagain:
     fileclose();
     if (!OpenNextFile())
     {
+      // NOLINTNEXTLINE(hicpp-avoid-goto)
       goto readagain;
     }
     return -1;
@@ -209,6 +210,7 @@ readagain:
   // check if the local SubsysReco discards this event
   if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
   {
+    // NOLINTNEXTLINE(hicpp-avoid-goto)
     goto readagain;
   }
   syncobject = findNode::getClass<SyncObject>(dstNode, syncdefs::SYNCNODENAME);
@@ -498,6 +500,7 @@ readnextsync:
       return Fun4AllReturnCodes::SYNC_FAIL;
     }
     syncbranchname.clear();  // clear the sync branch name, who knows - it might be different on new file
+    // NOLINTNEXTLINE(hicpp-avoid-goto)
     goto readnextsync;
   }
   if (!readfull)

--- a/offline/framework/fun4all/Fun4AllInputManager.h
+++ b/offline/framework/fun4all/Fun4AllInputManager.h
@@ -57,8 +57,8 @@ class Fun4AllInputManager : public Fun4AllBase
   virtual int SkipForThisManager(const int /*nevents*/) { return 0; }
   virtual int HasSyncObject() const { return 0; }
   virtual std::string GetString(const std::string &) const { return ""; }
-  const std::list<std::string> GetFileList() const {return m_FileListCopy;}
-  const std::list<std::string> GetFileOpenedList() const {return m_FileListOpened;}
+  const std::list<std::string> GetFileList() const { return m_FileListCopy; }
+  const std::list<std::string> GetFileOpenedList() const { return m_FileListOpened; }
 
  protected:
   Fun4AllInputManager(const std::string &name = "DUMMY", const std::string &nodename = "DST", const std::string &topnodename = "TOP");

--- a/offline/framework/fun4all/Fun4AllOutputManager.cc
+++ b/offline/framework/fun4all/Fun4AllOutputManager.cc
@@ -77,7 +77,7 @@ int Fun4AllOutputManager::DoNotWriteEvent(std::vector<int> *retcodes) const
 
 int Fun4AllOutputManager::RunAfterClosing()
 {
-  int iret = 0;
+  unsigned int iret = 0;
   if (!m_RunAfterClosingScript.empty())
   {
     std::string fullcmd = m_RunAfterClosingScript + " " + m_ClosingArgs;
@@ -85,7 +85,7 @@ int Fun4AllOutputManager::RunAfterClosing()
   }
   if (iret)
   {
-    iret = iret >> 8;
+    iret = iret >> 8U;
   }
   return iret;
 }

--- a/offline/framework/fun4all/Fun4AllReturnCodes.h
+++ b/offline/framework/fun4all/Fun4AllReturnCodes.h
@@ -18,7 +18,6 @@
 // SYNC_NOOBJECT: no synchronization object in this input manager, take current event without check
 // RESET_NODE_TREE: internal use - under certain conditions during the synchronization process Fun4All needs to reset the node tree to clear the prvious event
 
-
 namespace Fun4AllReturnCodes
 {
   enum

--- a/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
+++ b/offline/framework/fun4all/Fun4AllRunNodeInputManager.h
@@ -32,7 +32,6 @@ class Fun4AllRunNodeInputManager : public Fun4AllDstInputManager
   int PushBackEvents(const int /*i*/) override { return 0; }
   int SkipForThisManager(const int nevents) override { return PushBackEvents(nevents); }
   int HasSyncObject() const override { return 0; }
-
 };
 
 #endif  // FUN4ALL_FUN4ALLRUNNODEINPUTMANAGER_H

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -188,7 +188,7 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const std::string &t
     tmpdir = tmpdir->mkdir(topnodename.c_str());
     if (!tmpdir)
     {
-      std::cout << "Error creating TDirectory topdir " << topnodename.c_str() << std::endl;
+      std::cout << PHWHERE << " Error creating TDirectory topdir " << topnodename << std::endl;
       exit(1);
     }
     // store the TDir pointer so it can be cleaned up in the dtor
@@ -204,7 +204,7 @@ int Fun4AllServer::registerSubsystem(SubsysReco *subsystem, const std::string &t
     tmpdir = tmpdir->mkdir(subsystem->Name().c_str());
     if (!tmpdir)
     {
-      std::cout << "Error creating TDirectory subdir " << subsystem->Name() << std::endl;
+      std::cout << PHWHERE << "Error creating TDirectory subdir " << subsystem->Name() << std::endl;
       exit(1);
     }
     // store the TDir pointer so it can be cleaned up in the dtor
@@ -414,6 +414,7 @@ tryagain:
       std::cout << "Could not find module " << *striter
                 << ", removing it from list of event selector modules" << std::endl;
       manager->EventSelector()->erase(striter);
+      // NOLINTNEXTLINE(hicpp-avoid-goto)
       goto tryagain;
     }
   }
@@ -531,9 +532,8 @@ int Fun4AllServer::process_event()
     {
       std::cout << "Fun4AllServer::process_event processing " << Subsystem.first->Name() << std::endl;
     }
-    std::ostringstream newdirname;
-    newdirname << Subsystem.second->getName() << "/" << Subsystem.first->Name();
-    if (!gROOT->cd(newdirname.str().c_str()))
+    std::string newdirname = Subsystem.second->getName() + "/" + Subsystem.first->Name();
+    if (!gROOT->cd(newdirname.c_str()))
     {
       std::cout << PHWHERE << "Unexpected TDirectory Problem cd'ing to "
                 << Subsystem.second->getName()
@@ -544,7 +544,7 @@ int Fun4AllServer::process_event()
     {
       if (Verbosity() >= VERBOSITY_EVEN_MORE)
       {
-        std::cout << "process_event: cded to " << newdirname.str().c_str() << std::endl;
+        std::cout << "process_event: cded to " << newdirname << std::endl;
       }
     }
 
@@ -859,9 +859,8 @@ int Fun4AllServer::BeginRun(const int runno)
 int Fun4AllServer::BeginRunSubsystem(const std::pair<SubsysReco *, PHCompositeNode *> &subsys)
 {
   int iret = 0;
-  std::ostringstream newdirname;
-  newdirname << subsys.second->getName() << "/" << subsys.first->Name();
-  if (!gROOT->cd(newdirname.str().c_str()))
+  std::string newdirname = subsys.second->getName() + "/" + subsys.first->Name();
+  if (!gROOT->cd(newdirname.c_str()))
   {
     std::cout << PHWHERE << "Unexpected TDirectory Problem cd'ing to "
               << subsys.second->getName()
@@ -872,7 +871,7 @@ int Fun4AllServer::BeginRunSubsystem(const std::pair<SubsysReco *, PHCompositeNo
   {
     if (Verbosity() >= VERBOSITY_EVEN_MORE)
     {
-      std::cout << "BeginRun: cded to " << newdirname.str().c_str() << std::endl;
+      std::cout << "BeginRun: cded to " << newdirname << std::endl;
     }
   }
 
@@ -924,6 +923,7 @@ int Fun4AllServer::CountOutNodes(PHCompositeNode *startNode)
   return icount;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 int Fun4AllServer::CountOutNodesRecursive(PHCompositeNode *startNode, const int icount)
 {
   PHNodeIterator nodeiter(startNode);
@@ -948,6 +948,7 @@ int Fun4AllServer::CountOutNodesRecursive(PHCompositeNode *startNode, const int 
   return icnt;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 int Fun4AllServer::MakeNodesTransient(PHCompositeNode *startNode)
 {
   PHNodeIterator nodeiter(startNode);
@@ -967,6 +968,7 @@ int Fun4AllServer::MakeNodesTransient(PHCompositeNode *startNode)
   return 0;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 int Fun4AllServer::MakeNodesPersistent(PHCompositeNode *startNode)
 {
   PHNodeIterator nodeiter(startNode);
@@ -998,9 +1000,8 @@ int Fun4AllServer::EndRun(const int runno)
       std::cout << "Fun4AllServer::EndRun: EndRun("
                 << runno << ") for " << (*iter).first->Name() << std::endl;
     }
-    std::ostringstream newdirname;
-    newdirname << (*iter).second->getName() << "/" << (*iter).first->Name();
-    if (!gROOT->cd(newdirname.str().c_str()))
+    std::string newdirname = (*iter).second->getName() + "/" + (*iter).first->Name();
+    if (!gROOT->cd(newdirname.c_str()))
     {
       std::cout << PHWHERE << "Unexpected TDirectory Problem cd'ing to "
                 << (*iter).second->getName()
@@ -1011,7 +1012,7 @@ int Fun4AllServer::EndRun(const int runno)
     {
       if (Verbosity() >= VERBOSITY_EVEN_MORE)
       {
-        std::cout << "EndRun: cded to " << newdirname.str().c_str() << std::endl;
+        std::cout << "EndRun: cded to " << newdirname << std::endl;
       }
     }
     try
@@ -1051,9 +1052,8 @@ int Fun4AllServer::End()
     {
       std::cout << "Fun4AllServer::End: End for " << (*iter).first->Name() << std::endl;
     }
-    std::ostringstream newdirname;
-    newdirname << (*iter).second->getName() << "/" << (*iter).first->Name();
-    if (!gROOT->cd(newdirname.str().c_str()))
+    std::string newdirname = (*iter).second->getName() + "/" + (*iter).first->Name();
+    if (!gROOT->cd(newdirname.c_str()))
     {
       std::cout << PHWHERE << "Unexpected TDirectory Problem cd'ing to "
                 << (*iter).second->getName()
@@ -1064,7 +1064,7 @@ int Fun4AllServer::End()
     {
       if (Verbosity() >= VERBOSITY_EVEN_MORE)
       {
-        std::cout << "End: cded to " << newdirname.str().c_str() << std::endl;
+        std::cout << "End: cded to " << newdirname << std::endl;
       }
     }
     try
@@ -1289,7 +1289,7 @@ int Fun4AllServer::AddTopNode(const std::string &name)
   {
     return -1;
   }
-  PHCompositeNode *newNode = new PHCompositeNode(name.c_str());
+  PHCompositeNode *newNode = new PHCompositeNode(name);
   topnodemap[name] = newNode;
   return 0;
 }

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1662,13 +1662,13 @@ int Fun4AllServer::setRun(const int runno)
 {
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runno);
-  if (! rc->FlagExist("TIMESTAMP"))
+  if (!rc->FlagExist("TIMESTAMP"))
   {
-    rc->set_uint64Flag("TIMESTAMP",runno);
+    rc->set_uint64Flag("TIMESTAMP", runno);
   }
   std::cout << "Fun4AllServer::setRun(): run " << runno
-	    << " uses CDB TIMESTAMP " << rc->get_uint64Flag("TIMESTAMP")
-	    << std::endl;
+            << " uses CDB TIMESTAMP " << rc->get_uint64Flag("TIMESTAMP")
+            << std::endl;
   FrameWorkVars->SetBinContent(RUNNUMBERBIN, (Stat_t) runno);
   return 0;
 }

--- a/offline/framework/fun4all/Fun4AllServer.h
+++ b/offline/framework/fun4all/Fun4AllServer.h
@@ -33,7 +33,7 @@ class Fun4AllServer : public Fun4AllBase
   static Fun4AllServer *instance();
   ~Fun4AllServer() override;
 
-// cppcheck-suppress [virtualCallInConstructor]
+  // cppcheck-suppress [virtualCallInConstructor]
   virtual bool registerHisto(const std::string &hname, TNamed *h1d, const int replace = 0);
   virtual bool registerHisto(TNamed *h1d, const int replace = 0);
   template <typename T>
@@ -114,8 +114,8 @@ class Fun4AllServer : public Fun4AllBase
   void PrintMemoryTracker(const std::string &name = "") const;
   int RunNumber() const { return runnumber; }
   int EventCounter() const { return eventcounter; }
-  std::map<const std::string, PHTimer>::const_iterator timer_begin() {return timer_map.begin();}
-  std::map<const std::string, PHTimer>::const_iterator timer_end() {return timer_map.end();}
+  std::map<const std::string, PHTimer>::const_iterator timer_begin() { return timer_map.begin(); }
+  std::map<const std::string, PHTimer>::const_iterator timer_end() { return timer_map.end(); }
 
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");

--- a/offline/framework/fun4all/Fun4AllSyncManager.cc
+++ b/offline/framework/fun4all/Fun4AllSyncManager.cc
@@ -110,14 +110,17 @@ int Fun4AllSyncManager::run(const int nevnts)
         if (iter->HasSyncObject())  // if zero (no syncing) no need to go further
         {
           if (hassync != iter->HasSyncObject())  // we have sync and no sync mixed
+          // NOLINTNEXTLINE(bugprone-branch-clone)
           {
             PrintSyncProblem();
             gSystem->Exit(1);
+            exit(1);
           }
           else if (hassync < 0)  // we have more than one nosync input
           {
             PrintSyncProblem();
             gSystem->Exit(1);
+            exit(1);
           }
         }
       }
@@ -207,6 +210,7 @@ int Fun4AllSyncManager::run(const int nevnts)
           }
           ++InIter;
         }
+        // NOLINTNEXTLINE(hicpp-avoid-goto)
         goto readerror;
       }
       else

--- a/offline/framework/fun4all/InputFileHandler.cc
+++ b/offline/framework/fun4all/InputFileHandler.cc
@@ -25,7 +25,7 @@ int InputFileHandler::AddListFile(const std::string &filename)
   {
     if (std::filesystem::is_regular_file(filename.c_str()))
     {
-//      uintmax_t fsize = std::filesystem::file_size(filename.c_str());
+      //      uintmax_t fsize = std::filesystem::file_size(filename.c_str());
     }
     else
     {
@@ -50,18 +50,18 @@ int InputFileHandler::AddListFile(const std::string &filename)
   getline(infile, FullLine);
   while (!infile.eof())
   {
-    if (! std::all_of(FullLine.begin(), FullLine.end(), ::isprint))
+    if (!std::all_of(FullLine.begin(), FullLine.end(), ::isprint))
     {
-      std::cout << PHWHERE << "file " << filename 
+      std::cout << PHWHERE << "file " << filename
                 << " contains non printable characters, it is likely a binary file" << std::endl;
       return -1;
     }
-    if (! FullLine.empty() && FullLine[0] != '#')  // remove comments
+    if (!FullLine.empty() && FullLine[0] != '#')  // remove comments
     {
       AddFile(FullLine);
       nfiles++;
     }
-    else if (! FullLine.empty())
+    else if (!FullLine.empty())
     {
       if (GetVerbosity() > 0)
       {
@@ -101,10 +101,10 @@ int InputFileHandler::OpenNextFile()
   return 0;
 }
 
-void InputFileHandler::Print(const std::string &/* what */) const
+void InputFileHandler::Print(const std::string & /* what */) const
 {
   std::cout << "file list: " << std::endl;
-  for (const auto& iter : m_FileList)
+  for (const auto &iter : m_FileList)
   {
     std::cout << iter << std::endl;
   }

--- a/offline/framework/fun4all/InputFileHandler.h
+++ b/offline/framework/fun4all/InputFileHandler.h
@@ -6,10 +6,10 @@
 
 class InputFileHandler
 {
-public:
+ public:
   InputFileHandler() = default;
   virtual ~InputFileHandler() = default;
-  virtual int fileopen(const std::string & /*filename*/) {return 0;}
+  virtual int fileopen(const std::string & /*filename*/) { return 0; }
   virtual int fileclose() { return -1; }
   int OpenNextFile();
   int AddListFile(const std::string &filename);
@@ -18,13 +18,13 @@ public:
   void Print(const std::string &what = "ALL") const;
   int IsOpen() const { return m_IsOpen; }
   void IsOpen(const int i) { m_IsOpen = i; }
-  void SetVerbosity(const int i) {m_Verbosity = i;}
-  int GetVerbosity() const {return m_Verbosity;}
+  void SetVerbosity(const int i) { m_Verbosity = i; }
+  int GetVerbosity() const { return m_Verbosity; }
   void UpdateFileList();
-  void FileName(const std::string &fn) {m_FileName = fn;}
-  const std::string FileName() const {return m_FileName;}
+  void FileName(const std::string &fn) { m_FileName = fn; }
+  const std::string FileName() const { return m_FileName; }
 
-private:
+ private:
   int m_IsOpen = 0;
   int m_Repeat = 0;
   int m_Verbosity = 0;

--- a/offline/framework/fun4all/TDirectoryHelper.cc
+++ b/offline/framework/fun4all/TDirectoryHelper.cc
@@ -85,6 +85,7 @@ void TDirectoryHelper::copyToFile(TDirectory* src, TFile* dest)
 }
 
 //_____________________________________________________________________________
+// NOLINTNEXTLINE(misc-no-recursion)
 void TDirectoryHelper::duplicateDir(TDirectory* dest, TDirectory* source)
 {
   dest->cd();

--- a/offline/framework/fun4allraw/SinglePrdfInput.cc
+++ b/offline/framework/fun4allraw/SinglePrdfInput.cc
@@ -11,6 +11,8 @@
 #include <Event/Eventiterator.h>
 #include <Event/fileEventiterator.h>
 
+#include <limits>
+
 SinglePrdfInput::SinglePrdfInput(const std::string &name, Fun4AllPrdfInputPoolManager *inman)
   : Fun4AllBase(name)
   , m_InputMgr(inman)
@@ -300,7 +302,7 @@ int SinglePrdfInput::majority_beamclock()
     }
   }
   int imax = -1;
-  int bclk = INT_MAX;
+  int bclk = std::numeric_limits<int>::max();
   for (auto iter : evtcnt)
   {
     if (iter.second > imax)

--- a/offline/framework/fun4allraw/SingleZdcInput.cc
+++ b/offline/framework/fun4allraw/SingleZdcInput.cc
@@ -11,6 +11,8 @@
 #include <Event/Eventiterator.h>
 #include <Event/fileEventiterator.h>
 
+#include <limits>
+
 SingleZdcInput::SingleZdcInput(const std::string &name, Fun4AllPrdfInputPoolManager *inman)
   : SinglePrdfInput(name, inman)
 {
@@ -307,7 +309,7 @@ int SingleZdcInput::majority_beamclock()
     }
   }
   int imax = -1;
-  int bclk = INT_MAX;
+  int bclk = std::numeric_limits<int>::max();
   for (auto iter : evtcnt)
   {
     if (iter.second > imax)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
a / in the module name (where a filepath was used for the module name) lead to misleading errors when Fun4All tried to create a TDirectory using this name. Now all names are checked in Fun4AllBase if they are made up of character, numbers or _, -. More can be added but I don't think we should go overboard here. If the check fails, the bad characters are printed out with an error message followed by an exit

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

