### PR TITLE
feat: match silicon and tpc track seeds

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -196,7 +196,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   {
     mmGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS");
   }
-  if (!trackmap or !clustermap or !geometry or !hitmap)
+  if (!trackmap or !clustermap or !geometry or (!hitmap && m_doHits))
   {
     std::cout << "Missing node, can't continue" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -239,7 +239,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     {
       continue;
     }
-    m_trackid = key;
+    m_trackid = track->get_id();
     m_crossing = track->get_crossing();
     m_px = track->get_px();
     m_py = track->get_py();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -181,6 +181,7 @@ void TrackResiduals::clearClusterStateVectors()
 //____________________________________________________________________________..
 int TrackResiduals::process_event(PHCompositeNode* topNode)
 {
+  auto silseedmap = findNode::getClass<TrackSeedContainer>(topNode, "SiliconTrackSeedContainer");
   auto tpcseedmap = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
   auto trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trackMapName);
   auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
@@ -240,6 +241,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       continue;
     }
     m_trackid = track->get_id();
+
     m_crossing = track->get_crossing();
     m_px = track->get_px();
     m_py = track->get_py();
@@ -261,6 +263,26 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     m_nintt = 0;
     m_ntpc = 0;
     m_nmms = 0;
+    m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
+    m_silseedx = std::numeric_limits<float>::quiet_NaN();
+    m_silseedy = std::numeric_limits<float>::quiet_NaN();
+    m_silseedz = std::numeric_limits<float>::quiet_NaN();
+    m_silseedpx = std::numeric_limits<float>::quiet_NaN();
+    m_silseedpy = std::numeric_limits<float>::quiet_NaN();
+    m_silseedpz = std::numeric_limits<float>::quiet_NaN();
+    m_silseedphi = std::numeric_limits<float>::quiet_NaN();
+    m_silseedeta = std::numeric_limits<float>::quiet_NaN();
+    m_silseedcharge = std::numeric_limits<int>::quiet_NaN();
+    m_tpcseedx = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedy = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedz = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedpx = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedpy = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedpz = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedphi = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedeta = std::numeric_limits<float>::quiet_NaN();
+    m_tpcseedcharge = std::numeric_limits<int>::quiet_NaN();
     m_vertexid = track->get_vertex_id();
     if (vertexmap)
     {
@@ -284,20 +306,34 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     auto tpcseed = track->get_tpc_seed();
     if (tpcseed)
     {
+      m_tpcid = tpcseedmap->find(tpcseed);
       tpc_seed_ids.insert(tpcseedmap->find(tpcseed));
     }
     auto silseed = track->get_silicon_seed();
     if (silseed)
     {
-      m_seedx = silseed->get_x();
-      m_seedy = silseed->get_y();
-      m_seedz = silseed->get_z();
+      m_silid = silseedmap->find(silseed);
+      m_silseedx = silseed->get_x();
+      m_silseedy = silseed->get_y();
+      m_silseedz = silseed->get_z();
+      m_silseedpx = silseed->get_px();
+      m_silseedpy = silseed->get_py();
+      m_silseedpz = silseed->get_pz();
+      m_silseedphi = silseed->get_phi();
+      m_silseedeta = silseed->get_eta();
+      m_silseedcharge = silseed->get_qOverR() > 1 ? 1 : -1;
     }
-    else if (tpcseed)
+    if (tpcseed)
     {
-      m_seedx = tpcseed->get_x();
-      m_seedy = tpcseed->get_y();
-      m_seedz = tpcseed->get_z();
+      m_tpcseedx = tpcseed->get_x();
+      m_tpcseedy = tpcseed->get_y();
+      m_tpcseedz = tpcseed->get_z();
+      m_tpcseedpx = tpcseed->get_px();
+      m_tpcseedpy = tpcseed->get_py();
+      m_tpcseedpz = tpcseed->get_pz();
+      m_tpcseedphi = tpcseed->get_phi();
+      m_tpcseedeta = tpcseed->get_eta();
+      m_tpcseedcharge = tpcseed->get_qOverR() > 1 ? 1 : -1;
     }
     if (tpcseed)
     {
@@ -324,23 +360,23 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
         theta = silseed->get_theta();
       }
       float pt = fabs(1. / qor) * (0.3 / 100) * 0.01;
-      m_seedpx = pt * std::cos(phi);
-      m_seedpy = pt * std::sin(phi);
-      m_seedpz = pt * std::cosh(eta) * std::cos(theta);
+      m_tpcseedpx = pt * std::cos(phi);
+      m_tpcseedpy = pt * std::sin(phi);
+      m_tpcseedpz = pt * std::cosh(eta) * std::cos(theta);
     }
     else
     {
       if (tpcseed)
       {
-        m_seedpx = tpcseed->get_px();
-        m_seedpy = tpcseed->get_py();
-        m_seedpz = tpcseed->get_pz();
+        m_tpcseedpx = tpcseed->get_px();
+        m_tpcseedpy = tpcseed->get_py();
+        m_tpcseedpz = tpcseed->get_pz();
       }
       else if (silseed)
       {
-        m_seedpx = silseed->get_px();
-        m_seedpy = silseed->get_py();
-        m_seedpz = silseed->get_pz();
+        m_silseedpx = silseed->get_px();
+        m_silseedpy = silseed->get_py();
+        m_silseedpz = silseed->get_pz();
       }
     }
     clearClusterStateVectors();
