### PR TITLE
Tpc distortion extrapolation 2

### DIFF
--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -81,7 +81,7 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
 
     std::cout << "TpcLoadDistortionCorrection::InitRun - reading corrections from " << m_correction_filename[i] << std::endl;
     auto distortion_tfile = TFile::Open(m_correction_filename[i].c_str());
-    if (!distortion_tfile && m_correction_in_use[i])
+    if (!distortion_tfile)
     {
       std::cout << "TpcLoadDistortionCorrection::InitRun - cannot open " << m_correction_filename[i] << std::endl;
       exit(1);

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -45,6 +45,8 @@ TpcSpaceChargeMatrixInversion::TpcSpaceChargeMatrixInversion(const std::string& 
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections(const std::string& filename)
 {
+  std::cout << "TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections - loading " << filename << std::endl;
+
   // open TFile
   auto distortion_tfile = TFile::Open(filename.c_str());
   if (!distortion_tfile)
@@ -78,6 +80,8 @@ void TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections(const std::st
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::load_average_distortion_corrections(const std::string& filename)
 {
+  std::cout << "TpcSpaceChargeMatrixInversion::load_average_distortion_corrections - loading " << filename << std::endl;
+
   // open TFile
   auto distortion_tfile = TFile::Open(filename.c_str());
   if (!distortion_tfile)
@@ -351,10 +355,12 @@ void TpcSpaceChargeMatrixInversion::save_distortion_corrections(const std::strin
   std::unique_ptr<TFile> outputfile(TFile::Open(filename.c_str(), "RECREATE"));
   outputfile->cd();
 
-  for (const auto& h : {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint})
+  for (const auto& h_list : {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint})
   {
-    if (h[0]) h[0]->Write();
-    if (h[1]) h[1]->Write();
+    for (const auto& h : h_list)
+    {
+      if (h) h->Write(h->GetName());
+    }
   }
 
   // close TFile

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -272,8 +272,8 @@ void TpcSpaceChargeMatrixInversion::calculate_distortion_corrections()
     std::unique_ptr<TH3> hpos(std::get<1>(result));
 
     return std::make_tuple(
-        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hneg.get(), Form("%s_negz", name.Data())),
-        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hpos.get(), Form("%s_posz", name.Data())));
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hneg.get(), name+"_negz" ),
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hpos.get(), name+"_posz" ) );
   };
 
   // apply finishing transformations to histograms and save in container

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -298,7 +298,7 @@ void TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections()
     TpcSpaceChargeReconstructionHelper::extrapolate_phi1( hmask_extrap_p.get(), nullptr, hmask_extrap_z.get() );
 
     // labmda function to process a given histogram, and return the updated one
-    auto process_histogram = [this, &hmask, &hmask_extrap_z, &hmask_extrap_p]( TH3* h, TH2* h_cm )
+    auto process_histogram = [&hmask, &hmask_extrap_z, &hmask_extrap_p]( TH3* h, TH2* h_cm )
     {
       // perform z extrapolation
       TpcSpaceChargeReconstructionHelper::extrapolate_z( h, hmask.get() );

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -5,8 +5,8 @@
  */
 
 #include "TpcSpaceChargeMatrixInversion.h"
-#include "TpcSpaceChargeReconstructionHelper.h"
 #include "TpcSpaceChargeMatrixContainerv1.h"
+#include "TpcSpaceChargeReconstructionHelper.h"
 
 #include <frog/FROG.h>
 #include <tpc/TpcDistortionCorrectionContainer.h>
@@ -24,7 +24,7 @@ namespace
 {
   // phi range
   static constexpr float m_phimin = 0;
-  static constexpr float m_phimax = 2.*M_PI;
+  static constexpr float m_phimax = 2. * M_PI;
 
   // TODO: could try to get the r and z range from TPC geometry
   // r range
@@ -34,248 +34,269 @@ namespace
   // z range
   static constexpr float m_zmin = -105.5;
   static constexpr float m_zmax = 105.5;
+}  // namespace
+
+//_____________________________________________________________________
+TpcSpaceChargeMatrixInversion::TpcSpaceChargeMatrixInversion(const std::string& name)
+  : Fun4AllBase(name)
+{
 }
 
 //_____________________________________________________________________
-TpcSpaceChargeMatrixInversion::TpcSpaceChargeMatrixInversion( const std::string& name ):
-  Fun4AllBase( name)
-{}
-
-//_____________________________________________________________________
-void TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections( const std::string& filename )
+void TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections(const std::string& filename)
 {
   // open TFile
   auto distortion_tfile = TFile::Open(filename.c_str());
-  if( !distortion_tfile )
+  if (!distortion_tfile)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::load_cm_distortion_corrections - cannot open " << filename << std::endl;
     exit(1);
   }
 
   // make sure container exists
-  if( !m_dcc_cm ) { m_dcc_cm.reset(new TpcDistortionCorrectionContainer); }
+  if (!m_dcc_cm)
+  {
+    m_dcc_cm.reset(new TpcDistortionCorrectionContainer);
+  }
 
   const std::array<const std::string, 2> extension = {{"_negz", "_posz"}};
   for (int j = 0; j < 2; ++j)
   {
-    m_dcc_cm->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP")+extension[j]).c_str()));
+    m_dcc_cm->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP") + extension[j]).c_str()));
     assert(m_dcc_cm->m_hDPint[j]);
-    m_dcc_cm->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR")+extension[j]).c_str()));
+    m_dcc_cm->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR") + extension[j]).c_str()));
     assert(m_dcc_cm->m_hDRint[j]);
-    m_dcc_cm->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ")+extension[j]).c_str()));
+    m_dcc_cm->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ") + extension[j]).c_str()));
     assert(m_dcc_cm->m_hDZint[j]);
   }
 
   // check histogram dimension. We expect 2D histograms
   m_dcc_cm->m_dimensions = m_dcc_cm->m_hDPint[0]->GetDimension();
-  assert( m_dcc_cm->m_dimensions == 2 );
+  assert(m_dcc_cm->m_dimensions == 2);
 }
 
 //_____________________________________________________________________
-void TpcSpaceChargeMatrixInversion::load_average_distortion_corrections( const std::string& filename )
+void TpcSpaceChargeMatrixInversion::load_average_distortion_corrections(const std::string& filename)
 {
   // open TFile
   auto distortion_tfile = TFile::Open(filename.c_str());
-  if( !distortion_tfile )
+  if (!distortion_tfile)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::load_average_distortion_corrections - cannot open " << filename << std::endl;
     exit(1);
   }
 
   // make sure container exists
-  if( !m_dcc_average ) { m_dcc_average.reset(new TpcDistortionCorrectionContainer); }
+  if (!m_dcc_average)
+  {
+    m_dcc_average.reset(new TpcDistortionCorrectionContainer);
+  }
 
   const std::array<const std::string, 2> extension = {{"_negz", "_posz"}};
   for (int j = 0; j < 2; ++j)
   {
-    m_dcc_average->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP")+extension[j]).c_str()));
+    m_dcc_average->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP") + extension[j]).c_str()));
     assert(m_dcc_average->m_hDPint[j]);
-    m_dcc_average->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR")+extension[j]).c_str()));
+    m_dcc_average->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR") + extension[j]).c_str()));
     assert(m_dcc_average->m_hDRint[j]);
-    m_dcc_average->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ")+extension[j]).c_str()));
+    m_dcc_average->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ") + extension[j]).c_str()));
     assert(m_dcc_average->m_hDZint[j]);
   }
 
   // check histogram dimension. We expect 2D histograms
   m_dcc_average->m_dimensions = m_dcc_average->m_hDPint[0]->GetDimension();
-  assert( m_dcc_average->m_dimensions == 3 );
+  assert(m_dcc_average->m_dimensions == 3);
 }
 
 //_____________________________________________________________________
-bool TpcSpaceChargeMatrixInversion::add_from_file( const std::string& shortfilename, const std::string& objectname )
+bool TpcSpaceChargeMatrixInversion::add_from_file(const std::string& shortfilename, const std::string& objectname)
 {
   // get filename from frog
   FROG frog;
-  const auto filename = frog.location( shortfilename );
+  const auto filename = frog.location(shortfilename);
 
   // open TFile
-  std::unique_ptr<TFile> inputfile( TFile::Open( filename ) );
-  if( !inputfile )
+  std::unique_ptr<TFile> inputfile(TFile::Open(filename));
+  if (!inputfile)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::add_from_file - could not open file " << filename << std::endl;
     return false;
   }
 
   // load object from input file
-  std::unique_ptr<TpcSpaceChargeMatrixContainer> source( dynamic_cast<TpcSpaceChargeMatrixContainer*>( inputfile->Get( objectname.c_str() ) ) );
-  if( !source )
+  std::unique_ptr<TpcSpaceChargeMatrixContainer> source(dynamic_cast<TpcSpaceChargeMatrixContainer*>(inputfile->Get(objectname.c_str())));
+  if (!source)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::add_from_file - could not find object name " << objectname << " in file " << filename << std::endl;
     return false;
   }
 
   // add object
-  return add( *source.get() );
+  return add(*source.get());
 }
 
 //_____________________________________________________________________
