### PR TITLE
fix remaining perennial clang-tidy warning

### DIFF
--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.cc
@@ -272,8 +272,8 @@ void TpcSpaceChargeMatrixInversion::calculate_distortion_corrections()
     std::unique_ptr<TH3> hpos(std::get<1>(result));
 
     return std::make_tuple(
-        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hneg.get(), name+"_negz" ),
-        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hpos.get(), name+"_posz" ) );
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hneg.get(), name + "_negz"),
+        TpcSpaceChargeReconstructionHelper::add_guarding_bins(hpos.get(), name + "_posz"));
   };
 
   // apply finishing transformations to histograms and save in container
@@ -333,10 +333,10 @@ void TpcSpaceChargeMatrixInversion::extrapolate_distortion_corrections()
      * decide on which side of the histograms the pad plane is set.
      * this is used to guide the last z interpolation from readout plane to the outermost micromegas module
      */
-    const uint8_t side = (i==0) ? TpcSpaceChargeReconstructionHelper::Side_negative : TpcSpaceChargeReconstructionHelper::Side_positive;
+    const uint8_t side = (i == 0) ? TpcSpaceChargeReconstructionHelper::Side_negative : TpcSpaceChargeReconstructionHelper::Side_positive;
 
     // labmda function to process a given histogram, and return the updated one
-    auto process_histogram = [&hmask, &hmask_extrap_z, &hmask_extrap_p, &hmask_extrap_p2, side](TH3* h, TH2* h_cm )
+    auto process_histogram = [&hmask, &hmask_extrap_z, &hmask_extrap_p, &hmask_extrap_p2, side](TH3* h, TH2* h_cm)
     {
       // perform z extrapolation
       TpcSpaceChargeReconstructionHelper::extrapolate_z(h, hmask.get());
@@ -375,7 +375,10 @@ void TpcSpaceChargeMatrixInversion::save_distortion_corrections(const std::strin
   {
     for (const auto& h : h_list)
     {
-      if (h) h->Write(h->GetName());
+      if (h)
+      {
+        h->Write(h->GetName());
+      }
     }
   }
 

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixInversion.h
@@ -18,27 +18,26 @@
  * \brief performs space charge distortion reconstruction using tracks
  */
 
-class TpcSpaceChargeMatrixInversion: public Fun4AllBase
+class TpcSpaceChargeMatrixInversion : public Fun4AllBase
 {
-  public:
-
+ public:
   /// constructor
-  TpcSpaceChargeMatrixInversion( const std::string& = "TPCSPACECHARGEMATRIXINVERSION" );
+  TpcSpaceChargeMatrixInversion(const std::string& = "TPCSPACECHARGEMATRIXINVERSION");
 
   ///@name modifiers
   //@{
 
   /// load central membrane distortion correction
-  void load_cm_distortion_corrections( const std::string& /*filename*/ );
+  void load_cm_distortion_corrections(const std::string& /*filename*/);
 
   /// load average distortion correction
-  void load_average_distortion_corrections( const std::string& /*filename*/ );
+  void load_average_distortion_corrections(const std::string& /*filename*/);
 
   /// add space charge correction matrix to current. Returns true on success
-  bool add( const TpcSpaceChargeMatrixContainer& );
+  bool add(const TpcSpaceChargeMatrixContainer&);
 
   /// add space charge correction matrix, loaded from file, to current. Returns true on success
-  bool add_from_file( const std::string& /*filename*/, const std::string& /*objectname*/ = "TpcSpaceChargeMatrixContainer" );
+  bool add_from_file(const std::string& /*filename*/, const std::string& /*objectname*/ = "TpcSpaceChargeMatrixContainer");
 
   /// calculate distortions by inverting stored matrices, and save relevant histograms
   void calculate_distortion_corrections();
@@ -51,8 +50,7 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
 
   //@}
 
-  private:
-
+ private:
   /// matrix container
   std::unique_ptr<TpcSpaceChargeMatrixContainer> m_matrix_container;
 
@@ -61,7 +59,6 @@ class TpcSpaceChargeMatrixInversion: public Fun4AllBase
 
   /// central membrane distortion container
   std::unique_ptr<TpcDistortionCorrectionContainer> m_dcc_cm;
-
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes the remaining perennial clang-tidy complaint, this should now give us a clean clang-tidy report if no new errors crept in with a PR

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

