### PR TITLE
feat: cosmic track fitting

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -99,6 +99,8 @@ int TrackResiduals::InitRun(PHCompositeNode*)
 void TrackResiduals::clearClusterStateVectors()
 {
   m_cluskeys.clear();
+  m_clusphisize.clear();
+  m_cluszsize.clear();
   m_idealsurfcenterx.clear();
   m_idealsurfcentery.clear();
   m_idealsurfcenterz.clear();
@@ -805,7 +807,9 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   m_clusgy.push_back(clusglob.y());
   m_clusgz.push_back(clusglob.z());
   m_cluslayer.push_back(TrkrDefs::getLayer(ckey));
-  m_clussize.push_back(cluster->getPhiSize() + cluster->getZSize());
+  m_clusphisize.push_back(cluster->getPhiSize());
+  m_cluszsize.push_back(cluster->getZSize());
+  m_clussize.push_back(cluster->getPhiSize() * cluster->getZSize());
   m_clushitsetkey.push_back(TrkrDefs::getHitSetKeyFromClusKey(ckey));
 
   if (Verbosity() > 1)
@@ -1156,6 +1160,8 @@ void TrackResiduals::createBranches()
   m_tree->Branch("clusgz", &m_clusgz);
   m_tree->Branch("cluslayer", &m_cluslayer);
   m_tree->Branch("clussize", &m_clussize);
+  m_tree->Branch("clusphisize",&m_clusphisize);
+  m_tree->Branch("cluszsize",&m_cluszsize);
   m_tree->Branch("clushitsetkey", &m_clushitsetkey);
   m_tree->Branch("idealsurfcenterx", &m_idealsurfcenterx);
   m_tree->Branch("idealsurfcentery", &m_idealsurfcentery);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -171,6 +171,8 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_clusgz;
   std::vector<int> m_cluslayer;
   std::vector<int> m_clussize;
+  std::vector<int> m_clusphisize;
+  std::vector<int> m_cluszsize;
   std::vector<int> m_clusedge;
   std::vector<int> m_clusoverlap;
   std::vector<uint32_t> m_clushitsetkey;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -304,6 +304,10 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 								   crossing);
     sourceLinks.insert(sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end());
 
+  if(sourceLinks.size() == 0)
+  {
+    continue;
+  }
     int charge = 0;
     float cosmicslope = 0;
 
@@ -420,6 +424,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     if (Verbosity() > 2)
     {
+      std::cout << "Source link size " << sourceLinks.size() << std::endl;
       printTrackSeed(seed.value());
     }
 
@@ -857,6 +862,7 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed *tpcseed, TrackSeed* siseed)
       {
         continue;
       }
+      
       for(auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys();
 	  ++it)
 	{

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -64,9 +64,12 @@ namespace
     return x * x;
   }
 
- /// get radius from coordinates
-  template<class T> T radius(const T& x, const T& y)
-  { return std::sqrt(square(x) + square(y));}
+  /// get radius from coordinates
+  template <class T>
+  T radius(const T& x, const T& y)
+  {
+    return std::sqrt(square(x) + square(y));
+  }
 
 }  // namespace
 
@@ -135,13 +138,12 @@ int PHCosmicsTrkFitter::InitRun(PHCompositeNode* topNode)
     m_evaluator->verbosity(Verbosity());
   }
 
