### PR TITLE
Propagate tower status to embed DST from data DST

### DIFF
--- a/offline/packages/CaloEmbedding/caloTowerEmbed.cc
+++ b/offline/packages/CaloEmbedding/caloTowerEmbed.cc
@@ -126,17 +126,10 @@ int caloTowerEmbed::process_event(PHCompositeNode * /*topNode*/)
       keySim = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::HCALOUT, ieta_sim, iphi_sim);
     }
 
+    _sim_towers->get_tower_at_channel(channel)->set_status(_data_towers->get_tower_at_channel(channel)->get_status());
+
     TowerInfo *caloinfo_data = _data_towers->get_tower_at_channel(channel);
     TowerInfo *caloinfo_sim = _sim_towers->get_tower_at_channel(channel);
-
-    if (m_removeBadTowers && !caloinfo_data->get_isGood())
-    {
-
-      _sim_towers->get_tower_at_channel(channel)->set_energy(0.0);
-      _sim_towers->get_tower_at_channel(channel)->set_time(-11);
-
-      continue;
-    }
 
     float data_E = caloinfo_data->get_energy();
     float sim_E = caloinfo_sim->get_energy();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Propagates TowerInfo status from data to embedding automatically during embedding (requires use of TowerInfov2 for sim)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

