### PR TITLE
Made INTT unpacker work standalone

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataDecoder.h
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.h
@@ -11,6 +11,7 @@
 #include <string>
 
 class PHCompositeNode;
+class InttEventInfo;
 
 class InttCombinedRawDataDecoder : public SubsysReco
 {
@@ -23,10 +24,17 @@ class InttCombinedRawDataDecoder : public SubsysReco
   int LoadHotChannelMapLocal(std::string const& = "INTT_HotChannelMap.root");
   int LoadHotChannelMapRemote(std::string const& = "INTT_HotChannelMap");
 
+  void runInttStandalone(bool runAlone) { m_runStandAlone = runAlone; }
+
+  void writeInttEventHeader(bool write) { m_writeInttEventHeader = write; }
+
  private:
+  InttEventInfo* intt_event_header = nullptr;
   std::string m_InttRawNodeName = "INTTRAWHIT";
   typedef std::set<InttNameSpace::RawData_s, InttNameSpace::RawDataComparator> Set_t;
   Set_t m_HotChannelSet;
+  bool m_runStandAlone = false;
+  bool m_writeInttEventHeader = false;
 };
 
 #endif  // INTT_COMBINEDRAWDATADECODER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I added some flags to allow the INTT unpacker to work standalone. This is for the dN/deta and v_n analyses which will make separate INTT and centrality nTuples then combine them offline. This will allow analysers to use the latest sPHENIX software.

I tested the INTT combiner macro in https://github.com/sPHENIX-Collaboration/macros/blob/master/InttProduction/Fun4All_Intt_Combiner.C which would work if I set
```c++
sngl->SetNegativeBco(0);
```
and give me a DST with raw hits. However, when I added 
```c++
InttCombinedRawDataDecoder *myDecoder = new InttCombinedRawDataDecoder("myUnpacker");
```
then I would get an abort event as ```GL1RawHit``` is missing. I assume this will always fail without running through the official combiner.

The flags are defaulted to ensure the standard running where it looks for ```GL1RawHit```. 

The other flag writes the INTT event info to get a single BCO which is needed to sync to the MBD FEM clock
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

