### PR TITLE
Fix embedding

### DIFF
--- a/generators/phhepmc/Makefile.am
+++ b/generators/phhepmc/Makefile.am
@@ -22,6 +22,7 @@ pkginclude_HEADERS = \
   HepMCFlowAfterBurner.h \
   PHGenIntegral.h \
   PHGenIntegralv1.h \
+  PHHepMCDefs.h \
   PHHepMCGenEvent.h \
   PHHepMCGenEventv1.h \
   PHHepMCGenEventMap.h \

--- a/generators/phhepmc/PHHepMCDefs.h
+++ b/generators/phhepmc/PHHepMCDefs.h
@@ -1,0 +1,13 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef PHHEPMC_PHHEPMCDEFS_H
+#define PHHEPMC_PHHEPMCDEFS_H
+
+#include <limits>
+
+namespace PHHepMCDefs
+{
+  static int DataVertexIndex = std::numeric_limits<int>::max()-1;
+}
+
+#endif

--- a/offline/packages/NodeDump/DumpPHHepMCGenEventMap.cc
+++ b/offline/packages/NodeDump/DumpPHHepMCGenEventMap.cc
@@ -40,14 +40,21 @@ int DumpPHHepMCGenEventMap::process_Node(PHNode *myNode)
     {
       *fout << "map entry: " << iter->first << std::endl;
       PHHepMCGenEvent *genevt = iter->second;
-      HepMC::GenEvent *evt = genevt->getEvent();
       *fout << "Embedding id " << genevt->get_embedding_id() << std::endl;
       *fout << "is simulated " << genevt->is_simulated() << std::endl;
       *fout << "Collision vertex x: " << genevt->get_collision_vertex().x() << std::endl;
       *fout << "Collision vertex y: " << genevt->get_collision_vertex().y() << std::endl;
       *fout << "Collision vertex z: " << genevt->get_collision_vertex().z() << std::endl;
       *fout << "Collision vertex t: " << genevt->get_collision_vertex().t() << std::endl;
-      evt->print(*fout);
+      HepMC::GenEvent *evt = genevt->getEvent();
+      if (!evt)
+      {
+	*fout << "GenEvent is nullptr" << std::endl;
+      }
+      else
+      {
+        evt->print(*fout);
+      }
     }
   }
   return 0;

--- a/simulation/g4simulation/g4main/EicEventHeaderv1.cc
+++ b/simulation/g4simulation/g4main/EicEventHeaderv1.cc
@@ -4,8 +4,8 @@
 
 #include <iostream>  // for operator<<, basic_ostream, basic_ostream::o...
 #include <limits>
-#include <string>    // for operator<<, string, char_traits
-#include <utility>   // for pair
+#include <string>   // for operator<<, string, char_traits
+#include <utility>  // for pair
 
 using namespace std;
 

--- a/simulation/g4simulation/g4main/EicEventHeaderv1.cc
+++ b/simulation/g4simulation/g4main/EicEventHeaderv1.cc
@@ -2,10 +2,8 @@
 
 #include <phool/phool.h>
 
-#include <climits>
-#include <cmath>
-#include <cstdlib>
 #include <iostream>  // for operator<<, basic_ostream, basic_ostream::o...
+#include <limits>
 #include <string>    // for operator<<, string, char_traits
 #include <utility>   // for pair
 
@@ -64,7 +62,7 @@ int EicEventHeaderv1::get_property_int(const PROPERTY prop_id) const
     return u_property(i->second).idata;
   }
 
-  return INT_MIN;
+  return std::numeric_limits<int>::min();
 }
 
 unsigned int
@@ -85,7 +83,7 @@ EicEventHeaderv1::get_property_uint(const PROPERTY prop_id) const
     return u_property(i->second).uidata;
   }
 
-  return UINT_MAX;
+  return std::numeric_limits<unsigned int>::max();
 }
 
 void EicEventHeaderv1::set_property(const PROPERTY prop_id, const float value)
@@ -135,5 +133,5 @@ EicEventHeaderv1::get_property_nocheck(const PROPERTY prop_id) const
   {
     return iter->second;
   }
-  return UINT_MAX;
+  return std::numeric_limits<unsigned int>::max();
 }

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>  // for pair
 
 class SyncObject;
 

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupMerger.h
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <string>
+#include <utility>  // for pair
 
 class PHCompositeNode;
 class PHG4HitContainer;

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -209,7 +209,6 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
     genevt->is_simulated(true);
 
-
     double xshift = vertex_pos_x + genevt->get_collision_vertex().x();
     double yshift = vertex_pos_y + genevt->get_collision_vertex().y();
     double zshift = vertex_pos_z + genevt->get_collision_vertex().z();
