### PR TITLE
feat: cosmic seeding workflow for nonzero field

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -625,6 +625,8 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         m_strip = std::numeric_limits<int>::quiet_NaN();
         m_hitpad = std::numeric_limits<int>::quiet_NaN();
         m_hittbin = std::numeric_limits<int>::quiet_NaN();
+
+        m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
         break;
       }
       case TrkrDefs::TrkrId::inttId:
@@ -647,6 +649,7 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         m_strip = std::numeric_limits<int>::quiet_NaN();
         m_hitpad = std::numeric_limits<int>::quiet_NaN();
         m_hittbin = std::numeric_limits<int>::quiet_NaN();
+        m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
         break;
       }
       case TrkrDefs::TrkrId::tpcId:
@@ -664,10 +667,10 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         auto phi = geoLayer->get_phicenter(m_hitpad);
         auto radius = geoLayer->get_radius();
         float AdcClockPeriod = geoLayer->get_zstep(); 
-        double zdriftlength = m_hittbin * geometry->get_drift_velocity() * AdcClockPeriod;
+        m_zdriftlength = m_hittbin * geometry->get_drift_velocity() * AdcClockPeriod;
         unsigned short NTBins = (unsigned short) geoLayer->get_zbins();
         double tdriftmax = AdcClockPeriod * NTBins / 2.0;
-        m_hitgz = (tdriftmax * geometry->get_drift_velocity()) - zdriftlength;
+        m_hitgz = (tdriftmax * geometry->get_drift_velocity()) - m_zdriftlength;
         if (m_side == 0)
         {
           m_hitgz *= -1;
@@ -690,6 +693,8 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         m_tileid = std::numeric_limits<int>::quiet_NaN();
         m_hitpad = std::numeric_limits<int>::quiet_NaN();
         m_hittbin = std::numeric_limits<int>::quiet_NaN();
+
+        m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
       }
       default:
         break;
@@ -996,6 +1001,7 @@ void TrackResiduals::createBranches()
   m_hittree->Branch("tile", &m_tileid, "m_tileid/I");
   m_hittree->Branch("strip", &m_strip, "m_strip/I");
   m_hittree->Branch("adc", &m_adc, "m_adc/F");
+  m_hittree->Branch("zdriftlength",&m_zdriftlength,"m_zdriftlength/F");
 
   m_clustree = new TTree("clustertree", "A tree with all clusters");
   m_clustree->Branch("run",&m_runnumber,"m_runnumber/I");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -44,6 +44,9 @@ class TrackResiduals : public SubsysReco
   void clusterTree() { m_doClusters = true; }
   void hitTree() { m_doHits = true; }
   void zeroField() { m_zeroField = true; }
+  void runnumber(const int run){m_runnumber = run;}
+  void segment(const int seg){m_segment = seg;}
+
 
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
@@ -76,6 +79,8 @@ class TrackResiduals : public SubsysReco
   bool m_doAlignment = false;
 
   int m_event = 0;
+  int m_segment = std::numeric_limits<int>::quiet_NaN();
+  int m_runnumber = std::numeric_limits<int>::quiet_NaN();
   //! Track level quantities
   uint64_t m_bco = std::numeric_limits<uint64_t>::quiet_NaN();
   uint64_t m_bcotr = std::numeric_limits<uint64_t>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -44,9 +44,8 @@ class TrackResiduals : public SubsysReco
   void clusterTree() { m_doClusters = true; }
   void hitTree() { m_doHits = true; }
   void zeroField() { m_zeroField = true; }
-  void runnumber(const int run){m_runnumber = run;}
-  void segment(const int seg){m_segment = seg;}
-
+  void runnumber(const int run) { m_runnumber = run; }
+  void segment(const int seg) { m_segment = seg; }
 
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
@@ -62,6 +61,10 @@ class TrackResiduals : public SubsysReco
                            PHCompositeNode *topNode);
   void lineFitClusters(std::vector<TrkrDefs::cluskey> &keys, ActsGeometry *geometry,
                        TrkrClusterContainer *clusters);
+  void circleFitClusters(std::vector<TrkrDefs::cluskey> &keys, ActsGeometry *geometry,
+                         TrkrClusterContainer *clusters);
+  void fillStatesWithCircleFit(const TrkrDefs::cluskey &key, TrkrCluster *cluster,
+                               Acts::Vector3 &glob, ActsGeometry *geometry);
 
   std::string m_outfileName = "";
   TFile *m_outfile = nullptr;
@@ -113,6 +116,9 @@ class TrackResiduals : public SubsysReco
   float m_rzint = std::numeric_limits<float>::quiet_NaN();
   float m_xyslope = std::numeric_limits<float>::quiet_NaN();
   float m_xyint = std::numeric_limits<float>::quiet_NaN();
+  float m_R = std::numeric_limits<float>::quiet_NaN();
+  float m_X0 = std::numeric_limits<float>::quiet_NaN();
+  float m_Y0 = std::numeric_limits<float>::quiet_NaN();
 
   //! hit tree info
   uint32_t m_hitsetkey = std::numeric_limits<uint32_t>::quiet_NaN();
