### PR TITLE
Hcal cdb gdml

### DIFF
--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -61,6 +61,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cmath>
 #include <filesystem>
 #include <iostream>
 #include <memory>   // for unique_ptr
@@ -525,9 +526,9 @@ void PHG4IHCalDetector::AddGeometryNode()
     {
       const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(RawTowerDefs::convert_name_to_caloid(m_SuperDetector), ieta, iphi);
 
-      const double x(geom_ref_radius * cos(m_RawTowerGeom->get_phicenter(iphi)));
-      const double y(geom_ref_radius * sin(m_RawTowerGeom->get_phicenter(iphi)));
-      const double z(geom_ref_radius / tan(PHG4Utils::get_theta(m_RawTowerGeom->get_etacenter(ieta))));
+      const double x(geom_ref_radius * std::cos(m_RawTowerGeom->get_phicenter(iphi)));
+      const double y(geom_ref_radius * std::sin(m_RawTowerGeom->get_phicenter(iphi)));
+      const double z(geom_ref_radius / std::tan(PHG4Utils::get_theta(m_RawTowerGeom->get_etacenter(ieta))));
 
       RawTowerGeom *tg = m_RawTowerGeom->get_tower_geometry(key);
       if (tg)
@@ -537,20 +538,20 @@ void PHG4IHCalDetector::AddGeometryNode()
           std::cout << "IHCalDetector::InitRun - Tower geometry " << key << " already exists" << std::endl;
         }
 
-        if (fabs(tg->get_center_x() - x) > 1e-4)
+        if (std::fabs(tg->get_center_x() - x) > 1e-4)
         {
           std::cout << "IHCalDetector::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
                     << std::endl;
 
           return;
         }
-        if (fabs(tg->get_center_y() - y) > 1e-4)
+        if (std::fabs(tg->get_center_y() - y) > 1e-4)
         {
           std::cout << "IHCalDetector::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
                     << std::endl;
           return;
         }
-        if (fabs(tg->get_center_z() - z) > 1e-4)
+        if (std::fabs(tg->get_center_z() - z) > 1e-4)
         {
           std::cout << "IHCalDetector::InitRun - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
                     << std::endl;

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalDetector.cc
@@ -2,8 +2,8 @@
 
 #include "PHG4IHCalDisplayAction.h"
 
-#include <g4detectors/PHG4HcalDefs.h>
 #include <g4detectors/PHG4DetectorSubsystem.h>
+#include <g4detectors/PHG4HcalDefs.h>
 
 #include <phparameter/PHParameters.h>
 
@@ -31,7 +31,6 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 #include <phool/recoConsts.h>
-
 
 #include <TSystem.h>
 
@@ -82,12 +81,12 @@ PHG4IHCalDetector::PHG4IHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
 {
   gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
   assert(gdml_config);
-// changes in the parameters have to be made here
-// otherwise they will not be propagated to the node tree
+  // changes in the parameters have to be made here
+  // otherwise they will not be propagated to the node tree
   if (std::filesystem::path(m_GDMPath).extension() != ".gdml")
   {
     m_GDMPath = CDBInterface::instance()->getUrl(m_GDMPath);
-    m_Params->set_string_param("GDMPath",m_GDMPath);
+    m_Params->set_string_param("GDMPath", m_GDMPath);
   }
 }
 
@@ -166,7 +165,7 @@ int PHG4IHCalDetector::ConstructIHCal(G4LogicalVolume *hcalenvelope)
   std::unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
   gdmlParser.SetOverlapCheck(OverlapCheck());
-  if (! std::filesystem::exists(m_GDMPath))
+  if (!std::filesystem::exists(m_GDMPath))
   {
     std::cout << PHWHERE << " Inner HCal gdml file " << m_GDMPath << " not found" << std::endl;
     gSystem->Exit(1);

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -81,7 +81,7 @@ PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, PH
   if (std::filesystem::path(mapfile).extension() != ".root")
   {
     mapfile = CDBInterface::instance()->getUrl(mapfile);
-    m_Params->set_string_param("MapFileName",mapfile);
+    m_Params->set_string_param("MapFileName", mapfile);
   }
 }
 

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.cc
@@ -6,12 +6,19 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfoDefs.h>
+
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
+
+#include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -23,16 +30,10 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <calobase/TowerInfo.h>
-#include <calobase/TowerInfoContainer.h>
-#include <calobase/TowerInfoContainerv1.h>
-#include <calobase/TowerInfoDefs.h>
-
-#include <TSystem.h>
-
 // Root headers
 #include <TFile.h>
 #include <TH2.h>
+#include <TSystem.h>
 
 #include <Geant4/G4NavigationHistory.hh>
 #include <Geant4/G4ParticleDefinition.hh>      // for G4ParticleDefinition
@@ -59,7 +60,7 @@
 #include <tuple>
 
 //____________________________________________________________________________..
-PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, const PHParameters* parameters)
+PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
   , m_Params(parameters)
