### PR TITLE
Adding SvtxTrackInfo/Containers v2 and v3

### DIFF
--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -55,10 +55,15 @@ pkginclude_HEADERS = \
   TrackAnalysisUtils.h \
   SvtxTrackInfo.h \
   SvtxTrackInfo_v1.h \
+	SvtxTrackInfo_v2.h \
+	SvtxTrackInfo_v3.h \
   TrackInfoContainer.h \
   TrackInfoContainer_v1.h \
+	TrackInfoContainer_v2.h \
+	TrackInfoContainer_v3.h \
+	DSTTrackInfoWriter_x.h \
   TrackStateInfo.h \
-  TrackStateInfo_v1.h 
+  TrackStateInfo_v1.h
 
 ROOTDICTS = \
   TrackSeed_Dict.cc \
@@ -95,10 +100,15 @@ ROOTDICTS = \
   SvtxTrackCaloClusterMap_v1_Dict.cc \
   SvtxTrackInfo_Dict.cc \
   SvtxTrackInfo_v1_Dict.cc \
+	SvtxTrackInfo_v2_Dict.cc \
+	SvtxTrackInfo_v3_Dict.cc \
   TrackInfoContainer_Dict.cc \
   TrackInfoContainer_v1_Dict.cc \
+	TrackInfoContainer_v2_Dict.cc \
+	TrackInfoContainer_v3_Dict.cc \
+	DSTTrackInfoWriter_x_Dict.cc \
   TrackStateInfo_Dict.cc \
-  TrackStateInfo_v1_Dict.cc 
+  TrackStateInfo_v1_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
@@ -136,10 +146,15 @@ nobase_dist_pcm_DATA = \
   SvtxTrackCaloClusterMap_v1_Dict_rdict.pcm \
   SvtxTrackInfo_Dict_rdict.pcm \
   SvtxTrackInfo_v1_Dict_rdict.pcm \
+	SvtxTrackInfo_v2_Dict_rdict.pcm \
+	SvtxTrackInfo_v3_Dict_rdict.pcm \
   TrackInfoContainer_Dict_rdict.pcm \
   TrackInfoContainer_v1_Dict_rdict.pcm \
+	TrackInfoContainer_v2_Dict_rdict.pcm \
+	TrackInfoContainer_v3_Dict_rdict.pcm \
+	DSTTrackInfoWriter_x_Dict_rdict.pcm \
   TrackStateInfo_Dict_rdict.pcm \
-  TrackStateInfo_v1_Dict_rdict.pcm 
+  TrackStateInfo_v1_Dict_rdict.pcm
 
 # sources for io library
 libtrackbase_historic_io_la_SOURCES = \
@@ -178,7 +193,12 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrackCaloClusterMap_v1.cc \
   TrackAnalysisUtils.cc \
   SvtxTrackInfo_v1.cc \
+	SvtxTrackInfo_v2.cc \
+	SvtxTrackInfo_v3.cc \
   TrackInfoContainer_v1.cc \
+	TrackInfoContainer_v2.cc \
+	TrackInfoContainer_v3.cc \
+	DSTTrackInfoWriter_x.cc \
   TrackStateInfo_v1.cc
 
 libtrackbase_historic_io_la_LDFLAGS = \

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -55,12 +55,12 @@ pkginclude_HEADERS = \
   TrackAnalysisUtils.h \
   SvtxTrackInfo.h \
   SvtxTrackInfo_v1.h \
-	SvtxTrackInfo_v2.h \
-	SvtxTrackInfo_v3.h \
+  SvtxTrackInfo_v2.h \
+  SvtxTrackInfo_v3.h \
   TrackInfoContainer.h \
   TrackInfoContainer_v1.h \
-	TrackInfoContainer_v2.h \
-	TrackInfoContainer_v3.h \
+  TrackInfoContainer_v2.h \
+  TrackInfoContainer_v3.h \
   TrackStateInfo.h \
   TrackStateInfo_v1.h
 
@@ -99,12 +99,12 @@ ROOTDICTS = \
   SvtxTrackCaloClusterMap_v1_Dict.cc \
   SvtxTrackInfo_Dict.cc \
   SvtxTrackInfo_v1_Dict.cc \
-	SvtxTrackInfo_v2_Dict.cc \
-	SvtxTrackInfo_v3_Dict.cc \
+  SvtxTrackInfo_v2_Dict.cc \
+  SvtxTrackInfo_v3_Dict.cc \
   TrackInfoContainer_Dict.cc \
   TrackInfoContainer_v1_Dict.cc \
-	TrackInfoContainer_v2_Dict.cc \
-	TrackInfoContainer_v3_Dict.cc \
+  TrackInfoContainer_v2_Dict.cc \
+  TrackInfoContainer_v3_Dict.cc \
   TrackStateInfo_Dict.cc \
   TrackStateInfo_v1_Dict.cc
 
@@ -144,8 +144,8 @@ nobase_dist_pcm_DATA = \
   SvtxTrackCaloClusterMap_v1_Dict_rdict.pcm \
   SvtxTrackInfo_Dict_rdict.pcm \
   SvtxTrackInfo_v1_Dict_rdict.pcm \
-	SvtxTrackInfo_v2_Dict_rdict.pcm \
-	SvtxTrackInfo_v3_Dict_rdict.pcm \
+  SvtxTrackInfo_v2_Dict_rdict.pcm \
+  SvtxTrackInfo_v3_Dict_rdict.pcm \
   TrackInfoContainer_Dict_rdict.pcm \
   TrackInfoContainer_v1_Dict_rdict.pcm \
 	TrackInfoContainer_v2_Dict_rdict.pcm \
@@ -190,11 +190,11 @@ libtrackbase_historic_io_la_SOURCES = \
   SvtxTrackCaloClusterMap_v1.cc \
   TrackAnalysisUtils.cc \
   SvtxTrackInfo_v1.cc \
-	SvtxTrackInfo_v2.cc \
-	SvtxTrackInfo_v3.cc \
+  SvtxTrackInfo_v2.cc \
+  SvtxTrackInfo_v3.cc \
   TrackInfoContainer_v1.cc \
-	TrackInfoContainer_v2.cc \
-	TrackInfoContainer_v3.cc \
+  TrackInfoContainer_v2.cc \
+  TrackInfoContainer_v3.cc \
   TrackStateInfo_v1.cc
 
 libtrackbase_historic_io_la_LDFLAGS = \

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -148,8 +148,8 @@ nobase_dist_pcm_DATA = \
   SvtxTrackInfo_v3_Dict_rdict.pcm \
   TrackInfoContainer_Dict_rdict.pcm \
   TrackInfoContainer_v1_Dict_rdict.pcm \
-	TrackInfoContainer_v2_Dict_rdict.pcm \
-	TrackInfoContainer_v3_Dict_rdict.pcm \
+  TrackInfoContainer_v2_Dict_rdict.pcm \
+  TrackInfoContainer_v3_Dict_rdict.pcm \
   TrackStateInfo_Dict_rdict.pcm \
   TrackStateInfo_v1_Dict_rdict.pcm
 

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -61,7 +61,6 @@ pkginclude_HEADERS = \
   TrackInfoContainer_v1.h \
 	TrackInfoContainer_v2.h \
 	TrackInfoContainer_v3.h \
-	DSTTrackInfoWriter_x.h \
   TrackStateInfo.h \
   TrackStateInfo_v1.h
 
@@ -106,7 +105,6 @@ ROOTDICTS = \
   TrackInfoContainer_v1_Dict.cc \
 	TrackInfoContainer_v2_Dict.cc \
 	TrackInfoContainer_v3_Dict.cc \
-	DSTTrackInfoWriter_x_Dict.cc \
   TrackStateInfo_Dict.cc \
   TrackStateInfo_v1_Dict.cc
 
@@ -152,7 +150,6 @@ nobase_dist_pcm_DATA = \
   TrackInfoContainer_v1_Dict_rdict.pcm \
 	TrackInfoContainer_v2_Dict_rdict.pcm \
 	TrackInfoContainer_v3_Dict_rdict.pcm \
-	DSTTrackInfoWriter_x_Dict_rdict.pcm \
   TrackStateInfo_Dict_rdict.pcm \
   TrackStateInfo_v1_Dict_rdict.pcm
 
@@ -198,7 +195,6 @@ libtrackbase_historic_io_la_SOURCES = \
   TrackInfoContainer_v1.cc \
 	TrackInfoContainer_v2.cc \
 	TrackInfoContainer_v3.cc \
-	DSTTrackInfoWriter_x.cc \
   TrackStateInfo_v1.cc
 
 libtrackbase_historic_io_la_LDFLAGS = \

--- a/offline/packages/trackbase_historic/SvtxTrackInfo.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo.h
@@ -43,6 +43,12 @@ class SvtxTrackInfo : public PHObject
   // basic track information ---------------------------------------------------
   //
 
+  virtual unsigned int get_track_id() const { return std::numeric_limits<unsigned int>::quiet_NaN(); }
+  virtual void set_track_id(unsigned int ) { }
+
+  virtual uint16_t get_subsurfkey() const { return std::numeric_limits<uint8_t>::quiet_NaN(); }
+  virtual void set_subsurfkey(uint16_t ) { }
+
   virtual float get_chisq() const { return NAN; }
   virtual void set_chisq(float) {}
 
@@ -86,6 +92,69 @@ class SvtxTrackInfo : public PHObject
 
   virtual short int get_crossing() const { return SHRT_MAX; }
   virtual void set_crossing(short int /*crossing*/) {}