@@ -340,10 +339,10 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
               fabs(zpos) > worldsizez / 2)
           {
             std::cout << "vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
-                 << " id: " << (*v)->barcode()
-                 << " outside world volume radius/z (+-) " << worldsizex / 2
-                 << "/" << worldsizez / 2 << ", dropping it and its particles"
-                 << std::endl;
+                      << " id: " << (*v)->barcode()
+                      << " outside world volume radius/z (+-) " << worldsizex / 2
+                      << "/" << worldsizez / 2 << ", dropping it and its particles"
+                      << std::endl;
             continue;
           }
         }
@@ -353,16 +352,16 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
               fabs(zpos) > worldsizez / 2)
           {
             std::cout << "Vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
-                 << " outside world volume x/y/z (+-) " << worldsizex / 2 << "/"
-                 << worldsizey / 2 << "/" << worldsizez / 2
-                 << ", dropping it and its particles" << std::endl;
+                      << " outside world volume x/y/z (+-) " << worldsizex / 2 << "/"
+                      << worldsizey / 2 << "/" << worldsizez / 2
+                      << ", dropping it and its particles" << std::endl;
             continue;
           }
         }
         else
         {
           std::cout << PHWHERE << " shape " << ishape << " not implemented. exiting"
-               << std::endl;
+                    << std::endl;
           exit(1);
         }
 
