### PR TITLE
feat: more track diagnostic tools

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -23,6 +23,7 @@
 
 #include <mvtx/CylinderGeom_Mvtx.h>
 
+#include <trackbase_historic/TrackAnalysisUtils.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
@@ -267,7 +268,11 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     m_pcax = track->get_x();
     m_pcay = track->get_y();
     m_pcaz = track->get_z();
-
+    Acts::Vector3 zero = Acts::Vector3::Zero();
+    auto dcapair = TrackAnalysisUtils::get_dca(track, zero);
+    m_dcaxy = dcapair.first.first;
+    m_dcaz = dcapair.second.first;
+   
     clearClusterStateVectors();
     if (Verbosity() > 1)
     {
@@ -1203,6 +1208,8 @@ void TrackResiduals::createBranches()
   m_tree->Branch("R", &m_R, "m_R/F");
   m_tree->Branch("X0", &m_X0, "m_X0/F");
   m_tree->Branch("Y0", &m_Y0, "m_Y0/F");
+  m_tree->Branch("dcaxy", &m_dcaxy, "m_dcaxy/F");
+  m_tree->Branch("dcaz", &m_dcaz, "m_dcaz/F");
 
   m_tree->Branch("cluskeys", &m_cluskeys);
   m_tree->Branch("clusedge", &m_clusedge);

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -23,14 +23,14 @@
 
 #include <mvtx/CylinderGeom_Mvtx.h>
 
-#include <trackbase_historic/TrackAnalysisUtils.h>
 #include <trackbase_historic/ActsTransformations.h>
-#include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
+#include <trackbase_historic/TrackAnalysisUtils.h>
 #include <trackbase_historic/TrackSeed.h>
+#include <trackbase_historic/TrackSeedContainer.h>
 
 #include <ffarawobjects/Gl1RawHit.h>
 
@@ -227,7 +227,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     clearClusterStateVectors();
     fillClusterTree(clustermap, geometry);
   }
-  
+
   std::set<unsigned int> tpc_seed_ids;
 
   for (const auto& [key, track] : *trackmap)
@@ -278,12 +278,11 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     auto dcapair = TrackAnalysisUtils::get_dca(track, zero);
     m_dcaxy = dcapair.first.first;
     m_dcaz = dcapair.second.first;
-   
 
     auto tpcseed = track->get_tpc_seed();
-    if(tpcseed)
+    if (tpcseed)
     {
-    tpc_seed_ids.insert(tpcseedmap->find(tpcseed));
+      tpc_seed_ids.insert(tpcseedmap->find(tpcseed));
     }
     auto silseed = track->get_silicon_seed();
     std::cout << "silseed check" << std::endl;
@@ -293,7 +292,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       m_seedy = silseed->get_y();
       m_seedz = silseed->get_z();
     }
-    else if(tpcseed)
+    else if (tpcseed)
     {
       m_seedx = tpcseed->get_x();
       m_seedy = tpcseed->get_y();
@@ -309,7 +308,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
         qor = tpcseed->get_qOverR();
         phi = tpcseed->get_phi();
       }
-      else if(silseed)
+      else if (silseed)
       {
         qor = silseed->get_qOverR();
         phi = silseed->get_phi();
@@ -325,11 +324,11 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       std::cout << "nonzf" << std::endl;
       if (tpcseed)
       {
-      m_seedpx = tpcseed->get_px();
-      m_seedpy = tpcseed->get_py();
-      m_seedpz = tpcseed->get_pz();
+        m_seedpx = tpcseed->get_px();
+        m_seedpy = tpcseed->get_py();
+        m_seedpz = tpcseed->get_pz();
       }
-      else if(silseed)
+      else if (silseed)
       {
         m_seedpx = silseed->get_px();
         m_seedpy = silseed->get_py();
@@ -348,9 +347,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       std::vector<TrkrDefs::cluskey> keys;
       for (const auto& ckey : get_cluster_keys(track))
       {
-     
-          keys.push_back(ckey);
-        
+        keys.push_back(ckey);
       }
       if (m_zeroField)
       {
@@ -362,7 +359,6 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       }
       for (const auto& ckey : get_cluster_keys(track))
       {
-
         fillClusterBranches(ckey, track, topNode);
       }
     }
@@ -418,7 +414,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   }
 
   fillVertexTree(topNode);
