### PR TITLE
Micromegas fix data decoding

### DIFF
--- a/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
@@ -163,15 +163,19 @@ int MicromegasCombinedDataDecoder::process_event(PHCompositeNode *topNode)
     if( rms <= 0 ) continue;
 
     // loop over samples find maximum
-    std::vector<int> adc;
+    std::vector<uint16_t> adc_list;
     for( int is = std::max( m_sample_min,0 ); is < std::min( m_sample_max,samples ); ++ is )
-    { adc.push_back(rawhit->get_adc(is)); }
+    {
+      const uint16_t adc = rawhit->get_adc(is);
+      if( adc != MicromegasDefs::m_adc_invalid )
+      { adc_list.push_back(adc); }
+    }
 
-    if( adc.empty() ) continue;
+    if( adc_list.empty() ) continue;
 
     // get max adc value in range
     /* TODO: use more advanced signal processing */
-    auto max_adc = *std::max_element( adc.begin(), adc.end() );
+    auto max_adc = *std::max_element( adc_list.begin(), adc_list.end() );
 
     // compare to hard min_adc value
     if( max_adc < m_min_adc ) continue;

--- a/offline/packages/micromegas/MicromegasCombinedDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataEvaluation.cc
@@ -209,7 +209,8 @@ int MicromegasCombinedDataEvaluation::process_event(PHCompositeNode *topNode)
     for( unsigned short is = 0; is < std::min<unsigned short>( samples, 1024 ); ++is )
     {
       // assign sample id and corresponding adc, save copy in container
-      auto adc = rawhit->get_adc(is);
+      const auto adc = rawhit->get_adc(is);
+      if( adc == MicromegasDefs::m_adc_invalid ) continue;
       sample.sample = is;
       sample.adc = adc;
       sample_map.emplace( sample.lvl1_bco, sample );

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -94,8 +94,8 @@ namespace MicromegasDefs
   uint8_t getTileId(TrkrDefs::cluskey);
 
   //! TPOT packet ids
-  /** 
-   * note: TPOT only uses 2 packets. 
+  /**
+   * note: TPOT only uses 2 packets.
    * For early runs (before 07/28/2023) they are 5000 and 5001
    * For later run, (after 07/28/2023) and because, as instructed by Martin, they are 5001 and 5002
    * We keep all 3 values here in order to be able to read both type of runs
@@ -103,7 +103,7 @@ namespace MicromegasDefs
    */
   static constexpr int m_npackets = 3;
   static constexpr std::array<unsigned int,m_npackets> m_packet_ids = {5000, 5001, 5002};
-  
+
   //! number of channels per fee board
   static constexpr int m_nchannels_fee = 256;
 
@@ -113,9 +113,6 @@ namespace MicromegasDefs
   //! total number of channels
   static constexpr int m_nchannels_total = m_nfee*m_nchannels_fee;
 
-  //! max adc value per readout sample
-  static constexpr int m_max_adc = 1024;
-  
 }
 
 #endif

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -12,6 +12,7 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <array>
+#include <cstdint>
 
 namespace MicromegasDefs
 {
@@ -112,6 +113,9 @@ namespace MicromegasDefs
 
   //! total number of channels
   static constexpr int m_nchannels_total = m_nfee*m_nchannels_fee;
+
+  //! mark invalid ADC values
+  static constexpr uint16_t m_adc_invalid = 65000;
 
 }
 

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -300,7 +300,8 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         for( unsigned short is = 0; is < std::min<unsigned short>( samples, 1024 ); ++is )
         {
           // assign sample id and corresponding adc, save copy in container
-          unsigned short adc = packet->iValue(iwf,is);
+          const uint16_t adc = packet->iValue(iwf,is);
+          if( adc == MicromegasDefs::m_adc_invalid ) continue;
           sample.sample = is;
           sample.adc = adc;
           sample_map.emplace( sample.lvl1_bco, sample );

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -191,7 +191,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
       sample.layer = TrkrDefs::getLayer( hitsetkey );
       sample.tile = MicromegasDefs::getTileId( hitsetkey );
 
-      // beam crossing, checksum, checksum error
+      // beam crossing
       sample.fee_bco = packet->iValue(iwf, "BCO");
       sample.lvl1_bco = 0;
 
@@ -249,6 +249,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
         }
       }
 
