### PR TITLE
Fix clang tidy 14

### DIFF
--- a/offline/QA/Calorimeters/Makefile.am
+++ b/offline/QA/Calorimeters/Makefile.am
@@ -10,7 +10,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \

--- a/offline/QA/EventDisplay/Makefile.am
+++ b/offline/QA/EventDisplay/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/QA/SimulationModules/Makefile.am
+++ b/offline/QA/SimulationModules/Makefile.am
@@ -2,8 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  -I$(OFFLINE_MAIN)/include/eigen3 \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem`root-config --incdir`\
   -DHomogeneousField
 

--- a/offline/QA/Trigger/Makefile.am
+++ b/offline/QA/Trigger/Makefile.am
@@ -10,7 +10,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 pkginclude_HEADERS = \

--- a/offline/packages/TPCHitTrackDisplay/Makefile.am
+++ b/offline/packages/TPCHitTrackDisplay/Makefile.am
@@ -8,8 +8,8 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  -I$(G4_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
+  -isystem$(G4_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -12,18 +12,18 @@
 
 #include "AlignmentDefs.h"
 
-#include <fun4all/SubsysReco.h>
-
-#include <string>
-#include <vector>
-
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
 
+#include <fun4all/SubsysReco.h>
+
 #include <ActsExamples/EventData/Trajectories.hpp>
+
+#include <string>
+#include <vector>
 
 class PHCompositeNode;
 class PHG4TpcCylinderGeomContainer;

--- a/offline/packages/TrackerMillepedeAlignment/Makefile.am
+++ b/offline/packages/TrackerMillepedeAlignment/Makefile.am
@@ -5,7 +5,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/TrackingDiagnostics/BeamCrossingAnalysis.cc
+++ b/offline/packages/TrackingDiagnostics/BeamCrossingAnalysis.cc
@@ -9,7 +9,7 @@
 #include <utility>
 
 #include <TFile.h>
-#include <TH1D.h>
+#include <TH1.h>
 #include <TNtuple.h>
 
 BeamCrossingAnalysis::BeamCrossingAnalysis(const std::string& name)

--- a/offline/packages/TrackingDiagnostics/KshortReconstruction.cc
+++ b/offline/packages/TrackingDiagnostics/KshortReconstruction.cc
@@ -13,7 +13,7 @@
 #include <TLorentzVector.h>
 
 #include <TFile.h>
-#include <TH1D.h>
+#include <TH1.h>
 #include <TNtuple.h>
 
 int KshortReconstruction::process_event(PHCompositeNode* /**topNode*/)

--- a/offline/packages/TrackingDiagnostics/Makefile.am
+++ b/offline/packages/TrackingDiagnostics/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -45,6 +45,8 @@
 #include <phool/PHNodeIterator.h>
 #include <phool/getClass.h>
 
+#include <limits>
+
 namespace
 {
   template <class T>
@@ -298,15 +300,16 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       m_seedy = tpcseed->get_y();
       m_seedz = tpcseed->get_z();
     }
-    if (tpcseed){
-      m_dedx = calc_dedx(tpcseed, clustermap,tpcGeom);
+    if (tpcseed)
+    {
+      m_dedx = calc_dedx(tpcseed, clustermap, tpcGeom);
     }
     if (m_zeroField)
     {
-      float qor = NAN;
-      float phi = NAN;
-      float theta = NAN;
-      float eta = NAN;
+      float qor = std::numeric_limits<float>::quiet_NaN();
+      float phi = std::numeric_limits<float>::quiet_NaN();
+      float theta = std::numeric_limits<float>::quiet_NaN();
+      float eta = std::numeric_limits<float>::quiet_NaN();
       if (tpcseed)
       {
         qor = tpcseed->get_qOverR();
@@ -427,33 +430,34 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
-float TrackResiduals::calc_dedx(TrackSeed *tpcseed, TrkrClusterContainer *clustermap, PHG4TpcCylinderGeomContainer *tpcGeom){
-
+float TrackResiduals::calc_dedx(TrackSeed* tpcseed, TrkrClusterContainer* clustermap, PHG4TpcCylinderGeomContainer* tpcGeom)
+{
   std::vector<TrkrDefs::cluskey> clusterKeys;
   clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
-		       tpcseed->end_cluster_keys());
-  
+                     tpcseed->end_cluster_keys());
+
   std::vector<float> dedxlist;
-  for (unsigned int i = 0; i < clusterKeys.size(); i++){
-    TrkrDefs::cluskey cluster_key = clusterKeys.at(i);
+  for (unsigned long cluster_key : clusterKeys)
+  {
     unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
     TrkrCluster* cluster = clustermap->findCluster(cluster_key);
     float adc = cluster->getAdc();
     PHG4TpcCylinderGeom* GeoLayer_local = tpcGeom->GetLayerCellGeom(layer_local);
     float thick = GeoLayer_local->get_thickness();
-    
-    dedxlist.push_back(adc/thick);
+
+    dedxlist.push_back(adc / thick);
     sort(dedxlist.begin(), dedxlist.end());
   }
   int trunc_min = 0;
-  int trunc_max = (int)dedxlist.size()*0.7;
+  int trunc_max = (int) dedxlist.size() * 0.7;
   float sumdedx = 0;
   int ndedx = 0;
-  for(int j = trunc_min; j<=trunc_max;j++){
-    sumdedx+=dedxlist.at(j);
+  for (int j = trunc_min; j <= trunc_max; j++)
+  {
+    sumdedx += dedxlist.at(j);
     ndedx++;
   }
-  sumdedx/=ndedx;
+  sumdedx /= ndedx;
   return sumdedx;
 }
 
@@ -517,7 +521,7 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
       m_seedpz = tpcseed->get_pz();
     }
     m_seedcharge = tpcseed->get_qOverR() > 1 ? 1 : -1;
-    m_dedx = calc_dedx(tpcseed, clustermap,tpcGeo);
+    m_dedx = calc_dedx(tpcseed, clustermap, tpcGeo);
     std::cout << "m_dedx: " << m_dedx << std::endl;
     m_nmaps = 0;
     m_nintt = 0;
@@ -1075,32 +1079,32 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
     }
   }
 
-  if(Verbosity() > 2)
+  if (Verbosity() > 2)
+  {
+    if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
     {
-      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
-	{
-	  unsigned int layer =  TrkrDefs::getLayer(ckey);
-	  auto loc = geometry->getLocalCoords(ckey, cluster);  
-	  std::cout << " MMs layer " << layer << " cluslx " << loc(0) << " clusly " << loc(1) << std:: endl; 
-	  std::cout << "     clusgx " <<  clusglob.x() 
-		    << " clusgy " << clusglob.y() 
-		    << " clusgz " << clusglob.z() 
-		    << std::endl;
+      unsigned int layer = TrkrDefs::getLayer(ckey);
+      auto loc = geometry->getLocalCoords(ckey, cluster);
+      std::cout << " MMs layer " << layer << " cluslx " << loc(0) << " clusly " << loc(1) << std::endl;
+      std::cout << "     clusgx " << clusglob.x()
+                << " clusgy " << clusglob.y()
+                << " clusgz " << clusglob.z()
+                << std::endl;
 
-	  if(!state)
-	    {
-	      std::cout << " ****** ckey " << ckey << " track " << track->get_id() << " in layer " << layer << " found no matching state " << std::endl;
-	    }
-	  else
-	    {
-	      std::cout << "found matching state for ckey " << ckey  << " track " << track->get_id() << " in layer " <<  layer  << std::endl;
-	      std::cout << "   stategx  " << state->get_x() 
-			<< " stategy " << state->get_y() 
-			<< " stategz " << state->get_z()
-			<< std::endl; 	  
-	    }
-	}
+      if (!state)
+      {
+        std::cout << " ****** ckey " << ckey << " track " << track->get_id() << " in layer " << layer << " found no matching state " << std::endl;
+      }
+      else
+      {
+        std::cout << "found matching state for ckey " << ckey << " track " << track->get_id() << " in layer " << layer << std::endl;
+        std::cout << "   stategx  " << state->get_x()
+                  << " stategy " << state->get_y()
+                  << " stategz " << state->get_z()
+                  << std::endl;
+      }
     }
+  }
 
   m_cluskeys.push_back(ckey);
 
@@ -1147,17 +1151,17 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
       fillStatesWithCircleFit(ckey, cluster, clusglob, geometry);
     }
 
-    if(Verbosity() > 2)
+    if (Verbosity() > 2)
+    {
+      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
       {
-	if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
-	  {
-	    unsigned int ssize = m_stategx.size();
-	    std::cout << "   ckey " << ckey << " after circle fit: stategx  " << m_stategx[ssize-1]
-		      << " stategy " << m_stategy[ssize-1]
-		      << " stategz " << m_stategy[ssize-1]
-		      << std::endl; 	  
-	  }
+        unsigned int ssize = m_stategx.size();
+        std::cout << "   ckey " << ckey << " after circle fit: stategx  " << m_stategx[ssize - 1]
+                  << " stategy " << m_stategy[ssize - 1]
+                  << " stategz " << m_stategy[ssize - 1]
+                  << std::endl;
       }
+    }
 
     //! skip filling the state information if a state is not there
     //! or we just ran the seeding. Fill with Nans to maintain the

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -50,7 +50,7 @@ class TrackResiduals : public SubsysReco
   void zeroField() { m_zeroField = true; }
   void runnumber(const int run) { m_runnumber = run; }
   void segment(const int seg) { m_segment = seg; }
-  void linefitAll() { m_linefitTPCOnly = false;  }
+  void linefitAll() { m_linefitTPCOnly = false; }
   void failedTree() { m_doFailedSeeds = true; }
 
  private:
@@ -72,7 +72,7 @@ class TrackResiduals : public SubsysReco
   void fillStatesWithCircleFit(const TrkrDefs::cluskey &key, TrkrCluster *cluster,
                                Acts::Vector3 &glob, ActsGeometry *geometry);
   void fillVertexTree(PHCompositeNode *topNode);
-  void fillFailedSeedTree(PHCompositeNode *topNode, std::set<unsigned int>& tpc_seed_ids);
+  void fillFailedSeedTree(PHCompositeNode *topNode, std::set<unsigned int> &tpc_seed_ids);
   float calc_dedx(TrackSeed *tpcseed, TrkrClusterContainer *clusters, PHG4TpcCylinderGeomContainer *tpcGeom);
 
   std::string m_outfileName = "";
@@ -139,7 +139,6 @@ class TrackResiduals : public SubsysReco
   float m_Y0 = std::numeric_limits<float>::quiet_NaN();
   float m_dcaxy = std::numeric_limits<float>::quiet_NaN();
   float m_dcaz = std::numeric_limits<float>::quiet_NaN();
-  
 
   float m_seedx = std::numeric_limits<float>::quiet_NaN();
   float m_seedy = std::numeric_limits<float>::quiet_NaN();
@@ -164,115 +163,115 @@ class TrackResiduals : public SubsysReco
   int m_strip = std::numeric_limits<int>::quiet_NaN();
   float m_zdriftlength = std::numeric_limits<float>::quiet_NaN();
 
-int m_ntracks = std::numeric_limits<int>::quiet_NaN();
-int m_nvertices = std::numeric_limits<int>::quiet_NaN();
+  int m_ntracks = std::numeric_limits<int>::quiet_NaN();
+  int m_nvertices = std::numeric_limits<int>::quiet_NaN();
 
-//! cluster tree info
-float m_sclusgr = std::numeric_limits<float>::quiet_NaN();
-float m_sclusphi = std::numeric_limits<float>::quiet_NaN();
-float m_scluseta = std::numeric_limits<float>::quiet_NaN();
-float m_adc = std::numeric_limits<float>::quiet_NaN();
-float m_clusmaxadc = std::numeric_limits<float>::quiet_NaN();
-int m_phisize = std::numeric_limits<int>::quiet_NaN();
-int m_zsize = std::numeric_limits<int>::quiet_NaN();
-float m_scluslx = std::numeric_limits<float>::quiet_NaN();
-float m_scluslz = std::numeric_limits<float>::quiet_NaN();
-float m_sclusgx = std::numeric_limits<float>::quiet_NaN();
-float m_sclusgy = std::numeric_limits<float>::quiet_NaN();
-float m_sclusgz = std::numeric_limits<float>::quiet_NaN();
-int m_scluslayer = std::numeric_limits<int>::quiet_NaN();
-float m_scluselx = std::numeric_limits<float>::quiet_NaN();
-float m_scluselz = std::numeric_limits<float>::quiet_NaN();
-int m_clussector = std::numeric_limits<int>::quiet_NaN();
-int m_side = std::numeric_limits<int>::quiet_NaN();
-int m_staveid = std::numeric_limits<int>::quiet_NaN();
-int m_chipid = std::numeric_limits<int>::quiet_NaN();
-int m_strobeid = std::numeric_limits<int>::quiet_NaN();
-int m_ladderzid = std::numeric_limits<int>::quiet_NaN();
-int m_ladderphiid = std::numeric_limits<int>::quiet_NaN();
-int m_timebucket = std::numeric_limits<int>::quiet_NaN();
-int m_segtype = std::numeric_limits<int>::quiet_NaN();
-int m_tileid = std::numeric_limits<int>::quiet_NaN();
+  //! cluster tree info
+  float m_sclusgr = std::numeric_limits<float>::quiet_NaN();
+  float m_sclusphi = std::numeric_limits<float>::quiet_NaN();
+  float m_scluseta = std::numeric_limits<float>::quiet_NaN();
+  float m_adc = std::numeric_limits<float>::quiet_NaN();
+  float m_clusmaxadc = std::numeric_limits<float>::quiet_NaN();
+  int m_phisize = std::numeric_limits<int>::quiet_NaN();
+  int m_zsize = std::numeric_limits<int>::quiet_NaN();
+  float m_scluslx = std::numeric_limits<float>::quiet_NaN();
+  float m_scluslz = std::numeric_limits<float>::quiet_NaN();
+  float m_sclusgx = std::numeric_limits<float>::quiet_NaN();
+  float m_sclusgy = std::numeric_limits<float>::quiet_NaN();
+  float m_sclusgz = std::numeric_limits<float>::quiet_NaN();
+  int m_scluslayer = std::numeric_limits<int>::quiet_NaN();
+  float m_scluselx = std::numeric_limits<float>::quiet_NaN();
+  float m_scluselz = std::numeric_limits<float>::quiet_NaN();
+  int m_clussector = std::numeric_limits<int>::quiet_NaN();
+  int m_side = std::numeric_limits<int>::quiet_NaN();
+  int m_staveid = std::numeric_limits<int>::quiet_NaN();
+  int m_chipid = std::numeric_limits<int>::quiet_NaN();
+  int m_strobeid = std::numeric_limits<int>::quiet_NaN();
+  int m_ladderzid = std::numeric_limits<int>::quiet_NaN();
+  int m_ladderphiid = std::numeric_limits<int>::quiet_NaN();
+  int m_timebucket = std::numeric_limits<int>::quiet_NaN();
+  int m_segtype = std::numeric_limits<int>::quiet_NaN();
+  int m_tileid = std::numeric_limits<int>::quiet_NaN();
 
-//! clusters on track information
-std::vector<float> m_clusAdc;
-std::vector<float> m_clusMaxAdc;
-std::vector<float> m_cluslx;
-std::vector<float> m_cluslz;
-std::vector<float> m_cluselx;
-std::vector<float> m_cluselz;
-std::vector<float> m_clusgx;
-std::vector<float> m_clusgy;
-std::vector<float> m_clusgz;
-std::vector<float> m_clusgr;
-std::vector<int> m_cluslayer;
-std::vector<int> m_clussize;
-std::vector<int> m_clusphisize;
-std::vector<int> m_cluszsize;
-std::vector<int> m_clusedge;
-std::vector<int> m_clusoverlap;
-std::vector<uint32_t> m_clushitsetkey;
-std::vector<uint64_t> m_cluskeys;
-std::vector<float> m_idealsurfcenterx;
-std::vector<float> m_idealsurfcentery;
-std::vector<float> m_idealsurfcenterz;
-std::vector<float> m_idealsurfnormx;
-std::vector<float> m_idealsurfnormy;
-std::vector<float> m_idealsurfnormz;
-std::vector<float> m_missurfcenterx;
-std::vector<float> m_missurfcentery;
-std::vector<float> m_missurfcenterz;
-std::vector<float> m_missurfnormx;
-std::vector<float> m_missurfnormy;
-std::vector<float> m_missurfnormz;
-std::vector<float> m_clusgxideal;
-std::vector<float> m_clusgyideal;
-std::vector<float> m_clusgzideal;
-std::vector<float> m_idealsurfalpha;
-std::vector<float> m_idealsurfbeta;
-std::vector<float> m_idealsurfgamma;
-std::vector<float> m_missurfalpha;
-std::vector<float> m_missurfbeta;
-std::vector<float> m_missurfgamma;
+  //! clusters on track information
+  std::vector<float> m_clusAdc;
+  std::vector<float> m_clusMaxAdc;
+  std::vector<float> m_cluslx;
+  std::vector<float> m_cluslz;
+  std::vector<float> m_cluselx;
+  std::vector<float> m_cluselz;
+  std::vector<float> m_clusgx;
+  std::vector<float> m_clusgy;
+  std::vector<float> m_clusgz;
+  std::vector<float> m_clusgr;
+  std::vector<int> m_cluslayer;
+  std::vector<int> m_clussize;
+  std::vector<int> m_clusphisize;
+  std::vector<int> m_cluszsize;
+  std::vector<int> m_clusedge;
+  std::vector<int> m_clusoverlap;
+  std::vector<uint32_t> m_clushitsetkey;
+  std::vector<uint64_t> m_cluskeys;
+  std::vector<float> m_idealsurfcenterx;
+  std::vector<float> m_idealsurfcentery;
+  std::vector<float> m_idealsurfcenterz;
+  std::vector<float> m_idealsurfnormx;
+  std::vector<float> m_idealsurfnormy;
+  std::vector<float> m_idealsurfnormz;
+  std::vector<float> m_missurfcenterx;
+  std::vector<float> m_missurfcentery;
+  std::vector<float> m_missurfcenterz;
+  std::vector<float> m_missurfnormx;
+  std::vector<float> m_missurfnormy;
+  std::vector<float> m_missurfnormz;
+  std::vector<float> m_clusgxideal;
+  std::vector<float> m_clusgyideal;
+  std::vector<float> m_clusgzideal;
+  std::vector<float> m_idealsurfalpha;
+  std::vector<float> m_idealsurfbeta;
+  std::vector<float> m_idealsurfgamma;
+  std::vector<float> m_missurfalpha;
+  std::vector<float> m_missurfbeta;
+  std::vector<float> m_missurfgamma;
 
-//! states on track information
-std::vector<float> m_statelx;
-std::vector<float> m_statelz;
-std::vector<float> m_stateelx;
-std::vector<float> m_stateelz;
-std::vector<float> m_stategx;
-std::vector<float> m_stategy;
-std::vector<float> m_stategz;
-std::vector<float> m_statepx;
-std::vector<float> m_statepy;
-std::vector<float> m_statepz;
-std::vector<float> m_statepl;
+  //! states on track information
+  std::vector<float> m_statelx;
+  std::vector<float> m_statelz;
+  std::vector<float> m_stateelx;
+  std::vector<float> m_stateelz;
+  std::vector<float> m_stategx;
+  std::vector<float> m_stategy;
+  std::vector<float> m_stategz;
+  std::vector<float> m_statepx;
+  std::vector<float> m_statepy;
+  std::vector<float> m_statepz;
+  std::vector<float> m_statepl;
 
-std::vector<float> m_statelxglobderivdx;
-std::vector<float> m_statelxglobderivdy;
-std::vector<float> m_statelxglobderivdz;
-std::vector<float> m_statelxglobderivdalpha;
-std::vector<float> m_statelxglobderivdbeta;
-std::vector<float> m_statelxglobderivdgamma;
+  std::vector<float> m_statelxglobderivdx;
+  std::vector<float> m_statelxglobderivdy;
+  std::vector<float> m_statelxglobderivdz;
+  std::vector<float> m_statelxglobderivdalpha;
+  std::vector<float> m_statelxglobderivdbeta;
+  std::vector<float> m_statelxglobderivdgamma;
 
-std::vector<float> m_statelxlocderivd0;
-std::vector<float> m_statelxlocderivz0;
-std::vector<float> m_statelxlocderivphi;
-std::vector<float> m_statelxlocderivtheta;
-std::vector<float> m_statelxlocderivqop;
+  std::vector<float> m_statelxlocderivd0;
+  std::vector<float> m_statelxlocderivz0;
+  std::vector<float> m_statelxlocderivphi;
+  std::vector<float> m_statelxlocderivtheta;
+  std::vector<float> m_statelxlocderivqop;
 
-std::vector<float> m_statelzglobderivdx;
-std::vector<float> m_statelzglobderivdy;
-std::vector<float> m_statelzglobderivdz;
-std::vector<float> m_statelzglobderivdalpha;
-std::vector<float> m_statelzglobderivdbeta;
-std::vector<float> m_statelzglobderivdgamma;
+  std::vector<float> m_statelzglobderivdx;
+  std::vector<float> m_statelzglobderivdy;
+  std::vector<float> m_statelzglobderivdz;
+  std::vector<float> m_statelzglobderivdalpha;
+  std::vector<float> m_statelzglobderivdbeta;
+  std::vector<float> m_statelzglobderivdgamma;
 
-std::vector<float> m_statelzlocderivd0;
-std::vector<float> m_statelzlocderivz0;
-std::vector<float> m_statelzlocderivphi;
-std::vector<float> m_statelzlocderivtheta;
-std::vector<float> m_statelzlocderivqop;
+  std::vector<float> m_statelzlocderivd0;
+  std::vector<float> m_statelzlocderivz0;
+  std::vector<float> m_statelzlocderivphi;
+  std::vector<float> m_statelzlocderivtheta;
+  std::vector<float> m_statelzlocderivqop;
 };
 
 #endif  // TRACKRESIDUALS_H

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -3,22 +3,22 @@
 #ifndef TRACKRESIDUALS_H
 #define TRACKRESIDUALS_H
 
-#include <fun4all/SubsysReco.h>
-
-#include <TFile.h>
-#include <TH1.h>
-#include <TTree.h>
-#include <string>
+#include <tpc/TpcClusterZCrossingCorrection.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrDefs.h>
 
-#include <tpc/TpcClusterZCrossingCorrection.h>
+#include <fun4all/SubsysReco.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TTree.h>
 
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <string>
 
 class TrkrCluster;
 class PHCompositeNode;

--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -142,7 +142,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
           svtxtrack->set_x(tpcseed->get_x());
           svtxtrack->set_y(tpcseed->get_y());
           svtxtrack->set_z(tpcseed->get_z());
-          svtxtrack->set_crossing(SHRT_MAX);
+          svtxtrack->set_crossing(std::numeric_limits<short int>::max());
         }
         else
         {

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -7,7 +7,6 @@
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHit.h>
 #include <trackbase/TrkrHitSetContainer.h>
-#include <trackbase/TrackFitUtils.h>
 
 #include <trackbase_historic/TrackSeedContainer_v1.h>
 
@@ -1179,8 +1178,8 @@ void TrkrNtuplizer::fillOutputNtuples(PHCompositeNode* topNode)
         //      nhits_local += tpcseed->size_cluster_keys();
         // fill the Gseed NTuple
         //---------------------
-	float dedx = calc_dedx(tpcseed);
-	float n1pix = get_n1pix(tpcseed);
+        float dedx = calc_dedx(tpcseed);
+        float n1pix = get_n1pix(tpcseed);
         float fx_seed[n_seed::seedsize] = {(float) track->get_id(), 0, tpt, teta, tphi, xyint, rzint, xyslope, rzslope, tX0, tY0, tZ0, R0, charge, dedx, n1pix, nhits_local};
 
         if (_ntp_tpcseed)
@@ -1285,7 +1284,7 @@ void TrkrNtuplizer::FillTrack(float fX[50], SvtxTrack* track, GlobalVertexMap* v
   short int crossing_int = track->get_crossing();
   fX[n_track::ntrktrackID] = trackID;
   fX[n_track::ntrkcrossing] = std::numeric_limits<float>::quiet_NaN();
-  if (crossing_int == SHRT_MAX)
+  if (crossing_int == std::numeric_limits<short int>::max())
   {
     fX[n_track::ntrkcrossing] = std::numeric_limits<float>::quiet_NaN();
   }
@@ -1457,51 +1456,53 @@ void TrkrNtuplizer::FillTrack(float fX[50], SvtxTrack* track, GlobalVertexMap* v
   fX[n_track::ntrkpcaz] = track->get_z();
 }
 
-float TrkrNtuplizer::calc_dedx(TrackSeed *tpcseed){
+float TrkrNtuplizer::calc_dedx(TrackSeed* tpcseed)
+{
+  std::vector<TrkrDefs::cluskey> clusterKeys;
+  clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
+                     tpcseed->end_cluster_keys());
 
-    std::vector<TrkrDefs::cluskey> clusterKeys;
-    clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
-		       tpcseed->end_cluster_keys());
+  std::vector<float> dedxlist;
+  for (unsigned long cluster_key : clusterKeys)
+  {
+    unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
+    TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
+    float adc = cluster->getAdc();
+    PHG4TpcCylinderGeom* GeoLayer_local = _geom_container->GetLayerCellGeom(layer_local);
+    float thick = GeoLayer_local->get_thickness();
 
-    std::vector<float> dedxlist;
-    for (unsigned int i = 0; i < clusterKeys.size(); i++){
-      TrkrDefs::cluskey cluster_key = clusterKeys.at(i);
-      unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
-      TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
-      float adc = cluster->getAdc();
-      PHG4TpcCylinderGeom* GeoLayer_local = _geom_container->GetLayerCellGeom(layer_local);
-      float thick = GeoLayer_local->get_thickness();
-
-      dedxlist.push_back(adc/thick);
-      sort(dedxlist.begin(), dedxlist.end());
-    }
-    int trunc_min = 0;
-    int trunc_max = (int)dedxlist.size()*0.7;
-    float sumdedx = 0;
-    int ndedx = 0;
-    for(int j = trunc_min; j<=trunc_max;j++){
-      sumdedx+=dedxlist.at(j);
-      ndedx++;
-    }
-    sumdedx/=ndedx;
-    return sumdedx;
+    dedxlist.push_back(adc / thick);
+    sort(dedxlist.begin(), dedxlist.end());
+  }
+  int trunc_min = 0;
+  int trunc_max = (int) dedxlist.size() * 0.7;
+  float sumdedx = 0;
+  int ndedx = 0;
+  for (int j = trunc_min; j <= trunc_max; j++)
+  {
+    sumdedx += dedxlist.at(j);
+    ndedx++;
+  }
+  sumdedx /= ndedx;
+  return sumdedx;
 }
 
-float TrkrNtuplizer::get_n1pix(TrackSeed *tpcseed){
+float TrkrNtuplizer::get_n1pix(TrackSeed* tpcseed)
+{
+  std::vector<TrkrDefs::cluskey> clusterKeys;
+  clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
+                     tpcseed->end_cluster_keys());
 
-    std::vector<TrkrDefs::cluskey> clusterKeys;
-    clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
-		       tpcseed->end_cluster_keys());
-
-    float n1pix = 0;
-    for (unsigned int i = 0; i < clusterKeys.size(); i++){
-      TrkrDefs::cluskey cluster_key = clusterKeys.at(i);
-      TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
-      if(cluster->getPhiSize()==1){
-	n1pix++;
-      }
+  float n1pix = 0;
+  for (unsigned long cluster_key : clusterKeys)
+  {
+    TrkrCluster* cluster = _cluster_map->findCluster(cluster_key);
+    if (cluster->getPhiSize() == 1)
+    {
+      n1pix++;
     }
-    return n1pix;
+  }
+  return n1pix;
 }
 
 void TrkrNtuplizer::FillCluster(float fXcluster[49], TrkrDefs::cluskey cluster_key)
@@ -1638,7 +1639,7 @@ SvtxTrack* TrkrNtuplizer::best_track_from(TrkrDefs::cluskey cluster_key)
   }
 
   SvtxTrack* best_track = nullptr;
