### PR TITLE
Add TNtuple to track progress of seeding

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -8,6 +8,9 @@
  *  \author Michael Peters & Christof Roland
  */
 
+// Statement for if we want to save out the intermediary clustering steps
+/* #define _CLUSTER_LOG_TUPOUT_ */
+
 // begin
 
 #include "ALICEKF.h"
@@ -40,6 +43,11 @@
 #include <unordered_set>
 #include <utility>  // for pair
 #include <vector>   // for vector
+
+#if defined(_CLUSTER_LOG_TUPOUT_)
+#include <TFile.h>
+#include <TNtuple.h>
+#endif
 
 class PHCompositeNode;
 class PHTimer;
@@ -117,6 +125,18 @@ class PHCASeeding : public PHTrackSeeding
   int End() override;
 
  private:
+  bool _save_clus_proc = false;
+
+#if defined(_CLUSTER_LOG_TUPOUT_)
+  TFile* _f_clustering_process;
+  int      _nevent=-1;
+  TNtuple* _tupclus_all; // save the steps of the clustering
+  TNtuple* _tupclus_links; // save the steps of the clustering
+  TNtuple* _tupclus_bilinks; // save the steps of the clustering
+  TNtuple* _tupclus_seeds; // save the steps of the clustering
+  TNtuple* _tupclus_grown_seeds; // save the steps of the clustering
+#endif
+
   enum skip_layers
   {
     on,

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -128,13 +128,14 @@ class PHCASeeding : public PHTrackSeeding
   bool _save_clus_proc = false;
 
 #if defined(_CLUSTER_LOG_TUPOUT_)
-  TFile* _f_clustering_process;
+  TFile* _f_clustering_process = nullptr;
   int      _nevent=-1;
-  TNtuple* _tupclus_all; // save the steps of the clustering
-  TNtuple* _tupclus_links; // save the steps of the clustering
-  TNtuple* _tupclus_bilinks; // save the steps of the clustering
-  TNtuple* _tupclus_seeds; // save the steps of the clustering
-  TNtuple* _tupclus_grown_seeds; // save the steps of the clustering
+  // Save the steps of the clustering
+  TNtuple* _tupclus_all = nullptr;    // all clusters
+  TNtuple* _tupclus_links = nullptr; //  clusters which are linked
+  TNtuple* _tupclus_bilinks = nullptr; // bi-linked clusters
+  TNtuple* _tupclus_seeds = nullptr; // seed (outermost three bi-linked chain
+  TNtuple* _tupclus_grown_seeds = nullptr; // seeds saved out
 #endif
 
   enum skip_layers


### PR DESCRIPTION
All changes are at the pre-processer level, controlled by a `#define _CLUSTER_LOG_TUPOUT_` 
variable that can be uncommented prior to compiling. Without this un-commenting, this PR makes
no changes to the code. It will, however, be helpful with diagnosing changes and effects in the
PHCASeeding code.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

