### PR TITLE
Phtpcresiduals update

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -49,9 +49,9 @@
 #include <iostream>
 #include <sstream>
 
-namespace 
+namespace
 {
-  
+
   // square
   template<class T> inline constexpr T square( const T& x ) { return x*x; }
 
@@ -60,19 +60,19 @@ namespace
 
   template<class T> inline constexpr T deltaPhi(const T& phi)
   {
-    if (phi > M_PI) 
+    if (phi > M_PI)
       return phi - 2. * M_PI;
-    else if (phi <= -M_PI) 
+    else if (phi <= -M_PI)
       return phi + 2.* M_PI;
-    else 
+    else
       return phi;
   }
-  
+
   /// get sector median angle associated to a given index
   /** this assumes that sector 0 is centered on phi=0, then numbered along increasing phi */
-  inline constexpr double get_sector_phi( int isec ) 
+  inline constexpr double get_sector_phi( int isec )
   { return isec*M_PI/6; }
-  
+
   // specify bins for which one will save histograms
   static const std::vector<float> phi_rec = { get_sector_phi(9) };
   static const std::vector<float> z_rec = { 5. };
@@ -97,6 +97,13 @@ namespace
       []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == type; } );
   }
 
+  /// streamer
+  std::ostream& operator << (std::ostream& out, const Acts::Vector3& v )
+  {
+    out << "(" << v.x() << "," << v.y() << "," << v.z() << ")";
+    return out;
+  }
+
 }
 
 //___________________________________________________________________________________
@@ -115,7 +122,7 @@ int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
   std::cout << "PHTpcResiduals::Init - m_maxResidualDrphi: " << m_maxResidualDrphi << " cm" << std::endl;
   std::cout << "PHTpcResiduals::Init - m_maxResidualDz: " << m_maxResidualDz << " cm" << std::endl;
   std::cout << "PHTpcResiduals::Init - m_minPt: " << m_minPt << " GeV/c" << std::endl;
-  
+
   // reset counters
   m_total_tracks = 0;
   m_accepted_tracks = 0;
