### PR TITLE
Handle RefBCO correctly if running without the GL1

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -302,6 +302,7 @@ int Fun4AllStreamingInputManager::ResetEvent()
   //   iter->CleanupUsedPackets(m_CurrentBeamClock);
   // }
   //  m_SyncObject->Reset();
+  m_RefBCO = 0;
   return 0;
 }
 
@@ -567,6 +568,8 @@ int Fun4AllStreamingInputManager::FillGl1()
     MySyncManager()->CurrentEvent(gl1rawhit->getEvtSequence());
     m_RefBCO = gl1hititer->get_bco();
     m_RefBCO = m_RefBCO & 0xFFFFFFFFFFU;  // 40 bits (need to handle rollovers)
+//    std::cout << "BCOis " << std::hex << m_RefBCO << std::dec << std::endl;
+
   }
   for (auto iter : m_Gl1InputVector)
   {
@@ -594,14 +597,12 @@ int Fun4AllStreamingInputManager::FillIntt()
   // FillInttPool() contains this check already and will return non zero
   // so here m_InttRawHitMap will always contain entries
   uint64_t select_crossings = m_intt_bco_range;
-  if (m_RefBCO > 0)
+  if (m_RefBCO == 0)
   {
-    select_crossings += m_RefBCO;
+    m_RefBCO = m_InttRawHitMap.begin()->first;
+//    std::cout << "BCOis " << std::hex << m_RefBCO << std::dec << std::endl;
   }
-  else
-  {
-    select_crossings += m_InttRawHitMap.begin()->first;
-  }
+  select_crossings += m_RefBCO;
   if (Verbosity() > 2)
   {
     std::cout << "select INTT crossings"
@@ -677,14 +678,11 @@ int Fun4AllStreamingInputManager::FillMvtx()
   }
   // std::cout << "before filling m_MvtxRawHitMap size: " <<  m_MvtxRawHitMap.size() << std::endl;
   uint64_t select_crossings = m_mvtx_bco_range;
-  if (m_RefBCO > 0)
+  if (m_RefBCO == 0)
   {
-    select_crossings += m_RefBCO;
+    m_RefBCO = m_MvtxRawHitMap.begin()->first;
   }
-  else
-  {
-    select_crossings += m_MvtxRawHitMap.begin()->first;
-  }
+  select_crossings += m_RefBCO;
 
   uint64_t ref_bco_minus_range = m_RefBCO < m_mvtx_bco_range ? 0 : m_RefBCO - m_mvtx_bco_range;
   if (Verbosity() > 2)
@@ -767,14 +765,11 @@ int Fun4AllStreamingInputManager::FillMicromegas()
 
   auto container = findNode::getClass<MicromegasRawHitContainer>(m_topNode, "MICROMEGASRAWHIT");
   uint64_t select_crossings = m_micromegas_bco_range;
-  if (m_RefBCO > 0)
+  if (m_RefBCO == 0)
   {
-    select_crossings += m_RefBCO;
+    m_RefBCO = m_MicromegasRawHitMap.begin()->first;
   }
-  else
-  {
-    select_crossings += m_MicromegasRawHitMap.begin()->first;
-  }
+  select_crossings += m_RefBCO;
   if (Verbosity() > 2)
   {
     std::cout << "select MicroMegas crossings"
@@ -837,14 +832,11 @@ int Fun4AllStreamingInputManager::FillTpc()
   TpcRawHitContainer *tpccont = findNode::getClass<TpcRawHitContainer>(m_topNode, "TPCRAWHIT");
   //  std::cout << "before filling m_TpcRawHitMap size: " <<  m_TpcRawHitMap.size() << std::endl;
   uint64_t select_crossings = m_tpc_bco_range;
-  if (m_RefBCO > 0)
+  if (m_RefBCO == 0)
   {
-    select_crossings += m_RefBCO;
+    m_RefBCO = m_TpcRawHitMap.begin()->first;
   }
-  else
-  {
-    select_crossings += m_TpcRawHitMap.begin()->first;
-  }
+  select_crossings += m_RefBCO;
   if (Verbosity() > 2)
   {
     std::cout << "select TPC crossings"


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
When using data without the GL1 the reference bco wasn't set correctly, now it is set to the first subsystem in the order of gl1, intt, mvtx, tpot, tpc

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

