### PR TITLE
Micromegas full event assembly

### DIFF
--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -87,7 +87,7 @@ unsigned int SingleMicromegasPoolInput::bco_matching_information_t::get_predicte
   static constexpr double multiplier = 4.2629164;
 
   // get lvl1 bco difference with proper rollover accounting
-  uint64_t gtm_bco_difference = (gtm_bco > m_gtm_bco_first) ?
+  uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
     (gtm_bco - m_gtm_bco_first):
     (gtm_bco + (1LL<<40) - m_gtm_bco_first);
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -26,28 +26,29 @@ namespace
 {
   // streamer for lists
   template <class T>
-  std::ostream& operator<<(std::ostream& out, const std::list<T>& list)
+  std::ostream& operator<<(std::ostream& o, const std::list<T>& list)
   {
     if (list.empty())
     {
-      out << "{}";
+      o << "{}";
     }
     else
     {
-      out << "{ ";
+      const bool is_hex = (o.flags()&std::ios_base::hex);
+      o << "{ ";
       bool first = true;
       for (const auto& value : list)
       {
         if (!first)
         {
-          out << ", ";
+          o << ", ";
         }
-        out << value;
+        o << value;
         first = false;
       }
-      out << " }";
+      o << " }";
     }
-    return out;
+    return o;
   }
 
   // get the difference of two unsiged numbers

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -43,6 +43,7 @@ namespace
         {
           o << ", ";
         }
+        if( is_hex ) o << "0x";
         o << value;
         first = false;
       }
@@ -202,7 +203,15 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
             bco_matching_information.m_has_gtm_bco_first = true;
 
             if( Verbosity() )
-            { std::cout << "SingleMicromegasPoolInput::FillPool - packet: " << packet_id << " m_gtm_bco_first: " << gtm_bco << std::endl; }
+            {
+              std::cout
+                << "SingleMicromegasPoolInput::FillPool -"
+                << " packet: " << packet_id
+                << std::hex
+                << " m_gtm_bco_first: 0x" << gtm_bco
+                << std::dec
+                << std::endl;
+            }
           }
 
           // store in list of available bco
@@ -279,7 +288,15 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
           bco_matching_information.m_has_fee_bco_first = true;
 
           if( Verbosity() )
