### PR TITLE
FAST: use last two samples for pedestal if peak is too early

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -248,6 +248,11 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_fast(std::v
         }
       }
       ped /= 3;
+      //if maxx <=5 nsample >=10 use the last two sample for pedestal(for HCal TP)
+      if (maxx <= 5 && nsamples >= 10)
+      {
+        ped = 0.5 * (v.at(nsamples - 2) + v.at(nsamples - 1));
+      }
       if (maxx == 0 || maxx == nsamples - 1)
       {
         amp = maxy;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This is for HCal TP runs, for some runs we have the peak around 4 which caused using the average of first three samples as pedestal being not accurate. This PR switch to use last two samples for the pedestal if the peak appears before sample 5.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