@@ -436,10 +435,10 @@ void HepMCNodeReader::VertexPosition(const double v_x, const double v_y,
                                      const double v_z)
 {
   std::cout << "HepMCNodeReader::VertexPosition - WARNING - this function is depreciated. "
-       << "HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location. "
-       << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
-       << "Recommendation: the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << std::endl;
+            << "HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location. "
+            << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
+            << "Recommendation: the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
+            << std::endl;
 
   vertex_pos_x = v_x;
   vertex_pos_y = v_y;
@@ -451,10 +450,10 @@ void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
                                   const double s_z)
 {
   std::cout << "HepMCNodeReader::SmearVertex - WARNING - this function is depreciated. "
-       << "HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location. "
-       << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
-       << "Recommendation: the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << std::endl;
+            << "HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location. "
+            << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
+            << "Recommendation: the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
+            << std::endl;
 
   width_vx = s_x;
   width_vy = s_y;
@@ -465,8 +464,8 @@ void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
 void HepMCNodeReader::Embed(const int /*unused*/)
 {
   std::cout << "HepMCNodeReader::Embed - WARNING - this function is depreciated. "
-       << "Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << std::endl;
+            << "Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
+            << std::endl;
 
   return;
 }

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -29,6 +29,7 @@
 #include <HepMC/Units.h>
 
 #include <CLHEP/Vector/LorentzRotation.h>
+#include <CLHEP/Vector/LorentzVector.h>
 
 #include <gsl/gsl_const.h>
 #include <gsl/gsl_randist.h>
@@ -41,8 +42,6 @@
 #include <iterator>
 #include <list>
 #include <utility>
-
-using namespace std;
 
 //// All length Units are in cm, no conversion to G4 internal units since
 //// this is filled into our objects (PHG4VtxPoint and PHG4Particle)
@@ -72,16 +71,6 @@ static IsStateFinal isfinal;
 
 HepMCNodeReader::HepMCNodeReader(const std::string &name)
   : SubsysReco(name)
-  , is_pythia(false)
-  , use_seed(0)
-  , seed(0)
-  , vertex_pos_x(0.0)
-  , vertex_pos_y(0.0)
-  , vertex_pos_z(0.0)
-  , vertex_t0(0.0)
-  , width_vx(0.0)
-  , width_vy(0.0)
-  , width_vz(0.0)
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   return;
@@ -110,7 +99,7 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
   if (use_seed)
   {
     phseed = seed;
-    cout << Name() << " override random seed: " << phseed << endl;
+    std::cout << Name() << " override random seed: " << phseed << std::endl;
   }
   gsl_rng_set(RandomGenerator, phseed);
   return 0;
@@ -129,7 +118,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
     {
       once = false;
 
-      cout << "HepMCNodeReader::process_event - No PHHepMCGenEventMap node. Do not perform HepMC->Geant4 input" << endl;
+      std::cout << "HepMCNodeReader::process_event - No PHHepMCGenEventMap node. Do not perform HepMC->Geant4 input" << std::endl;
     }
 
     return Fun4AllReturnCodes::DISCARDEVENT;
@@ -138,7 +127,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
   PHG4InEvent *ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
   if (!ineve)
   {
-    cout << PHWHERE << "no PHG4INEVENT node" << endl;
+    std::cout << PHWHERE << "no PHG4INEVENT node" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -147,7 +136,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
   float worldsizex = rc->get_FloatFlag("WorldSizex");
   float worldsizey = rc->get_FloatFlag("WorldSizey");
   float worldsizez = rc->get_FloatFlag("WorldSizez");
-  string worldshape = rc->get_StringFlag("WorldShape");
+  std::string worldshape = rc->get_StringFlag("WorldShape");
 
   enum
   {
@@ -166,7 +155,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
   }
   else
   {
-    cout << PHWHERE << " unknown world shape " << worldshape << endl;
+    std::cout << PHWHERE << " unknown world shape " << worldshape << std::endl;
     exit(1);
   }
 
@@ -182,7 +171,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
     {
       if (Verbosity())
       {
-        cout << "HepMCNodeReader::process_event - this event is already simulated. Move on: ";
+        std::cout << "HepMCNodeReader::process_event - this event is already simulated. Move on: ";
         genevt->identify();
       }
 
@@ -191,29 +180,35 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
     if (Verbosity())
     {
-      cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found PHHepMCGenEvent:" << endl;
+      std::cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found PHHepMCGenEvent:" << std::endl;
       genevt->identify();
     }
 
     const auto collisionVertex = genevt->get_collision_vertex();
+    const int embed_flag = genevt->get_embedding_id();
 
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
-      cout << PHWHERE << " no evt pointer under HEPMC Node found:";
-      genevt->identify();
-      return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << "embed id: " << genevt->get_embedding_id() << std::endl;
+      if (Verbosity() > 1)
+      {
+        std::cout << PHWHERE << " no evt pointer under HEPMC Node found, this is normal for embedding";
+        genevt->identify();
+      }
+      // int idkey = iter->first;
+      // genevtmap->erase(idkey);
+      continue;
     }
 
     if (Verbosity())
     {
-      cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found HepMC::GenEvent:" << endl;
+      std::cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found HepMC::GenEvent:" << std::endl;
       evt->print();
     }
 
     genevt->is_simulated(true);
 
-    const int embed_flag = genevt->get_embedding_id();
 
     double xshift = vertex_pos_x + genevt->get_collision_vertex().x();
     double yshift = vertex_pos_y + genevt->get_collision_vertex().y();
@@ -263,7 +258,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
     {
       if (Verbosity() > 1)
       {
-        cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found vertex:" << endl;
+        std::cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found vertex:" << std::endl;
         (*v)->print();
       }
 
@@ -274,16 +269,16 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       {
         if (Verbosity() > 1)
         {
-          cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found particle:" << endl;
+          std::cout << __PRETTY_FUNCTION__ << " : L" << __LINE__ << " Found particle:" << std::endl;
           (*p)->print();
-          cout << "end vertex " << (*p)->end_vertex() << endl;
+          std::cout << "end vertex " << (*p)->end_vertex() << std::endl;
         }
         if (isfinal(*p))
         {
           if (Verbosity() > 1)
           {
-            cout << __PRETTY_FUNCTION__ << " " << __LINE__ << endl;
-            cout << "\tparticle passed " << endl;
+            std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+            std::cout << "\tparticle passed " << std::endl;
           }
           finalstateparticles.push_back(*p);
         }
@@ -291,8 +286,8 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
         {
           if (Verbosity() > 1)
           {
-            cout << __PRETTY_FUNCTION__ << " " << __LINE__ << endl;
-            cout << "\tparticle failed " << endl;
+            std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+            std::cout << "\tparticle failed " << std::endl;
           }
         }
       }
@@ -328,15 +323,15 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
         if (Verbosity() > 1)
         {
-          cout << __PRETTY_FUNCTION__ << " " << __LINE__ << endl;
-          cout << "Vertex : " << endl;
+          std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+          std::cout << "Vertex : " << std::endl;
           (*v)->print();
-          cout << "id: " << (*v)->barcode() << endl;
-          cout << "x: " << xpos << endl;
-          cout << "y: " << ypos << endl;
-          cout << "z: " << zpos << endl;
-          cout << "t: " << time << endl;
-          cout << "Particles" << endl;
+          std::cout << "id: " << (*v)->barcode() << std::endl;
+          std::cout << "x: " << xpos << std::endl;
+          std::cout << "y: " << ypos << std::endl;
+          std::cout << "z: " << zpos << std::endl;
+          std::cout << "t: " << time << std::endl;
+          std::cout << "Particles" << std::endl;
         }
 
         if (ishape == ShapeG4Tubs)
@@ -344,11 +339,11 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           if (sqrt(xpos * xpos + ypos * ypos) > worldsizey / 2 ||
               fabs(zpos) > worldsizez / 2)
           {
-            cout << "vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
+            std::cout << "vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
                  << " id: " << (*v)->barcode()
                  << " outside world volume radius/z (+-) " << worldsizex / 2
                  << "/" << worldsizez / 2 << ", dropping it and its particles"
-                 << endl;
+                 << std::endl;
             continue;
           }
         }
@@ -357,17 +352,17 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           if (fabs(xpos) > worldsizex / 2 || fabs(ypos) > worldsizey / 2 ||
               fabs(zpos) > worldsizez / 2)
           {
-            cout << "Vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
+            std::cout << "Vertex x/y/z " << xpos << "/" << ypos << "/" << zpos
                  << " outside world volume x/y/z (+-) " << worldsizex / 2 << "/"
                  << worldsizey / 2 << "/" << worldsizez / 2
-                 << ", dropping it and its particles" << endl;
+                 << ", dropping it and its particles" << std::endl;
             continue;
           }
         }
         else
         {
-          cout << PHWHERE << " shape " << ishape << " not implemented. exiting"
-               << endl;
+          std::cout << PHWHERE << " shape " << ishape << " not implemented. exiting"
+               << std::endl;
           exit(1);
         }
 
@@ -379,7 +374,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
         {
           if (Verbosity() > 1)
           {
-            cout << __PRETTY_FUNCTION__ << " " << __LINE__ << endl;
+            std::cout << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
             (*fiter)->print();
           }
 
@@ -440,11 +435,11 @@ double HepMCNodeReader::smearflat(const double width)
 void HepMCNodeReader::VertexPosition(const double v_x, const double v_y,
                                      const double v_z)
 {
-  cout << "HepMCNodeReader::VertexPosition - WARNING - this function is depreciated. "
+  std::cout << "HepMCNodeReader::VertexPosition - WARNING - this function is depreciated. "
        << "HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location. "
        << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
        << "Recommendation: the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << endl;
+       << std::endl;
 
   vertex_pos_x = v_x;
   vertex_pos_y = v_y;
@@ -455,11 +450,11 @@ void HepMCNodeReader::VertexPosition(const double v_x, const double v_y,
 void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
                                   const double s_z)
 {
-  cout << "HepMCNodeReader::SmearVertex - WARNING - this function is depreciated. "
+  std::cout << "HepMCNodeReader::SmearVertex - WARNING - this function is depreciated. "
        << "HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location. "
        << "This also leads to a different vertex is used for HepMC subevent in Geant4 than that recorded in the HepMCEvent Node."
        << "Recommendation: the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << endl;
+       << std::endl;
 
   width_vx = s_x;
   width_vy = s_y;
@@ -469,9 +464,9 @@ void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
 
 void HepMCNodeReader::Embed(const int /*unused*/)
 {
-  cout << "HepMCNodeReader::Embed - WARNING - this function is depreciated. "
+  std::cout << "HepMCNodeReader::Embed - WARNING - this function is depreciated. "
        << "Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators."
-       << endl;
+       << std::endl;
 
   return;
 }

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -190,14 +190,12 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
-      std::cout << "embed id: " << genevt->get_embedding_id() << std::endl;
       if (Verbosity() > 1)
       {
         std::cout << PHWHERE << " no evt pointer under HEPMC Node found, this is normal for embedding";
         genevt->identify();
       }
-      // int idkey = iter->first;
-      // genevtmap->erase(idkey);
+      genevtmap->erase(iter->first);
       continue;
     }
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -194,21 +194,21 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
       genevt->identify();
     }
 
-    if (! use_embedding_vertex)
+    if (!use_embedding_vertex)
     {
       collisionVertex = genevt->get_collision_vertex();
     }
     else
     {
-      genevt->set_collision_vertex(collisionVertex); // save used vertex in HepMC
+      genevt->set_collision_vertex(collisionVertex);  // save used vertex in HepMC
     }
     const int embed_flag = genevt->get_embedding_id();
     HepMC::GenEvent *evt = genevt->getEvent();
     if (!evt)
     {
-        std::cout << PHWHERE << " no evt pointer under HEPMC Node found";
-        genevt->identify();
-	return Fun4AllReturnCodes::ABORTEVENT;
+      std::cout << PHWHERE << " no evt pointer under HEPMC Node found";
+      genevt->identify();
+      return Fun4AllReturnCodes::ABORTEVENT;
     }
 
     if (Verbosity())

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -58,10 +58,10 @@ class HepMCNodeReader : public SubsysReco
   double smeargauss(const double width);
   double smearflat(const double width);
 
-  gsl_rng *RandomGenerator {nullptr};
-  bool is_pythia {false};
-  int use_seed {0};
-  unsigned int seed {0};
+  gsl_rng *RandomGenerator{nullptr};
+  bool is_pythia{false};
+  int use_seed{0};
+  unsigned int seed{0};
   double vertex_pos_x{0.0};
   double vertex_pos_y{0.0};
   double vertex_pos_z{0.0};

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -17,7 +17,7 @@ class PHCompositeNode;
 class HepMCNodeReader : public SubsysReco
 {
  public:
-  HepMCNodeReader(const std::string &name = "HEPMCREADER");
+  HepMCNodeReader(const std::string &name = "HepMCNodeReader");
   ~HepMCNodeReader() override;
 
   int Init(PHCompositeNode *topNode) override;
@@ -58,17 +58,17 @@ class HepMCNodeReader : public SubsysReco
   double smeargauss(const double width);
   double smearflat(const double width);
 
-  gsl_rng *RandomGenerator;
-  bool is_pythia;
-  int use_seed;
-  unsigned int seed;
-  double vertex_pos_x;
-  double vertex_pos_y;
-  double vertex_pos_z;
-  double vertex_t0;
-  double width_vx;
-  double width_vy;
-  double width_vz;
+  gsl_rng *RandomGenerator {nullptr};
+  bool is_pythia {false};
+  int use_seed {0};
+  unsigned int seed {0};
+  double vertex_pos_x{0.0};
+  double vertex_pos_y{0.0};
+  double vertex_pos_z{0.0};
+  double vertex_t0{0.0};
+  double width_vx{0.0};
+  double width_vy{0.0};
+  double width_vz{0.0};
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Detector.cc
+++ b/simulation/g4simulation/g4main/PHG4Detector.cc
@@ -5,6 +5,7 @@
 #include <TSystem.h>
 
 #include <Geant4/G4Colour.hh>  // for G4Colour
+#include <Geant4/G4Element.hh>
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4Material.hh>
 #include <Geant4/G4NistManager.hh>
@@ -17,6 +18,8 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #include <boost/stacktrace.hpp>
 #pragma GCC diagnostic pop
+
+#include <cstdlib>
 
 PHG4Detector::PHG4Detector(PHG4Subsystem *subsys, PHCompositeNode *Node, const std::string &nam)
   : m_topNode(Node)

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -3,13 +3,11 @@
 
 #include <phool/phool.h>
 
-#include <climits>
 #include <cmath>
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <utility>
-
-using namespace std;
 
 PHG4Hitv1::PHG4Hitv1(const PHG4Hit* g4hit)
 {
@@ -18,16 +16,16 @@ PHG4Hitv1::PHG4Hitv1(const PHG4Hit* g4hit)
 
 void PHG4Hitv1::Reset()
 {
-  hitid = ULONG_LONG_MAX;
-  trackid = INT_MIN;
-  showerid = INT_MIN;
-  edep = NAN;
+  hitid = std::numeric_limits<PHG4HitDefs::keytype>::max();
+  trackid = std::numeric_limits<int>::min();
+  showerid = std::numeric_limits<int>::min();
+  edep = std::numeric_limits<float>::quiet_NaN();
   for (int i = 0; i < 2; i++)
   {
-    set_x(i, NAN);
-    set_y(i, NAN);
-    set_z(i, NAN);
-    set_t(i, NAN);
+    set_x(i, std::numeric_limits<float>::quiet_NaN());
+    set_y(i, std::numeric_limits<float>::quiet_NaN());
+    set_z(i, std::numeric_limits<float>::quiet_NaN());
+    set_t(i, std::numeric_limits<float>::quiet_NaN());
   }
   prop_map.clear();
 }
@@ -42,31 +40,31 @@ int PHG4Hitv1::get_detid() const
 
 void PHG4Hitv1::print() const
 {
-  std::cout << "New Hitv1  0x" << hex << hitid
-            << dec << "  on track " << trackid << " EDep " << edep << std::endl;
+  std::cout << "New Hitv1  0x" << std::hex << hitid
+            << std::dec << "  on track " << trackid << " EDep " << edep << std::endl;
   std::cout << "Location: X " << x[0] << "/" << x[1] << "  Y " << y[0] << "/" << y[1] << "  Z " << z[0] << "/" << z[1] << std::endl;
   std::cout << "Time        " << t[0] << "/" << t[1] << std::endl;
 
   for (auto i : prop_map)
   {
     PROPERTY prop_id = static_cast<PROPERTY>(i.first);
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << "\t" << prop_id << ":\t" << property_info.first << " = \t";
     switch (property_info.second)
     {
     case type_int:
-      cout << get_property_int(prop_id);
+      std::cout << get_property_int(prop_id);
       break;
     case type_uint:
-      cout << get_property_uint(prop_id);
+      std::cout << get_property_uint(prop_id);
       break;
     case type_float:
-      cout << get_property_float(prop_id);
+      std::cout << get_property_float(prop_id);
       break;
     default:
-      cout << " unknown type ";
+      std::cout << " unknown type ";
     }
-    cout << endl;
+    std::cout << std::endl;
   }
 }
 
@@ -80,10 +78,10 @@ float PHG4Hitv1::get_property_float(const PROPERTY prop_id) const
 {
   if (!check_property(prop_id, type_float))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << endl;
+         << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -93,17 +91,17 @@ float PHG4Hitv1::get_property_float(const PROPERTY prop_id) const
     return u_property(i->second).fdata;
   }
 
-  return NAN;
+  return std::numeric_limits<float>::quiet_NaN();
 }
 
 int PHG4Hitv1::get_property_int(const PROPERTY prop_id) const
 {
   if (!check_property(prop_id, type_int))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << endl;
+         << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -113,7 +111,7 @@ int PHG4Hitv1::get_property_int(const PROPERTY prop_id) const
     return u_property(i->second).idata;
   }
 
-  return INT_MIN;
+  return std::numeric_limits<int>::min();
 }
 
 unsigned int
@@ -121,10 +119,10 @@ PHG4Hitv1::get_property_uint(const PROPERTY prop_id) const
 {
   if (!check_property(prop_id, type_uint))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << endl;
+         << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -134,17 +132,17 @@ PHG4Hitv1::get_property_uint(const PROPERTY prop_id) const
     return u_property(i->second).uidata;
   }
 
-  return UINT_MAX;
+  return std::numeric_limits<unsigned int>::max();
 }
 
 void PHG4Hitv1::set_property(const PROPERTY prop_id, const float value)
 {
   if (!check_property(prop_id, type_float))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << endl;
+         << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -154,10 +152,10 @@ void PHG4Hitv1::set_property(const PROPERTY prop_id, const int value)
 {
   if (!check_property(prop_id, type_int))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << endl;
+         << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -167,10 +165,10 @@ void PHG4Hitv1::set_property(const PROPERTY prop_id, const unsigned int value)
 {
   if (!check_property(prop_id, type_uint))
   {
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
-    cout << PHWHERE << " Property " << property_info.first << " with id "
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::cout << PHWHERE << " Property " << property_info.first << " with id "
          << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << endl;
+         << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -184,7 +182,7 @@ PHG4Hitv1::get_property_nocheck(const PROPERTY prop_id) const
   {
     return iter->second;
   }
-  return UINT_MAX;
+  return std::numeric_limits<unsigned int>::max();
 }
 
 float PHG4Hitv1::get_px(const int i) const
@@ -196,7 +194,7 @@ float PHG4Hitv1::get_px(const int i) const
   case 1:
     return get_property_float(prop_px_1);
   default:
-    cout << "Invalid index in get_px: " << i << endl;
+    std::cout << "Invalid index in get_px: " << i << std::endl;
     exit(1);
   }
 }
@@ -210,7 +208,7 @@ float PHG4Hitv1::get_py(const int i) const
   case 1:
     return get_property_float(prop_py_1);
   default:
-    cout << "Invalid index in get_py: " << i << endl;
+    std::cout << "Invalid index in get_py: " << i << std::endl;
     exit(1);
   }
 }
