### PR TITLE
fix: generalize helical fitter use

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -200,11 +200,11 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
   for (unsigned int trackid = 0; trackid < maxtracks; ++trackid)
   {
     TrackSeed* tracklet = nullptr;
-    if (fitsilicon)
+    if (fitsilicon && _track_map_silicon != nullptr)
     {
       tracklet = _track_map_silicon->get(trackid);
     }
-    else if (fittpc)
+    else if (fittpc && _track_map_tpc != nullptr)
     {
       tracklet = _track_map_tpc->get(trackid);
     }
@@ -230,7 +230,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
         nintt++;
       }
     }
-    if(nintt<2)
+    if(fitsilicon && nintt<2)
     {
       continue;
     }

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -163,14 +163,14 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
     }
   }
 
-  if (fitsilicon)
+  if (fitsilicon && _track_map_silicon != nullptr)
   {
     if(_track_map_silicon->size() == 0)
     {
       return Fun4AllReturnCodes::ABORTEVENT;
     }
   }
-  if (fittpc)
+  if (fittpc && _track_map_tpc != nullptr)
   {
     if (_track_map_tpc->size() == 0){
       return Fun4AllReturnCodes::ABORTEVENT;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -222,6 +222,18 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
     {
       continue;
     }
+    int nintt = 0;
+    for (auto& key : cluskey_vec)
+    {
+      if(TrkrDefs::getTrkrId(key) == TrkrDefs::inttId)
+      {
+        nintt++;
+      }
+    }
+    if(nintt<2)
+    {
+      continue;
+    }
     // store cluster global positions in a vector global_vec and cluskey_vec
     TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);
 
@@ -630,11 +642,11 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
       }
 
       // add some cluster cuts
-      if (residual(0) > 0.2)
+      if (residual(0) > 1.0)
       {
         continue;  // 2 mm cut
       }
-      if (residual(1) > 0.2)
+      if (residual(1) > 1.0)
       {
         continue;  // 2 mm cut
       }
