### PR TITLE
move ohcal fieldmap loading after check for constant field

### DIFF
--- a/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
+++ b/simulation/g4simulation/g4ohcal/PHG4OHCalDetector.cc
@@ -94,15 +94,15 @@ PHG4OHCalDetector::PHG4OHCalDetector(PHG4Subsystem *subsys, PHCompositeNode *Nod
     m_GDMPath = CDBInterface::instance()->getUrl(m_GDMPath);
     m_Params->set_string_param("GDMPath", m_GDMPath);
   }
-  std::string ironfieldmap = m_Params->get_string_param("IronFieldMapPath");
-  if (std::filesystem::path(ironfieldmap).extension() != ".root")
-  {
-    ironfieldmap = CDBInterface::instance()->getUrl(ironfieldmap);
-    m_Params->set_string_param("IronFieldMapPath", ironfieldmap);
-  }
   PHFieldConfig *fieldconf = findNode::getClass<PHFieldConfig>(Node, PHFieldUtility::GetDSTConfigNodeName());
   if (fieldconf->get_field_config() != PHFieldConfig::kFieldUniform)
   {
+    std::string ironfieldmap = m_Params->get_string_param("IronFieldMapPath");
+    if (std::filesystem::path(ironfieldmap).extension() != ".root")
+    {
+      ironfieldmap = CDBInterface::instance()->getUrl(ironfieldmap);
+      m_Params->set_string_param("IronFieldMapPath", ironfieldmap);
+    }
     m_FieldSetup =
         new PHG4OHCalFieldSetup(
             ironfieldmap, m_Params->get_double_param("IronFieldMapScale"),
@@ -269,9 +269,9 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
     ++it2;
   }
 
-  //Inner HCal support ring (only the part in Outer HCal volume)
-  // it only exists in the new gdml file, this check keeps the old file
-  // without the inner hcal support readable
+  // Inner HCal support ring (only the part in Outer HCal volume)
+  //  it only exists in the new gdml file, this check keeps the old file
+  //  without the inner hcal support readable
   G4AssemblyVolume *m_iHCalRing = reader->GetAssembly("iHCalRing");  // ihcal ring
   if (m_iHCalRing)
   {
@@ -281,7 +281,7 @@ int PHG4OHCalDetector::ConstructOHCal(G4LogicalVolume *hcalenvelope)
       m_DisplayAction->AddSupportRingVolume((*itr)->GetLogicalVolume());
       m_SteelAbsorberLogVolSet.insert((*itr)->GetLogicalVolume());
       hcalenvelope->AddDaughter((*itr));
-      //std::cout<<(*itr)->GetName()<<std::endl;
+      // std::cout<<(*itr)->GetName()<<std::endl;
       ++itr;
     }
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The ohcal steel fieldmap was loaded even for constant magnetic fields. It wasn't used but the logs and saved cdb files made the impression that it was. This moves the loading after the check if we have a constant field. This works for zero field, if a non zero strength is used the outer hcal magnet field does not work

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

