### PR TITLE
fix: Unregister modules if raw hit container does not exist

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -15,7 +15,7 @@
 #include <ffarawobjects/InttRawHitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-
+#include <fun4all/Fun4AllServer.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>  // for PHIODataNode
 #include <phool/PHNodeIterator.h>
@@ -112,6 +112,17 @@ int InttCombinedRawDataDecoder::InitRun(PHCompositeNode* topNode)
     }
   }
 
+  InttRawHitContainer* inttcont = findNode::getClass<InttRawHitContainer>(topNode, m_InttRawNodeName);
+  if (!inttcont)
+  {
+    std::cout << PHWHERE << std::endl;
+    std::cout << "Could not get \"" << m_InttRawNodeName << "\" from Node Tree" << std::endl;
+    std::cout << "removing module" << std::endl;
+
+    Fun4AllServer* se = Fun4AllServer::instance();
+    se->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
 
   ///////////////////////////////////////
   std::cout<<"calibinfo DAC : "<<m_calibinfoDAC.first<<" "<<(m_calibinfoDAC.second==CDB?"CDB":"FILE")<<std::endl;

--- a/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
@@ -14,6 +14,7 @@
 #include <ffarawobjects/MicromegasRawHitContainer.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>
@@ -93,6 +94,13 @@ int MicromegasCombinedDataDecoder::InitRun(PHCompositeNode* topNode)
     hitsetcontainer = new TrkrHitSetContainerv1;
     auto newNode = new PHIODataNode<PHObject>(hitsetcontainer, "TRKR_HITSET", "PHObject");
     trkrnode->addNode(newNode);
+  }
+  auto rawhitcontainer = findNode::getClass<MicromegasRawHitContainer>(topNode, m_rawhitnodename);
+  if(!rawhitcontainer)
+  {
+    Fun4AllServer* se = Fun4AllServer::instance();
+    se->unregisterSubsystem(this);
+    std::cout << PHWHERE << "Removing TPOT unpacker, no raw hit container" << std::endl;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -12,6 +12,8 @@
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitv2.h>
 
+#include <fun4all/Fun4AllServer.h>
+
 #include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/MvtxRawEvtHeader.h>
 #include <ffarawobjects/MvtxRawHit.h>
@@ -102,10 +104,8 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
       findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
   if (!mvtx_raw_event_header)
   {
-    std::cout << PHWHERE << "::" << __func__ << ": Could not get \""
-              << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
-    std::cout << "Have you built this yet?" << std::endl;
-    exit(1);
+    Fun4AllServer* se = Fun4AllServer::instance();
+    se->unregisterSubsystem(this);
   }
 
   // Mask Hot MVTX Pixels

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -14,6 +14,8 @@
 #include <ffarawobjects/TpcRawHitContainerv1.h>
 #include <ffarawobjects/TpcRawHitv1.h>
 
+#include <fun4all/Fun4AllServer.h>
+
 #include <cdbobjects/CDBTTree.h>
 #include <ffamodules/CDBInterface.h>
 
@@ -129,6 +131,20 @@ int TpcCombinedRawDataUnpacker::InitRun(PHCompositeNode* topNode)
     PHIODataNode<PHObject>* new_node = new PHIODataNode<PHObject>(trkr_hit_set_container, "TRKR_HITSET", "PHObject");
     trkr_node->addNode(new_node);
   }
+
+  TpcRawHitContainerv1* tpccont = findNode::getClass<TpcRawHitContainerv1>(topNode, m_TpcRawNodeName);
+  if (!tpccont)
+  {
+    std::cout << PHWHERE << std::endl;
+    std::cout << "TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)" << std::endl;
+    std::cout << "Could not get \"" << m_TpcRawNodeName << "\" from Node Tree" << std::endl;
+    std::cout << "Removing module" << std::endl;
+
+    Fun4AllServer *se = Fun4AllServer::instance();
+    se->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   if (m_writeTree)
   {
     m_file = new TFile(outfile_name.c_str(), "RECREATE");


### PR DESCRIPTION
This changes the raw hit unpackers to unregister the module and continue processing the job if their respective raw hit container does not exist on the node tree. This change is being made to allow our production to be more flexible with the files/DSTs that are produced.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

