### PR TITLE
Updating jet reconstruction to properly account for masked towers

### DIFF
--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -169,8 +169,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
             const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALIN, comp_ieta, comp_iphi);
             tower_geom = geomIH->get_tower_geometry(key);
             comp_ET = towerinfo->get_energy() / cosh(tower_geom->get_eta());
-	    comp_isBad = towerinfo->get_isHot() || towerinfo->get_isNoCalib() || towerinfo->get_isNotInstr() || towerinfo->get_isBadChi2();          
-	  }
+            comp_isBad = towerinfo->get_isHot() || towerinfo->get_isNoCalib() || towerinfo->get_isNotInstr() || towerinfo->get_isBadChi2();
+          }
           else if (comp.first == 7 || comp.first == 27)
           {
             towerinfo = towerinfosOH3->get_tower_at_channel(comp.second);
@@ -180,8 +180,8 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
             const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, comp_ieta, comp_iphi);
             tower_geom = geomOH->get_tower_geometry(key);
             comp_ET = towerinfo->get_energy() / cosh(tower_geom->get_eta());
-	    comp_isBad = towerinfo->get_isHot() || towerinfo->get_isNoCalib() || towerinfo->get_isNotInstr() || towerinfo->get_isBadChi2();
-	  }
+            comp_isBad = towerinfo->get_isHot() || towerinfo->get_isNoCalib() || towerinfo->get_isNotInstr() || towerinfo->get_isBadChi2();
+          }
           else if (comp.first == 13 || comp.first == 28)
           {
             towerinfo = towerinfosEM3->get_tower_at_channel(comp.second);

--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -63,9 +63,9 @@ class DetermineTowerBackground : public SubsysReco
   std::vector<std::vector<float> > _IHCAL_E;
   std::vector<std::vector<float> > _OHCAL_E;
 
-  std::vector<std::vector<int> > _EMCAL_T;
-  std::vector<std::vector<int> > _IHCAL_T;
-  std::vector<std::vector<int> > _OHCAL_T;
+  std::vector<std::vector<int> > _EMCAL_ISBAD;
+  std::vector<std::vector<int> > _IHCAL_ISBAD;
+  std::vector<std::vector<int> > _OHCAL_ISBAD;
 
   // 1-D energies vs. phi (integrated over eta strips with complete
   // phi coverage, and all layers)

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -73,7 +73,8 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
     _NPHI = geomIH->get_phibins();
 
     _EMCAL_RETOWER_E.resize(_NETA, std::vector<float>(_NPHI, 0));
-    _EMCAL_RETOWER_T.resize(_NETA, std::vector<int>(_NPHI, 0));
+    _EMCAL_RETOWER_MASKED_A.resize(_NETA, std::vector<float>(_NPHI, 0));
+    _EMCAL_RETOWER_TOTAL_A.resize(_NETA, std::vector<float>(_NPHI, 0));
   }
 
   for (int eta = 0; eta < _NETA; eta++)
@@ -81,7 +82,8 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
     for (int phi = 0; phi < _NPHI; phi++)
     {
       _EMCAL_RETOWER_E[eta][phi] = 0;
-      _EMCAL_RETOWER_T[eta][phi] = 0;
+      _EMCAL_RETOWER_MASKED_A[eta][phi] = 0;
+      _EMCAL_RETOWER_TOTAL_A[eta][phi] = 0;
     }
   }
 
@@ -142,19 +144,24 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 
       int this_IHphibin = geomIH->get_phibin(tower_geom->get_phi());
       float this_E = tower->get_energy();
-      int this_T = tower->get_time();
+      int this_isBad = tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2();
       for (int etabin_iter = -1; etabin_iter <= 1; etabin_iter++)
       {
         if (this_IHetabin + etabin_iter < 0 || this_IHetabin + etabin_iter >= _NETA)
         {
           continue;
         }
-        _EMCAL_RETOWER_E[this_IHetabin + etabin_iter][this_IHphibin] += this_E * fractionalcontribution[etabin_iter + 1];
-        if (this_T == -10 || this_T == -11)  // if a tower in this retower is masked, mask the retower as well. Masking is noted by time = -10 or -11
-        {
-          // currently just set the retowered tower to -10 even if the original tower was -11
-          _EMCAL_RETOWER_T[this_IHetabin + etabin_iter][this_IHphibin] = -10;
-        }
+	if(!this_isBad)
+	  {
+	    _EMCAL_RETOWER_E[this_IHetabin + etabin_iter][this_IHphibin] += this_E * fractionalcontribution[etabin_iter + 1];
+	  }
+	else
+	  {
+	    //if the tower is bad, don't add its energy to the retower and keep track of how much is masked
+	    _EMCAL_RETOWER_MASKED_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
+	  }
+	//also keep track of the total area going into the retower
+	_EMCAL_RETOWER_TOTAL_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
       }
     }
   }