-  if(m_seedClusAnalysis)
-    {
-      m_outfile =  new TFile(m_evalname.c_str(),"RECREATE");
-      m_tree = new TTree("seedclustree","Tree with cosmic seeds and their clusters");
-      makeBranches();
-      
-    }
+  if (m_seedClusAnalysis)
+  {
+    m_outfile = new TFile(m_evalname.c_str(), "RECREATE");
+    m_tree = new TTree("seedclustree", "Tree with cosmic seeds and their clusters");
+    makeBranches();
+  }
 
   if (Verbosity() > 1)
   {
@@ -153,7 +155,6 @@ int PHCosmicsTrkFitter::InitRun(PHCompositeNode* topNode)
 
 int PHCosmicsTrkFitter::process_event(PHCompositeNode* topNode)
 {
-
   auto logLevel = Acts::Logging::FATAL;
 
   if (m_actsEvaluator)
@@ -213,16 +214,16 @@ int PHCosmicsTrkFitter::End(PHCompositeNode* /*topNode*/)
   {
     m_evaluator->End();
   }
-  if( m_seedClusAnalysis)
-    {
-      m_outfile->cd();
-      m_tree->Write();
-      m_outfile->Close();
-    }
+  if (m_seedClusAnalysis)
+  {
+    m_outfile->cd();
+    m_tree->Write();
+    m_outfile->Close();
+  }
   if (Verbosity() > 0)
   {
     std::cout << "The Acts track fitter succeeded " << m_nGoodFits
-    << " times and had " << m_nBadFits
+              << " times and had " << m_nBadFits
               << " fits return an error" << std::endl;
 
     std::cout << "Finished PHCosmicsTrkFitter" << std::endl;
@@ -282,43 +283,42 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     makeSourceLinks.set_pp_mode(false);
 
     makeSourceLinks.resetTransientTransformMap(
-						   m_alignmentTransformationMapTransient,
-						   m_transient_id_set,
-						   m_tGeometry);
+        m_alignmentTransformationMapTransient,
+        m_transient_id_set,
+        m_tGeometry);
 
     if (siseed)
     {
-       sourceLinks = makeSourceLinks.getSourceLinks(
-							     siseed, 
-							     measurements, 
-							     m_clusterContainer, 
-							     m_tGeometry, 
-							     m_alignmentTransformationMapTransient, 
-							     m_transient_id_set, 
-							     crossing);
+      sourceLinks = makeSourceLinks.getSourceLinks(
+          siseed,
+          measurements,
+          m_clusterContainer,
+          m_tGeometry,
+          m_alignmentTransformationMapTransient,
+          m_transient_id_set,
+          crossing);
     }
     const auto tpcSourceLinks = makeSourceLinks.getSourceLinks(
-								   tpcseed, 
-								   measurements, 
-								   m_clusterContainer, 
-								   m_tGeometry, 
-								   m_alignmentTransformationMapTransient, 
-								   m_transient_id_set, 
-								   crossing);
+        tpcseed,
+        measurements,
+        m_clusterContainer,
+        m_tGeometry,
+        m_alignmentTransformationMapTransient,
+        m_transient_id_set,
+        crossing);
     sourceLinks.insert(sourceLinks.end(), tpcSourceLinks.begin(), tpcSourceLinks.end());
 
-  if(sourceLinks.size() < 5)
-  {
-    continue;
-  }
+    if (sourceLinks.size() < 5)
+    {
+      continue;
+    }
     int charge = 0;
     float cosmicslope = 0;
 
     getCharge(tpcseed, charge, cosmicslope);
 
     // copy transient map for this track into transient geoContext
-    m_transient_geocontext =  m_alignmentTransformationMapTransient;
-	
+    m_transient_geocontext = m_alignmentTransformationMapTransient;
 
     tpcseed->circleFitByTaubin(m_clusterContainer, m_tGeometry, 0, 58);
 
@@ -342,28 +342,31 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       inty = std::get<3>(intersect);
     }
     std::vector<TrkrDefs::cluskey> keys;
-  std::vector<Acts::Vector3> clusPos;
-  std::copy(tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys(), std::back_inserter(keys));
-  TrackFitUtils::getTrackletClusters(m_tGeometry, m_clusterContainer,
-                                     clusPos, keys);
-  TrackFitUtils::position_vector_t xypoints, rzpoints;
-  for (auto& pos : clusPos)
-  {
-    float clusr = radius(pos.x(), pos.y());
-    if (pos.y() < 0) { clusr *= -1; }
-
-    // exclude silicon and tpot clusters for now
-    if (fabs(clusr) > 80 || fabs(clusr) < 30)
+    std::vector<Acts::Vector3> clusPos;
+    std::copy(tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys(), std::back_inserter(keys));
+    TrackFitUtils::getTrackletClusters(m_tGeometry, m_clusterContainer,
+                                       clusPos, keys);
+    TrackFitUtils::position_vector_t xypoints, rzpoints;
+    for (auto& pos : clusPos)
     {
-      continue;
-    }
-    xypoints.push_back(std::make_pair(pos.x(), pos.y()));
-    rzpoints.push_back(std::make_pair(pos.z(), clusr));
-  }
+      float clusr = radius(pos.x(), pos.y());
+      if (pos.y() < 0)
+      {
+        clusr *= -1;
+      }
 
-  auto rzparams = TrackFitUtils::line_fit(rzpoints);
-  float fulllineintz = std::get<1>(rzparams);
-  float fulllineslope = std::get<0>(rzparams);
+      // exclude silicon and tpot clusters for now
+      if (fabs(clusr) > 80 || fabs(clusr) < 30)
+      {
+        continue;
+      }
+      xypoints.push_back(std::make_pair(pos.x(), pos.y()));
+      rzpoints.push_back(std::make_pair(pos.z(), clusr));
+    }
+
+    auto rzparams = TrackFitUtils::line_fit(rzpoints);
+    float fulllineintz = std::get<1>(rzparams);
+    float fulllineslope = std::get<0>(rzparams);
 
     float slope = tpcseed->get_slope();
     float intz = m_vertexRadius * slope + tpcseed->get_Z0();
@@ -374,7 +377,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
                                  tpcseed->get_Z0()};
     auto tangent = TrackFitUtils::get_helix_tangent(tpcparams,
                                                     inter);
- 
+
     auto tan = tangent.second;
     auto pca = tangent.first;
 
@@ -396,26 +399,32 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     //! same with px/py since a single cosmic produces two seeds that bend
     //! in opposite directions
     float theta = std::atan(fulllineslope);
