### PR TITLE
Fix bug in TrackResiduals dE/dx calculation

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -436,6 +436,13 @@ float TrackResiduals::calc_dedx(TrackSeed *tpcseed, TrkrClusterContainer *cluste
   std::vector<float> dedxlist;
   for (unsigned int i = 0; i < clusterKeys.size(); i++){
     TrkrDefs::cluskey cluster_key = clusterKeys.at(i);
+ 
+    auto detid = TrkrDefs::getTrkrId(cluster_key);
+    if (detid != TrkrDefs::TrkrId::tpcId) 
+      {
+	continue;   // the micromegas clusters are added to the TPC seeds
+      }
+
     unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
     TrkrCluster* cluster = clustermap->findCluster(cluster_key);
     float adc = cluster->getAdc();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This fixes a bug in the dE/dx calculation in TrackResiduals. It was assumed that the TPC seed clusters were all TPC clusters, but matched TPOT clusters are also added to the TPC seed cluster list. This produced a fatal geometry lookup error for the TPOT clusters.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

