### PR TITLE
KFP: Truth matching bug fix

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -264,7 +264,7 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
 
     PHG4VtxPoint *truePoint = vertexeval->max_truth_point_by_ntracks(svtxvertex);
 
-    if (truePoint == nullptr)
+    if (truePoint == nullptr && isParticleValid)
     {
       PHG4Particle *g4mother = m_truthinfo->GetPrimaryParticle(g4particle->get_primary_id());
       truePoint = m_truthinfo->GetVtx(g4mother->get_vtx_id());  // Note, this may not be the PV for a decay with tertiaries


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
@josephbertaux uncovered a bug in a truth vertex matching addition where I would try to associate a truth particle to a truth vertex without checking if the truth particle was valid. This would cause a segfault and has been patched
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

