### PR TITLE
removed m_phi

### DIFF
--- a/offline/packages/trackbase_historic/TrackSeed_v1.h
+++ b/offline/packages/trackbase_historic/TrackSeed_v1.h
@@ -102,7 +102,6 @@ class TrackSeed_v1 : public TrackSeed
   float m_Y0 = NAN;
   float m_slope = NAN;
   float m_Z0 = NAN;
-  float m_phi = NAN;
 
   short int m_crossing = std::numeric_limits<short int>::max();
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
m_phi was introduced not only to trackseed_v2 (as it should) but also to trackseed_v1, by mistake
This breaks backward readability of DSTs in which seeds are stored.
This fixes that.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

