### PR TITLE
Temp remedy for ZS data for production

### DIFF
--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -161,7 +161,10 @@ void SingleTpcPoolInput::FillPool(const unsigned int /*nbclks*/)
 
         // samples
         const uint16_t samples = packet->iValue(wf, "SAMPLES");
-        newhit->set_samples(samples);
+        //newhit->set_samples(samples);
+
+	// Temp remedy as we set the time window as 360 for now
+        newhit->set_samples(360);
 
         // adc values
         for (uint16_t is = 0; is < samples; ++is)
@@ -169,8 +172,11 @@ void SingleTpcPoolInput::FillPool(const unsigned int /*nbclks*/)
           uint16_t adval = packet->iValue(wf, is);
 
           // This is temporary fix for decoder change. Will be changed again for real ZS data decoding.
-          if(adval >= 64000){ newhit->set_samples(is); break;}
-          newhit->set_adc(is, adval);
+          //if(adval >= 64000){ newhit->set_samples(is); break;}
+ 
+          // With this, the hit is unseen from clusterizer
+          if(adval >= 64000) newhit->set_adc(is,0);
+          else newhit->set_adc(is, adval);
         }
 
         m_BeamClockFEE[gtm_bco].insert(FEE);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Temp remedy was added for production of zero-suppression data.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

The data looks almost same as non-ZS data, except for those time samples that
are not existing are set to zero.

## Links to other PRs in macros and calibration repositories (if applicable)

