### PR TITLE
Adding Code for Jet Kinematics QA in QA/Jet

### DIFF
--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -1,0 +1,516 @@
+//____________________________________________________________________________..
+
+
+#include "JetKinematicCheck.h"
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <jetbase/JetContainer.h>
+#include <jetbase/Jetv2.h>
+#include <TH3D.h>
+#include <TH2D.h>
+#include <TH1D.h>
+#include <TPad.h>
+#include <TLegend.h>
+#include <cmath>
+#include <string>
+#include <vector>
+
+
+//____________________________________________________________________________..
+
+JetKinematicCheck::JetKinematicCheck(const std::string& recojetnameR02, const std::string& recojetnameR03, const std::string& recojetnameR04):
+SubsysReco("JetKinematicCheck")
+  , m_recoJetNameR02(recojetnameR02)
+  , m_recoJetNameR03(recojetnameR03)
+  , m_recoJetNameR04(recojetnameR04)
+  , m_etaRange(-1.1, 1.1)
+  , m_ptRange(10, 100)
+
+
+{
+  std::cout << "JetKinematicCheck::JetKinematicCheck(const std::string &name) Calling ctor" << std::endl;
+}
+
+//____________________________________________________________________________..
+JetKinematicCheck::~JetKinematicCheck()
+{
+  std::cout << "JetKinematicCheck::~JetKinematicCheck() Calling dtor" << std::endl;
+}
+
+//____________________________________________________________________________..
+int JetKinematicCheck::Init(PHCompositeNode *topNode)
+{
+
+
+  hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+
+  // initialize histograms
+
+  jet_spectra_r02 = new TH1D("h_spectra_r02", "", 19, 5, 100);
+  jet_spectra_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+
+  jet_spectra_r03 = new TH1D("h_spectra_r03", "", 19, 5, 100);
+  jet_spectra_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+
+  jet_spectra_r04 = new TH1D("h_spectra_r04", "", 19, 5, 100);
+  jet_spectra_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+
+  jet_eta_phi_r02 = new TH2D("h_eta_phi_r02","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r02->GetXaxis()->SetTitle("#eta");
+  jet_eta_phi_r02->GetYaxis()->SetTitle("#Phi");
+
+  jet_eta_phi_r03 = new TH2D("h_eta_phi_r03","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r03->GetXaxis()->SetTitle("#eta");
+  jet_eta_phi_r03->GetYaxis()->SetTitle("#Phi");
+
+  jet_eta_phi_r04 = new TH2D("h_eta_phi_r04","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r04->GetXaxis()->SetTitle("#eta");
+  jet_eta_phi_r04->GetYaxis()->SetTitle("#Phi");
+
+  jet_mass_pt_r02 = new TH2D("h_jet_mass_pt_r02","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_pt_r03 = new TH2D("h_jet_mass_pt_r03","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_pt_r04 = new TH2D("h_jet_mass_pt_r04","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+
+  jet_mass_eta_r02 = new TH2D("h_jet_mass_eta_r02","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r02->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_r03 = new TH2D("h_jet_mass_eta_r03","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r03->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_r04 = new TH2D("h_jet_mass_eta_r04","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r04->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+
+  jet_mass_pt_1D_r02 = new TH1D("h_jet_mass_pt_1D_r02", "", 19, 5, 100);
+  jet_mass_pt_1D_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_pt_1D_r03 = new TH1D("h_jet_mass_pt_1D_r03", "", 19, 5, 100);
+  jet_mass_pt_1D_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_pt_1D_r04 = new TH1D("h_jet_mass_pt_1D_r04", "", 19, 5, 100);
+  jet_mass_pt_1D_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+
+  jet_mass_eta_1D_r02 = new TH2D("h_jet_mass_eta_1D_r02","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r02->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_1D_r03 = new TH2D("h_jet_mass_eta_1D_r03","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r03->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_1D_r04 = new TH2D("h_jet_mass_eta_1D_r04","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r04->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+
+
+
+  std::cout << "JetKinematicCheck::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+//____________________________________________________________________________..
+int JetKinematicCheck::InitRun(PHCompositeNode *topNode)
+{
+  std::cout << "JetKinematicCheck::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+
+//____________________________________________________________________________..
+int JetKinematicCheck::process_event(PHCompositeNode *topNode)
+{
+
+
+  std::vector<std::string> m_recoJetName_array = {m_recoJetNameR02, m_recoJetNameR03, m_recoJetNameR04};
+  m_radii = {0.2, 0.3, 0.4};
+  int n_radii = m_radii.size();
+
+
+  // Loop over each reco jet radii from array
+  for(int i = 0; i < n_radii; i++){
+
+    std::string recoJetName = m_recoJetName_array[i];
+
+    JetContainer* jets = findNode::getClass<JetContainer>(topNode, recoJetName);
+    if (!jets)
+      {
+  	std::cout
+  	  << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
+  	  << recoJetName << std::endl;
+  	exit(-1);
+      }
+
+
+    //loop over jets
+    for (auto jet : *jets)
+      {
+  	bool eta_cut = (jet->get_eta() >= m_etaRange.first) and (jet->get_eta() <= m_etaRange.second);
+  	bool pt_cut = (jet->get_pt() >= m_ptRange.first) and (jet->get_pt() <= m_ptRange.second);
+  	if ((not eta_cut) or (not pt_cut)) continue;
+  	if(jet->get_pt() < 1) continue; // to remove noise jets
+
+        if(i == 0){
+          jet_spectra_r02->Fill(jet->get_pt());
+          jet_eta_phi_r02->Fill(jet->get_eta(), jet->get_phi());
+	  jet_mass_pt_r02->Fill(jet->get_pt(), jet->get_mass());
+	  jet_mass_eta_r02->Fill(jet->get_eta(), jet->get_mass());
+        }
+
+        else if(i == 1){
+	  jet_spectra_r03->Fill(jet->get_pt());
+  	  jet_eta_phi_r03->Fill(jet->get_eta(), jet->get_phi());
+	  jet_mass_pt_r03->Fill(jet->get_pt(), jet->get_mass());
+	  jet_mass_eta_r03->Fill(jet->get_eta(), jet->get_mass());
+
+  	}
+
+  	else if(i == 2){
+  	  jet_spectra_r04->Fill(jet->get_pt());
+  	  jet_eta_phi_r04->Fill(jet->get_eta(), jet->get_phi());
+	  jet_mass_pt_r04->Fill(jet->get_pt(), jet->get_mass());
+	  jet_mass_eta_r04->Fill(jet->get_eta(), jet->get_mass());
+  	}
+      }
+  }
+
+
+
+  std::cout << "JetKinematicCheck::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+//____________________________________________________________________________..
+int JetKinematicCheck::EndRun(const int runnumber)
+{
+  std::cout << "JetKinematicCheck::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int JetKinematicCheck::End(PHCompositeNode *topNode)
+{
+
+  std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) Entering the end" << std::endl;
+
+
+
+  //for jet spectra [R02]
+  TLegend *leg1 = new TLegend(.7,.9,.9,1);
+  leg1->SetFillStyle(0);
+  leg1->SetBorderSize(0);
+  leg1->SetTextSize(0.06);
+  leg1->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg1->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_spectra_r02->SetMarkerStyle(8);
+  jet_spectra_r02->SetMarkerColor(1);
+  jet_spectra_r02->SetLineColor(1);
+  jet_spectra_r02->SetTitle("Jet Spectra [R = 0.2]");
+  jet_spectra_r02->GetYaxis()->SetTitle("Counts");
+  jet_spectra_r02->GetListOfFunctions()->Add(leg1);
+  jet_spectra_r02->SetStats(0);
+
+
+  //for jet spectra [R03]
+  TLegend *leg2 = new TLegend(.7,.9,.9,1);
+  leg2->SetFillStyle(0);
+  leg2->SetBorderSize(0);
+  leg2->SetTextSize(0.06);
+  leg2->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg2->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_spectra_r03->SetMarkerStyle(8);
+  jet_spectra_r03->SetMarkerColor(1);
+  jet_spectra_r03->SetLineColor(1);
+  jet_spectra_r03->SetTitle("Jet Spectra [R = 0.3]");
+  jet_spectra_r03->GetYaxis()->SetTitle("Counts");
+  jet_spectra_r03->GetListOfFunctions()->Add(leg2);
+  jet_spectra_r03->SetStats(0);
+
+  //for jet spectra [R04]
+  TLegend *leg3 = new TLegend(.7,.9,.9,1);
+  leg3->SetFillStyle(0);
+  leg3->SetBorderSize(0);
+  leg3->SetTextSize(0.06);
+  leg3->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg3->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_spectra_r04->SetMarkerStyle(8);
+  jet_spectra_r04->SetMarkerColor(1);
+  jet_spectra_r04->SetLineColor(1);
+  jet_spectra_r04->SetTitle("Jet Spectra [R = 0.4]");
+  jet_spectra_r04->GetYaxis()->SetTitle("Counts");
+  jet_spectra_r04->GetListOfFunctions()->Add(leg3);
+  jet_spectra_r04->SetStats(0);
+
+
+  //for jet eta-phi [R02]
+  TLegend *leg4 = new TLegend(.7,.9,.9,1);
+  leg4->SetFillStyle(0);
+  leg4->SetBorderSize(0);
+  leg4->SetTextSize(0.06);
+  leg4->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg4->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_eta_phi_r02->SetStats(0);
+  jet_eta_phi_r02->SetTitle("Jet Eta-Phi [R = 0.2]");
+  jet_eta_phi_r02->GetListOfFunctions()->Add(leg4);
+
+
+  //for jet eta-phi [R03]
+  TLegend *leg5 = new TLegend(.7,.9,.9,1);
+  leg5->SetFillStyle(0);
+  leg5->SetBorderSize(0);
+  leg5->SetTextSize(0.06);
+  leg5->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg5->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_eta_phi_r03->SetStats(0);
+  jet_eta_phi_r03->SetTitle("Jet Eta-Phi [R = 0.3]");
+  jet_eta_phi_r03->GetListOfFunctions()->Add(leg5);
+
+  //for jet eta-phi [R04]
+  TLegend *leg6 = new TLegend(.7,.9,.9,1);
+  leg6->SetFillStyle(0);
+  leg6->SetBorderSize(0);
+  leg6->SetTextSize(0.06);
+  leg6->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg6->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_eta_phi_r04->SetStats(0);
+  jet_eta_phi_r04->SetTitle("Jet Eta-Phi [R = 0.4]");
+  jet_eta_phi_r04->GetListOfFunctions()->Add(leg6);
+
+  //for jet mass vs pt [R02]
+  TLegend *leg7 = new TLegend(.7,.9,.9,1);
+  leg7->SetFillStyle(0);
+  leg7->SetBorderSize(0);
+  leg7->SetTextSize(0.06);
+  leg7->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg7->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_r02->SetStats(0);
+  jet_mass_pt_r02->SetTitle("Jet Mass vs p_{T} [R = 0.2]");
+  jet_mass_pt_r02->GetListOfFunctions()->Add(leg7);
+
+  //for average jet mass vs pt [R02]
+  TLegend *leg8 = new TLegend(.7,.9,.9,1);
+  leg8->SetFillStyle(0);
+  leg8->SetBorderSize(0);
+  leg8->SetTextSize(0.06);
+  leg8->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg8->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_1D_r02 = (TH1D*)jet_mass_pt_r02->ProfileX();
+  jet_mass_pt_1D_r02->SetStats(0);
+  jet_mass_pt_1D_r02->SetTitle("Average Jet Mass vs p_{T} [R = 0.2]");
+  jet_mass_pt_1D_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_pt_1D_r02->SetMarkerStyle(8);
+  jet_mass_pt_1D_r02->SetMarkerColor(1);
+  jet_mass_pt_1D_r02->SetLineColor(1);
+  jet_mass_pt_1D_r02->GetListOfFunctions()->Add(leg8);
+
+
+  //for jet mass vs pt [R03]
+  TLegend *leg9 = new TLegend(.7,.9,.9,1);
+  leg9->SetFillStyle(0);
+  leg9->SetBorderSize(0);
+  leg9->SetTextSize(0.06);
+  leg9->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg9->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_r03->SetStats(0);
+  jet_mass_pt_r03->SetTitle("Jet Mass vs p_{T} [R = 0.3]");
+  jet_mass_pt_r03->GetListOfFunctions()->Add(leg9);
+
+
+  //for average jet mass vs pt [R03]
+  TLegend *leg10 = new TLegend(.7,.9,.9,1);
+  leg10->SetFillStyle(0);
+  leg10->SetBorderSize(0);
+  leg10->SetTextSize(0.06);
+  leg10->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg10->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_1D_r03 = (TH1D*)jet_mass_pt_r03->ProfileX();
+  jet_mass_pt_1D_r03->SetStats(0);
+  jet_mass_pt_1D_r03->SetTitle("Average Jet Mass vs p_{T} [R = 0.3]");
+  jet_mass_pt_1D_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_pt_1D_r03->SetMarkerStyle(8);
+  jet_mass_pt_1D_r03->SetMarkerColor(1);
+  jet_mass_pt_1D_r03->SetLineColor(1);
+  jet_mass_pt_1D_r03->GetListOfFunctions()->Add(leg10);
+
+
+  //for jet mass vs pt [R04]
+  TLegend *leg11 = new TLegend(.7,.9,.9,1);
+  leg11->SetFillStyle(0);
+  leg11->SetBorderSize(0);
+  leg11->SetTextSize(0.06);
+  leg11->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg11->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_r04->SetStats(0);
+  jet_mass_pt_r04->SetTitle("Jet Mass vs p_{T} [R = 0.4]");
+  jet_mass_pt_r04->GetListOfFunctions()->Add(leg11);
+
+  //for average jet mass vs pt [R04]
+  TLegend *leg12 = new TLegend(.7,.9,.9,1);
+  leg12->SetFillStyle(0);
+  leg12->SetBorderSize(0);
+  leg12->SetTextSize(0.06);
+  leg12->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg12->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_pt_1D_r04 = (TH1D*)jet_mass_pt_r04->ProfileX();
+  jet_mass_pt_1D_r04->SetStats(0);
+  jet_mass_pt_1D_r04->SetTitle("Average Jet Mass vs p_{T} [R = 0.4]");
+  jet_mass_pt_1D_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_pt_1D_r04->SetMarkerStyle(8);
+  jet_mass_pt_1D_r04->SetMarkerColor(1);
+  jet_mass_pt_1D_r04->SetLineColor(1);
+  jet_mass_pt_1D_r04->GetListOfFunctions()->Add(leg12);
+
+
+  //for jet mass vs eta [R02]
+  TLegend *leg13 = new TLegend(.7,.9,.9,1);
+  leg13->SetFillStyle(0);
+  leg13->SetBorderSize(0);
+  leg13->SetTextSize(0.06);
+  leg13->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg13->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_r02->SetStats(0);
+  jet_mass_eta_r02->SetTitle("Jet Mass vs #eta [R = 0.2]");
+  jet_mass_eta_r02->GetListOfFunctions()->Add(leg13);
+
+  //for average jet mass vs eta [R02]
+  TLegend *leg14 = new TLegend(.7,.9,.9,1);
+  leg14->SetFillStyle(0);
+  leg14->SetBorderSize(0);
+  leg14->SetTextSize(0.06);
+  leg14->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg14->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_1D_r02 = (TH1D*)jet_mass_eta_r02->ProfileX();
+  jet_mass_eta_1D_r02->SetStats(0);
+  jet_mass_eta_1D_r02->SetTitle("Average Jet Mass vs #eta [R = 0.2]");
+  jet_mass_eta_1D_r02->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_eta_1D_r02->SetMarkerStyle(8);
+  jet_mass_eta_1D_r02->SetMarkerColor(1);
+  jet_mass_eta_1D_r02->SetLineColor(1);
+  jet_mass_eta_1D_r02->GetListOfFunctions()->Add(leg14);
+
+  //for jet mass vs eta [R03]
+  TLegend *leg15 = new TLegend(.7,.9,.9,1);
+  leg15->SetFillStyle(0);
+  leg15->SetBorderSize(0);
+  leg15->SetTextSize(0.06);
+  leg15->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg15->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_r03->SetStats(0);
+  jet_mass_eta_r03->SetTitle("Jet Mass vs #eta [R = 0.3]");
+  jet_mass_eta_r03->GetListOfFunctions()->Add(leg15);
+
+  //for average jet mass vs eta [R03]
+  TLegend *leg16 = new TLegend(.7,.9,.9,1);
+  leg16->SetFillStyle(0);
+  leg16->SetBorderSize(0);
+  leg16->SetTextSize(0.06);
+  leg16->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg16->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_1D_r03 = (TH1D*)jet_mass_eta_r03->ProfileX();
+  jet_mass_eta_1D_r03->SetStats(0);
+  jet_mass_eta_1D_r03->SetTitle("Average Jet Mass vs #eta [R = 0.3]");
+  jet_mass_eta_1D_r03->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_eta_1D_r03->SetMarkerStyle(8);
+  jet_mass_eta_1D_r03->SetMarkerColor(1);
+  jet_mass_eta_1D_r03->SetLineColor(1);
+  jet_mass_eta_1D_r03->GetListOfFunctions()->Add(leg16);
+
+
+  //for jet mass vs eta [R04]
+  TLegend *leg17 = new TLegend(.7,.9,.9,1);
+  leg17->SetFillStyle(0);
+  leg17->SetBorderSize(0);
+  leg17->SetTextSize(0.06);
+  leg17->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg17->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_r04->SetStats(0);
+  jet_mass_eta_r04->SetTitle("Jet Mass vs #eta [R = 0.4]");
+  jet_mass_eta_r04->GetListOfFunctions()->Add(leg17);
+
+  //for average jet mass vs eta [R04]
+  TLegend *leg18 = new TLegend(.7,.9,.9,1);
+  leg18->SetFillStyle(0);
+  leg18->SetBorderSize(0);
+  leg18->SetTextSize(0.06);
+  leg18->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
+  leg18->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  jet_mass_eta_1D_r04 = (TH1D*)jet_mass_eta_r04->ProfileX();
+  jet_mass_eta_1D_r04->SetStats(0);
+  jet_mass_eta_1D_r04->SetTitle("Average Jet Mass vs #eta [R = 0.4]");
+  jet_mass_eta_1D_r04->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+  jet_mass_eta_1D_r04->SetMarkerStyle(8);
+  jet_mass_eta_1D_r04->SetMarkerColor(1);
+  jet_mass_eta_1D_r04->SetLineColor(1);
+  jet_mass_eta_1D_r04->GetListOfFunctions()->Add(leg18);
+
+
+
+  hm->registerHisto(jet_spectra_r02);
+  hm->registerHisto(jet_spectra_r03);
+  hm->registerHisto(jet_spectra_r04);
+  hm->registerHisto(jet_eta_phi_r02);
+  hm->registerHisto(jet_eta_phi_r03);
+  hm->registerHisto(jet_eta_phi_r04);
+  hm->registerHisto(jet_mass_pt_r02);
+  hm->registerHisto(jet_mass_pt_r03);
+  hm->registerHisto(jet_mass_pt_r04);
+  hm->registerHisto(jet_mass_pt_1D_r02);
+  hm->registerHisto(jet_mass_pt_1D_r03);
+  hm->registerHisto(jet_mass_pt_1D_r04);
+  hm->registerHisto(jet_mass_eta_r02);
+  hm->registerHisto(jet_mass_eta_r03);
+  hm->registerHisto(jet_mass_eta_r04);
+  hm->registerHisto(jet_mass_eta_1D_r02);
+  hm->registerHisto(jet_mass_eta_1D_r03);
+  hm->registerHisto(jet_mass_eta_1D_r04);
+
+
+
+
+  std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int JetKinematicCheck::Reset(PHCompositeNode *topNode)
+{
+ std::cout << "JetKinematicCheck::Reset(PHCompositeNode *topNode) being Reset" << std::endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+void JetKinematicCheck::Print(const std::string &what) const
+{
+  std::cout << "JetKinematicCheck::Print(const std::string &what) const Printing info for " << what << std::endl;
+}

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -1,58 +1,52 @@
 //____________________________________________________________________________..
 
-
 #include "JetKinematicCheck.h"
-#include <fun4all/Fun4AllReturnCodes.h>
+#include <TH1D.h>
+#include <TH2D.h>
+#include <TH3D.h>
+#include <TLegend.h>
+#include <TPad.h>
 #include <fun4all/Fun4AllHistoManager.h>
-#include <phool/PHCompositeNode.h>
-#include <phool/getClass.h>
+#include <fun4all/Fun4AllReturnCodes.h>
 #include <jetbase/JetContainer.h>
 #include <jetbase/Jetv2.h>
-#include <TH3D.h>
-#include <TH2D.h>
-#include <TH1D.h>
-#include <TPad.h>
-#include <TLegend.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
 #include <cmath>
 #include <string>
 #include <vector>
 
-
 //____________________________________________________________________________..
 
-JetKinematicCheck::JetKinematicCheck(const std::string& recojetnameR02, const std::string& recojetnameR03, const std::string& recojetnameR04):
-SubsysReco("JetKinematicCheck")
+JetKinematicCheck::JetKinematicCheck(const std::string &recojetnameR02, const std::string &recojetnameR03, const std::string &recojetnameR04)
+  : SubsysReco("JetKinematicCheck")
   , m_recoJetNameR02(recojetnameR02)
   , m_recoJetNameR03(recojetnameR03)
   , m_recoJetNameR04(recojetnameR04)
   , m_etaRange(-1.1, 1.1)
   , m_ptRange(10, 100)
 
-
 {
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::JetKinematicCheck(const std::string &name) Calling ctor" << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::JetKinematicCheck(const std::string &name) Calling ctor" << std::endl;
+  }
 }
 
 //____________________________________________________________________________..
 JetKinematicCheck::~JetKinematicCheck()
 {
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::~JetKinematicCheck() Calling dtor" << std::endl;
-    }
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::~JetKinematicCheck() Calling dtor" << std::endl;
+  }
 }
 
 //____________________________________________________________________________..
-int JetKinematicCheck::Init(PHCompositeNode *)
+int JetKinematicCheck::Init(PHCompositeNode * /*unused*/)
 {
-
-
   hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-
 
   // initialize histograms
 
@@ -65,43 +59,41 @@ int JetKinematicCheck::Init(PHCompositeNode *)
   jet_spectra_r04 = new TH1D("h_spectra_r04", "", 19, 5, 100);
   jet_spectra_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
 
-  jet_eta_phi_r02 = new TH2D("h_eta_phi_r02","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r02 = new TH2D("h_eta_phi_r02", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r02->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r02->GetYaxis()->SetTitle("#Phi");
 
-  jet_eta_phi_r03 = new TH2D("h_eta_phi_r03","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r03 = new TH2D("h_eta_phi_r03", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r03->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r03->GetYaxis()->SetTitle("#Phi");
 
-  jet_eta_phi_r04 = new TH2D("h_eta_phi_r04","", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r04 = new TH2D("h_eta_phi_r04", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r04->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r04->GetYaxis()->SetTitle("#Phi");
 
-  jet_mass_pt_r02 = new TH2D("h_jet_mass_pt_r02","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r02 = new TH2D("h_jet_mass_pt_r02", "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_r03 = new TH2D("h_jet_mass_pt_r03","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r03 = new TH2D("h_jet_mass_pt_r03", "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_r04 = new TH2D("h_jet_mass_pt_r04","", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r04 = new TH2D("h_jet_mass_pt_r04", "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-
-  jet_mass_eta_r02 = new TH2D("h_jet_mass_eta_r02","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r02 = new TH2D("h_jet_mass_eta_r02", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r02->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_r03 = new TH2D("h_jet_mass_eta_r03","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r03 = new TH2D("h_jet_mass_eta_r03", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r03->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_r04 = new TH2D("h_jet_mass_eta_r04","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r04 = new TH2D("h_jet_mass_eta_r04", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r04->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
-
 
   jet_mass_pt_1D_r02 = new TH1D("h_jet_mass_pt_1D_r02", "", 19, 5, 100);
   jet_mass_pt_1D_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
@@ -115,229 +107,219 @@ int JetKinematicCheck::Init(PHCompositeNode *)
   jet_mass_pt_1D_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-
-  jet_mass_eta_1D_r02 = new TH2D("h_jet_mass_eta_1D_r02","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r02 = new TH2D("h_jet_mass_eta_1D_r02", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r02->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_1D_r03 = new TH2D("h_jet_mass_eta_1D_r03","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r03 = new TH2D("h_jet_mass_eta_1D_r03", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r03->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_1D_r04 = new TH2D("h_jet_mass_eta_1D_r04","", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r04 = new TH2D("h_jet_mass_eta_1D_r04", "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r04->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-
-
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::Init(PHCompositeNode *topNode) Initializing" << std::endl;
-    }
-return Fun4AllReturnCodes::EVENT_OK;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
 }
-
 
 //____________________________________________________________________________..
-int JetKinematicCheck::InitRun(PHCompositeNode *)
+int JetKinematicCheck::InitRun(PHCompositeNode * /*unused*/)
 {
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
-    }
-return Fun4AllReturnCodes::EVENT_OK;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
 }
-
-
-
 
 //____________________________________________________________________________..
 int JetKinematicCheck::process_event(PHCompositeNode *topNode)
 {
-
-
   std::vector<std::string> m_recoJetName_array = {m_recoJetNameR02, m_recoJetNameR03, m_recoJetNameR04};
   m_radii = {0.2, 0.3, 0.4};
   int n_radii = m_radii.size();
 
-
   // Loop over each reco jet radii from array
-  for(int i = 0; i < n_radii; i++){
-
+  for (int i = 0; i < n_radii; i++)
+  {
     std::string recoJetName = m_recoJetName_array[i];
 
-    JetContainer* jets = findNode::getClass<JetContainer>(topNode, recoJetName);
+    JetContainer *jets = findNode::getClass<JetContainer>(topNode, recoJetName);
     if (!jets)
-      {
-  	std::cout
-  	  << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
-  	  << recoJetName << std::endl;
-  	return Fun4AllReturnCodes::ABORTRUN;
-      }
+    {
+      std::cout
+          << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
+          << recoJetName << std::endl;
+      return Fun4AllReturnCodes::ABORTRUN;
+    }
 
-
-    //loop over jets
+    // loop over jets
     for (auto jet : *jets)
+    {
+      bool eta_cut = (jet->get_eta() >= m_etaRange.first) and (jet->get_eta() <= m_etaRange.second);
+      bool pt_cut = (jet->get_pt() >= m_ptRange.first) and (jet->get_pt() <= m_ptRange.second);
+      if ((not eta_cut) or (not pt_cut))
       {
-  	bool eta_cut = (jet->get_eta() >= m_etaRange.first) and (jet->get_eta() <= m_etaRange.second);
-  	bool pt_cut = (jet->get_pt() >= m_ptRange.first) and (jet->get_pt() <= m_ptRange.second);
-  	if ((not eta_cut) or (not pt_cut)) continue;
-  	if(jet->get_pt() < 1) continue; // to remove noise jets
-
-        if(i == 0){
-          jet_spectra_r02->Fill(jet->get_pt());
-          jet_eta_phi_r02->Fill(jet->get_eta(), jet->get_phi());
-	  jet_mass_pt_r02->Fill(jet->get_pt(), jet->get_mass());
-	  jet_mass_eta_r02->Fill(jet->get_eta(), jet->get_mass());
-        }
-
-        else if(i == 1){
-	  jet_spectra_r03->Fill(jet->get_pt());
-  	  jet_eta_phi_r03->Fill(jet->get_eta(), jet->get_phi());
-	  jet_mass_pt_r03->Fill(jet->get_pt(), jet->get_mass());
-	  jet_mass_eta_r03->Fill(jet->get_eta(), jet->get_mass());
-
-  	}
-
-  	else if(i == 2){
-  	  jet_spectra_r04->Fill(jet->get_pt());
-  	  jet_eta_phi_r04->Fill(jet->get_eta(), jet->get_phi());
-	  jet_mass_pt_r04->Fill(jet->get_pt(), jet->get_mass());
-	  jet_mass_eta_r04->Fill(jet->get_eta(), jet->get_mass());
-  	}
+        continue;
       }
+      if (jet->get_pt() < 1)
+      {
+        continue;  // to remove noise jets
+      }
+
+      if (i == 0)
+      {
+        jet_spectra_r02->Fill(jet->get_pt());
+        jet_eta_phi_r02->Fill(jet->get_eta(), jet->get_phi());
+        jet_mass_pt_r02->Fill(jet->get_pt(), jet->get_mass());
+        jet_mass_eta_r02->Fill(jet->get_eta(), jet->get_mass());
+      }
+
+      else if (i == 1)
+      {
+        jet_spectra_r03->Fill(jet->get_pt());
+        jet_eta_phi_r03->Fill(jet->get_eta(), jet->get_phi());
+        jet_mass_pt_r03->Fill(jet->get_pt(), jet->get_mass());
+        jet_mass_eta_r03->Fill(jet->get_eta(), jet->get_mass());
+      }
+
+      else if (i == 2)
+      {
+        jet_spectra_r04->Fill(jet->get_pt());
+        jet_eta_phi_r04->Fill(jet->get_eta(), jet->get_phi());
+        jet_mass_pt_r04->Fill(jet->get_pt(), jet->get_mass());
+        jet_mass_eta_r04->Fill(jet->get_eta(), jet->get_mass());
+      }
+    }
   }
 
-
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
-    }
-return Fun4AllReturnCodes::EVENT_OK;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
 }
-
-
 
 //____________________________________________________________________________..
 int JetKinematicCheck::EndRun(const int runnumber)
 {
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
-    }
-return Fun4AllReturnCodes::EVENT_OK;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int JetKinematicCheck::End(PHCompositeNode *)
+int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
 {
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) Entering the end" << std::endl;
-    }
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) Entering the end" << std::endl;
+  }
 
-
-  //for jet spectra [R02]
-  TLegend *leg1 = new TLegend(.7,.9,.9,1);
+  // for jet spectra [R02]
+  TLegend *leg1 = new TLegend(.7, .9, .9, 1);
   leg1->SetFillStyle(0);
   leg1->SetBorderSize(0);
   leg1->SetTextSize(0.06);
-  leg1->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg1->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  leg1->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg1->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
   jet_spectra_r02->SetMarkerStyle(8);
   jet_spectra_r02->SetMarkerColor(1);
   jet_spectra_r02->SetLineColor(1);
   jet_spectra_r02->SetTitle("Jet Spectra [R = 0.2]");
   jet_spectra_r02->GetYaxis()->SetTitle("Counts");
   jet_spectra_r02->GetListOfFunctions()->Add(leg1);
-  jet_spectra_r02->SetStats(0);
+  jet_spectra_r02->SetStats(false);
 
-
-  //for jet spectra [R03]
-  TLegend *leg2 = new TLegend(.7,.9,.9,1);
+  // for jet spectra [R03]
+  TLegend *leg2 = new TLegend(.7, .9, .9, 1);
   leg2->SetFillStyle(0);
   leg2->SetBorderSize(0);
   leg2->SetTextSize(0.06);
-  leg2->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg2->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  leg2->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg2->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
   jet_spectra_r03->SetMarkerStyle(8);
   jet_spectra_r03->SetMarkerColor(1);
   jet_spectra_r03->SetLineColor(1);
   jet_spectra_r03->SetTitle("Jet Spectra [R = 0.3]");
   jet_spectra_r03->GetYaxis()->SetTitle("Counts");
   jet_spectra_r03->GetListOfFunctions()->Add(leg2);
-  jet_spectra_r03->SetStats(0);
+  jet_spectra_r03->SetStats(false);
 
-  //for jet spectra [R04]
-  TLegend *leg3 = new TLegend(.7,.9,.9,1);
+  // for jet spectra [R04]
+  TLegend *leg3 = new TLegend(.7, .9, .9, 1);
   leg3->SetFillStyle(0);
   leg3->SetBorderSize(0);
   leg3->SetTextSize(0.06);
-  leg3->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg3->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
+  leg3->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg3->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
   jet_spectra_r04->SetMarkerStyle(8);
   jet_spectra_r04->SetMarkerColor(1);
   jet_spectra_r04->SetLineColor(1);
   jet_spectra_r04->SetTitle("Jet Spectra [R = 0.4]");
   jet_spectra_r04->GetYaxis()->SetTitle("Counts");
   jet_spectra_r04->GetListOfFunctions()->Add(leg3);
-  jet_spectra_r04->SetStats(0);
+  jet_spectra_r04->SetStats(false);
 
-
-  //for jet eta-phi [R02]
-  TLegend *leg4 = new TLegend(.7,.9,.9,1);
+  // for jet eta-phi [R02]
+  TLegend *leg4 = new TLegend(.7, .9, .9, 1);
   leg4->SetFillStyle(0);
   leg4->SetBorderSize(0);
   leg4->SetTextSize(0.06);
-  leg4->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg4->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_eta_phi_r02->SetStats(0);
+  leg4->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg4->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_eta_phi_r02->SetStats(false);
   jet_eta_phi_r02->SetTitle("Jet Eta-Phi [R = 0.2]");
   jet_eta_phi_r02->GetListOfFunctions()->Add(leg4);
 
-
-  //for jet eta-phi [R03]
-  TLegend *leg5 = new TLegend(.7,.9,.9,1);
+  // for jet eta-phi [R03]
+  TLegend *leg5 = new TLegend(.7, .9, .9, 1);
   leg5->SetFillStyle(0);
   leg5->SetBorderSize(0);
   leg5->SetTextSize(0.06);
-  leg5->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg5->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_eta_phi_r03->SetStats(0);
+  leg5->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg5->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_eta_phi_r03->SetStats(false);
   jet_eta_phi_r03->SetTitle("Jet Eta-Phi [R = 0.3]");
   jet_eta_phi_r03->GetListOfFunctions()->Add(leg5);
 
-  //for jet eta-phi [R04]
-  TLegend *leg6 = new TLegend(.7,.9,.9,1);
+  // for jet eta-phi [R04]
+  TLegend *leg6 = new TLegend(.7, .9, .9, 1);
   leg6->SetFillStyle(0);
   leg6->SetBorderSize(0);
   leg6->SetTextSize(0.06);
-  leg6->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg6->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_eta_phi_r04->SetStats(0);
+  leg6->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg6->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_eta_phi_r04->SetStats(false);
   jet_eta_phi_r04->SetTitle("Jet Eta-Phi [R = 0.4]");
   jet_eta_phi_r04->GetListOfFunctions()->Add(leg6);
 
-  //for jet mass vs pt [R02]
-  TLegend *leg7 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs pt [R02]
+  TLegend *leg7 = new TLegend(.7, .9, .9, 1);
   leg7->SetFillStyle(0);
   leg7->SetBorderSize(0);
   leg7->SetTextSize(0.06);
-  leg7->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg7->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_r02->SetStats(0);
+  leg7->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg7->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_r02->SetStats(false);
   jet_mass_pt_r02->SetTitle("Jet Mass vs p_{T} [R = 0.2]");
   jet_mass_pt_r02->GetListOfFunctions()->Add(leg7);
 
-  //for average jet mass vs pt [R02]
-  TLegend *leg8 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs pt [R02]
+  TLegend *leg8 = new TLegend(.7, .9, .9, 1);
   leg8->SetFillStyle(0);
   leg8->SetBorderSize(0);
   leg8->SetTextSize(0.06);
-  leg8->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg8->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_1D_r02 = (TH1D*)jet_mass_pt_r02->ProfileX();
-  jet_mass_pt_1D_r02->SetStats(0);
+  leg8->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg8->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_1D_r02 = (TH1D *) jet_mass_pt_r02->ProfileX();
+  jet_mass_pt_1D_r02->SetStats(false);
   jet_mass_pt_1D_r02->SetTitle("Average Jet Mass vs p_{T} [R = 0.2]");
   jet_mass_pt_1D_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -346,28 +328,26 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_pt_1D_r02->SetLineColor(1);
   jet_mass_pt_1D_r02->GetListOfFunctions()->Add(leg8);
 
-
-  //for jet mass vs pt [R03]
-  TLegend *leg9 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs pt [R03]
+  TLegend *leg9 = new TLegend(.7, .9, .9, 1);
   leg9->SetFillStyle(0);
   leg9->SetBorderSize(0);
   leg9->SetTextSize(0.06);
-  leg9->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg9->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_r03->SetStats(0);
+  leg9->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg9->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_r03->SetStats(false);
   jet_mass_pt_r03->SetTitle("Jet Mass vs p_{T} [R = 0.3]");
   jet_mass_pt_r03->GetListOfFunctions()->Add(leg9);
 
-
-  //for average jet mass vs pt [R03]
-  TLegend *leg10 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs pt [R03]
+  TLegend *leg10 = new TLegend(.7, .9, .9, 1);
   leg10->SetFillStyle(0);
   leg10->SetBorderSize(0);
   leg10->SetTextSize(0.06);
-  leg10->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg10->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_1D_r03 = (TH1D*)jet_mass_pt_r03->ProfileX();
-  jet_mass_pt_1D_r03->SetStats(0);
+  leg10->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg10->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_1D_r03 = (TH1D *) jet_mass_pt_r03->ProfileX();
+  jet_mass_pt_1D_r03->SetStats(false);
   jet_mass_pt_1D_r03->SetTitle("Average Jet Mass vs p_{T} [R = 0.3]");
   jet_mass_pt_1D_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -376,27 +356,26 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_pt_1D_r03->SetLineColor(1);
   jet_mass_pt_1D_r03->GetListOfFunctions()->Add(leg10);
 
-
-  //for jet mass vs pt [R04]
-  TLegend *leg11 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs pt [R04]
+  TLegend *leg11 = new TLegend(.7, .9, .9, 1);
   leg11->SetFillStyle(0);
   leg11->SetBorderSize(0);
   leg11->SetTextSize(0.06);
-  leg11->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg11->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_r04->SetStats(0);
+  leg11->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg11->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_r04->SetStats(false);
   jet_mass_pt_r04->SetTitle("Jet Mass vs p_{T} [R = 0.4]");
   jet_mass_pt_r04->GetListOfFunctions()->Add(leg11);
 
-  //for average jet mass vs pt [R04]
-  TLegend *leg12 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs pt [R04]
+  TLegend *leg12 = new TLegend(.7, .9, .9, 1);
   leg12->SetFillStyle(0);
   leg12->SetBorderSize(0);
   leg12->SetTextSize(0.06);
-  leg12->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg12->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_pt_1D_r04 = (TH1D*)jet_mass_pt_r04->ProfileX();
-  jet_mass_pt_1D_r04->SetStats(0);
+  leg12->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg12->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_pt_1D_r04 = (TH1D *) jet_mass_pt_r04->ProfileX();
+  jet_mass_pt_1D_r04->SetStats(false);
   jet_mass_pt_1D_r04->SetTitle("Average Jet Mass vs p_{T} [R = 0.4]");
   jet_mass_pt_1D_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -405,27 +384,26 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_pt_1D_r04->SetLineColor(1);
   jet_mass_pt_1D_r04->GetListOfFunctions()->Add(leg12);
 
-
-  //for jet mass vs eta [R02]
-  TLegend *leg13 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs eta [R02]
+  TLegend *leg13 = new TLegend(.7, .9, .9, 1);
   leg13->SetFillStyle(0);
   leg13->SetBorderSize(0);
   leg13->SetTextSize(0.06);
-  leg13->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg13->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_r02->SetStats(0);
+  leg13->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg13->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_r02->SetStats(false);
   jet_mass_eta_r02->SetTitle("Jet Mass vs #eta [R = 0.2]");
   jet_mass_eta_r02->GetListOfFunctions()->Add(leg13);
 
-  //for average jet mass vs eta [R02]
-  TLegend *leg14 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs eta [R02]
+  TLegend *leg14 = new TLegend(.7, .9, .9, 1);
   leg14->SetFillStyle(0);
   leg14->SetBorderSize(0);
   leg14->SetTextSize(0.06);
-  leg14->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg14->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_1D_r02 = (TH1D*)jet_mass_eta_r02->ProfileX();
-  jet_mass_eta_1D_r02->SetStats(0);
+  leg14->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg14->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_1D_r02 = (TH1D *) jet_mass_eta_r02->ProfileX();
+  jet_mass_eta_1D_r02->SetStats(false);
   jet_mass_eta_1D_r02->SetTitle("Average Jet Mass vs #eta [R = 0.2]");
   jet_mass_eta_1D_r02->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -434,26 +412,26 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_eta_1D_r02->SetLineColor(1);
   jet_mass_eta_1D_r02->GetListOfFunctions()->Add(leg14);
 
-  //for jet mass vs eta [R03]
-  TLegend *leg15 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs eta [R03]
+  TLegend *leg15 = new TLegend(.7, .9, .9, 1);
   leg15->SetFillStyle(0);
   leg15->SetBorderSize(0);
   leg15->SetTextSize(0.06);
-  leg15->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg15->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_r03->SetStats(0);
+  leg15->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg15->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_r03->SetStats(false);
   jet_mass_eta_r03->SetTitle("Jet Mass vs #eta [R = 0.3]");
   jet_mass_eta_r03->GetListOfFunctions()->Add(leg15);
 
-  //for average jet mass vs eta [R03]
-  TLegend *leg16 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs eta [R03]
+  TLegend *leg16 = new TLegend(.7, .9, .9, 1);
   leg16->SetFillStyle(0);
   leg16->SetBorderSize(0);
   leg16->SetTextSize(0.06);
-  leg16->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg16->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_1D_r03 = (TH1D*)jet_mass_eta_r03->ProfileX();
-  jet_mass_eta_1D_r03->SetStats(0);
+  leg16->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg16->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_1D_r03 = (TH1D *) jet_mass_eta_r03->ProfileX();
+  jet_mass_eta_1D_r03->SetStats(false);
   jet_mass_eta_1D_r03->SetTitle("Average Jet Mass vs #eta [R = 0.3]");
   jet_mass_eta_1D_r03->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -462,27 +440,26 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_eta_1D_r03->SetLineColor(1);
   jet_mass_eta_1D_r03->GetListOfFunctions()->Add(leg16);
 
-
-  //for jet mass vs eta [R04]
-  TLegend *leg17 = new TLegend(.7,.9,.9,1);
+  // for jet mass vs eta [R04]
+  TLegend *leg17 = new TLegend(.7, .9, .9, 1);
   leg17->SetFillStyle(0);
   leg17->SetBorderSize(0);
   leg17->SetTextSize(0.06);
-  leg17->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg17->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_r04->SetStats(0);
+  leg17->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg17->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_r04->SetStats(false);
   jet_mass_eta_r04->SetTitle("Jet Mass vs #eta [R = 0.4]");
   jet_mass_eta_r04->GetListOfFunctions()->Add(leg17);
 
-  //for average jet mass vs eta [R04]
-  TLegend *leg18 = new TLegend(.7,.9,.9,1);
+  // for average jet mass vs eta [R04]
+  TLegend *leg18 = new TLegend(.7, .9, .9, 1);
   leg18->SetFillStyle(0);
   leg18->SetBorderSize(0);
   leg18->SetTextSize(0.06);
-  leg18->AddEntry((TObject*)0, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second),"");
-  leg18->AddEntry((TObject*)0, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second),"");
-  jet_mass_eta_1D_r04 = (TH1D*)jet_mass_eta_r04->ProfileX();
-  jet_mass_eta_1D_r04->SetStats(0);
+  leg18->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
+  leg18->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  jet_mass_eta_1D_r04 = (TH1D *) jet_mass_eta_r04->ProfileX();
+  jet_mass_eta_1D_r04->SetStats(false);
   jet_mass_eta_1D_r04->SetTitle("Average Jet Mass vs #eta [R = 0.4]");
   jet_mass_eta_1D_r04->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
@@ -490,8 +467,6 @@ int JetKinematicCheck::End(PHCompositeNode *)
   jet_mass_eta_1D_r04->SetMarkerColor(1);
   jet_mass_eta_1D_r04->SetLineColor(1);
   jet_mass_eta_1D_r04->GetListOfFunctions()->Add(leg18);
-
-
 
   hm->registerHisto(jet_spectra_r02);
   hm->registerHisto(jet_spectra_r03);
@@ -512,11 +487,9 @@ int JetKinematicCheck::End(PHCompositeNode *)
   hm->registerHisto(jet_mass_eta_1D_r03);
   hm->registerHisto(jet_mass_eta_1D_r04);
 
-
-
-  if(Verbosity() > 1)
-    {
-  std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) This is the End..." << std::endl;
-    }
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/format.hpp>
 //____________________________________________________________________________..
 
 JetKinematicCheck::JetKinematicCheck(const std::string &recojetnameR02, const std::string &recojetnameR03, const std::string &recojetnameR04)
@@ -227,8 +228,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg1->SetFillStyle(0);
   leg1->SetBorderSize(0);
   leg1->SetTextSize(0.06);
-  leg1->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg1->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg1->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]")% m_ptRange.first% m_ptRange.second).c_str(),"");
+  leg1->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%")% m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_spectra_r02->SetMarkerStyle(8);
   jet_spectra_r02->SetMarkerColor(1);
   jet_spectra_r02->SetLineColor(1);
@@ -242,8 +243,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg2->SetFillStyle(0);
   leg2->SetBorderSize(0);
   leg2->SetTextSize(0.06);
-  leg2->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg2->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg2->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg2->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_spectra_r03->SetMarkerStyle(8);
   jet_spectra_r03->SetMarkerColor(1);
   jet_spectra_r03->SetLineColor(1);
@@ -257,8 +258,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg3->SetFillStyle(0);
   leg3->SetBorderSize(0);
   leg3->SetTextSize(0.06);
-  leg3->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg3->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg3->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]")%  m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg3->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_spectra_r04->SetMarkerStyle(8);
   jet_spectra_r04->SetMarkerColor(1);
   jet_spectra_r04->SetLineColor(1);
@@ -272,8 +273,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg4->SetFillStyle(0);
   leg4->SetBorderSize(0);
   leg4->SetTextSize(0.06);
-  leg4->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg4->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg4->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg4->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_eta_phi_r02->SetStats(false);
   jet_eta_phi_r02->SetTitle("Jet Eta-Phi [R = 0.2]");
   jet_eta_phi_r02->GetListOfFunctions()->Add(leg4);
@@ -283,8 +284,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg5->SetFillStyle(0);
   leg5->SetBorderSize(0);
   leg5->SetTextSize(0.06);
-  leg5->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg5->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg5->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg5->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_eta_phi_r03->SetStats(false);
   jet_eta_phi_r03->SetTitle("Jet Eta-Phi [R = 0.3]");
   jet_eta_phi_r03->GetListOfFunctions()->Add(leg5);
@@ -294,8 +295,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg6->SetFillStyle(0);
   leg6->SetBorderSize(0);
   leg6->SetTextSize(0.06);
-  leg6->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg6->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg6->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg6->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first %  m_etaRange.second).c_str(), "");
   jet_eta_phi_r04->SetStats(false);
   jet_eta_phi_r04->SetTitle("Jet Eta-Phi [R = 0.4]");
   jet_eta_phi_r04->GetListOfFunctions()->Add(leg6);
@@ -305,8 +306,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg7->SetFillStyle(0);
   leg7->SetBorderSize(0);
   leg7->SetTextSize(0.06);
-  leg7->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg7->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg7->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg7->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_r02->SetStats(false);
   jet_mass_pt_r02->SetTitle("Jet Mass vs p_{T} [R = 0.2]");
   jet_mass_pt_r02->GetListOfFunctions()->Add(leg7);
@@ -316,8 +317,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg8->SetFillStyle(0);
   leg8->SetBorderSize(0);
   leg8->SetTextSize(0.06);
-  leg8->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg8->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg8->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg8->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_1D_r02 = (TH1D *) jet_mass_pt_r02->ProfileX();
   jet_mass_pt_1D_r02->SetStats(false);
   jet_mass_pt_1D_r02->SetTitle("Average Jet Mass vs p_{T} [R = 0.2]");
@@ -333,8 +334,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg9->SetFillStyle(0);
   leg9->SetBorderSize(0);
   leg9->SetTextSize(0.06);
-  leg9->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg9->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg9->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg9->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_r03->SetStats(false);
   jet_mass_pt_r03->SetTitle("Jet Mass vs p_{T} [R = 0.3]");
   jet_mass_pt_r03->GetListOfFunctions()->Add(leg9);
@@ -344,8 +345,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg10->SetFillStyle(0);
   leg10->SetBorderSize(0);
   leg10->SetTextSize(0.06);
-  leg10->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg10->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg10->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg10->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_1D_r03 = (TH1D *) jet_mass_pt_r03->ProfileX();
   jet_mass_pt_1D_r03->SetStats(false);
   jet_mass_pt_1D_r03->SetTitle("Average Jet Mass vs p_{T} [R = 0.3]");
@@ -361,8 +362,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg11->SetFillStyle(0);
   leg11->SetBorderSize(0);
   leg11->SetTextSize(0.06);
-  leg11->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg11->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg11->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first%  m_ptRange.second).c_str(), "");
+  leg11->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %1.1f") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_r04->SetStats(false);
   jet_mass_pt_r04->SetTitle("Jet Mass vs p_{T} [R = 0.4]");
   jet_mass_pt_r04->GetListOfFunctions()->Add(leg11);
@@ -372,8 +373,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg12->SetFillStyle(0);
   leg12->SetBorderSize(0);
   leg12->SetTextSize(0.06);
-  leg12->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg12->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg12->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg12->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_1D_r04 = (TH1D *) jet_mass_pt_r04->ProfileX();
   jet_mass_pt_1D_r04->SetStats(false);
   jet_mass_pt_1D_r04->SetTitle("Average Jet Mass vs p_{T} [R = 0.4]");
@@ -389,8 +390,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg13->SetFillStyle(0);
   leg13->SetBorderSize(0);
   leg13->SetTextSize(0.06);
-  leg13->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg13->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg13->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg13->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_eta_r02->SetStats(false);
   jet_mass_eta_r02->SetTitle("Jet Mass vs #eta [R = 0.2]");
   jet_mass_eta_r02->GetListOfFunctions()->Add(leg13);
@@ -400,8 +401,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg14->SetFillStyle(0);
   leg14->SetBorderSize(0);
   leg14->SetTextSize(0.06);
-  leg14->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg14->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg14->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg14->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_eta_1D_r02 = (TH1D *) jet_mass_eta_r02->ProfileX();
   jet_mass_eta_1D_r02->SetStats(false);
   jet_mass_eta_1D_r02->SetTitle("Average Jet Mass vs #eta [R = 0.2]");
@@ -417,8 +418,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg15->SetFillStyle(0);
   leg15->SetBorderSize(0);
   leg15->SetTextSize(0.06);
-  leg15->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg15->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg15->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg15->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_eta_r03->SetStats(false);
   jet_mass_eta_r03->SetTitle("Jet Mass vs #eta [R = 0.3]");
   jet_mass_eta_r03->GetListOfFunctions()->Add(leg15);
@@ -428,8 +429,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg16->SetFillStyle(0);
   leg16->SetBorderSize(0);
   leg16->SetTextSize(0.06);
-  leg16->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg16->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg16->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg16->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first %  m_etaRange.second).c_str(), "");
   jet_mass_eta_1D_r03 = (TH1D *) jet_mass_eta_r03->ProfileX();
   jet_mass_eta_1D_r03->SetStats(false);
   jet_mass_eta_1D_r03->SetTitle("Average Jet Mass vs #eta [R = 0.3]");
@@ -445,8 +446,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg17->SetFillStyle(0);
   leg17->SetBorderSize(0);
   leg17->SetTextSize(0.06);
-  leg17->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg17->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg17->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg17->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_eta_r04->SetStats(false);
   jet_mass_eta_r04->SetTitle("Jet Mass vs #eta [R = 0.4]");
   jet_mass_eta_r04->GetListOfFunctions()->Add(leg17);
@@ -456,8 +457,8 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg18->SetFillStyle(0);
   leg18->SetBorderSize(0);
   leg18->SetTextSize(0.06);
-  leg18->AddEntry((TObject *) nullptr, Form("%2.0f < p_{T} < %2.0f [GeV/c]", m_ptRange.first, m_ptRange.second), "");
-  leg18->AddEntry((TObject *) nullptr, Form("%1.1f < #eta < %1.1f", m_etaRange.first, m_etaRange.second), "");
+  leg18->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first % m_ptRange.second).c_str(), "");
+  leg18->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_eta_1D_r04 = (TH1D *) jet_mass_eta_r04->ProfileX();
   jet_mass_eta_1D_r04->SetStats(false);
   jet_mass_eta_1D_r04->SetTitle("Average Jet Mass vs #eta [R = 0.4]");

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -30,17 +30,23 @@ SubsysReco("JetKinematicCheck")
 
 
 {
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::JetKinematicCheck(const std::string &name) Calling ctor" << std::endl;
+}
 }
 
 //____________________________________________________________________________..
 JetKinematicCheck::~JetKinematicCheck()
 {
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::~JetKinematicCheck() Calling dtor" << std::endl;
+    }
 }
 
 //____________________________________________________________________________..
-int JetKinematicCheck::Init(PHCompositeNode *topNode)
+int JetKinematicCheck::Init(PHCompositeNode *)
 {
 
 
@@ -124,17 +130,22 @@ int JetKinematicCheck::Init(PHCompositeNode *topNode)
 
 
 
-
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::Init(PHCompositeNode *topNode) Initializing" << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
+    }
+return Fun4AllReturnCodes::EVENT_OK;
 }
 
 
 //____________________________________________________________________________..
-int JetKinematicCheck::InitRun(PHCompositeNode *topNode)
+int JetKinematicCheck::InitRun(PHCompositeNode *)
 {
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
+    }
+return Fun4AllReturnCodes::EVENT_OK;
 }
 
 
@@ -161,7 +172,7 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
   	std::cout
   	  << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
   	  << recoJetName << std::endl;
-  	exit(-1);
+  	return Fun4AllReturnCodes::ABORTRUN;
       }
 
 
@@ -198,9 +209,11 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
   }
 
 
-
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
+    }
+return Fun4AllReturnCodes::EVENT_OK;
 }
 
 
