### PR TITLE
Trackstateinfo cleanup

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrackInfo.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo.h
@@ -65,22 +65,22 @@ class SvtxTrackInfo : public PHObject
 
   virtual float get_pos(unsigned int) const { return NAN; }
 
+  virtual void set_phi(const float) {}
+  virtual void set_theta(const float) {}
+  virtual void set_qOp(const float) {}
+
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) {}
-
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) {}
-
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) {}
-
   virtual float get_mom(unsigned int) const { return NAN; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }
   virtual float get_eta() const { return NAN; }
   virtual float get_phi() const { return NAN; }
-
+  virtual float get_theta() const {return NAN; }
+  virtual float get_qOp() const { return NAN; }
+  virtual int get_charge() const { return std::numeric_limits<int>::quiet_NaN();}
   virtual float get_covariance(int /*i*/, int /*j*/) const { return NAN; }
   virtual void set_covariance(int /*i*/, int /*j*/, float /*value*/) {}
 

--- a/offline/packages/trackbase_historic/SvtxTrackInfo.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo.h
@@ -78,9 +78,9 @@ class SvtxTrackInfo : public PHObject
   virtual float get_pt() const { return NAN; }
   virtual float get_eta() const { return NAN; }
   virtual float get_phi() const { return NAN; }
-  virtual float get_theta() const {return NAN; }
+  virtual float get_theta() const { return NAN; }
   virtual float get_qOp() const { return NAN; }
-  virtual int get_charge() const { return std::numeric_limits<int>::quiet_NaN();}
+  virtual int get_charge() const { return std::numeric_limits<int>::quiet_NaN(); }
   virtual float get_covariance(int /*i*/, int /*j*/) const { return NAN; }
   virtual void set_covariance(int /*i*/, int /*j*/, float /*value*/) {}
 

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
@@ -20,9 +20,9 @@ void SvtxTrackInfo_v1::CopyFrom(const SvtxTrackInfo& source)
   set_x(source.get_x());
   set_y(source.get_y());
   set_z(source.get_z());
-  set_px(source.get_px());
-  set_py(source.get_py());
-  set_pz(source.get_pz());
+  set_phi(source.get_phi());
+  set_theta(source.get_theta());
+  set_qOp(source.get_qOp());
 
   for (int i = 0; i < 6; i++)
   {

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
@@ -96,9 +96,9 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
   float get_z() const override { return m_state.get_z(); }
   void set_z(float z) override { m_state.set_z(z); }
 
-  void set_phi(const float phi) override {m_state.set_phi(phi);}
-  void set_theta(const float theta) override {m_state.set_theta(theta);}
-  void set_qOp(const float qop) override {m_state.set_qOp(qop);}
+  void set_phi(const float phi) override { m_state.set_phi(phi); }
+  void set_theta(const float theta) override { m_state.set_theta(theta); }
+  void set_qOp(const float qop) override { m_state.set_qOp(qop); }
 
   float get_pos(unsigned int i) const override { return m_state.get_pos(i); }
 
@@ -111,10 +111,10 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
   float get_pt() const override { return m_state.get_pt(); }
   float get_eta() const override { return m_state.get_eta(); }
   float get_phi() const override { return m_state.get_phi(); }
-  float get_theta() const override {return m_state.get_theta(); }
+  float get_theta() const override { return m_state.get_theta(); }
   float get_qOp() const override { return m_state.get_qOp(); }
   int get_charge() const override { return m_state.get_charge(); }
-  
+
   float get_covariance(int i, int j) const override { return m_state.get_covariance(i, j); }
   void set_covariance(int i, int j, float value) override { m_state.set_covariance(i, j, value); }
 

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
@@ -34,9 +34,9 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
     set_x(source.get_x());
     set_y(source.get_y());
     set_z(source.get_z());
-    set_px(source.get_px());
-    set_py(source.get_py());
-    set_pz(source.get_pz());
+    set_phi(source.get_phi());
+    set_theta(source.get_theta());
+    set_qOp(source.get_qOp());
 
     for (int i = 0; i < 6; i++)
     {
@@ -96,24 +96,25 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
   float get_z() const override { return m_state.get_z(); }
   void set_z(float z) override { m_state.set_z(z); }
 
+  void set_phi(const float phi) override {m_state.set_phi(phi);}
+  void set_theta(const float theta) override {m_state.set_theta(theta);}
+  void set_qOp(const float qop) override {m_state.set_qOp(qop);}
+
   float get_pos(unsigned int i) const override { return m_state.get_pos(i); }
 
   float get_px() const override { return m_state.get_px(); }
-  void set_px(float px) override { m_state.set_px(px); }
-
   float get_py() const override { return m_state.get_py(); }
-  void set_py(float py) override { m_state.set_py(py); }
-
   float get_pz() const override { return m_state.get_pz(); }
-  void set_pz(float pz) override { m_state.set_pz(pz); }
-
   float get_mom(unsigned int i) const override { return m_state.get_mom(i); }
 
-  float get_p() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2) + pow(get_pz(), 2)); }
-  float get_pt() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2)); }
-  float get_eta() const override { return asinh(get_pz() / get_pt()); }
-  float get_phi() const override { return atan2(get_py(), get_px()); }
-
+  float get_p() const override { return m_state.get_p(); }
+  float get_pt() const override { return m_state.get_pt(); }
+  float get_eta() const override { return m_state.get_eta(); }
+  float get_phi() const override { return m_state.get_phi(); }
+  float get_theta() const override {return m_state.get_theta(); }
+  float get_qOp() const override { return m_state.get_qOp(); }
+  int get_charge() const override { return m_state.get_charge(); }
+  
   float get_covariance(int i, int j) const override { return m_state.get_covariance(i, j); }
   void set_covariance(int i, int j, float value) override { m_state.set_covariance(i, j, value); }
 

