### PR TITLE
Tpc distortion extrapolation

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -186,17 +186,17 @@ void TpcSpaceChargeMatrixInversion::calculate_distortions()
   std::unique_ptr<TFile> outputfile( TFile::Open( m_outputfile.c_str(), "RECREATE" ) );
   outputfile->cd();
 
-  // when using migromegas, one needs to extrapolate to the rest of the acceptance
-  if( m_use_micromegas )
-  {
-    for( const auto& h: {hentries, hphi, hr, hz} )
-    {
-      if( !h ) continue;
-      TpcSpaceChargeReconstructionHelper::extrapolate_z(h);
-      TpcSpaceChargeReconstructionHelper::extrapolate_phi1(h);
-      TpcSpaceChargeReconstructionHelper::extrapolate_phi2(h);
-    }
-  }
+//   // when using migromegas, one needs to extrapolate to the rest of the acceptance
+//   if( m_use_micromegas )
+//   {
+//     for( const auto& h: {hentries, hphi, hr, hz} )
+//     {
+//       if( !h ) continue;
+//       TpcSpaceChargeReconstructionHelper::extrapolate_z(h);
+//       TpcSpaceChargeReconstructionHelper::extrapolate_phi1(h);
+//       TpcSpaceChargeReconstructionHelper::extrapolate_phi2(h);
+//     }
+//   }
 
   // write source histograms
   for( const auto& h: { hentries, hphi, hr, hz } ) { h->Write(); }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -83,6 +83,8 @@ namespace
 //____________________________________________________________________________________
 void TpcSpaceChargeReconstructionHelper::create_tpot_mask( TH3* hmask )
 {
+  hmask->Reset();
+
   // loop over bins
   for( int ip = 0; ip < hmask->GetNbinsX(); ++ip )
     for( int ir = 0; ir < hmask->GetNbinsY(); ++ir )
@@ -189,6 +191,7 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* source, TH2* sou
     if( in_range ) continue;
 
     // phi not in TPOT range, rotate by steps of 2pi/12 (= one TPC sector) until found in range
+    const double r = source->GetYaxis()->GetBinCenter(ir+1);
     const double phi = source->GetXaxis()->GetBinCenter(ip+1);
     static constexpr int n_sectors = 12;
     for( int sector = 1; sector < n_sectors; ++sector )
@@ -205,8 +208,8 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* source, TH2* sou
       double scale = 1;
       if( source_cm )
       {
-        const double distortion_local = source_cm->GetBinContent( ip+1, ir+1 );
-        const double distortion_ref = source_cm->GetBinContent( ip_ref+1, ir+1 );
+        const double  distortion_local = source_cm->Interpolate( phi, r );
+        const double distortion_ref = source_cm->Interpolate( phi_ref, r );
         scale = distortion_local/distortion_ref;
       }
 

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -6,8 +6,7 @@
 
 #include "TpcSpaceChargeReconstructionHelper.h"
 
-#include <micromegas/CylinderGeomMicromegas.h>
-
+#include <TH2.h>
 #include <TH3.h>
 #include <TString.h>
 
@@ -16,221 +15,276 @@
 namespace
 {
   /// square
-  template<class T> 
+  template<class T>
   inline constexpr T square( T x ) { return x*x; }
 
   // regularize angle between 0 and 2PI
   template<class T>
-  inline constexpr T get_bound_angle( T phi ) 
+  inline constexpr T get_bound_angle( T phi )
   {
     while( phi < 0 ) phi += 2*M_PI;
     while( phi >= 2*M_PI ) phi -= 2*M_PI;
     return phi;
   }
- 
-  // angle from a given sector
-  constexpr double get_sector_phi( int isec ) { return isec*M_PI/6; }
 
-  // Micromegas geometry
-  // TODO: should get those numbers from actual geometry configuration
+  /// shortcut to angular window, needed to define TPOT acceptance
+  using range_t = std::pair<double, double>;
 
-  /// fully equiped sector
-  static constexpr double isec_ref = 9;
-  static constexpr double phi_ref = get_sector_phi(isec_ref);
+  /// list of angular windows
+  using range_list_t = std::vector<range_t>;
 
-  // radius of the outermost micromegas layer
-  static constexpr double r_ref = 85.1;
+  /// make sure angles in a given window are betwwen [0, 2PI]
+  range_t transform_range( const range_t& a )
+  { return { get_bound_angle( a.first ), get_bound_angle( a.second ) }; }
 
-  /// micromegas azimutal angle. It is used for interpolation between sectors
-  /** 
-   * 31.6cm corresponds to the micromegas tile width from CAD drawings, also used in PHG4MicromegasDetector.cc
-   * there is a reduction factor of 0.6, to avoid side effects
-   */
-  static constexpr double delta_phi_mm = 0.6*(31.6/CylinderGeomMicromegas::reference_radius); 
-  
-  /// z extrapolation window
-  static constexpr double zextrap_min = 53.2 - 5.0;
-  static constexpr double zextrap_max = 56.6 + 5.0;
-  
+  ///@name detector geometry
+  //@{
+  /// phi range for central sector (TPC sectors 9 and 21)
+  const range_t phi_range_central=transform_range({-1.742,-1.43979});
+
+  /// phi range for east sector (TPC sectors 8 and 20)
+  const range_t phi_range_east=transform_range({-2.27002,-1.9673});
+
+  /// phi range for west sector (TPC sectors 10 and 22)
+  const range_t phi_range_west=transform_range({-1.21452,-0.911172});
+
+  /// list of theta (polar) angles for each micromeas in central sector
+  const range_list_t theta_range_central={{-0.918257,-0.613136}, {-0.567549,-0.031022}, {0.0332154,0.570419}, {0.613631,0.919122}};
+
+  /// list of theta (polar) angles for each micromeas in east sector
+  const range_list_t theta_range_east={{-0.636926,-0.133603}, {0.140678,0.642714}};
+
+  /// list of theta (polar) angles for each micromeas in west sector
+  const range_list_t theta_range_west={{-0.643676,-0.141004}, {0.13485,0.640695}};
+  //@}
+
+  /// short class to check if a given value is in provided range
+  class range_ftor_t
+  {
+    public:
+    range_ftor_t( double value ): m_value( value ){};
+    bool operator ()( const range_t& range )
+    { return m_value > range.first && m_value < range.second; }
+
+    private:
+    double m_value = 0;
+  };
+
+  /// returns true if given value is in provided range
+  bool in_range( const double& value, const range_t range )
+  { return range_ftor_t(value)(range); }
+
+  /// returns true if given value is in any of the provided range
+  bool in_range( const double& value, const range_list_t range_list )
+  { return std::any_of( range_list.begin(), range_list.end(), range_ftor_t(value)); }
+
 }
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_z( TH3* hin )
+void TpcSpaceChargeReconstructionHelper::create_tpot_mask( TH3* hmask )
 {
-  if( !hin ) return;
-
-  // get reference phi bin
-  const int phibin_ref = hin->GetXaxis()->FindBin( phi_ref );
-
-  // loop over radial bins
-  for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
+  // loop over bins
+  for( int ip = 0; ip < hmask->GetNbinsX(); ++ip )
+    for( int ir = 0; ir < hmask->GetNbinsY(); ++ir )
+    for( int iz = 0; iz < hmask->GetNbinsZ(); ++iz )
   {
-
-    // get current radius
-    const auto r = hin->GetYaxis()->GetBinCenter( ir+1 );
-
-    // get z integration window for reference
-    const auto zextrap_min_loc = zextrap_min * r/r_ref;
-    const auto zextrap_max_loc = zextrap_max * r/r_ref;
-
-    // get corresponding bins
-    const int zbin_min[2] = { hin->GetZaxis()->FindBin( -zextrap_max_loc ), hin->GetZaxis()->FindBin( zextrap_min_loc ) };
-    const int zbin_max[2] = { hin->GetZaxis()->FindBin( -zextrap_min_loc ), hin->GetZaxis()->FindBin( zextrap_max_loc ) };
-
-    for( int isign = 0; isign < 2; ++isign )
-    {
-      // adjust z positions
-      const auto z_min = hin->GetZaxis()->GetBinCenter( zbin_min[isign] );
-      const auto z_max = hin->GetZaxis()->GetBinCenter( zbin_max[isign] );
-
-      // get reference
-      const auto content_min = hin->GetBinContent( phibin_ref, ir+1, zbin_min[isign] );
-      const auto content_max = hin->GetBinContent( phibin_ref, ir+1, zbin_max[isign] );
-      const auto error_min = hin->GetBinError( phibin_ref, ir+1, zbin_min[isign] );
-      const auto error_max = hin->GetBinError( phibin_ref, ir+1, zbin_max[isign] );
-
-      // loop over z bins
-      for( int iz = zbin_min[isign]+1; iz < zbin_max[isign]; ++iz )
-      {
-
-        const auto z = hin->GetZaxis()->GetBinCenter( iz );
-
-        // interpolate
-        const auto alpha_min = (z_max-z)/(z_max-z_min);
-        const auto alpha_max = (z-z_min)/(z_max-z_min);
-
-        const auto content = alpha_min*content_min + alpha_max*content_max;
-        const auto error = std::sqrt(square( alpha_min * error_min ) + square( alpha_max*error_max));
-
-        hin->SetBinContent( phibin_ref, ir+1, iz, content );
-        hin->SetBinError( phibin_ref, ir+1, iz, error );
-      }
-    }
+    const double phi = hmask->GetXaxis()->GetBinCenter(ip+1);
+    const double r = hmask->GetYaxis()->GetBinCenter(ir+1);
+    const double z = hmask->GetZaxis()->GetBinCenter(iz+1);
+    const double theta = std::atan2( z, r );
+    if( in_range( phi, phi_range_central ) && in_range( theta, theta_range_central )  )
+    { hmask->SetBinContent( ip+1, ir+1, iz+1, 1 ); }
   }
 }
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* hin )
+void TpcSpaceChargeReconstructionHelper::extrapolate_z( TH3* source, TH3* mask )
 {
-  if( !hin ) return;
-  
-  // get phi bin range for a given sector
-  auto get_phibin_range = []( TH3* hin, int isec  )
+
+  if( !source )
   {
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_z - invalid source histogram" << std::endl;
+    return;
+  }
 
-    // get corresponding first and last bin
-    const double phi = get_sector_phi( isec );
-    const double phi_min = get_bound_angle( phi - M_PI/12 );
-    const double phi_max = get_bound_angle( phi + M_PI/12 ); 
-
-    // find corresponding bins
-    const int phibin_min = hin->GetXaxis()->FindBin( phi_min );
-    const int phibin_max = hin->GetXaxis()->FindBin( phi_max );    
-    return std::make_pair( phibin_min, phibin_max ); 
-  };
-  
-  // get reference bins
-  const auto [phibin_min_ref, phibin_max_ref] = get_phibin_range( hin, isec_ref );
-  
-  // get number of phi bins
-  const int nphibins = hin->GetNbinsX();
-
-  // copy all r and z bins from reference phi bin to destination
-  auto copy_phi_bin = []( TH3* hin, int phibin_ref, int phibin_dest )
+  if( !mask )
   {
-    
-    // loop over radial bins
-    for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_z - invalid mask histogram" << std::endl;
+    return;
+  }
+
+  // loop over phi bins
+  for( int ir = 0; ir < source->GetNbinsY(); ++ir )
+    for( int ip = 0; ip < source->GetNbinsX(); ++ip )
+  {
+    int iz_min = -1;
+    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
     {
-      
-      // loop over z bins
-      for( int iz = 0; iz < hin->GetZaxis()->GetNbins(); ++iz )
+      bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
+      if( in_range )
       {
-        const auto content_ref = hin->GetBinContent( phibin_ref, ir+1, iz+1 );
-        const auto error_ref = hin->GetBinError( phibin_ref, ir+1, iz+1 );
-        
-        // calculate scale factor
-        const auto scale = 1;
-        
-        // assign to output histogram
-        hin->SetBinContent( phibin_dest, ir+1, iz+1, content_ref*scale );
-        hin->SetBinError( phibin_dest, ir+1, iz+1, error_ref*std::abs(scale) );
+        iz_min = iz;
+        continue;
       }
+
+      // iz is not in range. Check if iz_min was set. If not, skip this bin. If yes, find next bin in range
+      if( iz_min < 0 ) continue;
+
+      int iz_max = iz+1;
+      for( ; iz_max < source->GetNbinsZ(); ++iz_max )
+      {
+        in_range = mask->GetBinContent( ip+1, ir+1, iz_max+1 ) > 0;
+        if( in_range ) break;
+      }
+
+      // check interpolation range validity
+      if( iz_max == source->GetNbinsZ() ) continue;
+
+      // do the interpolation
+      const double z_min =  source->GetZaxis()->GetBinCenter(iz_min+1);
+      const double z_max =  source->GetZaxis()->GetBinCenter(iz_max+1);
+      const double z = source->GetZaxis()->GetBinCenter(iz+1);
+      const double alpha_min = (z_max-z)/(z_max-z_min);
+      const double alpha_max = (z-z_min)/(z_max-z_min);
+
+      const double distortion_min = source->GetBinContent( ip+1, ir+1, iz_min+1 );
+      const double distortion_max = source->GetBinContent( ip+1, ir+1, iz_max+1 );
+      const double distortion = alpha_min*distortion_min + alpha_max*distortion_max;
+
+      const double error_min = source->GetBinError( ip+1, ir+1, iz_min+1 );
+      const double error_max = source->GetBinError( ip+1, ir+1, iz_max+1 );
+      const double error = std::sqrt(square(alpha_min*error_min) + square(alpha_max*error_max));
+
+      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
+      source->SetBinError( ip+1, ir+1, iz+1, error );
     }
-    
-  };
-  
-  // loop over sectors
-  for( int isec = 0; isec < 12; ++isec )
+  }
+
+}
+
+//____________________________________________________________________________________
+void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* source, TH2* source_cm, TH3* mask )
+{
+
+  if( !source )
   {
-    // skip reference sector
-    if( isec == isec_ref ) continue;
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi1 - invalid source histogram" << std::endl;
+    return;
+  }
 
-    const auto [phibin_min, phibin_max] = get_phibin_range( hin, isec );
+  if( !mask )
+  {
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi1 - invalid mask histogram" << std::endl;
+    return;
+  }
 
-    // loop over bins
-    for( int ibin = 0; ibin < phibin_max_ref - phibin_min_ref; ++ibin )
+  // loop over phi bins
+  for( int ip = 0; ip < source->GetNbinsX(); ++ip )
+    for( int ir = 0; ir < source->GetNbinsY(); ++ir )
+    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
+  {
+
+    // do nothing if in TPOT acceptance
+    bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
+    if( in_range ) continue;
+
+    // phi not in TPOT range, rotate by steps of 2pi/12 (= one TPC sector) until found in range
+    const double phi = source->GetXaxis()->GetBinCenter(ip+1);
+    static constexpr int n_sectors = 12;
+    for( int sector = 1; sector < n_sectors; ++sector )
     {
-      int phibin_ref = (phibin_min_ref + ibin); 
-      if( phibin_ref > nphibins ) phibin_ref -= nphibins;
-      
-      int phibin = (phibin_min + ibin);   
-      if( phibin > nphibins ) phibin -= nphibins;
-      
-      copy_phi_bin( hin, phibin_ref, phibin );
+      // get ref phi
+      double phi_ref = phi + 2.*M_PI*sector/n_sectors;
+      while( phi_ref >= 2*M_PI ) { phi_ref -= 2*M_PI; };
+
+      int ip_ref = source->GetXaxis()->FindBin( phi_ref ) - 1;
+      in_range = mask->GetBinContent( ip_ref+1, ir+1, iz+1 ) > 0;
+      if( !in_range ) continue;
+
+      // get normalization factor from CM histograms
+      double scale = 1;
+      if( source_cm )
+      {
+        const double distortion_local = source_cm->GetBinContent( ip+1, ir+1 );
+        const double distortion_ref = source_cm->GetBinContent( ip_ref+1, ir+1 );
+        scale = distortion_local/distortion_ref;
+      }
+
+      // update content and error
+      const double distortion = scale*source->GetBinContent( ip_ref+1, ir+1, iz+1 );
+      const double error = scale*source->GetBinError( ip_ref+1, ir+1, iz+1 );
+      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
+      source->SetBinError( ip+1, ir+1, iz+1, error );
     }
   }
 }
 
 //_______________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_phi2( TH3* hin )