-bool TpcSpaceChargeMatrixInversion::add( const TpcSpaceChargeMatrixContainer& source )
+bool TpcSpaceChargeMatrixInversion::add(const TpcSpaceChargeMatrixContainer& source)
 {
   // check internal container, create if necessary
-  if( !m_matrix_container )
+  if (!m_matrix_container)
   {
-    m_matrix_container.reset( new TpcSpaceChargeMatrixContainerv1 );
+    m_matrix_container.reset(new TpcSpaceChargeMatrixContainerv1);
 
     // get grid dimensions from source
     int phibins = 0;
     int rbins = 0;
     int zbins = 0;
-    source.get_grid_dimensions( phibins, rbins, zbins );
+    source.get_grid_dimensions(phibins, rbins, zbins);
 
     // assign
-    m_matrix_container->set_grid_dimensions( phibins, rbins, zbins );
+    m_matrix_container->set_grid_dimensions(phibins, rbins, zbins);
   }
 
   // add content
-  return m_matrix_container->add( source );
+  return m_matrix_container->add(source);
 }
 
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::calculate_distortion_corrections()
 {
-
   // get grid dimensions from matrix container
   int phibins = 0;
   int rbins = 0;
   int zbins = 0;
-  m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
+  m_matrix_container->get_grid_dimensions(phibins, rbins, zbins);
 
   // create output histograms
-  std::unique_ptr<TH3> hentries( new TH3F( "hentries_rec", "hentries_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  std::unique_ptr<TH3> hphi( new TH3F( "hDistortionP_rec", "hDistortionP_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  std::unique_ptr<TH3> hz( new TH3F( "hDistortionZ_rec", "hDistortionZ_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  std::unique_ptr<TH3> hr( new TH3F( "hDistortionR_rec", "hDistortionR_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
+  std::unique_ptr<TH3> hentries(new TH3F("hentries_rec", "hentries_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax));
+  std::unique_ptr<TH3> hphi(new TH3F("hDistortionP_rec", "hDistortionP_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax));
+  std::unique_ptr<TH3> hz(new TH3F("hDistortionZ_rec", "hDistortionZ_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax));
+  std::unique_ptr<TH3> hr(new TH3F("hDistortionR_rec", "hDistortionR_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax));
 
   // set axis labels
-  for( const auto& h:{ hentries.get(), hphi.get(), hz.get(), hr.get() } )
+  for (const auto& h : {hentries.get(), hphi.get(), hz.get(), hr.get()})
   {
-    h->GetXaxis()->SetTitle( "#phi (rad)" );
-    h->GetYaxis()->SetTitle( "r (cm)" );
-    h->GetZaxis()->SetTitle( "z (cm)" );
+    h->GetXaxis()->SetTitle("#phi (rad)");
+    h->GetYaxis()->SetTitle("r (cm)");
+    h->GetZaxis()->SetTitle("z (cm)");
   }
 
   // matrix convenience definition
   /* number of coordinates must match that of the matrix container */
   static constexpr int ncoord = 3;
-  using matrix_t = Eigen::Matrix<float, ncoord, ncoord >;
-  using column_t = Eigen::Matrix<float, ncoord, 1 >;
+  using matrix_t = Eigen::Matrix<float, ncoord, ncoord>;
+  using column_t = Eigen::Matrix<float, ncoord, 1>;
 
   // loop over bins
-  for( int iphi = 0; iphi < phibins; ++iphi )
-    for( int ir = 0; ir < rbins; ++ir )
-    for( int iz = 0; iz < zbins; ++iz )
+  for (int iphi = 0; iphi < phibins; ++iphi)
   {
-
-    // get cell index
-    const auto icell = m_matrix_container->get_cell_index( iphi, ir, iz );
-
-    // minimum number of entries per bin
-    static constexpr int min_cluster_count = 2;
-    const auto cell_entries = m_matrix_container->get_entries(icell);
-    if( cell_entries < min_cluster_count ) continue;
-
-    // build eigen matrices from container
-    matrix_t lhs;
-    for( int i = 0; i < ncoord; ++i )
-      for( int j = 0; j < ncoord; ++j )
-    { lhs(i,j) = m_matrix_container->get_lhs( icell, i, j ); }
-
-    column_t rhs;
-    for( int i = 0; i < ncoord; ++i )
-    { rhs(i) = m_matrix_container->get_rhs( icell, i ); }
-
-    if (Verbosity())
+    for (int ir = 0; ir < rbins; ++ir)
     {
-      // print matrices and entries
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - inverting bin " << iz << ", " << ir << ", " << iphi << std::endl;
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - entries: " << cell_entries << std::endl;
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - lhs: \n" << lhs << std::endl;
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - rhs: \n" << rhs << std::endl;
-    }
+      for (int iz = 0; iz < zbins; ++iz)
+      {
+        // get cell index
+        const auto icell = m_matrix_container->get_cell_index(iphi, ir, iz);
 
-    // calculate result using linear solving
-    const auto cov = lhs.inverse();
-    auto partialLu = lhs.partialPivLu();
-    const auto result = partialLu.solve( rhs );
+        // minimum number of entries per bin
+        static constexpr int min_cluster_count = 2;
+        const auto cell_entries = m_matrix_container->get_entries(icell);
+        if (cell_entries < min_cluster_count)
+        {
+          continue;
+        }
 
-    // fill histograms
-    hentries->SetBinContent( iphi+1, ir+1, iz+1, cell_entries );
+        // build eigen matrices from container
+        matrix_t lhs;
+        for (int i = 0; i < ncoord; ++i)
+        {
+          for (int j = 0; j < ncoord; ++j)
+          {
+            lhs(i, j) = m_matrix_container->get_lhs(icell, i, j);
+          }
+        }
 
-    hphi->SetBinContent( iphi+1, ir+1, iz+1, result(0) );
-    hphi->SetBinError( iphi+1, ir+1, iz+1, std::sqrt( cov(0,0) ) );
+        column_t rhs;
+        for (int i = 0; i < ncoord; ++i)
+        {
+          rhs(i) = m_matrix_container->get_rhs(icell, i);
+        }
 
-    hz->SetBinContent( iphi+1, ir+1, iz+1, result(1) );
-    hz->SetBinError( iphi+1, ir+1, iz+1, std::sqrt( cov(1,1) ) );
+        if (Verbosity())
+        {
+          // print matrices and entries
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - inverting bin " << iz << ", " << ir << ", " << iphi << std::endl;
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - entries: " << cell_entries << std::endl;
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - lhs: \n"
+                    << lhs << std::endl;
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - rhs: \n"
+                    << rhs << std::endl;
+        }
 
-    hr->SetBinContent( iphi+1, ir+1, iz+1, result(2) );
-    hr->SetBinError( iphi+1, ir+1, iz+1, std::sqrt( cov(2,2) ) );
+        // calculate result using linear solving
+        const auto cov = lhs.inverse();
+        auto partialLu = lhs.partialPivLu();
+        const auto result = partialLu.solve(rhs);
 
-    if (Verbosity())
-    {
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - drphi: " << result(0) << " +/- " << std::sqrt( cov(0,0) ) << std::endl;
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - dz: " << result(1) << " +/- " << std::sqrt( cov(1,1) ) << std::endl;
-      std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - dr: " << result(2) << " +/- " << std::sqrt( cov(2,2) ) << std::endl;
-      std::cout << std::endl;
+        // fill histograms
+        hentries->SetBinContent(iphi + 1, ir + 1, iz + 1, cell_entries);
+
+        hphi->SetBinContent(iphi + 1, ir + 1, iz + 1, result(0));
+        hphi->SetBinError(iphi + 1, ir + 1, iz + 1, std::sqrt(cov(0, 0)));
+
+        hz->SetBinContent(iphi + 1, ir + 1, iz + 1, result(1));
+        hz->SetBinError(iphi + 1, ir + 1, iz + 1, std::sqrt(cov(1, 1)));
+
+        hr->SetBinContent(iphi + 1, ir + 1, iz + 1, result(2));
+        hr->SetBinError(iphi + 1, ir + 1, iz + 1, std::sqrt(cov(2, 2)));
+
+        if (Verbosity())
+        {
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - drphi: " << result(0) << " +/- " << std::sqrt(cov(0, 0)) << std::endl;
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - dz: " << result(1) << " +/- " << std::sqrt(cov(1, 1)) << std::endl;
+          std::cout << "TpcSpaceChargeMatrixInversion::calculate_distortion_corrections - dr: " << result(2) << " +/- " << std::sqrt(cov(2, 2)) << std::endl;
+          std::cout << std::endl;
+        }
+      }
     }
   }
 
   // split histograms in two along z axis and write
   // also write histograms suitable for space charge reconstruction
-  auto process_histogram = []( TH3* h, const TString& name )
+  auto process_histogram = [](TH3* h, const TString& name)
   {
-    const auto& result = TpcSpaceChargeReconstructionHelper::split( h );
-    std::unique_ptr<TH3> hneg( std::get<0>(result) );
-    std::unique_ptr<TH3> hpos( std::get<1>(result) );
+    const auto& result = TpcSpaceChargeReconstructionHelper::split(h);
+    std::unique_ptr<TH3> hneg(std::get<0>(result));
+    std::unique_ptr<TH3> hpos(std::get<1>(result));
 
     return std::make_tuple(
-      TpcSpaceChargeReconstructionHelper::add_guarding_bins( hneg.get(), Form( "%s_negz", name.Data() ) ),
-      TpcSpaceChargeReconstructionHelper::add_guarding_bins( hpos.get(), Form( "%s_posz", name.Data() ) ));
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hneg.get(), Form("%s_negz", name.Data())),
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hpos.get(), Form("%s_posz", name.Data())));
   };
 
-
   // apply finishing transformations to histograms and save in container
-  if( !m_dcc_average ) { m_dcc_average.reset(new TpcDistortionCorrectionContainer); }
+  if (!m_dcc_average)
+  {
+    m_dcc_average.reset(new TpcDistortionCorrectionContainer);
+  }
 
-  std::tie( m_dcc_average->m_hentries[0], m_dcc_average->m_hentries[1] ) = process_histogram( hentries.get(), "hentries" );
-  std::tie( m_dcc_average->m_hDRint[0], m_dcc_average->m_hDRint[1] ) = process_histogram( hr.get(), "hIntDistortionR" );
-  std::tie( m_dcc_average->m_hDPint[0], m_dcc_average->m_hDPint[1] ) = process_histogram( hphi.get(), "hIntDistortionP" );
-  std::tie( m_dcc_average->m_hDZint[0], m_dcc_average->m_hDZint[1] ) = process_histogram( hz.get(), "hIntDistortionZ" );
-
+  std::tie(m_dcc_average->m_hentries[0], m_dcc_average->m_hentries[1]) = process_histogram(hentries.get(), "hentries");
+  std::tie(m_dcc_average->m_hDRint[0], m_dcc_average->m_hDRint[1]) = process_histogram(hr.get(), "hIntDistortionR");
+  std::tie(m_dcc_average->m_hDPint[0], m_dcc_average->m_hDPint[1]) = process_histogram(hphi.get(), "hIntDistortionP");
+  std::tie(m_dcc_average->m_hDZint[0], m_dcc_average->m_hDZint[1]) = process_histogram(hz.get(), "hIntDistortionZ");
 }
 
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections()
 {
-  if( !m_dcc_average )
+  if (!m_dcc_average)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections - invalid distortion correction container." << std::endl;
     return;
   }
 
   // handle sides independently
-  for( int i = 0; i < 2; ++i )
+  for (int i = 0; i < 2; ++i)
   {
-    if( !m_dcc_average->m_hDRint[i] )
+    if (!m_dcc_average->m_hDRint[i])
     {
       std::cout << "TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections - invalid histograms m_hDRint" << std::endl;
       continue;
@@ -283,45 +304,43 @@ void TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections()
 
     // create relevant masks. They are used to define the cells in which distortion correction interpolation must be performed
     // this is a mask matching TPOT acceptance
-    std::unique_ptr<TH3> hmask( static_cast<TH3*>(m_dcc_average->m_hDRint[i]->Clone("hmask")));
-    TpcSpaceChargeReconstructionHelper::create_tpot_mask( hmask.get() );
+    std::unique_ptr<TH3> hmask(static_cast<TH3*>(m_dcc_average->m_hDRint[i]->Clone("hmask")));
+    TpcSpaceChargeReconstructionHelper::create_tpot_mask(hmask.get());
 
     // this is a mask matching TPOT acceptance, with small z interpolation between Micromegas modules
-    std::unique_ptr<TH3> hmask_extrap_z(static_cast<TH3*>(hmask->Clone( "hmask_extrap_z" )));
-    TpcSpaceChargeReconstructionHelper::extrapolate_z( hmask_extrap_z.get(), hmask.get() );
+    std::unique_ptr<TH3> hmask_extrap_z(static_cast<TH3*>(hmask->Clone("hmask_extrap_z")));
+    TpcSpaceChargeReconstructionHelper::extrapolate_z(hmask_extrap_z.get(), hmask.get());
 
     /*
      * this is a mask matching TPOT acceptance, with small z interpolation between Micromegas modules,
      * copied from sector to sector (no scaling)
      */
     std::unique_ptr<TH3> hmask_extrap_p(static_cast<TH3*>(hmask_extrap_z->Clone("hmask_extrap_p")));
-    TpcSpaceChargeReconstructionHelper::extrapolate_phi1( hmask_extrap_p.get(), nullptr, hmask_extrap_z.get() );
+    TpcSpaceChargeReconstructionHelper::extrapolate_phi1(hmask_extrap_p.get(), nullptr, hmask_extrap_z.get());
 
     // labmda function to process a given histogram, and return the updated one
-    auto process_histogram = [&hmask, &hmask_extrap_z, &hmask_extrap_p]( TH3* h, TH2* h_cm )
+    auto process_histogram = [&hmask, &hmask_extrap_z, &hmask_extrap_p](TH3* h, TH2* h_cm)
     {
       // perform z extrapolation
-      TpcSpaceChargeReconstructionHelper::extrapolate_z( h, hmask.get() );
+      TpcSpaceChargeReconstructionHelper::extrapolate_z(h, hmask.get());
 
       // perform first phi extrapolation, sector to sector, with normalization from central membrane
-      TpcSpaceChargeReconstructionHelper::extrapolate_phi1( h, h_cm, hmask_extrap_z.get() );
+      TpcSpaceChargeReconstructionHelper::extrapolate_phi1(h, h_cm, hmask_extrap_z.get());
 
       // perform second phi extrapolation, between sectors, using masks
-      TpcSpaceChargeReconstructionHelper::extrapolate_phi2( h, hmask_extrap_p.get() );
+      TpcSpaceChargeReconstructionHelper::extrapolate_phi2(h, hmask_extrap_p.get());
     };
 
-    process_histogram( static_cast<TH3*>(m_dcc_average->m_hDRint[i]), static_cast<TH2*>(m_dcc_cm->m_hDRint[i]));
-    process_histogram( static_cast<TH3*>(m_dcc_average->m_hDPint[i]), static_cast<TH2*>(m_dcc_cm->m_hDPint[i]));
-    process_histogram( static_cast<TH3*>(m_dcc_average->m_hDZint[i]), static_cast<TH2*>(m_dcc_cm->m_hDZint[i]));
-
+    process_histogram(static_cast<TH3*>(m_dcc_average->m_hDRint[i]), static_cast<TH2*>(m_dcc_cm->m_hDRint[i]));
+    process_histogram(static_cast<TH3*>(m_dcc_average->m_hDPint[i]), static_cast<TH2*>(m_dcc_cm->m_hDPint[i]));
+    process_histogram(static_cast<TH3*>(m_dcc_average->m_hDZint[i]), static_cast<TH2*>(m_dcc_cm->m_hDZint[i]));
   }
-
 }
 
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::save_distortion_corrections(const std::string& filename)
 {
-  if( !m_dcc_average )
+  if (!m_dcc_average)
   {
     std::cout << "TpcSpaceChargeMatrixInversion::save_distortion_corrections - invalid distortion correction container." << std::endl;
     return;
@@ -329,13 +348,13 @@ void TpcSpaceChargeMatrixInversion::save_distortion_corrections(const std::strin
 
   // save everything to root file
   std::cout << "TpcSpaceChargeMatrixInversion::save_distortions - writing histograms to " << filename << std::endl;
-  std::unique_ptr<TFile> outputfile( TFile::Open( filename.c_str(), "RECREATE" ) );
+  std::unique_ptr<TFile> outputfile(TFile::Open(filename.c_str(), "RECREATE"));
   outputfile->cd();
 
-  for( const auto& h: {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint } )
+  for (const auto& h : {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint})
   {
-    if( h[0] ) h[0]->Write();
-    if( h[1] ) h[1]->Write();
+    if (h[0]) h[0]->Write();
+    if (h[1]) h[1]->Write();
   }
 
   // close TFile

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -202,6 +202,35 @@ void TpcSpaceChargeMatrixInversion::calculate_distortions()
 
 }
 
+//_____________________________________________________________________
+void TpcSpaceChargeMatrixInversion::load_cm_distortion_correction( const std::string& filename )
+{
+  // open TFile
+  auto distortion_tfile = TFile::Open(filename.c_str());
+  if( !distortion_tfile )
+  {
+    std::cout << "TpcSpaceChargeMatrixInversion::load_cm_distortion_correction - cannot open " << filename << std::endl;
+    exit(1);
+  }
+
+  // make sure container exists
+  if( !m_dcc_cm ) { m_dcc_cm.reset(new TpcDistortionCorrectionContainer); }
+
+  const std::array<const std::string, 2> extension = {{"_negz", "_posz"}};
+  for (int j = 0; j < 2; ++j)
+  {
+    m_dcc_cm->m_hDPint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionP")+extension[j]).c_str()));
+    assert(m_dcc_cm->m_hDPint[j]);
+    m_dcc_cm->m_hDRint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionR")+extension[j]).c_str()));
+    assert(m_dcc_cm->m_hDRint[j]);
+    m_dcc_cm->m_hDZint[j] = dynamic_cast<TH1*>(distortion_tfile->Get((std::string("hIntDistortionZ")+extension[j]).c_str()));
+    assert(m_dcc_cm->m_hDZint[j]);
+  }
+
+  // check histogram dimension. We expect 2D histograms
+  m_dcc_cm->m_dimensions = m_dcc_cm->m_hDPint[0]->GetDimension();
+  assert( m_dcc_cm->m_dimensions == 2 );
+}
 
 //_____________________________________________________________________
 void TpcSpaceChargeMatrixInversion::save_distortions(const std::string& filename)

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -201,3 +201,28 @@ void TpcSpaceChargeMatrixInversion::calculate_distortions()
   std::tie( m_dcc_average->m_hDZint[0], m_dcc_average->m_hDZint[1] ) = process_histogram( hz.get(), "hIntDistortionZ" );
 
 }
+
+
+//_____________________________________________________________________
+void TpcSpaceChargeMatrixInversion::save_distortions(const std::string& filename)
+{
+  if( !m_dcc_average )
+  {
+    std::cout << "TpcSpaceChargeMatrixInversion::save_distortions - invalid histograms." << std::endl;
+    return;
+  }
+
+  // save everything to root file
+  std::cout << "TpcSpaceChargeMatrixInversion::save_distortions - writing histograms to " << filename << std::endl;
+  std::unique_ptr<TFile> outputfile( TFile::Open( filename.c_str(), "RECREATE" ) );
+  outputfile->cd();
+
+  for( const auto& h: {m_dcc_average->m_hentries, m_dcc_average->m_hDRint, m_dcc_average->m_hDPint, m_dcc_average->m_hDZint } )
+  {
+    if( h[0] ) h[0]->Write();
+    if( h[1] ) h[1]->Write();
+  }
+
+  // close TFile
+  outputfile->Close();
+}

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -100,13 +100,13 @@ void TpcSpaceChargeMatrixInversion::calculate_distortions()
   m_matrix_container->get_grid_dimensions( phibins, rbins, zbins );
 
   // create output histograms
-  auto hentries( new TH3F( "hentries_rec", "hentries_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  auto hphi( new TH3F( "hDistortionP_rec", "hDistortionP_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  auto hz( new TH3F( "hDistortionZ_rec", "hDistortionZ_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
-  auto hr( new TH3F( "hDistortionR_rec", "hDistortionR_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
+  std::unique_ptr<TH3> hentries( new TH3F( "hentries_rec", "hentries_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
+  std::unique_ptr<TH3> hphi( new TH3F( "hDistortionP_rec", "hDistortionP_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
+  std::unique_ptr<TH3> hz( new TH3F( "hDistortionZ_rec", "hDistortionZ_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
+  std::unique_ptr<TH3> hr( new TH3F( "hDistortionR_rec", "hDistortionR_rec", phibins, m_phimin, m_phimax, rbins, m_rmin, m_rmax, zbins, m_zmin, m_zmax ) );
 
   // set axis labels
-  for( const auto& h:{ hentries, hphi, hz, hr } )
+  for( const auto& h:{ hentries.get(), hphi.get(), hz.get(), hr.get() } )
   {
     h->GetXaxis()->SetTitle( "#phi (rad)" );
     h->GetYaxis()->SetTitle( "r (cm)" );
@@ -195,9 +195,9 @@ void TpcSpaceChargeMatrixInversion::calculate_distortions()
   // apply finishing transformations to histograms and save in container
   if( !m_dcc_average ) { m_dcc_average.reset(new TpcDistortionCorrectionContainer); }
 
-  std::tie( m_dcc_average->m_hentries[0], m_dcc_average->m_hentries[1] ) = process_histogram( hentries, "hentries" );
-  std::tie( m_dcc_average->m_hDRint[0], m_dcc_average->m_hDRint[1] ) = process_histogram( hr, "hIntDistortionR" );
-  std::tie( m_dcc_average->m_hDPint[0], m_dcc_average->m_hDPint[1] ) = process_histogram( hphi, "hIntDistortionP" );
-  std::tie( m_dcc_average->m_hDZint[0], m_dcc_average->m_hDZint[1] ) = process_histogram( hz, "hIntDistortionZ" );
+  std::tie( m_dcc_average->m_hentries[0], m_dcc_average->m_hentries[1] ) = process_histogram( hentries.get(), "hentries" );
+  std::tie( m_dcc_average->m_hDRint[0], m_dcc_average->m_hDRint[1] ) = process_histogram( hr.get(), "hIntDistortionR" );
+  std::tie( m_dcc_average->m_hDPint[0], m_dcc_average->m_hDPint[1] ) = process_histogram( hphi.get(), "hIntDistortionP" );
+  std::tie( m_dcc_average->m_hDZint[0], m_dcc_average->m_hDZint[1] ) = process_histogram( hz.get(), "hIntDistortionZ" );
 
 }

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
@@ -11,6 +11,7 @@
 
 // forward declaration
 class TpcSpaceChargeMatrixContainer;
+class TpcDistortionCorrectionContainer;
 
 /**
  * \class TpcSpaceChargeMatrixInversion
@@ -27,38 +28,36 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
   ///@name modifiers
   //@{
 
-  /// set whether to use only tracks with micromegas or not
-  void set_use_micromegas( bool value )
-  { m_use_micromegas = value; }
+  /// set central membrane distortion file
+  void set_central_membrane_correction_filename( const std::string& );
 
-  /// output file
-  /**
-   * this is the file where space charge correction 3D histograms are stored
-   * they are suitable for being read by TpcClusterizer
-   */
-  void set_outputfile( const std::string& filename );
-  
   /// add space charge correction matrix to current. Returns true on success
   bool add( const TpcSpaceChargeMatrixContainer& );
 
   /// add space charge correction matrix, loaded from file, to current. Returns true on success
-  bool add_from_file( const std::string& filename, const std::string& objectname = "TpcSpaceChargeMatrixContainer" );
-  
+  bool add_from_file( const std::string& /*filename*/, const std::string& /*objectname*/ = "TpcSpaceChargeMatrixContainer" );
+
   /// calculate distortions by inverting stored matrices, and save relevant histograms
   void calculate_distortions();
+
+  /// extrapolate distortions
+  void extrapolate_distortions();
+
+  /// save distortions
+  void save_distortions(const std::string& /*filename*/ = "DistortionCorrections.root");
 
   //@}
 
   private:
 
-  /// output file
-  std::string m_outputfile = "DistortionCorrections.root";
-
-  /// true if only tracks with micromegas must be used
-  bool m_use_micromegas = true;
-
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
+
+  /// output distortion container
+  std::unique_ptr<TpcDistortionCorrectionContainer> m_dcc_average;
+
+  /// central membrane distortion container
+  std::unique_ptr<TpcDistortionCorrectionContainer> m_dcc_cm;
 
 };
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
@@ -29,7 +29,10 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
   //@{
 
   /// load central membrane distortion correction
-  void load_cm_distortion_correction( const std::string& /*filename*/ );
+  void load_cm_distortion_corrections( const std::string& /*filename*/ );
+
+  /// load average distortion correction
+  void load_average_distortion_corrections( const std::string& /*filename*/ );
 
   /// add space charge correction matrix to current. Returns true on success
   bool add( const TpcSpaceChargeMatrixContainer& );
@@ -38,13 +41,13 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
   bool add_from_file( const std::string& /*filename*/, const std::string& /*objectname*/ = "TpcSpaceChargeMatrixContainer" );
 
   /// calculate distortions by inverting stored matrices, and save relevant histograms
-  void calculate_distortions();
+  void calculate_distortion_corrections();
 
   /// extrapolate distortions
-  void extrapolate_distortions();
+  void extrapolate_distortion_corrections();
 
   /// save distortions
-  void save_distortions(const std::string& /*filename*/ = "DistortionCorrections.root");
+  void save_distortion_corrections(const std::string& /*filename*/ = "DistortionCorrections.root");
 
   //@}
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
@@ -5,13 +5,13 @@
  * \brief aggregate space charge reconstruction matrices from several jobs and perform the inversion
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
+
+#include "TpcSpaceChargeMatrixContainer.h"
+
 #include <fun4all/Fun4AllBase.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
 
 #include <memory>
-
-// forward declaration
-class TpcSpaceChargeMatrixContainer;
-class TpcDistortionCorrectionContainer;
 
 /**
  * \class TpcSpaceChargeMatrixInversion

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
@@ -28,8 +28,8 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
   ///@name modifiers
   //@{
 
-  /// set central membrane distortion file
-  void set_central_membrane_correction_filename( const std::string& );
+  /// load central membrane distortion correction
+  void load_cm_distortion_correction( const std::string& /*filename*/ );
 
   /// add space charge correction matrix to current. Returns true on success
   bool add( const TpcSpaceChargeMatrixContainer& );

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -67,7 +67,7 @@ namespace
   class range_ftor_t
   {
    public:
-    range_ftor_t(double value)
+    explicit range_ftor_t(double value)
       : m_value(value){};
     bool operator()(const range_t& range)
     {

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -15,15 +15,18 @@
 namespace
 {
   /// square
-  template<class T>
-  inline constexpr T square( T x ) { return x*x; }
+  template <class T>
+  inline constexpr T square(T x)
+  {
+    return x * x;
+  }
 
   // regularize angle between 0 and 2PI
-  template<class T>
-  inline constexpr T get_bound_angle( T phi )
+  template <class T>
+  inline constexpr T get_bound_angle(T phi)
   {
-    while( phi < 0 ) phi += 2*M_PI;
-    while( phi >= 2*M_PI ) phi -= 2*M_PI;
+    while (phi < 0) phi += 2 * M_PI;
+    while (phi >= 2 * M_PI) phi -= 2 * M_PI;
     return phi;
   }
 
@@ -34,346 +37,390 @@ namespace
   using range_list_t = std::vector<range_t>;
 
   /// make sure angles in a given window are betwwen [0, 2PI]
-  range_t transform_range( const range_t& a )
-  { return { get_bound_angle( a.first ), get_bound_angle( a.second ) }; }
+  range_t transform_range(const range_t& a)
+  {
+    return {get_bound_angle(a.first), get_bound_angle(a.second)};
+  }
 
   ///@name detector geometry
   //@{
   /// phi range for central sector (TPC sectors 9 and 21)
-  const range_t phi_range_central=transform_range({-1.742,-1.43979});
+  const range_t phi_range_central = transform_range({-1.742, -1.43979});
 
   /// phi range for east sector (TPC sectors 8 and 20)
-  const range_t phi_range_east=transform_range({-2.27002,-1.9673});
+  const range_t phi_range_east = transform_range({-2.27002, -1.9673});
 
   /// phi range for west sector (TPC sectors 10 and 22)
-  const range_t phi_range_west=transform_range({-1.21452,-0.911172});
+  const range_t phi_range_west = transform_range({-1.21452, -0.911172});
 
   /// list of theta (polar) angles for each micromeas in central sector
-  const range_list_t theta_range_central={{-0.918257,-0.613136}, {-0.567549,-0.031022}, {0.0332154,0.570419}, {0.613631,0.919122}};
+  const range_list_t theta_range_central = {{-0.918257, -0.613136}, {-0.567549, -0.031022}, {0.0332154, 0.570419}, {0.613631, 0.919122}};
 
   /// list of theta (polar) angles for each micromeas in east sector
-  const range_list_t theta_range_east={{-0.636926,-0.133603}, {0.140678,0.642714}};
+  const range_list_t theta_range_east = {{-0.636926, -0.133603}, {0.140678, 0.642714}};
 
   /// list of theta (polar) angles for each micromeas in west sector
-  const range_list_t theta_range_west={{-0.643676,-0.141004}, {0.13485,0.640695}};
+  const range_list_t theta_range_west = {{-0.643676, -0.141004}, {0.13485, 0.640695}};
   //@}
 
   /// short class to check if a given value is in provided range
   class range_ftor_t
   {
-    public:
-    range_ftor_t( double value ): m_value( value ){};
-    bool operator ()( const range_t& range )
-    { return m_value > range.first && m_value < range.second; }
+   public:
+    range_ftor_t(double value)
+      : m_value(value){};
+    bool operator()(const range_t& range)
+    {
+      return m_value > range.first && m_value < range.second;
+    }
 
-    private:
+   private:
     double m_value = 0;
   };
 
   /// returns true if given value is in provided range
-  bool in_range( const double& value, const range_t& range )
-  { return range_ftor_t(value)(range); }
+  bool in_range(const double& value, const range_t& range)
+  {
+    return range_ftor_t(value)(range);
+  }
 
   /// returns true if given value is in any of the provided range
-  bool in_range( const double& value, const range_list_t& range_list )
-  { return std::any_of( range_list.begin(), range_list.end(), range_ftor_t(value)); }
+  bool in_range(const double& value, const range_list_t& range_list)
+  {
+    return std::any_of(range_list.begin(), range_list.end(), range_ftor_t(value));
+  }
 
-}
+}  // namespace
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::create_tpot_mask( TH3* hmask )
+void TpcSpaceChargeReconstructionHelper::create_tpot_mask(TH3* hmask)
 {
   hmask->Reset();
 
   // loop over bins
-  for( int ip = 0; ip < hmask->GetNbinsX(); ++ip )
-    for( int ir = 0; ir < hmask->GetNbinsY(); ++ir )
-    for( int iz = 0; iz < hmask->GetNbinsZ(); ++iz )
+  for (int ip = 0; ip < hmask->GetNbinsX(); ++ip)
   {
-    const double phi = hmask->GetXaxis()->GetBinCenter(ip+1);
-    const double r = hmask->GetYaxis()->GetBinCenter(ir+1);
-    const double z = hmask->GetZaxis()->GetBinCenter(iz+1);
-    const double theta = std::atan2( z, r );
-    if( in_range( phi, phi_range_central ) && in_range( theta, theta_range_central )  )
-    { hmask->SetBinContent( ip+1, ir+1, iz+1, 1 ); }
+    for (int ir = 0; ir < hmask->GetNbinsY(); ++ir)
+    {
+      for (int iz = 0; iz < hmask->GetNbinsZ(); ++iz)
+      {
+        const double phi = hmask->GetXaxis()->GetBinCenter(ip + 1);
+        const double r = hmask->GetYaxis()->GetBinCenter(ir + 1);
+        const double z = hmask->GetZaxis()->GetBinCenter(iz + 1);
+        const double theta = std::atan2(z, r);
+        if (in_range(phi, phi_range_central) && in_range(theta, theta_range_central))
+        {
+          hmask->SetBinContent(ip + 1, ir + 1, iz + 1, 1);
+        }
+      }
+    }
   }
 }
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_z( TH3* source, TH3* mask )
+void TpcSpaceChargeReconstructionHelper::extrapolate_z(TH3* source, TH3* mask)
 {
-
-  if( !source )
+  if (!source)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_z - invalid source histogram" << std::endl;
     return;
   }
 
-  if( !mask )
+  if (!mask)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_z - invalid mask histogram" << std::endl;
     return;
   }
 
   // loop over phi bins
-  for( int ir = 0; ir < source->GetNbinsY(); ++ir )
-    for( int ip = 0; ip < source->GetNbinsX(); ++ip )
+  for (int ir = 0; ir < source->GetNbinsY(); ++ir)
   {
-    int iz_min = -1;
-    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
+    for (int ip = 0; ip < source->GetNbinsX(); ++ip)
     {
-      bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
-      if( in_range )
+      int iz_min = -1;
+      for (int iz = 0; iz < source->GetNbinsZ(); ++iz)
       {
-        iz_min = iz;
-        continue;
+        bool in_range = mask->GetBinContent(ip + 1, ir + 1, iz + 1) > 0;
+        if (in_range)
+        {
+          iz_min = iz;
+          continue;
+        }
+
+        // iz is not in range. Check if iz_min was set. If not, skip this bin. If yes, find next bin in range
+        if (iz_min < 0)
+        {
+          continue;
+        }
+
+        int iz_max = iz + 1;
+        for (; iz_max < source->GetNbinsZ(); ++iz_max)
+        {
+          in_range = mask->GetBinContent(ip + 1, ir + 1, iz_max + 1) > 0;
+          if (in_range)
+          {
+            break;
+          }
+        }
+
+        // check interpolation range validity
+        if (iz_max == source->GetNbinsZ())
+        {
+          continue;
+        }
+
+        // do the interpolation
+        const double z_min = source->GetZaxis()->GetBinCenter(iz_min + 1);
+        const double z_max = source->GetZaxis()->GetBinCenter(iz_max + 1);
+        const double z = source->GetZaxis()->GetBinCenter(iz + 1);
+        const double alpha_min = (z_max - z) / (z_max - z_min);
+        const double alpha_max = (z - z_min) / (z_max - z_min);
+
+        const double distortion_min = source->GetBinContent(ip + 1, ir + 1, iz_min + 1);
+        const double distortion_max = source->GetBinContent(ip + 1, ir + 1, iz_max + 1);
+        const double distortion = alpha_min * distortion_min + alpha_max * distortion_max;
+
+        const double error_min = source->GetBinError(ip + 1, ir + 1, iz_min + 1);
+        const double error_max = source->GetBinError(ip + 1, ir + 1, iz_max + 1);
+        const double error = std::sqrt(square(alpha_min * error_min) + square(alpha_max * error_max));
+
+        source->SetBinContent(ip + 1, ir + 1, iz + 1, distortion);
+        source->SetBinError(ip + 1, ir + 1, iz + 1, error);
       }
-
-      // iz is not in range. Check if iz_min was set. If not, skip this bin. If yes, find next bin in range
-      if( iz_min < 0 ) continue;
-
-      int iz_max = iz+1;
-      for( ; iz_max < source->GetNbinsZ(); ++iz_max )
-      {
-        in_range = mask->GetBinContent( ip+1, ir+1, iz_max+1 ) > 0;
-        if( in_range ) break;
-      }
-
-      // check interpolation range validity
-      if( iz_max == source->GetNbinsZ() ) continue;
-
-      // do the interpolation
-      const double z_min =  source->GetZaxis()->GetBinCenter(iz_min+1);
-      const double z_max =  source->GetZaxis()->GetBinCenter(iz_max+1);
-      const double z = source->GetZaxis()->GetBinCenter(iz+1);
-      const double alpha_min = (z_max-z)/(z_max-z_min);
-      const double alpha_max = (z-z_min)/(z_max-z_min);
-
-      const double distortion_min = source->GetBinContent( ip+1, ir+1, iz_min+1 );
-      const double distortion_max = source->GetBinContent( ip+1, ir+1, iz_max+1 );
-      const double distortion = alpha_min*distortion_min + alpha_max*distortion_max;
-
-      const double error_min = source->GetBinError( ip+1, ir+1, iz_min+1 );
-      const double error_max = source->GetBinError( ip+1, ir+1, iz_max+1 );
-      const double error = std::sqrt(square(alpha_min*error_min) + square(alpha_max*error_max));
-
-      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
-      source->SetBinError( ip+1, ir+1, iz+1, error );
     }
   }
-
 }
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_phi1( TH3* source, TH2* source_cm, TH3* mask )
+void TpcSpaceChargeReconstructionHelper::extrapolate_phi1(TH3* source, TH2* source_cm, TH3* mask)
 {
-
-  if( !source )
+  if (!source)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi1 - invalid source histogram" << std::endl;
     return;
   }
 
-  if( !mask )
+  if (!mask)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi1 - invalid mask histogram" << std::endl;
     return;
   }
 
   // loop over phi bins
-  for( int ip = 0; ip < source->GetNbinsX(); ++ip )
-    for( int ir = 0; ir < source->GetNbinsY(); ++ir )
-    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
+  for (int ip = 0; ip < source->GetNbinsX(); ++ip)
   {
-
-    // do nothing if in TPOT acceptance
-    bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
-    if( in_range ) continue;
-
-    // phi not in TPOT range, rotate by steps of 2pi/12 (= one TPC sector) until found in range
-    const double r = source->GetYaxis()->GetBinCenter(ir+1);
-    const double phi = source->GetXaxis()->GetBinCenter(ip+1);
-    static constexpr int n_sectors = 12;
-    for( int sector = 1; sector < n_sectors; ++sector )
+    for (int ir = 0; ir < source->GetNbinsY(); ++ir)
     {
-      // get ref phi
-      double phi_ref = phi + 2.*M_PI*sector/n_sectors;
-      while( phi_ref >= 2*M_PI ) { phi_ref -= 2*M_PI; };
-
-      int ip_ref = source->GetXaxis()->FindBin( phi_ref ) - 1;
-      in_range = mask->GetBinContent( ip_ref+1, ir+1, iz+1 ) > 0;
-      if( !in_range ) continue;
-
-      // get normalization factor from CM histograms
-      double scale = 1;
-      if( source_cm )
+      for (int iz = 0; iz < source->GetNbinsZ(); ++iz)
       {
-        const double  distortion_local = source_cm->Interpolate( phi, r );
-        const double distortion_ref = source_cm->Interpolate( phi_ref, r );
-        scale = distortion_local/distortion_ref;
-      }
+        // do nothing if in TPOT acceptance
+        bool in_range = mask->GetBinContent(ip + 1, ir + 1, iz + 1) > 0;
+        if (in_range)
+        {
+          continue;
+        }
 
-      // update content and error
-      const double distortion = scale*source->GetBinContent( ip_ref+1, ir+1, iz+1 );
-      const double error = scale*source->GetBinError( ip_ref+1, ir+1, iz+1 );
-      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
-      source->SetBinError( ip+1, ir+1, iz+1, error );
+        // phi not in TPOT range, rotate by steps of 2pi/12 (= one TPC sector) until found in range
+        const double r = source->GetYaxis()->GetBinCenter(ir + 1);
+        const double phi = source->GetXaxis()->GetBinCenter(ip + 1);
+        static constexpr int n_sectors = 12;
+        for (int sector = 1; sector < n_sectors; ++sector)
+        {
+          // get ref phi
+          double phi_ref = phi + 2. * M_PI * sector / n_sectors;
+          while (phi_ref >= 2 * M_PI)
+          {
+            phi_ref -= 2 * M_PI;
+          };
+
+          int ip_ref = source->GetXaxis()->FindBin(phi_ref) - 1;
+          in_range = mask->GetBinContent(ip_ref + 1, ir + 1, iz + 1) > 0;
+          if (!in_range)
+          {
+            continue;
+          }
+
+          // get normalization factor from CM histograms
+          double scale = 1;
+          if (source_cm)
+          {
+            const double distortion_local = source_cm->Interpolate(phi, r);
+            const double distortion_ref = source_cm->Interpolate(phi_ref, r);
+            scale = distortion_local / distortion_ref;
+          }
+
+          // update content and error
+          const double distortion = scale * source->GetBinContent(ip_ref + 1, ir + 1, iz + 1);
+          const double error = scale * source->GetBinError(ip_ref + 1, ir + 1, iz + 1);
+          source->SetBinContent(ip + 1, ir + 1, iz + 1, distortion);
+          source->SetBinError(ip + 1, ir + 1, iz + 1, error);
+        }
+      }
     }
   }
 }
 
 //_______________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_phi2( TH3* source, TH3* mask )
+void TpcSpaceChargeReconstructionHelper::extrapolate_phi2(TH3* source, TH3* mask)
 {
-
-  if( !source )
+  if (!source)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi2 - invalid source histogram" << std::endl;
     return;
   }
 
-  if( !mask )
+  if (!mask)
   {
     std::cout << "TpcSpaceChargeReconstructionHelper::extrapolate_phi2 - invalid mask histogram" << std::endl;
     return;
   }
 
   // loop over phi bins
-  for( int ir = 0; ir < source->GetNbinsY(); ++ir )
-    for( int iz = 0; iz < source->GetNbinsZ(); ++iz )
+  for (int ir = 0; ir < source->GetNbinsY(); ++ir)
   {
-    int ip_min = -1;
-    for( int ip = 0; ip < source->GetNbinsX(); ++ip )
+    for (int iz = 0; iz < source->GetNbinsZ(); ++iz)
     {
-      bool in_range = mask->GetBinContent( ip+1, ir+1, iz+1 ) > 0;
-      if( in_range )
+      int ip_min = -1;
+      for (int ip = 0; ip < source->GetNbinsX(); ++ip)
       {
-        ip_min = ip;
-        continue;
+        bool in_range = mask->GetBinContent(ip + 1, ir + 1, iz + 1) > 0;
+        if (in_range)
+        {
+          ip_min = ip;
+          continue;
+        }
+
+        // ip is not in range. Check if ip_min was set. If not, skip this bin. If yes, find next bin in range
+        if (ip_min < 0)
+        {
+          continue;
+        }
+
+        int ip_max = ip + 1;
+        for (; ip_max < source->GetNbinsX(); ++ip_max)
+        {
+          in_range = mask->GetBinContent(ip_max + 1, ir + 1, iz + 1) > 0;
+          if (in_range)
+          {
+            break;
+          }
+        }
+
+        // check that a valid bin was found
+        if (ip_max == source->GetNbinsX())
+        {
+          continue;
+        }
+
+        // do the interpolation
+        const double phi_min = source->GetXaxis()->GetBinCenter(ip_min + 1);
+        const double phi_max = source->GetXaxis()->GetBinCenter(ip_max + 1);
+        const double phi = source->GetXaxis()->GetBinCenter(ip + 1);
+
+        const double alpha_min = (phi_max - phi) / (phi_max - phi_min);
+        const double alpha_max = (phi - phi_min) / (phi_max - phi_min);
+
+        const double distortion_min = source->GetBinContent(ip_min + 1, ir + 1, iz + 1);
+        const double distortion_max = source->GetBinContent(ip_max + 1, ir + 1, iz + 1);
+        const double distortion = alpha_min * distortion_min + alpha_max * distortion_max;
+
+        const double error_min = source->GetBinError(ip_min + 1, ir + 1, iz + 1);
+        const double error_max = source->GetBinError(ip_max + 1, ir + 1, iz + 1);
+        const double error = std::sqrt(square(alpha_min * error_min) + square(alpha_max * error_max));
+
+        source->SetBinContent(ip + 1, ir + 1, iz + 1, distortion);
+        source->SetBinError(ip + 1, ir + 1, iz + 1, error);
       }
-
-      // ip is not in range. Check if ip_min was set. If not, skip this bin. If yes, find next bin in range
-      if( ip_min < 0 ) continue;
-
-      int ip_max = ip+1;
-      for( ; ip_max < source->GetNbinsX(); ++ip_max )
-      {
-        in_range = mask->GetBinContent( ip_max+1, ir+1, iz+1 ) > 0;
-        if( in_range ) break;
-      }
-
-      // check that a valid bin was found
-      if( ip_max == source->GetNbinsX() ) continue;
-
-      // do the interpolation
-      const double phi_min =  source->GetXaxis()->GetBinCenter(ip_min+1);
-      const double phi_max =  source->GetXaxis()->GetBinCenter(ip_max+1);
-      const double phi = source->GetXaxis()->GetBinCenter(ip+1);
-
-      const double alpha_min = (phi_max-phi)/(phi_max-phi_min);
-      const double alpha_max = (phi-phi_min)/(phi_max-phi_min);
-
-
-      const double distortion_min = source->GetBinContent( ip_min+1, ir+1, iz+1 );
-      const double distortion_max = source->GetBinContent( ip_max+1, ir+1, iz+1 );
-      const double distortion = alpha_min*distortion_min + alpha_max*distortion_max;
-
-      const double error_min = source->GetBinError( ip_min+1, ir+1, iz+1 );
-      const double error_max = source->GetBinError( ip_max+1, ir+1, iz+1 );
-      const double error = std::sqrt(square(alpha_min*error_min) + square(alpha_max*error_max));
-
-      source->SetBinContent( ip+1, ir+1, iz+1, distortion );
-      source->SetBinError( ip+1, ir+1, iz+1, error );
     }
-
   }
-
 }
 
 //_______________________________________________
-std::tuple<TH3*, TH3*> TpcSpaceChargeReconstructionHelper::split( TH3* hin )
+std::tuple<TH3*, TH3*> TpcSpaceChargeReconstructionHelper::split(TH3* hin)
 {
-  if( !hin ) return std::make_tuple<TH3*, TH3*>( nullptr, nullptr );
+  if (!hin) return std::make_tuple<TH3*, TH3*>(nullptr, nullptr);
 
   auto xaxis = hin->GetXaxis();
   auto yaxis = hin->GetYaxis();
   auto zaxis = hin->GetZaxis();
-  auto ibin = zaxis->FindBin( (double) 0 );
+  auto ibin = zaxis->FindBin((double) 0);
 
   // create histograms
   auto hneg = new TH3F(
-    Form( "%s_negz", hin->GetName() ), Form( "%s_negz", hin->GetTitle() ),
-    xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
-    yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
-    ibin-1, zaxis->GetXmin(), zaxis->GetBinUpEdge( ibin-1 ) );
+      Form("%s_negz", hin->GetName()), Form("%s_negz", hin->GetTitle()),
+      xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
+      yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
+      ibin - 1, zaxis->GetXmin(), zaxis->GetBinUpEdge(ibin - 1));
 
   auto hpos = new TH3F(
-    Form( "%s_posz", hin->GetName() ), Form( "%s_posz", hin->GetTitle() ),
-    xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
-    yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
-    zaxis->GetNbins() - (ibin-1), zaxis->GetBinLowEdge(ibin), zaxis->GetXmax() );
+      Form("%s_posz", hin->GetName()), Form("%s_posz", hin->GetTitle()),
+      xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
+      yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
+      zaxis->GetNbins() - (ibin - 1), zaxis->GetBinLowEdge(ibin), zaxis->GetXmax());
 
   // copy content and errors
-  for( int ix = 0; ix < xaxis->GetNbins(); ++ix )
-    for( int iy = 0; iy < yaxis->GetNbins(); ++iy )
-    for( int iz = 0; iz < zaxis->GetNbins(); ++iz )
-  {
-    const auto content = hin->GetBinContent( ix+1, iy+1, iz+1 );
-    const auto error = hin->GetBinError( ix+1, iy+1, iz+1 );
+  for (int ix = 0; ix < xaxis->GetNbins(); ++ix)
+    for (int iy = 0; iy < yaxis->GetNbins(); ++iy)
+      for (int iz = 0; iz < zaxis->GetNbins(); ++iz)
+      {
+        const auto content = hin->GetBinContent(ix + 1, iy + 1, iz + 1);
+        const auto error = hin->GetBinError(ix + 1, iy + 1, iz + 1);
 
-    if( iz < ibin-1 )
-    {
-      hneg->SetBinContent( ix+1, iy+1, iz+1, content );
-      hneg->SetBinError( ix+1, iy+1, iz+1, error );
-    } else {
-      hpos->SetBinContent( ix+1, iy+1, iz - (ibin-1) + 1, content );
-      hpos->SetBinError( ix+1, iy+1, iz - (ibin-1) + 1, error );
-    }
-  }
+        if (iz < ibin - 1)
+        {
+          hneg->SetBinContent(ix + 1, iy + 1, iz + 1, content);
+          hneg->SetBinError(ix + 1, iy + 1, iz + 1, error);
+        }
+        else
+        {
+          hpos->SetBinContent(ix + 1, iy + 1, iz - (ibin - 1) + 1, content);
+          hpos->SetBinError(ix + 1, iy + 1, iz - (ibin - 1) + 1, error);
+        }
+      }
 
   // also copy axis titles
-  for( const auto h: {hneg, hpos} )
+  for (const auto h : {hneg, hpos})
   {
-    h->GetXaxis()->SetTitle( hin->GetXaxis()->GetTitle() );
-    h->GetYaxis()->SetTitle( hin->GetYaxis()->GetTitle() );
-    h->GetZaxis()->SetTitle( hin->GetZaxis()->GetTitle() );
+    h->GetXaxis()->SetTitle(hin->GetXaxis()->GetTitle());
+    h->GetYaxis()->SetTitle(hin->GetYaxis()->GetTitle());
+    h->GetZaxis()->SetTitle(hin->GetZaxis()->GetTitle());
   }
 
-  return std::make_tuple( hneg, hpos );
+  return std::make_tuple(hneg, hpos);
 }
 
 //___________________________________________________________________________
-TH3* TpcSpaceChargeReconstructionHelper::copy_histogram( TH3* hin, const TString& name )
+TH3* TpcSpaceChargeReconstructionHelper::copy_histogram(TH3* hin, const TString& name)
 {
   std::array<int, 3> bins;
   std::array<double, 3> x_min;
   std::array<double, 3> x_max;
 
   int index = 0;
-  for( const auto axis:{ hin->GetXaxis(), hin->GetYaxis(), hin->GetZaxis() } )
+  for (const auto axis : {hin->GetXaxis(), hin->GetYaxis(), hin->GetZaxis()})
   {
     // calculate bin width
-    const auto bin_width = (axis->GetXmax() - axis->GetXmin())/axis->GetNbins();
+    const auto bin_width = (axis->GetXmax() - axis->GetXmin()) / axis->GetNbins();
 
     // increase the number of bins by two
-    bins[index] = axis->GetNbins()+2;
+    bins[index] = axis->GetNbins() + 2;
 
     // update axis limits accordingly
-    x_min[index] = axis->GetXmin()-bin_width;
-    x_max[index] = axis->GetXmax()+bin_width;
+    x_min[index] = axis->GetXmin() - bin_width;
+    x_max[index] = axis->GetXmax() + bin_width;
     ++index;
   }
 
   // create new histogram
-  auto hout = new TH3F( name, name,
-    bins[0], x_min[0], x_max[0],
-    bins[1], x_min[1], x_max[1],
-    bins[2], x_min[2], x_max[2] );
+  auto hout = new TH3F(name, name,
+                       bins[0], x_min[0], x_max[0],
+                       bins[1], x_min[1], x_max[1],
+                       bins[2], x_min[2], x_max[2]);
 
   // update axis legend
-  hout->GetXaxis()->SetTitle( hin->GetXaxis()->GetTitle() );
-  hout->GetYaxis()->SetTitle( hin->GetYaxis()->GetTitle() );
-  hout->GetZaxis()->SetTitle( hin->GetZaxis()->GetTitle() );
+  hout->GetXaxis()->SetTitle(hin->GetXaxis()->GetTitle());
+  hout->GetYaxis()->SetTitle(hin->GetYaxis()->GetTitle());
+  hout->GetZaxis()->SetTitle(hin->GetZaxis()->GetTitle());
 
   // copy content
   const auto phibins = hin->GetXaxis()->GetNbins();
@@ -381,13 +428,13 @@ TH3* TpcSpaceChargeReconstructionHelper::copy_histogram( TH3* hin, const TString
   const auto zbins = hin->GetZaxis()->GetNbins();
 
   // fill center
-  for( int iphi = 0; iphi < phibins; ++iphi )
-    for( int ir = 0; ir < rbins; ++ir )
-    for( int iz = 0; iz < zbins; ++iz )
-  {
-    hout->SetBinContent( iphi+2, ir+2, iz+2, hin->GetBinContent( iphi+1, ir+1, iz+1 ) );
-    hout->SetBinError( iphi+2, ir+2, iz+2, hin->GetBinError( iphi+1, ir+1, iz+1 ) );
-  }
+  for (int iphi = 0; iphi < phibins; ++iphi)
+    for (int ir = 0; ir < rbins; ++ir)
+      for (int iz = 0; iz < zbins; ++iz)
+      {
+        hout->SetBinContent(iphi + 2, ir + 2, iz + 2, hin->GetBinContent(iphi + 1, ir + 1, iz + 1));
+        hout->SetBinError(iphi + 2, ir + 2, iz + 2, hin->GetBinError(iphi + 1, ir + 1, iz + 1));
+      }
 
   // fill guarding phi bins
   /*
@@ -395,40 +442,39 @@ TH3* TpcSpaceChargeReconstructionHelper::copy_histogram( TH3* hin, const TString
    * - last valid bin is copied to first guarding bin;
    * - first valid bin is copied to last guarding bin
    */
-  for( int ir = 0; ir < rbins+2; ++ir )
-    for( int iz = 0; iz < zbins+2; ++iz )
-  {
-    // copy last bin to first guarding bin
-    hout->SetBinContent( 1, ir+1, iz+1, hout->GetBinContent( phibins+1, ir+1, iz+1 ) );
-    hout->SetBinError( 1, ir+1, iz+1, hout->GetBinError( phibins+1, ir+1, iz+1 ) );
+  for (int ir = 0; ir < rbins + 2; ++ir)
+    for (int iz = 0; iz < zbins + 2; ++iz)
+    {
+      // copy last bin to first guarding bin
+      hout->SetBinContent(1, ir + 1, iz + 1, hout->GetBinContent(phibins + 1, ir + 1, iz + 1));
+      hout->SetBinError(1, ir + 1, iz + 1, hout->GetBinError(phibins + 1, ir + 1, iz + 1));
 
-    // copy first bin to last guarding bin
-    hout->SetBinContent( phibins+2, ir+1, iz+1, hout->GetBinContent( 2, ir+1, iz+1 ) );
-    hout->SetBinError( phibins+2, ir+1, iz+1, hout->GetBinError( 2, ir+1, iz+1 ) );
-  }
+      // copy first bin to last guarding bin
+      hout->SetBinContent(phibins + 2, ir + 1, iz + 1, hout->GetBinContent(2, ir + 1, iz + 1));
+      hout->SetBinError(phibins + 2, ir + 1, iz + 1, hout->GetBinError(2, ir + 1, iz + 1));
+    }
 
   // fill guarding r bins
-  for( int iphi = 0; iphi < phibins+2; ++iphi )
-    for( int iz = 0; iz < zbins+2; ++iz )
-  {
-    hout->SetBinContent( iphi+1, 1, iz+1, hout->GetBinContent( iphi+1, 2, iz+1 ) );
-    hout->SetBinError( iphi+1, 1, iz+1, hout->GetBinError( iphi+1, 2, iz+1 ) );
+  for (int iphi = 0; iphi < phibins + 2; ++iphi)
+    for (int iz = 0; iz < zbins + 2; ++iz)
+    {
+      hout->SetBinContent(iphi + 1, 1, iz + 1, hout->GetBinContent(iphi + 1, 2, iz + 1));
+      hout->SetBinError(iphi + 1, 1, iz + 1, hout->GetBinError(iphi + 1, 2, iz + 1));
 
-    hout->SetBinContent( iphi+1, rbins+2, iz+1, hout->GetBinContent( iphi+1, rbins+1, iz+1 ) );
-    hout->SetBinError( iphi+1, rbins+2, iz+1, hout->GetBinError( iphi+1, rbins+1, iz+1 ) );
-  }
+      hout->SetBinContent(iphi + 1, rbins + 2, iz + 1, hout->GetBinContent(iphi + 1, rbins + 1, iz + 1));
+      hout->SetBinError(iphi + 1, rbins + 2, iz + 1, hout->GetBinError(iphi + 1, rbins + 1, iz + 1));
+    }
 
   // fill guarding z bins
-  for( int iphi = 0; iphi < phibins+2; ++iphi )
-    for( int ir = 0; ir < rbins+2; ++ir )
-  {
-    hout->SetBinContent( iphi+1, ir+1, 1, hout->GetBinContent( iphi+1, ir+1, 2 ) );
-    hout->SetBinError( iphi+1, ir+1, 1, hout->GetBinError( iphi+1, ir+1, 2 ) );
+  for (int iphi = 0; iphi < phibins + 2; ++iphi)
+    for (int ir = 0; ir < rbins + 2; ++ir)
+    {
+      hout->SetBinContent(iphi + 1, ir + 1, 1, hout->GetBinContent(iphi + 1, ir + 1, 2));
+      hout->SetBinError(iphi + 1, ir + 1, 1, hout->GetBinError(iphi + 1, ir + 1, 2));
 
-    hout->SetBinContent( iphi+1, ir+1, zbins+2, hout->GetBinContent( iphi+1, ir+1, zbins+1 ) );
-    hout->SetBinError( iphi+1, ir+1, zbins+2, hout->GetBinError( iphi+1, ir+1, zbins+1 ) );
-  }
+      hout->SetBinContent(iphi + 1, ir + 1, zbins + 2, hout->GetBinContent(iphi + 1, ir + 1, zbins + 1));
+      hout->SetBinError(iphi + 1, ir + 1, zbins + 2, hout->GetBinError(iphi + 1, ir + 1, zbins + 1));
+    }
 
   return hout;
-
 }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -346,14 +346,15 @@ std::tuple<TH3*, TH3*> TpcSpaceChargeReconstructionHelper::split(TH3* hin)
   auto ibin = zaxis->FindBin((double) 0);
 
   // create histograms
+  const TString name( hin->GetName() );
   auto hneg = new TH3F(
-      Form("%s_negz", hin->GetName()), Form("%s_negz", hin->GetTitle()),
+      name+"_negz", name+"_negz",
       xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
       yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
       ibin - 1, zaxis->GetXmin(), zaxis->GetBinUpEdge(ibin - 1));
 
   auto hpos = new TH3F(
-      Form("%s_posz", hin->GetName()), Form("%s_posz", hin->GetTitle()),
+      name+"_posz", name+"_posz",
       xaxis->GetNbins(), xaxis->GetXmin(), xaxis->GetXmax(),
       yaxis->GetNbins(), yaxis->GetXmin(), yaxis->GetXmax(),
       zaxis->GetNbins() - (ibin - 1), zaxis->GetBinLowEdge(ibin), zaxis->GetXmax());
@@ -392,9 +393,9 @@ std::tuple<TH3*, TH3*> TpcSpaceChargeReconstructionHelper::split(TH3* hin)
 //___________________________________________________________________________
 TH3* TpcSpaceChargeReconstructionHelper::add_guarding_bins(TH3* hin, const TString& name)
 {
-  std::array<int, 3> bins;
-  std::array<double, 3> x_min;
-  std::array<double, 3> x_max;
+  std::array<int, 3> bins{};
+  std::array<double, 3> x_min{};
+  std::array<double, 3> x_max{};
 
   int index = 0;
   for (const auto axis : {hin->GetXaxis(), hin->GetYaxis(), hin->GetZaxis()})

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -71,11 +71,11 @@ namespace
   };
 
   /// returns true if given value is in provided range
-  bool in_range( const double& value, const range_t range )
+  bool in_range( const double& value, const range_t& range )
   { return range_ftor_t(value)(range); }
 
   /// returns true if given value is in any of the provided range
-  bool in_range( const double& value, const range_list_t range_list )
+  bool in_range( const double& value, const range_list_t& range_list )
   { return std::any_of( range_list.begin(), range_list.end(), range_ftor_t(value)); }
 
 }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -193,7 +193,7 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_z(TH3* source, const TH3* m
 
 
 //____________________________________________________________________________________
-void TpcSpaceChargeReconstructionHelper::extrapolate_z2(TH3* source, const TH3* mask)
+void TpcSpaceChargeReconstructionHelper::extrapolate_z2(TH3* source, const TH3* mask, uint8_t side)
 {
   if (!source)
   {
@@ -207,20 +207,14 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_z2(TH3* source, const TH3* 
     return;
   }
 
-  // decide if extrapolation must be done with increasing or decreasing bin numbers
-  /*
-   * this is broken when there are guarding bins
-   * this will also break if we want to extrapolate from both sides
-   */
-  const bool extrapolate_forward = source->GetZaxis()->GetXmax() > 0;
-
   // loop over phi bins
   for (int ir = 0; ir < source->GetNbinsY(); ++ir)
   {
     for (int ip = 0; ip < source->GetNbinsX(); ++ip)
     {
 
-      if( extrapolate_forward )
+      // handle pad plane on the positive side (zmax)
+      if( side&Side_positive )
       {
 
         // find first non empty bin, starting from last zaxis bin
@@ -259,7 +253,12 @@ void TpcSpaceChargeReconstructionHelper::extrapolate_z2(TH3* source, const TH3* 
           source->SetBinError(ip + 1, ir + 1, iz + 1, error);
         }
 
-      } else {
+      }
+
+
+      // handle pad plane on the negative side (zmin
+      if( side&Side_negative )
+      {
 
         // find first non empty bin, starting from first zaxis bin
         int iz_max = -1;

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -390,7 +390,7 @@ std::tuple<TH3*, TH3*> TpcSpaceChargeReconstructionHelper::split(TH3* hin)
 }
 
 //___________________________________________________________________________
-TH3* TpcSpaceChargeReconstructionHelper::copy_histogram(TH3* hin, const TString& name)
+TH3* TpcSpaceChargeReconstructionHelper::add_guarding_bins(TH3* hin, const TString& name)
 {
   std::array<int, 3> bins;
   std::array<double, 3> x_min;

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -7,6 +7,7 @@
  */
 
 #include <array>
+#include <cstdint>
 
 // forward declarations
 class TH2;
@@ -34,10 +35,18 @@ class TpcSpaceChargeReconstructionHelper
 
   /// second z extrapolation
   /**
-   * interpolate along z between the readoutplane (at which location the distortion is zero) and the first micromegas module
+   * interpolate along z between the readout plane (at which location the distortion is zero) and the outermost micromegas module
    * the mask is used to decide in which bins the extrapolation must be performed
+   * the side is a bit mask to tell on which side of the histograms the pad-planes are
    */
-  static void extrapolate_z2( TH3* /*source*/, const TH3* /*mask*/ );
+  enum Side:uint8_t
+  {
+    Side_negative = 1<<0,
+    Side_positive = 1<<1,
+    Side_both = Side_negative|Side_positive
+  };
+
+  static void extrapolate_z2( TH3* /*source*/, const TH3* /*mask*/, uint8_t /* side */ );
 
   /// first phi extrapolation
   /**

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -57,10 +57,8 @@ class TpcSpaceChargeReconstructionHelper
    * each axis, with identical content and error as the first and last bin of the original histogram
    * this is necessary for being able to call TH3->Interpolate() when using these histograms
    * to correct for the space charge distortions.
-   * TODO: is this really necessary ? Possibly one could just use the bin content for the correction rather than using TH3->Interpolate,
-   * in which case the "guarding bins" would be unnecessary. Should check if it leads to a significant deterioration of the momentum resolution
    */
-  static TH3* copy_histogram( TH3* hin, const TString& name );
+  static TH3* add_guarding_bins( TH3* hin, const TString& name );
 
 };
 

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -32,12 +32,12 @@ class TpcSpaceChargeReconstructionHelper
    */
   static void extrapolate_z( TH3* /*source*/, const TH3* /*mask*/ );
 
-//   /// second z extrapolation
-//   /**
-//    * interpolate along z between the readoutplane (at which location the distortion is zero) and the first micromegas module
-//    * the mask is used to decide in which bins the extrapolation must be performed
-//    */
-//   static void extrapolate_z2( TH3* /*source*/, const TH3* /*mask*/ );
+  /// second z extrapolation
+  /**
+   * interpolate along z between the readoutplane (at which location the distortion is zero) and the first micromegas module
+   * the mask is used to decide in which bins the extrapolation must be performed
+   */
+  static void extrapolate_z2( TH3* /*source*/, const TH3* /*mask*/ );
 
   /// first phi extrapolation
   /**

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -25,24 +25,33 @@ class TpcSpaceChargeReconstructionHelper
    */
   static void create_tpot_mask( TH3* /*source*/ );
 
-  /// z extrapolation
+  /// first z extrapolation
   /**
-   * interpolate between micromegas in the fully equiped sector
+   * interpolate along z between the two micromegas modules fully equiped sector
+   * the mask is used to decide in which bins the extrapolation must be performed
    */
-  static void extrapolate_z( TH3* /*source*/, TH3* /*mask*/ );
+  static void extrapolate_z( TH3* /*source*/, const TH3* /*mask*/ );
+
+//   /// second z extrapolation
+//   /**
+//    * interpolate along z between the readoutplane (at which location the distortion is zero) and the first micromegas module
+//    * the mask is used to decide in which bins the extrapolation must be performed
+//    */
+//   static void extrapolate_z2( TH3* /*source*/, const TH3* /*mask*/ );
 
   /// first phi extrapolation
   /**
-   * copy the full z dependence of reference sector to all other sectors, separately for positive and negative z,
+   * copy the full z dependence of reference sector to all other sectors
    * normalized by the measurement from provided micromegas, at the appropriate z
+   * the mask is used to decide in which bins the extrapolation must be performed
    */
-  static void extrapolate_phi1( TH3* /*source*/, TH2* /*source_cm*/, TH3* /*mask*/ );
+  static void extrapolate_phi1( TH3* /*source*/, const TH2* /*source_cm*/, const TH3* /*mask*/ );
 
   /// second phi extrapolation
   /**
    * for each r, z and phi bin, linearly extrapolate between neighbor phi sector measurements
    */
-  static void extrapolate_phi2(  TH3* /*source*/, TH3* /*mask*/ );
+  static void extrapolate_phi2(  TH3* /*source*/, const TH3* /*mask*/ );
 
   /// separate positive and negative z histograms
   /**
@@ -50,7 +59,7 @@ class TpcSpaceChargeReconstructionHelper
    * this must be done before adding guarding bins around each axis, in order to prevent artifacts during calls to Interpolate
    * at the central membrane (z = 0)
    */
-  static std::tuple<TH3*, TH3*> split( TH3* hin );
+  static std::tuple<TH3*, TH3*> split( const TH3* /*source*/ );
 
   /**
    * copy input histogram into output, with new name, while adding two "guarding bins" on
@@ -58,7 +67,7 @@ class TpcSpaceChargeReconstructionHelper
    * this is necessary for being able to call TH3->Interpolate() when using these histograms
    * to correct for the space charge distortions.
    */
-  static TH3* add_guarding_bins( TH3* hin, const TString& name );
+  static TH3* add_guarding_bins( const TH3* /*source*/, const TString& /*name*/ );
 
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR complete the extrapolation code for TPC distortion corrections.
TpcSpaceChargeMatrixInversion can now load 2D central-membrane distortion corrections, and use it to perform the extrapolation from TPOT acceptance to TPC acceptance.
Still missing is a steering macro (JobB), which will look like this: 

  TpcSpaceChargeMatrixInversion matrix_inversion;
  matrix_inversion.load_average_distortion_corrections( inputfile );
  matrix_inversion.load_cm_distortion_corrections( inputfile_cm );
  matrix_inversion.extrapolate_distortion_corrections();
  matrix_inversion.save_distortion_corrections( outputfile );


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

