### PR TITLE
MVTX standalone event combining

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -685,16 +685,19 @@ int Fun4AllStreamingInputManager::FillMvtx()
   {
     select_crossings += m_MvtxRawHitMap.begin()->first;
   }
+
+  uint64_t ref_bco_minus_range = m_RefBCO < m_mvtx_bco_range ? 0 : m_RefBCO - m_mvtx_bco_range;
   if (Verbosity() > 2)
   {
     std::cout << "select MVTX crossings"
-              << " from 0x" << std::hex << m_RefBCO - m_mvtx_bco_range
+              << " from 0x" << std::hex << ref_bco_minus_range
               << " to 0x" << select_crossings - m_mvtx_bco_range
               << std::dec << std::endl;
   }
   // m_MvtxRawHitMap.empty() does not need to be checked here, FillMvtxPool returns non zero
   // if this map is empty which is handled above
-  while (m_MvtxRawHitMap.begin()->first < m_RefBCO - m_mvtx_bco_range)
+  //All three values used in the while loop evaluation are unsigned ints. If m_RefBCO is < m_mvtx_bco_range then we will overflow and delete all hits
+  while (m_MvtxRawHitMap.begin()->first < ref_bco_minus_range)
   {
     if (Verbosity() > 2)
     {

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -155,6 +155,21 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     std::cout << "Have you built this yet?" << std::endl;
     exit(1);
   }
+
+  Gl1RawHit* gl1 = nullptr;
+  if (!m_runStandAlone)
+  {
+    gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+    if (!gl1)
+    {
+      std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+  //Could we just get the first strobe BCO instead of setting this to 0?
+  //Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
+  uint64_t gl1rawhitbco = m_runStandAlone ? 0 : gl1->get_bco();
+
   auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
   if (!gl1)
   {
@@ -194,8 +209,6 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     assert(mvtx_event_header);
   }
 
-  //  int NMasked = 0;
-
   for (unsigned int i = 0; i < mvtx_hit_container->get_nhits(); i++)
   {
     mvtx_hit = mvtx_hit_container->get_hit(i);
@@ -206,7 +219,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     row = mvtx_hit->get_row();
     col = mvtx_hit->get_col();
 
-    uint64_t bcodiff = gl1bco - strobe;
+    uint64_t bcodiff = m_runStandAlone ? 0 : gl1bco - strobe;
     double timeElapsed = bcodiff * 0.106;  // 106 ns rhic clock
     int index = std::floor(timeElapsed / m_strobeWidth);
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -169,14 +169,6 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   //Could we just get the first strobe BCO instead of setting this to 0?
   //Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
   uint64_t gl1rawhitbco = m_runStandAlone ? 0 : gl1->get_bco();
-
-  auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
-  if (!gl1)
-  {
-    std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-  uint64_t gl1rawhitbco = gl1->get_bco();
   // get the last 40 bits by bit shifting left then right to match
   // to the mvtx bco
   auto lbshift = gl1rawhitbco << 24U;

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -46,8 +46,6 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   void useRawEvtHeaderNodeName(const std::string& name) { m_MvtxRawEvtHeaderNodeName = name; }
 
-  void runMvtxStandalone(bool runAlone) { m_runStandAlone = runAlone; }
-
   void writeMvtxEventHeader(bool write) { m_writeMvtxEventHeader = write; }
 
  private:
@@ -61,7 +59,6 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
   std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
   float m_strobeWidth = 89.;  //! microseconds
-  bool m_runStandAlone = false;
   bool m_writeMvtxEventHeader = true;
   std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
 };

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -46,6 +46,8 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   void useRawEvtHeaderNodeName(const std::string& name) { m_MvtxRawEvtHeaderNodeName = name; }
 
+  void runMvtxStandalone(bool runAlone) { m_runStandAlone = runAlone; }
+
   void writeMvtxEventHeader(bool write) { m_writeMvtxEventHeader = write; }
 
  private:
@@ -59,6 +61,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
   std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
   float m_strobeWidth = 89.;  //! microseconds
+  bool m_runStandAlone = false;
   bool m_writeMvtxEventHeader = true;
   std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

When we run the event combiner for the MVTX and no other detectors, all hits are deleted. This is due to a check on the reference BCO and the BCO range to look for hits in. All values are unsigned ints and the reference BCO defaults to 0. When we subtract the range from the reference, we wrap around to almost the max value of and unsigned 64-bit int.

Also, in the unpacker, there's a check for the GL1 so we can figure out the MVTX time bucket. There's no GL1 in standalone mode so flags were put in to avoid this

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

