### PR TITLE
apply cut on number of entries for tpc container, reset if > 500000

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -815,8 +815,17 @@ int Fun4AllStreamingInputManager::FillTpc()
       break;
     }
   }
-  // std::cout << "size  m_TpcRawHitMap: " <<  m_TpcRawHitMap.size()
-  // 	    << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "tpc container size: " << tpccont->get_nhits();
+    std::cout << ", size  m_TpcRawHitMap: " <<  m_TpcRawHitMap.size()
+	      << std::endl;
+  }
+  if (tpccont->get_nhits() > 500000)
+  {
+    std::cout << "Resetting TPC Container with number of entries " << tpccont->get_nhits() << std::endl;
+    tpccont->Reset();
+  }
   return 0;
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The streaming readout combining crashes in the tpc with an overflow in root (which uses ints for sizes???)
Fatal in <TBufferFile::AutoExpand>: Request to expand to a negative size, likely due to an integer overflow: 0x800002c6 for a max of 0x7ffffffe.
aborting
This PR resets the tpc hit container if it has > 500k entries (for the current cosmics/calibrations the number of entries is ~160k), the crash occurs with 4702171 entries


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