@@ -675,7 +687,19 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 
     if (use_event_vertex)
     {
-      if (Verbosity() > 3)
+      for(int p = 0; p<3; p++)
+      {
+
+      
+      if(is_vertex_param_fixed(p))
+      {
+        glblvtx_derivativeX[p] = 0;
+        glblvtx_derivativeY[p] = 0;
+      }
+      
+
+      }
+      if (Verbosity() > -1)
       {
         std::cout << "vertex info for track " << trackid << " with charge " << newTrack.get_charge() << std::endl;
 
@@ -705,15 +729,15 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
       }
 
       // add some track cuts
-      if (fabs(newTrack.get_z() - event_vtx(2)) > 0.2)
+      if (fabs(newTrack.get_z() - event_vtx(2)) > 1)
       {
         continue;  // 2 mm cut
       }
-      if (fabs(newTrack.get_x()) > 0.2)
+      if (fabs(newTrack.get_x()) > 1)
       {
         continue;  // 2 mm cut
       }
-      if (fabs(newTrack.get_y()) > 0.2)
+      if (fabs(newTrack.get_y()) > 1)
       {
         continue;  // 2 mm cut
       }
@@ -1337,7 +1361,16 @@ unsigned int HelicalFitter::addSiliconClusters(std::vector<float>& fitpars, std:
 {
   return TrackFitUtils::addClusters(fitpars, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec, 0, 6);
 }
-
+bool HelicalFitter::is_vertex_param_fixed(unsigned int param)
+{
+  bool ret = false;
+  auto it = fixed_vertex_params.find(param);
+  if(it != fixed_vertex_params.end())
+  {
+    ret = true;
+  }
+  return ret;
+}
 bool HelicalFitter::is_intt_layer_fixed(unsigned int layer)
 {
   bool ret = false;

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -189,11 +189,11 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
   std::vector<TrackSeed> cumulative_someseed;
   std::vector<SvtxTrack_v4> cumulative_newTrack;
 
-  if (fittpc)
+  if (fittpc && _track_map_tpc != nullptr)
   {
     maxtracks = _track_map_tpc->size();
   }
-  if (fitsilicon)
+  if (fitsilicon && _track_map_silicon != nullptr)
   {
     maxtracks = _track_map_silicon->size();
   }

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -74,6 +74,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   void set_tpc_sector_fixed(unsigned int region, unsigned int sector, unsigned int side);
   void set_layer_param_fixed(unsigned int layer, unsigned int param);
   void set_ntuplefile_name(const std::string& file) { ntuple_outfilename = file; }
+  void set_vertex_param_fixed(unsigned int param){ fixed_vertex_params.insert(param);}
 
   void set_fitted_subsystems(bool si, bool tpc, bool full)
   {
@@ -133,6 +134,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   bool is_mvtx_layer_fixed(unsigned int layer, unsigned int stave);
   bool is_intt_layer_fixed(unsigned int layer);
   bool is_layer_param_fixed(unsigned int layer, unsigned int param);
+  bool is_vertex_param_fixed(unsigned int param);
 
   void getLocalDerivativesXY(const Surface& surf, const Acts::Vector3& global, const std::vector<float>& fitpars, float lcl_derivativeX[5], float lcl_derivativeY[5], unsigned int layer);
 
@@ -165,6 +167,7 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   std::set<unsigned int> fixed_intt_layers;
   std::set<unsigned int> fixed_sectors;
   std::set<std::pair<unsigned int, unsigned int>> fixed_layer_params;
+  std::set<unsigned int> fixed_vertex_params;
 
   // set default groups to lowest level
   AlignmentDefs::mvtxGrp mvtx_grp = AlignmentDefs::mvtxGrp::snsr;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1175,69 +1175,13 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
               << (unsigned int) TrkrDefs::getLayer(ckey) << " with pos "
               << clusglob.transpose() << std::endl;
   }
-  if (!state)
-  {
-    if (m_zeroField)
-    {
-      fillStatesWithLineFit(ckey, cluster, geometry);
-    }
-    else
-    {
-      fillStatesWithCircleFit(ckey, cluster, clusglob, geometry);
-    }
-
-    if (Verbosity() > 2)
-    {
-      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
-      {
-        unsigned int ssize = m_stategx.size();
-        std::cout << "   ckey " << ckey << " after circle fit: stategx  " << m_stategx[ssize - 1]
-                  << " stategy " << m_stategy[ssize - 1]
-                  << " stategz " << m_stategy[ssize - 1]
-                  << std::endl;
-      }
-    }
-
-    //! skip filling the state information if a state is not there
-    //! or we just ran the seeding. Fill with Nans to maintain the
-    //! 1-to-1 mapping between cluster/state vectors
-    m_idealsurfalpha.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfbeta.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfgamma.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfalpha.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfbeta.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfgamma.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfcenterx.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfcentery.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfcenterz.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfnormx.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfnormy.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_idealsurfnormz.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfcenterx.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfcentery.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfcenterz.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfnormx.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfnormy.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_missurfnormz.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_clusgxideal.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_clusgyideal.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_clusgzideal.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_statepx.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_statepy.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_statepz.push_back(std::numeric_limits<float>::quiet_NaN());
-    m_statepl.push_back(std::numeric_limits<float>::quiet_NaN());
-    return;
-  }
 
   auto surf = geometry->maps().getSurface(ckey, cluster);
-  Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
-  Acts::Vector2 stateloc;
+
   auto misaligncenter = surf->center(geometry->geometry().getGeoContext());
   auto misalignnorm = -1 * surf->normal(geometry->geometry().getGeoContext());
   auto misrot = surf->transform(geometry->geometry().getGeoContext()).rotation();
-  auto result = surf->globalToLocal(geometry->geometry().getGeoContext(),
-                                    stateglob * Acts::UnitConstants::cm,
-                                    misalignnorm);
+
 
   float mgamma = atan2(-misrot(1, 0), misrot(0, 0));
   float mbeta = -asin(misrot(0, 1));
@@ -1291,6 +1235,45 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   m_clusgxideal.push_back(ideal_glob.x());
   m_clusgyideal.push_back(ideal_glob.y());
   m_clusgzideal.push_back(ideal_glob.z());
+
+  if (!state)
+  {
+    if (m_zeroField)
+    {
+      fillStatesWithLineFit(ckey, cluster, geometry);
+    }
+    else
+    {
+      fillStatesWithCircleFit(ckey, cluster, clusglob, geometry);
+    }
+
+    if (Verbosity() > 2)
+    {
+      if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::micromegasId)
+      {
+        unsigned int ssize = m_stategx.size();
+        std::cout << "   ckey " << ckey << " after circle fit: stategx  " << m_stategx[ssize - 1]
+                  << " stategy " << m_stategy[ssize - 1]
+                  << " stategz " << m_stategy[ssize - 1]
+                  << std::endl;
+      }
+    }
+
+    //! skip filling the state information if a state is not there
+    //! or we just ran the seeding. Fill with Nans to maintain the
+    //! 1-to-1 mapping between cluster/state vectors
+    m_statepx.push_back(std::numeric_limits<float>::quiet_NaN());
+    m_statepy.push_back(std::numeric_limits<float>::quiet_NaN());
+    m_statepz.push_back(std::numeric_limits<float>::quiet_NaN());
+    m_statepl.push_back(std::numeric_limits<float>::quiet_NaN());
+    return;
+  }
+
+  Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
+  Acts::Vector2 stateloc;
+  auto result = surf->globalToLocal(geometry->geometry().getGeoContext(),
+                                    stateglob * Acts::UnitConstants::cm,
+                                    misalignnorm);
 
   if (result.ok())
   {


### PR DESCRIPTION
Generalizes the helical fitter to use the silicon tpc track seed container, and also adds a check for a track size of at least 4 since 3 cluster tracks trivially have all of their circle-fit residuals == 0.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

