### PR TITLE
KFP: avoid duplicate tracks used in different intermediate resonances

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -181,6 +181,26 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
             finalTracks.insert(finalTracks.end(), potentialDaughters[j][matchIterators[j]].begin(), potentialDaughters[j][matchIterators[j]].end());
           }
 
+          bool have_duplicate_track = false;
+
+          for (size_t i = 0; i < finalTracks.size(); ++i)
+          {
+            for (size_t j = i + 1; j < finalTracks.size(); ++j)
+            {
+              if (finalTracks[i].Id() == finalTracks[j].Id())
+              {
+                have_duplicate_track = true;
+                break;
+              }
+            }
+            if (have_duplicate_track)
+            {
+              break;
+            }
+          }
+
+          if (have_duplicate_track) continue;
+
           // If there are daughter tracks coming from the mother not an intermediate, need to ensure that the intermeditate decay tracks aren't used again
           std::vector<int> goodTrackIndexAdv_withoutIntermediates = goodTrackIndexAdv;
           for (int m = 0; m < num_tracks_used_by_intermediates; ++m)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Add duplicate tracks check in final track list to avoid same tracks being used in different intermediate resonances.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

