### PR TITLE
DF: Remove resonant mothers

### DIFF
--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -331,6 +331,8 @@ bool DecayFinder::findDecay(PHCompositeNode* topNode)
     n = deleteElement(listOfResonantPIDs, n, i);
   }
 
+  n = deleteElement(listOfResonantPIDs, n, m_mother_ID);
+
   for (int m_motherDecayProduct : m_motherDecayProducts)
   {
     positive_motherDecayProducts.push_back(std::abs(m_motherDecayProduct));


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Some mothers can be tagged twice as a decay if they have a radiative correction. This only applies to resonant mothers like upsilons, phis and J/psi. There was a check for radiative or resonant decays but this only applied to intermediate states. This has been extended to cover reonant mothers tool

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

