### PR TITLE
fix: suppress verbosity

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -232,9 +232,12 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     auto hit = hitset_it->second->getHit(hitkey);
     if (hit)
     {
+      if(Verbosity() > 1)
+	{
       std::cout << PHWHERE << "::" << __func__
                 << " - duplicated hit, hitsetkey: " << hitsetkey
                 << " hitkey: " << hitkey << std::endl;
+	}
       continue;
     }
 


### PR DESCRIPTION
Branches got mixed up, this one juts suppresses the mvtx unpacker verbosity 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