--- a/offline/packages/trackbase_historic/TrackStateInfo.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo.h
@@ -60,20 +60,22 @@ class TrackStateInfo : public PHObject
   virtual float get_pos(unsigned int) const { return NAN; }
 
   virtual float get_px() const { return NAN; }
-  virtual void set_px(float) {}
-
   virtual float get_py() const { return NAN; }
-  virtual void set_py(float) {}
-
   virtual float get_pz() const { return NAN; }
-  virtual void set_pz(float) {}
+  virtual int get_charge() const {return std::numeric_limits<int>::quiet_NaN();}
+
+  virtual float get_phi() const  { return NAN; }
+  virtual float get_theta() const {return NAN; }
+  virtual float get_qOp() const {return NAN; }
+  virtual void set_phi(const float) {}
+  virtual void set_theta(const float) {}
+  virtual void set_qOp(const float) {}
 
   virtual float get_mom(unsigned int) const { return NAN; }
 
   virtual float get_p() const { return NAN; }
   virtual float get_pt() const { return NAN; }
   virtual float get_eta() const { return NAN; }
-  virtual float get_phi() const { return NAN; }
 
   virtual float get_covariance(int, int) const { return NAN; }
   virtual void set_covariance(int, int, float) {}

--- a/offline/packages/trackbase_historic/TrackStateInfo.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo.h
@@ -62,11 +62,11 @@ class TrackStateInfo : public PHObject
   virtual float get_px() const { return NAN; }
   virtual float get_py() const { return NAN; }
   virtual float get_pz() const { return NAN; }
-  virtual int get_charge() const {return std::numeric_limits<int>::quiet_NaN();}
+  virtual int get_charge() const { return std::numeric_limits<int>::quiet_NaN(); }
 
