### PR TITLE
feat: take two best clusters per layer

### DIFF
--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -220,21 +220,20 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
     }
 
     //! remove any obvious outlier clusters from the track that were mistakenly
-    //! picked up by the seeder 
+    //! picked up by the seeder
     if (m_iter == 1)
     {
       getBestClustersPerLayer(tpcseed1);
-      if(silseed1)
+      if (silseed1)
       {
         getBestClustersPerLayer(silseed1);
       }
     }
-      removeOutliers(tpcseed1);
-      if (silseed1)
-      {
-        removeOutliers(silseed1);
-      }
-    
+    removeOutliers(tpcseed1);
+    if (silseed1)
+    {
+      removeOutliers(silseed1);
+    }
   }
   if (Verbosity() > 3)
   {
@@ -264,7 +263,7 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
+void PHCosmicTrackMerger::getBestClustersPerLayer(TrackSeed *seed)
 {
   TrackFitUtils::position_vector_t tr_rz_pts, tr_xy_pts;
 
@@ -306,7 +305,7 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
     {
       clusr *= -1;
     }
- 
+
     float perpxyslope = -1. / std::get<0>(xyParams);
     float perpxyint = pos.y() - perpxyslope * pos.x();
     float perprzslope = -1. / std::get<0>(rzParams);
@@ -340,7 +339,6 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
     {
       if (dcaxydiff1 > dcaxydiff2)
       {
-     
         if (dcaxy < bestLayerDcasxy.find(layer)->second.first &&
             dcarz < bestLayerDcasrz.find(layer)->second.first)
         {
@@ -381,7 +379,7 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
         }
       }
     }
-    else if(trkid == TrkrDefs::TrkrId::micromegasId)
+    else if (trkid == TrkrDefs::TrkrId::micromegasId)
     {
       //! add all tpot clusters, since they are 1d
       tpotClus.emplace_back(glob.first[i]);
@@ -392,13 +390,13 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
   seed->clear_cluster_keys();
   for (auto &[layer, keypair] : bestLayerCluskeys)
   {
-    for(auto& key : {keypair.first, keypair.second})
-    if (key > 0)
-    {
-      seed->insert_cluster_key(key);
-    }
+    for (auto &key : {keypair.first, keypair.second})
+      if (key > 0)
+      {
+        seed->insert_cluster_key(key);
+      }
   }
-  for(auto& key : tpotClus)
+  for (auto &key : tpotClus)
   {
     seed->insert_cluster_key(key);
   }
@@ -424,9 +422,15 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
   {
     auto &pos = glob.second[i];
     float clusr = r(pos.x(), pos.y());
-    if (pos.y() < 0) {clusr *= -1;}
+    if (pos.y() < 0)
+    {
+      clusr *= -1;
+    }
     // skip tpot clusters, as they are always bad in 1D due to 1D resolution
-    if (fabs(clusr) > 80.) {continue;}
+    if (fabs(clusr) > 80.)
+    {
+      continue;
+    }
     float perpxyslope = -1. / std::get<0>(xyParams);
     float perpxyint = pos.y() - perpxyslope * pos.x();
     float perprzslope = -1. / std::get<0>(rzParams);
@@ -443,12 +447,12 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
     float dcaz = pcaz - pos.z();
     float dcaxy = std::sqrt(square(dcax) + square(dcay));
     float dcarz = std::sqrt(square(dcar) + square(dcaz));
-  
+
     //! exclude silicon from DCAz cut
-    if (dcaxy > m_dcaxycut || 
-    (dcarz > m_dcarzcut && (r(pos.x(), pos.y()) > 20)))
+    if (dcaxy > m_dcaxycut ||
+        (dcarz > m_dcarzcut && (r(pos.x(), pos.y()) > 20)))
     {
-      if(Verbosity() > 2)
+      if (Verbosity() > 2)
       {
         std::cout << "Erasing ckey " << glob.first[i] << " with position " << pos.transpose() << std::endl;
       }

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -222,6 +222,10 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
     //! remove any obvious outlier clusters from the track that were mistakenly
     //! picked up by the seeder
     removeOutliers(tpcseed1);
+    if(silseed1)
+    {
+      removeOutliers(silseed1);
+    }
   }
   if (Verbosity() > 3)
   {

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -301,6 +301,7 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
     bestLayerCluskeys.insert(std::make_pair(i, std::make_pair(0, 0)));
   }
 
+  std::vector<TrkrDefs::cluskey> tpotClus;
   for (int i = 0; i < glob.first.size(); i++)
   {
     auto &pos = glob.second[i];
@@ -387,6 +388,11 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
         }
       }
     }
+    else if(trkid == TrkrDefs::TrkrId::micromegasId)
+    {
+      //! add all tpot clusters, since they are 1d
+      tpotClus.emplace_back(glob.first[i]);
+    }
   }
   seed->identify();
   // now erase all cluskeys and fill with the new set of cluskeys
@@ -403,6 +409,10 @@ void PHCosmicTrackMerger::getBestClustersPerLayer (TrackSeed* seed)
       std::cout << "inserting " << keypair.second << std::endl;
       seed->insert_cluster_key(keypair.second);
     }