-          { std::cout << "SingleMicromegasPoolInput::FillPool - packet: " << packet_id << " m_fee_bco_first: " << fee_bco << std::endl; }
+          {
+            std::cout
+              << "SingleMicromegasPoolInput::FillPool -"
+              << " packet: " << packet_id
+              << std::hex
+              << " m_fee_bco_first: 0x" << fee_bco
+              << std::dec
+              << std::endl;
+            }
         }
 
         // find matching gtm bco

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -80,7 +80,7 @@ void SingleMicromegasPoolInput::bco_matching_information_t::truncate( unsigned i
 unsigned int SingleMicromegasPoolInput::bco_matching_information_t::get_predicted_fee_bco( uint64_t gtm_bco ) const
 {
   // check proper initialization
-  if( !(m_has_gtm_bco_first && m_has_fee_bco_first ) ) return 0;
+  if( !(m_has_gtm_bco_first && m_has_fee_bco_first ) ) { return 0; }
 
   // this is the clock multiplier from lvl1 to fee clock
   /* todo: should replace with actual rational number for John K. */
@@ -89,7 +89,7 @@ unsigned int SingleMicromegasPoolInput::bco_matching_information_t::get_predicte
   // get lvl1 bco difference with proper rollover accounting
   uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
     (gtm_bco - m_gtm_bco_first):
-    (gtm_bco + (1LL<<40) - m_gtm_bco_first);
+    (gtm_bco + (1ULL<<40) - m_gtm_bco_first);
 
   // convert to fee bco, and truncate to 20 bits
   uint64_t fee_bco_predicted = m_fee_bco_first + multiplier*(gtm_bco_difference);
@@ -339,7 +339,7 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
 
             // fee_bco is new. Assume it corresponds to the first available gtm bco
             // update running fee_bco and gtm_bco pair accordingly
-            bco_matching_information.m_bco_matching_list.push_back(std::make_pair(fee_bco, gtm_bco));
+            bco_matching_information.m_bco_matching_list.emplace_back(fee_bco, gtm_bco);
 
             // remove bco from running list
             bco_matching_information.m_gtm_bco_list.erase(iter);

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -41,25 +41,40 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   std::map<int, uint64_t> m_FEEBclkMap;
   std::set<uint64_t> m_BclkStack;
 
-  //! keep track of matching between fee and gtm_bco
-  class bco_alignment_t
+  //! store relevant information for bco matching between lvl1 and fee.
+  using m_bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
+  class bco_matching_information_t
   {
-   public:
-    //! available gtm bcos
-    std::list<uint64_t> gtm_bco_list;
+    public:
 
-    //! current fee bco
-    unsigned int fee_bco{0};
+    //! first gtm bco (40 bits)
+    /** it is needed to be able to convert gtm bco in a predicted fee bco */
+    bool m_has_gtm_bco_first = false;
+    uint64_t m_gtm_bco_first = 0;
 
-    //! current gtm bco
-    uint64_t gtm_bco{0};
+    //! first fee bco (20 bits)
+    /** it is needed to be able to convert gtm bco in a predicted fee bco */
+    bool m_has_fee_bco_first = false;
+    unsigned int m_fee_bco_first = 0;
+
+    //! list of available bco
+    std::list<uint64_t> m_gtm_bco_list;
+
+    //! matching between fee bco and lvl1 bco
+    std::list<m_bco_matching_pair_t> m_bco_matching_list;
+
+    //! need to truncate bco matching list to some decent value
+    void truncate( unsigned int /* maxsize */ );
+
+    //! get predicted fee_bco from gtm_bco
+    unsigned int get_predicted_fee_bco( uint64_t ) const;
+
   };
 
-  //! max number of fees per single micromegas input
-  static constexpr unsigned short m_max_fee{26};
+  //! map bco_information_t to packet id
+  using bco_matching_information_map_t = std::map<unsigned int, bco_matching_information_t>;
+  bco_matching_information_map_t m_bco_matching_information_map;
 
-  //! keep one bco alignment object per fee
-  std::array<bco_alignment_t, m_max_fee> m_bco_alignment_list;
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -114,6 +114,9 @@ namespace MicromegasDefs
   //! total number of channels
   static constexpr int m_nchannels_total = m_nfee*m_nchannels_fee;
 
+  //! maximum valid ADC
+  static constexpr uint16_t m_adc_max = 1024;
+
   //! mark invalid ADC values
   static constexpr uint16_t m_adc_invalid = 65000;
 

--- a/offline/packages/micromegas/MicromegasMapping.cc
+++ b/offline/packages/micromegas/MicromegasMapping.cc
@@ -96,25 +96,26 @@ m_detectors( {
    * see https://wiki.sphenix.bnl.gov/index.php/TPc_Outer_Tracker_(TPOT)#Fiber_mapping.2C_as_of_2023.2F3.2F22
    */
   // south side
-  {5,  MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 4 ), "sec20.0", "R3.1", "M9P",  "SEIP" },
-  {7,  MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   4 ), "sec20.1", "R3.2", "M9Z",  "SEIZ" },
-  {6,  MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 0 ), "sec21.0", "R3.3", "M5P",  "SCOP" },
-  {8,  MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   0 ), "sec21.1", "R3.4", "M5Z",  "SCOZ" },
-  {9,  MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 1 ), "sec21.2", "R3.5", "M8P",  "SCIP" },
+  {5002, 5, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 4 ), "sec20.0", "R3.1", "M9P",  "SEIP" },
+  {5002, 7, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   4 ), "sec20.1", "R3.2", "M9Z",  "SEIZ" },
+  {5002, 6, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 0 ), "sec21.0", "R3.3", "M5P",  "SCOP" },
+  {5002, 8, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   0 ), "sec21.1", "R3.4", "M5Z",  "SCOZ" },
+  {5002, 9, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 1 ), "sec21.2", "R3.5", "M8P",  "SCIP" },
   /* {10, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   1 ), "sec21.3", "R3.6", "M8Z",  "SCIZ" }, */
   // updated after fiber swapping on May 23, to fix flaky initialization of the FEE
-  {23, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   1 ), "sec21.3", "R3.9", "M8Z",  "SCIZ" },
-  {24, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 6 ), "sec22.0", "R3.8", "M6P",  "SWIP" },
-  {25, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   6 ), "sec22.1", "R3.8", "M6Z",  "SWIZ" },
+  {5001, 23, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   1 ), "sec21.3", "R3.9", "M8Z",  "SCIZ" },
+  {5001, 24, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 6 ), "sec22.0", "R3.8", "M6P",  "SWIP" },
+  {5001, 25, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   6 ), "sec22.1", "R3.8", "M6Z",  "SWIZ" },
 