-     /// Normalize to 0<theta<pi
-     if (theta < 0)
-     {
-       theta += M_PI;
-     }
-     float pz = std::cos(theta) * p;
-     if(fulllineslope < 0) { pz = fabs(pz);}
-     else {pz = fabs(pz) * -1;}
-    Acts::Vector3 momentum = Acts::Vector3::Zero();
-
-    if(!m_zeroField)
+    /// Normalize to 0<theta<pi
+    if (theta < 0)
     {
-    momentum.x() = charge < 0 ? tan.x() : tan.x() * -1;
-    momentum.y() = charge < 0 ? tan.y() : tan.y() * -1;
+      theta += M_PI;
+    }
+    float pz = std::cos(theta) * p;
+    if (fulllineslope < 0)
+    {
+      pz = fabs(pz);
     }
     else
     {
-        auto xyparams = TrackFitUtils::line_fit(xypoints);
+      pz = fabs(pz) * -1;
+    }
+    Acts::Vector3 momentum = Acts::Vector3::Zero();
+
+    if (!m_zeroField)
+    {
+      momentum.x() = charge < 0 ? tan.x() : tan.x() * -1;
+      momentum.y() = charge < 0 ? tan.y() : tan.y() * -1;
+    }
+    else
+    {
+      auto xyparams = TrackFitUtils::line_fit(xypoints);
       float fulllineslopexy = std::get<0>(xyparams);
-      if(fulllineslopexy < 0)
+      if (fulllineslopexy < 0)
       {
         momentum.x() = fabs(tan.x());
       }
@@ -427,54 +436,56 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
     momentum.z() = pz;
-   Acts::Vector3 position(pca.x(), pca.y(),
-                           (m_vertexRadius-fulllineintz)/ fulllineslope);
+    Acts::Vector3 position(pca.x(), pca.y(),
+                           (m_vertexRadius - fulllineintz) / fulllineslope);
 
     position *= Acts::UnitConstants::cm;
-    if (!is_valid(momentum)) { continue; }
- 
+    if (!is_valid(momentum))
+    {
+      continue;
+    }
+
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         Acts::Vector3(0, m_vertexRadius * Acts::UnitConstants::cm, 0));
     auto actsFourPos = Acts::Vector4(position(0), position(1),
                                      position(2),
                                      10 * Acts::UnitConstants::ns);
- 
+
     Acts::BoundSquareMatrix cov = setDefaultCovariance();
-    if(m_seedClusAnalysis)
-      {
-	clearVectors();
-	m_seed = tpcid;
-	m_R = tpcR;
-	m_X0 = tpcx;
-	m_Y0 = tpcy;
-	m_Z0 = fulllineintz;
-	m_slope = fulllineslope;
-	m_pcax = position(0);
-	m_pcay = position(1);
-	m_pcaz = position(2);
-	m_px = momentum(0);
-	m_py = momentum(1);
-	m_pz = momentum(2);
-	m_charge = charge;
-	fillVectors(siseed, tpcseed);
-	m_tree->Fill();
-      }
+    if (m_seedClusAnalysis)
+    {
+      clearVectors();
+      m_seed = tpcid;
+      m_R = tpcR;
+      m_X0 = tpcx;
+      m_Y0 = tpcy;
+      m_Z0 = fulllineintz;
+      m_slope = fulllineslope;
+      m_pcax = position(0);
+      m_pcay = position(1);
+      m_pcaz = position(2);
+      m_px = momentum(0);
+      m_py = momentum(1);
+      m_pz = momentum(2);
+      m_charge = charge;
+      fillVectors(siseed, tpcseed);
+      m_tree->Fill();
+    }
     //! Reset the track seed with the dummy covariance
     auto seed = ActsTrackFittingAlgorithm::TrackParameters::create(
-                    pSurface,
-		    m_transient_geocontext,
-                    actsFourPos,
-                    momentum,
-                    charge / momentum.norm(),
-                    cov,
-                    Acts::ParticleHypothesis::muon(), 
-		    100*Acts::UnitConstants::cm);
-    if(!seed.ok())
-      { 
-	      std::cout << "Could not create track params, skipping track" << std::endl;
-	      continue;
-      }
-    
+        pSurface,
+        m_transient_geocontext,
+        actsFourPos,
+        momentum,
+        charge / momentum.norm(),
+        cov,
+        Acts::ParticleHypothesis::muon(),
+        100 * Acts::UnitConstants::cm);
+    if (!seed.ok())
+    {
+      std::cout << "Could not create track params, skipping track" << std::endl;
+      continue;
+    }
 
     if (Verbosity() > 0)
     {
@@ -505,8 +516,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         std::make_shared<Acts::VectorMultiTrajectory>();
     ActsTrackFittingAlgorithm::TrackContainer
         tracks(trackContainer, trackStateContainer);
-    auto result = fitTrack(sourceLinks, seed.value(), kfOptions, 
-			   calibrator, tracks);
+    auto result = fitTrack(sourceLinks, seed.value(), kfOptions,
+                           calibrator, tracks);
 
     /// Check that the track fit result did not return an error
     if (result.ok())
@@ -784,13 +795,13 @@ int PHCosmicsTrkFitter::createNodes(PHCompositeNode* topNode)
   }
 
   m_alignmentTransformationMapTransient = findNode::getClass<alignmentTransformationContainer>(topNode, "alignmentTransformationContainerTransient");
