### PR TITLE
Add general tracks-in-jets QA module

### DIFF
--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -39,11 +39,13 @@ libjetqa_la_SOURCES = \
   TrksInJetQAJetManager.cc
 
 libjetqa_la_LIBADD = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
   -lcalo_io \
-  -lcalotrigger_io \
   -lfun4all \
   -lphool \
   -lg4dst \
+  -lg4eval \
   -lSubsysReco \
   -lqautils
 

--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -14,14 +14,36 @@ AM_CPPFLAGS = \
   -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
+  TrksInJetQA.h \
+  TrksInJetQAHist.h \
+  TrksInJetQATypes.h \
+  TrksInJetQAConfig.h \
+  TrksInJetQABaseFiller.h \
+  TrksInJetQAInJetFiller.h \
+  TrksInJetQAInclusiveFiller.h \
+  TrksInJetQABaseManager.h \
+  TrksInJetQAHitManager.h \
+  TrksInJetQAClustManager.h \
+  TrksInJetQATrkManager.h \
+  TrksInJetQAJetManager.h
 
 libjetqa_la_SOURCES = \
+  TrksInJetQA.cc \
+  TrksInJetQABaseFiller.cc \
+  TrksInJetQAInJetFiller.cc \
+  TrksInJetQAInclusiveFiller.cc \
+  TrksInJetQABaseManager.cc \
+  TrksInJetQAHitManager.cc \
+  TrksInJetQAClustManager.cc \
+  TrksInJetQATrkManager.cc \
+  TrksInJetQAJetManager.cc
 
 libjetqa_la_LIBADD = \
   -lcalo_io \
   -lcalotrigger_io \
   -lfun4all \
   -lphool \
+  -lg4dst \
   -lSubsysReco \
   -lqautils
 

--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -1,0 +1,49 @@
+AUTOMAKE_OPTIONS = foreign
+
+lib_LTLIBRARIES = \
+    libjetqa.la
+
+AM_LDFLAGS = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -L$(OFFLINE_MAIN)/lib64
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include
+
+pkginclude_HEADERS = \
+
+libjetqa_la_SOURCES = \
+
+libjetqa_la_LIBADD = \
+  -lcalo_io \
+  -lcalotrigger_io \
+  -lfun4all \
+  -lphool \
+  -lSubsysReco \
+  -lqautils
+
+################################################
+# linking tests
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = testexternals.C
+testexternals_LDADD = libjetqa.la
+
+testexternals.C:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+# Rule for generating table CINT dictionaries.
+%_Dict.cc: %.h %LinkDef.h
+	rootcint -f $@ @CINTDEFS@ -c $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $^
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -10,7 +10,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \
@@ -44,8 +44,8 @@ libjetqa_la_LIBADD = \
   -lcalo_io \
   -lfun4all \
   -lphool \
-  -lg4dst \
   -lg4eval \
+  -lparticleflow_io \
   -lSubsysReco \
   -lqautils
 