-  {11, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "sec8.0",  "R2.1", "M2P",  "NEIP" },
-  {12, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   5 ), "sec8.1",  "R2.2", "M2Z",  "NEIZ" },
-  {19, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 3 ), "sec9.0",  "R2.3", "M10P", "NCOP" },
-  {18, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   3 ), "sec9.1",  "R2.4", "M10Z", "NCOZ" },
-  {0,  MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 2 ), "sec9.2",  "R2.5", "M4P",  "NCIP" },
-  {1,  MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   2 ), "sec9.3",  "R2.6", "M4Z",  "NCIZ" },
-  {15, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 7 ), "sec10.0", "R2.7", "M7P",  "NWIP" },
-  {14, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   7 ), "sec10.1", "R2.8", "M7Z",  "NWIZ" }
+  // north side
+  {5001, 11, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "sec8.0",  "R2.1", "M2P",  "NEIP" },
+  {5001, 12, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   5 ), "sec8.1",  "R2.2", "M2Z",  "NEIZ" },
+  {5001, 19, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 3 ), "sec9.0",  "R2.3", "M10P", "NCOP" },
+  {5001, 18, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   3 ), "sec9.1",  "R2.4", "M10Z", "NCOZ" },
+  {5002, 0,  MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 2 ), "sec9.2",  "R2.5", "M4P",  "NCIP" },
+  {5002, 1,  MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   2 ), "sec9.3",  "R2.6", "M4Z",  "NCIZ" },
+  {5002, 15, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 7 ), "sec10.0", "R2.7", "M7P",  "NWIP" },
+  {5002, 14, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   7 ), "sec10.1", "R2.8", "M7Z",  "NWIZ" }
 } )
 {
   std::cout << "MicromegasMapping::MicromegasMapping." << std::endl;
@@ -147,6 +148,19 @@ std::vector<int> MicromegasMapping::get_fee_id_list() const
 {
   std::vector<int> out;
   std::transform( m_detectors.begin(), m_detectors.end(), std::back_inserter( out ), []( const DetectorId& det_id ){ return det_id.m_fee_id; } );
+  return out;
+}
+
+
+//____________________________________________________________________________________________________
+std::vector<int> MicromegasMapping::get_fee_id_list( int packet_id ) const
+{
+  std::vector<int> out;
+  for( const auto& detector:m_detectors )
+  {
+    if( detector.m_packet_id == packet_id )
+    {out.push_back( detector.m_fee_id );}
+  }
   return out;
 }
 

--- a/offline/packages/micromegas/MicromegasMapping.h
+++ b/offline/packages/micromegas/MicromegasMapping.h
@@ -25,6 +25,9 @@ class MicromegasMapping
   /// get list of fee ids
   std::vector<int> get_fee_id_list() const;
 
+  /// get list of fee ids for a given packet
+  std::vector<int> get_fee_id_list(int /*packet_id*/) const;
+
   /// get hitsetkey from fiber_id (fee_id)
   TrkrDefs::hitsetkey get_hitsetkey(int /*fee_id*/) const;
 
@@ -66,10 +69,14 @@ class MicromegasMapping
    public:
     /// constructor
     DetectorId(
-        int fee_id, TrkrDefs::hitsetkey hitsetkey,
+        int packet_id,
+        int fee_id,
+        TrkrDefs::hitsetkey hitsetkey,
         const std::string& fibername, const std::string& breakoutname,
         const std::string& detname_saclay, const std::string& detname_sphenix)
-      : m_fee_id(fee_id)
+      :
+      m_packet_id(packet_id)
+      , m_fee_id(fee_id)
       , m_hitsetkey(hitsetkey)
       , m_fibername(fibername)
       , m_breakoutname(breakoutname)
@@ -77,6 +84,9 @@ class MicromegasMapping
       , m_detname_sphenix(detname_sphenix)
     {
     }
+
+    /// packet_id
+    int m_packet_id = 0;
 
     /// fee_id
     int m_fee_id = 0;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -37,28 +37,30 @@ namespace
 
   // streamer for lists
   template <class T>
-  std::ostream& operator<<(std::ostream& out, const std::list<T>& list)
+  std::ostream& operator<<(std::ostream& o, const std::list<T>& list)
   {
     if (list.empty())
     {
-      out << "{}";
+      o << "{}";
     }
     else
     {
-      out << "{ ";
+      const bool is_hex = (o.flags()&std::ios_base::hex);
+      o << "{ ";
       bool first = true;
       for (const auto& value : list)
       {
         if (!first)
         {
-          out << ", ";
+          o << ", ";
         }
-        out << value;
+        if( is_hex ) o << "0x";
+        o << value;
         first = false;
       }
-      out << " }";
+      o << " }";
     }
-    return out;
+    return o;
   }
 
 }

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -250,13 +250,13 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         std::transform(
           bco_matching_information.m_lvl1_bco_list.begin(),
           bco_matching_information.m_lvl1_bco_list.end(),
-          fee_bco_predicted_list.begin(),
+          std::back_inserter(fee_bco_predicted_list),
           [&bco_matching_information](const uint64_t& lvl1_bco ){ return bco_matching_information.get_predicted_fee_bco(lvl1_bco); } );
 
         std::cout
           << "MicromegasRawDataEvaluation::process_event -"
           << " packet: " << packet_id
