### PR TITLE
Cleaning up code for on-the-fly calibrations, online and rawdst processing

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -466,7 +466,7 @@ int MbdCalib::Download_Ped(const std::string& dbase_location)
 
   if ( std::isnan(_pedmean[0]) )
   {
-    std::cout << PHWHERE << ", ERROR, unknown file type, " << dbase_location << std::endl;
+    std::cout << PHWHERE << ", WARNING, ped calib missing, " << dbase_location << std::endl;
     _status = -1;
     return _status;
   }
@@ -530,7 +530,7 @@ int MbdCalib::Download_SampMax(const std::string& dbase_location)
 
   if ( _sampmax[0] == -1 )
   {
-    std::cout << PHWHERE << ", ERROR, calib file not processed, " << dbase_location << std::endl;
+    std::cout << PHWHERE << ", WARNING, sampmax calib missing, " << dbase_location << std::endl;
     _status = -1;
     return _status;  // file not found
   }
@@ -1228,7 +1228,7 @@ int MbdCalib::Write_CDB_Ped(const std::string& dbfile)
     cdbttree->SetFloatValue(ifeech, "pedsigma", _pedsigma[ifeech]);
     cdbttree->SetFloatValue(ifeech, "pedsigmaerr", _pedsigmaerr[ifeech]);
 
-    if (ifeech < 5 || ifeech >= MbdDefs::MBD_N_PMT - 5)
+    if (ifeech < 5 || ifeech >= MbdDefs::MBD_N_FEECH - 5)
     {
       std::cout << ifeech << "\t" << cdbttree->GetFloatValue(ifeech, "pedmean") << std::endl;
     }
@@ -1496,39 +1496,47 @@ int MbdCalib::Write_CDB_All()
 }
 #endif
 
-void MbdCalib::Update_TQT0(const float dz)
+// dz is what we need to move the MBD z by
+// dt is what we change the MBD t0 by
+void MbdCalib::Update_TQT0(const float dz, const float dt)
 {
-  // dz is what we need to move the MBD z by
-  const float dt = dz/MbdDefs::C;
+  const float z_dt = dz/MbdDefs::C;
 
   for (int ipmt=0; ipmt<MbdDefs::MBD_N_PMT; ipmt++)
   {
+    // update zvtx
     if ( ipmt<64 )  // south
     {
-      _tqfit_t0mean[ipmt] -= dt;
+      _tqfit_t0mean[ipmt] -= z_dt;
     }
     else
     {
-      _tqfit_t0mean[ipmt] += dt;
+      _tqfit_t0mean[ipmt] += z_dt;
     }
+
+    // update t0
+    _tqfit_t0mean[ipmt] -= dt;
   }
 }
 
-void MbdCalib::Update_TTT0(const float dz)
+void MbdCalib::Update_TTT0(const float dz, const float dt)
 {
   // dz is what we need to move the MBD z by
-  const float dt = dz/MbdDefs::C;
+  const float z_dt = dz/MbdDefs::C;
 
   for (int ipmt=0; ipmt<MbdDefs::MBD_N_PMT; ipmt++)
   {
     if ( ipmt<64 )  // south
     {
-      _ttfit_t0mean[ipmt] -= dt;
+      _ttfit_t0mean[ipmt] -= z_dt;
     }
     else
     {
-      _ttfit_t0mean[ipmt] += dt;
+      _ttfit_t0mean[ipmt] += z_dt;
     }
+
+    // update t0
+    _ttfit_t0mean[ipmt] -= dt;
   }
 }
 

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -101,8 +101,8 @@ class MbdCalib
   void Reset_Ped();
   void Reset_Gains();
 
-  void Update_TQT0(const float dz); // update with new z-vertex
-  void Update_TTT0(const float dz);
+  void Update_TQT0(const float dz, const float dt = 0.); // update with new z-vertex, t0
+  void Update_TTT0(const float dz, const float dt = 0.);
 
   // void Dump_to_file(const std::string& what = "ALL");
 

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -138,10 +138,7 @@ int MbdEvent::InitRun()
     if ( scheck<0 && _calpass!=1 )
     {
       _no_sampmax = 1000;    // num events for on the fly calculation
-      if ( _calpass!=1 )
-      {
-        std::cout << PHWHERE << ",no sampmax calib, determining it on the fly using first " << _no_sampmax << " evts." << std::endl;
-      }
+      std::cout << PHWHERE << ",no sampmax calib, determining it on the fly using first " << _no_sampmax << " evts." << std::endl;
     }
   }
 

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -92,8 +92,8 @@ MbdEvent::~MbdEvent()
     delete iarm;
   }
 