-  float best_quality = FLT_MAX;
+  float best_quality = std::numeric_limits<float>::max();
 
   std::set<SvtxTrack*> tracks = all_tracks_from(cluster_key);
   // loop over all SvtxTracks

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -539,27 +539,18 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
       static constexpr std::array<double, 7> scalefactors_phi = {
           {0.36, 0.6, 0.37, 0.49, 0.4, 0.37, 0.33}};
 
-      if (phibins.size() == 1 && zbins.size() == 1)
+      if ((phibins.size() == 1 && zbins.size() == 1) ||
+          (phibins.size() == 2 && zbins.size() == 2))
       {
         phierror *= scalefactors_phi[0];
       }
-      else if (phibins.size() == 2 && zbins.size() == 1)
+      else if ((phibins.size() == 2 && zbins.size() == 1) ||
+               (phibins.size() == 2 && zbins.size() == 3))
       {
         phierror *= scalefactors_phi[1];
       }
-      else if (phibins.size() == 1 && zbins.size() == 2)
-      {
-        phierror *= scalefactors_phi[2];
-      }
-      else if (phibins.size() == 2 && zbins.size() == 2)
-      {
-        phierror *= scalefactors_phi[0];
-      }
-      else if (phibins.size() == 2 && zbins.size() == 3)
-      {
-        phierror *= scalefactors_phi[1];
-      }
-      else if (phibins.size() == 3 && zbins.size() == 2)
+      else if ((phibins.size() == 1 && zbins.size() == 2) ||
+               (phibins.size() == 3 && zbins.size() == 2))
       {
         phierror *= scalefactors_phi[2];
       }