-          << " fee_bco_predicted: " << std::hex << bco_matching_information.m_lvl1_bco_list << std::dec
+          << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
           << std::endl;
 
       }

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -88,7 +88,7 @@ unsigned int MicromegasRawDataEvaluation::bco_matching_information_t::get_predic
   static constexpr double multiplier = 4.2629164;
 
   // get gtm bco difference with proper rollover accounting
-  uint64_t gtm_bco_difference = (gtm_bco > m_gtm_bco_first) ?
+  uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
     (gtm_bco - m_gtm_bco_first):
     (gtm_bco + (1LL<<40) - m_gtm_bco_first);
 
@@ -339,7 +339,6 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
             bco_matching_information.m_gtm_bco_list.end(),
             [&sample, &bco_matching_information]( const uint64_t& gtm_bco )
             { return get_bco_diff( bco_matching_information.get_predicted_fee_bco(gtm_bco), sample.fee_bco ) < max_gtm_bco_diff; } );
-
           if( iter != bco_matching_information.m_gtm_bco_list.end() )
           {
             const auto& gtm_bco = *iter;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -22,12 +22,16 @@
 
 #include <cassert>
 #include <fstream>
-#include <list>
 #include <memory>
 #include <set>
 
 namespace
 {
+
+  // define limit for matching two fee_bco
+  static constexpr unsigned int max_fee_bco_diff = 10;
+  static constexpr unsigned int max_lvl1_bco_diff = 100;
+
   // streamer for lists
   template <class T>
   std::ostream& operator<<(std::ostream& out, const std::list<T>& list)
@@ -54,11 +58,31 @@ namespace
     return out;
   }
 
-  // get the difference between two BCO.
-  template<class T>
-  inline static constexpr T get_bco_diff( const T& first, const T& second )
-  { return first < second ? (second-first):(first-second); }
+}
 
+// get the difference between two BCO.
+template<class T>
+  inline static constexpr T get_bco_diff( const T& first, const T& second )
+{ return first < second ? (second-first):(first-second); }
+
+//_________________________________________________________
+unsigned int MicromegasRawDataEvaluation::bco_matching_information_t::get_predicted_fee_bco( uint64_t lvl1_bco )
+{
+  // check proper initialization
+  if( !(m_has_lvl1_bco_first && m_has_fee_bco_first ) ) return 0;
+
+  // this is the clock multiplier from lvl1 to fee clock
+  /* todo: should replace with actual rational number for John K. */
+  static constexpr double multiplier = 4.2629164;
+
+  // get lvl1 bco difference with proper rollover accounting
+  uint64_t lvl1_bco_difference = (lvl1_bco > m_lvl1_bco_first) ?
+    (lvl1_bco - m_lvl1_bco_first):
+    (lvl1_bco + (1LL<<40) - m_lvl1_bco_first);
+
+  // convert to fee bco, and truncate to 20 bits
+  uint64_t fee_bco_predicted = m_fee_bco_first + multiplier*(lvl1_bco_difference);
+  return (unsigned int)(fee_bco_predicted & 0xFFFFF);
 }
 
 //_________________________________________________________
@@ -152,9 +176,10 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
     // taggers
     int n_tagger = packet->lValue(0, "N_TAGGER");
 
-    // store tagged lvl1 bcos into a vector
-    using bco_list_t = std::list<uint64_t>;
-    bco_list_t main_bco_list;
+    // get relevant bco matching information
+    auto& bco_matching_information = m_bco_matching_information_map[packet_id];
+
+    // append lvl1_bco from taggers in this event to packet-specific list of available lv1_bco
     for (int t = 0; t < n_tagger; t++)
     {
       TaggerInformation tagger;
@@ -174,12 +199,23 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
 
       if (tagger.is_lvl1 && (m_flags & (EvalSample | EvalWaveform)))
       {
-        // store bco
-        main_bco_list.push_back(tagger.bco);
+        // initialize first lvl1_bco
+        if( !bco_matching_information.m_has_lvl1_bco_first )
+        {
+          bco_matching_information.m_lvl1_bco_first = tagger.bco;
+          bco_matching_information.m_has_lvl1_bco_first = true;
+
+          if( Verbosity() )
+          { std::cout << "MicromegasRawDataEvaluation::process_event - packet: " << packet_id << " m_lvl1_bco_first: " << tagger.bco << std::endl; }
+
+        }
+
+        // store in list of available bco
+        bco_matching_information.m_lvl1_bco_list.push_back(tagger.bco);
       }
     }
 
