### PR TITLE
fix: streaming/triggered lz

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -794,9 +794,14 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::tpcId)
   {
     float rawclusz = convertTimeToZ(geometry, ckey, cluster);
+    
     int crossing = track->get_crossing();
     unsigned int side = TpcDefs::getSide(ckey);
     clusz = m_clusterCrossingCorrection.correctZ(rawclusz, side, crossing);
+    if(!m_ppmode)
+    {
+      cluslz = rawclusz;
+    }
   }
 
   m_cluslz.push_back(clusz);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -800,7 +800,7 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     clusz = m_clusterCrossingCorrection.correctZ(rawclusz, side, crossing);
     if(!m_ppmode)
     {
-      cluslz = rawclusz;
+      clusz = rawclusz;
     }
   }
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -45,6 +45,7 @@ class TrackResiduals : public SubsysReco
   void trackmapName(const std::string &name) { m_trackMapName = name; }
   void clusterTree() { m_doClusters = true; }
   void hitTree() { m_doHits = true; }
+  void ppmode() { m_ppmode = true;}
   void zeroField() { m_zeroField = true; }
   void runnumber(const int run) { m_runnumber = run; }
   void segment(const int seg) { m_segment = seg; }
@@ -84,7 +85,8 @@ class TrackResiduals : public SubsysReco
   std::string m_trackMapName = "SvtxTrackMap";
 
   bool m_doAlignment = false;
-
+  bool m_ppmode = false;
+  
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();
   int m_runnumber = std::numeric_limits<int>::quiet_NaN();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Fixes a bug that was introduced in the streaming reco development which returns NANs for cluster lzs in the cosmics data since we don't have a crossing defined.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