+void TpcSpaceChargeReconstructionHelper::extrapolate_phi2( TH3* source, TH3* mask )
 {
-  if( !hin ) return;
 
-  
-  // loop over sectors
-  for( int isec = 0; isec < 12; ++isec )
-  {    
-    // get phi range for interpolation from this sector to the next
-    const double phi_min = get_sector_phi(isec)+delta_phi_mm/2;
-    const double phi_max = get_sector_phi(isec+1)-delta_phi_mm/2;
-    
-    // get corresponding bins
-    const int phibin_min = hin->GetXaxis()->FindBin(get_bound_angle(phi_min));
-    const int phibin_max = hin->GetXaxis()->FindBin(get_bound_angle(phi_max));
-        
-    // loop over radial bins
-    for( int ir = 0; ir < hin->GetYaxis()->GetNbins(); ++ir )
-    {
-      
-      // loop over z bins
-      for( int iz = 0; iz < hin->GetZaxis()->GetNbins(); ++iz )
-      {
-        const auto content_min = hin->GetBinContent( phibin_min, ir+1, iz+1 );
-        const auto content_max = hin->GetBinContent( phibin_max, ir+1, iz+1 );
-        const auto error_min = hin->GetBinError( phibin_min, ir+1, iz+1 );
-        const auto error_max = hin->GetBinError( phibin_max, ir+1, iz+1 );
-
-        // loop over relevant phi bins
-        for( int iphi = phibin_min+1; iphi < phibin_max; ++iphi )
-        {
-          // get phi
-          const auto phi = hin->GetXaxis()->GetBinCenter( iphi );
-          
-          // perform linear extrapolation
-          const auto alpha_min = (phi_max-phi)/(phi_max-phi_min);
-          const auto alpha_max = (phi-phi_min)/(phi_max-phi_min);
-          
-          const auto content = alpha_min*content_min + alpha_max*content_max;
-          const auto error = std::sqrt(square( alpha_min * error_min ) + square( alpha_max*error_max));
-          
-          hin->SetBinContent( iphi, ir+1, iz+1, content );
-          hin->SetBinError( iphi, ir+1, iz+1, error );
-        }
-      }
-    }
+  if( !source )
+  {
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi2 - invalid source histogram" << std::endl;
+    return;
   }
-  
+
+  if( !mask )
+  {
+    std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi2 - invalid mask histogram" << std::endl;
+    return;
+  }
+
+  // loop over phi bins
+  for( int ir = 0; ir < source->GetNbinsY(); ++ir )
+    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
+  {
+    int ip_min = -1;
+    for( int ip = 0; ip < source->GetNbinsX(); ++ip )
+    {
+      bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
+      if( in_range )
+      {
+        ip_min = ip;
+        continue;
+      }
+
+      // ip is not in range. Check if ip_min was set. If not, skip this bin. If yes, find next bin in range
+      if( ip_min < 0 ) continue;
+
+      int ip_max = ip+1;
+      for( ; ip_max < source->GetNbinsX(); ++ip_max )
+      {
+        in_range = mask->GetBinContent( ip_max+1, ir+1, iz+1 ) > 0;
+        if( in_range ) break;
+      }
+
+      // check that a valid bin was found
+      if( ip_max == source->GetNbinsX() ) continue;
+
+      // do the interpolation
+      const double phi_min =  source->GetXaxis()->GetBinCenter(ip_min+1);
+      const double phi_max =  source->GetXaxis()->GetBinCenter(ip_max+1);
+      const double phi = source->GetXaxis()->GetBinCenter(ip+1);
+
+      const double alpha_min = (phi_max-phi)/(phi_max-phi_min);
+      const double alpha_max = (phi-phi_min)/(phi_max-phi_min);
+
+
+      const double distortion_min = source->GetBinContent( ip_min+1, ir+1, iz+1 );
+      const double distortion_max = source->GetBinContent( ip_max+1, ir+1, iz+1 );
+      const double distortion = alpha_min*distortion_min + alpha_max*distortion_max;
+
+      const double error_min = source->GetBinError( ip_min+1, ir+1, iz+1 );
+      const double error_max = source->GetBinError( ip_max+1, ir+1, iz+1 );
+      const double error = std::sqrt(square(alpha_min*error_min) + square(alpha_max*error_max));
+
+      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
+      source->SetBinError( ip+1, ir+1, iz+1, error );
+    }
+
+  }
+
 }
 
 //_______________________________________________

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -9,6 +9,7 @@
 #include <array>
 
 // forward declarations
+class TH2;
 class TH3;
 class TString;
 
@@ -17,27 +18,31 @@ class TpcSpaceChargeReconstructionHelper
 
   public:
 
+  /// create TPOT acceptance mask, using provided binning
+  /**
+   * this histogram contains 1 in cells that match the TPOT acceptance
+   * only Micromegas in the central sector (TPC sectors 9 and 21) are considered
+   */
+  static void create_tpot_mask( TH3* /*source*/ );
+
   /// z extrapolation
   /**
    * interpolate between micromegas in the fully equiped sector
    */
-  static void extrapolate_z( TH3* hin );
-
-  /// get reference z range used for phi extrapolation normalization at a given radius
-  static std::tuple<double, double> get_zref_range( double r );
+  static void extrapolate_z( TH3* /*source*/, TH3* /*mask*/ );
 
   /// first phi extrapolation
   /**
    * copy the full z dependence of reference sector to all other sectors, separately for positive and negative z,
    * normalized by the measurement from provided micromegas, at the appropriate z
    */
-  static void extrapolate_phi1( TH3* hin );
+  static void extrapolate_phi1( TH3* /*source*/, TH2* /*source_cm*/, TH3* /*mask*/ );
 
   /// second phi extrapolation
   /**
    * for each r, z and phi bin, linearly extrapolate between neighbor phi sector measurements
    */
-  static void extrapolate_phi2( TH3* hin );
+  static void extrapolate_phi2(  TH3* /*source*/, TH3* /*mask*/ );
 
   /// separate positive and negative z histograms
   /**


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
- First step towards implementing the proper extrapolation of the distortion corrctions measured in TPOT, with normalization using the central membrane data. 
- all utility functions have been tested using private steering macro
- missing calling these functions inside TpcSpaceChargeMatrixInversion.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

