### PR TITLE
- use the same default parameter values as that as PHG4TpcPadPlaneReadout

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -225,7 +225,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector
   set_default_double_param("tpc_sector_phi_outer", 0.5097);  // 2 * M_PI / 12 );//sector size in phi for R3 sector
 
-  set_default_int_param("ntpc_phibins_inner", 1152);
-  set_default_int_param("ntpc_phibins_mid", 1536);
-  set_default_int_param("ntpc_phibins_outer", 2304);
+  set_default_int_param("ntpc_phibins_inner", 1128);  // 94 * 12
+  set_default_int_param("ntpc_phibins_mid", 1536);    // 128 * 12
+  set_default_int_param("ntpc_phibins_outer", 2304);  // 192 * 12
 }


### PR DESCRIPTION
@mohaas33 
- Please double check the value.  If I understand right, it is the correct one. 
- in any case, with a coming PR in the macros repository, this is overriden by G4TPC::tpc_layer_rphi_count_inner, as defined in macros/common/G4_TrkrVariables.C

Note: only the value set in PHG4TpcSubsystem is relevant for offline reconstruction of real data.
However, the values must be the same between PHG4TpcSubsystem and PHG4TpcPadPlaneReadout in the simulations, to have consistency between were hits are generated and where they are reconstructe.d

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

