### PR TITLE
Micromegas survey flag

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -281,17 +281,17 @@ void PHG4DetectorSubsystem::InitializeParameters()
 
   SetDefaultParameters();  // call method from specific subsystem
   // now load those parameters to our params class
-  for (std::map<const std::string, double>::const_iterator iter = default_double.begin(); iter != default_double.end(); ++iter)
+  for( const auto& [key, value]:default_double )
   {
-    params->set_double_param(iter->first, iter->second);
+    params->set_double_param(key,value);
   }
-  for (std::map<const std::string, int>::const_iterator iter = default_int.begin(); iter != default_int.end(); ++iter)
+  for( const auto& [key, value]:default_int )
   {
-    params->set_int_param(iter->first, iter->second);
+    params->set_int_param(key,value);
   }
-  for (std::map<const std::string, std::string>::const_iterator iter = default_string.begin(); iter != default_string.end(); ++iter)
+  for( const auto& [key, value]:default_string )
   {
-    params->set_string_param(iter->first, iter->second);
+    params->set_string_param(key,value);
   }
 }
 

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasDetector.cc
@@ -253,7 +253,8 @@ void PHG4MicromegasDetector::construct_micromegas(G4LogicalVolume* logicWorld)
 
   // load survey data
   PHG4MicromegasSurvey micromegas_survey;
-  static constexpr bool apply_survey = true;
+  const bool apply_survey = m_Params->get_int_param("apply_survey");
+  std::cout << "PHG4MicromegasDetector::construct_micromegas - apply_survey: " << apply_survey << std::endl;
 
   // create detector
   // loop over tiles

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.cc
@@ -125,3 +125,10 @@ PHG4Detector *PHG4MicromegasSubsystem::GetDetector() const
 {
   return m_Detector;
 }
+
+//_______________________________________________________________________
+void PHG4MicromegasSubsystem::SetDefaultParameters()
+{
+  set_default_int_param("apply_survey", 1);
+}
+

--- a/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
+++ b/simulation/g4simulation/g4micromegas/PHG4MicromegasSubsystem.h
@@ -60,7 +60,7 @@ class PHG4MicromegasSubsystem : public PHG4DetectorSubsystem
 
  private:
   // \brief Set default parameter values
-  void SetDefaultParameters() override { return; }
+  void SetDefaultParameters() override;
 
   //! detector construction
   /*! derives from PHG4Detector */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Make whether survey is applied to Micromegas geometry or not configurable, for testing purposes. 
Default is to apply the survey data.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

