### PR TITLE
Drop single strip clusters in Micromegas clusterizer

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1039,6 +1039,33 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     }
   }
 
+  if(Verbosity() > 2)
+    {
+      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
+	{
+	  unsigned int layer =  TrkrDefs::getLayer(ckey);
+	  auto loc = geometry->getLocalCoords(ckey, cluster);  
+	  std::cout << " MMs layer " << layer << " cluslx " << loc(0) << " clusly " << loc(1) << std:: endl; 
+	  std::cout << "     clusgx " <<  clusglob.x() 
+		    << " clusgy " << clusglob.y() 
+		    << " clusgz " << clusglob.z() 
+		    << std::endl;
+
+	  if(!state)
+	    {
+	      std::cout << " ****** ckey " << ckey << " track " << track->get_id() << " in layer " << layer << " found no matching state " << std::endl;
+	    }
+	  else
+	    {
+	      std::cout << "found matching state for ckey " << ckey  << " track " << track->get_id() << " in layer " <<  layer  << std::endl;
+	      std::cout << "   stategx  " << state->get_x() 
+			<< " stategy " << state->get_y() 
+			<< " stategz " << state->get_z()
+			<< std::endl; 	  
+	    }
+	}
+    }
+
   m_cluskeys.push_back(ckey);
 
   //! have cluster and state, fill vectors
@@ -1083,6 +1110,19 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     {
       fillStatesWithCircleFit(ckey, cluster, clusglob, geometry);
     }
+
+    if(Verbosity() > 2)
+      {
+	if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
+	  {
+	    unsigned int ssize = m_stategx.size();
+	    std::cout << "   ckey " << ckey << " after circle fit: stategx  " << m_stategx[ssize-1]
+		      << " stategy " << m_stategy[ssize-1]
+		      << " stategz " << m_stategy[ssize-1]
+		      << std::endl; 	  
+	  }
+      }
+
     //! skip filling the state information if a state is not there
     //! or we just ran the seeding. Fill with Nans to maintain the
     //! 1-to-1 mapping between cluster/state vectors

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -391,18 +391,18 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
       // eliminate single strip clusters
       if(segmentation_type == MicromegasDefs::SegmentationType::SEGMENTATION_PHI)
           {
-	    if(cluster->getPhiSize() > 1)
-	      {
-		trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-	      }
+	    if(m_drop_single_strips && cluster->getPhiSize() < 2) 
+	      { continue; }
+
+	    trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
 	  }
 
       if(segmentation_type == MicromegasDefs::SegmentationType::SEGMENTATION_Z)
           {
-	    if(cluster->getZSize() > 1)
-	      {
-		trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
-	      }
+	    if(m_drop_single_strips && cluster->getZSize() < 2)
+	      { continue; }
+
+	    trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
 	  }
     }
 

--- a/offline/packages/micromegas/MicromegasClusterizer.cc
+++ b/offline/packages/micromegas/MicromegasClusterizer.cc
@@ -363,7 +363,6 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
         }
       }
 
-
       auto cluster = std::make_unique<TrkrClusterv5>();
       cluster->setAdc( adc_sum );
       cluster->setMaxAdc( max_adc );
@@ -388,10 +387,23 @@ int MicromegasClusterizer::process_event(PHCompositeNode *topNode)
             break;
           }
         }
-      // add to container
-      trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
 
+      // eliminate single strip clusters
+      if(segmentation_type == MicromegasDefs::SegmentationType::SEGMENTATION_PHI)
+          {
+	    if(cluster->getPhiSize() > 1)
+	      {
+		trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
+	      }
+	  }
 
+      if(segmentation_type == MicromegasDefs::SegmentationType::SEGMENTATION_Z)
+          {
+	    if(cluster->getZSize() > 1)
+	      {
+		trkrClusterContainer->addClusterSpecifyKey( ckey, cluster.release() );
+	      }
+	  }
     }
 
   }

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -39,6 +39,9 @@ class MicromegasClusterizer : public SubsysReco
   void set_use_default_pedestal( bool value )
   { m_use_default_pedestal = value; }
 
+  void set_drop_single_strips(bool drop)
+  { m_drop_single_strips = drop; }
+
   /// calibration file
   void set_calibration_file( const std::string& value )
   { m_calibration_filename = value; }
@@ -47,6 +50,9 @@ class MicromegasClusterizer : public SubsysReco
 
   //!@name calibration filename
   //@{
+
+  // discard single strip clusters if true
+  bool m_drop_single_strips = false;
 
   /// if true, use default pedestal to get hit charge. Relies on calibration data otherwise
   bool m_use_default_pedestal = true;

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -174,14 +174,22 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
     auto seed = _svtx_seed_map->get(seedID);
     auto siID = seed->get_silicon_seed_index();
     auto tracklet_si = _si_track_map->get(siID);
-    if(!tracklet_si) continue;  // cannot use tracks not matched to silicon because crossing is unknown
 
-    short int crossing = tracklet_si->get_crossing();
-    if (crossing == SHRT_MAX) 
+    short int crossing = 0;
+    if(_pp_mode)
       {
-	if(Verbosity() > 0) 
-	  std::cout  << " svtx seed " << seedID << " with si seed " << siID << " crossing not defined: crossing = " << crossing << " skip this track" << std::endl;
-	continue;
+	if(!tracklet_si) continue;  // cannot use tracks not matched to silicon because crossing is unknown
+	
+	crossing = tracklet_si->get_crossing();
+	if (crossing == SHRT_MAX) 
+	  {
+	    if(Verbosity() > 0)
+	      { 
+		std::cout  << " svtx seed " << seedID << " with si seed " << siID 
+			   << " crossing not defined: crossing = " << crossing << " skip this track" << std::endl;
+	      }
+	    continue;
+	  }
       }
 
     auto tpcID = seed->get_tpc_seed_index();
@@ -393,6 +401,8 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
               << " dz " << dz
               << " mm_clus_rphi " << mm_clus_rphi << " mm_clus_z " << mm_clus_z
               << " rphi_proj " <<  rphi_proj << " z_proj " << z_proj
+	      << " pt " << tracklet_tpc->get_pt()
+	      << " charge " << tracklet_tpc->get_charge()
               << std::endl;
           }
         }

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -37,6 +37,7 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_z_search_window_lyr2(const double win){_z_search_win[1] = win;}
   void set_min_tpc_layer(const unsigned int layer){_min_tpc_layer = layer;}
   void set_test_windows_printout(const bool test){_test_windows = test;}
+  void set_pp_mode(const bool mode){_pp_mode = mode;}
   void SetIteration(int iter){_n_iteration = iter;}
   
   int InitRun(PHCompositeNode* topNode) override;
@@ -103,7 +104,8 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   //! true to printout actual residuals for testing
   bool _test_windows = false;   
-  
+
+  bool _pp_mode = false;  
 };
 
 #endif // PHMICROMEGASTPCTRACKMATCHING_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Found that in real data there are multiple micromegas clusters with different positions associated with a single track. Traced this to the micromegas clustering finding many single strip clusters in addition to what appear to be more realistic 2 or more strip clusters. Modified the clustering to not add single strip clusters to the cluster container. This may not be the optimal fix, that needs more study.

Also, modified micromegas-TPC matcher to not skip tracks with no silicon association for now. 

Also modified TrackResiduals with some ugly (but temporary) diagnostic output until micromegas-TPC matching is understood in data.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