+
+  virtual float get_x_outer_tpc() const { return NAN; }
+  virtual void set_x_outer_tpc(float ) { }
+
+  virtual float get_y_outer_tpc() const { return NAN; }
+  virtual void set_y_outer_tpc(float ) { }
+
+  virtual float get_z_outer_tpc() const { return NAN; }
+  virtual void set_z_outer_tpc(float ) { }
+
+  virtual void set_phi_outer_tpc(const float ) { }
+  virtual void set_theta_outer_tpc(const float ) { }
+  virtual void set_qOp_outer_tpc(const float ) { }
+
+  virtual float get_px_outer_tpc() const { return NAN; }
+  virtual float get_py_outer_tpc() const { return NAN; }
+  virtual float get_pz_outer_tpc() const { return NAN; }
+
+  virtual float get_mom_outer_tpc(unsigned int ) const { return NAN; }
+
+  virtual float get_p_outer_tpc() const { return NAN; }
+  virtual float get_pt_outer_tpc() const { return NAN; }
+  virtual float get_eta_outer_tpc() const { return NAN; }
+  virtual float get_phi_outer_tpc() const { return NAN; }
+  virtual float get_theta_outer_tpc() const { return NAN; }
+  virtual float get_qOp_outer_tpc() const { return NAN; }
+
+  virtual float get_covariance_outer_tpc(int /*i*/, int /*j*/) const { return NAN;}
+  virtual void set_covariance_outer_tpc(int /*i*/, int /*j*/, float /*value*/) { }
+
+  virtual float get_x(int /*state*/) const { return NAN; }
+  virtual void set_x(int /*state*/, float ) {  }
+
+  virtual float get_y(int /*state*/) const { return NAN; }
+  virtual void set_y(int /*state*/, float ) { }
+
+  virtual float get_z(int /*state*/) const { return NAN; }
+  virtual void set_z(int /*state*/, float ) { }
+
+  virtual float get_pos(int /*state*/, unsigned int ) const { return NAN; }
+
+  virtual float get_px(int /*state*/) const { return NAN; }
+  virtual float get_py(int /*state*/) const { return NAN; }
+  virtual float get_pz(int /*state*/) const { return NAN; }
+
+  virtual void set_phi(int /*state*/, const float ) { NAN; }
+  virtual void set_theta(int /*state*/, const float ) { NAN; }
+  virtual void set_qOp(int /*state*/, const float ) { NAN; }
+
+  virtual float get_mom(int /*state*/, unsigned int ) const { return NAN; }
+
+  virtual float get_p(int /*state*/) const { return NAN; }
+  virtual float get_pt(int /*state*/) const { return NAN; }
+  virtual float get_eta(int /*state*/) const { return NAN; }
+  virtual float get_phi(int /*state*/) const { return NAN; }
+  virtual float get_theta(int /*state*/) const { return NAN; }
+  virtual float get_qOp(int /*state*/) const { return NAN; }
+
+  virtual float get_projected_eta(int /*state*/) const { return NAN; }
+  virtual float get_projected_phi(int /*state*/) const { return NAN; }
+
+  virtual float get_covariance(int /*state*/, int /*i*/, int /*j*/) const { return NAN; }
+  virtual void set_covariance(int /*state*/, int /*i*/, int /*j*/, float /*value*/) { }
 
  private:
   ClassDefOverride(SvtxTrackInfo, 1);

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
@@ -24,9 +24,9 @@ void SvtxTrackInfo_v1::CopyFrom(const SvtxTrackInfo& source)
   set_theta(source.get_theta());
   set_qOp(source.get_qOp());
 
