### PR TITLE
Module to find run time and calorimeter temperatures from daq db

### DIFF
--- a/offline/database/rundb/CaloTemp.cc
+++ b/offline/database/rundb/CaloTemp.cc
@@ -1,5 +1,7 @@
 #include "CaloTemp.h"
 
+#include <boost/format.hpp>
+
 // Tower includes
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
@@ -223,10 +225,13 @@ int CaloTemp::getTempHist() {
   }
 
   odbc::ResultSet* tempResultSet = tempStmt->executeQuery(sql);
-  h_calo_temp->SetTitle(Form("%s Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str()));
+  string calo_title = boost::str(boost::format("%s Temperature RunNumber %d RunTime %s DBTime %s") %detector %runnumber %runtime %closest_time);
+  h_calo_temp->SetTitle(calo_title.c_str());
   if (detector == "CEMC") { 
-    h_calo_temp->SetTitle(Form("%s SIPM Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str()));
-    h_calo_temp2->SetTitle(Form("%s PreAmp Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str())); 
+    calo_title = boost::str(boost::format("%s SIPM Temperature RunNumber %d RunTime %s DBTime %s") %detector %runnumber %runtime %closest_time);
+    string calo_title2 = calo_title = boost::str(boost::format("%s PreAmp Temperature RunNumber %d RunTime %s DBTime %s") %detector %runnumber %runtime %closest_time);
+    h_calo_temp->SetTitle(calo_title.c_str());
+    h_calo_temp2->SetTitle(calo_title2.c_str()); 
   }
   if (tempResultSet) {
     while (tempResultSet->next()) {

--- a/offline/database/rundb/CaloTemp.cc
+++ b/offline/database/rundb/CaloTemp.cc
@@ -1,0 +1,265 @@
+#include "CaloTemp.h"
+
+// Tower includes
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoDefs.h>
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TTree.h>
+#include <TProfile2D.h>
+
+#include <Event/Event.h>
+#include <Event/packet.h>
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <ffaobjects/RunHeader.h>
+
+#include <odbc++/connection.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <odbc++/drivermanager.h>
+#pragma GCC diagnostic pop
+#include <odbc++/resultset.h>
+#include <odbc++/statement.h>  // for Statement
+#include <odbc++/types.h>
+
+using namespace std;
+
+CaloTemp::CaloTemp(const std::string& name, const std::string& filename)
+  : SubsysReco(name)
+  , detector("HCALIN")
+  , outfilename(filename)
+{
+}
+
+CaloTemp::~CaloTemp()
+{
+  delete hm;
+}
+
+
+
+int CaloTemp::Init(PHCompositeNode* /*topNode*/)
+{
+  hm = new Fun4AllHistoManager(Name());
+  // create and register your histos (all types) here
+
+  if (Verbosity() > 1) {
+    std::cout << "Enter CaloTemp Init function" << std::endl;
+  }
+
+  outfile = new TFile(outfilename.c_str(), "UPDATE");
+
+  if (detector == "CEMC") {
+    h_calo_temp = new TProfile2D("h_cemc_sipm_temp", ";eta;phi", 96, 0, 96, 256, 0, 256);
+    h_calo_temp2 = new TProfile2D("h_cemc_pa_temp", ";eta;phi", 96, 0, 96, 256, 0, 256);
+  } else if (detector == "HCALIN") {
+    h_calo_temp = new TProfile2D("h_ihcal_temp", ";eta;phi", 24, 0, 24, 64, 0, 64);
+  } else if (detector == "HCALOUT") {
+    h_calo_temp = new TProfile2D("h_ohcal_temp", ";eta;phi", 24, 0, 24, 64, 0, 64);
+  } else {
+    std::cout << "Unknown detector type " << detector << ". Options are CEMC, HCALIN and HCALOUT." << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+int CaloTemp::InitRun(PHCompositeNode* topNode) 
+{
+  if (Verbosity() > 1) { 
+    std::cout << "Get run header" << std::endl;
+  }
+  
+  runheader = findNode::getClass<RunHeader>(topNode, "RunHeader");
+  if (!runheader) {
+    std::cout << "can't find runheader" << std::endl;
+    return 1;
+  }
+  runnumber = runheader->get_RunNumber();
+
+  if (Verbosity()) {
+    std::cout << "run number " << runnumber << std::endl;
+  }
+  
+  int result = getRunTime();
+  if (result == 1) {
+    std::cout << "Unable to connect to database. Exiting now." << std::endl;
+    return 1;
+  }
+  
+  result = getTempHist();
+  if (result == 1) {
+    std::cout << "Unable to fill calorimeter temperature from database. Exiting now." << std::endl;
+    return 1;
+  }
+
+  if (Verbosity()) {
+    std::cout << "runtime " << runtime << std::endl;
+  }
+
+  return 0;
+}
+
+int CaloTemp::getRunTime() {
+  odbc::Connection *m_OdbcConnection = nullptr;
+  int icount = 0;
+  do {
+    try {
+      m_OdbcConnection = odbc::DriverManager::getConnection("daq","","");
+    } catch (odbc::SQLException &e) {
+      std::cout << " Exception caught during DriverManager::getConnection" << std::endl;
+      std::cout << "Message: " << e.getMessage() << std::endl;
+    }
+    icount++;
+    if (!m_OdbcConnection) { std::this_thread::sleep_for(std::chrono::seconds(30)); }  // sleep 30 seconds before retry
+  } while (!m_OdbcConnection && icount < 3);
+  if (icount == 3) { return 1; }
+
+  std::string sql = "SELECT brtimestamp FROM run WHERE runnumber = " + std::to_string(runnumber) + ";";
+  
+  if (Verbosity() > 1) {
+    std::cout << sql << std::endl;
+  }
+  odbc::Statement* stmt = m_OdbcConnection->createStatement();
+  odbc::ResultSet* resultSet = stmt->executeQuery(sql);
+
+  if (resultSet && resultSet->next()) {
+    odbc::Timestamp brtimestamp = resultSet->getTimestamp("brtimestamp");
+    runtime = brtimestamp.toString(); // brtimestamp is in 'America/New_York' time zone
+  }
+
+  if (Verbosity() > 1) { 
+    std::cout << "runtime " << runtime << std::endl;
+  }
+
+  delete resultSet; 
+  delete stmt; 
+  delete m_OdbcConnection;
+  return 0;
+
+}
+
+
+int CaloTemp::getTempHist() {
+  
+  odbc::Connection *m_OdbcConnection = nullptr;
+  int icount = 0;
+  do {
+    try {
+      m_OdbcConnection = odbc::DriverManager::getConnection("daq","","");
+    } catch (odbc::SQLException &e) {
+      std::cout << " Exception caught during DriverManager::getConnection" << std::endl;
+      std::cout << "Message: " << e.getMessage() << std::endl;
+    }
+    icount++;
+    if (!m_OdbcConnection) { std::this_thread::sleep_for(std::chrono::seconds(30)); }  // sleep 30 seconds before retry
+  } while (!m_OdbcConnection && icount < 3);
+  if (icount == 3) { return 1; }
+
+  int det = 0;
+  std::string tablename;
+  std::string tempstring = "temp";
+  if (detector == "CEMC") {
+    tablename = "emcal_heartbeat";
+    tempstring = "temp_sipm as temp, temp_pa";
+  } else if (detector == "HCALIN") {
+    tablename = "hcal_heartbeat";
+    det = 1; 
+  } else if (detector == "HCALOUT") {
+    tablename = "hcal_heartbeat";
+    det = 0;
+  } else {
+    std::cout << "Unknown detector type " << detector << ". Options are CEMC, HCALIN and HCALOUT." << std::endl;
+    return 1;
+  }
+
+  // first get the closest time for the database 
+  std::string sql = "SELECT time FROM " + tablename + " ORDER BY ABS(EXTRACT(epoch FROM time) - EXTRACT(epoch FROM '" + runtime + "'::timestamp)) LIMIT 1;";
+  if (Verbosity() > 1) {
+    std::cout << sql << std::endl;
+  }
+
+  odbc::Statement* timeStmt = m_OdbcConnection->createStatement();
+  odbc::ResultSet* timeResultSet = timeStmt->executeQuery(sql);
+
+  std::string closest_time;
+  if (timeResultSet && timeResultSet->next()) {
+    odbc::Timestamp timestamp = timeResultSet->getTimestamp("time");
+    closest_time = timestamp.toString(); // Convert timestamp to string
+  }
+
+  if (Verbosity() > 1) {
+    std::cout << "closest time " << closest_time << std::endl;
+  }
+
+  delete timeResultSet;
+  delete timeStmt;
+
+  odbc::Statement* tempStmt = m_OdbcConnection->createStatement();
+  sql = "SELECT towerid, " + tempstring + " FROM " + tablename + " WHERE time = '" + closest_time + "'"; 
+  if (detector == "HCALIN") {
+    sql += " and detector = " + std::to_string(det);
+  } else if (detector == "HCALOUT") {
+    sql += " and detector = " + std::to_string(det);
+  }
+  sql += ";";
+  
+  if (Verbosity() > 1) {
+    std::cout << sql << std::endl;
+  }
+
+  odbc::ResultSet* tempResultSet = tempStmt->executeQuery(sql);
+  h_calo_temp->SetTitle(Form("%s Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str()));
+  if (detector == "CEMC") { 
+    h_calo_temp->SetTitle(Form("%s SIPM Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str()));
+    h_calo_temp2->SetTitle(Form("%s PreAmp Temperature RunNumber %d RunTime %s DBTime %s", detector.c_str(), runnumber, runtime.c_str(), closest_time.c_str())); 
+  }
+  if (tempResultSet) {
+    while (tempResultSet->next()) {
+      int towerid = tempResultSet->getInt("towerid"); 
+      float temp = tempResultSet->getFloat("temp"); 
+      int calo_key;
+      if (detector == "CEMC") { calo_key = TowerInfoDefs::encode_emcal(towerid); } 
+      else { calo_key = TowerInfoDefs::encode_hcal(towerid); }
+      int etabin = TowerInfoDefs::getCaloTowerEtaBin(calo_key);
+      int phibin = TowerInfoDefs::getCaloTowerPhiBin(calo_key);
+      h_calo_temp->Fill(etabin, phibin, temp);
+      if (detector == "CEMC") { 
+        float temp_pa = tempResultSet->getFloat("temp_pa");
+        h_calo_temp2->Fill(etabin, phibin, temp_pa); 
+      }
+    }
+} else {
+    std::cerr << "Error: tempResultSet is NULL." << std::endl;
+}
+
+  delete tempResultSet;
+  delete tempStmt;
+  delete m_OdbcConnection;
+  return 0;
+}
+
+
+int CaloTemp::End(PHCompositeNode* /*topNode*/)
+{
+  outfile->cd();
+  outfile->Write();
+  outfile->Close();
+  delete outfile;
+  hm->dumpHistos(outfilename, "UPDATE");
+  return 0;
+}

--- a/offline/database/rundb/CaloTemp.cc
+++ b/offline/database/rundb/CaloTemp.cc
@@ -7,8 +7,6 @@
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoDefs.h>
 
-#include <ffaobjects/RunHeader.h>
-
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -20,6 +18,17 @@
 #include <TTree.h>
 #include <TProfile2D.h>
 
+#include <Event/Event.h>
+#include <Event/packet.h>
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <ffaobjects/RunHeader.h>
+
 #include <odbc++/connection.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -28,13 +37,6 @@
 #include <odbc++/resultset.h>
 #include <odbc++/statement.h>  // for Statement
 #include <odbc++/types.h>
-
-#include <cassert>
-#include <sstream>
-#include <string>
-#include <chrono>
-#include <iostream>
-#include <thread>
 
 using namespace std;
 
@@ -211,9 +213,7 @@ int CaloTemp::getTempHist() {
 
   odbc::Statement* tempStmt = m_OdbcConnection->createStatement();
   sql = "SELECT towerid, " + tempstring + " FROM " + tablename + " WHERE time = '" + closest_time + "'"; 
-  if (detector == "HCALIN") {
-    sql += " and detector = " + std::to_string(det);
-  } else if (detector == "HCALOUT") {
+  if (detector == "HCALIN" || detector == "HCALOUT") {
     sql += " and detector = " + std::to_string(det);
   }
   sql += ";";

--- a/offline/database/rundb/CaloTemp.h
+++ b/offline/database/rundb/CaloTemp.h
@@ -1,0 +1,51 @@
+#ifndef CALOTEMP_H__
+#define CALOTEMP_H__
+
+#include <fun4all/SubsysReco.h>
+#include <vector>
+// Forward declarations
+class Fun4AllHistoManager;
+class PHCompositeNode;
+class TFile;
+class TNtuple;
+class TTree;
+class TH2F;
+class TH1F;
+class TH1;
+class TProfile2D;
+class RunHeader;
+
+class CaloTemp : public SubsysReco
+{
+ public:
+  //! constructor
+  CaloTemp(const std::string &name = "CaloTemp", const std::string &fname = "MyNtuple.root");
+
+  //! destructor
+  virtual ~CaloTemp();
+
+  //! full initialization
+  int Init(PHCompositeNode *);
+  int InitRun(PHCompositeNode *);
+
+  //! end of run method
+  int End(PHCompositeNode *);
+
+  void Detector(const std::string &name) { detector = name; }
+  int getRunTime();
+  int getTempHist();
+
+ protected:
+  std::string detector;
+  std::string outfilename;
+  Fun4AllHistoManager *hm = nullptr;
+  TFile *outfile = nullptr;
+  TProfile2D* h_calo_temp = nullptr;
+  TProfile2D* h_calo_temp2 = nullptr;
+  RunHeader* runheader = nullptr;
+  int runnumber;
+  std::string runtime;
+
+};
+
+#endif

--- a/offline/database/rundb/Makefile.am
+++ b/offline/database/rundb/Makefile.am
@@ -1,0 +1,53 @@
+AUTOMAKE_OPTIONS = foreign
+
+lib_LTLIBRARIES = \
+    libcalotemp.la
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OPT_SPHENIX)/lib
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -I$(ROOTSYS)/include \
+  -I$(OPT_SPHENIX)/include
+
+pkginclude_HEADERS = \
+  CaloTemp.h
+
+libcalotemp_la_SOURCES = \
+  CaloTemp.cc 
+
+libcalotemp_la_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OPT_SPHENIX)/lib \
+  -lcalo_io \
+  -lodbc++ \
+  -lfun4all \
+  -lg4detectors_io
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.C
+testexternals_LDADD = libcalotemp.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/offline/database/rundb/autogen.sh
+++ b/offline/database/rundb/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure "$@"

--- a/offline/database/rundb/configure.ac
+++ b/offline/database/rundb/configure.ac
@@ -1,0 +1,13 @@
+AC_INIT(caloana,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+if test $ac_cv_prog_gxx = yes; then
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror -Wshadow"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Creates new module to find the run time and calorimeter temperatures from the daq database. Calorimeter temperatures that are closest to the begin run time of the run of interest are output. Histograms of tower by tower calorimeter temperatures are output to file of choice. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

