### PR TITLE
KFP: Safer magnetic field reading

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -28,8 +28,9 @@
 
 #include <phool/getClass.h>
 
+#include <TEntryList.h>
 #include <TFile.h>
-#include <TH1.h>  // for obtaining the B field value
+#include <TLeaf.h>
 #include <TSystem.h>
 #include <TTree.h>  // for getting the TTree from the file
 
@@ -113,45 +114,7 @@ int KFParticle_sPHENIX::InitRun(PHCompositeNode *topNode)
 {
   assert(topNode);
 
-  // Load the official offline B-field map that is also used in tracking, basically copying the codes from: https://github.com/sPHENIX-Collaboration/coresoftware/blob/master/offline/packages/trackreco/MakeActsGeometry.cc#L478-L483, provide by Joe Osborn.
-  if (std::filesystem::path(m_magField).extension() != ".root")
-  {
-    m_magField = CDBInterface::instance()->getUrl(m_magField);
-  }
-  // Joe's New Implementation to get the field map file name on 05/10/2023
-  if (!std::filesystem::exists(m_magField))
-  {
-    if (m_magField.empty())
-    {
-      m_magField = "empty string";
-    }
-    std::cout << PHWHERE << "Fieldmap " << m_magField
-              << " does not exist" << std::endl;
-    gSystem->Exit(1);
-  }
-  std::cout << "KFPARTICLE: using fieldmap : " << m_magField << std::endl;
-  TFile *fin = new TFile(m_magField.c_str());
-  fin->cd();
-
-  TTree *fieldmap = (TTree *) fin->Get("fieldmap");
-
-  TH1F *BzHist = new TH1F("BzHist", "", 100, 0, 10);
-
-  int NBFieldEntries = fieldmap->Project("BzHist", "bz", "x==0 && y==0 && z==0");
-
-  if (NBFieldEntries != 1)
-  {  // Validate exactly 1 B field value at (0,0,0) in the field map
-    std::cout << "Not a single B field value at (0,0,0) in the field map, need to check why" << std::endl;
-    exit(1);
-  }
-
-  // The actual unit of KFParticle is in kilo Gauss (kG), which is equivalent to 0.1 T, instead of Tesla (T). The positive value indicates the B field is in the +z direction
-  float m_Bz = BzHist->GetMean() * 10;  // Factor of 10 to convert the B field unit from kG to T
-  KFParticle::SetField(m_Bz);
-
-  fieldmap->Delete();
-  BzHist->Delete();
-  fin->Close();
+  getField();
 
   return 0;
 }
@@ -508,4 +471,70 @@ int KFParticle_sPHENIX::parseDecayDescriptor()
     }
     return Fun4AllReturnCodes::ABORTRUN;
   }
+}
+
+void KFParticle_sPHENIX::getField()
+{
+  //This sweeps the sPHENIX magnetic field map from some point radially then grabs the first event that passes the selection
+  m_magField = std::filesystem::exists(m_magField) ? m_magField : CDBInterface::instance()->getUrl(m_magField);
+
+  if (Verbosity() > 0)
+  {
+    std::cout << PHWHERE << ": using fieldmap : " << m_magField << std::endl;
+  }
+
+  TFile *fin = new TFile(m_magField.c_str());
+  TTree *fieldmap = (TTree *) fin->Get("fieldmap");
+
+  float Bz = 0.;
+  unsigned int r = 0.;
+  float z = 1.;
+
+  double arc = M_PI/2;
+  unsigned int n = 0;
+
+  while (Bz == 0)
+  {
+    if (n == 4)
+    {
+      ++r;
+    }
+
+    if (r == 3) //Dont go too far out radially
+    {
+      ++z;
+    }
+
+    n = n & 0x3; //Constrains n from 0 to 3
+    r = r & 0x2;
+
+    double x = r*std::cos(n*arc);
+    double y = r*std::sin(n*arc);
+
+    std::string sweep = "x == " + std::to_string(x) + " && y == " + std::to_string(y) + " && z == " + std::to_string(z);
+
+    fieldmap->Draw(">>elist", sweep.c_str(), "entrylist");
+    TEntryList *elist = (TEntryList*)gDirectory->Get("elist");
+    if (elist->GetEntry(0))
+    {
+      TLeaf *xpos = fieldmap->GetLeaf("bz");
+      xpos->GetBranch()->GetEntry(elist->GetEntry(0));
+      Bz = xpos->GetValue();
+    }
+
+    ++n;
+
+    if (r == 0) // No point in rescanning (0,0)
+    {
+      ++r;
+      n = 0;
+    }
+  }
+
+  // The actual unit of KFParticle is in kilo Gauss (kG), which is equivalent to 0.1 T, instead of Tesla (T). The positive value indicates the B field is in the +z direction
+  Bz *= 10;  // Factor of 10 to convert the B field unit from kG to T
+  KFParticle::SetField((double) Bz);
+
+  fieldmap->Delete();
+  fin->Close();
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -307,6 +307,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void magFieldFile(const std::string &fname) { m_magField = fname; }
 
+  void getField();
+
  private:
   bool m_has_intermediates_sPHENIX;
   bool m_constrain_to_vertex_sPHENIX;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

The new magnetic field doesn't have an entry at the origin. KFParticle was hardcoded to read this value. This PR now performs a radial sweep of the field map along z until it finds the first entry of the map and sets the KFParticle field to this.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

