### PR TITLE
Fix boost::geometry::index intersect call

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -224,11 +224,21 @@ Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster*
 
 void PHCASeeding::QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>> &rtree, double phimin, double etamin, double lmin, double phimax, double etamax, double lmax, std::vector<pointKey> &returned_values) const
 {
-  double phimin_2pi = phimin;
-  double phimax_2pi = phimax;
-  if (phimin < 0) phimin_2pi = 2*M_PI+phimin;
-  if (phimax > 2*M_PI) phimax_2pi = phimax-2*M_PI;
-  rtree.query(bgi::intersects(box(point(phimin_2pi, etamin, lmin), point(phimax_2pi, etamax, lmax))), std::back_inserter(returned_values));
+  bool query_both_ends = false;
+  if (phimin<0) {
+    query_both_ends = true;
+    phimin += 2*M_PI;
+  }
+  if (phimax>2*M_PI) {
+    query_both_ends = true;
+    phimax -= 2*M_PI;
+  }
+  if (query_both_ends) {
+    rtree.query(bgi::intersects(box(point(phimin, etamin, lmin), point(2*M_PI, etamax, lmax))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(    0., etamin, lmin), point(phimax, etamax, lmax))), std::back_inserter(returned_values));
+  } else {
+    rtree.query(bgi::intersects(box(point(phimin, etamin, lmin), point(phimax, etamax, lmax))), std::back_inserter(returned_values));
+  }
 }
 
 PositionMap PHCASeeding::FillTree()


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
There was a small bug in PHCA seeding in which the call to find neighboring clusters across the periodic phi boundaries were not found. This is fixed. The effect is quit small, as it is relatively rare to have the phi search across the boundary.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

