### PR TITLE
Update PHCASeeding with more efficient code to execute same algorithm.

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -74,6 +74,13 @@
 #define LogWarning(exp) \
   if (Verbosity() > 0) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp
 
+#if defined(_PHCASEEDING_TIMER_OUT_)
+#define _PHCASEEDING_PRINT_TIME(timer,statement) timer->stop(); \
+  std::cout << " _PHCASEEDING_PRINT_TIME: Time to " << statement << ": " << timer->elapsed()/1000 << " s" << std::endl;
+#else
+#define _PHCASEEDING_PRINT_TIME(timer, statement) (void) 0
+#endif
+
 /* #define FIXME(str) std::cout <<" FIXME: " << str << std::endl; */
 
 //#define _DEBUG_
@@ -401,21 +408,15 @@ int PHCASeeding::FindSeedsWithMerger(const PHCASeeding::PositionMap& globalPosit
   t_seed->restart();
 
   keyLinksPerLayer bilinks = CreateBiLinks(globalPositions, ckeys);
-  if (Verbosity() > 0) {
-    t_makebilinks->stop();
-    std::cout << "Time to make bilinks: " << t_makebilinks->elapsed() / 1000 << " s" << std::endl;
-  }
+  _PHCASEEDING_PRINT_TIME(t_makebilinks, "init and make bilinks");
   // std::pair<ckeylinks_per_layer, ckeylinks_per_layer> = CreateLinks(fromPointKey(allClusters), globalPositions); // put the bilinks finder into the end of create links --> don't have to save all the rows
   // std::vector<std::vector<keylink>> biLinks = FindBiLinks(links.first, links.second);
   
 
-  if (Verbosity() > 0) { t_makeseeds->restart(); }
+  t_makeseeds->restart();
   std::vector<keyList> trackSeedKeyLists = FollowBiLinks(bilinks, globalPositions);
-  if (Verbosity() > 0 )
-  {
-    t_makeseeds->stop();
-    std::cout << "Time to make seeds: " << t_makeseeds->elapsed() / 1000 << " s" << std::endl;
-  }
+  _PHCASEEDING_PRINT_TIME(t_makeseeds, "make seeds");
+
   std::vector<TrackSeed_v2> seeds = RemoveBadClusters(trackSeedKeyLists, globalPositions);
 
   publishSeeds(seeds);

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -773,46 +773,43 @@ std::vector<PHCASeeding::keyList> PHCASeeding::FollowBiLinks(const PHCASeeding::
   std::vector<keyList> trackSeedPairs;
   // get starting cluster keys, create a keyList for each
   // (only check last element of each pair because we start from the outer layers and go inward)
-  for (unsigned int layer = 0; layer < _nlayers_tpc - 1; ++layer)
-  {
+  /* for (unsigned int layer = 0; layer < _nlayers_tpc - 1; ++layer) */
+  /* { */
     
-    for (const auto& startCand : bidirectionalLinks[layer]) {
-      //see if any link in an above layer is pointing to the starCand
-      const auto& l_above = bidirectionalLinks[layer+1];
-      if (!std::binary_search(l_above.begin(), l_above.end(), startCand,
-            [](const keyLink& a, const keyLink& b) { return a.second < b.first; })) 
+  /*   for (const auto& startCand : bidirectionalLinks[layer]) { */
+  /*     //see if any link in an above layer is pointing to the starCand */
+  /*     const auto& l_above = bidirectionalLinks[layer+1]; */
+  /*     if (!std::binary_search(l_above.begin(), l_above.end(), startCand, */
+  /*           [](const keyLink& a, const keyLink& b) { return a.second < b.first; })) */ 
+  /*     { */
+  /*       trackSeedPairs.push_back({startCand.first, startCand.second}); */
+  /*     } */
+  /*   } */
+  /* } */
+
+
+
+  for (unsigned int layer = 0; layer < _NLAYERS_TPC - 1; ++layer)
+  {
+    for (auto startCand = bidirectionalLinks[layer].begin(); startCand != bidirectionalLinks[layer].end(); ++startCand)
+    {
+      bool has_above_link = false;
+      unsigned int imax = 1;
+      if (layer == _nlayers_tpc - 2)
       {
-        trackSeedPairs.push_back({startCand.first, startCand.second});
+        imax = 1;
+      }
+      for (unsigned int i = 1; i <= imax; i++)
+      {
+        has_above_link = has_above_link || std::any_of(bidirectionalLinks[layer + i].begin(), bidirectionalLinks[layer + i].end(), [&](keyLink k)
+          { return startCand->first == k.second; });
+      }
+      if (!has_above_link)
+      {
+        trackSeedPairs.push_back({startCand->first, startCand->second});
       }
     }
   }
-
-
-
-/*     for (auto startCand = bidirectionalLinks[layer].begin(); startCand != bidirectionalLinks[layer].end(); ++startCand) */
-/*     { */
-/*       bool has_above_link = false; */
-/*       unsigned int imax = 1; */
-/*       if (layer == _nlayers_tpc - 2) */
-/*       { */
-/*         imax = 1; */
-/*       } */
-/*       for (unsigned int i = 1; i <= imax; i++) */
-/*       { */
-/*         has_above_link = has_above_link || std::any_of(bidirectionalLinks[layer + i].begin(), bidirectionalLinks[layer + i].end(), [&](keyLink k) */
-/*           { return startCand->first == k.second; }); */
-/*       } */
-/*       //      for(std::vector<keylink>::iterator testlink = bidirectionalLinks[layer+1].begin(); !has_above_link && (testlink != bidirectionalLinks[layer+1].end()); ++testlink) */
-/*       //      { */
-/*       //        if((*startCand) == (*testlink)) continue; */
-/*       //        if((*startCand)[0] == (*testlink)[1]) has_above_link = true; */
-/*       //      } */
-/*       if (!has_above_link) */
-/*       { */
-/*         trackSeedPairs.push_back({startCand->first, startCand->second}); */
-/*       } */
-/*     } */
-/*   } */
 
   // form all possible starting 3-cluster tracks (we need that to calculate curvature)
   std::vector<keyList> trackSeedKeyLists;

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -8,10 +8,9 @@
  *  \author Michael Peters & Christof Roland
  */
 
-// Statement for if we want to save out the intermediary clustering steps
+// Statements for if we want to save out the intermediary clustering steps
 /* #define _CLUSTER_LOG_TUPOUT_ */
-
-// begin test here
+#define _PHCASEEDING_TIMER_OUT_
 
 #include "ALICEKF.h"
 #include "PHTrackSeeding.h"  // for PHTrackSeeding


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
The code revises PHCASeeding for efficiency of execution. The result is that PHCASeeding now runs ~12-30% faster for generating the bilinks (the most time consuming part of the code). Some changes are:
* The boost trees are now 2D instead of 3D
* The cached map is now a std::unordered_map instead of a std::map
* `using` statements are now scoped internal to the namespace of the PHCASeeding class (before they were set in the global namespace)
* The keyLinks now are just std::pair<TrkrDefs::cluskey,TrkrDefs::cluskey> instead of the std::array<coordKey,2> with coordkey=std::pair<std::array<float,3>,TrkrDefs::cluskey. This is because in the code, as implemented, the global position of the links was always taken from the cached cluster positions, instead of the internal std::arrayu<float,3> anyway
etc...

In better news, the code that follows the bilinks is actually on the order of ~10% or less of the time it takes to generate the bilinks. This means that if we want, we *could* make that part of the code more sophisticated and still only consume part of the time we have already saved with this PR by making the bilink generation more efficient.

While this all works, it seems likely that for our application, we could actually forgo some of the actual algorithm, and just pass key-chains directly to the `PHSimpleKFPProp` without so much logic inside of PHCASeeding itself. If we really want to decrease time, we could also probably not even measure the bilinks in the inner ~15 rows of the TPC, as all the tracks should be seeded from the external rows anyway. The change to the code would be negligible (just adjusting the loop).

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