--- a/offline/QA/Jet/TrksInJetQA.cc
+++ b/offline/QA/Jet/TrksInJetQA.cc
@@ -66,11 +66,11 @@ void TrksInJetQA::Configure(
 
 // fun4all methods ------------------------------------------------------------
 
-int TrksInJetQA::Init(PHCompositeNode* topNode) {
+int TrksInJetQA::Init(PHCompositeNode* /*topNode*/) {
 
   // print debug message
   if (m_config.doDebug && (m_config.verbose > 0)) {
-    std::cout << "TrksInJetQA::Init(PHCompositeNode* topNode) Initializing" << std::endl;
+    std::cout << "TrksInJetQA::Init(PHCompositeNode* /*topNode*/) Initializing" << std::endl;
   }
 
   // initialize output & histograms
@@ -103,11 +103,11 @@ int TrksInJetQA::process_event(PHCompositeNode* topNode) {
 
 
 
-int TrksInJetQA::End(PHCompositeNode* topNode) {
+int TrksInJetQA::End(PHCompositeNode* /*topNode*/) {
 
   // print debug message
   if (m_config.doDebug && (m_config.verbose > 0)) {
-    std::cout << "TrksInJetQA::End(PHCompositeNode* topNode) This is the End..." << std::endl;
+    std::cout << "TrksInJetQA::End(PHCompositeNode* /*topNode*/) This is the End..." << std::endl;
   }
 
   // save hists to file if needed

--- a/offline/QA/Jet/TrksInJetQA.cc
+++ b/offline/QA/Jet/TrksInJetQA.cc
@@ -1,0 +1,226 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQA.cc'
+// Derek Anderson
+// 03.25.2024
+//
+// A "small" Fun4All module to produce QA plots for tracks,
+// hits, and more.
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQA_CC
+
+// module defintion
+#include "TrksInJetQA.h"
+
+
+
+// ctor/dtor ------------------------------------------------------------------
+
+TrksInJetQA::TrksInJetQA(const std::string& name) : SubsysReco(name) {
+
+  /* nothing to do */
+
+}  // end ctor
+
+
+
+TrksInJetQA::~TrksInJetQA() {
+
+  // print debug messages
+  if (m_config.doDebug && (m_config.verbose > 4)) {
+    std::cout << "TrksInJetQA::~TrksInJetQA() Calling dtor" << std::endl;
+  }
+
+  // clean up any dangling pointers
+  //   - FIXME use smart pointers instead!
+  if (m_outFile) {
+    delete m_outFile;
+    m_outFile = NULL;
+  }
+
+}  // end dtor
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQA::Configure(
+  TrksInJetQAConfig config,
+  std::optional<TrksInJetQAHist> hist
+) {
+
+  // print debug messages
+  if (m_config.doDebug && (m_config.verbose > 3)) {
+    std::cout << "TrksInJetQA::~TrksInJetQA() Calling dtor" << std::endl;
+  }
+
+  m_config = config;
+  if (hist.has_value()) {
+    m_hist = hist.value();
+  }
+  return;
+
+}  // end 'Configure(TrksInJetQAConfig, std::optional<TrksInJetQAHist>)'
+
+
+
+// fun4all methods ------------------------------------------------------------
+
+int TrksInJetQA::Init(PHCompositeNode* topNode) {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 0)) {
+    std::cout << "TrksInJetQA::Init(PHCompositeNode* topNode) Initializing" << std::endl;
+  }
+
+  // initialize output & histograms
+  InitOutput();
+  InitHistograms();
+
+  // register histograms with manager if needed
+  if (m_config.outMode == OutMode::QA) {
+    RegisterHistograms();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}  // end 'Init(PHCompositeNode*)'
+
+
+
+int TrksInJetQA::process_event(PHCompositeNode* topNode) {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 2)) {
+    std::cout << "TrksInJetQA::process_event(PHCompositeNode* topNode) Processing Event" << std::endl;
+  }
+
+  // run submodules
+  if (m_config.doInJet)     m_inJet     -> Fill(topNode);
+  if (m_config.doInclusive) m_inclusive -> Fill(topNode);
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}  // end 'process_event(PHCompositeNode*)'
+
+
+
+int TrksInJetQA::End(PHCompositeNode* topNode) {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 0)) {
+    std::cout << "TrksInJetQA::End(PHCompositeNode* topNode) This is the End..." << std::endl;
+  }
+
+  // save hists to file if needed
+  if (m_config.outMode == OutMode::File) {
+
+    // save histograms
+    if (m_config.doInJet)     m_inJet     -> SaveHistograms(m_outFile, "InJet");
+    if (m_config.doInclusive) m_inclusive -> SaveHistograms(m_outFile, "Inclusive");
+
+    // close file
+    m_outFile -> cd();
+    m_outFile -> Close();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}  // end 'End(PHCompositeNode*)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQA::InitOutput() {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 1)) {
+    std::cout << "TrksInJetQA::InitOutput() Initializing outputs..." << std::endl;
+  }
+
+  // initialize relevent outputs
+  switch (m_config.outMode) {
+
+    case OutMode::File:
+      m_outFile = new TFile(m_outFileName.data(), "RECREATE");
+      if (!m_outFile) {
+        std::cerr << PHWHERE << ": PANIC: couldn't create output file!" << std::endl;
+        assert(m_outFile); 
+      }
+      break;
+
+    case OutMode::QA:
+      m_manager = QAHistManagerDef::getHistoManager();
+      if (!m_manager) {
+        std::cerr << PHWHERE << ": PANIC: couldn't grab histogram manager!" << std::endl;
+        assert(m_manager);
+      }
+      break;
+
+    default:
+      std::cerr << PHWHERE << ": PANIC: unknown output mode specified!\n"
+                << "  Please set .outMode = OutMode::File OR OutMode::QA!"
+                << std::endl;
+      assert((m_config.outMode == OutMode::File) || (m_config.outMode == OutMode::QA));
+      break;
+  }
+  return;
+
+}  // end 'InitOutput()'
+
+
+
+void TrksInJetQA::InitHistograms() {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 1)) {
+    std::cout << "TrksInJetQA::InitHistograms() Initializing histograms..." << std::endl;
+  }
+
+  // make labels
+  std::string inJetLabel     = "InJet";
+  std::string inclusiveLabel = "Inclusive";
+  if (m_histSuffix.has_value()) {
+    inJetLabel     += "_";
+    inJetLabel     += m_histSuffix.value();
+    inclusiveLabel += "_";
+    inclusiveLabel += m_histSuffix.value();
+  }
+
+  // initialize submodules, as needed
+  if (m_config.doInJet) {
+    m_inJet = std::make_unique<TrksInJetQAInJetFiller>(m_config, m_hist);
+    m_inJet -> MakeHistograms(inJetLabel);
+  }
+  if (m_config.doInclusive) {
+    m_inclusive = std::make_unique<TrksInJetQAInclusiveFiller>(m_config, m_hist);
+    m_inclusive -> MakeHistograms(inclusiveLabel);
+  }
+  return;
+
+}  // end 'InitHistograms()'
+
+
+
+void TrksInJetQA::RegisterHistograms() {
+
+  // print debug message
+  if (m_config.doDebug && (m_config.verbose > 1)) {
+    std::cout << "TrksInJetQA::RegisterHistograms() Registering histograms..." << std::endl;
+  }
+
+  std::vector<TH1D*> vecHist1D;
+  std::vector<TH2D*> vecHist2D;
+  if (m_config.doInJet)     m_inJet     -> GrabHistograms(vecHist1D, vecHist2D);
+  if (m_config.doInclusive) m_inclusive -> GrabHistograms(vecHist1D, vecHist2D);
+
+  // register w/ manager
+  for (TH1D* hist1D : vecHist1D) {
+    m_manager -> registerHisto(hist1D);
+  }
+  for (TH2D* hist2D : vecHist2D) {
+    m_manager -> registerHisto(hist2D);
+  }
+  return;
+
+}  // end 'RegisterHistograms()'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQA.cc
+++ b/offline/QA/Jet/TrksInJetQA.cc
@@ -45,16 +45,16 @@ TrksInJetQA::~TrksInJetQA() {
 // public methods -------------------------------------------------------------
 
 void TrksInJetQA::Configure(
-  TrksInJetQAConfig config,
+  const TrksInJetQAConfig &config,
   std::optional<TrksInJetQAHist> hist
-) {
-
+)
+ {
+   m_config = config;
   // print debug messages
   if (m_config.doDebug && (m_config.verbose > 3)) {
     std::cout << "TrksInJetQA::~TrksInJetQA() Calling dtor" << std::endl;
   }
 
-  m_config = config;
   if (hist.has_value()) {
     m_hist = hist.value();
   }

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -61,9 +61,9 @@ class TrksInJetQA : public SubsysReco {
 
 
     // f4a methods
-    int Init(PHCompositeNode* topNode)          override;
+    int Init(PHCompositeNode* /*topNode*/)      override;
     int process_event(PHCompositeNode* topNode) override;
-    int End(PHCompositeNode* topNode)           override;
+    int End(PHCompositeNode* /*topNode*/)       override;
 
   private:
 

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -1,0 +1,96 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQA.h'
+// Derek Anderson
+// 03.25.2024
+//
+// A "small" Fun4All module to produce QA plots for tracks,
+// hits, and more.
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQA_H
+#define TRKSINJETQA_H
+
+// c++ utilities
+#include <string>
+#include <vector>
+#include <cassert>
+#include <utility>
+#include <optional>
+// root libraries
+#include <TFile.h>
+// f4a libraries
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+// phool libraries
+#include <phool/phool.h>
+#include <phool/PHCompositeNode.h>
+// qa utilities
+#include <qautils/QAHistManagerDef.h>
+// module utilities
+#include "TrksInJetQAHist.h"
+#include "TrksInJetQAConfig.h"
+// submodule definitions
+#include "TrksInJetQAInJetFiller.h"
+#include "TrksInJetQAInclusiveFiller.h"
+
+
+
+// TrksInJetQA definition -----------------------------------------------------
+
+class TrksInJetQA : public SubsysReco {
+
+  public:
+
+    //  output modes
+    enum OutMode {File, QA};
+
+    // ctor/dtor
+    TrksInJetQA(const std::string& name);
+    ~TrksInJetQA() override;
+
+    // setters
+    void SetOutFileName(const std::string& name)  {m_outFileName = name;}
+    void SetHistSuffix(const std::string& suffix) {m_histSuffix  = suffix;}
+
+    // public methods
+    void Configure(
+      TrksInJetQAConfig config,
+      std::optional<TrksInJetQAHist> hist = std::nullopt
+    );
+
+
+    // f4a methods
+    int Init(PHCompositeNode* topNode)          override;
+    int process_event(PHCompositeNode* topNode) override;
+    int End(PHCompositeNode* topNode)           override;
+
+  private:
+
+    // private methods
+    void InitOutput();
+    void InitHistograms();
+    void RegisterHistograms();
+
+    // io members
+    //   - FIXME raw pointers should be smart ones!
+    TFile*               m_outFile     = NULL;
+    std::string          m_outFileName = "tracksInJetsQA.root";
+    Fun4AllHistoManager* m_manager     = NULL;
+
+    // optional suffix for histograms
+    std::optional<std::string> m_histSuffix  = std::nullopt;
+
+    // submodules to run
+    std::unique_ptr<TrksInJetQAInJetFiller>     m_inJet;
+    std::unique_ptr<TrksInJetQAInclusiveFiller> m_inclusive;
+
+    // module utilities
+    TrksInJetQAConfig m_config;
+    TrksInJetQAHist   m_hist;
+
+};  // end TrksInJetQA
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -10,30 +10,31 @@
 #ifndef TRKSINJETQA_H
 #define TRKSINJETQA_H
 
+// module utilities
+#include "TrksInJetQAHist.h"
+#include "TrksInJetQAConfig.h"
+#include "TrksInJetQAInJetFiller.h"
+#include "TrksInJetQAInclusiveFiller.h"
+
+// qa utilities
+#include <qautils/QAHistManagerDef.h>
+
+// f4a includes
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+// phool includes
+#include <phool/phool.h>
+#include <phool/PHCompositeNode.h>
+// root includes
+#include <TFile.h>
+
 // c++ utilities
 #include <string>
 #include <vector>
 #include <cassert>
 #include <utility>
 #include <optional>
-// root libraries
-#include <TFile.h>
-// f4a libraries
-#include <fun4all/SubsysReco.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
-// phool libraries
-#include <phool/phool.h>
-#include <phool/PHCompositeNode.h>
-// qa utilities
-#include <qautils/QAHistManagerDef.h>
-// module utilities
-#include "TrksInJetQAHist.h"
-#include "TrksInJetQAConfig.h"
-// submodule definitions
-#include "TrksInJetQAInJetFiller.h"
-#include "TrksInJetQAInclusiveFiller.h"
-
 
 
 // TrksInJetQA definition -----------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -56,7 +56,7 @@ class TrksInJetQA : public SubsysReco {
 
     // public methods
     void Configure(
-      TrksInJetQAConfig config,
+      const TrksInJetQAConfig &config,
       std::optional<TrksInJetQAHist> hist = std::nullopt
     );
 

--- a/offline/QA/Jet/TrksInJetQABaseFiller.cc
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.cc
@@ -1,0 +1,143 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQABaseFiller.cc'
+// Derek Anderson
+// 04.11.2024
+//
+// A submodule for the TrksInJetQA F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQABASEFILLER_CC
+
+#include "TrksInJetQABaseFiller.h"
+
+
+
+// ctor/dtor ------------------------------------------------------------------
+
+TrksInJetQABaseFiller::TrksInJetQABaseFiller(
+  TrksInJetQAConfig& config,
+  TrksInJetQAHist& hist
+) {
+
+  // grab utilities
+  m_config = config;
+  m_hist   = hist;
+
+  // initialize managers
+  if (m_config.doHitQA)   m_hitManager   = std::make_unique<TrksInJetQAHitManager>(m_config, m_hist);
+  if (m_config.doClustQA) m_clustManager = std::make_unique<TrksInJetQAClustManager>(m_config, m_hist);
+  if (m_config.doTrackQA) m_trackManager = std::make_unique<TrksInJetQATrkManager>(m_config, m_hist);
+  if (m_config.doJetQA)   m_jetManager   = std::make_unique<TrksInJetQAJetManager>(m_config, m_hist);
+
+}  // end ctor()'
+
+
+
+TrksInJetQABaseFiller::~TrksInJetQABaseFiller() {
+
+  /* nothing to do */
+
+}  // end dtor
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQABaseFiller::MakeHistograms(std::string label) {
+
+  // initialize relevant submodules
+  if (m_config.doHitQA)   m_hitManager   -> MakeHistograms(label);
+  if (m_config.doClustQA) m_clustManager -> MakeHistograms(label);
+  if (m_config.doTrackQA) m_trackManager -> MakeHistograms(label);
+  if (m_config.doJetQA)   m_jetManager   -> MakeHistograms(label);
+  return;
+
+}  // end 'MakeHistograms(std::string)'
+
+
+
+void TrksInJetQABaseFiller::SaveHistograms(TFile* outFile, std::string outDirName) {
+
+  TDirectory* outDir = outFile -> mkdir(outDirName.data());
+  if (!outDir) {
+    std::cerr << PHWHERE << ": PANIC: unable to make output directory!" << std::endl;
+    assert(outDir);
+  }
+
+  if (m_config.doHitQA)   m_hitManager   -> SaveHistograms(outDir, m_config.hitOutDir);
+  if (m_config.doClustQA) m_clustManager -> SaveHistograms(outDir, m_config.clustOutDir);
+  if (m_config.doTrackQA) m_trackManager -> SaveHistograms(outDir, m_config.trackOutDir);
+  if (m_config.doJetQA)   m_jetManager   -> SaveHistograms(outDir, m_config.jetOutDir);
+  return;
+
+}  // end 'SaveHistograms(TFile*, std::string)'
+
+
+
+void TrksInJetQABaseFiller::GrabHistograms(
+  std::vector<TH1D*>& vecOutHist1D,
+  std::vector<TH2D*>& vecOutHist2D
+) {
+
+  if (m_config.doHitQA)   m_hitManager   -> GrabHistograms(vecOutHist1D, vecOutHist2D);
+  if (m_config.doClustQA) m_clustManager -> GrabHistograms(vecOutHist1D, vecOutHist2D);
+  if (m_config.doTrackQA) m_trackManager -> GrabHistograms(vecOutHist1D, vecOutHist2D);
+  if (m_config.doJetQA)   m_jetManager   -> GrabHistograms(vecOutHist1D, vecOutHist2D);
+  return;
+
+}  // end 'GrabHistograms(std::vector<TH1D*>&, std::vector<TH2D*>&)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQABaseFiller::GetNodes(PHCompositeNode* topNode) {
+
+  // grab necessary jet nodes
+  if (m_config.doJetQA) {
+    m_jetMap = findNode::getClass<JetContainer>(topNode, m_config.jetInNode.data());
+    if (!m_jetMap) {
+      std::cerr << PHWHERE << ": PANIC: couldn't grab jet map from node tree!" << std::endl;
+      assert(m_jetMap);
+    }
+  }
+
+  // grab necessary track nodes
+  if (m_config.doTrackQA) {
+    m_trkMap = findNode::getClass<SvtxTrackMap>(topNode, m_config.trkInNode.data());
+    if (!m_trkMap) {
+      std::cerr << PHWHERE << ": PANIC: couldn't grab track map from node tree!" << std::endl;
+      assert(m_trkMap);
+    }
+  }
+
+  // grab necessary cluster nodes
+  if (m_config.doClustQA) {
+
+    m_actsGeom = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+    if (!m_actsGeom) {
+      std::cerr << PHWHERE << ": PANIC: couldn't grab ACTS geometry from node tree!" << std::endl;
+      assert(m_actsGeom);
+    }
+
+    m_clustMap = findNode::getClass<TrkrClusterContainer>(topNode, m_config.clustInNode.data());
+    if (!m_clustMap) {
+      std::cerr << PHWHERE << ": PANIC: couldn't grab cluster map from node tree!" << std::endl;
+      assert(m_clustMap);
+    }
+  }
+
+  // grab necessary hit nodes
+  if (m_config.doHitQA) {
+    m_hitMap = findNode::getClass<TrkrHitSetContainer>(topNode, m_config.hitInNode.data());
+    if (!m_hitMap) {
+      std::cerr << PHWHERE << ": PANIC: couldn't grab hit map from node tree!" << std::endl;
+      assert(m_hitMap);
+    }
+  }
+  return;
+
+}  // end 'GetNodes(PHCompositeNode*)'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQABaseFiller.cc
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.cc
@@ -16,13 +16,11 @@
 // ctor/dtor ------------------------------------------------------------------
 
 TrksInJetQABaseFiller::TrksInJetQABaseFiller(
-  TrksInJetQAConfig& config,
-  TrksInJetQAHist& hist
-) {
-
-  // grab utilities
-  m_config = config;
-  m_hist   = hist;
+  const TrksInJetQAConfig& config,
+  TrksInJetQAHist& hist)
+  : m_config(config)
+  , m_hist(hist)
+{
 
   // initialize managers
   if (m_config.doHitQA)   m_hitManager   = std::make_unique<TrksInJetQAHitManager>(m_config, m_hist);
@@ -44,7 +42,7 @@ TrksInJetQABaseFiller::~TrksInJetQABaseFiller() {
 
 // public methods -------------------------------------------------------------
 
-void TrksInJetQABaseFiller::MakeHistograms(std::string label) {
+void TrksInJetQABaseFiller::MakeHistograms(const std::string &label) {
 
   // initialize relevant submodules
   if (m_config.doHitQA)   m_hitManager   -> MakeHistograms(label);
@@ -57,9 +55,9 @@ void TrksInJetQABaseFiller::MakeHistograms(std::string label) {
 
 
 
-void TrksInJetQABaseFiller::SaveHistograms(TFile* outFile, std::string outDirName) {
+void TrksInJetQABaseFiller::SaveHistograms(TFile* outFile, const std::string &outDirName) {
 
-  TDirectory* outDir = outFile -> mkdir(outDirName.data());
+  TDirectory* outDir = outFile -> mkdir(outDirName.c_str());
   if (!outDir) {
     std::cerr << PHWHERE << ": PANIC: unable to make output directory!" << std::endl;
     assert(outDir);

--- a/offline/QA/Jet/TrksInJetQABaseFiller.h
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.h
@@ -1,0 +1,84 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQABaseFiller.h'
+// Derek Anderson
+// 04.11.2024
+//
+// A submodule for the TrksInJetQA F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQABASEFILLER_H
+#define TRKSINJETQABASEFILLER_H
+
+// c++ utilities
+#include <string>
+// root libraries
+#include <TFile.h>
+// phool libraries
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+// tracking libraries
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+// jet libraries
+#include <jetbase/JetContainer.h>
+// submodule definitions
+#include "TrksInJetQAHitManager.h"
+#include "TrksInJetQAClustManager.h"
+#include "TrksInJetQATrkManager.h"
+#include "TrksInJetQAJetManager.h"
+// module utilties
+#include "TrksInJetQAHist.h"
+#include "TrksInJetQAConfig.h"
+
+
+
+// TrksInJetQABaseFiller ------------------------------------------------------
+
+class TrksInJetQABaseFiller {
+
+  public:
+
+    // ctor/dtor
+    TrksInJetQABaseFiller(TrksInJetQAConfig& config, TrksInJetQAHist& hist);
+    ~TrksInJetQABaseFiller();
+
+    // public methods
+    void MakeHistograms(std::string label = "");
+    void SaveHistograms(TFile* outFile, std::string outDirName);
+    void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
+
+    // virtual public methods
+    virtual void Fill(PHCompositeNode* topNode) = 0;
+
+  protected:
+
+    // private methods
+    void GetNodes(PHCompositeNode* topNode);
+
+    // necessary dst nodes
+    //   - FIXME these should be smart pointers!
+    ActsGeometry*         m_actsGeom = NULL;
+    TrkrHitSetContainer*  m_hitMap   = NULL;
+    TrkrClusterContainer* m_clustMap = NULL;
+    SvtxTrackMap*         m_trkMap   = NULL;
+    JetContainer*         m_jetMap   = NULL;
+
+    // submodules to use
+    std::unique_ptr<TrksInJetQAHitManager>   m_hitManager   = NULL;
+    std::unique_ptr<TrksInJetQAClustManager> m_clustManager = NULL;
+    std::unique_ptr<TrksInJetQATrkManager>   m_trackManager = NULL;
+    std::unique_ptr<TrksInJetQAJetManager>   m_jetManager   = NULL;
+
+    // module utilities
+    TrksInJetQAConfig m_config;
+    TrksInJetQAHist   m_hist;
+
+};  // end TrksInJetQABaseFiller
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQABaseFiller.h
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.h
@@ -10,21 +10,6 @@
 #ifndef TRKSINJETQABASEFILLER_H
 #define TRKSINJETQABASEFILLER_H
 
-// c++ utilities
-#include <string>
-// root libraries
-#include <TFile.h>
-// phool libraries
-#include <phool/phool.h>
-#include <phool/getClass.h>
-#include <phool/PHCompositeNode.h>
-// tracking libraries
-#include <trackbase/ActsGeometry.h>
-#include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrkrClusterContainer.h>
-#include <trackbase_historic/SvtxTrackMap.h>
-// jet libraries
-#include <jetbase/JetContainer.h>
 // submodule definitions
 #include "TrksInJetQAHitManager.h"
 #include "TrksInJetQAClustManager.h"
@@ -34,6 +19,24 @@
 #include "TrksInJetQAHist.h"
 #include "TrksInJetQAConfig.h"
 
+// tracking includes
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+// jet includes
+#include <jetbase/JetContainer.h>
+
+// phool libraries
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+
+// root includes
+#include <TFile.h>
+
+// c++ includes
+#include <string>
 
 
 // TrksInJetQABaseFiller ------------------------------------------------------
@@ -44,7 +47,7 @@ class TrksInJetQABaseFiller {
 
     // ctor/dtor
     TrksInJetQABaseFiller(TrksInJetQAConfig& config, TrksInJetQAHist& hist);
-    ~TrksInJetQABaseFiller();
+    virtual ~TrksInJetQABaseFiller();
 
     // public methods
     void MakeHistograms(std::string label = "");

--- a/offline/QA/Jet/TrksInJetQABaseFiller.h
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.h
@@ -46,12 +46,12 @@ class TrksInJetQABaseFiller {
   public:
 
     // ctor/dtor
-    TrksInJetQABaseFiller(TrksInJetQAConfig& config, TrksInJetQAHist& hist);
+    TrksInJetQABaseFiller(const TrksInJetQAConfig& config, TrksInJetQAHist& hist);
     virtual ~TrksInJetQABaseFiller();
 
     // public methods
-    void MakeHistograms(std::string label = "");
-    void SaveHistograms(TFile* outFile, std::string outDirName);
+    void MakeHistograms(const std::string &label = "");
+    void SaveHistograms(TFile* outFile, const std::string &outDirName);
     void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
 
     // virtual public methods

--- a/offline/QA/Jet/TrksInJetQABaseManager.cc
+++ b/offline/QA/Jet/TrksInJetQABaseManager.cc
@@ -1,0 +1,202 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQABaseManager.cc'
+// Derek Anderson
+// 04.03.2024
+//
+// Base hist manager submodule for the TrksInJetQA module which
+// consolidates methods/data common to all of the hist managers
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQABASEMANAGER_CC
+
+// submodule definition
+#include "TrksInJetQABaseManager.h"
+
+
+
+// ctor/dtor ------------------------------------------------------------------
+
+TrksInJetQABaseManager::TrksInJetQABaseManager(
+  TrksInJetQAConfig& config,
+  TrksInJetQAHist& hist
+) {
+
+  ResetVectors();
+
+  // grab vectors
+  m_config = config;
+  m_hist   = hist;
+
+}  // end ctor(TrksInJetQAConfig&, TrksInJetQAHist&)
+
+
+
+TrksInJetQABaseManager::~TrksInJetQABaseManager() {
+
+  ResetVectors();
+
+}  // end dtor
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQABaseManager::MakeHistograms(std::string label) {
+
+  DefineHistograms();
+  BuildHistograms(label);
+  return;
+
+}  // end 'MakeHistograms(std::string)'
+
+
+
+void TrksInJetQABaseManager::SaveHistograms(TDirectory* topDir, std::string outDirName) {
+
+  TDirectory* outDir = topDir -> mkdir(outDirName.data());
+  if (!outDir) {
+    std::cerr << PHWHERE << ": PANIC: unable to make output directory!" << std::endl;
+    assert(outDir);
+  }
+
+  outDir -> cd();
+  for (auto hist1Ds : m_vecHist1D) {
+    for (TH1D* hist1D : hist1Ds) {
+      hist1D -> Write();
+    }
+  }
+  for (auto hist2Ds : m_vecHist2D) {
+    for (TH2D* hist2D : hist2Ds) {
+      hist2D -> Write();
+    }
+  }
+  return;
+
+}  // end 'SaveHistograms(TDirectory*, std::string)'
+
+
+
+void TrksInJetQABaseManager::GrabHistograms(
+  std::vector<TH1D*>& vecOutHist1D,
+  std::vector<TH2D*>& vecOutHist2D
+) {
+
+  for (auto hist1Ds : m_vecHist1D) {
+    for (TH1D* hist1D : hist1Ds) {
+      vecOutHist1D.push_back(hist1D);
+    }
+  }
+  for (auto hist2Ds : m_vecHist2D) {
+    for (TH2D* hist2D : hist2Ds) {
+      vecOutHist2D.push_back(hist2D);
+    }
+  }
+  return;
+
+}  // end 'GrabHistograms(std::vector<TH1D*>&, std::vector<TH2D*>&)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQABaseManager::BuildHistograms(std::string label) {
+
+  // build 1d histograms
+  m_vecHist1D.resize( m_vecHistTypes.size() );
+  for (size_t iType = 0; iType < m_vecHistTypes.size(); iType++) {
+    for (HistDef1D histDef1D : m_vecHistDef1D) {
+
+      // make name
+      std::string sHistName("h");
+      sHistName += m_vecHistTypes.at(iType);
+      sHistName += std::get<0>(histDef1D);
+      sHistName += "_";
+      sHistName += label;
+
+      // create histogram
+      m_vecHist1D.at(iType).push_back(
+        new TH1D(
+          sHistName.data(),
+          "",
+          std::get<1>(histDef1D).first,
+          std::get<1>(histDef1D).second.first,
+          std::get<1>(histDef1D).second.second
+        )
+      );
+    }  // end hist loop
+  }  // end type loop
+
+  // build 2d histograms
+  m_vecHist2D.resize( m_vecHistTypes.size() );
+  for (size_t iType = 0; iType < m_vecHistTypes.size(); iType++) {
+    for (HistDef2D histDef2D : m_vecHistDef2D) {
+
+      // make name
+      std::string sHistName("h");
+      sHistName += m_vecHistTypes.at(iType);
+      sHistName += std::get<0>(histDef2D);
+      sHistName += "_";
+      sHistName += label;
+
+      // create histogram
+      m_vecHist2D.at(iType).push_back(
+        new TH2D(
+          sHistName.data(),
+          "",
+          std::get<1>(histDef2D).first,
+          std::get<1>(histDef2D).second.first,
+          std::get<1>(histDef2D).second.second,
+          std::get<2>(histDef2D).first,
+          std::get<2>(histDef2D).second.first,
+          std::get<2>(histDef2D).second.second
+        )
+      );
+    }  // end hist loop
+  }  // end type loop
+  return;
+
+}  // end 'BuildHistograms(std::string)'
+
+
+
+void TrksInJetQABaseManager::ResetVectors() {
+
+  m_vecHist1D.clear();
+  m_vecHist2D.clear();
+  m_vecHistTypes.clear();
+  m_vecHistDef1D.clear();
+  m_vecHistDef2D.clear();
+  return;
+
+}  // end 'ResetVectors()'
+
+
+
+// private helper methods -----------------------------------------------------
+
+bool TrksInJetQABaseManager::IsInMvtx(const uint16_t layer) {
+
+  return (layer < m_config.nMvtxLayer);
+
+}  // end 'IsInMvtx(uint16_t)'
+
+
+
+bool TrksInJetQABaseManager::IsInIntt(const uint16_t layer) {
+
+  return (
+    (layer >= m_config.nMvtxLayer) &&
+    (layer <  m_config.nInttLayer + m_config.nMvtxLayer)
+  );
+
+}  // end 'IsInIntt(uint16_t)'
+
+
+
+bool TrksInJetQABaseManager::IsInTpc(const uint16_t layer) {
+
+  return (layer >= m_config.nMvtxLayer + m_config.nInttLayer);
+
+}  // end 'IsInTpc(uint16_t)'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQABaseManager.cc
+++ b/offline/QA/Jet/TrksInJetQABaseManager.cc
@@ -41,7 +41,7 @@ TrksInJetQABaseManager::~TrksInJetQABaseManager() {
 
 // public methods -------------------------------------------------------------
 
-void TrksInJetQABaseManager::MakeHistograms(std::string label) {
+void TrksInJetQABaseManager::MakeHistograms(const std::string &label) {
 
   DefineHistograms();
   BuildHistograms(label);
@@ -51,12 +51,13 @@ void TrksInJetQABaseManager::MakeHistograms(std::string label) {
 
 
 
-void TrksInJetQABaseManager::SaveHistograms(TDirectory* topDir, std::string outDirName) {
+void TrksInJetQABaseManager::SaveHistograms(TDirectory* topDir, const std::string &outDirName) {
 
-  TDirectory* outDir = topDir -> mkdir(outDirName.data());
+  TDirectory* outDir = topDir -> mkdir(outDirName.c_str());
   if (!outDir) {
     std::cerr << PHWHERE << ": PANIC: unable to make output directory!" << std::endl;
-    assert(outDir);
+    exit(1);
+    
   }
 
   outDir -> cd();
@@ -99,7 +100,7 @@ void TrksInJetQABaseManager::GrabHistograms(
 
 // private methods ------------------------------------------------------------
 
-void TrksInJetQABaseManager::BuildHistograms(std::string label) {
+void TrksInJetQABaseManager::BuildHistograms(const std::string &label) {
 
   // build 1d histograms
   m_vecHist1D.resize( m_vecHistTypes.size() );

--- a/offline/QA/Jet/TrksInJetQABaseManager.h
+++ b/offline/QA/Jet/TrksInJetQABaseManager.h
@@ -1,0 +1,78 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQABaseManager.h'
+// Derek Anderson
+// 04.03.2024
+//
+// Base hist manager submodule for the TrksInJetQA module which
+// consolidates methods/data common to all of the hist managers
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQABASEMANAGER_H
+#define TRKSINJETQABASEMANAGER_H
+
+// c++ utilities
+#include <string>
+#include <vector>
+#include <utility>
+#include <iostream>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+#include <TDirectory.h>
+// phool libraries
+#include <phool/phool.h>
+// module utilities
+#include "TrksInJetQAHist.h"
+#include "TrksInJetQATypes.h"
+#include "TrksInJetQAConfig.h"
+
+
+
+// TrksInJetQABaseManager definition ------------------------------------------
+
+class TrksInJetQABaseManager {
+
+  public:
+
+    // ctor/dtor
+    TrksInJetQABaseManager(TrksInJetQAConfig& config, TrksInJetQAHist& hist);
+    ~TrksInJetQABaseManager();
+
+    // public methods
+    void MakeHistograms(std::string label = "");
+    void SaveHistograms(TDirectory* outFile, std::string outDirName);
+    void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
+
+  protected:
+
+    // private methods
+    void BuildHistograms(std::string label = "");
+    void ResetVectors();
+
+    // private helper methods
+    bool IsInMvtx(const uint16_t layer);
+    bool IsInIntt(const uint16_t layer);
+    bool IsInTpc(const uint16_t layer);
+
+    // virtual private methods
+    virtual void DefineHistograms() = 0;
+
+    // histograms
+    VecHist1D m_vecHist1D;
+    VecHist2D m_vecHist2D;
+
+    // histogram definitions
+    VecHistTypes m_vecHistTypes;
+    VecHistDef1D m_vecHistDef1D;
+    VecHistDef2D m_vecHistDef2D;
+
+    // module utilities
+    TrksInJetQAConfig m_config;
+    TrksInJetQAHist   m_hist;
+
+};  // end TrksInJetQABaseManager
+
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQABaseManager.h
+++ b/offline/QA/Jet/TrksInJetQABaseManager.h
@@ -10,22 +10,24 @@
 #ifndef TRKSINJETQABASEMANAGER_H
 #define TRKSINJETQABASEMANAGER_H
 
-// c++ utilities
-#include <string>
-#include <vector>
-#include <utility>
-#include <iostream>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-#include <TDirectory.h>
-// phool libraries
-#include <phool/phool.h>
 // module utilities
 #include "TrksInJetQAHist.h"
 #include "TrksInJetQATypes.h"
 #include "TrksInJetQAConfig.h"
 
+// phool includes
+#include <phool/phool.h>
+
+// root includes
+#include <TH1.h>
+#include <TH2.h>
+#include <TDirectory.h>
+
+// c++ utilities
+#include <string>
+#include <vector>
+#include <utility>
+#include <iostream>
 
 
 // TrksInJetQABaseManager definition ------------------------------------------
@@ -36,7 +38,7 @@ class TrksInJetQABaseManager {
 
     // ctor/dtor
     TrksInJetQABaseManager(TrksInJetQAConfig& config, TrksInJetQAHist& hist);
-    ~TrksInJetQABaseManager();
+    virtual ~TrksInJetQABaseManager();
 
     // public methods
     void MakeHistograms(std::string label = "");

--- a/offline/QA/Jet/TrksInJetQABaseManager.h
+++ b/offline/QA/Jet/TrksInJetQABaseManager.h
@@ -41,14 +41,14 @@ class TrksInJetQABaseManager {
     virtual ~TrksInJetQABaseManager();
 
     // public methods
-    void MakeHistograms(std::string label = "");
-    void SaveHistograms(TDirectory* outFile, std::string outDirName);
+    void MakeHistograms(const std::string &label = "");
+    void SaveHistograms(TDirectory* outFile, const std::string &outDirName);
     void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
 
   protected:
 
     // private methods
-    void BuildHistograms(std::string label = "");
+    void BuildHistograms(const std::string &label = "");
     void ResetVectors();
 
     // private helper methods

--- a/offline/QA/Jet/TrksInJetQAClustManager.cc
+++ b/offline/QA/Jet/TrksInJetQAClustManager.cc
@@ -1,0 +1,107 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAClustManager.cc'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module to generate
+// QA plots for track clusters
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQACLUSTMANAGER_CC
+
+// submodule definition
+#include "TrksInJetQAClustManager.h"
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQAClustManager::GetInfo(TrkrCluster* cluster, TrkrDefs::cluskey& clustKey, ActsGeometry* actsGeom) {
+
+  // check which subsystem cluster is in
+  const uint16_t layer  = TrkrDefs::getLayer(clustKey);
+  const bool     isMvtx = IsInMvtx(layer);
+  const bool     isIntt = IsInIntt(layer);
+  const bool     isTpc  = IsInTpc(layer);
+
+  // get cluster position
+  Acts::Vector3 actsPos = actsGeom -> getGlobalPosition(clustKey, cluster);
+
+  // collect cluster info
+  ClustQAContent content {
+    .x = actsPos(0),
+    .y = actsPos(1),
+    .z = actsPos(2),
+    .r = std::hypot( actsPos(0), actsPos(1) )
+  };
+
+  // fill histograms
+  FillHistograms(Type::All, content);
+  if (isMvtx) {
+    FillHistograms(Type::Mvtx, content);
+  } else if (isIntt) {
+    FillHistograms(Type::Intt, content);
+  } else if (isTpc) {
+    FillHistograms(Type::Tpc, content);
+  }
+
+}  // end GetInfo(TrkrCluster*, TrkrDefs::cluskey&, ActsGeometry*)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQAClustManager::FillHistograms(const int type, ClustQAContent& content) {
+
+  // fill 1d histograms
+  m_vecHist1D.at(type).at(H1D::PosX) -> Fill(content.x);
+  m_vecHist1D.at(type).at(H1D::PosY) -> Fill(content.y);
+  m_vecHist1D.at(type).at(H1D::PosZ) -> Fill(content.z);
+  m_vecHist1D.at(type).at(H1D::PosR) -> Fill(content.r);
+
+  // fill 2d histograms
+  m_vecHist2D.at(type).at(H2D::PosYvsX) -> Fill(content.x, content.y);
+  m_vecHist2D.at(type).at(H2D::PosRvsZ) -> Fill(content.z, content.r);
+  return;
+
+}  //  end 'FillHistograms(int, ClustQAContent&)'
+
+
+
+void TrksInJetQAClustManager::DefineHistograms() {
+
+  // grab binning schemes
+  std::vector<BinDef> vecBins = m_hist.GetVecHistBins();
+
+  // set histogram types
+  m_vecHistTypes.push_back( "Mvtx" );
+  m_vecHistTypes.push_back( "Intt" );
+  m_vecHistTypes.push_back( "Tpc"  );
+  m_vecHistTypes.push_back( "All"  );
+
+  // define 1d histograms
+  m_vecHistDef1D.push_back( std::make_tuple( "ClustPosX", vecBins.at(TrksInJetQAHist::Var::PosXY) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "ClustPosY", vecBins.at(TrksInJetQAHist::Var::PosXY) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "ClustPosZ", vecBins.at(TrksInJetQAHist::Var::PosZ)  ));
+  m_vecHistDef1D.push_back( std::make_tuple( "ClustPosR", vecBins.at(TrksInJetQAHist::Var::PosR)  ));
+
+  // define 2d histograms
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "ClustPosYvsX",
+      vecBins.at(TrksInJetQAHist::Var::PosXY),
+      vecBins.at(TrksInJetQAHist::Var::PosXY)
+    )
+  );
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "ClustPosRvsZ",
+      vecBins.at(TrksInJetQAHist::Var::PosZ),
+      vecBins.at(TrksInJetQAHist::Var::PosR)
+    )
+  );
+  return;
+
+}  // end 'BuildHistograms()'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAClustManager.h
+++ b/offline/QA/Jet/TrksInJetQAClustManager.h
@@ -1,0 +1,68 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAClustManager.h'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module to generate
+// QA plots for track clusters
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQACLUSTMANAGER_H
+#define TRKSINJETQACLUSTMANAGER_H
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+// tracking libraries
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/ActsGeometry.h>
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+
+
+// TrksInJetQAClustManager definition -----------------------------------------
+
+class TrksInJetQAClustManager : public TrksInJetQABaseManager {
+
+  public:
+
+    // histogram accessors
+    enum Type {Mvtx, Intt, Tpc, All};
+    enum H1D  {PosX, PosY, PosZ, PosR};
+    enum H2D  {PosYvsX, PosRvsZ};
+
+    // histogram content
+    struct ClustQAContent {
+      double x = std::numeric_limits<double>::max();
+      double y = std::numeric_limits<double>::max();
+      double z = std::numeric_limits<double>::max();
+      double r = std::numeric_limits<double>::max();
+    };
+
+    // ctor/dtor
+    using TrksInJetQABaseManager::TrksInJetQABaseManager;
+    ~TrksInJetQAClustManager() {};
+
+    // public methods
+    void GetInfo(TrkrCluster* cluster, TrkrDefs::cluskey& clustKey, ActsGeometry* actsGeom);
+
+  private:
+
+    // private methods
+    void FillHistograms(const int type, ClustQAContent& content);
+
+    // inherited private methods
+    void DefineHistograms() override;
+
+};  // end TrksInJetQAClustManager
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAClustManager.h
+++ b/offline/QA/Jet/TrksInJetQAClustManager.h
@@ -10,21 +10,23 @@
 #ifndef TRKSINJETQACLUSTMANAGER_H
 #define TRKSINJETQACLUSTMANAGER_H
 
-// c++ utilities
-#include <limits>
-#include <vector>
-#include <utility>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-// tracking libraries
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+// tracking includes
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/ActsGeometry.h>
-// submodule definitions
-#include "TrksInJetQABaseManager.h"
 
+// root includes
+#include <TH1.h>
+#include <TH2.h>
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
 
 
 // TrksInJetQAClustManager definition -----------------------------------------

--- a/offline/QA/Jet/TrksInJetQAConfig.h
+++ b/offline/QA/Jet/TrksInJetQAConfig.h
@@ -1,0 +1,58 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAConfig.h'
+// Derek Anderson
+// 03.25.2024
+//
+// Configurable parameters for the TrksInJetQA module.
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQACONFIG_H
+#define TRKSINJETQACONFIG_H
+
+// c++ utilities
+#include <string>
+
+
+
+// TrksInJetQAConfig definition -----------------------------------------------
+
+struct TrksInJetQAConfig {
+
+  // system options
+  int  outMode     = 0;
+  int  verbose     = 0;
+  bool doDebug     = false;
+  bool doInclusive = true;
+  bool doInJet     = true;
+  bool doHitQA     = false;
+  bool doClustQA   = false;
+  bool doTrackQA   = true;
+  bool doJetQA     = true;
+
+  // jet options
+  double rJet = 0.4;
+
+  // input options
+  std::string jetInNode   = "AntiKt_Track_r04";
+  std::string trkInNode   = "SvtxTrackMap";
+  std::string clustInNode = "TRKR_CLUSTER";
+  std::string hitInNode   = "TRKR_HITSET";
+
+  // output options
+  std::string inclusiveDir = "Inclusive";
+  std::string inJetDir     = "InJet";
+  std::string hitOutDir    = "Hit";
+  std::string clustOutDir  = "Clust";
+  std::string trackOutDir  = "Track";
+  std::string jetOutDir    = "Jet";
+
+  // tracker parameters
+  uint16_t nMvtxLayer = 3;
+  uint16_t nInttLayer = 4;
+  uint16_t nTpcLayer  = 48;
+
+};  // end TrksInJetQAConfig
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAHist.h
+++ b/offline/QA/Jet/TrksInJetQAHist.h
@@ -1,0 +1,96 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAHist.h'
+// Derek Anderson
+// 03.25.2024
+//
+// Configurable parameters for histograms (like binning, etc.)
+// for the TrksInJetQA module.
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETSQAHIST_H
+#define TRKSINJETSQAHIST_H
+
+// c++ utilities
+#include <string>
+#include <utility>
+// module utilities
+#include "TrksInJetQATypes.h"
+
+
+
+// TrksInJetQAHist definition -------------------------------------------------
+
+struct TrksInJetQAHist {
+
+  enum Var {
+    Num,
+    Adc,
+    ZBin,
+    PhiBin,
+    Layer,
+    PosXY,
+    PosZ,
+    PosR,
+    Phi,
+    Eta,
+    Ene,
+    Qual
+  };
+
+  // no. of bins
+  //   - FIXME the phi/z bin binning needs
+  //     some more thought...
+  //   - FIXME same with the ADC...
+  uint32_t nNumBins    = 101;
+  uint32_t nAdcBins    = 101;
+  uint32_t nZBinBins   = 101;
+  uint32_t nPhiBinBins = 101;
+  uint32_t nLayerBins  = 101;
+  uint32_t nPosXYBins  = 6000;
+  uint32_t nPosZBins   = 6000;
+  uint32_t nPosRBins   = 3000;
+  uint32_t nPhiBins    = 180;
+  uint32_t nEtaBins    = 180;
+  uint32_t nEneBins    = 505;
+  uint32_t nQualBins   = 22;
+
+  // bin ranges
+  BinRange rNumBins    = {-0.5, (float) nNumBins + 0.5};
+  BinRange rAdcBins    = {-0.5, (float) nAdcBins + 0.5};
+  BinRange rZBinBins   = {-0.5, (float) nZBinBins + 0.5};
+  BinRange rPhiBinBins = {-0.5, (float) nPhiBinBins + 0.5};
+  BinRange rLayerBins  = {-0.5, (float) nLayerBins + 0.5};
+  BinRange rPosXYBins  = {-300., 300.};
+  BinRange rPosZBins   = {-300., 300.};
+  BinRange rPosRBins   = {0., 300.};
+  BinRange rPhiBins    = {-3.15, 3.15};
+  BinRange rEtaBins    = {-4.0, 4.0};
+  BinRange rEneBins    = {-0.5, 100.5};
+  BinRange rQualBins   = {-0.5, 10.5};
+
+  // construct list of binnings
+  std::vector<BinDef> GetVecHistBins() {
+
+    std::vector<BinDef> vecHistBins = {
+      std::make_pair(nNumBins,    rNumBins),
+      std::make_pair(nAdcBins,    rAdcBins),
+      std::make_pair(nZBinBins,   rZBinBins),
+      std::make_pair(nPhiBinBins, rPhiBinBins),
+      std::make_pair(nLayerBins,  rLayerBins),
+      std::make_pair(nPosXYBins,  rPosXYBins),
+      std::make_pair(nPosZBins,   rPosZBins),
+      std::make_pair(nPosRBins,   rPosRBins),
+      std::make_pair(nPhiBins,    rPhiBins),
+      std::make_pair(nEtaBins,    rEtaBins),
+      std::make_pair(nEneBins,    rEneBins),
+      std::make_pair(nQualBins,   rQualBins)
+    };
+    return vecHistBins;
+
+  }  // end 'GetVecHistBins()'
+
+};  // end TrksInJetQAHist
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAHist.h
+++ b/offline/QA/Jet/TrksInJetQAHist.h
@@ -10,11 +10,12 @@
 #ifndef TRKSINJETSQAHIST_H
 #define TRKSINJETSQAHIST_H
 
+// module utilities
+#include "TrksInJetQATypes.h"
+
 // c++ utilities
 #include <string>
 #include <utility>
-// module utilities
-#include "TrksInJetQATypes.h"
 
 
 

--- a/offline/QA/Jet/TrksInJetQAHitManager.cc
+++ b/offline/QA/Jet/TrksInJetQAHitManager.cc
@@ -1,0 +1,132 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAHitManager.cc'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module
+// to generate QA plots for track hits
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQAHITMANAGER_CC
+
+// submodule definition
+#include "TrksInJetQAHitManager.h"
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQAHitManager::GetInfo(TrkrHit* hit, TrkrDefs::hitsetkey& setKey, TrkrDefs::hitkey& hitKey) {
+
+  // check which subsystem hit is in
+  const uint16_t layer  = TrkrDefs::getLayer(setKey);
+  const bool     isMvtx = IsInMvtx(layer);
+  const bool     isIntt = IsInIntt(layer);
+  const bool     isTpc  = IsInTpc(layer);
+
+  // get phi and z values
+  //   - FIXME should be more explicit about
+  //     row/column vs. z/phi...
+  uint16_t phiBin = std::numeric_limits<uint16_t>::max();
+  uint16_t zBin   = std::numeric_limits<uint16_t>::max();
+  if (isMvtx) {
+    phiBin = MvtxDefs::getCol(hitKey);
+    zBin   = MvtxDefs::getRow(hitKey);
+  } else if (isIntt) {
+    phiBin = InttDefs::getCol(hitKey);
+    zBin   = InttDefs::getRow(hitKey);
+  } else if (isTpc) {
+    phiBin = TpcDefs::getPad(hitKey);
+    /* TODO put in z calculation */
+  }
+
+  // collect hit info
+  HitQAContent content {
+    .ene    = hit -> getEnergy(),
+    .adc    = hit -> getAdc(),
+    .layer  = layer,
+    .phiBin = phiBin,
+    .zBin   = zBin
+  };
+
+  // fill histograms
+  FillHistograms(Type::All, content);
+  if (isMvtx) {
+    FillHistograms(Type::Mvtx, content);
+  } else if (isIntt) {
+    FillHistograms(Type::Intt, content);
+  } else if (isTpc) {
+    FillHistograms(Type::Tpc, content);
+  }
+  return;
+
+}  // end 'GetInfo(TrkrHit*, TrkrDefs::hitsetkey&, TrkrDefs::hitkey&)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQAHitManager::FillHistograms(const int type, HitQAContent& content) {
+
+  // fill 1d histograms
+  m_vecHist1D.at(type).at(H1D::Ene)    -> Fill(content.ene);
+  m_vecHist1D.at(type).at(H1D::ADC)    -> Fill(content.adc);
+  m_vecHist1D.at(type).at(H1D::Layer)  -> Fill(content.layer);
+  m_vecHist1D.at(type).at(H1D::PhiBin) -> Fill(content.phiBin);
+  m_vecHist1D.at(type).at(H1D::ZBin)   -> Fill(content.zBin);
+
+  // fill 2d histograms
+  m_vecHist2D.at(type).at(H2D::EneVsLayer) -> Fill(content.layer, content.ene);
+  m_vecHist2D.at(type).at(H2D::EneVsADC)   -> Fill(content.adc, content.ene);
+  m_vecHist2D.at(type).at(H2D::PhiVsZBin)  -> Fill(content.zBin, content.phiBin);
+  return;
+
+}  //  end 'FillHistograms(Type, HitQAContent&)'
+
+
+
+void TrksInJetQAHitManager::DefineHistograms() {
+
+  // grab binning schemes
+  std::vector<BinDef> vecBins = m_hist.GetVecHistBins();
+
+  // set histogram types
+  m_vecHistTypes.push_back( "Mvtx" );
+  m_vecHistTypes.push_back( "Intt" );
+  m_vecHistTypes.push_back( "Tpc"  );
+  m_vecHistTypes.push_back( "All"  );
+
+  // define 1d histograms
+  m_vecHistDef1D.push_back( std::make_tuple( "HitEne",    vecBins.at(TrksInJetQAHist::Var::Ene)    ));
+  m_vecHistDef1D.push_back( std::make_tuple( "HitAdc",    vecBins.at(TrksInJetQAHist::Var::Adc)    ));
+  m_vecHistDef1D.push_back( std::make_tuple( "HitLayer",  vecBins.at(TrksInJetQAHist::Var::Layer)  ));
+  m_vecHistDef1D.push_back( std::make_tuple( "HitPhiBin", vecBins.at(TrksInJetQAHist::Var::PhiBin) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "HitZBin",   vecBins.at(TrksInJetQAHist::Var::ZBin)   ));
+
+  // define 2d histograms
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "HitEneVsLayer",
+      vecBins.at(TrksInJetQAHist::Var::Layer),
+      vecBins.at(TrksInJetQAHist::Var::Ene)
+    )
+  );
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "HitEneVsADC",
+      vecBins.at(TrksInJetQAHist::Var::Adc),
+      vecBins.at(TrksInJetQAHist::Var::Ene)
+    )
+  );
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "HitPhiVsZBin",
+      vecBins.at(TrksInJetQAHist::Var::ZBin),
+      vecBins.at(TrksInJetQAHist::Var::PhiBin)
+    )
+  );
+  return;
+
+}  // end 'DefineHistograms()'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAHitManager.h
+++ b/offline/QA/Jet/TrksInJetQAHitManager.h
@@ -1,0 +1,70 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAHitManager.h'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module
+// to generate QA plots for track hits
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQAHITMANAGER_H
+#define TRKSINJETQAHITMANAGER_H
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+// tracking libraries
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TpcDefs.h>
+#include <trackbase/InttDefs.h>
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TrkrDefs.h>
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+
+
+// TrksInJetQAHitManager definition -------------------------------------------
+
+class TrksInJetQAHitManager : public TrksInJetQABaseManager {
+
+  public:
+
+    // histogram accessors
+    enum Type {Mvtx, Intt, Tpc, All};
+    enum H1D  {Ene, ADC, Layer, PhiBin, ZBin};
+    enum H2D  {EneVsLayer, EneVsADC, PhiVsZBin};
+
+    // histogram content
+    struct HitQAContent {
+      double   ene    = std::numeric_limits<double>::max();
+      uint64_t adc    = std::numeric_limits<uint64_t>::max();
+      uint16_t layer  = std::numeric_limits<uint16_t>::max();
+      uint16_t phiBin = std::numeric_limits<uint16_t>::max();
+      uint16_t zBin   = std::numeric_limits<uint16_t>::max();
+    };
+
+    // ctor/dtor
+    using TrksInJetQABaseManager::TrksInJetQABaseManager;
+    ~TrksInJetQAHitManager() {};
+
+    // public methods
+    void GetInfo(TrkrHit* hit, TrkrDefs::hitsetkey& setKey, TrkrDefs::hitkey& hitKey);
+
+  private:
+
+    // private methods
+    void FillHistograms(const int type, HitQAContent& content);
+
+    // inherited private methods
+    void DefineHistograms() override;
+
+};  // end TrksInJetQAHitManager
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAHitManager.h
+++ b/offline/QA/Jet/TrksInJetQAHitManager.h
@@ -10,22 +10,24 @@
 #ifndef TRKSINJETQAHITMANAGER_H
 #define TRKSINJETQAHITMANAGER_H
 
-// c++ utilities
-#include <limits>
-#include <vector>
-#include <utility>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-// tracking libraries
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+// tracking includes
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TpcDefs.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrDefs.h>
-// submodule definitions
-#include "TrksInJetQABaseManager.h"
 
+// root includes
+#include <TH1.h>
+#include <TH2.h>
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
 
 
 // TrksInJetQAHitManager definition -------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAInJetFiller.cc
+++ b/offline/QA/Jet/TrksInJetQAInJetFiller.cc
@@ -67,7 +67,7 @@ void TrksInJetQAInJetFiller::FillJetAndTrackQAHists(PHCompositeNode* topNode) {
 
     // get all tracks "in" a jet
     GetCstTracks(jet, topNode);
-    GetNonCstTracks(jet, topNode);
+    GetNonCstTracks(jet);
 
     // grab jet info and fill histograms
     if (m_config.doJetQA) m_jetManager -> GetInfo(jet, m_trksInJet);
@@ -80,7 +80,7 @@ void TrksInJetQAInJetFiller::FillJetAndTrackQAHists(PHCompositeNode* topNode) {
 
       // fill cluster and hit histograms as needed
       if (m_config.doClustQA || m_config.doHitQA) {
-        FillClustAndHitQAHists(track, topNode);
+        FillClustAndHitQAHists(track);
       }
     }  // end track loop
   }  // end jet loop
@@ -90,7 +90,7 @@ void TrksInJetQAInJetFiller::FillJetAndTrackQAHists(PHCompositeNode* topNode) {
 
 
 
-void TrksInJetQAInJetFiller::FillClustAndHitQAHists(SvtxTrack* track, PHCompositeNode* topNode) {
+void TrksInJetQAInJetFiller::FillClustAndHitQAHists(SvtxTrack* track) {
 
   // get cluster keys
   for (auto clustKey : ClusKeyIter(track)) {
@@ -132,7 +132,7 @@ void TrksInJetQAInJetFiller::FillClustAndHitQAHists(SvtxTrack* track, PHComposit
   }  // end cluster key loop
   return;
 
-}  // end 'FillClustQAHists(SvtxTrack*, PHCompositeNode*)'
+}  // end 'FillClustQAHists(SvtxTrack*)'
 
 
 
@@ -170,7 +170,7 @@ void TrksInJetQAInJetFiller::GetCstTracks(Jet* jet, PHCompositeNode* topNode) {
 
 
 
-void TrksInJetQAInJetFiller::GetNonCstTracks(Jet* jet, PHCompositeNode* topNode) {
+void TrksInJetQAInJetFiller::GetNonCstTracks(Jet* jet) {
 
   // loop over tracks
   for (
@@ -201,7 +201,7 @@ void TrksInJetQAInJetFiller::GetNonCstTracks(Jet* jet, PHCompositeNode* topNode)
   }  // end track loop
   return;
 
-}  // end 'GetNonCstTracks(Jet* jet, PHCompositeNode* topNode)'
+}  // end 'GetNonCstTracks(Jet* jet)'
 
 
 

--- a/offline/QA/Jet/TrksInJetQAInJetFiller.cc
+++ b/offline/QA/Jet/TrksInJetQAInJetFiller.cc
@@ -1,0 +1,298 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAInJetFiller.cc'
+// Derek Anderson
+// 04.03.2024
+//
+// A submodule for the TrksInJetsQAM F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQAINJETFILLER_CC
+
+// submodule definition
+#include "TrksInJetQAInJetFiller.h"
+
+
+
+// inherited public methods ---------------------------------------------------
+
+void TrksInJetQAInJetFiller::Fill(PHCompositeNode* topNode) {
+
+  GetNodes(topNode);
+
+  FillJetAndTrackQAHists(topNode);
+  return;
+
+}  // end 'Fill(PHCompositeNode* topNode)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQAInJetFiller::GetNode(const int node, PHCompositeNode* topNode) {
+
+  // jump to relevant node
+  switch (node) {
+
+    case Node::Flow:
+      m_flowStore = findNode::getClass<ParticleFlowElementContainer>(topNode, "ParticleFlowElements");
+      if (!m_flowStore) {
+        std::cerr << PHWHERE << ": PANIC: Couldn't grab particle flow container from node tree!" << std::endl;
+        assert(m_flowStore);
+      }
+      break;
+
+    default:
+      std::cerr << PHWHERE << ": WARNING: trying to grab unkown additional node..." << std::endl;
+      break;
+  }
+  return;
+
+}  // end 'GetNode(int, PHCompositeNode*)'
+
+
+
+void TrksInJetQAInJetFiller::FillJetAndTrackQAHists(PHCompositeNode* topNode) {
+
+  // loop over jets
+  for (
+    uint64_t iJet = 0;
+    iJet < m_jetMap -> size();
+    ++iJet
+  ) {
+
+    // grab jet and make sure track vector is clear
+    Jet* jet = m_jetMap -> get_jet(iJet);
+    m_trksInJet.clear();
+
+    // get all tracks "in" a jet
+    GetCstTracks(jet, topNode);
+    GetNonCstTracks(jet, topNode);
+
+    // grab jet info and fill histograms
+    if (m_config.doJetQA) m_jetManager -> GetInfo(jet, m_trksInJet);
+
+    // loop over tracks in the jet
+    for (SvtxTrack* track : m_trksInJet) {
+
+      // grab track info and fill histograms
+      if (m_config.doTrackQA) m_trackManager -> GetInfo(track);
+
+      // fill cluster and hit histograms as needed
+      if (m_config.doClustQA || m_config.doHitQA) {
+        FillClustAndHitQAHists(track, topNode);
+      }
+    }  // end track loop
+  }  // end jet loop
+  return;
+
+}  // end 'FillJetAndTrackQAHists(PHCompositeNode*)'
+
+
+
+void TrksInJetQAInJetFiller::FillClustAndHitQAHists(SvtxTrack* track, PHCompositeNode* topNode) {
+
+  // get cluster keys
+  for (auto clustKey : ClusKeyIter(track)) {
+
+    // grab cluster and its info
+    if (m_config.doClustQA) {
+      m_clustManager -> GetInfo(
+        m_clustMap -> findCluster(clustKey),
+        clustKey,
+        m_actsGeom
+      );
+    }
+
+    // get hits if needed
+    if (m_config.doHitQA) {
+
+      // grab hit set and key associated with cluster key
+      TrkrDefs::hitsetkey setKey = TrkrDefs::getHitSetKeyFromClusKey(clustKey);
+      TrkrHitSet*         set    = m_hitMap -> findHitSet(setKey);
+      if (!set || !(set -> size() > 0)) return;
+
+      // loop over all hits in hit set
+      TrkrHitSet::ConstRange hits = set -> getHits();
+      for (
+        TrkrHitSet::ConstIterator itHit = hits.first;
+        itHit != hits.second;
+        ++itHit
+      ) {
+
+        // grab hit
+        TrkrDefs::hitkey hitKey = itHit -> first;
+        TrkrHit*         hit    = itHit -> second;
+
+        // grab info and fill histograms
+        m_hitManager -> GetInfo(hit, setKey, hitKey);
+
+      }  // end hit loop
+    }
+  }  // end cluster key loop
+  return;
+
+}  // end 'FillClustQAHists(SvtxTrack*, PHCompositeNode*)'
+
+
+
+void TrksInJetQAInJetFiller::GetCstTracks(Jet* jet, PHCompositeNode* topNode) {
+
+  // loop over consituents
+  auto csts = jet -> get_comp_vec();
+  for (
+    auto cst = csts.begin();
+    cst != csts.end();
+    ++cst
+  ) {
+
+    // ignore cst if non-relevent type
+    const uint32_t src = cst -> first;
+    if ( IsCstNotRelevant(src) ) continue;
+
+    // if cst is track, add to list
+    if (src == Jet::SRC::TRACK) {
+      m_trksInJet.push_back( m_trkMap -> get(cst -> second) );
+    }
+
+    // if pfo, grab track if needed
+    if (src == Jet::SRC::PARTICLE) {
+      PFObject*  pfo   = GetPFObject(cst -> second, topNode);
+      SvtxTrack* track = GetTrkFromPFO(pfo);
+      if (track) {
+        m_trksInJet.push_back( track );
+      }
+    }
+  }  // end cst loop
+  return;
+
+}  // end 'GetCstTracks(Jet* jet, PHCompositeNode* topNode)'
+
+
+
+void TrksInJetQAInJetFiller::GetNonCstTracks(Jet* jet, PHCompositeNode* topNode) {
+
+  // loop over tracks
+  for (
+    SvtxTrackMap::Iter itTrk = m_trkMap -> begin();
+    itTrk != m_trkMap -> end();
+    ++itTrk
+  ) {
+
+    // grab track
+    SvtxTrack* track = itTrk -> second;
+
+    // ignore tracks we've already added to the list
+    if ( IsTrkInList(track -> get_id()) ) continue;
+
+    // FIXME this can be improved!
+    //   - jets don't necessarily have areas of
+    //     pi*(Rjet)^2
+    //   - it may be better to instead check
+    //     if a track projection falls in
+    //     a constituent tower/cluster
+    //   - Also track projections to a calo
+    //     would be better to use than just
+    //     the track
+    const double dr = GetTrackJetDist(track, jet);
+    if (dr < m_config.rJet) {
+      m_trksInJet.push_back( track );
+    }
+  }  // end track loop
+  return;
+
+}  // end 'GetNonCstTracks(Jet* jet, PHCompositeNode* topNode)'
+
+
+
+bool TrksInJetQAInJetFiller::IsCstNotRelevant(const uint32_t type) {
+
+  const bool isVoid   = (type == Jet::SRC::VOID);
+  const bool isImport = (type == Jet::SRC::HEPMC_IMPORT);
+  const bool isProbe  = (type == Jet::SRC::JET_PROBE);
+  return (isVoid || isImport || isProbe);
+
+}  // end 'IsCstNotRelevant(uint32_t)'
+
+
+
+bool TrksInJetQAInJetFiller::IsTrkInList(const uint32_t id) {
+
+  bool isAdded = false;
+  for (SvtxTrack* trkInJet : m_trksInJet) {
+    if (id == trkInJet -> get_id() ) {
+      isAdded = true;
+      break;
+    }
+  }
+  return isAdded;
+
+}  // end 'IsTrkInList(uint32_t)'
+
+
+
+double TrksInJetQAInJetFiller::GetTrackJetDist(SvtxTrack* track, Jet* jet) {
+
+  // get delta eta
+  const double dEta = (track -> get_eta()) - (jet -> get_eta());
+
+  // get delta phi
+  double dPhi = (track -> get_phi()) - (jet -> get_phi());
+  if (dPhi < (-1. * TMath::Pi())) dPhi += TMath::TwoPi();
+  if (dPhi > (1. * TMath::Pi()))  dPhi -= TMath::TwoPi();
+
+  // return distance
+  return std::hypot(dEta, dPhi);
+
+}  // end 'GetTrackJetDist(SvtxTrack*, Jet*)'
+
+
+
+PFObject* TrksInJetQAInJetFiller::GetPFObject(const uint32_t id, PHCompositeNode* topNode) {
+
+  // pointer to pfo 
+  PFObject* pfoToFind = NULL;
+
+  // grab pf node if needed
+  if (!m_flowStore) GetNode(Node::Flow, topNode);
+
+  // loop over pfos
+  for (
+      ParticleFlowElementContainer::ConstIterator itFlow = m_flowStore -> getParticleFlowElements().first;
+      itFlow != m_flowStore -> getParticleFlowElements().second;
+      ++itFlow
+  ) {
+
+    // get pfo
+    PFObject* pfo = itFlow -> second;
+
+    // if has provided id, set pointer and exit
+    if (id == pfo -> get_id()) {
+      pfoToFind = pfo;
+      break;
+    }
+  }  // end pfo loop
+  return pfoToFind;
+
+}  // end 'GetPFObject(uint32_t, PHCompositeNode*)'
+
+
+
+SvtxTrack* TrksInJetQAInJetFiller::GetTrkFromPFO(PFObject* pfo) {
+
+  // pointer to track
+  SvtxTrack* track = NULL;
+
+  // if pfo has track, try to grab
+  const auto type = pfo -> get_type();
+  if (
+    (type == ParticleFlowElement::PFLOWTYPE::MATCHED_CHARGED_HADRON) ||
+    (type == ParticleFlowElement::PFLOWTYPE::UNMATCHED_CHARGED_HADRON)
+  ) {
+    track = pfo -> get_track();
+  }
+  return track;
+
+}  // end 'GetTrkFromPFO(PFObject*)'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAInJetFiller.h
+++ b/offline/QA/Jet/TrksInJetQAInJetFiller.h
@@ -65,9 +65,9 @@ class TrksInJetQAInJetFiller : public TrksInJetQABaseFiller {
     // private methods
     void       GetNode(const int node, PHCompositeNode* topNode);
     void       FillJetAndTrackQAHists(PHCompositeNode* topNode);
-    void       FillClustAndHitQAHists(SvtxTrack* track, PHCompositeNode* topNode);
+    void       FillClustAndHitQAHists(SvtxTrack* track);
     void       GetCstTracks(Jet* jet, PHCompositeNode* topNode);
-    void       GetNonCstTracks(Jet* jet, PHCompositeNode* topNode);
+    void       GetNonCstTracks(Jet* jet);
     bool       IsCstNotRelevant(const uint32_t type);
     bool       IsTrkInList(const uint32_t id);
     double     GetTrackJetDist(SvtxTrack* track, Jet* jet);

--- a/offline/QA/Jet/TrksInJetQAInJetFiller.h
+++ b/offline/QA/Jet/TrksInJetQAInJetFiller.h
@@ -10,16 +10,12 @@
 #ifndef TRKSINJETQAINJETFILLER_H
 #define TRKSINJETQAINJETFILLER_H
 
-// c+ utilities
-#include <vector>
-#include <cassert>
-// root libraries
-#include <TMath.h>
-// phool libraries
-#include <phool/phool.h>
-#include <phool/getClass.h>
-#include <phool/PHCompositeNode.h>
-// tracking libraries
+// module utilities
+#include "TrksInJetQATypes.h"
+// submodule definitions
+#include "TrksInJetQABaseFiller.h"
+
+// tracking includes
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHitSet.h>
@@ -29,18 +25,26 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
-// particle flow libraries
+// particle flow includes
 #include <particleflowreco/ParticleFlowElement.h>
 #include <particleflowreco/ParticleFlowElementContainer.h>
-// jet libraries
+// jet includes
 #include <jetbase/Jet.h>
 #include <jetbase/JetContainer.h>
-// g4eval libraries
+// g4eval includes
 #include <g4eval/ClusKeyIter.h>
-// module utilities
-#include "TrksInJetQATypes.h"
-// submodule definitions
-#include "TrksInJetQABaseFiller.h"
+
+// phool includes
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+
+// root includes
+#include <TMath.h>
+
+// c+ utilities
+#include <vector>
+#include <cassert>
 
 
 
@@ -55,7 +59,7 @@ class TrksInJetQAInJetFiller : public TrksInJetQABaseFiller {
 
     // ctor/dtor
     using TrksInJetQABaseFiller::TrksInJetQABaseFiller;
-    ~TrksInJetQAInJetFiller() {};
+    ~TrksInJetQAInJetFiller() override = default;
 
     // inherited public methods
     void Fill(PHCompositeNode* topNode) override;

--- a/offline/QA/Jet/TrksInJetQAInJetFiller.h
+++ b/offline/QA/Jet/TrksInJetQAInJetFiller.h
@@ -1,0 +1,87 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAInJetFiller.h'
+// Derek Anderson
+// 04.03.2024
+//
+// A submodule for the TrksInJetsQA F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQAINJETFILLER_H
+#define TRKSINJETQAINJETFILLER_H
+
+// c+ utilities
+#include <vector>
+#include <cassert>
+// root libraries
+#include <TMath.h>
+// phool libraries
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+// tracking libraries
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+// particle flow libraries
+#include <particleflowreco/ParticleFlowElement.h>
+#include <particleflowreco/ParticleFlowElementContainer.h>
+// jet libraries
+#include <jetbase/Jet.h>
+#include <jetbase/JetContainer.h>
+// g4eval libraries
+#include <g4eval/ClusKeyIter.h>
+// module utilities
+#include "TrksInJetQATypes.h"
+// submodule definitions
+#include "TrksInJetQABaseFiller.h"
+
+
+
+// TrksInJetQAInJetFiller -----------------------------------------------------
+
+class TrksInJetQAInJetFiller : public TrksInJetQABaseFiller {
+
+  public:
+
+    // additional nodes to grab
+    enum Node {Flow};
+
+    // ctor/dtor
+    using TrksInJetQABaseFiller::TrksInJetQABaseFiller;
+    ~TrksInJetQAInJetFiller() {};
+
+    // inherited public methods
+    void Fill(PHCompositeNode* topNode) override;
+
+  private:
+
+    // private methods
+    void       GetNode(const int node, PHCompositeNode* topNode);
+    void       FillJetAndTrackQAHists(PHCompositeNode* topNode);
+    void       FillClustAndHitQAHists(SvtxTrack* track, PHCompositeNode* topNode);
+    void       GetCstTracks(Jet* jet, PHCompositeNode* topNode);
+    void       GetNonCstTracks(Jet* jet, PHCompositeNode* topNode);
+    bool       IsCstNotRelevant(const uint32_t type);
+    bool       IsTrkInList(const uint32_t id);
+    double     GetTrackJetDist(SvtxTrack* track, Jet* jet);
+    PFObject*  GetPFObject(const uint32_t id, PHCompositeNode* topNode);
+    SvtxTrack* GetTrkFromPFO(PFObject* pfo);
+
+    // additional dst nodes needed
+    PFObjectStore* m_flowStore = NULL;
+
+    // for tracks in jet
+    std::vector<SvtxTrack*> m_trksInJet;
+
+};  // end TrksInJetQAInJetFiller
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAInclusiveFiller.cc
+++ b/offline/QA/Jet/TrksInJetQAInclusiveFiller.cc
@@ -1,0 +1,149 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAInclusiveFiller.cc'
+// Derek Anderson
+// 04.03.2024
+//
+// A submodule for the TrksInJetQA F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQAINCLUSIVEFILLER_CC
+
+// submodule definition
+#include "TrksInJetQAInclusiveFiller.h"
+
+
+
+// inherited public methods ---------------------------------------------------
+
+void TrksInJetQAInclusiveFiller::Fill(PHCompositeNode* topNode) {
+
+  GetNodes(topNode);
+  
+  if (m_config.doHitQA)   FillHitQAHists();
+  if (m_config.doClustQA) FillClustQAHists();
+  if (m_config.doTrackQA) FillTrackQAHists();
+  if (m_config.doJetQA)   FillJetQAHists();
+  return;
+
+}  // end 'Fill(PHCompositeNode* topNode)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQAInclusiveFiller::FillHitQAHists() {
+
+  // loop over hit sets
+  TrkrHitSetContainer::ConstRange hitSets = m_hitMap -> getHitSets();
+  for (
+    TrkrHitSetContainer::ConstIterator itSet = hitSets.first;
+    itSet != hitSets.second;
+    ++itSet
+  ) {
+
+    // grab hit set
+    TrkrDefs::hitsetkey setKey = itSet -> first;
+    TrkrHitSet*         set    = itSet -> second;
+
+    // loop over all hits in hit set
+    TrkrHitSet::ConstRange hits = set -> getHits();
+    for (
+      TrkrHitSet::ConstIterator itHit = hits.first;
+      itHit != hits.second;
+      ++itHit
+    ) {
+
+      // grab hit
+      TrkrDefs::hitkey hitKey = itHit -> first;
+      TrkrHit*         hit    = itHit -> second;
+
+      // grab info and fill histograms
+      m_hitManager -> GetInfo(hit, setKey, hitKey);
+
+    }  // end hit loop
+  }  // end hit set loop
+  return;
+
+}  // end 'FillHitQAHists()'
+
+
+
+void TrksInJetQAInclusiveFiller::FillClustQAHists() {
+
+  // loop over hit sets
+  TrkrHitSetContainer::ConstRange hitSets = m_hitMap -> getHitSets();
+  for (
+    TrkrHitSetContainer::ConstIterator itSet = hitSets.first;
+    itSet != hitSets.second;
+    ++itSet
+  ) {
+
+    // loop over clusters associated w/ hit set
+    TrkrDefs::hitsetkey              setKey   = itSet      -> first;
+    TrkrClusterContainer::ConstRange clusters = m_clustMap -> getClusters(setKey);
+    for (
+      TrkrClusterContainer::ConstIterator itClust = clusters.first;
+      itClust != clusters.second;
+      ++itClust
+    ) {
+
+      // grab cluster
+      TrkrDefs::cluskey clustKey = itClust    -> first;
+      TrkrCluster*      cluster  = m_clustMap -> findCluster(clustKey);
+
+      // grab cluster info
+      m_clustManager -> GetInfo(cluster, clustKey, m_actsGeom);
+
+    }  // end cluster loop
+  }  // end hit set loop
+  return;
+
+}  // end 'Process()'
+
+
+
+void TrksInJetQAInclusiveFiller::FillTrackQAHists() {
+
+  // loop over tracks
+  for (
+    SvtxTrackMap::Iter itTrk = m_trkMap -> begin();
+    itTrk != m_trkMap -> end();
+    ++itTrk
+  ) {
+
+    // grab track
+    SvtxTrack* track = itTrk -> second;
+
+    // grab info and fill histograms
+    m_trackManager -> GetInfo(track);
+
+  }  // end track loop
+  return;
+
+}  // end 'Process()'
+
+
+
+void TrksInJetQAInclusiveFiller::FillJetQAHists() {
+
+  // loop over jets
+  for (
+    uint64_t iJet = 0;
+    iJet < m_jetMap -> size();
+    ++iJet
+  ) {
+
+    // grab jet
+    Jet* jet = m_jetMap -> get_jet(iJet);
+
+    // grab info and fill histograms
+    m_jetManager -> GetInfo(jet);
+
+  }  // end jet loop
+  return;
+
+}  // end 'FillJetQAHists()'
+
+// end ------------------------------------------------------------------------
+

--- a/offline/QA/Jet/TrksInJetQAInclusiveFiller.h
+++ b/offline/QA/Jet/TrksInJetQAInclusiveFiller.h
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAInclusiveFiller.h'
+// Derek Anderson
+// 04.03.2024
+//
+// A submodule for the TrksInJetQA F4A module to produce
+// QA histograms for tracks and more in jets
+// ----------------------------------------------------------------------------
+
+#ifndef TRACKSINJETSQAMAKER_INCLUSIVEQAHISTFILLER_H
+#define TRACKSINJETSQAMAKER_INCLUSIVEQAHISTFILLER_H
+
+// c+ utilities
+#include <cassert>
+// phool libraries
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+// tracking libraries
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrHitSetContainer.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+// jet libraries
+#include <jetbase/Jet.h>
+#include <jetbase/JetContainer.h>
+// submodule definitions
+#include "TrksInJetQABaseFiller.h"
+
+
+
+// TrksInJetQAInclusiveFiller -------------------------------------------------
+
+class TrksInJetQAInclusiveFiller : public TrksInJetQABaseFiller {
+
+  public:
+
+    // ctor/dtor
+    using TrksInJetQABaseFiller::TrksInJetQABaseFiller;
+    ~TrksInJetQAInclusiveFiller() {};
+
+    // inherited public methods
+    void Fill(PHCompositeNode* topNode) override;
+
+  private:
+
+    // private methods
+    void FillHitQAHists();
+    void FillClustQAHists();
+    void FillTrackQAHists();
+    void FillJetQAHists();
+
+};  // end TrksInJetQAInclusiveFiller
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAInclusiveFiller.h
+++ b/offline/QA/Jet/TrksInJetQAInclusiveFiller.h
@@ -10,12 +10,9 @@
 #ifndef TRACKSINJETSQAMAKER_INCLUSIVEQAHISTFILLER_H
 #define TRACKSINJETSQAMAKER_INCLUSIVEQAHISTFILLER_H
 
-// c+ utilities
-#include <cassert>
-// phool libraries
-#include <phool/phool.h>
-#include <phool/getClass.h>
-#include <phool/PHCompositeNode.h>
+// submodule definitions
+#include "TrksInJetQABaseFiller.h"
+
 // tracking libraries
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrDefs.h>
@@ -29,9 +26,14 @@
 // jet libraries
 #include <jetbase/Jet.h>
 #include <jetbase/JetContainer.h>
-// submodule definitions
-#include "TrksInJetQABaseFiller.h"
 
+// phool libraries
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+
+// c+ utilities
+#include <cassert>
 
 
 // TrksInJetQAInclusiveFiller -------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAJetManager.cc
+++ b/offline/QA/Jet/TrksInJetQAJetManager.cc
@@ -1,0 +1,107 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAJetManager.cc'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module
+// to generate QA plots for jets
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQAJETMANAGER_CC
+
+// submodule definition
+#include "TrksInJetQAJetManager.h"
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQAJetManager::GetInfo(
+  Jet* jet,
+  std::optional<std::vector<SvtxTrack*>> tracks
+) {
+
+  // collect jet info
+  JetQAContent jetContent {
+    .eta    = jet -> get_eta(),
+    .phi    = jet -> get_phi(),
+    .pt     = jet -> get_pt(),
+    .nTrk   = 0,
+    .ptSum  = 0.
+  };
+
+  // if tracks are available, do calculations 
+  if (tracks.has_value()) {
+    for (SvtxTrack* track : tracks.value()) {
+
+      jetContent.nTrk++;
+      jetContent.ptSum += track -> get_pt();
+
+    }  // end track loop
+  }  // end if tracks.has_value
+
+  // fill histograms
+  FillHistograms(Type::All, jetContent);
+  return;
+
+}  // end 'Process(PHCompositeNode*)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQAJetManager::FillHistograms(const int type, JetQAContent& content) {
+
+  // fill 1d histograms
+  m_vecHist1D.at(type).at(H1D::Eta)   -> Fill(content.eta);
+  m_vecHist1D.at(type).at(H1D::Phi)   -> Fill(content.phi);
+  m_vecHist1D.at(type).at(H1D::Pt)    -> Fill(content.pt);
+  m_vecHist1D.at(type).at(H1D::NTrk)  -> Fill(content.nTrk);
+  m_vecHist1D.at(type).at(H1D::PtSum) -> Fill(content.ptSum);
+
+  // fill 2d histograms
+  m_vecHist2D.at(type).at(H2D::PtVsEta)   -> Fill(content.eta, content.pt);
+  m_vecHist2D.at(type).at(H2D::PtSumVsPt) -> Fill(content.pt, content.ptSum);
+  return;
+
+}  //  end 'FillHistograms(Type, JetQAContent&)'
+
+
+
+void TrksInJetQAJetManager::DefineHistograms() {
+
+  // grab binning schemes
+  std::vector<BinDef> vecBins = m_hist.GetVecHistBins();
+
+  // histogram labels
+  m_vecHistTypes.push_back( "All" );
+
+  // 1d histogram definitions
+  m_vecHistDef1D.push_back( std::make_tuple( "JetEta",   vecBins.at(TrksInJetQAHist::Var::Eta) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "JetPhi",   vecBins.at(TrksInJetQAHist::Var::Phi) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "JetPt",    vecBins.at(TrksInJetQAHist::Var::Ene) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "JetNTrks", vecBins.at(TrksInJetQAHist::Var::Num) ));
+  m_vecHistDef1D.push_back( std::make_tuple( "SumTrkPt", vecBins.at(TrksInJetQAHist::Var::Ene) ));
+
+  // 2d histogram definitions
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "JetPtVsEta",
+      vecBins.at(TrksInJetQAHist::Var::Eta),
+      vecBins.at(TrksInJetQAHist::Var::Ene)
+    )
+  );
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "SumTrkVsJetPt",
+      vecBins.at(TrksInJetQAHist::Var::Ene),
+      vecBins.at(TrksInJetQAHist::Var::Ene)
+    )
+  );
+  return;
+
+}  // end 'DefineHistograms()'
+
+// end ------------------------------------------------------------------------
+
+

--- a/offline/QA/Jet/TrksInJetQAJetManager.h
+++ b/offline/QA/Jet/TrksInJetQAJetManager.h
@@ -1,0 +1,69 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQAJetManager.h'
+// Derek Anderson
+// 03.26.2024
+//
+// A submodule for the TrksInJetQA module
+// to generate QA plots for jets
+// ----------------------------------------------------------------------------
+
+#ifndef TRACKSINJETSQAMAKER_JETQAHISTMANAGER_H
+#define TRACKSINJETSQAMAKER_JETQAHISTMANAGER_H
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
+#include <optional>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+// jet libraries
+#include <jetbase/Jet.h>
+// tracking libraries
+#include <trackbase_historic/SvtxTrack.h>
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+
+
+// TrksInJetQAJetManager definition -------------------------------------------
+
+class TrksInJetQAJetManager : public TrksInJetQABaseManager {
+
+  public:
+
+    // histogram accessors
+    enum Type {All};
+    enum H1D  {Eta, Phi, Pt, NTrk, PtSum};
+    enum H2D  {PtVsEta, PtSumVsPt};
+
+    // histogram content
+    struct JetQAContent {
+      double eta   = std::numeric_limits<double>::max();
+      double phi   = std::numeric_limits<double>::max();
+      double pt    = std::numeric_limits<double>::max();
+      double nTrk  = std::numeric_limits<double>::max();
+      double ptSum = std::numeric_limits<double>::max();
+    };
+
+    // ctor/dtor
+    using TrksInJetQABaseManager::TrksInJetQABaseManager;
+    ~TrksInJetQAJetManager() {};
+
+    // public methods
+    void GetInfo(Jet* jet, std::optional<std::vector<SvtxTrack*>> tracks = std::nullopt);
+
+  private:
+
+    // private methods
+    void FillHistograms(const int type, JetQAContent& content);
+
+    // inherited interal methods
+    void DefineHistograms() override;
+
+};  // end TrksInJetQAJetManager
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQAJetManager.h
+++ b/offline/QA/Jet/TrksInJetQAJetManager.h
@@ -10,20 +10,23 @@
 #ifndef TRACKSINJETSQAMAKER_JETQAHISTMANAGER_H
 #define TRACKSINJETSQAMAKER_JETQAHISTMANAGER_H
 
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+// jet includes
+#include <jetbase/Jet.h>
+// tracking includes
+#include <trackbase_historic/SvtxTrack.h>
+
+// root includes
+#include <TH1.h>
+#include <TH2.h>
+
 // c++ utilities
 #include <limits>
 #include <vector>
 #include <utility>
 #include <optional>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-// jet libraries
-#include <jetbase/Jet.h>
-// tracking libraries
-#include <trackbase_historic/SvtxTrack.h>
-// submodule definitions
-#include "TrksInJetQABaseManager.h"
 
 
 
@@ -49,7 +52,7 @@ class TrksInJetQAJetManager : public TrksInJetQABaseManager {
 
     // ctor/dtor
     using TrksInJetQABaseManager::TrksInJetQABaseManager;
-    ~TrksInJetQAJetManager() {};
+    virtual ~TrksInJetQAJetManager() override = default;
 
     // public methods
     void GetInfo(Jet* jet, std::optional<std::vector<SvtxTrack*>> tracks = std::nullopt);

--- a/offline/QA/Jet/TrksInJetQATrkManager.cc
+++ b/offline/QA/Jet/TrksInJetQATrkManager.cc
@@ -1,0 +1,89 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQATrkManager.cc'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module to generate
+// QA plots for tracks
+// ----------------------------------------------------------------------------
+
+#define TRKSINJETQATRKMANAGER_CC
+
+// submodule definition
+#include "TrksInJetQATrkManager.h"
+
+
+
+// public methods -------------------------------------------------------------
+
+void TrksInJetQATrkManager::GetInfo(SvtxTrack* track) {
+
+  // collect track info
+  TrackQAContent content = {
+    .eta  = track -> get_eta(),
+    .phi  = track -> get_phi(),
+    .pt   = track -> get_pt(),
+    .qual = track -> get_quality()
+  };
+
+  // fill histograms
+  FillHistograms(Type::All, content);
+  return;
+
+}  // end 'GetInfo(SvtxTrack*)'
+
+
+
+// private methods ------------------------------------------------------------
+
+void TrksInJetQATrkManager::FillHistograms(const int type, TrackQAContent& content) {
+
+  // fill 1d histograms
+  m_vecHist1D.at(type).at(H1D::Eta)  -> Fill(content.eta);
+  m_vecHist1D.at(type).at(H1D::Phi)  -> Fill(content.phi);
+  m_vecHist1D.at(type).at(H1D::Pt)   -> Fill(content.pt);
+  m_vecHist1D.at(type).at(H1D::Qual) -> Fill(content.qual);
+
+  // fill 2d histograms
+  m_vecHist2D.at(type).at(H2D::EtaVsPhi) -> Fill(content.phi, content.eta);
+  m_vecHist2D.at(type).at(H2D::PtVsQual) -> Fill(content.qual, content.pt);
+  return;
+
+}  //  end 'FillHistograms(Type, TrackQAContent&)'
+
+
+
+void TrksInJetQATrkManager::DefineHistograms() {
+
+  // grab binning schemes
+  std::vector<BinDef> vecBins = m_hist.GetVecHistBins();
+
+  // set histogram types
+  m_vecHistTypes.push_back( "All" );
+
+  // define 1d histograms
+  m_vecHistDef1D.push_back( std::make_tuple( "TrackEta",  vecBins.at(TrksInJetQAHist::Var::Eta)  ));
+  m_vecHistDef1D.push_back( std::make_tuple( "TrackPhi",  vecBins.at(TrksInJetQAHist::Var::Phi)  ));
+  m_vecHistDef1D.push_back( std::make_tuple( "TrackPt",   vecBins.at(TrksInJetQAHist::Var::Ene)  ));
+  m_vecHistDef1D.push_back( std::make_tuple( "TrackQual", vecBins.at(TrksInJetQAHist::Var::Qual) ));
+
+  // define 2d histograms
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "TrackEtaVsPhi",
+      vecBins.at(TrksInJetQAHist::Var::Phi),
+      vecBins.at(TrksInJetQAHist::Var::Eta)
+    )
+  );
+  m_vecHistDef2D.push_back(
+    std::make_tuple(
+      "TrackPtVsQual",
+      vecBins.at(TrksInJetQAHist::Var::Qual),
+      vecBins.at(TrksInJetQAHist::Var::Ene)
+    )
+  );
+  return;
+
+}  // end 'BuildHistograms()'
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQATrkManager.h
+++ b/offline/QA/Jet/TrksInJetQATrkManager.h
@@ -1,0 +1,67 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQATrkManager.h'
+// Derek Anderson
+// 03.25.2024
+//
+// A submodule for the TrksInJetQA module to generate
+// QA plots for tracks
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETQATRKMANAGER_H
+#define TRKSINJETQATRKMANAGER_H
+
+// c++ utilities
+#include <limits>
+#include <vector>
+#include <utility>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+// tracking libraries
+#include <trackbase_historic/SvtxTrack.h>
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+
+
+// TrksInJetQATrkManager definition -------------------------------------------
+
+class TrksInJetQATrkManager : public TrksInJetQABaseManager {
+
+  public:
+
+    // histogram accessors
+    //   - TODO split tracks into seed types
+    enum Type {All};
+    enum H1D  {Eta, Phi, Pt, Qual};
+    enum H2D  {EtaVsPhi, PtVsQual};
+
+    // histogram content
+    struct TrackQAContent {
+      double eta  = std::numeric_limits<double>::max();
+      double phi  = std::numeric_limits<double>::max();
+      double pt   = std::numeric_limits<double>::max();
+      double qual = std::numeric_limits<double>::max();
+    };
+
+    // ctor/dtor
+    using TrksInJetQABaseManager::TrksInJetQABaseManager;
+    ~TrksInJetQATrkManager() {};
+
+    // public methods
+    void GetInfo(SvtxTrack* track);
+
+  private:
+
+    // private methods
+    void FillHistograms(const int type, TrackQAContent& content);
+
+    // inherited private methods
+    void DefineHistograms() override;
+
+};  // end TrksInJetQATrkManager
+
+#endif
+
+// end ------------------------------------------------------------------------
+

--- a/offline/QA/Jet/TrksInJetQATrkManager.h
+++ b/offline/QA/Jet/TrksInJetQATrkManager.h
@@ -10,18 +10,20 @@
 #ifndef TRKSINJETQATRKMANAGER_H
 #define TRKSINJETQATRKMANAGER_H
 
+// submodule definitions
+#include "TrksInJetQABaseManager.h"
+
+// tracking includes
+#include <trackbase_historic/SvtxTrack.h>
+
+// root includes
+#include <TH1.h>
+#include <TH2.h>
+
 // c++ utilities
 #include <limits>
 #include <vector>
 #include <utility>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-// tracking libraries
-#include <trackbase_historic/SvtxTrack.h>
-// submodule definitions
-#include "TrksInJetQABaseManager.h"
-
 
 
 // TrksInJetQATrkManager definition -------------------------------------------

--- a/offline/QA/Jet/TrksInJetQATypes.h
+++ b/offline/QA/Jet/TrksInJetQATypes.h
@@ -1,0 +1,41 @@
+// ----------------------------------------------------------------------------
+// 'TrksInJetQATypes.h'
+// Derek Anderson
+// 04.30.2024
+//
+// Conveninent type definitions for the TrksInJetQA module.
+// ----------------------------------------------------------------------------
+
+#ifndef TRKSINJETSQATYPES_H
+#define TRKSINJETSQATYPES_H
+
+// c++ utilities
+#include <string>
+#include <vector>
+#include <utility>
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+// particle flow libraries
+#include <particleflowreco/ParticleFlowElement.h>
+#include <particleflowreco/ParticleFlowElementContainer.h>
+
+
+
+// type definitions -----------------------------------------------------------
+
+typedef std::pair<float, float>                 BinRange;
+typedef std::pair<uint32_t, BinRange>           BinDef;
+typedef std::tuple<std::string, BinDef>         HistDef1D;
+typedef std::tuple<std::string, BinDef, BinDef> HistDef2D;
+typedef std::vector<HistDef1D>                  VecHistDef1D;
+typedef std::vector<HistDef2D>                  VecHistDef2D;
+typedef std::vector<std::vector<TH1D*>>         VecHist1D;
+typedef std::vector<std::vector<TH2D*>>         VecHist2D;
+typedef std::vector<std::string>                VecHistTypes;
+typedef ParticleFlowElement                     PFObject;
+typedef ParticleFlowElementContainer            PFObjectStore;
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/TrksInJetQATypes.h
+++ b/offline/QA/Jet/TrksInJetQATypes.h
@@ -9,16 +9,18 @@
 #ifndef TRKSINJETSQATYPES_H
 #define TRKSINJETSQATYPES_H
 
+// particle flow libraries
+#include <particleflowreco/ParticleFlowElement.h>
+#include <particleflowreco/ParticleFlowElementContainer.h>
+
+// root libraries
+#include <TH1.h>
+#include <TH2.h>
+
 // c++ utilities
 #include <string>
 #include <vector>
 #include <utility>
-// root libraries
-#include <TH1.h>
-#include <TH2.h>
-// particle flow libraries
-#include <particleflowreco/ParticleFlowElement.h>
-#include <particleflowreco/ParticleFlowElementContainer.h>
 
 
 

--- a/offline/QA/Jet/autogen.sh
+++ b/offline/QA/Jet/autogen.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+(cd $srcdir; aclocal -I ${OFFLINE_MAIN}/share;\
+libtoolize --force; automake -a --add-missing; autoconf)
+
+$srcdir/configure "$@"

--- a/offline/QA/Jet/configure.ac
+++ b/offline/QA/Jet/configure.ac
@@ -1,0 +1,13 @@
+AC_INIT(jetqa,[1.00])
+AC_CONFIG_SRCDIR([configure.ac])
+
+AM_INIT_AUTOMAKE
+AC_PROG_CXX(CC g++)
+LT_INIT([disable-static])
+
+if test $ac_cv_prog_gxx = yes; then
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror -Wshadow"
+fi
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
This PR adds a QA module which accumulates histograms for tracks and their constituent clusters and hits both in jets and inclusively. The code is designed to be flexible with respect to inputs (it will work for jets made from tracks, particle flow elements, calorimeter towers/clusters, or any combination of them) and easy to extend with respect to outputs (additional histograms are easily generated for different populations of jets, tracks, etc.).

Furthermore, the module can be run both as a plain `SubsysReco` with output being written to a specified file, or with histograms being handled by the QA Histogram Manager.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds a new feature, and the module was developed as part of the Jet Structure QA workfest. A macro illustrating usage of the module and a README with further information about the structure of the code can be found in the analysis repo at:

https://github.com/sPHENIX-Collaboration/analysis/tree/master/JS-Jet/TrackJetQAMaker

## TODOs (if applicable)

The exact suite of histograms and which populations of jets, tracks, clusters, and hits to be written out will need to be decided on by the Jet Structure and Tracking Software groups.

There are also some clear areas for improvement (most of which are commented on in the code):
 - Matching non-constituent tracks to jets is currently done geometrically based on the specified resolution parameter, but this should be done either using the actual jet area (which isn't necessarily pi*R_{jet}^2) or by matching tracks to constituent  calorimeter towers/clusters;
 - Raw pointers are used in several places which should be smart pointers;
 - And additional debugging output should be added to the components outside of the top-level Fun4All module.