@@ -127,7 +133,7 @@ class TrackResiduals : public SubsysReco
   int m_row = std::numeric_limits<int>::quiet_NaN();
   int m_strip = std::numeric_limits<int>::quiet_NaN();
   float m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
-  
+
   //! cluster tree info
   float m_sclusgr = std::numeric_limits<float>::quiet_NaN();
   float m_sclusphi = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -126,7 +126,8 @@ class TrackResiduals : public SubsysReco
   int m_col = std::numeric_limits<int>::quiet_NaN();
   int m_row = std::numeric_limits<int>::quiet_NaN();
   int m_strip = std::numeric_limits<int>::quiet_NaN();
-
+  float m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
+  
   //! cluster tree info
   float m_sclusgr = std::numeric_limits<float>::quiet_NaN();
   float m_sclusphi = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -1,6 +1,7 @@
 #ifndef TRACKBASE_TRACKFITUTILS_H
 #define TRACKBASE_TRACKFITUTILS_H
 
+#include "ActsSurfaceMaps.h"
 #include "TrkrDefs.h"
 
 #include <Acts/Definitions/Algebra.hpp>
@@ -102,7 +103,10 @@ class TrackFitUtils
                                   std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
   static Acts::Vector3 getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref);
-
+  static Acts::Vector3 get_helix_surface_intersection(Surface surf,
+                                                      std::vector<float>& fitpars, Acts::Vector3& global, ActsGeometry* _tGeometry);
+  static Acts::Vector3 get_line_plane_intersection(const Acts::Vector3& pca, const Acts::Vector3& tangent,
+                                                   const Acts::Vector3& sensorCenter, const Acts::Vector3& sensorNormal);
   static std::vector<double> getLineClusterResiduals(position_vector_t& rz_pts, float slope, float intercept);
   static std::vector<double> getCircleClusterResiduals(position_vector_t& xy_pts, float R, float X0, float Y0);
 };

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -104,8 +104,6 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       auto globTr1 = getGlobalPositions(tpcseed1);
       for (auto &pos : globTr1.second)
       {
-        if(fabs(pos.z()) > 105)
-        std::cout << "global pos on track " << pos.transpose() << std::endl;
         float clusr = r(pos.x(), pos.y());
         if (pos.y() < 0) clusr *= -1;
         tr1_rz_pts.push_back(std::make_pair(pos.z(), clusr));
@@ -113,10 +111,10 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       }
 
       float tr1xyslope = NAN;
-      if(m_zeroField)
+      if (m_zeroField)
       {
-      auto xyTr1Params = TrackFitUtils::line_fit(tr1_xy_pts);
-      tr1xyslope = std::get<0>(xyTr1Params);
+        auto xyTr1Params = TrackFitUtils::line_fit(tr1_xy_pts);
+        tr1xyslope = std::get<0>(xyTr1Params);
       }
       else
       {
@@ -162,10 +160,10 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
       }
 
       float tr2xyslope = NAN;
-      if(m_zeroField)
+      if (m_zeroField)
       {
-      auto xyTr2Params = TrackFitUtils::line_fit(tr2_xy_pts);
-      tr2xyslope = std::get<0>(xyTr2Params);
+        auto xyTr2Params = TrackFitUtils::line_fit(tr2_xy_pts);
+        tr2xyslope = std::get<0>(xyTr2Params);
       }
       else
       {
@@ -294,7 +292,7 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
     float dcaxy = std::sqrt(square(dcax) + square(dcay));
     float dcarz = std::sqrt(square(dcar) + square(dcaz));
     std::cout << "cluster global is " << pos.transpose() << " and dca is "
-    << dcaxy << ", " << dcarz << " and pca is " << pcax << ", " << pcay << ", " << pcaz << std::endl;
+              << dcaxy << ", " << dcarz << " and pca is " << pcax << ", " << pcay << ", " << pcaz << std::endl;
     if (dcaxy > 1. || dcarz > 1.)
     {
       seed->erase_cluster_key(glob.first[i]);

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -34,6 +34,8 @@ class PHCosmicTrackMerger : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *) override;
 
+  void zero_field() { m_zeroField = true;}
+
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);
   void removeOutliers(TrackSeed *seed);
@@ -44,6 +46,8 @@ class PHCosmicTrackMerger : public SubsysReco
   TrackSeedContainer *m_seeds = nullptr;
   TrackSeedContainer *m_tpcSeeds = nullptr;
   TrackSeedContainer *m_siliconSeeds = nullptr;
+
+  bool m_zeroField = false;
 };
 
 #endif  // PHCOSMICTRACKMERGER_H

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -34,7 +34,7 @@ class PHCosmicTrackMerger : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *) override;
 
-  void zero_field() { m_zeroField = true;}
+  void zero_field() { m_zeroField = true; }
 
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds circle fitting options and diagnostics throughout the cosmic track seeding workflow. It also adds a helix-surface intersection function into `TrackFitUtils` for general use, taken from the `HelicalFitter`. It works on current data, albeit with a little worse performance since the tracks are straight. The track merging will have to be tuned once we get field on data since, when you circle fit two (straight) tracks on opposite sides of the TPC, they often don't point to the same place in the same way a line would. Nonetheless, this PR gets the infrastructure there so that we can tune the cuts as soon as we get field on data.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