@@ -224,7 +222,7 @@ float PHG4Hitv1::get_pz(const int i) const
   case 1:
     return get_property_float(prop_pz_1);
   default:
-    cout << "Invalid index in get_pz: " << i << endl;
+    std::cout << "Invalid index in get_pz: " << i << std::endl;
     exit(1);
   }
 }
@@ -240,7 +238,7 @@ void PHG4Hitv1::set_px(const int i, const float f)
     set_property(prop_px_1, f);
     return;
   default:
-    cout << "Invalid index in set_px: " << i << endl;
+    std::cout << "Invalid index in set_px: " << i << std::endl;
     exit(1);
   }
 }
@@ -256,7 +254,7 @@ void PHG4Hitv1::set_py(const int i, const float f)
     set_property(prop_py_1, f);
     return;
   default:
-    cout << "Invalid index in set_py: " << i << endl;
+    std::cout << "Invalid index in set_py: " << i << std::endl;
     exit(1);
   }
 }
@@ -272,7 +270,7 @@ void PHG4Hitv1::set_pz(const int i, const float f)
     set_property(prop_pz_1, f);
     return;
   default:
-    cout << "Invalid index in set_pz: " << i << endl;
+    std::cout << "Invalid index in set_pz: " << i << std::endl;
     exit(1);
   }
 }
