### PR TITLE
fix: add guards for unfittable cluster set sizes

### DIFF
--- a/offline/packages/trackbase_historic/TrackSeed_v2.cc
+++ b/offline/packages/trackbase_historic/TrackSeed_v2.cc
@@ -232,6 +232,11 @@ void TrackSeed_v2::circleFitByTaubin(const std::map<TrkrDefs::cluskey, Acts::Vec
                                      uint8_t endLayer)
 {
   TrackFitUtils::position_vector_t positions_2d;
+  //! Can only fit 3 points or more
+  if(m_cluster_keys.size() < 3)
+  {
+    return;
+  }
   for (const auto& key : m_cluster_keys)
   {
     const auto layer = TrkrDefs::getLayer(key);
@@ -287,6 +292,11 @@ void TrackSeed_v2::lineFit(const std::map<TrkrDefs::cluskey, Acts::Vector3>& pos
                            uint8_t endLayer)
 {
   TrackFitUtils::position_vector_t positions_2d;
+  //! need at least 2 to fit
+  if(m_cluster_keys.size() < 2)
+  {
+    return;
+  }
   for (const auto& key : m_cluster_keys)
   {
     const auto layer = TrkrDefs::getLayer(key);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This gets the cosmic seeding back in order by placing guards around the new circle and line fit functions for cluster key set sizes that are unfittable.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

