### PR TITLE
fix: remove per run histos

### DIFF
--- a/offline/QA/Tracking/InttClusterQA.cc
+++ b/offline/QA/Tracking/InttClusterQA.cc
@@ -95,30 +95,8 @@ int InttClusterQA::process_event(PHCompositeNode *topNode)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
-int InttClusterQA::EndRun(const int runnumber)
+int InttClusterQA::EndRun(const int /*runnumber*/)
 {
-  auto hm = QAHistManagerDef::getHistoManager();
-  assert(hm);
-
-  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto( boost::str(boost::format("%snclusperrun") %getHistoPrefix()).c_str()));
-  // NOLINTNEXTLINE(bugprone-integer-division)
-  h_totalclusters->Fill(runnumber, m_totalClusters / m_event);
-
-  for (const auto &[layer, ladders] : m_layerLadderMap)
-  {
-    for (int ladder = 0; ladder < ladders; ladder++)
-    {
-      for (int sensor = 0; sensor < 4; sensor++)
-      {
-        TH2 *h = dynamic_cast<TH2 *>(hm->getHisto( boost::str(boost::format("%sncluspersensorperrun%i_%i_%i") %getHistoPrefix() %layer %ladder %sensor).c_str()));
-        if (h)
-        {
-          // NOLINTNEXTLINE(bugprone-integer-division)
-          h->Fill(runnumber, m_nclustersPerSensor[layer][ladder][sensor] / m_event);
-        }
-      }
-    }
-  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -131,13 +109,6 @@ void InttClusterQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  {
-    auto h = new TH2F( boost::str(boost::format("%snclusperrun") %getHistoPrefix()).c_str(),
-                      "INTT Clusters per event per run number", m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("Run number");
-    h->GetYaxis()->SetTitle("Clusters per event");
-    hm->registerHisto(h);
-  }
 
   for (const auto &[layer, ladders] : m_layerLadderMap)
   {
@@ -153,11 +124,6 @@ void InttClusterQA::createHistos()
         h->GetYaxis()->SetTitle("Local rphi [cm]");
         hm->registerHisto(h);
 
-	auto h2 = new TH2F( boost::str(boost::format("%sncluspersensorperrun%i_%i_%i") %getHistoPrefix() %layer %ladder %sensor).c_str(),
-                           "INTT clusters per event per sensor per run", m_runbins, m_beginRun, m_endRun, 100, 0, 100);
-        h2->GetXaxis()->SetTitle("Run number");
-        h2->GetYaxis()->SetTitle("Clusters per event");
-        hm->registerHisto(h2);
       }
     }
   }

--- a/offline/QA/Tracking/InttClusterQA.h
+++ b/offline/QA/Tracking/InttClusterQA.h
@@ -22,9 +22,6 @@ class InttClusterQA : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
 
-  void beginRun(const int run) { m_beginRun = run; }
-  void endRun(const int run) { m_endRun = run; }
-
  private:
   void createHistos();
 
@@ -32,9 +29,6 @@ class InttClusterQA : public SubsysReco
   std::map<int, int> m_layerLadderMap;
   int m_event = 0;
   int m_totalClusters = 0;
-  int m_beginRun = 25900;
-  int m_endRun = 26200;
-  int m_runbins = m_endRun - m_beginRun;
   int m_nclustersPerSensor[4][16][4] = {{{0}}};
 };
 