@@ -499,34 +535,33 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
 
     if (silseed)
     {
-      m_seedx = silseed->get_x();
-      m_seedy = silseed->get_y();
-      m_seedz = silseed->get_z();
+      m_silseedx = silseed->get_x();
+      m_silseedy = silseed->get_y();
+      m_silseedz = silseed->get_z();
     }
     else
     {
-      m_seedx = tpcseed->get_x();
-      m_seedy = tpcseed->get_y();
-      m_seedz = tpcseed->get_z();
+      m_tpcseedx = tpcseed->get_x();
+      m_tpcseedy = tpcseed->get_y();
+      m_tpcseedz = tpcseed->get_z();
     }
 
     if (m_zeroField)
     {
       float pt = fabs(1. / tpcseed->get_qOverR()) * (0.3 / 100) * 0.01;
       float phi = tpcseed->get_phi();
-      m_seedpx = pt * std::cos(phi);
-      m_seedpy = pt * std::sin(phi);
-      m_seedpz = pt * std::cosh(tpcseed->get_eta()) * std::cos(tpcseed->get_theta());
+      m_tpcseedpx = pt * std::cos(phi);
+      m_tpcseedpy = pt * std::sin(phi);
+      m_tpcseedpz = pt * std::cosh(tpcseed->get_eta()) * std::cos(tpcseed->get_theta());
     }
     else
     {
-      m_seedpx = tpcseed->get_px();
-      m_seedpy = tpcseed->get_py();
-      m_seedpz = tpcseed->get_pz();
+      m_tpcseedpx = tpcseed->get_px();
+      m_tpcseedpy = tpcseed->get_py();
+      m_tpcseedpz = tpcseed->get_pz();
     }
-    m_seedcharge = tpcseed->get_qOverR() > 1 ? 1 : -1;
+    m_tpcseedcharge = tpcseed->get_qOverR() > 1 ? 1 : -1;
     m_dedx = calc_dedx(tpcseed, clustermap, tpcGeo);
-    std::cout << "m_dedx: " << m_dedx << std::endl;
     m_nmaps = 0;
     m_nintt = 0;
     m_ntpc = 0;
@@ -1364,13 +1399,16 @@ void TrackResiduals::createBranches()
   m_failedfits->Branch("segment", &m_segment, "m_segment/I");
   m_failedfits->Branch("trackid", &m_trackid, "m_trackid/I");
   m_failedfits->Branch("event", &m_event, "m_event/I");