@@ -236,11 +243,18 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         unsigned int towerindex = emcal_retower->decode_key(towerkey);
         TowerInfo *towerinfo = emcal_retower->get_tower_at_channel(towerindex);
         towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi]);
-        if (_EMCAL_RETOWER_T[eta][phi] == -10)
+        if (_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi] > _FRAC_CUT)
         {
           towerinfo->set_energy(0);
+	  towerinfo->set_isHot(1);
         }
-        towerinfo->set_time(_EMCAL_RETOWER_T[eta][phi]);
+	else
+	  {
+	    //scale up the total energy to account for the amount that's been masked
+	    towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi]*1./(1.-_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi]));
+	    //set the chi2 to be the masked fraction
+	    towerinfo->set_chi2(_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi]);
+	  }
       }
     }
   }

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -246,7 +246,7 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         if (_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi] > _FRAC_CUT)
         {
           towerinfo->set_energy(0);
-	  towerinfo->set_isHot(1);
+	  towerinfo->set_isHot(true);
         }
 	else
 	  {

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -151,17 +151,17 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         {
           continue;
         }
-	if(!this_isBad)
-	  {
-	    _EMCAL_RETOWER_E[this_IHetabin + etabin_iter][this_IHphibin] += this_E * fractionalcontribution[etabin_iter + 1];
-	  }
-	else
-	  {
-	    //if the tower is bad, don't add its energy to the retower and keep track of how much is masked
-	    _EMCAL_RETOWER_MASKED_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
-	  }
-	//also keep track of the total area going into the retower
-	_EMCAL_RETOWER_TOTAL_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
+        if (!this_isBad)
+        {
+          _EMCAL_RETOWER_E[this_IHetabin + etabin_iter][this_IHphibin] += this_E * fractionalcontribution[etabin_iter + 1];
+        }
+        else
+        {
+          // if the tower is bad, don't add its energy to the retower and keep track of how much is masked
+          _EMCAL_RETOWER_MASKED_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
+        }
+        // also keep track of the total area going into the retower
+        _EMCAL_RETOWER_TOTAL_A[this_IHetabin + etabin_iter][this_IHphibin] += fractionalcontribution[etabin_iter + 1];
       }
     }
   }
@@ -243,18 +243,18 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
         unsigned int towerindex = emcal_retower->decode_key(towerkey);
         TowerInfo *towerinfo = emcal_retower->get_tower_at_channel(towerindex);
         towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi]);
-        if (_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi] > _FRAC_CUT)
+        if (_EMCAL_RETOWER_MASKED_A[eta][phi] / _EMCAL_RETOWER_TOTAL_A[eta][phi] > _FRAC_CUT)
         {
           towerinfo->set_energy(0);
-	  towerinfo->set_isHot(true);
+          towerinfo->set_isHot(true);
         }
-	else
-	  {
-	    //scale up the total energy to account for the amount that's been masked
-	    towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi]*1./(1.-_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi]));
-	    //set the chi2 to be the masked fraction
-	    towerinfo->set_chi2(_EMCAL_RETOWER_MASKED_A[eta][phi]/_EMCAL_RETOWER_TOTAL_A[eta][phi]);
-	  }
+        else
+        {
+          // scale up the total energy to account for the amount that's been masked
+          towerinfo->set_energy(_EMCAL_RETOWER_E[eta][phi] * 1. / (1. - _EMCAL_RETOWER_MASKED_A[eta][phi] / _EMCAL_RETOWER_TOTAL_A[eta][phi]));
+          // set the chi2 to be the masked fraction
+          towerinfo->set_chi2(_EMCAL_RETOWER_MASKED_A[eta][phi] / _EMCAL_RETOWER_TOTAL_A[eta][phi]);
+        }
       }
     }
   }

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -36,15 +36,22 @@ class RetowerCEMC : public SubsysReco
   {
     m_use_towerinfo = use_towerinfo;
   }
