### PR TITLE
read fieldmap from optional from cdb

### DIFF
--- a/simulation/g4simulation/g4main/PHG4DisplayAction.cc
+++ b/simulation/g4simulation/g4main/PHG4DisplayAction.cc
@@ -3,6 +3,7 @@
 #include <Geant4/G4LogicalVolume.hh>
 #include <Geant4/G4VPhysicalVolume.hh>
 
+// NOLINTNEXTLINE(misc-no-recursion)
 int PHG4DisplayAction::FindVolumes(G4VPhysicalVolume* physvol)
 {
   int iret = 0;

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -99,6 +99,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <exception>  // for exception
+#include <filesystem>
 #include <iostream>   // for operator<<, endl
 #include <memory>
 
@@ -278,10 +279,10 @@ int PHG4Reco::InitField(PHCompositeNode *topNode)
 
   std::unique_ptr<PHFieldConfig> default_field_cfg(nullptr);
 
-  if (m_FieldMapFile == "CDB")
+  if (std::filesystem::path(m_FieldMapFile).extension() != ".root")
   {
     // loading from database
-    std::string url = CDBInterface::instance()->getUrl("FIELDMAPBIG", m_FieldMapFile);
+    std::string url = CDBInterface::instance()->getUrl(m_FieldMapFile);
     default_field_cfg.reset(new PHFieldConfigv1(m_FieldConfigType, url, m_MagneticFieldRescale));
   }
   else if (m_FieldMapFile != "NONE")


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR prepares for reading the fieldmap from the cdb, if the name of the calibration is used for the fieldmap it will be read from the cdb. This allows comparing between old and new fieldmaps

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