+      // checksum and checksum error
       sample.checksum = packet->iValue(iwf, "CHECKSUM");
       sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
 
@@ -338,9 +339,10 @@ int MicromegasRawDataEvaluation::End(PHCompositeNode* /*topNode*/ )
   // print bco map
   if( Verbosity() )
   for( const auto& [bco,nwaveforms]:m_bco_map )
-  { std::cout << "MicromegasRawDataEvaluation::End - bco: 0x" << std::hex << bco << std::dec << ", nwaveforms: " << nwaveforms << std::endl; }
+  { std::cout << "MicromegasRawDataEvaluation::End - bco: " << bco << ", nwaveforms: " << nwaveforms << std::endl; }
 
   // print bco list, for offline processing
+  if( Verbosity() )
   {
     std::cout << "const std::vector<uint64_t> lvl1_bco_list = {" << std::endl;
     bool first = true;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -73,12 +73,9 @@ void MicromegasRawDataEvaluation::Waveform::copy_from( const MicromegasRawDataEv
 //_________________________________________________________
 void MicromegasRawDataEvaluation::Container::Reset()
 {
-  n_tagger.clear();
-  n_waveform.clear();
   samples.clear();
   waveforms.clear();
-  lvl1_bco_list.clear();
-  lvl1_count_list.clear();
+  taggers.clear();
 }
 
 //_________________________________________________________
@@ -135,190 +132,217 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode *topNode)
 
     // taggers
     int n_tagger = packet->lValue(0, "N_TAGGER");
-    m_container->n_tagger.push_back(n_tagger);
-
-    // get number of datasets (also call waveforms)
-    const auto n_waveform = packet->iValue(0, "NR_WF" );
-    m_container->n_waveform.push_back(n_waveform);
 
     // store tagged lvl1 bcos into a vector
     using bco_list_t = std::list<uint64_t>;
     bco_list_t main_bco_list;
     for (int t = 0; t < n_tagger; t++)
     {
-      const auto is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
-      const auto bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
-      const auto lvl1_count = static_cast<uint32_t>(packet->lValue(t, "LEVEL1_COUNT"));
-      if( is_lvl1 )
-      {
-        main_bco_list.push_back( bco );
+      TaggerInformation tagger;
+      tagger.packet_id = packet_id;
+      tagger.tagger_type = (uint16_t) (packet->lValue(t, "TAGGER_TYPE"));
+      tagger.is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
+      tagger.is_endat = static_cast<uint8_t>(packet->lValue(t, "IS_ENDAT"));
+      tagger.bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+      tagger.last_bco = static_cast<uint64_t>(packet->lValue(t, "LAST_BCO"));
+      tagger.lvl1_count = static_cast<uint32_t>(packet->lValue(t, "LEVEL1_COUNT"));
+      tagger.endat_count = static_cast<uint32_t>(packet->lValue(t, "ENDAT_COUNT"));
 
-        // also store in evaluation container
-        m_container->lvl1_bco_list.push_back(bco);
-        m_container->lvl1_count_list.push_back(lvl1_count);
+      if( m_flags&EvalTagger )
+      {
+        m_container->taggers.push_back( tagger );
+      }
+
+      if( tagger.is_lvl1 && (m_flags&(EvalSample|EvalWaveform)) )
+      {
+        // store bco
+        main_bco_list.push_back( tagger.bco );
       }
     }
+
+    // get number of datasets (also call waveforms)
+    const auto n_waveform = packet->iValue(0, "NR_WF" );
 
     if( Verbosity() )
     {
       std::cout << "MicromegasRawDataEvaluation::process_event -"
         << " packet: " << packet_id
+        << " taggers: " << n_tagger
         << " n_lvl1_bco: " << main_bco_list.size()
         << " n_waveform: " << n_waveform
         << std::endl;
 
-      std::cout << "MicromegasRawDataEvaluation::process_event -"
-        << " packet: " << packet_id
-        << " bco: " << std::hex << main_bco_list << std::dec
-        << std::endl;
-
+      if( !main_bco_list.empty() )
+      {
+        std::cout << "MicromegasRawDataEvaluation::process_event -"
+          << " packet: " << packet_id
+          << " bco: " << std::hex << main_bco_list << std::dec
+          << std::endl;
+      }
     }
 
-    // store available bco list for each fee
-    std::map<unsigned short, bco_list_t> bco_list_map;
-
-    // keep track of orphans
-    using fee_pair_t = std::pair< unsigned int, unsigned int>;
-    std::set<fee_pair_t> orphans;
-
-    for( int iwf=0; iwf<n_waveform; ++iwf )
+    if( m_flags&(EvalSample|EvalWaveform) )
     {
-      // create running sample, assign packet, fee, layer and tile id
-      Sample sample;
-      sample.packet_id = packet_id;
-      sample.fee_id = packet->iValue(iwf, "FEE" );
-      const auto hitsetkey = m_mapping.get_hitsetkey(sample.fee_id);
-      sample.layer = TrkrDefs::getLayer( hitsetkey );
-      sample.tile = MicromegasDefs::getTileId( hitsetkey );
 
-      // beam crossing
-      sample.fee_bco = packet->iValue(iwf, "BCO");
-      sample.lvl1_bco = 0;
+      // store available bco list for each fee
+      std::map<unsigned short, bco_list_t> bco_list_map;
 
-      // find bco matching map corresponding to fee
-      auto& bco_matching_pair = m_fee_bco_matching_map[sample.fee_id];
+      // keep track of orphans
+      using fee_pair_t = std::pair< unsigned int, unsigned int>;
+      std::set<fee_pair_t> orphans;
 
-      // find matching lvl1 bco
-      if( bco_matching_pair.first == sample.fee_bco )
+      for( int iwf=0; iwf<n_waveform; ++iwf )
       {
+        // create running sample, assign packet, fee, layer and tile id
+        Sample sample;
+        sample.packet_id = packet_id;
+        sample.fee_id = packet->iValue(iwf, "FEE" );
+        const auto hitsetkey = m_mapping.get_hitsetkey(sample.fee_id);
+        sample.layer = TrkrDefs::getLayer( hitsetkey );
+        sample.tile = MicromegasDefs::getTileId( hitsetkey );
 
-        sample.lvl1_bco = bco_matching_pair.second;
+        // beam crossing
+        sample.fee_bco = packet->iValue(iwf, "BCO");
+        sample.lvl1_bco = 0;
 
-      } else {
+        // find bco matching map corresponding to fee
+        auto& bco_matching_pair = m_fee_bco_matching_map[sample.fee_id];
 
-        // find bco list corresponding to fee, insert main list if not found
-        auto bco_list_iter = bco_list_map.lower_bound( sample.fee_id );
-        if( bco_list_iter == bco_list_map.end() || sample.fee_id < bco_list_iter->first )
-        { bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) ); }
-
-        // get local reference to fee's bco list
-        auto& bco_list = bco_list_iter->second;
-        if( !bco_list.empty() )
+        // find matching lvl1 bco
+        if( bco_matching_pair.first == sample.fee_bco )
         {
 
-          if( Verbosity() )
-          {
-            std::cout << "MicromegasRawDataEvaluation::process_event -"
-              << " fee_id: " << sample.fee_id
-              << " fee_bco: 0x" << std::hex << sample.fee_bco
-              << " gtm_bco: 0x" << bco_list.front()
-              << std::dec
-              << std::endl;
-          }
-
-          // fee_bco is new. Assume it corresponds to the first available lvl1 bco
-          // update running fee_bco and lvl1_bco pair accordingly
-          const auto lvl1_bco = bco_list.front();
-          bco_matching_pair.first = sample.fee_bco;
-          bco_matching_pair.second = lvl1_bco;
-          sample.lvl1_bco = lvl1_bco;
-
-          // remove bco from running list
-          bco_list.pop_front();
+          sample.lvl1_bco = bco_matching_pair.second;
 
         } else {
 
-          if( Verbosity() && orphans.insert( std::make_pair( sample.fee_id, sample.fee_bco ) ).second )
+          // find bco list corresponding to fee, insert main list if not found
+          auto bco_list_iter = bco_list_map.lower_bound( sample.fee_id );
+          if( bco_list_iter == bco_list_map.end() || sample.fee_id < bco_list_iter->first )
+          { bco_list_iter = bco_list_map.insert( bco_list_iter, std::make_pair( sample.fee_id, main_bco_list ) ); }
+
+          // get local reference to fee's bco list
+          auto& bco_list = bco_list_iter->second;
+          if( !bco_list.empty() )
           {
-            std::cout << "MicromegasRawDataEvaluation::process_event -"
-              << " fee_id: " << sample.fee_id
-              << " fee_bco: 0x" << std::hex << sample.fee_bco << std::dec
-              << " gtm_bco: none"
-              << std::endl;
+
+            if( Verbosity() )
+            {
+              std::cout << "MicromegasRawDataEvaluation::process_event -"
+                << " fee_id: " << sample.fee_id
+                << " fee_bco: 0x" << std::hex << sample.fee_bco
+                << " gtm_bco: 0x" << bco_list.front()
+                << std::dec
+                << std::endl;
+            }
+
+            // fee_bco is new. Assume it corresponds to the first available lvl1 bco
+            // update running fee_bco and lvl1_bco pair accordingly
+            const auto lvl1_bco = bco_list.front();
+            bco_matching_pair.first = sample.fee_bco;
+            bco_matching_pair.second = lvl1_bco;
+            sample.lvl1_bco = lvl1_bco;
+
+            // remove bco from running list
+            bco_list.pop_front();
+
+          } else {
+
+            if( Verbosity() && orphans.insert( std::make_pair( sample.fee_id, sample.fee_bco ) ).second )
+            {
+              std::cout << "MicromegasRawDataEvaluation::process_event -"
+                << " fee_id: " << sample.fee_id
+                << " fee_bco: 0x" << std::hex << sample.fee_bco << std::dec
+                << " gtm_bco: none"
+                << std::endl;
+            }
           }
         }
+
+        // checksum and checksum error
+        sample.checksum = packet->iValue(iwf, "CHECKSUM");
+        sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
+
+        // increment bco map
+        ++m_bco_map[sample.lvl1_bco];
+
+        // channel, sampa_channel, sampa address and strip
+        sample.sampa_address = packet->iValue( iwf, "SAMPAADDRESS" );
+        sample.sampa_channel = packet->iValue( iwf, "SAMPACHANNEL" );
+        sample.channel = packet->iValue( iwf, "CHANNEL" );
+        sample.strip = m_mapping.get_physical_strip(sample.fee_id, sample.channel);
+
+        // get channel rms and pedestal from calibration data
+        const double pedestal = m_calibration_data.get_pedestal( sample.fee_id, sample.channel );
+        const double rms = m_calibration_data.get_rms( sample.fee_id, sample.channel );
+        sample.pedestal = pedestal;
+        sample.rms = rms;
+
+        // get number of samples and loop
+        const unsigned short samples = packet->iValue( iwf, "SAMPLES" );
+        if( Verbosity() > 1 )
+        {
+          std::cout << "MicromegasRawDataEvaluation::process_event -"
+            << " fee: " << sample.fee_id
+            << " tile: " << sample.tile
+            << " layer: " << sample.layer
+            << " tile: " << sample.tile
+            << " lvl1_bco: " << sample.lvl1_bco
+            << " fee_bco: " << sample.fee_bco
+            << " error: " << sample.checksum_error
+            << " channel: " << sample.channel
+            << " strip: " << sample.strip
+            << " samples: " << samples
+            << std::endl;
+        }
+
+        Sample sample_max;
+        for( unsigned short is = 0; is < std::min<unsigned short>( samples, 1024 ); ++is )
+        {
+          // assign sample id and corresponding adc, save copy in container
+          unsigned short adc = packet->iValue(iwf,is);
+          sample.sample = is;
+          sample.adc = adc;
+          sample_map.emplace( sample.lvl1_bco, sample );
+
+          if( sample.adc > sample_max.adc )
+          { sample_max = sample; }
+
+        }
+
+        if( m_flags & EvalWaveform )
+        {
+          Waveform waveform( sample_max );
+
+          waveform.is_signal =
+            rms > 0 &&
+            waveform.adc_max >= m_min_adc &&
+            waveform.sample_max >= m_sample_min &&
+            waveform.sample_max < m_sample_max &&
+            waveform.adc_max > pedestal+m_n_sigma * rms;
+
+          waveform_map.emplace( waveform.lvl1_bco, waveform );
+
+        }
+
       }
 
-      // checksum and checksum error
-      sample.checksum = packet->iValue(iwf, "CHECKSUM");
-      sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
-
-      // increment bco map
-      ++m_bco_map[sample.lvl1_bco];
-
-      // channel, sampa_channel, sampa address and strip
-      sample.sampa_address = packet->iValue( iwf, "SAMPAADDRESS" );
-      sample.sampa_channel = packet->iValue( iwf, "SAMPACHANNEL" );
-      sample.channel = packet->iValue( iwf, "CHANNEL" );
-      sample.strip = m_mapping.get_physical_strip(sample.fee_id, sample.channel);
-
-      // get channel rms and pedestal from calibration data
-      const double pedestal = m_calibration_data.get_pedestal( sample.fee_id, sample.channel );
-      const double rms = m_calibration_data.get_rms( sample.fee_id, sample.channel );
-      sample.pedestal = pedestal;
-      sample.rms = rms;
-
-      // get number of samples and loop
-      const unsigned short samples = packet->iValue( iwf, "SAMPLES" );
-      if( Verbosity() > 1 )
-      {
-        std::cout << "MicromegasRawDataEvaluation::process_event -"
-          << " fee: " << sample.fee_id
-          << " tile: " << sample.tile
-          << " layer: " << sample.layer
-          << " tile: " << sample.tile
-          << " lvl1_bco: " << sample.lvl1_bco
-          << " fee_bco: " << sample.fee_bco
-          << " error: " << sample.checksum_error
-          << " channel: " << sample.channel
-          << " strip: " << sample.strip
-          << " samples: " << samples
-          << std::endl;
-      }
-
-      Sample sample_max;
-      for( unsigned short is = 0; is < std::min<unsigned short>( samples, 1024 ); ++is )
-      {
-        // assign sample id and corresponding adc, save copy in container
-        unsigned short adc = packet->iValue(iwf,is);
-        sample.sample = is;
-        sample.adc = adc;
-        sample_map.emplace( sample.lvl1_bco, sample );
-
-        if( sample.adc > sample_max.adc )
-        { sample_max = sample; }
-
-      }
-
-      Waveform waveform( sample_max );
-
-      waveform.is_signal =
-        rms > 0 &&
-        waveform.adc_max >= m_min_adc &&
-        waveform.sample_max >= m_sample_min &&
-        waveform.sample_max < m_sample_max &&
-        waveform.adc_max > pedestal+m_n_sigma * rms;
-
-      waveform_map.emplace( waveform.lvl1_bco, waveform );
     }
