### PR TITLE
Update to use the values for min and max length of seeds

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -9,7 +9,7 @@
  */
 
 // Statements for if we want to save out the intermediary clustering steps
-/* #define _PHCASEEDING_CLUSTERLOG_TUPOUT_ */
+#define _PHCASEEDING_CLUSTERLOG_TUPOUT_
 /* #define _PHCASEEDING_TIMER_OUT_ */
 
 #include "ALICEKF.h"
@@ -221,8 +221,8 @@ class PHCASeeding : public PHTrackSeeding
   unsigned int _end_layer;
   unsigned int _min_nhits_per_cluster;
   unsigned int _min_clusters_per_track;
-  unsigned int _max_clusters_per_seed = 6;
-  unsigned int _min_clusters_per_seed = 6;
+  unsigned int _max_clusters_per_seed = 6; // currently not used
+  unsigned int _min_clusters_per_seed = 6; // currently the abs. number used
   //  float _cluster_z_error;
   //  float _cluster_alice_y_error;
   float _neighbor_phi_width;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Talked with Michael. This allows the PHCASeeder to follow seeds not at a fix value of 6 clusters, but from N-M clusters, where N and M are set with the already existing setter `PHCASeeding::SetNClustersPerSeedRange`

I've tested it with short and longer values and it works as intended.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