-    // get number of datasets (also call waveforms)
+    // get number of waveforms
     const auto n_waveform = packet->iValue(0, "NR_WF");
 
     if (Verbosity())
@@ -187,24 +223,21 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
       std::cout << "MicromegasRawDataEvaluation::process_event -"
                 << " packet: " << packet_id
                 << " taggers: " << n_tagger
-                << " n_lvl1_bco: " << main_bco_list.size()
+                << " n_lvl1_bco: " << bco_matching_information.m_lvl1_bco_list.size()
                 << " n_waveform: " << n_waveform
                 << std::endl;
 
-      if (!main_bco_list.empty())
+      if (!bco_matching_information.m_lvl1_bco_list.empty())
       {
         std::cout << "MicromegasRawDataEvaluation::process_event -"
                   << " packet: " << packet_id
-                  << " bco: " << std::hex << main_bco_list << std::dec
+                  << " bco: " << std::hex << bco_matching_information.m_lvl1_bco_list << std::dec
                   << std::endl;
       }
     }
 
     if (m_flags & (EvalSample | EvalWaveform))
     {
-      // store available bco list for each fee
-      std::map<unsigned short, bco_list_t> bco_list_map;
-
       // keep track of orphans
       using fee_pair_t = std::pair<unsigned int, unsigned int>;
       std::set<fee_pair_t> orphans;
@@ -233,52 +266,97 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         // beam crossing
         sample.fee_bco = static_cast<uint32_t>(packet->iValue(iwf, "BCO"));
         sample.lvl1_bco = 0;
-        sample.lvl1_bco_masked = 0;
 
-        // find bco matching map corresponding to fee
-        auto& bco_matching_pair = m_fee_bco_matching_map[sample.fee_id];
+        // checksum and checksum error
+        sample.checksum = packet->iValue(iwf, "CHECKSUM");
+        sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
+
+        // initialize first fee_bco
+        if( !bco_matching_information.m_has_fee_bco_first )
+        {
+          bco_matching_information.m_fee_bco_first = sample.fee_bco;
+          bco_matching_information.m_has_fee_bco_first = true;
+
+          if( Verbosity() )
+          { std::cout << "MicromegasRawDataEvaluation::process_event - packet: " << packet_id << " m_fee_bco_first: " << sample.fee_bco << std::endl; }
+        }
 
         // find matching lvl1 bco
-        static constexpr unsigned int max_fee_bco_diff = 10;
-        if( get_bco_diff(sample.fee_bco,bco_matching_pair.first) < max_fee_bco_diff )
+        const auto bco_matching_iter = std::find_if(
+          bco_matching_information.m_bco_matching_list.begin(),
+          bco_matching_information.m_bco_matching_list.end(),
+          [&sample]( const m_bco_matching_pair_t& pair )
+          { return get_bco_diff( pair.first, sample.fee_bco ) < max_fee_bco_diff; } );
+
+        if( bco_matching_iter != bco_matching_information.m_bco_matching_list.end() )
         {
-          sample.lvl1_bco = bco_matching_pair.second;
-          sample.lvl1_bco_masked = ( bco_matching_pair.second & 0xFFFFFU );
+
+          // found matching lvl1
+          sample.lvl1_bco = bco_matching_iter->second;
 
         } else {
 
-          // find bco list corresponding to fee, insert main list if not found
-          auto bco_list_iter = bco_list_map.lower_bound(sample.fee_id);
-          if (bco_list_iter == bco_list_map.end() || sample.fee_id < bco_list_iter->first)
-          {
-            bco_list_iter = bco_list_map.insert(bco_list_iter, std::make_pair(sample.fee_id, main_bco_list));
-          }
+          #if true
+          auto iter = std::find_if(
+            bco_matching_information.m_lvl1_bco_list.begin(),
+            bco_matching_information.m_lvl1_bco_list.end(),
+            [&sample, &bco_matching_information]( const uint64_t& lvl1_bco )
+            { return get_bco_diff( bco_matching_information.get_predicted_fee_bco(lvl1_bco), sample.fee_bco ) < max_lvl1_bco_diff; } );
 
-          // get local reference to fee's bco list
-          auto& bco_list = bco_list_iter->second;
-          if (!bco_list.empty())
+          if( iter != bco_matching_information.m_lvl1_bco_list.end() )
           {
+            const auto& lvl1_bco = *iter;
             if (Verbosity())
             {
               std::cout << "MicromegasRawDataEvaluation::process_event -"
                         << " fee_id: " << sample.fee_id
-                        << " fee_bco: 0x" << std::hex << sample.fee_bco
-                        << " gtm_bco: 0x" << bco_list.front()
+                        << std::hex
+                        << " fee_bco: 0x" << sample.fee_bco
+                        << " predicted: 0x" << bco_matching_information.get_predicted_fee_bco(lvl1_bco)
+                        << " gtm_bco: 0x" << lvl1_bco
                         << std::dec
                         << std::endl;
             }
 
             // fee_bco is new. Assume it corresponds to the first available lvl1 bco
             // update running fee_bco and lvl1_bco pair accordingly
-            const auto lvl1_bco = bco_list.front();
-            bco_matching_pair.first = sample.fee_bco;
-            bco_matching_pair.second = lvl1_bco;
+            bco_matching_information.m_bco_matching_list.push_back(std::make_pair(sample.fee_bco, lvl1_bco));
             sample.lvl1_bco = lvl1_bco;
-            sample.lvl1_bco_masked = ( lvl1_bco & 0xFFFFFU );
 
             // remove bco from running list
-            bco_list.pop_front();
+            bco_matching_information.m_lvl1_bco_list.erase(iter);
+
           }
+
+          #else
+
+          if( !bco_matching_information.m_lvl1_bco_list.empty() )
+          {
+            const auto& lvl1_bco = bco_matching_information.m_lvl1_bco_list.front();
+            if (Verbosity())
+            {
+              std::cout << "MicromegasRawDataEvaluation::process_event -"
+                        << " fee_id: " << sample.fee_id
+                        << std::hex
+                        << " fee_bco: 0x" << sample.fee_bco
+                        << " predicted: 0x" << bco_matching_information.get_predicted_fee_bco(lvl1_bco)
+                        << " gtm_bco: 0x" << lvl1_bco
+                        << std::dec
+                        << std::endl;
+            }
+
+            // fee_bco is new. Assume it corresponds to the first available lvl1 bco
+            // update running fee_bco and lvl1_bco pair accordingly
+            bco_matching_information.m_bco_matching_list.push_back(std::make_pair(sample.fee_bco, lvl1_bco));
+            sample.lvl1_bco = lvl1_bco;
+
+            // remove bco from running list
+            bco_matching_information.m_lvl1_bco_list.pop_front();
+
+          }
+
+          #endif
+
           else
           {
             if (Verbosity() && orphans.insert(std::make_pair(sample.fee_id, sample.fee_bco)).second)
@@ -292,11 +370,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
           }
         }
 
-        // checksum and checksum error
-        sample.checksum = packet->iValue(iwf, "CHECKSUM");
-        sample.checksum_error = packet->iValue(iwf, "CHECKSUMERROR");
-
-        // increment bco map
+        // increment number of waveforms found for this lvl1_bco
         ++m_bco_map[sample.lvl1_bco];
 
         // channel, sampa_channel, sampa address and strip

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -85,7 +85,7 @@ unsigned int MicromegasRawDataEvaluation::bco_matching_information_t::get_predic
   /* todo: should replace with actual rational number for John K. */
   static constexpr double multiplier = 4.2629164;
 
-  // get lvl1 bco difference with proper rollover accounting
+  // get gtm bco difference with proper rollover accounting
   uint64_t gtm_bco_difference = (gtm_bco > m_gtm_bco_first) ?
     (gtm_bco - m_gtm_bco_first):
     (gtm_bco + (1LL<<40) - m_gtm_bco_first);
@@ -165,7 +165,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
 
   m_container->Reset();
 
-  // temporary storage for samples and waveforms, sorted by lvl1 bco
+  // temporary storage for samples and waveforms, sorted by gtm bco
   std::multimap<uint64_t, Sample> sample_map;
   std::multimap<uint64_t, Waveform> waveform_map;
 
@@ -256,7 +256,6 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
           << " packet: " << packet_id
           << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
           << std::endl;
-
       }
     }
 