@@ -141,7 +148,7 @@ int PHTpcResiduals::InitRun(PHCompositeNode *topNode)
 //___________________________________________________________________________________
 int PHTpcResiduals::process_event(PHCompositeNode *topNode)
 {
-  const auto returnVal = processTracks(topNode);  
+  const auto returnVal = processTracks(topNode);
   ++m_event;
 
   return returnVal;
@@ -151,7 +158,7 @@ int PHTpcResiduals::process_event(PHCompositeNode *topNode)
 int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
 {
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
-      
+
   // save matrix container in output file
   if( m_matrix_container )
   {
@@ -159,7 +166,7 @@ int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
     outputfile->cd();
     m_matrix_container->Write( "TpcSpaceChargeMatrixContainer" );
   }
-  
+
   // print counters
   std::cout
     << "PHTpcResiduals::End -"
@@ -187,9 +194,9 @@ int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
 
   for(const auto &[trackKey, track] : *m_trackMap)
   {
-    if(Verbosity() > 1) 
+    if(Verbosity() > 1)
     { std::cout << "PHTpcResiduals::processTracks - Processing track key " << trackKey << std::endl; }
-    
+
     ++m_total_tracks;
     if(checkTrack(track))
     {
@@ -197,7 +204,7 @@ int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
       processTrack(track);
     }
   }
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -206,7 +213,7 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
 {
   if(Verbosity() > 2)
   { std::cout << "PHTpcResiduals::checkTrack - pt: " << track->get_pt() << std::endl; }
- 
+
   if(track->get_pt() < m_minPt)
   { return false; }
 
@@ -223,46 +230,70 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
 
 //___________________________________________________________________________________
 Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track) const
+{ return makeTrackParams(track,track->get_state(0)); }
+
+//___________________________________________________________________________________
+Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track, SvtxTrackState* state) const
 {
-  Acts::Vector3 momentum(track->get_px(), 
-			 track->get_py(), 
+  Acts::Vector3 momentum(track->get_px(),
+			 track->get_py(),
 			 track->get_pz());
   double trackQ = track->get_charge() * Acts::UnitConstants::e;
-  double p = track->get_p();
+  double p = state->get_p();
 
-  /* get acts covariance matrix from track parameters */
-  const auto cov = m_transformer.rotateSvtxTrackCovToActs( track );
-  
-  /* get position from  track parameters */
-  const Acts::Vector3 position(track->get_x() * Acts::UnitConstants::cm,
-    track->get_y() * Acts::UnitConstants::cm,
-    track->get_z() * Acts::UnitConstants::cm);
+  // covariance
+  const auto cov = m_transformer.rotateSvtxTrackCovToActs(state);
+
+  // position
+  const Acts::Vector3 position(
+    state->get_x() * Acts::UnitConstants::cm,
+    state->get_y() * Acts::UnitConstants::cm,
+    state->get_z() * Acts::UnitConstants::cm);
+
+  if( Verbosity() )
+  {
+    std::cout << "PHTpcResiduals::makeTrackParams -"
+      << " position: " << position
+      << " momentum: " << momentum
+      << std::endl;
+
+    // covariance
+    std::cout << "PHTpcResiduals::makeTrackParams - cov: " << std::endl;
+    for( int i = 0; i < 6; ++i )
+    {
+      std::cout << "  ";
+      for( int j = 0; j<6; ++j )
+      {
+        std::cout << state->get_error(i,j) << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
 
   const auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(position);
   const auto actsFourPos = Acts::Vector4(position(0), position(1), position(2), 10 * Acts::UnitConstants::ns);
-
   return Acts::BoundTrackParameters::create(perigee, m_tGeometry->geometry().getGeoContext(),
 					    actsFourPos, momentum,
 					    trackQ/p, cov,
 					    Acts::ParticleHypothesis::pion()).value();
- 
 }
 
+//_____________________________________________________________________________________________
 void PHTpcResiduals::processTrack(SvtxTrack* track)
 {
 
   if(Verbosity() > 1)
   {
-    std::cout << "PHTpcResiduals::processTrack -" 
-      << " track momentum: " << track->get_p() 
-      << " position: (" << track->get_x() << ", " << track->get_y() << ", " << track->get_z() << ")"
+    std::cout << "PHTpcResiduals::processTrack -"
+      << " track momentum: " << track->get_p()
+      << " position: " << Acts::Vector3( track->get_x(), track->get_y(), track->get_z() )
       << std::endl;
   }
   ActsPropagator propagator(m_tGeometry);
 
   // create ACTS parameters from track parameters at origin
   auto trackParams = makeTrackParams(track);
-  
+
   // store crossing. It is used in calculating cluster's global position
   m_crossing = track->get_crossing();
   assert( m_crossing != SHRT_MAX );
@@ -271,15 +302,15 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
   {
     // increment counter
     ++m_total_clusters;
-    
+
     // make sure cluster is from TPC
     const auto detId = TrkrDefs::getTrkrId(cluskey);
-    if(detId != TrkrDefs::tpcId) continue;  
-    
-    const auto cluster = m_clusterContainer->findCluster(cluskey);      
-    const auto surface = m_tGeometry->maps().getSurface( cluskey, cluster );   
+    if(detId != TrkrDefs::tpcId) continue;
+
+    const auto cluster = m_clusterContainer->findCluster(cluskey);
+    const auto surface = m_tGeometry->maps().getSurface( cluskey, cluster );
     auto result = propagator.propagateTrack(trackParams, surface);
-    
+
     // skip if propagation failed
     if(!result.ok())
     {
@@ -296,12 +327,12 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
           << std::atanh(trackParams.momentum().z()/trackParams.momentum().norm())
           << std::endl;
       }
-      
+
       continue;
     }
-    
+
     // get extrapolated track state, convert to sPHENIX and add to track
-    auto& [pathLength, trackStateParams] = result.value();    
+    auto& [pathLength, trackStateParams] = result.value();
     pathLength /= Acts::UnitConstants::cm;
 
     if(Verbosity() > 1)
@@ -317,116 +348,125 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 
 
     addTrackState( track, cluskey, pathLength, trackStateParams );
-    
+
     // calculate residuals with respect to cluster
     // Get all the relevant information for residual calculation
     const auto globClusPos = getGlobalPosition(cluskey, cluster, m_crossing);
     const double clusR = get_r(globClusPos(0),globClusPos(1));
     const double clusPhi = std::atan2(globClusPos(1), globClusPos(0));
     const double clusZ = globClusPos(2);
-    
+
     // cluster errors
     double clusRPhiErr = 0;
     double clusZErr = 0;
- 
+
     clusRPhiErr = cluster->getRPhiError();
     clusZErr = cluster->getZError();
-    
-    
+
+
     if(Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack -"
         << " cluskey: " << cluskey
-        << " clusR: " << clusR 
+        << " clusR: " << clusR
         << " clusPhi: " << clusPhi << "+/-" << clusRPhiErr
         << " clusZ: " << clusZ << "+/-" << clusZErr
         << std::endl;
     }
-    
-    /* 
+
+    /*
      * as instructed by Christof, it should not be necessary to cut on small
-     * cluster errors any more with clusters of version 4 or higher 
-     */ 
-    
+     * cluster errors any more with clusters of version 4 or higher
+     */
+
     const auto globalStatePos = trackStateParams.position(m_tGeometry->geometry().getGeoContext());
     const auto globalStateMom = trackStateParams.momentum();
     const auto globalStateCov = *trackStateParams.covariance();
-    
+
     const double trackRPhiErr = std::sqrt(globalStateCov(Acts::eBoundLoc0, Acts::eBoundLoc0))/Acts::UnitConstants::cm;
-    const double trackZErr = sqrt(globalStateCov(Acts::eBoundLoc1, Acts::eBoundLoc1))/Acts::UnitConstants::cm;    
-    
+    const double trackZErr = sqrt(globalStateCov(Acts::eBoundLoc1, Acts::eBoundLoc1))/Acts::UnitConstants::cm;
+
     const double globStateX = globalStatePos.x()/Acts::UnitConstants::cm;
     const double globStateY = globalStatePos.y()/Acts::UnitConstants::cm;
     const double globStateZ = globalStatePos.z()/Acts::UnitConstants::cm;
-    
+
     const double trackR = std::sqrt(square(globStateX) + square(globStateY));
-    
+
     const double dr = clusR - trackR;
     const double trackDrDt = (globStateX * globalStateMom(0) + globStateY * globalStateMom(1)) / trackR;
     const double trackDxDr = globalStateMom(0) / trackDrDt;
     const double trackDyDr = globalStateMom(1) / trackDrDt;
     const double trackDzDr = globalStateMom(2) / trackDrDt;
-    
+
     const double trackX = globStateX + dr * trackDxDr;
     const double trackY = globStateY + dr * trackDyDr;
     const double trackZ = globStateZ + dr * trackDzDr;
     const double trackPhi = std::atan2(trackY, trackX);
-    
+
     if(Verbosity() > 2)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " trackR: " << trackR 
-        << " dr: " << dr 
-        << " trackDrDt: " << trackDrDt 
+        << " trackR: " << trackR
+        << " dr: " << dr
+        << " trackDrDt: " << trackDrDt
         << " trackDxDr: " << trackDxDr
-        << " trackDyDr: " << trackDyDr 
+        << " trackDyDr: " << trackDyDr
         << " trackDzDr: " << trackDzDr
         << " trackPhi: " << trackPhi << "+/-" << trackRPhiErr
         << " track position: (" << trackX << ", " << trackY << ", " << trackZ  << ")"
         << std::endl;
     }
-        
+
     const double erp = square(clusRPhiErr) + square(trackRPhiErr);
+    if( std::isnan( erp ) ) continue;
+
     const double ez = square(clusZErr) + square(trackZErr);
-    
+    if( std::isnan( ez ) ) continue;
+
     // Calculate residuals
     const double drphi = clusR * deltaPhi(clusPhi - trackPhi);
+    if( std::isnan(drphi) ) continue;
+
     const double dz  = clusZ - trackZ;
-    
+    if( std::isnan(dz) ) continue;
+
     if(Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " drphi: " << drphi 
-        << " dz: " << dz 
+        << " drphi: " << drphi
+        << " dz: " << dz
         << std::endl;
     }
-        
+
     const double trackPPhi = -trackStateParams.momentum()(0) * std::sin(trackPhi) + trackStateParams.momentum()(1) * std::cos(trackPhi);
     const double trackPR = trackStateParams.momentum()(0) * std::cos(trackPhi) + trackStateParams.momentum()(1) * std::sin(trackPhi);
     const double trackPZ = trackStateParams.momentum()(2);
-    
+
     const double trackAlpha = -trackPPhi / trackPR;
+    if( std::isnan(trackAlpha) ) continue;
+
     const double trackBeta = -trackPZ / trackPR;
-    
+    if( std::isnan(trackBeta) ) continue;
+
     if(Verbosity() > 3)
     {
-      std::cout 
+      std::cout
         << "PHTpcResiduals::processTrack -"
-        << " trackPPhi: " << trackPPhi 
+        << " trackPPhi: " << trackPPhi
         << " trackPR: " << trackPR
-        << " trackPZ: " << trackPZ 
-        << " trackAlpha: " << trackAlpha 
+        << " trackPZ: " << trackPZ
+        << " trackAlpha: " << trackAlpha
         << " trackBeta: " << trackBeta
         << std::endl;
     }
-        
+
     // get cell index
     const auto index = getCell(globClusPos);
     if(Verbosity() > 3)
     { std::cout << "Bin index found is " << index << std::endl; }
-    
+
     if(index < 0 ) continue;
-    
+
     if(Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack - layer: " << (int) TrkrDefs::getLayer(cluskey) << std::endl;
@@ -434,7 +474,7 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
         << " cluster: (" << clusR << ", " << clusR*clusPhi << ", " << clusZ << ")"
         << " (" << clusRPhiErr << ", " << clusZErr << ")"
         << std::endl;
-      
+
       std::cout << "PHTpcResiduals::processTrack -"
         << " track: (" << trackR << ", " << clusR*trackPhi << ", " << trackZ << ")"
         << " (" << trackAlpha << ", " << trackBeta << ")"
@@ -442,39 +482,39 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
         << std::endl;
       std::cout << std::endl;
     }
-    
+
     // check track angles and residuals agains cuts
     if(std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
     { continue; }
-    
+
     if(std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
     { continue; }
-    
+
     // Fill distortion matrices
     m_matrix_container->add_to_lhs(index, 0, 0, 1./erp );
     m_matrix_container->add_to_lhs(index, 0, 1, 0 );
     m_matrix_container->add_to_lhs(index, 0, 2, trackAlpha/erp );
-    
+
     m_matrix_container->add_to_lhs(index, 1, 0, 0 );
     m_matrix_container->add_to_lhs(index, 1, 1, 1./ez );
     m_matrix_container->add_to_lhs(index, 1, 2, trackBeta/ez );
-    
+
     m_matrix_container->add_to_lhs(index, 2, 0, trackAlpha/erp );
     m_matrix_container->add_to_lhs(index, 2, 1, trackBeta/ez );
     m_matrix_container->add_to_lhs(index, 2, 2, square(trackAlpha)/erp + square(trackBeta)/ez );
-    
+
     m_matrix_container->add_to_rhs(index, 0, drphi/erp );
     m_matrix_container->add_to_rhs(index, 1, dz/ez );
     m_matrix_container->add_to_rhs(index, 2, trackAlpha*drphi/erp + trackBeta*dz/ez );
-    
+
     // update entries in cell
     m_matrix_container->add_to_entries(index);
-    
+
     // increment number of accepted clusters
     ++m_accepted_clusters;
-      
+
   }
-        
+
 }
 
 //_______________________________________________________________________________________________________
@@ -482,7 +522,7 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, flo
 {
 
   /* this is essentially a copy of the code from trackbase_historic/ActsTransformations::fillSvtxTrackStates */
-  
+
   // create track state
   SvtxTrackState_v1 state( pathlength );
 
@@ -503,7 +543,7 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, flo
   for (int i = 0; i < 6; ++i)
     for (int j = 0; j < 6; ++j)
   { state.set_error(i, j, globalCov(i,j)); }
- 
+
   state.set_name(std::to_string((TrkrDefs::cluskey) key));
 
   track->insert_state(&state);
@@ -518,18 +558,18 @@ int PHTpcResiduals::getCell(const Acts::Vector3& loc)
   int rbins = 0;
   int zbins = 0;
   m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
-  
+
   // phi
   float phi = std::atan2(loc(1), loc(0));
   while( phi < m_phiMin ) phi += 2.*M_PI;
   while( phi >= m_phiMax ) phi -= 2.*M_PI;
   const int iphi = phibins * (phi - m_phiMin) / (m_phiMax - m_phiMin);
-  
+
   // r
   const auto r = get_r( loc(0), loc(1) );
   if( r < m_rMin || r >= m_rMax ) return -1;
   const int ir = rbins * (r - m_rMin) / (m_rMax - m_rMin);
-  
+
   // z
   const auto z = loc(2);
   if( z < m_zMin || z >= m_zMax ) return -1;
@@ -561,7 +601,7 @@ int PHTpcResiduals::getNodes(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");  
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");
   if (!m_trackMap)
   {
     std::cout << PHWHERE << "SvtxSiliconMMTrackMap not on node tree. Exiting." << std::endl;
@@ -581,31 +621,31 @@ Acts::Vector3 PHTpcResiduals::getGlobalPosition( TrkrDefs::cluskey key, TrkrClus
 {
   // get global position from Acts transform
   auto globalPosition = m_tGeometry->getGlobalPosition(key, cluster);
-  
+
   // for the TPC calculate the proper z based on crossing and side
   const auto trkrid = TrkrDefs::getTrkrId(key);
   if(trkrid ==  TrkrDefs::tpcId)
-  {	 
+  {
     const auto side = TpcDefs::getSide(key);
-    globalPosition.z() = m_clusterCrossingCorrection.correctZ(globalPosition.z(), side, crossing);    
-    
+    globalPosition.z() = m_clusterCrossingCorrection.correctZ(globalPosition.z(), side, crossing);
+
     // apply distortion corrections
-    if(m_dcc_static) 
+    if(m_dcc_static)
     {
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_static ); 
+      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_static );
     }
-    
-    if(m_dcc_average) 
-    { 
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_average ); 
+
+    if(m_dcc_average)
+    {
+      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_average );
     }
-    
-    if(m_dcc_fluctuation) 
-    { 
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_fluctuation ); 
+
+    if(m_dcc_fluctuation)
+    {
+      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_fluctuation );
     }
   }
-    
+
   return globalPosition;
 }
 

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -334,8 +334,8 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
   auto trackParams = makeTrackParams(track);
 
   // store crossing. It is used in calculating cluster's global position
-  m_crossing = track->get_crossing();
-  assert(m_crossing != SHRT_MAX);
+  const auto crossing = track->get_crossing();
+  assert(crossing != SHRT_MAX);
 
   for (const auto& cluskey : get_cluster_keys(track))
   {
@@ -389,7 +389,7 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 
     // calculate residuals with respect to cluster
     // Get all the relevant information for residual calculation
-    const auto globClusPos = getGlobalPosition(cluskey, cluster, m_crossing);
+    const auto globClusPos = getGlobalPosition(cluskey, cluster, crossing);
     const double clusR = get_r(globClusPos(0), globClusPos(1));
     const double clusPhi = std::atan2(globClusPos(1), globClusPos(0));
     const double clusZ = globClusPos(2);

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -3,13 +3,13 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
-#include <phool/phool.h>
 #include <phool/PHDataNode.h>
 #include <phool/PHNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
 #include <phool/PHTimer.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
 
 #include <tpc/TpcDistortionCorrectionContainer.h>
 
@@ -24,10 +24,10 @@
 
 #include <micromegas/MicromegasDefs.h>
 
-#include <Acts/Surfaces/PerigeeSurface.hpp>
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/MagneticField/ConstantBField.hpp>
 #include <Acts/MagneticField/InterpolatedBFieldMap.hpp>
+#include <Acts/Surfaces/PerigeeSurface.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -39,12 +39,11 @@
 
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 
-
-#include <cmath>
 #include <TFile.h>
-#include <TTree.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TTree.h>
+#include <cmath>
 
 #include <iostream>
 #include <sstream>
@@ -53,69 +52,89 @@ namespace
 {
 
   // square
-  template<class T> inline constexpr T square( const T& x ) { return x*x; }
+  template <class T>
+  inline constexpr T square(const T& x)
+  {
+    return x * x;
+  }
 
   // radius
-  template<class T> T get_r( const T& x, const T& y ) { return std::sqrt( square(x) + square(y) ); }
+  template <class T>
+  T get_r(const T& x, const T& y)
+  {
+    return std::sqrt(square(x) + square(y));
+  }
 
-  template<class T> inline constexpr T deltaPhi(const T& phi)
+  template <class T>
+  inline constexpr T deltaPhi(const T& phi)
   {
     if (phi > M_PI)
+    {
       return phi - 2. * M_PI;
+    }
     else if (phi <= -M_PI)
-      return phi + 2.* M_PI;
+    {
+      return phi + 2. * M_PI;
+    }
     else
+    {
       return phi;
+    }
   }
 
   /// get sector median angle associated to a given index
   /** this assumes that sector 0 is centered on phi=0, then numbered along increasing phi */
-  inline constexpr double get_sector_phi( int isec )
-  { return isec*M_PI/6; }
+  inline constexpr double get_sector_phi(int isec)
+  {
+    return isec * M_PI / 6;
+  }
 
   // specify bins for which one will save histograms
-  static const std::vector<float> phi_rec = { get_sector_phi(9) };
-  static const std::vector<float> z_rec = { 5. };
+  static const std::vector<float> phi_rec = {get_sector_phi(9)};
+  static const std::vector<float> z_rec = {5.};
 
   //! get cluster keys from a given track
-  std::vector<TrkrDefs::cluskey> get_cluster_keys( SvtxTrack* track )
+  std::vector<TrkrDefs::cluskey> get_cluster_keys(SvtxTrack* track)
   {
     std::vector<TrkrDefs::cluskey> out;
-    for( const auto& seed: { track->get_silicon_seed(), track->get_tpc_seed() } )
+    for (const auto& seed : {track->get_silicon_seed(), track->get_tpc_seed()})
     {
-      if( seed )
-      { std::copy( seed->begin_cluster_keys(), seed->end_cluster_keys(), std::back_inserter( out ) ); }
+      if (seed)
+      {
+        std::copy(seed->begin_cluster_keys(), seed->end_cluster_keys(), std::back_inserter(out));
+      }
     }
     return out;
   }
 
   /// return number of clusters of a given type that belong to a tracks
-  template<int type>
-    int count_clusters( const std::vector<TrkrDefs::cluskey>& keys )
+  template <int type>
+  int count_clusters(const std::vector<TrkrDefs::cluskey>& keys)
   {
-    return std::count_if( keys.begin(), keys.end(),
-      []( const TrkrDefs::cluskey& key ) { return TrkrDefs::getTrkrId(key) == type; } );
+    return std::count_if(keys.begin(), keys.end(),
+                         [](const TrkrDefs::cluskey& key)
+                         { return TrkrDefs::getTrkrId(key) == type; });
   }
 
   /// streamer
-  std::ostream& operator << (std::ostream& out, const Acts::Vector3& v )
+  std::ostream& operator<<(std::ostream& out, const Acts::Vector3& v)
   {
     out << "(" << v.x() << "," << v.y() << "," << v.z() << ")";
     return out;
   }
 
+}  // namespace
+
+//___________________________________________________________________________________
+PHTpcResiduals::PHTpcResiduals(const std::string& name)
+  : SubsysReco(name)
+  , m_matrix_container(new TpcSpaceChargeMatrixContainerv1)
+{
 }
 
 //___________________________________________________________________________________
-PHTpcResiduals::PHTpcResiduals(const std::string &name)
-  : SubsysReco(name)
-  , m_matrix_container( new TpcSpaceChargeMatrixContainerv1 )
-{}
-
-//___________________________________________________________________________________
-int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::Init(PHCompositeNode* /*topNode*/)
 {
-
   // configuration printout
   std::cout << "PHTpcResiduals::Init - m_maxTAlpha: " << m_maxTAlpha << std::endl;
   std::cout << "PHTpcResiduals::Init - m_maxTBeta: " << m_maxTBeta << std::endl;
@@ -134,19 +153,23 @@ int PHTpcResiduals::Init(PHCompositeNode */*topNode*/)
 }
 
 //___________________________________________________________________________________
-int PHTpcResiduals::InitRun(PHCompositeNode *topNode)
+int PHTpcResiduals::InitRun(PHCompositeNode* topNode)
 {
-  if(getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-  { return Fun4AllReturnCodes::ABORTEVENT; }
+  if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
-  if(createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
-  { return Fun4AllReturnCodes::ABORTEVENT; }
+  if (createNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //___________________________________________________________________________________
-int PHTpcResiduals::process_event(PHCompositeNode *topNode)
+int PHTpcResiduals::process_event(PHCompositeNode* topNode)
 {
   const auto returnVal = processTracks(topNode);
   ++m_event;
@@ -155,50 +178,53 @@ int PHTpcResiduals::process_event(PHCompositeNode *topNode)
 }
 
 //___________________________________________________________________________________
-int PHTpcResiduals::End(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::End(PHCompositeNode* /*topNode*/)
 {
   std::cout << "PHTpcResiduals::End - writing matrices to " << m_outputfile << std::endl;
 
   // save matrix container in output file
-  if( m_matrix_container )
+  if (m_matrix_container)
   {
-    std::unique_ptr<TFile> outputfile( TFile::Open( m_outputfile.c_str(), "RECREATE" ) );
+    std::unique_ptr<TFile> outputfile(TFile::Open(m_outputfile.c_str(), "RECREATE"));
     outputfile->cd();
-    m_matrix_container->Write( "TpcSpaceChargeMatrixContainer" );
+    m_matrix_container->Write("TpcSpaceChargeMatrixContainer");
   }
 
   // print counters
   std::cout
-    << "PHTpcResiduals::End -"
-    << " track statistics total: " << m_total_tracks
-    << " accepted: " << m_accepted_tracks
-    << " fraction: " << 100.*m_accepted_tracks/m_total_tracks << "%"
-    << std::endl;
+      << "PHTpcResiduals::End -"
+      << " track statistics total: " << m_total_tracks
+      << " accepted: " << m_accepted_tracks
+      << " fraction: " << 100. * m_accepted_tracks / m_total_tracks << "%"
+      << std::endl;
 
   std::cout
-    << "PHTpcResiduals::End -"
-    << " cluster statistics total: " << m_total_clusters
-    << " accepted: " << m_accepted_clusters << " fraction: "
-    << 100.*m_accepted_clusters/m_total_clusters << "%"
-    << std::endl;
+      << "PHTpcResiduals::End -"
+      << " cluster statistics total: " << m_total_clusters
+      << " accepted: " << m_accepted_clusters << " fraction: "
+      << 100. * m_accepted_clusters / m_total_clusters << "%"
+      << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //___________________________________________________________________________________
-int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
+int PHTpcResiduals::processTracks(PHCompositeNode* /*topNode*/)
 {
-
-  if( Verbosity() )
-  { std::cout << "PHTpcResiduals::processTracks - proto track size " << m_trackMap->size() <<std::endl; }
-
-  for(const auto &[trackKey, track] : *m_trackMap)
+  if (Verbosity())
   {
-    if(Verbosity() > 1)
-    { std::cout << "PHTpcResiduals::processTracks - Processing track key " << trackKey << std::endl; }
+    std::cout << "PHTpcResiduals::processTracks - proto track size " << m_trackMap->size() << std::endl;
+  }
+
+  for (const auto& [trackKey, track] : *m_trackMap)
+  {
+    if (Verbosity() > 1)
+    {
+      std::cout << "PHTpcResiduals::processTracks - Processing track key " << trackKey << std::endl;
+    }
 
     ++m_total_tracks;
-    if(checkTrack(track))
+    if (checkTrack(track))
     {
       ++m_accepted_tracks;
       processTrack(track);
@@ -211,33 +237,46 @@ int PHTpcResiduals::processTracks(PHCompositeNode */*topNode*/)
 //___________________________________________________________________________________
 bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
 {
-  if(Verbosity() > 2)
-  { std::cout << "PHTpcResiduals::checkTrack - pt: " << track->get_pt() << std::endl; }
+  if (Verbosity() > 2)
+  {
+    std::cout << "PHTpcResiduals::checkTrack - pt: " << track->get_pt() << std::endl;
+  }
 
-  if(track->get_pt() < m_minPt)
-  { return false; }
+  if (track->get_pt() < m_minPt)
+  {
+    return false;
+  }
 
   // ignore tracks with too few mvtx, intt and micromegas hits
-  const auto cluster_keys( get_cluster_keys( track ) );
-  if( count_clusters<TrkrDefs::mvtxId>(cluster_keys) < 2 ) return false;
-  if( count_clusters<TrkrDefs::inttId>(cluster_keys) < 2 ) return false;
-  if( m_useMicromegas && count_clusters<TrkrDefs::micromegasId>(cluster_keys) < 2 ) return false;
-
+  const auto cluster_keys(get_cluster_keys(track));
+  if (count_clusters<TrkrDefs::mvtxId>(cluster_keys) < 2)
+  {
+    return false;
+  }
+  if (count_clusters<TrkrDefs::inttId>(cluster_keys) < 2)
+  {
+    return false;
+  }
+  if (m_useMicromegas && count_clusters<TrkrDefs::micromegasId>(cluster_keys) < 2)
+  {
+    return false;
+  }
 
   return true;
-
 }
 
 //___________________________________________________________________________________
 Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track) const
-{ return makeTrackParams(track,track->get_state(0)); }
+{
+  return makeTrackParams(track, track->get_state(0));
+}
 
 //___________________________________________________________________________________
 Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track, SvtxTrackState* state) const
 {
   Acts::Vector3 momentum(track->get_px(),
-			 track->get_py(),
-			 track->get_pz());
+                         track->get_py(),
+                         track->get_pz());
   double trackQ = track->get_charge() * Acts::UnitConstants::e;
   double p = state->get_p();
 
@@ -246,25 +285,25 @@ Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track, Svt
 
   // position
   const Acts::Vector3 position(
-    state->get_x() * Acts::UnitConstants::cm,
-    state->get_y() * Acts::UnitConstants::cm,
-    state->get_z() * Acts::UnitConstants::cm);
+      state->get_x() * Acts::UnitConstants::cm,
+      state->get_y() * Acts::UnitConstants::cm,
+      state->get_z() * Acts::UnitConstants::cm);
 
-  if( Verbosity() )
+  if (Verbosity())
   {
     std::cout << "PHTpcResiduals::makeTrackParams -"
-      << " position: " << position
-      << " momentum: " << momentum
-      << std::endl;
+              << " position: " << position
+              << " momentum: " << momentum
+              << std::endl;
 
     // covariance
     std::cout << "PHTpcResiduals::makeTrackParams - cov: " << std::endl;
-    for( int i = 0; i < 6; ++i )
+    for (int i = 0; i < 6; ++i)
     {
       std::cout << "  ";
-      for( int j = 0; j<6; ++j )
+      for (int j = 0; j < 6; ++j)
       {
-        std::cout << state->get_error(i,j) << " ";
+        std::cout << state->get_error(i, j) << " ";
       }
       std::cout << std::endl;
     }
@@ -273,21 +312,21 @@ Acts::BoundTrackParameters PHTpcResiduals::makeTrackParams(SvtxTrack* track, Svt
   const auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(position);
   const auto actsFourPos = Acts::Vector4(position(0), position(1), position(2), 10 * Acts::UnitConstants::ns);
   return Acts::BoundTrackParameters::create(perigee, m_tGeometry->geometry().getGeoContext(),
-					    actsFourPos, momentum,
-					    trackQ/p, cov,
-					    Acts::ParticleHypothesis::pion()).value();
+                                            actsFourPos, momentum,
+                                            trackQ / p, cov,
+                                            Acts::ParticleHypothesis::pion())
+      .value();
 }
 
 //_____________________________________________________________________________________________
 void PHTpcResiduals::processTrack(SvtxTrack* track)
 {
-
-  if(Verbosity() > 1)
+  if (Verbosity() > 1)
   {
     std::cout << "PHTpcResiduals::processTrack -"
-      << " track momentum: " << track->get_p()
-      << " position: " << Acts::Vector3( track->get_x(), track->get_y(), track->get_z() )
-      << std::endl;
+              << " track momentum: " << track->get_p()
+              << " position: " << Acts::Vector3(track->get_x(), track->get_y(), track->get_z())
+              << std::endl;
   }
   ActsPropagator propagator(m_tGeometry);
 
@@ -296,36 +335,36 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
 
   // store crossing. It is used in calculating cluster's global position
   m_crossing = track->get_crossing();
-  assert( m_crossing != SHRT_MAX );
+  assert(m_crossing != SHRT_MAX);
 
-  for( const auto& cluskey:get_cluster_keys( track ) )
+  for (const auto& cluskey : get_cluster_keys(track))
   {
     // increment counter
     ++m_total_clusters;
 
     // make sure cluster is from TPC
     const auto detId = TrkrDefs::getTrkrId(cluskey);
-    if(detId != TrkrDefs::tpcId) continue;
+    if (detId != TrkrDefs::tpcId) continue;
 
     const auto cluster = m_clusterContainer->findCluster(cluskey);
-    const auto surface = m_tGeometry->maps().getSurface( cluskey, cluster );
+    const auto surface = m_tGeometry->maps().getSurface(cluskey, cluster);
     auto result = propagator.propagateTrack(trackParams, surface);
 
     // skip if propagation failed
-    if(!result.ok())
+    if (!result.ok())
     {
-      if( Verbosity() > 1 )
+      if (Verbosity() > 1)
       {
         std::cout << "Starting track params position/momentum: "
-          << trackParams.position(m_tGeometry->geometry().geoContext).transpose()
-          << std::endl
-          << std::endl
-          << "Track params phi/eta "
-          << std::atan2(trackParams.momentum().y(),
-          trackParams.momentum().x())
-          << " and "
-          << std::atanh(trackParams.momentum().z()/trackParams.momentum().norm())
-          << std::endl;
+                  << trackParams.position(m_tGeometry->geometry().geoContext).transpose()
+                  << std::endl
+                  << std::endl
+                  << "Track params phi/eta "
+                  << std::atan2(trackParams.momentum().y(),
+                                trackParams.momentum().x())
+                  << " and "
+                  << std::atanh(trackParams.momentum().z() / trackParams.momentum().norm())
+                  << std::endl;
       }
 
       continue;
@@ -335,24 +374,23 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     auto& [pathLength, trackStateParams] = result.value();
     pathLength /= Acts::UnitConstants::cm;
 
-    if(Verbosity() > 1)
+    if (Verbosity() > 1)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " path length: " << pathLength
-        << " track momentum : "
-        << trackParams.momentum()
-        << " propagator momentum : "
-        << trackStateParams.momentum()
-        << std::endl;
+                << " path length: " << pathLength
+                << " track momentum : "
+                << trackParams.momentum()
+                << " propagator momentum : "
+                << trackStateParams.momentum()
+                << std::endl;
     }
 
-
-    addTrackState( track, cluskey, pathLength, trackStateParams );
+    addTrackState(track, cluskey, pathLength, trackStateParams);
 
     // calculate residuals with respect to cluster
     // Get all the relevant information for residual calculation
     const auto globClusPos = getGlobalPosition(cluskey, cluster, m_crossing);
-    const double clusR = get_r(globClusPos(0),globClusPos(1));
+    const double clusR = get_r(globClusPos(0), globClusPos(1));
     const double clusPhi = std::atan2(globClusPos(1), globClusPos(0));
     const double clusZ = globClusPos(2);
 
@@ -363,15 +401,14 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     clusRPhiErr = cluster->getRPhiError();
     clusZErr = cluster->getZError();
 
-
-    if(Verbosity() > 3)
+    if (Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " cluskey: " << cluskey
-        << " clusR: " << clusR
-        << " clusPhi: " << clusPhi << "+/-" << clusRPhiErr
-        << " clusZ: " << clusZ << "+/-" << clusZErr
-        << std::endl;
+                << " cluskey: " << cluskey
+                << " clusR: " << clusR
+                << " clusPhi: " << clusPhi << "+/-" << clusRPhiErr
+                << " clusZ: " << clusZ << "+/-" << clusZErr
+                << std::endl;
     }
 
     /*
@@ -383,12 +420,12 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     const auto globalStateMom = trackStateParams.momentum();
     const auto globalStateCov = *trackStateParams.covariance();
 
-    const double trackRPhiErr = std::sqrt(globalStateCov(Acts::eBoundLoc0, Acts::eBoundLoc0))/Acts::UnitConstants::cm;
-    const double trackZErr = sqrt(globalStateCov(Acts::eBoundLoc1, Acts::eBoundLoc1))/Acts::UnitConstants::cm;
+    const double trackRPhiErr = std::sqrt(globalStateCov(Acts::eBoundLoc0, Acts::eBoundLoc0)) / Acts::UnitConstants::cm;
+    const double trackZErr = sqrt(globalStateCov(Acts::eBoundLoc1, Acts::eBoundLoc1)) / Acts::UnitConstants::cm;
 
-    const double globStateX = globalStatePos.x()/Acts::UnitConstants::cm;
-    const double globStateY = globalStatePos.y()/Acts::UnitConstants::cm;
-    const double globStateZ = globalStatePos.z()/Acts::UnitConstants::cm;
+    const double globStateX = globalStatePos.x() / Acts::UnitConstants::cm;
+    const double globStateY = globalStatePos.y() / Acts::UnitConstants::cm;
+    const double globStateZ = globalStatePos.z() / Acts::UnitConstants::cm;
 
     const double trackR = std::sqrt(square(globStateX) + square(globStateY));
 
@@ -403,39 +440,39 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     const double trackZ = globStateZ + dr * trackDzDr;
     const double trackPhi = std::atan2(trackY, trackX);
 
-    if(Verbosity() > 2)
+    if (Verbosity() > 2)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " trackR: " << trackR
-        << " dr: " << dr
-        << " trackDrDt: " << trackDrDt
-        << " trackDxDr: " << trackDxDr
-        << " trackDyDr: " << trackDyDr
-        << " trackDzDr: " << trackDzDr
-        << " trackPhi: " << trackPhi << "+/-" << trackRPhiErr
-        << " track position: (" << trackX << ", " << trackY << ", " << trackZ  << ")"
-        << std::endl;
+                << " trackR: " << trackR
+                << " dr: " << dr
+                << " trackDrDt: " << trackDrDt
+                << " trackDxDr: " << trackDxDr
+                << " trackDyDr: " << trackDyDr
+                << " trackDzDr: " << trackDzDr
+                << " trackPhi: " << trackPhi << "+/-" << trackRPhiErr
+                << " track position: (" << trackX << ", " << trackY << ", " << trackZ << ")"
+                << std::endl;
     }
 
     const double erp = square(clusRPhiErr) + square(trackRPhiErr);
-    if( std::isnan( erp ) ) continue;
+    if (std::isnan(erp)) continue;
 
     const double ez = square(clusZErr) + square(trackZErr);
-    if( std::isnan( ez ) ) continue;
+    if (std::isnan(ez)) continue;
 
     // Calculate residuals
     const double drphi = clusR * deltaPhi(clusPhi - trackPhi);
-    if( std::isnan(drphi) ) continue;
+    if (std::isnan(drphi)) continue;
 
-    const double dz  = clusZ - trackZ;
-    if( std::isnan(dz) ) continue;
+    const double dz = clusZ - trackZ;
+    if (std::isnan(dz)) continue;
 
-    if(Verbosity() > 3)
+    if (Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack -"
-        << " drphi: " << drphi
-        << " dz: " << dz
-        << std::endl;
+                << " drphi: " << drphi
+                << " dz: " << dz
+                << std::endl;
     }
 
     const double trackPPhi = -trackStateParams.momentum()(0) * std::sin(trackPhi) + trackStateParams.momentum()(1) * std::cos(trackPhi);
@@ -443,88 +480,91 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     const double trackPZ = trackStateParams.momentum()(2);
 
     const double trackAlpha = -trackPPhi / trackPR;
-    if( std::isnan(trackAlpha) ) continue;
+    if (std::isnan(trackAlpha)) continue;
 
     const double trackBeta = -trackPZ / trackPR;
-    if( std::isnan(trackBeta) ) continue;
+    if (std::isnan(trackBeta)) continue;
 
-    if(Verbosity() > 3)
+    if (Verbosity() > 3)
     {
       std::cout
-        << "PHTpcResiduals::processTrack -"
-        << " trackPPhi: " << trackPPhi
-        << " trackPR: " << trackPR
-        << " trackPZ: " << trackPZ
-        << " trackAlpha: " << trackAlpha
-        << " trackBeta: " << trackBeta
-        << std::endl;
+          << "PHTpcResiduals::processTrack -"
+          << " trackPPhi: " << trackPPhi
+          << " trackPR: " << trackPR
+          << " trackPZ: " << trackPZ
+          << " trackAlpha: " << trackAlpha
+          << " trackBeta: " << trackBeta
+          << std::endl;
     }
 
     // get cell index
     const auto index = getCell(globClusPos);
-    if(Verbosity() > 3)
-    { std::cout << "Bin index found is " << index << std::endl; }
+    if (Verbosity() > 3)
+    {
+      std::cout << "Bin index found is " << index << std::endl;
+    }
 
-    if(index < 0 ) continue;
+    if (index < 0) continue;
 
-    if(Verbosity() > 3)
+    if (Verbosity() > 3)
     {
       std::cout << "PHTpcResiduals::processTrack - layer: " << (int) TrkrDefs::getLayer(cluskey) << std::endl;
       std::cout << "PHTpcResiduals::processTrack -"
-        << " cluster: (" << clusR << ", " << clusR*clusPhi << ", " << clusZ << ")"
-        << " (" << clusRPhiErr << ", " << clusZErr << ")"
-        << std::endl;
+                << " cluster: (" << clusR << ", " << clusR * clusPhi << ", " << clusZ << ")"
+                << " (" << clusRPhiErr << ", " << clusZErr << ")"
+                << std::endl;
 
       std::cout << "PHTpcResiduals::processTrack -"
-        << " track: (" << trackR << ", " << clusR*trackPhi << ", " << trackZ << ")"
-        << " (" << trackAlpha << ", " << trackBeta << ")"
-        << " (" << trackRPhiErr << ", " << trackZErr << ")"
-        << std::endl;
+                << " track: (" << trackR << ", " << clusR * trackPhi << ", " << trackZ << ")"
+                << " (" << trackAlpha << ", " << trackBeta << ")"
+                << " (" << trackRPhiErr << ", " << trackZErr << ")"
+                << std::endl;
       std::cout << std::endl;
     }
 
     // check track angles and residuals agains cuts
-    if(std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
-    { continue; }
+    if (std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
+    {
+      continue;
+    }
 
-    if(std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
-    { continue; }
+    if (std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
+    {
+      continue;
+    }
 
     // Fill distortion matrices
-    m_matrix_container->add_to_lhs(index, 0, 0, 1./erp );
-    m_matrix_container->add_to_lhs(index, 0, 1, 0 );
-    m_matrix_container->add_to_lhs(index, 0, 2, trackAlpha/erp );
+    m_matrix_container->add_to_lhs(index, 0, 0, 1. / erp);
+    m_matrix_container->add_to_lhs(index, 0, 1, 0);
+    m_matrix_container->add_to_lhs(index, 0, 2, trackAlpha / erp);
 
-    m_matrix_container->add_to_lhs(index, 1, 0, 0 );
-    m_matrix_container->add_to_lhs(index, 1, 1, 1./ez );
-    m_matrix_container->add_to_lhs(index, 1, 2, trackBeta/ez );
+    m_matrix_container->add_to_lhs(index, 1, 0, 0);
+    m_matrix_container->add_to_lhs(index, 1, 1, 1. / ez);
+    m_matrix_container->add_to_lhs(index, 1, 2, trackBeta / ez);
 
-    m_matrix_container->add_to_lhs(index, 2, 0, trackAlpha/erp );
-    m_matrix_container->add_to_lhs(index, 2, 1, trackBeta/ez );
-    m_matrix_container->add_to_lhs(index, 2, 2, square(trackAlpha)/erp + square(trackBeta)/ez );
+    m_matrix_container->add_to_lhs(index, 2, 0, trackAlpha / erp);
+    m_matrix_container->add_to_lhs(index, 2, 1, trackBeta / ez);
+    m_matrix_container->add_to_lhs(index, 2, 2, square(trackAlpha) / erp + square(trackBeta) / ez);
 
-    m_matrix_container->add_to_rhs(index, 0, drphi/erp );
-    m_matrix_container->add_to_rhs(index, 1, dz/ez );
-    m_matrix_container->add_to_rhs(index, 2, trackAlpha*drphi/erp + trackBeta*dz/ez );
+    m_matrix_container->add_to_rhs(index, 0, drphi / erp);
+    m_matrix_container->add_to_rhs(index, 1, dz / ez);
+    m_matrix_container->add_to_rhs(index, 2, trackAlpha * drphi / erp + trackBeta * dz / ez);
 
     // update entries in cell
     m_matrix_container->add_to_entries(index);
 
     // increment number of accepted clusters
     ++m_accepted_clusters;
-
   }
-
 }
 
 //_______________________________________________________________________________________________________
-void PHTpcResiduals::addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, float pathlength, const Acts::BoundTrackParameters& params )
+void PHTpcResiduals::addTrackState(SvtxTrack* track, TrkrDefs::cluskey key, float pathlength, const Acts::BoundTrackParameters& params)
 {
-
   /* this is essentially a copy of the code from trackbase_historic/ActsTransformations::fillSvtxTrackStates */
 
   // create track state
-  SvtxTrackState_v1 state( pathlength );
+  SvtxTrackState_v1 state(pathlength);
 
   // save global position
   const auto global = params.position(m_tGeometry->geometry().getGeoContext());
@@ -541,8 +581,12 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, flo
   // covariance
   const auto globalCov = m_transformer.rotateActsCovToSvtxTrack(params);
   for (int i = 0; i < 6; ++i)
+  {
     for (int j = 0; j < 6; ++j)
-  { state.set_error(i, j, globalCov(i,j)); }
+    {
+      state.set_error(i, j, globalCov(i, j));
+    }
+  }
 
   state.set_name(std::to_string((TrkrDefs::cluskey) key));
 
@@ -552,50 +596,62 @@ void PHTpcResiduals::addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, flo
 //_______________________________________________________________________________
 int PHTpcResiduals::getCell(const Acts::Vector3& loc)
 {
-
   // get grid dimensions from matrix container
   int phibins = 0;
   int rbins = 0;
   int zbins = 0;
-  m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
+  m_matrix_container->get_grid_dimensions(phibins, rbins, zbins);
 
   // phi
   float phi = std::atan2(loc(1), loc(0));
-  while( phi < m_phiMin ) phi += 2.*M_PI;
-  while( phi >= m_phiMax ) phi -= 2.*M_PI;
+  while (phi < m_phiMin)
+  {
+    phi += 2. * M_PI;
+  }
+  while (phi >= m_phiMax)
+  {
+    phi -= 2. * M_PI;
+  }
   const int iphi = phibins * (phi - m_phiMin) / (m_phiMax - m_phiMin);
 
   // r
-  const auto r = get_r( loc(0), loc(1) );
-  if( r < m_rMin || r >= m_rMax ) return -1;
+  const auto r = get_r(loc(0), loc(1));
+  if (r < m_rMin || r >= m_rMax)
+  {
+    return -1;
+  }
   const int ir = rbins * (r - m_rMin) / (m_rMax - m_rMin);
 
   // z
   const auto z = loc(2);
-  if( z < m_zMin || z >= m_zMax ) return -1;
+  if (z < m_zMin || z >= m_zMax)
+  {
+    return -1;
+  }
   const int iz = zbins * (z - m_zMin) / (m_zMax - m_zMin);
 
   // get index from matrix container
-  return m_matrix_container->get_cell_index( iphi, ir, iz );
-
+  return m_matrix_container->get_cell_index(iphi, ir, iz);
 }
 
 //_______________________________________________________________________________
-int PHTpcResiduals::createNodes(PHCompositeNode */*topNode*/)
-{ return Fun4AllReturnCodes::EVENT_OK; }
+int PHTpcResiduals::createNodes(PHCompositeNode* /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 
 //_______________________________________________________________________________
-int PHTpcResiduals::getNodes(PHCompositeNode *topNode)
+int PHTpcResiduals::getNodes(PHCompositeNode* topNode)
 {
-  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode,"TRKR_CLUSTER");
-  if(!m_clusterContainer)
+  m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if (!m_clusterContainer)
   {
     std::cout << PHWHERE << "No TRKR_CLUSTER node on node tree. Exiting." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-  if(!m_tGeometry)
+  if (!m_tGeometry)
   {
     std::cout << "ActsTrackingGeometry not on node tree. Exiting." << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
@@ -609,40 +665,40 @@ int PHTpcResiduals::getNodes(PHCompositeNode *topNode)
   }
 
   // tpc distortion corrections
-  m_dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerStatic");
-  m_dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerAverage");
-  m_dcc_fluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode,"TpcDistortionCorrectionContainerFluctuation");
+  m_dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerStatic");
+  m_dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerAverage");
+  m_dcc_fluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerFluctuation");
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //_________________________________________________________________________________
-Acts::Vector3 PHTpcResiduals::getGlobalPosition( TrkrDefs::cluskey key, TrkrCluster* cluster, short int crossing ) const
+Acts::Vector3 PHTpcResiduals::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster* cluster, short int crossing) const
 {
   // get global position from Acts transform
   auto globalPosition = m_tGeometry->getGlobalPosition(key, cluster);
 
   // for the TPC calculate the proper z based on crossing and side
   const auto trkrid = TrkrDefs::getTrkrId(key);
-  if(trkrid ==  TrkrDefs::tpcId)
+  if (trkrid == TrkrDefs::tpcId)
   {
     const auto side = TpcDefs::getSide(key);
     globalPosition.z() = m_clusterCrossingCorrection.correctZ(globalPosition.z(), side, crossing);
 
     // apply distortion corrections
-    if(m_dcc_static)
+    if (m_dcc_static)
     {
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_static );
+      globalPosition = m_distortionCorrection.get_corrected_position(globalPosition, m_dcc_static);
     }
 
-    if(m_dcc_average)
+    if (m_dcc_average)
     {
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_average );
+      globalPosition = m_distortionCorrection.get_corrected_position(globalPosition, m_dcc_average);
     }
 
-    if(m_dcc_fluctuation)
+    if (m_dcc_fluctuation)
     {
-      globalPosition = m_distortionCorrection.get_corrected_position( globalPosition, m_dcc_fluctuation );
+      globalPosition = m_distortionCorrection.get_corrected_position(globalPosition, m_dcc_fluctuation);
     }
   }
 
@@ -650,5 +706,6 @@ Acts::Vector3 PHTpcResiduals::getGlobalPosition( TrkrDefs::cluskey key, TrkrClus
 }
 
 void PHTpcResiduals::setGridDimensions(const int phiBins, const int rBins, const int zBins)
-{ m_matrix_container->set_grid_dimensions( phiBins, rBins, zBins ); }
-
+{
+  m_matrix_container->set_grid_dimensions(phiBins, rBins, zBins);
+}

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -172,9 +172,6 @@ class PHTpcResiduals : public SubsysReco
   /// output file
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
 
-  /// running track crossing id
-  short int m_crossing = 0;
-
   ///@name counters
   //@{
   int m_total_tracks = 0;

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -28,8 +28,8 @@ class TH2;
 class TTree;
 
 /**
- * This class takes preliminary fits from PHActsTrkFitter to the 
- * silicon + MM clusters and calculates the residuals in the TPC 
+ * This class takes preliminary fits from PHActsTrkFitter to the
+ * silicon + MM clusters and calculates the residuals in the TPC
  * from that track fit. The TPC state has to be explicitly determined
  * here since the Acts::DirectNavigator does not visit the TPC states
  */
@@ -48,30 +48,29 @@ class PHTpcResiduals : public SubsysReco
 
   ///@name Option for setting distortion correction calculation limits
   //@{
-  void setMaxTrackAlpha(float maxTAlpha) 
+  void setMaxTrackAlpha(float maxTAlpha)
   { m_maxTAlpha = maxTAlpha;}
-  
+
   void setMaxTrackBeta(float maxTBeta)
   { m_maxTBeta = maxTBeta; }
-  
-  void setMaxTrackResidualDrphi(float maxResidualDrphi) 
+
+  void setMaxTrackResidualDrphi(float maxResidualDrphi)
   { m_maxResidualDrphi = maxResidualDrphi;}
-  
+
   void setMaxTrackResidualDz(float maxResidualDz)
   { m_maxResidualDz = maxResidualDz; }
-  
   //@}
 
-  /// track min pT 
-  void setMinPt( double value ) 
+  /// track min pT
+  void setMinPt( double value )
   { m_minPt = value; }
-  
+
   /// Grid dimensions
   void setGridDimensions(const int phiBins, const int rBins, const int zBins);
 
   /// set to true to store evaluation histograms and ntuples
   void setSavehistograms( bool ) {}
-    
+
   /// output file name for evaluation histograms
   void setHistogramOutputfile(const std::string&) {}
 
@@ -85,9 +84,9 @@ class PHTpcResiduals : public SubsysReco
 
   private:
 
-  using BoundTrackParam = 
+  using BoundTrackParam =
     const Acts::BoundTrackParameters;
-  
+
   /// pairs path length and track parameters
   using BoundTrackParamPair = std::pair<float,BoundTrackParam>;
 
@@ -107,16 +106,19 @@ class PHTpcResiduals : public SubsysReco
 
   /// fill track state from bound track parameters
   void addTrackState( SvtxTrack* track, TrkrDefs::cluskey key, float pathlength, const Acts::BoundTrackParameters& params );
-  
+
   /// Gets distortion cell for identifying bins in TPC
   int getCell(const Acts::Vector3& loc);
 
   //! create ACTS track parameters from Svtx track
   Acts::BoundTrackParameters makeTrackParams(SvtxTrack* ) const;
 
-  /// actis transformation
+  //! create ACTS track parameters from Svtx track state
+  Acts::BoundTrackParameters makeTrackParams(SvtxTrack*, SvtxTrackState* ) const;
+
+  /// acts transformation
   ActsTransformations m_transformer;
-  
+
   /// Node information for Acts tracking geometry and silicon+MM
   /// track fit
   SvtxTrackMap *m_trackMap = nullptr;
@@ -125,7 +127,7 @@ class PHTpcResiduals : public SubsysReco
 
   // crossing z correction
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
-  
+
   // distortion corrections
   TpcDistortionCorrectionContainer* m_dcc_static = nullptr;
   TpcDistortionCorrectionContainer* m_dcc_average = nullptr;
@@ -133,7 +135,7 @@ class PHTpcResiduals : public SubsysReco
 
   /// tpc distortion correction utility class
   TpcDistortionCorrection m_distortionCorrection;
-  
+
   float m_maxTAlpha = 0.6;
   float m_maxResidualDrphi = 0.5; // cm
   float m_maxTBeta = 1.5;
@@ -151,28 +153,28 @@ class PHTpcResiduals : public SubsysReco
   static constexpr unsigned int m_nLayersTpc = 48;
   static constexpr float m_zMin = -105.5; // cm
   static constexpr float m_zMax = 105.5;  // cm
- 
+
   /// cluster error parametrisation
   ClusterErrorPara m_cluster_error_parametrization;
-  
+
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
-  
+
   // TODO: check if needed
   int m_event = 0;
-  
+
   /// require micromegas to be present when extrapolating tracks to the TPC
   bool m_useMicromegas = true;
 
   /// minimum pT required for track to be considered in residuals calculation (GeV/c)
   double m_minPt = 0.5;
-  
+
   /// output file
   std::string m_outputfile = "TpcSpaceChargeMatrices.root";
 
   /// running track crossing id
   short int m_crossing = 0;
-  
+
   ///@name counters
   //@{
   int m_total_tracks = 0;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This consolidates PHTPCResiduals to get more robust distortion correction maps. 

- extrapolate from any track state rather than only the one at beginning
- check from not-a-number in matrix calculation. one could also track down the reasons for nan in the first place, but since any single occurence, no matter how rare, breaks the whole matrix calculation (and all processed past events), better keep the check in place.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