+  void set_frac_cut(float frac_cut)
+  {
+    _FRAC_CUT = frac_cut;
+  }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
   int _WEIGHTED_ENERGY_DISTRIBUTION{1};
   int _NETA{-1};
   int _NPHI{-1};
+  float _FRAC_CUT{0.5};
   bool m_use_towerinfo{false};
   std::vector<std::vector<float> > _EMCAL_RETOWER_E;
   std::vector<std::vector<int> > _EMCAL_RETOWER_T;
+  std::vector<std::vector<float> > _EMCAL_RETOWER_MASKED_A;
+  std::vector<std::vector<float> > _EMCAL_RETOWER_TOTAL_A;
 };
 
 #endif

--- a/offline/packages/jetbackground/SubtractTowers.cc
+++ b/offline/packages/jetbackground/SubtractTowers.cc
@@ -156,8 +156,8 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
         UE = UE * (1 + 2 * background_v2 * std::cos(2 * (tower_phi - background_Psi2)));
       }
       float new_energy = raw_energy - UE;
-      // if a tower has time = -10 or -11 it is masked, leave it at zero
-      if (tower->get_time() == -10 || tower->get_time() == -11)
+      // if a tower is masked, leave it at zero
+      if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2())
       {
         new_energy = 0;
       }
@@ -245,8 +245,8 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
         UE = UE * (1 + 2 * background_v2 * std::cos(2 * (tower_phi - background_Psi2)));
       }
       float new_energy = raw_energy - UE;
-      // if a tower has time = -10 or -11 it is masked, leave it at zero
-      if (tower->get_time() == -10 || tower->get_time() == -11)
+      // if a tower is masked, leave it at zero
+      if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2())
       {
         new_energy = 0;
       }
@@ -330,8 +330,8 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
         UE = UE * (1 + 2 * background_v2 * std::cos(2 * (tower_phi - background_Psi2)));
       }
       float new_energy = raw_energy - UE;
-      // if a tower has time = -10 or -11 it is masked, leave it at zero
-      if (tower->get_time() == -10 || tower->get_time() == -11)
+      // if a tower is masked, leave it at zero
+      if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2())
       {
         new_energy = 0;
       }

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -415,6 +415,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(geocaloid, ieta, iphi);
 	  //skip masked towers
 	  if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2()) continue;
+	  if(std::isnan(tower->get_energy())) continue;
 	  RawTowerGeom *tower_geom = geom->get_tower_geometry(key);
 	  assert(tower_geom);
 
@@ -424,7 +425,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  double z = z0 - vtxz;
 	  double eta = asinh(z / r);  // eta after shift from vertex
 	  double pt = tower->get_energy() / cosh(eta);
-	  if (tower->get_energy() == NAN) {pt = 0/cosh(eta);}
+	  double e = tower->get_energy();
 	  double px = pt * cos(phi);
 	  double py = pt * sin(phi);
 	  double pz = pt * sinh(eta);
@@ -433,7 +434,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  jet->set_px(px);
 	  jet->set_py(py);
 	  jet->set_pz(pz);
-	  jet->set_e(tower->get_energy());
+	  jet->set_e(e);
 	  jet->insert_comp(m_input,channel);
 	  pseudojets.push_back(jet);
 	}

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -414,7 +414,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 	  int iphi = towerinfos->getTowerPhiBin(calokey);
 	  const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(geocaloid, ieta, iphi);
 	  //skip masked towers
-	  if (tower->get_time()==-10 || tower->get_time()==-11) continue;
+	  if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2()) continue;
 	  RawTowerGeom *tower_geom = geom->get_tower_geometry(key);
 	  assert(tower_geom);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR updates the jetbase and jetbackground packages to account for the updates to calorimeter masking based on the calo tower status. Additionally, this introduces a method of propogating masking to the retowered EMCal towers, which scales the retowered tower energy to account for the masked area. Towers with > 50% of their area masked are fully masked, with the 50% threshold being configurable using set_frac_cut(CUT).

This was discussed in the jet structure TG meeting on 5/22: https://indico.bnl.gov/event/23535/

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