@@ -75,6 +76,13 @@ PHG4IHCalSteppingAction::PHG4IHCalSteppingAction(PHG4IHCalDetector* detector, co
                      m_Params->get_double_param("light_balance_inner_corr"),
                      m_Params->get_double_param("light_balance_outer_radius") * cm,
                      m_Params->get_double_param("light_balance_outer_corr"));
+
+  std::string mapfile = m_Params->get_string_param("MapFileName");
+  if (std::filesystem::path(mapfile).extension() != ".root")
+  {
+    mapfile = CDBInterface::instance()->getUrl(mapfile);
+    m_Params->set_string_param("MapFileName",mapfile);
+  }
 }
 
 PHG4IHCalSteppingAction::~PHG4IHCalSteppingAction()

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
@@ -42,38 +42,38 @@ class PHG4IHCalSteppingAction : public PHG4SteppingAction
  private:
   bool NoHitSteppingAction(const G4Step *aStep);
   //! pointer to the detector
-  PHG4IHCalDetector *m_Detector {nullptr};
+  PHG4IHCalDetector *m_Detector{nullptr};
 
   //! efficiency maps from Mephi
-  TH2 *m_MapCorrHist {nullptr};
+  TH2 *m_MapCorrHist{nullptr};
 
   //! pointer to hit container
-  PHG4HitContainer *m_HitContainer {nullptr};
-  PHG4HitContainer *m_AbsorberHitContainer {nullptr};
-  PHG4Hit *m_Hit {nullptr};
-  PHParameters *m_Params {nullptr};
-  PHG4HitContainer *m_SaveHitContainer {nullptr};
-  PHG4Shower *m_SaveShower {nullptr};
-  G4VPhysicalVolume *m_SaveVolPre {nullptr};
-  G4VPhysicalVolume *m_SaveVolPost {nullptr};
-  int m_SaveTrackId {-1};
-  int m_SavePreStepStatus {-1};
-  int m_SavePostStepStatus {-1};
+  PHG4HitContainer *m_HitContainer{nullptr};
+  PHG4HitContainer *m_AbsorberHitContainer{nullptr};
+  PHG4Hit *m_Hit{nullptr};
+  PHParameters *m_Params{nullptr};
+  PHG4HitContainer *m_SaveHitContainer{nullptr};
+  PHG4Shower *m_SaveShower{nullptr};
+  G4VPhysicalVolume *m_SaveVolPre{nullptr};
+  G4VPhysicalVolume *m_SaveVolPost{nullptr};
+  int m_SaveTrackId{-1};
+  int m_SavePreStepStatus{-1};
+  int m_SavePostStepStatus{-1};
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActive {0};
-  int m_IsBlackHole {0};
-  int m_LightScintModelFlag {0};
-  bool m_doG4Hit {true};
-  double m_tmin {-20.};
-  double m_tmax {60.};
-  double m_dt {100.};
+  int m_IsActive{0};
+  int m_IsBlackHole{0};
+  int m_LightScintModelFlag{0};
+  bool m_doG4Hit{true};
+  double m_tmin{-20.};
+  double m_tmax{60.};
+  double m_dt{100.};
 
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
 
-  TowerInfoContainer *m_CaloInfoContainer {nullptr};
+  TowerInfoContainer *m_CaloInfoContainer{nullptr};
 };
 
 #endif  // G4IHCAL_PHG4IHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSteppingAction.h
@@ -22,7 +22,7 @@ class PHG4IHCalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4IHCalSteppingAction(PHG4IHCalDetector *, const PHParameters *parameters);
+  PHG4IHCalSteppingAction(PHG4IHCalDetector *, PHParameters *parameters);
 
   //! destructor
   ~PHG4IHCalSteppingAction() override;
