### PR TITLE
Tpc silicon matching distortions

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -74,6 +74,11 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
    */
   Acts::Vector3 getGlobalPosition(TrkrDefs::cluskey, TrkrCluster*) const;
 
+
+  // calculate phi for a given tracklet, properly accounting for distortions
+  double getPhi( TrackSeed* ) const;
+
+
    //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
   //double getMedian(std::vector<double> &v);
   //void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
@@ -118,8 +123,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeedContainer *_track_map{nullptr};
   TrackSeedContainer *_track_map_silicon{nullptr};
-  TrackSeed *_tracklet_tpc{nullptr};
-  TrackSeed *_tracklet_si{nullptr};
+
   TrkrClusterContainer *_cluster_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

DO NOT MERGE !
This is mostly for @adfrawley 

This fix illustrates how to properly account for distortions when calculating the TPC seed phi angle for matching to the silicons, in presence of distortion corrections. Relevant methods are ::getGlobalPositions and ::getPhi
The corrections are only applied in triggered mode, so this should have no impact on the current streaming (pp) mode.
More fixes (and possibly a different approach) are needed in streaming mode.


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

