### PR TITLE
fix: bug in unpacking with new mapping

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -222,7 +222,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     std::string varname = "layer";
     int layer = m_cdbttree->GetIntValue(key, varname);
     // antenna pads will be in 0 layer
-    if (layer == 0)
+    if (layer <= 0)
     {
       continue;
     }


### PR DESCRIPTION
The TPC mapping for the antennae needs to be updated but hasn't gone through into the DB yet. This gets us back running again for the time being.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