-  m_failedfits->Branch("seedx", &m_seedx, "m_seedx/F");
-  m_failedfits->Branch("seedy", &m_seedy, "m_seedy/F");
-  m_failedfits->Branch("seedz", &m_seedz, "m_seedz/F");
-  m_failedfits->Branch("seedpx", &m_seedpx, "m_seedpx/F");
-  m_failedfits->Branch("seedpy", &m_seedpy, "m_seedpy/F");
-  m_failedfits->Branch("seedpz", &m_seedpz, "m_seedpz/F");
-  m_failedfits->Branch("seedcharge", &m_seedcharge, "m_seedcharge/I");
+  m_failedfits->Branch("silseedx", &m_silseedx, "m_silseedx/F");
+  m_failedfits->Branch("silseedy", &m_silseedy, "m_silseedy/F");
+  m_failedfits->Branch("silseedz", &m_silseedz, "m_silseedz/F");
+  m_failedfits->Branch("tpcseedx", &m_tpcseedx, "m_tpcseedx/F");
+  m_failedfits->Branch("tpcseedy", &m_tpcseedy, "m_tpcseedy/F");
+  m_failedfits->Branch("tpcseedz", &m_tpcseedz, "m_tpcseedz/F");
+  m_failedfits->Branch("tpcseedpx", &m_tpcseedpx, "m_tpcseedpx/F");
+  m_failedfits->Branch("tpcseedpy", &m_tpcseedpy, "m_tpcseedpy/F");
+  m_failedfits->Branch("tpcseedpz", &m_tpcseedpz, "m_tpcseedpz/F");
+  m_failedfits->Branch("tpcseedcharge", &m_tpcseedcharge, "m_tpcseedcharge/I");
   m_failedfits->Branch("dedx", &m_dedx, "m_dedx/F");
   m_failedfits->Branch("nmaps", &m_nmaps, "m_nmaps/I");
   m_failedfits->Branch("nintt", &m_nintt, "m_nintt/I");
@@ -1466,16 +1504,29 @@ void TrackResiduals::createBranches()
   m_tree->Branch("segment", &m_segment, "m_segment/I");
   m_tree->Branch("event", &m_event, "m_event/I");
   m_tree->Branch("trackid", &m_trackid, "m_trackid/I");