@@ -286,7 +284,7 @@ float PHG4Hitv1::get_local_x(const int i) const
   case 1:
     return get_property_float(prop_local_x_1);
   default:
-    cout << "Invalid index in get_local_x: " << i << endl;
+    std::cout << "Invalid index in get_local_x: " << i << std::endl;
     exit(1);
   }
 }
@@ -300,7 +298,7 @@ float PHG4Hitv1::get_local_y(const int i) const
   case 1:
     return get_property_float(prop_local_y_1);
   default:
-    cout << "Invalid index in get_local_y: " << i << endl;
+    std::cout << "Invalid index in get_local_y: " << i << std::endl;
     exit(1);
   }
 }
@@ -314,7 +312,7 @@ float PHG4Hitv1::get_local_z(const int i) const
   case 1:
     return get_property_float(prop_local_z_1);
   default:
-    cout << "Invalid index in get_local_z: " << i << endl;
+    std::cout << "Invalid index in get_local_z: " << i << std::endl;
     exit(1);
   }
 }
@@ -330,7 +328,7 @@ void PHG4Hitv1::set_local_x(const int i, const float f)
     set_property(prop_local_x_1, f);
     return;
   default:
-    cout << "Invalid index in set_local_x: " << i << endl;
+    std::cout << "Invalid index in set_local_x: " << i << std::endl;
     exit(1);
   }
 }
