### PR TITLE
Adding TowerInfoV2 Compatibility for Simulation

### DIFF
--- a/offline/packages/CaloReco/RawTowerCalibration.cc
+++ b/offline/packages/CaloReco/RawTowerCalibration.cc
@@ -437,11 +437,10 @@ void RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
     }
   }
   if (m_UseTowerInfo > 0)
-  {
-    RawTowerInfoNodeName = "TOWERINFO_" + _raw_tower_node_prefix + "_" + m_Detector;
-    //if(!m_UseTowerInfoV2)
-    _raw_towerinfos = findNode::getClass<TowerInfoContainerv1>(dstNode, RawTowerInfoNodeName);
-    //  else  _raw_towerinfos = findNode::getClass<TowerInfoContainerv2>(dstNode, RawTowerInfoNodeName);
+    {
+      RawTowerInfoNodeName = "TOWERINFO_" + _raw_tower_node_prefix + "_" + m_Detector;
+      _raw_towerinfos = findNode::getClass<TowerInfoContainerv1>(dstNode, RawTowerInfoNodeName);
+ 
     if (!_raw_towerinfos)
     {
       std::cout << Name() << "::" << m_Detector << "::" << __PRETTY_FUNCTION__

--- a/offline/packages/CaloReco/RawTowerCalibration.cc
+++ b/offline/packages/CaloReco/RawTowerCalibration.cc
@@ -9,7 +9,9 @@
 #include <calobase/TowerInfo.h>
 #include <calobase/TowerInfoContainer.h>
 #include <calobase/TowerInfoContainerv1.h>
+#include <calobase/TowerInfoContainerv2.h>
 #include <calobase/TowerInfov1.h>
+#include <calobase/TowerInfov2.h>
 
 #include <phparameter/PHParameters.h>
 
@@ -437,7 +439,9 @@ void RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
   if (m_UseTowerInfo > 0)
   {
     RawTowerInfoNodeName = "TOWERINFO_" + _raw_tower_node_prefix + "_" + m_Detector;
+    //if(!m_UseTowerInfoV2)
     _raw_towerinfos = findNode::getClass<TowerInfoContainerv1>(dstNode, RawTowerInfoNodeName);
+    //  else  _raw_towerinfos = findNode::getClass<TowerInfoContainerv2>(dstNode, RawTowerInfoNodeName);
     if (!_raw_towerinfos)
     {
       std::cout << Name() << "::" << m_Detector << "::" << __PRETTY_FUNCTION__
@@ -474,7 +478,8 @@ void RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
   if (m_UseTowerInfo > 0)
   {
     CaliTowerInfoNodeName = "TOWERINFO_" + _calib_tower_node_prefix + "_" + m_Detector;
-    _calib_towerinfos = findNode::getClass<TowerInfoContainerv1>(DetNode, CaliTowerInfoNodeName);
+    if(!m_UseTowerInfoV2)_calib_towerinfos = findNode::getClass<TowerInfoContainerv1>(DetNode, CaliTowerInfoNodeName);
+    else _calib_towerinfos = findNode::getClass<TowerInfoContainerv2>(DetNode, CaliTowerInfoNodeName);
     if (!_calib_towerinfos)
     {
       TowerInfoContainerv1::DETECTOR detec;
@@ -491,7 +496,9 @@ void RawTowerCalibration::CreateNodes(PHCompositeNode *topNode)
         std::cout << PHWHERE << "Detector not implemented into the TowerInfoContainer object, defaulting to HCal implementation." << std::endl;
         detec = TowerInfoContainer::DETECTOR::HCAL;
       }
-      _calib_towerinfos = new TowerInfoContainerv1(detec);
+      if(!m_UseTowerInfoV2)_calib_towerinfos = new TowerInfoContainerv1(detec);
+      else _calib_towerinfos = new TowerInfoContainerv2(detec);
+
       PHIODataNode<PHObject> *towerinfoNode = new PHIODataNode<PHObject>(_calib_towerinfos, CaliTowerInfoNodeName, "PHObject");
       DetNode->addNode(towerinfoNode);
     }

--- a/offline/packages/CaloReco/RawTowerCalibration.h
+++ b/offline/packages/CaloReco/RawTowerCalibration.h
@@ -13,6 +13,7 @@ class CDBTTree;
 class PHCompositeNode;
 class RawTowerContainer;
 class TowerInfoContainerv1;
+class TowerInfoContainer;
 class RawTowerGeomContainer;
 
 //! calibrate ADC value to measured energy deposition in calorimeter towers
@@ -145,6 +146,11 @@ class RawTowerCalibration : public SubsysReco
     m_UseTowerInfo = UseTowerInfo;
   }
 
+  void set_usetowerinfo_v2(bool usetowerinfov2)
+  {
+    m_UseTowerInfoV2 = usetowerinfov2;
+  }
+
  protected:
   void CreateNodes(PHCompositeNode *topNode);
 
@@ -152,8 +158,8 @@ class RawTowerCalibration : public SubsysReco
   RawTowerContainer *_calib_towers = nullptr;
   RawTowerContainer *_raw_towers = nullptr;
 
-  TowerInfoContainerv1 *_calib_towerinfos = nullptr;
-  TowerInfoContainerv1 *_raw_towerinfos = nullptr;
+  TowerInfoContainer *_calib_towerinfos = nullptr;
+  TowerInfoContainer *_raw_towerinfos = nullptr;
 
   RawTowerGeomContainer *rawtowergeom = nullptr;
 
@@ -189,7 +195,8 @@ class RawTowerCalibration : public SubsysReco
 
   std::string m_CalibrationFileName;
   bool m_UseConditionsDB = false;
-
+  bool m_UseTowerInfoV2 = false;
+  
   CDBTTree *m_CDBTTree = nullptr;
   RawTowerCalibration::ProcessTowerType m_UseTowerInfo = RawTowerCalibration::ProcessTowerType::kBothTowers;  // 0 just produce RawTowers, 1 just produce TowerInfo objects, and 2 produce both
 };


### PR DESCRIPTION
This PR is the first of three (One to coresoftware, one to macros/common, and one to the MDC2 area) that will enable TowerInfoV2 functionality in simulation, making it easier to model the data acceptance in simulation via the masking stored in the status fields of the TowerInfoV2 objects. 

A setter and corresponding boolean have been added telling the software whether to store V1 or V2 objects. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