+  m_tree->Branch("tpcid",&m_tpcid,"m_tpcid/I");
+  m_tree->Branch("silid",&m_silid,"m_silid/I");
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_tree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
-  m_tree->Branch("seedpx", &m_seedpx, "m_seedpx/F");
-  m_tree->Branch("seedpy", &m_seedpy, "m_seedpy/F");
-  m_tree->Branch("seedpz", &m_seedpz, "m_seedpz/F");
-  m_tree->Branch("seedx", &m_seedx, "m_seedx/F");
-  m_tree->Branch("seedy", &m_seedy, "m_seedy/F");
-  m_tree->Branch("seedz", &m_seedz, "m_seedz/F");
-  m_tree->Branch("seedcharge", &m_seedcharge, "m_seedcharge/I");
+  m_tree->Branch("silseedx",&m_silseedx,"m_silseedx/F");
+  m_tree->Branch("silseedy",&m_silseedy,"m_silseedy/F");
+  m_tree->Branch("silseedz",&m_silseedz,"m_silseedz/F");
+  m_tree->Branch("silseedpx",&m_silseedpx,"m_silseedpx/F");
+  m_tree->Branch("silseedpy",&m_silseedpy,"m_silseedpy/F");
+  m_tree->Branch("silseedpz",&m_silseedpz,"m_silseedpz/F");
+  m_tree->Branch("silseedphi",&m_silseedphi,"m_silseedphi/F");
+  m_tree->Branch("silseedeta",&m_silseedeta,"m_silseedeta/F");
+  m_tree->Branch("silseedcharge",&m_silseedcharge,"m_silseedcharge/I");
+  m_tree->Branch("tpcseedx", &m_tpcseedx, "m_tpcseedx/F");
+  m_tree->Branch("tpcseedy", &m_tpcseedy, "m_tpcseedy/F");
+  m_tree->Branch("tpcseedz", &m_tpcseedz, "m_tpcseedz/F");
+  m_tree->Branch("tpcseedpx", &m_tpcseedpx, "m_tpcseedpx/F");
+  m_tree->Branch("tpcseedpy", &m_tpcseedpy, "m_tpcseedpy/F");
+  m_tree->Branch("tpcseedpz", &m_tpcseedpz, "m_tpcseedpz/F");
+  m_tree->Branch("tpcseedphi", &m_tpcseedphi, "m_tpcseedphi/F");
+  m_tree->Branch("tpcseedeta", &m_tpcseedeta, "m_tpcseedeta/F");
+  m_tree->Branch("tpcseedcharge", &m_tpcseedcharge, "m_tpcseedcharge/I");
   m_tree->Branch("dedx", &m_dedx, "m_dedx/F");
   m_tree->Branch("px", &m_px, "m_px/F");
   m_tree->Branch("py", &m_py, "m_py/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -105,6 +105,8 @@ class TrackResiduals : public SubsysReco
   uint64_t m_bcotr = std::numeric_limits<uint64_t>::quiet_NaN();
   unsigned int m_trackid = std::numeric_limits<unsigned int>::quiet_NaN();
   unsigned int m_crossing = std::numeric_limits<unsigned int>::quiet_NaN();
+  unsigned int m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
+  unsigned int m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
   float m_px = std::numeric_limits<float>::quiet_NaN();
   float m_py = std::numeric_limits<float>::quiet_NaN();
   float m_pz = std::numeric_limits<float>::quiet_NaN();
@@ -140,13 +142,25 @@ class TrackResiduals : public SubsysReco
   float m_dcaxy = std::numeric_limits<float>::quiet_NaN();
   float m_dcaz = std::numeric_limits<float>::quiet_NaN();
 
-  float m_seedx = std::numeric_limits<float>::quiet_NaN();
-  float m_seedy = std::numeric_limits<float>::quiet_NaN();
-  float m_seedz = std::numeric_limits<float>::quiet_NaN();
-  float m_seedpx = std::numeric_limits<float>::quiet_NaN();
-  float m_seedpy = std::numeric_limits<float>::quiet_NaN();
-  float m_seedpz = std::numeric_limits<float>::quiet_NaN();
-  int m_seedcharge = std::numeric_limits<int>::quiet_NaN();
+float m_silseedx = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedy = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedz = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedpx = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedpy = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedpz = std::numeric_limits<float>::quiet_NaN();
+  int m_silseedcharge = std::numeric_limits<int>::quiet_NaN();
+  float m_silseedphi = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedeta = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedx = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedy = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedz = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedpx = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedpy = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedpz = std::numeric_limits<float>::quiet_NaN();
+  int m_tpcseedcharge = std::numeric_limits<int>::quiet_NaN();
+  float m_tpcseedphi = std::numeric_limits<float>::quiet_NaN();
+  float m_tpcseedeta = std::numeric_limits<float>::quiet_NaN();
+
   float m_dedx = std::numeric_limits<float>::quiet_NaN();
 
   //! hit tree info

--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -121,7 +121,6 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
 
     svtxtrack->set_id(trackid);
     trackid++;
-
     /// If we've run the track matching
     if (m_trackSeedName.find("SvtxTrackSeed") != std::string::npos)
     {
@@ -253,6 +252,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
     else
     {
       /// Otherwise we are using an individual subdetectors container
+      svtxtrack->set_id(m_seedContainer->find(trackSeed));
 
       svtxtrack->set_x(trackSeed->get_x());
       svtxtrack->set_y(trackSeed->get_y());

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -268,7 +268,6 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     uint16_t sampadd = tpchit->get_sampaaddress();
     uint16_t sampch = tpchit->get_sampachannel();
     uint16_t sam = tpchit->get_samples();
-
     varname = "phi";  // + std::to_string(key);
     double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
     PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
@@ -384,8 +383,11 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       for (uint16_t s = 0; s < sam; s++)
       {
         uint16_t adc = tpchit->get_adc(s);
-        int t = s;
-
+        int t = s-m_presampleShift;
+        if(t<0)
+        {
+          continue;
+        }
         if ((float(adc) - hpedestal) > (hpedwidth * m_ped_sig_cut))
         {
           hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
@@ -26,6 +26,7 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   void do_zero_suppression(bool b) { m_do_zerosup = b; }
   void set_pedestalSigmaCut(float b) { m_ped_sig_cut = b; }
   void do_noise_rejection(bool b) { m_do_noise_rejection = b; }
+  void set_presampleShift(int b) { m_presampleShift = b; }
   void skipNevent(int b) { startevt = b; }
   void event_range(int a, int b)
   {
@@ -39,6 +40,7 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   CDBTTree *m_cdbttree{nullptr};
   CDBInterface *m_cdb{nullptr};
 
+  int m_presampleShift = 40; // number of presamples shifted to line up t0
   int _ievent{0};
   int startevt{-1};
   int endevt{9999999};

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -380,7 +380,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       trackSeed->set_phi(phi);
       if(m_searchInIntt)
       {
-        //trackSeed->lineFit(positions, 0, 7);
+        trackSeed->lineFit(positions, 0, 2);
       }
 
       if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -380,7 +380,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       trackSeed->set_phi(phi);
       if(m_searchInIntt)
       {
-        trackSeed->lineFit(positions, 0, 7);
+        //trackSeed->lineFit(positions, 0, 7);
       }
 
       if (Verbosity() > 0)

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -375,9 +375,14 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       fitTimer->restart();
 
       //! Circle fit again to take advantage of INTT lever arm
-      trackSeed->circleFitByTaubin(positions, 0, 8);
+      trackSeed->circleFitByTaubin(positions, 0, 7);
       phi = trackSeed->get_phi(positions);
       trackSeed->set_phi(phi);
+      if(m_searchInIntt)
+      {
+        trackSeed->lineFit(positions, 0, 7);
+      }
+
       if (Verbosity() > 0)
       {
         std::cout << "find intt clusters time " << addClusters << std::endl;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -16,6 +16,8 @@ class TrackSeed;
 class TrkrClusterContainer;
 class TF1;
 class TrkrClusterCrossingAssoc;
+class TFile;
+class TNtuple;
 
 class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 {
@@ -70,6 +72,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   double getBunchCrossing(unsigned int trid, double z_mismatch);
   double getMatchingInflationFactor(double tpc_pt);
 
+  TFile *_file = nullptr;
+  TNtuple *_tree = nullptr;
+
   // default values, can be replaced from the macro
   double _phi_search_win = 0.01;
   double _eta_search_win = 0.004;
@@ -91,7 +96,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   TrkrClusterContainer *_cluster_map{nullptr};
   ActsGeometry *_tGeometry{nullptr};
   TrkrClusterCrossingAssoc *_cluster_crossing_map{nullptr};
-
+  int m_event = 0;
   std::map<unsigned int, double> _z_mismatch_map;
 
   //  double _collision_rate = 50e3;  // input rate for phi correction

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -427,6 +427,8 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   publishSeeds(unused_tracks);
 
   /// Remove tracks that are duplicates from the KFProp
+  if(m_ghostrejection)
+  {
   PHGhostRejection rejector(Verbosity());
   rejector.positionMap(globalPositions);
   rejector.trackSeedContainer(_track_map);
@@ -438,7 +440,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   {
     std::cout << "ghost rejection time " << timer.elapsed() << std::endl;
   }
-
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -56,6 +56,7 @@ class PHSimpleKFProp : public SubsysReco
       _fieldDir = -1;
     }
   }
+  void ghostRejection() { m_ghostrejection = false; }
   void magFieldFile(const std::string& fname) { m_magField = fname; }
   void set_max_window(double s) { _max_dist = s; }
   void useConstBField(bool opt) { _use_const_field = opt; }
@@ -71,7 +72,7 @@ class PHSimpleKFProp : public SubsysReco
 
  private:
   bool _use_truth_clusters = false;
-
+  bool m_ghostrejection = true;
   /// fetch node pointers
   int get_nodes(PHCompositeNode* topNode);
   std::vector<double> radii;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR contains development that allows us to match tracks in the silicon and tpc in the run 24 data. A few changes that need noting:

1. The tpc unpacker now has a pre sample shift that can be set. This is to accommodate the change from 80 to 120 pre samples in the readout that occurred at run 41624. @blackcathj your comment would be valuable on this - for example do we need to store this in the run db and look it up automatically? Is this planning to be changed again? See [this](https://github.com/sPHENIX-Collaboration/coresoftware/commit/32eac34ed5514f5dc80726e413c17f9a9b7ab1ce) commit for more details
2. The setting to use the old matching windows with fixed pT spacing is used, where the magnification of the windows is set to 1 by default so that we can just the windows to some fixed value. This is useful right now as the tracks don't match well, so we don't want to make a pT based cut and likely are biased towards high pT tracks that are relatively straight.
3. This adds a flag to skip the ghost rejection. The ghost rejector is removing tpc seeds that may be legitimate seeds. We don't know enough yet to throw these away.
4. Adds a diagnostic tuple to the matching module
5. Adds more diagnostic information to TrackResiduals so that one can look at the silicon and tpc seed track parameters of a total silicon+TPC seed. Useful for understanding what actually got matched and why.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