@@ -42,38 +42,38 @@ class PHG4IHCalSteppingAction : public PHG4SteppingAction
  private:
   bool NoHitSteppingAction(const G4Step *aStep);
   //! pointer to the detector
-  PHG4IHCalDetector *m_Detector = nullptr;
+  PHG4IHCalDetector *m_Detector {nullptr};
 
   //! efficiency maps from Mephi
-  TH2 *m_MapCorrHist = nullptr;
+  TH2 *m_MapCorrHist {nullptr};
 
   //! pointer to hit container
-  PHG4HitContainer *m_HitContainer = nullptr;
-  PHG4HitContainer *m_AbsorberHitContainer = nullptr;
-  PHG4Hit *m_Hit = nullptr;
-  const PHParameters *m_Params = nullptr;
-  PHG4HitContainer *m_SaveHitContainer = nullptr;
-  PHG4Shower *m_SaveShower = nullptr;
-  G4VPhysicalVolume *m_SaveVolPre = nullptr;
-  G4VPhysicalVolume *m_SaveVolPost = nullptr;
-  int m_SaveTrackId = -1;
-  int m_SavePreStepStatus = -1;
-  int m_SavePostStepStatus = -1;
+  PHG4HitContainer *m_HitContainer {nullptr};
+  PHG4HitContainer *m_AbsorberHitContainer {nullptr};
+  PHG4Hit *m_Hit {nullptr};
+  PHParameters *m_Params {nullptr};
+  PHG4HitContainer *m_SaveHitContainer {nullptr};
+  PHG4Shower *m_SaveShower {nullptr};
+  G4VPhysicalVolume *m_SaveVolPre {nullptr};
+  G4VPhysicalVolume *m_SaveVolPost {nullptr};
+  int m_SaveTrackId {-1};
+  int m_SavePreStepStatus {-1};
+  int m_SavePostStepStatus {-1};
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActive = 0;
-  int m_IsBlackHole = 0;
-  int m_LightScintModelFlag = 0;
-  bool m_doG4Hit = true;
-  double m_tmin = -20.;
-  double m_tmax = 60.;
-  double m_dt = 100.;
+  int m_IsActive {0};
+  int m_IsBlackHole {0};
+  int m_LightScintModelFlag {0};
+  bool m_doG4Hit {true};
+  double m_tmin {-20.};
+  double m_tmax {60.};
+  double m_dt {100.};
 
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
 
-  TowerInfoContainer *m_CaloInfoContainer = nullptr;
+  TowerInfoContainer *m_CaloInfoContainer {nullptr};
 };
 
 #endif  // G4IHCAL_PHG4IHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ihcal/PHG4IHCalSubsystem.cc
@@ -175,15 +175,8 @@ void PHG4IHCalSubsystem::SetDefaultParameters()
   set_default_int_param("etabins", 24);
   set_default_int_param("saveg4hit", 1);
 