@@ -623,7 +614,10 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
         clus->identify();
       }
 
-      if (zbins.size() <= 127) m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+      if (zbins.size() <= 127)
+      {
+        m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+      }
 
     }  // clusitr loop
   }    // loop over hitsets
@@ -824,27 +818,18 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
 
       static constexpr std::array<double, 7> scalefactors_phi = {
           {0.36, 0.6, 0.37, 0.49, 0.4, 0.37, 0.33}};
-      if (phibins.size() == 1 && zbins.size() == 1)
+      if ((phibins.size() == 1 && zbins.size() == 1) ||
+          (phibins.size() == 2 && zbins.size() == 2))
       {
         phierror *= scalefactors_phi[0];
       }
-      else if (phibins.size() == 2 && zbins.size() == 1)
+      else if ((phibins.size() == 2 && zbins.size() == 1) ||
+               (phibins.size() == 2 && zbins.size() == 3))
       {
         phierror *= scalefactors_phi[1];
       }
-      else if (phibins.size() == 1 && zbins.size() == 2)
-      {
-        phierror *= scalefactors_phi[2];
-      }
-      else if (phibins.size() == 2 && zbins.size() == 2)
-      {
-        phierror *= scalefactors_phi[0];
-      }
-      else if (phibins.size() == 2 && zbins.size() == 3)
-      {
-        phierror *= scalefactors_phi[1];
-      }
-      else if (phibins.size() == 3 && zbins.size() == 2)
+      else if ((phibins.size() == 1 && zbins.size() == 2) ||
+               (phibins.size() == 3 && zbins.size() == 2))
       {
         phierror *= scalefactors_phi[2];
       }
@@ -909,7 +894,10 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
         clus->identify();
       }
 
-      if (zbins.size() <= 127) m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+      if (zbins.size() <= 127)
+      {
+        m_clusterlist->addClusterSpecifyKey(ckey, clus.release());
+      }
     }  // clusitr loop
   }    // loop over hitsets
 

--- a/offline/packages/mvtx/SegmentationAlpide.cc
+++ b/offline/packages/mvtx/SegmentationAlpide.cc
@@ -4,15 +4,17 @@
  * @brief mvtx object with ALPIDE chip description
  */
 #include "SegmentationAlpide.h"
-#include <cstdio>
+
+#include <boost/format.hpp>
+
+#include <iostream>
 
 void SegmentationAlpide::print()
 {
-  printf("Pixel size: %.2f (along %d rows) %.2f (along %d columns) microns\n",
-         PitchRow * 1e4, NRows, PitchCol * 1e4, NCols);
-  printf("Passive edges: bottom: %.2f, top: %.2f, left/right: %.2f microns\n",
-         PassiveEdgeReadOut * 1e4, PassiveEdgeTop * 1e4, PassiveEdgeSide * 1e4);
-  printf("Active/Total size: %.6f/%.6f (rows) %.6f/%.6f (cols) cm\n",
-         ActiveMatrixSizeRows, SensorSizeRows, ActiveMatrixSizeCols,
-         SensorSizeCols);
+  std::cout << (boost::format("Pixel size: %.2f (along %d rows) %.2f (along %d columns) microns") % (PitchRow * 1e4) % NRows % (PitchCol * 1e4) % NCols).str()
+            << std::endl;
+  std::cout << (boost::format("Passive edges: bottom: %.2f, top: %.2f, left/right: %.2f microns") % (PassiveEdgeReadOut * 1e4) % (PassiveEdgeTop * 1e4) % (PassiveEdgeSide * 1e4)).str()
+            << std::endl;
+  std::cout << (boost::format("Active/Total size: %.6f/%.6f (rows) %.6f/%.6f (cols) cm") % ActiveMatrixSizeRows % SensorSizeRows % ActiveMatrixSizeCols % SensorSizeCols).str()
+            << std::endl;
 }

--- a/offline/packages/trackbase/ActsGsfTrackFittingAlgorithm.h
+++ b/offline/packages/trackbase/ActsGsfTrackFittingAlgorithm.h
@@ -1,14 +1,9 @@
+#include "ActsTrackFittingAlgorithm.h"
+
+#include <Acts/Definitions/TrackParametrization.hpp>
+
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#include <Acts/Definitions/TrackParametrization.hpp>
-#pragma GCC diagnostic ignored "-Wshadow"
-#include <Acts/TrackFitting/GaussianSumFitter.hpp>
-#pragma GCC diagnostic pop
 
 #include <Acts/EventData/VectorTrackContainer.hpp>
 #include <Acts/Propagator/Navigator.hpp>
@@ -17,10 +12,10 @@
 #include <Acts/TrackFitting/BetheHeitlerApprox.hpp>
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
+#include <Acts/TrackFitting/GaussianSumFitter.hpp>
 #include <Acts/TrackFitting/GsfMixtureReduction.hpp>
 #include <Acts/Utilities/Helpers.hpp>
 