@@ -346,7 +344,7 @@ void PHG4Hitv1::set_local_y(const int i, const float f)
     set_property(prop_local_y_1, f);
     return;
   default:
-    cout << "Invalid index in set_local_y: " << i << endl;
+    std::cout << "Invalid index in set_local_y: " << i << std::endl;
     exit(1);
   }
 }
@@ -362,29 +360,29 @@ void PHG4Hitv1::set_local_z(const int i, const float f)
     set_property(prop_local_z_1, f);
     return;
   default:
-    cout << "Invalid index in set_local_z: " << i << endl;
+    std::cout << "Invalid index in set_local_z: " << i << std::endl;
     exit(1);
   }
 }
 
-void PHG4Hitv1::identify(ostream& os) const
+void PHG4Hitv1::identify(std::ostream& os) const
 {
-  os << "Class " << this->ClassName() << endl;
-  os << "hitid: 0x" << hex << hitid << dec << endl;
+  os << "Class " << this->ClassName() << std::endl;
+  os << "hitid: 0x" << std::hex << hitid << std::dec << std::endl;
   os << "x0: " << get_x(0)
      << ", y0: " << get_y(0)
      << ", z0: " << get_z(0)
-     << ", t0: " << get_t(0) << endl;
+     << ", t0: " << get_t(0) << std::endl;
   os << "x1: " << get_x(1)
      << ", y1: " << get_y(1)
      << ", z1: " << get_z(1)
-     << ", t1: " << get_t(1) << endl;
+     << ", t1: " << get_t(1) << std::endl;
   os << "trackid: " << trackid << ", showerid: " << showerid
-     << ", edep: " << edep << endl;
+     << ", edep: " << edep << std::endl;
   for (auto i : prop_map)
   {
     PROPERTY prop_id = static_cast<PROPERTY>(i.first);
-    pair<const string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
+    std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     os << "\t" << prop_id << ":\t" << property_info.first << " = \t";
     switch (property_info.second)
     {
@@ -400,6 +398,6 @@ void PHG4Hitv1::identify(ostream& os) const
     default:
       os << " unknown type ";
     }
-    os << endl;
+    os << std::endl;
   }
 }