-  if(!m_alignmentTransformationMapTransient)
-    {
-      std::cout << PHWHERE << "alignmentTransformationContainerTransient not on node tree. Bailing"
-                << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  
+  if (!m_alignmentTransformationMapTransient)
+  {
+    std::cout << PHWHERE << "alignmentTransformationContainerTransient not on node tree. Bailing"
+              << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   if (m_actsEvaluator)
   {
     m_seedTracks = findNode::getClass<SvtxTrackMap>(topNode, _seed_track_map_name);
@@ -871,89 +882,85 @@ int PHCosmicsTrkFitter::getNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-
 void PHCosmicsTrkFitter::makeBranches()
 {
-  m_tree->Branch("seed",&m_seed,"m_seed/I");
-  m_tree->Branch("event",&m_event,"m_event/I");
-  m_tree->Branch("R",&m_R,"m_R/F");
-  m_tree->Branch("X0",&m_X0,"m_X0/F");
-  m_tree->Branch("Y0",&m_Y0,"m_Y0/F");
-  m_tree->Branch("Z0",&m_Z0,"m_Z0/F");
-  m_tree->Branch("slope",&m_slope,"m_slope/F");
-  m_tree->Branch("pcax",&m_pcax,"m_pcax/F");
-  m_tree->Branch("pcay",&m_pcay,"m_pcay/F");
-  m_tree->Branch("pcaz",&m_pcaz,"m_pcaz/F");
-  m_tree->Branch("px",&m_px,"m_px/F");
-  m_tree->Branch("py",&m_py,"m_py/F");
-  m_tree->Branch("pz",&m_pz,"m_pz/F");
-  m_tree->Branch("charge",&m_charge,"m_charge/I");
-  m_tree->Branch("nmaps",&m_nmaps,"m_nmaps/I");
-  m_tree->Branch("nintt",&m_nintt,"m_nintt/I");
-  m_tree->Branch("ntpc",&m_ntpc,"m_ntpc/I");
-  m_tree->Branch("nmm",&m_nmm,"m_nmm/I");
-  m_tree->Branch("locx",&m_locx);
-  m_tree->Branch("locy",&m_locy);
-  m_tree->Branch("x",&m_x);
-  m_tree->Branch("y",&m_y);
-  m_tree->Branch("z",&m_z);
-  m_tree->Branch("r",&m_r);
-  m_tree->Branch("layer",&m_layer);
-  m_tree->Branch("phi",&m_phi);
-  m_tree->Branch("eta",&m_eta);
-  m_tree->Branch("phisize",&m_phisize);
-  m_tree->Branch("zsize",&m_zsize);
-  m_tree->Branch("ephi",&m_ephi);
-  m_tree->Branch("ez",&m_ez);
-
-
-
+  m_tree->Branch("seed", &m_seed, "m_seed/I");
+  m_tree->Branch("event", &m_event, "m_event/I");
+  m_tree->Branch("R", &m_R, "m_R/F");
+  m_tree->Branch("X0", &m_X0, "m_X0/F");
+  m_tree->Branch("Y0", &m_Y0, "m_Y0/F");
+  m_tree->Branch("Z0", &m_Z0, "m_Z0/F");
+  m_tree->Branch("slope", &m_slope, "m_slope/F");
+  m_tree->Branch("pcax", &m_pcax, "m_pcax/F");
+  m_tree->Branch("pcay", &m_pcay, "m_pcay/F");
+  m_tree->Branch("pcaz", &m_pcaz, "m_pcaz/F");
+  m_tree->Branch("px", &m_px, "m_px/F");
+  m_tree->Branch("py", &m_py, "m_py/F");
+  m_tree->Branch("pz", &m_pz, "m_pz/F");
+  m_tree->Branch("charge", &m_charge, "m_charge/I");
+  m_tree->Branch("nmaps", &m_nmaps, "m_nmaps/I");
+  m_tree->Branch("nintt", &m_nintt, "m_nintt/I");
+  m_tree->Branch("ntpc", &m_ntpc, "m_ntpc/I");
+  m_tree->Branch("nmm", &m_nmm, "m_nmm/I");
+  m_tree->Branch("locx", &m_locx);
+  m_tree->Branch("locy", &m_locy);
+  m_tree->Branch("x", &m_x);
+  m_tree->Branch("y", &m_y);
+  m_tree->Branch("z", &m_z);
+  m_tree->Branch("r", &m_r);
+  m_tree->Branch("layer", &m_layer);
+  m_tree->Branch("phi", &m_phi);
+  m_tree->Branch("eta", &m_eta);
+  m_tree->Branch("phisize", &m_phisize);
+  m_tree->Branch("zsize", &m_zsize);
+  m_tree->Branch("ephi", &m_ephi);
+  m_tree->Branch("ez", &m_ez);
 }
-void PHCosmicsTrkFitter::fillVectors(TrackSeed *tpcseed, TrackSeed* siseed)
+void PHCosmicsTrkFitter::fillVectors(TrackSeed* tpcseed, TrackSeed* siseed)
 {
-  for(auto seed : {tpcseed, siseed})
+  for (auto seed : {tpcseed, siseed})
+  {
+    if (!seed)
     {
-      if(!seed)
-      {
-        continue;
-      }
-      
-      for(auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys();
-	  ++it)
-	{
-	  auto key = *it;
-	  auto cluster = m_clusterContainer->findCluster(key);
-	  m_locx.push_back(cluster->getLocalX());
-	  float ly = cluster->getLocalY();
-	  if(TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::tpcId)
-	    {
-	      double drift_velocity = m_tGeometry->get_drift_velocity();
-	      double zdriftlength = cluster->getLocalY() * drift_velocity;
-	      double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
-	      double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
-	      unsigned int side = TpcDefs::getSide(key);
-	      if (side == 0) zloc = -zloc;
-	      ly = zloc * 10;  
-	    }
-	  m_locy.push_back(ly);
-	  auto glob = m_tGeometry->getGlobalPosition(key, cluster);
-	  m_x.push_back(glob.x());
-	  m_y.push_back(glob.y());
-	  m_z.push_back(glob.z());
-	  float r = std::sqrt(glob.x()*glob.x()+glob.y()*glob.y());
-	  m_r.push_back(r);
-	  TVector3 globt(glob.x(), glob.y(), glob.z());
-	  m_phi.push_back(globt.Phi());
-	  m_eta.push_back(globt.Eta());
-	  m_phisize.push_back(cluster->getPhiSize());
-	  m_zsize.push_back(cluster->getZSize());
-	  auto para_errors = 
-	    m_clusErrPara.get_clusterv5_modified_error(cluster,r , key);
-
-	  m_ephi.push_back(std::sqrt(para_errors.first));
-	  m_ez.push_back(std::sqrt(para_errors.second));
-	}
+      continue;
     }
+
+    for (auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys();
+         ++it)
+    {
+      auto key = *it;
+      auto cluster = m_clusterContainer->findCluster(key);
+      m_locx.push_back(cluster->getLocalX());
+      float ly = cluster->getLocalY();
+      if (TrkrDefs::getTrkrId(key) == TrkrDefs::TrkrId::tpcId)
+      {
+        double drift_velocity = m_tGeometry->get_drift_velocity();
+        double zdriftlength = cluster->getLocalY() * drift_velocity;
+        double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
+        double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
+        unsigned int side = TpcDefs::getSide(key);
+        if (side == 0) zloc = -zloc;
+        ly = zloc * 10;
+      }
+      m_locy.push_back(ly);
+      auto glob = m_tGeometry->getGlobalPosition(key, cluster);
+      m_x.push_back(glob.x());
+      m_y.push_back(glob.y());
+      m_z.push_back(glob.z());
+      float r = std::sqrt(glob.x() * glob.x() + glob.y() * glob.y());
+      m_r.push_back(r);
+      TVector3 globt(glob.x(), glob.y(), glob.z());
+      m_phi.push_back(globt.Phi());
+      m_eta.push_back(globt.Eta());
+      m_phisize.push_back(cluster->getPhiSize());
+      m_zsize.push_back(cluster->getZSize());
+      auto para_errors =
+          m_clusErrPara.get_clusterv5_modified_error(cluster, r, key);
+
+      m_ephi.push_back(std::sqrt(para_errors.first));
+      m_ez.push_back(std::sqrt(para_errors.second));
+    }
+  }
 }
 void PHCosmicsTrkFitter::clearVectors()
 {
@@ -973,53 +980,55 @@ void PHCosmicsTrkFitter::clearVectors()
 }
 
 void PHCosmicsTrkFitter::getCharge(
-				TrackSeed* track,
-				//TrkrClusterContainer*  clusterContainer,
-				//ActsGeometry* tGeometry,
-				//alignmentTransformationContainer* transformMapTransient,
-				//float vertexRadius,
-				int& charge,
-				float& cosmicslope )
+    TrackSeed* track,
+    // TrkrClusterContainer*  clusterContainer,
+    // ActsGeometry* tGeometry,
+    // alignmentTransformationContainer* transformMapTransient,
+    // float vertexRadius,
+    int& charge,
+    float& cosmicslope)
 {
-
   Acts::GeometryContext transient_geocontext;
-  transient_geocontext =   m_alignmentTransformationMapTransient;  // set local/global transforms to distortion corrected ones for this track
+  transient_geocontext = m_alignmentTransformationMapTransient;  // set local/global transforms to distortion corrected ones for this track
 
   std::vector<Acts::Vector3> global_vec;
 
   for (auto clusIter = track->begin_cluster_keys();
        clusIter != track->end_cluster_keys();
        ++clusIter)
+  {
+    auto key = *clusIter;
+    auto cluster = m_clusterContainer->findCluster(key);
+    if (!cluster)
     {
-      auto key = *clusIter;
-      auto cluster = m_clusterContainer->findCluster(key);
-      if (!cluster)
-	{
-	  std::cout << "MakeSourceLinks::getCharge: Failed to get cluster with key " << key << " for track seed" << std::endl;
-	  continue;
-	}
-      
-      auto surf = m_tGeometry->maps().getSurface(key, cluster);
-      if (!surf)    {  continue; }
-      
-      // get cluster global positions
-      Acts::Vector2 local = m_tGeometry->getLocalCoords(key, cluster);  // converts TPC time to z
-      Acts::Vector3 glob = surf->localToGlobal(transient_geocontext,
-				    local * Acts::UnitConstants::cm,
-				    Acts::Vector3(1,1,1));
-      glob /= Acts::UnitConstants::cm;
-
-      global_vec.push_back(glob);
+      std::cout << "MakeSourceLinks::getCharge: Failed to get cluster with key " << key << " for track seed" << std::endl;
+      continue;
     }
 
- Acts::Vector3 globalMostOuter;
+    auto surf = m_tGeometry->maps().getSurface(key, cluster);
+    if (!surf)
+    {
+      continue;
+    }
+
+    // get cluster global positions
+    Acts::Vector2 local = m_tGeometry->getLocalCoords(key, cluster);  // converts TPC time to z
+    Acts::Vector3 glob = surf->localToGlobal(transient_geocontext,
+                                             local * Acts::UnitConstants::cm,
+                                             Acts::Vector3(1, 1, 1));
+    glob /= Acts::UnitConstants::cm;
+
+    global_vec.push_back(glob);
+  }
+
+  Acts::Vector3 globalMostOuter;
   Acts::Vector3 globalSecondMostOuter(0, 999999, 0);
   float largestR = 0;
   // loop over global positions
   for (int i = 0; i < global_vec.size(); ++i)
   {
     Acts::Vector3 global = global_vec[i];
-    //float r = std::sqrt(square(global.x()) + square(global.y()));
+    // float r = std::sqrt(square(global.x()) + square(global.y()));
     float r = radius(global.x(), global.y());
 
     /// use the top hemisphere to determine the charge
@@ -1033,48 +1042,47 @@ void PHCosmicsTrkFitter::getCharge(
   //! find the closest cluster to the outermost cluster
   float maxdr = std::numeric_limits<float>::max();
   for (int i = 0; i < global_vec.size(); i++)
+  {
+    if (global_vec[i].y() < 0) continue;
+
+    float dr = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y())) - std::sqrt(square(global_vec[i].x()) + square(global_vec[i].y()));
+    //! Place a dr cut to get maximum bend due to TPC clusters having
+    //! larger fluctuations
+    if (dr < maxdr && dr > 10)
     {
-      if (global_vec[i].y() < 0) continue;
-      
-      float dr = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y())) - std::sqrt(square(global_vec[i].x()) + square(global_vec[i].y()));
-      //! Place a dr cut to get maximum bend due to TPC clusters having
-      //! larger fluctuations
-      if (dr < maxdr && dr > 10)
-	{
-	  maxdr = dr;
-	  globalSecondMostOuter = global_vec[i];
-	}
+      maxdr = dr;
+      globalSecondMostOuter = global_vec[i];
     }
-  
+  }
+
   //! we have to calculate phi WRT the vertex position outside the detector,
   //! not at (0,0)
   Acts::Vector3 vertex(0, m_vertexRadius, 0);
   globalMostOuter -= vertex;
   globalSecondMostOuter -= vertex;
-  
+
   const auto firstphi = atan2(globalMostOuter.y(), globalMostOuter.x());
   const auto secondphi = atan2(globalSecondMostOuter.y(),
-			       globalSecondMostOuter.x());
+                               globalSecondMostOuter.x());
   auto dphi = secondphi - firstphi;