-#include "ActsTrackFittingAlgorithm.h"
 
 namespace
 {

--- a/offline/packages/trackbase/ActsSourceLink.h
+++ b/offline/packages/trackbase/ActsSourceLink.h
@@ -1,11 +1,11 @@
 #ifndef TRACKBASE_ACTSSOURCELINK_H
 #define TRACKBASE_ACTSSOURCELINK_H
 
+#include "TrkrDefs.h"
+
 #include <Acts/EventData/SourceLink.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 #include <Acts/Surfaces/Surface.hpp>
-
-#include "TrkrDefs.h"
 
 #include <cassert>
 #include <iostream>

--- a/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
+++ b/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
@@ -6,26 +6,16 @@
 #include "ResidualOutlierFinder.h"
 
 #include <Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp>
-#include <Acts/Geometry/TrackingGeometry.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#pragma GCC diagnostic ignored "-Wunused-value"
-#include <Acts/TrackFitting/KalmanFitter.hpp>
-#pragma GCC diagnostic pop
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#include <Acts/Propagator/MultiEigenStepperLoop.hpp>
-#pragma GCC diagnostic pop
-
 #include <Acts/EventData/SourceLink.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
+
+#include <Acts/Geometry/TrackingGeometry.hpp>
+
+#include <Acts/Propagator/MultiEigenStepperLoop.hpp>
+
+#include <Acts/TrackFitting/KalmanFitter.hpp>
 
 #include <functional>
 #include <memory>

--- a/offline/packages/trackbase/Calibrator.h
+++ b/offline/packages/trackbase/Calibrator.h
@@ -2,16 +2,14 @@
 #ifndef TRACKBASE_CALIBRATOR_H
 #define TRACKBASE_CALIBRATOR_H
 
-#include <Acts/EventData/Measurement.hpp>
-#include <Acts/EventData/MultiTrajectory.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#include <Acts/EventData/VectorMultiTrajectory.hpp>
-#pragma GCC diagnostic pop
-
 #include "ActsSourceLink.h"
 #include "TrkrDefs.h"
 #include "alignmentTransformationContainer.h"
+
+#include <Acts/EventData/Measurement.hpp>
+#include <Acts/EventData/MultiTrajectory.hpp>
+#include <Acts/EventData/VectorMultiTrajectory.hpp>
+
 
 class Calibrator
 {

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -18,7 +18,7 @@ else
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/trackbase/TrackFittingAlgorithmFunctionsGsf.cc
+++ b/offline/packages/trackbase/TrackFittingAlgorithmFunctionsGsf.cc
@@ -1,6 +1,6 @@
-#include <utility>
-
 #include "ActsGsfTrackFittingAlgorithm.h"
+
+#include <utility>
 
 std::shared_ptr<ActsTrackFittingAlgorithm::TrackFitterFunction>
 ActsGsfTrackFittingAlgorithm::makeGsfFitterFunction(

--- a/offline/packages/trackbase/TrackFittingAlgorithmFunctionsKalman.cc
+++ b/offline/packages/trackbase/TrackFittingAlgorithmFunctionsKalman.cc
@@ -1,24 +1,21 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#include "ActsTrackFittingAlgorithm.h"
+
 #include <Acts/Definitions/TrackParametrization.hpp>
-#pragma GCC diagnostic pop
+
 #include <Acts/Geometry/GeometryIdentifier.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#pragma GCC diagnostic ignored "-Wunused-value"
 #include <Acts/Propagator/EigenStepper.hpp>
-#pragma GCC diagnostic pop
-
 #include <Acts/Propagator/Navigator.hpp>
 #include <Acts/Propagator/Propagator.hpp>
+
 #include <Acts/Surfaces/Surface.hpp>
+
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
+
 #include <Acts/Utilities/Helpers.hpp>
 
-#include "ActsTrackFittingAlgorithm.h"
 
 namespace
 {

--- a/offline/packages/trackbase/configure.ac
+++ b/offline/packages/trackbase/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -pedantic -Wextra -Werror -Wshadow -Wno-dangling-pointer"
+   CXXFLAGS="$CXXFLAGS -Wall -pedantic -Wextra -Werror -Wshadow -Wno-dangling-pointer -Wno-maybe-uninitialized"
 fi
 
 case $CXX in

--- a/offline/packages/trackbase_historic/ActsTransformations.h
+++ b/offline/packages/trackbase_historic/ActsTransformations.h
@@ -1,6 +1,8 @@
 #ifndef TRACKRECO_ACTSTRANSFORMATIONS_H
 #define TRACKRECO_ACTSTRANSFORMATIONS_H
 
+#include "SvtxTrack.h"
+
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ActsTrackFittingAlgorithm.h>
 #include <trackbase/TrkrDefs.h>
@@ -10,8 +12,6 @@
 #include <Acts/EventData/VectorMultiTrajectory.hpp>
 #include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/Logger.hpp>
-
-#include "SvtxTrack.h"
 
 /// std (and the like) includes
 #include <cmath>

--- a/offline/packages/trackbase_historic/Makefile.am
+++ b/offline/packages/trackbase_historic/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include  \
+  -isystem$(OFFLINE_MAIN)/include  \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \
@@ -120,7 +120,7 @@ nobase_dist_pcm_DATA = \
   SvtxTrackSeed_v1_Dict_rdict.pcm \
   SvtxTrackSeed_v2_Dict_rdict.pcm \
   TrackSeed_FastSim_v1_Dict_rdict.pcm \
- 	TrackSeed_FastSim_v2_Dict_rdict.pcm \
+  TrackSeed_FastSim_v2_Dict_rdict.pcm \
   TrackSeedContainer_Dict_rdict.pcm \
   TrackSeedContainer_v1_Dict_rdict.pcm \
   PHG4ParticleSvtxMap_Dict_rdict.pcm \

--- a/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
+++ b/offline/packages/trackbase_historic/SvtxPHG4ParticleMap_v1.h
@@ -1,8 +1,9 @@
 #ifndef TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_V1_H
 #define TRACKBASEHISTORIC_SVTXPHG4PARTICLEMAP_V1_H
 
-#include <iostream>
 #include "SvtxPHG4ParticleMap.h"
+
+#include <iostream>
 
 class SvtxPHG4ParticleMap_v1 : public SvtxPHG4ParticleMap
 {

--- a/offline/packages/trackbase_historic/SvtxTrackCaloClusterMap.h
+++ b/offline/packages/trackbase_historic/SvtxTrackCaloClusterMap.h
@@ -1,8 +1,9 @@
 #ifndef TRACKBASEHISTORIC_SVTXTRACKCALOCLUSTERMAP_H
 #define TRACKBASEHISTORIC_SVTXTRACKCALOCLUSTERMAP_H
 
-#include <calobase/RawCluster.h>
 #include "SvtxTrack.h"
+
+#include <calobase/RawCluster.h>
 
 #include <phool/PHObject.h>
 

--- a/offline/packages/trackbase_historic/SvtxTrackSeed_v1.h
+++ b/offline/packages/trackbase_historic/SvtxTrackSeed_v1.h
@@ -1,9 +1,9 @@
 #ifndef TRACKBASEHISTORIC_SVTXTRACKSEED_V1_H
 #define TRACKBASEHISTORIC_SVTXTRACKSEED_V1_H
 
-#include <phool/PHObject.h>
-
 #include "TrackSeed.h"
+
+#include <phool/PHObject.h>
 
 #include <cmath>
 #include <iostream>

--- a/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
+++ b/offline/packages/trackbase_historic/TrackAnalysisUtils.cc
@@ -1,7 +1,8 @@
 #include "TrackAnalysisUtils.h"
 
-#include <cmath>
 #include "SvtxTrack.h"
+
+#include <cmath>
 
 namespace TrackAnalysisUtils
 {

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v1.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v1.cc
@@ -1,6 +1,8 @@
 #include "TrackInfoContainer_v1.h"
-#include <phool/PHObject.h>
+
 #include "SvtxTrackInfo.h"
+
+#include <phool/PHObject.h>
 
 #include <climits>
 #include <map>

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v1.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v1.h
@@ -1,10 +1,12 @@
 #ifndef TRACKINFOCONTAINERV1_H
 #define TRACKINFOCONTAINERV1_H
 
-#include <phool/PHObject.h>
+#include "TrackInfoContainer.h"
+
 #include "SvtxTrackInfo.h"
 #include "SvtxTrackInfo_v1.h"
-#include "TrackInfoContainer.h"
+
+#include <phool/PHObject.h>
 
 #include <TClonesArray.h>
 #include <climits>

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.cc
@@ -1,6 +1,8 @@
 #include "TrackInfoContainer_v2.h"
-#include <phool/PHObject.h>
+
 #include "SvtxTrackInfo_v2.h"
+
+#include <phool/PHObject.h>
 
 TrackInfoContainer_v2::TrackInfoContainer_v2()
 {

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v2.h
@@ -1,9 +1,11 @@
 #ifndef TRACKINFOCONTAINERV2_H
 #define TRACKINFOCONTAINERV2_H
 
-#include <phool/PHObject.h>
-#include "SvtxTrackInfo_v2.h"
 #include "TrackInfoContainer.h"
+
+#include "SvtxTrackInfo_v2.h"
+
+#include <phool/PHObject.h>
 
 #include <TClonesArray.h>
 

--- a/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
+++ b/offline/packages/trackbase_historic/TrackInfoContainer_v3.cc
@@ -1,7 +1,9 @@
 #include "TrackInfoContainer_v3.h"
-#include <phool/PHObject.h>
+
 #include "SvtxTrackInfo.h"
 #include "SvtxTrackInfo_v3.h"
+
+#include <phool/PHObject.h>
 
 #include <climits>
 #include <map>

--- a/offline/packages/trackbase_historic/TrackStateInfo.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo.h
@@ -1,9 +1,6 @@
 #ifndef TRACKBASEHISTORIC_TRACKSTATEINFO_H
 #define TRACKBASEHISTORIC_TRACKSTATEINFO_H
 
-//#include "SvtxTrackState.h"
-//#include "TrackSeed.h"
-
 #include <trackbase/TrkrDefs.h>
 
 #include <g4main/PHG4HitDefs.h>

--- a/offline/packages/trackbase_historic/TrackStateInfo_v1.h
+++ b/offline/packages/trackbase_historic/TrackStateInfo_v1.h
@@ -1,8 +1,8 @@
 #ifndef TRACKBASEHISTORIC_TRACKSTATEINFOV1_H
 #define TRACKBASEHISTORIC_TRACKSTATEINFOV1_H
 
-#include <trackbase/TrkrDefs.h>
 #include "TrackStateInfo.h"
+#include <trackbase/TrkrDefs.h>
 
 #include <cmath>
 #include <cstddef>  // for size_t

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -58,7 +58,6 @@
 #include <utility>  // for pair, make_pair
 #include <vector>
 
-
 //#define _DEBUG_
 
 #if defined(_DEBUG_)
@@ -76,19 +75,20 @@
 // _PHCASEEDING_TUPOUT_ defined statement in the header file
 #if defined(_PHCASEEDING_TUPOUT_)
 #define FILL_TUPLE(tupname, num, key, pos) \
-  tupname->Fill(_tupout_count,TrkrDefs::getLayer(key), num, pos.x(), pos.y(), pos.z())
-#define FILL_TUPLE_WITH_SEED(tupname, seed,pos) \
-  for (unsigned int i=0; i<seed.size();++i) FILL_TUPLE(tupname, i, seed[i], pos.at(seed[i]))
+  tupname->Fill(_tupout_count, TrkrDefs::getLayer(key), num, pos.x(), pos.y(), pos.z())
+#define FILL_TUPLE_WITH_SEED(tupname, seed, pos) \
+  for (unsigned int i = 0; i < seed.size(); ++i) FILL_TUPLE(tupname, i, seed[i], pos.at(seed[i]))
 #define PROGRESS_TUPOUT_COUNT() _tupout_count += 1
-#else 
-#define FILL_TUPLE(tupname, num, key,pos) (void) 0
+#else
+#define FILL_TUPLE(tupname, num, key, pos) (void) 0
 #define FILL_TUPLE_WITH_SEED(tupname, seed, pos) (void) 0
 #define PROGRESS_TUPOUT_COUNT() (void) 0
 #endif
 
 #if defined(_PHCASEEDING_TIMER_OUT_)
-#define PHCASEEDING_PRINT_TIME(timer,statement) timer->stop(); \
-  std::cout << " PHCASEEDING_PRINT_TIME: Time to " << statement << ": " << timer->elapsed()/1000 << " s" << std::endl;
+#define PHCASEEDING_PRINT_TIME(timer, statement) \
+  timer->stop();                                 \
+  std::cout << " PHCASEEDING_PRINT_TIME: Time to " << statement << ": " << timer->elapsed() / 1000 << " s" << std::endl;
 #else
 #define PHCASEEDING_PRINT_TIME(timer, statement) (void) 0
 #endif
@@ -96,7 +96,6 @@
 //#define _DEBUG_
 
 // end
-
 
 // apparently there is no builtin STL hash function for a std::array
 // so to use std::unordered_set (essentially a hash table), we have to make our own hasher
@@ -259,10 +258,11 @@ void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadrat
   }
 }
 
-std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::FillGlobalPositions() {
+std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::FillGlobalPositions()
+{
   keyListPerLayer ckeys;
   PositionMap cachedPositions;
-  cachedPositions.reserve(_cluster_map->size());  //avoid resizing mid-execution
+  cachedPositions.reserve(_cluster_map->size());  // avoid resizing mid-execution
 
   for (const auto& hitsetkey : _cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
   {
@@ -292,14 +292,14 @@ std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::F
       const Acts::Vector3 globalpos_d = getGlobalPosition(ckey, cluster);
       const Acts::Vector3 globalpos = {globalpos_d.x(), globalpos_d.y(), globalpos_d.z()};
       cachedPositions.insert(std::make_pair(ckey, globalpos));
-      ckeys[layer-_FIRST_LAYER_TPC].push_back(ckey);
+      ckeys[layer - _FIRST_LAYER_TPC].push_back(ckey);
       FILL_TUPLE(_tupclus_all, 0, ckey, globalpos);
     }
   }
   return std::make_pair(cachedPositions, ckeys);
 }
 
-std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding::pointKey,bgi::quadratic<16>>& _rtree, const PHCASeeding::keyList& ckeys, const PHCASeeding::PositionMap& globalPositions, const int layer) 
+std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& _rtree, const PHCASeeding::keyList& ckeys, const PHCASeeding::PositionMap& globalPositions, const int layer)
 {
   // Fill _rtree with the clusters in ckeys; remove duplicates, and return a vector of the coordKeys
   // Note that layer is only used for a cout statement
@@ -307,7 +307,8 @@ std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding:
   std::vector<coordKey> coords;
   _rtree.clear();
   /* _rtree.reserve(ckeys.size()); */
-  for (const auto& ckey : ckeys) {
+  for (const auto& ckey : ckeys)
+  {
     const auto& globalpos_d = globalPositions.at(ckey);
     const double clus_phi = get_phi(globalpos_d);
     const double clus_eta = get_eta(globalpos_d);
@@ -323,14 +324,14 @@ std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding:
       ++n_dupli;
       continue;
     }
-    coords.push_back({{static_cast<float>(clus_phi), static_cast<float>(clus_eta)},ckey});
+    coords.push_back({{static_cast<float>(clus_phi), static_cast<float>(clus_eta)}, ckey});
     t_fill->restart();
     _rtree.insert(std::make_pair(point(clus_phi, globalpos_d.z()), ckey));
     t_fill->stop();
   }
   if (Verbosity() > 1)
   {
-      std::cout << "nhits in layer("<<layer<<"): " << coords.size() << std::endl;
+    std::cout << "nhits in layer(" << layer << "): " << coords.size() << std::endl;
   }
   if (Verbosity() > 0)
   {
@@ -374,7 +375,7 @@ int PHCASeeding::Process(PHCompositeNode* /*topNode*/)
   }
   t_seed->restart();
   int numberofseeds = 0;
-  numberofseeds += FindSeedsWithMerger(globalPositions,ckeys);
+  numberofseeds += FindSeedsWithMerger(globalPositions, ckeys);
   t_seed->stop();
   if (Verbosity() > 0)
   {
@@ -402,7 +403,7 @@ int PHCASeeding::FindSeedsWithMerger(const PHCASeeding::PositionMap& globalPosit
   t_makeseeds->restart();
   keyLists trackSeedKeyLists = FollowBiLinks(trackSeedPairs, bodyLinks, globalPositions);
   PHCASEEDING_PRINT_TIME(t_makeseeds, "make seeds");
-  if (Verbosity() > 0 )
+  if (Verbosity() > 0)
   {
     t_makeseeds->stop();
     std::cout << "Time to make seeds: " << t_makeseeds->elapsed() / 1000 << " s" << std::endl;
@@ -411,13 +412,12 @@ int PHCASeeding::FindSeedsWithMerger(const PHCASeeding::PositionMap& globalPosit
 
   publishSeeds(seeds);
   return seeds.size();
-
 }
 
-std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::CreateBiLinks(const PHCASeeding::PositionMap& globalPositions, const PHCASeeding::keyListPerLayer& ckeys)
+std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::CreateBiLinks(const PHCASeeding::PositionMap& globalPositions, const PHCASeeding::keyListPerLayer& ckeys)
 {
-  keyLinks startLinks; // bilinks at start of chains
-  keyLinkPerLayer bodyLinks; //  bilinks to build chains
+  keyLinks startLinks;        // bilinks at start of chains
+  keyLinkPerLayer bodyLinks;  //  bilinks to build chains
                               //
   double cluster_find_time = 0;
   double rtree_query_time = 0;
@@ -425,48 +425,48 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::Cre
   double compute_best_angle_time = 0;
   double set_insert_time = 0;
 
-
   // there are three coord_array (only the current layer is used at a time,
   // but it is filled the same time as the _rtrees, which are used two at
   // a time -- the prior padplane row and the next padplain row
-  std::array<std::vector<coordKey>,3> coord_arr;
-  std::array<std::unordered_set<keyLink>,2> previous_downlinks_arr;
-  std::array<std::unordered_set<TrkrDefs::cluskey>,2> bottom_of_bilink_arr;
+  std::array<std::vector<coordKey>, 3> coord_arr;
+  std::array<std::unordered_set<keyLink>, 2> previous_downlinks_arr;
+  std::array<std::unordered_set<TrkrDefs::cluskey>, 2> bottom_of_bilink_arr;
 
   // iterate from outer to inner layers
-  const int inner_index = _start_layer - _FIRST_LAYER_TPC+1;
-  const int outer_index = _end_layer   - _FIRST_LAYER_TPC-2;
+  const int inner_index = _start_layer - _FIRST_LAYER_TPC + 1;
+  const int outer_index = _end_layer - _FIRST_LAYER_TPC - 2;
 
   // fill the current and prior row coord and ttrees for the first iteration
-  int _index_above   = (outer_index+1)%3;
-  int _index_current = (outer_index)%3;
-  coord_arr[_index_above]   = FillTree(_rtrees[_index_above],   ckeys[outer_index+1], globalPositions, outer_index+1);
-  coord_arr[_index_current] = FillTree(_rtrees[_index_current], ckeys[outer_index],   globalPositions, outer_index);
+  int _index_above = (outer_index + 1) % 3;
+  int _index_current = (outer_index) % 3;
+  coord_arr[_index_above] = FillTree(_rtrees[_index_above], ckeys[outer_index + 1], globalPositions, outer_index + 1);
+  coord_arr[_index_current] = FillTree(_rtrees[_index_current], ckeys[outer_index], globalPositions, outer_index);
 
-  for (int layer_index=outer_index; layer_index>=inner_index;--layer_index) {
+  for (int layer_index = outer_index; layer_index >= inner_index; --layer_index)
+  {
     // these lines of code will rotates through all three _rtree's in the array,
     // where the old lower becomes the new middle, the old middle the new upper,
     // and the old upper drops out and that _rtree is filled with the new lower
-    int index_above   = (layer_index+1)%3;
-    int index_current = (layer_index  )%3;
-    int index_below   = (layer_index-1)%3;
+    int index_above = (layer_index + 1) % 3;
+    int index_current = (layer_index) % 3;
+    int index_below = (layer_index - 1) % 3;
 
-    coord_arr[index_below] = FillTree(_rtrees[index_below], ckeys[layer_index-1], globalPositions, layer_index-1);
+    coord_arr[index_below] = FillTree(_rtrees[index_below], ckeys[layer_index - 1], globalPositions, layer_index - 1);
 
     auto& _rtree_above = _rtrees[index_above];
-    const std::vector<coordKey>& coord        = coord_arr[index_current];
+    const std::vector<coordKey>& coord = coord_arr[index_current];
     auto& _rtree_below = _rtrees[index_below];
 
-    auto& curr_downlinks = previous_downlinks_arr[layer_index%2];
-    auto& last_downlinks = previous_downlinks_arr[(layer_index+1)%2];
+    auto& curr_downlinks = previous_downlinks_arr[layer_index % 2];
+    auto& last_downlinks = previous_downlinks_arr[(layer_index + 1) % 2];
 
-    auto& curr_bottom_of_bilink = bottom_of_bilink_arr[layer_index%2];
-    auto& last_bottom_of_bilink = bottom_of_bilink_arr[(layer_index+1)%2];
+    auto& curr_bottom_of_bilink = bottom_of_bilink_arr[layer_index % 2];
+    auto& last_bottom_of_bilink = bottom_of_bilink_arr[(layer_index + 1) % 2];
 
     curr_downlinks.clear();
     curr_bottom_of_bilink.clear();
 
-    // For all the clusters in coord, find nearest neighbors in the 
+    // For all the clusters in coord, find nearest neighbors in the
     // above and below layers and make links
     // Any link to an above node which matches the same clusters
     // on the previous iteration (to a "below node") becomes a "bilink"
@@ -490,18 +490,18 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::Cre
       std::vector<pointKey> ClustersBelow;
 
       QueryTree(_rtree_below,
-          StartPhi - _neighbor_phi_width,
-          StartZ - _neighbor_eta_width,
-          StartPhi + _neighbor_phi_width,
-          StartZ + _neighbor_eta_width,
-          ClustersBelow);
+                StartPhi - _neighbor_phi_width,
+                StartZ - _neighbor_eta_width,
+                StartPhi + _neighbor_phi_width,
+                StartZ + _neighbor_eta_width,
+                ClustersBelow);
 
       QueryTree(_rtree_above,
-          StartPhi - _neighbor_phi_width,
-          StartZ - _neighbor_eta_width,
-          StartPhi + _neighbor_phi_width,
-          StartZ + _neighbor_eta_width,
-          ClustersAbove);
+                StartPhi - _neighbor_phi_width,
+                StartZ - _neighbor_eta_width,
+                StartPhi + _neighbor_phi_width,
+                StartZ + _neighbor_eta_width,
+                ClustersAbove);
 
       t_seed->stop();
       rtree_query_time += t_seed->elapsed();
@@ -517,16 +517,16 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::Cre
       // calculate (delta_eta, delta_phi) vector for each neighboring cluster
 
       std::transform(ClustersBelow.begin(), ClustersBelow.end(), delta_below.begin(),
-          [&](pointKey BelowCandidate)
-          {
+                     [&](pointKey BelowCandidate)
+                     {
           const auto& belowpos = globalPositions.at(BelowCandidate.second);
           return std::array<double,3>{belowpos(0)-StartX,
           belowpos(1)-StartY,
           belowpos(2)-StartZ}; });
 
       std::transform(ClustersAbove.begin(), ClustersAbove.end(), delta_above.begin(),
-          [&](pointKey AboveCandidate)
-          {
+                     [&](pointKey AboveCandidate)
+                     {
           const auto& abovepos = globalPositions.at(AboveCandidate.second);
           return std::array<double,3>{abovepos(0)-StartX,
           abovepos(1)-StartY,
@@ -565,8 +565,8 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::Cre
         }
       }
       // NOTE:
-      // There was some old commented-out code here for allowing layers to be skipped. This 
-      // may be useful in the future. This chunk of code has been moved towards the 
+      // There was some old commented-out code here for allowing layers to be skipped. This
+      // may be useful in the future. This chunk of code has been moved towards the
       // end fo the file under the title: "---OLD CODE 0: SKIP_LAYERS---"
       t_seed->stop();
       compute_best_angle_time += t_seed->elapsed();
@@ -592,20 +592,23 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer>  PHCASeeding::Cre
           curr_bottom_of_bilink.insert(key_bot);
           FILL_TUPLE(_tupclus_bilinks, 0, key_top, globalPositions.at(cluster));
           FILL_TUPLE(_tupclus_bilinks, 1, key_bot, globalPositions.at(cluster));
-          
-          if (last_bottom_of_bilink.find(key_top)==last_bottom_of_bilink.end()) {
-            startLinks.push_back(std::make_pair(key_top,key_bot));
-          } else {
-            bodyLinks[layer_index+1].push_back(std::make_pair(key_top,key_bot));
+
+          if (last_bottom_of_bilink.find(key_top) == last_bottom_of_bilink.end())
+          {
+            startLinks.push_back(std::make_pair(key_top, key_bot));
+          }
+          else
+          {
+            bodyLinks[layer_index + 1].push_back(std::make_pair(key_top, key_bot));
           }
         }
-      } // end loop over all up-links
-    } // end loop over start clusters
+      }  // end loop over all up-links
+    }    // end loop over start clusters
     t_seed->stop();
     set_insert_time += t_seed->elapsed();
     t_seed->restart();
     LogDebug(" max collinearity: " << maxCosPlaneAngle << std::endl);
-  } // end loop over layers (to make links)
+  }  // end loop over layers (to make links)
 
   t_seed->stop();
   if (Verbosity() > 0)
@@ -642,9 +645,8 @@ double PHCASeeding::getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b,
   return 2 * sin(break_angle) / hypot_length;
 }
 
-PHCASeeding::keyLists PHCASeeding::FollowBiLinks( const PHCASeeding::keyLinks& trackSeedPairs, const PHCASeeding::keyLinkPerLayer& bilinks, const PHCASeeding::PositionMap& globalPositions) const
+PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& trackSeedPairs, const PHCASeeding::keyLinkPerLayer& bilinks, const PHCASeeding::PositionMap& globalPositions) const
 {
-
   // form all possible starting 3-cluster tracks (we need that to calculate curvature)
   std::vector<keyList> trackSeedKeyLists;
   for (auto& startLink : trackSeedPairs)
@@ -652,12 +654,15 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks( const PHCASeeding::keyLinks& t
     TrkrDefs::cluskey trackHead = startLink.second;
     unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead) - _FIRST_LAYER_TPC;
     // the following call with get iterators to all bilinks which match the head
-    for (const auto& matchlink : bilinks[trackHead_layer]) {
-    /* auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); */
-    /* for (auto matchlink = matched_links.first; matchlink != matched_links.second; ++matchlink) */
-    /* { */
-      if (matchlink.first != trackHead) { continue;
-}
+    for (const auto& matchlink : bilinks[trackHead_layer])
+    {
+      /* auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); */
+      /* for (auto matchlink = matched_links.first; matchlink != matched_links.second; ++matchlink) */
+      /* { */
+      if (matchlink.first != trackHead)
+      {
+        continue;
+      }
       keyList trackSeedTriplet;
       trackSeedTriplet.push_back(startLink.first);
       trackSeedTriplet.push_back(startLink.second);
@@ -701,14 +706,17 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks( const PHCASeeding::keyLinks& t
       unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead) - (_nlayers_intt + _nlayers_maps);
       // bool no_next_link = true;
       /* for (auto testlink = matched_links.first; testlink != matched_links.second; ++testlink) */
-    for (const auto& link : bilinks[trackHead_layer]) {
-      if (link.first != trackHead) { continue;
-}
-      // It appears that it is just faster to traverse the lists, then use a binary-sorted search
-      // In any case, if we use this cord in the future, be sure to sort the bilinks before using
-    /* auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); */
-    /* for (auto link = matched_links.first; link != matched_links.second; ++link) */
-      /* { */
+      for (const auto& link : bilinks[trackHead_layer])
+      {
+        if (link.first != trackHead)
+        {
+          continue;
+        }
+        // It appears that it is just faster to traverse the lists, then use a binary-sorted search
+        // In any case, if we use this cord in the future, be sure to sort the bilinks before using
+        /* auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); */
+        /* for (auto link = matched_links.first; link != matched_links.second; ++link) */
+        /* { */
         auto& head_pos = globalPositions.at(trackHead);
         auto& prev_pos = globalPositions.at(seed.rbegin()[1]);
         float x1 = head_pos.x();
@@ -725,7 +733,9 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks( const PHCASeeding::keyLinks& t
         float zt = test_pos.z();
         float new_dr = sqrt(xt * xt + yt * yt) - sqrt(x1 * x1 + y1 * y1);
         if (fabs((z1 - z2) / dr_12 - (zt - z1) / new_dr) > _clusadd_delta_dzdr_window)
-        { continue; }
+        {
+          continue;
+        }
         auto& third_pos = globalPositions.at(seed.rbegin()[2]);
         float x3 = third_pos.x();
         float y3 = third_pos.y();
@@ -781,7 +791,7 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks( const PHCASeeding::keyLinks& t
     double lastphi = -100;
     for (unsigned long& j : trackSeedKeyList)
     {
-      const auto& globalpos = globalPositions.at(j); 
+      const auto& globalpos = globalPositions.at(j);
       const double clus_phi = get_phi(globalpos);
       const double clus_eta = get_eta(globalpos);
       const double etajump = clus_eta - lasteta;
@@ -886,7 +896,7 @@ void PHCASeeding::publishSeeds(const std::vector<TrackSeed_v2>& seeds)
   }
 }
 
-int PHCASeeding::Setup(PHCompositeNode* topNode) // This is called by ::InitRun
+int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
 {
   //  if(Verbosity()>0)
   std::cout << "Called Setup" << std::endl;
@@ -948,17 +958,16 @@ int PHCASeeding::Setup(PHCompositeNode* topNode) // This is called by ::InitRun
   fitter->setFixedClusterError(0, _fixed_clus_err.at(0));
   fitter->setFixedClusterError(1, _fixed_clus_err.at(1));
   fitter->setFixedClusterError(2, _fixed_clus_err.at(2));
-  
+
 #if defined(_PHCASEEDING_TUPOUT_)
   std::cout << " Writing _CLUSTER_LOG_TUPOUT.root file " << std::endl;
   _f_clustering_process = new TFile("_CLUSTER_LOG_TUPOUT.root", "recreate");
-  _tupclus_all         = new TNtuple("all",         "all clusters","event:layer:num:x:y:z");
-  _tupclus_links       = new TNtuple("links",       "links","event:layer:updown01:x:y:z");
-  _tupclus_bilinks     = new TNtuple("bilinks",     "bilinks","event:layer:topbot01:x:y:z");
-  _tupclus_seeds       = new TNtuple("seeds",       "3 bilink seeds cores","event:layer:seed012:x:y:z");
+  _tupclus_all = new TNtuple("all", "all clusters", "event:layer:num:x:y:z");
+  _tupclus_links = new TNtuple("links", "links", "event:layer:updown01:x:y:z");
+  _tupclus_bilinks = new TNtuple("bilinks", "bilinks", "event:layer:topbot01:x:y:z");
+  _tupclus_seeds = new TNtuple("seeds", "3 bilink seeds cores", "event:layer:seed012:x:y:z");
   _tupclus_grown_seeds = new TNtuple("grown_seeds", "grown seeds", "event:layer:seednum05:x:y:z");
 #endif
-
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -972,151 +981,151 @@ int PHCASeeding::End()
 
 #if defined(_PHCASEEDING_TUPOUT_)
   _f_clustering_process->cd();
-  _tupclus_all         ->Write();
-  _tupclus_links       ->Write();
-  _tupclus_bilinks     ->Write();
-  _tupclus_seeds       ->Write();
-  _tupclus_grown_seeds ->Write();
+  _tupclus_all->Write();
+  _tupclus_links->Write();
+  _tupclus_bilinks->Write();
+  _tupclus_seeds->Write();
+  _tupclus_grown_seeds->Write();
   _f_clustering_process->Close();
 #endif
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-    // ---OLD CODE 1: SKIP_LAYERS---
-  //  trackSeedKeyLists = tempSeedKeyLists;
-  /*
-    for(auto trackKeyChain = trackSeedKeyLists.begin(); trackKeyChain != trackSeedKeyLists.end(); ++trackKeyChain)
+// ---OLD CODE 1: SKIP_LAYERS---
+//  trackSeedKeyLists = tempSeedKeyLists;
+/*
+  for(auto trackKeyChain = trackSeedKeyLists.begin(); trackKeyChain != trackSeedKeyLists.end(); ++trackKeyChain)
+  {
+    bool reached_end = false;
+    while(!reached_end)
     {
-      bool reached_end = false;
-      while(!reached_end)
+      TrkrDefs::cluskey trackHead = trackKeyChain->back();
+      TrkrDefs::cluskey secondToLast = trackKeyChain->rbegin()[1];
+      TrkrDefs::cluskey thirdToLast = trackKeyChain->rbegin()[2];
+      auto& head_pos = globalPositions.at(trackHead);
+      auto& sec_pos = globalPositions.at(secondToLast);
+      auto& third_pos = globalPositions.at(thirdToLast);
+      double dz_avg = ((head_pos.z()-sec_pos.z())+(sec_pos.z()-third_pos.z()))/2.;
+      double dx1 = head_pos.x()-sec_pos.x();
+      double dy1 = head_pos.y()-sec_pos.y();
+      double dx2 = sec_pos.x()-third_pos.x();
+      double dy2 = sec_pos.y()-third_pos.y();
+      double ddx = dx1-dx2;
+      double ddy = dy1-dy2;
+      double new_dx = dx1+ddx;
+      double new_dy = dy1+ddy;
+      double new_x = head_pos.x()+new_dx;
+      double new_y = head_pos.y()+new_dy;
+      double new_z = head_pos.z()+dz_avg;
+      std::cout << "(x,y,z) = (" << head_pos.x() << ", " << head_pos.y() << ", " << head_pos.z() << ")" << std::endl;
+      unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead) - (_nlayers_intt + _nlayers_maps);
+      std::cout << "layer " << trackHead_layer << std::endl;
+      std::cout << "projected: (" << new_x << ", " << new_y << ", " << new_z << ")" << std::endl;
+      TrkrDefs::cluskey nextCluster;
+      double bestDist = 1e9;
+      bool no_next_link = true;
+      for(auto testlink = bilinks[trackHead_layer].begin(); testlink != bilinks[trackHead_layer].end(); ++testlink)
       {
-        TrkrDefs::cluskey trackHead = trackKeyChain->back();
-        TrkrDefs::cluskey secondToLast = trackKeyChain->rbegin()[1];
-        TrkrDefs::cluskey thirdToLast = trackKeyChain->rbegin()[2];
-        auto& head_pos = globalPositions.at(trackHead);
-        auto& sec_pos = globalPositions.at(secondToLast);
-        auto& third_pos = globalPositions.at(thirdToLast);
-        double dz_avg = ((head_pos.z()-sec_pos.z())+(sec_pos.z()-third_pos.z()))/2.;
-        double dx1 = head_pos.x()-sec_pos.x();
-        double dy1 = head_pos.y()-sec_pos.y();
-        double dx2 = sec_pos.x()-third_pos.x();
-        double dy2 = sec_pos.y()-third_pos.y();
-        double ddx = dx1-dx2;
-        double ddy = dy1-dy2;
-        double new_dx = dx1+ddx;
-        double new_dy = dy1+ddy;
-        double new_x = head_pos.x()+new_dx;
-        double new_y = head_pos.y()+new_dy;
-        double new_z = head_pos.z()+dz_avg;
-        std::cout << "(x,y,z) = (" << head_pos.x() << ", " << head_pos.y() << ", " << head_pos.z() << ")" << std::endl;
-        unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead) - (_nlayers_intt + _nlayers_maps);
-        std::cout << "layer " << trackHead_layer << std::endl;
-        std::cout << "projected: (" << new_x << ", " << new_y << ", " << new_z << ")" << std::endl;
-        TrkrDefs::cluskey nextCluster;
-        double bestDist = 1e9;
-        bool no_next_link = true;
-        for(auto testlink = bilinks[trackHead_layer].begin(); testlink != bilinks[trackHead_layer].end(); ++testlink)
+        if((*testlink)[0].second==trackHead)
         {
-          if((*testlink)[0].second==trackHead)
+          TrkrDefs::cluskey testCluster = (*testlink)[1].second;
+          auto& test_pos = globalPositions.at(testCluster);
+          std::cout << "test cluster: (" << test_pos.x() << ", " << test_pos.y() << ", " << test_pos.z() << ")" << std::endl;
+          double distToNew = sqrt(square<double>(test_pos.x()-new_x)+square<double>(test_pos.y()-new_y)+square<double>(test_pos.z()-new_z));
+          if(distToNew<bestDist)
           {
-            TrkrDefs::cluskey testCluster = (*testlink)[1].second;
-            auto& test_pos = globalPositions.at(testCluster);
-            std::cout << "test cluster: (" << test_pos.x() << ", " << test_pos.y() << ", " << test_pos.z() << ")" << std::endl;
-            double distToNew = sqrt(square<double>(test_pos.x()-new_x)+square<double>(test_pos.y()-new_y)+square<double>(test_pos.z()-new_z));
-            if(distToNew<bestDist)
-            {
-              std::cout << "current best" << std::endl;
-              nextCluster = testCluster;
-              bestDist = distToNew;
-            }
-            no_next_link = false;
+            std::cout << "current best" << std::endl;
+            nextCluster = testCluster;
+            bestDist = distToNew;
           }
+          no_next_link = false;
         }
-        if(!no_next_link) trackKeyChain->push_back(nextCluster);
-        if(no_next_link) reached_end = true;
       }
+      if(!no_next_link) trackKeyChain->push_back(nextCluster);
+      if(no_next_link) reached_end = true;
     }
-  */
-    // ---OLD CODE 0: SKIP_LAYERS---
-    /*
-    if(mode == skip_layers::on)
+  }
+*/
+// ---OLD CODE 0: SKIP_LAYERS---
+/*
+if(mode == skip_layers::on)
+{
+  if(maxCosPlaneAngle > _cosTheta_limit)
+  {
+    // if no triplet is sufficiently linear, then it's likely that there's a missing cluster
+    // repeat search but skip one layer below
+    std::vector<pointKey> clustersTwoLayersBelow;
+    QueryTree(_rtree,
+            StartPhi-_neighbor_phi_width,
+            StartEta-_neighbor_eta_width,
+            (double) StartLayer - 2.5,
+            StartPhi+_neighbor_phi_width,
+            StartEta+_neighbor_eta_width,
+            (double) StartLayer - 1.5,
+            clustersTwoLayersBelow);
+    std::vector<std::array<double,3>> delta_2below;
+    delta_2below.clear();
+    delta_2below.resize(clustersTwoLayersBelow.size());
+    std::transform(clustersTwoLayersBelow.begin(),clustersTwoLayersBelow.end(),delta_2below.begin(),
+      [&](pointKey BelowCandidate){
+        const auto& belowpos = globalPositions.at(BelowCandidate.second);
+        return std::array<double,3>{(belowpos(0))-StartX,
+          (belowpos(1))-StartY,
+          (belowpos(2))-StartZ};});
+    for(size_t iAbove = 0; iAbove<delta_above.size(); ++iAbove)
     {
-      if(maxCosPlaneAngle > _cosTheta_limit)
+      for(size_t iBelow = 0; iBelow<delta_2below.size(); ++iBelow)
       {
-        // if no triplet is sufficiently linear, then it's likely that there's a missing cluster
-        // repeat search but skip one layer below
-        std::vector<pointKey> clustersTwoLayersBelow;
-        QueryTree(_rtree,
-                StartPhi-_neighbor_phi_width,
-                StartEta-_neighbor_eta_width,
-                (double) StartLayer - 2.5,
-                StartPhi+_neighbor_phi_width,
-                StartEta+_neighbor_eta_width,
-                (double) StartLayer - 1.5,
-                clustersTwoLayersBelow);
-        std::vector<std::array<double,3>> delta_2below;
-        delta_2below.clear();
-        delta_2below.resize(clustersTwoLayersBelow.size());
-        std::transform(clustersTwoLayersBelow.begin(),clustersTwoLayersBelow.end(),delta_2below.begin(),
-          [&](pointKey BelowCandidate){
-            const auto& belowpos = globalPositions.at(BelowCandidate.second);
-            return std::array<double,3>{(belowpos(0))-StartX,
-              (belowpos(1))-StartY,
-              (belowpos(2))-StartZ};});
-        for(size_t iAbove = 0; iAbove<delta_above.size(); ++iAbove)
+        double dotProduct = delta_2below[iBelow][0]*delta_above[iAbove][0]+delta_2below[iBelow][1]*delta_above[iAbove][1]+delta_2below[iBelow][2]*delta_above[iAbove][2];
+        double belowSqLength = sqrt(delta_2below[iBelow][0]*delta_2below[iBelow][0]+delta_2below[iBelow][1]*delta_2below[iBelow][1]+delta_2below[iBelow][2]*delta_2below[iBelow][2]);
+        double aboveSqLength = sqrt(delta_above[iAbove][0]*delta_above[iAbove][0]+delta_above[iAbove][1]*delta_above[iAbove][1]+delta_above[iAbove][2]*delta_above[iAbove][2]);
+        double cosPlaneAngle = dotProduct / (belowSqLength*aboveSqLength);
+        if(cosPlaneAngle < maxCosPlaneAngle)
         {
-          for(size_t iBelow = 0; iBelow<delta_2below.size(); ++iBelow)
-          {
-            double dotProduct = delta_2below[iBelow][0]*delta_above[iAbove][0]+delta_2below[iBelow][1]*delta_above[iAbove][1]+delta_2below[iBelow][2]*delta_above[iAbove][2];
-            double belowSqLength = sqrt(delta_2below[iBelow][0]*delta_2below[iBelow][0]+delta_2below[iBelow][1]*delta_2below[iBelow][1]+delta_2below[iBelow][2]*delta_2below[iBelow][2]);
-            double aboveSqLength = sqrt(delta_above[iAbove][0]*delta_above[iAbove][0]+delta_above[iAbove][1]*delta_above[iAbove][1]+delta_above[iAbove][2]*delta_above[iAbove][2]);
-            double cosPlaneAngle = dotProduct / (belowSqLength*aboveSqLength);
-            if(cosPlaneAngle < maxCosPlaneAngle)
-            {
-              maxCosPlaneAngle = cosPlaneAngle;
-              bestBelowCluster = fromPointKey(clustersTwoLayersBelow[iBelow]);
-              bestAboveCluster = fromPointKey(ClustersAbove[iAbove]);
-            }
-          }
-        }
-        // if no triplet is STILL sufficiently linear, then do the same thing, but skip one layer above
-        if(maxCosPlaneAngle > _cosTheta_limit)
-        {
-          std::vector<pointKey> clustersTwoLayersAbove;
-          QueryTree(_rtree,
-                  StartPhi-_neighbor_phi_width,
-                  StartEta-_neighbor_eta_width,
-                  (double) StartLayer + 1.5,
-                  StartPhi+_neighbor_phi_width,
-                  StartEta+_neighbor_eta_width,
-                  (double) StartLayer + 2.5,
-                  clustersTwoLayersAbove);
-          std::vector<std::array<double,3>> delta_2above;
-          delta_2above.clear();
-          delta_2above.resize(clustersTwoLayersAbove.size());
-          std::transform(clustersTwoLayersAbove.begin(),clustersTwoLayersAbove.end(),delta_2above.begin(),
-            [&](pointKey AboveCandidate){
-              const auto& abovepos = globalPositions.at(AboveCandidate.second);
-              return std::array<double,3>{(abovepos(0))-StartX,
-                (abovepos(1))-StartY,
-                (abovepos(2))-StartZ};});
-          for(size_t iAbove = 0; iAbove<delta_2above.size(); ++iAbove)
-          {
-            for(size_t iBelow = 0; iBelow<delta_below.size(); ++iBelow)
-            {
-              double dotProduct = delta_below[iBelow][0]*delta_2above[iAbove][0]+delta_below[iBelow][1]*delta_2above[iAbove][1]+delta_below[iBelow][2]*delta_2above[iAbove][2];
-              double belowSqLength = sqrt(delta_below[iBelow][0]*delta_below[iBelow][0]+delta_below[iBelow][1]*delta_below[iBelow][1]+delta_below[iBelow][2]*delta_below[iBelow][2]);
-              double aboveSqLength = sqrt(delta_2above[iAbove][0]*delta_2above[iAbove][0]+delta_2above[iAbove][1]*delta_2above[iAbove][1]+delta_2above[iAbove][2]*delta_2above[iAbove][2]);
-              double cosPlaneAngle = dotProduct / (belowSqLength*aboveSqLength);
-              if(cosPlaneAngle < maxCosPlaneAngle)
-              {
-                maxCosPlaneAngle = cosPlaneAngle;
-                bestBelowCluster = fromPointKey(ClustersBelow[iBelow]);
-                bestAboveCluster = fromPointKey(clustersTwoLayersAbove[iAbove]);
-              }
-            }
-          }
+          maxCosPlaneAngle = cosPlaneAngle;
+          bestBelowCluster = fromPointKey(clustersTwoLayersBelow[iBelow]);
+          bestAboveCluster = fromPointKey(ClustersAbove[iAbove]);
         }
       }
     }
-    */
+    // if no triplet is STILL sufficiently linear, then do the same thing, but skip one layer above
+    if(maxCosPlaneAngle > _cosTheta_limit)
+    {
+      std::vector<pointKey> clustersTwoLayersAbove;
+      QueryTree(_rtree,
+              StartPhi-_neighbor_phi_width,
+              StartEta-_neighbor_eta_width,
+              (double) StartLayer + 1.5,
+              StartPhi+_neighbor_phi_width,
+              StartEta+_neighbor_eta_width,
+              (double) StartLayer + 2.5,
+              clustersTwoLayersAbove);
+      std::vector<std::array<double,3>> delta_2above;
+      delta_2above.clear();
+      delta_2above.resize(clustersTwoLayersAbove.size());
+      std::transform(clustersTwoLayersAbove.begin(),clustersTwoLayersAbove.end(),delta_2above.begin(),
+        [&](pointKey AboveCandidate){
+          const auto& abovepos = globalPositions.at(AboveCandidate.second);
+          return std::array<double,3>{(abovepos(0))-StartX,
+            (abovepos(1))-StartY,
+            (abovepos(2))-StartZ};});
+      for(size_t iAbove = 0; iAbove<delta_2above.size(); ++iAbove)
+      {
+        for(size_t iBelow = 0; iBelow<delta_below.size(); ++iBelow)
+        {
+          double dotProduct = delta_below[iBelow][0]*delta_2above[iAbove][0]+delta_below[iBelow][1]*delta_2above[iAbove][1]+delta_below[iBelow][2]*delta_2above[iAbove][2];
+          double belowSqLength = sqrt(delta_below[iBelow][0]*delta_below[iBelow][0]+delta_below[iBelow][1]*delta_below[iBelow][1]+delta_below[iBelow][2]*delta_below[iBelow][2]);
+          double aboveSqLength = sqrt(delta_2above[iAbove][0]*delta_2above[iAbove][0]+delta_2above[iAbove][1]*delta_2above[iAbove][1]+delta_2above[iAbove][2]*delta_2above[iAbove][2]);
+          double cosPlaneAngle = dotProduct / (belowSqLength*aboveSqLength);
+          if(cosPlaneAngle < maxCosPlaneAngle)
+          {
+            maxCosPlaneAngle = cosPlaneAngle;
+            bestBelowCluster = fromPointKey(ClustersBelow[iBelow]);
+            bestAboveCluster = fromPointKey(clustersTwoLayersAbove[iAbove]);
+          }
+        }
+      }
+    }
+  }
+}
+*/

--- a/simulation/g4simulation/g4eval/ClusKeyIter.cc
+++ b/simulation/g4simulation/g4eval/ClusKeyIter.cc
@@ -2,51 +2,75 @@
 
 #include <trackbase_historic/SvtxTrack.h>
 
-ClusKeyIter::ClusKeyIter(SvtxTrack* _track) :
-  track {_track}
-  , in_silicon { _track->get_silicon_seed()!=nullptr }
-  , has_tpc    { _track->get_tpc_seed()!=nullptr }
-  , no_data    { !in_silicon && !has_tpc }
+ClusKeyIter::ClusKeyIter(SvtxTrack* _track)
+  : track{_track}
+  , in_silicon{_track->get_silicon_seed() != nullptr}
+  , has_tpc{_track->get_tpc_seed() != nullptr}
+  , no_data{!in_silicon && !has_tpc}
 {
 }
 
-ClusKeyIter ClusKeyIter::begin() {
-  ClusKeyIter iter0 { track }; 
-  if (iter0.no_data) return iter0;
-  if (iter0.in_silicon) {
+ClusKeyIter ClusKeyIter::begin()
+{
+  ClusKeyIter iter0{track};
+  if (iter0.no_data)
+  {
+    return iter0;
+  }
+  if (iter0.in_silicon)
+  {
     iter0.iter = track->get_silicon_seed()->begin_cluster_keys();
     iter0.iter_end_silicon = track->get_silicon_seed()->end_cluster_keys();
-  } else if (has_tpc) {
+  }
+  else if (has_tpc)
+  {
     iter0.iter = track->get_tpc_seed()->begin_cluster_keys();
-  } 
+  }
   return iter0;
 }
 
-ClusKeyIter ClusKeyIter::end() {
-  ClusKeyIter iter0 { track }; 
-  if (iter0.no_data) return iter0;
-  if (has_tpc) {
+ClusKeyIter ClusKeyIter::end()
+{
+  ClusKeyIter iter0{track};
+  if (iter0.no_data)
+  {
+    return iter0;
+  }
+  if (has_tpc)
+  {
     iter0.iter = track->get_tpc_seed()->end_cluster_keys();
-  } else if (in_silicon) {
+  }
+  else if (in_silicon)
+  {
     iter0.iter = track->get_silicon_seed()->end_cluster_keys();
-  } 
+  }
   return iter0;
 }
 
-void ClusKeyIter::operator++() {
-  if (no_data) return;
+void ClusKeyIter::operator++()
+{
+  if (no_data)
+  {
+    return;
+  }
   ++iter;
-  if (in_silicon && has_tpc && iter == iter_end_silicon) {
+  if (in_silicon && has_tpc && iter == iter_end_silicon)
+  {
     in_silicon = false;
     iter = track->get_tpc_seed()->begin_cluster_keys();
   }
 }
 
-bool ClusKeyIter::operator!=(const ClusKeyIter& rhs) {
-  if (no_data) return false;
+bool ClusKeyIter::operator!=(const ClusKeyIter& rhs)
+{
+  if (no_data)
+  {
+    return false;
+  }
   return iter != rhs.iter;
 }
 
-TrkrDefs::cluskey ClusKeyIter::operator*() {
+TrkrDefs::cluskey ClusKeyIter::operator*()
+{
   return *iter;
 }

--- a/simulation/g4simulation/g4eval/ClusKeyIter.h
+++ b/simulation/g4simulation/g4eval/ClusKeyIter.h
@@ -2,12 +2,13 @@
 #define CLUSKEYITER__H
 
 // an iterator to loop over all the TrkrClusters for a given track
-#include <set>
 #include <trackbase/TrkrDefs.h>
+#include <set>
 
 class SvtxTrack;
 
-struct ClusKeyIter {
+struct ClusKeyIter
+{
   typedef std::set<TrkrDefs::cluskey> ClusterKeySet;
   typedef ClusterKeySet::iterator ClusterKeyIter;
 
@@ -16,9 +17,9 @@ struct ClusKeyIter {
   SvtxTrack* track;
   bool in_silicon;
   bool has_tpc;
-  bool no_data; // neither a tpc nor a silicon seed
-  ClusterKeyIter iter             { };
-  ClusterKeyIter iter_end_silicon { };
+  bool no_data;  // neither a tpc nor a silicon seed
+  ClusterKeyIter iter{};
+  ClusterKeyIter iter_end_silicon{};
 
   ClusKeyIter begin();
   ClusKeyIter end();
@@ -27,7 +28,5 @@ struct ClusKeyIter {
   TrkrDefs::cluskey operator*();
   bool operator!=(const ClusKeyIter& rhs);
 };
-
-
 
 #endif

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -5,7 +5,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem`root-config --incdir`
 
 AM_LDFLAGS = \

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
@@ -1,21 +1,21 @@
 #include "TrkrClusterIsMatcher.h"
 #include "g4evalfn.h"
 
-#include <mvtx/CylinderGeom_Mvtx.h>
-#include <intt/CylinderGeomIntt.h>
+#include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4TpcCylinderGeom.h>
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
-#include <g4detectors/PHG4CylinderGeomContainer.h>
-#include <trackbase/TrkrClusterContainer.h>
+#include <intt/CylinderGeomIntt.h>
+#include <mvtx/CylinderGeom_Mvtx.h>
 #include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
 
-#include <phool/getClass.h>
-#include <phool/PHObject.h>  // for PHObject
-#include <phool/phool.h>  // for PHWHERE
+#include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNode.h>  // for PHNode
 #include <phool/PHNodeIterator.h>
-#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHObject.h>  // for PHObject
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
 
 int TrkrClusterIsMatcher::init(
     PHCompositeNode* topNode,
@@ -23,57 +23,65 @@ int TrkrClusterIsMatcher::init(
     const std::string& name_reco_clusters)
 {
   // ------ MVTX data ------
-  PHG4CylinderGeomContainer* geom_container_mvtx 
-    = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
-  if (!geom_container_mvtx) {
+  PHG4CylinderGeomContainer* geom_container_mvtx = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
+  if (!geom_container_mvtx)
+  {
     std::cout << PHWHERE << " Could not locate CYLINDERGEOM_MVTX " << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  for (int i=0; i<3; ++i) {
-    auto layergeom = dynamic_cast<CylinderGeom_Mvtx *>
-      (geom_container_mvtx->GetLayerGeom(i));
+  for (int i = 0; i < 3; ++i)
+  {
+    auto layergeom = dynamic_cast<CylinderGeom_Mvtx*>(geom_container_mvtx->GetLayerGeom(i));
     pitch_phi[i] = layergeom->get_pixel_x();
-    if (i == 0) pitch_z_MVTX = layergeom->get_pixel_z();
+    if (i == 0)
+    {
+      pitch_z_MVTX = layergeom->get_pixel_z();
+    }
   }
 
   // ------ INTT data ------
-  PHG4CylinderGeomContainer* geom_container_intt 
-    = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
-  if (!geom_container_intt) {
+  PHG4CylinderGeomContainer* geom_container_intt = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
+  if (!geom_container_intt)
+  {
     std::cout << PHWHERE << " Could not locate CYLINDERGEOM_INTT " << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
   // get phi and Z steps for intt
-  for (int i=3; i<7; ++i) {
-    CylinderGeomIntt* geom = 
-      dynamic_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(i));
+  for (int i = 3; i < 7; ++i)
+  {
+    CylinderGeomIntt* geom =
+        dynamic_cast<CylinderGeomIntt*>(geom_container_intt->GetLayerGeom(i));
     pitch_phi[i] = geom->get_strip_y_spacing();
   }
 
   // ------ TPC data ------
   auto geom_tpc =
-    findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
   if (!geom_tpc)
   {
     std::cout << PHWHERE << " Could not locate CYLINDERCELLGEOM_SVTX node " << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  for (int i=7; i<55; ++i) {
-    PHG4TpcCylinderGeom *layergeom = geom_tpc->GetLayerCellGeom(i);
-    if (i==7) step_t_TPC = layergeom->get_zstep();
+  for (int i = 7; i < 55; ++i)
+  {
+    PHG4TpcCylinderGeom* layergeom = geom_tpc->GetLayerCellGeom(i);
+    if (i == 7)
+    {
+      step_t_TPC = layergeom->get_zstep();
+    }
     pitch_phi[i] = layergeom->get_phistep() * layergeom->get_radius();
   }
 
-  m_TruthClusters = 
-    findNode::getClass<TrkrClusterContainer>(topNode, name_phg4_clusters.c_str());
+  m_TruthClusters =
+      findNode::getClass<TrkrClusterContainer>(topNode, name_phg4_clusters.c_str());
   if (!m_TruthClusters)
   {
     std::cout << PHWHERE << " Could not locate " << name_phg4_clusters << " node" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  m_RecoClusters = 
-    findNode::getClass<TrkrClusterContainer>(topNode, name_reco_clusters.c_str());
+  m_RecoClusters =
+      findNode::getClass<TrkrClusterContainer>(topNode, name_reco_clusters.c_str());
   if (!m_TruthClusters)
   {
     std::cout << PHWHERE << " Could not locate " << name_reco_clusters << " node" << std::endl;
@@ -87,109 +95,169 @@ int TrkrClusterIsMatcher::init(
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  set_tol_z_MVTX   (tol_z_MVTX);
-  set_tol_phi_MVTX (tol_phi_MVTX);
+  set_tol_z_MVTX(tol_z_MVTX);
+  set_tol_phi_MVTX(tol_phi_MVTX);
 
-  set_tol_phi_INTT (tol_phi_INTT);
+  set_tol_phi_INTT(tol_phi_INTT);
 
-  set_tol_t_TPC   (tol_t_TPC);
-  set_tol_phi_TPC (tol_phi_TPC);
+  set_tol_t_TPC(tol_t_TPC);
+  set_tol_phi_TPC(tol_phi_TPC);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void TrkrClusterIsMatcher::set_tol_phi_MVTX(float _val) {
+void TrkrClusterIsMatcher::set_tol_phi_MVTX(float _val)
+{
   tol_phi_MVTX = _val;
-  for (int i=0; i<3; ++i) {
+  for (int i = 0; i < 3; ++i)
+  {
     tol_pitch_phi[i] = tol_phi_MVTX * pitch_phi[i];
   }
 }
 
-void TrkrClusterIsMatcher::set_tol_z_MVTX(float _val) {
+void TrkrClusterIsMatcher::set_tol_z_MVTX(float _val)
+{
   tol_z_MVTX = _val;
   tol_pitch_z_MVTX = tol_z_MVTX * pitch_z_MVTX;
 }
 
-
-void TrkrClusterIsMatcher::set_tol_phi_INTT(float _val) {
+void TrkrClusterIsMatcher::set_tol_phi_INTT(float _val)
+{
   tol_phi_INTT = _val;
-  for (int i=3; i<7; ++i) {
+  for (int i = 3; i < 7; ++i)
+  {
     tol_pitch_phi[i] = tol_phi_INTT * pitch_phi[i];
   }
 }
 
-void TrkrClusterIsMatcher::set_tol_phi_TPC(float _val) {
+void TrkrClusterIsMatcher::set_tol_phi_TPC(float _val)
+{
   tol_phi_TPC = _val;
-  for (int i=7; i<55; ++i) {
+  for (int i = 7; i < 55; ++i)
+  {
     tol_pitch_phi[i] = tol_phi_TPC * pitch_phi[i];
   }
 }
 
-void TrkrClusterIsMatcher::set_tol_t_TPC(float _val) {
+void TrkrClusterIsMatcher::set_tol_t_TPC(float _val)
+{
   tol_t_TPC = _val;
   tol_step_t_TPC = tol_t_TPC * step_t_TPC;
 }
 
-  bool TrkrClusterIsMatcher::operator()
-(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R)
+bool TrkrClusterIsMatcher::operator()(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R)
 {
   // note: can use returned values, or just pull from these values
   layer = TrkrDefs::getLayer(key_T);
-  if (layer > 55) {
+  if (layer > 55)
+  {
     std::cout << " Error! Trying to compar cluster in layer > 55, "
-      << "which is not programmed yet!" << std::endl;
+              << "which is not programmed yet!" << std::endl;
     return false;
   }
 
-  clus_T = m_TruthClusters ->findCluster(key_T);
-  clus_R = m_RecoClusters  ->findCluster(key_R);
+  clus_T = m_TruthClusters->findCluster(key_T);
+  clus_R = m_RecoClusters->findCluster(key_R);
 
   det_0123 = g4evalfn::trklayer_det(layer);
-  dphi = g4evalfn::abs_dphi(clus_T->getPosition(0),clus_R->getPosition(0));
-  switch (det_0123) {
-    case g4evalfn::DET::MVTX : {
-              if (single_pixel_phi_MVTX) {
-                if (dphi > tol_pitch_phi[layer])  return false;
-              } else {
-                if (dphi > tol_pitch_phi[layer]*std::max(clus_T->getPhiSize(),clus_R->getPhiSize())) return false;
-              }
-              const float delta_z = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
-              if (single_pixel_z_MVTX) {
-                if (delta_z > tol_pitch_z_MVTX) return false;
-              } else {
-                if (delta_z > tol_pitch_z_MVTX*std::max(clus_T->getZSize(), clus_R->getZSize())) return false;
-              }
-              return true;
-            } break;
-
-    case g4evalfn::DET::INTT: { 
-              if (single_pixel_phi_INTT) {
-                if (dphi > tol_pitch_phi[layer])  return false;
-              } else {
-                if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize())) return false;
-              }
-              return true;
-            } break;
-
-    case g4evalfn::DET::TPC: {
-              if (single_bin_phi_TPC) {
-                if (dphi > tol_pitch_phi[layer])  return false;
-              } else {
-                if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize())) return false;
-              }
-              const float delta_t = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
-              if (single_bin_t_TPC) {
-                if (delta_t > tol_step_t_TPC) return false;
-              } else {
-                if (delta_t > tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize())) return false;
-              }
-              return true;
-            } break;
-
-    case g4evalfn::DET::TPOT: { // TPOT
-              return false; // no info for matching TPOT at this time
-            } break;
+  dphi = g4evalfn::abs_dphi(clus_T->getPosition(0), clus_R->getPosition(0));
+  switch (det_0123)
+  {
+  case g4evalfn::DET::MVTX:
+  {
+    if (single_pixel_phi_MVTX)
+    {
+      if (dphi > tol_pitch_phi[layer])
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()))
+      {
+        return false;
+      }
+    }
+    const float delta_z = fabs(clus_T->getPosition(1) - clus_R->getPosition(1));
+    if (single_pixel_z_MVTX)
+    {
+      if (delta_z > tol_pitch_z_MVTX)
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (delta_z > tol_pitch_z_MVTX * std::max(clus_T->getZSize(), clus_R->getZSize()))
+      {
+        return false;
+      }
+    }
+    return true;
   }
-  return false; // code shouldn't arrive here; just for completeness for compiler
-}
+  break;
 
+  case g4evalfn::DET::INTT:
+  {
+    if (single_pixel_phi_INTT)
+    {
+      if (dphi > tol_pitch_phi[layer])
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  break;
+
+  case g4evalfn::DET::TPC:
+  {
+    if (single_bin_phi_TPC)
+    {
+      if (dphi > tol_pitch_phi[layer])
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (dphi > tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()))
+      {
+        return false;
+      }
+    }
+    const float delta_t = fabs(clus_T->getPosition(1) - clus_R->getPosition(1));
+    if (single_bin_t_TPC)
+    {
+      if (delta_t > tol_step_t_TPC)
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (delta_t > tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize()))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  break;
+
+  case g4evalfn::DET::TPOT:
+  {                // TPOT
+    return false;  // no info for matching TPOT at this time
+  }
+  break;
+  }
+  return false;  // code shouldn't arrive here; just for completeness for compiler
+}

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.h
@@ -7,8 +7,8 @@
 //   overall size of the clusters (using the largest clustersize).
 //
 
-#include <string>
 #include <array>
+#include <string>
 
 #include <trackbase/TrkrDefs.h>
 
@@ -18,70 +18,70 @@ class PHCompositeNode;
 class TrkrClusterContainer;
 class TrackClusEvaluator;
 
-class TrkrClusterIsMatcher {
-  public:
-    TrkrClusterIsMatcher() {};
+class TrkrClusterIsMatcher
+{
+ public:
+  TrkrClusterIsMatcher(){};
 
-    bool operator()(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R);
+  bool operator()(TrkrDefs::cluskey key_T, TrkrDefs::cluskey key_R);
 
-    int init(PHCompositeNode* topNode, 
-        const std::string& name_truth_clusters="TRKR_TRUTHCLUSTERCONTAINER", 
-        const std::string& name_reco_clusters="TRKR_CLUSTER");
+  int init(PHCompositeNode* topNode,
+           const std::string& name_truth_clusters = "TRKR_TRUTHCLUSTERCONTAINER",
+           const std::string& name_reco_clusters = "TRKR_CLUSTER");
 
-    void set_tol_phi_MVTX (float _val);
-    void set_tol_phi_INTT (float _val);
-    void set_tol_phi_TPC  (float _val);
+  void set_tol_phi_MVTX(float _val);
+  void set_tol_phi_INTT(float _val);
+  void set_tol_phi_TPC(float _val);
 
-    void set_tol_z_MVTX   (float _val);
-    void set_tol_t_TPC    (float _val);
+  void set_tol_z_MVTX(float _val);
+  void set_tol_t_TPC(float _val);
 
-    // options for if tolerance is multipled by width of one pixel|bin, or by total number of pixel|bin's 
-    // in the larger of two clusters compared
-    bool  single_pixel_phi_MVTX { false }; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
-    bool  single_pixel_phi_INTT { false }; // ... same as for MVTX
-    bool  single_bin_phi_TPC    { true };  // default to pitch*tol_TPC
+  // options for if tolerance is multipled by width of one pixel|bin, or by total number of pixel|bin's
+  // in the larger of two clusters compared
+  bool single_pixel_phi_MVTX{false};  // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
+  bool single_pixel_phi_INTT{false};  // ... same as for MVTX
+  bool single_bin_phi_TPC{true};      // default to pitch*tol_TPC
 
-    bool  single_pixel_z_MVTX { false }; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
-    bool  single_pixel_z_INTT { false }; // ... same as for MVTX
-    bool  single_bin_t_TPC    { true  };  // default to pitch*tol_TPC
+  bool single_pixel_z_MVTX{false};  // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
+  bool single_pixel_z_INTT{false};  // ... same as for MVTX
+  bool single_bin_t_TPC{true};      // default to pitch*tol_TPC
 
-    // For efficiency and convenience, hang on to minimal information about most recent comparison: 
-    // --------------------------------------------------------------------------------------------
-    TrkrCluster* clus_T { nullptr }; // _T for truth cluster
-    TrkrCluster* clus_R { nullptr }; // _R for reco  cluster
-    int   layer    {0};
-    int   det_0123 {0};
-    bool  is_match {false}; // also the return value of operator()
-    float dphi     {0.};
+  // For efficiency and convenience, hang on to minimal information about most recent comparison:
+  // --------------------------------------------------------------------------------------------
+  TrkrCluster* clus_T{nullptr};  // _T for truth cluster
+  TrkrCluster* clus_R{nullptr};  // _R for reco  cluster
+  int layer{0};
+  int det_0123{0};
+  bool is_match{false};  // also the return value of operator()
+  float dphi{0.};
 
-    //multipliers for pixels and bins to cm and times
-    std::array<float, 56> pitch_phi {0.}; // the phistep squared
-    float pitch_z_MVTX {0.}; // pixel width for MVTX
-    float step_t_TPC {0.};   // time bin width for PTC
+  // multipliers for pixels and bins to cm and times
+  std::array<float, 56> pitch_phi{0.};  // the phistep squared
+  float pitch_z_MVTX{0.};               // pixel width for MVTX
+  float step_t_TPC{0.};                 // time bin width for PTC
 
-    std::array<float, 56> tol_pitch_phi {0.}; // pitched times tol_phi_{MVTX,INTT,TPC}
-    float tol_pitch_z_MVTX {0.}; // tol * pixel width for MVTX
-    float tol_step_t_TPC {0.};   // tol * time bin width for PTC
+  std::array<float, 56> tol_pitch_phi{0.};  // pitched times tol_phi_{MVTX,INTT,TPC}
+  float tol_pitch_z_MVTX{0.};               // tol * pixel width for MVTX
+  float tol_step_t_TPC{0.};                 // tol * time bin width for PTC
 
-    // containers to get the clusters from
-    TrkrClusterContainer* m_TruthClusters {nullptr};
-    TrkrClusterContainer* m_RecoClusters  {nullptr};
-    ActsGeometry* m_ActsGeometry{nullptr};
+  // containers to get the clusters from
+  TrkrClusterContainer* m_TruthClusters{nullptr};
+  TrkrClusterContainer* m_RecoClusters{nullptr};
+  ActsGeometry* m_ActsGeometry{nullptr};
 
   /* public: */
-    /* TrkrClusterContainer* get_TruthClusters() { return m_TruthClusters; }; */
-    /* TrkrClusterContainer* get_RecoClusters () { return m_RecoClusters; }; */
-    /* ActsGeometry* get_ActsGeometry () { return m_ActsGeometry; }; */
+  /* TrkrClusterContainer* get_TruthClusters() { return m_TruthClusters; }; */
+  /* TrkrClusterContainer* get_RecoClusters () { return m_RecoClusters; }; */
+  /* ActsGeometry* get_ActsGeometry () { return m_ActsGeometry; }; */
   /* private: */
 
-    // tolerances for comparison in MVTX, INTT, TPC, and TPOT
-    float tol_phi_MVTX {0.5};
-    float tol_phi_INTT {0.5};
-    float tol_phi_TPC  {1.0};
+  // tolerances for comparison in MVTX, INTT, TPC, and TPOT
+  float tol_phi_MVTX{0.5};
+  float tol_phi_INTT{0.5};
+  float tol_phi_TPC{1.0};
 
-    float tol_z_MVTX {0.5};
-    float tol_t_TPC  {1.0};
-
+  float tol_z_MVTX{0.5};
+  float tol_t_TPC{1.0};
 };
 
 #endif

--- a/simulation/g4simulation/g4eval/g4evalfn.cc
+++ b/simulation/g4simulation/g4eval/g4evalfn.cc
@@ -1,46 +1,68 @@
 #include <g4tracking/EmbRecoMatchContainer.h>
 
-#include "g4evalfn.h"
+#include <trackbase/TrkrCluster.h>
+#include <trackbase_historic/SvtxTrackMap.h>
 #include "TrkrClusLoc.h"
 #include "TrkrClusterIsMatcher.h"
-#include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase/TrkrCluster.h>
+#include "g4evalfn.h"
 
 #include <algorithm>
+#include <cmath>
 #include <set>
 
+namespace g4evalfn
+{
 
-namespace g4evalfn {
-
-  int trklayer_det(int layer) {
-    if (layer < 3)  return DET::MVTX;
-    if (layer < 7)  return DET::INTT;
-    if (layer < 55) return DET::TPC;
+  int trklayer_det(int layer)
+  {
+    if (layer < 3)
+    {
+      return DET::MVTX;
+    }
+    if (layer < 7)
+    {
+      return DET::INTT;
+    }
+    if (layer < 55)
+    {
+      return DET::TPC;
+    }
     return DET::TPOT;
   }
 
-  int trklayer_det(TrkrDefs::hitsetkey key) {
+  int trklayer_det(TrkrDefs::hitsetkey key)
+  {
     return trklayer_det(TrkrDefs::getLayer(key));
   }
 
-  int trklayer_det(TrkrDefs::cluskey key) {
+  int trklayer_det(TrkrDefs::cluskey key)
+  {
     return trklayer_det(TrkrDefs::getLayer(key));
   }
 
-
-  std::vector<int> unmatchedSvtxTrkIds(EmbRecoMatchContainer* matches, SvtxTrackMap* m_SvtxTrackMap) {
+  std::vector<int> unmatchedSvtxTrkIds(EmbRecoMatchContainer* matches, SvtxTrackMap* m_SvtxTrackMap)
+  {
     std::set<unsigned int> ids_matched{};
-    for (auto trkid : matches->ids_RecoMatched()) {
-      ids_matched.insert(trkid); 
+    for (auto trkid : matches->ids_RecoMatched())
+    {
+      ids_matched.insert(trkid);
     }
 
     std::set<int> ids_unmatched;
-    for (auto reco = m_SvtxTrackMap->begin(); reco != m_SvtxTrackMap->end(); ++reco) {
-      auto trkid = reco->first;
-      if (ids_matched.count(trkid)==0) ids_unmatched.insert(trkid);
+    for (auto& reco : *m_SvtxTrackMap)
+    {
+      auto trkid = reco.first;
+      if (ids_matched.count(trkid) == 0)
+      {
+        ids_unmatched.insert(trkid);
+      }
     }
     std::vector<int> ids_vec;
-    for (auto id : ids_unmatched) ids_vec.push_back((int)id);
+    ids_vec.reserve(ids_unmatched.size());
+    for (auto id : ids_unmatched)
+    {
+      ids_vec.push_back((int) id);
+    }
     std::sort(ids_vec.begin(), ids_vec.end());
     return ids_vec;
   }
@@ -61,55 +83,77 @@ namespace g4evalfn {
             cluster->getPosition(0), cluster->getPhiSize(), cluster->getPosition(1), cluster->getZSize(), key};
   }
 
-  float calc_match_statistic(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key_A, TrkrDefs::cluskey key_B) {
+  float calc_match_statistic(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key_A, TrkrDefs::cluskey key_B)
+  {
     int layer = TrkrDefs::getLayer(key_A);
     auto det_0123 = trklayer_det(layer);
-    auto clus_T = ismatcher->m_TruthClusters ->findCluster(key_A);
-    auto clus_R = ismatcher->m_RecoClusters  ->findCluster(key_B);
-    auto dphi = abs_dphi(clus_T->getPosition(0),clus_R->getPosition(0));
+    auto clus_T = ismatcher->m_TruthClusters->findCluster(key_A);
+    auto clus_R = ismatcher->m_RecoClusters->findCluster(key_B);
+    auto dphi = abs_dphi(clus_T->getPosition(0), clus_R->getPosition(0));
 
     float stat = 0.;
-    switch (det_0123) {
-      case 0: { // MVTX
-        if (ismatcher->single_pixel_phi_MVTX) {
-          stat += dphi / ismatcher->tol_pitch_phi[layer];
-        } else {
-          stat += dphi / (ismatcher->tol_pitch_phi[layer] *std::max(clus_T->getPhiSize(),clus_R->getPhiSize()));
-        }
-        const float delta_z = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
-        if (ismatcher->single_pixel_z_MVTX) {
-          stat += delta_z / ismatcher->tol_pitch_z_MVTX;
-        } else {
-          stat += delta_z / (ismatcher->tol_pitch_z_MVTX * std::max(clus_T->getZSize(), clus_R->getZSize()));
-        }
-      } break;
-      case 1: {
-        if (ismatcher->single_pixel_phi_INTT) {
-          stat += dphi / ismatcher->tol_pitch_phi[layer];
-        } else {
-          stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
-        }
-      } break;
-      case 2: { // TPC
-        if (ismatcher->single_bin_phi_TPC) {
-          stat += dphi / ismatcher->tol_pitch_phi[layer];
-        } else {
-          stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
-        }
-        const float delta_t = fabs(clus_T->getPosition(1)-clus_R->getPosition(1));
-        if (ismatcher->single_bin_t_TPC) {
-          stat += delta_t / ismatcher->tol_step_t_TPC;
-        } else {
-          stat += delta_t / (ismatcher->tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize()));
-        }
-      } break;
-      case 3: // TPOT
-        break;
-      default:
-        break;
+    switch (det_0123)
+    {
+    case 0:
+    {  // MVTX
+      if (ismatcher->single_pixel_phi_MVTX)
+      {
+        stat += dphi / ismatcher->tol_pitch_phi[layer];
+      }
+      else
+      {
+        stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
+      }
+      const float delta_z = std::fabs(clus_T->getPosition(1) - clus_R->getPosition(1));
+      if (ismatcher->single_pixel_z_MVTX)
+      {
+        stat += delta_z / ismatcher->tol_pitch_z_MVTX;
+      }
+      else
+      {
+        stat += delta_z / (ismatcher->tol_pitch_z_MVTX * std::max(clus_T->getZSize(), clus_R->getZSize()));
+      }
+    }
+    break;
+    case 1:
+    {
+      if (ismatcher->single_pixel_phi_INTT)
+      {
+        stat += dphi / ismatcher->tol_pitch_phi[layer];
+      }
+      else
+      {
+        stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
+      }
+    }
+    break;
+    case 2:
+    {  // TPC
+      if (ismatcher->single_bin_phi_TPC)
+      {
+        stat += dphi / ismatcher->tol_pitch_phi[layer];
+      }
+      else
+      {
+        stat += dphi / (ismatcher->tol_pitch_phi[layer] * std::max(clus_T->getPhiSize(), clus_R->getPhiSize()));
+      }
+      const float delta_t = std::fabs(clus_T->getPosition(1) - clus_R->getPosition(1));
+      if (ismatcher->single_bin_t_TPC)
+      {
+        stat += delta_t / ismatcher->tol_step_t_TPC;
+      }
+      else
+      {
+        stat += delta_t / (ismatcher->tol_step_t_TPC * std::max(clus_T->getZSize(), clus_R->getZSize()));
+      }
+    }
+    break;
+    // case 3:  // TPOT // empty case triggers clang-tidy warning
+    //   break;
+    default:
+      break;
     }
     return stat;
   }
 
-
-}
+}  // namespace g4evalfn

--- a/simulation/g4simulation/g4eval/g4evalfn.h
+++ b/simulation/g4simulation/g4eval/g4evalfn.h
@@ -7,26 +7,34 @@ class TrkrClusterIsMatcher;
 class EmbRecoMatchContainer;
 class SvtxTrackMap;
 
-namespace g4evalfn {
+namespace g4evalfn
+{
 
-  enum DET { MVTX=0, INTT=1, TPC=2, TPOT=3 }; // 
+  enum DET
+  {
+    MVTX = 0,
+    INTT = 1,
+    TPC = 2,
+    TPOT = 3
+  };  //
 
-  int trklayer_det(TrkrDefs::hitsetkey); // 0:MVTX 1:INTt 2:TPC 3:TPOT and beyond
-  int trklayer_det(TrkrDefs::cluskey);   
-  int trklayer_det(int layer);          
+  int trklayer_det(TrkrDefs::hitsetkey);  // 0:MVTX 1:INTt 2:TPC 3:TPOT and beyond
+  int trklayer_det(TrkrDefs::cluskey);
+  int trklayer_det(int layer);
 
   TrkrClusLoc clusloc_PHG4(TrkrClusterIsMatcher*, TrkrDefs::cluskey);
   TrkrClusLoc clusloc_SVTX(TrkrClusterIsMatcher*, TrkrDefs::cluskey);
 
-  inline float abs_dphi (float aphi, float bphi) {
-    float phi_delta = fabs(aphi-bphi);
-    while (phi_delta > M_PI) phi_delta = fabs(phi_delta-2*M_PI);
+  inline float abs_dphi(float aphi, float bphi)
+  {
+    float phi_delta = fabs(aphi - bphi);
+    while (phi_delta > M_PI) phi_delta = fabs(phi_delta - 2 * M_PI);
     return phi_delta;
   }
 
   std::vector<int> unmatchedSvtxTrkIds(EmbRecoMatchContainer*, SvtxTrackMap*);
 
   float calc_match_statistic(TrkrClusterIsMatcher* ismatcher, TrkrDefs::cluskey key_A, TrkrDefs::cluskey key_B);
-}
+}  // namespace g4evalfn
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
clang-tidy is in the meantime orange again with perennial warnings. This PR fixes the latest ones. Some acts related includes and .cc's in trackbase had their ordering wrong which then leads to very interesting combinations of loaded includes if you change one of those. In principal the -isystem$OFFLINE_MAIN/include should remove all compiler warnings but there is still one from eigen which shouldn't show up. Means there might still be a random include coming in from somewhere instead of the local dir. I'll see after this PR if that is still aroung with a consistent build

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

