### PR TITLE
make support ring grey

### DIFF
--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDisplayAction.cc
@@ -47,7 +47,7 @@ void PHG4OHCalDisplayAction::ApplyDisplayAction(G4VPhysicalVolume * /*physvol*/)
     G4VisAttributes *m_VisAtt = new G4VisAttributes();
     m_VisAtt->SetVisibility(true);
     m_VisAtt->SetForceSolid(true);
-    m_VisAtt->SetColor(G4Colour::Red());
+    m_VisAtt->SetColor(G4Colour::Grey());
     it->SetVisAttributes(m_VisAtt);
     m_VisAttVec.push_back(m_VisAtt);
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The inner hcal support ring from the outer hcal gdml was displayed in red to be easily seen. This PR reverts this back to grey

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