--- a/offline/QA/Tracking/MicromegasClusterQA.cc
+++ b/offline/QA/Tracking/MicromegasClusterQA.cc
@@ -102,27 +102,9 @@ int MicromegasClusterQA::process_event(PHCompositeNode *topNode)
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
-int MicromegasClusterQA::EndRun(const int runnumber)
+int MicromegasClusterQA::EndRun(const int /*runnumber*/)
 {
-  auto hm = QAHistManagerDef::getHistoManager();
-  assert(hm);
-
-  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "nclusperrun")));
-  // NOLINTNEXTLINE(bugprone-integer-division)
-  h_totalclusters->Fill(runnumber, m_totalClusters / m_event);
-
-  for (const auto &[layer, tiles] : m_layerTileMap)
-  {
-    for (int tile = 0; tile < tiles; tile++)
-    {
-      TH2 *h = dynamic_cast<TH2 *>(hm->getHisto((boost::format("%sncluspertileperrun%i_%i") % getHistoPrefix() % layer % tile).str()));
-      if (h)
-      {
-        // NOLINTNEXTLINE(bugprone-integer-division)
-        h->Fill(runnumber, m_nclustersPerTile[layer][tile] / m_event);
-      }
-    }
-  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -134,14 +116,7 @@ void MicromegasClusterQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  {
-    auto h = new TH2F(std::string(getHistoPrefix() + "nclusperrun").c_str(),
-                      "Micromegas Clusters per event per run number", m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("Run number");
-    h->GetYaxis()->SetTitle("Clusters per event");
-    hm->registerHisto(h);
-  }
-
+ 
   for (const auto &[layer, ntiles] : m_layerTileMap)
   {
     for (int tile = 0; tile < ntiles; tile++)
@@ -152,11 +127,6 @@ void MicromegasClusterQA::createHistos()
       h->GetYaxis()->SetTitle("Local rphi [cm]");
       hm->registerHisto(h);
 
-      auto h2 = new TH2F((boost::format("%sncluspertileperrun%i_%i") % getHistoPrefix() % layer % tile).str().c_str(),
-                         "Micromegas clusters per event per tile per run", m_runbins, m_beginRun, m_endRun, 100, 0, 20);
-      h2->GetXaxis()->SetTitle("Run number");
-      h2->GetYaxis()->SetTitle("Clusters per event");
-      hm->registerHisto(h2);
     }
   }
 

--- a/offline/QA/Tracking/MicromegasClusterQA.h
+++ b/offline/QA/Tracking/MicromegasClusterQA.h
@@ -22,9 +22,6 @@ class MicromegasClusterQA : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
 
-  void beginRun(const int run) { m_beginRun = run; }
-  void endRun(const int run) { m_endRun = run; }
-
  private:
   void createHistos();
 
@@ -32,9 +29,6 @@ class MicromegasClusterQA : public SubsysReco
   std::map<int, int> m_layerTileMap;
   int m_event = 0;
   int m_totalClusters = 0;
-  int m_beginRun = 25900;
-  int m_endRun = 26200;
-  int m_runbins = m_endRun - m_beginRun;
   int m_nclustersPerTile[2][8] = {{0}};
 };
 

--- a/offline/QA/Tracking/MvtxClusterQA.cc
+++ b/offline/QA/Tracking/MvtxClusterQA.cc
@@ -106,30 +106,9 @@ int MvtxClusterQA::process_event(PHCompositeNode *topNode)
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
-int MvtxClusterQA::EndRun(const int runnumber)
+int MvtxClusterQA::EndRun(const int /*runnumber*/)
 {
-  auto hm = QAHistManagerDef::getHistoManager();
-  assert(hm);
-
-  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "nclusperrun")));
-  // NOLINTNEXTLINE(bugprone-integer-division)
-  h_totalclusters->Fill(runnumber, m_totalClusters / m_event);
-
-  for (const auto &[layer, staves] : m_layerStaveMap)
-  {
-    for (int stave = 0; stave < staves; stave++)
-    {
-      for (int chip = 0; chip < 9; chip++)
-      {
-        TH2 *h = dynamic_cast<TH2 *>(hm->getHisto((boost::format("%snclusperchipperrun%i_%i_%i") % getHistoPrefix() % layer % stave % chip).str()));
-        if (h)
-        {
-          // NOLINTNEXTLINE(bugprone-integer-division)
-          h->Fill(runnumber, m_nclustersPerChip[layer][stave][chip] / m_event);
-        }
-      }
-    }
-  }
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 //____________________________________________________________________________..
@@ -143,13 +122,7 @@ void MvtxClusterQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  {
-    auto h = new TH2F(std::string(getHistoPrefix() + "nclusperrun").c_str(),
-                      "MVTX Clusters per event per run number", m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("Run number");
-    h->GetYaxis()->SetTitle("Clusters per event");
-    hm->registerHisto(h);
-  }
+  
 
   for (const auto &[layer, nstave] : m_layerStaveMap)
   {
@@ -164,11 +137,6 @@ void MvtxClusterQA::createHistos()
         h->GetYaxis()->SetTitle("Local rphi [cm]");
         hm->registerHisto(h);
 
-        auto h2 = new TH2F((boost::format("%snclusperchipperrun%i_%i_%i") % getHistoPrefix() % layer % stave % chip).str().c_str(),
-                           "MVTX clusters per event per chip per run", m_runbins, m_beginRun, m_endRun, 100, 0, 100);
-        h2->GetXaxis()->SetTitle("Run number");
-        h2->GetYaxis()->SetTitle("Clusters per event");
-        hm->registerHisto(h2);
       }
     }
   }