@@ -305,7 +304,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
           { std::cout << "MicromegasRawDataEvaluation::process_event - packet: " << packet_id << " m_fee_bco_first: " << sample.fee_bco << std::endl; }
         }
 
-        // find matching lvl1 bco
+        // find matching gtm bco
         const auto bco_matching_iter = std::find_if(
           bco_matching_information.m_bco_matching_list.begin(),
           bco_matching_information.m_bco_matching_list.end(),
@@ -315,10 +314,11 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         if( bco_matching_iter != bco_matching_information.m_bco_matching_list.end() )
         {
 
-          // found matching lvl1
+          // found matching gtm
           sample.gtm_bco = bco_matching_iter->second;
 
         } else {
+
           auto iter = std::find_if(
             bco_matching_information.m_gtm_bco_list.begin(),
             bco_matching_information.m_gtm_bco_list.end(),
@@ -340,7 +340,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
                 << std::endl;
             }
 
-            // fee_bco is new. Assume it corresponds to the first available lvl1 bco
+            // fee_bco is new. Assume it corresponds to the first available gtm bco
             // update running fee_bco and gtm_bco pair accordingly
             bco_matching_information.m_bco_matching_list.push_back(std::make_pair(sample.fee_bco, gtm_bco));
             sample.gtm_bco = gtm_bco;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -81,7 +81,7 @@ void MicromegasRawDataEvaluation::bco_matching_information_t::truncate( unsigned
 unsigned int MicromegasRawDataEvaluation::bco_matching_information_t::get_predicted_fee_bco( uint64_t gtm_bco ) const
 {
   // check proper initialization
-  if( !(m_has_gtm_bco_first && m_has_fee_bco_first ) ) return 0;
+  if( !(m_has_gtm_bco_first && m_has_fee_bco_first ) ) { return 0; }
 
   // this is the clock multiplier from lvl1 to fee clock
   /* todo: should replace with actual rational number for John K. */
@@ -90,7 +90,7 @@ unsigned int MicromegasRawDataEvaluation::bco_matching_information_t::get_predic
   // get gtm bco difference with proper rollover accounting
   uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
     (gtm_bco - m_gtm_bco_first):
-    (gtm_bco + (1LL<<40) - m_gtm_bco_first);
+    (gtm_bco + (1ULL<<40) - m_gtm_bco_first);
 
   // convert to fee bco, and truncate to 20 bits
   uint64_t fee_bco_predicted = m_fee_bco_first + multiplier*(gtm_bco_difference);
@@ -356,7 +356,7 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
 
             // fee_bco is new. Assume it corresponds to the first available gtm bco
             // update running fee_bco and gtm_bco pair accordingly
-            bco_matching_information.m_bco_matching_list.push_back(std::make_pair(sample.fee_bco, gtm_bco));
+            bco_matching_information.m_bco_matching_list.emplace_back(sample.fee_bco, gtm_bco);
             sample.gtm_bco = gtm_bco;
 
             // remove bco from running list

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -214,10 +214,16 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         {
           bco_matching_information.m_gtm_bco_first = tagger.bco;
           bco_matching_information.m_has_gtm_bco_first = true;
-
           if( Verbosity() )
-          { std::cout << "MicromegasRawDataEvaluation::process_event - packet: " << packet_id << " m_gtm_bco_first: " << tagger.bco << std::endl; }
-
+          {
+            std::cout
+              << "MicromegasRawDataEvaluation::process_event -"
+              << " packet: " << packet_id
+              << std::hex
+              << " m_gtm_bco_first: 0x" << tagger.bco
+              << std::dec
+              << std::endl;
+          }
         }
 
         // store in list of available bco
@@ -301,9 +307,16 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         {
           bco_matching_information.m_fee_bco_first = sample.fee_bco;
           bco_matching_information.m_has_fee_bco_first = true;
-
           if( Verbosity() )
-          { std::cout << "MicromegasRawDataEvaluation::process_event - packet: " << packet_id << " m_fee_bco_first: " << sample.fee_bco << std::endl; }
+          {
+            std::cout
+              << "MicromegasRawDataEvaluation::process_event -"
+              << " packet: " << packet_id
+              << std::hex
+              << " m_fee_bco_first: 0x" << sample.fee_bco
+              << std::dec
+              << std::endl;
+          }
         }
 
         // find matching gtm bco
@@ -356,7 +369,9 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
             {
               std::cout << "MicromegasRawDataEvaluation::process_event -"
                         << " fee_id: " << sample.fee_id
-                        << " fee_bco: 0x" << std::hex << sample.fee_bco << std::dec
+                        << std::hex
+                        << " fee_bco: 0x" << sample.fee_bco
+                        << std::dec
                         << " gtm_bco: none"
                         << std::endl;
             }

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -14,6 +14,7 @@
 
 #include <TTree.h>
 
+#include <list>
 #include <map>
 #include <memory>
 #include <string>
@@ -71,9 +72,6 @@ class MicromegasRawDataEvaluation : public SubsysReco
 
     /// ll1 bco
     uint64_t lvl1_bco = 0;
-
-    /// ll1 bco
-    unsigned int lvl1_bco_masked = 0;
 
     /// fee bco
     unsigned int fee_bco = 0;
@@ -249,12 +247,36 @@ class MicromegasRawDataEvaluation : public SubsysReco
   //! main branch
   Container* m_container = nullptr;
 
-  //! match fee bco to lvl1 bco
-  using bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
+  //! store relevant information for bco matching between lvl1 and fee.
+  using m_bco_matching_pair_t = std::pair<unsigned int, uint64_t>;
+  class bco_matching_information_t
+  {
+    public:
 
-  //! map fee_id to bco maps
-  using fee_bco_matching_map_t = std::map<unsigned short, bco_matching_pair_t>;
-  fee_bco_matching_map_t m_fee_bco_matching_map;
+    //! first lvl1 bco (40 bits)
+    bool m_has_lvl1_bco_first = false;
+    uint64_t m_lvl1_bco_first = 0;
+
+    //! first fee bco (20 bits)
+    bool m_has_fee_bco_first = false;
+    unsigned int m_fee_bco_first = 0;
+
+    //! list of available bco
+    std::list<uint64_t> m_lvl1_bco_list;
+
+    //! matching between fee bco and lvl1 bco
+    std::list<m_bco_matching_pair_t> m_bco_matching_list;
+
+    //! todo: need to truncate bco matching list to some decent value
+
+    //! get predicted fee_bco from lvl1_bco
+    unsigned int get_predicted_fee_bco( uint64_t );
+
+  };
+
+  /// map bco_information_t to packet id
+  using bco_matching_information_map_t = std::map<unsigned int, bco_matching_information_t>;
+  bco_matching_information_map_t m_bco_matching_information_map;
 
   /// map waveforms to bco
   /** this is used to count how many waveforms are found for a given lvl1 bco */

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -267,10 +267,11 @@ class MicromegasRawDataEvaluation : public SubsysReco
     //! matching between fee bco and lvl1 bco
     std::list<m_bco_matching_pair_t> m_bco_matching_list;
 
-    //! todo: need to truncate bco matching list to some decent value
+    //! need to truncate bco matching list to some decent value
+    void truncate( unsigned int /* maxsize */ );
 
     //! get predicted fee_bco from lvl1_bco
-    unsigned int get_predicted_fee_bco( uint64_t );
+    unsigned int get_predicted_fee_bco( uint64_t ) const;
 
   };
 

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.h
@@ -71,7 +71,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
     unsigned int packet_id = 0;
 
     /// ll1 bco
-    uint64_t lvl1_bco = 0;
+    uint64_t gtm_bco = 0;
 
     /// fee bco
     unsigned int fee_bco = 0;
@@ -115,7 +115,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
     unsigned int packet_id = 0;
 
     /// ll1 bco
-    uint64_t lvl1_bco = 0;
+    uint64_t gtm_bco = 0;
 
     /// fee bco
     unsigned int fee_bco = 0;
@@ -254,15 +254,15 @@ class MicromegasRawDataEvaluation : public SubsysReco
     public:
 
     //! first lvl1 bco (40 bits)
-    bool m_has_lvl1_bco_first = false;
-    uint64_t m_lvl1_bco_first = 0;
+    bool m_has_gtm_bco_first = false;
+    uint64_t m_gtm_bco_first = 0;
 
     //! first fee bco (20 bits)
     bool m_has_fee_bco_first = false;
     unsigned int m_fee_bco_first = 0;
 
     //! list of available bco
-    std::list<uint64_t> m_lvl1_bco_list;
+    std::list<uint64_t> m_gtm_bco_list;
 
     //! matching between fee bco and lvl1 bco
     std::list<m_bco_matching_pair_t> m_bco_matching_list;
@@ -270,7 +270,7 @@ class MicromegasRawDataEvaluation : public SubsysReco
     //! need to truncate bco matching list to some decent value
     void truncate( unsigned int /* maxsize */ );
 
-    //! get predicted fee_bco from lvl1_bco
+    //! get predicted fee_bco from gtm_bco
     unsigned int get_predicted_fee_bco( uint64_t ) const;
 
   };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This is a new attempt at full event assembly for TPOT, taking advantage of the new FEE firmware. 
It uses the gtm bco information, projected back to the 20 bits FEE BCO to decide which waveform belongs to which trigger. 
Works much better than what we had before. 

I am aware that Jin is working on a similar code for the TPC, but having two independantly written codes to do the same here: it will help debug the many foreseen error conditions from the high trigger rate, zero suppressed data we will soon have to assemble. 

Once everything is ironed out, we will converge on a unique version applicable to both the TPC and TPOT. 

In the meanwhile this PR will allow to properly assemble the recent high trigger rate, non-zero suppressed data taken with TPOT

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

