### PR TITLE
MBD: added on the fly sampmax calib for runs where it doesn't exist

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -133,6 +133,7 @@ int MbdCalib::Download_All()
   }
 #endif
 
+  // download local calibs (text versions)
   if ( bbc_caldir.size() > 0 )
   {
     std::string sampmax_file = bbc_caldir + "/mbd_sampmax.calib";

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -33,16 +33,16 @@ class MbdCalib
   float get_tt0(const int ipmt) const { return _ttfit_t0mean[ipmt]; }
   float get_ped(const int ifeech) const { return _pedmean[ifeech]; }
   float get_pedrms(const int ifeech) const { return _pedsigma[ifeech]; }
-  int get_sampmax(const int ifeech) const { return _sampmax[ifeech]; }
+  int   get_sampmax(const int ifeech) const { return _sampmax[ifeech]; }
   float get_tcorr(const int ifeech, const int tdc) const {
     if (tdc<0)
     {
-      std::cout << "bad tdc " << ifeech << " " << tdc << std::endl;
+      //std::cout << "bad tdc " << ifeech << " " << tdc << std::endl;
       return _tcorr_y_interp[ifeech][0];
     }
     if (tdc>=_tcorr_maxrange[ifeech])
     {
-      std::cout << "bad tdc " << ifeech << " " << tdc << " " << _tcorr_maxrange[ifeech] << std::endl;
+      //std::cout << "bad tdc " << ifeech << " " << tdc << " " << _tcorr_maxrange[ifeech] << std::endl;
       return _tcorr_y_interp[ifeech][_tcorr_maxrange[ifeech]-1];
     }
     //std::cout << "aaa " << _tcorr_y_interp[ifeech].size() << std::endl;
@@ -52,12 +52,12 @@ class MbdCalib
     if ( _scorr_y_interp[ifeech].size() == 0 ) return 0.; // return 0 if calib doesn't exist
     if (adc<0)
     {
-      std::cout << "bad adc " << ifeech << " " << adc << std::endl;
+      //std::cout << "bad adc " << ifeech << " " << adc << std::endl;
       return _scorr_y_interp[ifeech][0];
     }
     if (adc>=_scorr_maxrange[ifeech])
     {
-      //std::cout << "bad adc " << ifeech << " " << adc << std::endl;
+      //std::cout << "high adc " << ifeech << " " << adc << std::endl;
       return _scorr_y_interp[ifeech][_scorr_maxrange[ifeech]-1];
     }
     return _scorr_y_interp[ifeech][adc];
@@ -109,7 +109,7 @@ class MbdCalib
   void Reset();
   // void Print(Option_t* option) const;
 
-  int Verbosity() { return _verbose; }
+  int  Verbosity()            { return _verbose; }
   void Verbosity(const int v) { _verbose = v; }
 
  private:
@@ -153,7 +153,7 @@ class MbdCalib
   std::array<float, MbdDefs::MBD_N_FEECH> _pedsigma{};
   std::array<float, MbdDefs::MBD_N_FEECH> _pedsigmaerr{};
 
-  // Peak of waveform
+  // SampMax (Peak of waveform)
   std::array<int, MbdDefs::MBD_N_FEECH> _sampmax{};
 
   // Waveform Template

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -98,8 +98,9 @@ class MbdEvent
   int _runnum{0};
   int _simflag{0};
   int _nsamples{31};
-  int _calib_done{0};
-  int _is_online{0};
+  int _calib_done{0}; 
+  int _no_sampmax{0};     //! sampmax calib doesn't exist
+  int _is_online{0};      //! for OnlMon
 
   int ProcessRawPackets(MbdPmtContainer *mbdpmts);
 
@@ -133,7 +134,7 @@ class MbdEvent
   Float_t m_bbczerr{std::numeric_limits<Float_t>::quiet_NaN()};   // z-vertex error
   Float_t m_bbct0{std::numeric_limits<Float_t>::quiet_NaN()};     // start time
   Float_t m_bbct0err{std::numeric_limits<Float_t>::quiet_NaN()};  // start time error
-  Float_t _tres = std::numeric_limits<Float_t>::quiet_NaN();      // time resolution of one channel
+  Float_t _tres{std::numeric_limits<Float_t>::quiet_NaN()};       // time resolution of one channel
 
   TH1 *hevt_bbct[2]{};  // time in each bbc, per event
   TF1 *gausfit[2]{nullptr, nullptr};

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -73,11 +73,11 @@ int MbdReco::process_event(PHCompositeNode *topNode)
     int status = Fun4AllReturnCodes::ABORTEVENT;
     if ( m_event!=nullptr )
     {
-      m_mbdevent->SetRawData(m_event, m_mbdpmts);
+      status = m_mbdevent->SetRawData(m_event, m_mbdpmts);
     }
     else if ( m_mbdraw!=nullptr )
     {
-      m_mbdevent->SetRawData(m_mbdraw, m_mbdpmts);
+      status = m_mbdevent->SetRawData(m_mbdraw, m_mbdpmts);
     }
 
     if (status == Fun4AllReturnCodes::ABORTEVENT)
@@ -85,6 +85,10 @@ int MbdReco::process_event(PHCompositeNode *topNode)
       return Fun4AllReturnCodes::ABORTEVENT;  // there wasn't good data in BBC/MBD
     }
     else if (status == Fun4AllReturnCodes::DISCARDEVENT)
+    {
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+    else if (status == -1001)
     {
       return Fun4AllReturnCodes::DISCARDEVENT;
     }

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -507,6 +507,11 @@ void MbdSig::CalcEventPed0_PreSamp(const int presample, const int nsamps)
   double mean = ped0stats->Mean();
   //double rms = ped0stats->RMS();
   double rms = _mbdcal->get_pedrms(_ch);
+  if ( isnan(rms) )
+  {
+    // ped calib doesn't exist, set to average
+    rms = 5.0;
+  }
 
   ped_fcn->SetRange(minsamp-0.1,maxsamp+0.1);
   ped_fcn->SetParameter(0,1500.);
@@ -559,11 +564,11 @@ void MbdSig::CalcEventPed0_PreSamp(const int presample, const int nsamps)
     // ped fit was bad, we have signal contamination in ped region
     // or other thing going on
 
-    if ( ped0stats->Size() < ped0stats->MaxNum() ) // use pre-calib for early events
+    if ( ped0stats->Size() < ped0stats->MaxNum() && !isnan(_mbdcal->get_ped(_ch)) ) // use pre-calib for early events
     {
       mean = _mbdcal->get_ped(_ch);
     }
-    else  // use running mean, once enough stats are accumulated
+    else  // use running mean, once enough stats are accumulated, or if no pre-calib pedestals
     {
       mean = ped0stats->Mean();
 

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -507,7 +507,7 @@ void MbdSig::CalcEventPed0_PreSamp(const int presample, const int nsamps)
   double mean = ped0stats->Mean();
   //double rms = ped0stats->RMS();
   double rms = _mbdcal->get_pedrms(_ch);
-  if ( isnan(rms) )
+  if ( std::isnan(rms) )
   {
     // ped calib doesn't exist, set to average
     rms = 5.0;
@@ -564,7 +564,7 @@ void MbdSig::CalcEventPed0_PreSamp(const int presample, const int nsamps)
     // ped fit was bad, we have signal contamination in ped region
     // or other thing going on
 
-    if ( ped0stats->Size() < ped0stats->MaxNum() && !isnan(_mbdcal->get_ped(_ch)) ) // use pre-calib for early events
+    if ( ped0stats->Size() < ped0stats->MaxNum() && !std::isnan(_mbdcal->get_ped(_ch)) ) // use pre-calib for early events
     {
       mean = _mbdcal->get_ped(_ch);
     }


### PR DESCRIPTION
[comment]: Added a new feature where, if the sampmax calib doesn't exist, the reco will determine it from the first 1000 events (and discardevent).  After that, all will be as usual.  This requires that the other calibrations that are not run-dependent exist.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: In principle, one should run a calibration pass, then do the production.  But if the production is done first, this will allow the production to bootstrap itself, even if the run-to-run MBD calibrations don't exist.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