-  if(m_doFailedSeeds)
+  if (m_doFailedSeeds)
   {
     fillFailedSeedTree(topNode, tpc_seed_ids);
   }
@@ -426,7 +422,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void TrackResiduals::fillFailedSeedTree(PHCompositeNode *topNode, std::set<unsigned int>& tpc_seed_ids)
+void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsigned int>& tpc_seed_ids)
 {
   auto tpcseedmap = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
   auto trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trackMapName);
@@ -441,15 +437,15 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode *topNode, std::set<unsig
     return;
   }
 
-  for(const auto& seed : *svtxseedmap)
+  for (const auto& seed : *svtxseedmap)
   {
-    if(!seed)
+    if (!seed)
     {
       continue;
     }
     m_trackid = svtxseedmap->find(seed);
     auto tpcseedindex = seed->get_tpc_seed_index();
-    if(tpc_seed_ids.find(tpcseedindex) != tpc_seed_ids.end())
+    if (tpc_seed_ids.find(tpcseedindex) != tpc_seed_ids.end())
     {
       continue;
     }
@@ -492,53 +488,54 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode *topNode, std::set<unsig
     clearClusterStateVectors();
     for (auto tseed : {silseed, tpcseed})
     {
-      if(!tseed)
+      if (!tseed)
       {
         continue;
       }
-    for (auto it = tseed->begin_cluster_keys(); it != tseed->end_cluster_keys(); ++it)
-    {
-      auto ckey = *it;
-      auto cluster = clustermap->findCluster(ckey);
-      auto global = geometry->getGlobalPosition(ckey, cluster);
-      auto local = geometry->getLocalCoords(ckey, cluster);
-      m_cluslx.push_back(local.x());
-      m_cluslz.push_back(local.y());
-      m_clusgx.push_back(global.x());
-      m_clusgy.push_back(global.y());
-      m_clusgz.push_back(global.z());
-      float cr = r(global.x(), global.y());
-      if(global.y() < 0) {
-        cr = -cr;
-      }
-      m_clusgr.push_back(cr);
-      auto detid = TrkrDefs::getTrkrId(ckey);
-      if (detid == TrkrDefs::TrkrId::mvtxId)
+      for (auto it = tseed->begin_cluster_keys(); it != tseed->end_cluster_keys(); ++it)
       {
-        m_nmaps++;
-      }
-      else if (detid == TrkrDefs::TrkrId::inttId)
-      {
-        m_nintt++;
-      }
-      else if (detid == TrkrDefs::TrkrId::tpcId)
-      {
-        m_ntpc++;
-      }
-      else if (detid == TrkrDefs::TrkrId::micromegasId)
-      {
-        m_nmms++;
+        auto ckey = *it;
+        auto cluster = clustermap->findCluster(ckey);
+        auto global = geometry->getGlobalPosition(ckey, cluster);
+        auto local = geometry->getLocalCoords(ckey, cluster);
+        m_cluslx.push_back(local.x());
+        m_cluslz.push_back(local.y());
+        m_clusgx.push_back(global.x());
+        m_clusgy.push_back(global.y());
+        m_clusgz.push_back(global.z());
+        float cr = r(global.x(), global.y());
+        if (global.y() < 0)
+        {
+          cr = -cr;
+        }
+        m_clusgr.push_back(cr);
+        auto detid = TrkrDefs::getTrkrId(ckey);
+        if (detid == TrkrDefs::TrkrId::mvtxId)
+        {
+          m_nmaps++;
+        }
+        else if (detid == TrkrDefs::TrkrId::inttId)
+        {
+          m_nintt++;
+        }
+        else if (detid == TrkrDefs::TrkrId::tpcId)
+        {
+          m_ntpc++;
+        }
+        else if (detid == TrkrDefs::TrkrId::micromegasId)
+        {
+          m_nmms++;
+        }
       }
     }
-    }
-      m_failedfits->Fill();
+    m_failedfits->Fill();
   }
 }
 void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
 {
   auto svtxvertexmap = findNode::getClass<SvtxVertexMap>(topNode, "SvtxVertexMap");
   auto trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trackMapName);
