### PR TITLE
ensure sampmax on the fly calib is done in online when runs change

### DIFF
--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -135,9 +135,10 @@ int MbdEvent::InitRun()
 
     // check if sampmax and ped calibs exist
     int scheck = _mbdcal->get_sampmax(0);
-    if ( scheck<0 && _calpass!=1 )
+    if ( (scheck<0 || _is_online) && _calpass!=1 )
     {
       _no_sampmax = 1000;    // num events for on the fly calculation
+      _calib_done = 0;
       std::cout << PHWHERE << ",no sampmax calib, determining it on the fly using first " << _no_sampmax << " evts." << std::endl;
     }
   }
@@ -148,7 +149,7 @@ int MbdEvent::InitRun()
     _mbdsig[ifeech].SetCalib(_mbdcal);
 
     // Do evt-by-evt pedestal using sample range below
-    if ( _calpass==1 || _no_sampmax>0 )
+    if ( _calpass==1 || _is_online || _no_sampmax>0 )
     {
       _mbdsig[ifeech].SetEventPed0Range(0,1);
     }
@@ -216,13 +217,26 @@ int MbdEvent::InitRun()
         h2_wave[itype]->SetYTitle("ch");
       }
     }
+    else
+    {
+      // Reset histograms
+      for (int ich=0; ich<MbdDefs::MBD_N_FEECH; ich++)
+      {
+        h_smax[ich]->Reset();
+      }
+      h2_smax[0]->Reset();
+      h2_smax[1]->Reset();
+      h2_wave[0]->Reset();
+      h2_wave[1]->Reset();
+    }
 
     if ( _calpass==1 )
     {
       orig_dir->cd();
     }
   }
-  else if ( _calpass == 2 )
+
+  if ( _calpass == 2 )
   {
     // zero out the tt_t0, tq_t0, and gains to produce uncalibrated time and charge
     std::cout << "MBD Cal Pass 2" << std::endl;
@@ -920,7 +934,7 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
     // if (_verbose > 10)
     // if ( _verbose && mybbz[_syncevt]< -40. )
-    if (_verbose)
+    if (_verbose>1000)
     {
       std::cout << "bbcz " << m_bbcz << std::endl;
       std::string junk;
@@ -1057,6 +1071,7 @@ int MbdEvent::CalcSampMaxCalib()
     for (int ich=0; ich<8; ich++)
     {
       _mbdcal->set_sampmax( feech, samp_max );
+      //std::cout << "sampmax " << feech << "\t" << samp_max << std::endl;
       feech++;
     }
     delete h_projx;

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -220,9 +220,10 @@ int MbdEvent::InitRun()
     else
     {
       // Reset histograms
-      for (int ich=0; ich<MbdDefs::MBD_N_FEECH; ich++)
+      //for (int ich=0; ich<MbdDefs::MBD_N_FEECH; ich++)
+      for (auto h : h_smax )
       {
-        h_smax[ich]->Reset();
+        h->Reset();
       }
       h2_smax[0]->Reset();
       h2_smax[1]->Reset();


### PR DESCRIPTION
[comment]: Added additional _is_online to see if this fixes the problem of bad data at the beginning of a run.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: Suspicious that the online mon issue with bad data in the first few hundred events or so is due to the sampmax not being recalibrated on every run.  Changes here should help to make sure that the on-the-fly sampmax calib is done on every run change.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