+
   }
 
   // copy all samples and waveform to container
-  for( auto&& [lvl_bco, sample]:sample_map )
-  { m_container->samples.push_back(std::move(sample)); }
+  if(m_flags&EvalSample)
+  {
+    for( auto&& [lvl_bco, sample]:sample_map )
+    { m_container->samples.push_back(std::move(sample)); }
+  }
 
-  for( auto&& [lvl1_bco, waveform]:waveform_map )
-  { m_container->waveforms.push_back(std::move(waveform)); }
+  if( m_flags&EvalWaveform)
+  {
+    for( auto&& [lvl1_bco, waveform]:waveform_map )
+    { m_container->waveforms.push_back(std::move(waveform)); }
+  }
 
   // fill evaluation tree
   m_evaluation_tree->Fill();

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -51,7 +51,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
   /// set number of RMS sigma used to defined static threshold on a given channel
   void set_n_sigma( double value ) { m_n_sigma = value; }
 
-  /// set minimum ADC value, disregarding pedestal and RMS. 
+  /// set minimum ADC value, disregarding pedestal and RMS.
   /** This removes faulty channels for which calibration has failed */
   void set_min_adc( double value ) { m_min_adc = value; }
 
@@ -97,7 +97,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
 
     unsigned short sample = 0;
     unsigned short adc = 0;