-  auto geometry = findNode::getClass<ActsGeometry>(topNode,"ActsGeometry");
+  auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
   auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (svtxvertexmap)
   {
@@ -568,7 +565,8 @@ void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
           m_clusgy.push_back(clusglob.y());
           m_clusgz.push_back(clusglob.z());
           float clusr = r(clusglob.x(), clusglob.y());
-          if(clusglob.y() < 0) {
+          if (clusglob.y() < 0)
+          {
             clusr = -clusr;
           }
           m_clusgr.push_back(clusr);
@@ -613,7 +611,7 @@ void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
     }
 
     // exclude silicon and tpot clusters for now
-    if (fabs(clusr) > 80 || fabs(clusr) < 30)
+    if (fabs(clusr) > 80 || (m_linefitTPCOnly && fabs(clusr) < 20.))
     {
       continue;
     }
@@ -624,11 +622,22 @@ void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
 
   m_xyint = std::numeric_limits<float>::quiet_NaN();
   m_xyslope = std::numeric_limits<float>::quiet_NaN();
-  m_R = fitpars[0];
-  m_X0 = fitpars[1];
-  m_Y0 = fitpars[2];
-  m_rzslope = fitpars[3];
-  m_rzint = fitpars[4];
+  if (fitpars.size() > 0)
+  {
+    m_R = fitpars[0];
+    m_X0 = fitpars[1];
+    m_Y0 = fitpars[2];
+    m_rzslope = fitpars[3];
+    m_rzint = fitpars[4];
+  }
+  else
+  {
+    m_R = std::numeric_limits<float>::quiet_NaN();
+    m_X0 = std::numeric_limits<float>::quiet_NaN();
+    m_Y0 = std::numeric_limits<float>::quiet_NaN();
+    m_rzslope = std::numeric_limits<float>::quiet_NaN();
+    m_rzint = std::numeric_limits<float>::quiet_NaN();
+  }
 }
 
 void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
@@ -648,12 +657,12 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
     }
 
     // exclude 1d tpot clusters for now
-    
-    if (fabs(clusr) > 80 || (m_linefitTPCOnly && fabs(clusr)<20.))
+
+    if (fabs(clusr) > 80 || (m_linefitTPCOnly && fabs(clusr) < 20.))
     {
       continue;
     }
-    
+
     rzpoints.push_back(std::make_pair(pos.z(), clusr));
     xypoints.push_back(std::make_pair(pos.x(), pos.y()));
     yzpoints.push_back(std::make_pair(pos.z(), pos.y()));