-  delete h2_tmax[0];
-  delete h2_tmax[1];
+  delete h2_smax[0];
+  delete h2_smax[1];
   delete ac;
   delete gausfit[0];
   delete gausfit[1];
@@ -135,9 +135,13 @@ int MbdEvent::InitRun()
 
     // check if sampmax and ped calibs exist
     int scheck = _mbdcal->get_sampmax(0);
-    if ( scheck<0 )
+    if ( scheck<0 && _calpass!=1 )
     {
-      _no_sampmax = 1;
+      _no_sampmax = 1000;    // num events for on the fly calculation
+      if ( _calpass!=1 )
+      {
+        std::cout << PHWHERE << ",no sampmax calib, determining it on the fly using first " << _no_sampmax << " evts." << std::endl;
+      }
     }
   }
 
@@ -147,7 +151,7 @@ int MbdEvent::InitRun()
     _mbdsig[ifeech].SetCalib(_mbdcal);
 
     // Do evt-by-evt pedestal using sample range below
-    if ( _calpass==1 || _no_sampmax )
+    if ( _calpass==1 || _no_sampmax>0 )
     {
       _mbdsig[ifeech].SetEventPed0Range(0,1);
     }
@@ -178,42 +182,42 @@ int MbdEvent::InitRun()
     std::cout << "OUTPUT CALDIR = " << _caldir << std::endl;
   }
 
