### PR TITLE
limit clockdiff printouts to 1k

### DIFF
--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -90,18 +90,23 @@ int ClockDiffCheck::process_event(PHCompositeNode *topNode)
       {
 	if ((refdiff&0xFFFFFFFFU) != (std::get<2>(iter.second)&0xFFFFFFFFU))
 	{
-	  std::bitset<32> x(refdiff);
-	  std::bitset<32> y0(std::get<0>(iter.second));
-	  std::bitset<32> y1(std::get<1>(iter.second));
-	  std::bitset<32> y2(std::get<2>(iter.second));
-	  std::cout << "packet " << iter.first << " had different clock diff: 0x" << std::hex
-		    <<  std::get<1>(iter.second) << ", ref diff: 0x" << refdiff << std::dec << std::endl;
+	  static int nprint = 0;
+	  if (nprint < 1000 || Verbosity() > 1)
+	  {
+	    std::bitset<32> x(refdiff);
+	    std::bitset<32> y0(std::get<0>(iter.second));
+	    std::bitset<32> y1(std::get<1>(iter.second));
+	    std::bitset<32> y2(std::get<2>(iter.second));
+	    std::cout << "packet " << iter.first << " had different clock diff: 0x" << std::hex
+		      <<  std::get<1>(iter.second) << ", ref diff: 0x" << refdiff << std::dec << std::endl;
 
-	  std::cout << "reff: " << x << std::endl;
-	  std::cout << "this: " << y2 << std::endl;
+	    std::cout << "reff: " << x << std::endl;
+	    std::cout << "this: " << y2 << std::endl;
 
-	  std::cout << "prev: " << y0 << std::endl;
-	  std::cout << "curr: " << y1 << std::endl;
+	    std::cout << "prev: " << y0 << std::endl;
+	    std::cout << "curr: " << y1 << std::endl;
+	    nprint++;
+	  }
 	}
       }
     }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
the clock diff check just prints out too much, and it's likely a false positive after some unhandled rollover

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

