### PR TITLE
Fix improper writing to spin db with no run

### DIFF
--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -388,6 +388,24 @@ int XingShiftCal::CommitToSpinDB()
   std::cout << "XingShiftCal::CommitPatternToSpinDB()" << std::endl;
   std::string status;  //-------------------------------------------->
 
+
+  if (runnumber == 0)
+  {
+    std::cout << "Run doesn't exist" << std::endl;
+    commitSuccessSpinDB = 0;
+    return 0;
+  }
+
+  if (fillnumberBlue != fillnumberYellow)
+  {
+    std::cout << "fillnumber is wrong : fillnumberBlue = " << fillnumberBlue
+              << "fillnumberYellow = " << fillnumberYellow << std::endl;
+    commitSuccessSpinDB = 0;
+    return 0;
+  }
+
+  
+
   int xing_correction_offset = -999;
   if (success)
   {
@@ -407,13 +425,7 @@ int XingShiftCal::CommitToSpinDB()
   unsigned int qa_level = 0xffff;
   
 
-  if (fillnumberBlue != fillnumberYellow)
-  {
-    std::cout << "fillnumber is wrong : fillnumberBlue = " << fillnumberBlue
-              << "fillnumberYellow = " << fillnumberYellow << std::endl;
-    commitSuccessSpinDB = 0;
-    return 0;
-  }
+  
 
   // if (verbosity) {
   std::cout << "polb = " << polBlue << " +- " << polBlueErr


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR fixes the bug where xingshiftcal will write to the spin db even if the run doesn't exist.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