-    
+
     double pedestal = 0;
     double rms = 0;
 
@@ -141,7 +141,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
 
     unsigned short sample_max = 0;
     unsigned short adc_max = 0;
-    
+
     double pedestal = 0;
     double rms = 0;
 
@@ -160,31 +160,59 @@ class MicromegasRawDataEvaluation : public SubsysReco
     using List = std::vector<Waveform>;
   };
 
+  class TaggerInformation
+  {
+    public:
+
+    /// packet
+    unsigned int packet_id = 0;
+
+    /// tagger ttpe
+    int tagger_type = 0;
+    bool is_endat = false;
+    bool is_lvl1 = false;
+
+    /// ll1 bco
+    uint64_t bco = 0;
+
+    /// ll1 bco
+    uint64_t last_bco = 0;
+
+    /// counters
+    uint32_t lvl1_count = 0;
+    uint32_t endat_count = 0;
+
+    using List = std::vector<TaggerInformation>;
+
+  };
 
   class Container: public PHObject
   {
     public:
     void Reset();
-    
-    // number of taggers for each packet
-    std::vector<int> n_tagger;
-    
-    // number of waveform for each packet
-    std::vector<int> n_waveform;
 
+    TaggerInformation::List taggers;
     Waveform::List waveforms;
     Sample::List samples;
-    
-    // bco for this event
-    std::vector<uint64_t> lvl1_bco_list;
-    
-    // lvl1 count for this event
-    std::vector<uint32_t> lvl1_count_list;
-    
+
     ClassDef(Container,1)
   };
 
