### PR TITLE
xingshift - match general unfilled bunches

### DIFF
--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -49,6 +49,7 @@ XingShiftCal::~XingShiftCal()
 int XingShiftCal::Init(PHCompositeNode * /*topNode*/)
 {
   std::cout << "XingShiftCal::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -58,7 +59,6 @@ int XingShiftCal::InitRun(PHCompositeNode * /*topNode*/)
 
   recoConsts *rc = recoConsts::instance();
   runnumber = rc->get_IntFlag("RUNNUMBER");
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -113,6 +113,7 @@ int XingShiftCal::process_event(PHCompositeNode *topNode)
     {
       for (int i = 0; i < 360; i += 3)
       {
+	blueFillPattern[i / 3] = pBlueIntPattern->iValue(i);
         if (pBlueIntPattern->iValue(i))
         {
           blueSpinPattern[i / 3] = pBluePolPattern->iValue(i);
@@ -130,6 +131,7 @@ int XingShiftCal::process_event(PHCompositeNode *topNode)
     {
       for (int i = 0; i < 360; i += 3)
       {
+	yellFillPattern[i / 3] = pYellIntPattern->iValue(i);
         if (pYellIntPattern->iValue(i))
         {
           yellSpinPattern[i / 3] = pYellPolPattern->iValue(i);
@@ -308,9 +310,13 @@ int XingShiftCal::CalculateCrossingShift(int &xing, uint64_t counts[NTRIG][NBUNC
     for (int ishift = 0; ishift < NBUNCHES; ishift++)
     {
       long long abort_sum = 0;
-      for (int iabortbunch = NBUNCHES - 9; iabortbunch < NBUNCHES; iabortbunch++)
+      for (int iunfillbunch = 0; iunfillbunch < NBUNCHES; iunfillbunch++)
       {
-	int shiftbunch = iabortbunch - ishift;
+	if (blueFillPattern[iunfillbunch] && yellFillPattern[iunfillbunch])
+	{
+	  continue;
+	}
+	int shiftbunch = iunfillbunch - ishift;
 	if (shiftbunch < 0)
 	{
 	  shiftbunch = 120 + shiftbunch;

--- a/calibrations/xingshift/XingShiftCal.h
+++ b/calibrations/xingshift/XingShiftCal.h
@@ -83,6 +83,8 @@ class XingShiftCal : public SubsysReco
 
   int blueSpinPattern[NBUNCHES]{0};
   int yellSpinPattern[NBUNCHES]{0};
+  int blueFillPattern[NBUNCHES]{0};
+  int yellFillPattern[NBUNCHES]{0};
 
   float polBlue{0};
   float polBlueErr{0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR expands the capability of the crossing shift calculation to match all unfilled bunches instead of relying only on the abort gap. This can be useful for fills with less than 111 bunches.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