-  
+
   if (dphi > M_PI) dphi = 2. * M_PI - dphi;
   if (dphi < -M_PI) dphi = 2 * M_PI + dphi;
-  
+
   if (dphi > 0)
-    {
-      charge = -1;
-    }
+  {
+    charge = -1;
+  }
   else
-    {
-      charge = 1;
-    }
-  
+  {
+    charge = 1;
+  }
+
   float r1 = std::sqrt(square(globalMostOuter.x()) + square(globalMostOuter.y()));
   float r2 = std::sqrt(square(globalSecondMostOuter.x()) + square(globalSecondMostOuter.y()));
   float z1 = globalMostOuter.z();
   float z2 = globalSecondMostOuter.z();
   cosmicslope = (r2 - r1) / (z2 - z1);
-  
+
   return;
 }
-

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -853,6 +853,10 @@ void PHCosmicsTrkFitter::fillVectors(TrackSeed *tpcseed, TrackSeed* siseed)
 {
   for(auto seed : {tpcseed, siseed})
     {
+      if(!seed)
+      {
+        continue;
+      }
       for(auto it = seed->begin_cluster_keys(); it != seed->end_cluster_keys();
 	  ++it)
 	{

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -219,7 +219,7 @@ int PHCosmicsTrkFitter::End(PHCompositeNode* /*topNode*/)
     std::cout << "The Acts track fitter succeeded " << m_nGoodFits
               << " times and had " << m_nBadFits
               << " fits return an error" << std::endl;
-
+    std::cout << "There were " << m_nLongSeeds << " long seeds" << std::endl;
     std::cout << "Finished PHCosmicsTrkFitter" << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
@@ -444,11 +444,16 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     }
 
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
-        Acts::Vector3(0, m_vertexRadius * Acts::UnitConstants::cm, 0));
+        position);
     auto actsFourPos = Acts::Vector4(position(0), position(1),
                                      position(2),
                                      10 * Acts::UnitConstants::ns);
 
