### PR TITLE
put execessive printouts behind verbosity

### DIFF
--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -3,19 +3,16 @@
 
 #include "MbdDefs.h"
 
+#include <mbd/MbdGeom.h>
+
 #include <fun4all/Fun4AllBase.h>
 
 #include <phool/recoConsts.h>
 
 #include <array>
 #include <vector>
-//#include <math>
-//#include <stdint>
 #include <string>
-//#include <string_view>
 #include <memory>
-
-#include <mbd/MbdGeom.h>
 
 class TTree;
 class CDBInterface;

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -804,11 +804,14 @@ Double_t MbdSig::TemplateFcn(const Double_t* x, const Double_t* par)
 
     if ( isnan(xx) )
     {
-      std::cout << PHWHERE << " " << _evt_counter << ", " << _ch
-        << " ERROR x par0 par1 " << x[0] << "\t" << par[0] << "\t" << par[1] << std::endl;
-      if ( x[0] == 0. )
+      if (_verbose > 0)
       {
-        gSubPulse->Print("ALL");
+	std::cout << PHWHERE << " " << _evt_counter << ", " << _ch
+		  << " ERROR x par0 par1 " << x[0] << "\t" << par[0] << "\t" << par[1] << std::endl;
+	if ( x[0] == 0. )
+	{
+	  gSubPulse->Print("ALL");
+	}
       }
       return 0.;
     }

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -1,13 +1,14 @@
 #ifndef __MBDSIG_H__
 #define __MBDSIG_H__
 
+#include "MbdRunningStats.h"
+
 #include <TH1.h>
-//#include <TH2.h>
+
 #include <fstream>
 #include <vector>
 #include <queue>
 
-#include "MbdRunningStats.h"
 
 class TFile;
 class TTree;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The MbdSig printed excessive messages (10MB) if the spline fit failed. This PR puts this behind a verbosity flag

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