-  virtual float get_phi() const  { return NAN; }
-  virtual float get_theta() const {return NAN; }
-  virtual float get_qOp() const {return NAN; }
+  virtual float get_phi() const { return NAN; }
+  virtual float get_theta() const { return NAN; }
+  virtual float get_qOp() const { return NAN; }
   virtual void set_phi(const float) {}
   virtual void set_theta(const float) {}
   virtual void set_qOp(const float) {}

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.cc
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.cc
@@ -29,13 +29,13 @@ void TrackStateInfo_v1::set_covariance(int i, int j, float value)
 }
 float TrackStateInfo_v1::get_px() const
 {
-  return fabs(1./get_qOp()) * std::cos(get_phi()) * std::sin(get_theta());
+  return fabs(1. / get_qOp()) * std::cos(get_phi()) * std::sin(get_theta());
 }
 float TrackStateInfo_v1::get_py() const
 {
-  return fabs(1./get_qOp()) * std::sin(get_phi()) * std::sin(get_theta());
+  return fabs(1. / get_qOp()) * std::sin(get_phi()) * std::sin(get_theta());
 }
 float TrackStateInfo_v1::get_pz() const
 {
-  return fabs(1./get_qOp()) * std::cos(get_theta());
+  return fabs(1. / get_qOp()) * std::cos(get_theta());
 }

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.cc
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.cc
@@ -27,3 +27,15 @@ void TrackStateInfo_v1::set_covariance(int i, int j, float value)
 {
   m_Covariance[covar_index(i, j)] = value;
 }
+float TrackStateInfo_v1::get_px() const
+{
+  return fabs(1./get_qOp()) * std::cos(get_phi()) * std::sin(get_theta());
+}
+float TrackStateInfo_v1::get_py() const
+{
+  return fabs(1./get_qOp()) * std::sin(get_phi()) * std::sin(get_theta());
+}
+float TrackStateInfo_v1::get_pz() const
+{
+  return fabs(1./get_qOp()) * std::cos(get_theta());
+}

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.h
@@ -84,7 +84,7 @@ class TrackStateInfo_v1 : public TrackStateInfo
  private:
   float m_Momentum[3] = {std::numeric_limits<float>::quiet_NaN()}; // global phi, theta, q/p 
   float m_Position[3] = {std::numeric_limits<float>::quiet_NaN()};  // global [x,y,z]
-  float m_Covariance[21] = {std::numeric_limits<float>::quiet_NaN()};
+  float m_Covariance[15] = {std::numeric_limits<float>::quiet_NaN()};
 
   ClassDefOverride(TrackStateInfo_v1, 1)
 };

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.h
@@ -18,16 +18,6 @@ class TrackStateInfo_v1 : public TrackStateInfo
  public:
   TrackStateInfo_v1() = default;
 
-  //* base class copy constructor
-  // TrackStateInfo_v1( const TrackStateInfo& ) {}
-
-  //* copy constructor
-  // TrackStateInfo_v1(const TrackStateInfo_v1& ) {}
-
-  //* assignment operator
-  // TrackStateInfo_v1& operator=(const TrackStateInfo_v1& source);
-
-  //* destructor
   ~TrackStateInfo_v1() override = default;
 
   // The "standard PHObject response" functions...
@@ -36,7 +26,7 @@ class TrackStateInfo_v1 : public TrackStateInfo
     os << "TrackStateInfo_v1 class" << std::endl;
   }
   void Reset() override { *this = TrackStateInfo_v1(); }
-  // int isValid() const override;
+
   PHObject* CloneMe() const override { return new TrackStateInfo_v1(*this); }
 
   //! import PHObject CopyFrom, in order to avoid clang warning
@@ -63,35 +53,38 @@ class TrackStateInfo_v1 : public TrackStateInfo
 
   float get_pos(unsigned int i) const override { return m_Position[i]; }
 
-  float get_px() const override { return m_Momentum[0]; }
-  void set_px(float px) override { m_Momentum[0] = px; }
+  float get_px() const override;
+  float get_py() const override;
+  float get_pz() const override;
 
-  float get_py() const override { return m_Momentum[1]; }
-  void set_py(float py) override { m_Momentum[1] = py; }
+  float get_phi() const override {return m_Momentum[0];}
+  void set_phi(const float phi) override {m_Momentum[0] = phi;}
+  
+  int get_charge() const override {return get_qOp() > 0 ? 1 : -1; }
+  float get_theta() const override {return m_Momentum[1];}
+  void set_theta(const float theta) override {m_Momentum[1] = theta;}
 