-  for (int i = 0; i < 6; i++)
+  for (int i = 0; i < 5; i++)
   {
-    for (int j = i; j < 6; j++)
+    for (int j = i; j < 5; j++)
     {
       set_covariance(i, j, source.get_covariance(i, j));
     }

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.cc
@@ -1,4 +1,3 @@
-
 #include "SvtxTrackInfo_v1.h"
 #include "TrackStateInfo_v1.h"
 
@@ -12,6 +11,7 @@
 
 void SvtxTrackInfo_v1::CopyFrom(const SvtxTrackInfo& source)
 {
+  set_track_id(source.get_track_id());
   set_chisq(source.get_chisq());
   set_ndf(source.get_ndf());
   set_hitbitmap(source.get_hitbitmap());

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
@@ -125,7 +125,6 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
  private:
   // track information
   unsigned int _track_id = std::numeric_limits<unsigned int>::quiet_NaN();
-  // unsigned int _vertex_id = UINT_MAX;
   float m_chisq = std::numeric_limits<float>::quiet_NaN();
   uint8_t m_ndf = std::numeric_limits<uint8_t>::quiet_NaN();
   uint64_t m_hitbitmap = std::numeric_limits<uint64_t>::quiet_NaN();

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v1.h
@@ -26,6 +26,7 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
   //* copy constructor
   SvtxTrackInfo_v1(const SvtxTrackInfo_v1& source)
   {
+    _track_id = source.get_track_id();
     m_chisq = source.get_chisq();
     m_ndf = source.get_ndf();
     m_crossing = source.get_crossing();
@@ -38,9 +39,9 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
     set_theta(source.get_theta());
     set_qOp(source.get_qOp());
 
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < 5; i++)
     {
-      for (int j = i; j < 6; j++)
+      for (int j = i; j < 5; j++)
       {
         set_covariance(i, j, source.get_covariance(i, j));
       }
@@ -74,6 +75,9 @@ class SvtxTrackInfo_v1 : public SvtxTrackInfo
   //
   // basic track information ---------------------------------------------------
   //
+
+  unsigned int get_track_id() const override { return _track_id; }
+  void set_track_id(unsigned int id) override { _track_id = id; }
 
   float get_chisq() const override { return m_chisq; }
   void set_chisq(float chisq) override { m_chisq = chisq; }

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.cc
@@ -6,9 +6,9 @@
  * the outermost TPC surface to the calorimeters
 **/
 
-void SvtxTrackInfo_v2::CopyFrom(const SvtxTrackInfo_v2& source)
+void SvtxTrackInfo_v2::CopyFrom(const SvtxTrackInfo& source)
 {
-  set_id(source.get_id());
+  set_track_id(source.get_track_id());
   set_subsurfkey(source.get_subsurfkey());
 
   set_chisq(source.get_chisq());

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.cc
@@ -1,0 +1,50 @@
+#include "SvtxTrackInfo_v2.h"
+#include "TrackStateInfo_v1.h"
+
+/**
+ * SvtxTrackInfo_v2 is a class developed to project the track information from
+ * the outermost TPC surface to the calorimeters
+**/
+
+void SvtxTrackInfo_v2::CopyFrom(const SvtxTrackInfo_v2& source)
+{
+  set_id(source.get_id());
+  set_subsurfkey(source.get_subsurfkey());
+
+  set_chisq(source.get_chisq());
+  set_ndf(source.get_ndf());
+  set_hitbitmap(source.get_hitbitmap());
+  set_crossing(source.get_crossing());
+
+  set_x(source.get_x());
+  set_y(source.get_y());
+  set_z(source.get_z());
+  set_phi(source.get_phi());
+  set_theta(source.get_theta());
+  set_qOp(source.get_qOp());
+
+  set_x_outer_tpc(source.get_x_outer_tpc());
+  set_y_outer_tpc(source.get_y_outer_tpc());
+  set_z_outer_tpc(source.get_z_outer_tpc());
+  set_phi_outer_tpc(source.get_phi_outer_tpc());
+  set_theta_outer_tpc(source.get_theta_outer_tpc());
+  set_qOp_outer_tpc(source.get_qOp_outer_tpc());
+
+  for (int i = 0; i < 5; i++)
+  {
+    for (int j = i; j < 5; j++)
+    {
+      set_covariance(i, j, source.get_covariance(i, j));
+      set_covariance_outer_tpc(i, j, source.get_covariance_outer_tpc(i, j));
+    }
+  }
+}
+
+SvtxTrackInfo_v2& SvtxTrackInfo_v2::operator=(const SvtxTrackInfo_v2& source)
+{
+  if(this != &source)
+  {
+    CopyFrom(source);
+  }
+  return *this;
+}

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
@@ -15,7 +15,8 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
   SvtxTrackInfo_v2( const SvtxTrackInfo& ) {}
 
   //* copy constructor
-  SvtxTrackInfo_v2(const SvtxTrackInfo_v2& source){
+  SvtxTrackInfo_v2(const SvtxTrackInfo_v2& source)
+  {
     m_track_id = source.get_track_id();
     m_outer_tpc_subsurfkey = source.get_subsurfkey();
     m_chisq = source.get_chisq();
@@ -37,9 +38,9 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
     set_theta_outer_tpc(source.get_theta_outer_tpc());
     set_qOp_outer_tpc(source.get_qOp_outer_tpc());
 
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < 5; i++)
     {
-      for (int j = i; j < 6; j++)
+      for (int j = i; j < 5; j++)
       {
         set_covariance(i, j, source.get_covariance(i, j));
         set_covariance_outer_tpc(i, j, source.get_covariance_outer_tpc(i, j));

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
@@ -153,12 +153,12 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
  private:
 
   // track information
-  unsigned int m_track_id = UINT_MAX;
-  uint16_t m_outer_tpc_subsurfkey = UINT16_MAX;
-  float m_chisq = NAN;
-  uint8_t m_ndf = uint8_t(-1);
-  uint64_t m_hitbitmap = uint64_t(-1);
-  short int m_crossing = SHRT_MAX;
+  unsigned int m_track_id = std::numeric_limits<unsigned int>::quiet_NaN();
+  uint16_t m_outer_tpc_subsurfkey = std::numeric_limits<uint16_t>::quiet_NaN();
+  float m_chisq = std::numeric_limits<float>::quiet_NaN();
+  uint8_t m_ndf = std::numeric_limits<uint8_t>::quiet_NaN();
+  uint64_t m_hitbitmap = std::numeric_limits<uint64_t>::quiet_NaN();
+  short int m_crossing = std::numeric_limits<short int>::quiet_NaN();
 
   // track state information
   TrackStateInfo_v1 m_state_vertex;

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
@@ -1,0 +1,170 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKINFOV2_H
+#define TRACKBASEHISTORIC_SVTXTRACKINFOV2_H
+
+#include "SvtxTrackInfo.h"
+#include "TrackStateInfo_v1.h"
+
+class PHObject;
+
+class SvtxTrackInfo_v2: public SvtxTrackInfo
+{
+ public:
+  SvtxTrackInfo_v2() {}
+
+  //* base class copy constructor
+  SvtxTrackInfo_v2( const SvtxTrackInfo& ) {}
+
+  //* copy constructor
+  SvtxTrackInfo_v2(const SvtxTrackInfo_v2& source){
+    m_track_id = source.get_id();
+    m_outer_tpc_subsurfkey = source.get_subsurfkey();
+    m_chisq = source.get_chisq();
+    m_ndf = source.get_ndf();
+    m_crossing = source.get_crossing();
+    m_hitbitmap = source.get_hitbitmap();
+
+    set_x(source.get_x());
+    set_y(source.get_y());
+    set_z(source.get_z());
+    set_phi(source.get_phi());
+    set_theta(source.get_theta());
+    set_qOp(source.get_qOp());
+
+    set_x_outer_tpc(source.get_x_outer_tpc());
+    set_y_outer_tpc(source.get_y_outer_tpc());
+    set_z_outer_tpc(source.get_z_outer_tpc());
+    set_phi_outer_tpc(source.get_phi_outer_tpc());
+    set_theta_outer_tpc(source.get_theta_outer_tpc());
+    set_qOp_outer_tpc(source.get_qOp_outer_tpc());
+
+    for (int i = 0; i < 6; i++)
+    {
+      for (int j = i; j < 6; j++)
+      {
+        set_covariance(i, j, source.get_covariance(i, j));
+        set_covariance_outer_tpc(i, j, source.get_covariance_outer_tpc(i, j));
+      }
+    }
+  }
+
+  //* assignment operator
+  SvtxTrackInfo_v2& operator=(const SvtxTrackInfo_v2& track);
+
+  //* destructor
+  ~SvtxTrackInfo_v2() override {}
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const override {
+    os << "SvtxTrackInfo_v2 class" << std::endl;
+  }
+  void Reset() override { *this = SvtxTrackInfo_v2(); }
+
+  PHObject* CloneMe() const override { return new SvtxTrackInfo_v2(*this); }
+
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  // copy content
+  void CopyFrom( const SvtxTrackInfo_v2& );
+  void CopyFrom( SvtxTrackInfo_v2* source )
+  { CopyFrom( *source ); }
+
+  //
+  // basic track information ---------------------------------------------------
+  //
+
+  unsigned int get_id() const { return m_track_id; }
+  void set_id(unsigned int id) { m_track_id = id; }
+
+  uint16_t get_subsurfkey() const { return m_outer_tpc_subsurfkey; }
+  void set_subsurfkey(uint16_t key) { m_outer_tpc_subsurfkey = key; }
+
+  float get_chisq() const override { return m_chisq; }
+  void set_chisq(float chisq) override { m_chisq = chisq; }
+
+  uint8_t get_ndf() const override { return m_ndf; }
+  void set_ndf(uint8_t ndf) override { m_ndf = ndf; }
+
+  uint64_t get_hitbitmap() const override { return m_hitbitmap; }
+  void set_hitbitmap(uint64_t hitbitmap) override { m_hitbitmap = hitbitmap; }
+
+  short int get_crossing() const override { return m_crossing; }
+  void set_crossing(short int crossing) override { m_crossing = crossing; }
+
+  float get_x() const override { return m_state_vertex.get_x(); }
+  void set_x(float x) override { m_state_vertex.set_x(x); }
+
+  float get_y() const override { return m_state_vertex.get_y(); }
+  void set_y(float y) override { m_state_vertex.set_y(y); }
+
+  float get_z() const override { return m_state_vertex.get_z(); }
+  void set_z(float z) override { m_state_vertex.set_z(z); }
+
+  void set_phi(const float phi) override { m_state_vertex.set_phi(phi); }
+  void set_theta(const float theta) override { m_state_vertex.set_theta(theta); }
+  void set_qOp(const float qop) override { m_state_vertex.set_qOp(qop); }
+
+  float get_pos(unsigned int i) const override { return m_state_vertex.get_pos(i); }
+
+  float get_px() const override { return m_state_vertex.get_px(); }
+  float get_py() const override { return m_state_vertex.get_py(); }
+  float get_pz() const override { return m_state_vertex.get_pz(); }
+  float get_mom(unsigned int i) const override { return m_state_vertex.get_mom(i); }
+
+  float get_p() const override { return m_state_vertex.get_p(); }
+  float get_pt() const override { return m_state_vertex.get_pt(); }
+  float get_eta() const override { return m_state_vertex.get_eta(); }
+  float get_phi() const override { return m_state_vertex.get_phi(); }
+  float get_theta() const override { return m_state_vertex.get_theta(); }
+  float get_qOp() const override { return m_state_vertex.get_qOp(); }
+  int get_charge() const override { return m_state_vertex.get_charge(); }
+
+  float get_covariance(int i, int j) const override { return m_state_vertex.get_covariance(i, j);}
+  void set_covariance(int i, int j, float value) override {m_state_vertex.set_covariance(i, j, value);}
+
+  float get_x_outer_tpc() const { return m_state_outer_tpc.get_x(); }
+  void set_x_outer_tpc(float x) { m_state_outer_tpc.set_x(x); }
+
+  float get_y_outer_tpc() const { return m_state_outer_tpc.get_y(); }
+  void set_y_outer_tpc(float y) { m_state_outer_tpc.set_y(y); }
+
+  float get_z_outer_tpc() const { return m_state_outer_tpc.get_z(); }
+  void set_z_outer_tpc(float z) { m_state_outer_tpc.set_z(z); }
+
+  void set_phi_outer_tpc(const float phi) { m_state_outer_tpc.set_phi(phi); }
+  void set_theta_outer_tpc(const float theta) { m_state_outer_tpc.set_theta(theta); }
+  void set_qOp_outer_tpc(const float qop) { m_state_outer_tpc.set_qOp(qop); }
+
+  float get_px_outer_tpc() const { return m_state_outer_tpc.get_px(); }
+  float get_py_outer_tpc() const { return m_state_outer_tpc.get_py(); }
+  float get_pz_outer_tpc() const { return m_state_outer_tpc.get_pz(); }
+
+  float get_mom_outer_tpc(unsigned int i) const { return m_state_outer_tpc.get_mom(i); }
+
+  float get_p_outer_tpc() const { return m_state_outer_tpc.get_p(); }
+  float get_pt_outer_tpc() const { return m_state_outer_tpc.get_pt(); }
+  float get_eta_outer_tpc() const { return m_state_outer_tpc.get_eta(); }
+  float get_phi_outer_tpc() const { return m_state_outer_tpc.get_phi(); }
+  float get_theta_outer_tpc() const { return m_state_outer_tpc.get_theta(); }
+  float get_qOp_outer_tpc() const { return m_state_outer_tpc.get_qOp(); }
+
+  float get_covariance_outer_tpc(int i, int j) const { return m_state_outer_tpc.get_covariance(i, j);}
+  void set_covariance_outer_tpc(int i, int j, float value) {m_state_outer_tpc.set_covariance(i, j, value);}
+
+ private:
+
+  // track information
+  unsigned int m_track_id = UINT_MAX;
+  uint16_t m_outer_tpc_subsurfkey = UINT16_MAX;
+  float m_chisq = NAN;
+  uint8_t m_ndf = uint8_t(-1);
+  uint64_t m_hitbitmap = uint64_t(-1);
+  short int m_crossing = SHRT_MAX;
+
+  // track state information
+  TrackStateInfo_v1 m_state_vertex;
+  TrackStateInfo_v1 m_state_outer_tpc;
+
+  ClassDefOverride(SvtxTrackInfo_v2, 1)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2.h
@@ -16,7 +16,7 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
 
   //* copy constructor
   SvtxTrackInfo_v2(const SvtxTrackInfo_v2& source){
-    m_track_id = source.get_id();
+    m_track_id = source.get_track_id();
     m_outer_tpc_subsurfkey = source.get_subsurfkey();
     m_chisq = source.get_chisq();
     m_ndf = source.get_ndf();
@@ -64,19 +64,21 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
   //! import PHObject CopyFrom, in order to avoid clang warning
   using PHObject::CopyFrom;
   // copy content
-  void CopyFrom( const SvtxTrackInfo_v2& );
-  void CopyFrom( SvtxTrackInfo_v2* source )
-  { CopyFrom( *source ); }
+  void CopyFrom( const SvtxTrackInfo& ) override;
+  void CopyFrom( SvtxTrackInfo* source ) override
+  {
+    CopyFrom( *source );
+  }
 
   //
   // basic track information ---------------------------------------------------
   //
 
-  unsigned int get_id() const { return m_track_id; }
-  void set_id(unsigned int id) { m_track_id = id; }
+  unsigned int get_track_id() const override { return m_track_id; }
+  void set_track_id(unsigned int id) override { m_track_id = id; }
 
-  uint16_t get_subsurfkey() const { return m_outer_tpc_subsurfkey; }
-  void set_subsurfkey(uint16_t key) { m_outer_tpc_subsurfkey = key; }
+  uint16_t get_subsurfkey() const override { return m_outer_tpc_subsurfkey; }
+  void set_subsurfkey(uint16_t key) override { m_outer_tpc_subsurfkey = key; }
 
   float get_chisq() const override { return m_chisq; }
   void set_chisq(float chisq) override { m_chisq = chisq; }
@@ -121,34 +123,34 @@ class SvtxTrackInfo_v2: public SvtxTrackInfo
   float get_covariance(int i, int j) const override { return m_state_vertex.get_covariance(i, j);}
   void set_covariance(int i, int j, float value) override {m_state_vertex.set_covariance(i, j, value);}
 
-  float get_x_outer_tpc() const { return m_state_outer_tpc.get_x(); }
-  void set_x_outer_tpc(float x) { m_state_outer_tpc.set_x(x); }
+  float get_x_outer_tpc() const override { return m_state_outer_tpc.get_x(); }
+  void set_x_outer_tpc(float x) override { m_state_outer_tpc.set_x(x); }
 
-  float get_y_outer_tpc() const { return m_state_outer_tpc.get_y(); }
-  void set_y_outer_tpc(float y) { m_state_outer_tpc.set_y(y); }
+  float get_y_outer_tpc() const override { return m_state_outer_tpc.get_y(); }
+  void set_y_outer_tpc(float y) override { m_state_outer_tpc.set_y(y); }
 
-  float get_z_outer_tpc() const { return m_state_outer_tpc.get_z(); }
-  void set_z_outer_tpc(float z) { m_state_outer_tpc.set_z(z); }
+  float get_z_outer_tpc() const override { return m_state_outer_tpc.get_z(); }
+  void set_z_outer_tpc(float z) override { m_state_outer_tpc.set_z(z); }
 
-  void set_phi_outer_tpc(const float phi) { m_state_outer_tpc.set_phi(phi); }
-  void set_theta_outer_tpc(const float theta) { m_state_outer_tpc.set_theta(theta); }
-  void set_qOp_outer_tpc(const float qop) { m_state_outer_tpc.set_qOp(qop); }
+  void set_phi_outer_tpc(const float phi) override { m_state_outer_tpc.set_phi(phi); }
+  void set_theta_outer_tpc(const float theta) override { m_state_outer_tpc.set_theta(theta); }
+  void set_qOp_outer_tpc(const float qop) override { m_state_outer_tpc.set_qOp(qop); }
 
-  float get_px_outer_tpc() const { return m_state_outer_tpc.get_px(); }
-  float get_py_outer_tpc() const { return m_state_outer_tpc.get_py(); }
-  float get_pz_outer_tpc() const { return m_state_outer_tpc.get_pz(); }
+  float get_px_outer_tpc() const override { return m_state_outer_tpc.get_px(); }
+  float get_py_outer_tpc() const override { return m_state_outer_tpc.get_py(); }
+  float get_pz_outer_tpc() const override { return m_state_outer_tpc.get_pz(); }
 
-  float get_mom_outer_tpc(unsigned int i) const { return m_state_outer_tpc.get_mom(i); }
+  float get_mom_outer_tpc(unsigned int i) const override { return m_state_outer_tpc.get_mom(i); }
 
-  float get_p_outer_tpc() const { return m_state_outer_tpc.get_p(); }
-  float get_pt_outer_tpc() const { return m_state_outer_tpc.get_pt(); }
-  float get_eta_outer_tpc() const { return m_state_outer_tpc.get_eta(); }
-  float get_phi_outer_tpc() const { return m_state_outer_tpc.get_phi(); }
-  float get_theta_outer_tpc() const { return m_state_outer_tpc.get_theta(); }
-  float get_qOp_outer_tpc() const { return m_state_outer_tpc.get_qOp(); }
+  float get_p_outer_tpc() const override { return m_state_outer_tpc.get_p(); }
+  float get_pt_outer_tpc() const override { return m_state_outer_tpc.get_pt(); }
+  float get_eta_outer_tpc() const override { return m_state_outer_tpc.get_eta(); }
+  float get_phi_outer_tpc() const override { return m_state_outer_tpc.get_phi(); }
+  float get_theta_outer_tpc() const override { return m_state_outer_tpc.get_theta(); }
+  float get_qOp_outer_tpc() const override { return m_state_outer_tpc.get_qOp(); }
 
-  float get_covariance_outer_tpc(int i, int j) const { return m_state_outer_tpc.get_covariance(i, j);}
-  void set_covariance_outer_tpc(int i, int j, float value) {m_state_outer_tpc.set_covariance(i, j, value);}
+  float get_covariance_outer_tpc(int i, int j) const override { return m_state_outer_tpc.get_covariance(i, j);}
+  void set_covariance_outer_tpc(int i, int j, float value) override {m_state_outer_tpc.set_covariance(i, j, value);}
 
  private:
 

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v2LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrackInfo_v2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.cc
@@ -1,0 +1,77 @@
+#include "SvtxTrackInfo_v3.h"
+#include "TrackStateInfo_v1.h"
+
+/**
+ * SvtxTrackInfo_v3 is a class developed to hold the information from the track
+ * projection from the outermost TPC surface to the calorimeters
+**/
+
+void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v3& source)
+{
+  set_id(source.get_id());
+  set_subsurfkey(source.get_subsurfkey());
+  set_chisq(source.get_chisq());
+  set_ndf(source.get_ndf());
+  set_hitbitmap(source.get_hitbitmap());
+  set_crossing(source.get_crossing());
+
+  for(int istate = STATE::VERTEX; istate <= STATE::HCALOUT_BACKFACE; istate++)
+  {
+    set_x(istate, source.get_x(istate));
+    set_y(istate, source.get_y(istate));
+    set_z(istate, source.get_z(istate));
+    set_phi(istate, source.get_phi(istate));
+    set_theta(istate, source.get_theta(istate));
+    set_qOp(istate, source.get_qOp(istate));
+
+    for (int i = 0; i < 5; i++)
+    {
+      for (int j = i; j < 5; j++)
+      {
+        set_covariance(istate, i, j, source.get_covariance(istate, i, j));
+      }
+    }
+  }
+}
+
+void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v2& source)
+{
+  set_id(source.get_id());
+  set_subsurfkey(source.get_subsurfkey());
+  set_chisq(source.get_chisq());
+  set_ndf(source.get_ndf());
+  set_hitbitmap(source.get_hitbitmap());
+  set_crossing(source.get_crossing());
+
+  set_x(STATE::VERTEX, source.get_x());
+  set_y(STATE::VERTEX, source.get_y());
+  set_z(STATE::VERTEX, source.get_z());
+  set_phi(STATE::VERTEX, source.get_phi());
+  set_theta(STATE::VERTEX, source.get_theta());
+  set_qOp(STATE::VERTEX, source.get_qOp());
+
+  set_x(STATE::OUTER_TPC, source.get_x_outer_tpc());
+  set_y(STATE::OUTER_TPC, source.get_y_outer_tpc());
+  set_z(STATE::OUTER_TPC, source.get_z_outer_tpc());
+  set_phi(STATE::OUTER_TPC, source.get_phi_outer_tpc());
+  set_theta(STATE::OUTER_TPC, source.get_theta_outer_tpc());
+  set_qOp(STATE::OUTER_TPC, source.get_qOp_outer_tpc());
+
+  for (int i = 0; i < 5; i++)
+  {
+    for (int j = i; j < 5; j++)
+    {
+      set_covariance(STATE::VERTEX, i, j, source.get_covariance(i, j));
+      set_covariance(STATE::OUTER_TPC, i, j, source.get_covariance_outer_tpc(i, j));
+    }
+  }
+}
+
+SvtxTrackInfo_v3& SvtxTrackInfo_v3::operator=(const SvtxTrackInfo_v3& source)
+{
+  if(this != &source)
+  {
+    CopyFrom(source);
+  }
+  return *this;
+}

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.cc
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.cc
@@ -6,16 +6,23 @@
  * projection from the outermost TPC surface to the calorimeters
 **/
 
-void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v3& source)
+void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo& source)
 {
-  set_id(source.get_id());
+  set_track_id(source.get_track_id());
   set_subsurfkey(source.get_subsurfkey());
   set_chisq(source.get_chisq());
   set_ndf(source.get_ndf());
   set_hitbitmap(source.get_hitbitmap());
   set_crossing(source.get_crossing());
 
-  for(int istate = STATE::VERTEX; istate <= STATE::HCALOUT_BACKFACE; istate++)
+  set_x(STATE::VERTEX, source.get_x());
+  set_y(STATE::VERTEX, source.get_y());
+  set_z(STATE::VERTEX, source.get_z());
+  set_phi(STATE::VERTEX, source.get_phi());
+  set_theta(STATE::VERTEX, source.get_theta());
+  set_qOp(STATE::VERTEX, source.get_qOp());
+
+  for(int istate = STATE::OUTER_TPC; istate <= STATE::HCALOUT_BACKFACE; istate++)
   {
     set_x(istate, source.get_x(istate));
     set_y(istate, source.get_y(istate));
@@ -32,23 +39,11 @@ void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v3& source)
       }
     }
   }
-}
 
-void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v2& source)
-{
-  set_id(source.get_id());
-  set_subsurfkey(source.get_subsurfkey());
-  set_chisq(source.get_chisq());
-  set_ndf(source.get_ndf());
-  set_hitbitmap(source.get_hitbitmap());
-  set_crossing(source.get_crossing());
-
-  set_x(STATE::VERTEX, source.get_x());
-  set_y(STATE::VERTEX, source.get_y());
-  set_z(STATE::VERTEX, source.get_z());
-  set_phi(STATE::VERTEX, source.get_phi());
-  set_theta(STATE::VERTEX, source.get_theta());
-  set_qOp(STATE::VERTEX, source.get_qOp());
+  if(std::isnan(source.get_phi_outer_tpc()) || std::isnan(source.get_theta_outer_tpc()) || std::isnan(source.get_qOp_outer_tpc()))
+  {
+    return;
+  }
 
   set_x(STATE::OUTER_TPC, source.get_x_outer_tpc());
   set_y(STATE::OUTER_TPC, source.get_y_outer_tpc());
@@ -65,6 +60,7 @@ void SvtxTrackInfo_v3::CopyFrom(const SvtxTrackInfo_v2& source)
       set_covariance(STATE::OUTER_TPC, i, j, source.get_covariance_outer_tpc(i, j));
     }
   }