--- a/simulation/g4simulation/g4main/PHG4Hitv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Hitv1.cc
@@ -80,8 +80,8 @@ float PHG4Hitv1::get_property_float(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -100,8 +100,8 @@ int PHG4Hitv1::get_property_int(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -121,8 +121,8 @@ PHG4Hitv1::get_property_uint(const PROPERTY prop_id) const
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map_t::const_iterator i = prop_map.find(prop_id);
@@ -141,8 +141,8 @@ void PHG4Hitv1::set_property(const PROPERTY prop_id, const float value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_float) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_float) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -154,8 +154,8 @@ void PHG4Hitv1::set_property(const PROPERTY prop_id, const int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_int) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_int) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();
@@ -167,8 +167,8 @@ void PHG4Hitv1::set_property(const PROPERTY prop_id, const unsigned int value)
   {
     std::pair<const std::string, PROPERTY_TYPE> property_info = get_property_info(prop_id);
     std::cout << PHWHERE << " Property " << property_info.first << " with id "
-         << prop_id << " is of type " << get_property_type(property_info.second)
-         << " not " << get_property_type(type_uint) << std::endl;
+              << prop_id << " is of type " << get_property_type(property_info.second)
+              << " not " << get_property_type(type_uint) << std::endl;
     exit(1);
   }
   prop_map[prop_id] = u_property(value).get_storage();

--- a/simulation/g4simulation/g4main/PHG4MagneticField.cc
+++ b/simulation/g4simulation/g4main/PHG4MagneticField.cc
@@ -20,11 +20,6 @@ PHG4MagneticField::PHG4MagneticField(const PHField* field)
   assert(field_);
 }
 