-  float get_pz() const override { return m_Momentum[2]; }
-  void set_pz(float pz) override { m_Momentum[2] = pz; }
+  float get_qOp() const override {return m_Momentum[2];}
+  void set_qOp(const float qop) override {m_Momentum[2] = qop;}
 
-  float get_mom(unsigned int i) const override { return m_Momentum[i]; }
+  float get_mom(unsigned int i) const override { 
+    if(i==0) { return get_px();} 
+    if(i==1) { return get_py(); }
+    if (i==2) { return get_pz(); }
+    return std::numeric_limits<float>::quiet_NaN();
+  }
 
-  float get_p() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2) + pow(get_pz(), 2)); }
-  float get_pt() const override { return sqrt(pow(get_px(), 2) + pow(get_py(), 2)); }
-  float get_eta() const override { return asinh(get_pz() / get_pt()); }
-  float get_phi() const override { return atan2(get_py(), get_px()); }
-
-  // float get_error(int i, int j) const override { return _states.find(0.0)->second->get_error(i, j); }
-  // void set_error(int i, int j, float value) override { return _states[0.0]->set_error(i, j, value); }
+  float get_p() const override { return sqrt(std::pow(get_px(), 2) + std::pow(get_py(), 2) + std::pow(get_pz(), 2)); }
+  float get_pt() const override { return sqrt(std::pow(get_px(), 2) + std::pow(get_py(), 2)); }
+  float get_eta() const override { return -std::log(get_theta() / 2.); }
 
   float get_covariance(int i, int j) const override;
   void set_covariance(int i, int j, float value) override;
 
  private:
-  float m_Momentum[3] = {std::numeric_limits<float>::quiet_NaN()};  //[-100,100,16] //[x,y,z]
-  float m_Position[3] = {std::numeric_limits<float>::quiet_NaN()};  //[-30,30,20]  //[px,py,pz]
+  float m_Momentum[3] = {std::numeric_limits<float>::quiet_NaN()}; // global phi, theta, q/p 
+  float m_Position[3] = {std::numeric_limits<float>::quiet_NaN()};  // global [x,y,z]
   float m_Covariance[21] = {std::numeric_limits<float>::quiet_NaN()};
-
-  // Use m_Covariance[21] instead of [15] for now
-  // later on may convert to rotated and then cut to 5X5
 
   ClassDefOverride(TrackStateInfo_v1, 1)
 };

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.h
@@ -57,20 +57,30 @@ class TrackStateInfo_v1 : public TrackStateInfo
   float get_py() const override;
   float get_pz() const override;
 
-  float get_phi() const override {return m_Momentum[0];}
-  void set_phi(const float phi) override {m_Momentum[0] = phi;}
-  
-  int get_charge() const override {return get_qOp() > 0 ? 1 : -1; }
-  float get_theta() const override {return m_Momentum[1];}
-  void set_theta(const float theta) override {m_Momentum[1] = theta;}
+  float get_phi() const override { return m_Momentum[0]; }
+  void set_phi(const float phi) override { m_Momentum[0] = phi; }
 
-  float get_qOp() const override {return m_Momentum[2];}
-  void set_qOp(const float qop) override {m_Momentum[2] = qop;}
+  int get_charge() const override { return get_qOp() > 0 ? 1 : -1; }
+  float get_theta() const override { return m_Momentum[1]; }
+  void set_theta(const float theta) override { m_Momentum[1] = theta; }
 
