### PR TITLE
add const to trackseed get_phi implementation and cleanup

### DIFF
--- a/offline/packages/trackbase_historic/TrackSeed.h
+++ b/offline/packages/trackbase_historic/TrackSeed.h
@@ -76,9 +76,9 @@ class TrackSeed : public PHObject
 
   /// In case the global cluster positions have already been obtained,
   /// these can be called to avoid performing transformations twice
-  virtual void circleFitByTaubin(std::map<TrkrDefs::cluskey, Acts::Vector3>&,
+  virtual void circleFitByTaubin(const std::map<TrkrDefs::cluskey, Acts::Vector3>&,
                                  uint8_t, uint8_t) {}
-  virtual void lineFit(std::map<TrkrDefs::cluskey, Acts::Vector3>&,
+  virtual void lineFit(const std::map<TrkrDefs::cluskey, Acts::Vector3>&,
                        uint8_t, uint8_t) {}
 
   virtual void clear_cluster_keys() {}

--- a/offline/packages/trackbase_historic/TrackSeed.h
+++ b/offline/packages/trackbase_historic/TrackSeed.h
@@ -44,7 +44,7 @@ class TrackSeed : public PHObject
                        ActsGeometry*) const { return NAN; }
   virtual float get_phi(TrkrClusterContainer*,
                         ActsGeometry*) const { return NAN; }
-  virtual float get_phi(std::map<TrkrDefs::cluskey, Acts::Vector3>&) const { return NAN; }
+  virtual float get_phi(const std::map<TrkrDefs::cluskey, Acts::Vector3>&) const { return NAN; }
   virtual float get_pz() const { return NAN; }
   virtual float get_x() const { return NAN; }
   virtual float get_y() const { return NAN; }

--- a/offline/packages/trackbase_historic/TrackSeed_v1.cc
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.cc
@@ -149,7 +149,7 @@ void TrackSeed_v1::lineFit(TrkrClusterContainer* clusters,
   lineFit(positions, startLayer, endLayer);
 }
 
-void TrackSeed_v1::circleFitByTaubin(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
+void TrackSeed_v1::circleFitByTaubin(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
                                      uint8_t startLayer,
                                      uint8_t endLayer)
 {
@@ -204,7 +204,7 @@ void TrackSeed_v1::circleFitByTaubin(std::map<TrkrDefs::cluskey, Acts::Vector3>&
   }
 }
 
-void TrackSeed_v1::lineFit(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
+void TrackSeed_v1::lineFit(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
                            uint8_t startLayer,
                            uint8_t endLayer)
 {

--- a/offline/packages/trackbase_historic/TrackSeed_v1.cc
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.cc
@@ -286,7 +286,7 @@ float TrackSeed_v1::get_pt() const
   /// Scaling factor for radius in 1.4T field
   return 0.3 * 1.4 / 100. * fabs(1. / m_qOverR);
 }
-float TrackSeed_v1::get_phi(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions) const
+float TrackSeed_v1::get_phi(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions) const
 {
   const auto [x, y] = findRoot();
   float phi = std::atan2(-1 * (m_X0 - x), (m_Y0 - y));
@@ -328,23 +328,24 @@ float TrackSeed_v1::get_phi(std::map<TrkrDefs::cluskey, Acts::Vector3>& position
 float TrackSeed_v1::get_phi(TrkrClusterContainer* clusters,
                             ActsGeometry* tGeometry) const
 {
-  auto clus1 = clusters->findCluster(*(m_cluster_keys.begin()));
-  auto key = *std::next(m_cluster_keys.begin(), 1);
-  auto clus2 = clusters->findCluster(key);
-  if (!clus1 or !clus2)
-  {
-    return NAN;
-  }
+  // check that there are enough clusters associated to the seed
+  if( m_cluster_keys.size() < 2 ) return NAN;
 
-  Acts::Vector3 pos0 = tGeometry->getGlobalPosition(
-      *(m_cluster_keys.begin()),
-      clus1);
+  const auto key1 = *(m_cluster_keys.begin());
+  const auto clus1 = clusters->findCluster(key1);
+  if( !clus1 ) return NAN;
 
-  Acts::Vector3 pos1 = tGeometry->getGlobalPosition(key, clus2);
-  std::map<TrkrDefs::cluskey, Acts::Vector3> positions;
-  positions.insert(std::make_pair(*(m_cluster_keys.begin()), pos0));
-  positions.insert(std::make_pair(key, pos1));
+  const auto key2 = *(++m_cluster_keys.begin());
+  const auto clus2 = clusters->findCluster(key2);
+  if( !clus2 ) return NAN;
+
+  const auto pos1 = tGeometry->getGlobalPosition(key1, clus1);
+  const auto pos2 = tGeometry->getGlobalPosition(key2, clus2);
+  const std::map<TrkrDefs::cluskey, Acts::Vector3> positions = {
+    { key1, pos1 },
+    { key2, pos2 } };
   return get_phi(positions);
+
 }
 
 float TrackSeed_v1::get_theta() const

--- a/offline/packages/trackbase_historic/TrackSeed_v1.h
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.h
@@ -82,11 +82,11 @@ class TrackSeed_v1 : public TrackSeed
                uint8_t startLayer = 0,
                uint8_t endLayer = 58) override;
 
-  void circleFitByTaubin(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
+  void circleFitByTaubin(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
                          uint8_t startLayer = 0,
                          uint8_t endLayer = 58) override;
 
-  void lineFit(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
+  void lineFit(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions,
                uint8_t startLayer = 0,
                uint8_t endLayer = 58) override;
 

--- a/offline/packages/trackbase_historic/TrackSeed_v1.h
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.h
@@ -38,7 +38,7 @@ class TrackSeed_v1 : public TrackSeed
   float get_z() const override;
   float get_phi(TrkrClusterContainer* clusters,
                 ActsGeometry* tGeometry) const override;
-  float get_phi(std::map<TrkrDefs::cluskey, Acts::Vector3>& positions) const override;
+  float get_phi(const std::map<TrkrDefs::cluskey, Acts::Vector3>& positions) const override;
   float get_eta() const override;
   float get_theta() const override;
   float get_pt() const override;


### PR DESCRIPTION
- pass const_ref rather than ref to get_phi method. Using a non-const ref is quite dangerous, as it might mean that the passed argument gets modified internally. 
- also somewhat cleaned up get_phi implementation. 
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