@@ -673,7 +682,6 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
 void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
                                      ActsGeometry* geometry)
 {
-
   for (auto& det : {TrkrDefs::TrkrId::mvtxId, TrkrDefs::TrkrId::inttId,
                     TrkrDefs::TrkrId::tpcId, TrkrDefs::TrkrId::micromegasId})
   {
@@ -1049,7 +1057,7 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   m_cluselz.push_back(sqrt(para_errors.second));
   m_clusgx.push_back(clusglob.x());
   m_clusgy.push_back(clusglob.y());
-  m_clusgr.push_back(clusglob.y() > 0 ? clusr : -1*clusr);
+  m_clusgr.push_back(clusglob.y() > 0 ? clusr : -1 * clusr);
   m_clusgz.push_back(clusglob.z());
   m_clusAdc.push_back(cluster->getAdc());
   m_clusMaxAdc.push_back(cluster->getMaxAdc());
@@ -1287,12 +1295,12 @@ void TrackResiduals::createBranches()
   m_failedfits->Branch("nintt", &m_nintt, "m_nintt/I");
   m_failedfits->Branch("ntpc", &m_ntpc, "m_ntpc/I");
   m_failedfits->Branch("nmms", &m_nmms, "m_nmms/I");
-  m_failedfits->Branch("gx",&m_clusgx);
-  m_failedfits->Branch("gy",&m_clusgy);
-  m_failedfits->Branch("gz",&m_clusgz);
+  m_failedfits->Branch("gx", &m_clusgx);
+  m_failedfits->Branch("gy", &m_clusgy);
+  m_failedfits->Branch("gz", &m_clusgz);
   m_failedfits->Branch("gr", &m_clusgr);
   m_failedfits->Branch("lx", &m_cluslx);
-  m_failedfits->Branch("lz",&m_cluslz);
+  m_failedfits->Branch("lz", &m_cluslz);
 
   m_vertextree = new TTree("vertextree", "tree with vertices");
   m_vertextree->Branch("run", &m_runnumber, "m_runnumber/I");
@@ -1380,13 +1388,13 @@ void TrackResiduals::createBranches()
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_tree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
-  m_tree->Branch("seedpx",&m_seedpx, "m_seedpx/F");
+  m_tree->Branch("seedpx", &m_seedpx, "m_seedpx/F");
   m_tree->Branch("seedpy", &m_seedpy, "m_seedpy/F");
   m_tree->Branch("seedpz", &m_seedpz, "m_seedpz/F");
   m_tree->Branch("seedx", &m_seedx, "m_seedx/F");
   m_tree->Branch("seedy", &m_seedy, "m_seedy/F");
   m_tree->Branch("seedz", &m_seedz, "m_seedz/F");
-  m_tree->Branch("seedcharge",&m_seedcharge,"m_seedcharge/I");
+  m_tree->Branch("seedcharge", &m_seedcharge, "m_seedcharge/I");
   m_tree->Branch("px", &m_px, "m_px/F");
   m_tree->Branch("py", &m_py, "m_py/F");
   m_tree->Branch("pz", &m_pz, "m_pz/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -129,7 +129,9 @@ class TrackResiduals : public SubsysReco
   float m_R = std::numeric_limits<float>::quiet_NaN();
   float m_X0 = std::numeric_limits<float>::quiet_NaN();
   float m_Y0 = std::numeric_limits<float>::quiet_NaN();
-
+  float m_dcaxy = std::numeric_limits<float>::quiet_NaN();
+  float m_dcaz = std::numeric_limits<float>::quiet_NaN();
+  
   //! hit tree info
   uint32_t m_hitsetkey = std::numeric_limits<uint32_t>::quiet_NaN();
   float m_hitgx = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -158,14 +158,15 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
         svtxtrack->set_charge(tpcseed->get_qOverR() > 0 ? 1 : -1);
         if (m_fieldMap.find(".root") != std::string::npos)
         {
-          svtxtrack->set_px(tpcseed->get_px(m_clusters, m_tGeometry));
-          svtxtrack->set_py(tpcseed->get_py(m_clusters, m_tGeometry));
-          svtxtrack->set_pz(tpcseed->get_pz());
+        
+          svtxtrack->set_px(trackSeed->get_pt() * std::cos(trackSeed->get_phi()));
+          svtxtrack->set_py(trackSeed->get_pt() * std::sin(trackSeed->get_phi()));
+          svtxtrack->set_pz(trackSeed->get_pz());
         }
         else
         {
-          float pt = fabs(1. / tpcseed->get_qOverR()) * (0.3 / 100) * std::stod(m_fieldMap);
-          float phi = tpcseed->get_phi(m_clusters, m_tGeometry);
+          float pt = fabs(1. / tpcseed->get_qOverR()) * (0.3 / 100) * fieldstrength;
+          float phi = tpcseed->get_phi();
           svtxtrack->set_px(pt * std::cos(phi));
           svtxtrack->set_py(pt * std::sin(phi));
           svtxtrack->set_pz(pt * std::cosh(tpcseed->get_eta()) * std::cos(tpcseed->get_theta()));
@@ -273,8 +274,9 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
       }
       else
       {
-        svtxtrack->set_px(trackSeed->get_px(m_clusters, m_tGeometry));
-        svtxtrack->set_py(trackSeed->get_py(m_clusters, m_tGeometry));
+     
+        svtxtrack->set_px(trackSeed->get_pt() * std::cos(trackSeed->get_phi()));
+        svtxtrack->set_py(trackSeed->get_pt() * std::sin(trackSeed->get_phi()));
         svtxtrack->set_pz(trackSeed->get_pz());
       }
 

--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -370,7 +370,7 @@ void TrackSeedTrackMapConverter::lineFit(SvtxTrack_v4* track, TrackSeed* seed)
   Acts::Vector3 mom(std::cos(phi) * std::sin(theta),
                     std::sin(phi) * std::sin(theta), std::cos(theta));
 
-  auto pca = TrackFitUtils::getPCALinePoint(glob, mom, Acts::Vector3::Zero());
+  auto pca = TrackFitUtils::getPCALinePoint(Acts::Vector3::Zero(), mom, glob);
   track->set_x(pca.x());
   track->set_y(pca.y());
 }

--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.h
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.h
@@ -15,7 +15,6 @@ class TrackSeed;
 class TrackSeedContainer;
 class ActsGeometry;
 class TrkrClusterContainer;
-
 class TrackSeedTrackMapConverter : public SubsysReco
 {
  public:
@@ -39,6 +38,7 @@ class TrackSeedTrackMapConverter : public SubsysReco
   void addKeys(std::unique_ptr<SvtxTrack_v4> &track, TrackSeed *seed);
   void addKeys(TrackSeed *seedToAddTo, TrackSeed *seedToAdd);
   std::pair<int, float> getCosmicCharge(TrackSeed *seed, float vertexradius) const;
+  void lineFit(SvtxTrack_v4 *track, TrackSeed *seed);
 
   ActsGeometry *m_tGeometry{nullptr};
   SvtxTrackMap *m_trackMap{nullptr};
@@ -51,7 +51,8 @@ class TrackSeedTrackMapConverter : public SubsysReco
 
   bool m_cosmics{false};
   bool m_ConstField{false};
-
+  bool m_zeroField{false};
+  
   std::string m_fieldMap;
   std::string m_trackMapName{"SvtxTrackMap"};
   std::string m_trackSeedName{"TpcTrackSeedContainer"};

--- a/offline/packages/trackreco/AzimuthalSeeder.cc
+++ b/offline/packages/trackreco/AzimuthalSeeder.cc
@@ -152,7 +152,7 @@ int AzimuthalSeeder::process_event(PHCompositeNode * /*unused*/)
       }
       float distancexy = std::abs(xySlope * pos.x() - pos.y() + xyIntercept) / std::sqrt(xySlope * xySlope + 1);
       float distancerz = std::abs(rzSlope * pos.z() - r + rzIntercept) / std::sqrt(rzSlope * rzSlope + 1);
-      if (distancexy > 0.1 || distancerz > 0.1)
+      if (distancexy > m_outlierLimit || distancerz > m_outlierLimit)
       {
         badseed = true;
         break;
@@ -171,7 +171,10 @@ int AzimuthalSeeder::process_event(PHCompositeNode * /*unused*/)
       clusterPositions[0].insert(std::make_pair(key, pos));
     }
   }
-  std::cout << "finalseed size " << finalseeds.size() << std::endl;
+  if(Verbosity() > 2)
+  {
+    std::cout << "finalseed size " << finalseeds.size() << std::endl;
+  }
   for (auto &s : finalseeds)
   {
     if (s.ckeys.size() < 3)

--- a/offline/packages/trackreco/AzimuthalSeeder.h
+++ b/offline/packages/trackreco/AzimuthalSeeder.h
@@ -36,6 +36,7 @@ class AzimuthalSeeder : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   void histos() { m_outfile = true; }
+  void residualLimit(const float limit) { m_outlierLimit = limit; }
 
  private:
   int getNodes(PHCompositeNode *topNode);
@@ -49,6 +50,8 @@ class AzimuthalSeeder : public SubsysReco
   ActsGeometry *m_tGeometry = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;
   TrackSeedContainer *m_seedContainer = nullptr;
+
+  float m_outlierLimit = 0.1;
 };
 
 #endif  // AZIMUTHALSEEDER_H


### PR DESCRIPTION
This adds a number of diagnostic tools
1. Can configure the outlier limit for azimuthal seeder from the macro
2. Adds line fit with DCA to track back to (0,0,0) for zero field alignment testing
3. Enables field on running/diagnostic for individual track seed containers

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