@@ -208,16 +221,20 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int JetKinematicCheck::EndRun(const int runnumber)
 {
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
+    }
+return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
-int JetKinematicCheck::End(PHCompositeNode *topNode)
+int JetKinematicCheck::End(PHCompositeNode *)
 {
-
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) Entering the end" << std::endl;
-
+    }
 
 
   //for jet spectra [R02]
@@ -497,20 +514,9 @@ int JetKinematicCheck::End(PHCompositeNode *topNode)
 
 
 
-
+  if(Verbosity() > 1)
+    {
   std::cout << "JetKinematicCheck::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+    }
   return Fun4AllReturnCodes::EVENT_OK;
-}
-
-//____________________________________________________________________________..
-int JetKinematicCheck::Reset(PHCompositeNode *topNode)
-{
- std::cout << "JetKinematicCheck::Reset(PHCompositeNode *topNode) being Reset" << std::endl;
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-//____________________________________________________________________________..
-void JetKinematicCheck::Print(const std::string &what) const
-{
-  std::cout << "JetKinematicCheck::Print(const std::string &what) const Printing info for " << what << std::endl;
 }

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -4,11 +4,11 @@
 #ifndef JETKINEMATICCHECK_H
 #define JETKINEMATICCHECK_H
 
-#include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/SubsysReco.h>
 #include <qautils/QAHistManagerDef.h>
-#include <vector>
 #include <string>
+#include <vector>
 
 class TH1;
 class TH2;
@@ -18,11 +18,10 @@ class PHCompositeNode;
 class JetKinematicCheck : public SubsysReco
 {
  public:
-
   JetKinematicCheck(const std::string &recojetnameR02 = "AntiKt_Tower_r02",
-		    const std::string &recojetnameR03 = "AntiKt_Tower_r03",
-		    const std::string &recojetnameR04 = "AntiKt_Tower_r04");
-		    
+                    const std::string &recojetnameR03 = "AntiKt_Tower_r03",
+                    const std::string &recojetnameR04 = "AntiKt_Tower_r04");
+
   ~JetKinematicCheck() override;
 
   // set eta range
@@ -38,8 +37,6 @@ class JetKinematicCheck : public SubsysReco
     m_ptRange.first = low;
     m_ptRange.second = high;
   }