+  enum Flags
+  {
+    EvalSample = 1<<0,
+    EvalWaveform = 1<<1,
+    EvalTagger = 1<<2,
+  };
+
+  //! set flags. Should be a bitwise or of Flags enum
+  void set_flags( int flags )
+  { m_flags = flags; }
+
   private:
+
+  //! flags
+  int m_flags = EvalSample | EvalWaveform | EvalTagger;
 
   //! calibration filename
   std::string m_calibration_filename = "TPOT_Pedestal_000.root";
@@ -198,10 +226,10 @@ class MicromegasRawDataEvaluation : public SubsysReco
   /// number of RMS sigma used to define threshold
   double m_n_sigma = 5;
 
-  //! minimum ADC value, disregarding pedestal and RMS. 
+  //! minimum ADC value, disregarding pedestal and RMS.
   /* This removes faulty channels for which calibration has failed */
   double m_min_adc = 50;
-  
+
   /// min sample for signal
   int m_sample_min = 0;
 
@@ -217,14 +245,14 @@ class MicromegasRawDataEvaluation : public SubsysReco
 
   //! main branch
   Container* m_container = nullptr;
-  
+
   //! match fee bco to lvl1 bco
   using bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
 
   //! map fee_id to bco maps
   using fee_bco_matching_map_t = std::map<unsigned short, bco_matching_pair_t>;
   fee_bco_matching_map_t m_fee_bco_matching_map;
-  
+
   /// map waveforms to bco
   /** this is used to count how many waveforms are found for a given lvl1 bco */
   using bco_map_t = std::map<uint64_t,unsigned int>;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -218,7 +218,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
   //! main branch
   Container* m_container = nullptr;
   
-  //! map fee bco to lvl1 bco
+  //! match fee bco to lvl1 bco
   using bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
 
   //! map fee_id to bco maps


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR makes the Micromegas decoding, calibration and evaluation code ignore all samples for which ADC value is invalid, with 'invalid' value being set to 65000, as per @tsakagu prescription. 
Also include a change on RawDataEvaluation to get tagger's in the output tree.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