--- a/offline/QA/Tracking/MvtxClusterQA.h
+++ b/offline/QA/Tracking/MvtxClusterQA.h
@@ -22,9 +22,6 @@ class MvtxClusterQA : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
 
-  void beginRun(const int run) { m_beginRun = run; }
-  void endRun(const int run) { m_endRun = run; }
-
  private:
   void createHistos();
 
@@ -32,9 +29,6 @@ class MvtxClusterQA : public SubsysReco
   std::map<int, int> m_layerStaveMap;
   int m_event = 0;
   int m_totalClusters = 0;
-  int m_beginRun = 25900;
-  int m_endRun = 26200;
-  int m_runbins = m_endRun - m_beginRun;
   int m_nclustersPerChip[3][20][9] = {{{0}}};
 };
 

--- a/offline/QA/Tracking/TpcClusterQA.cc
+++ b/offline/QA/Tracking/TpcClusterQA.cc
@@ -167,19 +167,8 @@ int TpcClusterQA::process_event(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int TpcClusterQA::EndRun(const int runnumber)
+int TpcClusterQA::EndRun(const int /*runnumber*/)
 {
-  auto hm = QAHistManagerDef::getHistoManager();
-  assert(hm);
-
-  TH2 *h_totalclusters = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "nclusperrun")));
-  h_totalclusters->Fill(runnumber, (float) m_totalClusters / m_event);
-
-  for (int i = 0; i < 24; i++)
-  {
-    TH2 *h = dynamic_cast<TH2 *>(hm->getHisto((boost::format("%snclusperrun_sector%i") % getHistoPrefix() % i).str()));
-    h->Fill(runnumber, (float) m_clustersPerSector[i] / m_event);
-  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -192,23 +181,7 @@ void TpcClusterQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  {
-    auto h = new TH2F(std::string(getHistoPrefix() + "nclusperrun").c_str(),
-                      "TPC Clusters per event per run number", m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("Run number");
-    h->GetYaxis()->SetTitle("Clusters per event");
-    hm->registerHisto(h);
-  }
-  {
-    for (int i = 0; i < 24; i++)
-    {
-      auto h = new TH2F((boost::format("%snclusperrun_sector%i") % getHistoPrefix() % i).str().c_str(),
-                        (boost::format("TPC Clusters per event per run number sector %i") % i).str().c_str(), m_runbins, m_beginRun, m_endRun, 1000, 0, 1000);
-      h->GetXaxis()->SetTitle("Run number");
-      h->GetYaxis()->SetTitle((boost::format("Clusters per event in Sector %i") % i).str().c_str());
-      hm->registerHisto(h);
-    }
-  }
+ 
   {
     auto h = new TH2F(std::string(getHistoPrefix() + "ncluspersector").c_str(),
                       "TPC Clusters per event per sector", 24, 0, 24, 1000, 0, 1000);

--- a/offline/QA/Tracking/TpcClusterQA.h
+++ b/offline/QA/Tracking/TpcClusterQA.h
@@ -21,9 +21,7 @@ class TpcClusterQA : public SubsysReco
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
-  void beginRun(const int run) { m_beginRun = run; }
-  void endRun(const int run) { m_endRun = run; }
-
+  
  private:
   void createHistos();
 
@@ -33,9 +31,6 @@ class TpcClusterQA : public SubsysReco
 
   int m_event = 0;
   int m_totalClusters = 0;
-  int m_beginRun = 25900;
-  int m_endRun = 26200;
-  int m_runbins = m_endRun - m_beginRun;
   int m_clustersPerSector[24] = {0};
 };
 


### PR DESCRIPTION
Removes per run histograms as they don't make sense in the offline qa framework that now exists

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