+  }
+  for(auto& key : tpotClus)
+  {
+    seed->insert_cluster_key(key);
   }
   seed->identify();
   std::cout << "done " << std::endl;

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -37,9 +37,12 @@ class PHCosmicTrackMerger : public SubsysReco
   void zero_field() { m_zeroField = true; }
   void dca_xycut(const float cut) { m_dcaxycut = cut; }
   void dca_rzcut(const float cut) { m_dcarzcut = cut; }
+  void iter(const int it) { m_iter = it;  }
+
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);
   void removeOutliers(TrackSeed *seed);
+  void getBestClustersPerLayer(TrackSeed *seed);
 
   ActsGeometry *m_geometry = nullptr;
   KeyPosMap getGlobalPositions(TrackSeed *seed);
@@ -51,6 +54,7 @@ class PHCosmicTrackMerger : public SubsysReco
   float m_dcaxycut = 0.5; // cm
   float m_dcarzcut = 2.; // cm
   bool m_zeroField = false;
+  int m_iter = 0;
 };
 
 #endif  // PHCOSMICTRACKMERGER_H

--- a/offline/packages/trackreco/PHCosmicTrackMerger.h
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.h
@@ -37,7 +37,7 @@ class PHCosmicTrackMerger : public SubsysReco
   void zero_field() { m_zeroField = true; }
   void dca_xycut(const float cut) { m_dcaxycut = cut; }
   void dca_rzcut(const float cut) { m_dcarzcut = cut; }
-  void iter(const int it) { m_iter = it;  }
+  void iter(const int it) { m_iter = it; }
 
  private:
   void addKeys(TrackSeed *toAddTo, TrackSeed *toAdd);
@@ -51,8 +51,8 @@ class PHCosmicTrackMerger : public SubsysReco
   TrackSeedContainer *m_tpcSeeds = nullptr;
   TrackSeedContainer *m_siliconSeeds = nullptr;
 
-  float m_dcaxycut = 0.5; // cm
-  float m_dcarzcut = 2.; // cm
+  float m_dcaxycut = 0.5;  // cm
+  float m_dcarzcut = 2.;   // cm
   bool m_zeroField = false;
   int m_iter = 0;
 };

--- a/offline/packages/trackreco/TrackQA.cc
+++ b/offline/packages/trackreco/TrackQA.cc
@@ -71,7 +71,7 @@ int TrackQA::process_event(PHCompositeNode* topNode)
     auto lineFitParams = lineFitClusters(cluspos);
 
     /// Only look at tracks that go through 20 cm of origin
-    if(std::fabs(std::get<1>(lineFitParams)) > 20)
+    if (std::fabs(std::get<1>(lineFitParams)) > 20)
     {
       continue;
     }
@@ -88,7 +88,28 @@ int TrackQA::process_event(PHCompositeNode* topNode)
     int ntpc = 0;
     int nmms = 0;
 
-
+    for (auto& ckey : ckeys)
+    {
+      switch (TrkrDefs::getTrkrId(ckey))
+      {
+      case TrkrDefs::mvtxId:
+        nmaps++;
+        break;
+      case TrkrDefs::inttId:
+        nintt++;
+        break;
+      case TrkrDefs::tpcId:
+        ntpc++;
+        break;
+      case TrkrDefs::micromegasId:
+        nmms++;
+        break;
+      }
+    }
+    if (nmaps == 0)
+    {
+      continue;
+    }
     int i = 0;
     for (auto& ckey : ckeys)
     {
@@ -96,8 +117,8 @@ int TrackQA::process_event(PHCompositeNode* topNode)
       i++;
       auto cluster = clustermap->findCluster(ckey);
 
-      auto intersection = TrackFitUtils::surface_3Dline_intersection(ckey, cluster, geometry, 
-                                                                     std::get<0>(lineFitParams), std::get<1>(lineFitParams), std::get<2>(lineFitParams), std::get<3>(lineFitParams)); 
+      auto intersection = TrackFitUtils::surface_3Dline_intersection(ckey, cluster, geometry,
+                                                                     std::get<0>(lineFitParams), std::get<1>(lineFitParams), std::get<2>(lineFitParams), std::get<3>(lineFitParams));
 
       auto surf = geometry->maps().getSurface(ckey, cluster);
 
@@ -131,22 +152,6 @@ int TrackQA::process_event(PHCompositeNode* topNode)
       h_gxresid->Fill(layer, glob.x() - intersection.x());
       h_gyresid->Fill(layer, glob.y() - intersection.y());
       h_gzresid->Fill(layer, glob.z() - intersection.z());
-
-      switch (TrkrDefs::getTrkrId(ckey))
-      {
-      case TrkrDefs::mvtxId:
-        nmaps++;
-        break;
-      case TrkrDefs::inttId:
-        nintt++;
-        break;
-      case TrkrDefs::tpcId:
-        ntpc++;
-        break;
-      case TrkrDefs::micromegasId:
-        nmms++;
-        break;
-      }
     }
     h_nmaps->Fill(nmaps);
     h_nintt->Fill(nintt);


### PR DESCRIPTION
This PR adds a function to take the closest two clusters to the line fit per layer. It improves the silicon residuals. It improves the widths of the residuals especially since many clusters per layer are created for the TPC in the run 23 conditions.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

