### PR TITLE
add option to simulate different gain mode

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -100,6 +100,14 @@ int CaloWaveformSim::Init(PHCompositeNode *topNode)
     decode_tower = TowerInfoDefs::decode_emcal;
     m_sampling_fraction = 2e-02;
     m_nchannels = 24576;
+    if(m_highgain)
+    {
+      m_gain = 16;
+    }
+    else
+    {
+      m_gain = 1;
+    }
 
     if (!m_overrideCalibName)
     {
@@ -127,6 +135,14 @@ int CaloWaveformSim::Init(PHCompositeNode *topNode)
     decode_tower = TowerInfoDefs::decode_hcal;
     m_sampling_fraction = 0.162166;
     m_nchannels = 1536;
+    if(m_highgain)
+    {
+      m_gain = 32;
+    }
+    else
+    {
+      m_gain = 1;
+    }
 
     if (!m_overrideCalibName)
     {
@@ -154,6 +170,14 @@ int CaloWaveformSim::Init(PHCompositeNode *topNode)
     decode_tower = TowerInfoDefs::decode_hcal;
     m_sampling_fraction = 3.38021e-02;
     m_nchannels = 1536;
+    if(m_highgain)
+    {
+      m_gain = 32;
+    }
+    else
+    {
+      m_gain = 1;
+    }
 
     if (!m_overrideCalibName)
     {
@@ -269,6 +293,7 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
     e_vis *= correction;
     float e_dep = e_vis / m_sampling_fraction;
     float ADC = (calibconst != 0) ? e_dep / calibconst : 0.;
+    ADC *= m_gain;
 
     float t0 = hit->get_t(0) / m_sampletime;
     unsigned int tower_index = decode_tower(key);

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -125,6 +125,11 @@ class CaloWaveformSim : public SubsysReco
     m_peakpos = _peakpos;
     return;
   }
+  void set_highgain(bool _highgain = true)
+  {
+    m_highgain = _highgain;
+    return;
+  }
   // for CEMC light yield correction
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
@@ -145,12 +150,14 @@ class CaloWaveformSim : public SubsysReco
   int m_runNumber{0};
   int m_nsamples{31};
   int m_nchannels{24576};
-  int m_pedestalsamples{12};
+  int m_pedestalsamples{31};
   float m_sampletime{50. / 3.};
   int m_fixpedestal{1500};
   int m_gaussian_noise{3};
   float m_deltaT{100.};
   float m_timeshiftwidth{0.};
+  bool m_highgain{false};
+  int m_gain{1};
   float m_peakpos{6.};
   gsl_rng *m_RandomGenerator{nullptr};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
add a switch to simulate high gain calo waveforms.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

