### PR TITLE
add flag to suppress histogram not found error message

### DIFF
--- a/offline/database/cdbobjects/CDBHistos.cc
+++ b/offline/database/cdbobjects/CDBHistos.cc
@@ -102,12 +102,15 @@ void CDBHistos::registerHisto(TH1 *h1)
   return;
 }
 
-TH1 *CDBHistos::getHisto(const std::string &name)
+TH1 *CDBHistos::getHisto(const std::string &name, bool printerror)
 {
   const auto iter = m_HistoMap.find(name);
   if (iter == m_HistoMap.end())
   {
-    std::cout << __PRETTY_FUNCTION__ << ": Histogram " << name << " not found" << std::endl;
+    if (printerror)
+    {
+      std::cout << __PRETTY_FUNCTION__ << ": Histogram " << name << " not found" << std::endl;
+    }
     return nullptr;
   }
   return iter->second;

--- a/offline/database/cdbobjects/CDBHistos.h
+++ b/offline/database/cdbobjects/CDBHistos.h
@@ -16,7 +16,7 @@ class CDBHistos
   void Print() const;
   void LoadCalibrations();
   void registerHisto(TH1 *h1);
-  TH1 *getHisto(const std::string &name);
+  TH1 *getHisto(const std::string &name, bool printerror = true);
 
  private:
   std::string m_Filename;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a flag to CDBHisto::getHisto to suppress the error message. It will still return null ptrs for non existing histograms but now this can be used to check if a histogram exists in the cdb

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

