### PR TITLE
DecayFinder: Patched logic error in print out

### DIFF
--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -843,9 +843,8 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
             if (Verbosity() >= VERBOSITY_MAX)
             {
               std::cout << "pT = " << myFourVector.perp() << ", eta = " << myFourVector.eta() << std::endl;
-              std::string ptPass = trackFailedPT ? "passed" : "failed";
-              std::string etaPass = trackFailedETA ? "passed" : "failed";
-              std::cout << "The track " << ptPass << " the pT requirement, the track " << etaPass << " the eta requirement." << std::endl;
+              std::cout << "The track " << passOrFail(myFourVector.perp() >= m_pt_req) << " the pT requirement, ";
+              std::cout << "the track " << passOrFail(isInRange(m_eta_low_req, myFourVector.eta(), m_eta_high_req)) << " the eta requirement." << std::endl;
             }
           }
         }
@@ -885,9 +884,8 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
         if (Verbosity() >= VERBOSITY_MAX)
         {
           std::cout << "pT = " << myFourVector.perp() << ", eta = " << myFourVector.eta() << std::endl;
-          std::string ptPass = trackFailedPT ? "passed" : "failed";
-          std::string etaPass = trackFailedETA ? "passed" : "failed";
-          std::cout << "The track " << ptPass << " the pT requirement, the track " << etaPass << " the eta requirement." << std::endl;
+          std::cout << "The track " << passOrFail(myFourVector.perp() >= m_pt_req) << " the pT requirement, ";
+          std::cout << "the track " << passOrFail(isInRange(m_eta_low_req, myFourVector.eta(), m_eta_high_req)) << " the eta requirement." << std::endl;
         }
       }
     }
@@ -925,9 +923,8 @@ bool DecayFinder::checkIfCorrectHepMCParticle(HepMC::GenParticle* particle, bool
     if (Verbosity() >= VERBOSITY_MAX)
     {
       std::cout << "pT = " << myFourVector.perp() << ", eta = " << myFourVector.eta() << std::endl;
-      std::string ptPass = trackFailedPT ? "passed" : "failed";
-      std::string etaPass = trackFailedETA ? "passed" : "failed";
-      std::cout << "The track " << ptPass << " the pT requirement, the track " << etaPass << " the eta requirement." << std::endl;
+      std::cout << "The track " << passOrFail(myFourVector.perp() >= m_pt_req) << " the pT requirement, ";
+      std::cout << "the track " << passOrFail(isInRange(m_eta_low_req, myFourVector.eta(), m_eta_high_req)) << " the eta requirement." << std::endl;
     }
     acceptParticle = true;
   }
@@ -1021,9 +1018,8 @@ bool DecayFinder::checkIfCorrectGeant4Particle(PHG4Particle* particle, bool& has
     if (Verbosity() >= VERBOSITY_MAX)
     {
       std::cout << "pT = " << pt << ", eta = " << eta << std::endl;
-      std::string ptPass = trackFailedPT ? "passed" : "failed";
-      std::string etaPass = trackFailedETA ? "passed" : "failed";
-      std::cout << "The track " << ptPass << " the pT requirement, the track " << etaPass << " the eta requirement." << std::endl;
+      std::cout << "The track " << passOrFail(pt >= m_pt_req) << " the pT requirement, ";
+      std::cout << "the track " << passOrFail(isInRange(m_eta_low_req, eta, m_eta_high_req)) << " the eta requirement." << std::endl;
     }
 
     acceptParticle = true;
@@ -1304,4 +1300,9 @@ void DecayFinder::printNode(PHCompositeNode* topNode)
     }
   }
   std::cout << "--------------------------------------------------------------------------------------------------" << std::endl;
+}
+
+std::string DecayFinder::passOrFail(bool condition)
+{
+  return condition ? "passed" : "failed";
 }

--- a/offline/packages/decayfinder/DecayFinder.h
+++ b/offline/packages/decayfinder/DecayFinder.h
@@ -150,6 +150,8 @@ class DecayFinder : public SubsysReco
    */
   void useDecaySpecificEtaRange(bool use) { m_recalcualteEtaRange = use; }
 
+  std::string passOrFail(bool condition);
+
  private:
   PHHepMCGenEventMap *m_geneventmap = nullptr;
   PHHepMCGenEvent *m_genevt = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

There was a logic error in a high verbosity print out in decay finder. The logic was both backwards and checked a variable global to a decay instead of local to a track. This had been fixed a couple of weeks ago but I forgot to make the PR

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

