### PR TITLE
Hcal support gdml

### DIFF
--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -40,6 +40,7 @@
 #include <Geant4/G4AssemblyVolume.hh>
 #include <Geant4/G4IonisParamMat.hh>
 #include <Geant4/G4LogicalVolume.hh>
+#include <Geant4/G4LogicalVolumeStore.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4MaterialTable.hh>
 #include <Geant4/G4PVPlacement.hh>
@@ -67,6 +68,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <list>
 #include <memory>   // for unique_ptr
 #include <utility>  // for pair, make_pair
 #include <vector>   // for vector, vector<>::iter...
@@ -266,7 +268,20 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
     }
     ++it2;
   }
-
+  //Inner HCal support ring (only the part in Outer HCal volume)
+  // it only exists in the new gdml file, this check keeps the old file
+// without the inner hcal support readable
+  std::list<std::string> volumelist = {"RingSupport_steel_1", "RingSupport_steel_2","RingSupport_alum_1","RingSupport_alum_2","HCalRing_alum_1","HCalRing_alum_2"};
+  for (auto volumename: volumelist)
+  {
+    G4LogicalVolume *logvolptr = G4LogicalVolumeStore::GetInstance()->GetVolume(volumename,false);
+    if (logvolptr)
+    {
+      m_DisplayAction->AddSupportRingVolume(logvolptr);
+      m_SteelAbsorberLogVolSet.insert(logvolptr);
+      hcalenvelope->AddDaughter(reader->GetWorldVolume(volumename));
+    }
+  }
   for (auto &logical_vol : m_SteelAbsorberLogVolSet)
   {
     if (m_FieldSetup)  // only if we have a field defined for the steel absorber

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -272,7 +272,7 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
   // it only exists in the new gdml file, this check keeps the old file
 // without the inner hcal support readable
   std::list<std::string> volumelist = {"RingSupport_steel_1", "RingSupport_steel_2","RingSupport_alum_1","RingSupport_alum_2","HCalRing_alum_1","HCalRing_alum_2"};
-  for (auto volumename: volumelist)
+  for (auto const &volumename: volumelist)
   {
     G4LogicalVolume *logvolptr = G4LogicalVolumeStore::GetInstance()->GetVolume(volumename,false);
     if (logvolptr)

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.cc
@@ -19,6 +19,7 @@ PHG4OHCalDisplayAction::~PHG4OHCalDisplayAction()
   }
   m_VisAttVec.clear();
   m_ScintiLogVolSet.clear();
+  m_SupportRingLogVolSet.clear();
 }
 
 void PHG4OHCalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
@@ -33,6 +34,20 @@ void PHG4OHCalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
     m_VisAtt->SetColor(G4Colour::Green());
+    it->SetVisAttributes(m_VisAtt);
+    m_VisAttVec.push_back(m_VisAtt);
+  }
+
+  for (auto &it : m_SupportRingLogVolSet)
+  {
+    if (it->GetVisAttributes())
+    {
+      return;
+    }
+    G4VisAttributes *m_VisAtt = new G4VisAttributes();
+    m_VisAtt->SetVisibility(true);
+    m_VisAtt->SetForceSolid(true);
+    m_VisAtt->SetColor(G4Colour::Red());
     it->SetVisAttributes(m_VisAtt);
     m_VisAttVec.push_back(m_VisAtt);
   }
@@ -57,11 +72,11 @@ void PHG4OHCalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
     {
       return;
     }
-    G4VisAttributes *m_VisAtt2 = new G4VisAttributes();
-    m_VisAtt2->SetVisibility(true);
-    m_VisAtt2->SetForceSolid(true);
-    m_VisAtt2->SetColor(G4Colour::Grey());
-    m_ChimSteelVol->SetVisAttributes(m_VisAtt2);
-    m_VisAttVec2.push_back(m_VisAtt2);
+    G4VisAttributes *m_VisAtt = new G4VisAttributes();
+    m_VisAtt->SetVisibility(true);
+    m_VisAtt->SetForceSolid(true);
+    m_VisAtt->SetColor(G4Colour::Grey());
+    m_ChimSteelVol->SetVisAttributes(m_VisAtt);
+    m_VisAttVec2.push_back(m_VisAtt);
   }
 }

--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.h
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.h
@@ -25,6 +25,7 @@ class PHG4OHCalDisplayAction : public PHG4DisplayAction
   void AddScintiVolume(G4LogicalVolume *vol) { m_ScintiLogVolSet.insert(vol); }
   void AddSteelVolume(G4LogicalVolume *vol) { m_SteelVol = vol; }
   void AddChimSteelVolume(G4LogicalVolume *vol) { m_ChimSteelVol = vol; }
+  void AddSupportRingVolume(G4LogicalVolume *vol) { m_SupportRingLogVolSet.insert(vol); }
 
  private:
   G4VPhysicalVolume *m_MyTopVolume = nullptr;
@@ -33,6 +34,7 @@ class PHG4OHCalDisplayAction : public PHG4DisplayAction
   std::vector<G4VisAttributes *> m_VisAttVec;
   std::vector<G4VisAttributes *> m_VisAttVec2;
   std::set<G4LogicalVolume *> m_ScintiLogVolSet;
+  std::set<G4LogicalVolume *> m_SupportRingLogVolSet;
 };
 
 #endif  // G4OHCAL_PHG4OHCALDISPLAYACTION_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR superseeds https://github.com/sPHENIX-Collaboration/coresoftware/pull/2526
The new version can read both old and new gdml files. It will only add the ring to the display if it is found in the gdml file. There is an issue with the G4 logical volume management which existed in the old PR as well which needs to be sorted out before we can use the ring from the gdml file

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

