### PR TITLE
KFP: fix bugs about double loop of daughter combination

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -569,7 +569,7 @@ float KFParticle_Tools::flightDistanceChi2(const KFParticle &particle, const KFP
   return m_chi2Value(0, 0);
 }
 
-std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters[], std::string daughterOrder[],
+std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters[], int daughterOrder[],
                                                            bool isIntermediate, int intermediateNumber, int nTracks,
                                                            bool constrainMass, float required_vertexID)
 {
@@ -592,17 +592,43 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   for (int i = 0; i < nTracks; ++i)
   {
     float daughterMass = 0;
-    daughterMass = constrainMass ? getParticleMass(daughterOrder[i].c_str()) : vDaughters[i].GetMass();
+
+    if ((Int_t) vDaughters[i].GetQ() != 0)
+    {
+      // For charged particle, like p+/-, pi+/-, Sigma+/-, etc...
+      // different charged particle has different PDGID
+      // just to protect if they have different mass for different charge
+      // but in EvtGen, there is no C-violation...so this is just a protection
+      daughterMass = constrainMass ? getParticleMass(vDaughters[i].GetQ()*daughterOrder[i]) : vDaughters[i].GetMass();
+    }
+    else if ((Int_t) vDaughters[i].GetQ() == 0)
+    {
+      // For neutral particle, like pi0, eta, J/psi, etc... who do not have an anti-particle with anti-PDGID
+      // and other neutral particle, like Lambda0/anti-Lambda0 ... who have an anti-particle with anti-PDGID
+      // avoid charge*PDGID=0 case and getting wrong mass
+      daughterMass = constrainMass ? getParticleMass(daughterOrder[i]) : vDaughters[i].GetMass();
+
+      std::cout<<"daughterMass = "<<daughterMass<<" , constrainMass = "<<constrainMass<<" , getParticleMass(daughterOrder[i]) = "<<getParticleMass(daughterOrder[i])<<" , vDaughters[i].GetMass() = "<<vDaughters[i].GetMass()<<std::endl;
+    }
+
     if ((num_remaining_tracks > 0 && i >= m_num_intermediate_states) || isIntermediate)
     {
-      daughterMass = getParticleMass(daughterOrder[i].c_str());
+      if ((Int_t) vDaughters[i].GetQ() != 0)
+      {
+        daughterMass = getParticleMass(vDaughters[i].GetQ()*daughterOrder[i]);
+      }
+      else if ((Int_t) vDaughters[i].GetQ() == 0)
+      {
+        daughterMass = getParticleMass(daughterOrder[i]);
+      }
+
     }
     inputTracks[i].Create(vDaughters[i].Parameters(),
                           vDaughters[i].CovarianceMatrix(),
                           (Int_t) vDaughters[i].GetQ(),
                           daughterMass);
     mother.AddDaughter(inputTracks[i]);
-    unique_vertexID += vDaughters[i].GetQ() * getParticleMass(daughterOrder[i].c_str());
+    unique_vertexID += vDaughters[i].GetQ() * getParticleMass(daughterOrder[i]);
   }
 
   if (isIntermediate)
@@ -703,7 +729,7 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
   }
 }
 