-  float get_mom(unsigned int i) const override { 
-    if(i==0) { return get_px();} 
-    if(i==1) { return get_py(); }
-    if (i==2) { return get_pz(); }
+  float get_qOp() const override { return m_Momentum[2]; }
+  void set_qOp(const float qop) override { m_Momentum[2] = qop; }
+
+  float get_mom(unsigned int i) const override
+  {
+    if (i == 0)
+    {
+      return get_px();
+    }
+    if (i == 1)
+    {
+      return get_py();
+    }
+    if (i == 2)
+    {
+      return get_pz();
+    }
     return std::numeric_limits<float>::quiet_NaN();
   }
 
@@ -82,7 +92,7 @@ class TrackStateInfo_v1 : public TrackStateInfo
   void set_covariance(int i, int j, float value) override;
 
  private:
-  float m_Momentum[3] = {std::numeric_limits<float>::quiet_NaN()}; // global phi, theta, q/p 
+  float m_Momentum[3] = {std::numeric_limits<float>::quiet_NaN()};  // global phi, theta, q/p
   float m_Position[3] = {std::numeric_limits<float>::quiet_NaN()};  // global [x,y,z]
   float m_Covariance[15] = {std::numeric_limits<float>::quiet_NaN()};
 

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.h
@@ -76,7 +76,7 @@ class TrackStateInfo_v1 : public TrackStateInfo
 
   float get_p() const override { return sqrt(std::pow(get_px(), 2) + std::pow(get_py(), 2) + std::pow(get_pz(), 2)); }
   float get_pt() const override { return sqrt(std::pow(get_px(), 2) + std::pow(get_py(), 2)); }
-  float get_eta() const override { return -std::log(get_theta() / 2.); }
+  float get_eta() const override { return -std::log(std::tan(get_theta() / 2.)); }
 
   float get_covariance(int i, int j) const override;
   void set_covariance(int i, int j, float value) override;

--- a/simulation/g4simulation/g4eval/DSTTrackInfoWriter.cc
+++ b/simulation/g4simulation/g4eval/DSTTrackInfoWriter.cc
@@ -247,9 +247,9 @@ void DSTTrackInfoWriter::evaluate_track_info()
     trackInfo->set_x(track->get_x());
     trackInfo->set_y(track->get_y());
     trackInfo->set_z(track->get_z());
-    trackInfo->set_px(track->get_px());
-    trackInfo->set_py(track->get_py());
-    trackInfo->set_pz(track->get_pz());
+    trackInfo->set_phi(track->get_phi());
+    trackInfo->set_theta(2.* std::atan(std::exp(-1*track->get_eta())));
+    trackInfo->set_qOp(track->get_charge() / track->get_p());
     if (Verbosity() > 1)
     {
       std::cout << "track crossing: " << track->get_crossing() << std::endl;

--- a/simulation/g4simulation/g4eval/DSTTrackInfoWriter.cc
+++ b/simulation/g4simulation/g4eval/DSTTrackInfoWriter.cc
@@ -36,6 +36,7 @@
 #include <trackbase_historic/SvtxTrack_v4.h>
 #include <trackbase_historic/TrackInfoContainer_v1.h>
 #include <trackbase_historic/TrackStateInfo_v1.h>
+#include <trackbase_historic/ActsTransformations.h>
 
 #include <algorithm>
 #include <bitset>
@@ -173,6 +174,7 @@ void DSTTrackInfoWriter::evaluate_track_info()
     std::cout << "Before loop"
               << "\n";
   }
+  ActsTransformations transformer;
   for (const auto& trackpair : *m_track_map)
   {
     const auto track = trackpair.second;
@@ -261,12 +263,13 @@ void DSTTrackInfoWriter::evaluate_track_info()
       std::cout << "chi^2: " << trackInfo->get_chisq() << std::endl;
       std::cout << "ndf: " << unsigned(trackInfo->get_ndf()) << std::endl;
     }
-    
-    for (int i = 0; i < 6; i++)
+    auto actsMatrix = transformer.rotateSvtxTrackCovToActs(track);
+    //! only take the first 5 entries, which correspond to d0, z0, phi, theta, q/p
+    for (int i = 0; i < 5; i++)
     {
-      for (int j = i; j < 6; j++)
+      for (int j = i; j < 5; j++)
       {
-        trackInfo->set_covariance(i, j, track->get_error(i, j));
+        trackInfo->set_covariance(i, j, actsMatrix(i,j));
       }
     }
     if (Verbosity() > 1)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This cleans up the track state info to 
1. use a 15 entry covariance
2. use phi, theta, and q/p for momentum storage instead of px, py, pz, which allows us to save the charge on the track


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