-
-
 
   /** Called during initialization.
       Typically this is where you can book histograms, and e.g.
@@ -67,7 +64,6 @@ class JetKinematicCheck : public SubsysReco
   int End(PHCompositeNode *topNode) override;
 
  private:
-
   Fun4AllHistoManager *hm{nullptr};
 
   std::string m_recoJetNameR02;
@@ -83,7 +79,7 @@ class JetKinematicCheck : public SubsysReco
   std::vector<float> m_pt;
   std::vector<float> m_radii;
 
-  // output histograms 
+  // output histograms
   TH1 *jet_spectra_r02 = nullptr;
   TH1 *jet_spectra_r03 = nullptr;
   TH1 *jet_spectra_r04 = nullptr;
@@ -102,7 +98,6 @@ class JetKinematicCheck : public SubsysReco
   TH1 *jet_mass_eta_1D_r03 = nullptr;
   TH2 *jet_mass_eta_r04 = nullptr;
   TH1 *jet_mass_eta_1D_r04 = nullptr;
-
 };
 
-#endif // JETKINEMATICCHECK_H
+#endif  // JETKINEMATICCHECK_H

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -66,11 +66,6 @@ class JetKinematicCheck : public SubsysReco
   /// Called at the end of all processing.
   int End(PHCompositeNode *topNode) override;
 
-  /// Reset
-  int Reset(PHCompositeNode * /*topNode*/) override;
-
-  void Print(const std::string &what = "ALL") const override;
-
  private:
 
   Fun4AllHistoManager *hm{nullptr};

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -1,0 +1,113 @@
+
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef JETKINEMATICCHECK_H
+#define JETKINEMATICCHECK_H
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <qautils/QAHistManagerDef.h>
+#include <vector>
+#include <string>
+
+class TH1;
+class TH2;
+class TH3;
+class PHCompositeNode;
+
+class JetKinematicCheck : public SubsysReco
+{
+ public:
+
+  JetKinematicCheck(const std::string &recojetnameR02 = "AntiKt_Tower_r02",
+		    const std::string &recojetnameR03 = "AntiKt_Tower_r03",
+		    const std::string &recojetnameR04 = "AntiKt_Tower_r04");
+		    
+  ~JetKinematicCheck() override;
+
+  // set eta range
+  void setEtaRange(double low, double high)
+  {
+    m_etaRange.first = low;
+    m_etaRange.second = high;
+  }
+
+  // set pt range
+  void setPtRange(double low, double high)
+  {
+    m_ptRange.first = low;
+    m_ptRange.second = high;
+  }
+
+
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for first event when run number is known.
+      Typically this is where you may want to fetch data from
+      database, because you know the run number. A place
+      to book histograms which have to know the run number.
+   */
+  int InitRun(PHCompositeNode *topNode) override;
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  int process_event(PHCompositeNode *topNode) override;
+
+  /// Called at the end of each run.
+  int EndRun(const int runnumber) override;
+
+  /// Called at the end of all processing.
+  int End(PHCompositeNode *topNode) override;
+
+  /// Reset
+  int Reset(PHCompositeNode * /*topNode*/) override;
+
+  void Print(const std::string &what = "ALL") const override;
+
+ private:
+
+  Fun4AllHistoManager *hm{nullptr};
+
+  std::string m_recoJetNameR02;
+  std::string m_recoJetNameR03;
+  std::string m_recoJetNameR04;
+  std::string m_outputFileName;
+  std::pair<double, double> m_etaRange;
+  std::pair<double, double> m_ptRange;
+
+  // reconstructed jets
+  std::vector<float> m_eta;
+  std::vector<float> m_phi;
+  std::vector<float> m_pt;
+  std::vector<float> m_radii;
+
+  // output histograms 
+  TH1 *jet_spectra_r02 = nullptr;
+  TH1 *jet_spectra_r03 = nullptr;
+  TH1 *jet_spectra_r04 = nullptr;
+  TH2 *jet_eta_phi_r02 = nullptr;
+  TH2 *jet_eta_phi_r03 = nullptr;
+  TH2 *jet_eta_phi_r04 = nullptr;
+  TH2 *jet_mass_pt_r02 = nullptr;
+  TH1 *jet_mass_pt_1D_r02 = nullptr;
+  TH2 *jet_mass_pt_r03 = nullptr;
+  TH1 *jet_mass_pt_1D_r03 = nullptr;
+  TH2 *jet_mass_pt_r04 = nullptr;
+  TH1 *jet_mass_pt_1D_r04 = nullptr;
+  TH2 *jet_mass_eta_r02 = nullptr;
+  TH1 *jet_mass_eta_1D_r02 = nullptr;
+  TH2 *jet_mass_eta_r03 = nullptr;
+  TH1 *jet_mass_eta_1D_r03 = nullptr;
+  TH2 *jet_mass_eta_r04 = nullptr;
+  TH1 *jet_mass_eta_1D_r04 = nullptr;
+
+};
+
+#endif // JETKINEMATICCHECK_H

--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -27,7 +27,8 @@ pkginclude_HEADERS = \
   TrksInJetQAClustManager.h \
   TrksInJetQATrkManager.h \
   TrksInJetQAJetManager.h \
-  JetSeedCount.h
+  JetSeedCount.h \
+  JetKinematicCheck.h
 
 libjetqa_la_SOURCES = \
   StructureinJets.cc \
@@ -40,7 +41,8 @@ libjetqa_la_SOURCES = \
   TrksInJetQAClustManager.cc \
   TrksInJetQATrkManager.cc \
   TrksInJetQAJetManager.cc \
-  JetSeedCount.cc
+  JetSeedCount.cc \
+  JetKinematicCheck.cc
 
 libjetqa_la_LIBADD = \
   -L$(libdir) \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Adding code to QA/Jet to monitor jet kinematics in p+p collisions. 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the source files JetKinematicCheck.cc and JetKinematicCheck.h to the QA/Jet directory. These files are used to generate histograms for the jet spectra, jet eta-phi distribution, and jet mass spectra (for pt and eta) for reconstructed jets with radii R = 0.2, 0.3, and 0.4 in p+p collisions.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