-std::tuple<KFParticle, bool> KFParticle_Tools::getCombination(KFParticle vDaughters[], std::string daughterOrder[], KFParticle vertex, bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID)
+std::tuple<KFParticle, bool> KFParticle_Tools::getCombination(KFParticle vDaughters[], int daughterOrder[], KFParticle vertex, bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID)
 {
   KFParticle candidate;
   bool isGoodCandidate;
@@ -718,21 +744,21 @@ std::tuple<KFParticle, bool> KFParticle_Tools::getCombination(KFParticle vDaught
   return std::make_tuple(candidate, isGoodCandidate);
 }
 
-std::vector<std::vector<std::string>> KFParticle_Tools::findUniqueDaughterCombinations(int start, int end)
+std::vector<std::vector<int>> KFParticle_Tools::findUniqueDaughterCombinations(int start, int end)
 {
   std::vector<int> vect_permutations;
-  std::vector<std::vector<std::string>> uniqueCombinations;
-  std::map<int, std::string> daughterMap;
+  std::vector<std::vector<int>> uniqueCombinations;
+  std::map<int, int> daughterMap;
   for (int i = start; i < end; i++)
   {
-    daughterMap.insert(std::pair<int, std::string>(i, m_daughter_name[i]));
+    daughterMap.insert(std::pair<int, int>(i, abs(getParticleID(m_daughter_name[i].c_str()))));
     vect_permutations.push_back(i);
   }
   int *permutations = &vect_permutations[0];
 
   do
   {
-    std::vector<std::string> combination;
+    std::vector<int> combination;
     combination.reserve((end - start));
     for (int i = 0; i < (end - start); i++)
     {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -599,7 +599,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
       // different charged particle has different PDGID
       // just to protect if they have different mass for different charge
       // but in EvtGen, there is no C-violation...so this is just a protection
-      daughterMass = constrainMass ? getParticleMass(vDaughters[i].GetQ()*daughterOrder[i]) : vDaughters[i].GetMass();
+      daughterMass = constrainMass ? getParticleMass((Int_t) vDaughters[i].GetQ() * daughterOrder[i]) : vDaughters[i].GetMass();
     }
     else if ((Int_t) vDaughters[i].GetQ() == 0)
     {
@@ -615,7 +615,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     {
       if ((Int_t) vDaughters[i].GetQ() != 0)
       {
-        daughterMass = getParticleMass(vDaughters[i].GetQ()*daughterOrder[i]);
+        daughterMass = getParticleMass((Int_t) vDaughters[i].GetQ() * daughterOrder[i]);
       }
       else if ((Int_t) vDaughters[i].GetQ() == 0)
       {
@@ -628,7 +628,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
                           (Int_t) vDaughters[i].GetQ(),
                           daughterMass);
     mother.AddDaughter(inputTracks[i]);
-    unique_vertexID += vDaughters[i].GetQ() * getParticleMass(daughterOrder[i]);
+    unique_vertexID += (Int_t) vDaughters[i].GetQ() * getParticleMass(daughterOrder[i]);
   }
 
   if (isIntermediate)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -76,14 +76,14 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float flightDistanceChi2(const KFParticle &particle, const KFParticle &vertex);
 
-  std::tuple<KFParticle, bool> buildMother(KFParticle vDaughters[], std::string daughterOrder[], bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID);
+  std::tuple<KFParticle, bool> buildMother(KFParticle vDaughters[], int daughterOrder[], bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID);
 
   void constrainToVertex(KFParticle &particle, bool &goodCandidate, KFParticle &vertex);
 
-  std::tuple<KFParticle, bool> getCombination(KFParticle vDaughters[], std::string daughterOrder[], KFParticle vertex,
+  std::tuple<KFParticle, bool> getCombination(KFParticle vDaughters[], int daughterOrder[], KFParticle vertex,
                                               bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID);
 
-  std::vector<std::vector<std::string>> findUniqueDaughterCombinations(int start, int end);
+  std::vector<std::vector<int>> findUniqueDaughterCombinations(int start, int end);
 
   double calculateEllipsoidRadius(int posOrNeg, double sigma_ii, double sigma_jj, double sigma_ij);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -210,7 +210,7 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
             required_unique_vertexID += m_intermediate_charge[n] * kfp_Tools_evtReco.getParticleMass(m_intermediate_name[n].c_str());
           }
 
-          std::vector<std::vector<std::string>> uniqueCombinations;
+          std::vector<std::vector<int>> uniqueCombinations;
           std::vector<std::vector<int>> listOfTracksToAppend;
 
           if (num_remaining_tracks != 0)
@@ -226,12 +226,21 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
 
             for (auto& uniqueCombination : uniqueCombinations)
             {
-              uniqueCombination.insert(begin(uniqueCombination), begin(m_intermediate_name), end(m_intermediate_name));
+              for (auto element_of_intermediate : m_intermediate_name)
+              {
+                uniqueCombination.insert(begin(uniqueCombination), kfp_Tools_evtReco.getParticleID(element_of_intermediate));
+              }
             }
           }
           else
           {
-            uniqueCombinations.push_back(m_intermediate_name);
+            std::vector<int> m_intermediate_id;
+            m_intermediate_id.clear();
+            for (auto element_of_intermediate : m_intermediate_name)
+            {
+              m_intermediate_id.push_back(kfp_Tools_evtReco.getParticleID(element_of_intermediate));
+            }
+            uniqueCombinations.push_back(m_intermediate_id);
             listOfTracksToAppend.push_back({0});
           }
 
@@ -268,15 +277,27 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                   for (int k = 0; k < num_remaining_tracks; ++k)
                   {  // Need to deal with track mass and PID assignment for extra tracks
                     int trackArrayID = k + m_num_intermediate_states;
+                    double slowTrackMass;
+                    int slowTrackPDG;
+                    if ((Int_t) motherDecayProducts[trackArrayID].GetQ() != 0)
+                    {
+                      slowTrackMass = kfp_Tools_evtReco.getParticleMass((Int_t) motherDecayProducts[trackArrayID].GetQ() * uniqueCombination[trackArrayID]);
+                      slowTrackPDG = (Int_t) motherDecayProducts[trackArrayID].GetQ() * uniqueCombination[trackArrayID];
+                    }
+                    else if ((Int_t) motherDecayProducts[trackArrayID].GetQ() == 0)
+                    {
+                      slowTrackMass = kfp_Tools_evtReco.getParticleMass(uniqueCombination[trackArrayID]);
+                      slowTrackPDG = uniqueCombination[trackArrayID];
+                    }
                     KFParticle slowTrack;
                     slowTrack.Create(motherDecayProducts[trackArrayID].Parameters(),
                                      motherDecayProducts[trackArrayID].CovarianceMatrix(),
                                      (Int_t) motherDecayProducts[trackArrayID].GetQ(),
-                                     kfp_Tools_evtReco.getParticleMass(uniqueCombination[trackArrayID].c_str()));
+                                     slowTrackMass);
                     slowTrack.NDF() = motherDecayProducts[trackArrayID].GetNDF();
                     slowTrack.Chi2() = motherDecayProducts[trackArrayID].GetChi2();
                     slowTrack.SetId(motherDecayProducts[trackArrayID].Id());
-                    slowTrack.SetPDG(motherDecayProducts[trackArrayID].GetQ() * kfp_Tools_evtReco.getParticleID(uniqueCombination[trackArrayID].c_str()));
+                    slowTrack.SetPDG(slowTrackPDG);
                     goodDaughters[k + num_tracks_used_by_intermediates].push_back(slowTrack);
                   }
                 }
@@ -334,7 +355,7 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
                                                        bool isIntermediate, int intermediateNumber, bool constrainMass)
 {
   int nTracks = n_track_stop - n_track_start;
-  std::vector<std::vector<std::string>> uniqueCombinations = findUniqueDaughterCombinations(n_track_start, n_track_stop);
+  std::vector<std::vector<int>> uniqueCombinations = findUniqueDaughterCombinations(n_track_start, n_track_stop);
   std::vector<KFParticle> goodCandidates, goodVertex, goodDaughters[nTracks];
   KFParticle candidate;
   bool isGood;
@@ -359,8 +380,8 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
     {
       for (unsigned int i_pv = 0; i_pv < primaryVerticesCand.size(); ++i_pv)  // Loop over all PVs in the event
       {
-        std::string* names = &uniqueCombination[0];
-        std::tie(candidate, isGood) = getCombination(daughterTracks, names, primaryVerticesCand[i_pv], m_constrain_to_vertex,
+        int* PDGIDofFirstParticleInCombination = &uniqueCombination[0];
+        std::tie(candidate, isGood) = getCombination(daughterTracks, PDGIDofFirstParticleInCombination, primaryVerticesCand[i_pv], m_constrain_to_vertex,
                                                      isIntermediate, intermediateNumber, nTracks, constrainMass, required_unique_vertexID);
 
         if (isIntermediate && isGood)
@@ -381,14 +402,26 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
           for (int i = 0; i < nTracks; ++i)
           {
             KFParticle intParticle;
+            double intParticleMass;
+            int intParticlePDG;
+            if ((Int_t) daughterTracks[i].GetQ() != 0)
+            {
+              intParticleMass = kfp_Tools_evtReco.getParticleMass((Int_t) daughterTracks[i].GetQ() * PDGIDofFirstParticleInCombination[i]);
+              intParticlePDG = (Int_t) daughterTracks[i].GetQ() * PDGIDofFirstParticleInCombination[i];
+            }
+            else if ((Int_t) daughterTracks[i].GetQ() == 0)
+            {
+              intParticleMass = kfp_Tools_evtReco.getParticleMass(PDGIDofFirstParticleInCombination[i]);
+              intParticlePDG = PDGIDofFirstParticleInCombination[i];
+            }
             intParticle.Create(daughterTracks[i].Parameters(),
                                daughterTracks[i].CovarianceMatrix(),
                                (Int_t) daughterTracks[i].GetQ(),
-                               kfp_Tools_evtReco.getParticleMass(names[i]));
+                               intParticleMass);
             intParticle.NDF() = daughterTracks[i].GetNDF();
             intParticle.Chi2() = daughterTracks[i].GetChi2();
             intParticle.SetId(daughterTracks[i].Id());
-            intParticle.SetPDG(daughterTracks[i].GetQ() * kfp_Tools_evtReco.getParticleID(names[i]));
+            intParticle.SetPDG(intParticlePDG);
             goodDaughters[i].push_back(intParticle);
           }
         }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
We found that findUniqueDaughterCombinations functions will return duplicate PID combinations with only difference in charge. For example, for Jpsi -> e+ e- decay, daughter combinations include ``e+ e-`` and ``e- e+``. This bug will not influence final result since only PDGID is used, and charge of combinations is not used. However, it will cause duplicate computing. Therefore, We change the type of combinations from (std::string) name to (int) abs(PDGID). Also, we add some protection for the case where charge is zero.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

