### PR TITLE
Streaming TPC cluster z fix

### DIFF
--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -447,7 +447,7 @@ namespace
       double clusz  =  my_data.m_tdriftmax * my_data.tGeometry->get_drift_velocity() - zdriftlength; 
       if(my_data.side == 0) 
 	clusz = -clusz;
-      std::cout << " clusz " << clusz << " clust " << clust << " driftmax " << my_data.m_tdriftmax << std::endl;
+      //std::cout << " side " << my_data.side << " clusz " << clusz << " clust " << clust << " driftmax " << my_data.m_tdriftmax << std::endl;
       const double phi_cov = (iphi2_sum/adc_sum - square(clusiphi))* pow(my_data.layergeom->get_phistep(),2);
       const double t_cov = t2_sum/adc_sum - square(clust);
 
@@ -1088,8 +1088,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	unsigned short PhiOffset = NPhiBinsSector * sector;
 	unsigned short TOffset = NTBinsMin;
 	
-	//m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
-	m_tdriftmax = AdcClockPeriod * 498 / 2.0;  // number of zbins (not tbins) on one side of TPC
+	m_tdriftmax = AdcClockPeriod * NZBinsSide;  
 	thread_pair.data.m_tdriftmax = m_tdriftmax;
 	
 	thread_pair.data.phibins   = NPhiBinsSector;
@@ -1192,8 +1191,7 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       unsigned short PhiOffset = NPhiBinsSector * sector;
       unsigned short TOffset = NTBinsMin;
 
-      //m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
-      m_tdriftmax = AdcClockPeriod * 498 / 2.0;  
+      m_tdriftmax = AdcClockPeriod * NZBinsSide;  
       thread_pair.data.m_tdriftmax = m_tdriftmax;
 
       thread_pair.data.phibins   = NPhiBinsSector;

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -447,7 +447,7 @@ namespace
       double clusz  =  my_data.m_tdriftmax * my_data.tGeometry->get_drift_velocity() - zdriftlength; 
       if(my_data.side == 0) 
 	clusz = -clusz;
-
+      std::cout << " clusz " << clusz << " clust " << clust << " driftmax " << my_data.m_tdriftmax << std::endl;
       const double phi_cov = (iphi2_sum/adc_sum - square(clusiphi))* pow(my_data.layergeom->get_phistep(),2);
       const double t_cov = t2_sum/adc_sum - square(clust);
 
@@ -1088,7 +1088,8 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
 	unsigned short PhiOffset = NPhiBinsSector * sector;
 	unsigned short TOffset = NTBinsMin;
 	
-	m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
+	//m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
+	m_tdriftmax = AdcClockPeriod * 498 / 2.0;  // number of zbins (not tbins) on one side of TPC
 	thread_pair.data.m_tdriftmax = m_tdriftmax;
 	
 	thread_pair.data.phibins   = NPhiBinsSector;
@@ -1191,7 +1192,8 @@ int TpcClusterizer::process_event(PHCompositeNode *topNode)
       unsigned short PhiOffset = NPhiBinsSector * sector;
       unsigned short TOffset = NTBinsMin;
 
-      m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
+      //m_tdriftmax = AdcClockPeriod * NTBins / 2.0;  
+      m_tdriftmax = AdcClockPeriod * 498 / 2.0;  
       thread_pair.data.m_tdriftmax = m_tdriftmax;
 
       thread_pair.data.phibins   = NPhiBinsSector;

--- a/offline/packages/tpc/TpcClusterizer.h
+++ b/offline/packages/tpc/TpcClusterizer.h
@@ -99,6 +99,7 @@ class TpcClusterizer : public SubsysReco
  
   double m_tdriftmax = 0;
   double AdcClockPeriod = 53.0;   // ns 
+  double NZBinsSide = 249;
 
   // TPC shaping offset correction parameter
   // From Tony Frawley July 5, 2022

--- a/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDetector.cc
@@ -532,7 +532,8 @@ void PHG4TpcDetector::add_geometry_node()
   const double MinT = 0;
   const int NTBins = (int) ((MaxT - MinT) / TBinWidth) + 1;
 
-  std::cout << PHWHERE << "MaxT " << MaxT << " NTBins = " << NTBins << " drift velocity " << drift_velocity << std::endl;
+  std::cout << PHWHERE << "MaxT " << MaxT << " TBinWidth " << TBinWidth << " extended readout time " 
+	    << extended_readout_time  << " NTBins = " << NTBins << " drift velocity " << drift_velocity << std::endl;
 
   const std::array<double, 3> SectorPhi =
   {{

--- a/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDigitizer.cc
@@ -307,7 +307,7 @@ void PHG4TpcDigitizer::DigitizeCylinderCells(PHCompositeNode *topNode)
 	    }
 	  
 	  // Process one phi bin at a time
-	  if(Verbosity() > 1) std::cout << "    phi_sorted_hits size " <<  phi_sorted_hits.size() << std::endl;
+	  if(Verbosity() > 1) std::cout << "    phi_sorted_hits size " <<  phi_sorted_hits.size() << " ntbins " << layergeom->get_zbins() << std::endl;
 	  for (unsigned int iphi = 0; iphi < phi_sorted_hits.size(); iphi++)
 	    {
 	      // Make a fixed length vector to indicate whether each time bin is signal or noise

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -565,7 +565,7 @@ void PHG4TpcPadPlaneReadout::populate_tbins(const double t, const std::array<dou
   int tbin = LayerGeom->get_zbin(t);
   if (tbin < 0 || tbin > LayerGeom->get_zbins())
   {
-    // std::cout << " t bin is outside range, return" << std::endl;
+    std::cout << " t bin " << tbin << " is outside range of " << LayerGeom->get_zbins() << " so return" << std::endl;
     return;
   }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes a bug in the TPC clustering code that affected the calculation of the cluster z position from the readout time in pp running when analyzing extended readout data. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

