### PR TITLE
Write to spinDB even if XingShift calibration fails

### DIFF
--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -31,6 +31,7 @@ XingShiftCal::XingShiftCal(const std::string &name, const int poverwriteSpinEntr
 {
   // overwriteSpinEntry = poverwriteSpinEntry;
   nevt = 0;
+  
   for (auto &scalercount : scalercounts)
   {
     for (unsigned long &j : scalercount)
@@ -343,7 +344,7 @@ int XingShiftCal::CalculateCrossingShift(int &xing, uint64_t counts[NTRIG][NBUNC
       }
       else
       {
-        xing = 0;
+        xing = -999;
         succ = false;
         return 0;
       }
@@ -387,7 +388,7 @@ int XingShiftCal::CommitToSpinDB()
   std::cout << "XingShiftCal::CommitPatternToSpinDB()" << std::endl;
   std::string status;  //-------------------------------------------->
 
-  int xing_correction_offset = 0;
+  int xing_correction_offset = -999;
   if (success)
   {
     xing_correction_offset = xingshift;
@@ -395,8 +396,8 @@ int XingShiftCal::CommitToSpinDB()
   else
   {
     // if (verbosity) {
-    std::cout << "no successful calibration, do not commit crossing shift to spinDB" << std::endl;
-    std::cout << "committing other spin quantities" << std::endl;
+    std::cout << "no successful calibration, commit crossing shift -999 to spinDB" << std::endl;
+    
     //}
     commitSuccessSpinDB = 0;
     //return 0;
@@ -541,11 +542,8 @@ int XingShiftCal::CommitToSpinDB()
         << "polarblue = " << SQLArrayConstF(polBlue, NBUNCHES) << ", "
         << "polarblueerror = " << SQLArrayConstF(polBlueErr, NBUNCHES) << ", "
         << "polaryellow = " << SQLArrayConstF(polYellow, NBUNCHES) << ", "
-        << "polaryellowerror = " << SQLArrayConstF(polYellowErr, NBUNCHES) << ", ";
-    if (success)
-    {
-      sql << "crossingshift = " << xing_correction_offset << ", ";
-    }  
+        << "polaryellowerror = " << SQLArrayConstF(polYellowErr, NBUNCHES) << ", "
+	<< "crossingshift = " << xing_correction_offset << ", ";
     sql << "spinpatternblue = '{";
     for (int icross = 0; icross < NBUNCHES; icross++)
     {
@@ -574,25 +572,14 @@ int XingShiftCal::CommitToSpinDB()
   else
   {
     sql << "INSERT INTO " << dbtable;
-    if (success)
-    {
-      sql << " (runnumber, fillnumber, polarblue, polarblueerror, polaryellow, polaryellowerror, crossingshift, spinpatternblue, spinpatternyellow, qa_level) VALUES (";
-    }
-    else
-    {
-      sql << " (runnumber, fillnumber, polarblue, polarblueerror, polaryellow, polaryellowerror, spinpatternblue, spinpatternyellow, qa_level) VALUES (";
-    }
+    sql << " (runnumber, fillnumber, polarblue, polarblueerror, polaryellow, polaryellowerror, crossingshift, spinpatternblue, spinpatternyellow, qa_level) VALUES (";
     sql << runnumber << ", "
         << fillnumberBlue << ", "
         << SQLArrayConstF(polBlue, NBUNCHES) << ", "
         << SQLArrayConstF(polBlueErr, NBUNCHES) << ", "
         << SQLArrayConstF(polYellow, NBUNCHES) << ", "
-        << SQLArrayConstF(polYellowErr, NBUNCHES) << ", ";
-    if (success)
-    {
-      sql << xing_correction_offset << ", ";
-    }
-        
+        << SQLArrayConstF(polYellowErr, NBUNCHES) << ", "
+	<< xing_correction_offset << ", ";  
     sql << "'{";
     for (int icross = 0; icross < NBUNCHES; icross++)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR will write spin patterns, fillnumber, polarizations, and xingshift=-999 to the spinDB in the event that the crossing shift calibration fails. Previously, if the crossing shift calibration failed, nothing would be written to spinDB.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