-  if ( _calpass == 1 || _is_online || _no_sampmax )
+  if ( _no_sampmax>0 || _is_online || _calpass == 1 )
   {
     TDirectory *orig_dir = gDirectory;
-    if ( _calpass == 1 )
+    if ( _calpass == 1 && h2_smax[0]==nullptr )
     {
       std::cout << "MBD Cal Pass 1" << std::endl;
 
-      TString savefname = _caldir; savefname += "calpass1.root";
+      TString savefname = _caldir; savefname += "mbdcalpass1.root";
       std::cout << "Saving calpass 1 results to " << savefname << std::endl;
-      _smax_tfile = std::make_unique<TFile>(savefname,"RECREATE");
+      _calpass1_tfile = std::make_unique<TFile>(savefname,"RECREATE");
     }
 
     std::string name;
 
-    for (int ich=0; ich<MbdDefs::MBD_N_FEECH; ich++)
+    if ( h2_smax[0]==nullptr )
     {
-      name = "h_tmax"; name += std::to_string(ich);
-      h_tmax[ich] = new TH1F(name.c_str(),name.c_str(),_nsamples,-0.5,_nsamples-0.5);
-      h_tmax[ich]->SetXTitle("sample");
-      h_tmax[ich]->SetYTitle("ch");
-    }
-    h2_tmax[0] = new TH2F("h2_tsmax","time smax vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
-    h2_tmax[1] = new TH2F("h2_qsmax","chg smax vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
-    h2_wave[0] = new TH2F("h2_twave","time adc vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
-    h2_wave[1] = new TH2F("h2_qwave","chg adc vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
+      for (int ich=0; ich<MbdDefs::MBD_N_FEECH; ich++)
+      {
+        name = "h_smax"; name += std::to_string(ich);
+        h_smax[ich] = new TH1F(name.c_str(),name.c_str(),_nsamples,-0.5,_nsamples-0.5);
+        h_smax[ich]->SetXTitle("sample");
+        h_smax[ich]->SetYTitle("ch");
+      }
+      h2_smax[0] = new TH2F("h2_tsmax","time smax vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
+      h2_smax[1] = new TH2F("h2_qsmax","chg smax vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
+      h2_wave[0] = new TH2F("h2_twave","time adc vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
+      h2_wave[1] = new TH2F("h2_qwave","chg adc vs ch", MbdDefs::MAX_SAMPLES, -0.5, MbdDefs::MAX_SAMPLES-0.5, 128, 0, 128);
 
-    h2_trange_raw = new TH2F("h2_trange_raw","tadc (raw) at trig samp vs ch",1600,0,16384,128,0,128);
-    h2_trange = new TH2F("h2_trange","tadc at trig samp vs ch",1638,-100,16280,128,0,128);
+      for (int itype=0; itype<2; itype++)
+      {
+        h2_smax[itype]->SetXTitle("sample");
+        h2_smax[itype]->SetYTitle("ch");
 
-    for (int itype=0; itype<2; itype++)
-    {
-      h2_tmax[itype]->SetXTitle("sample");
-      h2_tmax[itype]->SetYTitle("ch");
-
-      h2_wave[itype]->SetXTitle("sample");
-      h2_wave[itype]->SetYTitle("ch");
+        h2_wave[itype]->SetXTitle("sample");
+        h2_wave[itype]->SetYTitle("ch");
+      }
     }
 
     if ( _calpass==1 )
@@ -228,6 +232,25 @@ int MbdEvent::InitRun()
     _mbdcal->Reset_TTT0();
     _mbdcal->Reset_TQT0();
     _mbdcal->Reset_Gains();
+
+    TDirectory *orig_dir = gDirectory;
+
+    if ( h2_trange==nullptr )
+    {
+      TString savefname = _caldir; savefname += "mbdcalpass2.root";
+      std::cout << "Saving calpass 2 results to " << savefname << std::endl;
+      _calpass2_tfile = std::make_unique<TFile>(savefname,"RECREATE");
+
+      h2_trange_raw = new TH2F("h2_trange_raw","tadc (raw) at trig samp vs ch",1600,0,16384,128,0,128);
+      h2_trange = new TH2F("h2_trange","tadc at trig samp vs ch",1638,-100,16280,128,0,128);
+    }
+    else
+    {
+      h2_trange_raw->Reset();
+      h2_trange->Reset();
+    }
+
+    orig_dir->cd();
   }
 
   return 0;
@@ -248,7 +271,7 @@ int MbdEvent::End()
 #endif
 
     TDirectory *orig_dir = gDirectory;
-    _smax_tfile->cd();
+    _calpass1_tfile->cd();
 
     for (auto & sig : _mbdsig)
     {
@@ -265,8 +288,14 @@ int MbdEvent::End()
     _mbdcal->Write_CDB_Ped( pedfname );
 #endif
 
-    _smax_tfile->Write();
+    _calpass1_tfile->Write();
 
+    orig_dir->cd();
+  }
+  else if ( _calpass == 2 )
+  {
+    TDirectory *orig_dir = gDirectory;
+    _calpass2_tfile->Write();
     orig_dir->cd();
   }
 
@@ -515,16 +544,11 @@ int MbdEvent::ProcessRawPackets(MbdPmtContainer *bbcpmts)
   m_femclk = m_femclocks[0][0];
 
   // We get SAMPMAX on this pass
-  if ( _calpass == 1 || _no_sampmax == 1 )
+  if ( _calpass == 1 || _no_sampmax > 0 )
   {
+    //std::cout << "fillsamp " << _no_sampmax << std::endl;
     FillSampMaxCalib();
     m_evt++;
-    static int counter = 0;
-    if ( counter<1 )
-    {
-      std::cout << "MBD: no sampmax calib, determining it on the fly" << std::endl;
-      counter++;
-    }
     return -1001; // stop processing event (negative return values end event processing)
   }
 
@@ -646,6 +670,32 @@ int MbdEvent::ProcessRawPackets(MbdPmtContainer *bbcpmts)
   // Have uncalibrated charge and time at this pass
   if ( _calpass == 2 )
   {
+    for (int ifeech = 0; ifeech<MbdDefs::MBD_N_FEECH; ifeech++)
+    {
+      // determine the trig_samp board by board
+      int type = _mbdgeom->get_type(ifeech);  // 0 = T-channel, 1 = Q-channel
+      int pmtch = _mbdgeom->get_pmt(ifeech);
+
+      // fill the h2_trange histograms
+      if ( type==0 )
+      {
+        int samp_max = _mbdcal->get_sampmax( ifeech );
+
+        h2_trange_raw->Fill( m_adc[ifeech][samp_max], pmtch );
+
+        /*
+        if ( pmtch == 127 )
+        {
+          std::cout << "xxx " << samp_max << "\t" << m_adc[ifeech][samp_max] << std::endl;
+        }
+        */
+
+        TGraphErrors *gsubpulse = _mbdsig[ifeech].GetGraph();
+        Double_t *y = gsubpulse->GetY();
+        h2_trange->Fill( y[samp_max], pmtch );  // fill ped-subtracted tdc
+      }
+    }
+
     return -1002;
   }
 
@@ -789,6 +839,11 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
     m_bbcte[iarm] = earliest;
     m_bbctl[iarm] = latest;
 
+    if ( m_bbcn[iarm]==1 )
+    {
+      m_bbct[iarm] = earliest;
+    }
+
     //_bbcout->set_arm(iarm, m_bbcn[iarm], m_bbcq[iarm], m_bbct[iarm]);
 
     // if ( _verbose && mybbz[_syncevt]< -40. )
@@ -833,6 +888,13 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
   // Get Zvertex, T0
   if (m_bbcn[0] > 0 && m_bbcn[1] > 0)
   {
+    /*
+    if ( m_bbcn[0]==1 || m_bbcn[1]==1 )
+    {
+      _verbose = 100;
+    }
+    */
+
     // Now calculate zvtx, t0 from best times
     if (_verbose >= 10)
     {
@@ -866,7 +928,8 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
       std::cout << "bbcz " << m_bbcz << std::endl;
       std::string junk;
       std::cout << "? ";
-      //std::cin >> junk;
+      std::cin >> junk;
+      _verbose = 0;
     }
   }
 
@@ -907,8 +970,6 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
 
 // Store data for sampmax calibration (to correct ADC sample offsets by channel)
-// This will replace DoQuickClockOffsetCalib() for 2024
-// We might have to set this so it stops the sampmax calibration after N events
 int MbdEvent::FillSampMaxCalib()
 {
   for (int ifeech = 0; ifeech<MbdDefs::MBD_N_FEECH; ifeech++)
@@ -932,35 +993,29 @@ int MbdEvent::FillSampMaxCalib()
     double maxsamp, maxadc;
     _mbdsig[ifeech].LocMax( maxsamp, maxadc );
 
-    h_tmax[ifeech]->Fill( maxsamp );
-    h2_tmax[type]->Fill( maxsamp, pmtch );
-    //std::cout << "fillint h2_tmax " << pmtch << "\t" << maxsamp << std::endl;
-    //_mbdsig[ifeech].Print();
-
-    if ( type==0 && h2_tmax[0]->GetEntries() > (128*500) )
+    if ( maxadc > 20 )
     {
-      int samp_max = _mbdcal->get_sampmax( ifeech );
-
-      h2_trange_raw->Fill( m_adc[ifeech][samp_max] , pmtch );
-
-      TGraphErrors *gsubpulse = _mbdsig[ifeech].GetGraph();
-      Double_t *y = gsubpulse->GetY();
-      Double_t tdc = y[samp_max];
-      h2_trange->Fill( tdc , pmtch );
+      h_smax[ifeech]->Fill( maxsamp );
+      h2_smax[type]->Fill( maxsamp, pmtch );
+      //std::cout << "fillint h2_smax " << pmtch << "\t" << maxsamp << std::endl;
+      //_mbdsig[ifeech].Print();
     }
 
   }
 
-  // At 1000 events, get the tmax for the time channels
-  // so we can fill the h2_trange histograms
-  if ( h2_tmax[0]->GetEntries() == (128*1000) )
+  // _no_sampmax keeps track of how many events to use for on-the-fly calibration
+  _no_sampmax--;
+
+  if ( _no_sampmax==0 && _calpass != 1 )
   {
     CalcSampMaxCalib();
     _calib_done = 1;
-    std::cout << "MBD: on the fly sampmax calib done" << std::endl;
+    std::cout << PHWHERE << " on the fly sampmax calib done" << std::endl;
 
     for (int ifeech=0; ifeech<MbdDefs::MBD_N_FEECH; ifeech++)
     {
+      _mbdsig[ifeech].SetEventPed0Range(-9999,-9999);
+
       const int presamp = 5;  // start from 5 samples before sampmax
       const int nsamps = -1;  // use all to sample 0
       _mbdsig[ifeech].SetEventPed0PreSamp(presamp, nsamps, _mbdcal->get_sampmax(ifeech));
@@ -975,7 +1030,7 @@ int MbdEvent::CalcSampMaxCalib()
   TDirectory *orig_dir = gDirectory;
   if ( _calpass==1 )
   {
-    _smax_tfile->cd();
+    _calpass1_tfile->cd();
   }
 
   // sampmax for each board, for time and ch channels
@@ -987,7 +1042,7 @@ int MbdEvent::CalcSampMaxCalib()
 
     // sampmax for time channels
     TString name = "t_sampmax_bd"; name += iboard;
-    TH1 *h_projx = h2_tmax[0]->ProjectionX(name,min_ybin,max_ybin);
+    TH1 *h_projx = h2_smax[0]->ProjectionX(name,min_ybin,max_ybin);
     int maxbin = h_projx->GetMaximumBin();
     int samp_max = h_projx->GetBinCenter( maxbin );
     for (int ich=0; ich<8; ich++)
@@ -999,7 +1054,7 @@ int MbdEvent::CalcSampMaxCalib()
 
     // sampmax for charge channels
     name = "t_sampmax_bd"; name += iboard;
-    h_projx = h2_tmax[1]->ProjectionX(name,min_ybin,max_ybin);
+    h_projx = h2_smax[1]->ProjectionX(name,min_ybin,max_ybin);
     maxbin = h_projx->GetMaximumBin();
     samp_max = h_projx->GetBinCenter( maxbin );
     for (int ich=0; ich<8; ich++)
@@ -1025,7 +1080,7 @@ int MbdEvent::CalcPedCalib()
   TDirectory *orig_dir = gDirectory;
   if ( _calpass==1 )
   {
-    _smax_tfile->cd();
+    _calpass1_tfile->cd();
   }
 
   // ped for each feech

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -15,7 +15,6 @@
 
 class PHCompositeNode;
 class Event;
-class Packet;
 class MbdPmtContainer;
 class MbdOut;
 class MbdCalib;
@@ -69,6 +68,9 @@ class MbdEvent
   int FillSampMaxCalib();
 
   int  calib_is_done() { return _calib_done; }
+
+  int ProcessRawPackets(MbdPmtContainer *mbdpmts);
+
   int  Verbosity() { return _verbose; }
   void Verbosity(const int v) { _verbose = v; }
 
@@ -101,9 +103,8 @@ class MbdEvent
   int _simflag{0};
   int _nsamples{31};
   int _calib_done{0}; 
-  int _no_sampmax{0};     //! sampmax calib doesn't exist
-  int _is_online{0};      //! for OnlMon
-
+  unsigned int _no_sampmax{0};      //! sampmax calib doesn't exist
+  int _is_online{0};                //! for OnlMon
 
   // alignment data
   Int_t   m_evt{0};
@@ -147,11 +148,12 @@ class MbdEvent
   TString _caldir;
   //std::string _caldir;
 
-  // sampmax
+  // sampmax and other calib stuff
   int CalcSampMaxCalib();
-  std::unique_ptr<TFile> _smax_tfile{nullptr};
-  TH1 *h_tmax[256]{};     // [feech], max sample in event
-  TH2 *h2_tmax[2]{};      // [0 == time ch, 1 == chg ch], max sample in evt vs ch
+  std::unique_ptr<TFile> _calpass1_tfile{nullptr};
+  std::unique_ptr<TFile> _calpass2_tfile{nullptr};
+  TH1 *h_smax[256]{};     // [feech], max sample in event
+  TH2 *h2_smax[2]{};      // [0 == time ch, 1 == chg ch], max sample in evt vs ch
   TH2 *h2_wave[2]{};      // [0 == time ch, 1 == chg ch], all samples in evt vs ch
   TH2 *h2_trange_raw{};   // raw tdc at maxsamp vs ch
   TH2 *h2_trange{};       // subtracted tdc at maxsamp vs ch

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -74,8 +74,6 @@ class MbdEvent
   int  Verbosity() { return _verbose; }
   void Verbosity(const int v) { _verbose = v; }
 
-  int ProcessRawPackets(MbdPmtContainer *mbdpmts);
-
  private:
   static const int NCHPERPKT = 128;
 

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -90,14 +90,19 @@ int MbdReco::process_event(PHCompositeNode *topNode)
       status = m_mbdevent->SetRawData(m_mbdraw, m_mbdpmts);
     }
 
-    if (status == Fun4AllReturnCodes::DISCARDEVENT || status == -1001)
+    if (status == Fun4AllReturnCodes::DISCARDEVENT )
     {
       static int counter = 0;
-      if ( counter<2 )
+      if ( counter<3 )
       {
         std::cout << PHWHERE << " ERROR, no good data in MBD" << std::endl;
         counter++;
       }
+      return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+    else if ( status == -1001 )
+    {
+      // calculating sampmax on this event
       return Fun4AllReturnCodes::DISCARDEVENT;
     }
     else if (status < 0)

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -22,46 +22,6 @@ using namespace std;
 MbdSig::MbdSig(const int chnum, const int nsamp)
   : _ch{chnum}
   , _nsamples{nsamp}
-  , f_ampl{0}
-  , f_time{0}
-  , f_time_offset{4.0}
-  ,  // time shift from fit
-  f_integral{0.}
-  ,  // time shift from fit
-  hRawPulse{nullptr}
-  , hSubPulse{nullptr}
-  , hpulse{nullptr}
-  , gRawPulse{nullptr}
-  , gSubPulse{nullptr}
-  , gpulse{nullptr}
-  , ped0{0}
-  ,  // ped average
-  ped0rms{0}
-  , use_ped0{0}
-  , minped0samp{-9999}
-  , maxped0samp{-9999}
-  , minped0x{0.}
-  , maxped0x{0.}
-  ,
-  // time_calib{0},
-  h2Template{nullptr}
-  , h2Residuals{nullptr}
-  ,
-  // range of good amplitudes for templates
-  // units are usually in ADC counts
-  hAmpl{nullptr}
-  , hTime{nullptr}
-  , template_npointsx{0}
-  , template_npointsy{0}
-  , template_begintime{0}
-  , template_endtime{0}
-  ,
-  // template_min_good_amplitude{20.},
-  // template_max_good_amplitude{4080},
-  // template_min_xrange{0},
-  // template_max_xrange{0},
-  template_fcn{nullptr}
-  , _verbose{0}
 {
   // cout << "In MbdSig::MbdSig(" << _ch << "," << _nsamples << ")" << endl;
 }
@@ -734,6 +694,14 @@ Double_t MbdSig::Integral(const Double_t xmin, const Double_t xmax)
 
 void MbdSig::LocMax(Double_t& x_at_max, Double_t& ymax, Double_t xminrange, Double_t xmaxrange)
 {
+  _verbose = 0;
+  if ( _verbose && _ch==250 )
+  {
+    gSubPulse->Draw("ap");
+    gPad->Modified();
+    gPad->Update();
+  }
+
   // Find index of maximum peak
   Int_t n = gSubPulse->GetN();
   Double_t* x = gSubPulse->GetX();
@@ -766,6 +734,14 @@ void MbdSig::LocMax(Double_t& x_at_max, Double_t& ymax, Double_t xminrange, Doub
       ymax = y[i];
       x_at_max = x[i];
     }
+  }
+
+  if ( _verbose )
+  {
+    string junk;
+    cin >> junk;
+    std::cout << "MbdSig::LocMax, " << x_at_max << "\t" << ymax << std::endl;
+    _verbose = 0;
   }
 }
 
@@ -989,13 +965,13 @@ int MbdSig::FitTemplate( const Int_t sampmax )
   }
 
   // Threshold cut
-  if ( ymax < 10. )
+  if ( ymax < 20. )
   {
     f_ampl = 0.;
     f_time = std::numeric_limits<Float_t>::quiet_NaN();
     if ( _verbose>10 )
     {
-      std::cout << "skipping, ymax < 10" << std::endl;
+      std::cout << "skipping, ymax < 20" << std::endl;
       gSubPulse->Draw("ap");
       gSubPulse->GetHistogram()->SetTitle(gSubPulse->GetName());
       gPad->SetGridy(1);

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -133,19 +133,19 @@ class MbdSig
 
   /** fit values*/
   // should make an array for the different methods
-  Double_t f_ampl; /** best guess (from fit of spline or template, or max adc) */
-  Double_t f_time; /** best guess (from fit of spline or template, or max adc) */
+  Double_t f_ampl{0,}; /** best guess (from fit of spline or template, or max adc) */
+  Double_t f_time{0.}; /** best guess (from fit of spline or template, or max adc) */
 
-  Double_t f_time_offset; /** time offset used in fit */
+  Double_t f_time_offset{4.0}; /** time offset used in fit */
 
-  Double_t f_integral; /** integral */
+  Double_t f_integral{0.}; /** integral */
 
-  TH1 *hRawPulse;           //!
-  TH1 *hSubPulse;           //!
-  TH1 *hpulse;              //!
-  TGraphErrors *gRawPulse;  //!
-  TGraphErrors *gSubPulse;  //!
-  TGraphErrors *gpulse;     //!
+  TH1 *hRawPulse{nullptr};           //!
+  TH1 *hSubPulse{nullptr};           //!
+  TH1 *hpulse{nullptr};              //!
+  TGraphErrors *gRawPulse{nullptr};  //!
+  TGraphErrors *gSubPulse{nullptr};  //!
+  TGraphErrors *gpulse{nullptr};     //!
 
   /** for CalcPed0 */
   //std::unique_ptr<MbdRunningStats> ped0stats{nullptr};    //!
@@ -154,13 +154,13 @@ class MbdSig
   TH1 *hPedEvt{nullptr};          //! evt-by-event pedestal
   TF1 *ped_fcn{nullptr};
   TF1 *ped_tail{nullptr};         //! tail of prev signal
-  Double_t ped0;                  //!
-  Double_t ped0rms;               //!
-  Int_t use_ped0;                 //! whether to apply ped0
-  Int_t minped0samp;              //! min sample for event-by-event ped, inclusive
-  Int_t maxped0samp;              //! max sample for event-by-event ped, inclusive
-  Double_t minped0x;              //! min x for event-by-event ped, inclusive
-  Double_t maxped0x;              //! max x for event-by-event ped, inclusive
+  Double_t ped0{0.};                  //!
+  Double_t ped0rms{0.};               //!
+  int   use_ped0{0};                 //! whether to apply ped0
+  Int_t minped0samp{-9999};       //! min sample for event-by-event ped, inclusive
+  Int_t maxped0samp{-9999};       //! max sample for event-by-event ped, inclusive
+  Double_t minped0x{0.};              //! min x for event-by-event ped, inclusive
+  Double_t maxped0x{0.};              //! max x for event-by-event ped, inclusive
   Double_t ped_presamp{};         //! presamples for ped calculation
   Double_t ped_presamp_nsamps{};  //! num of presamples for ped calculation
   Double_t ped_presamp_maxsamp{-1}; //! a peak sample for ped calc (-1 = use max)
@@ -169,26 +169,26 @@ class MbdSig
   // Double_t time_calib;
 
   /** For pulse template extraction */
-  TH2 *h2Template;
-  TH2 *h2Residuals;
+  TH2 *h2Template{nullptr};
+  TH2 *h2Residuals{nullptr};
 
-  TH1 *hAmpl;
-  TH1 *hTime;
-  Int_t template_npointsx;
-  Int_t template_npointsy;
-  Double_t template_begintime;
-  Double_t template_endtime;
-  // Double_t template_min_good_amplitude;  //! for template, in original units of waveform data
-  // Double_t template_max_good_amplitude;  //! for template, in original units of waveform data
-  // Double_t template_min_xrange;          //! for template, in original units of waveform data
-  // Double_t template_max_xrange;          //! for template, in original units of waveform data
+  TH1 *hAmpl{nullptr};
+  TH1 *hTime{nullptr};
+  Int_t template_npointsx{0};
+  Int_t template_npointsy{0};
+  Double_t template_begintime{0.};
+  Double_t template_endtime{0.};
+  // Double_t template_min_good_amplitude{20.};    //! for template, in original units of waveform data
+  // Double_t template_max_good_amplitude{4080.};  //! for template, in original units of waveform data
+  // Double_t template_min_xrange{0.};             //! for template, in original units of waveform data
+  // Double_t template_max_xrange{0.};             //! for template, in original units of waveform data
   std::vector<float> template_y;
   std::vector<float> template_yrms;
-  TF1 *template_fcn;
+  TF1 *template_fcn{nullptr};
   Double_t fit_min_time{};  //! min time for fit, in original units of waveform data
   Double_t fit_max_time{};  //! max time for fit, in original units of waveform data
 
-  int _verbose;
+  int _verbose{0};
 };
 
 #endif  // __MBDSIG_H__


### PR DESCRIPTION


[comment]: Cleaning up code for on-the-fly calibrations, online and rawdst processing

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: Cleaned up the way the calibration of samp max is done (potential for confusion between online mon, on-the-fly, and regular calibration).  Fixed up the h2_trange so that it is in the correct calib pass.  Fixed reco so events with 1 hit pmt on a side  get a time in that pmt.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

