### PR TITLE
Minimal additions to event plane reco

### DIFF
--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -31,6 +31,7 @@
 #include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
+#include <phool/recoConsts.h>
 
 #include <array>  // for array
 #include <cfloat>
@@ -82,53 +83,42 @@ EventPlaneReco::EventPlaneReco(const std::string &name)
     
 }
 
-int EventPlaneReco::Init(PHCompositeNode *topNode)
+int EventPlaneReco::InitRun(PHCompositeNode *topNode)
 {
-
-    OutFileName =  boost::str(boost::format("eventplane_correction_histograms_run_%d.root") %m_runNo).c_str();
+     recoConsts *rc = recoConsts::instance();
+     m_runNo = rc->get_IntFlag("RUNNUMBER");
+    
+     if (Verbosity() > 0)
+     {
+       std::cout << "======================= EventPlaneReco::InitRun() =======================" << std::endl;
+       std::cout << PHWHERE << "RUNNUMBER " << m_runNo << std::endl;
+     }
+    
+     OutFileName =  boost::str(boost::format("eventplane_correction_histograms_run_%d.root") %m_runNo).c_str();
 
     //-----------------------------------load calibration histograms-----------------------------------------//
     CDBHistos *cdbhistosIn = new CDBHistos(OutFileName);
     cdbhistosIn->LoadCalibrations();
-    
+   
     // Get recentering histograms
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
-        if(!(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str())))
-        {
-            tprof_mean_cos_south_mbd_input[order - 1] = NULL;
-            tprof_mean_sin_south_mbd_input[order - 1] =  NULL;
-            tprof_mean_cos_north_mbd_input[order - 1] =  NULL;
-            tprof_mean_sin_north_mbd_input[order - 1] =  NULL;
-        }
-        else
-        {
-            tprof_mean_cos_south_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str()));
-            tprof_mean_sin_south_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_south_mbd_order_%d") %order).c_str()));
-            tprof_mean_cos_north_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_north_mbd_order_%d") %order).c_str()));
-            tprof_mean_sin_north_mbd_input[order - 1] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_north_mbd_order_%d") %order).c_str()));
-        }
+            tprof_mean_cos_south_mbd_input[order] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str(), false));
+            tprof_mean_sin_south_mbd_input[order] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_south_mbd_order_%d") %order).c_str(), false));
+            tprof_mean_cos_north_mbd_input[order] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_north_mbd_order_%d") %order).c_str(), false));
+            tprof_mean_sin_north_mbd_input[order] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_north_mbd_order_%d") %order).c_str(), false));
     }
 
     // Get shifting histograms
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
         for ( int p = 0; p < _imax; p++ )
         {
-            if(!(cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_north_mbd_shift_order_%d_%d") %order %p).c_str())))
-            {
-                tprof_cos_north_mbd_shift_input[order - 1][p] = NULL;
-                tprof_sin_north_mbd_shift_input[order - 1][p] =  NULL;
-                tprof_cos_south_mbd_shift_input[order - 1][p] =  NULL;
-                tprof_sin_south_mbd_shift_input[order - 1][p] =  NULL;
-            }
-            else
-            {
-                tprof_cos_north_mbd_shift_input[order - 1][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_north_mbd_shift_order_%d_%d") %order %p).c_str()));
-                tprof_sin_north_mbd_shift_input[order - 1][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_north_mbd_shift_order_%d_%d") %order %p).c_str()));
-                tprof_cos_south_mbd_shift_input[order - 1][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_south_mbd_shift_order_%d_%d") %order %p).c_str()));
-                tprof_sin_south_mbd_shift_input[order - 1][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_south_mbd_shift_order_%d_%d") %order %p).c_str()));
-            }
+
+                tprof_cos_north_mbd_shift_input[order][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_north_mbd_shift_order_%d_%d") %order %p).c_str(),false));
+                tprof_sin_north_mbd_shift_input[order][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_north_mbd_shift_order_%d_%d") %order %p).c_str(),false));
+                tprof_cos_south_mbd_shift_input[order][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_south_mbd_shift_order_%d_%d") %order %p).c_str(),false));
+                tprof_sin_south_mbd_shift_input[order][p] = dynamic_cast<TProfile *> (cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_south_mbd_shift_order_%d_%d") %order %p).c_str(),false));
         }
       }
     
@@ -138,38 +128,37 @@ int EventPlaneReco::Init(PHCompositeNode *topNode)
     cdbhistosOut = new CDBHistos(OutFileName);
 
     // Create and register recentering histograms
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
         //total charge in MBD in data max out ~2500, sim ~ factor 100
-        tprof_mean_cos_south_mbd[order - 1] =  new TProfile(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-        tprof_mean_sin_south_mbd[order - 1] =  new TProfile(boost::str(boost::format("tprof_mean_sin_south_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-        tprof_mean_cos_north_mbd[order - 1] =  new TProfile(boost::str(boost::format("tprof_mean_cos_north_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-        tprof_mean_sin_north_mbd[order - 1] =  new TProfile(boost::str(boost::format("tprof_mean_sin_north_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+        tprof_mean_cos_south_mbd[order] =  new TProfile(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+        tprof_mean_sin_south_mbd[order] =  new TProfile(boost::str(boost::format("tprof_mean_sin_south_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+        tprof_mean_cos_north_mbd[order] =  new TProfile(boost::str(boost::format("tprof_mean_cos_north_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+        tprof_mean_sin_north_mbd[order] =  new TProfile(boost::str(boost::format("tprof_mean_sin_north_mbd_order_%d") %order).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
        
-        cdbhistosOut->registerHisto(tprof_mean_cos_south_mbd[order - 1]);
-        cdbhistosOut->registerHisto(tprof_mean_sin_south_mbd[order - 1]);
-        cdbhistosOut->registerHisto(tprof_mean_cos_north_mbd[order - 1]);
-        cdbhistosOut->registerHisto(tprof_mean_sin_north_mbd[order - 1]);
-        
+        cdbhistosOut->registerHisto(tprof_mean_cos_south_mbd[order]);
+        cdbhistosOut->registerHisto(tprof_mean_sin_south_mbd[order]);
+        cdbhistosOut->registerHisto(tprof_mean_cos_north_mbd[order]);
+        cdbhistosOut->registerHisto(tprof_mean_sin_north_mbd[order]);
     }
 
     // Create and register shifting histograms
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
         // Request that recentering histograms already exists before creating
-        if(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str()))
+        if(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_mbd_order_%d") %order).c_str(),false))
         {
             for ( int p = 0; p < _imax; p++ )
             {
-                tprof_cos_north_mbd_shift[order - 1][p] =  new TProfile(boost::str(boost::format("tprof_cos_north_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-                tprof_sin_north_mbd_shift[order - 1][p] =  new TProfile(boost::str(boost::format("tprof_sin_north_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-                tprof_cos_south_mbd_shift[order - 1][p] =  new TProfile(boost::str(boost::format("tprof_cos_south_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
-                tprof_sin_south_mbd_shift[order - 1][p] =  new TProfile(boost::str(boost::format("tprof_sin_south_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+                tprof_cos_north_mbd_shift[order][p] =  new TProfile(boost::str(boost::format("tprof_cos_north_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+                tprof_sin_north_mbd_shift[order][p] =  new TProfile(boost::str(boost::format("tprof_sin_north_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+                tprof_cos_south_mbd_shift[order][p] =  new TProfile(boost::str(boost::format("tprof_cos_south_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
+                tprof_sin_south_mbd_shift[order][p] =  new TProfile(boost::str(boost::format("tprof_sin_south_mbd_shift_order_%d_%d") %order %p).c_str(), "", 125*400, 0, 250000, -1e10, 1e10);
                 
-                cdbhistosOut->registerHisto(tprof_cos_north_mbd_shift[order - 1][p]);
-                cdbhistosOut->registerHisto(tprof_sin_north_mbd_shift[order - 1][p]);
-                cdbhistosOut->registerHisto(tprof_cos_south_mbd_shift[order - 1][p]);
-                cdbhistosOut->registerHisto(tprof_sin_south_mbd_shift[order - 1][p]);
+                cdbhistosOut->registerHisto(tprof_cos_north_mbd_shift[order][p]);
+                cdbhistosOut->registerHisto(tprof_sin_north_mbd_shift[order][p]);
+                cdbhistosOut->registerHisto(tprof_cos_south_mbd_shift[order][p]);
+                cdbhistosOut->registerHisto(tprof_sin_south_mbd_shift[order][p]);
             }
         }
         
@@ -177,21 +166,11 @@ int EventPlaneReco::Init(PHCompositeNode *topNode)
  
     hvertex = new TH1D("hvertex","z-vertex [cm]",2100,-1050,1050);
     cdbhistosOut->registerHisto(hvertex);
- 
+
     return CreateNodes(topNode);
     
 }
 
-int EventPlaneReco::InitRun(PHCompositeNode *topNode)
-{
-  if (Verbosity() > 0)
-  {
-    std::cout << "======================= EventPlaneReco::InitRun() =======================" << std::endl;
-    std::cout << "===========================================================================" << std::endl;
-  }
-
-  return CreateNodes(topNode);
-}
 
 int EventPlaneReco::process_event(PHCompositeNode *topNode)
 {
@@ -271,30 +250,30 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
         float truncated_e = (epd_e < _epd_e) ? epd_e : _epd_e;
         if (arm == 0)
         {
-          for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+          for (unsigned int order = 0; order < m_MaxOrder; order++)
           {
-            double Cosine = cos(tile_phi * (double) order);
-            double Sine = sin(tile_phi * (double) order);
-            south_q[order - 1][0] += truncated_e * Cosine;  // south Qn,x
-            south_q[order - 1][1] += truncated_e * Sine;    // south Qn,y
+            double Cosine = cos(tile_phi * (double) (order+1));
+            double Sine = sin(tile_phi * (double) (order+1));
+            south_q[order][0] += truncated_e * Cosine;  // south Qn,x
+            south_q[order][1] += truncated_e * Sine;    // south Qn,y
           }
         }
         else if (arm == 1)
         {
-          for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+          for (unsigned int order = 0; order < m_MaxOrder; order++)
           {
-            double Cosine = cos(tile_phi * (double) order);
-            double Sine = sin(tile_phi * (double) order);
-            north_q[order - 1][0] += truncated_e * Cosine;  // north Qn,x
-            north_q[order - 1][1] += truncated_e * Sine;    // north Qn,y
+            double Cosine = cos(tile_phi * (double) (order+1));
+            double Sine = sin(tile_phi * (double) (order+1));
+            north_q[order][0] += truncated_e * Cosine;  // north Qn,x
+            north_q[order][1] += truncated_e * Sine;    // north Qn,y
           }
         }
       }
     }
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
-      south_Qvec.emplace_back(south_q[order - 1][0], south_q[order - 1][1]);
-      north_Qvec.emplace_back(north_q[order - 1][0], north_q[order - 1][1]);
+      south_Qvec.emplace_back(south_q[order][0], south_q[order][1]);
+      north_Qvec.emplace_back(north_q[order][0], north_q[order][1]);
     }
 
     if (epd_towerinfo)
@@ -322,6 +301,7 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
   if (_mbdEpReco && (std::fabs(_mbd_vertex) < _vertex_cut))
   {
       ResetMe();
+
       MbdPmtContainer *mbdpmts = findNode::getClass<MbdPmtContainer>(topNode, "MbdPmtContainer");
       if (!mbdpmts)
       {
@@ -365,63 +345,63 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
               if (arm == 0)
               {
                   mbd_e_south += mbd_q;
-                  for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+                  for (unsigned int order = 0; order < m_MaxOrder; order++)
                   {
-                      double Cosine = cos(phi * (double) order);
-                      double Sine = sin(phi * (double) order);
-                      south_q[order - 1][0] += mbd_q * Cosine;  // south Qn,x
-                      south_q[order - 1][1] += mbd_q * Sine;    // south Qn,y
+                      double Cosine = cos(phi * (double) (order+1));
+                      double Sine = sin(phi * (double) (order+1));
+                      south_q[order][0] += mbd_q * Cosine;  // south Qn,x
+                      south_q[order][1] += mbd_q * Sine;    // south Qn,y
                   }
               }
               else if (arm == 1)
               {
                   mbd_e_north += mbd_q;
-                  for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+                  for (unsigned int order = 0; order < m_MaxOrder; order++)
                   {
-                      double Cosine = cos(phi * (double) order);
-                      double Sine = sin(phi * (double) order);
-                      north_q[order - 1][0] += mbd_q * Cosine;  // north Qn,x
-                      north_q[order - 1][1] += mbd_q * Sine;    // north Qn,y
+                      double Cosine = cos(phi * (double) (order+1));
+                      double Sine = sin(phi * (double) (order+1));
+                      north_q[order][0] += mbd_q * Cosine;  // north Qn,x
+                      north_q[order][1] += mbd_q * Sine;    // north Qn,y
                   }
               }
             }
           }
       
           // Filled during first run
-          for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+          for (unsigned int order = 0; order < m_MaxOrder; order++)
           {
               // Fill recentering histograms by order
-              tprof_mean_cos_south_mbd[order - 1]->Fill(mbd_e_south,south_q[order - 1][0]/mbd_e_south);
-              tprof_mean_sin_south_mbd[order - 1]->Fill(mbd_e_south,south_q[order - 1][1]/mbd_e_south);
-              tprof_mean_cos_north_mbd[order - 1]->Fill(mbd_e_north,north_q[order - 1][0]/mbd_e_north);
-              tprof_mean_sin_north_mbd[order - 1]->Fill(mbd_e_north,north_q[order - 1][1]/mbd_e_north);
+              tprof_mean_cos_south_mbd[order]->Fill(mbd_e_south,south_q[order][0]/mbd_e_south);
+              tprof_mean_sin_south_mbd[order]->Fill(mbd_e_south,south_q[order][1]/mbd_e_south);
+              tprof_mean_cos_north_mbd[order]->Fill(mbd_e_north,north_q[order][0]/mbd_e_north);
+              tprof_mean_sin_north_mbd[order]->Fill(mbd_e_north,north_q[order][1]/mbd_e_north);
           }
           
           
           // Get recentering histograms and do recentering
           // Recentering: subtract Qn,x and Qn,y values averaged over all events
           // Recentering histogram should be available on second run
-          for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+          for (unsigned int order = 0; order < m_MaxOrder; order++)
           {
-              if (tprof_mean_cos_south_mbd_input[order-1]) //check if recentering histograms exist
+              if (tprof_mean_cos_south_mbd_input[order]) //check if recentering histograms exist
               {
                   // south
-                  int bin_south = tprof_mean_cos_south_mbd_input[order - 1]->FindBin(mbd_e_south);
-                  double event_ave_cos_south = tprof_mean_cos_south_mbd_input[order - 1]->GetBinContent(bin_south);
-                  double event_ave_sin_south = tprof_mean_sin_south_mbd_input[order - 1]->GetBinContent(bin_south);
-                  south_q_subtract[order - 1][0] = mbd_e_south*event_ave_cos_south;
-                  south_q_subtract[order - 1][1] = mbd_e_south*event_ave_sin_south;
-                  south_q[order - 1][0] -= south_q_subtract[order - 1][0];
-                  south_q[order - 1][1] -= south_q_subtract[order - 1][1];
+                  int bin_south = tprof_mean_cos_south_mbd_input[order]->FindBin(mbd_e_south);
+                  double event_ave_cos_south = tprof_mean_cos_south_mbd_input[order]->GetBinContent(bin_south);
+                  double event_ave_sin_south = tprof_mean_sin_south_mbd_input[order]->GetBinContent(bin_south);
+                  south_q_subtract[order][0] = mbd_e_south*event_ave_cos_south;
+                  south_q_subtract[order][1] = mbd_e_south*event_ave_sin_south;
+                  south_q[order][0] -= south_q_subtract[order][0];
+                  south_q[order][1] -= south_q_subtract[order][1];
                   
                   // north
-                  int bin_north = tprof_mean_cos_north_mbd_input[order - 1]->FindBin(mbd_e_north);
-                  double event_ave_cos_north = tprof_mean_cos_north_mbd_input[order - 1]->GetBinContent(bin_north);
-                  double event_ave_sin_north = tprof_mean_sin_north_mbd_input[order - 1]->GetBinContent(bin_north);
-                  north_q_subtract[order - 1][0] = mbd_e_north*event_ave_cos_north;
-                  north_q_subtract[order - 1][1] = mbd_e_north*event_ave_sin_north;
-                  north_q[order - 1][0] -= north_q_subtract[order - 1][0];
-                  north_q[order - 1][1] -= north_q_subtract[order - 1][1];
+                  int bin_north = tprof_mean_cos_north_mbd_input[order]->FindBin(mbd_e_north);
+                  double event_ave_cos_north = tprof_mean_cos_north_mbd_input[order]->GetBinContent(bin_north);
+                  double event_ave_sin_north = tprof_mean_sin_north_mbd_input[order]->GetBinContent(bin_north);
+                  north_q_subtract[order][0] = mbd_e_north*event_ave_cos_north;
+                  north_q_subtract[order][1] = mbd_e_north*event_ave_sin_north;
+                  north_q[order][0] -= north_q_subtract[order][0];
+                  north_q[order][1] -= north_q_subtract[order][1];
               }
           }
           
@@ -430,37 +410,38 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
       // Higher order harmonics might still be present after recentering, so do event-by-event shifting of the planes
       // First get temp psi_n. Important to start with recentered planes, so ask for recentered histograms
       Eventplaneinfo *epinfo = new Eventplaneinfov1();
-      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
       {
-          if(tprof_mean_cos_south_mbd_input[order-1]) // if present, Qs are recentered
+          double n = order + 1.0;
+          if(tprof_mean_cos_south_mbd_input[order]) // if present, Qs are recentered
           {
-              tmp_south_psi[order - 1] = epinfo->GetPsi(south_q[order - 1][0], south_q[order - 1][1], order);
-              tmp_north_psi[order - 1] = epinfo->GetPsi(north_q[order - 1][0], north_q[order - 1][1], order);
+              tmp_south_psi[order] = epinfo->GetPsi(south_q[order][0], south_q[order][1], n);
+              tmp_north_psi[order] = epinfo->GetPsi(north_q[order][0], north_q[order][1], n);
           }
           else
           {
-              tmp_south_psi[order - 1] = NAN;
-              tmp_north_psi[order - 1] = NAN;
+              tmp_south_psi[order] = NAN;
+              tmp_north_psi[order] = NAN;
           }
-
       }
       
 
     // Filled during second run
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
-        if( tprof_mean_cos_south_mbd_input[order-1]) // if present, Qs are recentered
+        if( tprof_mean_cos_south_mbd_input[order]) // if present, Qs are recentered
         {
             // Fill shifting histograms by order and terms
             for ( int p = 0; p < _imax; p++ )
             {
                 double terms = p+1.0;
-                double tmp = (double)(order*terms);
+                double n = order + 1.0;
+                double tmp = (double)(n*terms);
                 
-                tprof_cos_south_mbd_shift[order - 1][p]->Fill(mbd_e_south, cos(tmp*tmp_south_psi[order - 1])); // south <cos(i*n*psi_n)>
-                tprof_sin_south_mbd_shift[order - 1][p]->Fill(mbd_e_south, sin(tmp*tmp_south_psi[order - 1])); // south <sin(i*n*psi_n)>
-                tprof_cos_north_mbd_shift[order - 1][p]->Fill(mbd_e_north, cos(tmp*tmp_north_psi[order - 1])); // north <cos(i*n*psi_n)>
-                tprof_sin_north_mbd_shift[order - 1][p]->Fill(mbd_e_north, sin(tmp*tmp_north_psi[order - 1])); // north <sin(i*n*psi_n)>
+                tprof_cos_south_mbd_shift[order][p]->Fill(mbd_e_south, cos(tmp*tmp_south_psi[order])); // south <cos(i*n*psi_n)>
+                tprof_sin_south_mbd_shift[order][p]->Fill(mbd_e_south, sin(tmp*tmp_south_psi[order])); // south <sin(i*n*psi_n)>
+                tprof_cos_north_mbd_shift[order][p]->Fill(mbd_e_north, cos(tmp*tmp_north_psi[order])); // north <cos(i*n*psi_n)>
+                tprof_sin_north_mbd_shift[order][p]->Fill(mbd_e_north, sin(tmp*tmp_north_psi[order])); // north <sin(i*n*psi_n)>
                    
             }
         }
@@ -469,28 +450,29 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
      // Get shifting histograms and calculate shift
      // This was filled at the end of the second run
      // In third run, shifting histograms should be available
-      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
       {
         for ( int p = 0; p < _imax; p++ )
         {
-            if (tprof_cos_south_mbd_shift_input[order-1][p]) // check if shifting histograms exist
+            if (tprof_cos_south_mbd_shift_input[order][p]) // check if shifting histograms exist
             {
                 double terms = p+1.0;
-                double tmp = (double)(order*terms);
+                double n = order + 1.0;
+                double tmp = (double)(n*terms);
                 double prefactor = 2.0/terms;
 
-                int bin_north = tprof_cos_north_mbd_shift_input[order - 1][p]->FindBin(mbd_e_north);
-                int bin_south = tprof_cos_south_mbd_shift_input[order - 1][p]->FindBin(mbd_e_south);
+                int bin_north = tprof_cos_north_mbd_shift_input[order][p]->FindBin(mbd_e_north);
+                int bin_south = tprof_cos_south_mbd_shift_input[order][p]->FindBin(mbd_e_south);
  
                 // Equation (6) of arxiv:nucl-ex/9805001
                 // i = terms; n = order; i*n = tmp
                 // (2 / i ) * <cos(i*n*psi_n)> * sin(i*n*psi_n) - <sin(i*n*psi_n)> * cos(i*n*psi_n)
                 
                 // north
-                shift_north[order - 1] += prefactor*(tprof_cos_north_mbd_shift_input[order - 1][p]->GetBinContent(bin_north) * sin(tmp*tmp_north_psi[order-1]) - tprof_sin_north_mbd_shift_input[order - 1][p]->GetBinContent(bin_north) * cos(tmp*tmp_north_psi[order-1]));
+                shift_north[order] += prefactor*(tprof_cos_north_mbd_shift_input[order][p]->GetBinContent(bin_north) * sin(tmp*tmp_north_psi[order]) - tprof_sin_north_mbd_shift_input[order][p]->GetBinContent(bin_north) * cos(tmp*tmp_north_psi[order]));
                 
                 // south
-                shift_south[order - 1] += prefactor*(tprof_cos_south_mbd_shift_input[order - 1][p]->GetBinContent(bin_south) * sin(tmp*tmp_south_psi[order-1]) - tprof_sin_south_mbd_shift_input[order - 1][p]->GetBinContent(bin_south) * cos(tmp*tmp_south_psi[order-1]));
+                shift_south[order] += prefactor*(tprof_cos_south_mbd_shift_input[order][p]->GetBinContent(bin_south) * sin(tmp*tmp_south_psi[order]) - tprof_sin_south_mbd_shift_input[order][p]->GetBinContent(bin_south) * cos(tmp*tmp_south_psi[order]));
                 
             }
         }
@@ -498,44 +480,45 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode)
       
       // n * deltapsi_n = (2 / i ) * <cos(i*n*psi_n)> * sin(i*n*psi_n) - <sin(i*n*psi_n)> * cos(i*n*psi_n)
       // Divide out n
-      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
       {
-          shift_north[order - 1] /= order;
-          shift_south[order - 1] /= order;
+          double n = order + 1.0;
+          shift_north[order] /= n;
+          shift_south[order] /= n;
       }
       
       
       // Now add shift to psi_n to flatten it
       // Verify that this is done only in third run by asking for shifting hists
-      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
       {
           if(tprof_cos_north_mbd_shift_input[0][0])
           {
-            tmp_south_psi[order - 1] += shift_south[order - 1];
-            tmp_north_psi[order - 1] += shift_north[order - 1];
+            tmp_south_psi[order] += shift_south[order];
+            tmp_north_psi[order] += shift_north[order];
           }
       }
       
       // Now enforce the range
-      for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
       {
           if(tprof_cos_north_mbd_shift_input[0][0])
           {
-            double range = M_PI/(double)order;
-            if(tmp_south_psi[order - 1] < -1.0*range) tmp_south_psi[order - 1] += 2.0*range;
-            if(tmp_south_psi[order - 1] > range) tmp_south_psi[order - 1] -= 2.0*range;
-            if(tmp_north_psi[order - 1] < -1.0*range) tmp_north_psi[order - 1] += 2.0*range;
-            if(tmp_north_psi[order - 1] > range) tmp_north_psi[order - 1] -= 2.0*range;
+            double range = M_PI/(double) (order+1);
+            if(tmp_south_psi[order] < -1.0*range) tmp_south_psi[order] += 2.0*range;
+            if(tmp_south_psi[order] > range) tmp_south_psi[order] -= 2.0*range;
+            if(tmp_north_psi[order] < -1.0*range) tmp_north_psi[order] += 2.0*range;
+            if(tmp_north_psi[order] > range) tmp_north_psi[order] -= 2.0*range;
           }
       }
 
     //-------------------------------- store all MBD eventplane information ---------------------------------//
-    for (unsigned int order = 1; order < m_MaxOrder + 1; order++)
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
     {
-         south_Qvec.emplace_back(south_q[order - 1][0], south_q[order - 1][1]);
-         north_Qvec.emplace_back(north_q[order - 1][0], north_q[order - 1][1]); 
+         south_Qvec.emplace_back(south_q[order][0], south_q[order][1]);
+         north_Qvec.emplace_back(north_q[order][0], north_q[order][1]);
     }
-                                                                                                    
+                                                                                              
 
     if (mbdpmts)
     { 

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -22,7 +22,6 @@ class EventPlaneReco : public SubsysReco
  public:
   EventPlaneReco(const std::string &name = "EventPlaneReco");
   ~EventPlaneReco() override = default;
-  int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End (PHCompositeNode * /*topNode*/) override;
@@ -52,10 +51,6 @@ class EventPlaneReco : public SubsysReco
   {
     m_MaxOrder = n;
   }
-  void set_run_number(const unsigned int &r)
-  {
-    m_runNo = r;
-  }
  
   private:
     
@@ -63,8 +58,8 @@ class EventPlaneReco : public SubsysReco
    
   unsigned int m_MaxOrder = 3;
 
-  unsigned  int m_runNo = 21813;
- 
+  int m_runNo = 0;
+    
   std::string OutFileName;
   
   CDBHistos *cdbhistosOut = nullptr;

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -15,7 +15,7 @@
 class PHCompositeNode;
 class CDBHistos;
 class TProfile;
-class TH1D;
+class TH1;
 
 class EventPlaneReco : public SubsysReco
 {
@@ -24,7 +24,7 @@ class EventPlaneReco : public SubsysReco
   ~EventPlaneReco() override = default;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End (PHCompositeNode * /*topNode*/) override;
+  int End(PHCompositeNode * /*topNode*/) override;
 
   void ResetMe();
   void set_sepd_epreco(bool sepdEpReco)
@@ -51,72 +51,69 @@ class EventPlaneReco : public SubsysReco
   {
     m_MaxOrder = n;
   }
- 
-  private:
-    
-  int CreateNodes(PHCompositeNode *topNode);
-   
-  unsigned int m_MaxOrder = 3;
 
-  int m_runNo = 0;
-    
+ private:
+  int CreateNodes(PHCompositeNode *topNode);
+
+  unsigned int m_MaxOrder{3};
+
+  int m_runNo{0};
+
   std::string OutFileName;
-  
-  CDBHistos *cdbhistosOut = nullptr;
+
+  CDBHistos *cdbhistosOut{nullptr};
 
   std::vector<std::vector<double>> south_q;
   std::vector<std::vector<double>> north_q;
   std::vector<std::pair<double, double>> south_Qvec;
   std::vector<std::pair<double, double>> north_Qvec;
-    
-  //recentering utility
+
+  // recentering utility
   std::vector<std::vector<double>> south_q_subtract;
   std::vector<std::vector<double>> north_q_subtract;
-    
-  //shifting utility
+
+  // shifting utility
   std::vector<double> tmp_south_psi;
   std::vector<double> tmp_north_psi;
   std::vector<double> shift_north;
   std::vector<double> shift_south;
-    
 
-  bool _mbdEpReco = false;
-  bool _sepdEpReco = false;
-    
-  float _epd_e  = 6.0;
-  float _mbd_e = 10.0;
-  float _mbd_vertex = 999.0;
-  float _vertex_cut = 100.0;
+  bool _mbdEpReco{false};
+  bool _sepdEpReco{false};
 
-  float mbd_e_south;
-  float mbd_e_north;
-  float mbdQ;
- 
-  TH1D * hvertex = {};
+  float _epd_e{6.0};
+  float _mbd_e{10.0};
+  float _mbd_vertex{999.0};
+  float _vertex_cut{100.0};
 
-  //recentering histograms
-  TProfile * tprof_mean_cos_north_mbd[6] = {};
-  TProfile * tprof_mean_sin_north_mbd[6] = {};
-  TProfile * tprof_mean_cos_south_mbd[6] = {};
-  TProfile * tprof_mean_sin_south_mbd[6] = {};
-    
-  TProfile * tprof_mean_cos_north_mbd_input[6] = {};
-  TProfile * tprof_mean_sin_north_mbd_input[6] = {};
-  TProfile * tprof_mean_cos_south_mbd_input[6] = {};
-  TProfile * tprof_mean_sin_south_mbd_input[6] = {};
-    
-  //shifting histograms
-  const int _imax = 6;
-  TProfile * tprof_cos_north_mbd_shift[6][6] = {};
-  TProfile * tprof_sin_north_mbd_shift[6][6] = {};
-  TProfile * tprof_cos_south_mbd_shift[6][6] = {};
-  TProfile * tprof_sin_south_mbd_shift[6][6] = {};
-    
-  TProfile * tprof_cos_north_mbd_shift_input[6][6] = {};
-  TProfile * tprof_sin_north_mbd_shift_input[6][6] = {};
-  TProfile * tprof_cos_south_mbd_shift_input[6][6] = {};
-  TProfile * tprof_sin_south_mbd_shift_input[6][6] = {};
-    
+  float mbd_e_south{0.};
+  float mbd_e_north{0.};
+  float mbdQ{0.};
+
+  TH1 *hvertex{nullptr};
+
+  // recentering histograms
+  TProfile *tprof_mean_cos_north_mbd[6]{};
+  TProfile *tprof_mean_sin_north_mbd[6]{};
+  TProfile *tprof_mean_cos_south_mbd[6]{};
+  TProfile *tprof_mean_sin_south_mbd[6]{};
+
+  TProfile *tprof_mean_cos_north_mbd_input[6]{};
+  TProfile *tprof_mean_sin_north_mbd_input[6]{};
+  TProfile *tprof_mean_cos_south_mbd_input[6]{};
+  TProfile *tprof_mean_sin_south_mbd_input[6]{};
+
+  // shifting histograms
+  const int _imax{6};
+  TProfile *tprof_cos_north_mbd_shift[6][6]{};
+  TProfile *tprof_sin_north_mbd_shift[6][6]{};
+  TProfile *tprof_cos_south_mbd_shift[6][6]{};
+  TProfile *tprof_sin_south_mbd_shift[6][6]{};
+
+  TProfile *tprof_cos_north_mbd_shift_input[6][6]{};
+  TProfile *tprof_sin_north_mbd_shift_input[6][6]{};
+  TProfile *tprof_cos_south_mbd_shift_input[6][6]{};
+  TProfile *tprof_sin_south_mbd_shift_input[6][6]{};
 };
 
 #endif  // EVENTPLANERECO_H


### PR DESCRIPTION
Some cosmetic changes (no change in the physics output) based on Chris' request:
- Move loop over orders from 1 to 0
- include changes to cdbhist (turn off warning messages for unavailable hists)
- use rc flag for run number 

The fetching of the final calibration from the cdb for the reconstruction pass so that this can be added to the production cannot be implemented at this time. This will require direct insertion of the calibration histograms into the cdb, which is currently solely under expert (Chris') control. 