+
+    if (sourceLinks.size() > 20)
+    {
+      m_nLongSeeds++;
+    }
     Acts::BoundSquareMatrix cov = setDefaultCovariance();
     if (m_seedClusAnalysis)
     {

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -268,9 +268,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       continue;
     }
 
-    if (Verbosity() > 0)
+    if (Verbosity() > 1)
     {
-      if (siseed) std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
       std::cout << " tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
     }
 
@@ -395,12 +394,17 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     //! the full cosmic track
     //! same with px/py since a single cosmic produces two seeds that bend
     //! in opposite directions
-
+    float theta = std::atan(1. / fulllineslope);
+     /// Normalize to 0<theta<pi
+     if (theta < 0)
+     {
+       theta += M_PI;
+     }
+     float pz = std::cos(theta) * p;
     Acts::Vector3 momentum(charge < 0 ? tan.x() : tan.x() * -1,
                            charge < 0 ? tan.y() : tan.y() * -1,
-                           cosmicslope > 0 ? fabs(tan.z()) : -1 * fabs(tan.z()));
-   std::cout << "pca " << pca.transpose() << std::endl << " and pcaz "
-   << (m_vertexRadius-fulllineintz) / fulllineslope << std::endl;
+                           pz);
+
    Acts::Vector3 position(pca.x(), pca.y(),
                            (m_vertexRadius-fulllineintz)/ fulllineslope);
 