+
 }
 
 SvtxTrackInfo_v3& SvtxTrackInfo_v3::operator=(const SvtxTrackInfo_v3& source)

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
@@ -171,12 +171,12 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
  private:
 
   // track information
-  unsigned int m_track_id = UINT_MAX;
-  uint16_t m_outer_tpc_subsurfkey = UINT16_MAX;
-  float m_chisq = NAN;
-  uint8_t m_ndf = uint8_t(-1);
-  uint64_t m_hitbitmap = uint64_t(-1);
-  short int m_crossing = SHRT_MAX;
+  unsigned int m_track_id = std::numeric_limits<unsigned int>::quiet_NaN();
+  uint16_t m_outer_tpc_subsurfkey = std::numeric_limits<uint16_t>::quiet_NaN();
+  float m_chisq = std::numeric_limits<float>::quiet_NaN();
+  uint8_t m_ndf = std::numeric_limits<uint8_t>::quiet_NaN();
+  uint64_t m_hitbitmap = std::numeric_limits<uint64_t>::quiet_NaN();
+  short int m_crossing = std::numeric_limits<short int>::quiet_NaN();
 
   // track state information
   std::vector<TrackStateInfo_v1> m_states;

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
@@ -1,0 +1,187 @@
+#ifndef TRACKBASEHISTORIC_SVTXTRACKINFOV3_H
+#define TRACKBASEHISTORIC_SVTXTRACKINFOV3_H
+
+#include "SvtxTrackInfo.h"
+#include "SvtxTrackInfo_v2.h"
+#include "TrackStateInfo_v1.h"
+
+class PHObject;
+
+class SvtxTrackInfo_v3: public SvtxTrackInfo
+{
+ public:
+  enum STATE
+  {
+    VERTEX = 0,
+    OUTER_TPC = 1,
+    EMCAL_FRONTFACE = 2,
+    EMCAL_BACKFACE = 3,
+    HCALIN_FRONTFACE = 4,
+    HCALIN_BACKFACE = 5,
+    HCALOUT_FRONTFACE = 6,
+    HCALOUT_BACKFACE = 7
+  };
+
+  SvtxTrackInfo_v3() : m_states(8, TrackStateInfo_v1()) {}
+
+  //* base class copy constructor
+  SvtxTrackInfo_v3( const SvtxTrackInfo& ) : m_states(8, TrackStateInfo_v1()) {}
+
+  //* copy constructor
+  SvtxTrackInfo_v3(const SvtxTrackInfo_v3& source) : m_states(8, TrackStateInfo_v1())
+  {
+    m_track_id = source.get_id();
+    m_outer_tpc_subsurfkey = source.get_subsurfkey();
+    m_chisq = source.get_chisq();
+    m_ndf = source.get_ndf();
+    m_crossing = source.get_crossing();
+    m_hitbitmap = source.get_hitbitmap();
+
+    for(int istate = STATE::VERTEX; istate <= STATE::HCALOUT_BACKFACE; istate++)
+    {
+      set_x(istate, source.get_x(istate));
+      set_y(istate, source.get_y(istate));
+      set_z(istate, source.get_z(istate));
+      set_phi(istate, source.get_phi());
+      set_theta(istate, source.get_theta());
+      set_qOp(istate, source.get_qOp());
+
+      for (int i = 0; i < 6; i++)
+      {
+        for (int j = i; j < 6; j++)
+        {
+          set_covariance(istate, i, j, source.get_covariance(istate, i, j));
+        }
+      }
+    }
+  }
+
+  //* assignment operator
+  SvtxTrackInfo_v3& operator=(const SvtxTrackInfo_v3& track);
+
+  //* destructor
+  ~SvtxTrackInfo_v3() override {}
+
+  // The "standard PHObject response" functions...
+  void identify(std::ostream& os = std::cout) const override {
+    os << "SvtxTrackInfo_v3 class" << std::endl;
+  }
+  void Reset() override { *this = SvtxTrackInfo_v3(); }
+
+  PHObject* CloneMe() const override { return new SvtxTrackInfo_v3(*this); }
+
+  //! import PHObject CopyFrom, in order to avoid clang warning
+  using PHObject::CopyFrom;
+  // copy content
+  void CopyFrom( const SvtxTrackInfo_v3& );
+  void CopyFrom( SvtxTrackInfo_v3* source )
+  { CopyFrom( *source ); }
+  void CopyFrom( const SvtxTrackInfo_v2& );
+  void CopyFrom( SvtxTrackInfo_v2* source )
+  { CopyFrom( *source ); }
+
+  //
+  // basic track information ---------------------------------------------------
+  //
+
+  unsigned int get_id() const { return m_track_id; }
+  void set_id(unsigned int id) { m_track_id = id; }
+
+  uint16_t get_subsurfkey() const { return m_outer_tpc_subsurfkey; }
+  void set_subsurfkey(uint16_t key) { m_outer_tpc_subsurfkey = key; }
+
+  float get_chisq() const override { return m_chisq; }
+  void set_chisq(float chisq) override { m_chisq = chisq; }
+
+  uint8_t get_ndf() const override { return m_ndf; }
+  void set_ndf(uint8_t ndf) override { m_ndf = ndf; }
+
+  uint64_t get_hitbitmap() const override { return m_hitbitmap; }
+  void set_hitbitmap(uint64_t hitbitmap) override { m_hitbitmap = hitbitmap; }
+
+  short int get_crossing() const override { return m_crossing; }
+  void set_crossing(short int crossing) override { m_crossing = crossing; }
+
+  float get_x() const override { return m_states.at(STATE::VERTEX).get_x(); }
+  void set_x(float x) override { m_states.at(STATE::VERTEX).set_x(x); }
+
+  float get_y() const override { return m_states.at(STATE::VERTEX).get_y(); }
+  void set_y(float y) override { m_states.at(STATE::VERTEX).set_y(y); }
+
+  float get_z() const override { return m_states.at(STATE::VERTEX).get_z(); }
+  void set_z(float z) override { m_states.at(STATE::VERTEX).set_z(z); }
+
+  float get_pos(unsigned int i) const override { return m_states.at(STATE::VERTEX).get_pos(i); }
+
+  float get_px() const override { return m_states.at(STATE::VERTEX).get_px(); }
+  float get_py() const override { return m_states.at(STATE::VERTEX).get_py(); }
+  float get_pz() const override { return m_states.at(STATE::VERTEX).get_pz(); }
+
+  void set_phi(const float phi) override { m_states.at(STATE::VERTEX).set_phi(phi); }
+  void set_theta(const float theta) override { m_states.at(STATE::VERTEX).set_theta(theta); }
+  void set_qOp(const float qop) override { m_states.at(STATE::VERTEX).set_qOp(qop); }
+
+  float get_mom(unsigned int i) const override { return m_states.at(STATE::VERTEX).get_mom(i); }
+
+  float get_p() const override { return m_states.at(STATE::VERTEX).get_p(); }
+  float get_pt() const override { return m_states.at(STATE::VERTEX).get_pt(); }
+  float get_eta() const override { return m_states.at(STATE::VERTEX).get_eta(); }
+  float get_phi() const override { return m_states.at(STATE::VERTEX).get_phi(); }
+  float get_theta() const override { return m_states.at(STATE::VERTEX).get_theta(); }
+  float get_qOp() const override { return m_states.at(STATE::VERTEX).get_qOp(); }
+  int get_charge() const override { return m_states.at(STATE::VERTEX).get_charge(); }
+
+  float get_covariance(int i, int j) const override { return m_states.at(STATE::VERTEX).get_covariance(i, j);}
+  void set_covariance(int i, int j, float value) override {m_states.at(STATE::VERTEX).set_covariance(i, j, value);}
+
+  float get_x(int state) const { return m_states.at(state).get_x(); }
+  void set_x(int state, float x) { m_states.at(state).set_x(x); }
+
+  float get_y(int state) const { return m_states.at(state).get_y(); }
+  void set_y(int state, float y) { m_states.at(state).set_y(y); }
+
+  float get_z(int state) const { return m_states.at(state).get_z(); }
+  void set_z(int state, float z) { m_states.at(state).set_z(z); }
+
+  float get_pos(int state, unsigned int i) const { return m_states.at(state).get_pos(i); }
+
+  float get_px(int state) const { return m_states.at(state).get_px(); }
+  float get_py(int state) const { return m_states.at(state).get_py(); }
+  float get_pz(int state) const { return m_states.at(state).get_pz(); }
+
+  void set_phi(int state, const float phi) { m_states.at(state).set_phi(phi); }
+  void set_theta(int state, const float theta) { m_states.at(state).set_theta(theta); }
+  void set_qOp(int state, const float qop) { m_states.at(state).set_qOp(qop); }
+
+  float get_mom(int state, unsigned int i) const { return m_states.at(state).get_mom(i); }
+
+  float get_p(int state) const { return m_states.at(state).get_p(); }
+  float get_pt(int state) const { return m_states.at(state).get_pt(); }
+  float get_eta(int state) const { return m_states.at(state).get_eta(); }
+  float get_phi(int state) const { return m_states.at(state).get_phi(); }
+  float get_theta(int state) const { return m_states.at(state).get_theta(); }
+  float get_qOp(int state) const { return m_states.at(state).get_qOp(); }
+
+  float get_projected_eta(int state) const { return asinh(m_states.at(state).get_z()/sqrt(pow(m_states.at(state).get_x(), 2) + pow(m_states.at(state).get_y(), 2))); }
+  float get_projected_phi(int state) const { return atan2(m_states.at(state).get_y(), m_states.at(state).get_x()); }
+
+  float get_covariance(int state, int i, int j) const { return m_states.at(state).get_covariance(i, j);}
+  void set_covariance(int state, int i, int j, float value) {m_states.at(state).set_covariance(i, j, value);}
+
+ private:
+
+  // track information
+  unsigned int m_track_id = UINT_MAX;
+  uint16_t m_outer_tpc_subsurfkey = UINT16_MAX;
+  float m_chisq = NAN;
+  uint8_t m_ndf = uint8_t(-1);
+  uint64_t m_hitbitmap = uint64_t(-1);
+  short int m_crossing = SHRT_MAX;
+
+  // track state information
+  std::vector<TrackStateInfo_v1> m_states;
+
+  ClassDefOverride(SvtxTrackInfo_v3, 1)
+};
+
+#endif

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
@@ -30,7 +30,7 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
   //* copy constructor
   SvtxTrackInfo_v3(const SvtxTrackInfo_v3& source) : m_states(8, TrackStateInfo_v1())
   {
-    m_track_id = source.get_id();
+    m_track_id = source.get_track_id();
     m_outer_tpc_subsurfkey = source.get_subsurfkey();
     m_chisq = source.get_chisq();
     m_ndf = source.get_ndf();
@@ -46,9 +46,9 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
       set_theta(istate, source.get_theta());
       set_qOp(istate, source.get_qOp());
 
-      for (int i = 0; i < 6; i++)
+      for (int i = 0; i < 5; i++)
       {
-        for (int j = i; j < 6; j++)
+        for (int j = i; j < 5; j++)
         {
           set_covariance(istate, i, j, source.get_covariance(istate, i, j));
         }
@@ -73,22 +73,21 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
   //! import PHObject CopyFrom, in order to avoid clang warning
   using PHObject::CopyFrom;
   // copy content
-  void CopyFrom( const SvtxTrackInfo_v3& );
-  void CopyFrom( SvtxTrackInfo_v3* source )
-  { CopyFrom( *source ); }
-  void CopyFrom( const SvtxTrackInfo_v2& );
-  void CopyFrom( SvtxTrackInfo_v2* source )
-  { CopyFrom( *source ); }
+  void CopyFrom( const SvtxTrackInfo& ) override;
+  void CopyFrom( SvtxTrackInfo* source ) override
+  {
+    CopyFrom( *source );
+  }
 
   //
   // basic track information ---------------------------------------------------
   //
 
-  unsigned int get_id() const { return m_track_id; }
-  void set_id(unsigned int id) { m_track_id = id; }
+  unsigned int get_track_id() const override { return m_track_id; }
+  void set_track_id(unsigned int id) override { m_track_id = id; }
 
-  uint16_t get_subsurfkey() const { return m_outer_tpc_subsurfkey; }
-  void set_subsurfkey(uint16_t key) { m_outer_tpc_subsurfkey = key; }
+  uint16_t get_subsurfkey() const override { return m_outer_tpc_subsurfkey; }
+  void set_subsurfkey(uint16_t key) override { m_outer_tpc_subsurfkey = key; }
 
   float get_chisq() const override { return m_chisq; }
   void set_chisq(float chisq) override { m_chisq = chisq; }
@@ -134,39 +133,39 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
   float get_covariance(int i, int j) const override { return m_states.at(STATE::VERTEX).get_covariance(i, j);}
   void set_covariance(int i, int j, float value) override {m_states.at(STATE::VERTEX).set_covariance(i, j, value);}
 
-  float get_x(int state) const { return m_states.at(state).get_x(); }
-  void set_x(int state, float x) { m_states.at(state).set_x(x); }
+  float get_x(int state) const override { return m_states.at(state).get_x(); }
+  void set_x(int state, float x) override { m_states.at(state).set_x(x); }
 
-  float get_y(int state) const { return m_states.at(state).get_y(); }
-  void set_y(int state, float y) { m_states.at(state).set_y(y); }
+  float get_y(int state) const override { return m_states.at(state).get_y(); }
+  void set_y(int state, float y) override { m_states.at(state).set_y(y); }
 
-  float get_z(int state) const { return m_states.at(state).get_z(); }
-  void set_z(int state, float z) { m_states.at(state).set_z(z); }
+  float get_z(int state) const override { return m_states.at(state).get_z(); }
+  void set_z(int state, float z) override { m_states.at(state).set_z(z); }
 
-  float get_pos(int state, unsigned int i) const { return m_states.at(state).get_pos(i); }
+  float get_pos(int state, unsigned int i) const override { return m_states.at(state).get_pos(i); }
 
-  float get_px(int state) const { return m_states.at(state).get_px(); }
-  float get_py(int state) const { return m_states.at(state).get_py(); }
-  float get_pz(int state) const { return m_states.at(state).get_pz(); }
+  float get_px(int state) const override { return m_states.at(state).get_px(); }
+  float get_py(int state) const override { return m_states.at(state).get_py(); }
+  float get_pz(int state) const override { return m_states.at(state).get_pz(); }
 
-  void set_phi(int state, const float phi) { m_states.at(state).set_phi(phi); }
-  void set_theta(int state, const float theta) { m_states.at(state).set_theta(theta); }
-  void set_qOp(int state, const float qop) { m_states.at(state).set_qOp(qop); }
+  void set_phi(int state, const float phi) override { m_states.at(state).set_phi(phi); }
+  void set_theta(int state, const float theta) override { m_states.at(state).set_theta(theta); }
+  void set_qOp(int state, const float qop) override { m_states.at(state).set_qOp(qop); }
 
-  float get_mom(int state, unsigned int i) const { return m_states.at(state).get_mom(i); }
+  float get_mom(int state, unsigned int i) const override { return m_states.at(state).get_mom(i); }
 
-  float get_p(int state) const { return m_states.at(state).get_p(); }
-  float get_pt(int state) const { return m_states.at(state).get_pt(); }
-  float get_eta(int state) const { return m_states.at(state).get_eta(); }
-  float get_phi(int state) const { return m_states.at(state).get_phi(); }
-  float get_theta(int state) const { return m_states.at(state).get_theta(); }
-  float get_qOp(int state) const { return m_states.at(state).get_qOp(); }
+  float get_p(int state) const override { return m_states.at(state).get_p(); }
+  float get_pt(int state) const override { return m_states.at(state).get_pt(); }
+  float get_eta(int state) const override { return m_states.at(state).get_eta(); }
+  float get_phi(int state) const override { return m_states.at(state).get_phi(); }
+  float get_theta(int state) const override { return m_states.at(state).get_theta(); }
+  float get_qOp(int state) const override { return m_states.at(state).get_qOp(); }
 
-  float get_projected_eta(int state) const { return asinh(m_states.at(state).get_z()/sqrt(pow(m_states.at(state).get_x(), 2) + pow(m_states.at(state).get_y(), 2))); }
-  float get_projected_phi(int state) const { return atan2(m_states.at(state).get_y(), m_states.at(state).get_x()); }
+  float get_projected_eta(int state) const override { return asinh(m_states.at(state).get_z()/sqrt(pow(m_states.at(state).get_x(), 2) + pow(m_states.at(state).get_y(), 2))); }
+  float get_projected_phi(int state) const override { return atan2(m_states.at(state).get_y(), m_states.at(state).get_x()); }
 
-  float get_covariance(int state, int i, int j) const { return m_states.at(state).get_covariance(i, j);}
-  void set_covariance(int state, int i, int j, float value) {m_states.at(state).set_covariance(i, j, value);}
+  float get_covariance(int state, int i, int j) const override { return m_states.at(state).get_covariance(i, j);}
+  void set_covariance(int state, int i, int j, float value) override {m_states.at(state).set_covariance(i, j, value);}
 
  private:
 

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3.h
@@ -2,7 +2,6 @@
 #define TRACKBASEHISTORIC_SVTXTRACKINFOV3_H
 
 #include "SvtxTrackInfo.h"
-#include "SvtxTrackInfo_v2.h"
 #include "TrackStateInfo_v1.h"
 
 class PHObject;
@@ -63,7 +62,8 @@ class SvtxTrackInfo_v3: public SvtxTrackInfo
   ~SvtxTrackInfo_v3() override {}
 
   // The "standard PHObject response" functions...
-  void identify(std::ostream& os = std::cout) const override {
+  void identify(std::ostream& os = std::cout) const override
+  {
     os << "SvtxTrackInfo_v3 class" << std::endl;
   }
   void Reset() override { *this = SvtxTrackInfo_v3(); }

--- a/offline/packages/trackbase_historic/SvtxTrackInfo_v3LinkDef.h
+++ b/offline/packages/trackbase_historic/SvtxTrackInfo_v3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SvtxTrackInfo_v3 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v1.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v1.cc
@@ -1,4 +1,3 @@
-
 #include "SvtxTrackInfo.h"
 #include "TrackInfoContainer_v1.h"
 #include <phool/PHObject.h>
@@ -7,55 +6,24 @@
 #include <map>
 
 
-    TrackInfoContainer_v1::TrackInfoContainer_v1() {
+TrackInfoContainer_v1::TrackInfoContainer_v1()
+{
+  _clones = new TClonesArray("TrackInfoContainer_v1");
+  _clones->SetOwner();
+  _clones->SetName("TrackInfoContainer_v1");
+}
 
+TrackInfoContainer_v1::~TrackInfoContainer_v1()
+{
+  _clones->Clear("C");
+}
 
-    _clones = new TClonesArray("SvtxTrackInfo");
+void TrackInfoContainer_v1::identify(std::ostream& os) const
+{
+  os << "TrackInfoContainer_v1 of size " << size() << std::endl;
+}
 
-    _clones->SetOwner();
-    _clones->SetName("TrackInfoContainer_v1");
-
-    }
-
-    TrackInfoContainer_v1::~TrackInfoContainer_v1(){
-
-      _clones->Clear("C");
-    }
-    
-    void TrackInfoContainer_v1::identify(std::ostream& os) const{
-      os << "TrackInfoContainer_v1 of size " << size() << std::endl;
-    }
-
-    void TrackInfoContainer_v1::Reset()
-  {
-  // clear content of towers in the container for the next event
-
-  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
-  {
-    TObject* obj = _clones->UncheckedAt(i);
-
-    if (obj == nullptr)
-    {
-      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
-                << " _clones->GetSize() = " << _clones->GetSize()
-                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
-                << " i = " << i << std::endl;
-      _clones->Print();
-    }
-
-    assert(obj);
-    // same as TClonesArray::Clear() but only clear but not to erase all towers
-    obj->Clear();
-    obj->ResetBit(kHasUUID);
-    obj->ResetBit(kIsReferenced);
-    obj->SetUniqueID(0);
-  }
-    _clones->Clear("C");
-
-  }
-
-
- 
-
-  
-
+void TrackInfoContainer_v1::Reset()
+{
+  _clones->Clear("C");
+}

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v1.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v1.h
@@ -7,44 +7,35 @@
 #include <phool/PHObject.h>
 
 #include <climits>
-#include <map>
 #include <TClonesArray.h>
 #include <cstdint>
 
 class TrackInfoContainer_v1 : public TrackInfoContainer
 {
     public:
- 
+
     TrackInfoContainer_v1();
     ~TrackInfoContainer_v1() override;
     void identify(std::ostream& os = std::cout) const override;
-
-      void Reset() override;
-     //virtual SvtxTrackInfo* get_trackinfo(int /*index*/) override { return nullptr; }
-    //virtual TrackInfo* get_tower_at_key(int /*key*/) { return nullptr; }
-    //virtual size_t size() const { return 0; }
+    void Reset() override;
 
     size_t size() const override { return _clones->GetEntries(); }
 
-    SvtxTrackInfo* get_trackinfo(int pos) override{
-    return (SvtxTrackInfo*) _clones->At(pos);
+    SvtxTrackInfo* get_trackinfo(int pos) override {
+      return (SvtxTrackInfo*) _clones->At(pos);
     }
 
-    //    void TrackInfoContainer_v1::add_trackinfo(int, SvtxTrackInfo_v1 ) {}
-    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override{
-      new((*_clones)[pos]) SvtxTrackInfo;
-      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
+    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override {
+      new((*_clones)[pos]) SvtxTrackInfo_v1;
+      SvtxTrackInfo_v1 *info = (SvtxTrackInfo_v1 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
-
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override{
-      new((*_clones)[pos]) SvtxTrackInfo;
-      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override {
+      new((*_clones)[pos]) SvtxTrackInfo_v1;
+      SvtxTrackInfo_v1 *info = (SvtxTrackInfo_v1 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
-
     }
-
 
     protected:
     TClonesArray *_clones = nullptr;

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
@@ -1,0 +1,46 @@
+#include "SvtxTrackInfo_v2.h"
+#include "TrackInfoContainer_v2.h"
+#include <phool/PHObject.h>
+
+TrackInfoContainer_v2::TrackInfoContainer_v2()
+{
+  _clones = new TClonesArray("SvtxTrackInfo_v2");
+  _clones->SetOwner();
+  _clones->SetName("TrackInfoContainer_v2");
+}
+
+TrackInfoContainer_v2::~TrackInfoContainer_v2()
+{
+  _clones->Clear("C");
+}
+
+void TrackInfoContainer_v2::identify(std::ostream& os) const
+{
+  os << "TrackInfoContainer_v2 of size " << size() << std::endl;
+}
+
+void TrackInfoContainer_v2::Reset()
+{
+  // clear content of towers in the container for the next event
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj == nullptr)
+    {
+      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
+                << " _clones->GetSize() = " << _clones->GetSize()
+                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
+                << " i = " << i << std::endl;
+      _clones->Print();
+    }
+
+    assert(obj);
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
+  _clones->Clear("C");
+}

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
@@ -21,26 +21,5 @@ void TrackInfoContainer_v2::identify(std::ostream& os) const
 
 void TrackInfoContainer_v2::Reset()
 {
-  // clear content of towers in the container for the next event
-  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
-  {
-    TObject* obj = _clones->UncheckedAt(i);
-
-    if (obj == nullptr)
-    {
-      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
-                << " _clones->GetSize() = " << _clones->GetSize()
-                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
-                << " i = " << i << std::endl;
-      _clones->Print();
-    }
-
-    assert(obj);
-    // same as TClonesArray::Clear() but only clear but not to erase all towers
-    obj->Clear();
-    obj->ResetBit(kHasUUID);
-    obj->ResetBit(kIsReferenced);
-    obj->SetUniqueID(0);
-  }
   _clones->Clear("C");
 }

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
@@ -1,0 +1,54 @@
+#ifndef TRACKINFOCONTAINERV2_H
+#define TRACKINFOCONTAINERV2_H
+
+#include "TrackInfoContainer.h"
+#include "SvtxTrackInfo_v2.h"
+#include <phool/PHObject.h>
+
+#include <TClonesArray.h>
+
+class TrackInfoContainer_v2 : public TrackInfoContainer
+{
+    public:
+
+    TrackInfoContainer_v2();
+    ~TrackInfoContainer_v2() override;
+    void identify(std::ostream& os = std::cout) const override;
+
+      void Reset() override;
+     //virtual SvtxTrackInfo* get_trackinfo(int /*index*/) override { return nullptr; }
+    //virtual TrackInfo* get_tower_at_key(int /*key*/) { return nullptr; }
+    //virtual size_t size() const { return 0; }
+
+    size_t size() const override { return _clones->GetEntries(); }
+
+    SvtxTrackInfo_v2* get_trackinfo(int pos) override
+    {
+      return (SvtxTrackInfo_v2*) _clones->At(pos);
+    }
+
+    void add_trackinfo(int pos, SvtxTrackInfo_v2 trackinfo)
+    {
+      new((*_clones)[pos]) SvtxTrackInfo_v2;
+      SvtxTrackInfo_v2 *info = (SvtxTrackInfo_v2 *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+
+    }
+
+    void add_trackinfo(int pos, SvtxTrackInfo_v2* trackinfo)
+    {
+      new((*_clones)[pos]) SvtxTrackInfo_v2;
+      SvtxTrackInfo_v2 *info = (SvtxTrackInfo_v2 *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+    }
+
+
+
+    protected:
+    TClonesArray *_clones = nullptr;
+
+    private:
+    ClassDefOverride(TrackInfoContainer_v2, 1);
+};
+
+#endif

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
@@ -31,7 +31,7 @@ class TrackInfoContainer_v2 : public TrackInfoContainer
 
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override
     {
       new((*_clones)[pos]) SvtxTrackInfo_v2;
       SvtxTrackInfo_v2 *info = (SvtxTrackInfo_v2 *)_clones->ConstructedAt(pos);

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
@@ -14,11 +14,7 @@ class TrackInfoContainer_v2 : public TrackInfoContainer
     TrackInfoContainer_v2();
     ~TrackInfoContainer_v2() override;
     void identify(std::ostream& os = std::cout) const override;
-
-      void Reset() override;
-     //virtual SvtxTrackInfo* get_trackinfo(int /*index*/) override { return nullptr; }
-    //virtual TrackInfo* get_tower_at_key(int /*key*/) { return nullptr; }
-    //virtual size_t size() const { return 0; }
+    void Reset() override;
 
     size_t size() const override { return _clones->GetEntries(); }
 
@@ -27,7 +23,7 @@ class TrackInfoContainer_v2 : public TrackInfoContainer
       return (SvtxTrackInfo_v2*) _clones->At(pos);
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo_v2 trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override
     {
       new((*_clones)[pos]) SvtxTrackInfo_v2;
       SvtxTrackInfo_v2 *info = (SvtxTrackInfo_v2 *)_clones->ConstructedAt(pos);
@@ -35,14 +31,12 @@ class TrackInfoContainer_v2 : public TrackInfoContainer
 
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo_v2* trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo)
     {
       new((*_clones)[pos]) SvtxTrackInfo_v2;
       SvtxTrackInfo_v2 *info = (SvtxTrackInfo_v2 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
     }
-
-
 
     protected:
     TClonesArray *_clones = nullptr;

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2LinkDef.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrackInfoContainer_v2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
@@ -1,0 +1,51 @@
+#include "SvtxTrackInfo.h"
+#include "SvtxTrackInfo_v3.h"
+#include "TrackInfoContainer_v3.h"
+#include <phool/PHObject.h>
+
+#include <climits>
+#include <map>
+
+TrackInfoContainer_v3::TrackInfoContainer_v3()
+{
+  _clones = new TClonesArray("SvtxTrackInfo_v3");
+  _clones->SetOwner();
+  _clones->SetName("TrackInfoContainer_v3");
+}
+
+TrackInfoContainer_v3::~TrackInfoContainer_v3()
+{
+  _clones->Clear("C");
+}
+
+void TrackInfoContainer_v3::identify(std::ostream& os) const
+{
+  os << "TrackInfoContainer_v3 of size " << size() << std::endl;
+}
+
+void TrackInfoContainer_v3::Reset()
+{
+  // clear content of towers in the container for the next event
+  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
+  {
+    TObject* obj = _clones->UncheckedAt(i);
+
+    if (obj == nullptr)
+    {
+      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
+                << " _clones->GetSize() = " << _clones->GetSize()
+                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
+                << " i = " << i << std::endl;
+      _clones->Print();
+    }
+
+    assert(obj);
+    // same as TClonesArray::Clear() but only clear but not to erase all towers
+    obj->Clear();
+    obj->ResetBit(kHasUUID);
+    obj->ResetBit(kIsReferenced);
+    obj->SetUniqueID(0);
+  }
+
+  _clones->Clear("C");
+}

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
@@ -25,27 +25,5 @@ void TrackInfoContainer_v3::identify(std::ostream& os) const
 
 void TrackInfoContainer_v3::Reset()
 {
-  // clear content of towers in the container for the next event
-  for (Int_t i = 0; i < _clones->GetEntriesFast(); ++i)
-  {
-    TObject* obj = _clones->UncheckedAt(i);
-
-    if (obj == nullptr)
-    {
-      std::cout << __PRETTY_FUNCTION__ << " Fatal access error:"
-                << " _clones->GetSize() = " << _clones->GetSize()
-                << " _clones->GetEntriesFast() = " << _clones->GetEntriesFast()
-                << " i = " << i << std::endl;
-      _clones->Print();
-    }
-
-    assert(obj);
-    // same as TClonesArray::Clear() but only clear but not to erase all towers
-    obj->Clear();
-    obj->ResetBit(kHasUUID);
-    obj->ResetBit(kIsReferenced);
-    obj->SetUniqueID(0);
-  }
-
   _clones->Clear("C");
 }

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
@@ -24,14 +24,14 @@ class TrackInfoContainer_v3 : public TrackInfoContainer
       return (SvtxTrackInfo_v3*) _clones->At(pos);
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override
     {
       new((*_clones)[pos]) SvtxTrackInfo_v3;
       SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override
     {
       new((*_clones)[pos]) SvtxTrackInfo_v3;
       SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
@@ -30,23 +30,6 @@ class TrackInfoContainer_v3 : public TrackInfoContainer
     return (SvtxTrackInfo_v3*) _clones->At(pos);
     }
 
-    //    void TrackInfoContainer_v3::add_trackinfo(int, SvtxTrackInfo_v3 ) {}
-    /*
-    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override{
-      new((*_clones)[pos]) SvtxTrackInfo;
-      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
-      info->CopyFrom(trackinfo);
-
-    }
-
-    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override{
-      new((*_clones)[pos]) SvtxTrackInfo;
-      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
-      info->CopyFrom(trackinfo);
-
-    }
-    */
-
     void add_trackinfo(int pos, SvtxTrackInfo_v3 trackinfo)
     {
       new((*_clones)[pos]) SvtxTrackInfo_v3;

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
@@ -1,0 +1,74 @@
+#ifndef TRACKINFOCONTAINERV3_H
+#define TRACKINFOCONTAINERV3_H
+
+#include "TrackInfoContainer.h"
+#include "SvtxTrackInfo_v3.h"
+#include "SvtxTrackInfo.h"
+#include <phool/PHObject.h>
+
+#include <climits>
+#include <map>
+#include <TClonesArray.h>
+#include <cstdint>
+
+class TrackInfoContainer_v3 : public TrackInfoContainer
+{
+    public:
+
+    TrackInfoContainer_v3();
+    ~TrackInfoContainer_v3() override;
+    void identify(std::ostream& os = std::cout) const override;
+
+      void Reset() override;
+     //virtual SvtxTrackInfo* get_trackinfo(int /*index*/) override { return nullptr; }
+    //virtual TrackInfo* get_tower_at_key(int /*key*/) { return nullptr; }
+    //virtual size_t size() const { return 0; }
+
+    size_t size() const override { return _clones->GetEntries(); }
+
+    SvtxTrackInfo_v3* get_trackinfo(int pos) override{
+    return (SvtxTrackInfo_v3*) _clones->At(pos);
+    }
+
+    //    void TrackInfoContainer_v3::add_trackinfo(int, SvtxTrackInfo_v3 ) {}
+    /*
+    void add_trackinfo(int pos, SvtxTrackInfo trackinfo) override{
+      new((*_clones)[pos]) SvtxTrackInfo;
+      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+
+    }
+
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo) override{
+      new((*_clones)[pos]) SvtxTrackInfo;
+      SvtxTrackInfo *info = (SvtxTrackInfo *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+
+    }
+    */
+
+    void add_trackinfo(int pos, SvtxTrackInfo_v3 trackinfo)
+    {
+      new((*_clones)[pos]) SvtxTrackInfo_v3;
+      SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+
+    }
+
+    void add_trackinfo(int pos, SvtxTrackInfo_v3* trackinfo)
+    {
+      new((*_clones)[pos]) SvtxTrackInfo_v3;
+      SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);
+      info->CopyFrom(trackinfo);
+
+    }
+
+
+    protected:
+    TClonesArray *_clones = nullptr;
+
+    private:
+    ClassDefOverride(TrackInfoContainer_v3, 1);
+};
+
+#endif

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.h
@@ -6,10 +6,7 @@
 #include "SvtxTrackInfo.h"
 #include <phool/PHObject.h>
 
-#include <climits>
-#include <map>
 #include <TClonesArray.h>
-#include <cstdint>
 
 class TrackInfoContainer_v3 : public TrackInfoContainer
 {
@@ -18,34 +15,28 @@ class TrackInfoContainer_v3 : public TrackInfoContainer
     TrackInfoContainer_v3();
     ~TrackInfoContainer_v3() override;
     void identify(std::ostream& os = std::cout) const override;
-
-      void Reset() override;
-     //virtual SvtxTrackInfo* get_trackinfo(int /*index*/) override { return nullptr; }
-    //virtual TrackInfo* get_tower_at_key(int /*key*/) { return nullptr; }
-    //virtual size_t size() const { return 0; }
+    void Reset() override;
 
     size_t size() const override { return _clones->GetEntries(); }
 
-    SvtxTrackInfo_v3* get_trackinfo(int pos) override{
-    return (SvtxTrackInfo_v3*) _clones->At(pos);
+    SvtxTrackInfo_v3* get_trackinfo(int pos) override
+    {
+      return (SvtxTrackInfo_v3*) _clones->At(pos);
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo_v3 trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo trackinfo)
     {
       new((*_clones)[pos]) SvtxTrackInfo_v3;
       SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
-
     }
 
-    void add_trackinfo(int pos, SvtxTrackInfo_v3* trackinfo)
+    void add_trackinfo(int pos, SvtxTrackInfo* trackinfo)
     {
       new((*_clones)[pos]) SvtxTrackInfo_v3;
       SvtxTrackInfo_v3 *info = (SvtxTrackInfo_v3 *)_clones->ConstructedAt(pos);
       info->CopyFrom(trackinfo);
-
     }
-
 
     protected:
     TClonesArray *_clones = nullptr;

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3LinkDef.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrackInfoContainer_v3 + ;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This introduces a SvtxTrackInfo_v2 that is intended to be used for the propagation of tracks from the outermost TPC layer to the calorimeters. SvtxTrackInfo_v3 will be used to hold the projection information to the calorimeters for analyses purposes. 


## TODOs (if applicable)

Later, other classes will be modified to make use of SvtxTrackInfo_v2 and SvtxTrackInfo_v3

