### PR TITLE
Added an InttFeeMap class that loads the fee mapping from CDB

### DIFF
--- a/offline/packages/intt/InttClusterQA.cc
+++ b/offline/packages/intt/InttClusterQA.cc
@@ -1,15 +1,7 @@
-
 #include "InttClusterQA.h"
 #include "CylinderGeomIntt.h"
 
-#include <fun4all/Fun4AllHistoManager.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>
-
 #include <g4detectors/PHG4CylinderGeomContainer.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <qautils/QAHistManagerDef.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/InttDefs.h>
@@ -22,23 +14,22 @@
 #include <qautils/QAHistManagerDef.h>
 #include <qautils/QAUtil.h>
 
-#include <TH1F.h>
-#include <TH2F.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+
+#include <TH1.h>
+#include <TH2.h>
+
+#include <boost/format.hpp>
 
 //____________________________________________________________________________..
 InttClusterQA::InttClusterQA(const std::string &name)
   : SubsysReco(name)
 {
-}
-
-//____________________________________________________________________________..
-InttClusterQA::~InttClusterQA()
-= default;
-
-//____________________________________________________________________________..
-int InttClusterQA::Init(PHCompositeNode * /*unused*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
@@ -87,7 +78,7 @@ int InttClusterQA::process_event(PHCompositeNode *topNode)
     auto layer = TrkrDefs::getLayer(hsk);
     auto ladderphiid = InttDefs::getLadderPhiId(hsk);
     auto sensor = InttDefs::getLadderZId(hsk);
-    auto h = dynamic_cast<TH2 *>(hm->getHisto(Form("%sncluspersensor%i_%i_%i", getHistoPrefix().c_str(), ((int) layer) - 3, (int) ladderphiid, (int) sensor)));
+    auto h = dynamic_cast<TH2 *>(hm->getHisto( boost::str(boost::format("%sncluspersensor%i_%i_%i") %getHistoPrefix() %(((int) layer) - 3) %((int) ladderphiid) %((int) sensor)).c_str()));
 
     for (auto iter = range.first; iter != range.second; ++iter)
     {
@@ -109,7 +100,8 @@ int InttClusterQA::EndRun(const int runnumber)
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto(Form("%snclusperrun", getHistoPrefix().c_str())));
+  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto( boost::str(boost::format("%snclusperrun") %getHistoPrefix()).c_str()));
+  // NOLINTNEXTLINE(bugprone-integer-division)
   h_totalclusters->Fill(runnumber, m_totalClusters / m_event);
 
   for (const auto &[layer, ladders] : m_layerLadderMap)
@@ -118,20 +110,16 @@ int InttClusterQA::EndRun(const int runnumber)
     {
       for (int sensor = 0; sensor < 4; sensor++)
       {
-        TH2 *h = dynamic_cast<TH2 *>(hm->getHisto(Form("%sncluspersensorperrun%i_%i_%i", getHistoPrefix().c_str(), layer, ladder, sensor)));
+        TH2 *h = dynamic_cast<TH2 *>(hm->getHisto( boost::str(boost::format("%sncluspersensorperrun%i_%i_%i") %getHistoPrefix() %layer %ladder %sensor).c_str()));
         if (h)
         {
+          // NOLINTNEXTLINE(bugprone-integer-division)
           h->Fill(runnumber, m_nclustersPerSensor[layer][ladder][sensor] / m_event);
         }
       }
     }
   }
 
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-//____________________________________________________________________________..
-int InttClusterQA::End(PHCompositeNode * /*unused*/)
-{
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -144,7 +132,7 @@ void InttClusterQA::createHistos()
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
   {
-    auto h = new TH2F(Form("%snclusperrun", getHistoPrefix().c_str()),
+    auto h = new TH2F( boost::str(boost::format("%snclusperrun") %getHistoPrefix()).c_str(),
                       "INTT Clusters per event per run number", m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
     h->GetXaxis()->SetTitle("Run number");
     h->GetYaxis()->SetTitle("Clusters per event");
@@ -158,14 +146,14 @@ void InttClusterQA::createHistos()
       //! 4 sensor on each ladder
       for (int sensor = 0; sensor < 4; sensor++)
       {
-        auto h = new TH2F(Form("%sncluspersensor%i_%i_%i", getHistoPrefix().c_str(),
-                               layer, ladder, sensor),
+        auto h = new TH2F( boost::str(boost::format("%sncluspersensor%i_%i_%i") %getHistoPrefix()
+				      %layer %ladder %sensor).c_str(),
                           "INTT clusters per sensor", 100, -5, 5, 1000, -1, 1);
         h->GetXaxis()->SetTitle("Local z [cm]");
         h->GetYaxis()->SetTitle("Local rphi [cm]");
         hm->registerHisto(h);
 
-        auto h2 = new TH2F(Form("%sncluspersensorperrun%i_%i_%i", getHistoPrefix().c_str(), layer, ladder, sensor),
+	auto h2 = new TH2F( boost::str(boost::format("%sncluspersensorperrun%i_%i_%i") %getHistoPrefix() %layer %ladder %sensor).c_str(),
                            "INTT clusters per event per sensor per run", m_runbins, m_beginRun, m_endRun, 100, 0, 100);
         h2->GetXaxis()->SetTitle("Run number");
         h2->GetYaxis()->SetTitle("Clusters per event");

--- a/offline/packages/intt/InttClusterQA.cc
+++ b/offline/packages/intt/InttClusterQA.cc
@@ -33,17 +33,16 @@ InttClusterQA::InttClusterQA(const std::string &name)
 
 //____________________________________________________________________________..
 InttClusterQA::~InttClusterQA()
-{
-}
+= default;
 
 //____________________________________________________________________________..
-int InttClusterQA::Init(PHCompositeNode *)
+int InttClusterQA::Init(PHCompositeNode * /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int InttClusterQA::InitRun(PHCompositeNode *)
+int InttClusterQA::InitRun(PHCompositeNode * /*unused*/)
 {
   for (auto &layer : {0, 1, 2, 3})
   {
@@ -131,7 +130,7 @@ int InttClusterQA::EndRun(const int runnumber)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 //____________________________________________________________________________..
-int InttClusterQA::End(PHCompositeNode *)
+int InttClusterQA::End(PHCompositeNode * /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/intt/InttClusterQA.h
+++ b/offline/packages/intt/InttClusterQA.h
@@ -16,13 +16,11 @@ class InttClusterQA : public SubsysReco
  public:
   InttClusterQA(const std::string &name = "InttClusterQA");
 
-  ~InttClusterQA() override;
+  ~InttClusterQA() override = default;
 
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
-  int End(PHCompositeNode *topNode) override;
 
   void beginRun(const int run) { m_beginRun = run; }
   void endRun(const int run) { m_endRun = run; }

--- a/offline/packages/intt/InttFeeMap.cc
+++ b/offline/packages/intt/InttFeeMap.cc
@@ -1,0 +1,152 @@
+#include "InttFeeMap.h"
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <filesystem>  // for exists
+#include <utility>     // for pair
+
+int InttFeeMap::LoadFromFile(
+    std::string const& filename)
+{
+  if (filename.empty())
+  {
+    std::cout << "int InttFeeMap::LoadFromFile(std::string const& filename)" << std::endl;
+    std::cout << "\tArgument 'filename' is empty string" << std::endl;
+    return 1;
+  }
+
+  if (!std::filesystem::exists(filename))
+  {
+    std::cout << "int InttFeeMap::LoadFromFile(std::string const& filename)" << std::endl;
+    std::cout << "\tFile '" << filename << "' does not exist" << std::endl;
+    return 1;
+  }
+
+  CDBTTree cdbttree(filename);
+  cdbttree.LoadCalibrations();
+
+  return v_LoadFromCDBTTree(cdbttree);
+}
+
+int InttFeeMap::LoadFromCDB(
+    std::string const& name)
+{
+  if (name.empty())
+  {
+    std::cout << "int InttFeeMap::LoadFromCDB(std::string const& name)" << std::endl;
+    std::cout << "\tArgument 'name' is empty string" << std::endl;
+    return 1;
+  }
+
+  std::string database = CDBInterface::instance()->getUrl(name);
+  CDBTTree cdbttree(database);
+  cdbttree.LoadCalibrations();
+
+  return v_LoadFromCDBTTree(cdbttree);
+}
+
+void InttFeeMap::identify(
+  std::ostream& out) const
+{
+  out << "InttFeeMap\n"
+      << "\tBase Version\n"
+      << "\tUnimplemented" << std::endl;
+}
+
+int InttFeeMap::Convert(
+  InttMap::Online_s& /*unused*/,
+  InttMap::Offline_s const& /*unused*/) const
+{
+  return 1;
+}
+
+int InttFeeMap::Convert(
+  InttMap::Offline_s& /*unused*/,
+  InttMap::Online_s const& /*unused*/) const
+{
+  return 1;
+}
+
+int InttFeeMap::Convert(
+  InttMap::RawData_s& /*unused*/,
+  InttMap::Online_s const& /*unused*/) const
+{
+  return 1;
+}
+
+int InttFeeMap::Convert(
+  InttMap::Online_s& /*unused*/,
+  InttMap::RawData_s const& /*unused*/) const
+{
+  return 1;
+}
+
+int InttFeeMap::Convert(
+  InttMap::RawData_s& /*unused*/,
+  InttMap::Offline_s const& /*unused*/) const
+{
+  return 1;
+}
+
+int InttFeeMap::Convert(
+  InttMap::Offline_s& /*unused*/,
+  InttMap::RawData_s const& /*unused*/) const
+{
+  return 1;
+}
+
+InttMap::Online_s InttFeeMap::ToOnline(
+  InttMap::Offline_s const& ofl) const
+{
+	InttMap::Online_s onl;
+	Convert(onl, ofl);
+	return onl;
+}
+
+InttMap::Online_s InttFeeMap::ToOnline(
+  InttMap::RawData_s const& raw) const
+{
+	InttMap::Online_s onl;
+	Convert(onl, raw);
+	return onl;
+}
+
+InttMap::RawData_s InttFeeMap::ToRawData(
+  InttMap::Online_s const& onl) const
+{
+	InttMap::RawData_s raw;
+	Convert(raw, onl);
+	return raw;
+}
+
+InttMap::RawData_s InttFeeMap::ToRawData(
+  InttMap::Offline_s const& ofl) const
+{
+	InttMap::RawData_s raw;
+	Convert(raw, ofl);
+	return raw;
+}
+
+InttMap::Offline_s InttFeeMap::ToOffline(
+  InttMap::Online_s const& onl) const
+{
+	InttMap::Offline_s ofl;
+	Convert(ofl, onl);
+	return ofl;
+}
+
+InttMap::Offline_s InttFeeMap::ToOffline(
+  InttMap::RawData_s const& raw) const
+{
+	InttMap::Offline_s ofl;
+	Convert(ofl, raw);
+	return ofl;
+}
+
+int InttFeeMap::v_LoadFromCDBTTree(
+    CDBTTree& /*unused*/)
+{
+  return 1;
+}

--- a/offline/packages/intt/InttFeeMap.h
+++ b/offline/packages/intt/InttFeeMap.h
@@ -1,0 +1,50 @@
+#ifndef INTT_FEE_MAP_H
+#define INTT_FEE_MAP_H
+
+#include "InttMap.h"
+
+#include <phool/PHObject.h>
+
+#include <cstddef>  // for size_t
+#include <iostream>
+#include <string>
+
+class CDBTTree;
+
+class InttFeeMap : public PHObject
+{
+ public:
+  InttFeeMap() = default;
+  ~InttFeeMap() override = default;
+
+  int LoadFromFile(std::string const& = "InttFeeMap.root");
+  int LoadFromCDB(std::string const& = "InttFeeMap");
+
+  virtual void identify(std::ostream& = std::cout) const override;
+
+  virtual int Convert(InttMap::Online_s&, InttMap::Offline_s const&) const;
+  virtual int Convert(InttMap::Offline_s&, InttMap::Online_s const&) const;
+
+  virtual int Convert(InttMap::RawData_s&, InttMap::Online_s const&) const;
+  virtual int Convert(InttMap::Online_s&, InttMap::RawData_s const&) const;
+
+  virtual int Convert(InttMap::RawData_s&, InttMap::Offline_s const&) const;
+  virtual int Convert(InttMap::Offline_s&, InttMap::RawData_s const&) const;
+
+  InttMap::Online_s ToOnline(InttMap::Offline_s const&) const;
+  InttMap::Online_s ToOnline(InttMap::RawData_s const&) const;
+
+  InttMap::RawData_s ToRawData(InttMap::Online_s const&) const;
+  InttMap::RawData_s ToRawData(InttMap::Offline_s const&) const;
+
+  InttMap::Offline_s ToOffline(InttMap::Online_s const&) const;
+  InttMap::Offline_s ToOffline(InttMap::RawData_s const&) const;
+
+ protected:
+  virtual int v_LoadFromCDBTTree(CDBTTree&);
+
+ private:
+  ClassDefOverride(InttFeeMap, 1)
+};
+
+#endif  // INTT_FEE_MAP_H

--- a/offline/packages/intt/InttFeeMapLinkDef.h
+++ b/offline/packages/intt/InttFeeMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class InttFeeMap + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/intt/InttFeeMapv1.cc
+++ b/offline/packages/intt/InttFeeMapv1.cc
@@ -1,0 +1,199 @@
+#include "InttFeeMapv1.h"
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <filesystem>  // for exists
+#include <utility>     // for pair
+
+InttFeeMapv1::~InttFeeMapv1()
+{
+  delete m_onl_to_raw;
+  delete m_raw_to_onl;
+}
+void InttFeeMapv1::identify(
+  std::ostream& out) const
+{
+  out << "InttFeeMapv1" << std::endl;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::Online_s& onl,
+  InttMap::Offline_s const& ofl) const
+{
+  if(!InttMap::IsValid(ofl))
+  {
+	  return 1;
+  }
+  int num_ldrs = ofl.layer < 5 ? 12 : 16;
+
+  onl.lyr = ofl.layer - 3;
+  onl.ldr = (7 * num_ldrs / 4 - ofl.ladder_phi) % num_ldrs;
+  // onl.ldr = (7 * num_ldrs / 4 - ofl.ladder_phi + (ofl.layer % 2 ? num_ldrs - 1 : 0)) % num_ldrs;
+  onl.arm = ofl.ladder_z / 2;
+  switch(ofl.ladder_z)
+  {
+  case 1:
+	  onl.chp = ofl.strip_z + 13 * (ofl.strip_phi < 128);
+	  break;
+  case 0:
+	  onl.chp = ofl.strip_z + 13 * (ofl.strip_phi < 128) + 5;
+	  break;
+  case 2:
+	  onl.chp = 12 - ofl.strip_z + 13 * (127 < ofl.strip_phi);
+	  break;
+  case 3:
+	  onl.chp = 4 - ofl.strip_z + 13 * (127 < ofl.strip_phi);
+	  break;
+  default:
+	  break;
+  }
+  onl.chn = ofl.strip_phi < 128 ? ofl.strip_phi : 255 - ofl.strip_phi;
+  return 0;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::Offline_s& ofl,
+  InttMap::Online_s const& onl) const
+{
+  if(!InttMap::IsValid(onl))
+  {
+	  return 1;
+  }
+  int num_ldrs = onl.lyr < 2 ? 12 : 16;
+
+  ofl.layer = onl.lyr + 3;
+  ofl.ladder_phi = (7 * num_ldrs / 4 - onl.ldr) % num_ldrs;
+  // ofl.ladder_phi = (7 * num_ldrs / 4 - onl.ldr + (onl.lyr % 2 ? 0 : num_ldrs - 1)) % num_ldrs;
+  ofl.ladder_z = 2 * onl.arm + (onl.chp % 13 < 5);
+  switch(ofl.ladder_z)
+  {
+  case 1:
+	  ofl.strip_z = onl.chp % 13;
+	  break;
+  case 0:
+	  ofl.strip_z = onl.chp % 13 - 5;
+	  break;
+  case 2:
+	  ofl.strip_z = 12 - (onl.chp % 13);
+	  break;
+  case 3:
+	  ofl.strip_z = 4 - (onl.chp % 13);
+	  break;
+  default:
+	  break;
+  }
+  ofl.strip_phi = (onl.arm == (onl.chp / 13)) ? 255 - onl.chn : onl.chn;
+  return 0;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::RawData_s& raw,
+  InttMap::Online_s const& onl) const
+{
+  if(!m_onl_to_raw)
+  {
+    return 1;
+  }
+
+  if(m_onl_to_raw->find(onl) != m_onl_to_raw->end())
+  {
+    raw = m_onl_to_raw->at(onl);
+	raw.chp = onl.chp;
+	raw.chn = onl.chn;
+
+	return 0;
+  }
+
+  return 1;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::Online_s& onl,
+  InttMap::RawData_s const& raw) const
+{
+  if(!m_raw_to_onl)
+  {
+    return 1;
+  }
+
+  if(m_raw_to_onl->find(raw) != m_raw_to_onl->end())
+  {
+    onl = m_raw_to_onl->at(raw);
+	onl.chp = raw.chp;
+	onl.chn = raw.chn;
+
+	return 0;
+  }
+
+  return 1;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::RawData_s& raw,
+  InttMap::Offline_s const& ofl) const
+{
+  InttMap::Online_s onl;
+
+  if(Convert(onl, ofl))
+  {
+    return 1;
+  }
+  if(Convert(raw, onl))
+  {
+    return 1;
+  }
+  return 0;
+}
+
+int InttFeeMapv1::Convert(
+  InttMap::Offline_s& ofl,
+  InttMap::RawData_s const& raw) const
+{
+  InttMap::Online_s onl;
+
+  if(Convert(onl, raw))
+  {
+    return 1;
+  }
+  if(Convert(ofl, onl))
+  {
+    return 1;
+  }
+  return 0;
+}
+
+int InttFeeMapv1::v_LoadFromCDBTTree(
+    CDBTTree& cdbttree)
+{
+  InttMap::Online_s onl;
+  onl.chp = InttMap::Wildcard;
+  onl.chn = InttMap::Wildcard;
+
+  InttMap::RawData_s raw;
+  raw.chp = InttMap::Wildcard;
+  raw.chn = InttMap::Wildcard;
+
+  delete m_onl_to_raw;
+  delete m_raw_to_onl;
+
+  m_onl_to_raw = new std::map<InttMap::Online_s, InttMap::RawData_s, InttMap::OnlineWildcardComparator>;
+  m_raw_to_onl = new std::map<InttMap::RawData_s, InttMap::Online_s, InttMap::RawDataWildcardComparator>;
+
+  Int_t N = cdbttree.GetSingleIntValue("size");
+  for(Int_t n = 0; n < N; ++n)
+  {
+	  onl.lyr = cdbttree.GetIntValue(n, "lyr");
+	  onl.ldr = cdbttree.GetIntValue(n, "ldr");
+	  onl.arm = cdbttree.GetIntValue(n, "arm");
+
+	  raw.pid = cdbttree.GetIntValue(n, "pid");
+	  raw.fee = cdbttree.GetIntValue(n, "fee");
+
+	  m_onl_to_raw->insert({onl, raw});
+	  m_raw_to_onl->insert({raw, onl});
+  }
+
+  return 1;
+}

--- a/offline/packages/intt/InttFeeMapv1.h
+++ b/offline/packages/intt/InttFeeMapv1.h
@@ -1,0 +1,43 @@
+#ifndef INTT_FEE_MAPv1_H
+#define INTT_FEE_MAPv1_H
+
+#include "InttMap.h"
+#include "InttFeeMap.h"
+
+#include <phool/PHObject.h>
+
+#include <cstddef>  // for size_t
+#include <iostream>
+#include <map>
+#include <string>
+
+class CDBTTree;
+
+class InttFeeMapv1 : public InttFeeMap
+{
+ public:
+  InttFeeMapv1() = default;
+  ~InttFeeMapv1() override;
+
+  void identify(std::ostream& = std::cout) const override;
+
+  int Convert(InttMap::Online_s&, InttMap::Offline_s const&) const override;
+  int Convert(InttMap::Offline_s&, InttMap::Online_s const&) const override;
+
+  int Convert(InttMap::RawData_s&, InttMap::Online_s const&) const override;
+  int Convert(InttMap::Online_s&, InttMap::RawData_s const&) const override;
+
+  int Convert(InttMap::RawData_s&, InttMap::Offline_s const&) const override;
+  int Convert(InttMap::Offline_s&, InttMap::RawData_s const&) const override;
+
+ protected:
+  int v_LoadFromCDBTTree(CDBTTree&) override;
+
+ private:
+  std::map<InttMap::Online_s, InttMap::RawData_s, InttMap::OnlineWildcardComparator>* m_onl_to_raw{nullptr};
+  std::map<InttMap::RawData_s, InttMap::Online_s, InttMap::RawDataWildcardComparator>* m_raw_to_onl{nullptr};
+
+  ClassDefOverride(InttFeeMapv1, 1)
+};
+
+#endif  // INTT_FEE_MAPv1_H

--- a/offline/packages/intt/InttFeeMapv1LinkDef.h
+++ b/offline/packages/intt/InttFeeMapv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class InttFeeMapv1 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/intt/InttMap.cc
+++ b/offline/packages/intt/InttMap.cc
@@ -1,4 +1,483 @@
 #include "InttMap.h"
+#include <boost/format.hpp>
+
+InttMap::Online_s& InttMap::Online_s::operator++()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::OnlineEnd;
+		return *this;
+	}
+
+	if(++chn < 128)
+	{
+		return *this;
+	}
+	chn = 0;
+	if(++chp < 26)
+	{
+		return *this;
+	}
+	chp = 0;
+	if(++arm < 2)
+	{
+		return *this;
+	}
+	arm = 0;
+	if(++ldr < (lyr < 2 ? 12 : 16))
+	{
+		return *this;
+	}
+	ldr = 0;
+	if(++lyr < 4)
+	{
+		return *this;
+	}
+	lyr = 0;
+
+	*this = InttMap::OnlineEnd;
+	return *this;
+}
+
+InttMap::Online_s& InttMap::Online_s::operator--()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::OnlineREnd;
+		return *this;
+	}
+
+	if(--chn >= 0)
+	{
+		return *this;
+	}
+	chn = 127;
+	if(--chp >= 0)
+	{
+		return *this;
+	}
+	chp = 25;
+	if(--arm >= 0)
+	{
+		return *this;
+	}
+	arm = 1;
+	if(--ldr >= 0)
+	{
+		return *this;
+	}
+	ldr = lyr < 3 ? 11 : 15;
+	if(--lyr >= 0)
+	{
+		return *this;
+	}
+	lyr = -1;
+
+	*this = InttMap::OnlineREnd;
+	return *this;
+}
+
+bool InttMap::IsValid(
+	InttMap::Online_s const& onl)
+{
+	if(onl.lyr < 0 || 3 < onl.lyr)
+	{
+		return false;
+	}
+	if(onl.ldr < 0 || (onl.lyr < 2 ? 11 : 15) < onl.ldr)
+	{
+		return false;
+	}
+	if(onl.arm < 0 || 1 < onl.arm)
+	{
+		return false;
+	}
+	if(onl.chp < 0 || 25 < onl.chp)
+	{
+		return false;
+	}
+	if(onl.chn < 0 || 127 < onl.chn)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool InttMap::IsValidOrWildcard(
+	InttMap::Online_s const& onl)
+{
+	if(IsValid(onl))
+	{
+		return true;
+	}
+
+	if(onl.chn != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(onl.chp != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(onl.arm != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(onl.ldr != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(onl.lyr != InttMap::Wildcard)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+const struct InttMap::Online_s InttMap::OnlineBegin {
+	.lyr = 0,
+	.ldr = 0,
+	.arm = 0,
+	.chp = 0,
+	.chn = 0,
+};
+
+const struct InttMap::Online_s InttMap::OnlineEnd {
+	.lyr = 4,
+	.ldr = 0,
+	.arm = 0,
+	.chp = 0,
+	.chn = 0,
+};
+
+const struct InttMap::Online_s InttMap::OnlineRBegin {
+	.lyr = 3,
+	.ldr = 15,
+	.arm = 1,
+	.chp = 25,
+	.chn = 127,
+};
+
+const struct InttMap::Online_s InttMap::OnlineREnd {
+	.lyr = -1,
+	.ldr = 11,
+	.arm = 1,
+	.chp = 25,
+	.chn = 127,
+};
+
+InttMap::RawData_s& InttMap::RawData_s::operator++()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::RawDataEnd;
+		return *this;
+	}
+
+	if(++chn < 128)
+	{
+		return *this;
+	}
+	chn = 0;
+	if(++chp < 26)
+	{
+		return *this;
+	}
+	chp = 0;
+	if(++fee < 14)
+	{
+		return *this;
+	}
+	fee = 0;
+	if(++pid < 3009)
+	{
+		return *this;
+	}
+	pid = 0;
+
+	*this = InttMap::RawDataEnd;
+	return *this;
+}
+
+InttMap::RawData_s& InttMap::RawData_s::operator--()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::RawDataREnd;
+		return *this;
+	}
+
+	if(--chn >= 0)
+	{
+		return *this;
+	}
+	chn = 127;
+	if(--chp >= 0)
+	{
+		return *this;
+	}
+	chp = 25;
+	if(--fee >= 0)
+	{
+		return *this;
+	}
+	fee = 13;
+	if(--pid >= 3001)
+	{
+		return *this;
+	}
+	pid = 3000;
+
+	*this = InttMap::RawDataREnd;
+	return *this;
+}
+
+bool InttMap::IsValid(
+	InttMap::RawData_s const& raw)
+{
+	if(raw.pid < 3001 || 3008 < raw.pid)
+	{
+		return false;
+	}
+	if(raw.fee < 0 || 13 < raw.fee)
+	{
+		return false;
+	}
+	if(raw.chp < 0 || 25 < raw.chp)
+	{
+		return false;
+	}
+	if(raw.chn < 0 || 127 < raw.chn)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool InttMap::IsValidOrWildcard(
+	InttMap::RawData_s const& raw)
+{
+	if(IsValid(raw))
+	{
+		return true;
+	}
+
+	if(raw.chn != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(raw.chp != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(raw.fee != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(raw.pid != InttMap::Wildcard)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+const struct InttMap::RawData_s InttMap::RawDataBegin {
+	.pid = 3001,
+	.fee = 0,
+	.chp = 0,
+	.chn = 0,
+};
+
+const struct InttMap::RawData_s InttMap::RawDataEnd {
+	.pid = 3009,
+	.fee = 0,
+	.chp = 0,
+	.chn = 0,
+};
+
+const struct InttMap::RawData_s InttMap::RawDataRBegin {
+	.pid = 3008,
+	.fee = 13,
+	.chp = 25,
+	.chn = 127,
+};
+
+const struct InttMap::RawData_s InttMap::RawDataREnd {
+	.pid = 3000,
+	.fee = 13,
+	.chp = 25,
+	.chn = 127,
+};
+
+InttMap::Offline_s& InttMap::Offline_s::operator++()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::OfflineEnd;
+		return *this;
+	}
+
+	if(++strip_phi < 256)
+	{
+		return *this;
+	}
+	strip_phi = 0;
+	if(++strip_z < (ladder_z % 2 ? 5 : 8))
+	{
+		return *this;
+	}
+	strip_z = 0;
+	if(++ladder_z < 4)
+	{
+		return *this;
+	}
+	ladder_z = 0;
+	if(++ladder_phi < (layer < 5 ? 12 : 16))
+	{
+		return *this;
+	}
+	ladder_phi = 0;
+	if(++layer < 7)
+	{
+		return *this;
+	}
+
+	*this = InttMap::OfflineEnd;
+	return *this;
+}
+
+InttMap::Offline_s& InttMap::Offline_s::operator--()
+{
+	if(!InttMap::IsValid(*this))
+	{
+		*this = InttMap::OfflineREnd;
+		return *this;
+	}
+
+	if(--strip_phi >= 0)
+	{
+		return *this;
+	}
+	strip_phi = 255;
+	if(--strip_z >= 0)
+	{
+		return *this;
+	}
+	strip_z = ladder_z % 2 ? 7 : 4;
+	if(--ladder_z >= 0)
+	{
+		return *this;
+	}
+	ladder_z = 3;
+	if(--ladder_phi >= 0)
+	{
+		return *this;
+	}
+	ladder_phi = layer < 6 ? 11 : 15;
+	if(--layer >= 3)
+	{
+		return *this;
+	}
+	layer = 2;
+
+	*this = InttMap::OfflineREnd;
+	return *this;
+}
+
+bool InttMap::IsValid(
+	InttMap::Offline_s const& ofl)
+{
+	if(ofl.layer < 3 || 6 < ofl.layer)
+	{
+		return false;
+	}
+	if(ofl.ladder_phi < 0 || (ofl.layer < 5 ? 11 : 15) < ofl.ladder_phi)
+	{
+		return false;
+	}
+	if(ofl.ladder_z < 0 || 3 < ofl.ladder_z)
+	{
+		return false;
+	}
+	if(ofl.strip_z < 0 || (ofl.ladder_z % 2 ? 4 : 7) < ofl.strip_z)
+	{
+		return false;
+	}
+	if(ofl.strip_phi < 0 || 255 < ofl.strip_phi)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool InttMap::IsValidOrWildcard(
+	InttMap::Offline_s const& ofl)
+{
+	if(IsValid(ofl))
+	{
+		return true;
+	}
+
+	if(ofl.strip_phi != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(ofl.strip_z != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(ofl.ladder_z != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(ofl.ladder_phi != InttMap::Wildcard)
+	{
+		return false;
+	}
+	if(ofl.layer != InttMap::Wildcard)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+const struct InttMap::Offline_s InttMap::OfflineBegin {
+	.layer = 3,
+	.ladder_phi = 0,
+	.ladder_z = 0,
+	.strip_z = 0,
+	.strip_phi = 0,
+};
+
+const struct InttMap::Offline_s InttMap::OfflineEnd {
+	.layer = 7,
+	.ladder_phi = 0,
+	.ladder_z = 0,
+	.strip_z = 0,
+	.strip_phi = 0,
+};
+
+const struct InttMap::Offline_s InttMap::OfflineRBegin {
+	.layer = 6,
+	.ladder_phi = 15,
+	.ladder_z = 3,
+	.strip_z = 4,
+	.strip_phi = 255,
+};
+
+const struct InttMap::Offline_s InttMap::OfflineREnd {
+	.layer = 2,
+	.ladder_phi = 11,
+	.ladder_z = 3,
+	.strip_z = 4,
+	.strip_phi = 255,
+};
 
 bool InttMap::OnlineComparator::operator()(
     struct InttMap::Online_s const& lhs,
@@ -40,7 +519,6 @@ bool InttMap::OnlineWildcardComparator::operator()(
   {
     return lhs.lyr < rhs.lyr;
   }
-  // if(lhs.lyr != Wildcard && rhs.lyr == Wildcard && lhs.lyr != rhs.lyr)return lhs.lyr < rhs.lyr;
 
   if (lhs.ldr == Wildcard || rhs.ldr == Wildcard)
   {
@@ -50,7 +528,6 @@ bool InttMap::OnlineWildcardComparator::operator()(
   {
     return lhs.ldr < rhs.ldr;
   }
-  // if(lhs.ldr != Wildcard && rhs.ldr != Wildcard && lhs.ldr != rhs.ldr)return lhs.ldr < rhs.ldr;
 
   if (lhs.arm == Wildcard || rhs.arm == Wildcard)
   {
@@ -60,7 +537,6 @@ bool InttMap::OnlineWildcardComparator::operator()(
   {
     return lhs.arm < rhs.arm;
   }
-  // if(lhs.arm != Wildcard && rhs.arm != Wildcard && lhs.arm != rhs.arm)return lhs.arm < rhs.arm;
 
   if (lhs.chp == Wildcard || rhs.chp == Wildcard)
   {
@@ -70,7 +546,6 @@ bool InttMap::OnlineWildcardComparator::operator()(
   {
     return lhs.chp < rhs.chp;
   }
-  // if(lhs.chp != Wildcard && rhs.chp != Wildcard && lhs.chp != rhs.chp)return lhs.chp < rhs.chp;
 
   if (lhs.chn == Wildcard || rhs.chn == Wildcard)
   {
@@ -80,7 +555,6 @@ bool InttMap::OnlineWildcardComparator::operator()(
   {
     return lhs.chn < rhs.chn;
   }
-  // if(lhs.chn != Wildcard && rhs.chn != Wildcard && lhs.chn != rhs.chn)return lhs.chn < rhs.chn;
 
   return false;
 }
@@ -121,7 +595,6 @@ bool InttMap::RawDataWildcardComparator::operator()(
   {
     return lhs.pid < rhs.pid;
   }
-  // if(lhs.pid != Wildcard && rhs.pid != Wildcard && lhs.pid != rhs.pid)return lhs.pid < rhs.pid;
 
   if (lhs.fee == Wildcard || rhs.fee == Wildcard)
   {
@@ -131,7 +604,6 @@ bool InttMap::RawDataWildcardComparator::operator()(
   {
     return lhs.fee < rhs.fee;
   }
-  // if(lhs.fee != Wildcard && rhs.fee != Wildcard && lhs.fee != rhs.fee)return lhs.fee < rhs.fee;
 
   if (lhs.chp == Wildcard || rhs.chp == Wildcard)
   {
@@ -141,7 +613,6 @@ bool InttMap::RawDataWildcardComparator::operator()(
   {
     return lhs.chp < rhs.chp;
   }
-  // if(lhs.chp != Wildcard && rhs.chp != Wildcard && lhs.chp != rhs.chp)return lhs.chp < rhs.chp;
 
   if (lhs.chn == Wildcard || rhs.chn == Wildcard)
   {
@@ -151,7 +622,6 @@ bool InttMap::RawDataWildcardComparator::operator()(
   {
     return lhs.chn < rhs.chn;
   }
-  // if(lhs.chn != Wildcard && rhs.chn != Wildcard && lhs.chn != rhs.chn)return lhs.chn < rhs.chn;
 
   return false;
 }
@@ -196,7 +666,6 @@ bool InttMap::OfflineWildcardComparator::operator()(
   {
     return lhs.layer < rhs.layer;
   }
-  // if(lhs.layer != Wildcard && rhs.layer != Wildcard && lhs.layer != rhs.layer)return lhs.layer < rhs.layer;
 
   if (lhs.ladder_phi == Wildcard || rhs.ladder_phi == Wildcard)
   {
@@ -206,7 +675,6 @@ bool InttMap::OfflineWildcardComparator::operator()(
   {
     return lhs.ladder_phi < rhs.ladder_phi;
   }
-  // if(lhs.ladder_phi != Wildcard && rhs.ladder_phi != Wildcard && lhs.ladder_phi != rhs.ladder_phi)return lhs.ladder_phi < rhs.ladder_phi;
 
   if (lhs.ladder_z == Wildcard || rhs.ladder_z == Wildcard)
   {
@@ -216,7 +684,6 @@ bool InttMap::OfflineWildcardComparator::operator()(
   {
     return lhs.ladder_z < rhs.ladder_z;
   }
-  // if(lhs.ladder_z != Wildcard && rhs.ladder_z != Wildcard && lhs.ladder_z != rhs.ladder_z)return lhs.ladder_z < rhs.ladder_z;
 
   if (lhs.strip_z == Wildcard || rhs.strip_z == Wildcard)
   {
@@ -226,7 +693,6 @@ bool InttMap::OfflineWildcardComparator::operator()(
   {
     return lhs.strip_z < rhs.strip_z;
   }
-  // if(lhs.strip_z != Wildcard && rhs.strip_z != Wildcard && lhs.strip_z != rhs.strip_z)return lhs.strip_z < rhs.strip_z;
 
   if (lhs.strip_phi == Wildcard || rhs.strip_phi == Wildcard)
   {
@@ -236,7 +702,288 @@ bool InttMap::OfflineWildcardComparator::operator()(
   {
     return lhs.strip_phi < rhs.strip_phi;
   }
-  // if(lhs.strip_phi != Wildcard && rhs.strip_phi != Wildcard && lhs.strip_phi != rhs.strip_phi)return lhs.strip_phi < rhs.strip_phi;
 
   return false;
+}
+
+bool operator<(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  if(lhs.lyr != rhs.lyr)
+  {
+	return lhs.lyr < rhs.lyr;
+  }
+  if(lhs.ldr != rhs.ldr)
+  {
+    return lhs.ldr < rhs.ldr;
+  }
+  if(lhs.arm != rhs.arm)
+  {
+    return lhs.arm < rhs.arm;
+  }
+  if(lhs.chp != rhs.chp)
+  {
+    return lhs.chp < rhs.chp;
+  }
+  if(lhs.chn != rhs.chn)
+  {
+    return lhs.chn < rhs.chn;
+  }
+
+  return false;
+}
+
+bool operator==(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  if(lhs.lyr != rhs.lyr)
+  {
+    return false;
+  }
+  if(lhs.ldr != rhs.ldr)
+  {
+    return false;
+  }
+  if(lhs.arm != rhs.arm)
+  {
+    return false;
+  }
+  if(lhs.chp != rhs.chp)
+  {
+    return false;
+  }
+  if(lhs.chn != rhs.chn)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool operator!=(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+bool operator>(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  return rhs < lhs;
+}
+
+bool operator<=(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  return !(lhs > rhs);
+}
+
+bool operator>=(
+  struct InttMap::Online_s const& lhs,
+  struct InttMap::Online_s const& rhs)
+{
+  return !(lhs < rhs);
+}
+
+bool operator<(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  if(lhs.pid != rhs.pid)
+  {
+    return lhs.pid < rhs.pid;
+  }
+  if(lhs.fee != rhs.fee)
+  {
+    return lhs.fee < rhs.fee;
+  }
+  if(lhs.chp != rhs.chp)
+  {
+    return lhs.chp < rhs.chp;
+  }
+  if(lhs.chn != rhs.chn)
+  {
+    return lhs.chn < rhs.chn;
+  }
+
+  return false;
+}
+
+bool operator==(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  if(lhs.pid != rhs.pid)
+  {
+    return false;
+  }
+  if(lhs.fee != rhs.fee)
+  {
+    return false;
+  }
+  if(lhs.chp != rhs.chp)
+  {
+    return false;
+  }
+  if(lhs.chn != rhs.chn)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool operator!=(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+bool operator>(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  return rhs < lhs;
+}
+
+bool operator<=(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  return !(lhs > rhs);
+}
+
+bool operator>=(
+  struct InttMap::RawData_s const& lhs,
+  struct InttMap::RawData_s const& rhs)
+{
+  return !(lhs < rhs);
+}
+
+bool operator<(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  if(lhs.layer != rhs.layer)
+  {
+    return lhs.layer < rhs.layer;
+  }
+  if(lhs.ladder_phi != rhs.ladder_phi)
+  {
+    return lhs.ladder_phi < rhs.ladder_phi;
+  }
+  if(lhs.ladder_z != rhs.ladder_z)
+  {
+    return lhs.ladder_z < rhs.ladder_z;
+  }
+  if(lhs.strip_z != rhs.strip_z)
+  {
+    return lhs.strip_z < rhs.strip_z;
+  }
+  if(lhs.strip_phi != rhs.strip_phi)
+  {
+    return lhs.strip_phi < rhs.strip_phi;
+  }
+
+  return false;
+}
+
+bool operator==(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  if(lhs.layer != rhs.layer)
+  {
+    return false;
+  }
+  if(lhs.ladder_phi != rhs.ladder_phi)
+  {
+    return false;
+  }
+  if(lhs.ladder_z != rhs.ladder_z)
+  {
+    return false;
+  }
+  if(lhs.strip_z != rhs.strip_z)
+  {
+    return false;
+  }
+  if(lhs.strip_phi != rhs.strip_phi)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool operator!=(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  return !(lhs == rhs);
+}
+
+bool operator>(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  return rhs < lhs;
+}
+
+bool operator<=(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  return !(lhs > rhs);
+}
+
+bool operator>=(
+  struct InttMap::Offline_s const& lhs,
+  struct InttMap::Offline_s const& rhs)
+{
+  return !(lhs < rhs);
+}
+
+std::ostream& operator<<(
+  std::ostream& os,
+  struct InttMap::Online_s const& onl)
+{
+  os << "InttMap::Online_s\n"
+	 << boost::str(boost::format("\t%-12s%4d\n") % "lyr:" % onl.lyr)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "ldr:" % onl.ldr)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "arm:" % onl.arm)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "chp:" % onl.chp)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "chn:" % onl.chn);
+  return os;
+}
+
+std::ostream& operator<<(
+  std::ostream& os,
+  struct InttMap::RawData_s const& raw)
+{
+  os << "InttMap::RawData_s\n"
+	 << boost::str(boost::format("\t%-12s%4d\n") % "pid:" % raw.pid)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "fee:" % raw.fee)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "chp:" % raw.chp)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "chn:" % raw.chn);
+  return os;
+}
+
+std::ostream& operator<<(
+  std::ostream& os,
+  struct InttMap::Offline_s const& ofl)
+{
+  os << "InttMap::Offline_s\n"
+	 << boost::str(boost::format("\t%-12s%4d\n") % "layer:" % ofl.layer)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "ladder_phi:" % ofl.ladder_phi)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "ladder_z:" % ofl.ladder_z)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "strip_z:" % ofl.strip_z)
+	 << boost::str(boost::format("\t%-12s%4d\n") % "strip_phi:" % ofl.strip_phi);
+  return os;
 }

--- a/offline/packages/intt/InttMap.cc
+++ b/offline/packages/intt/InttMap.cc
@@ -1,4 +1,5 @@
 #include "InttMap.h"
+
 #include <boost/format.hpp>
 
 InttMap::Online_s& InttMap::Online_s::operator++()

--- a/offline/packages/intt/InttMap.h
+++ b/offline/packages/intt/InttMap.h
@@ -1,6 +1,7 @@
 #ifndef INTT_MAP_H
 #define INTT_MAP_H
 
+#include <iostream>
 #include <phool/PHObject.h>
 
 class InttMap : public PHObject
@@ -11,29 +12,59 @@ class InttMap : public PHObject
 
   struct Online_s
   {
-    field_t lyr = 0;
-    field_t ldr = 0;
-    field_t arm = 0;
-    field_t chp = 0;
-    field_t chn = 0;
+    field_t lyr = Wildcard;
+    field_t ldr = Wildcard;
+    field_t arm = Wildcard;
+    field_t chp = Wildcard;
+    field_t chn = Wildcard;
+
+	Online_s& operator++();
+	Online_s& operator--();
   };
+  static bool IsValid(struct Online_s const&);
+  static bool IsValidOrWildcard(struct Online_s const&);
+
+  const static struct Online_s OnlineBegin;
+  const static struct Online_s OnlineEnd;
+  const static struct Online_s OnlineRBegin;
+  const static struct Online_s OnlineREnd;
 
   struct RawData_s
   {
-    field_t pid = 0;
-    field_t fee = 0;
-    field_t chp = 0;
-    field_t chn = 0;
+    field_t pid = Wildcard;
+    field_t fee = Wildcard;
+    field_t chp = Wildcard;
+    field_t chn = Wildcard;
+
+	RawData_s& operator++();
+	RawData_s& operator--();
   };
+  static bool IsValid(struct RawData_s const&);
+  static bool IsValidOrWildcard(struct RawData_s const&);
+
+  const static struct RawData_s RawDataBegin;
+  const static struct RawData_s RawDataEnd;
+  const static struct RawData_s RawDataRBegin;
+  const static struct RawData_s RawDataREnd;
 
   struct Offline_s
   {
-    field_t layer = 0;
-    field_t ladder_phi = 0;
-    field_t ladder_z = 0;
-    field_t strip_phi = 0;
-    field_t strip_z = 0;
+    field_t layer = Wildcard;
+    field_t ladder_phi = Wildcard;
+    field_t ladder_z = Wildcard;
+    field_t strip_z = Wildcard;
+    field_t strip_phi = Wildcard;
+
+	Offline_s& operator++();
+	Offline_s& operator--();
   };
+  static bool IsValid(struct Offline_s const&);
+  static bool IsValidOrWildcard(struct Offline_s const&);
+
+  const static struct Offline_s OfflineBegin;
+  const static struct Offline_s OfflineEnd;
+  const static struct Offline_s OfflineRBegin;
+  const static struct Offline_s OfflineREnd;
 
   struct OnlineComparator
   {
@@ -68,6 +99,31 @@ class InttMap : public PHObject
  private:
   ClassDefOverride(InttMap, 1);
 };
+
+bool operator<(struct InttMap::Online_s const&, InttMap::Online_s const&);
+bool operator==(struct InttMap::Online_s const&, InttMap::Online_s const&);
+bool operator!=(struct InttMap::Online_s const&, InttMap::Online_s const&);
+bool operator>(struct InttMap::Online_s const&, InttMap::Online_s const&);
+bool operator<=(struct InttMap::Online_s const&, InttMap::Online_s const&);
+bool operator>=(struct InttMap::Online_s const&, InttMap::Online_s const&);
+
+bool operator<(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+bool operator==(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+bool operator!=(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+bool operator>(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+bool operator<=(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+bool operator>=(struct InttMap::RawData_s const&, InttMap::RawData_s const&);
+
+bool operator<(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+bool operator==(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+bool operator!=(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+bool operator>(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+bool operator<=(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+bool operator>=(struct InttMap::Offline_s const&, InttMap::Offline_s const&);
+
+std::ostream& operator<<(std::ostream&, struct InttMap::Online_s const&);
+std::ostream& operator<<(std::ostream&, struct InttMap::RawData_s const&);
+std::ostream& operator<<(std::ostream&, struct InttMap::Offline_s const&);
 
 #endif  // INTT_MAP_H
 

--- a/offline/packages/intt/InttMaskedChannelSet.cc
+++ b/offline/packages/intt/InttMaskedChannelSet.cc
@@ -1,25 +1,8 @@
 #include "InttMaskedChannelSet.h"
 
 #include <cdbobjects/CDBTTree.h>
-
 #include <ffamodules/CDBInterface.h>
-
 #include <filesystem>  // for exists
-
-void InttMaskedChannelSet::identify(
-    std::ostream& out) const
-{
-  out << "InttMaskedChannelSet"
-      << "\n"
-      << "\tBase Version"
-      << "\n"
-      << "\tUnimplemented" << std::endl;
-}
-
-std::size_t InttMaskedChannelSet::size() const
-{
-  return 0;
-}
 
 int InttMaskedChannelSet::LoadFromFile(
     std::string const& filename)
@@ -61,6 +44,21 @@ int InttMaskedChannelSet::LoadFromCDB(
   return v_LoadFromCDBTTree(cdbttree);
 }
 
+void InttMaskedChannelSet::identify(
+    std::ostream& out) const
+{
+  out << "InttMaskedChannelSet"
+      << "\n"
+      << "\tBase Version"
+      << "\n"
+      << "\tUnimplemented" << std::endl;
+}
+
+std::size_t InttMaskedChannelSet::size() const
+{
+  return 0;
+}
+
 bool InttMaskedChannelSet::IsDeadChannel(
     int const& layer,
     int const& ladder_phi,
@@ -72,8 +70,8 @@ bool InttMaskedChannelSet::IsDeadChannel(
       .layer = layer,
       .ladder_phi = ladder_phi,
       .ladder_z = ladder_z,
-      .strip_phi = strip_phi,
       .strip_z = strip_z,
+      .strip_phi = strip_phi,
   });
 }
 

--- a/offline/packages/intt/InttMaskedChannelSet.h
+++ b/offline/packages/intt/InttMaskedChannelSet.h
@@ -4,7 +4,6 @@
 #include "InttMap.h"
 
 #include <phool/PHObject.h>
-
 #include <iostream>
 #include <string>
 
@@ -16,11 +15,11 @@ class InttMaskedChannelSet : public PHObject
   InttMaskedChannelSet() = default;
   ~InttMaskedChannelSet() override = default;
 
-  virtual void identify(std::ostream& = std::cout) const override;
-  virtual std::size_t size() const;
-
   int LoadFromFile(std::string const& = "InttMaskedChannelSet.root");
   int LoadFromCDB(std::string const& = "InttMaskedChannelSet");
+
+  virtual void identify(std::ostream& = std::cout) const override;
+  virtual std::size_t size() const;
 
   bool IsDeadChannel(int const&, int const&, int const&, int const&, int const&) const;
   virtual bool IsDeadChannel(InttMap::Offline_s const&) const;

--- a/offline/packages/intt/InttMaskedChannelSetv1.cc
+++ b/offline/packages/intt/InttMaskedChannelSetv1.cc
@@ -29,10 +29,8 @@ std::size_t InttMaskedChannelSetv1::size() const
 int InttMaskedChannelSetv1::v_LoadFromCDBTTree(
     CDBTTree& cdbttree)
 {
-  if (!m_HotChannelSet)
-  {
-    m_HotChannelSet = new Set_t;
-  }
+  delete m_HotChannelSet;
+  m_HotChannelSet = new Set_t;
 
   m_HotChannelSet->clear();
   Long64_t N = cdbttree.GetSingleIntValue("size");
@@ -42,8 +40,8 @@ int InttMaskedChannelSetv1::v_LoadFromCDBTTree(
         .layer = cdbttree.GetIntValue(n, "layer"),
         .ladder_phi = cdbttree.GetIntValue(n, "ladder_phi"),
         .ladder_z = cdbttree.GetIntValue(n, "ladder_z"),
-        .strip_phi = cdbttree.GetIntValue(n, "strip_phi"),
         .strip_z = cdbttree.GetIntValue(n, "strip_z"),
+        .strip_phi = cdbttree.GetIntValue(n, "strip_phi"),
     });
   }
 

--- a/offline/packages/intt/InttSurveyMap.cc
+++ b/offline/packages/intt/InttSurveyMap.cc
@@ -7,21 +7,6 @@
 #include <filesystem>  // for exists
 #include <utility>     // for pair
 
-void InttSurveyMap::identify(
-    std::ostream& out) const
-{
-  out << "InttSurveyMap"
-      << "\n"
-      << "\tBase Version"
-      << "\n"
-      << "\tUnimplemented" << std::endl;
-}
-
-std::size_t InttSurveyMap::size() const
-{
-  return 0;
-}
-
 int InttSurveyMap::LoadFromFile(
     std::string const& filename)
 {
@@ -62,109 +47,66 @@ int InttSurveyMap::LoadFromCDB(
   return v_LoadFromCDBTTree(cdbttree);
 }
 
-int InttSurveyMap::v_LoadFromCDBTTree(
-    CDBTTree&
-    /*unused*/)
+int InttSurveyMap::GetStripTransform(
+    key_t const& k,
+	val_t& v) const
+{
+  if(!GetAbsoluteTransform(k))
+  {
+    return 1;
+  }
+
+  for(int i = 0; i < 16; ++i)
+  {
+    v.matrix()(i / 4, i % 4) = i / 4 == i % 4;
+  }
+
+  // strip_z determines local z
+  //  10, 16 are double the max range strip_z takes for the sensor type (ladder_z % 2)
+  //  100, 128 are the lengths of the sensor type (ladder_z % 2) in mm
+  v.matrix()(2, 3) = (2.0 * k.strip_z + 1.0) / ((k.ladder_z % 2) ? 10.0 : 16.0) - 0.5;
+  v.matrix()(2, 3) *= (k.ladder_z % 2) ? 100.0 : 128.0;
+
+  // strip_phi determines the local x
+  // 512 is double the max range strip_phi takes
+  // 19.968 is the sensor width in mm
+  v.matrix()(0, 3) = (2.0 * k.strip_phi + 1.0) / 512.0 - 0.5;
+  v.matrix()(0, 3) *= 19.968;
+
+  v = *GetAbsoluteTransform(k) * v;
+
+  return 0;
+}
+
+void InttSurveyMap::identify(
+    std::ostream& out) const
+{
+  out << "InttSurveyMap"
+      << "\n"
+      << "\tBase Version"
+      << "\n"
+      << "\tUnimplemented" << std::endl;
+}
+
+std::size_t InttSurveyMap::size() const
 {
   return 0;
 }
 
 InttSurveyMap::val_t const* InttSurveyMap::GetAbsoluteTransform(
-    key_t k) const
+    key_t const& /*unused*/) const
 {
-  map_t::const_iterator itr;
-
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.strip_z = InttMap::Wildcard;
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.strip_phi = InttMap::Wildcard;
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.ladder_z = InttMap::Wildcard;
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.ladder_phi = InttMap::Wildcard;
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.layer = InttMap::Wildcard;
-  if (v_LookupAbsoluteTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  return (val_t const*) nullptr;
+	return nullptr;
 }
 
 InttSurveyMap::val_t const* InttSurveyMap::GetRelativeTransform(
-    key_t k) const
+    key_t const& /*unused*/) const
 {
-  map_t::const_iterator itr;
-
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.strip_z = InttMap::Wildcard;
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.strip_phi = InttMap::Wildcard;
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.ladder_z = InttMap::Wildcard;
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.ladder_phi = InttMap::Wildcard;
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  k.layer = InttMap::Wildcard;
-  if (v_LookupRelativeTransform(k, itr))
-  {
-    return &(itr->second);
-  }
-
-  return (val_t const*) nullptr;
+	return nullptr;
 }
 
-int InttSurveyMap::v_LookupAbsoluteTransform(
-    key_t const& /*unused*/, map_t::const_iterator&
-    /*unused*/) const
-{
-  return 0;
-}
-
-int InttSurveyMap::v_LookupRelativeTransform(
-    key_t const& /*unused*/, map_t::const_iterator&
-    /*unused*/) const
+int InttSurveyMap::v_LoadFromCDBTTree(
+    CDBTTree& /*unused*/)
 {
   return 0;
 }

--- a/offline/packages/intt/InttSurveyMap.h
+++ b/offline/packages/intt/InttSurveyMap.h
@@ -24,20 +24,19 @@ class InttSurveyMap : public PHObject
   InttSurveyMap() = default;
   ~InttSurveyMap() override = default;
 
-  virtual void identify(std::ostream& = std::cout) const override;
-  virtual std::size_t size() const;
-
   int LoadFromFile(std::string const& = "InttSurveyMap.root");
   int LoadFromCDB(std::string const& = "InttSurveyMap");
 
-  virtual val_t const* GetAbsoluteTransform(key_t) const;
-  virtual val_t const* GetRelativeTransform(key_t) const;
+  int GetStripTransform(key_t const&, val_t&) const;
+
+  virtual void identify(std::ostream& = std::cout) const override;
+  virtual std::size_t size() const;
+
+  virtual val_t const* GetAbsoluteTransform(key_t const&) const;
+  virtual val_t const* GetRelativeTransform(key_t const&) const;
 
  protected:
   virtual int v_LoadFromCDBTTree(CDBTTree&);
-
-  virtual int v_LookupAbsoluteTransform(key_t const&, map_t::const_iterator&) const;
-  virtual int v_LookupRelativeTransform(key_t const&, map_t::const_iterator&) const;
 
  private:
   ClassDefOverride(InttSurveyMap, 1)

--- a/offline/packages/intt/InttSurveyMapv1.cc
+++ b/offline/packages/intt/InttSurveyMapv1.cc
@@ -20,7 +20,11 @@ void InttSurveyMapv1::identify(
 
 std::size_t InttSurveyMapv1::size() const
 {
-  return 0;
+  if (!m_absolute_transforms)
+  {
+    return 0;
+  }
+  return m_absolute_transforms->size();
 }
 
 int InttSurveyMapv1::v_LoadFromCDBTTree(
@@ -29,17 +33,11 @@ int InttSurveyMapv1::v_LoadFromCDBTTree(
   Eigen::Affine3d aff;
   InttMap::Offline_s ofl;
 
-  if (!m_absolute_transforms)
-  {
-    m_absolute_transforms = new map_t;
-  }
-  m_absolute_transforms->clear();
+  delete m_absolute_transforms;
+  delete m_relative_transforms;
 
-  if (!m_relative_transforms)
-  {
-    m_relative_transforms = new map_t;
-  }
-  m_relative_transforms->clear();
+  m_absolute_transforms = new map_t;
+  m_relative_transforms = new map_t;
 
   Int_t N = cdbttree.GetSingleIntValue("size");
   for (Int_t n = 0; n < N; ++n)
@@ -47,47 +45,45 @@ int InttSurveyMapv1::v_LoadFromCDBTTree(
     ofl.layer = cdbttree.GetIntValue(n, "layer");
     ofl.ladder_phi = cdbttree.GetIntValue(n, "ladder_phi");
     ofl.ladder_z = cdbttree.GetIntValue(n, "ladder_z");
-    ofl.strip_phi = cdbttree.GetIntValue(n, "strip_phi");
     ofl.strip_z = cdbttree.GetIntValue(n, "strip_z");
+    ofl.strip_phi = cdbttree.GetIntValue(n, "strip_phi");
 
     for (int i = 0; i < 16; ++i)
     {
-      std::string boost_formatted = boost::str(boost::format("m_rel_%01d_%01d") %  (i / 4) % (i%4));
-      aff.matrix()(i / 4, i % 4) = cdbttree.GetDoubleValue(n,boost_formatted );
-    }
-    m_relative_transforms->insert({ofl, aff});
-
-    for (int i = 0; i < 16; ++i)
-    {
-      std::string boost_formatted = boost::str(boost::format("m_abs_%01d_%01d") %  (i / 4) % (i%4));
+      std::string boost_formatted = boost::str(boost::format("m_abs_%01d_%01d") %  (i/4) % (i%4));
       aff.matrix()(i / 4, i % 4) = cdbttree.GetDoubleValue(n, boost_formatted);
     }
     m_absolute_transforms->insert({ofl, aff});
+
+    for (int i = 0; i < 16; ++i)
+    {
+      std::string boost_formatted = boost::str(boost::format("m_rel_%01d_%01d") %  (i/4) % (i%4));
+      aff.matrix()(i / 4, i % 4) = cdbttree.GetDoubleValue(n,boost_formatted );
+    }
+    m_relative_transforms->insert({ofl, aff});
   }
 
   return 0;
 }
 
-int InttSurveyMapv1::v_LookupAbsoluteTransform(
-    key_t const& k,
-    map_t::const_iterator& itr) const
+InttSurveyMap::val_t const* InttSurveyMapv1::GetAbsoluteTransform(
+    key_t const& k) const
 {
   if (!m_absolute_transforms)
   {
     return 0;
   }
-  itr = m_absolute_transforms->find(k);
-  return itr != m_absolute_transforms->end();
+  map_t::const_iterator itr = m_absolute_transforms->find(k);
+  return itr != m_absolute_transforms->end() ? &itr->second : nullptr;
 }
 
-int InttSurveyMapv1::v_LookupRelativeTransform(
-    key_t const& k,
-    map_t::const_iterator& itr) const
+InttSurveyMap::val_t const* InttSurveyMapv1::GetRelativeTransform(
+    key_t const& k) const
 {
   if (!m_relative_transforms)
   {
     return 0;
   }
-  itr = m_relative_transforms->find(k);
-  return itr != m_relative_transforms->end();
+  map_t::const_iterator itr = m_relative_transforms->find(k);
+  return itr != m_relative_transforms->end() ? &itr->second : nullptr;
 }

--- a/offline/packages/intt/InttSurveyMapv1.cc
+++ b/offline/packages/intt/InttSurveyMapv1.cc
@@ -71,7 +71,7 @@ InttSurveyMap::val_t const* InttSurveyMapv1::GetAbsoluteTransform(
 {
   if (!m_absolute_transforms)
   {
-    return 0;
+    return nullptr;
   }
   map_t::const_iterator itr = m_absolute_transforms->find(k);
   return itr != m_absolute_transforms->end() ? &itr->second : nullptr;
@@ -82,7 +82,7 @@ InttSurveyMap::val_t const* InttSurveyMapv1::GetRelativeTransform(
 {
   if (!m_relative_transforms)
   {
-    return 0;
+    return nullptr;
   }
   map_t::const_iterator itr = m_relative_transforms->find(k);
   return itr != m_relative_transforms->end() ? &itr->second : nullptr;

--- a/offline/packages/intt/InttSurveyMapv1.h
+++ b/offline/packages/intt/InttSurveyMapv1.h
@@ -21,11 +21,11 @@ class InttSurveyMapv1 : public InttSurveyMap
   void identify(std::ostream& = std::cout) const override;
   std::size_t size() const override;
 
+  val_t const* GetAbsoluteTransform(key_t const&) const override;
+  val_t const* GetRelativeTransform(key_t const&) const override;
+
  protected:
   int v_LoadFromCDBTTree(CDBTTree&) override;
-
-  int v_LookupAbsoluteTransform(key_t const&, map_t::const_iterator&) const override;
-  int v_LookupRelativeTransform(key_t const&, map_t::const_iterator&) const override;
 
  private:
   map_t* m_absolute_transforms = nullptr;

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -39,6 +39,8 @@ pkginclude_HEADERS = \
   InttCombinedRawDataDecoder.h \
   InttMaskedChannelSet.h \
   InttMaskedChannelSetv1.h \
+  InttFeeMap.h \
+  InttFeeMapv1.h \
   InttFelixMap.h \
   InttMap.h \
   InttMapping.h \
@@ -57,6 +59,8 @@ ROOTDICTS = \
   CylinderGeomIntt_Dict.cc \
   InttMaskedChannelSet_Dict.cc \
   InttMaskedChannelSetv1_Dict.cc \
+  InttFeeMap_Dict.cc \
+  InttFeeMapv1_Dict.cc \
   InttMap_Dict.cc \
   InttSurveyMap_Dict.cc \
   InttSurveyMapv1_Dict.cc \
@@ -70,6 +74,8 @@ nobase_dist_pcm_DATA = \
   CylinderGeomIntt_Dict_rdict.pcm \
   InttMaskedChannelSet_Dict_rdict.pcm \
   InttMaskedChannelSetv1_Dict_rdict.pcm \
+  InttFeeMap_Dict_rdict.pcm \
+  InttFeeMapv1_Dict_rdict.pcm \
   InttMap_Dict_rdict.pcm \
   InttSurveyMap_Dict_rdict.pcm \
   InttSurveyMapv1_Dict_rdict.pcm \
@@ -86,6 +92,8 @@ libintt_la_SOURCES = \
   InttCombinedRawDataDecoder.cc \
   InttMaskedChannelSet.cc \
   InttMaskedChannelSetv1.cc \
+  InttFeeMap.cc \
+  InttFeeMapv1.cc \
   InttFelixMap.cc \
   InttMapping.cc \
   InttMap.cc \
@@ -109,6 +117,8 @@ libintt_io_la_SOURCES = \
   CylinderGeomIntt.cc \
   InttMaskedChannelSet.cc \
   InttMaskedChannelSetv1.cc \
+  InttFeeMap.cc \
+  InttFeeMapv1.cc \
   InttMap.cc \
   InttSurveyMap.cc \
   InttSurveyMapv1.cc \


### PR DESCRIPTION
 to eventually replace the autogenerated switch statements InttFelixMap uses. Expanded functionality of InttMap, implemented comparators and inc/dec operators for the structs

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