@@ -421,8 +425,8 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 	m_R = tpcR;
 	m_X0 = tpcx;
 	m_Y0 = tpcy;
-	m_Z0 = tpcseed->get_Z0();
-	m_slope = slope;
+	m_Z0 = fulllineintz;
+	m_slope = fulllineslope;
 	m_pcax = position(0);
 	m_pcay = position(1);
 	m_pcaz = position(2);
@@ -450,7 +454,7 @@ void PHCosmicsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       }
     
 
-    if (Verbosity() > 2)
+    if (Verbosity() > 0)
     {
       std::cout << "Source link size " << sourceLinks.size() << std::endl;
       printTrackSeed(seed.value());

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -155,7 +155,6 @@ class PHCosmicsTrkFitter : public SubsysReco
   TrackSeedContainer* m_siliconSeeds = nullptr;
 
   // Used for distortion correction transformations
-  alignmentTransformationContainer* m_alignmentTransformationMap = nullptr;  // added for testing purposes
   alignmentTransformationContainer* m_alignmentTransformationMapTransient = nullptr;
   std::set<Acts::GeometryIdentifier> m_transient_id_set;
   Acts::GeometryContext m_transient_geocontext;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -163,6 +163,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   /// Number of acts fits that returned an error
   int m_nBadFits = 0;
   int m_nGoodFits = 0;
+  int m_nLongSeeds = 0;
   //! bool to fill alignment state map for further processing
   bool m_commissioning = true;
 

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -100,7 +100,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   void ignoreLayer(int layer) { m_ignoreLayer.insert(layer); }
   void setVertexRadius(const float rad) { m_vertexRadius = rad; }
 
-  void getCharge(TrackSeed* track, int& charge, float& cosmicslope );
+  void getCharge(TrackSeed* track, int& charge, float& cosmicslope);
 
  private:
   /// Get all the nodes
@@ -167,7 +167,7 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   /// Number of acts fits that returned an error
   int m_nBadFits = 0;
-
+  int m_nGoodFits = 0;
   //! bool to fill alignment state map for further processing
   bool m_commissioning = true;
 
@@ -217,8 +217,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   //! for diagnosing seed param + clusters
   bool m_seedClusAnalysis = false;
-  std::unique_ptr<TFile> m_outfile = nullptr;
-  std::unique_ptr<TTree> m_tree = nullptr;
+  TFile* m_outfile = nullptr;
+  TTree* m_tree = nullptr;
   int m_seed = std::numeric_limits<int>::max();
   float m_R = NAN;
   float m_X0 = NAN;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -99,9 +99,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   void ignoreLayer(int layer) { m_ignoreLayer.insert(layer); }
   void setVertexRadius(const float rad) { m_vertexRadius = rad; }
-
-  void getCharge(TrackSeed* track, int& charge, float& cosmicslope);
-
+  void zeroField() { m_zeroField = true; }
+ 
  private:
   /// Get all the nodes
   int getNodes(PHCompositeNode* topNode);
@@ -110,13 +109,8 @@ class PHCosmicsTrkFitter : public SubsysReco
   int createNodes(PHCompositeNode* topNode);
 
   void loopTracks(Acts::Logging::Level logLevel);
-
-  //  SourceLinkVec getSourceLinks(TrackSeed* track,
-  //                         ActsTrackFittingAlgorithm::MeasurementContainer& measurements,
-  //                         short int crossing,
-  //                         int& charge,
-  //                         float& cosmicslope);
-
+  void getCharge(TrackSeed* track, int& charge, float& cosmicslope);
+  
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(std::vector<Acts::MultiTrajectoryTraits::IndexType>& tips,
                        Trajectory::IndexedParameters& paramsMap,
@@ -214,6 +208,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
   ActsAlignmentStates m_alignStates;
 
+  bool m_zeroField = false;
 
   //! for diagnosing seed param + clusters
   bool m_seedClusAnalysis = false;

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -78,8 +78,8 @@ class PHCosmicsTrkFitter : public SubsysReco
     m_actsEvaluator = actsEvaluator;
   }
 
-  void setEvaluatorName(const std::string &name) { m_evalname = name; }
-  void setFieldMap(const std::string &fieldMap)
+  void setEvaluatorName(const std::string& name) { m_evalname = name; }
+  void setFieldMap(const std::string& fieldMap)
   {
     m_fieldMap = fieldMap;
   }
@@ -100,7 +100,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   void ignoreLayer(int layer) { m_ignoreLayer.insert(layer); }
   void setVertexRadius(const float rad) { m_vertexRadius = rad; }
   void zeroField() { m_zeroField = true; }
- 
+
  private:
   /// Get all the nodes
   int getNodes(PHCompositeNode* topNode);
@@ -110,7 +110,7 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   void loopTracks(Acts::Logging::Level logLevel);
   void getCharge(TrackSeed* track, int& charge, float& cosmicslope);
-  
+
   /// Convert the acts track fit result to an svtx track
   void updateSvtxTrack(std::vector<Acts::MultiTrajectoryTraits::IndexType>& tips,
                        Trajectory::IndexedParameters& paramsMap,
@@ -155,8 +155,8 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   // Used for distortion correction transformations
   alignmentTransformationContainer* m_alignmentTransformationMap = nullptr;  // added for testing purposes
-  alignmentTransformationContainer* m_alignmentTransformationMapTransient = nullptr;  
-  std::set< Acts::GeometryIdentifier> m_transient_id_set;
+  alignmentTransformationContainer* m_alignmentTransformationMapTransient = nullptr;
+  std::set<Acts::GeometryIdentifier> m_transient_id_set;
   Acts::GeometryContext m_transient_geocontext;
 
   /// Number of acts fits that returned an error
@@ -197,7 +197,6 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   std::string m_fieldMap = "";
 
-
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
   std::string _seed_track_map_name = "SeedTrackMap";
@@ -231,12 +230,11 @@ class PHCosmicsTrkFitter : public SubsysReco
   int m_nintt = std::numeric_limits<int>::max();
   int m_ntpc = std::numeric_limits<int>::max();
   int m_nmm = std::numeric_limits<int>::max();
-  std::vector<float> m_locx, m_locy, m_x, m_y, m_z, m_r, m_layer,m_phi, m_eta, 
-    m_phisize, m_zsize, m_ephi, m_ez;
+  std::vector<float> m_locx, m_locy, m_x, m_y, m_z, m_r, m_layer, m_phi, m_eta,
+      m_phisize, m_zsize, m_ephi, m_ez;
   void clearVectors();
-  void fillVectors(TrackSeed* tpcseed, TrackSeed *siseed);
+  void fillVectors(TrackSeed* tpcseed, TrackSeed* siseed);
   ClusterErrorPara m_clusErrPara;
-
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR gets the Acts Kalman Filter in shape to run on the cosmic data. We can now build tracks and fit them with the Kalman Filter to get real cluster-state residuals as determined by Acts. Tested on zero field data, when we start taking field on cosmics we will have to retune to ensure the charge and circle fit determination is functional in the same way as it is for zero field. Attached are some (cherry picked) examples from run 25926 and segment 15 that show
1. Red - all clusters in the event
2. Blue lines - initial track seed momentum and PCA at perigee surface of radius of 80 cm, for input to Acts
3. Black - clusters that were successfully included in the KF fit by Acts

event 11
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/c5206002-89d7-4a67-ac8b-1a05e9e0eb0f)
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/985f2ad1-3db2-48d1-87d8-ece9ae3c1747)

event 29
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/0a642ae1-516a-4432-a2e8-1eb1fa0aa996)
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/e9f1f0c7-437b-47c8-beff-acde5911d96b)

event 50
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/f2e3c2d4-584e-42d9-9dd6-47af3c8de3ce)
![image](https://github.com/sPHENIX-Collaboration/coresoftware/assets/53052717/e485bbc1-a375-4750-b07a-85e022bebaaf)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

