### PR TITLE
Fix clang tidy 5

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -1,7 +1,7 @@
 #include "AlignmentDefs.h"
 #include <trackbase/TpcDefs.h>
 
-void AlignmentDefs::getMvtxGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::mvtxGrp grp)
+void AlignmentDefs::getMvtxGlobalLabels(const Surface& surf, int glbl_label[], AlignmentDefs::mvtxGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
@@ -29,7 +29,7 @@ void AlignmentDefs::getMvtxGlobalLabels(Surface surf, int glbl_label[], Alignmen
   }
 }
 
-void AlignmentDefs::getInttGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::inttGrp grp)
+void AlignmentDefs::getInttGlobalLabels(const Surface& surf, int glbl_label[], AlignmentDefs::inttGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
@@ -56,7 +56,7 @@ void AlignmentDefs::getInttGlobalLabels(Surface surf, int glbl_label[], Alignmen
   }
 }
 
-void AlignmentDefs::getTpcGlobalLabels(Surface surf, TrkrDefs::cluskey cluskey, int glbl_label[], AlignmentDefs::tpcGrp grp)
+void AlignmentDefs::getTpcGlobalLabels(const Surface& surf, TrkrDefs::cluskey cluskey, int glbl_label[], AlignmentDefs::tpcGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
@@ -79,7 +79,7 @@ void AlignmentDefs::getTpcGlobalLabels(Surface surf, TrkrDefs::cluskey cluskey, 
     glbl_label[i] = label_base + i;
   }
 }
-void AlignmentDefs::getMMGlobalLabels(Surface surf, int glbl_label[], AlignmentDefs::mmsGrp grp)
+void AlignmentDefs::getMMGlobalLabels(const Surface& surf, int glbl_label[], AlignmentDefs::mmsGrp grp)
 {
   Acts::GeometryIdentifier id = surf->geometryId();
   int group = 0;
@@ -103,10 +103,12 @@ void AlignmentDefs::getMMGlobalLabels(Surface surf, int glbl_label[], AlignmentD
 int AlignmentDefs::getTpcRegion(int layer)
 {
   int region = 0;
-  if (layer > 22 && layer < 39)
+  if (layer > 22 && layer < 39) {
     region = 1;
-  if (layer > 38 && layer < 55)
+}
+  if (layer > 38 && layer < 55) {
     region = 2;
+}
 
   return region;
 }
@@ -118,8 +120,9 @@ int AlignmentDefs::getMvtxClamshell(int layer, int stave)
       for(int ishell = 0; ishell < 2; ++ishell)
 	{
 	  int stave_ref = clamshell_stave_list[layer][ishell][istave];
-	  if(stave == stave_ref)
+	  if(stave == stave_ref) {
 	    return ishell;
+}
 	}
     }
 
@@ -410,11 +413,11 @@ std::vector<int> AlignmentDefs::getAllTpcGlobalLabels(int grp)
 std::vector<int> AlignmentDefs::makeLabelsFromBase(std::vector<int>& label_base)
 {
   std::vector<int> labels;
-  for(unsigned int ilbl = 0; ilbl < label_base.size(); ++ilbl)
+  for(int ilbl : label_base)
     {
       for(int ipar=0; ipar < 6; ++ipar)
 	{
-	  int label_plus = label_base[ilbl] + ipar;
+	  int label_plus = ilbl + ipar;
 	  labels.push_back(label_plus);
 	}
     }
@@ -429,13 +432,15 @@ void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector
             << "  " << residual(index);
   for (int il = 0; il < NLC; ++il)
   {
-    if (lcl_derivative[il] != 0) std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
+    if (lcl_derivative[il] != 0) { std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
+}
   }
   std::cout << " sigma "
             << "  " << clus_sigma(index) << "  ";
   for (int ig = 0; ig < NGL; ++ig)
   {
-    if (glbl_derivative[ig] != 0) std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
+    if (glbl_derivative[ig] != 0) { std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
+}
   }
   std::cout << " int buffer: "
             << " 0 "
@@ -443,13 +448,15 @@ void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector
             << " ";  // spacer, rmeas placeholder
   for (int il = 0; il < NLC; ++il)
   {
-    if (lcl_derivative[il] != 0) std::cout << " lcl_label[" << il << "] " << il + 1 << "  ";
+    if (lcl_derivative[il] != 0) { std::cout << " lcl_label[" << il << "] " << il + 1 << "  ";
+}
   }
   std::cout << " 0 "
             << "  ";
   for (int ig = 0; ig < NGL; ++ig)
   {
-    if (glbl_derivative[ig] != 0) std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
+    if (glbl_derivative[ig] != 0) { std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
+}
   }
   std::cout << " end of meas " << std::endl;
 }

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.cc
@@ -103,32 +103,34 @@ void AlignmentDefs::getMMGlobalLabels(const Surface& surf, int glbl_label[], Ali
 int AlignmentDefs::getTpcRegion(int layer)
 {
   int region = 0;
-  if (layer > 22 && layer < 39) {
+  if (layer > 22 && layer < 39)
+  {
     region = 1;
-}
-  if (layer > 38 && layer < 55) {
+  }
+  if (layer > 38 && layer < 55)
+  {
     region = 2;
-}
+  }
 
   return region;
 }
 
 int AlignmentDefs::getMvtxClamshell(int layer, int stave)
 {
-  for(int istave=0;istave<nstaves_layer_mvtx[layer];++istave)
+  for (int istave = 0; istave < nstaves_layer_mvtx[layer]; ++istave)
+  {
+    for (int ishell = 0; ishell < 2; ++ishell)
     {
-      for(int ishell = 0; ishell < 2; ++ishell)
-	{
-	  int stave_ref = clamshell_stave_list[layer][ishell][istave];
-	  if(stave == stave_ref) {
-	    return ishell;
-}
-	}
+      int stave_ref = clamshell_stave_list[layer][ishell][istave];
+      if (stave == stave_ref)
+      {
+        return ishell;
+      }
     }
+  }
 
-  std::cout << " AlignemntDefs::getMvtxClamshell: did not find stave " << stave << std::endl; 
-  return  0;
-
+  std::cout << " AlignemntDefs::getMvtxClamshell: did not find stave " << stave << std::endl;
+  return 0;
 }
 
 int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, TrkrDefs::cluskey cluskey, int group)
@@ -151,96 +153,99 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, TrkrDefs::cluskey c
       return label_base;
     }
     if (group == 1)
-      {
-	// layer and stave, assign all sensors to the stave number
-	int stave = sensor / nsensors_stave[layer];
-	label_base += layer * 1000000 + stave * 10000;
-	/*
-	  std::cout << id << std::endl;
-	  std::cout << "    label_base " << label_base << " volume " << volume << " acts_layer " << acts_layer 
-	  << " layer " << layer << " stave " << stave << " sensor " << sensor << std::endl;
-	*/
-	return label_base;
-      }
-    if (group == 2)
-      {
-	// layer only, assign all sensors to sensor 0 in each clamshell
-	int stave = sensor / nsensors_stave[layer];
-	int clamshell = getMvtxClamshell(layer, stave);
-	label_base += layer * 1000000 + clamshell*10000;
-	//	std::cout << " mvtx group 2 layer " << layer << " sensor " << sensor << " stave " << stave 
-	//	  << " clamshell " << clamshell << " label_base " << label_base << std::endl; 
-
-	return label_base;
-      }
-    if(group == 3)
-      {
-	// group by half-barrel, or clamshell
-	// Assume for now low staves are in clamshell 0 - check!!!
-	int stave = sensor / nsensors_stave[layer];
-	int breakat = nstaves_layer_mvtx[layer] / 2;
-	int clamshell = 1;
-	if(stave < breakat) { clamshell = 0; }
-	label_base += 0 * 1000000 + clamshell * 10000;	
-	//	std::cout << " mvtx group 3 layer " << layer << " sensor " << sensor << " clamshell " << clamshell << " label_base " << label_base << std::endl; 
-
-	return label_base;
-      }
-  }
-  else if(layer > 2 && layer < 7)
     {
-      // calculating the stave number from the sensor is different between the INTT and MVTX
-      // There are 4 sensors/stave, but they are mapped to staves in a strange way
-      // sensors 1-> (nstaves/layer)*2 are in staves 1->nstaves/layer in pairs
-      // sensors (nstaves/layer * 2) +1->nstaves/layer)*2 are in staves 1->nstaves/layer in pairs
-
-      int stave;
-      unsigned int breakat = nstaves_layer_intt[layer-3] * 2;
-      if(sensor < breakat)
-	{
-	  stave = sensor/2;  // staves 0 -> (nstaves/layer) -1
-	}
-      else
-	{
-	  stave = (sensor - breakat)/2;  //staves 0 -> (nstaves/layer) -1
-	}
-
-      if (group == 4)
-	{
-	  // every sensor has a different label
-	  label_base += layer * 1000000 + stave * 10000 + sensor * 10;
-	  return label_base;
-	}
-      if (group == 5)
-	{
-	  // layer and stave, assign all sensors to the stave number
-	  label_base += layer * 1000000 + stave * 10000;
-	  /*
-	  std::cout << "    "  << id << std::endl;
-	  std::cout << "    label_base " << label_base << " volume " << volume << " acts_layer " << acts_layer 
-		    << " layer " << layer << " breakat " << breakat << " stave " << stave << " sensor " << sensor << std::endl;
-	  */
-	  return label_base;
-	}
-      if (group == 6)
-	{
-	  // layer only, assign all sensors to sensor 0 for this layer
-	  label_base += layer * 1000000 + 0;
-	  return label_base;
-	}
-      if(group == 7)
-	{
-	  // entire INTT
-	  // assign all sensors to layer 3
-	  label_base += 3 * 1000000 + 0;
-	  return label_base;
-	}
+      // layer and stave, assign all sensors to the stave number
+      int stave = sensor / nsensors_stave[layer];
+      label_base += layer * 1000000 + stave * 10000;
+      /*
+        std::cout << id << std::endl;
+        std::cout << "    label_base " << label_base << " volume " << volume << " acts_layer " << acts_layer
+        << " layer " << layer << " stave " << stave << " sensor " << sensor << std::endl;
+      */
+      return label_base;
     }
+    if (group == 2)
+    {
+      // layer only, assign all sensors to sensor 0 in each clamshell
+      int stave = sensor / nsensors_stave[layer];
+      int clamshell = getMvtxClamshell(layer, stave);
+      label_base += layer * 1000000 + clamshell * 10000;
+      //	std::cout << " mvtx group 2 layer " << layer << " sensor " << sensor << " stave " << stave
+      //	  << " clamshell " << clamshell << " label_base " << label_base << std::endl;
+
+      return label_base;
+    }
+    if (group == 3)
+    {
+      // group by half-barrel, or clamshell
+      // Assume for now low staves are in clamshell 0 - check!!!
+      int stave = sensor / nsensors_stave[layer];
+      int breakat = nstaves_layer_mvtx[layer] / 2;
+      int clamshell = 1;
+      if (stave < breakat)
+      {
+        clamshell = 0;
+      }
+      label_base += 0 * 1000000 + clamshell * 10000;
+      //	std::cout << " mvtx group 3 layer " << layer << " sensor " << sensor << " clamshell " << clamshell << " label_base " << label_base << std::endl;
+
+      return label_base;
+    }
+  }
+  else if (layer > 2 && layer < 7)
+  {
+    // calculating the stave number from the sensor is different between the INTT and MVTX
+    // There are 4 sensors/stave, but they are mapped to staves in a strange way
+    // sensors 1-> (nstaves/layer)*2 are in staves 1->nstaves/layer in pairs
+    // sensors (nstaves/layer * 2) +1->nstaves/layer)*2 are in staves 1->nstaves/layer in pairs
+
+    int stave;
+    unsigned int breakat = nstaves_layer_intt[layer - 3] * 2;
+    if (sensor < breakat)
+    {
+      stave = sensor / 2;  // staves 0 -> (nstaves/layer) -1
+    }
+    else
+    {
+      stave = (sensor - breakat) / 2;  // staves 0 -> (nstaves/layer) -1
+    }
+
+    if (group == 4)
+    {
+      // every sensor has a different label
+      label_base += layer * 1000000 + stave * 10000 + sensor * 10;
+      return label_base;
+    }
+    if (group == 5)
+    {
+      // layer and stave, assign all sensors to the stave number
+      label_base += layer * 1000000 + stave * 10000;
+      /*
+      std::cout << "    "  << id << std::endl;
+      std::cout << "    label_base " << label_base << " volume " << volume << " acts_layer " << acts_layer
+                << " layer " << layer << " breakat " << breakat << " stave " << stave << " sensor " << sensor << std::endl;
+      */
+      return label_base;
+    }
+    if (group == 6)
+    {
+      // layer only, assign all sensors to sensor 0 for this layer
+      label_base += layer * 1000000 + 0;
+      return label_base;
+    }
+    if (group == 7)
+    {
+      // entire INTT
+      // assign all sensors to layer 3
+      label_base += 3 * 1000000 + 0;
+      return label_base;
+    }
+  }
   else if (layer > 6 && layer < 55)
   {
     if (group == 8)
-      {
-	// want every hitset (layer, sector, side) to have a separate label
+    {
+      // want every hitset (layer, sector, side) to have a separate label
       // each group of 12 subsurfaces (sensors) is in a single hitset
       int hitset = sensor / 12;  // 0-11 on side 0, 12-23 on side 1
       label_base += layer * 1000000 + hitset * 10000;
@@ -250,15 +255,16 @@ int AlignmentDefs::getLabelBase(Acts::GeometryIdentifier id, TrkrDefs::cluskey c
     {
       // group all tpc layers in each region and sector, assign layer 7 and side and sector number to all layers and hitsets
       int side = TpcDefs::getSide(cluskey);
-      int sector = TpcDefs::getSectorId(cluskey);;
+      int sector = TpcDefs::getSectorId(cluskey);
+      ;
       int region = getTpcRegion(layer);  // inner, mid, outer
 
       // for a given layer there are only 12 sectors x 2 sides
       // The following gives the sectors in the inner, mid, outer regions unique group labels
       label_base += 7 * 1000000 + (region * 24 + side * 12 + sector) * 10000;
       /*
-      std::cout << " sensor " << sensor << " sector " << sector << " region " << region 
-		<< " side " << side << " label base " << label_base << std::endl;
+      std::cout << " sensor " << sensor << " sector " << sector << " region " << region
+                << " side " << side << " label base " << label_base << std::endl;
       std::cout << " Volume " << volume << " acts_layer " << acts_layer << " base_layer " <<  base_layer_map.find(volume)->second << " layer " << layer << std::endl;
       */
 
@@ -294,50 +300,50 @@ std::vector<int> AlignmentDefs::getAllMvtxGlobalLabels(int grp)
 {
   std::vector<int> label_base;
 
-  if(grp == mvtxGrp::clamshl)
+  if (grp == mvtxGrp::clamshl)
+  {
+    for (int ishl = 0; ishl < 2; ++ishl)
     {
-      for(int ishl=0;ishl<2;++ishl)
-	{
-	  int label = 1 + 0 * 1000000 + ishl*10000;
-	  label_base.push_back(label);
-	}
+      int label = 1 + 0 * 1000000 + ishl * 10000;
+      label_base.push_back(label);
     }
-  else if(grp == mvtxGrp::mvtxlyr)
+  }
+  else if (grp == mvtxGrp::mvtxlyr)
+  {
+    for (int ishl = 0; ishl < 2; ++ishl)
     {
-      for(int ishl=0;ishl<2;++ishl)
-	{
-	  for(int ilyr = 0; ilyr < 3; ++ilyr)
-	    {
-	      int label = 1 + ilyr * 1000000 + ishl * 10000;
-	      label_base.push_back(label);
-	    }
-	}
+      for (int ilyr = 0; ilyr < 3; ++ilyr)
+      {
+        int label = 1 + ilyr * 1000000 + ishl * 10000;
+        label_base.push_back(label);
+      }
     }
-  else if(grp == mvtxGrp::stv)
+  }
+  else if (grp == mvtxGrp::stv)
+  {
+    for (int ilyr = 0; ilyr < 3; ++ilyr)
     {
-      for(int ilyr = 0; ilyr < 3; ++ilyr)
-	{
-	  for(int istv = 0; istv < nstaves_layer_mvtx[ilyr]; ++istv)
-	    {
-	      int label = 1 + ilyr * 1000000 + istv * 10000;		  
-	      label_base.push_back(label);
-	    }
-	}	
+      for (int istv = 0; istv < nstaves_layer_mvtx[ilyr]; ++istv)
+      {
+        int label = 1 + ilyr * 1000000 + istv * 10000;
+        label_base.push_back(label);
+      }
     }
-  else if(grp == mvtxGrp::snsr)
+  }
+  else if (grp == mvtxGrp::snsr)
+  {
+    for (int ilyr = 0; ilyr < 3; ++ilyr)
     {
-      for(int ilyr = 0; ilyr < 3; ++ilyr)
-	{
-	  for(int istv = 0; istv < nstaves_layer_mvtx[ilyr]; ++istv)
-	    {
-	      for(int isnsr=0; isnsr<nsensors_stave[ilyr]; ++ isnsr)
-		{
-		  int label = 1 + ilyr * 1000000 + istv * 10000 + isnsr * 10;		  
-		  label_base.push_back(label);
-		}
-	    }
-	}	
+      for (int istv = 0; istv < nstaves_layer_mvtx[ilyr]; ++istv)
+      {
+        for (int isnsr = 0; isnsr < nsensors_stave[ilyr]; ++isnsr)
+        {
+          int label = 1 + ilyr * 1000000 + istv * 10000 + isnsr * 10;
+          label_base.push_back(label);
+        }
+      }
     }
+  }
 
   auto labels = makeLabelsFromBase(label_base);
 
@@ -348,44 +354,44 @@ std::vector<int> AlignmentDefs::getAllInttGlobalLabels(int grp)
 {
   std::vector<int> label_base;
 
-  if(grp == inttGrp::inttbrl)
+  if (grp == inttGrp::inttbrl)
+  {
+    int label = 1 + 3 * 1000000 + 0;
+    label_base.push_back(label);
+  }
+  else if (grp == inttGrp::inttlyr)
+  {
+    for (int ilyr = 3; ilyr < 7; ++ilyr)
     {
-      int  label = 1 + 3 * 1000000 + 0;
+      int label = 1 + ilyr * 1000000 + 0;
       label_base.push_back(label);
     }
-  else if(grp == inttGrp::inttlyr)
+  }
+  else if (grp == inttGrp::lad)
+  {
+    for (int ilyr = 3; ilyr < 7; ++ilyr)
     {
-      for(int ilyr = 3; ilyr < 7; ++ilyr)
-	{
-	  int label = 1 + ilyr * 1000000 + 0;
-	  label_base.push_back(label);
-	}
+      for (int istv = 0; istv < nstaves_layer_intt[ilyr - 3]; ++istv)
+      {
+        int label = 1 + ilyr * 1000000 + istv * 10000;
+        label_base.push_back(label);
+      }
     }
-  else if(grp == inttGrp::lad)
+  }
+  else if (grp == inttGrp::chp)
+  {
+    for (int ilyr = 3; ilyr < 7; ++ilyr)
     {
-      for(int ilyr = 3; ilyr < 7; ++ilyr)
-	{
-	  for(int istv = 0; istv < nstaves_layer_intt[ilyr-3]; ++istv)
-	    {
-	      int label = 1 + ilyr * 1000000 + istv * 10000;		  
-	      label_base.push_back(label);
-	    }
-	}	
+      for (int istv = 0; istv < nstaves_layer_intt[ilyr - 3]; ++istv)
+      {
+        for (int isnsr = 0; isnsr < nsensors_stave[ilyr]; ++isnsr)
+        {
+          int label = 1 + ilyr * 1000000 + istv * 10000 + isnsr * 10;
+          label_base.push_back(label);
+        }
+      }
     }
-  else if(grp == inttGrp::chp)
-    {
-      for(int ilyr = 3; ilyr < 7; ++ilyr)
-	{
-	  for(int istv = 0; istv < nstaves_layer_intt[ilyr-3]; ++istv)
-	    {
-	      for(int isnsr=0; isnsr<nsensors_stave[ilyr]; ++ isnsr)
-		{
-		  int label = 1 + ilyr * 1000000 + istv * 10000 + isnsr * 10;		  
-		  label_base.push_back(label);
-		}
-	    }
-	}	
-    }
+  }
 
   auto labels = makeLabelsFromBase(label_base);
 
@@ -396,14 +402,14 @@ std::vector<int> AlignmentDefs::getAllTpcGlobalLabels(int grp)
 {
   std::vector<int> label_base;
 
-  if(grp == tpcGrp::sctr)
+  if (grp == tpcGrp::sctr)
+  {
+    for (int isec = 0; isec < 72; ++isec)
     {
-      for(int isec = 0; isec < 72; ++isec)
-	{
-	  int label = 1 + 7 * 1000000 + isec * 10000;
-	  label_base.push_back(label);
-	}
+      int label = 1 + 7 * 1000000 + isec * 10000;
+      label_base.push_back(label);
     }
+  }
 
   auto labels = makeLabelsFromBase(label_base);
 
@@ -413,14 +419,14 @@ std::vector<int> AlignmentDefs::getAllTpcGlobalLabels(int grp)
 std::vector<int> AlignmentDefs::makeLabelsFromBase(std::vector<int>& label_base)
 {
   std::vector<int> labels;
-  for(int ilbl : label_base)
+  for (int ilbl : label_base)
+  {
+    for (int ipar = 0; ipar < 6; ++ipar)
     {
-      for(int ipar=0; ipar < 6; ++ipar)
-	{
-	  int label_plus = ilbl + ipar;
-	  labels.push_back(label_plus);
-	}
+      int label_plus = ilbl + ipar;
+      labels.push_back(label_plus);
     }
+  }
 
   return labels;
 }
@@ -432,15 +438,19 @@ void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector
             << "  " << residual(index);
   for (int il = 0; il < NLC; ++il)
   {
-    if (lcl_derivative[il] != 0) { std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
-}
+    if (lcl_derivative[il] != 0)
+    {
+      std::cout << " lcl_deriv[" << il << "] " << lcl_derivative[il] << "  ";
+    }
   }
   std::cout << " sigma "
             << "  " << clus_sigma(index) << "  ";
   for (int ig = 0; ig < NGL; ++ig)
   {
-    if (glbl_derivative[ig] != 0) { std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
-}
+    if (glbl_derivative[ig] != 0)
+    {
+      std::cout << " glbl_deriv[" << ig << "] " << glbl_derivative[ig] << "  ";
+    }
   }
   std::cout << " int buffer: "
             << " 0 "
@@ -448,15 +458,19 @@ void AlignmentDefs::printBuffers(int index, Acts::Vector2 residual, Acts::Vector
             << " ";  // spacer, rmeas placeholder
   for (int il = 0; il < NLC; ++il)
   {
-    if (lcl_derivative[il] != 0) { std::cout << " lcl_label[" << il << "] " << il + 1 << "  ";
-}
+    if (lcl_derivative[il] != 0)
+    {
+      std::cout << " lcl_label[" << il << "] " << il + 1 << "  ";
+    }
   }
   std::cout << " 0 "
             << "  ";
   for (int ig = 0; ig < NGL; ++ig)
   {
-    if (glbl_derivative[ig] != 0) { std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
-}
+    if (glbl_derivative[ig] != 0)
+    {
+      std::cout << " glbl_label[" << ig << "] " << glbl_label[ig] << "  ";
+    }
   }
   std::cout << " end of meas " << std::endl;
 }

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -44,15 +44,15 @@ namespace AlignmentDefs
   static constexpr int nstaves_layer_intt[4] = {12, 12, 16, 16};
   static constexpr int nstaves_layer_mvtx[3] = {12, 16, 20};
 
-  static constexpr int clamshell_stave_list[3][2][10] = {    // [layer][clamshell][stave]
-    {{3,4,5,6,7,8,0,0,0,0},
-     {0,1,2,9,10,11,0,0,0,0}},
-    {{4,5,6,7,8,9,10,11,0,0},
-     {0,1,2,3,12,13,14,15,0,0}},
-    {{5,6,7,8,9,10,11,12,13,14},
-     {0,1,2,3,4,15,16,17,18,19 }} };
+  static constexpr int clamshell_stave_list[3][2][10] = {  // [layer][clamshell][stave]
+      {{3, 4, 5, 6, 7, 8, 0, 0, 0, 0},
+       {0, 1, 2, 9, 10, 11, 0, 0, 0, 0}},
+      {{4, 5, 6, 7, 8, 9, 10, 11, 0, 0},
+       {0, 1, 2, 3, 12, 13, 14, 15, 0, 0}},
+      {{5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
+       {0, 1, 2, 3, 4, 15, 16, 17, 18, 19}}};
 
-  static constexpr int glbl_vtx_label[NGLVTX] = {60000000,60000001,60000002};
+  static constexpr int glbl_vtx_label[NGLVTX] = {60000000, 60000001, 60000002};
 
   int getTpcRegion(int layer);
   void getMvtxGlobalLabels(const Surface& surf, int glbl_label[], mvtxGrp grp);

--- a/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
+++ b/offline/packages/TrackerMillepedeAlignment/AlignmentDefs.h
@@ -55,10 +55,10 @@ namespace AlignmentDefs
   static constexpr int glbl_vtx_label[NGLVTX] = {60000000,60000001,60000002};
 
   int getTpcRegion(int layer);
-  void getMvtxGlobalLabels(Surface surf, int glbl_label[], mvtxGrp grp);
-  void getInttGlobalLabels(Surface surf, int glbl_label[], inttGrp grp);
-  void getTpcGlobalLabels(Surface surf, TrkrDefs::cluskey cluskey, int glbl_label[], tpcGrp grp);
-  void getMMGlobalLabels(Surface surf, int glbl_label[], mmsGrp grp);
+  void getMvtxGlobalLabels(const Surface& surf, int glbl_label[], mvtxGrp grp);
+  void getInttGlobalLabels(const Surface& surf, int glbl_label[], inttGrp grp);
+  void getTpcGlobalLabels(const Surface& surf, TrkrDefs::cluskey cluskey, int glbl_label[], tpcGrp grp);
+  void getMMGlobalLabels(const Surface& surf, int glbl_label[], mmsGrp grp);
   int getMvtxClamshell(int layer, int stave);
 
   std::vector<int> getAllMvtxGlobalLabels(int grp);

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -67,9 +67,7 @@ HelicalFitter::HelicalFitter(const std::string &name):
 
 //____________________________________________________________________________..
 HelicalFitter::~HelicalFitter()
-{
-
-}
+= default;
 
 //____________________________________________________________________________..
 int HelicalFitter::InitRun(PHCompositeNode *topNode)
@@ -77,10 +75,12 @@ int HelicalFitter::InitRun(PHCompositeNode *topNode)
   UpdateParametersWithMacro();
 
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
+}
 
   ret = CreateNodes(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  if(ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
+}
 
   // Instantiate Mille and open output data file
   if(test_output)
@@ -143,7 +143,7 @@ void HelicalFitter::SetDefaultParameters()
 }
 
 //____________________________________________________________________________..
-int HelicalFitter::process_event(PHCompositeNode*)
+int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 {
   // _track_map_tpc contains the TPC seed track stubs
   // _track_map_silicon contains the silicon seed track stubs
@@ -151,14 +151,16 @@ int HelicalFitter::process_event(PHCompositeNode*)
 
   event++;
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     cout << PHWHERE 
 	 << " TPC seed map size " << _track_map_tpc->size() 
 	 << " Silicon seed map size "  << _track_map_silicon->size() 
 	 << endl;
+}
 
-  if(_track_map_silicon->size() == 0 && _track_map_tpc->size() == 0)
+  if(_track_map_silicon->size() == 0 && _track_map_tpc->size() == 0) {
     return Fun4AllReturnCodes::EVENT_OK;
+}
 
   // Decide whether we want to make a helical fit for silicon or TPC
   unsigned int maxtracks = 0; 
@@ -194,7 +196,8 @@ int HelicalFitter::process_event(PHCompositeNode*)
 
       std::vector<float> fitpars =  TrackFitUtils::fitClusters(global_vec, cluskey_vec);       // do helical fit
 
-      if(fitpars.size() == 0) continue;  // discard this track, not enough clusters to fit
+      if(fitpars.size() == 0) { continue;  // discard this track, not enough clusters to fit
+}
 
       if(Verbosity() > 1)  
 	{ std::cout << " Track " << trackid   << " radius " << fitpars[0] << " X0 " << fitpars[1]<< " Y0 " << fitpars[2]
@@ -212,7 +215,8 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	  // this associates silicon clusters and adds them to the vectors
 	  ntpc = cluskey_vec.size();
 	  nsilicon = TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec,0,6);
-	  if(nsilicon < 3) continue;  // discard this TPC seed, did not get a good match to silicon
+	  if(nsilicon < 3) { continue;  // discard this TPC seed, did not get a good match to silicon
+}
 	  auto trackseed = std::make_unique<TrackSeed_v2>();
 	  for(auto& ckey : cluskey_vec)
 	    {
@@ -228,7 +232,8 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	  // fit the full track now
 	  fitpars.clear();
 	  fitpars =  TrackFitUtils::fitClusters(global_vec, cluskey_vec);       // do helical fit
-          if(fitpars.size() == 0) continue;  // discard this track, fit failed
+          if(fitpars.size() == 0) { continue;  // discard this track, fit failed
+}
 
 	  if(Verbosity() > 1)  
 	    { std::cout << " Full track " << trackid   << " radius " << fitpars[0] << " X0 " << fitpars[1]<< " Y0 " << fitpars[2]
@@ -559,8 +564,10 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	    }
 
 	  // add some cluster cuts
-	  if(residual(0) > 0.2)  continue;   // 2 mm cut
-	  if(residual(1) > 0.2)  continue;   // 2 mm cut
+	  if(residual(0) > 0.2) {  continue;   // 2 mm cut
+}
+	  if(residual(1) > 0.2) {  continue;   // 2 mm cut
+}
 
 	  if( !isnan(residual(0)) && clus_sigma(0) < 1.0)  // discards crazy clusters
 	    {
@@ -606,21 +613,28 @@ int HelicalFitter::process_event(PHCompositeNode*)
 	      std::cout << "vertex residuals " << vtx_residual.transpose() 
 			<< std::endl;
 	      std::cout << "local derivatives " << std::endl;
-	      for(int i=0; i<AlignmentDefs::NLC; i++)
-		std::cout << lclvtx_derivativeX[i] << ", ";
+	      for(float i : lclvtx_derivativeX) {
+		std::cout << i << ", ";
+}
 	      std::cout << std::endl;
-	      for(int i=0; i<AlignmentDefs::NLC; i++)
-		std::cout << lclvtx_derivativeY[i] << ", ";
+	      for(float i : lclvtx_derivativeY) {
+		std::cout << i << ", ";
+}
 	      std::cout << "global vtx derivaties " << std::endl;
-	      for(int i=0; i<3; i++) std::cout << glblvtx_derivativeX[i] << ", ";
+	      for(float i : glblvtx_derivativeX) { std::cout << i << ", ";
+}
 	      std::cout << std::endl;
-	      for(int i=0; i<3; i++) std::cout << glblvtx_derivativeY[i] << ", ";
+	      for(float i : glblvtx_derivativeY) { std::cout << i << ", ";
+}
 	    }
 
 	  // add some track cuts
-	  if(fabs(newTrack.get_z() - event_vtx(2)) > 0.2) continue;  // 2 mm cut
-	  if(fabs(newTrack.get_x()) > 0.2) continue;  // 2 mm cut
-	  if(fabs(newTrack.get_y()) > 0.2) continue;  // 2 mm cut
+	  if(fabs(newTrack.get_z() - event_vtx(2)) > 0.2) { continue;  // 2 mm cut
+}
+	  if(fabs(newTrack.get_x()) > 0.2) { continue;  // 2 mm cut
+}
+	  if(fabs(newTrack.get_y()) > 0.2) { continue;  // 2 mm cut
+}
 	  
 	  if(!isnan(vtx_residual(0)))
 	    {
@@ -665,7 +679,7 @@ int HelicalFitter::process_event(PHCompositeNode*)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::vector<float>& fitpars, Acts::Vector3 global)
+Acts::Vector3 HelicalFitter::get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global)
 {
   // we want the point where the helix intersects the plane of the surface
   // get the plane of the surface
@@ -675,7 +689,7 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::v
 
   // there are analytic solutions for a line-plane intersection.
   // to use this, need to get the vector tangent to the helix near the measurement and a point on it.
-  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, global);
+  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, std::move(global));
   Acts::Vector3 pca = line.first;
   Acts::Vector3 tangent = line.second;
 
@@ -684,7 +698,7 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::v
   return intersection;
 }
 
-Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::vector<float>& fitpars, Acts::Vector3 global, Acts::Vector3& pca, Acts::Vector3& tangent)
+Acts::Vector3 HelicalFitter::get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global, Acts::Vector3& pca, Acts::Vector3& tangent)
 {
   // we want the point where the helix intersects the plane of the surface
 
@@ -695,7 +709,7 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::v
 
   // there are analytic solutions for a line-plane intersection.
   // to use this, need to get the vector tangent to the helix near the measurement and a point on it.
-  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, global);
+  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, std::move(global));
   pca = line.first;
   tangent = line.second;
 
@@ -707,14 +721,14 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(Surface surf, std::v
 
 Acts::Vector3 HelicalFitter::get_helix_vtx(Acts::Vector3 event_vtx, const std::vector<float>& fitpars)
 {  
-  Acts::Vector2 pca2d = TrackFitUtils::get_circle_point_pca(fitpars[0], fitpars[1], fitpars[2], event_vtx);
+  Acts::Vector2 pca2d = TrackFitUtils::get_circle_point_pca(fitpars[0], fitpars[1], fitpars[2], std::move(event_vtx));
   Acts::Vector3 helix_vtx (pca2d(0),pca2d(1),fitpars[4]);
 
   return helix_vtx;
 }
 
 
-Acts::Vector3 HelicalFitter::get_line_plane_intersection(Acts::Vector3 PCA, Acts::Vector3 tangent, Acts::Vector3 sensor_center, Acts::Vector3 sensor_normal)
+Acts::Vector3 HelicalFitter::get_line_plane_intersection(const Acts::Vector3& PCA, const Acts::Vector3& tangent, const Acts::Vector3& sensor_center, const Acts::Vector3& sensor_normal)
 {
   // get the intersection of the line made by PCA and tangent with the plane of the sensor
 
@@ -770,7 +784,7 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_helix_tangent(const s
   return pair;
 }
   
-int HelicalFitter::End(PHCompositeNode* )
+int HelicalFitter::End(PHCompositeNode*  /*unused*/)
 {
   // closes output file in destructor
   delete _mille;
@@ -858,13 +872,13 @@ int  HelicalFitter::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 } 
 
-Acts::Vector3 HelicalFitter::get_helix_pca(std::vector<float>& fitpars, Acts::Vector3 global)
+Acts::Vector3 HelicalFitter::get_helix_pca(std::vector<float>& fitpars, const Acts::Vector3& global)
 {
   return TrackFitUtils::get_helix_pca(fitpars, global);
 }
 
 
-Acts::Vector3 HelicalFitter::getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref)
+Acts::Vector3 HelicalFitter::getPCALinePoint(const Acts::Vector3& global, const Acts::Vector3& tangent, const Acts::Vector3& posref)
 {
   // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)   
 
@@ -884,7 +898,8 @@ float HelicalFitter::convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster *
   double surfCenterZ = 52.89; // 52.89 is where G4 thinks the surface center is
   double zloc = surfCenterZ - zdriftlength;   // converts z drift length to local z position in the TPC in north
   unsigned int side = TpcDefs::getSide(cluster_key);
-  if(side == 0) zloc = -zloc;
+  if(side == 0) { zloc = -zloc;
+}
   float z = zloc;  // in cm
  
   return z; 
@@ -939,7 +954,7 @@ void HelicalFitter::getTrackletClusterList(TrackSeed *tracklet, std::vector<Trkr
 
 std::vector<float> HelicalFitter::fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec)
 {
-  return TrackFitUtils::fitClusters(global_vec, cluskey_vec);       // do helical fit
+  return TrackFitUtils::fitClusters(global_vec, std::move(cluskey_vec));       // do helical fit
 }
 
 Acts::Vector2 HelicalFitter::getClusterError(TrkrCluster *cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global)
@@ -957,7 +972,7 @@ Acts::Vector2 HelicalFitter::getClusterError(TrkrCluster *cluster, TrkrDefs::clu
 }
 
 // new one
-void HelicalFitter::getLocalDerivativesXY(Surface surf, Acts::Vector3 global, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5], unsigned int layer)
+void HelicalFitter::getLocalDerivativesXY(const Surface& surf, const Acts::Vector3& global, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5], unsigned int layer)
 {
   // Calculate the derivatives of the residual wrt the track parameters numerically
   std::vector<float> temp_fitpars;
@@ -969,13 +984,15 @@ void HelicalFitter::getLocalDerivativesXY(Surface surf, Acts::Vector3 global, co
   fitpars_delta.push_back(0.1);   // zslope, cm
   fitpars_delta.push_back(0.1);   // Z0, cm
 
-  for(unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  temp_fitpars.reserve(fitpars.size());
+for(float fitpar : fitpars)
     {
-      temp_fitpars.push_back(fitpars[ip]);
+      temp_fitpars.push_back(fitpar);
     }
 
   // calculate projX and projY vectors once for the optimum fit parameters
-  if(Verbosity() > 1) std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;
+  if(Verbosity() > 1) { std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;
+}
   std::pair<Acts::Vector3, Acts::Vector3> tangent = get_helix_tangent(fitpars, global);
 
   Acts::Vector3 projX(0,0,0), projY(0,0,0);
@@ -1014,7 +1031,7 @@ void HelicalFitter::getLocalDerivativesXY(Surface surf, Acts::Vector3 global, co
 }
 
 
-void HelicalFitter::getLocalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 event_vtx, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5])
+void HelicalFitter::getLocalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& event_vtx, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5])
 {
   // Calculate the derivatives of the residual wrt the track parameters numerically
   std::vector<float> temp_fitpars;
@@ -1027,9 +1044,10 @@ void HelicalFitter::getLocalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 eve
   fitpars_delta.push_back(0.1);   // zslope, cm
   fitpars_delta.push_back(0.1);   // Z0, cm
 
-  for(unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  temp_fitpars.reserve(fitpars.size());
+for(float fitpar : fitpars)
     {
-      temp_fitpars.push_back(fitpars[ip]);
+      temp_fitpars.push_back(fitpar);
     }
 
   // calculate projX and projY vectors once for the optimum fit parameters
@@ -1080,14 +1098,14 @@ void HelicalFitter::getLocalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 eve
     }
 }
 
-void HelicalFitter::getGlobalDerivativesXY(Surface surf, Acts::Vector3 global, Acts::Vector3 fitpoint, const std::vector<float>& fitpars, float glbl_derivativeX[6], float glbl_derivativeY[6], unsigned int layer)
+void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 global, const Acts::Vector3& fitpoint, const std::vector<float>& fitpars, float glbl_derivativeX[6], float glbl_derivativeY[6], unsigned int layer)
 {
   Acts::Vector3 unitx(1, 0, 0);
   Acts::Vector3 unity(0, 1, 0);
   Acts::Vector3 unitz(0, 0, 1);
 
   // calculate projX and projY vectors once for the optimum fit parameters
-  std::pair<Acts::Vector3, Acts::Vector3> tangent = get_helix_tangent(fitpars, global);  // should this be global, not fitpoint?
+  std::pair<Acts::Vector3, Acts::Vector3> tangent = get_helix_tangent(fitpars, std::move(global));  // should this be global, not fitpoint?
 
   Acts::Vector3 projX(0,0,0), projY(0,0,0);
   get_projectionXY(surf, tangent, projX, projY);
@@ -1138,7 +1156,7 @@ void HelicalFitter::getGlobalDerivativesXY(Surface surf, Acts::Vector3 global, A
 }
 
 
-void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 event_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3])
+void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& event_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3])
 {
   Acts::Vector3 unitx(1, 0, 0);
   Acts::Vector3 unity(0, 1, 0);
@@ -1173,7 +1191,7 @@ void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 ev
 
 }
 
-void HelicalFitter::get_projectionXY(Surface surf, std::pair<Acts::Vector3, Acts::Vector3> tangent, Acts::Vector3& projX, Acts::Vector3& projY)
+void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::Vector3, Acts::Vector3>& tangent, Acts::Vector3& projX, Acts::Vector3& projY)
 {
   // we only need the direction part of the tangent
   Acts::Vector3 tanvec = tangent.second;
@@ -1197,7 +1215,7 @@ void HelicalFitter::get_projectionXY(Surface surf, std::pair<Acts::Vector3, Acts
   return;
 }
 
-void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, Acts::Vector3 event_vtx, Acts::Vector3& projX, Acts::Vector3& projY)
+void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, const Acts::Vector3& event_vtx, Acts::Vector3& projX, Acts::Vector3& projY)
 {
   Acts::Vector3 tanvec(track.get_px(),track.get_py(),track.get_pz());
   Acts::Vector3 normal(track.get_px(),track.get_py(),0); 
@@ -1230,8 +1248,9 @@ bool HelicalFitter::is_intt_layer_fixed(unsigned int layer)
 {
   bool ret = false;
   auto it = fixed_intt_layers.find(layer);
-  if(it != fixed_intt_layers.end()) 
+  if(it != fixed_intt_layers.end()) { 
     ret = true;
+}
 
   return ret;
 }
@@ -1242,8 +1261,9 @@ bool HelicalFitter::is_mvtx_layer_fixed(unsigned int layer, unsigned int clamshe
 
   std::pair pair = std::make_pair(layer,clamshell);
   auto it = fixed_mvtx_layers.find(pair);
-  if(it != fixed_mvtx_layers.end()) 
+  if(it != fixed_mvtx_layers.end()) { 
     ret = true;
+}
 
   return ret;
 }
@@ -1264,8 +1284,9 @@ bool HelicalFitter::is_layer_param_fixed(unsigned int layer, unsigned int param)
   bool ret = false;
   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
   auto it = fixed_layer_params.find(pair);
-  if(it != fixed_layer_params.end()) 
+  if(it != fixed_layer_params.end()) { 
     ret = true;
+}
 
   return ret;
 }
@@ -1289,8 +1310,9 @@ bool HelicalFitter::is_tpc_sector_fixed(unsigned int layer, unsigned int sector,
   unsigned int region = AlignmentDefs::getTpcRegion(layer);
   unsigned int subsector = region * 24 + side * 12 + sector;
   auto it = fixed_sectors.find(subsector);
-  if(it != fixed_sectors.end()) 
+  if(it != fixed_sectors.end()) { 
     ret = true;
+}
   
   return ret;
 }
@@ -1326,7 +1348,7 @@ float HelicalFitter::getVertexResidual(Acts::Vector3 vtx)
   return r;
 }
 
-void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, Acts::Vector3 event_vertex)
+void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& event_vertex)
 {
   //give trackseed 
   dca3dxy = NAN;
@@ -1376,7 +1398,7 @@ void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, floa
   
 }
 
-Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3 event_vertex)
+Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex)
 {
 
   Acts::Vector3 track_vtx(track.get_x(),track.get_y(),track.get_z());
@@ -1409,7 +1431,7 @@ Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3
   return pos_R; 
 }
 
-Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3 event_vertex, Acts::Vector3 PCA)
+Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex, Acts::Vector3 PCA)
 {
   Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
   PCA -= event_vertex; // difference between track_vertex and event_vtx
@@ -1441,7 +1463,7 @@ Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3
 }
 
 
-Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, Acts::Vector3 event_vtx,  Acts::Vector3 local)
+Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx,  const Acts::Vector3& local)
 {
 
   //Acts::Vector3 track_vtx = local;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -3,56 +3,56 @@
 #include "Mille.h"
 
 /// Tracking includes
-#include <trackbase/TrkrDefs.h>                // for cluskey, getTrkrId, tpcId
-#include <trackbase/TpcDefs.h>
-#include <trackbase/MvtxDefs.h>
 #include <trackbase/InttDefs.h>
-#include <trackbase/TrkrClusterv3.h>   
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterContainerv4.h>
-#include <trackbase/TrkrClusterContainer.h>   
-#include <trackbase/TrkrClusterCrossingAssoc.h>   
+#include <trackbase/TrkrClusterCrossingAssoc.h>
+#include <trackbase/TrkrClusterv3.h>
+#include <trackbase/TrkrDefs.h>  // for cluskey, getTrkrId, tpcId
 #include <trackbase/alignmentTransformationContainer.h>
 
-#include <trackbase_historic/TrackSeed_v2.h>
-#include <trackbase_historic/TrackSeedContainer_v1.h>
-#include <trackbase_historic/SvtxTrackSeed_v1.h>
-#include <trackbase_historic/SvtxTrack_v4.h>
-#include <trackbase_historic/SvtxTrackMap_v2.h>
-#include <trackbase_historic/SvtxAlignmentState_v1.h>
 #include <trackbase_historic/SvtxAlignmentStateMap_v1.h>
+#include <trackbase_historic/SvtxAlignmentState_v1.h>
+#include <trackbase_historic/SvtxTrackMap_v2.h>
+#include <trackbase_historic/SvtxTrackSeed_v1.h>
 #include <trackbase_historic/SvtxTrackState_v1.h>
+#include <trackbase_historic/SvtxTrack_v4.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeed_v2.h>
 
-#include <globalvertex/SvtxVertex.h>     
+#include <globalvertex/SvtxVertex.h>
 #include <globalvertex/SvtxVertexMap.h>
 
 #include <Acts/Surfaces/PerigeeSurface.hpp>
 
-#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Hit.h>       // for PHG4Hit
+#include <g4main/PHG4HitDefs.h>   // for keytype
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
-#include <g4main/PHG4HitDefs.h>  // for keytype
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
-#include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <TF1.h>
-#include <TNtuple.h>
 #include <TFile.h>
+#include <TNtuple.h>
 
-#include <climits>                            // for UINT_MAX
-#include <iostream>                            // for operator<<, basic_ostream
-#include <cmath>                              // for fabs, sqrt
-#include <set>                                 // for _Rb_tree_const_iterator
-#include <utility>                             // for pair
+#include <climits>   // for UINT_MAX
+#include <cmath>     // for fabs, sqrt
+#include <iostream>  // for operator<<, basic_ostream
 #include <memory>
+#include <set>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 
 using namespace std;
 
 //____________________________________________________________________________..
-HelicalFitter::HelicalFitter(const std::string &name):
-  SubsysReco(name)
+HelicalFitter::HelicalFitter(const std::string& name)
+  : SubsysReco(name)
   , PHParameterInterface(name)
   , _mille(nullptr)
 {
@@ -66,70 +66,71 @@ HelicalFitter::HelicalFitter(const std::string &name):
 }
 
 //____________________________________________________________________________..
-HelicalFitter::~HelicalFitter()
-= default;
+HelicalFitter::~HelicalFitter() = default;
 
 //____________________________________________________________________________..
-int HelicalFitter::InitRun(PHCompositeNode *topNode)
+int HelicalFitter::InitRun(PHCompositeNode* topNode)
 {
   UpdateParametersWithMacro();
 
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
-}
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
 
   ret = CreateNodes(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
-}
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
 
   // Instantiate Mille and open output data file
-  if(test_output)
-    {
-      _mille = new Mille(data_outfilename.c_str(), false);   // write text in data files, rather than binary, for debugging only
-    }
+  if (test_output)
+  {
+    _mille = new Mille(data_outfilename.c_str(), false);  // write text in data files, rather than binary, for debugging only
+  }
   else
-    {
-      _mille = new Mille(data_outfilename.c_str()); 
-    }
+  {
+    _mille = new Mille(data_outfilename.c_str());
+  }
 
   // Write the steering file here, and add the data file path to it
   std::ofstream steering_file(steering_outfilename);
   steering_file << data_outfilename << std::endl;
   steering_file.close();
 
-  if(make_ntuple)
-    {
-      //fout = new TFile("HF_ntuple.root","recreate");
-      fout = new TFile(ntuple_outfilename.c_str(),"recreate");
-      ntp  = new TNtuple("ntp","HF ntuple","event:trkid:layer:nsilicon:ntpc:nclus:trkrid:sector:side:subsurf:phi:glbl0:glbl1:glbl2:glbl3:glbl4:glbl5:sensx:sensy:sensz:normx:normy:normz:sensxideal:sensyideal:senszideal:normxideal:normyideal:normzideal:xglobideal:yglobideal:zglobideal:R:X0:Y0:Zs:Z0:xglob:yglob:zglob:xfit:yfit:zfit:pcax:pcay:pcaz:tangx:tangy:tangz:X:Y:fitX:fitY:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdalpha:dXdbeta:dXdgamma:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdalpha:dYdbeta:dYdgamma:dYdx:dYdy:dYdz");
+  if (make_ntuple)
+  {
+    // fout = new TFile("HF_ntuple.root","recreate");
+    fout = new TFile(ntuple_outfilename.c_str(), "recreate");
+    ntp = new TNtuple("ntp", "HF ntuple", "event:trkid:layer:nsilicon:ntpc:nclus:trkrid:sector:side:subsurf:phi:glbl0:glbl1:glbl2:glbl3:glbl4:glbl5:sensx:sensy:sensz:normx:normy:normz:sensxideal:sensyideal:senszideal:normxideal:normyideal:normzideal:xglobideal:yglobideal:zglobideal:R:X0:Y0:Zs:Z0:xglob:yglob:zglob:xfit:yfit:zfit:pcax:pcay:pcaz:tangx:tangy:tangz:X:Y:fitX:fitY:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdalpha:dXdbeta:dXdgamma:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdalpha:dYdbeta:dYdgamma:dYdx:dYdy:dYdz");
 
-      track_ntp = new TNtuple("track_ntp","HF track ntuple","track_id:residual_x:residual_y:residualxsigma:residualysigma:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdx:dYdy:dYdz:xvtx:yvtx:zvtx:event_zvtx:track_phi:perigee_phi");
+    track_ntp = new TNtuple("track_ntp", "HF track ntuple", "track_id:residual_x:residual_y:residualxsigma:residualysigma:dXdR:dXdX0:dXdY0:dXdZs:dXdZ0:dXdx:dXdy:dXdz:dYdR:dYdX0:dYdY0:dYdZs:dYdZ0:dYdx:dYdy:dYdz:xvtx:yvtx:zvtx:event_zvtx:track_phi:perigee_phi");
+  }
 
-    }
-
- 
   // print grouping setup to log file:
-  std::cout << "HelicalFitter::InitRun: Surface groupings are mvtx " << mvtx_grp << " intt " << intt_grp << " tpc " << tpc_grp << " mms " << mms_grp << std::endl; 
+  std::cout << "HelicalFitter::InitRun: Surface groupings are mvtx " << mvtx_grp << " intt " << intt_grp << " tpc " << tpc_grp << " mms " << mms_grp << std::endl;
   std::cout << " possible groupings are:" << std::endl
-	    << " mvtx " 
-	    << AlignmentDefs::mvtxGrp::snsr << "  " 
-	    << AlignmentDefs::mvtxGrp::stv << "  " 
-	    << AlignmentDefs::mvtxGrp::mvtxlyr << "  "
-	    << AlignmentDefs::mvtxGrp::clamshl << "  " << std::endl
-	    << " intt " 
-	    << AlignmentDefs::inttGrp::chp << "  "
-	    << AlignmentDefs::inttGrp::lad << "  "
-	    << AlignmentDefs::inttGrp::inttlyr << "  "
-	    << AlignmentDefs::inttGrp::inttbrl << "  " << std::endl
-	    << " tpc " 
-	    << AlignmentDefs::tpcGrp::htst << "  "
-	    << AlignmentDefs::tpcGrp::sctr << "  "
-	    << AlignmentDefs::tpcGrp::tp << "  " << std::endl
-	    << " mms " 
-	    << AlignmentDefs::mmsGrp::tl << "  "
-	    << AlignmentDefs::mmsGrp::mm << "  " << std::endl;
- 
-  event=-1;
+            << " mvtx "
+            << AlignmentDefs::mvtxGrp::snsr << "  "
+            << AlignmentDefs::mvtxGrp::stv << "  "
+            << AlignmentDefs::mvtxGrp::mvtxlyr << "  "
+            << AlignmentDefs::mvtxGrp::clamshl << "  " << std::endl
+            << " intt "
+            << AlignmentDefs::inttGrp::chp << "  "
+            << AlignmentDefs::inttGrp::lad << "  "
+            << AlignmentDefs::inttGrp::inttlyr << "  "
+            << AlignmentDefs::inttGrp::inttbrl << "  " << std::endl
+            << " tpc "
+            << AlignmentDefs::tpcGrp::htst << "  "
+            << AlignmentDefs::tpcGrp::sctr << "  "
+            << AlignmentDefs::tpcGrp::tp << "  " << std::endl
+            << " mms "
+            << AlignmentDefs::mmsGrp::tl << "  "
+            << AlignmentDefs::mmsGrp::mm << "  " << std::endl;
+
+  event = -1;
 
   return ret;
 }
@@ -137,8 +138,6 @@ int HelicalFitter::InitRun(PHCompositeNode *topNode)
 //_____________________________________________________________________
 void HelicalFitter::SetDefaultParameters()
 {
-
-
   return;
 }
 
@@ -151,19 +150,21 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 
   event++;
 
-  if(Verbosity() > 0) {
-    cout << PHWHERE 
-	 << " TPC seed map size " << _track_map_tpc->size() 
-	 << " Silicon seed map size "  << _track_map_silicon->size() 
-	 << endl;
-}
+  if (Verbosity() > 0)
+  {
+    cout << PHWHERE
+         << " TPC seed map size " << _track_map_tpc->size()
+         << " Silicon seed map size " << _track_map_silicon->size()
+         << endl;
+  }
 
-  if(_track_map_silicon->size() == 0 && _track_map_tpc->size() == 0) {
+  if (_track_map_silicon->size() == 0 && _track_map_tpc->size() == 0)
+  {
     return Fun4AllReturnCodes::EVENT_OK;
-}
+  }
 
   // Decide whether we want to make a helical fit for silicon or TPC
-  unsigned int maxtracks = 0; 
+  unsigned int maxtracks = 0;
   unsigned int nsilicon = 0;
   unsigned int ntpc = 0;
   unsigned int nclus = 0;
@@ -174,508 +175,569 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
   std::vector<TrackSeed> cumulative_someseed;
   std::vector<SvtxTrack_v4> cumulative_newTrack;
 
-
-  if(fittpc) { maxtracks =  _track_map_tpc->size();  }
-  if(fitsilicon)  { maxtracks =  _track_map_silicon->size(); }
-  for(unsigned int trackid = 0; trackid < maxtracks; ++trackid)
+  if (fittpc)
+  {
+    maxtracks = _track_map_tpc->size();
+  }
+  if (fitsilicon)
+  {
+    maxtracks = _track_map_silicon->size();
+  }
+  for (unsigned int trackid = 0; trackid < maxtracks; ++trackid)
+  {
+    TrackSeed* tracklet = nullptr;
+    if (fitsilicon)
     {
-       TrackSeed* tracklet = nullptr;
-      if(fitsilicon) {  tracklet = _track_map_silicon->get(trackid); }
-      else if(fittpc) {  tracklet = _track_map_tpc->get(trackid);	 }
-      if(!tracklet) { continue; }
-
-      std::vector<Acts::Vector3> global_vec;
-      std::vector<TrkrDefs::cluskey> cluskey_vec;
-
-      // Get a vector of cluster keys from the tracklet  
-      getTrackletClusterList(tracklet, cluskey_vec);
-      // store cluster global positions in a vector global_vec and cluskey_vec
-      TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);   
-     
-      correctTpcGlobalPositions( global_vec, cluskey_vec);
-
-      std::vector<float> fitpars =  TrackFitUtils::fitClusters(global_vec, cluskey_vec);       // do helical fit
-
-      if(fitpars.size() == 0) { continue;  // discard this track, not enough clusters to fit
-}
-
-      if(Verbosity() > 1)  
-	{ std::cout << " Track " << trackid   << " radius " << fitpars[0] << " X0 " << fitpars[1]<< " Y0 " << fitpars[2]
-		    << " zslope " << fitpars[3]  << " Z0 " << fitpars[4] << std::endl; }
-      
-      //// Create a track map for diagnostics
-      SvtxTrack_v4 newTrack;
-      newTrack.set_id(trackid);
-      if(fitsilicon) { newTrack.set_silicon_seed(tracklet); }
-      else if(fittpc) {  newTrack.set_tpc_seed(tracklet); }
-      
-      // if a full track is requested, get the silicon clusters too and refit
-      if(fittpc && fitfulltrack)
-	{
-	  // this associates silicon clusters and adds them to the vectors
-	  ntpc = cluskey_vec.size();
-	  nsilicon = TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec,0,6);
-	  if(nsilicon < 3) { continue;  // discard this TPC seed, did not get a good match to silicon
-}
-	  auto trackseed = std::make_unique<TrackSeed_v2>();
-	  for(auto& ckey : cluskey_vec)
-	    {
-	      if(TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::mvtxId or
-		 TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::inttId)
-		{
-		  trackseed->insert_cluster_key(ckey);
-		}
-	    }
-
-	  newTrack.set_silicon_seed(trackseed.get());
-	  
-	  // fit the full track now
-	  fitpars.clear();
-	  fitpars =  TrackFitUtils::fitClusters(global_vec, cluskey_vec);       // do helical fit
-          if(fitpars.size() == 0) { continue;  // discard this track, fit failed
-}
-
-	  if(Verbosity() > 1)  
-	    { std::cout << " Full track " << trackid   << " radius " << fitpars[0] << " X0 " << fitpars[1]<< " Y0 " << fitpars[2]
-			<< " zslope " << fitpars[3]  << " Z0 " << fitpars[4] << std::endl; }
-	}
-      else if(fitsilicon)
-	{
-	  nsilicon = cluskey_vec.size();
-	}
-      else if(fittpc && !fitfulltrack)
-	{
-	  ntpc = cluskey_vec.size();
-	}
- 
-      Acts::Vector3 beamline(0,0,0);
-      Acts::Vector2 pca2d = TrackFitUtils::get_circle_point_pca(fitpars[0], fitpars[1], fitpars[2], beamline);
-      Acts::Vector3 track_vtx (pca2d(0),pca2d(1),fitpars[4]);
-
-      newTrack.set_crossing(tracklet->get_crossing());
-      newTrack.set_id(trackid);
-
-      /// use the track seed functions to help get the track trajectory values
-      /// in the usual coordinates
-  
-      TrackSeed_v2 someseed;
-      for(auto& ckey : cluskey_vec)
-	{ someseed.insert_cluster_key(ckey); }
-      someseed.set_qOverR(tracklet->get_charge() / fitpars[0]);
-      someseed.set_phi(tracklet->get_phi());
- 
-      someseed.set_X0(fitpars[1]);
-      someseed.set_Y0(fitpars[2]);
-      someseed.set_Z0(fitpars[4]);
-      someseed.set_slope(fitpars[3]);
-
-      newTrack.set_x(someseed.get_x());
-      newTrack.set_y(someseed.get_y());
-      newTrack.set_z(someseed.get_z());
-      newTrack.set_px(someseed.get_px());
-      newTrack.set_py(someseed.get_py());
-      newTrack.set_pz(someseed.get_pz());  
-      newTrack.set_charge(tracklet->get_charge());
-
-      nclus = ntpc+nsilicon;
-
-      // some basic track quality requirements
-      if(fittpc && ntpc < 35) 
-	{
-	  if(Verbosity() > 1) { std::cout << " reject this track, ntpc = " << ntpc << std::endl; } 
-	  continue;
-	}
-      if((fitsilicon || fitfulltrack) && nsilicon < 4) 
-	{
-	  if(Verbosity() > 1) { std::cout << " reject this track, nsilicon = " << nsilicon << std::endl; } 
-	  continue; 
-	}
-
-      cumulative_global_vec.push_back(global_vec);
-      cumulative_cluskey_vec.push_back(cluskey_vec);
-      cumulative_vertex.push_back(track_vtx);
-      cumulative_fitpars_vec.push_back(fitpars);
-      cumulative_someseed.push_back(someseed);
-      cumulative_newTrack.push_back(newTrack);
+      tracklet = _track_map_silicon->get(trackid);
+    }
+    else if (fittpc)
+    {
+      tracklet = _track_map_tpc->get(trackid);
+    }
+    if (!tracklet)
+    {
+      continue;
     }
 
-  //terminate loop over tracks
-  //Collect fitpars for each track by intializing array of size maxtracks and populaating thorughout the loop
-  //Then start new loop over tracks and for each track go over clsutaer 
-  // make vector of global_vecs
+    std::vector<Acts::Vector3> global_vec;
+    std::vector<TrkrDefs::cluskey> cluskey_vec;
+
+    // Get a vector of cluster keys from the tracklet
+    getTrackletClusterList(tracklet, cluskey_vec);
+    // store cluster global positions in a vector global_vec and cluskey_vec
+    TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);
+
+    correctTpcGlobalPositions(global_vec, cluskey_vec);
+
+    std::vector<float> fitpars = TrackFitUtils::fitClusters(global_vec, cluskey_vec);  // do helical fit
+
+    if (fitpars.size() == 0)
+    {
+      continue;  // discard this track, not enough clusters to fit
+    }
+
+    if (Verbosity() > 1)
+    {
+      std::cout << " Track " << trackid << " radius " << fitpars[0] << " X0 " << fitpars[1] << " Y0 " << fitpars[2]
+                << " zslope " << fitpars[3] << " Z0 " << fitpars[4] << std::endl;
+    }
+
+    //// Create a track map for diagnostics
+    SvtxTrack_v4 newTrack;
+    newTrack.set_id(trackid);
+    if (fitsilicon)
+    {
+      newTrack.set_silicon_seed(tracklet);
+    }
+    else if (fittpc)
+    {
+      newTrack.set_tpc_seed(tracklet);
+    }
+
+    // if a full track is requested, get the silicon clusters too and refit
+    if (fittpc && fitfulltrack)
+    {
+      // this associates silicon clusters and adds them to the vectors
+      ntpc = cluskey_vec.size();
+      nsilicon = TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec, 0, 6);
+      if (nsilicon < 3)
+      {
+        continue;  // discard this TPC seed, did not get a good match to silicon
+      }
+      auto trackseed = std::make_unique<TrackSeed_v2>();
+      for (auto& ckey : cluskey_vec)
+      {
+        if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::mvtxId or
+            TrkrDefs::getTrkrId(ckey) == TrkrDefs::TrkrId::inttId)
+        {
+          trackseed->insert_cluster_key(ckey);
+        }
+      }
+
+      newTrack.set_silicon_seed(trackseed.get());
+
+      // fit the full track now
+      fitpars.clear();
+      fitpars = TrackFitUtils::fitClusters(global_vec, cluskey_vec);  // do helical fit
+      if (fitpars.size() == 0)
+      {
+        continue;  // discard this track, fit failed
+      }
+
+      if (Verbosity() > 1)
+      {
+        std::cout << " Full track " << trackid << " radius " << fitpars[0] << " X0 " << fitpars[1] << " Y0 " << fitpars[2]
+                  << " zslope " << fitpars[3] << " Z0 " << fitpars[4] << std::endl;
+      }
+    }
+    else if (fitsilicon)
+    {
+      nsilicon = cluskey_vec.size();
+    }
+    else if (fittpc && !fitfulltrack)
+    {
+      ntpc = cluskey_vec.size();
+    }
+
+    Acts::Vector3 beamline(0, 0, 0);
+    Acts::Vector2 pca2d = TrackFitUtils::get_circle_point_pca(fitpars[0], fitpars[1], fitpars[2], beamline);
+    Acts::Vector3 track_vtx(pca2d(0), pca2d(1), fitpars[4]);
+
+    newTrack.set_crossing(tracklet->get_crossing());
+    newTrack.set_id(trackid);
+
+    /// use the track seed functions to help get the track trajectory values
+    /// in the usual coordinates
+
+    TrackSeed_v2 someseed;
+    for (auto& ckey : cluskey_vec)
+    {
+      someseed.insert_cluster_key(ckey);
+    }
+    someseed.set_qOverR(tracklet->get_charge() / fitpars[0]);
+    someseed.set_phi(tracklet->get_phi());
+
+    someseed.set_X0(fitpars[1]);
+    someseed.set_Y0(fitpars[2]);
+    someseed.set_Z0(fitpars[4]);
+    someseed.set_slope(fitpars[3]);
+
+    newTrack.set_x(someseed.get_x());
+    newTrack.set_y(someseed.get_y());
+    newTrack.set_z(someseed.get_z());
+    newTrack.set_px(someseed.get_px());
+    newTrack.set_py(someseed.get_py());
+    newTrack.set_pz(someseed.get_pz());
+    newTrack.set_charge(tracklet->get_charge());
+
+    nclus = ntpc + nsilicon;
+
+    // some basic track quality requirements
+    if (fittpc && ntpc < 35)
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << " reject this track, ntpc = " << ntpc << std::endl;
+      }
+      continue;
+    }
+    if ((fitsilicon || fitfulltrack) && nsilicon < 4)
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << " reject this track, nsilicon = " << nsilicon << std::endl;
+      }
+      continue;
+    }
+
+    cumulative_global_vec.push_back(global_vec);
+    cumulative_cluskey_vec.push_back(cluskey_vec);
+    cumulative_vertex.push_back(track_vtx);
+    cumulative_fitpars_vec.push_back(fitpars);
+    cumulative_someseed.push_back(someseed);
+    cumulative_newTrack.push_back(newTrack);
+  }
+
+  // terminate loop over tracks
+  // Collect fitpars for each track by intializing array of size maxtracks and populaating thorughout the loop
+  // Then start new loop over tracks and for each track go over clsutaer
+  //  make vector of global_vecs
   float xsum = 0;
   float ysum = 0;
   float zsum = 0;
   unsigned int accepted_tracks = cumulative_fitpars_vec.size();
 
-  //std::cout<<"accepted_tracks: " << accepted_tracks << std::endl;
-  for(unsigned int trackid = 0; trackid < accepted_tracks; ++trackid)
+  // std::cout<<"accepted_tracks: " << accepted_tracks << std::endl;
+  for (unsigned int trackid = 0; trackid < accepted_tracks; ++trackid)
+  {
+    xsum += cumulative_vertex[trackid][0];
+    ysum += cumulative_vertex[trackid][1];
+    zsum += cumulative_vertex[trackid][2];
+  }
+  Acts::Vector3 averageVertex(xsum / accepted_tracks, ysum / accepted_tracks, zsum / accepted_tracks);
+
+  for (unsigned int trackid = 0; trackid < accepted_tracks; ++trackid)
+  {
+    auto global_vec = cumulative_global_vec[trackid];
+    auto cluskey_vec = cumulative_cluskey_vec[trackid];
+    auto fitpars = cumulative_fitpars_vec[trackid];
+    auto someseed = cumulative_someseed[trackid];
+    auto newTrack = cumulative_newTrack[trackid];
+    // std::cout << "trackid " << trackid << " get id " <<newTrack.get_id()<< std::endl;
+    SvtxAlignmentStateMap::StateVec statevec;
+
+    // get the residuals and derivatives for all clusters
+    for (unsigned int ivec = 0; ivec < global_vec.size(); ++ivec)
     {
-      xsum += cumulative_vertex[trackid][0];
-      ysum += cumulative_vertex[trackid][1];
-      zsum += cumulative_vertex[trackid][2];
-    }
-  Acts::Vector3 averageVertex (xsum/accepted_tracks,ysum/accepted_tracks,zsum/accepted_tracks); 
-      
-  for(unsigned int trackid = 0; trackid < accepted_tracks; ++trackid)
-    { 
-      auto global_vec  = cumulative_global_vec[trackid];
-      auto cluskey_vec = cumulative_cluskey_vec[trackid];
-      auto fitpars     = cumulative_fitpars_vec[trackid];
-      auto someseed    = cumulative_someseed[trackid];
-      auto newTrack    = cumulative_newTrack[trackid];
-      //std::cout << "trackid " << trackid << " get id " <<newTrack.get_id()<< std::endl;
-      SvtxAlignmentStateMap::StateVec statevec;
-      
-      // get the residuals and derivatives for all clusters
-      for(unsigned int ivec=0;ivec<global_vec.size(); ++ivec)
-	{
-	  auto global  = global_vec[ivec];
-	  auto cluskey = cluskey_vec[ivec];
-	  auto cluster = _cluster_map->findCluster(cluskey);
-	  if(!cluster) { continue;}
-	  
-	  unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
+      auto global = global_vec[ivec];
+      auto cluskey = cluskey_vec[ivec];
+      auto cluster = _cluster_map->findCluster(cluskey);
+      if (!cluster)
+      {
+        continue;
+      }
 
-	  // What we need now is to find the point on the surface at which the helix would intersect
-	  // If we have that point, we can transform the fit back to local coords
-	  // we have fitpars for the helix, and the cluster key - from which we get the surface
+      unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
 
-	  Surface surf = _tGeometry->maps().getSurface(cluskey, cluster);
-	  Acts::Vector3 helix_pca(0,0,0);
-	  Acts::Vector3 helix_tangent(0,0,0);
-	  Acts::Vector3 fitpoint = get_helix_surface_intersection(surf, fitpars, global, helix_pca, helix_tangent);
+      // What we need now is to find the point on the surface at which the helix would intersect
+      // If we have that point, we can transform the fit back to local coords
+      // we have fitpars for the helix, and the cluster key - from which we get the surface
 
-	  // fitpoint is the point where the helical fit intersects the plane of the surface
-	  // Now transform the helix fitpoint to local coordinates to compare with cluster local coordinates
-	  Acts::Vector3 fitpoint_local = surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (fitpoint *  Acts::UnitConstants::cm);
-	  
-	  fitpoint_local /= Acts::UnitConstants::cm;
+      Surface surf = _tGeometry->maps().getSurface(cluskey, cluster);
+      Acts::Vector3 helix_pca(0, 0, 0);
+      Acts::Vector3 helix_tangent(0, 0, 0);
+      Acts::Vector3 fitpoint = get_helix_surface_intersection(surf, fitpars, global, helix_pca, helix_tangent);
 
-	  auto xloc = cluster->getLocalX();  // in cm
-	  auto zloc = cluster->getLocalY();	  
+      // fitpoint is the point where the helical fit intersects the plane of the surface
+      // Now transform the helix fitpoint to local coordinates to compare with cluster local coordinates
+      Acts::Vector3 fitpoint_local = surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (fitpoint * Acts::UnitConstants::cm);
 
-	  if(trkrid == TrkrDefs::tpcId) { zloc = convertTimeToZ(cluskey, cluster); }
-	  //float yloc = 0.0;   // Because the fitpoint is on the surface, y will always be zero in local coordinates
+      fitpoint_local /= Acts::UnitConstants::cm;
 
-	  Acts::Vector2 residual(xloc - fitpoint_local(0), zloc - fitpoint_local(1));
- 
-	  unsigned int layer = TrkrDefs::getLayer(cluskey_vec[ivec]);	  
-	  float phi          =  atan2(global(1), global(0));
+      auto xloc = cluster->getLocalX();  // in cm
+      auto zloc = cluster->getLocalY();
 
-	  SvtxTrackState_v1 svtxstate(fitpoint.norm());
-	  svtxstate.set_x(fitpoint(0));
-	  svtxstate.set_y(fitpoint(1));
-	  svtxstate.set_z(fitpoint(2));
-	  auto tangent = get_helix_tangent(fitpars, global);  
-	  svtxstate.set_px(someseed.get_p() * tangent.second.x());
-	  svtxstate.set_py(someseed.get_p() * tangent.second.y());
-	  svtxstate.set_pz(someseed.get_p() * tangent.second.z());
-	  newTrack.insert_state(&svtxstate);
-	  
-	  if(Verbosity() > 1) {
-	    Acts::Vector3 loc_check =  surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (global *  Acts::UnitConstants::cm);
-	    loc_check /= Acts::UnitConstants::cm;
-	    std::cout << "    layer " << layer << std::endl
-		      << " cluster global " << global(0) << " " << global(1) << " " << global(2) << std::endl
-		      << " fitpoint " << fitpoint(0) << " " << fitpoint(1) << " " << fitpoint(2) << std::endl
-		      << " fitpoint_local " << fitpoint_local(0) << " " << fitpoint_local(1) << " " << fitpoint_local(2) << std::endl  
-		      << " cluster local x " << cluster->getLocalX() << " cluster local y " << cluster->getLocalY() << std::endl
-		      << " cluster global to local x " << loc_check(0) << " local y " << loc_check(1) << "  local z " << loc_check(2) << std::endl
-		      << " cluster local residual x " << residual(0) << " cluster local residual y " <<residual(1) << std::endl;
-	  }
+      if (trkrid == TrkrDefs::tpcId)
+      {
+        zloc = convertTimeToZ(cluskey, cluster);
+      }
+      // float yloc = 0.0;   // Because the fitpoint is on the surface, y will always be zero in local coordinates
 
-	  if(Verbosity() > 1) 
-	    {
-	      Acts::Transform3 transform = surf->transform(_tGeometry->geometry().getGeoContext());
-	      std::cout << "Transform is:" << std::endl;
-	      std::cout <<  transform.matrix() << std::endl;
-	      Acts::Vector3 loc_check = surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (global *  Acts::UnitConstants::cm);
-	      loc_check /= Acts::UnitConstants::cm;
-	      unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);	  
-	      unsigned int side = TpcDefs::getSide(cluskey_vec[ivec]);	  
-	      std::cout << "    layer " << layer << " sector " << sector << " side " << side << " subsurf " <<   cluster->getSubSurfKey() << std::endl
-			<< " cluster global " << global(0) << " " << global(1) << " " << global(2) << std::endl
-			<< " fitpoint " << fitpoint(0) << " " << fitpoint(1) << " " << fitpoint(2) << std::endl
-			<< " fitpoint_local " << fitpoint_local(0) << " " << fitpoint_local(1) << " " << fitpoint_local(2) << std::endl  
-			<< " cluster local x " << cluster->getLocalX() << " cluster local y " << cluster->getLocalY() << std::endl
-			<< " cluster global to local x " << loc_check(0) << " local y " << loc_check(1) << "  local z " << loc_check(2) << std::endl
-			<< " cluster local residual x " << residual(0) << " cluster local residual y " <<residual(1) << std::endl;
-	    }
-	  
-	  // need standard deviation of measurements
-	  Acts::Vector2 clus_sigma = getClusterError(cluster, cluskey, global);
-	  if(isnan(clus_sigma(0)) || isnan(clus_sigma(1)))  { continue; }
+      Acts::Vector2 residual(xloc - fitpoint_local(0), zloc - fitpoint_local(1));
 
-	  int glbl_label[AlignmentDefs::NGL];
-	  if(layer < 3)
-	    {
-	      AlignmentDefs::getMvtxGlobalLabels(surf, glbl_label, mvtx_grp);	      
-	    }
-	  else if(layer > 2 && layer < 7)
-	    {
-	      AlignmentDefs::getInttGlobalLabels(surf, glbl_label, intt_grp);
-	    }
-	  else if (layer < 55)
-	    {
-	      AlignmentDefs::getTpcGlobalLabels(surf, cluskey, glbl_label, tpc_grp);
-	    }
-	  else
-	    {
-	      continue;
-	    }
-	    
-	  // These derivatives are for the local parameters
-	  float lcl_derivativeX[AlignmentDefs::NLC];
-	  float lcl_derivativeY[AlignmentDefs::NLC];
+      unsigned int layer = TrkrDefs::getLayer(cluskey_vec[ivec]);
+      float phi = atan2(global(1), global(0));
 
-	  getLocalDerivativesXY(surf, global, fitpars, lcl_derivativeX, lcl_derivativeY, layer);
+      SvtxTrackState_v1 svtxstate(fitpoint.norm());
+      svtxstate.set_x(fitpoint(0));
+      svtxstate.set_y(fitpoint(1));
+      svtxstate.set_z(fitpoint(2));
+      auto tangent = get_helix_tangent(fitpars, global);
+      svtxstate.set_px(someseed.get_p() * tangent.second.x());
+      svtxstate.set_py(someseed.get_p() * tangent.second.y());
+      svtxstate.set_pz(someseed.get_p() * tangent.second.z());
+      newTrack.insert_state(&svtxstate);
 
-	  // The global derivs dimensions are [alpha/beta/gamma](x/y/z)
-	  float glbl_derivativeX[AlignmentDefs::NGL];
-	  float glbl_derivativeY[AlignmentDefs::NGL];
-	  getGlobalDerivativesXY(surf, global, fitpoint, fitpars, glbl_derivativeX, glbl_derivativeY, layer);
+      if (Verbosity() > 1)
+      {
+        Acts::Vector3 loc_check = surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (global * Acts::UnitConstants::cm);
+        loc_check /= Acts::UnitConstants::cm;
+        std::cout << "    layer " << layer << std::endl
+                  << " cluster global " << global(0) << " " << global(1) << " " << global(2) << std::endl
+                  << " fitpoint " << fitpoint(0) << " " << fitpoint(1) << " " << fitpoint(2) << std::endl
+                  << " fitpoint_local " << fitpoint_local(0) << " " << fitpoint_local(1) << " " << fitpoint_local(2) << std::endl
+                  << " cluster local x " << cluster->getLocalX() << " cluster local y " << cluster->getLocalY() << std::endl
+                  << " cluster global to local x " << loc_check(0) << " local y " << loc_check(1) << "  local z " << loc_check(2) << std::endl
+                  << " cluster local residual x " << residual(0) << " cluster local residual y " << residual(1) << std::endl;
+      }
 
-	  auto alignmentstate = std::make_unique<SvtxAlignmentState_v1>();
-	  alignmentstate->set_residual(residual);
-	  alignmentstate->set_cluster_key(cluskey);
-	  SvtxAlignmentState::GlobalMatrix svtxglob = 
-	    SvtxAlignmentState::GlobalMatrix::Zero();
-	  SvtxAlignmentState::LocalMatrix svtxloc = 
-	    SvtxAlignmentState::LocalMatrix::Zero();
-	  for(int i=0; i<AlignmentDefs::NLC; i++)
-	    {
-	      svtxloc(0,i) = lcl_derivativeX[i];
-	      svtxloc(1,i) = lcl_derivativeY[i];
-	    }
-	  for(int i=0; i<AlignmentDefs::NGL; i++)
-	    {
-	      svtxglob(0,i) = glbl_derivativeX[i];
-	      svtxglob(1,i) = glbl_derivativeY[i];
-	    }
+      if (Verbosity() > 1)
+      {
+        Acts::Transform3 transform = surf->transform(_tGeometry->geometry().getGeoContext());
+        std::cout << "Transform is:" << std::endl;
+        std::cout << transform.matrix() << std::endl;
+        Acts::Vector3 loc_check = surf->transform(_tGeometry->geometry().getGeoContext()).inverse() * (global * Acts::UnitConstants::cm);
+        loc_check /= Acts::UnitConstants::cm;
+        unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);
+        unsigned int side = TpcDefs::getSide(cluskey_vec[ivec]);
+        std::cout << "    layer " << layer << " sector " << sector << " side " << side << " subsurf " << cluster->getSubSurfKey() << std::endl
+                  << " cluster global " << global(0) << " " << global(1) << " " << global(2) << std::endl
+                  << " fitpoint " << fitpoint(0) << " " << fitpoint(1) << " " << fitpoint(2) << std::endl
+                  << " fitpoint_local " << fitpoint_local(0) << " " << fitpoint_local(1) << " " << fitpoint_local(2) << std::endl
+                  << " cluster local x " << cluster->getLocalX() << " cluster local y " << cluster->getLocalY() << std::endl
+                  << " cluster global to local x " << loc_check(0) << " local y " << loc_check(1) << "  local z " << loc_check(2) << std::endl
+                  << " cluster local residual x " << residual(0) << " cluster local residual y " << residual(1) << std::endl;
+      }
 
-	  alignmentstate->set_local_derivative_matrix(svtxloc);
-	  alignmentstate->set_global_derivative_matrix(svtxglob);
-	  
-	  statevec.push_back(alignmentstate.release());
-	  
-	  for(unsigned int i = 0; i < AlignmentDefs::NGL; ++i) 
-	    {
-	      if(trkrid == TrkrDefs::mvtxId)
-		{
-		  // need stave to get clamshell
-		  auto stave  = MvtxDefs::getStaveId(cluskey_vec[ivec]);
-		  auto clamshell = AlignmentDefs::getMvtxClamshell(layer, stave);
-		  if( is_layer_param_fixed(layer, i) || is_mvtx_layer_fixed(layer,clamshell) )
-		    {
-		      glbl_derivativeX[i] = 0;
-		      glbl_derivativeY[i] = 0;
-		    }
-		}
+      // need standard deviation of measurements
+      Acts::Vector2 clus_sigma = getClusterError(cluster, cluskey, global);
+      if (isnan(clus_sigma(0)) || isnan(clus_sigma(1)))
+      {
+        continue;
+      }
 
-	      if(trkrid == TrkrDefs::inttId)
-		{
-		  if( is_layer_param_fixed(layer, i) || is_intt_layer_fixed(layer) )
-		    {
-		      glbl_derivativeX[i] = 0;
-		      glbl_derivativeY[i] = 0;
-		    }
-		}
+      int glbl_label[AlignmentDefs::NGL];
+      if (layer < 3)
+      {
+        AlignmentDefs::getMvtxGlobalLabels(surf, glbl_label, mvtx_grp);
+      }
+      else if (layer > 2 && layer < 7)
+      {
+        AlignmentDefs::getInttGlobalLabels(surf, glbl_label, intt_grp);
+      }
+      else if (layer < 55)
+      {
+        AlignmentDefs::getTpcGlobalLabels(surf, cluskey, glbl_label, tpc_grp);
+      }
+      else
+      {
+        continue;
+      }
 
+      // These derivatives are for the local parameters
+      float lcl_derivativeX[AlignmentDefs::NLC];
+      float lcl_derivativeY[AlignmentDefs::NLC];
 
-	      if(trkrid == TrkrDefs::tpcId)
-		{
-		  unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);	  
-		  unsigned int side   = TpcDefs::getSide(cluskey_vec[ivec]);	  
-		  if(is_layer_param_fixed(layer, i) || is_tpc_sector_fixed(layer, sector, side))
-		    {
-		      glbl_derivativeX[i] = 0;
-		      glbl_derivativeY[i] = 0;
-		    }
-		}
-	    }
+      getLocalDerivativesXY(surf, global, fitpars, lcl_derivativeX, lcl_derivativeY, layer);
 
-	  // Add the measurement separately for each coordinate direction to Mille
-	  // set the derivatives non-zero only for parameters we want to be optimized
-	  // local parameter numbering is arbitrary:
-	  float errinf = 1.0;
-
-	  if(_layerMisalignment.find(layer) != _layerMisalignment.end())
-	    {
-	      errinf = _layerMisalignment.find(layer)->second;
-	    }
-	  if(make_ntuple)
-	    {
-	      // get the local parameters using the ideal transforms
-	      alignmentTransformationContainer::use_alignment = false;
-	      Acts::Vector3 ideal_center =  surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  
-	      Acts::Vector3 ideal_norm   = -surf->normal(_tGeometry->geometry().getGeoContext());  
-	      Acts::Vector3 ideal_local(xloc, zloc, 0.0); // cm
-	      Acts::Vector3 ideal_glob = surf->transform(_tGeometry->geometry().getGeoContext())*(ideal_local * Acts::UnitConstants::cm);
-	      ideal_glob /= Acts::UnitConstants::cm;
-	      alignmentTransformationContainer::use_alignment = true;
-
-	      Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1; // cm
-	      Acts::Vector3 sensorNormal = -surf->normal(_tGeometry->geometry().getGeoContext());
-	      unsigned int sector  = TpcDefs::getSectorId(cluskey_vec[ivec]);	  
-	      unsigned int side    = TpcDefs::getSide(cluskey_vec[ivec]);	  	      
-	      unsigned int subsurf = cluster->getSubSurfKey();
-	      if(layer < 3)
-		{
-		  sector  = MvtxDefs::getStaveId(cluskey_vec[ivec]);
-		  subsurf = MvtxDefs::getChipId(cluskey_vec[ivec]);
-		}
-	      else if(layer >2 && layer < 7)
-		{
-		  sector  = InttDefs::getLadderPhiId(cluskey_vec[ivec]);
-		  subsurf = InttDefs::getLadderZId(cluskey_vec[ivec]);
-		}
-	      float ntp_data[75] = {
-		(float) event, (float) trackid,
-		(float) layer, (float) nsilicon, (float) ntpc, (float) nclus, (float) trkrid,  (float) sector,  (float) side,
-		(float) subsurf, phi,
-		(float) glbl_label[0], (float) glbl_label[1], (float) glbl_label[2], (float) glbl_label[3], (float) glbl_label[4], (float) glbl_label[5], 
-		(float) sensorCenter(0), (float) sensorCenter(1), (float) sensorCenter(2),
-		(float) sensorNormal(0), (float) sensorNormal(1), (float) sensorNormal(2),
-		(float) ideal_center(0), (float) ideal_center(1), (float) ideal_center(2),
-		(float) ideal_norm(0), (float) ideal_norm(1), (float) ideal_norm(2),
-		(float) ideal_glob(0), (float) ideal_glob(1), (float) ideal_glob(2),
-		(float) fitpars[0], (float) fitpars[1], (float) fitpars[2], (float) fitpars[3], (float) fitpars[4], 
-		(float) global(0), (float) global(1), (float) global(2),
-		(float) fitpoint(0), (float) fitpoint(1), (float) fitpoint(2), 
-		(float) helix_pca(0), (float) helix_pca(1), (float) helix_pca(2),
-		(float) helix_tangent(0), (float) helix_tangent(1), (float) helix_tangent(2),
-		xloc,zloc, (float) fitpoint_local(0), (float) fitpoint_local(1), 
-		lcl_derivativeX[0],lcl_derivativeX[1],lcl_derivativeX[2],lcl_derivativeX[3],lcl_derivativeX[4],
-		glbl_derivativeX[0],glbl_derivativeX[1],glbl_derivativeX[2],glbl_derivativeX[3],glbl_derivativeX[4],glbl_derivativeX[5],
-		lcl_derivativeY[0],lcl_derivativeY[1],lcl_derivativeY[2],lcl_derivativeY[3],lcl_derivativeY[4],
-		glbl_derivativeY[0],glbl_derivativeY[1],glbl_derivativeY[2],glbl_derivativeY[3],glbl_derivativeY[4],glbl_derivativeY[5] };
-
-	      ntp->Fill(ntp_data);
-
-	      if(Verbosity() > 2)
-		{
-		  for(int i=0;i<34;++i)
-		    {
-		      std::cout << ntp_data[i] << "  " ;
-		    }
-		  std::cout << std::endl;
-		}
-	    }
-
-	  // add some cluster cuts
-	  if(residual(0) > 0.2) {  continue;   // 2 mm cut
-}
-	  if(residual(1) > 0.2) {  continue;   // 2 mm cut
-}
-
-	  if( !isnan(residual(0)) && clus_sigma(0) < 1.0)  // discards crazy clusters
-	    {
-	      _mille->mille(AlignmentDefs::NLC,lcl_derivativeX,AlignmentDefs::NGL,glbl_derivativeX,glbl_label,residual(0), errinf*clus_sigma(0));
-	    }
-	  if(!isnan(residual(1)) && clus_sigma(1) < 1.0 && trkrid != TrkrDefs::inttId)
-	    {
-	      _mille->mille(AlignmentDefs::NLC, lcl_derivativeY,AlignmentDefs::NGL,glbl_derivativeY,glbl_label,residual(1), errinf*clus_sigma(1));
-	    }
-	}
-
-      m_alignmentmap->insertWithKey(trackid, statevec);
-      m_trackmap->insertWithKey(&newTrack, trackid);
-	
-      //calculate vertex residual with perigee surface 
-      Acts::Vector3 event_vtx(0,0,averageVertex(2)); 
-      
-      // The residual for the vtx case is (event vtx - track vtx) 
-      // that is -dca
-      float dca3dxy;
-      float dca3dz; 
-      float dca3dxysigma; 
-      float dca3dzsigma;	  
-      get_dca(newTrack,dca3dxy,dca3dz,dca3dxysigma,dca3dzsigma,event_vtx);
-      Acts::Vector2 vtx_residual(-dca3dxy, -dca3dz);
-      
-      float lclvtx_derivativeX[AlignmentDefs::NLC];
-      float lclvtx_derivativeY[AlignmentDefs::NLC];
-      getLocalVtxDerivativesXY(newTrack, event_vtx, fitpars, lclvtx_derivativeX, lclvtx_derivativeY);
-      
       // The global derivs dimensions are [alpha/beta/gamma](x/y/z)
-      float glblvtx_derivativeX[3];
-      float glblvtx_derivativeY[3];
-      getGlobalVtxDerivativesXY(newTrack, event_vtx, glblvtx_derivativeX, glblvtx_derivativeY);
-  
-      if(use_event_vertex)
-	{	  
-	  if(Verbosity() > 3)
-	    {
-	      std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
-	      
-	      std::cout << "vertex is " << event_vtx.transpose() << std::endl;
-	      std::cout << "vertex residuals " << vtx_residual.transpose() 
-			<< std::endl;
-	      std::cout << "local derivatives " << std::endl;
-	      for(float i : lclvtx_derivativeX) {
-		std::cout << i << ", ";
-}
-	      std::cout << std::endl;
-	      for(float i : lclvtx_derivativeY) {
-		std::cout << i << ", ";
-}
-	      std::cout << "global vtx derivaties " << std::endl;
-	      for(float i : glblvtx_derivativeX) { std::cout << i << ", ";
-}
-	      std::cout << std::endl;
-	      for(float i : glblvtx_derivativeY) { std::cout << i << ", ";
-}
-	    }
+      float glbl_derivativeX[AlignmentDefs::NGL];
+      float glbl_derivativeY[AlignmentDefs::NGL];
+      getGlobalDerivativesXY(surf, global, fitpoint, fitpars, glbl_derivativeX, glbl_derivativeY, layer);
 
-	  // add some track cuts
-	  if(fabs(newTrack.get_z() - event_vtx(2)) > 0.2) { continue;  // 2 mm cut
-}
-	  if(fabs(newTrack.get_x()) > 0.2) { continue;  // 2 mm cut
-}
-	  if(fabs(newTrack.get_y()) > 0.2) { continue;  // 2 mm cut
-}
-	  
-	  if(!isnan(vtx_residual(0)))
-	    {
-	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeX,AlignmentDefs::NGLVTX,glblvtx_derivativeX,AlignmentDefs::glbl_vtx_label,vtx_residual(0), vtx_sigma(0));
-	    }    
-	  if(!isnan(vtx_residual(1)))
-	    {  
-	      _mille->mille(AlignmentDefs::NLC,lclvtx_derivativeY,AlignmentDefs::NGLVTX,glblvtx_derivativeY,AlignmentDefs::glbl_vtx_label,vtx_residual(1), vtx_sigma(1));
-	    }
-	}
+      auto alignmentstate = std::make_unique<SvtxAlignmentState_v1>();
+      alignmentstate->set_residual(residual);
+      alignmentstate->set_cluster_key(cluskey);
+      SvtxAlignmentState::GlobalMatrix svtxglob =
+          SvtxAlignmentState::GlobalMatrix::Zero();
+      SvtxAlignmentState::LocalMatrix svtxloc =
+          SvtxAlignmentState::LocalMatrix::Zero();
+      for (int i = 0; i < AlignmentDefs::NLC; i++)
+      {
+        svtxloc(0, i) = lcl_derivativeX[i];
+        svtxloc(1, i) = lcl_derivativeY[i];
+      }
+      for (int i = 0; i < AlignmentDefs::NGL; i++)
+      {
+        svtxglob(0, i) = glbl_derivativeX[i];
+        svtxglob(1, i) = glbl_derivativeY[i];
+      }
 
-      if(make_ntuple)
-	{          
-	  Acts::Vector3 mom(newTrack.get_px(),newTrack.get_py(),newTrack.get_pz());
-	  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
-	  float perigee_phi       = atan2(r(1), r(0));
-	  float track_phi = atan2(newTrack.get_py(), newTrack.get_px());
-	  //	  float ntp_data[30] = {(float) trackid,dca3dxy,dca3dz,(float) vtx_sigma(0),(float) vtx_sigma(1),
-	  float ntp_data[30] = {(float) trackid,(float) vtx_residual(0),(float) vtx_residual(1),(float) vtx_sigma(0),(float) vtx_sigma(1),
-				lclvtx_derivativeX[0],lclvtx_derivativeX[1],lclvtx_derivativeX[2],lclvtx_derivativeX[3],lclvtx_derivativeX[4],
-				glblvtx_derivativeX[0],glblvtx_derivativeX[1],glblvtx_derivativeX[2],
-				lclvtx_derivativeY[0],lclvtx_derivativeY[1],lclvtx_derivativeY[2],lclvtx_derivativeY[3],lclvtx_derivativeY[4],
-				glblvtx_derivativeY[0],glblvtx_derivativeY[1],glblvtx_derivativeY[2],
-				newTrack.get_x(), newTrack.get_y(), newTrack.get_z(),(float) event_vtx(2),track_phi, perigee_phi};
-	  
-	  track_ntp->Fill(ntp_data);
-	}
-      
-      if(Verbosity()>1)
-	{
-	  std::cout << "vtx_residual xy: " << vtx_residual(0)<< " vtx_residual z: " << vtx_residual(1) << " vtx_sigma xy: " << vtx_sigma(0) << " vtx_sigma z: " << vtx_sigma(1) << std::endl; 
-	  std::cout << "track_x" << newTrack.get_x()<<"track_y" << newTrack.get_y()<<"track_z" << newTrack.get_z()<<std::endl;
-	}
+      alignmentstate->set_local_derivative_matrix(svtxloc);
+      alignmentstate->set_global_derivative_matrix(svtxglob);
 
-  
-      // close out this track	
-      _mille->end();
-          
-    }  // end loop over tracks
-  
-  
+      statevec.push_back(alignmentstate.release());
+
+      for (unsigned int i = 0; i < AlignmentDefs::NGL; ++i)
+      {
+        if (trkrid == TrkrDefs::mvtxId)
+        {
+          // need stave to get clamshell
+          auto stave = MvtxDefs::getStaveId(cluskey_vec[ivec]);
+          auto clamshell = AlignmentDefs::getMvtxClamshell(layer, stave);
+          if (is_layer_param_fixed(layer, i) || is_mvtx_layer_fixed(layer, clamshell))
+          {
+            glbl_derivativeX[i] = 0;
+            glbl_derivativeY[i] = 0;
+          }
+        }
+
+        if (trkrid == TrkrDefs::inttId)
+        {
+          if (is_layer_param_fixed(layer, i) || is_intt_layer_fixed(layer))
+          {
+            glbl_derivativeX[i] = 0;
+            glbl_derivativeY[i] = 0;
+          }
+        }
+
+        if (trkrid == TrkrDefs::tpcId)
+        {
+          unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);
+          unsigned int side = TpcDefs::getSide(cluskey_vec[ivec]);
+          if (is_layer_param_fixed(layer, i) || is_tpc_sector_fixed(layer, sector, side))
+          {
+            glbl_derivativeX[i] = 0;
+            glbl_derivativeY[i] = 0;
+          }
+        }
+      }
+
+      // Add the measurement separately for each coordinate direction to Mille
+      // set the derivatives non-zero only for parameters we want to be optimized
+      // local parameter numbering is arbitrary:
+      float errinf = 1.0;
+
+      if (_layerMisalignment.find(layer) != _layerMisalignment.end())
+      {
+        errinf = _layerMisalignment.find(layer)->second;
+      }
+      if (make_ntuple)
+      {
+        // get the local parameters using the ideal transforms
+        alignmentTransformationContainer::use_alignment = false;
+        Acts::Vector3 ideal_center = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;
+        Acts::Vector3 ideal_norm = -surf->normal(_tGeometry->geometry().getGeoContext());
+        Acts::Vector3 ideal_local(xloc, zloc, 0.0);  // cm
+        Acts::Vector3 ideal_glob = surf->transform(_tGeometry->geometry().getGeoContext()) * (ideal_local * Acts::UnitConstants::cm);
+        ideal_glob /= Acts::UnitConstants::cm;
+        alignmentTransformationContainer::use_alignment = true;
+
+        Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // cm
+        Acts::Vector3 sensorNormal = -surf->normal(_tGeometry->geometry().getGeoContext());
+        unsigned int sector = TpcDefs::getSectorId(cluskey_vec[ivec]);
+        unsigned int side = TpcDefs::getSide(cluskey_vec[ivec]);
+        unsigned int subsurf = cluster->getSubSurfKey();
+        if (layer < 3)
+        {
+          sector = MvtxDefs::getStaveId(cluskey_vec[ivec]);
+          subsurf = MvtxDefs::getChipId(cluskey_vec[ivec]);
+        }
+        else if (layer > 2 && layer < 7)
+        {
+          sector = InttDefs::getLadderPhiId(cluskey_vec[ivec]);
+          subsurf = InttDefs::getLadderZId(cluskey_vec[ivec]);
+        }
+        float ntp_data[75] = {
+            (float) event, (float) trackid,
+            (float) layer, (float) nsilicon, (float) ntpc, (float) nclus, (float) trkrid, (float) sector, (float) side,
+            (float) subsurf, phi,
+            (float) glbl_label[0], (float) glbl_label[1], (float) glbl_label[2], (float) glbl_label[3], (float) glbl_label[4], (float) glbl_label[5],
+            (float) sensorCenter(0), (float) sensorCenter(1), (float) sensorCenter(2),
+            (float) sensorNormal(0), (float) sensorNormal(1), (float) sensorNormal(2),
+            (float) ideal_center(0), (float) ideal_center(1), (float) ideal_center(2),
+            (float) ideal_norm(0), (float) ideal_norm(1), (float) ideal_norm(2),
+            (float) ideal_glob(0), (float) ideal_glob(1), (float) ideal_glob(2),
+            (float) fitpars[0], (float) fitpars[1], (float) fitpars[2], (float) fitpars[3], (float) fitpars[4],
+            (float) global(0), (float) global(1), (float) global(2),
+            (float) fitpoint(0), (float) fitpoint(1), (float) fitpoint(2),
+            (float) helix_pca(0), (float) helix_pca(1), (float) helix_pca(2),
+            (float) helix_tangent(0), (float) helix_tangent(1), (float) helix_tangent(2),
+            xloc, zloc, (float) fitpoint_local(0), (float) fitpoint_local(1),
+            lcl_derivativeX[0], lcl_derivativeX[1], lcl_derivativeX[2], lcl_derivativeX[3], lcl_derivativeX[4],
+            glbl_derivativeX[0], glbl_derivativeX[1], glbl_derivativeX[2], glbl_derivativeX[3], glbl_derivativeX[4], glbl_derivativeX[5],
+            lcl_derivativeY[0], lcl_derivativeY[1], lcl_derivativeY[2], lcl_derivativeY[3], lcl_derivativeY[4],
+            glbl_derivativeY[0], glbl_derivativeY[1], glbl_derivativeY[2], glbl_derivativeY[3], glbl_derivativeY[4], glbl_derivativeY[5]};
+
+        ntp->Fill(ntp_data);
+
+        if (Verbosity() > 2)
+        {
+          for (int i = 0; i < 34; ++i)
+          {
+            std::cout << ntp_data[i] << "  ";
+          }
+          std::cout << std::endl;
+        }
+      }
+
+      // add some cluster cuts
+      if (residual(0) > 0.2)
+      {
+        continue;  // 2 mm cut
+      }
+      if (residual(1) > 0.2)
+      {
+        continue;  // 2 mm cut
+      }
+
+      if (!isnan(residual(0)) && clus_sigma(0) < 1.0)  // discards crazy clusters
+      {
+        _mille->mille(AlignmentDefs::NLC, lcl_derivativeX, AlignmentDefs::NGL, glbl_derivativeX, glbl_label, residual(0), errinf * clus_sigma(0));
+      }
+      if (!isnan(residual(1)) && clus_sigma(1) < 1.0 && trkrid != TrkrDefs::inttId)
+      {
+        _mille->mille(AlignmentDefs::NLC, lcl_derivativeY, AlignmentDefs::NGL, glbl_derivativeY, glbl_label, residual(1), errinf * clus_sigma(1));
+      }
+    }
+
+    m_alignmentmap->insertWithKey(trackid, statevec);
+    m_trackmap->insertWithKey(&newTrack, trackid);
+
+    // calculate vertex residual with perigee surface
+    Acts::Vector3 event_vtx(0, 0, averageVertex(2));
+
+    // The residual for the vtx case is (event vtx - track vtx)
+    // that is -dca
+    float dca3dxy;
+    float dca3dz;
+    float dca3dxysigma;
+    float dca3dzsigma;
+    get_dca(newTrack, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma, event_vtx);
+    Acts::Vector2 vtx_residual(-dca3dxy, -dca3dz);
+
+    float lclvtx_derivativeX[AlignmentDefs::NLC];
+    float lclvtx_derivativeY[AlignmentDefs::NLC];
+    getLocalVtxDerivativesXY(newTrack, event_vtx, fitpars, lclvtx_derivativeX, lclvtx_derivativeY);
+
+    // The global derivs dimensions are [alpha/beta/gamma](x/y/z)
+    float glblvtx_derivativeX[3];
+    float glblvtx_derivativeY[3];
+    getGlobalVtxDerivativesXY(newTrack, event_vtx, glblvtx_derivativeX, glblvtx_derivativeY);
+
+    if (use_event_vertex)
+    {
+      if (Verbosity() > 3)
+      {
+        std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
+
+        std::cout << "vertex is " << event_vtx.transpose() << std::endl;
+        std::cout << "vertex residuals " << vtx_residual.transpose()
+                  << std::endl;
+        std::cout << "local derivatives " << std::endl;
+        for (float i : lclvtx_derivativeX)
+        {
+          std::cout << i << ", ";
+        }
+        std::cout << std::endl;
+        for (float i : lclvtx_derivativeY)
+        {
+          std::cout << i << ", ";
+        }
+        std::cout << "global vtx derivaties " << std::endl;
+        for (float i : glblvtx_derivativeX)
+        {
+          std::cout << i << ", ";
+        }
+        std::cout << std::endl;
+        for (float i : glblvtx_derivativeY)
+        {
+          std::cout << i << ", ";
+        }
+      }
+
+      // add some track cuts
+      if (fabs(newTrack.get_z() - event_vtx(2)) > 0.2)
+      {
+        continue;  // 2 mm cut
+      }
+      if (fabs(newTrack.get_x()) > 0.2)
+      {
+        continue;  // 2 mm cut
+      }
+      if (fabs(newTrack.get_y()) > 0.2)
+      {
+        continue;  // 2 mm cut
+      }
+
+      if (!isnan(vtx_residual(0)))
+      {
+        _mille->mille(AlignmentDefs::NLC, lclvtx_derivativeX, AlignmentDefs::NGLVTX, glblvtx_derivativeX, AlignmentDefs::glbl_vtx_label, vtx_residual(0), vtx_sigma(0));
+      }
+      if (!isnan(vtx_residual(1)))
+      {
+        _mille->mille(AlignmentDefs::NLC, lclvtx_derivativeY, AlignmentDefs::NGLVTX, glblvtx_derivativeY, AlignmentDefs::glbl_vtx_label, vtx_residual(1), vtx_sigma(1));
+      }
+    }
+
+    if (make_ntuple)
+    {
+      Acts::Vector3 mom(newTrack.get_px(), newTrack.get_py(), newTrack.get_pz());
+      Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
+      float perigee_phi = atan2(r(1), r(0));
+      float track_phi = atan2(newTrack.get_py(), newTrack.get_px());
+      //	  float ntp_data[30] = {(float) trackid,dca3dxy,dca3dz,(float) vtx_sigma(0),(float) vtx_sigma(1),
+      float ntp_data[30] = {(float) trackid, (float) vtx_residual(0), (float) vtx_residual(1), (float) vtx_sigma(0), (float) vtx_sigma(1),
+                            lclvtx_derivativeX[0], lclvtx_derivativeX[1], lclvtx_derivativeX[2], lclvtx_derivativeX[3], lclvtx_derivativeX[4],
+                            glblvtx_derivativeX[0], glblvtx_derivativeX[1], glblvtx_derivativeX[2],
+                            lclvtx_derivativeY[0], lclvtx_derivativeY[1], lclvtx_derivativeY[2], lclvtx_derivativeY[3], lclvtx_derivativeY[4],
+                            glblvtx_derivativeY[0], glblvtx_derivativeY[1], glblvtx_derivativeY[2],
+                            newTrack.get_x(), newTrack.get_y(), newTrack.get_z(), (float) event_vtx(2), track_phi, perigee_phi};
+
+      track_ntp->Fill(ntp_data);
+    }
+
+    if (Verbosity() > 1)
+    {
+      std::cout << "vtx_residual xy: " << vtx_residual(0) << " vtx_residual z: " << vtx_residual(1) << " vtx_sigma xy: " << vtx_sigma(0) << " vtx_sigma z: " << vtx_sigma(1) << std::endl;
+      std::cout << "track_x" << newTrack.get_x() << "track_y" << newTrack.get_y() << "track_z" << newTrack.get_z() << std::endl;
+    }
+
+    // close out this track
+    _mille->end();
+
+  }  // end loop over tracks
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -683,13 +745,13 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(const Surface& surf,
 {
   // we want the point where the helix intersects the plane of the surface
   // get the plane of the surface
-  Acts::Vector3 sensorCenter      = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // convert to cm
-  Acts::Vector3 sensorNormal    = -surf->normal(_tGeometry->geometry().getGeoContext());
+  Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // convert to cm
+  Acts::Vector3 sensorNormal = -surf->normal(_tGeometry->geometry().getGeoContext());
   sensorNormal /= sensorNormal.norm();
 
   // there are analytic solutions for a line-plane intersection.
   // to use this, need to get the vector tangent to the helix near the measurement and a point on it.
-  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, std::move(global));
+  std::pair<Acts::Vector3, Acts::Vector3> line = get_helix_tangent(fitpars, std::move(global));
   Acts::Vector3 pca = line.first;
   Acts::Vector3 tangent = line.second;
 
@@ -703,13 +765,13 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(const Surface& surf,
   // we want the point where the helix intersects the plane of the surface
 
   // get the plane of the surface
-  Acts::Vector3 sensorCenter      = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // convert to cm
-  Acts::Vector3 sensorNormal    = -surf->normal(_tGeometry->geometry().getGeoContext());
+  Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) * 0.1;  // convert to cm
+  Acts::Vector3 sensorNormal = -surf->normal(_tGeometry->geometry().getGeoContext());
   sensorNormal /= sensorNormal.norm();
 
   // there are analytic solutions for a line-plane intersection.
   // to use this, need to get the vector tangent to the helix near the measurement and a point on it.
-  std::pair<Acts::Vector3, Acts::Vector3> line =  get_helix_tangent(fitpars, std::move(global));
+  std::pair<Acts::Vector3, Acts::Vector3> line = get_helix_tangent(fitpars, std::move(global));
   pca = line.first;
   tangent = line.second;
 
@@ -718,15 +780,13 @@ Acts::Vector3 HelicalFitter::get_helix_surface_intersection(const Surface& surf,
   return intersection;
 }
 
-
 Acts::Vector3 HelicalFitter::get_helix_vtx(Acts::Vector3 event_vtx, const std::vector<float>& fitpars)
-{  
+{
   Acts::Vector2 pca2d = TrackFitUtils::get_circle_point_pca(fitpars[0], fitpars[1], fitpars[2], std::move(event_vtx));
-  Acts::Vector3 helix_vtx (pca2d(0),pca2d(1),fitpars[4]);
+  Acts::Vector3 helix_vtx(pca2d(0), pca2d(1), fitpars[4]);
 
   return helix_vtx;
 }
-
 
 Acts::Vector3 HelicalFitter::get_line_plane_intersection(const Acts::Vector3& PCA, const Acts::Vector3& tangent, const Acts::Vector3& sensor_center, const Acts::Vector3& sensor_normal)
 {
@@ -744,7 +804,6 @@ Acts::Vector3 HelicalFitter::get_line_plane_intersection(const Acts::Vector3& PC
   return intersection;
 }
 
-
 std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3 global)
 {
   auto pair = TrackFitUtils::get_helix_tangent(fitpars, global);
@@ -753,8 +812,8 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_helix_tangent(const s
   if(Verbosity() > 2)
     {
       // different method for checking:
-      // project the circle PCA vector an additional small amount and find the helix PCA to that point 
-      
+      // project the circle PCA vector an additional small amount and find the helix PCA to that point
+
       float projection = 0.25;  // cm
       Acts::Vector3 second_point = pca + projection * pca/pca.norm();
       Acts::Vector2 second_point_pca_circle = TrackFitUtils::get_circle_point_pca(radius, x0, y0, second_point);
@@ -762,80 +821,79 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_helix_tangent(const s
       Acts::Vector3 second_point_pca2(second_point_pca_circle(0), second_point_pca_circle(1), second_point_pca_z);
       Acts::Vector3 tangent2 = (second_point_pca2 - pca) /  (second_point_pca2 - pca).norm();
       Acts::Vector3 final_pca2 = getPCALinePoint(global, tangent2, pca);
-    
-      std::cout << " get_helix_tangent: getting tangent at angle_pca: " << angle_pca * 180.0 / M_PI << std::endl 
-		<< " original first point pca                      " << pca(0) << "  " << pca(1) << "  " << pca(2) << std::endl
-		<< " original second point pca  " << second_point_pca(0) << "  " << second_point_pca(1) << "  " << second_point_pca(2) << std::endl
-		<< " original tangent " << tangent(0) << "  " << tangent(1) << "  " << tangent(2) << std::endl	
-		<< " original final pca from line " << final_pca(0) << "  " << final_pca(1) << "  " << final_pca(2) << std::endl;
+
+      std::cout << " get_helix_tangent: getting tangent at angle_pca: " << angle_pca * 180.0 / M_PI << std::endl
+                << " original first point pca                      " << pca(0) << "  " << pca(1) << "  " << pca(2) << std::endl
+                << " original second point pca  " << second_point_pca(0) << "  " << second_point_pca(1) << "  " << second_point_pca(2) << std::endl
+                << " original tangent " << tangent(0) << "  " << tangent(1) << "  " << tangent(2) << std::endl
+                << " original final pca from line " << final_pca(0) << "  " << final_pca(1) << "  " << final_pca(2) << std::endl;
 
       if(Verbosity() > 3)
-	{
-	  std::cout	<< "    Check: 2nd point pca meth 2 "<< second_point_pca2(0)<< "  "<< second_point_pca2(1) << "  "<< second_point_pca2(2) << std::endl
-			<< "    check tangent " << tangent2(0) << "  " << tangent2(1) << "  " << tangent2(2) << std::endl	
-			<< "    check final pca from line " << final_pca2(0) << "  " << final_pca2(1) << "  " << final_pca2(2) 
-			<< std::endl;
-	}
-      
+        {
+          std::cout	<< "    Check: 2nd point pca meth 2 "<< second_point_pca2(0)<< "  "<< second_point_pca2(1) << "  "<< second_point_pca2(2) << std::endl
+                        << "    check tangent " << tangent2(0) << "  " << tangent2(1) << "  " << tangent2(2) << std::endl
+                        << "    check final pca from line " << final_pca2(0) << "  " << final_pca2(1) << "  " << final_pca2(2)
+                        << std::endl;
+        }
+
     }
   */
 
-
   return pair;
 }
-  
-int HelicalFitter::End(PHCompositeNode*  /*unused*/)
+
+int HelicalFitter::End(PHCompositeNode* /*unused*/)
 {
   // closes output file in destructor
   delete _mille;
 
-  if(make_ntuple)
-    {
-      fout->Write();
-      fout->Close();
-    }
+  if (make_ntuple)
+  {
+    fout->Write();
+    fout->Close();
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 int HelicalFitter::CreateNodes(PHCompositeNode* topNode)
 {
   PHNodeIterator iter(topNode);
-  
-  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
   if (!dstNode)
-    {
-      std::cerr << "DST node is missing, quitting" << std::endl;
-      throw std::runtime_error("Failed to find DST node in PHActsTrkFitter::createNodes");
-    }
-  
-  PHNodeIterator dstIter(topNode);
-  PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", "SVTX"));
-  if (!svtxNode)
-    {
-      svtxNode = new PHCompositeNode("SVTX");
-      dstNode->addNode(svtxNode);
-    }
-  
-  m_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "HelicalFitterTrackMap");
-  if(!m_trackmap)
-    {
-      m_trackmap = new SvtxTrackMap_v2;
-      PHIODataNode<PHObject> *node = new PHIODataNode<PHObject>(m_trackmap,"HelicalFitterTrackMap","PHObject");
-      svtxNode->addNode(node);
-    }
+  {
+    std::cerr << "DST node is missing, quitting" << std::endl;
+    throw std::runtime_error("Failed to find DST node in PHActsTrkFitter::createNodes");
+  }
 
-  m_alignmentmap = findNode::getClass<SvtxAlignmentStateMap>(topNode,"HelicalFitterAlignmentStateMap");
-  if(!m_alignmentmap)
-    {
-      m_alignmentmap = new SvtxAlignmentStateMap_v1;
-      PHIODataNode<PHObject> *node = new PHIODataNode<PHObject>(m_alignmentmap,"HelicalFitterAlignmentStateMap","PHObject");
-      svtxNode->addNode(node);
-    }
+  PHNodeIterator dstIter(topNode);
+  PHCompositeNode* svtxNode = dynamic_cast<PHCompositeNode*>(dstIter.findFirst("PHCompositeNode", "SVTX"));
+  if (!svtxNode)
+  {
+    svtxNode = new PHCompositeNode("SVTX");
+    dstNode->addNode(svtxNode);
+  }
+
+  m_trackmap = findNode::getClass<SvtxTrackMap>(topNode, "HelicalFitterTrackMap");
+  if (!m_trackmap)
+  {
+    m_trackmap = new SvtxTrackMap_v2;
+    PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_trackmap, "HelicalFitterTrackMap", "PHObject");
+    svtxNode->addNode(node);
+  }
+
+  m_alignmentmap = findNode::getClass<SvtxAlignmentStateMap>(topNode, "HelicalFitterAlignmentStateMap");
+  if (!m_alignmentmap)
+  {
+    m_alignmentmap = new SvtxAlignmentStateMap_v1;
+    PHIODataNode<PHObject>* node = new PHIODataNode<PHObject>(m_alignmentmap, "HelicalFitterAlignmentStateMap", "PHObject");
+    svtxNode->addNode(node);
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-int  HelicalFitter::GetNodes(PHCompositeNode* topNode)
+int HelicalFitter::GetNodes(PHCompositeNode* topNode)
 {
   //---------------------------------
   // Get additional objects off the Node Tree
@@ -843,66 +901,66 @@ int  HelicalFitter::GetNodes(PHCompositeNode* topNode)
 
   _track_map_silicon = findNode::getClass<TrackSeedContainer>(topNode, _silicon_track_map_name);
   if (!_track_map_silicon)
-    {
-      cerr << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    cerr << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   _track_map_tpc = findNode::getClass<TrackSeedContainer>(topNode, _track_map_name);
   if (!_track_map_tpc)
-    {
-      cerr << PHWHERE << " ERROR: Can't find " << _track_map_name.c_str() << endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    cerr << PHWHERE << " ERROR: Can't find " << _track_map_name.c_str() << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!_cluster_map)
-    {
-      std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  {
+    std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
-  _tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
-  if(!_tGeometry)
-    {
-      std::cout << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  
+  _tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!_tGeometry)
+  {
+    std::cout << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
-} 
+}
 
 Acts::Vector3 HelicalFitter::get_helix_pca(std::vector<float>& fitpars, const Acts::Vector3& global)
 {
   return TrackFitUtils::get_helix_pca(fitpars, global);
 }
 
-
 Acts::Vector3 HelicalFitter::getPCALinePoint(const Acts::Vector3& global, const Acts::Vector3& tangent, const Acts::Vector3& posref)
 {
-  // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)   
+  // Approximate track with a straight line consisting of the state position posref and the vector (px,py,pz)
 
   // The position of the closest point on the line to global is:
   // posref + projection of difference between the point and posref on the tangent vector
-  Acts::Vector3 pca = posref + ( (global - posref).dot(tangent) ) * tangent;
+  Acts::Vector3 pca = posref + ((global - posref).dot(tangent)) * tangent;
 
   return pca;
 }
 
-
-float HelicalFitter::convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster *cluster)
+float HelicalFitter::convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster)
 {
   // must convert local Y from cluster average time of arival to local cluster z position
   double drift_velocity = _tGeometry->get_drift_velocity();
   double zdriftlength = cluster->getLocalY() * drift_velocity;
-  double surfCenterZ = 52.89; // 52.89 is where G4 thinks the surface center is
-  double zloc = surfCenterZ - zdriftlength;   // converts z drift length to local z position in the TPC in north
+  double surfCenterZ = 52.89;                // 52.89 is where G4 thinks the surface center is
+  double zloc = surfCenterZ - zdriftlength;  // converts z drift length to local z position in the TPC in north
   unsigned int side = TpcDefs::getSide(cluster_key);
-  if(side == 0) { zloc = -zloc;
-}
+  if (side == 0)
+  {
+    zloc = -zloc;
+  }
   float z = zloc;  // in cm
- 
-  return z; 
+
+  return z;
 }
 
 void HelicalFitter::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global)
@@ -911,64 +969,79 @@ void HelicalFitter::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, shor
   unsigned int side = TpcDefs::getSide(cluster_key);
   float z = m_clusterCrossingCorrection.correctZ(global[2], side, crossing);
   global[2] = z;
-  
+
   // apply distortion corrections
-  if(_dcc_static) { global = _distortionCorrection.get_corrected_position( global, _dcc_static ); }
-  if(_dcc_average) { global = _distortionCorrection.get_corrected_position( global, _dcc_average ); }
-  if(_dcc_fluctuation) { global = _distortionCorrection.get_corrected_position( global, _dcc_fluctuation ); }
+  if (_dcc_static)
+  {
+    global = _distortionCorrection.get_corrected_position(global, _dcc_static);
+  }
+  if (_dcc_average)
+  {
+    global = _distortionCorrection.get_corrected_position(global, _dcc_average);
+  }
+  if (_dcc_fluctuation)
+  {
+    global = _distortionCorrection.get_corrected_position(global, _dcc_fluctuation);
+  }
 }
 
-void HelicalFitter::getTrackletClusters(TrackSeed *tracklet, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec)
+void HelicalFitter::getTrackletClusters(TrackSeed* tracklet, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {
   getTrackletClusterList(tracklet, cluskey_vec);
   // store cluster global positions in a vector
-  TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);   
+  TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);
 }
 
-void HelicalFitter::getTrackletClusterList(TrackSeed *tracklet, std::vector<TrkrDefs::cluskey>& cluskey_vec)
+void HelicalFitter::getTrackletClusterList(TrackSeed* tracklet, std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {
   for (auto clusIter = tracklet->begin_cluster_keys();
        clusIter != tracklet->end_cluster_keys();
        ++clusIter)
+  {
+    auto key = *clusIter;
+    auto cluster = _cluster_map->findCluster(key);
+    if (!cluster)
     {
-      auto key = *clusIter;
-      auto cluster = _cluster_map->findCluster(key);
-      if(!cluster)
-	{
-	  std::cout << "Failed to get cluster with key " << key << std::endl;
-	  continue;
-	}	  
-      
-      /// Make a safety check for clusters that couldn't be attached to a surface
-      auto surf = _tGeometry->maps().getSurface(key, cluster);
-      if(!surf)  { continue; }
+      std::cout << "Failed to get cluster with key " << key << std::endl;
+      continue;
+    }
 
-      // drop some bad layers in the TPC completely
-      unsigned int layer = TrkrDefs::getLayer(key);
-      if(layer == 7 || layer == 22 || layer == 23 || layer == 38 || layer == 39) {continue;}
+    /// Make a safety check for clusters that couldn't be attached to a surface
+    auto surf = _tGeometry->maps().getSurface(key, cluster);
+    if (!surf)
+    {
+      continue;
+    }
 
-      cluskey_vec.push_back(key);
-      
-    } // end loop over clusters for this track 
+    // drop some bad layers in the TPC completely
+    unsigned int layer = TrkrDefs::getLayer(key);
+    if (layer == 7 || layer == 22 || layer == 23 || layer == 38 || layer == 39)
+    {
+      continue;
+    }
+
+    cluskey_vec.push_back(key);
+
+  }  // end loop over clusters for this track
 }
 
 std::vector<float> HelicalFitter::fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec)
 {
-  return TrackFitUtils::fitClusters(global_vec, std::move(cluskey_vec));       // do helical fit
+  return TrackFitUtils::fitClusters(global_vec, std::move(cluskey_vec));  // do helical fit
 }
 
-Acts::Vector2 HelicalFitter::getClusterError(TrkrCluster *cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global)
+Acts::Vector2 HelicalFitter::getClusterError(TrkrCluster* cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global)
 {
-  Acts::Vector2 clus_sigma(0,0);
+  Acts::Vector2 clus_sigma(0, 0);
 
-  double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-  auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster,clusRadius,cluskey);
+  double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
+  auto para_errors = _ClusErrPara.get_clusterv5_modified_error(cluster, clusRadius, cluskey);
   double phierror = sqrt(para_errors.first);
   double zerror = sqrt(para_errors.second);
   clus_sigma(1) = zerror;
   clus_sigma(0) = phierror;
-  
-  return clus_sigma; 
+
+  return clus_sigma;
 }
 
 // new one
@@ -978,124 +1051,132 @@ void HelicalFitter::getLocalDerivativesXY(const Surface& surf, const Acts::Vecto
   std::vector<float> temp_fitpars;
 
   std::vector<float> fitpars_delta;
-  fitpars_delta.push_back(0.1);   // radius, cm
-  fitpars_delta.push_back(0.1);   // X0, cm
-  fitpars_delta.push_back(0.1);   // Y0, cm
-  fitpars_delta.push_back(0.1);   // zslope, cm
-  fitpars_delta.push_back(0.1);   // Z0, cm
+  fitpars_delta.push_back(0.1);  // radius, cm
+  fitpars_delta.push_back(0.1);  // X0, cm
+  fitpars_delta.push_back(0.1);  // Y0, cm
+  fitpars_delta.push_back(0.1);  // zslope, cm
+  fitpars_delta.push_back(0.1);  // Z0, cm
 
   temp_fitpars.reserve(fitpars.size());
-for(float fitpar : fitpars)
-    {
-      temp_fitpars.push_back(fitpar);
-    }
+  for (float fitpar : fitpars)
+  {
+    temp_fitpars.push_back(fitpar);
+  }
 
   // calculate projX and projY vectors once for the optimum fit parameters
-  if(Verbosity() > 1) { std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;
+  }
   std::pair<Acts::Vector3, Acts::Vector3> tangent = get_helix_tangent(fitpars, global);
 
-  Acts::Vector3 projX(0,0,0), projY(0,0,0);
+  Acts::Vector3 projX(0, 0, 0), projY(0, 0, 0);
   get_projectionXY(surf, tangent, projX, projY);
 
   Acts::Vector3 intersection = get_helix_surface_intersection(surf, temp_fitpars, global);
 
   // loop over the track fit parameters
-  for(unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  for (unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  {
+    Acts::Vector3 intersection_delta[2];
+    for (int ipm = 0; ipm < 2; ++ipm)
     {
-      Acts::Vector3 intersection_delta[2];
-      for(int ipm = 0; ipm < 2; ++ipm)
-	{
-	  temp_fitpars[ip]  = fitpars[ip];  // reset to best fit value
-	  float deltapm     = pow(-1.0, ipm);
-	  temp_fitpars[ip] += deltapm * fitpars_delta[ip];
+      temp_fitpars[ip] = fitpars[ip];  // reset to best fit value
+      float deltapm = pow(-1.0, ipm);
+      temp_fitpars[ip] += deltapm * fitpars_delta[ip];
 
-	  Acts::Vector3 temp_intersection = get_helix_surface_intersection(surf, temp_fitpars, global);
-	  intersection_delta[ipm]         = temp_intersection - intersection;
-	}
-      Acts::Vector3 average_intersection_delta = (intersection_delta[0] - intersection_delta[1]) / (2 * fitpars_delta[ip]);
-
-      if(Verbosity() > 1)
-	{std::cout << " average_intersection_delta / delta " << average_intersection_delta(0) << "  " << average_intersection_delta(1) << "  " << average_intersection_delta(2) << std::endl;}
-
-      // calculate the change in fit for X and Y 
-      // - note negative sign from ATLAS paper is dropped here because mille wants the derivative of the fit, not the derivative of the residual
-      lcl_derivativeX[ip] = average_intersection_delta.dot(projX);
-      lcl_derivativeY[ip] = average_intersection_delta.dot(projY);
-      if(Verbosity() > 1)
-	{std::cout << " layer " << layer << " ip " << ip << "  derivativeX " << lcl_derivativeX[ip] << "  " 
-		   << " derivativeY " << lcl_derivativeY[ip] << std::endl;}
-
-      temp_fitpars[ip] = fitpars[ip];
+      Acts::Vector3 temp_intersection = get_helix_surface_intersection(surf, temp_fitpars, global);
+      intersection_delta[ipm] = temp_intersection - intersection;
     }
-}
+    Acts::Vector3 average_intersection_delta = (intersection_delta[0] - intersection_delta[1]) / (2 * fitpars_delta[ip]);
 
+    if (Verbosity() > 1)
+    {
+      std::cout << " average_intersection_delta / delta " << average_intersection_delta(0) << "  " << average_intersection_delta(1) << "  " << average_intersection_delta(2) << std::endl;
+    }
+
+    // calculate the change in fit for X and Y
+    // - note negative sign from ATLAS paper is dropped here because mille wants the derivative of the fit, not the derivative of the residual
+    lcl_derivativeX[ip] = average_intersection_delta.dot(projX);
+    lcl_derivativeY[ip] = average_intersection_delta.dot(projY);
+    if (Verbosity() > 1)
+    {
+      std::cout << " layer " << layer << " ip " << ip << "  derivativeX " << lcl_derivativeX[ip] << "  "
+                << " derivativeY " << lcl_derivativeY[ip] << std::endl;
+    }
+
+    temp_fitpars[ip] = fitpars[ip];
+  }
+}
 
 void HelicalFitter::getLocalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& event_vtx, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5])
 {
   // Calculate the derivatives of the residual wrt the track parameters numerically
   std::vector<float> temp_fitpars;
-  Acts::Vector3 track_vtx (track.get_x(),track.get_y(),track.get_z());
+  Acts::Vector3 track_vtx(track.get_x(), track.get_y(), track.get_z());
 
   std::vector<float> fitpars_delta;
-  fitpars_delta.push_back(0.1);   // radius, cm
-  fitpars_delta.push_back(0.1);   // X0, cm
-  fitpars_delta.push_back(0.1);   // Y0, cm
-  fitpars_delta.push_back(0.1);   // zslope, cm
-  fitpars_delta.push_back(0.1);   // Z0, cm
+  fitpars_delta.push_back(0.1);  // radius, cm
+  fitpars_delta.push_back(0.1);  // X0, cm
+  fitpars_delta.push_back(0.1);  // Y0, cm
+  fitpars_delta.push_back(0.1);  // zslope, cm
+  fitpars_delta.push_back(0.1);  // Z0, cm
 
   temp_fitpars.reserve(fitpars.size());
-for(float fitpar : fitpars)
-    {
-      temp_fitpars.push_back(fitpar);
-    }
+  for (float fitpar : fitpars)
+  {
+    temp_fitpars.push_back(fitpar);
+  }
 
   // calculate projX and projY vectors once for the optimum fit parameters
-  if(Verbosity() > 1) {std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;}
+  if (Verbosity() > 1)
+  {
+    std::cout << "Call get_helix_tangent for best fit fitpars" << std::endl;
+  }
 
-  Acts::Vector3 perigeeNormal (track.get_px(),track.get_py(),track.get_pz()) ;  
+  Acts::Vector3 perigeeNormal(track.get_px(), track.get_py(), track.get_pz());
 
   // loop over the track fit parameters
-  for(unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  for (unsigned int ip = 0; ip < fitpars.size(); ++ip)
+  {
+    Acts::Vector3 localPerturb[2];
+    Acts::Vector3 paperPerturb[2];  // for local derivative calculation like from the paper
+
+    for (int ipm = 0; ipm < 2; ++ipm)
     {
-      Acts::Vector3 localPerturb[2];
-      Acts::Vector3 paperPerturb[2]; // for local derivative calculation like from the paper
+      temp_fitpars[ip] = fitpars[ip];  // reset to best fit value
+      float deltapm = pow(-1.0, ipm);
+      temp_fitpars[ip] += deltapm * fitpars_delta[ip];
 
-      for(int ipm = 0; ipm < 2; ++ipm)
-	{
-	  temp_fitpars[ip]  = fitpars[ip];  // reset to best fit value
-	  float deltapm     = pow(-1.0, ipm);
-	  temp_fitpars[ip] += deltapm * fitpars_delta[ip];
+      Acts::Vector3 temp_track_vtx = get_helix_vtx(event_vtx, temp_fitpars);  // temporary pca
+      paperPerturb[ipm] = temp_track_vtx;                                     // for og local derivative calculation
 
-	  Acts::Vector3 temp_track_vtx       = get_helix_vtx(event_vtx, temp_fitpars); // temporary pca
-	  paperPerturb[ipm]                  = temp_track_vtx; // for og local derivative calculation 
+      // old method is next two lines
+      Acts::Vector3 localtemp_track_vtx = globalvtxToLocalvtx(track, event_vtx, temp_track_vtx);
+      localPerturb[ipm] = localtemp_track_vtx;
 
-	  // old method is next two lines
-	  Acts::Vector3 localtemp_track_vtx  = globalvtxToLocalvtx(track, event_vtx, temp_track_vtx);
-	  localPerturb[ipm]                  =  localtemp_track_vtx  ;
-	  
-	  if(Verbosity() > 1)
-	    {
-	      std::cout << "vtx local parameter " << ip << " with ipm " << ipm << " deltapm " << deltapm << " :" << std::endl;
-	      std::cout<<" fitpars "<< fitpars[ip]<<" temp_fitpars "<<temp_fitpars[ip]<<std::endl;
-	      std::cout << " localtmp_track_vtx: "<< localtemp_track_vtx<<std::endl;
-	    }
-	}
-
-      Acts::Vector3 projX(0,0,0), projY(0,0,0);
-      get_projectionVtxXY(track, event_vtx, projX, projY);
-
-      Acts::Vector3 average_vtxX = (paperPerturb[0] - paperPerturb[1]) / (2 * fitpars_delta[ip]);
-      Acts::Vector3 average_vtxY = (paperPerturb[0] - paperPerturb[1]) / (2 * fitpars_delta[ip]);
-
-      // average_vtxX and average_vtxY are the numerical results in global coords for d(fit)/d(par)
-      // The ATLAS paper formula is for the derivative of the residual, which is (measurement - fit = event vertex - track vertex)
-      // Millepede wants the derivative of the fit, so we drop the minus sign from the paper
-      lcl_derivativeX[ip] = average_vtxX.dot(projX); // 
-      lcl_derivativeY[ip] = average_vtxY.dot(projY);
-
-      temp_fitpars[ip] = fitpars[ip];
+      if (Verbosity() > 1)
+      {
+        std::cout << "vtx local parameter " << ip << " with ipm " << ipm << " deltapm " << deltapm << " :" << std::endl;
+        std::cout << " fitpars " << fitpars[ip] << " temp_fitpars " << temp_fitpars[ip] << std::endl;
+        std::cout << " localtmp_track_vtx: " << localtemp_track_vtx << std::endl;
+      }
     }
+
+    Acts::Vector3 projX(0, 0, 0), projY(0, 0, 0);
+    get_projectionVtxXY(track, event_vtx, projX, projY);
+
+    Acts::Vector3 average_vtxX = (paperPerturb[0] - paperPerturb[1]) / (2 * fitpars_delta[ip]);
+    Acts::Vector3 average_vtxY = (paperPerturb[0] - paperPerturb[1]) / (2 * fitpars_delta[ip]);
+
+    // average_vtxX and average_vtxY are the numerical results in global coords for d(fit)/d(par)
+    // The ATLAS paper formula is for the derivative of the residual, which is (measurement - fit = event vertex - track vertex)
+    // Millepede wants the derivative of the fit, so we drop the minus sign from the paper
+    lcl_derivativeX[ip] = average_vtxX.dot(projX);  //
+    lcl_derivativeY[ip] = average_vtxY.dot(projY);
+
+    temp_fitpars[ip] = fitpars[ip];
+  }
 }
 
 void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 global, const Acts::Vector3& fitpoint, const std::vector<float>& fitpars, float glbl_derivativeX[6], float glbl_derivativeY[6], unsigned int layer)
@@ -1107,9 +1188,9 @@ void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 gl
   // calculate projX and projY vectors once for the optimum fit parameters
   std::pair<Acts::Vector3, Acts::Vector3> tangent = get_helix_tangent(fitpars, std::move(global));  // should this be global, not fitpoint?
 
-  Acts::Vector3 projX(0,0,0), projY(0,0,0);
+  Acts::Vector3 projX(0, 0, 0), projY(0, 0, 0);
   get_projectionXY(surf, tangent, projX, projY);
-  
+
   // translations
   glbl_derivativeX[3] = unitx.dot(projX);
   glbl_derivativeX[4] = unity.dot(projX);
@@ -1120,20 +1201,20 @@ void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 gl
   glbl_derivativeY[5] = unitz.dot(projY);
 
   /*
-  // note: the global derivative sign should be reversed from the ATLAS paper 
+  // note: the global derivative sign should be reversed from the ATLAS paper
   // because mille wants the derivative of the fit, while the ATLAS paper gives the derivative of the residual.
-  // But this sign reversal does NOT work. 
+  // But this sign reversal does NOT work.
   // Verified that not reversing the sign here produces the correct sign of the prediction of the residual..
   for(unsigned int i = 3; i < 6; ++i)
   {
-  glbl_derivativeX[i] *= -1.0; 
-  glbl_derivativeY[i] *= -1.0; 
+  glbl_derivativeX[i] *= -1.0;
+  glbl_derivativeY[i] *= -1.0;
   }
   */
   // rotations
   // need center of sensor to intersection point
   Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;  // convert to cm
-  Acts::Vector3 OM           = fitpoint - sensorCenter;   // this effectively reverses the sign from the ATLAS paper
+  Acts::Vector3 OM = fitpoint - sensorCenter;                                                                   // this effectively reverses the sign from the ATLAS paper
 
   glbl_derivativeX[0] = (unitx.cross(OM)).dot(projX);
   glbl_derivativeX[1] = (unity.cross(OM)).dot(projX);
@@ -1142,19 +1223,16 @@ void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 gl
   glbl_derivativeY[0] = (unitx.cross(OM)).dot(projY);
   glbl_derivativeY[1] = (unity.cross(OM)).dot(projY);
   glbl_derivativeY[2] = (unitz.cross(OM)).dot(projY);
-  
 
-  if(Verbosity() > 1)
+  if (Verbosity() > 1)
+  {
+    for (int ip = 0; ip < 6; ++ip)
     {
-      for(int ip=0;ip<6;++ip)
-	{
-	  std::cout << " layer " << layer << " ip " << ip << "  glbl_derivativeX " << glbl_derivativeX[ip] << "  " 
-		    << " glbl_derivativeY " << glbl_derivativeY[ip] << std::endl;
-	}
+      std::cout << " layer " << layer << " ip " << ip << "  glbl_derivativeX " << glbl_derivativeX[ip] << "  "
+                << " glbl_derivativeY " << glbl_derivativeY[ip] << std::endl;
     }
-  
+  }
 }
-
 
 void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& event_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3])
 {
@@ -1162,11 +1240,11 @@ void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vect
   Acts::Vector3 unity(0, 1, 0);
   Acts::Vector3 unitz(0, 0, 1);
 
-  Acts::Vector3 track_vtx (track.get_x(),track.get_y(),track.get_z());
-  Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
+  Acts::Vector3 track_vtx(track.get_x(), track.get_y(), track.get_z());
+  Acts::Vector3 mom(track.get_px(), track.get_py(), track.get_pz());
 
   // calculate projX and projY vectors once for the optimum fit parameters
-  Acts::Vector3 projX(0,0,0), projY(0,0,0);
+  Acts::Vector3 projX(0, 0, 0), projY(0, 0, 0);
   get_projectionVtxXY(track, event_vtx, projX, projY);
 
   // translations
@@ -1182,13 +1260,12 @@ void HelicalFitter::getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vect
 
   // Verified that reversing these signs produces the correct sign and magnitude for the prediction of the residual.
   // tested this by offsetting the simulated event vertex with zero misalignments. Pede fit reproduced simulated (xvtx, yvtx) within 7%.
-  //   -- test gave zero for zvtx param, since this is determined relative to the measured event z vertex. 
-  for(int i = 0; i<3;++i)
-    {
-      glbl_derivativeX[i] *= -1.0;
-      glbl_derivativeY[i] *= -1.0;
-    }
-
+  //   -- test gave zero for zvtx param, since this is determined relative to the measured event z vertex.
+  for (int i = 0; i < 3; ++i)
+  {
+    glbl_derivativeX[i] *= -1.0;
+    glbl_derivativeY[i] *= -1.0;
+  }
 }
 
 void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::Vector3, Acts::Vector3>& tangent, Acts::Vector3& projX, Acts::Vector3& projY)
@@ -1198,17 +1275,17 @@ void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::
   // get the plane of the surface
   Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;  // convert to cm
   // sensorNormal is the Z vector
-  Acts::Vector3 Z = -surf->normal(_tGeometry->geometry().getGeoContext()) / Acts::UnitConstants::cm; 
+  Acts::Vector3 Z = -surf->normal(_tGeometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;
   // get surface X and Y unit vectors in global frame
   // transform Xlocal = 1.0 to global, subtract the surface center, normalize to 1
-  Acts::Vector3 xloc(1.0,0.0,0.0); //local coord unit vector in x
-  Acts::Vector3 xglob =  surf->transform(_tGeometry->geometry().getGeoContext()) * (xloc *  Acts::UnitConstants::cm);
-  xglob /=  Acts::UnitConstants::cm;
-  Acts::Vector3 yloc(0.0,1.0,0.0);
-  Acts::Vector3 yglob =  surf->transform(_tGeometry->geometry().getGeoContext()) * (yloc *  Acts::UnitConstants::cm);
-  yglob /=  Acts::UnitConstants::cm;
-  Acts::Vector3 X = (xglob-sensorCenter) / (xglob-sensorCenter).norm();
-  Acts::Vector3 Y = (yglob-sensorCenter) / (yglob-sensorCenter).norm();
+  Acts::Vector3 xloc(1.0, 0.0, 0.0);  // local coord unit vector in x
+  Acts::Vector3 xglob = surf->transform(_tGeometry->geometry().getGeoContext()) * (xloc * Acts::UnitConstants::cm);
+  xglob /= Acts::UnitConstants::cm;
+  Acts::Vector3 yloc(0.0, 1.0, 0.0);
+  Acts::Vector3 yglob = surf->transform(_tGeometry->geometry().getGeoContext()) * (yloc * Acts::UnitConstants::cm);
+  yglob /= Acts::UnitConstants::cm;
+  Acts::Vector3 X = (xglob - sensorCenter) / (xglob - sensorCenter).norm();
+  Acts::Vector3 Y = (yglob - sensorCenter) / (yglob - sensorCenter).norm();
   // see equation 31 of the ATLAS paper (and discussion) for this
   projX = X - (tanvec.dot(X) / tanvec.dot(Z)) * Z;
   projY = Y - (tanvec.dot(Y) / tanvec.dot(Z)) * Z;
@@ -1217,19 +1294,19 @@ void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::
 
 void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, const Acts::Vector3& event_vtx, Acts::Vector3& projX, Acts::Vector3& projY)
 {
-  Acts::Vector3 tanvec(track.get_px(),track.get_py(),track.get_pz());
-  Acts::Vector3 normal(track.get_px(),track.get_py(),0); 
+  Acts::Vector3 tanvec(track.get_px(), track.get_py(), track.get_pz());
+  Acts::Vector3 normal(track.get_px(), track.get_py(), 0);
 
   tanvec /= tanvec.norm();
   normal /= normal.norm();
 
   // get surface X and Y unit vectors in global frame
-  Acts::Vector3 xloc(1.0,0.0,0.0);
-  Acts::Vector3 yloc(0.0,0.0,1.0); // local y 
+  Acts::Vector3 xloc(1.0, 0.0, 0.0);
+  Acts::Vector3 yloc(0.0, 0.0, 1.0);  // local y
   Acts::Vector3 xglob = localvtxToGlobalvtx(track, event_vtx, xloc);
   Acts::Vector3 yglob = yloc + event_vtx;
-  Acts::Vector3 X     = (xglob-event_vtx) / (xglob-event_vtx).norm(); // local unit vector transformed to global coordinates
-  Acts::Vector3 Y     = (yglob-event_vtx) / (yglob-event_vtx).norm();
+  Acts::Vector3 X = (xglob - event_vtx) / (xglob - event_vtx).norm();  // local unit vector transformed to global coordinates
+  Acts::Vector3 Y = (yglob - event_vtx) / (yglob - event_vtx).norm();
 
   // see equation 31 of the ATLAS paper (and discussion) for this
   projX = X - (tanvec.dot(X) / tanvec.dot(normal)) * normal;
@@ -1238,19 +1315,19 @@ void HelicalFitter::get_projectionVtxXY(SvtxTrack& track, const Acts::Vector3& e
   return;
 }
 
-unsigned int HelicalFitter::addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec)
+unsigned int HelicalFitter::addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec)
 {
-
-  return TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec,0,6);
+  return TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec, 0, 6);
 }
 
 bool HelicalFitter::is_intt_layer_fixed(unsigned int layer)
 {
   bool ret = false;
   auto it = fixed_intt_layers.find(layer);
-  if(it != fixed_intt_layers.end()) { 
+  if (it != fixed_intt_layers.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
@@ -1259,11 +1336,12 @@ bool HelicalFitter::is_mvtx_layer_fixed(unsigned int layer, unsigned int clamshe
 {
   bool ret = false;
 
-  std::pair pair = std::make_pair(layer,clamshell);
+  std::pair pair = std::make_pair(layer, clamshell);
   auto it = fixed_mvtx_layers.find(pair);
-  if(it != fixed_mvtx_layers.end()) { 
+  if (it != fixed_mvtx_layers.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
@@ -1275,18 +1353,18 @@ void HelicalFitter::set_intt_layer_fixed(unsigned int layer)
 
 void HelicalFitter::set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell)
 {
-  fixed_mvtx_layers.insert(std::make_pair(layer,clamshell));
+  fixed_mvtx_layers.insert(std::make_pair(layer, clamshell));
 }
 
- 
 bool HelicalFitter::is_layer_param_fixed(unsigned int layer, unsigned int param)
 {
   bool ret = false;
   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
   auto it = fixed_layer_params.find(pair);
-  if(it != fixed_layer_params.end()) { 
+  if (it != fixed_layer_params.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
@@ -1310,191 +1388,187 @@ bool HelicalFitter::is_tpc_sector_fixed(unsigned int layer, unsigned int sector,
   unsigned int region = AlignmentDefs::getTpcRegion(layer);
   unsigned int subsector = region * 24 + side * 12 + sector;
   auto it = fixed_sectors.find(subsector);
-  if(it != fixed_sectors.end()) { 
+  if (it != fixed_sectors.end())
+  {
     ret = true;
-}
-  
+  }
+
   return ret;
 }
 
-void HelicalFitter::correctTpcGlobalPositions(std::vector<Acts::Vector3> global_vec,  std::vector<TrkrDefs::cluskey> cluskey_vec)
+void HelicalFitter::correctTpcGlobalPositions(std::vector<Acts::Vector3> global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec)
 {
-  for(unsigned int iclus=0;iclus<cluskey_vec.size();++iclus)
+  for (unsigned int iclus = 0; iclus < cluskey_vec.size(); ++iclus)
+  {
+    auto cluskey = cluskey_vec[iclus];
+    auto global = global_vec[iclus];
+    const unsigned int trkrId = TrkrDefs::getTrkrId(cluskey);
+    if (trkrId == TrkrDefs::tpcId)
     {
-      auto cluskey = cluskey_vec[iclus];
-      auto global = global_vec[iclus];
-      const unsigned int trkrId = TrkrDefs::getTrkrId(cluskey);	  
-      if(trkrId == TrkrDefs::tpcId) 
-	{  
-	  // have to add corrections for TPC clusters after transformation to global
-	  int crossing = 0;  // for now
-	  makeTpcGlobalCorrections(cluskey, crossing, global); 
-	  global_vec[iclus] = global;
-	}
+      // have to add corrections for TPC clusters after transformation to global
+      int crossing = 0;  // for now
+      makeTpcGlobalCorrections(cluskey, crossing, global);
+      global_vec[iclus] = global;
     }
+  }
 }
 
 float HelicalFitter::getVertexResidual(Acts::Vector3 vtx)
 {
-  float phi = atan2(vtx(1),vtx(0));
-  float r   = vtx(0)/cos(phi);
-  float test_r = sqrt(vtx(0)*vtx(0)+vtx(1)*vtx(1));
+  float phi = atan2(vtx(1), vtx(0));
+  float r = vtx(0) / cos(phi);
+  float test_r = sqrt(vtx(0) * vtx(0) + vtx(1) * vtx(1));
 
-  if(Verbosity() > 1)
-    {
-      std::cout << "my method position: " << vtx << std::endl;
-      std::cout << "r " << r <<" phi: " << phi*180/M_PI<<" test_r"<< test_r << std::endl;
-    }
+  if (Verbosity() > 1)
+  {
+    std::cout << "my method position: " << vtx << std::endl;
+    std::cout << "r " << r << " phi: " << phi * 180 / M_PI << " test_r" << test_r << std::endl;
+  }
   return r;
 }
 
-void HelicalFitter::get_dca(SvtxTrack& track,float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& event_vertex)
+void HelicalFitter::get_dca(SvtxTrack& track, float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& event_vertex)
 {
-  //give trackseed 
+  // give trackseed
   dca3dxy = NAN;
-  Acts::Vector3 track_vtx(track.get_x(),track.get_y(),track.get_z());
-  Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
+  Acts::Vector3 track_vtx(track.get_x(), track.get_y(), track.get_z());
+  Acts::Vector3 mom(track.get_px(), track.get_py(), track.get_pz());
 
-  track_vtx -= event_vertex; // difference between track_vertex and event_vtx
-  
+  track_vtx -= event_vertex;  // difference between track_vertex and event_vtx
+
   Acts::ActsSquareMatrix<3> posCov;
-  for(int i = 0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
+  {
+    for (int j = 0; j < 3; ++j)
     {
-      for(int j = 0; j < 3; ++j)
-	{
-	  posCov(i, j) = track.get_error(i, j);
-	} 
+      posCov(i, j) = track.get_error(i, j);
     }
-  
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
+  }
 
-  float phi       = atan2(r(1), r(0));
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
+
+  float phi = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
   phi *= -1;
-  rot(0,0) = cos(phi);
-  rot(0,1) = -sin(phi);
-  rot(0,2) = 0;
-  rot(1,0) = sin(phi);
-  rot(1,1) = cos(phi);
-  rot(1,2) = 0;
-  rot(2,0) = 0;
-  rot(2,1) = 0;
-  rot(2,2) = 1;
-  rot_T    = rot.transpose();
+  rot(0, 0) = cos(phi);
+  rot(0, 1) = -sin(phi);
+  rot(0, 2) = 0;
+  rot(1, 0) = sin(phi);
+  rot(1, 1) = cos(phi);
+  rot(1, 2) = 0;
+  rot(2, 0) = 0;
+  rot(2, 1) = 0;
+  rot(2, 2) = 1;
+  rot_T = rot.transpose();
 
-  Acts::Vector3 pos_R           = rot * track_vtx;
+  Acts::Vector3 pos_R = rot * track_vtx;
   Acts::ActsSquareMatrix<3> rotCov = rot * posCov * rot_T;
-  dca3dxy      = pos_R(0);
-  dca3dz       = pos_R(2);
-  dca3dxysigma = sqrt(rotCov(0,0));
-  dca3dzsigma  = sqrt(rotCov(2,2));
-	
-  if(Verbosity()>1)
-    {
-      std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;
-      std::cout << "dca3dxy " << dca3dxy << " dca3dz: " << dca3dz << " pos_R(1): "<<pos_R(1)<<" dca3dxysigma " << dca3dxysigma << " dca3dzsigma " << dca3dzsigma << std::endl;
-    }
-  
+  dca3dxy = pos_R(0);
+  dca3dz = pos_R(2);
+  dca3dxysigma = sqrt(rotCov(0, 0));
+  dca3dzsigma = sqrt(rotCov(2, 2));
+
+  if (Verbosity() > 1)
+  {
+    std::cout << " momentum X z: " << r << " phi: " << phi * 180 / M_PI << std::endl;
+    std::cout << "dca3dxy " << dca3dxy << " dca3dz: " << dca3dz << " pos_R(1): " << pos_R(1) << " dca3dxysigma " << dca3dxysigma << " dca3dzsigma " << dca3dzsigma << std::endl;
+  }
 }
 
 Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex)
 {
+  Acts::Vector3 track_vtx(track.get_x(), track.get_y(), track.get_z());
+  Acts::Vector3 mom(track.get_px(), track.get_py(), track.get_pz());
+  track_vtx -= event_vertex;  // difference between track_vertex and event_vtx
 
-  Acts::Vector3 track_vtx(track.get_x(),track.get_y(),track.get_z());
-  Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
-  track_vtx -= event_vertex; // difference between track_vertex and event_vtx
-
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
-  float phi       = atan2(r(1), r(0));
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
+  float phi = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
-  phi     *= -1;
-  rot(0,0) = cos(phi);
-  rot(0,1) = -sin(phi);
-  rot(0,2) = 0;
-  rot(1,0) = sin(phi);
-  rot(1,1) = cos(phi);
-  rot(1,2) = 0;
-  rot(2,0) = 0;
-  rot(2,1) = 0;
-  rot(2,2) = 1;
-  rot_T    = rot.transpose();
+  phi *= -1;
+  rot(0, 0) = cos(phi);
+  rot(0, 1) = -sin(phi);
+  rot(0, 2) = 0;
+  rot(1, 0) = sin(phi);
+  rot(1, 1) = cos(phi);
+  rot(1, 2) = 0;
+  rot(2, 0) = 0;
+  rot(2, 1) = 0;
+  rot(2, 2) = 1;
+  rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * track_vtx;
 
-  if(Verbosity()>1)
-    {
-      std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;
-      std::cout << " pos_R(0): "<<pos_R(0)<<" pos_R(1): "<<pos_R(1) << std::endl;
-    }
-  return pos_R; 
+  if (Verbosity() > 1)
+  {
+    std::cout << " momentum X z: " << r << " phi: " << phi * 180 / M_PI << std::endl;
+    std::cout << " pos_R(0): " << pos_R(0) << " pos_R(1): " << pos_R(1) << std::endl;
+  }
+  return pos_R;
 }
 
 Acts::Vector3 HelicalFitter::globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex, Acts::Vector3 PCA)
 {
-  Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
-  PCA -= event_vertex; // difference between track_vertex and event_vtx
+  Acts::Vector3 mom(track.get_px(), track.get_py(), track.get_pz());
+  PCA -= event_vertex;  // difference between track_vertex and event_vtx
 
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
-  float phi       = atan2(r(1), r(0));
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
+  float phi = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
-  phi     *= -1;
-  rot(0,0) = cos(phi);
-  rot(0,1) = -sin(phi);
-  rot(0,2) = 0;
-  rot(1,0) = sin(phi);
-  rot(1,1) = cos(phi);
-  rot(1,2) = 0;
-  rot(2,0) = 0;
-  rot(2,1) = 0;
-  rot(2,2) = 1;
-  rot_T    = rot.transpose();
+  phi *= -1;
+  rot(0, 0) = cos(phi);
+  rot(0, 1) = -sin(phi);
+  rot(0, 2) = 0;
+  rot(1, 0) = sin(phi);
+  rot(1, 1) = cos(phi);
+  rot(1, 2) = 0;
+  rot(2, 0) = 0;
+  rot(2, 1) = 0;
+  rot(2, 2) = 1;
+  rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * PCA;
 
-  if(Verbosity()>1)
-    {
-      std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;
-      std::cout << " pos_R(0): "<<pos_R(0)<<" pos_R(1): "<<pos_R(1) << std::endl;
-    }
-  return pos_R; 
+  if (Verbosity() > 1)
+  {
+    std::cout << " momentum X z: " << r << " phi: " << phi * 180 / M_PI << std::endl;
+    std::cout << " pos_R(0): " << pos_R(0) << " pos_R(1): " << pos_R(1) << std::endl;
+  }
+  return pos_R;
 }
 
-
-Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx,  const Acts::Vector3& local)
+Acts::Vector3 HelicalFitter::localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx, const Acts::Vector3& local)
 {
+  // Acts::Vector3 track_vtx = local;
+  Acts::Vector3 mom(track.get_px(), track.get_py(), track.get_pz());
+  // std::cout << "first pos: " << pos << " mom: " << mom << std::endl;
+  // local -= event_vertex; // difference between track_vertex and event_vtx
 
-  //Acts::Vector3 track_vtx = local;
-  Acts::Vector3 mom(track.get_px(),track.get_py(),track.get_pz());
-  //std::cout << "first pos: " << pos << " mom: " << mom << std::endl; 
-  //local -= event_vertex; // difference between track_vertex and event_vtx
-
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
-  float phi       = atan2(r(1), r(0));
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
+  float phi = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
   // phi *= -1;
-  rot(0,0) = cos(phi);
-  rot(0,1) = -sin(phi);
-  rot(0,2) = 0;
-  rot(1,0) = sin(phi);
-  rot(1,1) = cos(phi);
-  rot(1,2) = 0;
-  rot(2,0) = 0;
-  rot(2,1) = 0;
-  rot(2,2) = 1;
-  
+  rot(0, 0) = cos(phi);
+  rot(0, 1) = -sin(phi);
+  rot(0, 2) = 0;
+  rot(1, 0) = sin(phi);
+  rot(1, 1) = cos(phi);
+  rot(1, 2) = 0;
+  rot(2, 0) = 0;
+  rot(2, 1) = 0;
+  rot(2, 2) = 1;
+
   rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * local;
   pos_R += event_vtx;
-  if(Verbosity()>1)
-    {
-      std::cout << " momentum X z: "<<r<< " phi: " << phi*180/M_PI << std::endl;
-      std::cout << " pos_R(0): "<<pos_R(0)<<" pos_R(1): "<<pos_R(1)<<"pos_R(2): "<<pos_R(2) << std::endl;
-    }
-  return pos_R; 
+  if (Verbosity() > 1)
+  {
+    std::cout << " momentum X z: " << r << " phi: " << phi * 180 / M_PI << std::endl;
+    std::cout << " pos_R(0): " << pos_R(0) << " pos_R(1): " << pos_R(1) << "pos_R(2): " << pos_R(2) << std::endl;
+  }
+  return pos_R;
 }
-

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -5,14 +5,16 @@
 
 #include "AlignmentDefs.h"
 
-#include <fun4all/SubsysReco.h>
+#include <tpc/TpcClusterZCrossingCorrection.h>
+#include <tpc/TpcDistortionCorrection.h>
+
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrackFitUtils.h>
 #include <trackbase/ClusterErrorPara.h>
+
 #include <phparameter/PHParameterInterface.h>
 
-#include <tpc/TpcClusterZCrossingCorrection.h>
-#include <tpc/TpcDistortionCorrection.h>
+#include <fun4all/SubsysReco.h>
 
 #include <string>
 #include <map>
@@ -45,7 +47,9 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   {
     _fieldDir = -1;
     if(rescale > 0)
+    {
       _fieldDir = 1;     
+    }
   }
   void set_field(const std::string &field) { _field = field;}
 
@@ -177,34 +181,34 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   TrkrClusterContainer *_cluster_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
 
-  std::string data_outfilename = ("mille_helical_output_data_file.bin");  
-  std::string steering_outfilename = ("steer_helical.txt");  
-  std::string ntuple_outfilename = ("HF_ntuple.root"); 
+  std::string data_outfilename {"mille_helical_output_data_file.bin"};
+  std::string steering_outfilename {"steer_helical.txt"};
+  std::string ntuple_outfilename {"HF_ntuple.root"};
 
-  bool fitsilicon = true;
-  bool fittpc = false;
-  bool fitfulltrack = false;
+  bool fitsilicon {true};
+  bool fittpc {false};
+  bool fitfulltrack {false};
 
-  float dca_cut = 0.19;  // cm
+  float dca_cut {0.19};  // cm
 
-  SvtxTrackMap* m_trackmap = nullptr;
-  SvtxAlignmentStateMap* m_alignmentmap = nullptr;
+  SvtxTrackMap* m_trackmap {nullptr};
+  SvtxAlignmentStateMap* m_alignmentmap {nullptr};
 
   std::string _field;
-  int _fieldDir = -1;
+  int _fieldDir {-1};
   std::map<unsigned int, float> _layerMisalignment;
 
-  std::string _track_map_name = "TpcTrackSeedContainer";
-  std::string _silicon_track_map_name = "SiliconTrackSeedContainer";
+  std::string _track_map_name {"TpcTrackSeedContainer"};
+  std::string _silicon_track_map_name {"SiliconTrackSeedContainer"};
 
-  bool make_ntuple = true;
+  bool make_ntuple {true};
   TNtuple *ntp{nullptr};
   TNtuple *track_ntp{nullptr};
   TFile *fout{nullptr};
 
-  bool use_event_vertex = false;
+  bool use_event_vertex {false};
 
-  int event = 0;
+  int event {0};
 
   Acts::Vector3 vertexPosition;
   Acts::Vector3 vertexPosUncertainty;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -9,15 +9,15 @@
 #include <tpc/TpcDistortionCorrection.h>
 
 #include <trackbase/ActsGeometry.h>
-#include <trackbase/TrackFitUtils.h>
 #include <trackbase/ClusterErrorPara.h>
+#include <trackbase/TrackFitUtils.h>
 
 #include <phparameter/PHParameterInterface.h>
 
 #include <fun4all/SubsysReco.h>
 
-#include <string>
 #include <map>
+#include <string>
 
 class PHCompositeNode;
 class TrackSeedContainer;
@@ -36,22 +36,21 @@ class SvtxTrack;
 class HelicalFitter : public SubsysReco, public PHParameterInterface
 {
  public:
-
-  HelicalFitter(const std::string &name = "HelicalFitter");
+  HelicalFitter(const std::string& name = "HelicalFitter");
 
   ~HelicalFitter() override;
 
- void SetDefaultParameters() override;
+  void SetDefaultParameters() override;
 
   void set_field_dir(const double rescale)
   {
     _fieldDir = -1;
-    if(rescale > 0)
+    if (rescale > 0)
     {
-      _fieldDir = 1;     
+      _fieldDir = 1;
     }
   }
-  void set_field(const std::string &field) { _field = field;}
+  void set_field(const std::string& field) { _field = field; }
 
   int InitRun(PHCompositeNode* topNode) override;
 
@@ -59,73 +58,76 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
   int End(PHCompositeNode*) override;
 
-  void set_silicon_track_map_name(const std::string &map_name) { _silicon_track_map_name = map_name; }
-  void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
+  void set_silicon_track_map_name(const std::string& map_name) { _silicon_track_map_name = map_name; }
+  void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
 
-  void set_use_event_vertex(bool flag){ use_event_vertex = flag; }
-  void set_datafile_name(const std::string& file) { data_outfilename = file;}
-  void set_steeringfile_name(const std::string& file) { steering_outfilename = file;}
-  void set_mvtx_grouping(int group) {mvtx_grp = (AlignmentDefs::mvtxGrp) group;}
-  void set_intt_grouping(int group) {intt_grp = (AlignmentDefs::inttGrp) group;}
-  void set_tpc_grouping(int group) {tpc_grp = (AlignmentDefs::tpcGrp) group;}
-  void set_mms_grouping(int group) {mms_grp = (AlignmentDefs::mmsGrp) group;}
-  void set_test_output(bool test) {test_output = test;}
+  void set_use_event_vertex(bool flag) { use_event_vertex = flag; }
+  void set_datafile_name(const std::string& file) { data_outfilename = file; }
+  void set_steeringfile_name(const std::string& file) { steering_outfilename = file; }
+  void set_mvtx_grouping(int group) { mvtx_grp = (AlignmentDefs::mvtxGrp) group; }
+  void set_intt_grouping(int group) { intt_grp = (AlignmentDefs::inttGrp) group; }
+  void set_tpc_grouping(int group) { tpc_grp = (AlignmentDefs::tpcGrp) group; }
+  void set_mms_grouping(int group) { mms_grp = (AlignmentDefs::mmsGrp) group; }
+  void set_test_output(bool test) { test_output = test; }
   void set_intt_layer_fixed(unsigned int layer);
   void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_tpc_sector_fixed(unsigned int region, unsigned int sector, unsigned int side);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
-  void set_ntuplefile_name(const std::string& file) { ntuple_outfilename = file;}
+  void set_ntuplefile_name(const std::string& file) { ntuple_outfilename = file; }
 
-  void set_fitted_subsystems(bool si, bool tpc, bool full) { fitsilicon = si; fittpc = tpc; fitfulltrack = full; }
-
-  void set_error_inflation_factor(unsigned int layer, float factor) 
+  void set_fitted_subsystems(bool si, bool tpc, bool full)
   {
-    _layerMisalignment.insert(std::make_pair(layer,factor));
+    fitsilicon = si;
+    fittpc = tpc;
+    fitfulltrack = full;
   }
-  
-  void set_vertex(Acts::Vector3 inVertex,  Acts::Vector3 inVertex_uncertainty)
+
+  void set_error_inflation_factor(unsigned int layer, float factor)
   {
-    vertexPosition       = inVertex;
+    _layerMisalignment.insert(std::make_pair(layer, factor));
+  }
+
+  void set_vertex(Acts::Vector3 inVertex, Acts::Vector3 inVertex_uncertainty)
+  {
+    vertexPosition = inVertex;
     vertexPosUncertainty = inVertex_uncertainty;
   }
 
   void set_vtx_sigma(float x_sigma, float y_sigma)
   {
-    vtx_sigma(0)= x_sigma;
-    vtx_sigma(1)= y_sigma;
+    vtx_sigma(0) = x_sigma;
+    vtx_sigma(1) = y_sigma;
   }
-
 
   // utility functions for analysis modules
   std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);
-  void getTrackletClusters(TrackSeed *_track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
+  void getTrackletClusters(TrackSeed* _track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
   Acts::Vector3 get_helix_pca(std::vector<float>& fitpars, const Acts::Vector3& global);
-  void correctTpcGlobalPositions(std::vector<Acts::Vector3> global_vec,  std::vector<TrkrDefs::cluskey> cluskey_vec);
-  unsigned int addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec);
+  void correctTpcGlobalPositions(std::vector<Acts::Vector3> global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);
+  unsigned int addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
-  void set_dca_cut(float dca) {dca_cut = dca;}
+  void set_dca_cut(float dca) { dca_cut = dca; }
 
  private:
-
   Mille* _mille;
 
   int GetNodes(PHCompositeNode* topNode);
   int CreateNodes(PHCompositeNode* topNode);
-  void getTrackletClusterList(TrackSeed *tracklet, std::vector<TrkrDefs::cluskey>& cluskey_vec);
+  void getTrackletClusterList(TrackSeed* tracklet, std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
   Acts::Vector3 getPCALinePoint(const Acts::Vector3& global, const Acts::Vector3& tangent, const Acts::Vector3& posref);
-  Acts::Vector3 get_line_plane_intersection(const Acts::Vector3& PCA, const Acts::Vector3& tangent, 
-					    const Acts::Vector3& sensor_center, const Acts::Vector3& sensor_normal);
+  Acts::Vector3 get_line_plane_intersection(const Acts::Vector3& PCA, const Acts::Vector3& tangent,
+                                            const Acts::Vector3& sensor_center, const Acts::Vector3& sensor_normal);
   std::pair<Acts::Vector3, Acts::Vector3> get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3 global);
   Acts::Vector3 get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global);
   Acts::Vector3 get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global, Acts::Vector3& pca, Acts::Vector3& tangent);
 
   Acts::Vector3 get_helix_vtx(Acts::Vector3 event_vtx, const std::vector<float>& fitpars);
 
-  float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster *cluster);
+  float convertTimeToZ(TrkrDefs::cluskey cluster_key, TrkrCluster* cluster);
   void makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, short int crossing, Acts::Vector3& global);
 
-  Acts::Vector2 getClusterError(TrkrCluster *cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global);
+  Acts::Vector2 getClusterError(TrkrCluster* cluster, TrkrDefs::cluskey cluskey, Acts::Vector3& global);
 
   bool is_tpc_sector_fixed(unsigned int layer, unsigned int sector, unsigned int side);
   bool is_mvtx_layer_fixed(unsigned int layer, unsigned int stave);
@@ -140,17 +142,15 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
   void getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& track_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3]);
 
-  void get_projectionXY(const Surface& surf, const std::pair<Acts::Vector3, Acts::Vector3>& tangent, Acts::Vector3& projX, Acts::Vector3& projY);  
+  void get_projectionXY(const Surface& surf, const std::pair<Acts::Vector3, Acts::Vector3>& tangent, Acts::Vector3& projX, Acts::Vector3& projY);
   void get_projectionVtxXY(SvtxTrack& track, const Acts::Vector3& event_vtx, Acts::Vector3& projX, Acts::Vector3& projY);
 
   float getVertexResidual(Acts::Vector3 vtx);
-  
-  void get_dca(SvtxTrack& track,  float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& vertex);
+
+  void get_dca(SvtxTrack& track, float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& vertex);
   Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex);
   Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex, Acts::Vector3 PCA);
   Acts::Vector3 localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx, const Acts::Vector3& PCA);
-
-
 
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
   TpcDistortionCorrectionContainer* _dcc_static{nullptr};
@@ -161,10 +161,10 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
 
   ClusterErrorPara _ClusErrPara;
 
-  std::set<std::pair<unsigned int,unsigned int>> fixed_mvtx_layers;
+  std::set<std::pair<unsigned int, unsigned int>> fixed_mvtx_layers;
   std::set<unsigned int> fixed_intt_layers;
   std::set<unsigned int> fixed_sectors;
-  std::set<std::pair<unsigned int,unsigned int>> fixed_layer_params;
+  std::set<std::pair<unsigned int, unsigned int>> fixed_layer_params;
 
   // set default groups to lowest level
   AlignmentDefs::mvtxGrp mvtx_grp = AlignmentDefs::mvtxGrp::snsr;
@@ -172,48 +172,47 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   AlignmentDefs::tpcGrp tpc_grp = AlignmentDefs::tpcGrp::htst;
   AlignmentDefs::mmsGrp mms_grp = AlignmentDefs::mmsGrp::tl;
 
- /// tpc distortion correction utility class
+  /// tpc distortion correction utility class
   TpcDistortionCorrection _distortionCorrection;
 
   //  TrackSeedContainer *_svtx_seed_map{nullptr};
-  TrackSeedContainer *_track_map_tpc{nullptr};
-  TrackSeedContainer *_track_map_silicon{nullptr};
-  TrkrClusterContainer *_cluster_map{nullptr};
-  ActsGeometry *_tGeometry{nullptr};
+  TrackSeedContainer* _track_map_tpc{nullptr};
+  TrackSeedContainer* _track_map_silicon{nullptr};
+  TrkrClusterContainer* _cluster_map{nullptr};
+  ActsGeometry* _tGeometry{nullptr};
 
-  std::string data_outfilename {"mille_helical_output_data_file.bin"};
-  std::string steering_outfilename {"steer_helical.txt"};
-  std::string ntuple_outfilename {"HF_ntuple.root"};
+  std::string data_outfilename{"mille_helical_output_data_file.bin"};
+  std::string steering_outfilename{"steer_helical.txt"};
+  std::string ntuple_outfilename{"HF_ntuple.root"};
 
-  bool fitsilicon {true};
-  bool fittpc {false};
-  bool fitfulltrack {false};
+  bool fitsilicon{true};
+  bool fittpc{false};
+  bool fitfulltrack{false};
 
-  float dca_cut {0.19};  // cm
+  float dca_cut{0.19};  // cm
 
-  SvtxTrackMap* m_trackmap {nullptr};
-  SvtxAlignmentStateMap* m_alignmentmap {nullptr};
+  SvtxTrackMap* m_trackmap{nullptr};
+  SvtxAlignmentStateMap* m_alignmentmap{nullptr};
 
   std::string _field;
-  int _fieldDir {-1};
+  int _fieldDir{-1};
   std::map<unsigned int, float> _layerMisalignment;
 
-  std::string _track_map_name {"TpcTrackSeedContainer"};
-  std::string _silicon_track_map_name {"SiliconTrackSeedContainer"};
+  std::string _track_map_name{"TpcTrackSeedContainer"};
+  std::string _silicon_track_map_name{"SiliconTrackSeedContainer"};
 
-  bool make_ntuple {true};
-  TNtuple *ntp{nullptr};
-  TNtuple *track_ntp{nullptr};
-  TFile *fout{nullptr};
+  bool make_ntuple{true};
+  TNtuple* ntp{nullptr};
+  TNtuple* track_ntp{nullptr};
+  TFile* fout{nullptr};
 
-  bool use_event_vertex {false};
+  bool use_event_vertex{false};
 
-  int event {0};
+  int event{0};
 
   Acts::Vector3 vertexPosition;
   Acts::Vector3 vertexPosUncertainty;
   Acts::Vector2 vtx_sigma;
-
 };
 
-#endif // HELICALFITTER_H
+#endif  // HELICALFITTER_H

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -95,7 +95,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   // utility functions for analysis modules
   std::vector<float> fitClusters(std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey> cluskey_vec);
   void getTrackletClusters(TrackSeed *_track, std::vector<Acts::Vector3>& global_vec, std::vector<TrkrDefs::cluskey>& cluskey_vec);
-  Acts::Vector3 get_helix_pca(std::vector<float>& fitpars, Acts::Vector3 global);
+  Acts::Vector3 get_helix_pca(std::vector<float>& fitpars, const Acts::Vector3& global);
   void correctTpcGlobalPositions(std::vector<Acts::Vector3> global_vec,  std::vector<TrkrDefs::cluskey> cluskey_vec);
   unsigned int addSiliconClusters(std::vector<float>& fitpars, std::vector<Acts::Vector3>& global_vec,  std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
@@ -109,12 +109,12 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   int CreateNodes(PHCompositeNode* topNode);
   void getTrackletClusterList(TrackSeed *tracklet, std::vector<TrkrDefs::cluskey>& cluskey_vec);
 
-  Acts::Vector3 getPCALinePoint(Acts::Vector3 global, Acts::Vector3 tangent, Acts::Vector3 posref);
-  Acts::Vector3 get_line_plane_intersection(Acts::Vector3 PCA, Acts::Vector3 tangent, 
-					    Acts::Vector3 sensor_center, Acts::Vector3 sensor_normal);
+  Acts::Vector3 getPCALinePoint(const Acts::Vector3& global, const Acts::Vector3& tangent, const Acts::Vector3& posref);
+  Acts::Vector3 get_line_plane_intersection(const Acts::Vector3& PCA, const Acts::Vector3& tangent, 
+					    const Acts::Vector3& sensor_center, const Acts::Vector3& sensor_normal);
   std::pair<Acts::Vector3, Acts::Vector3> get_helix_tangent(const std::vector<float>& fitpars, Acts::Vector3 global);
-  Acts::Vector3 get_helix_surface_intersection(Surface surf, std::vector<float>& fitpars, Acts::Vector3 global);
-  Acts::Vector3 get_helix_surface_intersection(Surface surf, std::vector<float>& fitpars, Acts::Vector3 global, Acts::Vector3& pca, Acts::Vector3& tangent);
+  Acts::Vector3 get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global);
+  Acts::Vector3 get_helix_surface_intersection(const Surface& surf, std::vector<float>& fitpars, Acts::Vector3 global, Acts::Vector3& pca, Acts::Vector3& tangent);
 
   Acts::Vector3 get_helix_vtx(Acts::Vector3 event_vtx, const std::vector<float>& fitpars);
 
@@ -128,23 +128,23 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   bool is_intt_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
 
-  void getLocalDerivativesXY(Surface surf, Acts::Vector3 global, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5], unsigned int layer);
+  void getLocalDerivativesXY(const Surface& surf, const Acts::Vector3& global, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5], unsigned int layer);
 
-  void getLocalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 track_vtx, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5]);
+  void getLocalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& track_vtx, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5]);
 
-  void getGlobalDerivativesXY(Surface surf, Acts::Vector3 global, Acts::Vector3 fitpoint, const std::vector<float>& fitpars, float glb_derivativeX[6], float glbl_derivativeY[6], unsigned int layer);
+  void getGlobalDerivativesXY(const Surface& surf, Acts::Vector3 global, const Acts::Vector3& fitpoint, const std::vector<float>& fitpars, float glb_derivativeX[6], float glbl_derivativeY[6], unsigned int layer);
 
-  void getGlobalVtxDerivativesXY(SvtxTrack& track, Acts::Vector3 track_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3]);
+  void getGlobalVtxDerivativesXY(SvtxTrack& track, const Acts::Vector3& track_vtx, float glbl_derivativeX[3], float glbl_derivativeY[3]);
 
-  void get_projectionXY(Surface surf, std::pair<Acts::Vector3, Acts::Vector3> tangent, Acts::Vector3& projX, Acts::Vector3& projY);  
-  void get_projectionVtxXY(SvtxTrack& track, Acts::Vector3 event_vtx, Acts::Vector3& projX, Acts::Vector3& projY);
+  void get_projectionXY(const Surface& surf, const std::pair<Acts::Vector3, Acts::Vector3>& tangent, Acts::Vector3& projX, Acts::Vector3& projY);  
+  void get_projectionVtxXY(SvtxTrack& track, const Acts::Vector3& event_vtx, Acts::Vector3& projX, Acts::Vector3& projY);
 
   float getVertexResidual(Acts::Vector3 vtx);
   
-  void get_dca(SvtxTrack& track,  float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, Acts::Vector3 vertex);
-  Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3 event_vertex);
-  Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, Acts::Vector3 event_vertex, Acts::Vector3 PCA);
-  Acts::Vector3 localvtxToGlobalvtx(SvtxTrack& track, Acts::Vector3 event_vtx, Acts::Vector3 PCA);
+  void get_dca(SvtxTrack& track,  float& dca3dxy, float& dca3dz, float& dca3dxysigma, float& dca3dzsigma, const Acts::Vector3& vertex);
+  Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex);
+  Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex, Acts::Vector3 PCA);
+  Acts::Vector3 localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx, const Acts::Vector3& PCA);
 
 
 

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -4,12 +4,12 @@
 
 /// Tracking includes
 
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TpcDefs.h>  // for side
 #include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrDefs.h>
-#include <trackbase/MvtxDefs.h>
-#include <trackbase/TpcDefs.h>  // for side
 
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
@@ -61,8 +61,10 @@ MakeMilleFiles::MakeMilleFiles(const std::string& name)
 int MakeMilleFiles::InitRun(PHCompositeNode* topNode)
 {
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
-}
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
 
   // Instantiate Mille and open output data file
   //  _mille = new Mille(data_outfilename.c_str(), false);   // write text in data files, rather than binary, for debugging only
@@ -75,14 +77,14 @@ int MakeMilleFiles::InitRun(PHCompositeNode* topNode)
   steering_file.close();
 
   m_constraintFile.open(m_constraintFileName);
-  if(m_useEventVertex)
+  if (m_useEventVertex)
+  {
+    for (int i : AlignmentDefs::glbl_vtx_label)
     {
-      for(int i : AlignmentDefs::glbl_vtx_label)
-	{
-	  m_constraintFile << " Constraint   0.0" << std::endl;
-	  m_constraintFile << "       " << i << "   1" << std::endl;
-	}
+      m_constraintFile << " Constraint   0.0" << std::endl;
+      m_constraintFile << "       " << i << "   1" << std::endl;
     }
+  }
   // print grouping setup to log file:
   std::cout << "MakeMilleFiles::InitRun: Surface groupings are mvtx " << mvtx_group << " intt " << intt_group << " tpc " << tpc_group << " mms " << mms_group << std::endl;
 
@@ -119,12 +121,12 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
     std::cout << "state map size " << _state_map->size() << std::endl;
   }
 
-  Acts::Vector3 eventVertex = Acts::Vector3::Zero();  
-  if(m_useEventVertex)
-    {
-      eventVertex = getEventVertex();
-    }
-  
+  Acts::Vector3 eventVertex = Acts::Vector3::Zero();
+  if (m_useEventVertex)
+  {
+    eventVertex = getEventVertex();
+  }
+
   ActsPropagator propagator(_tGeometry);
 
   for (auto [key, statevec] : *_state_map)
@@ -135,9 +137,9 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
     {
       continue;
     }
-    
+
     SvtxTrack* track = iter->second;
-    
+
     if (Verbosity() > 0)
     {
       std::cout << std::endl
@@ -147,59 +149,62 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
 
     //! Make any desired track cuts here
     //! Maybe set a lower pT limit - low pT tracks are not very sensitive to alignment
-   addTrackToMilleFile(statevec);
+    addTrackToMilleFile(statevec);
 
-   //! Only take tracks that have 2 mm within event vertex
-   if(m_useEventVertex && 
-      fabs(track->get_z() - eventVertex.z()) < 0.2 &&
-      fabs(track->get_x()) < 0.2 && 
-      fabs(track->get_y()) < 0.2)
+    //! Only take tracks that have 2 mm within event vertex
+    if (m_useEventVertex &&
+        fabs(track->get_z() - eventVertex.z()) < 0.2 &&
+        fabs(track->get_x()) < 0.2 &&
+        fabs(track->get_y()) < 0.2)
+    {
+      //! set x and y to 0 since we are constraining to the x-y origin
+      //! and add constraints to pede later
+      eventVertex(0) = 0;
+      eventVertex(1) = 0;
+
+      auto dcapair = TrackAnalysisUtils::get_dca(track, eventVertex);
+      Acts::Vector2 vtx_residual(-dcapair.first.first, -dcapair.second.first);
+      vtx_residual *= Acts::UnitConstants::cm;
+
+      float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC];
+      bool success = getLocalVtxDerivativesXY(track, propagator,
+                                              eventVertex, lclvtx_derivative);
+
+      // The global derivs dimensions are [alpha/beta/gamma](x/y/z)
+      float glblvtx_derivative[SvtxAlignmentState::NRES][3];
+      getGlobalVtxDerivativesXY(track, eventVertex, glblvtx_derivative);
+
+      if (Verbosity() > 2)
       {
-	//! set x and y to 0 since we are constraining to the x-y origin
-	//! and add constraints to pede later
-	eventVertex(0) = 0; eventVertex(1) = 0;
-
-	auto dcapair = TrackAnalysisUtils::get_dca(track,eventVertex);
-	Acts::Vector2 vtx_residual(-dcapair.first.first, -dcapair.second.first);
-	vtx_residual *= Acts::UnitConstants::cm;
-
-	float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC];
-	bool success = getLocalVtxDerivativesXY(track, propagator,
-						eventVertex, lclvtx_derivative);
-	
-	// The global derivs dimensions are [alpha/beta/gamma](x/y/z)
-	float glblvtx_derivative[SvtxAlignmentState::NRES][3];
-	getGlobalVtxDerivativesXY(track, eventVertex, glblvtx_derivative);
-
-     	if(Verbosity() > 2)
-	  {
-	    std::cout << "vertex info for trakc " << track->get_id() << " with charge " << track->get_charge() << std::endl;
-	    std::cout << "vertex is " << eventVertex.transpose()<<std::endl;
-	    std::cout << "vertex residuals " << vtx_residual.transpose() 
-		      << std::endl;
-	    std::cout << "global vtx derivatives " << std::endl;
-	    for(auto & i : glblvtx_derivative) {
-	      for(float j : i) {
-		std::cout << j << ", ";
-	      }
-	      std::cout << std::endl;
-	    }
-	  }
-	if(success)
-	  {
-	    for(int i=0; i<2; i++)
-	      {	    
-		if(!isnan(vtx_residual(i)))
-		  {
-		    _mille->mille(SvtxAlignmentState::NLOC,lclvtx_derivative[i],
-				  AlignmentDefs::NGLVTX,glblvtx_derivative[i],
-				  AlignmentDefs::glbl_vtx_label,vtx_residual(i), 
-				  m_vtxSigma(i));
-		  }    
-	      }
-	  }
+        std::cout << "vertex info for trakc " << track->get_id() << " with charge " << track->get_charge() << std::endl;
+        std::cout << "vertex is " << eventVertex.transpose() << std::endl;
+        std::cout << "vertex residuals " << vtx_residual.transpose()
+                  << std::endl;
+        std::cout << "global vtx derivatives " << std::endl;
+        for (auto& i : glblvtx_derivative)
+        {
+          for (float j : i)
+          {
+            std::cout << j << ", ";
+          }
+          std::cout << std::endl;
+        }
       }
-   
+      if (success)
+      {
+        for (int i = 0; i < 2; i++)
+        {
+          if (!isnan(vtx_residual(i)))
+          {
+            _mille->mille(SvtxAlignmentState::NLOC, lclvtx_derivative[i],
+                          AlignmentDefs::NGLVTX, glblvtx_derivative[i],
+                          AlignmentDefs::glbl_vtx_label, vtx_residual(i),
+                          m_vtxSigma(i));
+          }
+        }
+      }
+    }
+
     //! Finish this track
     _mille->end();
   }
@@ -254,139 +259,140 @@ int MakeMilleFiles::GetNodes(PHCompositeNode* topNode)
 }
 
 bool MakeMilleFiles::getLocalVtxDerivativesXY(SvtxTrack* track,
-					      ActsPropagator& propagator,
-					      const Acts::Vector3& vertex,
-					      float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC])
+                                              ActsPropagator& propagator,
+                                              const Acts::Vector3& vertex,
+                                              float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC])
 {
-  //! Get the first track state beyond the vertex, which will be the 
+  //! Get the first track state beyond the vertex, which will be the
   //! innermost track state and propagate it to the vertex surface to
   //! get the jacobian at the vertex
-  SvtxTrackState* firststate = (*std::next(track->begin_states(),1)).second;
- 
+  SvtxTrackState* firststate = (*std::next(track->begin_states(), 1)).second;
+
   TrkrDefs::cluskey ckey = firststate->get_cluskey();
   auto cluster = _cluster_map->findCluster(ckey);
   auto surf = _tGeometry->maps().getSurface(ckey, cluster);
 
-  auto param = propagator.makeTrackParams(firststate,track->get_charge(),surf).value();
+  auto param = propagator.makeTrackParams(firststate, track->get_charge(), surf).value();
   auto perigee = propagator.makeVertexSurface(vertex);
   auto actspropagator = propagator.makePropagator();
 
   Acts::PropagatorOptions<> options(_tGeometry->geometry().getGeoContext(),
-				    _tGeometry->geometry().magFieldContext);
+                                    _tGeometry->geometry().magFieldContext);
 
   auto result = actspropagator.propagate(param, *perigee, options);
 
-  if(result.ok())
+  if (result.ok())
+  {
+    auto jacobian = *result.value().transportJacobian;
+
+    Eigen::Matrix<double, 2, 6> projector = Eigen::Matrix<double, 2, 6>::Zero();
+    projector(0, 0) = 1;
+    projector(1, 1) = 1;
+    auto deriv = projector * jacobian;
+    if (Verbosity() > 2)
     {
-      auto jacobian = *result.value().transportJacobian;
-
-      Eigen::Matrix<double,2,6> projector = Eigen::Matrix<double,2,6>::Zero();
-      projector(0,0) = 1;
-      projector(1,1) = 1;
-      auto deriv = projector * jacobian;
-      if(Verbosity() > 2)
-	{
-	  std::cout << "local vtxderiv " << std::endl << deriv << std::endl;
-	}
-
-      for(int i=0; i<deriv.rows(); i++)
-	{
-	for(int j=0; j<deriv.cols(); j++)
-	  {
-	    lclvtx_derivative[i][j] = deriv(i,j);
-	  }
-	}
-      
-      return true;
+      std::cout << "local vtxderiv " << std::endl
+                << deriv << std::endl;
     }
+
+    for (int i = 0; i < deriv.rows(); i++)
+    {
+      for (int j = 0; j < deriv.cols(); j++)
+      {
+        lclvtx_derivative[i][j] = deriv(i, j);
+      }
+    }
+
+    return true;
+  }
 
   return false;
 }
 
 void MakeMilleFiles::getGlobalVtxDerivativesXY(SvtxTrack* track,
-					       const Acts::Vector3& vertex,
-					       float glblvtx_derivative[SvtxAlignmentState::NRES][3])
+                                               const Acts::Vector3& vertex,
+                                               float glblvtx_derivative[SvtxAlignmentState::NRES][3])
 {
   Acts::SquareMatrix3 identity = Acts::SquareMatrix3::Identity();
 
   Acts::Vector3 projx = Acts::Vector3::Zero();
   Acts::Vector3 projy = Acts::Vector3::Zero();
   getProjectionVtxXY(track, vertex, projx, projy);
-  
+
   glblvtx_derivative[0][0] = identity.col(0).dot(projx);
   glblvtx_derivative[0][1] = identity.col(1).dot(projx);
   glblvtx_derivative[0][2] = identity.col(2).dot(projx);
   glblvtx_derivative[1][0] = identity.col(0).dot(projy);
   glblvtx_derivative[1][1] = identity.col(1).dot(projy);
   glblvtx_derivative[1][2] = identity.col(2).dot(projy);
-  
+
   /// swap sign to fit expectation of pede to have derivative of fit rather than
   /// residual
-  for(int i=0; i<2; i++) {
-    for(int j=0; j<3; j++) {
+  for (int i = 0; i < 2; i++)
+  {
+    for (int j = 0; j < 3; j++)
+    {
       glblvtx_derivative[i][j] *= -1;
     }
   }
 }
 void MakeMilleFiles::getProjectionVtxXY(SvtxTrack* track,
-					const Acts::Vector3& vertex,
-					Acts::Vector3& projx,
-					Acts::Vector3& projy)
+                                        const Acts::Vector3& vertex,
+                                        Acts::Vector3& projx,
+                                        Acts::Vector3& projy)
 {
   Acts::Vector3 tangent(track->get_px(), track->get_py(), track->get_pz());
   Acts::Vector3 normal(track->get_px(), track->get_py(), 0);
- 
+
   tangent /= tangent.norm();
   normal /= normal.norm();
 
-  Acts::Vector3 localx(1,0,0);
-  Acts::Vector3 localz(0,0,1);
-  
+  Acts::Vector3 localx(1, 0, 0);
+  Acts::Vector3 localz(0, 0, 1);
+
   Acts::Vector3 xglob = localToGlobalVertex(track, vertex, localx);
   Acts::Vector3 yglob = localz + vertex;
- 
-  Acts::Vector3 X = (xglob-vertex) / (xglob-vertex).norm(); 
-  Acts::Vector3 Y = (yglob-vertex) / (yglob-vertex).norm();
+
+  Acts::Vector3 X = (xglob - vertex) / (xglob - vertex).norm();
+  Acts::Vector3 Y = (yglob - vertex) / (yglob - vertex).norm();
 
   // see equation 31 of the ATLAS paper (and discussion) for this
   projx = X - (tangent.dot(X) / tangent.dot(normal)) * normal;
   projy = Y - (tangent.dot(Y) / tangent.dot(normal)) * normal;
 
   return;
-
 }
 Acts::Vector3 MakeMilleFiles::localToGlobalVertex(SvtxTrack* track,
-						  const Acts::Vector3& vertex,
-						  const Acts::Vector3& localx) const
+                                                  const Acts::Vector3& vertex,
+                                                  const Acts::Vector3& localx) const
 {
-   Acts::Vector3 mom(track->get_px(),
-		     track->get_py(),
-		     track->get_pz());
+  Acts::Vector3 mom(track->get_px(),
+                    track->get_py(),
+                    track->get_pz());
 
-  Acts::Vector3 r = mom.cross(Acts::Vector3(0.,0.,1.));
+  Acts::Vector3 r = mom.cross(Acts::Vector3(0., 0., 1.));
   float phi = atan2(r(1), r(0));
   Acts::RotationMatrix3 rot;
   Acts::RotationMatrix3 rot_T;
- 
-  rot(0,0) = cos(phi);
-  rot(0,1) = -sin(phi);
-  rot(0,2) = 0;
-  rot(1,0) = sin(phi);
-  rot(1,1) = cos(phi);
-  rot(1,2) = 0;
-  rot(2,0) = 0;
-  rot(2,1) = 0;
-  rot(2,2) = 1;
-  
+
+  rot(0, 0) = cos(phi);
+  rot(0, 1) = -sin(phi);
+  rot(0, 2) = 0;
+  rot(1, 0) = sin(phi);
+  rot(1, 1) = cos(phi);
+  rot(1, 2) = 0;
+  rot(2, 0) = 0;
+  rot(2, 1) = 0;
+  rot(2, 2) = 1;
+
   rot_T = rot.transpose();
 
   Acts::Vector3 pos_R = rot * localx;
 
   pos_R += vertex;
 
-  return pos_R; 
+  return pos_R;
 }
-						  
 
 Acts::Vector3 MakeMilleFiles::getEventVertex()
 {
@@ -398,28 +404,28 @@ Acts::Vector3 MakeMilleFiles::getEventVertex()
   float zsum = 0;
   int nacceptedtracks = 0;
 
-  for( auto [ key, statevec] : *_state_map)
+  for (auto [key, statevec] : *_state_map)
+  {
+    // Check if track was removed from cleaner
+    auto iter = _track_map->find(key);
+    if (iter == _track_map->end())
     {
-      // Check if track was removed from cleaner
-      auto iter = _track_map->find(key);
-      if (iter == _track_map->end())
-	{
-	  continue;
-	}
-      
-      SvtxTrack* track = iter->second;
-      
-      /// The track vertex is given by the fit as the PCA to the beamline
-      xsum += track->get_x();
-      ysum += track->get_y();
-      zsum += track->get_z();
-
-      nacceptedtracks++;
+      continue;
     }
 
-  return Acts::Vector3 (xsum/nacceptedtracks,
-			ysum/nacceptedtracks,
-			zsum/nacceptedtracks);
+    SvtxTrack* track = iter->second;
+
+    /// The track vertex is given by the fit as the PCA to the beamline
+    xsum += track->get_x();
+    ysum += track->get_y();
+    zsum += track->get_z();
+
+    nacceptedtracks++;
+  }
+
+  return Acts::Vector3(xsum / nacceptedtracks,
+                       ysum / nacceptedtracks,
+                       zsum / nacceptedtracks);
 }
 
 void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statevec)
@@ -431,7 +437,7 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
     if (Verbosity() > 2)
     {
       std::cout << "adding state for ckey " << ckey << " with hitsetkey "
-		<< (int) TrkrDefs::getHitSetKeyFromClusKey(ckey) << std::endl;
+                << (int) TrkrDefs::getHitSetKeyFromClusKey(ckey) << std::endl;
     }
     // The global alignment parameters are given initial values of zero by default, we do not specify them
     // We identify the global alignment parameters for this surface
@@ -451,8 +457,7 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
     double zerror = sqrt(para_errors.second);
     clus_sigma(1) = zerror * Acts::UnitConstants::cm;
     clus_sigma(0) = phierror * Acts::UnitConstants::cm;
-    
-    
+
     if (std::isnan(clus_sigma(0)) ||
         std::isnan(clus_sigma(1)))
     {
@@ -466,10 +471,10 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
     {
       AlignmentDefs::getMvtxGlobalLabels(surf, glbl_label, mvtx_group);
     }
-    else if(layer > 2 && layer < 7)
-      {
+    else if (layer > 2 && layer < 7)
+    {
       AlignmentDefs::getInttGlobalLabels(surf, glbl_label, intt_group);
-      }
+    }
     else if (layer < 55)
     {
       AlignmentDefs::getTpcGlobalLabels(surf, ckey, glbl_label, tpc_group);
@@ -493,42 +498,42 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
       {
         glbl_derivative[j] = state->get_global_derivative_matrix()(i, j);
 
-        if (is_layer_fixed(layer) || 
-	    is_layer_param_fixed(layer, j, fixed_layer_gparams))
+        if (is_layer_fixed(layer) ||
+            is_layer_param_fixed(layer, j, fixed_layer_gparams))
         {
           glbl_derivative[j] = 0.;
         }
 
-	if(trkrid == TrkrDefs::mvtxId)
-	  {
-	    // need stave to get clamshell
-	    auto stave  = MvtxDefs::getStaveId(ckey);
-	    auto clamshell = AlignmentDefs::getMvtxClamshell(layer, stave);
-	    if( is_layer_param_fixed(layer, j, fixed_layer_gparams) || 
-		is_mvtx_layer_fixed(layer,clamshell) )
-	      {
-		glbl_derivative[j] = 0;
-	      }
-	  }
-	else if(trkrid == TrkrDefs::inttId)
-	  {
-	    if( is_layer_param_fixed(layer, j, fixed_layer_gparams) || 
-		is_layer_fixed(layer) )
-	      {
-		glbl_derivative[j] = 0;
-	      }
-	  }
-	if(trkrid == TrkrDefs::tpcId)
-	  {
-	    auto sector = TpcDefs::getSectorId(ckey);
-	    auto side = TpcDefs::getSide(ckey);
-	    if(is_layer_param_fixed(layer, j, fixed_layer_gparams) || 
-	       is_tpc_sector_fixed(layer, sector, side) ||
-	       is_layer_fixed(layer))
-	      {
-		glbl_derivative[j] = 0.0;
-	      }
-	  }
+        if (trkrid == TrkrDefs::mvtxId)
+        {
+          // need stave to get clamshell
+          auto stave = MvtxDefs::getStaveId(ckey);
+          auto clamshell = AlignmentDefs::getMvtxClamshell(layer, stave);
+          if (is_layer_param_fixed(layer, j, fixed_layer_gparams) ||
+              is_mvtx_layer_fixed(layer, clamshell))
+          {
+            glbl_derivative[j] = 0;
+          }
+        }
+        else if (trkrid == TrkrDefs::inttId)
+        {
+          if (is_layer_param_fixed(layer, j, fixed_layer_gparams) ||
+              is_layer_fixed(layer))
+          {
+            glbl_derivative[j] = 0;
+          }
+        }
+        if (trkrid == TrkrDefs::tpcId)
+        {
+          auto sector = TpcDefs::getSectorId(ckey);
+          auto side = TpcDefs::getSide(ckey);
+          if (is_layer_param_fixed(layer, j, fixed_layer_gparams) ||
+              is_tpc_sector_fixed(layer, sector, side) ||
+              is_layer_fixed(layer))
+          {
+            glbl_derivative[j] = 0.0;
+          }
+        }
       }
 
       float lcl_derivative[SvtxAlignmentState::NLOC];
@@ -536,10 +541,10 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
       {
         lcl_derivative[j] = state->get_local_derivative_matrix()(i, j);
 
-	if(is_layer_param_fixed(layer, j, fixed_layer_lparams))
-	  {
-	    lcl_derivative[j] = 0.;
-	  }
+        if (is_layer_param_fixed(layer, j, fixed_layer_lparams))
+        {
+          lcl_derivative[j] = 0.;
+        }
       }
       if (Verbosity() > 2)
       {
@@ -548,9 +553,10 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
 
         for (float k : glbl_derivative)
         {
-          if (k > 0 || k < 0) {
+          if (k > 0 || k < 0)
+          {
             std::cout << "NONZERO GLOBAL DERIVATIVE" << std::endl;
-}
+          }
           std::cout << k << ", ";
         }
         std::cout << std::endl
@@ -574,13 +580,12 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
         {
           errinf = m_layerMisalignment.find(layer)->second;
         }
-              
-      _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf * clus_sigma(i));
+
+        _mille->mille(SvtxAlignmentState::NLOC, lcl_derivative, SvtxAlignmentState::NGL, glbl_derivative, glbl_label, residual(i), errinf * clus_sigma(i));
       }
     }
   }
 
-  
   return;
 }
 
@@ -588,9 +593,10 @@ bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
 {
   bool ret = false;
   auto it = fixed_layers.find(layer);
-  if (it != fixed_layers.end()) {
+  if (it != fixed_layers.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
@@ -611,47 +617,50 @@ bool MakeMilleFiles::is_mvtx_layer_fixed(unsigned int layer, unsigned int clamsh
 {
   bool ret = false;
 
-  std::pair pair = std::make_pair(layer,clamshell);
+  std::pair pair = std::make_pair(layer, clamshell);
   auto it = fixed_mvtx_layers.find(pair);
-  if(it != fixed_mvtx_layers.end()) { 
+  if (it != fixed_mvtx_layers.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
 void MakeMilleFiles::set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell)
 {
-  fixed_mvtx_layers.insert(std::make_pair(layer,clamshell));
+  fixed_mvtx_layers.insert(std::make_pair(layer, clamshell));
 }
 bool MakeMilleFiles::is_layer_param_fixed(unsigned int layer, unsigned int param, std::set<std::pair<unsigned int, unsigned int>>& param_fixed)
 {
   bool ret = false;
   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
   auto it = param_fixed.find(pair);
-  if (it != param_fixed.end()) {
+  if (it != param_fixed.end())
+  {
     ret = true;
-}
+  }
 
   return ret;
 }
 
 void MakeMilleFiles::set_layer_gparam_fixed(unsigned int layer, unsigned int param)
 {
-  fixed_layer_gparams.insert(std::make_pair(layer,param));
+  fixed_layer_gparams.insert(std::make_pair(layer, param));
 }
 void MakeMilleFiles::set_layer_lparam_fixed(unsigned int layer, unsigned int param)
 {
-  fixed_layer_lparams.insert(std::make_pair(layer,param));
+  fixed_layer_lparams.insert(std::make_pair(layer, param));
 }
 bool MakeMilleFiles::is_tpc_sector_fixed(unsigned int layer, unsigned int sector, unsigned int side)
- {
-   bool ret = false;
-   unsigned int region = AlignmentDefs::getTpcRegion(layer);
-   unsigned int subsector = region * 24 + side * 12 + sector;
-   auto it = fixed_sectors.find(subsector);
-   if(it != fixed_sectors.end()) { 
-     ret = true;
-}
+{
+  bool ret = false;
+  unsigned int region = AlignmentDefs::getTpcRegion(layer);
+  unsigned int subsector = region * 24 + side * 12 + sector;
+  auto it = fixed_sectors.find(subsector);
+  if (it != fixed_sectors.end())
+  {
+    ret = true;
+  }
 
-   return ret;
- }
+  return ret;
+}

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.cc
@@ -61,7 +61,8 @@ MakeMilleFiles::MakeMilleFiles(const std::string& name)
 int MakeMilleFiles::InitRun(PHCompositeNode* topNode)
 {
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
+}
 
   // Instantiate Mille and open output data file
   //  _mille = new Mille(data_outfilename.c_str(), false);   // write text in data files, rather than binary, for debugging only
@@ -76,10 +77,10 @@ int MakeMilleFiles::InitRun(PHCompositeNode* topNode)
   m_constraintFile.open(m_constraintFileName);
   if(m_useEventVertex)
     {
-      for(int i=0; i<AlignmentDefs::NGLVTX; i++)
+      for(int i : AlignmentDefs::glbl_vtx_label)
 	{
 	  m_constraintFile << " Constraint   0.0" << std::endl;
-	  m_constraintFile << "       " << AlignmentDefs::glbl_vtx_label[i] << "   1" << std::endl;
+	  m_constraintFile << "       " << i << "   1" << std::endl;
 	}
     }
   // print grouping setup to log file:
@@ -177,9 +178,9 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
 	    std::cout << "vertex residuals " << vtx_residual.transpose() 
 		      << std::endl;
 	    std::cout << "global vtx derivatives " << std::endl;
-	    for(int i=0; i<2;i++) {
-	      for(int j=0; j<3; j++) {
-		std::cout << glblvtx_derivative[i][j] << ", ";
+	    for(auto & i : glblvtx_derivative) {
+	      for(float j : i) {
+		std::cout << j << ", ";
 	      }
 	      std::cout << std::endl;
 	    }
@@ -211,7 +212,7 @@ int MakeMilleFiles::process_event(PHCompositeNode* /*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int MakeMilleFiles::End(PHCompositeNode*)
+int MakeMilleFiles::End(PHCompositeNode* /*unused*/)
 {
   delete _mille;
   m_constraintFile.close();
@@ -545,17 +546,18 @@ void MakeMilleFiles::addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statev
         std::cout << "coordinate " << i << " has residual " << residual(i) << " and clus_sigma " << clus_sigma(i) << std::endl
                   << "global deriv " << std::endl;
 
-        for (int k = 0; k < SvtxAlignmentState::NGL; k++)
+        for (float k : glbl_derivative)
         {
-          if (glbl_derivative[k] > 0 || glbl_derivative[k] < 0)
+          if (k > 0 || k < 0) {
             std::cout << "NONZERO GLOBAL DERIVATIVE" << std::endl;
-          std::cout << glbl_derivative[k] << ", ";
+}
+          std::cout << k << ", ";
         }
         std::cout << std::endl
                   << "local deriv " << std::endl;
-        for (int k = 0; k < SvtxAlignmentState::NLOC; k++)
+        for (float k : lcl_derivative)
         {
-          std::cout << lcl_derivative[k] << ", ";
+          std::cout << k << ", ";
         }
         std::cout << std::endl;
       }
@@ -586,8 +588,9 @@ bool MakeMilleFiles::is_layer_fixed(unsigned int layer)
 {
   bool ret = false;
   auto it = fixed_layers.find(layer);
-  if (it != fixed_layers.end())
+  if (it != fixed_layers.end()) {
     ret = true;
+}
 
   return ret;
 }
@@ -610,8 +613,9 @@ bool MakeMilleFiles::is_mvtx_layer_fixed(unsigned int layer, unsigned int clamsh
 
   std::pair pair = std::make_pair(layer,clamshell);
   auto it = fixed_mvtx_layers.find(pair);
-  if(it != fixed_mvtx_layers.end()) 
+  if(it != fixed_mvtx_layers.end()) { 
     ret = true;
+}
 
   return ret;
 }
@@ -624,8 +628,9 @@ bool MakeMilleFiles::is_layer_param_fixed(unsigned int layer, unsigned int param
   bool ret = false;
   std::pair<unsigned int, unsigned int> pair = std::make_pair(layer, param);
   auto it = param_fixed.find(pair);
-  if (it != param_fixed.end())
+  if (it != param_fixed.end()) {
     ret = true;
+}
 
   return ret;
 }
@@ -644,8 +649,9 @@ bool MakeMilleFiles::is_tpc_sector_fixed(unsigned int layer, unsigned int sector
    unsigned int region = AlignmentDefs::getTpcRegion(layer);
    unsigned int subsector = region * 24 + side * 12 + sector;
    auto it = fixed_sectors.find(subsector);
-   if(it != fixed_sectors.end()) 
+   if(it != fixed_sectors.end()) { 
      ret = true;
+}
 
    return ret;
  }

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -58,19 +58,19 @@ class MakeMilleFiles : public SubsysReco
   void set_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void set_layer_gparam_fixed(unsigned int layer, unsigned int param);
   void set_layer_lparam_fixed(unsigned int layer, unsigned int param);
-  
+
   void set_layers_fixed(unsigned int minlayer, unsigned int maxlayer);
   void set_error_inflation_factor(unsigned int layer, float factor)
   {
     m_layerMisalignment.insert(std::make_pair(layer, factor));
   }
-  void set_tpc_sector_fixed(unsigned int region, unsigned int sector, 
-			    unsigned int side)
- {
-   // make a combined subsector index
-   unsigned int subsector = region * 24 + side * 12 + sector;
-   fixed_sectors.insert(subsector);
- }
+  void set_tpc_sector_fixed(unsigned int region, unsigned int sector,
+                            unsigned int side)
+  {
+    // make a combined subsector index
+    unsigned int subsector = region * 24 + side * 12 + sector;
+    fixed_sectors.insert(subsector);
+  }
   void set_vtx_sigma(float xysig, float zsig)
   {
     m_vtxSigma(0) = xysig;
@@ -91,17 +91,17 @@ class MakeMilleFiles : public SubsysReco
   bool is_mvtx_layer_fixed(unsigned int layer, unsigned int clamshell);
   void addTrackToMilleFile(SvtxAlignmentStateMap::StateVec& statevec);
   void getGlobalVtxDerivativesXY(SvtxTrack* track,
-				 const Acts::Vector3& vertex,
-				 float glblvtx_derivative[SvtxAlignmentState::NRES][3]);
+                                 const Acts::Vector3& vertex,
+                                 float glblvtx_derivative[SvtxAlignmentState::NRES][3]);
   bool getLocalVtxDerivativesXY(SvtxTrack* track,
-				ActsPropagator& propagator,
-				const Acts::Vector3& vertex,
-				float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC]);
+                                ActsPropagator& propagator,
+                                const Acts::Vector3& vertex,
+                                float lclvtx_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC]);
   Acts::Vector3 localToGlobalVertex(SvtxTrack* track,
-				    const Acts::Vector3& vertex,
-				    const Acts::Vector3& localx) const;
+                                    const Acts::Vector3& vertex,
+                                    const Acts::Vector3& localx) const;
   void getProjectionVtxXY(SvtxTrack* track, const Acts::Vector3& vertex,
-			  Acts::Vector3& projx, Acts::Vector3& projy);
+                          Acts::Vector3& projx, Acts::Vector3& projy);
 
   std::string data_outfilename = ("mille_output_data_file.bin");
   std::string steering_outfilename = ("steer.txt");
@@ -120,7 +120,7 @@ class MakeMilleFiles : public SubsysReco
   AlignmentDefs::mmsGrp mms_group = AlignmentDefs::mmsGrp::tl;
 
   std::set<unsigned int> fixed_layers;
-  std::set<std::pair<unsigned int,unsigned int>> fixed_mvtx_layers;
+  std::set<std::pair<unsigned int, unsigned int>> fixed_mvtx_layers;
   std::set<std::pair<unsigned int, unsigned int>> fixed_layer_gparams, fixed_layer_lparams;
 
   std::string m_constraintFileName = "mp2con.txt";

--- a/offline/packages/TrackerMillepedeAlignment/Mille.cc
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.cc
@@ -79,9 +79,12 @@ void Mille::mille(int NLC, const float *derLc,
 		  int NGL, const float *derGl, const int *label,
 		  float rMeas, float sigma)
 {
-  if (sigma <= 0.) return;
-  if (myBufferPos == -1) this->newSet(); // start, e.g. new track
-  if (!this->checkBufferSize(NLC, NGL)) return;
+  if (sigma <= 0.) { return;
+}
+  if (myBufferPos == -1) { this->newSet(); // start, e.g. new track
+}
+  if (!this->checkBufferSize(NLC, NGL)) { return;
+}
 
   // first store measurement
   ++myBufferPos;
@@ -126,14 +129,17 @@ void Mille::mille(int NLC, const float *derLc,
  */
 void Mille::special(int nSpecial, const float *floatings, const int *integers)
 {
-  if (nSpecial == 0) return;
-  if (myBufferPos == -1) this->newSet(); // start, e.g. new track
+  if (nSpecial == 0) { return;
+}
+  if (myBufferPos == -1) { this->newSet(); // start, e.g. new track
+}
   if (myHasSpecial) {
     std::cerr << "Mille::special: Special values already stored for this record."
 	      << std::endl; 
     return;
   }
-  if (!this->checkBufferSize(nSpecial, 0)) return;
+  if (!this->checkBufferSize(nSpecial, 0)) { return;
+}
   myHasSpecial = true; // after newSet() (Note: MILLSP sets to buffer position...)
 
   //  myBufferFloat[.]  | myBufferInt[.]

--- a/offline/packages/TrackerMillepedeAlignment/Mille.cc
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.cc
@@ -42,18 +42,22 @@
  * \param[in] asBinary     flag for binary
  * \param[in] writeZero    flag for keeping of zeros
  */
-Mille::Mille(const char *outFileName, bool asBinary, bool writeZero) : 
-  myOutFile(outFileName, (asBinary ? (std::ios::binary | std::ios::out) : std::ios::out)),
-  myAsBinary(asBinary), myWriteZero(writeZero), myBufferPos(-1), myHasSpecial(false)
+Mille::Mille(const char *outFileName, bool asBinary, bool writeZero)
+  : myOutFile(outFileName, (asBinary ? (std::ios::binary | std::ios::out) : std::ios::out))
+  , myAsBinary(asBinary)
+  , myWriteZero(writeZero)
+  , myBufferPos(-1)
+  , myHasSpecial(false)
 {
   // Instead myBufferPos(-1), myHasSpecial(false) and the following two lines
   // we could call newSet() and kill()...
-  myBufferInt[0]   = 0;
+  myBufferInt[0] = 0;
   myBufferFloat[0] = 0.;
 
-  if (!myOutFile.is_open()) {
-    std::cerr << "Mille::Mille: Could not open " << outFileName 
-	      << " as output file." << std::endl;
+  if (!myOutFile.is_open())
+  {
+    std::cerr << "Mille::Mille: Could not open " << outFileName
+              << " as output file." << std::endl;
   }
 }
 
@@ -76,45 +80,58 @@ Mille::~Mille()
  * \param[in]    sigma  error
  */
 void Mille::mille(int NLC, const float *derLc,
-		  int NGL, const float *derGl, const int *label,
-		  float rMeas, float sigma)
+                  int NGL, const float *derGl, const int *label,
+                  float rMeas, float sigma)
 {
-  if (sigma <= 0.) { return;
-}
-  if (myBufferPos == -1) { this->newSet(); // start, e.g. new track
-}
-  if (!this->checkBufferSize(NLC, NGL)) { return;
-}
+  if (sigma <= 0.)
+  {
+    return;
+  }
+  if (myBufferPos == -1)
+  {
+    this->newSet();  // start, e.g. new track
+  }
+  if (!this->checkBufferSize(NLC, NGL))
+  {
+    return;
+  }
 
   // first store measurement
   ++myBufferPos;
   myBufferFloat[myBufferPos] = rMeas;
-  myBufferInt  [myBufferPos] = 0;
+  myBufferInt[myBufferPos] = 0;
 
   // store local derivatives and local 'lables' 1,...,NLC
-  for (int i = 0; i < NLC; ++i) {
-    if (derLc[i] || myWriteZero) { // by default store only non-zero derivatives
+  for (int i = 0; i < NLC; ++i)
+  {
+    if (derLc[i] || myWriteZero)
+    {  // by default store only non-zero derivatives
       ++myBufferPos;
-      myBufferFloat[myBufferPos] = derLc[i]; // local derivatives
-      myBufferInt  [myBufferPos] = i+1;      // index of local parameter
+      myBufferFloat[myBufferPos] = derLc[i];  // local derivatives
+      myBufferInt[myBufferPos] = i + 1;       // index of local parameter
     }
   }
 
   // store uncertainty of measurement in between locals and globals
   ++myBufferPos;
   myBufferFloat[myBufferPos] = sigma;
-  myBufferInt  [myBufferPos] = 0;
+  myBufferInt[myBufferPos] = 0;
 
   // store global derivatives and their labels
-  for (int i = 0; i < NGL; ++i) {
-    if (derGl[i] || myWriteZero) { // by default store only non-zero derivatives
-      if ((label[i] > 0 || myWriteZero) && label[i] <= myMaxLabel) { // and for valid labels
-	++myBufferPos;
-	myBufferFloat[myBufferPos] = derGl[i]; // global derivatives
-	myBufferInt  [myBufferPos] = label[i]; // index of global parameter
-      } else {
-	std::cerr << "Mille::mille: Invalid label " << label[i] 
-		  << " <= 0 or > " << myMaxLabel << std::endl; 
+  for (int i = 0; i < NGL; ++i)
+  {
+    if (derGl[i] || myWriteZero)
+    {  // by default store only non-zero derivatives
+      if ((label[i] > 0 || myWriteZero) && label[i] <= myMaxLabel)
+      {  // and for valid labels
+        ++myBufferPos;
+        myBufferFloat[myBufferPos] = derGl[i];  // global derivatives
+        myBufferInt[myBufferPos] = label[i];    // index of global parameter
+      }
+      else
+      {
+        std::cerr << "Mille::mille: Invalid label " << label[i]
+                  << " <= 0 or > " << myMaxLabel << std::endl;
       }
     }
   }
@@ -129,18 +146,25 @@ void Mille::mille(int NLC, const float *derLc,
  */
 void Mille::special(int nSpecial, const float *floatings, const int *integers)
 {
-  if (nSpecial == 0) { return;
-}
-  if (myBufferPos == -1) { this->newSet(); // start, e.g. new track
-}
-  if (myHasSpecial) {
-    std::cerr << "Mille::special: Special values already stored for this record."
-	      << std::endl; 
+  if (nSpecial == 0)
+  {
     return;
   }
-  if (!this->checkBufferSize(nSpecial, 0)) { return;
-}
-  myHasSpecial = true; // after newSet() (Note: MILLSP sets to buffer position...)
+  if (myBufferPos == -1)
+  {
+    this->newSet();  // start, e.g. new track
+  }
+  if (myHasSpecial)
+  {
+    std::cerr << "Mille::special: Special values already stored for this record."
+              << std::endl;
+    return;
+  }
+  if (!this->checkBufferSize(nSpecial, 0))
+  {
+    return;
+  }
+  myHasSpecial = true;  // after newSet() (Note: MILLSP sets to buffer position...)
 
   //  myBufferFloat[.]  | myBufferInt[.]
   // ------------------------------------
@@ -148,18 +172,19 @@ void Mille::special(int nSpecial, const float *floatings, const int *integers)
   //  -float(nSpecial)  |      0
   //  The above indicates special data, following are nSpecial floating and nSpecial integer data.
 
-  ++myBufferPos; // zero pair
+  ++myBufferPos;  // zero pair
   myBufferFloat[myBufferPos] = 0.;
-  myBufferInt  [myBufferPos] = 0;
+  myBufferInt[myBufferPos] = 0;
 
-  ++myBufferPos; // nSpecial and zero
-  myBufferFloat[myBufferPos] = -nSpecial; // automatic conversion to float
-  myBufferInt  [myBufferPos] = 0;
+  ++myBufferPos;                           // nSpecial and zero
+  myBufferFloat[myBufferPos] = -nSpecial;  // automatic conversion to float
+  myBufferInt[myBufferPos] = 0;
 
-  for (int i = 0; i < nSpecial; ++i) {
+  for (int i = 0; i < nSpecial; ++i)
+  {
     ++myBufferPos;
     myBufferFloat[myBufferPos] = floatings[i];
-    myBufferInt  [myBufferPos] = integers[i];
+    myBufferInt[myBufferPos] = integers[i];
   }
 }
 
@@ -176,30 +201,36 @@ void Mille::end()
 {
   // std:: cout << " Mille::end() called with myBufferPos " << myBufferPos << std::endl;
 
-  if (myBufferPos > 0) { // only if anything stored...
-    const int numWordsToWrite = (myBufferPos + 1)*2;
+  if (myBufferPos > 0)
+  {  // only if anything stored...
+    const int numWordsToWrite = (myBufferPos + 1) * 2;
 
-    if (myAsBinary) {
-      myOutFile.write(reinterpret_cast<const char*>(&numWordsToWrite), 
-		      sizeof(numWordsToWrite));
-      myOutFile.write(reinterpret_cast<char*>(myBufferFloat), 
-		      (myBufferPos+1) * sizeof(myBufferFloat[0]));
-      myOutFile.write(reinterpret_cast<char*>(myBufferInt), 
-		      (myBufferPos+1) * sizeof(myBufferInt[0]));
-    } else {
+    if (myAsBinary)
+    {
+      myOutFile.write(reinterpret_cast<const char *>(&numWordsToWrite),
+                      sizeof(numWordsToWrite));
+      myOutFile.write(reinterpret_cast<char *>(myBufferFloat),
+                      (myBufferPos + 1) * sizeof(myBufferFloat[0]));
+      myOutFile.write(reinterpret_cast<char *>(myBufferInt),
+                      (myBufferPos + 1) * sizeof(myBufferInt[0]));
+    }
+    else
+    {
       myOutFile << numWordsToWrite << "\n";
-      for (int i = 0; i < myBufferPos+1; ++i) {
-	myOutFile << myBufferFloat[i] << " ";
+      for (int i = 0; i < myBufferPos + 1; ++i)
+      {
+        myOutFile << myBufferFloat[i] << " ";
       }
       myOutFile << "\n";
-      
-      for (int i = 0; i < myBufferPos+1; ++i) {
-	myOutFile << myBufferInt[i] << " ";
+
+      for (int i = 0; i < myBufferPos + 1; ++i)
+      {
+        myOutFile << myBufferInt[i] << " ";
       }
       myOutFile << "\n";
     }
   }
-  myBufferPos = -1; // reset buffer for next set of derivatives
+  myBufferPos = -1;  // reset buffer for next set of derivatives
 
   //  std:: cout << " Mille::end() finished with myBufferPos " << myBufferPos << std::endl;
 }
@@ -211,7 +242,7 @@ void Mille::newSet()
   myBufferPos = 0;
   myHasSpecial = false;
   myBufferFloat[0] = 0.0;
-  myBufferInt  [0] = 0;   // position 0 used as error counter
+  myBufferInt[0] = 0;  // position 0 used as error counter
 }
 
 //___________________________________________________________________________
@@ -223,16 +254,19 @@ void Mille::newSet()
  */
 bool Mille::checkBufferSize(int nLocal, int nGlobal)
 {
-  if (myBufferPos + nLocal + nGlobal + 2 >= myBufferSize) {
-    ++(myBufferInt[0]); // increase error count
-    std::cerr << "Mille::checkBufferSize: Buffer too short (" 
-	      << myBufferSize << "),"
-	      << "\n need space for nLocal (" << nLocal<< ")"
-	      << "/nGlobal (" << nGlobal << ") local/global derivatives, " 
-	      << myBufferPos + 1 << " already stored!"
-	      << std::endl;
+  if (myBufferPos + nLocal + nGlobal + 2 >= myBufferSize)
+  {
+    ++(myBufferInt[0]);  // increase error count
+    std::cerr << "Mille::checkBufferSize: Buffer too short ("
+              << myBufferSize << "),"
+              << "\n need space for nLocal (" << nLocal << ")"
+              << "/nGlobal (" << nGlobal << ") local/global derivatives, "
+              << myBufferPos + 1 << " already stored!"
+              << std::endl;
     return false;
-  } else {
+  }
+  else
+  {
     return true;
   }
 }

--- a/offline/packages/TrackerMillepedeAlignment/Mille.h
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.h
@@ -23,9 +23,9 @@
  *  675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <fstream>
 #include <climits>
-
+#include <fstream>
+#include <limits>
 /**
  * \class Mille
  *
@@ -74,6 +74,6 @@ class Mille
   int   myBufferPos; ///< position in buffer
   bool  myHasSpecial; ///< if true, special(..) already called for this record
   /// largest label allowed
-   enum {myMaxLabel = INT_MAX - 1};
+  enum {myMaxLabel = std::numeric_limits<int>::max() - 1};
 };
 #endif

--- a/offline/packages/TrackerMillepedeAlignment/Mille.h
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.h
@@ -69,8 +69,8 @@ class Mille
   bool myWriteZero;        ///< if true also write out derivatives/labels ==0
   /// buffer size for ints and floats
   enum {myBufferSize = 10000};  ///< buffer size for ints and floats
-  int   myBufferInt[myBufferSize];   ///< to collect labels etc.
-  float myBufferFloat[myBufferSize]; ///< to collect derivatives etc.
+  int   myBufferInt[myBufferSize]{};   ///< to collect labels etc.
+  float myBufferFloat[myBufferSize]{}; ///< to collect derivatives etc.
   int   myBufferPos; ///< position in buffer
   bool  myHasSpecial; ///< if true, special(..) already called for this record
   /// largest label allowed

--- a/offline/packages/TrackerMillepedeAlignment/Mille.h
+++ b/offline/packages/TrackerMillepedeAlignment/Mille.h
@@ -48,14 +48,14 @@
  */
 
 /// Class to write C binary file.
-class Mille 
+class Mille
 {
  public:
   Mille(const char *outFileName, bool asBinary = true, bool writeZero = false);
   ~Mille();
 
   void mille(int NLC, const float *derLc, int NGL, const float *derGl,
-	     const int *label, float rMeas, float sigma);
+             const int *label, float rMeas, float sigma);
   void special(int nSpecial, const float *floatings, const int *integers);
   void kill();
   void end();
@@ -64,16 +64,22 @@ class Mille
   void newSet();
   bool checkBufferSize(int nLocal, int nGlobal);
 
-  std::ofstream myOutFile; ///< C-binary for output
-  bool myAsBinary;         ///< if false output as text
-  bool myWriteZero;        ///< if true also write out derivatives/labels ==0
+  std::ofstream myOutFile;  ///< C-binary for output
+  bool myAsBinary;          ///< if false output as text
+  bool myWriteZero;         ///< if true also write out derivatives/labels ==0
   /// buffer size for ints and floats
-  enum {myBufferSize = 10000};  ///< buffer size for ints and floats
-  int   myBufferInt[myBufferSize]{};   ///< to collect labels etc.
-  float myBufferFloat[myBufferSize]{}; ///< to collect derivatives etc.
-  int   myBufferPos; ///< position in buffer
-  bool  myHasSpecial; ///< if true, special(..) already called for this record
+  enum
+  {
+    myBufferSize = 10000
+  };                                    ///< buffer size for ints and floats
+  int myBufferInt[myBufferSize]{};      ///< to collect labels etc.
+  float myBufferFloat[myBufferSize]{};  ///< to collect derivatives etc.
+  int myBufferPos;                      ///< position in buffer
+  bool myHasSpecial;                    ///< if true, special(..) already called for this record
   /// largest label allowed
-  enum {myMaxLabel = std::numeric_limits<int>::max() - 1};
+  enum
+  {
+    myMaxLabel = std::numeric_limits<int>::max() - 1
+  };
 };
 #endif

--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -420,7 +420,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     if(trackSeed.GetQPt()<0) track_charge = -1 * _fieldDir;
     else track_charge = 1 * _fieldDir;
     
-    double s = sin(track_phi);
+    double sinphi = sin(track_phi); // who had the idea to use s here?????
     double c = cos(track_phi);
     double p = trackSeed.GetSinPhi();
     
@@ -489,7 +489,7 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     // py = pX*sin(track_phi) + pY*cos(track_phi)
     // pz = pt*(dz/ds)
     Eigen::Matrix<double,6,5> J;
-    J(0,0) = -s; // dx/dY
+    J(0,0) = -sinphi; // dx/dY
     J(0,1) = 0.; // dx/dZ
     J(0,2) = 0.; // dx/d(sinphi)
     J(0,3) = 0.; // dx/d(dz/ds)
@@ -509,15 +509,15 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
 
     J(3,0) = 0.; // dpx/dY
     J(3,1) = 0.; // dpx/dZ
-    J(3,2) = -track_pt*(p*c/sqrt(1-p*p)+s); // dpx/d(sinphi)
+    J(3,2) = -track_pt*(p*c/sqrt(1-p*p)+sinphi); // dpx/d(sinphi)
     J(3,3) = 0.; // dpx/d(dz/ds)
-    J(3,4) = track_pt*track_pt*track_charge*(p*s-c*sqrt(1-p*p)); // dpx/d(Q/pt)
+    J(3,4) = track_pt*track_pt*track_charge*(p*sinphi-c*sqrt(1-p*p)); // dpx/d(Q/pt)
 
     J(4,0) = 0.; // dpy/dY
     J(4,1) = 0.; // dpy/dZ
-    J(4,2) = track_pt*(c-p*s/sqrt(1-p*p)); // dpy/d(sinphi)
+    J(4,2) = track_pt*(c-p*sinphi/sqrt(1-p*p)); // dpy/d(sinphi)
     J(4,3) = 0.; // dpy/d(dz/ds)
-    J(4,4) = -track_pt*track_pt*track_charge*(p*c+s*sqrt(1-p*p)); // dpy/d(Q/pt)
+    J(4,4) = -track_pt*track_pt*track_charge*(p*c+sinphi*sqrt(1-p*p)); // dpy/d(Q/pt)
 
     J(5,0) = 0.; // dpz/dY
     J(5,1) = 0.; // dpz/dZ

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -61,7 +61,7 @@ class ActsAlignmentStates
 
   int m_verbosity = 0;
 
-  float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
+//  float sensorAngles[3] = {0.1, 0.1, 0.2};  // perturbation values for each alignment angle
 
   ClusterErrorPara m_clusErrPara;
   TpcDistortionCorrection m_distortionCorrection;

--- a/offline/packages/trackreco/ActsEvaluator.h
+++ b/offline/packages/trackreco/ActsEvaluator.h
@@ -94,7 +94,7 @@ class ActsEvaluator
   Acts::Vector3 getGlobalTruthHit(TrkrDefs::cluskey cluskey,
                                   float& _gt);
 
-  SvtxEvaluator* m_svtxEvaluator{nullptr};
+//  SvtxEvaluator* m_svtxEvaluator{nullptr};
   PHG4TruthInfoContainer* m_truthInfo{nullptr};
   SvtxTrackMap *m_trackMap{nullptr}, *m_actsProtoTrackMap{nullptr};
   SvtxEvalStack* m_svtxEvalStack{nullptr};

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -892,10 +892,10 @@ void MakeActsGeometry::makeInttMapPairs(TrackingVolumePtr &inttVolume)
       double layer_rad = sqrt(pow(world_center[0], 2) + pow(world_center[1], 2));
 
       unsigned int layer = 0;
-      for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int i2 = 0; i2 < 4; ++i2)
       {
-        if (fabs(layer_rad - ref_rad[i]) < 0.1)
-          layer = i + 3;
+        if (fabs(layer_rad - ref_rad[i2]) < 0.1)
+          layer = i2 + 3;
       }
 
       TrkrDefs::hitsetkey hitsetkey = getInttHitSetKeyFromCoords(layer, world_center);
@@ -968,10 +968,10 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
       std::vector<double> world_center = {vec3d(0) / 10.0, vec3d(1) / 10.0, vec3d(2) / 10.0};  // convert from mm to cm
       double layer_rad = sqrt(pow(world_center[0], 2) + pow(world_center[1], 2));
       unsigned int layer = 0;
-      for (unsigned int i = 0; i < 3; ++i)
+      for (unsigned int i2 = 0; i2 < 3; ++i2)
       {
-        if (fabs(layer_rad - ref_rad[i]) < 0.1)
-          layer = i;
+        if (fabs(layer_rad - ref_rad[i2]) < 0.1)
+          layer = i2;
       }
 
       TrkrDefs::hitsetkey hitsetkey = getMvtxHitSetKeyFromCoords(layer, world_center);

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -238,7 +238,7 @@ class MakeActsGeometry : public SubsysReco
   double m_modulePhiStart = 0;
 
   /// Debugger for printing out tpc active volumes
-  int nprint_tpc = 0;
+//  int nprint_tpc = 0;
 
   /// TPC TGeoManager editing box surfaces subdivisions
   const static int m_nTpcSectors = 3;
@@ -264,7 +264,7 @@ class MakeActsGeometry : public SubsysReco
   ActsGeometry *m_actsGeometry = nullptr;
 
   /// Verbosity value handed from PHActsSourceLinks
-  int m_verbosity = 0;
+//  int m_verbosity = 0;
 
   double m_drift_velocity = 8.0e-03;  // cm/ns, override from macro
 

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -11,14 +11,13 @@ lib_LTLIBRARIES = \
 AM_CPPFLAGS = \
   -DRAVE -DRaveDllExport= \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  -I${G4_MAIN}/include \
+  -isystem$(OFFLINE_MAIN)/include \
+  -isystem${G4_MAIN}/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
-  -L$(MYINSTALL)/lib64 \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \

--- a/offline/packages/trackreco/PHActsGSF.h
+++ b/offline/packages/trackreco/PHActsGSF.h
@@ -83,7 +83,7 @@ class PHActsGSF : public SubsysReco
   SvtxVertexMap* m_vertexMap = nullptr;
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
 
-  alignmentTransformationContainer* m_alignmentTransformationMap = nullptr;  // added for testing purposes
+//  alignmentTransformationContainer* m_alignmentTransformationMap = nullptr;  // added for testing purposes
   alignmentTransformationContainer* m_alignmentTransformationMapTransient = nullptr;  
   std::set< Acts::GeometryIdentifier> m_transient_id_set;
   Acts::GeometryContext m_transient_geocontext;
@@ -91,10 +91,10 @@ class PHActsGSF : public SubsysReco
   TpcDistortionCorrectionContainer* m_dccStatic = nullptr;
   TpcDistortionCorrectionContainer* m_dccAverage = nullptr;
   TpcDistortionCorrectionContainer* m_dccFluctuation{nullptr};
-  TpcDistortionCorrection m_distortionCorrection;
+//  TpcDistortionCorrection m_distortionCorrection;
 
   std::string m_trackMapName = "SvtxTrackMap";
-  unsigned int m_pHypothesis = 11;
+//  unsigned int m_pHypothesis = 11;
 
   bool m_pp_mode = false;
 

--- a/offline/packages/trackreco/PHActsKDTreeSeeding.cc
+++ b/offline/packages/trackreco/PHActsKDTreeSeeding.cc
@@ -363,8 +363,8 @@ std::vector<const SpacePoint*> PHActsKDTreeSeeding::getMvtxSpacePoints()
         }
       }
 
-      const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
-      const auto surface = m_tGeometry->maps().getSiliconSurface(hitsetkey);
+      const auto hitsetkey_A = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+      const auto surface = m_tGeometry->maps().getSiliconSurface(hitsetkey_A);
       if (!surface)
       {
         continue;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -30,10 +30,14 @@
 #include <trackbase_historic/TrackSeedContainer_v1.h>
 #include <trackbase_historic/TrackSeed_v2.h>
 
+#ifndef __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
 #include <Acts/Seeding/BinnedSPGroup.hpp>
+#ifndef __clang__
 #pragma GCC diagnostic pop
+#endif
 #include <Acts/Seeding/InternalSeed.hpp>
 #include <Acts/Seeding/InternalSpacePoint.hpp>
 #include <Acts/Seeding/Seed.hpp>
@@ -343,7 +347,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
 
       /// Add possible matches to cluster list to be parsed when
       /// Svtx tracks are made
-      for (int newkey = 0; newkey < additionalClusters.size(); newkey++)
+      for (unsigned int newkey = 0; newkey < additionalClusters.size(); newkey++)
       {
         trackSeed->insert_cluster_key(additionalClusters[newkey]);
         positions.insert(std::make_pair(additionalClusters[newkey], globalPositions[mvtxsize + newkey]));
@@ -448,7 +452,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findInttMatches(
   }
 
   /// Project the seed to the INTT to find matches
-  for (int layer = 0; layer < m_nInttLayers; ++layer)
+  for (unsigned int layer = 0; layer < m_nInttLayers; ++layer)
   {
     auto cci = TrackFitUtils::circle_circle_intersection(
         m_nInttLayerRadii[layer],
@@ -546,7 +550,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::matchInttClusters(
     }
   }
 
-  for (int inttlayer = 0; inttlayer < m_nInttLayers; inttlayer++)
+  for (unsigned int inttlayer = 0; inttlayer < m_nInttLayers; inttlayer++)
   {
     if(m_searchInIntt)
     {
@@ -782,8 +786,8 @@ std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts:
       }
 
       const auto cluster = clusIter->second;
-      const auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
-      const auto surface = m_tGeometry->maps().getSiliconSurface(hitsetkey);
+      const auto hitsetkey_A = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+      const auto surface = m_tGeometry->maps().getSiliconSurface(hitsetkey_A);
       if (!surface)
       {
         continue;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -803,7 +803,7 @@ SourceLinkVec PHActsTrkFitter::getSurfaceVector(const SourceLinkVec& sourceLinks
 
 void PHActsTrkFitter::checkSurfaceVec(SurfacePtrVec& surfaces) const
 {
-  for (int i = 0; i < surfaces.size() - 1; i++)
+  for (unsigned int i = 0; i < surfaces.size() - 1; i++)
   {
     const auto& surface = surfaces.at(i);
     const auto thisVolume = surface->geometryId().volume();

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -134,18 +134,18 @@ int PHCosmicSeeder::process_event(PHCompositeNode*)
   {
     longestseed = chainedSeeds.front();
   }
-  for (auto& seed : chainedSeeds)
+  for (auto& seed_A : chainedSeeds)
   {
     if (m_analysis)
     {
       float seed_data[] = {
           (float) m_event,
           (float) iseed,
-          (float) seed.ckeys.size(),
-          seed.xyintercept,
-          seed.xyslope,
-          seed.rzintercept,
-          seed.rzslope,
+          (float) seed_A.ckeys.size(),
+          seed_A.xyintercept,
+          seed_A.xyslope,
+          seed_A.rzintercept,
+          seed_A.rzslope,
           longestseed.xyintercept,
           longestseed.xyslope,
           longestseed.rzintercept,
@@ -153,7 +153,7 @@ int PHCosmicSeeder::process_event(PHCompositeNode*)
       m_tup->Fill(seed_data);
     }
     auto svtxseed = std::make_unique<TrackSeed_v2>();
-    for (auto& key : seed.ckeys)
+    for (auto& key : seed_A.ckeys)
     {
       svtxseed->insert_cluster_key(key);
     }
@@ -167,10 +167,10 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::findIntersections(PHCosmicSeeder::See
 {
   std::set<int> seedsToDelete;
   //! combine seeds with common ckeys
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
     auto& seed1 = initialSeeds[i];
-    for (int j = i; j < initialSeeds.size(); ++j)
+    for (unsigned int j = i; j < initialSeeds.size(); ++j)
     {
       if (i == j)
       {
@@ -194,7 +194,7 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::findIntersections(PHCosmicSeeder::See
   }
 
   SeedVector finalSeeds;
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
     if (seedsToDelete.find(i) != seedsToDelete.end())
     {
@@ -213,10 +213,10 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::chainSeeds(PHCosmicSeeder::SeedVector
 {
   PHCosmicSeeder::SeedVector returnseeds;
   std::set<int> seedsToDelete;
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
     auto& seed1 = initialSeeds[i];
-    for (int j = i; j < initialSeeds.size(); ++j)
+    for (unsigned int j = i; j < initialSeeds.size(); ++j)
     {
       if (i == j)
       {
@@ -254,7 +254,7 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::chainSeeds(PHCosmicSeeder::SeedVector
       }
     }
   }
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
     if (seedsToDelete.find(i) != seedsToDelete.end())
     {
@@ -271,9 +271,9 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::combineSeeds(PHCosmicSeeder::SeedVect
   SeedVector prunedSeeds;
   std::set<int> seedsToDelete;
 
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
-    for (int j = i; j < initialSeeds.size(); ++j)
+    for (unsigned int j = i; j < initialSeeds.size(); ++j)
     {
       if (i == j)
       {
@@ -305,7 +305,7 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::combineSeeds(PHCosmicSeeder::SeedVect
   {
     std::cout << "seeds to delete size is " << seedsToDelete.size() << std::endl;
   }
-  for (int i = 0; i < initialSeeds.size(); ++i)
+  for (unsigned int i = 0; i < initialSeeds.size(); ++i)
   {
     if (seedsToDelete.find(i) != seedsToDelete.end())
     {
@@ -420,32 +420,32 @@ PHCosmicSeeder::makeSeeds(PHCosmicSeeder::PositionMap& clusterPositions)
 
   /// erase doublets
   std::set<int> seedsToDelete;
-  for (int i = 0; i < seeds.size(); ++i)
+  for (unsigned int i = 0; i < seeds.size(); ++i)
   {
-    auto seed = seeds[i];
+    auto seed_A = seeds[i];
     if (Verbosity() > 2)
     {
       std::cout << "keys in seed " << std::endl;
-      for (auto& key : seed.ckeys)
+      for (auto& key : seed_A.ckeys)
       {
         std::cout << key << ", ";
       }
       std::cout << std::endl
                 << "seed pos " << std::endl;
-      for (auto& key : seed.ckeys)
+      for (auto& key : seed_A.ckeys)
       {
         std::cout << clusterPositions.find(key)->second.transpose() << std::endl;
       }
       std::cout << "Done printing seed info" << std::endl;
     }
-    if (seed.ckeys.size() < 3)
+    if (seed_A.ckeys.size() < 3)
     {
       seedsToDelete.insert(i);
     }
   }
 
   PHCosmicSeeder::SeedVector returnSeeds;
-  for (int i = 0; i < seeds.size(); i++)
+  for (unsigned int i = 0; i < seeds.size(); i++)
   {
     if (seedsToDelete.find(i) != seedsToDelete.end())
     {
@@ -455,13 +455,13 @@ PHCosmicSeeder::makeSeeds(PHCosmicSeeder::PositionMap& clusterPositions)
   }
   return returnSeeds;
 }
-void PHCosmicSeeder::recalculateSeedLineParameters(seed& seed,
+void PHCosmicSeeder::recalculateSeedLineParameters(seed& seed_A,
                                                    PHCosmicSeeder::PositionMap& clusters, bool isXY)
 {
   float avgx = 0;
   float avgy = 0;
   PHCosmicSeeder::PositionMap seedClusters;
-  for (auto& key : seed.ckeys)
+  for (auto& key : seed_A.ckeys)
   {
     auto glob = clusters.find(key)->second;
     if (isXY)
@@ -477,8 +477,8 @@ void PHCosmicSeeder::recalculateSeedLineParameters(seed& seed,
     seedClusters.insert(std::make_pair(key, glob));
   }
 
-  avgx /= seed.ckeys.size();
-  avgy /= seed.ckeys.size();
+  avgx /= seed_A.ckeys.size();
+  avgy /= seed_A.ckeys.size();
   float num = 0;
   float denom = 0;
   for (auto& [key, glob] : seedClusters)
@@ -496,13 +496,13 @@ void PHCosmicSeeder::recalculateSeedLineParameters(seed& seed,
   }
   if (isXY)
   {
-    seed.xyslope = num / denom;
-    seed.xyintercept = avgy - seed.xyslope * avgx;
+    seed_A.xyslope = num / denom;
+    seed_A.xyintercept = avgy - seed_A.xyslope * avgx;
   }
   else
   {
-    seed.rzslope = num / denom;
-    seed.rzintercept = avgy - seed.rzslope * avgx;
+    seed_A.rzslope = num / denom;
+    seed_A.rzintercept = avgy - seed_A.rzslope * avgx;
   }
 }
 int PHCosmicSeeder::getNodes(PHCompositeNode* topNode)

--- a/offline/packages/trackreco/PHCosmicSeeder.h
+++ b/offline/packages/trackreco/PHCosmicSeeder.h
@@ -48,7 +48,7 @@ class PHCosmicSeeder : public SubsysReco
   void recalculateSeedLineParameters(seed &seed, PositionMap &clusters, bool isXY);
 
   float m_xyTolerance = 2.;  //! cm
-  float m_rzTolerance = 2.;  //! cm
+//  float m_rzTolerance = 2.;  //! cm
   std::string m_trackMapName = "TpcTrackSeedContainer";
   ActsGeometry *m_tGeometry = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;

--- a/offline/packages/trackreco/PHCosmicTrackMerger.cc
+++ b/offline/packages/trackreco/PHCosmicTrackMerger.cc
@@ -1,15 +1,19 @@
 
 #include "PHCosmicTrackMerger.h"
 
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrClusterContainer.h>
 
 #include <trackbase_historic/TrackSeedContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+
+#include <limits>
+
 namespace
 {
   template <class T>
@@ -110,7 +114,7 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
         tr1_xy_pts.push_back(std::make_pair(pos.x(), pos.y()));
       }
 
-      float tr1xyslope = NAN;
+      float tr1xyslope = std::numeric_limits<float>::quiet_NaN();
       if (m_zeroField)
       {
         auto xyTr1Params = TrackFitUtils::line_fit(tr1_xy_pts);
@@ -159,7 +163,7 @@ int PHCosmicTrackMerger::process_event(PHCompositeNode *)
         tr2_xy_pts.push_back(std::make_pair(pos.x(), pos.y()));
       }
 
-      float tr2xyslope = NAN;
+      float tr2xyslope = std::numeric_limits<float>::quiet_NaN();
       if (m_zeroField)
       {
         auto xyTr2Params = TrackFitUtils::line_fit(tr2_xy_pts);
@@ -297,7 +301,7 @@ void PHCosmicTrackMerger::getBestClustersPerLayer(TrackSeed *seed)
   }
 
   std::vector<TrkrDefs::cluskey> tpotClus;
-  for (int i = 0; i < glob.first.size(); i++)
+  for (unsigned int i = 0; i < glob.first.size(); i++)
   {
     auto &pos = glob.second[i];
     float clusr = r(pos.x(), pos.y());
@@ -418,7 +422,7 @@ void PHCosmicTrackMerger::removeOutliers(TrackSeed *seed)
   auto xyParams = TrackFitUtils::line_fit(tr_xy_pts);
   auto rzParams = TrackFitUtils::line_fit(tr_rz_pts);
 
-  for (int i = 0; i < glob.first.size(); i++)
+  for (unsigned int i = 0; i < glob.first.size(); i++)
   {
     auto &pos = glob.second[i];
     float clusr = r(pos.x(), pos.y());

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.cc
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.cc
@@ -1024,11 +1024,11 @@ void PHCosmicsTrkFitter::getCharge(
     global_vec.push_back(glob);
   }
 
-  Acts::Vector3 globalMostOuter;
+  Acts::Vector3 globalMostOuter(std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN());
   Acts::Vector3 globalSecondMostOuter(0, 999999, 0);
   float largestR = 0;
   // loop over global positions
-  for (int i = 0; i < global_vec.size(); ++i)
+  for (unsigned int i = 0; i < global_vec.size(); ++i)
   {
     Acts::Vector3 global = global_vec[i];
     // float r = std::sqrt(square(global.x()) + square(global.y()));
@@ -1044,7 +1044,7 @@ void PHCosmicsTrkFitter::getCharge(
 
   //! find the closest cluster to the outermost cluster
   float maxdr = std::numeric_limits<float>::max();
-  for (int i = 0; i < global_vec.size(); i++)
+  for (unsigned int i = 0; i < global_vec.size(); i++)
   {
     if (global_vec[i].y() < 0) continue;
 

--- a/offline/packages/trackreco/PHCosmicsTrkFitter.h
+++ b/offline/packages/trackreco/PHCosmicsTrkFitter.h
@@ -148,7 +148,7 @@ class PHCosmicsTrkFitter : public SubsysReco
 
   /// TrackMap containing SvtxTracks
   SvtxTrackMap* m_trackMap = nullptr;
-  SvtxTrackMap* m_directedTrackMap = nullptr;
+//  SvtxTrackMap* m_directedTrackMap = nullptr;
   TrkrClusterContainer* m_clusterContainer = nullptr;
   TrackSeedContainer* m_seedMap = nullptr;
   TrackSeedContainer* m_tpcSeeds = nullptr;
@@ -188,7 +188,7 @@ class PHCosmicsTrkFitter : public SubsysReco
   TpcDistortionCorrectionContainer* _dcc_fluctuation{nullptr};
 
   /// tpc distortion correction utility class
-  TpcDistortionCorrection _distortionCorrection;
+//  TpcDistortionCorrection _distortionCorrection;
 
   // cluster mover utility class
   //  TpcClusterMover _clusterMover;

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1545,7 +1545,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
       // get position
       const auto globalPosition = getGlobalPosition( cluster_key, cluster, crossing );
-      const TVector3 pos(globalPosition.x(), globalPosition.y(), globalPosition.z() );
+      const TVector3 pos_A(globalPosition.x(), globalPosition.y(), globalPosition.z() );
       const float r_cluster = std::sqrt( square(globalPosition.x()) + square(globalPosition.y()) );
 
       // loop over states
@@ -1595,7 +1595,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
         auto kfi = static_cast<genfit::KalmanFitterInfo*>(trpoint->getFitterInfo(rep));
         gf_state = *kfi->getForwardUpdate();
-        pathlength = gf_state.extrapolateToPoint( pos );
+        pathlength = gf_state.extrapolateToPoint( pos_A );
         auto tmp = *kfi->getBackwardUpdate();
         pathlength -= tmp.extrapolateToPoint( vertex_position );
       } catch (...) {

--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -1,22 +1,21 @@
 #include "PHGhostRejection.h"
 
-#include "PHGhostRejection.h"   
+#include "PHGhostRejection.h"
 
 /// Tracking includes
 
-#include <trackbase/TrkrCluster.h>            // for TrkrCluster
-#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
+#include <trackbase/TrkrCluster.h>  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>  // for cluskey, getLayer, TrkrId
 
-#include <trackbase_historic/TrackSeed.h>     
+#include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 
-#include <cmath>                              // for sqrt, fabs, atan2, cos
-#include <iostream>                           // for operator<<, basic_ostream
-#include <map>                                // for map
-#include <set>                                // for _Rb_tree_const_iterator
-#include <utility>                            // for pair, make_pair
+#include <cmath>     // for sqrt, fabs, atan2, cos
+#include <iostream>  // for operator<<, basic_ostream
+#include <map>       // for map
+#include <set>       // for _Rb_tree_const_iterator
+#include <utility>   // for pair, make_pair
 
 //____________________________________________________________________________..
 PHGhostRejection::PHGhostRejection(unsigned int verbosity)
@@ -25,157 +24,170 @@ PHGhostRejection::PHGhostRejection(unsigned int verbosity)
 }
 
 //____________________________________________________________________________..
-PHGhostRejection::~PHGhostRejection()
-= default;
+PHGhostRejection::~PHGhostRejection() = default;
 
 //____________________________________________________________________________..
-void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
+void PHGhostRejection::rejectGhostTracks(std::vector<float>& trackChi2)
 {
+  if (!m_trackMap || m_positions.size() == 0)
+  {
+    std::cout << "Missing containers, will not run TPC seed ghost rejection"
+              << std::endl;
+    return;
+  }
 
-  if(!m_trackMap || m_positions.size() == 0)
-    {
-      std::cout << "Missing containers, will not run TPC seed ghost rejection"
-		<< std::endl;
-      return;
-    }
-
-  if(m_verbosity > 0) {
+  if (m_verbosity > 0)
+  {
     std::cout << "PHGhostRejection beginning track map size " << m_trackMap->size() << std::endl;
-}
+  }
 
   // Try to eliminate repeated tracks
 
   std::set<unsigned int> matches_set;
-  std::multimap<unsigned int, unsigned int>  matches;
-  
-  for (unsigned int trid1 = 0;
-       trid1 != m_trackMap->size(); 
-       ++trid1)
-    {
-      TrackSeed* track1 = m_trackMap->get(trid1);
-      if(!track1) 
-	{ continue; }
-      // float track1phi = track1->get_phi(m_positions); 
-      float track1phi = track1->get_phi(); 
-      float track1x = track1->get_x();
-      float track1y = track1->get_y();
-      float track1z = track1->get_z();
-      float track1eta = track1->get_eta();
-      for (unsigned int trid2 = trid1;
-	   trid2 != m_trackMap->size(); 
-	   ++trid2)
-	{
-	  if(trid1  ==  trid2) { continue;
-}
-	  
-	  TrackSeed* track2 = m_trackMap->get(trid2);
-	  if(!track2)
-	    { continue; }
-	  //if(fabs( track1phi - track2->get_phi(m_positions)) < _phi_cut &&
-	  if(std::fabs( track1phi - track2->get_phi()) < _phi_cut &&
-	     std::fabs( track1eta - track2->get_eta() ) < _eta_cut &&
-	     std::fabs( track1x - track2->get_x() ) < _x_cut &&
-	     std::fabs( track1y - track2->get_y() ) < _y_cut &&
-	     std::fabs( track1z - track2->get_z() ) < _z_cut
-	      )
-	    {
-	      matches_set.insert(trid1);
-	      matches.insert( std::pair( trid1, trid2) );
+  std::multimap<unsigned int, unsigned int> matches;
 
-	      if(m_verbosity > 1) {
-		std::cout << "Found match for tracks " << trid1 << " and " << trid2 << std::endl;
-}
-	    }
-	}
+  for (unsigned int trid1 = 0;
+       trid1 != m_trackMap->size();
+       ++trid1)
+  {
+    TrackSeed* track1 = m_trackMap->get(trid1);
+    if (!track1)
+    {
+      continue;
     }
+    // float track1phi = track1->get_phi(m_positions);
+    float track1phi = track1->get_phi();
+    float track1x = track1->get_x();
+    float track1y = track1->get_y();
+    float track1z = track1->get_z();
+    float track1eta = track1->get_eta();
+    for (unsigned int trid2 = trid1;
+         trid2 != m_trackMap->size();
+         ++trid2)
+    {
+      if (trid1 == trid2)
+      {
+        continue;
+      }
+
+      TrackSeed* track2 = m_trackMap->get(trid2);
+      if (!track2)
+      {
+        continue;
+      }
+      // if(fabs( track1phi - track2->get_phi(m_positions)) < _phi_cut &&
+      if (std::fabs(track1phi - track2->get_phi()) < _phi_cut &&
+          std::fabs(track1eta - track2->get_eta()) < _eta_cut &&
+          std::fabs(track1x - track2->get_x()) < _x_cut &&
+          std::fabs(track1y - track2->get_y()) < _y_cut &&
+          std::fabs(track1z - track2->get_z()) < _z_cut)
+      {
+        matches_set.insert(trid1);
+        matches.insert(std::pair(trid1, trid2));
+
+        if (m_verbosity > 1)
+        {
+          std::cout << "Found match for tracks " << trid1 << " and " << trid2 << std::endl;
+        }
+      }
+    }
+  }
 
   std::set<unsigned int> ghost_reject_list;
 
-  for(auto set_it : matches_set)
+  for (auto set_it : matches_set)
+  {
+    if (ghost_reject_list.find(set_it) != ghost_reject_list.end())
     {
-      if(ghost_reject_list.find(set_it) != ghost_reject_list.end()) { continue;  // already rejected  
-}
-
-      auto match_list = matches.equal_range(set_it);
-
-      auto tr1 = m_trackMap->get(set_it);
-      double best_qual = trackChi2.at(set_it);
-      unsigned int best_track = set_it;
-
-      if(m_verbosity > 1) {  
-	std::cout << " ****** start checking track " << set_it << " with best quality " << best_qual << " best_track " << best_track << std::endl;
-}
-
-      for (auto it=match_list.first; it!=match_list.second; ++it)
-	{
-	  if(m_verbosity > 1) {
-	    std::cout << "    match of track " << it->first << " to track " << it->second << std::endl;
-}
-	  
-	  auto tr2 = m_trackMap->get(it->second);	  
-
-	  // Check that these two tracks actually share the same clusters, if not skip this pair
-
-	  bool is_same_track = checkClusterSharing(tr1, set_it,
-						   tr2, it->second);
-	  if(!is_same_track) { continue;
-}
-
-	  // which one has the best quality?
-	  double tr2_qual = trackChi2.at(it->second);
-	  if(m_verbosity > 1)
-	    {
-	      std::cout << "       Compare: best quality " << best_qual << " track 2 quality " << tr2_qual << std::endl;
-	      std::cout << "       tr1: phi " << tr1->get_phi() << " eta " << tr1->get_eta() 
-			<<  " x " << tr1->get_x() << " y " << tr1->get_y() << " z " << tr1->get_z() << std::endl;
-	      std::cout << "       tr2: phi " << tr2->get_phi() << " eta " << tr2->get_eta() 
-			<<  " x " << tr2->get_x() << " y " << tr2->get_y() << " z " << tr2->get_z() << std::endl;
-	    }
-
-	  if(tr2_qual < best_qual)
-	    {
-	      if(m_verbosity > 1) {
-		std::cout << "       --------- Track " << it->second << " has better quality, erase track " << best_track << std::endl;
-}
-	      ghost_reject_list.insert(best_track);
-	      best_qual = tr2_qual;
-	      best_track = it->second;
-	    }
-	  else
-	    {
-	      if(m_verbosity > 1) {
-		std::cout << "       --------- Track " << best_track << " has better quality, erase track " << it->second << std::endl;
-}
-	      ghost_reject_list.insert(it->second);
-	    }
-
-	}
-      if(m_verbosity > 1) {
-	std::cout << " best track " << best_track << " best_qual " << best_qual << std::endl;      
-}
-
+      continue;  // already rejected
     }
+
+    auto match_list = matches.equal_range(set_it);
+
+    auto tr1 = m_trackMap->get(set_it);
+    double best_qual = trackChi2.at(set_it);
+    unsigned int best_track = set_it;
+
+    if (m_verbosity > 1)
+    {
+      std::cout << " ****** start checking track " << set_it << " with best quality " << best_qual << " best_track " << best_track << std::endl;
+    }
+
+    for (auto it = match_list.first; it != match_list.second; ++it)
+    {
+      if (m_verbosity > 1)
+      {
+        std::cout << "    match of track " << it->first << " to track " << it->second << std::endl;
+      }
+
+      auto tr2 = m_trackMap->get(it->second);
+
+      // Check that these two tracks actually share the same clusters, if not skip this pair
+
+      bool is_same_track = checkClusterSharing(tr1, set_it,
+                                               tr2, it->second);
+      if (!is_same_track)
+      {
+        continue;
+      }
+
+      // which one has the best quality?
+      double tr2_qual = trackChi2.at(it->second);
+      if (m_verbosity > 1)
+      {
+        std::cout << "       Compare: best quality " << best_qual << " track 2 quality " << tr2_qual << std::endl;
+        std::cout << "       tr1: phi " << tr1->get_phi() << " eta " << tr1->get_eta()
+                  << " x " << tr1->get_x() << " y " << tr1->get_y() << " z " << tr1->get_z() << std::endl;
+        std::cout << "       tr2: phi " << tr2->get_phi() << " eta " << tr2->get_eta()
+                  << " x " << tr2->get_x() << " y " << tr2->get_y() << " z " << tr2->get_z() << std::endl;
+      }
+
+      if (tr2_qual < best_qual)
+      {
+        if (m_verbosity > 1)
+        {
+          std::cout << "       --------- Track " << it->second << " has better quality, erase track " << best_track << std::endl;
+        }
+        ghost_reject_list.insert(best_track);
+        best_qual = tr2_qual;
+        best_track = it->second;
+      }
+      else
+      {
+        if (m_verbosity > 1)
+        {
+          std::cout << "       --------- Track " << best_track << " has better quality, erase track " << it->second << std::endl;
+        }
+        ghost_reject_list.insert(it->second);
+      }
+    }
+    if (m_verbosity > 1)
+    {
+      std::cout << " best track " << best_track << " best_qual " << best_qual << std::endl;
+    }
+  }
 
   // delete ghost tracks
-  for(auto it : ghost_reject_list)
+  for (auto it : ghost_reject_list)
+  {
+    if (m_verbosity > 1)
     {
-      if(m_verbosity > 1) {
-	std::cout << " erasing track ID " << it << std::endl;
-}
-
-      m_trackMap->erase(it);
+      std::cout << " erasing track ID " << it << std::endl;
     }
-  
-  if(m_verbosity > 0) {
-    std::cout << "Track map size after deleting ghost tracks: " << m_trackMap->size() << std::endl;
-}
 
+    m_trackMap->erase(it);
+  }
+
+  if (m_verbosity > 0)
+  {
+    std::cout << "Track map size after deleting ghost tracks: " << m_trackMap->size() << std::endl;
+  }
 
   return;
 }
 
 bool PHGhostRejection::checkClusterSharing(TrackSeed* tr1, unsigned int trid1,
-					   TrackSeed* tr2, unsigned int trid2)
+                                           TrackSeed* tr2, unsigned int trid2)
 {
   // Check that tr1 and tr2 share many clusters
 
@@ -187,45 +199,57 @@ bool PHGhostRejection::checkClusterSharing(TrackSeed* tr1, unsigned int trid1,
   for (TrackSeed::ConstClusterKeyIter key_iter = tr1->begin_cluster_keys();
        key_iter != tr1->end_cluster_keys();
        ++key_iter)
+  {
+    TrkrDefs::cluskey cluster_key = *key_iter;
+    if (m_verbosity > 2)
     {
-	  TrkrDefs::cluskey cluster_key = *key_iter;
-	  if(m_verbosity > 2) { std::cout << " track id: " << trid1 <<  " adding clusterkey " << cluster_key << std::endl;
-}
-	  cluskey_map.insert( std::make_pair(cluster_key, trid1) );
-	  clusterkeys.push_back(cluster_key);
+      std::cout << " track id: " << trid1 << " adding clusterkey " << cluster_key << std::endl;
     }
+    cluskey_map.insert(std::make_pair(cluster_key, trid1));
+    clusterkeys.push_back(cluster_key);
+  }
 
   for (TrackSeed::ConstClusterKeyIter key_iter = tr2->begin_cluster_keys();
        key_iter != tr2->end_cluster_keys();
        ++key_iter)
+  {
+    TrkrDefs::cluskey cluster_key = *key_iter;
+    if (m_verbosity > 2)
     {
-	  TrkrDefs::cluskey cluster_key = *key_iter;  
-	  if(m_verbosity > 2) { std::cout << " track id: " << trid2 <<  " adding clusterkey " << cluster_key << std::endl;
-}
-	  cluskey_map.insert( std::make_pair(cluster_key, trid2) );
+      std::cout << " track id: " << trid2 << " adding clusterkey " << cluster_key << std::endl;
     }
-  
+    cluskey_map.insert(std::make_pair(cluster_key, trid2));
+  }
+
   unsigned int nclus = clusterkeys.size();
 
   unsigned int nclus_used = 0;
   for (TrkrDefs::cluskey& cluskey : clusterkeys)
   {
-    if(cluskey_map.count(cluskey)>0) { nclus_used++;
-}
+    if (cluskey_map.count(cluskey) > 0)
+    {
+      nclus_used++;
+    }
   }
 
-  if( (float) nclus_used / (float) nclus > 0.5) {
+  if ((float) nclus_used / (float) nclus > 0.5)
+  {
     is_same_track = true;
-}
+  }
 
-  if(m_verbosity > 1) {
+  if (m_verbosity > 1)
+  {
     std::cout << " tr1 " << trid1 << " tr2 " << trid2 << " nclus_used " << nclus_used << " nclus " << nclus << std::endl;
-}
-  if(m_verbosity > 0) {
-    if(!is_same_track) { std::cout << "   ***** not the same track! ********" << " tr1 " << trid1 << " tr2 " 
-				 << trid2 << " nclus_used " << nclus_used << " nclus " << nclus << std::endl;
-}
-}
+  }
+  if (m_verbosity > 0)
+  {
+    if (!is_same_track)
+    {
+      std::cout << "   ***** not the same track! ********"
+                << " tr1 " << trid1 << " tr2 "
+                << trid2 << " nclus_used " << nclus_used << " nclus " << nclus << std::endl;
+    }
+  }
 
   return is_same_track;
 }

--- a/offline/packages/trackreco/PHGhostRejection.cc
+++ b/offline/packages/trackreco/PHGhostRejection.cc
@@ -26,8 +26,7 @@ PHGhostRejection::PHGhostRejection(unsigned int verbosity)
 
 //____________________________________________________________________________..
 PHGhostRejection::~PHGhostRejection()
-{
-}
+= default;
 
 //____________________________________________________________________________..
 void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
@@ -40,8 +39,9 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
       return;
     }
 
-  if(m_verbosity > 0)
+  if(m_verbosity > 0) {
     std::cout << "PHGhostRejection beginning track map size " << m_trackMap->size() << std::endl;
+}
 
   // Try to eliminate repeated tracks
 
@@ -65,24 +65,26 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
 	   trid2 != m_trackMap->size(); 
 	   ++trid2)
 	{
-	  if(trid1  ==  trid2) continue;
+	  if(trid1  ==  trid2) { continue;
+}
 	  
 	  TrackSeed* track2 = m_trackMap->get(trid2);
 	  if(!track2)
 	    { continue; }
 	  //if(fabs( track1phi - track2->get_phi(m_positions)) < _phi_cut &&
-	  if(fabs( track1phi - track2->get_phi()) < _phi_cut &&
-	     fabs( track1eta - track2->get_eta() ) < _eta_cut &&
-	     fabs( track1x - track2->get_x() ) < _x_cut &&
-	     fabs( track1y - track2->get_y() ) < _y_cut &&
-	     fabs( track1z - track2->get_z() ) < _z_cut
+	  if(std::fabs( track1phi - track2->get_phi()) < _phi_cut &&
+	     std::fabs( track1eta - track2->get_eta() ) < _eta_cut &&
+	     std::fabs( track1x - track2->get_x() ) < _x_cut &&
+	     std::fabs( track1y - track2->get_y() ) < _y_cut &&
+	     std::fabs( track1z - track2->get_z() ) < _z_cut
 	      )
 	    {
 	      matches_set.insert(trid1);
 	      matches.insert( std::pair( trid1, trid2) );
 
-	      if(m_verbosity > 1)
+	      if(m_verbosity > 1) {
 		std::cout << "Found match for tracks " << trid1 << " and " << trid2 << std::endl;
+}
 	    }
 	}
     }
@@ -91,7 +93,8 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
 
   for(auto set_it : matches_set)
     {
-      if(ghost_reject_list.find(set_it) != ghost_reject_list.end()) continue;  // already rejected  
+      if(ghost_reject_list.find(set_it) != ghost_reject_list.end()) { continue;  // already rejected  
+}
 
       auto match_list = matches.equal_range(set_it);
 
@@ -99,13 +102,15 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
       double best_qual = trackChi2.at(set_it);
       unsigned int best_track = set_it;
 
-      if(m_verbosity > 1)  
+      if(m_verbosity > 1) {  
 	std::cout << " ****** start checking track " << set_it << " with best quality " << best_qual << " best_track " << best_track << std::endl;
+}
 
       for (auto it=match_list.first; it!=match_list.second; ++it)
 	{
-	  if(m_verbosity > 1)
+	  if(m_verbosity > 1) {
 	    std::cout << "    match of track " << it->first << " to track " << it->second << std::endl;
+}
 	  
 	  auto tr2 = m_trackMap->get(it->second);	  
 
@@ -113,7 +118,8 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
 
 	  bool is_same_track = checkClusterSharing(tr1, set_it,
 						   tr2, it->second);
-	  if(!is_same_track) continue;
+	  if(!is_same_track) { continue;
+}
 
 	  // which one has the best quality?
 	  double tr2_qual = trackChi2.at(it->second);
@@ -128,36 +134,41 @@ void PHGhostRejection::rejectGhostTracks(std::vector<float> &trackChi2)
 
 	  if(tr2_qual < best_qual)
 	    {
-	      if(m_verbosity > 1)
+	      if(m_verbosity > 1) {
 		std::cout << "       --------- Track " << it->second << " has better quality, erase track " << best_track << std::endl;
+}
 	      ghost_reject_list.insert(best_track);
 	      best_qual = tr2_qual;
 	      best_track = it->second;
 	    }
 	  else
 	    {
-	      if(m_verbosity > 1)
+	      if(m_verbosity > 1) {
 		std::cout << "       --------- Track " << best_track << " has better quality, erase track " << it->second << std::endl;
+}
 	      ghost_reject_list.insert(it->second);
 	    }
 
 	}
-      if(m_verbosity > 1)
+      if(m_verbosity > 1) {
 	std::cout << " best track " << best_track << " best_qual " << best_qual << std::endl;      
+}
 
     }
 
   // delete ghost tracks
   for(auto it : ghost_reject_list)
     {
-      if(m_verbosity > 1)
+      if(m_verbosity > 1) {
 	std::cout << " erasing track ID " << it << std::endl;
+}
 
       m_trackMap->erase(it);
     }
   
-  if(m_verbosity > 0)
+  if(m_verbosity > 0) {
     std::cout << "Track map size after deleting ghost tracks: " << m_trackMap->size() << std::endl;
+}
 
 
   return;
@@ -178,7 +189,8 @@ bool PHGhostRejection::checkClusterSharing(TrackSeed* tr1, unsigned int trid1,
        ++key_iter)
     {
 	  TrkrDefs::cluskey cluster_key = *key_iter;
-	  if(m_verbosity > 2) std::cout << " track id: " << trid1 <<  " adding clusterkey " << cluster_key << std::endl;
+	  if(m_verbosity > 2) { std::cout << " track id: " << trid1 <<  " adding clusterkey " << cluster_key << std::endl;
+}
 	  cluskey_map.insert( std::make_pair(cluster_key, trid1) );
 	  clusterkeys.push_back(cluster_key);
     }
@@ -188,7 +200,8 @@ bool PHGhostRejection::checkClusterSharing(TrackSeed* tr1, unsigned int trid1,
        ++key_iter)
     {
 	  TrkrDefs::cluskey cluster_key = *key_iter;  
-	  if(m_verbosity > 2) std::cout << " track id: " << trid2 <<  " adding clusterkey " << cluster_key << std::endl;
+	  if(m_verbosity > 2) { std::cout << " track id: " << trid2 <<  " adding clusterkey " << cluster_key << std::endl;
+}
 	  cluskey_map.insert( std::make_pair(cluster_key, trid2) );
     }
   
@@ -197,17 +210,22 @@ bool PHGhostRejection::checkClusterSharing(TrackSeed* tr1, unsigned int trid1,
   unsigned int nclus_used = 0;
   for (TrkrDefs::cluskey& cluskey : clusterkeys)
   {
-    if(cluskey_map.count(cluskey)>0) nclus_used++;
+    if(cluskey_map.count(cluskey)>0) { nclus_used++;
+}
   }
 
-  if( (float) nclus_used / (float) nclus > 0.5)
+  if( (float) nclus_used / (float) nclus > 0.5) {
     is_same_track = true;
+}
 
-  if(m_verbosity > 1)
+  if(m_verbosity > 1) {
     std::cout << " tr1 " << trid1 << " tr2 " << trid2 << " nclus_used " << nclus_used << " nclus " << nclus << std::endl;
-  if(m_verbosity > 0)
-    if(!is_same_track) std::cout << "   ***** not the same track! ********" << " tr1 " << trid1 << " tr2 " 
+}
+  if(m_verbosity > 0) {
+    if(!is_same_track) { std::cout << "   ***** not the same track! ********" << " tr1 " << trid1 << " tr2 " 
 				 << trid2 << " nclus_used " << nclus_used << " nclus " << nclus << std::endl;
+}
+}
 
   return is_same_track;
 }

--- a/offline/packages/trackreco/PHGhostRejection.h
+++ b/offline/packages/trackreco/PHGhostRejection.h
@@ -47,7 +47,7 @@ class PHGhostRejection
   double _x_cut = 0.3;
   double _y_cut = 0.3;
   double _z_cut = 0.4;
-  int _n_iteration = 0;
+//  int _n_iteration = 0;
   unsigned int m_verbosity = 0;
   
   TrackSeedContainer *m_trackMap = nullptr;

--- a/offline/packages/trackreco/PHGhostRejection.h
+++ b/offline/packages/trackreco/PHGhostRejection.h
@@ -14,9 +14,9 @@
 #include <trackbase/ActsSurfaceMaps.h>
 #include <trackbase/ActsTrackingGeometry.h>
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 class PHCompositeNode;
 class TrackSeedContainer;
@@ -24,7 +24,7 @@ class TrkrCluster;
 class TrackSeed;
 class TrkrClusterContainer;
 
-class PHGhostRejection 
+class PHGhostRejection
 {
  public:
   PHGhostRejection() {}
@@ -32,27 +32,26 @@ class PHGhostRejection
 
   ~PHGhostRejection();
 
-  void rejectGhostTracks(std::vector<float>& trackChi2);
+  void rejectGhostTracks(std::vector<float> &trackChi2);
   void verbosity(int verb) { m_verbosity = verb; }
-  void trackSeedContainer(TrackSeedContainer *seeds){m_trackMap = seeds;}
-  void positionMap(std::map<TrkrDefs::cluskey, Acts::Vector3>& map) { m_positions = map; }
+  void trackSeedContainer(TrackSeedContainer *seeds) { m_trackMap = seeds; }
+  void positionMap(std::map<TrkrDefs::cluskey, Acts::Vector3> &map) { m_positions = map; }
 
  private:
-
   bool checkClusterSharing(TrackSeed *tr1, unsigned int trid1,
-			   TrackSeed *tr2, unsigned int trid2);
+                           TrackSeed *tr2, unsigned int trid2);
 
   double _phi_cut = 0.01;
   double _eta_cut = 0.004;
   double _x_cut = 0.3;
   double _y_cut = 0.3;
   double _z_cut = 0.4;
-//  int _n_iteration = 0;
+  //  int _n_iteration = 0;
   unsigned int m_verbosity = 0;
-  
+
   TrackSeedContainer *m_trackMap = nullptr;
- 
+
   std::map<TrkrDefs::cluskey, Acts::Vector3> m_positions;
 };
 
-#endif // PHGHOSTREJECTION_H
+#endif  // PHGHOSTREJECTION_H

--- a/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
+++ b/offline/packages/trackreco/PHSiliconHelicalPropagator.cc
@@ -139,7 +139,7 @@ int PHSiliconHelicalPropagator::process_event(PHCompositeNode* /*topNode*/)
       std::unique_ptr<TrackSeed_v2> si_seed = std::make_unique<TrackSeed_v2>();
       std::map<short, int> crossing_frequency;
 
-      Acts::Vector3 layer0global;
+      Acts::Vector3 layer0global(std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN());
 
       for (auto clusterkey : si_clusterKeys)
       {

--- a/offline/packages/trackreco/PHSiliconSeedMerger.h
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.h
@@ -27,17 +27,17 @@ class PHSiliconSeedMerger : public SubsysReco
   int End(PHCompositeNode *topNode) override;
 
   void trackMapName(const std::string& name) { m_trackMapName = name; }
-  void clusterOverlap(const int nclusters) { m_clusterOverlap = nclusters; }
+  void clusterOverlap(const unsigned int nclusters) { m_clusterOverlap = nclusters; }
   void searchIntt() { m_mvtxOnly = false; }
 
  private:
 
   int getNodes(PHCompositeNode *topNode);
 
-  TrackSeedContainer *m_siliconTracks = nullptr;
-  std::string m_trackMapName = "SiliconTrackSeedContainer";
-  int m_clusterOverlap = 1;
-  bool m_mvtxOnly = true;
+  TrackSeedContainer *m_siliconTracks {nullptr};
+  std::string m_trackMapName {"SiliconTrackSeedContainer"};
+  unsigned int m_clusterOverlap {1};
+  bool m_mvtxOnly {true};
 };
 
 #endif // PHSILICONSEEDMERGER_H

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -530,11 +530,11 @@ std::vector<short int> PHSiliconTpcTrackMatching::getInttCrossings(TrackSeed *si
 	  
 	  // get the bunch crossings for all hits in this cluster
 	  auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
-	  for(auto iter = crossings.first; iter != crossings.second; ++iter)
+	  for(auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
 	    {
 	      if(Verbosity() > 1) 
-		std::cout << "                si Track " << _track_map_silicon->find(si_track) << " cluster " << iter->first << " layer " << layer << " crossing " << iter->second  << std::endl;
-	      intt_crossings.push_back(iter->second);
+		std::cout << "                si Track " << _track_map_silicon->find(si_track) << " cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second  << std::endl;
+	      intt_crossings.push_back(iter1->second);
 	    }
 	}
     }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -1,52 +1,51 @@
 #include "PHSiliconTpcTrackMatching.h"
 
 /// Tracking includes
-#include <trackbase/TrkrDefs.h>                // for cluskey, getTrkrId, tpcId
-#include <trackbase/TpcDefs.h>
 #include <trackbase/MvtxDefs.h>
-#include <trackbase/TrkrClusterv3.h>   
-#include <trackbase/TrkrClusterContainer.h>   
-#include <trackbase/TrkrClusterCrossingAssoc.h>   
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterCrossingAssoc.h>
+#include <trackbase/TrkrClusterv3.h>
+#include <trackbase/TrkrDefs.h>  // for cluskey, getTrkrId, tpcId
 
-#include <trackbase_historic/TrackSeed_v2.h>
-#include <trackbase_historic/TrackSeedContainer_v1.h>
 #include <trackbase_historic/SvtxTrackSeed_v2.h>
+#include <trackbase_historic/TrackSeedContainer_v1.h>
+#include <trackbase_historic/TrackSeed_v2.h>
 
-#include <globalvertex/SvtxVertex.h>     // for SvtxVertex
+#include <globalvertex/SvtxVertex.h>  // for SvtxVertex
 #include <globalvertex/SvtxVertexMap.h>
 
-#include <g4main/PHG4Hit.h>  // for PHG4Hit
+#include <g4main/PHG4Hit.h>       // for PHG4Hit
+#include <g4main/PHG4HitDefs.h>   // for keytype
 #include <g4main/PHG4Particle.h>  // for PHG4Particle
-#include <g4main/PHG4HitDefs.h>  // for keytype
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
-#include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <TF1.h>
 
-#include <climits>                            // for UINT_MAX
-#include <iostream>                            // for operator<<, basic_ostream
-#include <cmath>                              // for fabs, sqrt
-#include <set>                                 // for _Rb_tree_const_iterator
-#include <utility>                             // for pair
+#include <climits>   // for UINT_MAX
+#include <cmath>     // for fabs, sqrt
+#include <iostream>  // for operator<<, basic_ostream
 #include <memory>
+#include <set>      // for _Rb_tree_const_iterator
+#include <utility>  // for pair
 
 using namespace std;
 
 //____________________________________________________________________________..
-PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name):
-  SubsysReco(name)
+PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name)
+  : SubsysReco(name)
   , PHParameterInterface(name)
 {
   InitializeParameters();
 }
 
 //____________________________________________________________________________..
-PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching()
-= default;
+PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching() = default;
 
 //____________________________________________________________________________..
 int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
@@ -54,13 +53,14 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
   UpdateParametersWithMacro();
 
   // put these in the output file
-  cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta " 
+  cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta "
        << _eta_search_win << " _pp_mode " << _pp_mode << " _use_intt_crossing " << _use_intt_crossing << endl;
 
-
-   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
-}
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
 
   return ret;
 }
@@ -77,38 +77,49 @@ void PHSiliconTpcTrackMatching::SetDefaultParameters()
 }
 
 //____________________________________________________________________________..
-int PHSiliconTpcTrackMatching::process_event(PHCompositeNode* /*unused*/)
+int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
 {
   // _track_map contains the TPC seed track stubs
   // _track_map_silicon contains the silicon seed track stubs
   // _svtx_seed_map contains the combined silicon and tpc track seeds
 
-  if(Verbosity() > 0) {
+  if (Verbosity() > 0)
+  {
     cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
-}
+  }
 
-  if(_track_map->size() == 0) {
+  if (_track_map->size() == 0)
+  {
     return Fun4AllReturnCodes::EVENT_OK;
-}
- 
+  }
+
   // loop over the silicon seeds and add the crossing to them
-  for (unsigned int trackid = 0; trackid != _track_map_silicon->size(); ++trackid) 
+  for (unsigned int trackid = 0; trackid != _track_map_silicon->size(); ++trackid)
+  {
+    _tracklet_si = _track_map_silicon->get(trackid);
+    if (!_tracklet_si)
     {
-      _tracklet_si = _track_map_silicon->get(trackid);	  
-      if(!_tracklet_si) { continue; }
+      continue;
+    }
 
-      // returns SHRT_MAX if no INTT clusters in silicon seed
-      short int crossing= getCrossingIntt(_tracklet_si);
-      if(_use_intt_crossing) { _tracklet_si->set_crossing(crossing); } // flag is for testing only, use_intt_crossing should always be true!
-      
-      if(Verbosity() > 8) {
-	std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta()  << " pt " << _tracklet_si->get_pt()  << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl; 
-}
+    // returns SHRT_MAX if no INTT clusters in silicon seed
+    short int crossing = getCrossingIntt(_tracklet_si);
+    if (_use_intt_crossing)
+    {
+      _tracklet_si->set_crossing(crossing);
+    }  // flag is for testing only, use_intt_crossing should always be true!
 
-      if(Verbosity() > 1) { cout << " Si track " << trackid << " crossing " << crossing << endl;
-}
-    }  
-  
+    if (Verbosity() > 8)
+    {
+      std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta() << " pt " << _tracklet_si->get_pt() << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl;
+    }
+
+    if (Verbosity() > 1)
+    {
+      cout << " Si track " << trackid << " crossing " << crossing << endl;
+    }
+  }
+
   // Find all matches of tpc and si tracklets in eta and phi, x and y
   //     If _pp_mode is not set, a match in z is also required - gives same behavior as old code
   std::multimap<unsigned int, unsigned int> tpc_matches;
@@ -119,57 +130,61 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode* /*unused*/)
   // Check that the crossing number is consistent with the tracklet z mismatch, removethe match otherwise
   // This does nothing if the crossing number is not set
   checkCrossingMatches(tpc_matches);
-  
+
   // We have a complete list of all eta/phi matched tracks in the map "tpc_matches"
   // make the combined track seeds from tpc_matches
-  for(auto [tpcid, si_id] : tpc_matches)
+  for (auto [tpcid, si_id] : tpc_matches)
+  {
+    auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
+    svtxseed->set_silicon_seed_index(si_id);
+    svtxseed->set_tpc_seed_index(tpcid);
+    // In pp mode, if a matched track does not have INTT clusters we have to find the crossing geometrically
+    // Record the geometrically estimated crossing in the track seeds for later use if needed
+    short int crossing_estimate = findCrossingGeometrically(tpcid, si_id);
+    svtxseed->set_crossing_estimate(crossing_estimate);
+    _svtx_seed_map->insert(svtxseed.get());
+
+    if (Verbosity() > 1)
     {
-      auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
-      svtxseed->set_silicon_seed_index(si_id);
-      svtxseed->set_tpc_seed_index(tpcid);
-      // In pp mode, if a matched track does not have INTT clusters we have to find the crossing geometrically
-      // Record the geometrically estimated crossing in the track seeds for later use if needed
-      short int crossing_estimate = findCrossingGeometrically(tpcid, si_id);
-      svtxseed->set_crossing_estimate(crossing_estimate);
-      _svtx_seed_map->insert(svtxseed.get());
-      
-      if(Verbosity() > 1) { std::cout << "  combined seed id " << _svtx_seed_map->size()-1 << " si id " << si_id << " tpc id " << tpcid  << " crossing estimate " << crossing_estimate << std::endl;
-}
+      std::cout << "  combined seed id " << _svtx_seed_map->size() - 1 << " si id " << si_id << " tpc id " << tpcid << " crossing estimate " << crossing_estimate << std::endl;
     }
+  }
 
   // Also make the unmatched TPC seeds into SvtxTrackSeeds
-  for(auto tpcid : tpc_unmatched_set)
+  for (auto tpcid : tpc_unmatched_set)
+  {
+    auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
+    svtxseed->set_tpc_seed_index(tpcid);
+    _svtx_seed_map->insert(svtxseed.get());
+
+    if (Verbosity() > 1)
     {
-      auto svtxseed = std::make_unique<SvtxTrackSeed_v2>();
-      svtxseed->set_tpc_seed_index(tpcid);
-      _svtx_seed_map->insert(svtxseed.get());
-
-      if(Verbosity() > 1) { std::cout << "  converted unmatched TPC seed id " << _svtx_seed_map->size()-1 << " tpc id " << tpcid << std::endl;
-}
+      std::cout << "  converted unmatched TPC seed id " << _svtx_seed_map->size() - 1 << " tpc id " << tpcid << std::endl;
     }
+  }
 
-  if(Verbosity() > 0)  
+  if (Verbosity() > 0)
+  {
+    std::cout << "final svtx seed map size " << _svtx_seed_map->size() << std::endl;
+  }
+
+  if (Verbosity() > 1)
+  {
+    for (const auto &seed : *_svtx_seed_map)
     {
-      std::cout << "final svtx seed map size " << _svtx_seed_map->size() << std::endl;
+      seed->identify();
     }
 
-  if(Verbosity() > 1)
-    { 
-      for(const auto& seed : *_svtx_seed_map) {
-	seed->identify();
-}
-
-      cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
-    }
+    cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
+}
 
- }
-
-short int  PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpcid, unsigned int si_id)
+short int PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpcid, unsigned int si_id)
 {
   // loop over all matches and check for ones with no INTT clusters in the silicon seed
-  TrackSeed *si_track =_track_map_silicon->get(si_id);
+  TrackSeed *si_track = _track_map_silicon->get(si_id);
   short int crossing = si_track->get_crossing();
 
   double si_z = si_track->get_z();
@@ -179,23 +194,23 @@ short int  PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpc
   // this is an initial estimate of the bunch crossing based on the z-mismatch of the seeds for this track
   short int crossing_estimate = (short int) getBunchCrossing(tpcid, tpc_z - si_z);
 
-  if(Verbosity() > 1)
-    {
-      std::cout << "findCrossing: " <<   " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z 
-		<< " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
-    }
+  if (Verbosity() > 1)
+  {
+    std::cout << "findCrossing: "
+              << " tpcid " << tpcid << " si_id " << si_id << " tpc_z " << tpc_z << " si_z " << si_z << " dz " << tpc_z - si_z
+              << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
+  }
 
   return crossing_estimate;
-  
 }
 
-double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_mismatch )
+double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_mismatch)
 {
   double vdrift = _tGeometry->get_drift_velocity();  // cm/ns
-  vdrift *= 1000.0;    // cm/microsecond
+  vdrift *= 1000.0;                                  // cm/microsecond
   //  double vdrift = 8.00;  // cm /microsecond
-  //double z_bunch_separation = 0.106 * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
-  double z_bunch_separation = (crossing_period/1000.0) * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
+  // double z_bunch_separation = 0.106 * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
+  double z_bunch_separation = (crossing_period / 1000.0) * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
 
   // The sign of z_mismatch will depend on which side of the TPC the tracklet is in
   TrackSeed *track = _track_map->get(trid);
@@ -208,54 +223,58 @@ double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_m
   for (TrackSeed::ConstClusterKeyIter iter = track->begin_cluster_keys();
        iter != track->end_cluster_keys();
        ++iter)
+  {
+    TrkrDefs::cluskey cluster_key = *iter;
+    unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+    if (trkrid == TrkrDefs::tpcId)
     {
-      TrkrDefs::cluskey cluster_key = *iter;
-      unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
-      if(trkrid == TrkrDefs::tpcId)
-	{
-	  side = TpcDefs::getSide(cluster_key);
-	  side_set.insert(side);
-	}
+      side = TpcDefs::getSide(cluster_key);
+      side_set.insert(side);
     }
+  }
 
-  if(side == 10) { return SHRT_MAX;
-}
+  if (side == 10)
+  {
+    return SHRT_MAX;
+  }
 
-  if(side_set.size() == 2 && Verbosity() > 1) {
-    std::cout << "     WARNING: tpc seed " << trid << " changed TPC sides, "  << "  final side " << side << std::endl;
-}
+  if (side_set.size() == 2 && Verbosity() > 1)
+  {
+    std::cout << "     WARNING: tpc seed " << trid << " changed TPC sides, "
+              << "  final side " << side << std::endl;
+  }
 
   // if side = 1 (north, +ve z side), a positive t0 will make the cluster late relative to true z, so it will look like z is less positive
   // so a negative z mismatch for side 1 means a positive t0, and positive crossing, so reverse the sign for side 1
-  if(side == 1) {
+  if (side == 1)
+  {
     crossings *= -1.0;
-}
-  
-  if(Verbosity() > 1) 
-    {
-      std::cout << "  gettrackid " << trid << " side " << side << " z_mismatch " << z_mismatch << " crossings " << crossings << std::endl;
-    }
+  }
+
+  if (Verbosity() > 1)
+  {
+    std::cout << "  gettrackid " << trid << " side " << side << " z_mismatch " << z_mismatch << " crossings " << crossings << std::endl;
+  }
 
   return crossings;
 }
 
-  
-int PHSiliconTpcTrackMatching::End(PHCompositeNode*  /*unused*/)
+int PHSiliconTpcTrackMatching::End(PHCompositeNode * /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int  PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
+int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
 {
   //---------------------------------
   // Get additional objects off the Node Tree
   //---------------------------------
 
-   _cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
+  _cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
   if (!_cluster_crossing_map)
   {
     cerr << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << endl;
-    //return Fun4AllReturnCodes::ABORTEVENT;
+    // return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _track_map_silicon = findNode::getClass<TrackSeedContainer>(topNode, _silicon_track_map_name);
@@ -273,238 +292,259 @@ int  PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
   }
 
   _svtx_seed_map = findNode::getClass<TrackSeedContainer>(topNode, "SvtxTrackSeedContainer");
-  if(!_svtx_seed_map)
+  if (!_svtx_seed_map)
+  {
+    std::cout << "Creating node SvtxTrackSeedContainer" << std::endl;
+    /// Get the DST Node
+    PHNodeIterator iter(topNode);
+    PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
+
+    /// Check that it is there
+    if (!dstNode)
     {
-      std::cout << "Creating node SvtxTrackSeedContainer" << std::endl;
-        /// Get the DST Node
-      PHNodeIterator iter(topNode);
-      PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
-  
-      /// Check that it is there
-      if (!dstNode)
-	{
-	  std::cerr << "DST Node missing, quitting" << std::endl;
-	  throw std::runtime_error("failed to find DST node in PHActsSourceLinks::createNodes");
-	}
-
-      /// Get the tracking subnode
-      PHNodeIterator dstIter(dstNode);
-      PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", "SVTX"));
-      
-      /// Check that it is there
-      if (!svtxNode)
-	{
-	  svtxNode = new PHCompositeNode("SVTX");
-	  dstNode->addNode(svtxNode);
-	}
-      
-      _svtx_seed_map = new TrackSeedContainer_v1();
-      PHIODataNode<PHObject> *node
-	= new PHIODataNode<PHObject>(_svtx_seed_map, "SvtxTrackSeedContainer","PHObject");
-      svtxNode->addNode(node);
-
+      std::cerr << "DST Node missing, quitting" << std::endl;
+      throw std::runtime_error("failed to find DST node in PHActsSourceLinks::createNodes");
     }
 
-    _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-    if (!_cluster_map)
-      {
-	std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
-	return Fun4AllReturnCodes::ABORTEVENT;
-      }
+    /// Get the tracking subnode
+    PHNodeIterator dstIter(dstNode);
+    PHCompositeNode *svtxNode = dynamic_cast<PHCompositeNode *>(dstIter.findFirst("PHCompositeNode", "SVTX"));
 
-   _tGeometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
-  if(!_tGeometry)
+    /// Check that it is there
+    if (!svtxNode)
     {
-      std::cout << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      svtxNode = new PHCompositeNode("SVTX");
+      dstNode->addNode(svtxNode);
     }
-  
+
+    _svtx_seed_map = new TrackSeedContainer_v1();
+    PHIODataNode<PHObject> *node = new PHIODataNode<PHObject>(_svtx_seed_map, "SvtxTrackSeedContainer", "PHObject");
+    svtxNode->addNode(node);
+  }
+
+  _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!_cluster_map)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find node TRKR_CLUSTER" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  _tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  if (!_tGeometry)
+  {
+    std::cout << PHWHERE << "Error, can't find acts tracking geometry" << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
-} 
+}
 
-void PHSiliconTpcTrackMatching::findEtaPhiMatches(  
-		        std::set<unsigned int> &tpc_matched_set,
-                        std::set<unsigned int> &tpc_unmatched_set,
-			std::multimap<unsigned int, unsigned int> &tpc_matches )
+void PHSiliconTpcTrackMatching::findEtaPhiMatches(
+    std::set<unsigned int> &tpc_matched_set,
+    std::set<unsigned int> &tpc_unmatched_set,
+    std::multimap<unsigned int, unsigned int> &tpc_matches)
 {
   // loop over the TPC track seeds
   for (unsigned int phtrk_iter = 0;
        phtrk_iter < _track_map->size();
        ++phtrk_iter)
+  {
+    _tracklet_tpc = _track_map->get(phtrk_iter);
+    if (!_tracklet_tpc)
     {
-      _tracklet_tpc = _track_map->get(phtrk_iter);
-      if(!_tracklet_tpc) 
-	{ continue; }
-      
-      unsigned int tpcid = phtrk_iter;
-      if (Verbosity() > 1)
-	{
-	  std::cout
-	    << __LINE__
-	    << ": Processing seed itrack: " << tpcid
-	    << ": nhits: " << _tracklet_tpc-> size_cluster_keys()
-	    << ": Total tracks: " << _track_map->size()
-	    << ": phi: " << _tracklet_tpc->get_phi()
-	    << endl;
-	}
-
-      double tpc_phi = _tracklet_tpc->get_phi();
-      double tpc_eta = _tracklet_tpc->get_eta();
-      double tpc_pt = fabs(1./_tracklet_tpc->get_qOverR()) *( 0.3/100. ) * std::stod(m_fieldMap);
-      if(Verbosity() > 8) {
-	std::cout << " tpc stub: " << tpcid << " eta " << tpc_eta << " phi " << tpc_phi << " pt " << tpc_pt << " tpc z " << _tracklet_tpc->get_z() << std::endl; 
-}
-
-      // this factor will increase the window size at low pT
-      // otherwise the matching efficiency drops off at low pT
-      // it would be better if this was a smooth function
-      double mag = 1.0;
-      if(tpc_pt < 6.0) { mag = 2;
-}
-      if(tpc_pt < 3.0) {  mag = 4.0;
-}
-      if(tpc_pt < 1.5) {  mag = 6.0;
-}
-
-      if(Verbosity() > 3)
-	{
-	  cout << "TPC tracklet:" << endl;
-	  _tracklet_tpc->identify();
-	}
-
-      double tpc_x = _tracklet_tpc->get_x();
-      double tpc_y = _tracklet_tpc->get_y();
-      double tpc_z = _tracklet_tpc->get_z();
-
-      bool matched = false;
-
-      // Now search the silicon track list for a match in eta and phi
-      for (unsigned int phtrk_iter_si = 0;
-	   phtrk_iter_si < _track_map_silicon->size(); 
-	   ++phtrk_iter_si)
-	{
-	  _tracklet_si = _track_map_silicon->get(phtrk_iter_si);	  
-	  if(!_tracklet_si)
-	    { continue; }
-
-	  bool eta_match = false;
-	  double si_eta = _tracklet_si->get_eta();
-	  if(  fabs(tpc_eta - si_eta) < _eta_search_win * mag) {  eta_match = true;
-}
-	  if(!eta_match) { continue;
-}
-	  unsigned int siid = phtrk_iter_si;
-	  double si_x = _tracklet_si->get_x();
-	  double si_y = _tracklet_si->get_y();
-	  double si_z = _tracklet_si->get_z();
-	  bool position_match = false;
-	  if(_pp_mode)
-	    {
-	      if(
-		 fabs(tpc_x - si_x) < _x_search_win * mag
-		 && fabs(tpc_y - si_y) < _y_search_win * mag 
-		 ) {
-		position_match = true;
-}
-	    }
-	  else
-	    {
-	      if(
-		 fabs(tpc_x - si_x) < _x_search_win * mag
-		 && fabs(tpc_y - si_y) < _y_search_win * mag 
-		 && fabs(tpc_z - si_z) < _z_search_win * mag 
-		 ) {
-		position_match = true;	    
-}
-	    }
-	  
-	  if(!position_match)
-	    { continue; }
-
-	  bool phi_match = false;
-	  double si_phi = _tracklet_si->get_phi();
-	  if(  fabs(tpc_phi - si_phi)  < _phi_search_win * mag) { phi_match = true;
-}
-	  if(  fabs( fabs(tpc_phi - si_phi)  - 2.0 * M_PI)  < _phi_search_win * mag ) { phi_match = true;
-}
-	  if(!phi_match) { continue;
-}
-	  if(Verbosity() > 3)
-	    {
-	      cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt() 
-		   << " and eta " << _tracklet_tpc->get_eta() << " with Si track " << siid << " with crossing " << _tracklet_si->get_crossing() << endl;	  
-	      cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " <<   tpc_phi-si_phi << " phi search " << _phi_search_win*mag  << " tpc_eta " << tpc_eta 
-		   << " si_eta " << si_eta << " deta " << tpc_eta-si_eta << " eta search " << _eta_search_win*mag << endl;
-	      std::cout << "      tpc x " << tpc_x << " si x " << si_x << " tpc y " << tpc_y << " si y " << si_y << " tpc_z " << tpc_z  << " si z " << si_z << std::endl;
-	      std::cout << "      x search " << _x_search_win*mag << " y search " << _y_search_win*mag << " z search " << _z_search_win*mag  << std::endl;
-	    }
-
-	  // got a match, add to the list
-	  // These stubs are matched in eta, phi, x and y already
-	  matched = true;
-	  tpc_matches.insert(std::make_pair(tpcid, siid));
-	  tpc_matched_set.insert(tpcid);
-	  
-	  if(Verbosity() > 1)  
-	    {
-	      cout << " found a match for TPC track " << tpcid << " with Si track " << siid << endl;
-	      cout << "          tpc_phi " << tpc_phi << " si_phi " <<  si_phi << " phi_match " << phi_match 
-		   << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << endl;
-	      std::cout << "      tpc x " << tpc_x << " si x " << si_x << " tpc y " << tpc_y << " si y " << si_y << " tpc_z " << tpc_z  << " si z " << si_z << std::endl;
-	    }
-	  
-	  // temporary!
-	  if(_test_windows) {
-	    cout << " Try_silicon:  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi-si_phi  
-		 << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta-si_eta << " tpc_x " << tpc_x << " tpc_y " << tpc_y << " tpc_z " << tpc_z 
-		 << " dx " << tpc_x - si_x << " dy " << tpc_y - si_y << " dz " << tpc_z - si_z  
-		 << endl;
-}
-	  
-	}
-      // if no match found, keep tpc seed for fitting
-      if(!matched)
-        {
-          if(Verbosity() > 1) { cout << "inserted unmatched tpc seed " << tpcid << endl;
-}
-          tpc_unmatched_set.insert(tpcid);
-        }
+      continue;
     }
-  
+
+    unsigned int tpcid = phtrk_iter;
+    if (Verbosity() > 1)
+    {
+      std::cout
+          << __LINE__
+          << ": Processing seed itrack: " << tpcid
+          << ": nhits: " << _tracklet_tpc->size_cluster_keys()
+          << ": Total tracks: " << _track_map->size()
+          << ": phi: " << _tracklet_tpc->get_phi()
+          << endl;
+    }
+
+    double tpc_phi = _tracklet_tpc->get_phi();
+    double tpc_eta = _tracklet_tpc->get_eta();
+    double tpc_pt = fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * std::stod(m_fieldMap);
+    if (Verbosity() > 8)
+    {
+      std::cout << " tpc stub: " << tpcid << " eta " << tpc_eta << " phi " << tpc_phi << " pt " << tpc_pt << " tpc z " << _tracklet_tpc->get_z() << std::endl;
+    }
+
+    // this factor will increase the window size at low pT
+    // otherwise the matching efficiency drops off at low pT
+    // it would be better if this was a smooth function
+    double mag = 1.0;
+    if (tpc_pt < 6.0)
+    {
+      mag = 2;
+    }
+    if (tpc_pt < 3.0)
+    {
+      mag = 4.0;
+    }
+    if (tpc_pt < 1.5)
+    {
+      mag = 6.0;
+    }
+
+    if (Verbosity() > 3)
+    {
+      cout << "TPC tracklet:" << endl;
+      _tracklet_tpc->identify();
+    }
+
+    double tpc_x = _tracklet_tpc->get_x();
+    double tpc_y = _tracklet_tpc->get_y();
+    double tpc_z = _tracklet_tpc->get_z();
+
+    bool matched = false;
+
+    // Now search the silicon track list for a match in eta and phi
+    for (unsigned int phtrk_iter_si = 0;
+         phtrk_iter_si < _track_map_silicon->size();
+         ++phtrk_iter_si)
+    {
+      _tracklet_si = _track_map_silicon->get(phtrk_iter_si);
+      if (!_tracklet_si)
+      {
+        continue;
+      }
+
+      bool eta_match = false;
+      double si_eta = _tracklet_si->get_eta();
+      if (fabs(tpc_eta - si_eta) < _eta_search_win * mag)
+      {
+        eta_match = true;
+      }
+      if (!eta_match)
+      {
+        continue;
+      }
+      unsigned int siid = phtrk_iter_si;
+      double si_x = _tracklet_si->get_x();
+      double si_y = _tracklet_si->get_y();
+      double si_z = _tracklet_si->get_z();
+      bool position_match = false;
+      if (_pp_mode)
+      {
+        if (
+            fabs(tpc_x - si_x) < _x_search_win * mag && fabs(tpc_y - si_y) < _y_search_win * mag)
+        {
+          position_match = true;
+        }
+      }
+      else
+      {
+        if (
+            fabs(tpc_x - si_x) < _x_search_win * mag && fabs(tpc_y - si_y) < _y_search_win * mag && fabs(tpc_z - si_z) < _z_search_win * mag)
+        {
+          position_match = true;
+        }
+      }
+
+      if (!position_match)
+      {
+        continue;
+      }
+
+      bool phi_match = false;
+      double si_phi = _tracklet_si->get_phi();
+      if (fabs(tpc_phi - si_phi) < _phi_search_win * mag)
+      {
+        phi_match = true;
+      }
+      if (fabs(fabs(tpc_phi - si_phi) - 2.0 * M_PI) < _phi_search_win * mag)
+      {
+        phi_match = true;
+      }
+      if (!phi_match)
+      {
+        continue;
+      }
+      if (Verbosity() > 3)
+      {
+        cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt()
+             << " and eta " << _tracklet_tpc->get_eta() << " with Si track " << siid << " with crossing " << _tracklet_si->get_crossing() << endl;
+        cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi << " phi search " << _phi_search_win * mag << " tpc_eta " << tpc_eta
+             << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " eta search " << _eta_search_win * mag << endl;
+        std::cout << "      tpc x " << tpc_x << " si x " << si_x << " tpc y " << tpc_y << " si y " << si_y << " tpc_z " << tpc_z << " si z " << si_z << std::endl;
+        std::cout << "      x search " << _x_search_win * mag << " y search " << _y_search_win * mag << " z search " << _z_search_win * mag << std::endl;
+      }
+
+      // got a match, add to the list
+      // These stubs are matched in eta, phi, x and y already
+      matched = true;
+      tpc_matches.insert(std::make_pair(tpcid, siid));
+      tpc_matched_set.insert(tpcid);
+
+      if (Verbosity() > 1)
+      {
+        cout << " found a match for TPC track " << tpcid << " with Si track " << siid << endl;
+        cout << "          tpc_phi " << tpc_phi << " si_phi " << si_phi << " phi_match " << phi_match
+             << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " eta_match " << eta_match << endl;
+        std::cout << "      tpc x " << tpc_x << " si x " << si_x << " tpc y " << tpc_y << " si y " << si_y << " tpc_z " << tpc_z << " si z " << si_z << std::endl;
+      }
+
+      // temporary!
+      if (_test_windows)
+      {
+        cout << " Try_silicon:  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi
+             << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " tpc_x " << tpc_x << " tpc_y " << tpc_y << " tpc_z " << tpc_z
+             << " dx " << tpc_x - si_x << " dy " << tpc_y - si_y << " dz " << tpc_z - si_z
+             << endl;
+      }
+    }
+    // if no match found, keep tpc seed for fitting
+    if (!matched)
+    {
+      if (Verbosity() > 1)
+      {
+        cout << "inserted unmatched tpc seed " << tpcid << endl;
+      }
+      tpc_unmatched_set.insert(tpcid);
+    }
+  }
+
   return;
 }
 
 short int PHSiliconTpcTrackMatching::getCrossingIntt(TrackSeed *si_track)
 {
   // If the Si track contains an INTT hit, use it to get the bunch crossing offset
-  
-  std::vector<short int> intt_crossings = getInttCrossings(si_track);      
-  
+
+  std::vector<short int> intt_crossings = getInttCrossings(si_track);
+
   bool keep_it = true;
   short int crossing_keep = 0;
-  if(intt_crossings.size() == 0) 
-    {
-      keep_it = false ;
-    }
+  if (intt_crossings.size() == 0)
+  {
+    keep_it = false;
+  }
   else
+  {
+    crossing_keep = intt_crossings[0];
+    for (unsigned int ic = 1; ic < intt_crossings.size(); ++ic)
     {
-      crossing_keep = intt_crossings[0];
-      for(unsigned int ic=1; ic<intt_crossings.size(); ++ic)
-	{	  
-	  if(intt_crossings[ic] != crossing_keep)
-	    {
-	      if(Verbosity() > 1)
-		{
-		  std::cout << " Warning: INTT crossings not all the same " << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " keep the first one in the list" << std::endl;  
-		}
-	    }
-	}
+      if (intt_crossings[ic] != crossing_keep)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << " Warning: INTT crossings not all the same "
+                    << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " keep the first one in the list" << std::endl;
+        }
+      }
     }
-  
-  if(keep_it)
-    {            
-      return crossing_keep;
-    }
+  }
+
+  if (keep_it)
+  {
+    return crossing_keep;
+  }
 
   return SHRT_MAX;
 }
@@ -518,57 +558,62 @@ std::vector<short int> PHSiliconTpcTrackMatching::getInttCrossings(TrackSeed *si
   for (TrackSeed::ConstClusterKeyIter iter = si_track->begin_cluster_keys();
        iter != si_track->end_cluster_keys();
        ++iter)
+  {
+    TrkrDefs::cluskey cluster_key = *iter;
+    const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+
+    if (Verbosity() > 1)
     {
-      
-      TrkrDefs::cluskey cluster_key = *iter;
-      const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+      unsigned int layer = TrkrDefs::getLayer(cluster_key);
 
-      if(Verbosity() > 1) 
-	{
-	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
+      if (trkrid == TrkrDefs::mvtxId)
+      {
+        TrkrCluster *cluster = _cluster_map->findCluster(cluster_key);
+        if (!cluster)
+        {
+          continue;
+        }
 
-	  if(trkrid == TrkrDefs::mvtxId)
-	    {
-	      TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	      if( !cluster ) { continue;	  
-}
+        Acts::Vector3 global = _tGeometry->getGlobalPosition(cluster_key, cluster);
 
-	      Acts::Vector3 global  = _tGeometry->getGlobalPosition(cluster_key, cluster);
-
-	      std::cout << "Checking  si Track " << _track_map_silicon->find(si_track) << " cluster " << cluster_key 
-			<< " in layer " << layer  << " position " << global(0) << "  " << global(1) << "  " << global(2) 
-			<< " eta " << si_track->get_eta() << std::endl;
-	    }
-	  else {
-	    std::cout << "Checking  si Track " << _track_map_silicon->find(si_track) << " cluster " << cluster_key  		
-		      << " in layer " << layer  << " with eta " << si_track->get_eta() << std::endl;
-}
-	}      
-
-      if(trkrid == TrkrDefs::inttId)
-	{
-	  TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	  if( !cluster ) { continue;	  
-}
-	  
-	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
-	  
-	  // get the bunch crossings for all hits in this cluster
-	  auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
-	  for(auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
-	    {
-	      if(Verbosity() > 1) { 
-		std::cout << "                si Track " << _track_map_silicon->find(si_track) << " cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second  << std::endl;
-}
-	      intt_crossings.push_back(iter1->second);
-	    }
-	}
+        std::cout << "Checking  si Track " << _track_map_silicon->find(si_track) << " cluster " << cluster_key
+                  << " in layer " << layer << " position " << global(0) << "  " << global(1) << "  " << global(2)
+                  << " eta " << si_track->get_eta() << std::endl;
+      }
+      else
+      {
+        std::cout << "Checking  si Track " << _track_map_silicon->find(si_track) << " cluster " << cluster_key
+                  << " in layer " << layer << " with eta " << si_track->get_eta() << std::endl;
+      }
     }
-  
+
+    if (trkrid == TrkrDefs::inttId)
+    {
+      TrkrCluster *cluster = _cluster_map->findCluster(cluster_key);
+      if (!cluster)
+      {
+        continue;
+      }
+
+      unsigned int layer = TrkrDefs::getLayer(cluster_key);
+
+      // get the bunch crossings for all hits in this cluster
+      auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
+      for (auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "                si Track " << _track_map_silicon->find(si_track) << " cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second << std::endl;
+        }
+        intt_crossings.push_back(iter1->second);
+      }
+    }
+  }
+
   return intt_crossings;
 }
 
-void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches )
+void PHSiliconTpcTrackMatching::checkCrossingMatches(std::multimap<unsigned int, unsigned int> &tpc_matches)
 {
   // if the  crossing was assigned correctly, the (crossing corrected) track position should satisfy the Z matching cut
   // this is a rough check that this is the case
@@ -577,160 +622,163 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int
 
   std::multimap<unsigned int, unsigned int> bad_map;
 
-  for(auto [tpcid, si_id] : tpc_matches)
+  for (auto [tpcid, si_id] : tpc_matches)
+  {
+    TrackSeed *tpc_track = _track_map->get(tpcid);
+    TrackSeed *si_track = _track_map_silicon->get(si_id);
+    short int crossing = si_track->get_crossing();
+
+    if (crossing == SHRT_MAX)
     {
-      TrackSeed *tpc_track = _track_map->get(tpcid);
-      TrackSeed *si_track = _track_map_silicon->get(si_id);
-      short int crossing = si_track->get_crossing();
-
-      if(crossing == SHRT_MAX) 
-	{
-	  if(Verbosity() > 2) {
-	    std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << si_track->get_z() << " because crossing is undefined " << std::endl; 
-	  }
-	  continue;
-	}
-
-      float z_si = si_track->get_z();
-      float z_tpc = tpc_track->get_z();
-      float z_mismatch = z_tpc-z_si;
-
-      float mag_crossing_z_mismatch = fabs(crossing) * crossing_period * vdrift;
-
-      // We do not know the sign  of the z mismatch for a given crossing unless we know the drift direction in the TPC, use magnitude
-      // could instead look up any TPC cluster key in the track to get side
-      // z-mismatch can occasionally be up to 2 crossings due to TPC extrapolation precision
-      if( fabs( fabs(z_mismatch) - mag_crossing_z_mismatch ) < 3.0)
-	{ 
-	  if(Verbosity() > 1) {	  
-	    std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
-		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << " drift velocity " << vdrift << std::endl;
-}
-	}
-      else
-	{
-	  if(Verbosity() > 1) {
-	    std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
-		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
-}
-
-	  //bad_map.insert(std::make_pair(tpcid, si_id));
-	}
+      if (Verbosity() > 2)
+      {
+        std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << si_track->get_z() << " because crossing is undefined " << std::endl;
+      }
+      continue;
     }
 
-  // remove bad entries from tpc_matches
-  for(auto [tpcid, si_id] : bad_map)
+    float z_si = si_track->get_z();
+    float z_tpc = tpc_track->get_z();
+    float z_mismatch = z_tpc - z_si;
+
+    float mag_crossing_z_mismatch = fabs(crossing) * crossing_period * vdrift;
+
+    // We do not know the sign  of the z mismatch for a given crossing unless we know the drift direction in the TPC, use magnitude
+    // could instead look up any TPC cluster key in the track to get side
+    // z-mismatch can occasionally be up to 2 crossings due to TPC extrapolation precision
+    if (fabs(fabs(z_mismatch) - mag_crossing_z_mismatch) < 3.0)
     {
-      // Have to iterate over tpc_matches and examine each pair to find the one matching bad_map
-      // this logic works because we call the equal range on vertex_map for every id_pair
-      // so we only delete one entry per equal range call
-      auto ret = tpc_matches.equal_range(tpcid);
-      for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  if(it->first == tpcid && it->second == si_id)
-	    {
-	      if(Verbosity() > 1) { 
-		std::cout << "                        erasing tpc_matches entry for tpcid " << tpcid << " si_id " << si_id << std::endl;
-}
-	      tpc_matches.erase(it);
-	      break;  // the iterator is no longer valid
-	    }
-	}
-    }	  
+      if (Verbosity() > 1)
+      {
+        std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
+                  << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch
+                  << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << " drift velocity " << vdrift << std::endl;
+      }
+    }
+    else
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
+                  << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch
+                  << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+      }
+
+      // bad_map.insert(std::make_pair(tpcid, si_id));
+    }
+  }
+
+  // remove bad entries from tpc_matches
+  for (auto [tpcid, si_id] : bad_map)
+  {
+    // Have to iterate over tpc_matches and examine each pair to find the one matching bad_map
+    // this logic works because we call the equal range on vertex_map for every id_pair
+    // so we only delete one entry per equal range call
+    auto ret = tpc_matches.equal_range(tpcid);
+    for (auto it = ret.first; it != ret.second; ++it)
+    {
+      if (it->first == tpcid && it->second == si_id)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "                        erasing tpc_matches entry for tpcid " << tpcid << " si_id " << si_id << std::endl;
+        }
+        tpc_matches.erase(it);
+        break;  // the iterator is no longer valid
+      }
+    }
+  }
 
   return;
-}	  
-
+}
 
 /*
-	{
-	  // This section is to correct the TPC z positions of tracks for all bunch crossings without relying on INTT time  
-	  //==================================================================================
-	  
-	  // All tracks treated as if we do not know the bunch crossing
-	  // The crossing estimate here is crude, for now
-	  tagMatchCrossing(tpc_matches, crossing_set, crossing_matches, tpc_crossing_map);
-	  
-	  // Sort candidates by the silicon tracklet Z position by putting them in si_sorted map
-	  //      -- captures crossing, tpc_id and si_id
-	  std::multimap<double, std::pair<unsigned int, unsigned int>> si_sorted_map;
-	  for( auto ncross : crossing_set)
-	    {
-	      if(Verbosity() > 1) std::cout << " ncross = " << ncross << std::endl;
-	      
-	      auto ret  = crossing_matches. equal_range(ncross);            
-	      for(auto it = ret.first; it != ret.second; ++it)
-		{
-		 if(Verbosity() > 1) 
-		    std::cout << "  crossing " << it->first << " tpc_id " << it->second.first << " si_id " << it->second.second 
-			      << " pT " << _track_map->get(it->second.first)->get_pt() 
-			      << " eta " << _track_map->get(it->second.first)->get_eta() 
-			      << " tpc_z " << _track_map->get(it->second.first)->get_z() 
-			      << " si_z " << _track_map_silicon->get(it->second.second)->get_z() 
-			      << std::endl;
-		  
-		  double z_si = _track_map_silicon->get(it->second.second)->get_z();
-		  si_sorted_map.insert(std::make_pair(z_si, std::make_pair(it->second.first, it->second.second)));
-		}	
-	    }
+        {
+          // This section is to correct the TPC z positions of tracks for all bunch crossings without relying on INTT time
+          //==================================================================================
+
+          // All tracks treated as if we do not know the bunch crossing
+          // The crossing estimate here is crude, for now
+          tagMatchCrossing(tpc_matches, crossing_set, crossing_matches, tpc_crossing_map);
+
+          // Sort candidates by the silicon tracklet Z position by putting them in si_sorted map
+          //      -- captures crossing, tpc_id and si_id
+          std::multimap<double, std::pair<unsigned int, unsigned int>> si_sorted_map;
+          for( auto ncross : crossing_set)
+            {
+              if(Verbosity() > 1) std::cout << " ncross = " << ncross << std::endl;
+
+              auto ret  = crossing_matches. equal_range(ncross);
+              for(auto it = ret.first; it != ret.second; ++it)
+                {
+                 if(Verbosity() > 1)
+                    std::cout << "  crossing " << it->first << " tpc_id " << it->second.first << " si_id " << it->second.second
+                              << " pT " << _track_map->get(it->second.first)->get_pt()
+                              << " eta " << _track_map->get(it->second.first)->get_eta()
+                              << " tpc_z " << _track_map->get(it->second.first)->get_z()
+                              << " si_z " << _track_map_silicon->get(it->second.second)->get_z()
+                              << std::endl;
+
+                  double z_si = _track_map_silicon->get(it->second.second)->get_z();
+                  si_sorted_map.insert(std::make_pair(z_si, std::make_pair(it->second.first, it->second.second)));
+                }
+            }
 
 
-	  // make a list of silicon vertices, and a multimap with all associated tpc/si pairs 
-	  std::multimap<unsigned int, std::pair<unsigned int, unsigned int>> vertex_map;
-	  std::vector<double> vertex_list;
-	  getSiVertexList(si_sorted_map, vertex_list, vertex_map);
-	  
-	  // find the crossing number for every track from the mismatch with the associated silicon vertex z position
-	  std::map<unsigned int, short int> vertex_crossings_map;
-	  getCrossingNumber(vertex_list, vertex_map, vertex_crossings_map);
-	  
-	  // Remove tracks from vertex_map where the vertex crossing is badly inconsistent with the initial crossing estimate
-	  cleanVertexMap( vertex_crossings_map, vertex_map, tpc_crossing_map );
-	  
-	  // add silicon clusters to the surviving tracks
-	  addSiliconClusters(vertex_map);
+          // make a list of silicon vertices, and a multimap with all associated tpc/si pairs
+          std::multimap<unsigned int, std::pair<unsigned int, unsigned int>> vertex_map;
+          std::vector<double> vertex_list;
+          getSiVertexList(si_sorted_map, vertex_list, vertex_map);
 
-	  // add the crossing to the combined track
-	  addTrackBunchCrossing(vertex_crossings_map, vertex_map);	  
-	  
-	  //===================================================
-	}
+          // find the crossing number for every track from the mismatch with the associated silicon vertex z position
+          std::map<unsigned int, short int> vertex_crossings_map;
+          getCrossingNumber(vertex_list, vertex_map, vertex_crossings_map);
+
+          // Remove tracks from vertex_map where the vertex crossing is badly inconsistent with the initial crossing estimate
+          cleanVertexMap( vertex_crossings_map, vertex_map, tpc_crossing_map );
+
+          // add silicon clusters to the surviving tracks
+          addSiliconClusters(vertex_map);
+
+          // add the crossing to the combined track
+          addTrackBunchCrossing(vertex_crossings_map, vertex_map);
+
+          //===================================================
+        }
 */
 
 /*
 void PHSiliconTpcTrackMatching::addTrackBunchCrossing(
-						   std::map<unsigned int, short int> &vertex_crossings_map,
-						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map)
+                                                   std::map<unsigned int, short int> &vertex_crossings_map,
+                                                   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map)
 {
 
  for(auto [ivert, crossing] : vertex_crossings_map)
     {
-      if(Verbosity() > 1) 
-	std::cout << "      ivert " << ivert << " crossing " << crossing << std::endl;		  
+      if(Verbosity() > 1)
+        std::cout << "      ivert " << ivert << " crossing " << crossing << std::endl;
 
       // loop over all tracks associated with this vertex
       // remember that any tracks not associated with one of the vertices are unusable
       auto  ret = vertex_map.equal_range(ivert);
       for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  unsigned int tpcid = it->second.first;
-	  SvtxTrack *tpc_track = _track_map->get(tpcid);
-	  tpc_track->set_crossing(crossing);
+        {
+          unsigned int tpcid = it->second.first;
+          SvtxTrack *tpc_track = _track_map->get(tpcid);
+          tpc_track->set_crossing(crossing);
 
-	  if(Verbosity() > 1) std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;		  
-	}
+          if(Verbosity() > 1) std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;
+        }
     }
  return;
 }
 */
 
 /*
-void PHSiliconTpcTrackMatching::getSiVertexList(  
-						std::multimap<double, std::pair<unsigned int, unsigned int>> &si_sorted_map,
-						  std::vector<double> &vertex_list,
-						std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map)
+void PHSiliconTpcTrackMatching::getSiVertexList(
+                                                std::multimap<double, std::pair<unsigned int, unsigned int>> &si_sorted_map,
+                                                  std::vector<double> &vertex_list,
+                                                std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map)
 {
   if(si_sorted_map.size() == 0) return;
 
@@ -743,31 +791,31 @@ void PHSiliconTpcTrackMatching::getSiVertexList(
     {
       double z_si = it->first;
       std::pair<unsigned int, unsigned int> id_pair = it->second;
-      if(Verbosity() > 1) std::cout << " z_si " << z_si << " tpc_id " << it->second.first << " si_id " << it->second.second << std::endl; 
-     
-      if( (zkeep == 999) || (fabs(z_si - zkeep) < _si_vertex_dzmax) )
-	{
-	  vertex_map.insert(std::make_pair(nvert, id_pair));
-	  zavge+= z_si;
-	  zwt++;
-	  zkeep = z_si;
-	}
-      else
-	{
-	  zavge /= zwt;
-	  vertex_list.push_back(zavge);
+      if(Verbosity() > 1) std::cout << " z_si " << z_si << " tpc_id " << it->second.first << " si_id " << it->second.second << std::endl;
 
-	  // start a new vertex
-	  nvert++;
-	  zavge = z_si;
-	  zwt = 1.0;
-	  zkeep = z_si;
-	  vertex_map.insert(std::make_pair(nvert, id_pair));	    
-	}
+      if( (zkeep == 999) || (fabs(z_si - zkeep) < _si_vertex_dzmax) )
+        {
+          vertex_map.insert(std::make_pair(nvert, id_pair));
+          zavge+= z_si;
+          zwt++;
+          zkeep = z_si;
+        }
+      else
+        {
+          zavge /= zwt;
+          vertex_list.push_back(zavge);
+
+          // start a new vertex
+          nvert++;
+          zavge = z_si;
+          zwt = 1.0;
+          zkeep = z_si;
+          vertex_map.insert(std::make_pair(nvert, id_pair));
+        }
     }
   // get the last one
   zavge /= zwt;
-  vertex_list.push_back(zavge);    
+  vertex_list.push_back(zavge);
 
   return;
 }
@@ -783,48 +831,48 @@ void PHSiliconTpcTrackMatching::addSiliconClusters(  std::multimap<unsigned int,
       unsigned int tpcid = it->second.first;
       SvtxTrack *tpc_track = _track_map->get(tpcid);
       if(Verbosity() > 1) std::cout << "  tpcid " << tpcid << " original z " << tpc_track->get_z() << std::endl;
-      
+
       // add the silicon cluster keys to the track
       unsigned int si_id = it->second.second;
       SvtxTrack *si_track = _track_map_silicon->get(si_id);
       if(Verbosity() > 1) std::cout << "  si track id " << si_id << std::endl;
       for (SvtxTrack::ConstClusterKeyIter si_iter = si_track->begin_cluster_keys();
-	   si_iter != si_track->end_cluster_keys();
-	   ++si_iter)
-	{
-	  TrkrDefs::cluskey si_cluster_key = *si_iter;
-	  
-	  if(Verbosity() > 1) 
-	    cout << "   inserting si cluster key " << si_cluster_key << " into existing TPC track " << tpc_track->get_id() << endl;
-	  
-	  tpc_track->insert_cluster_key(si_cluster_key);
-	  
-	}
-  
+           si_iter != si_track->end_cluster_keys();
+           ++si_iter)
+        {
+          TrkrDefs::cluskey si_cluster_key = *si_iter;
+
+          if(Verbosity() > 1)
+            cout << "   inserting si cluster key " << si_cluster_key << " into existing TPC track " << tpc_track->get_id() << endl;
+
+          tpc_track->insert_cluster_key(si_cluster_key);
+
+        }
+
       // update the track position to the si one
       tpc_track->set_x(si_track->get_x());
       tpc_track->set_y(si_track->get_y());
       tpc_track->set_z(si_track->get_z());
-      
+
       if(Verbosity() > 2)
-	{
-	  std::cout << " TPC seed track ID " << tpc_track->get_id() << " si track id " << si_track->get_id()
-		    << " new nclus " << tpc_track->size_cluster_keys() << std::endl;
-	}
-      
-      if(Verbosity() > 2)  
-	tpc_track->identify();
+        {
+          std::cout << " TPC seed track ID " << tpc_track->get_id() << " si track id " << si_track->get_id()
+                    << " new nclus " << tpc_track->size_cluster_keys() << std::endl;
+        }
+
+      if(Verbosity() > 2)
+        tpc_track->identify();
     }
-  
+
   return;
-}	  
+}
 */
 
 /*
-void PHSiliconTpcTrackMatching::cleanVertexMap(  
-						   std::map<unsigned int, short int> &vertex_crossings_map,
-						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map,
-						   std::map<unsigned int, short int> &tpc_crossing_map )
+void PHSiliconTpcTrackMatching::cleanVertexMap(
+                                                   std::map<unsigned int, short int> &vertex_crossings_map,
+                                                   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map,
+                                                   std::map<unsigned int, short int> &tpc_crossing_map )
 {
   if(vertex_crossings_map.size() == 0) return;
 
@@ -833,32 +881,32 @@ void PHSiliconTpcTrackMatching::cleanVertexMap(
   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>> bad_map;
   for(auto [ivert, crossing] : vertex_crossings_map)
     {
-      if(Verbosity() > 1) 
-	std::cout << " CleanVertexMap:   ivert " << ivert << " crossing " << crossing << std::endl;		  
-   
+      if(Verbosity() > 1)
+        std::cout << " CleanVertexMap:   ivert " << ivert << " crossing " << crossing << std::endl;
+
       // loop over all tracks associated with this vertex
       // remember that any tracks not associated with one of the vertices are unusable, they are ignored
       auto  ret = vertex_map.equal_range(ivert);
       for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  unsigned int tpcid = it->second.first;
-	  unsigned int si_id = it->second.second;
+        {
+          unsigned int tpcid = it->second.first;
+          unsigned int si_id = it->second.second;
 
-	  // need the initial crossing estimate for comparison - stored in tpc_ crossing_map
-	  auto sit = tpc_crossing_map.find(tpcid);	  
-	  if(abs(sit->second - crossing) > 2)
-	    {
-	      // Fails the sanity check, mark for removal from the vertex map
-	      if(Verbosity() > 1) 
-		std::cout << "      Crossing mismatch: ivert " << ivert << " tpc id " << tpcid  << " vert crossing " << crossing << " track crossing " << sit->second << std::endl;
+          // need the initial crossing estimate for comparison - stored in tpc_ crossing_map
+          auto sit = tpc_crossing_map.find(tpcid);
+          if(abs(sit->second - crossing) > 2)
+            {
+              // Fails the sanity check, mark for removal from the vertex map
+              if(Verbosity() > 1)
+                std::cout << "      Crossing mismatch: ivert " << ivert << " tpc id " << tpcid  << " vert crossing " << crossing << " track crossing " << sit->second << std::endl;
 
-	      bad_map.insert(std::make_pair(ivert, std::make_pair(tpcid, si_id)));
-	    }
-	}
+              bad_map.insert(std::make_pair(ivert, std::make_pair(tpcid, si_id)));
+            }
+        }
     }
 
-  // If we delete an entry from vertex map, the TPC track is not associated with a bunch crossing, 
-  //    -- the cluster z values are not changed, and the silicon clusters are not added. 
+  // If we delete an entry from vertex map, the TPC track is not associated with a bunch crossing,
+  //    -- the cluster z values are not changed, and the silicon clusters are not added.
   // The track remains in the track map as a TPC-only track, by default assumed to be in bunch crossing zero
   // If multiple entries are deleted from vertex map, the TPC-only track copies are left in the track map, and also in _seed-track_map
   // The track cleaner will remove all but one of them, based on chisq from the Acts fitter.
@@ -874,78 +922,78 @@ void PHSiliconTpcTrackMatching::cleanVertexMap(
       // so we only delete one entry per equal range call
       auto ret = vertex_map.equal_range(ivert);
       for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  if(it->second.first == tpc_id && it->second.second == si_id)
-	    {
-	      if(Verbosity() > 1) 
-		std::cout << "   erasing entry for ivert " << ivert << " tpc_id " << tpc_id << " si_id " << si_id << std::endl;
-	      vertex_map.erase(it);
-	      break;  // the iterator is no longer valid
-	    }
-	}
-    } 
-      
+        {
+          if(it->second.first == tpc_id && it->second.second == si_id)
+            {
+              if(Verbosity() > 1)
+                std::cout << "   erasing entry for ivert " << ivert << " tpc_id " << tpc_id << " si_id " << si_id << std::endl;
+              vertex_map.erase(it);
+              break;  // the iterator is no longer valid
+            }
+        }
+    }
+
   return;
 }
 */
 
 /*
-void PHSiliconTpcTrackMatching::getCrossingNumber(  
-						  std::vector<double> &vertex_list,
-						  std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map, 
-						  std::map<unsigned int, short int> &vertex_crossings_map)
+void PHSiliconTpcTrackMatching::getCrossingNumber(
+                                                  std::vector<double> &vertex_list,
+                                                  std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map,
+                                                  std::map<unsigned int, short int> &vertex_crossings_map)
 {
   if(vertex_list.size() == 0) return;
 
   for(unsigned int ivert = 0; ivert<vertex_list.size(); ++ivert)
-    {     
+    {
       std::vector<double> crossing_vec;
 
       double vert_z = vertex_list[ivert];
-      if(Verbosity() > 1) 
-	std::cout << "Vertex " << ivert << " vertex z " << vert_z << std::endl;
-      
+      if(Verbosity() > 1)
+        std::cout << "Vertex " << ivert << " vertex z " << vert_z << std::endl;
+
       auto  ret = vertex_map.equal_range(ivert);
       for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  unsigned int tpcid = it->second.first;
-	  double tpc_z =  _track_map->get(tpcid)->get_z();
-	  double z_mismatch = tpc_z - vert_z;
+        {
+          unsigned int tpcid = it->second.first;
+          double tpc_z =  _track_map->get(tpcid)->get_z();
+          double z_mismatch = tpc_z - vert_z;
 
-	  double crossings = getBunchCrossing(tpcid, z_mismatch);
-	  crossing_vec.push_back(crossings);
+          double crossings = getBunchCrossing(tpcid, z_mismatch);
+          crossing_vec.push_back(crossings);
 
-	  if(Verbosity() > 1) 
-	    std::cout << "   tpc_id " << tpcid << " tpc pT " << _track_map->get(tpcid)->get_pt() 
-					<< " tpc eta " << _track_map->get(tpcid)->get_eta() << " si_id " << it->second.second 
-					<< " tpc z " << tpc_z  << " crossings " << crossings << std::endl;
-	}
+          if(Verbosity() > 1)
+            std::cout << "   tpc_id " << tpcid << " tpc pT " << _track_map->get(tpcid)->get_pt()
+                                        << " tpc eta " << _track_map->get(tpcid)->get_eta() << " si_id " << it->second.second
+                                        << " tpc z " << tpc_z  << " crossings " << crossings << std::endl;
+        }
 
       if(crossing_vec.size() == 0) continue;
       double crossing_median = getMedian(crossing_vec);
-  
+
       double crossing_avge = 0.0;
       double crossing_wt = 0.0;
       for(auto cross : crossing_vec)
-	{
-	  if(fabs(cross-crossing_median) < 1.0)
-	    {
-	      crossing_avge += cross;
-	      crossing_wt++;	      
-	    }
-	}
+        {
+          if(fabs(cross-crossing_median) < 1.0)
+            {
+              crossing_avge += cross;
+              crossing_wt++;
+            }
+        }
       short int crossing = SHRT_MAX;
       if(crossing_wt != 0)
-	{
-	  crossing_avge /= crossing_wt;      
-	  double crossing_avge_rounded  =  round(crossing_avge);
-	  crossing = (short int) crossing_avge_rounded;
-	}
+        {
+          crossing_avge /= crossing_wt;
+          double crossing_avge_rounded  =  round(crossing_avge);
+          crossing = (short int) crossing_avge_rounded;
+        }
       vertex_crossings_map.insert(std::make_pair(ivert, crossing));
 
-      if(Verbosity() > 1) 
-	std::cout << "     crossing_median " << crossing_median << " crossing average = " << crossing_avge << " crossing_wt " << crossing_wt 
-				    << " crossing integer " << crossing << std::endl;
+      if(Verbosity() > 1)
+        std::cout << "     crossing_median " << crossing_median << " crossing average = " << crossing_avge << " crossing_wt " << crossing_wt
+                                    << " crossing integer " << crossing << std::endl;
     }
   return;
 }
@@ -959,21 +1007,21 @@ void PHSiliconTpcTrackMatching::addSiliconClusters( std::multimap<unsigned int, 
     {
       unsigned int tpcid = it->first;
       if(Verbosity() > 1) std::cout << "  tpcid " << tpcid << " original z " << _track_map->get(tpcid)->get_z() << std::endl;
-      
+
       // add the silicon cluster keys to the track
       unsigned int si_id = it->second;
-     
+
       auto svtxseed = std::make_unique<SvtxTrackSeed_v1>();
       svtxseed->set_silicon_seed_index(si_id);
       svtxseed->set_tpc_seed_index(tpcid);
       _svtx_seed_map->insert(svtxseed.get());
 
       if(Verbosity() > 1) std::cout << "  si track id " << si_id << std::endl;
-     
+
     }
 
   return;
-}	  
+}
 */
 /*
 // used for INTT matching
@@ -984,25 +1032,25 @@ void PHSiliconTpcTrackMatching::addSiliconClusters( std::multimap<short int, std
     {
       unsigned int tpcid = it->second.first;
       if(Verbosity() > 1) std::cout << "  tpcid " << tpcid << " original z " << _track_map->get(tpcid)->get_z() << std::endl;
-      
+
       // add the silicon cluster keys to the track
       unsigned int si_id = it->second.second;
       if(Verbosity() > 1) std::cout << "  si track id " << si_id << std::endl;
-    
+
       auto seed = std::make_unique<SvtxTrackSeed_v1>();
       seed->set_silicon_seed_index(si_id);
       seed->set_tpc_seed_index(tpcid);
       _svtx_seed_map->insert(seed.get());
-      
+
     }
-  
+
   return;
-}	  
+}
 */
 
 /*
-void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  
-						      std::map<unsigned int, short int> &tpc_crossing_map )
+void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+                                                      std::map<unsigned int, short int> &tpc_crossing_map )
 {
   bool make_crossing_guess = false;
 
@@ -1018,7 +1066,7 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<short int, s
 
       unsigned int tpcid = it->second.first;
       TrackSeed *tpc_track = _track_map->get(tpcid);
-      
+
       unsigned int si_id = it->second.second;
       TrackSeed *si_track = _track_map_silicon->get(si_id);
 
@@ -1035,28 +1083,28 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<short int, s
       // could instead look up any TPC cluster key in the track to get side
       // z-mismatch can occasionally be up to 2 crossings due to TPC extrapolation precision
       if( fabs( fabs(z_mismatch) - mag_crossing_z_mismatch ) < 3.0)
-	{ 
-	  if(Verbosity() > 1)	  
-	    std::cout << "  Success:  crossing " << crossing << " tpc_eta " << tpc_eta << " si eta " << si_eta << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
-	}
+        {
+          if(Verbosity() > 1)
+            std::cout << "  Success:  crossing " << crossing << " tpc_eta " << tpc_eta << " si eta " << si_eta << " tpcid " << tpcid << " si id " << si_id
+                      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+        }
       else
-	{
-	  if(Verbosity() > 1)
-	    std::cout << "  FAILURE:  crossing " << crossing << " tpc_eta " << tpc_eta  << " si eta " << si_eta << " tpcid " << tpcid << " si id " << si_id 
-		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+        {
+          if(Verbosity() > 1)
+            std::cout << "  FAILURE:  crossing " << crossing << " tpc_eta " << tpc_eta  << " si eta " << si_eta << " tpcid " << tpcid << " si id " << si_id
+                      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
 
-	  bad_map.insert(std::make_pair(crossing, std::make_pair(tpcid, si_id)));
+          bad_map.insert(std::make_pair(crossing, std::make_pair(tpcid, si_id)));
 
-	  if(make_crossing_guess)
-	    {
-	      // substitute a crossing estimate from the z_mismatch
-	      short int crossing_guess = (short int) getBunchCrossing(tpcid, z_mismatch);
-	      
-	      if(Verbosity() > 1) std::cout << "         substitute crossing guess " << crossing_guess << " for crossing " << crossing << std::endl; 	      
-	      good_map.insert(std::make_pair(crossing_guess, std::make_pair(tpcid, si_id)));
-	    }
-	}
+          if(make_crossing_guess)
+            {
+              // substitute a crossing estimate from the z_mismatch
+              short int crossing_guess = (short int) getBunchCrossing(tpcid, z_mismatch);
+
+              if(Verbosity() > 1) std::cout << "         substitute crossing guess " << crossing_guess << " for crossing " << crossing << std::endl;
+              good_map.insert(std::make_pair(crossing_guess, std::make_pair(tpcid, si_id)));
+            }
+        }
     }
 
   // remove bad entries from crossing_matches
@@ -1064,52 +1112,52 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<short int, s
     {
       unsigned int tpcid = id_pair.first;
       unsigned int si_id = id_pair.second;
-      
+
       // Have to iterate over crossing_matches and examine each pair to find the one matching bad_map
       // this logic works because we call the equal range on vertex_map for every id_pair
       // so we only delete one entry per equal range call
       auto ret = crossing_matches.equal_range(crossing);
       for(auto it = ret.first; it != ret.second; ++it)
-	{
-	  if(it->second.first == tpcid && it->second.second == si_id)
-	    {
-	      if(Verbosity() > 0) std::cout <<  "   checkCrossingMatches: erasing tpc_crossing_map entry for crossing " << crossing << " tpcid " << tpcid  << std::endl;
-	      tpc_crossing_map.erase(tpcid);
+        {
+          if(it->second.first == tpcid && it->second.second == si_id)
+            {
+              if(Verbosity() > 0) std::cout <<  "   checkCrossingMatches: erasing tpc_crossing_map entry for crossing " << crossing << " tpcid " << tpcid  << std::endl;
+              tpc_crossing_map.erase(tpcid);
 
-	      if(Verbosity() > 1) 
-		std::cout << "                        erasing crossing_matches entry for crossing " << crossing << " tpcid " << tpcid << " si_id " << si_id << std::endl;
-	      crossing_matches.erase(it);
-	      break;  // the iterator is no longer valid
-	    }
-	}
-    }	  
+              if(Verbosity() > 1)
+                std::cout << "                        erasing crossing_matches entry for crossing " << crossing << " tpcid " << tpcid << " si_id " << si_id << std::endl;
+              crossing_matches.erase(it);
+              break;  // the iterator is no longer valid
+            }
+        }
+    }
 
   if(make_crossing_guess)
     {
       // replace them with crossing guess
       for(auto [crossing_guess, id_pair] : good_map)
-	{
-	  unsigned int tpcid = id_pair.first;
-	  unsigned int si_id = id_pair.second;
-	  
-	  if(Verbosity() > 1) 
-	    std::cout << "  checkCrossingMatches:  adding crossing_matches and tpc_crossing_map entry for crossing_guess " << crossing_guess << " tpcid " << tpcid 
-		      << " si_id " << si_id << std::endl;
-	  crossing_matches.insert(std::make_pair(crossing_guess,std::make_pair(tpcid, si_id)));
-	  tpc_crossing_map.insert(std::make_pair(tpcid, crossing_guess));
-	}
+        {
+          unsigned int tpcid = id_pair.first;
+          unsigned int si_id = id_pair.second;
+
+          if(Verbosity() > 1)
+            std::cout << "  checkCrossingMatches:  adding crossing_matches and tpc_crossing_map entry for crossing_guess " << crossing_guess << " tpcid " << tpcid
+                      << " si_id " << si_id << std::endl;
+          crossing_matches.insert(std::make_pair(crossing_guess,std::make_pair(tpcid, si_id)));
+          tpc_crossing_map.insert(std::make_pair(tpcid, crossing_guess));
+        }
     }
-    
+
   return;
-}	  
+}
 */
 
 /*
 // uses INTT time to get bunch crossing
-void PHSiliconTpcTrackMatching::getMatchCrossingIntt(  
-						std::multimap<unsigned int, unsigned int> &tpc_matches,
-						std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-						std::map<unsigned int, short int> &tpc_crossing_map )
+void PHSiliconTpcTrackMatching::getMatchCrossingIntt(
+                                                std::multimap<unsigned int, unsigned int> &tpc_matches,
+                                                std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+                                                std::map<unsigned int, short int> &tpc_crossing_map )
 {
   if(Verbosity() > 0) std::cout << " tpc_matches size " << tpc_matches.size() << std::endl;
 
@@ -1117,43 +1165,43 @@ void PHSiliconTpcTrackMatching::getMatchCrossingIntt(
     {
       TrackSeed *si_track =_track_map_silicon->get(si_id);
 
-      if(Verbosity() > 0) 
-	std::cout << "TPC track " << tpcid << " si track " << si_id << std::endl;
+      if(Verbosity() > 0)
+        std::cout << "TPC track " << tpcid << " si track " << si_id << std::endl;
 
       // If the Si track contains an INTT hit, use it to get the bunch crossing offset
 
-      std::vector<short int> intt_crossings = getInttCrossings(si_track);      
+      std::vector<short int> intt_crossings = getInttCrossings(si_track);
 
       bool keep_it = true;
       short int crossing_keep = 0;
-      if(intt_crossings.size() == 0) 
-	{
-	  if(Verbosity() > 0)  std::cout << " Silicon track " << si_id << " has no INTT clusters, skip this combination " << std::endl;
-	  continue ;
-	}
+      if(intt_crossings.size() == 0)
+        {
+          if(Verbosity() > 0)  std::cout << " Silicon track " << si_id << " has no INTT clusters, skip this combination " << std::endl;
+          continue ;
+        }
       else
-	{
-	  crossing_keep = intt_crossings[0];
-	  for(unsigned int ic=1; ic<intt_crossings.size(); ++ic)
-	    {	  
-	      if(intt_crossings[ic] != crossing_keep)
-		{
-		  if(Verbosity() > -1)
-		    {
-		      std::cout << " Warning: INTT crossings not all the same for tpc track " << tpcid << " silicon track " << si_id << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " keep the first one in the list" << std::endl;  
-		    }
-		}
-	    }
-	}
-      
+        {
+          crossing_keep = intt_crossings[0];
+          for(unsigned int ic=1; ic<intt_crossings.size(); ++ic)
+            {
+              if(intt_crossings[ic] != crossing_keep)
+                {
+                  if(Verbosity() > -1)
+                    {
+                      std::cout << " Warning: INTT crossings not all the same for tpc track " << tpcid << " silicon track " << si_id << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " keep the first one in the list" << std::endl;
+                    }
+                }
+            }
+        }
+
       if(keep_it)
-	{            
-	  crossing_matches.insert(std::make_pair(crossing_keep,std::make_pair(tpcid, si_id)));
-	  tpc_crossing_map.insert(std::make_pair(tpcid, crossing_keep));
-	  
-	  if(Verbosity() > 0) 
-	    std::cout << "                    tpc track " << tpcid << " si Track " << si_id << " final crossing " << crossing_keep  << std::endl;           
-	}
+        {
+          crossing_matches.insert(std::make_pair(crossing_keep,std::make_pair(tpcid, si_id)));
+          tpc_crossing_map.insert(std::make_pair(tpcid, crossing_keep));
+
+          if(Verbosity() > 0)
+            std::cout << "                    tpc track " << tpcid << " si Track " << si_id << " final crossing " << crossing_keep  << std::endl;
+        }
     }
   return;
 }
@@ -1163,11 +1211,11 @@ void PHSiliconTpcTrackMatching::getMatchCrossingIntt(
 void PHSiliconTpcTrackMatching::addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map)
 {
   if(tpc_crossing_map.size() == 0) return;
-  
+
   for(auto [tpcid, crossing] : tpc_crossing_map)
     {
-     if(Verbosity() > 1) 
-      std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;		  
+     if(Verbosity() > 1)
+      std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;
 
        TrackSeed *tpc_track = _track_map->get(tpcid);
        tpc_track->set_crossing(crossing);
@@ -1188,18 +1236,18 @@ double PHSiliconTpcTrackMatching::getMedian(std::vector<double> &v)
       // we want the average of the middle two numbers, v.size()/2 and v.size()/2-1
       auto m1 = v.begin() + v.size()/2;
       std::nth_element(v.begin(), m1, v.end());
-      double median1 =  v[v.size()/2]; 
+      double median1 =  v[v.size()/2];
 
       auto m2 = v.begin() + v.size()/2 - 1;
       std::nth_element(v.begin(), m2, v.end());
-      double median2 =  v[v.size()/2 - 1]; 
+      double median2 =  v[v.size()/2 - 1];
 
-      median = (median1 + median2) / 2.0; 
-      if(Verbosity() > 2) std::cout << "The vector size is " << v.size() 
-				    << " element m is " << v.size() / 2  << " = " << v[v.size()/2] 
-				    << " element m-1 is " << v.size() / 2 -1 << " = " << v[v.size()/2-1] 
-				    <<  std::endl;
-    } 
+      median = (median1 + median2) / 2.0;
+      if(Verbosity() > 2) std::cout << "The vector size is " << v.size()
+                                    << " element m is " << v.size() / 2  << " = " << v[v.size()/2]
+                                    << " element m-1 is " << v.size() / 2 -1 << " = " << v[v.size()/2-1]
+                                    <<  std::endl;
+    }
   else
     {
       // odd number of entries
@@ -1213,13 +1261,11 @@ double PHSiliconTpcTrackMatching::getMedian(std::vector<double> &v)
 }
 */
 
-
-
 /*
-void PHSiliconTpcTrackMatching::tagInTimeTracks(  
-						std::multimap<unsigned int, unsigned int> &tpc_matches,
-						std::multimap<int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-						std::map<unsigned int, int> &tpc_crossing_map )
+void PHSiliconTpcTrackMatching::tagInTimeTracks(
+                                                std::multimap<unsigned int, unsigned int> &tpc_matches,
+                                                std::multimap<int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+                                                std::map<unsigned int, int> &tpc_crossing_map )
 {
 
   for(auto [tpcid, si_id] : tpc_matches)
@@ -1240,29 +1286,29 @@ void PHSiliconTpcTrackMatching::tagInTimeTracks(
 
       // Check for a match in z
       if(fabs(tpc_z - si_z) < _z_search_win * mag)
-	{
-	  //track from  triggered event
-	  int crossing = 0;
-	  crossing_matches.insert(std::make_pair(crossing,std::make_pair(tpcid, si_id)));
-	  tpc_crossing_map.insert(std::make_pair(tpcid, crossing));
-	  if(Verbosity() > 1)
-	    std::cout << " triggered: tpc_trackid " << tpcid
-		      << " eta " << tpc_track->get_eta()
-		      << " pT " << tpc_track->get_pt() 
-		      << " si_trackid " << si_id 
-		      << " z_tpc " << tpc_track->get_z() 
-		      << " z_si " << si_track->get_z() 
-		      << " crossing " << crossing 
-		      << std::endl;				  
-	}
+        {
+          //track from  triggered event
+          int crossing = 0;
+          crossing_matches.insert(std::make_pair(crossing,std::make_pair(tpcid, si_id)));
+          tpc_crossing_map.insert(std::make_pair(tpcid, crossing));
+          if(Verbosity() > 1)
+            std::cout << " triggered: tpc_trackid " << tpcid
+                      << " eta " << tpc_track->get_eta()
+                      << " pT " << tpc_track->get_pt()
+                      << " si_trackid " << si_id
+                      << " z_tpc " << tpc_track->get_z()
+                      << " z_si " << si_track->get_z()
+                      << " crossing " << crossing
+                      << std::endl;
+        }
     }
   return;
 }
 
-void PHSiliconTpcTrackMatching::tagMatchCrossing(  
-						std::multimap<unsigned int, unsigned int> &tpc_matches,
-						std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-						std::map<unsigned int, short int> &tpc_crossing_map )
+void PHSiliconTpcTrackMatching::tagMatchCrossing(
+                                                std::multimap<unsigned int, unsigned int> &tpc_matches,
+                                                std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+                                                std::map<unsigned int, short int> &tpc_crossing_map )
 {
 
   for(auto [tpcid, si_id] : tpc_matches)
@@ -1278,24 +1324,24 @@ void PHSiliconTpcTrackMatching::tagMatchCrossing(
       crossing_matches.insert(std::make_pair(crossing,std::make_pair(tpcid, si_id)));
       tpc_crossing_map.insert(std::make_pair(tpcid, crossing));
       if(Verbosity() > 1)
-	std::cout << " pileup: tpc_trackid " << tpcid
-		  << " eta " << tpc_track->get_eta()
-		  << " pT " << tpc_track->get_pt() 
-		  << " si_trackid " << si_id
-		  << " z_tpc " << tpc_track->get_z() 
-		  << " z_si " << si_track->get_z() 
-		  << " crossing " << crossing 
-		  << std::endl;		
+        std::cout << " pileup: tpc_trackid " << tpcid
+                  << " eta " << tpc_track->get_eta()
+                  << " pT " << tpc_track->get_pt()
+                  << " si_trackid " << si_id
+                  << " z_tpc " << tpc_track->get_z()
+                  << " z_si " << si_track->get_z()
+                  << " crossing " << crossing
+                  << std::endl;
     }
 
 return;
 }
 
 // This is for non-pp mode, i.e. straight geometric matching including a z cut
-void PHSiliconTpcTrackMatching::addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches)	  
+void PHSiliconTpcTrackMatching::addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches)
 {
   if(tpc_matches.size() == 0) return;
-  
+
   for(auto [tpcid, si_id] : tpc_matches)
     {
       short int crossing = 0;
@@ -1303,16 +1349,16 @@ void PHSiliconTpcTrackMatching::addTrackBunchCrossing(std::multimap<unsigned int
        TrackSeed *tpc_track = _track_map->get(tpcid);
        TrackSeed *si_track = _track_map_silicon->get(si_id);
        if(!tpc_track)
-	 {
-	   std::cout << PHWHERE << "Did not find track " << tpcid << std::endl;
-	   continue;
-	 }
+         {
+           std::cout << PHWHERE << "Did not find track " << tpcid << std::endl;
+           continue;
+         }
 
-       if(Verbosity() > 1) 
-	 std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;		  
-       
+       if(Verbosity() > 1)
+         std::cout << PHWHERE << "  Add bunch crossing to track " << tpcid << " crossing " << crossing << std::endl;
+
        si_track->set_crossing(crossing);
-       tpc_track->set_crossing(crossing);	 
+       tpc_track->set_crossing(crossing);
     }
 
   return;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -46,9 +46,7 @@ PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name):
 
 //____________________________________________________________________________..
 PHSiliconTpcTrackMatching::~PHSiliconTpcTrackMatching()
-{
-
-}
+= default;
 
 //____________________________________________________________________________..
 int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
@@ -61,7 +59,8 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
 
 
    int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
+}
 
   return ret;
 }
@@ -78,17 +77,19 @@ void PHSiliconTpcTrackMatching::SetDefaultParameters()
 }
 
 //____________________________________________________________________________..
-int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
+int PHSiliconTpcTrackMatching::process_event(PHCompositeNode* /*unused*/)
 {
   // _track_map contains the TPC seed track stubs
   // _track_map_silicon contains the silicon seed track stubs
   // _svtx_seed_map contains the combined silicon and tpc track seeds
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     cout << PHWHERE << " TPC track map size " << _track_map->size() << " Silicon track map size " << _track_map_silicon->size() << endl;
+}
 
-  if(_track_map->size() == 0)
+  if(_track_map->size() == 0) {
     return Fun4AllReturnCodes::EVENT_OK;
+}
  
   // loop over the silicon seeds and add the crossing to them
   for (unsigned int trackid = 0; trackid != _track_map_silicon->size(); ++trackid) 
@@ -100,10 +101,12 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
       short int crossing= getCrossingIntt(_tracklet_si);
       if(_use_intt_crossing) { _tracklet_si->set_crossing(crossing); } // flag is for testing only, use_intt_crossing should always be true!
       
-      if(Verbosity() > 8)
+      if(Verbosity() > 8) {
 	std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta()  << " pt " << _tracklet_si->get_pt()  << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl; 
+}
 
-      if(Verbosity() > 1) cout << " Si track " << trackid << " crossing " << crossing << endl;
+      if(Verbosity() > 1) { cout << " Si track " << trackid << " crossing " << crossing << endl;
+}
     }  
   
   // Find all matches of tpc and si tracklets in eta and phi, x and y
@@ -130,7 +133,8 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
       svtxseed->set_crossing_estimate(crossing_estimate);
       _svtx_seed_map->insert(svtxseed.get());
       
-      if(Verbosity() > 1) std::cout << "  combined seed id " << _svtx_seed_map->size()-1 << " si id " << si_id << " tpc id " << tpcid  << " crossing estimate " << crossing_estimate << std::endl;
+      if(Verbosity() > 1) { std::cout << "  combined seed id " << _svtx_seed_map->size()-1 << " si id " << si_id << " tpc id " << tpcid  << " crossing estimate " << crossing_estimate << std::endl;
+}
     }
 
   // Also make the unmatched TPC seeds into SvtxTrackSeeds
@@ -140,7 +144,8 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
       svtxseed->set_tpc_seed_index(tpcid);
       _svtx_seed_map->insert(svtxseed.get());
 
-      if(Verbosity() > 1) std::cout << "  converted unmatched TPC seed id " << _svtx_seed_map->size()-1 << " tpc id " << tpcid << std::endl;
+      if(Verbosity() > 1) { std::cout << "  converted unmatched TPC seed id " << _svtx_seed_map->size()-1 << " tpc id " << tpcid << std::endl;
+}
     }
 
   if(Verbosity() > 0)  
@@ -150,8 +155,9 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode*)
 
   if(Verbosity() > 1)
     { 
-      for(const auto& seed : *_svtx_seed_map)
+      for(const auto& seed : *_svtx_seed_map) {
 	seed->identify();
+}
 
       cout << "PHSiliconTpcTrackMatching::process_event(PHCompositeNode *topNode) Leaving process_event" << endl;  
     }
@@ -212,15 +218,18 @@ double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_m
 	}
     }
 
-  if(side == 10) return SHRT_MAX;
+  if(side == 10) { return SHRT_MAX;
+}
 
-  if(side_set.size() == 2 && Verbosity() > 1)
+  if(side_set.size() == 2 && Verbosity() > 1) {
     std::cout << "     WARNING: tpc seed " << trid << " changed TPC sides, "  << "  final side " << side << std::endl;
+}
 
   // if side = 1 (north, +ve z side), a positive t0 will make the cluster late relative to true z, so it will look like z is less positive
   // so a negative z mismatch for side 1 means a positive t0, and positive crossing, so reverse the sign for side 1
-  if(side == 1)
+  if(side == 1) {
     crossings *= -1.0;
+}
   
   if(Verbosity() > 1) 
     {
@@ -231,7 +240,7 @@ double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_m
 }
 
   
-int PHSiliconTpcTrackMatching::End(PHCompositeNode* )
+int PHSiliconTpcTrackMatching::End(PHCompositeNode*  /*unused*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -342,16 +351,20 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       double tpc_phi = _tracklet_tpc->get_phi();
       double tpc_eta = _tracklet_tpc->get_eta();
       double tpc_pt = fabs(1./_tracklet_tpc->get_qOverR()) *( 0.3/100. ) * std::stod(m_fieldMap);
-      if(Verbosity() > 8)
+      if(Verbosity() > 8) {
 	std::cout << " tpc stub: " << tpcid << " eta " << tpc_eta << " phi " << tpc_phi << " pt " << tpc_pt << " tpc z " << _tracklet_tpc->get_z() << std::endl; 
+}
 
       // this factor will increase the window size at low pT
       // otherwise the matching efficiency drops off at low pT
       // it would be better if this was a smooth function
       double mag = 1.0;
-      if(tpc_pt < 6.0) mag = 2;
-      if(tpc_pt < 3.0)  mag = 4.0;
-      if(tpc_pt < 1.5)  mag = 6.0;
+      if(tpc_pt < 6.0) { mag = 2;
+}
+      if(tpc_pt < 3.0) {  mag = 4.0;
+}
+      if(tpc_pt < 1.5) {  mag = 6.0;
+}
 
       if(Verbosity() > 3)
 	{
@@ -376,8 +389,10 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
 	  bool eta_match = false;
 	  double si_eta = _tracklet_si->get_eta();
-	  if(  fabs(tpc_eta - si_eta) < _eta_search_win * mag)  eta_match = true;
-	  if(!eta_match) continue;
+	  if(  fabs(tpc_eta - si_eta) < _eta_search_win * mag) {  eta_match = true;
+}
+	  if(!eta_match) { continue;
+}
 	  unsigned int siid = phtrk_iter_si;
 	  double si_x = _tracklet_si->get_x();
 	  double si_y = _tracklet_si->get_y();
@@ -388,8 +403,9 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 	      if(
 		 fabs(tpc_x - si_x) < _x_search_win * mag
 		 && fabs(tpc_y - si_y) < _y_search_win * mag 
-		 )
+		 ) {
 		position_match = true;
+}
 	    }
 	  else
 	    {
@@ -397,8 +413,9 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 		 fabs(tpc_x - si_x) < _x_search_win * mag
 		 && fabs(tpc_y - si_y) < _y_search_win * mag 
 		 && fabs(tpc_z - si_z) < _z_search_win * mag 
-		 )
+		 ) {
 		position_match = true;	    
+}
 	    }
 	  
 	  if(!position_match)
@@ -406,9 +423,12 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
 	  bool phi_match = false;
 	  double si_phi = _tracklet_si->get_phi();
-	  if(  fabs(tpc_phi - si_phi)  < _phi_search_win * mag) phi_match = true;
-	  if(  fabs( fabs(tpc_phi - si_phi)  - 2.0 * M_PI)  < _phi_search_win * mag ) phi_match = true;
-	  if(!phi_match) continue;
+	  if(  fabs(tpc_phi - si_phi)  < _phi_search_win * mag) { phi_match = true;
+}
+	  if(  fabs( fabs(tpc_phi - si_phi)  - 2.0 * M_PI)  < _phi_search_win * mag ) { phi_match = true;
+}
+	  if(!phi_match) { continue;
+}
 	  if(Verbosity() > 3)
 	    {
 	      cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt() 
@@ -434,17 +454,19 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 	    }
 	  
 	  // temporary!
-	  if(_test_windows)
+	  if(_test_windows) {
 	    cout << " Try_silicon:  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi-si_phi  
 		 << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta-si_eta << " tpc_x " << tpc_x << " tpc_y " << tpc_y << " tpc_z " << tpc_z 
 		 << " dx " << tpc_x - si_x << " dy " << tpc_y - si_y << " dz " << tpc_z - si_z  
 		 << endl;
+}
 	  
 	}
       // if no match found, keep tpc seed for fitting
       if(!matched)
         {
-          if(Verbosity() > 1) cout << "inserted unmatched tpc seed " << tpcid << endl;
+          if(Verbosity() > 1) { cout << "inserted unmatched tpc seed " << tpcid << endl;
+}
           tpc_unmatched_set.insert(tpcid);
         }
     }
@@ -508,7 +530,8 @@ std::vector<short int> PHSiliconTpcTrackMatching::getInttCrossings(TrackSeed *si
 	  if(trkrid == TrkrDefs::mvtxId)
 	    {
 	      TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	      if( !cluster ) continue;	  
+	      if( !cluster ) { continue;	  
+}
 
 	      Acts::Vector3 global  = _tGeometry->getGlobalPosition(cluster_key, cluster);
 
@@ -516,15 +539,17 @@ std::vector<short int> PHSiliconTpcTrackMatching::getInttCrossings(TrackSeed *si
 			<< " in layer " << layer  << " position " << global(0) << "  " << global(1) << "  " << global(2) 
 			<< " eta " << si_track->get_eta() << std::endl;
 	    }
-	  else
+	  else {
 	    std::cout << "Checking  si Track " << _track_map_silicon->find(si_track) << " cluster " << cluster_key  		
 		      << " in layer " << layer  << " with eta " << si_track->get_eta() << std::endl;
+}
 	}      
 
       if(trkrid == TrkrDefs::inttId)
 	{
 	  TrkrCluster *cluster =  _cluster_map->findCluster(cluster_key);	
-	  if( !cluster ) continue;	  
+	  if( !cluster ) { continue;	  
+}
 	  
 	  unsigned int layer = TrkrDefs::getLayer(cluster_key);
 	  
@@ -532,8 +557,9 @@ std::vector<short int> PHSiliconTpcTrackMatching::getInttCrossings(TrackSeed *si
 	  auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
 	  for(auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
 	    {
-	      if(Verbosity() > 1) 
+	      if(Verbosity() > 1) { 
 		std::cout << "                si Track " << _track_map_silicon->find(si_track) << " cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second  << std::endl;
+}
 	      intt_crossings.push_back(iter1->second);
 	    }
 	}
@@ -576,17 +602,19 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int
       // z-mismatch can occasionally be up to 2 crossings due to TPC extrapolation precision
       if( fabs( fabs(z_mismatch) - mag_crossing_z_mismatch ) < 3.0)
 	{ 
-	  if(Verbosity() > 1)	  
+	  if(Verbosity() > 1) {	  
 	    std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
 		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
 		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << " drift velocity " << vdrift << std::endl;
+}
 	}
       else
 	{
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 1) {
 	    std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id 
 		      << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch 
 		      << " mag_crossing_z_mismatch " << mag_crossing_z_mismatch << std::endl;
+}
 
 	  //bad_map.insert(std::make_pair(tpcid, si_id));
 	}
@@ -603,8 +631,9 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches( std::multimap<unsigned int
 	{
 	  if(it->first == tpcid && it->second == si_id)
 	    {
-	      if(Verbosity() > 1) 
+	      if(Verbosity() > 1) { 
 		std::cout << "                        erasing tpc_matches entry for tpcid " << tpcid << " si_id " << si_id << std::endl;
+}
 	      tpc_matches.erase(it);
 	      break;  // the iterator is no longer valid
 	    }

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -4,11 +4,11 @@
 #define PHSILICONTPCTRACKMATCHING_H
 
 #include <fun4all/SubsysReco.h>
-#include <trackbase/ActsGeometry.h>
 #include <phparameter/PHParameterInterface.h>
+#include <trackbase/ActsGeometry.h>
 
-#include <string>
 #include <map>
+#include <string>
 
 class PHCompositeNode;
 class TrackSeedContainer;
@@ -20,81 +20,80 @@ class TrkrClusterCrossingAssoc;
 class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 {
  public:
-
   PHSiliconTpcTrackMatching(const std::string &name = "PHSiliconTpcTrackMatching");
 
   ~PHSiliconTpcTrackMatching() override;
 
- void SetDefaultParameters() override;
+  void SetDefaultParameters() override;
 
-  void set_phi_search_window(const double win){_phi_search_win = win;}
-  void set_eta_search_window(const double win){_eta_search_win = win;}
-  void set_x_search_window(const double win){_x_search_win = win;}
-  void set_y_search_window(const double win){_y_search_win = win;}
-  void set_z_search_window(const double win){_z_search_win = win;}
+  void set_phi_search_window(const double win) { _phi_search_win = win; }
+  void set_eta_search_window(const double win) { _eta_search_win = win; }
+  void set_x_search_window(const double win) { _x_search_win = win; }
+  void set_y_search_window(const double win) { _y_search_win = win; }
+  void set_z_search_window(const double win) { _z_search_win = win; }
 
-  void set_test_windows_printout(const bool test){_test_windows = test ;}
-  void set_pp_mode(const bool flag){_pp_mode = flag ;}
-  void set_use_intt_crossing(const bool flag){_use_intt_crossing = flag ;}
+  void set_test_windows_printout(const bool test) { _test_windows = test; }
+  void set_pp_mode(const bool flag) { _pp_mode = flag; }
+  void set_use_intt_crossing(const bool flag) { _use_intt_crossing = flag; }
 
-  int InitRun(PHCompositeNode* topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
 
-  int process_event(PHCompositeNode*) override;
+  int process_event(PHCompositeNode *) override;
 
-  int End(PHCompositeNode*) override;
+  int End(PHCompositeNode *) override;
 
-  void fieldMap(std::string& fieldmap) { m_fieldMap = fieldmap; }
+  void fieldMap(std::string &fieldmap) { m_fieldMap = fieldmap; }
 
   void set_silicon_track_map_name(const std::string &map_name) { _silicon_track_map_name = map_name; }
   void set_track_map_name(const std::string &map_name) { _track_map_name = map_name; }
-  void SetIteration(int iter){_n_iteration = iter;}
+  void SetIteration(int iter) { _n_iteration = iter; }
+
  private:
+  int GetNodes(PHCompositeNode *topNode);
 
-  int GetNodes(PHCompositeNode* topNode);
-
-  void findEtaPhiMatches( std::set<unsigned int> &tpc_matched_set,
-                            std::set<unsigned int> &tpc_unmatched_set,
-			    std::multimap<unsigned int, unsigned int> &tpc_matches );
+  void findEtaPhiMatches(std::set<unsigned int> &tpc_matched_set,
+                         std::set<unsigned int> &tpc_unmatched_set,
+                         std::multimap<unsigned int, unsigned int> &tpc_matches);
   std::vector<short int> getInttCrossings(TrackSeed *si_track);
-   void checkCrossingMatches( std::multimap<unsigned int, unsigned int> &tpc_matches);
-   short int getCrossingIntt(TrackSeed *_tracklet_si);
-   //void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
-   short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
-   double getBunchCrossing(unsigned int trid, double z_mismatch);
+  void checkCrossingMatches(std::multimap<unsigned int, unsigned int> &tpc_matches);
+  short int getCrossingIntt(TrackSeed *_tracklet_si);
+  // void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
+  short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
+  double getBunchCrossing(unsigned int trid, double z_mismatch);
 
-   //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
-  //double getMedian(std::vector<double> &v);
-  //void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
-  //void addSiliconClusters(  std::multimap<unsigned int, unsigned int> &tpc_matches);
-  //void tagInTimeTracks(  std::multimap<unsigned int, unsigned int> &tpc_matches,
+  //   void checkCrossingMatches( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,  std::map<unsigned int, short int> &tpc_crossing_map );
+  // double getMedian(std::vector<double> &v);
+  // void addSiliconClusters( std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches);
+  // void addSiliconClusters(  std::multimap<unsigned int, unsigned int> &tpc_matches);
+  // void tagInTimeTracks(  std::multimap<unsigned int, unsigned int> &tpc_matches,
   //			 std::multimap<int, std::pair<unsigned int, unsigned int>> &crossing_matches,
   //			 std::map<unsigned int, int> &tpc_crossing_map );
-  //void tagMatchCrossing( std::multimap<unsigned int, unsigned int> &tpc_matches,
+  // void tagMatchCrossing( std::multimap<unsigned int, unsigned int> &tpc_matches,
   //			 std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
   //			 std::map<unsigned int, short int> &tpc_crossing_map );
-  //   void copySiliconClustersToCorrectedMap( );
-  //void correctTpcClusterZIntt(  std::map<unsigned int, short int> &tpc_crossing_map );
-   //void getMatchCrossingIntt(  
-   //			       std::multimap<unsigned int, unsigned int> &tpc_matches,
-   //			       std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
-   //			       std::map<unsigned int, short int> &tpc_crossing_map );
-   //  void addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches);	  
-    //  void addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map);	  
+  //    void copySiliconClustersToCorrectedMap( );
+  // void correctTpcClusterZIntt(  std::map<unsigned int, short int> &tpc_crossing_map );
+  // void getMatchCrossingIntt(
+  //			       std::multimap<unsigned int, unsigned int> &tpc_matches,
+  //			       std::multimap<short int, std::pair<unsigned int, unsigned int>> &crossing_matches,
+  //			       std::map<unsigned int, short int> &tpc_crossing_map );
+  //   void addTrackBunchCrossing(std::multimap<unsigned int, unsigned int> &tpc_matches);
+  //   void addTrackBunchCrossing( std::map<unsigned int, short int> &tpc_crossing_map);
   //  void addTrackBunchCrossing(
-   //						   std::map<unsigned int, short int> &vertex_crossings_map,
-   //						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map);	  
+  //						   std::map<unsigned int, short int> &vertex_crossings_map,
+  //						   std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map);
   //  void cleanVertexMap( std::map<unsigned int, short int> &vertex_crossings_map,
   //		       std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map,
   //		       std::map<unsigned int, short int> &tpc_crossing_map );
   // void getCrossingNumber( std::vector<double> &vertex_list,
-  //			    std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map, 
+  //			    std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map,
   //			    std::map<unsigned int, short int> &vertex_crossings_map);
-  //void getSiVertexList( std::multimap<double, std::pair<unsigned int, unsigned int>> &si_sorted_map,
+  // void getSiVertexList( std::multimap<double, std::pair<unsigned int, unsigned int>> &si_sorted_map,
   //			  std::vector<double> &vertex_list,
   //			  std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map);
   //  void addSiliconClusters(  std::multimap<unsigned int, std::pair<unsigned int, unsigned int>> &vertex_map);
-   //  void correctTpcClusterZ( std::map<unsigned int, double> &vertex_crossings_map,
-   //			     std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map );
+  //  void correctTpcClusterZ( std::map<unsigned int, double> &vertex_crossings_map,
+  //			     std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>  &vertex_map );
 
   // default values, can be replaced from the macro
   double _phi_search_win = 0.01;
@@ -102,7 +101,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   double _x_search_win = 0.3;
   double _y_search_win = 0.3;
   double _z_search_win = 0.4;
-  
+
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeedContainer *_track_map{nullptr};
   TrackSeedContainer *_track_map_silicon{nullptr};
@@ -114,9 +113,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   std::map<unsigned int, double> _z_mismatch_map;
 
-//  double _collision_rate = 50e3;  // input rate for phi correction
-//  double _reference_collision_rate = 50e3;  // reference rate for phi correction
-//  double _si_vertex_dzmax = 0.25;  // mm
+  //  double _collision_rate = 50e3;  // input rate for phi correction
+  //  double _reference_collision_rate = 50e3;  // reference rate for phi correction
+  //  double _si_vertex_dzmax = 0.25;  // mm
   double crossing_period = 106.0;  // ns
 
   bool _test_windows = false;
@@ -129,4 +128,4 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   std::string m_fieldMap = "1.4";
 };
 
-#endif // PHTRUTHSILICONASSOCIATION_H
+#endif  // PHTRUTHSILICONASSOCIATION_H

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -114,9 +114,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   std::map<unsigned int, double> _z_mismatch_map;
 
-  double _collision_rate = 50e3;  // input rate for phi correction
-  double _reference_collision_rate = 50e3;  // reference rate for phi correction
-  double _si_vertex_dzmax = 0.25;  // mm
+//  double _collision_rate = 50e3;  // input rate for phi correction
+//  double _reference_collision_rate = 50e3;  // reference rate for phi correction
+//  double _si_vertex_dzmax = 0.25;  // mm
   double crossing_period = 106.0;  // ns
 
   bool _test_windows = false;

--- a/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHSiliconTruthTrackSeeding.cc
@@ -118,16 +118,16 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* /*topNode*/)
   {
     TrkrDefs::hitkey hitkey = clushititer->second;
     // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
-    TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
+    TrkrDefs::hitsetkey hitsetkey_A = TrkrDefs::getHitSetKeyFromClusKey(cluskey);
     
       if (Verbosity() >= 3)
 	{
-	  cout << PHWHERE <<"      --- process hit with hitkey  " << hitkey << "  hitsetkey " << hitsetkey  << std::endl;
+	  cout << PHWHERE <<"      --- process hit with hitkey  " << hitkey << "  hitsetkey " << hitsetkey_A  << std::endl;
 	}
 
       // get all of the g4hits for this hitkey
       std::multimap<TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;
-      hittruthassoc->getG4Hits(hitsetkey, hitkey, temp_map);  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+      hittruthassoc->getG4Hits(hitsetkey_A, hitkey, temp_map);  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
       for( auto htiter = temp_map.begin(); htiter != temp_map.end(); ++htiter)
       {
         // extract the g4 hit key here and add the hits to the set
@@ -349,13 +349,13 @@ int PHSiliconTruthTrackSeeding::Process(PHCompositeNode* /*topNode*/)
       id++;
 
       //Print associated clusters;
-      for (TrackSeed::ConstClusterKeyIter iter =
+      for (TrackSeed::ConstClusterKeyIter iter_A =
                svtx_track->begin_cluster_keys();
-           iter != svtx_track->end_cluster_keys(); ++iter)
+           iter_A != svtx_track->end_cluster_keys(); ++iter_A)
       {
-        TrkrDefs::cluskey cluster_key = *iter;
+        TrkrDefs::cluskey cluster_key = *iter_A;
         TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
-        float radius = sqrt(
+        float radius = std::sqrt(
             cluster->getX() * cluster->getX() + cluster->getY() * cluster->getY());
         cout << "       cluster ID: "
              << cluster_key << ", cluster radius: " << radius

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -226,7 +226,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
   std::vector<TrackSeed_v2> unused_tracks;
-  for(int track_it = 0; track_it != _track_map->size(); ++track_it )
+  for(unsigned int track_it = 0; track_it != _track_map->size(); ++track_it )
   {
     if (Verbosity())
     {
@@ -242,7 +242,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
 
     if (is_tpc)
     {
-      std::vector<std::vector<TrkrDefs::cluskey>> keylist;
+      std::vector<std::vector<TrkrDefs::cluskey>> keylist_A;
       std::vector<TrkrDefs::cluskey> dumvec;
       std::map<TrkrDefs::cluskey, Acts::Vector3> trackClusPositions;
       for (TrackSeed::ConstClusterKeyIter iter = track->begin_cluster_keys();
@@ -260,7 +260,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         continue;
       }
 
-      keylist.push_back(dumvec);
+      keylist_A.push_back(dumvec);
 
       /// This will by definition return a single pair with each vector
       /// in the pair length 1 corresponding to the seed info
@@ -268,7 +268,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       timer.stop();
       timer.restart();
 
-      auto seedpair = fitter->ALICEKalmanFilter(keylist, false,
+      auto seedpair = fitter->ALICEKalmanFilter(keylist_A, false,
                                                 trackClusPositions, trackChi2);
 
       timer.stop();
@@ -1094,7 +1094,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   {
     std::cout << "\nlayers after outward propagation:" << std::endl;
   }
-  for (int i = 0; i < propagated_track.size(); i++)
+  for (unsigned int i = 0; i < propagated_track.size(); i++)
   {
     layers.push_back(TrkrDefs::getLayer(propagated_track[i]));
     if (Verbosity()) std::cout << layers[i] << std::endl;

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -61,7 +61,7 @@ class PHSimpleVertexFinder : public SubsysReco
  double getAverage(std::vector<double> &v);
 
   SvtxTrackMap *_track_map{nullptr};
-  SvtxTrack *_track{nullptr};  
+//  SvtxTrack *_track{nullptr};  
   SvtxVertexMap *_svtx_vertex_map{nullptr};
   
   double _base_dcacut = 0.0080;  // 80 microns 

--- a/offline/packages/trackreco/PHTpcClusterMover.h
+++ b/offline/packages/trackreco/PHTpcClusterMover.h
@@ -69,14 +69,14 @@ class PHTpcClusterMover : public SubsysReco
   TpcDistortionCorrectionContainer* _dcc{nullptr};
 
   double layer_radius[48] = {0};
-  double inner_tpc_min_radius = 30.0;
-  double mid_tpc_min_radius = 40.0;
-  double outer_tpc_min_radius = 60.0;
-  double outer_tpc_max_radius = 77.0;
+//  double inner_tpc_min_radius = 30.0;
+//  double mid_tpc_min_radius = 40.0;
+//  double outer_tpc_min_radius = 60.0;
+//  double outer_tpc_max_radius = 77.0;
 
-  double inner_tpc_spacing = 0.0;
-  double mid_tpc_spacing = 0.0;
-  double outer_tpc_spacing = 0.0;
+//  double inner_tpc_spacing = 0.0;
+//  double mid_tpc_spacing = 0.0;
+//  double outer_tpc_spacing = 0.0;
 
 };
 

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -31,15 +31,14 @@ PHTrackCleaner::PHTrackCleaner(const std::string &name)
 
 //____________________________________________________________________________..
 PHTrackCleaner::~PHTrackCleaner()
-{
-
-}
+= default;
 
 //____________________________________________________________________________..
 int PHTrackCleaner::InitRun(PHCompositeNode *topNode)
 {
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
+}
 
    return ret;
 }
@@ -48,8 +47,9 @@ int PHTrackCleaner::InitRun(PHCompositeNode *topNode)
 int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
 {
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     std::cout << PHWHERE << " track map size " << _track_map->size()  << std::endl;
+}
 
   std::set<unsigned int> track_keep_list;
   std::set<unsigned int> track_delete_list;
@@ -60,11 +60,12 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
   std::multimap<unsigned int, unsigned int> tpcid_track_mmap;
   std::set<unsigned int> tpc_id_set;
   // loop over the fitted tracks
-  for (auto it = _track_map->begin(); it != _track_map->end(); ++it)
+  for (auto & it : *_track_map)
     {
-      auto track_id = (*it).first;
-      auto track = (*it).second;
-      if(!track) continue;
+      auto track_id = it.first;
+      auto track = it.second;
+      if(!track) { continue;
+}
       
       auto tpc_seed =  track->get_tpc_seed();
       unsigned int tpc_index = _tpc_seed_map->find(tpc_seed);      
@@ -75,17 +76,17 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
       tpcid_track_mmap.insert(tpc_track_pair);
     }
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     std::cout << " tpcid_track_mmap  size " << tpcid_track_mmap.size() << std::endl;
+}
 
   // loop over the TPC seed ID's
 
-  for(auto seed_iter = tpc_id_set.begin(); seed_iter != tpc_id_set.end(); ++seed_iter)
+  for(unsigned int tpc_id : tpc_id_set)
     {
-      unsigned int tpc_id = *seed_iter;
-
-      if(Verbosity() > 1)
+      if(Verbosity() > 1) {
 	std::cout << " TPC ID " << tpc_id << std::endl;
+}
 
       auto tpc_range = tpcid_track_mmap.equal_range(tpc_id);
 
@@ -106,9 +107,10 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
 		  // skip tracks with no assigned crossing number in pp mode
 		  if(_track->get_crossing() == SHRT_MAX)
 		    {
-		      if(Verbosity() > 0) 
+		      if(Verbosity() > 0) { 
 			std::cout << "     skip  track ID " << track_id << " crossing " << _track->get_crossing() <<  " chisq " << _track->get_chisq() 
 				  << " ndf " << _track->get_ndf() << std::endl;
+}
 		      
 		      continue;
 		    }
@@ -118,12 +120,14 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
 
 	      unsigned int si_index = UINT_MAX;      
 	      auto si_seed =  _track->get_silicon_seed();
-	      if (si_seed)
+	      if (si_seed) {
 		si_index = _silicon_seed_map->find(si_seed);      
+}
 
-	      if(Verbosity() > 1)	      
+	      if(Verbosity() > 1) {	      
 		std::cout << "        track ID " << track_id << " tpc index " << tpc_id << " si index " << si_index << " crossing " << _track->get_crossing() 
 			  << " chisq " << _track->get_chisq() << " ndf " << _track->get_ndf() << " min_chisq_df " << min_chisq_df << std::endl;
+}
 
 	      // only accept tracks with ndf > min_ndf - very small ndf means something went wrong, as does ndf undefined
 	      if(_track->get_chisq()/_track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
@@ -139,54 +143,62 @@ int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
 	{
 	  double qual = min_chisq_df;
 
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 1) {
 	    std::cout << "        best track for tpc_id " << tpc_id << " has track_id " << best_id << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;
+}
 
 	  if(qual < quality_cut * 2)
 	    {
 	      track_keep_list.insert(best_id);
 	      ok_track++;
-	      if(qual < quality_cut)
+	      if(qual < quality_cut) {
 		good_track++;
+}
 	    }
 	}
       else
 	{
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 1) {
 	    std::cout << "        no track exists  for tpc_id " << tpc_id << std::endl;
+}
 	}
     }
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     std::cout << " Number of good tracks with qual < " << quality_cut << "  is " << good_track << " OK tracks " << ok_track << std::endl; 
+}
 
   // make a list of tracks that did not make the keep list
-  for(auto track_it = _track_map->begin(); track_it != _track_map->end(); ++track_it)
+  for(auto & track_it : *_track_map)
     {
-      auto id = track_it->first;
+      auto id = track_it.first;
 
       auto set_it = track_keep_list.find(id);
       if(set_it == track_keep_list.end())
 	{
-	  if(Verbosity() > 1)
+	  if(Verbosity() > 1) {
 	    std::cout << "    add id " << id << " to track_delete_list " << std::endl;
+}
 	  track_delete_list.insert(id);
 	}
     }
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     std::cout << " track_delete_list size " << track_delete_list.size() << std::endl;
+}
 
   // delete failed tracks
-  for(auto it = track_delete_list.begin(); it != track_delete_list.end(); ++it)
+  for(unsigned int it : track_delete_list)
     {
-      if(Verbosity() > 1)
-	std::cout << " erasing track ID " << *it << std::endl;
-      _track_map->erase(*it);
+      if(Verbosity() > 1) {
+	std::cout << " erasing track ID " << it << std::endl;
+}
+      _track_map->erase(it);
     }
 
-  if(Verbosity() > 0)
+  if(Verbosity() > 0) {
     std::cout << "Track map size after choosing best silicon match: " << _track_map->size() << std::endl;
+}
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -1,13 +1,13 @@
 #include "PHTrackCleaner.h"
 
-#include "PHTrackCleaner.h"   
+#include "PHTrackCleaner.h"
 
 /// Tracking includes
 
-#include <trackbase/TrkrCluster.h>            // for TrkrCluster
-#include <trackbase/TrkrDefs.h>               // for cluskey, getLayer, TrkrId
+#include <trackbase/TrkrCluster.h>  // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>
-#include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::C...
+#include <trackbase/TrkrDefs.h>            // for cluskey, getLayer, TrkrId
+#include <trackbase_historic/SvtxTrack.h>  // for SvtxTrack, SvtxTrack::C...
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 
@@ -16,201 +16,216 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>
 
-#include <cmath>                              // for sqrt, fabs, atan2, cos
-#include <iostream>                           // for operator<<, basic_ostream
-#include <map>                                // for map
-#include <set>                                // for _Rb_tree_const_iterator
-#include <utility>                            // for pair, make_pair
+#include <cmath>     // for sqrt, fabs, atan2, cos
+#include <iostream>  // for operator<<, basic_ostream
+#include <map>       // for map
+#include <set>       // for _Rb_tree_const_iterator
+#include <utility>   // for pair, make_pair
 
 //____________________________________________________________________________..
 PHTrackCleaner::PHTrackCleaner(const std::string &name)
   : SubsysReco(name)
 {
-
 }
 
 //____________________________________________________________________________..
-PHTrackCleaner::~PHTrackCleaner()
-= default;
+PHTrackCleaner::~PHTrackCleaner() = default;
 
 //____________________________________________________________________________..
 int PHTrackCleaner::InitRun(PHCompositeNode *topNode)
 {
   int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) { return ret;
-}
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return ret;
+  }
 
-   return ret;
+  return ret;
 }
 
 //____________________________________________________________________________..
-int PHTrackCleaner::process_event(PHCompositeNode */*topNode*/)
+int PHTrackCleaner::process_event(PHCompositeNode * /*topNode*/)
 {
-
-  if(Verbosity() > 0) {
-    std::cout << PHWHERE << " track map size " << _track_map->size()  << std::endl;
-}
+  if (Verbosity() > 0)
+  {
+    std::cout << PHWHERE << " track map size " << _track_map->size() << std::endl;
+  }
 
   std::set<unsigned int> track_keep_list;
   std::set<unsigned int> track_delete_list;
 
   unsigned int good_track = 0;  // for diagnostic output only
-  unsigned int ok_track = 0;   // tracks to keep
+  unsigned int ok_track = 0;    // tracks to keep
 
   std::multimap<unsigned int, unsigned int> tpcid_track_mmap;
   std::set<unsigned int> tpc_id_set;
   // loop over the fitted tracks
-  for (auto & it : *_track_map)
+  for (auto &it : *_track_map)
+  {
+    auto track_id = it.first;
+    auto track = it.second;
+    if (!track)
     {
-      auto track_id = it.first;
-      auto track = it.second;
-      if(!track) { continue;
-}
-      
-      auto tpc_seed =  track->get_tpc_seed();
-      unsigned int tpc_index = _tpc_seed_map->find(tpc_seed);      
-
-      auto tpc_track_pair = std::make_pair(tpc_index, track_id);
-
-      tpc_id_set.insert(tpc_index);
-      tpcid_track_mmap.insert(tpc_track_pair);
+      continue;
     }
 
-  if(Verbosity() > 0) {
+    auto tpc_seed = track->get_tpc_seed();
+    unsigned int tpc_index = _tpc_seed_map->find(tpc_seed);
+
+    auto tpc_track_pair = std::make_pair(tpc_index, track_id);
+
+    tpc_id_set.insert(tpc_index);
+    tpcid_track_mmap.insert(tpc_track_pair);
+  }
+
+  if (Verbosity() > 0)
+  {
     std::cout << " tpcid_track_mmap  size " << tpcid_track_mmap.size() << std::endl;
-}
+  }
 
   // loop over the TPC seed ID's
 
-  for(unsigned int tpc_id : tpc_id_set)
+  for (unsigned int tpc_id : tpc_id_set)
+  {
+    if (Verbosity() > 1)
     {
-      if(Verbosity() > 1) {
-	std::cout << " TPC ID " << tpc_id << std::endl;
-}
-
-      auto tpc_range = tpcid_track_mmap.equal_range(tpc_id);
-
-      unsigned int best_id = 99999;
-      double min_chisq_df = 99999.0;
-      unsigned int best_ndf = 1;
-      for (auto it = tpc_range.first; it !=tpc_range.second; ++it)
-	{
-	  unsigned int track_id = it->second;
-
-	  // note that the track no longer exists if it failed in the Acts fitter
-	  _track = _track_map->get(track_id);
-
-	  if(_track)
-	    {
-	      if(_pp_mode)
-		{
-		  // skip tracks with no assigned crossing number in pp mode
-		  if(_track->get_crossing() == SHRT_MAX)
-		    {
-		      if(Verbosity() > 0) { 
-			std::cout << "     skip  track ID " << track_id << " crossing " << _track->get_crossing() <<  " chisq " << _track->get_chisq() 
-				  << " ndf " << _track->get_ndf() << std::endl;
-}
-		      
-		      continue;
-		    }
-		}
-	      
-	      //Find the remaining track with the best chisq/ndf
-
-	      unsigned int si_index = UINT_MAX;      
-	      auto si_seed =  _track->get_silicon_seed();
-	      if (si_seed) {
-		si_index = _silicon_seed_map->find(si_seed);      
-}
-
-	      if(Verbosity() > 1) {	      
-		std::cout << "        track ID " << track_id << " tpc index " << tpc_id << " si index " << si_index << " crossing " << _track->get_crossing() 
-			  << " chisq " << _track->get_chisq() << " ndf " << _track->get_ndf() << " min_chisq_df " << min_chisq_df << std::endl;
-}
-
-	      // only accept tracks with ndf > min_ndf - very small ndf means something went wrong, as does ndf undefined
-	      if(_track->get_chisq()/_track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
-		{
-		  min_chisq_df = _track->get_chisq() / _track->get_ndf();
-		  best_id = track_id;
-		  best_ndf = _track->get_ndf();
-		}
-	    }
-	}
-
-      if(best_id != 99999)
-	{
-	  double qual = min_chisq_df;
-
-	  if(Verbosity() > 1) {
-	    std::cout << "        best track for tpc_id " << tpc_id << " has track_id " << best_id << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;
-}
-
-	  if(qual < quality_cut * 2)
-	    {
-	      track_keep_list.insert(best_id);
-	      ok_track++;
-	      if(qual < quality_cut) {
-		good_track++;
-}
-	    }
-	}
-      else
-	{
-	  if(Verbosity() > 1) {
-	    std::cout << "        no track exists  for tpc_id " << tpc_id << std::endl;
-}
-	}
+      std::cout << " TPC ID " << tpc_id << std::endl;
     }
 
-  if(Verbosity() > 0) {
-    std::cout << " Number of good tracks with qual < " << quality_cut << "  is " << good_track << " OK tracks " << ok_track << std::endl; 
-}
+    auto tpc_range = tpcid_track_mmap.equal_range(tpc_id);
+
+    unsigned int best_id = 99999;
+    double min_chisq_df = 99999.0;
+    unsigned int best_ndf = 1;
+    for (auto it = tpc_range.first; it != tpc_range.second; ++it)
+    {
+      unsigned int track_id = it->second;
+
+      // note that the track no longer exists if it failed in the Acts fitter
+      _track = _track_map->get(track_id);
+
+      if (_track)
+      {
+        if (_pp_mode)
+        {
+          // skip tracks with no assigned crossing number in pp mode
+          if (_track->get_crossing() == SHRT_MAX)
+          {
+            if (Verbosity() > 0)
+            {
+              std::cout << "     skip  track ID " << track_id << " crossing " << _track->get_crossing() << " chisq " << _track->get_chisq()
+                        << " ndf " << _track->get_ndf() << std::endl;
+            }
+
+            continue;
+          }
+        }
+
+        // Find the remaining track with the best chisq/ndf
+
+        unsigned int si_index = UINT_MAX;
+        auto si_seed = _track->get_silicon_seed();
+        if (si_seed)
+        {
+          si_index = _silicon_seed_map->find(si_seed);
+        }
+
+        if (Verbosity() > 1)
+        {
+          std::cout << "        track ID " << track_id << " tpc index " << tpc_id << " si index " << si_index << " crossing " << _track->get_crossing()
+                    << " chisq " << _track->get_chisq() << " ndf " << _track->get_ndf() << " min_chisq_df " << min_chisq_df << std::endl;
+        }
+
+        // only accept tracks with ndf > min_ndf - very small ndf means something went wrong, as does ndf undefined
+        if (_track->get_chisq() / _track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
+        {
+          min_chisq_df = _track->get_chisq() / _track->get_ndf();
+          best_id = track_id;
+          best_ndf = _track->get_ndf();
+        }
+      }
+    }
+
+    if (best_id != 99999)
+    {
+      double qual = min_chisq_df;
+
+      if (Verbosity() > 1)
+      {
+        std::cout << "        best track for tpc_id " << tpc_id << " has track_id " << best_id << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;
+      }
+
+      if (qual < quality_cut * 2)
+      {
+        track_keep_list.insert(best_id);
+        ok_track++;
+        if (qual < quality_cut)
+        {
+          good_track++;
+        }
+      }
+    }
+    else
+    {
+      if (Verbosity() > 1)
+      {
+        std::cout << "        no track exists  for tpc_id " << tpc_id << std::endl;
+      }
+    }
+  }
+
+  if (Verbosity() > 0)
+  {
+    std::cout << " Number of good tracks with qual < " << quality_cut << "  is " << good_track << " OK tracks " << ok_track << std::endl;
+  }
 
   // make a list of tracks that did not make the keep list
-  for(auto & track_it : *_track_map)
+  for (auto &track_it : *_track_map)
+  {
+    auto id = track_it.first;
+
+    auto set_it = track_keep_list.find(id);
+    if (set_it == track_keep_list.end())
     {
-      auto id = track_it.first;
-
-      auto set_it = track_keep_list.find(id);
-      if(set_it == track_keep_list.end())
-	{
-	  if(Verbosity() > 1) {
-	    std::cout << "    add id " << id << " to track_delete_list " << std::endl;
-}
-	  track_delete_list.insert(id);
-	}
+      if (Verbosity() > 1)
+      {
+        std::cout << "    add id " << id << " to track_delete_list " << std::endl;
+      }
+      track_delete_list.insert(id);
     }
+  }
 
-  if(Verbosity() > 0) {
+  if (Verbosity() > 0)
+  {
     std::cout << " track_delete_list size " << track_delete_list.size() << std::endl;
-}
+  }
 
   // delete failed tracks
-  for(unsigned int it : track_delete_list)
+  for (unsigned int it : track_delete_list)
+  {
+    if (Verbosity() > 1)
     {
-      if(Verbosity() > 1) {
-	std::cout << " erasing track ID " << it << std::endl;
-}
-      _track_map->erase(it);
+      std::cout << " erasing track ID " << it << std::endl;
     }
+    _track_map->erase(it);
+  }
 
-  if(Verbosity() > 0) {
+  if (Verbosity() > 0)
+  {
     std::cout << "Track map size after choosing best silicon match: " << _track_map->size() << std::endl;
-}
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHTrackCleaner::End(PHCompositeNode */*topNode*/)
+int PHTrackCleaner::End(PHCompositeNode * /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
+int PHTrackCleaner::GetNodes(PHCompositeNode *topNode)
 {
- _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
+  _tpc_seed_map = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
   if (!_tpc_seed_map)
   {
     std::cout << PHWHERE << " ERROR: Can't find TpcTrackSeedContainer: " << std::endl;
@@ -223,7 +238,7 @@ int  PHTrackCleaner::GetNodes(PHCompositeNode* topNode)
     std::cout << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
-  
+
   _track_map = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
   if (!_track_map)
   {

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -12,9 +12,9 @@
 
 #include <fun4all/SubsysReco.h>
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 class PHCompositeNode;
 class SvtxTrack;
@@ -25,7 +25,6 @@ class TrackSeedContainer;
 class PHTrackCleaner : public SubsysReco
 {
  public:
-
   PHTrackCleaner(const std::string &name = "PHTrackCleaner");
 
   ~PHTrackCleaner() override;
@@ -34,12 +33,11 @@ class PHTrackCleaner : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
- void set_pp_mode(const bool flag){_pp_mode = flag ;}
- void set_quality_cut(const float cut) {quality_cut = cut;}
+  void set_pp_mode(const bool flag) { _pp_mode = flag; }
+  void set_quality_cut(const float cut) { quality_cut = cut; }
 
  private:
-
-  int GetNodes(PHCompositeNode* topNode);
+  int GetNodes(PHCompositeNode *topNode);
   void findGhostTracks();
 
   SvtxTrackMap *_track_map{nullptr};
@@ -47,10 +45,9 @@ class PHTrackCleaner : public SubsysReco
   TrackSeedContainer *_tpc_seed_map{nullptr};
   TrackSeedContainer *_silicon_seed_map{nullptr};
 
- double min_ndf = 25;
- float quality_cut = 15.0;
- bool _pp_mode = false;
-
+  double min_ndf = 25;
+  float quality_cut = 15.0;
+  bool _pp_mode = false;
 };
 
-#endif // PHTRACKCLEANER_H
+#endif  // PHTRACKCLEANER_H

--- a/offline/packages/trackreco/PHTrackSelector.cc
+++ b/offline/packages/trackreco/PHTrackSelector.cc
@@ -74,9 +74,9 @@ int PHTrackSelector::process_event(PHCompositeNode */*topNode*/)
       _track = track_it->second;
       bool delete_track = false;
       double chi2_ndf = _track->get_chisq() / _track->get_ndf();
-      int ntpc = 0;
-      int nintt = 0;
-      int nmvtx = 0;
+      unsigned int ntpc = 0;
+      unsigned int nintt = 0;
+      unsigned int nmvtx = 0;
 
       for (SvtxTrack::ConstClusterKeyIter iter = _track->begin_cluster_keys();
 	   iter != _track->end_cluster_keys();

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -203,13 +203,13 @@ int PHTruthClustering::process_event(PHCompositeNode* topNode)
   // For the other subsystems, we just copy over all of the the clusters from the reco map
   for(const auto& hitsetkey:_reco_cluster_map->getHitSetKeys())
   {
-    auto range = _reco_cluster_map->getClusters(hitsetkey);
+    auto range_A = _reco_cluster_map->getClusters(hitsetkey);
     unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
 
     // skip TPC
     if(trkrid == TrkrDefs::tpcId)  continue;
     
-    for( auto clusIter = range.first; clusIter != range.second; ++clusIter ){
+    for( auto clusIter = range_A.first; clusIter != range_A.second; ++clusIter ){
       TrkrDefs::cluskey cluskey = clusIter->first;
 
       // we have to make a copy of the cluster, to avoid problems later
@@ -517,29 +517,29 @@ void PHTruthClustering::LayerClusterG4Hits(std::set<PHG4Hit*> truth_hits, std::v
 	  float yout = yl[1];
 	  float zout = zl[1];
 	  
-	  float t = NAN;
+	  float time = std::numeric_limits<float>::quiet_NaN();
 	  
 	  if (rbegin < rbin)
 	    {
 	      // line segment begins before boundary, find where it crosses
-	      t = line_circle_intersection(xl, yl, zl, rbin);
-	      if (t > 0)
+	      time = line_circle_intersection(xl, yl, zl, rbin);
+	      if (time > 0)
 		{
-		  xin = xl[0] + t * (xl[1] - xl[0]);
-		  yin = yl[0] + t * (yl[1] - yl[0]);
-		  zin = zl[0] + t * (zl[1] - zl[0]);
+		  xin = xl[0] + time * (xl[1] - xl[0]);
+		  yin = yl[0] + time * (yl[1] - yl[0]);
+		  zin = zl[0] + time * (zl[1] - zl[0]);
 		}
 	    }
 	  
 	  if (rend > rbout)
 	    {
 	      // line segment ends after boundary, find where it crosses
-	      t = line_circle_intersection(xl, yl, zl, rbout);
-	      if (t > 0)
+	      time = line_circle_intersection(xl, yl, zl, rbout);
+	      if (time > 0)
 		{
-		  xout = xl[0] + t * (xl[1] - xl[0]);
-		  yout = yl[0] + t * (yl[1] - yl[0]);
-		  zout = zl[0] + t * (zl[1] - zl[0]);
+		  xout = xl[0] + time * (xl[1] - xl[0]);
+		  yout = yl[0] + time * (yl[1] - yl[0]);
+		  zout = zl[0] + time * (zl[1] - zl[0]);
 		}
 	    }
 

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.cc
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.cc
@@ -434,17 +434,17 @@ std::set<TrkrDefs::cluskey> PHTruthSiliconAssociation::getSiliconClustersFromPar
 	{
 	  TrkrDefs::hitkey hitkey = clushititer->second;
 	  // TrkrHitTruthAssoc uses a map with (hitsetkey, std::pair(hitkey, g4hitkey)) - get the hitsetkey from the cluskey
-	  TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);	  
+	  TrkrDefs::hitsetkey hitsetkey_A = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);	  
 	  
 	  // get all of the g4hits for this hitkey
 	  std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> > temp_map;    
-	  _hit_truth_map->getG4Hits(hitsetkey, hitkey, temp_map); 	  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
+	  _hit_truth_map->getG4Hits(hitsetkey_A, hitkey, temp_map); 	  // returns pairs (hitsetkey, std::pair(hitkey, g4hitkey)) for this hitkey only
 	  for(std::multimap< TrkrDefs::hitsetkey, std::pair<TrkrDefs::hitkey, PHG4HitDefs::keytype> >::iterator htiter =  temp_map.begin(); htiter != temp_map.end(); ++htiter) 
 	    {
 	      // extract the g4 hit key 
 	      PHG4HitDefs::keytype g4hitkey = htiter->second.second;
 	      PHG4Hit * g4hit = nullptr;
-	      unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey);
+	      unsigned int trkrid = TrkrDefs::getTrkrId(hitsetkey_A);
 	      switch( trkrid )
 		{
 		case TrkrDefs::mvtxId: g4hit = _g4hits_mvtx->findHit(g4hitkey); break;
@@ -489,9 +489,9 @@ std::set<short int> PHTruthSiliconAssociation::getInttCrossings(TrackSeed *si_tr
 	  
 	  // get the bunch crossings for all hits in this cluster
 	  auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
-	  for(auto iter = crossings.first; iter != crossings.second; ++iter)
+	  for(auto iter_A = crossings.first; iter_A != crossings.second; ++iter_A)
 	    {
-        const auto& [key, crossing] = *iter;
+        const auto& [key, crossing] = *iter_A;
         if( Verbosity() )
         { std::cout << "PHTruthSiliconAssociation::getInttCrossings - si Track cluster " << key << " layer " << layer << " crossing " << crossing  << std::endl; }
 	      intt_crossings.insert(crossing);

--- a/offline/packages/trackreco/PHTruthSiliconAssociation.h
+++ b/offline/packages/trackreco/PHTruthSiliconAssociation.h
@@ -69,14 +69,14 @@ class PHTruthSiliconAssociation : public SubsysReco
   PHG4HitContainer *_g4hits_intt{nullptr};
   
   TrkrClusterContainer *_cluster_map{nullptr};
-  TrkrClusterContainer *_corrected_cluster_map{nullptr};
+//  TrkrClusterContainer *_corrected_cluster_map{nullptr};
   TrkrClusterHitAssoc *_cluster_hit_map{nullptr};
   TrkrHitTruthAssoc *_hit_truth_map{nullptr};
   TrackSeedContainer *_tpc_track_map{nullptr};
   TrackSeedContainer *_silicon_track_map{nullptr};
   TrackSeedContainer *_svtx_seed_map{nullptr};
   TrackSeed *_tracklet{nullptr};
-  SvtxVertexMap * _vertex_map{nullptr};
+//  SvtxVertexMap * _vertex_map{nullptr};
   TrkrClusterCrossingAssoc *_cluster_crossing_map{nullptr};
   ActsGeometry *_tgeometry{nullptr};
 

--- a/offline/packages/trackreco/PHTruthTrackSeeding.cc
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.cc
@@ -489,9 +489,9 @@ std::set<short int> PHTruthTrackSeeding::getInttCrossings(TrackSeed *si_track) c
       
       // get the bunch crossings for all hits in this cluster
       const auto crossings = m_cluster_crossing_map->getCrossings(cluster_key);
-      for(auto iter = crossings.first; iter != crossings.second; ++iter)
+      for(auto iter_A = crossings.first; iter_A != crossings.second; ++iter_A)
       {
-        const auto& [key, crossing] = *iter;
+        const auto& [key, crossing] = *iter_A;
         if( Verbosity() )
 	  { std::cout << "    PHTruthTrackSeeding::getInttCrossings - si Track cluster " << key << " layer " << layer << " crossing " << crossing  << std::endl; }
         intt_crossings.insert(crossing);

--- a/offline/packages/trackreco/PHTruthTrackSeeding.h
+++ b/offline/packages/trackreco/PHTruthTrackSeeding.h
@@ -111,7 +111,7 @@ class PHTruthTrackSeeding : public PHTrackSeeding
 
   ActsGeometry *tgeometry = nullptr;
 
-  bool _circle_fit_seed = false;
+//  bool _circle_fit_seed = false;
 
   //! rng de-allocator
   class Deleter

--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -1,5 +1,5 @@
 /*!
- *  \file PrelimDistortionCorrection.cc
+ *  \File PrelimDistortionCorrection.cc
  *  \brief	Makes preliminary TPC distortion corrections in pp running and replaces TPC seed parameters with new fits
  *  \author Tony Frawley
  */
@@ -206,10 +206,10 @@ int PrelimDistortionCorrection::process_event(PHCompositeNode* /*topNode*/)
 
   // These accumulate trackseeds as we loop over tracks, keylist is a vector of vectors of seed cluskeys
   // The seeds are all given to the fitter at once
-    std::vector<std::vector<TrkrDefs::cluskey>> keylist;
+    std::vector<std::vector<TrkrDefs::cluskey>> keylist_A;
     PositionMap correctedOffsetTrackClusPositions;   //  this is an std::map<TrkrDefs::cluskey, Acts::Vector3>
 
-  for(int track_it = 0; track_it != _track_map->size(); ++track_it )
+  for(unsigned int track_it = 0; track_it != _track_map->size(); ++track_it )
   {
     if(Verbosity()>0) { std::cout << "TPC seed " << track_it << std::endl; }
     // if not a TPC track, ignore
@@ -285,11 +285,11 @@ int PrelimDistortionCorrection::process_event(PHCompositeNode* /*topNode*/)
       /// Can't circle fit a seed with less than 3 clusters, skip it
       if(dumvec.size() < 3)
 	{ continue; }
-      keylist.push_back(dumvec);
+      keylist_A.push_back(dumvec);
 
       if(Verbosity() > 0)
 	{
-	  std::cout << "Added  input seed " << track_it << "  becomes output seed " << keylist.size() - 1 << std::endl;
+	  std::cout << "Added  input seed " << track_it << "  becomes output seed " << keylist_A.size() - 1 << std::endl;
 	}
 
     } // end if TPC seed
@@ -301,7 +301,7 @@ int PrelimDistortionCorrection::process_event(PHCompositeNode* /*topNode*/)
       
   // refit the corrected clusters 
   std::vector<float> trackChi2;
-  auto seeds = fitter->ALICEKalmanFilter(keylist, true, correctedOffsetTrackClusPositions,
+  auto seeds = fitter->ALICEKalmanFilter(keylist_A, true, correctedOffsetTrackClusPositions,
 					 trackChi2);
   
   // update the seed parameters on the node tree

--- a/offline/packages/trackreco/SecondaryVertexFinder.h
+++ b/offline/packages/trackreco/SecondaryVertexFinder.h
@@ -104,7 +104,7 @@ bool passConversionElectronCuts(TLorentzVector tsum,
 
   SvtxTrackMap *_track_map{nullptr};
   SvtxTrackMap *_track_map_electrons{nullptr};
-  SvtxTrack *_track{nullptr};  
+//  SvtxTrack *_track{nullptr};  
   SvtxVertexMap *_svtx_vertex_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
 

--- a/offline/packages/trackreco/configure.ac
+++ b/offline/packages/trackreco/configure.ac
@@ -17,24 +17,8 @@ dnl  ;;
 dnl esac
 
 if test $ac_cv_prog_gxx = yes; then
-     CXXFLAGS="$CXXFLAGS -Wall -Wextra"
+     CXXFLAGS="$CXXFLAGS -Wall -Wshadow -Wextra -Werror"
 fi
-
-dnl gcc 8.3 creates warning in boost header, needs -Wno-class-memaccess
-dnl need to check for *g++ since $CXX contains full path to g++
-case $CXX in
- clang++)
-   CXXFLAGS="$CXXFLAGS -Werror -Wno-undefined-var-template -Wno-unused-private-field -Wno-range-loop-construct -Wno-unused-local-typedef -Wno-deprecated-copy -Wno-sign-compare -Wno-unused-parameter -Wno-unused-value -Wno-bitwise-instead-of-logical -Wno-unknown-warning-option -Wno-deprecated-declarations"
- ;;
- *analyzer)
-   CXXFLAGS="$CXXFLAGS"
- ;;
- *g++)
-  if test `g++ -dumpversion | awk -F\. '{print $1>=8?"1":"0"}'` = 1; then
-     CXXFLAGS="$CXXFLAGS -Werror -Wno-class-memaccess -Wno-unused-local-typedefs -Wno-sign-compare -Wno-switch -Wno-unused-function -Wno-unused-value -Wno-maybe-uninitialized"
-  fi
- ;;
-esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "
 AC_SUBST(CINTDEFS)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Initially this was supposed to fix only the clang-tidy errors which have shown up in the recent PRs. It turns out that the trackreco package still used old compiler flags from the transition from gcc 4 to gcc 8 which basically removed all warnings (including critical ones). This PR fixes all warnings from gcc and clang, so this can now be compiled using our standard compilation flags (-Wall -Wextra -Wshadow -Werror). Likely there will be new warnings from clang-tidy since a lot of line numbers have changed. That's for the next PR

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