-PHG4MagneticField::~PHG4MagneticField()
-{
-  //  delete field_; // this cleans the hcal fieldmap but crashes the regular map
-}
-
 void PHG4MagneticField::GetFieldValue(const double Point[4], double* Bfield) const
 {
   assert(field_);

--- a/simulation/g4simulation/g4main/PHG4MagneticField.h
+++ b/simulation/g4simulation/g4main/PHG4MagneticField.h
@@ -24,7 +24,7 @@ class PHG4MagneticField : public G4MagneticField
 {
  public:
   PHG4MagneticField(const PHField* field);
-  ~PHG4MagneticField() override;
+  ~PHG4MagneticField() override = default;
 
   const PHField* get_field() const
   {

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -1,7 +1,6 @@
 #include "PHG4ParticleGeneratorD0.h"
 
 #include "PHG4InEvent.h"
-#include "PHG4Particle.h"  // for PHG4Particle
 #include "PHG4Particlev1.h"
 
 #include <phool/PHRandomSeed.h>
@@ -21,6 +20,7 @@
 #include <vector>    // for vector, vector<>::const_iterator
 
 class PHCompositeNode;
+class PHG4Particle;
 
 PHG4ParticleGeneratorD0::PHG4ParticleGeneratorD0(const std::string &name)
   : PHG4ParticleGeneratorBase(name)

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -1,7 +1,6 @@
 #include "PHG4ParticleGeneratorVectorMeson.h"
 
 #include "PHG4InEvent.h"
-#include "PHG4Particle.h"  // for PHG4Particle
 #include "PHG4Particlev1.h"
 
 #include <phool/PHCompositeNode.h>
@@ -27,6 +26,8 @@
 #include <iostream>  // for operator<<, basic_ostream, basic_...
 #include <utility>   // for pair
 #include <vector>    // for vector, vector<>::const_iterator
+
+class PHG4Particle;
 
 PHG4ParticleGeneratorVectorMeson::PHG4ParticleGeneratorVectorMeson(const std::string &name)
   : PHG4ParticleGeneratorBase(name)

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -2,7 +2,7 @@
 
 #include "PHG4Particle.h"  // for PHG4Particle
 
-using namespace std;
+#include <cmath>
 
 PHG4Particlev2::PHG4Particlev2()
   : PHG4Particlev1()
@@ -14,13 +14,8 @@ PHG4Particlev2::PHG4Particlev2()
 {
 }
 
-PHG4Particlev2::PHG4Particlev2(const string &name, const int pid, const double px, const double py, const double pz)
+PHG4Particlev2::PHG4Particlev2(const std::string &name, const int pid, const double px, const double py, const double pz)
   : PHG4Particlev1(name, pid, px, py, pz)
-  , trkid(0)
-  , vtxid(0)
-  , parentid(0)
-  , primaryid(0xFFFFFFFF)
-  , fe(0.0)
 {
 }
 
@@ -55,6 +50,6 @@ void PHG4Particlev2::identify(std::ostream &os) const
      << ", pz: " << fpz
      << ", phi: " << atan2(fpy, fpx)
      << ", eta: " << -1 * log(tan(0.5 * acos(fpz / sqrt(fpx * fpx + fpy * fpy + fpz * fpz))))
-     << ", e: " << fe << endl;
+     << ", e: " << fe << std::endl;
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -37,8 +37,8 @@ class PHG4Particlev2 : public PHG4Particlev1
   int trkid{0};
   int vtxid{0};
   int parentid{0};
-  int primaryid {std::numeric_limits<int>::min()};
-  double fe {0};
+  int primaryid{std::numeric_limits<int>::min()};
+  double fe{0};
 
   ClassDefOverride(PHG4Particlev2, 2)
 };

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -34,11 +34,11 @@ class PHG4Particlev2 : public PHG4Particlev1
   void set_e(const double e) override { fe = e; }
 
  protected:
-  int trkid;
-  int vtxid;
-  int parentid;
-  int primaryid;
-  double fe;
+  int trkid{0};
+  int vtxid{0};
+  int parentid{0};
+  int primaryid {std::numeric_limits<int>::min()};
+  double fe {0};
 
   ClassDefOverride(PHG4Particlev2, 2)
 };

--- a/simulation/g4simulation/g4main/PHG4PhenixStackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4PhenixStackingAction.h
@@ -3,11 +3,12 @@
 #ifndef G4MAIN_PHG4PHENIXSTACKINGACTION_H
 #define G4MAIN_PHG4PHENIXSTACKINGACTION_H
 
+#include <Geant4/G4ClassificationOfNewTrack.hh>
 #include <Geant4/G4UserStackingAction.hh>
 
 #include <list>
 
-class G4Step;
+class G4Track;
 class PHG4StackingAction;
 
 class PHG4PhenixStackingAction : public G4UserStackingAction

--- a/simulation/g4simulation/g4main/PHG4Showerv1.cc
+++ b/simulation/g4simulation/g4main/PHG4Showerv1.cc
@@ -70,11 +70,9 @@ void PHG4Showerv1::identify(ostream &os) const
   os << "G4Hit IDs" << endl;
   for (const auto &_g4hit_id : _g4hit_ids)
   {
-    for (std::set<PHG4HitDefs::keytype>::const_iterator jter =
-             _g4hit_id.second.begin();
-         jter != _g4hit_id.second.end(); ++jter)
+    for (unsigned long long jter : _g4hit_id.second)
     {
-      os << *jter << " ";
+      os << jter << " ";
     }
   }
   os << endl;

--- a/simulation/g4simulation/g4main/PHG4StackingAction.h
+++ b/simulation/g4simulation/g4main/PHG4StackingAction.h
@@ -3,14 +3,12 @@
 #ifndef G4MAIN_PHG4STACKINGACTION_H
 #define G4MAIN_PHG4STACKINGACTION_H
 
-#include <Geant4/G4UserStackingAction.hh>
+#include <Geant4/G4ClassificationOfNewTrack.hh>
 
-#include <set>
 #include <string>
 
 class G4Track;
 class PHCompositeNode;
-class PHG4Hit;
 
 class PHG4StackingAction
 {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the embedding. The HepMCNodeReader aborted the event reconstruction if the GenEvent ptr inside the PHHepMCGenEventMap was a nullptr. We use the first entry in this map to propagate the event vertex to the embedding generator (pythia8) but leave GenEvent null.
The new code skips over null pointers and removes those entries from the  PHHepMCGenEventMap so they are not stored on the DST confusing subsequent analysis code

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