-  set_default_string_param("GDMPath", "DefaultParameters-InvadPath");
-  const char *Calibroot = getenv("CALIBRATIONROOT");
-  std::string defaultmapfilename;
-  if (Calibroot)
-  {
-    defaultmapfilename = Calibroot;
-    defaultmapfilename += "/HCALIN/tilemap/ihcalgdmlmap09212022.root";
-  }
-  set_default_string_param("MapFileName", defaultmapfilename);
+  set_default_string_param("GDMPath", "HCALIN_GDML");
+  set_default_string_param("MapFileName", "HCALIN_MEPHI_MAP");
   set_default_string_param("MapHistoName", "ihcalcombinedgdmlnormtbyt");
 }
 

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -85,18 +85,18 @@ PHG4OHCalDetector::PHG4OHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
 {
   gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
   assert(gdml_config);
-// changes in the parameters have to be made here
-// otherwise they will not be propagated to the node tree
+  // changes in the parameters have to be made here
+  // otherwise they will not be propagated to the node tree
   if (std::filesystem::path(m_GDMPath).extension() != ".gdml")
   {
     m_GDMPath = CDBInterface::instance()->getUrl(m_GDMPath);
-    m_Params->set_string_param("GDMPath",m_GDMPath);
+    m_Params->set_string_param("GDMPath", m_GDMPath);
   }
   std::string ironfieldmap = m_Params->get_string_param("IronFieldMapPath");
   if (std::filesystem::path(ironfieldmap).extension() != ".root")
   {
     ironfieldmap = CDBInterface::instance()->getUrl(ironfieldmap);
-    m_Params->set_string_param("IronFieldMapPath",ironfieldmap);
+    m_Params->set_string_param("IronFieldMapPath", ironfieldmap);
   }
   PHFieldConfig *fieldconf = findNode::getClass<PHFieldConfig>(Node, PHFieldUtility::GetDSTConfigNodeName());
   if (fieldconf->get_field_config() != PHFieldConfig::kFieldUniform)
@@ -191,7 +191,7 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
   std::unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
   gdmlParser.SetOverlapCheck(OverlapCheck());
-  if (! std::filesystem::exists(m_GDMPath))
+  if (!std::filesystem::exists(m_GDMPath))
   {
     std::cout << PHWHERE << " Outer HCal gdml file " << m_GDMPath << " not found" << std::endl;
     gSystem->Exit(1);

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -7,22 +7,8 @@
 
 #include <phparameter/PHParameters.h>
 
-#include <g4main/PHG4Detector.h>
-#include <g4main/PHG4DisplayAction.h>
-#include <g4main/PHG4Subsystem.h>
-#include <g4main/PHG4Utils.h>
-
 #include <phfield/PHFieldConfig.h>
 #include <phfield/PHFieldUtility.h>
-
-#include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>
-#include <phool/PHNode.h>  // for PHNode
-#include <phool/PHNodeIterator.h>
-#include <phool/PHObject.h>  // for PHObject
-#include <phool/getClass.h>
-#include <phool/phool.h>
-#include <phool/recoConsts.h>
 
 #include <g4gdml/PHG4GDMLConfig.hh>
 #include <g4gdml/PHG4GDMLUtility.hh>
@@ -32,6 +18,22 @@
 #include <calobase/RawTowerGeomContainer.h>  // for RawTowerGeomC...
 #include <calobase/RawTowerGeomContainer_Cylinderv1.h>
 #include <calobase/RawTowerGeomv1.h>
+
+#include <g4main/PHG4Detector.h>
+#include <g4main/PHG4DisplayAction.h>
+#include <g4main/PHG4Subsystem.h>
+#include <g4main/PHG4Utils.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHNode.h>  // for PHNode
+#include <phool/PHNodeIterator.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/recoConsts.h>
 
 #include <TSystem.h>
 
@@ -63,6 +65,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <memory>   // for unique_ptr
 #include <utility>  // for pair, make_pair
@@ -82,12 +85,25 @@ PHG4OHCalDetector::PHG4OHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
 {
   gdml_config = PHG4GDMLUtility::GetOrMakeConfigNode(Node);
   assert(gdml_config);
+// changes in the parameters have to be made here
+// otherwise they will not be propagated to the node tree
+  if (std::filesystem::path(m_GDMPath).extension() != ".gdml")
+  {
+    m_GDMPath = CDBInterface::instance()->getUrl(m_GDMPath);
+    m_Params->set_string_param("GDMPath",m_GDMPath);
+  }
+  std::string ironfieldmap = m_Params->get_string_param("IronFieldMapPath");
+  if (std::filesystem::path(ironfieldmap).extension() != ".root")
+  {
+    ironfieldmap = CDBInterface::instance()->getUrl(ironfieldmap);
+    m_Params->set_string_param("IronFieldMapPath",ironfieldmap);
+  }
   PHFieldConfig *fieldconf = findNode::getClass<PHFieldConfig>(Node, PHFieldUtility::GetDSTConfigNodeName());
   if (fieldconf->get_field_config() != PHFieldConfig::kFieldUniform)
   {
     m_FieldSetup =
         new PHG4OHCalFieldSetup(
-            m_Params->get_string_param("IronFieldMapPath"), m_Params->get_double_param("IronFieldMapScale"),
+            ironfieldmap, m_Params->get_double_param("IronFieldMapScale"),
             m_InnerRadius - 10 * cm,  // subtract 10 cm to make sure fieldmap with 2x2 grid covers it
             m_OuterRadius + 10 * cm,  // add 10 cm to make sure fieldmap with 2x2 grid covers it
             m_SizeZ / 2. + 10 * cm    // div by 2 bc G4 convention
@@ -175,6 +191,12 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
   std::unique_ptr<G4GDMLReadStructure> reader(new G4GDMLReadStructure());
   G4GDMLParser gdmlParser(reader.get());
   gdmlParser.SetOverlapCheck(OverlapCheck());
+  if (! std::filesystem::exists(m_GDMPath))
+  {
+    std::cout << PHWHERE << " Outer HCal gdml file " << m_GDMPath << " not found" << std::endl;
+    gSystem->Exit(1);
+    exit(1);
+  }
   gdmlParser.Read(m_GDMPath, false);
 
   G4AssemblyVolume *abs_asym = reader->GetAssembly("sector");         // absorber

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -700,8 +700,8 @@ void PHG4OHCalSteppingAction::FieldChecker(const G4Step* aStep)
   globPosVec[2] = globPosition.z();
   globPosVec[3] = aStep->GetPreStepPoint()->GetGlobalTime();
 
-  const Int_t binx = h->GetXaxis()->FindBin(globPosVec[0] / cm);
-  const Int_t biny = h->GetYaxis()->FindBin(globPosVec[1] / cm);
+  const int binx = h->GetXaxis()->FindBin(globPosVec[0] / cm);
+  const int biny = h->GetYaxis()->FindBin(globPosVec[1] / cm);
 
   if (h->GetBinContent(binx, binx) == 0)
   {  // only fille unfilled bins

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -9,12 +9,19 @@
 
 #include <phparameter/PHParameters.h>
 
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfoDefs.h>
+
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4HitContainer.h>
 #include <g4main/PHG4Hitv1.h>
 #include <g4main/PHG4Shower.h>
 #include <g4main/PHG4SteppingAction.h>  // for PHG4SteppingAction
 #include <g4main/PHG4TrackUserInfoV1.h>
+
+#include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
@@ -26,11 +33,6 @@
 #include <phool/PHObject.h>        // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>
-
-#include <calobase/TowerInfo.h>
-#include <calobase/TowerInfoContainer.h>
-#include <calobase/TowerInfoContainerv1.h>
-#include <calobase/TowerInfoDefs.h>
 
 // Root headers
 #include <TAxis.h>  // for TAxis
@@ -74,7 +76,7 @@
 #include <tuple>   // for get, tuple
 
 //____________________________________________________________________________..
-PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, const PHParameters* parameters)
+PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, PHParameters* parameters)
   : PHG4SteppingAction(detector->GetName())
   , m_Detector(detector)
   , m_Params(parameters)
@@ -92,6 +94,13 @@ PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, co
                      m_Params->get_double_param("light_balance_inner_corr"),
                      m_Params->get_double_param("light_balance_outer_radius") * cm,
                      m_Params->get_double_param("light_balance_outer_corr"));
+
+  std::string mapfile = m_Params->get_string_param("MapFileName");
+  if (std::filesystem::path(mapfile).extension() != ".root")
+  {
+    mapfile = CDBInterface::instance()->getUrl(mapfile);
+    m_Params->set_string_param("MapFileName",mapfile);
+  }
 }
 
 PHG4OHCalSteppingAction::~PHG4OHCalSteppingAction()

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.cc
@@ -99,7 +99,7 @@ PHG4OHCalSteppingAction::PHG4OHCalSteppingAction(PHG4OHCalDetector* detector, PH
   if (std::filesystem::path(mapfile).extension() != ".root")
   {
     mapfile = CDBInterface::instance()->getUrl(mapfile);
-    m_Params->set_string_param("MapFileName",mapfile);
+    m_Params->set_string_param("MapFileName", mapfile);
   }
 }
 

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
@@ -22,7 +22,7 @@ class PHG4OHCalSteppingAction : public PHG4SteppingAction
 {
  public:
   //! constructor
-  PHG4OHCalSteppingAction(PHG4OHCalDetector *, const PHParameters *parameters);
+  PHG4OHCalSteppingAction(PHG4OHCalDetector *, PHParameters *parameters);
 
   //! destructor
   ~PHG4OHCalSteppingAction() override;
@@ -44,41 +44,41 @@ class PHG4OHCalSteppingAction : public PHG4SteppingAction
  private:
   bool NoHitSteppingAction(const G4Step *aStep);
   //! pointer to the detector
-  PHG4OHCalDetector *m_Detector = nullptr;
+  PHG4OHCalDetector *m_Detector {nullptr};
 
   //! efficiency maps from Mephi
-  TH2 *m_MapCorrHist[24] = {0};
-  TH2 *m_MapCorrHistChim[24] = {0};
+  TH2 *m_MapCorrHist[24] {0};
+  TH2 *m_MapCorrHistChim[24] {0};
 
   //! pointer to hit container
-  PHG4HitContainer *m_HitContainer = nullptr;
-  PHG4HitContainer *m_AbsorberHitContainer = nullptr;
-  PHG4Hit *m_Hit = nullptr;
-  const PHParameters *m_Params = nullptr;
-  PHG4HitContainer *m_SaveHitContainer = nullptr;
-  PHG4Shower *m_SaveShower = nullptr;
-  G4VPhysicalVolume *m_SaveVolPre = nullptr;
-  G4VPhysicalVolume *m_SaveVolPost = nullptr;
-  int m_SaveTrackId = -1;
-  int m_SavePreStepStatus = -1;
-  int m_SavePostStepStatus = -1;
-  int m_EnableFieldCheckerFlag = -1;
+  PHG4HitContainer *m_HitContainer {nullptr};
+  PHG4HitContainer *m_AbsorberHitContainer {nullptr};
+  PHG4Hit *m_Hit {nullptr};
+  PHParameters *m_Params {nullptr};
+  PHG4HitContainer *m_SaveHitContainer {nullptr};
+  PHG4Shower *m_SaveShower {nullptr};
+  G4VPhysicalVolume *m_SaveVolPre {nullptr};
+  G4VPhysicalVolume *m_SaveVolPost {nullptr};
+  int m_SaveTrackId {-1};
+  int m_SavePreStepStatus {-1};
+  int m_SavePostStepStatus {-1};
+  int m_EnableFieldCheckerFlag {-1};
 
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActiveFlag = 0;
-  int m_IsBlackHoleFlag = 0;
-  int m_NScintiPlates = -1;
-  int m_LightScintModelFlag = 0;
-  bool m_doG4Hit = true;
-  double m_tmin = -20.;
-  double m_tmax = 60.;
-  double m_dt = 100.;
+  int m_IsActiveFlag {0};
+  int m_IsBlackHoleFlag {0};
+  int m_NScintiPlates {-1};
+  int m_LightScintModelFlag {0};
+  bool m_doG4Hit {true};
+  double m_tmin {-20.};
+  double m_tmax {60.};
+  double m_dt {100.};
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
 
-  TowerInfoContainer *m_CaloInfoContainer = nullptr;
+  TowerInfoContainer *m_CaloInfoContainer {nullptr};
 };
 
 #endif  // G4OHCAL_PHG4OHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSteppingAction.h
@@ -44,41 +44,41 @@ class PHG4OHCalSteppingAction : public PHG4SteppingAction
  private:
   bool NoHitSteppingAction(const G4Step *aStep);
   //! pointer to the detector
-  PHG4OHCalDetector *m_Detector {nullptr};
+  PHG4OHCalDetector *m_Detector{nullptr};
 
   //! efficiency maps from Mephi
-  TH2 *m_MapCorrHist[24] {0};
-  TH2 *m_MapCorrHistChim[24] {0};
+  TH2 *m_MapCorrHist[24]{0};
+  TH2 *m_MapCorrHistChim[24]{0};
 
   //! pointer to hit container
-  PHG4HitContainer *m_HitContainer {nullptr};
-  PHG4HitContainer *m_AbsorberHitContainer {nullptr};
-  PHG4Hit *m_Hit {nullptr};
-  PHParameters *m_Params {nullptr};
-  PHG4HitContainer *m_SaveHitContainer {nullptr};
-  PHG4Shower *m_SaveShower {nullptr};
-  G4VPhysicalVolume *m_SaveVolPre {nullptr};
-  G4VPhysicalVolume *m_SaveVolPost {nullptr};
-  int m_SaveTrackId {-1};
-  int m_SavePreStepStatus {-1};
-  int m_SavePostStepStatus {-1};
-  int m_EnableFieldCheckerFlag {-1};
+  PHG4HitContainer *m_HitContainer{nullptr};
+  PHG4HitContainer *m_AbsorberHitContainer{nullptr};
+  PHG4Hit *m_Hit{nullptr};
+  PHParameters *m_Params{nullptr};
+  PHG4HitContainer *m_SaveHitContainer{nullptr};
+  PHG4Shower *m_SaveShower{nullptr};
+  G4VPhysicalVolume *m_SaveVolPre{nullptr};
+  G4VPhysicalVolume *m_SaveVolPost{nullptr};
+  int m_SaveTrackId{-1};
+  int m_SavePreStepStatus{-1};
+  int m_SavePostStepStatus{-1};
+  int m_EnableFieldCheckerFlag{-1};
 
   // since getting parameters is a map search we do not want to
   // do this in every step, the parameters used are cached
   // in the following variables
-  int m_IsActiveFlag {0};
-  int m_IsBlackHoleFlag {0};
-  int m_NScintiPlates {-1};
-  int m_LightScintModelFlag {0};
-  bool m_doG4Hit {true};
-  double m_tmin {-20.};
-  double m_tmax {60.};
-  double m_dt {100.};
+  int m_IsActiveFlag{0};
+  int m_IsBlackHoleFlag{0};
+  int m_NScintiPlates{-1};
+  int m_LightScintModelFlag{0};
+  bool m_doG4Hit{true};
+  double m_tmin{-20.};
+  double m_tmax{60.};
+  double m_dt{100.};
   std::string m_AbsorberNodeName;
   std::string m_HitNodeName;
 
-  TowerInfoContainer *m_CaloInfoContainer {nullptr};
+  TowerInfoContainer *m_CaloInfoContainer{nullptr};
 };
 
 #endif  // G4OHCAL_PHG4OHCALSTEPPINGACTION_H

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
@@ -184,22 +184,9 @@ void PHG4OHCalSubsystem::SetDefaultParameters()
   set_default_int_param("etabins", 24);
   set_default_int_param("saveg4hit", 1);
 
-  set_default_string_param("GDMPath", "DefaultParameters-InvadPath");
-  std::string defaultmapfilename;
-  const char *Calibroot = getenv("CALIBRATIONROOT");
-  if (Calibroot)
-  {
-    defaultmapfilename = Calibroot;
-    defaultmapfilename += "/HCALOUT/tilemap/ohcalgdmlmapfiles102022.root";
-  }
-  set_default_string_param("MapFileName", defaultmapfilename);
+  set_default_string_param("GDMPath", "HCALOUT_GDML"); // use CDB
+  set_default_string_param("MapFileName", "HCALOUT_MEPHI_MAP"); // use CDB
   set_default_string_param("MapHistoName", "ohcal_mephi_map_towerid_");
-
-  if (!Calibroot)
-  {
-    std::cout << __PRETTY_FUNCTION__ << ": no CALIBRATIONROOT environment variable" << std::endl;
-    exit(1);
-  }
-  set_default_string_param("IronFieldMapPath", std::string(Calibroot) + "/Field/Map/sphenix3dbigmapxyz_steel_rebuild.root");
+  set_default_string_param("IronFieldMapPath", "HCALOUT_STEEL_MAP"); // use CDB
   set_default_double_param("IronFieldMapScale", 1.);
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalSubsystem.cc
@@ -184,9 +184,9 @@ void PHG4OHCalSubsystem::SetDefaultParameters()
   set_default_int_param("etabins", 24);
   set_default_int_param("saveg4hit", 1);
 
-  set_default_string_param("GDMPath", "HCALOUT_GDML"); // use CDB
-  set_default_string_param("MapFileName", "HCALOUT_MEPHI_MAP"); // use CDB
+  set_default_string_param("GDMPath", "HCALOUT_GDML");           // use CDB
+  set_default_string_param("MapFileName", "HCALOUT_MEPHI_MAP");  // use CDB
   set_default_string_param("MapHistoName", "ohcal_mephi_map_towerid_");
-  set_default_string_param("IronFieldMapPath", "HCALOUT_STEEL_MAP"); // use CDB
+  set_default_string_param("IronFieldMapPath", "HCALOUT_STEEL_MAP");  // use CDB
   set_default_double_param("IronFieldMapScale", 1.);
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
The gdml files for the calorimeters are now read by default from the cdb. While at it, the Mephi maps are now also read by default from the cdb as is the steel magnetic field map for the outer hcal. This can be overridden by the macro which is currently the case. Once this PR is through the G4_Hcal*_ref.C macros will be adapted and then the new outer hcal gdml with the support ring will be implemented
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

