### PR TITLE
fix build order, libs need to depend on .la if lib is local

### DIFF
--- a/offline/framework/fun4allraw/Makefile.am
+++ b/offline/framework/fun4allraw/Makefile.am
@@ -67,8 +67,8 @@ libfun4allraw_la_SOURCES = \
   Fun4AllPrdfOutputManager.cc \
   Fun4AllRolloverFileOutStream.cc \
   Fun4AllStreamingInputManager.cc \
-	mvtx_pool.cc \
   intt_pool.cc \
+  mvtx_pool.cc \
   tpc_pool.cc \
   SingleGl1PoolInput.cc \
   SingleGl1TriggerInput.cc \
@@ -83,10 +83,10 @@ libfun4allraw_la_SOURCES = \
   SingleZdcInput.cc
 
 libfun4allraw_la_LIBADD = \
+  libmvtx_decoder.la \
   -lffarawobjects \
   -lfun4all \
   -lEvent \
-	-lmvtx_decoder \
   -lphoolraw
 
 BUILT_SOURCES = testexternals.cc


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the build ordering. If a library depends on another local library, one has to put he .la file into the library dependency to force make to build it before it tries to link the library

libfun4allraw_la_LIBADD = \
  libmvtx_decoder.la \
  -lffarawobjects \
...
instead of
libfun4allraw_la_LIBADD = \
  -lmvtx_decoder \
  -lffarawobjects \
...

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

