### PR TITLE
Fix duplication of chains in PHCASeeding

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -584,27 +584,6 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
       }  // end loop over all up-links
     }    // end loop over start clusters
 
-              int fixme_ndown = (int) startLinks.size();
-              for (int k=0; k<(fixme_ndown-1);++k) {
-                for (int j=k+1; j<fixme_ndown; ++j) {
-                  if (startLinks[k].first == startLinks[j].first && startLinks[k].second == startLinks[j].second) {
-                    std::cout << " FIXME C1 found duplicate in startLinks" << std::endl;
-                    /* continue; */
-                  }
-                }
-              }
-    
-      // check for duplicate downlinks
-            const auto& BL = bodyLinks[layer_index+1];
-              fixme_ndown = (int) BL.size();
-              for (int k=0; k<(fixme_ndown-1);++k) {
-                for (int j=k+1; j<fixme_ndown; ++j) {
-                  if (BL[k].first == BL[j].first && BL[k].second == BL[j].second) {
-                    std::cout << " FIXME C3 found duplicate in bodyLinks" << std::endl;
-                    /* continue; */
-                  }
-                }
-              }
     t_seed->stop();
     set_insert_time += t_seed->elapsed();
     t_seed->restart();
@@ -1076,14 +1055,8 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
   // now fill a chain of the possible added seeds
   index = -1;
   nlinks = add_links.size();
-  TrkrDefs::cluskey fixme_lastlink = 0;
 
-  bool first_err_link = true;
   for (const auto& link : add_links) {
-    if (first_err_link && link == fixme_lastlink) {
-       std::cout << " FIXME ERROR duplicate link! " << std::endl;
-    }
-    fixme_lastlink = link;
     index += 1;
     auto link_pos = pos.at(link);
     float xt = link_pos.x();
@@ -1097,7 +1070,7 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
     float dphit0 = std::fmod(phit-phi0, M_PI);
 
     float d2phidr2 = dphit0/dr_t0/dr_t0 - dphidr01;
-    _tup_chainfork->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, dzdr, d2phidr2, index, nlinks);
+    _tup_chainfork->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), xt, yt, zt, dzdr, d2phidr2, index, nlinks);
   }
 }
 

--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -168,9 +168,8 @@ PHCASeeding::PHCASeeding(
     unsigned int nlayers_intt,
     unsigned int nlayers_tpc,
     float neighbor_phi_width,
-    float neighbor_eta_width,
-    float maxSinPhi,
-    float cosTheta_limit)
+    float neighbor_z_width,
+    float maxSinPhi)
   : PHTrackSeeding(name)
   , _nlayers_maps(nlayers_maps)
   , _nlayers_intt(nlayers_intt)
@@ -180,9 +179,8 @@ PHCASeeding::PHCASeeding(
   , _min_nhits_per_cluster(min_nhits_per_cluster)
   , _min_clusters_per_track(min_clusters_per_track)
   , _neighbor_phi_width(neighbor_phi_width)
-  , _neighbor_eta_width(neighbor_eta_width)
+  , _neighbor_z_width(neighbor_z_width)
   , _max_sin_phi(maxSinPhi)
-  , _cosTheta_limit(cosTheta_limit)
 {
 }
 
@@ -290,20 +288,20 @@ std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding:
   {
     const auto& globalpos_d = globalPositions.at(ckey);
     const double clus_phi = get_phi(globalpos_d);
-    const double clus_eta = get_eta(globalpos_d);
+    const double clus_z = globalpos_d.z();
     if (Verbosity() > 0)
     {
       /* int layer = TrkrDefs::getLayer(ckey); */
       std::cout << "Found cluster " << ckey << " in layer " << layer << std::endl;
     }
     std::vector<pointKey> testduplicate;
-    QueryTree(_rtree, clus_phi - 0.00001, clus_eta - 0.00001, clus_phi + 0.00001, clus_eta + 0.00001, testduplicate);
+    QueryTree(_rtree, clus_phi - 0.00001, clus_z - 0.00001, clus_phi + 0.00001, clus_z + 0.00001, testduplicate);
     if (!testduplicate.empty())
     {
       ++n_dupli;
       continue;
     }
-    coords.push_back({{static_cast<float>(clus_phi), static_cast<float>(clus_eta)}, ckey});
+    coords.push_back({{static_cast<float>(clus_phi), static_cast<float>(clus_z)}, ckey});
     t_fill->restart();
     _rtree.insert(std::make_pair(point(clus_phi, globalpos_d.z()), ckey));
     t_fill->stop();
@@ -427,10 +425,12 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
     // where the old lower becomes the new middle, the old middle the new upper,
     // and the old upper drops out and that _rtree is filled with the new lower
     int index_above = (layer_index + 1) % 3;
-    int index_current = (layer_index) % 3;
+    int index_current = (layer_index)   % 3;
     int index_below = (layer_index - 1) % 3;
 
     coord_arr[index_below] = FillTree(_rtrees[index_below], ckeys[layer_index - 1], globalPositions, layer_index - 1);
+
+    // NO DUPLICATES FOUND IN COORD_ARR
 
     auto& _rtree_above = _rtrees[index_above];
     const std::vector<coordKey>& coord = coord_arr[index_current];
@@ -450,6 +450,7 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
     // Any link to an above node which matches the same clusters
     // on the previous iteration (to a "below node") becomes a "bilink"
     // Check if this bilink links to a prior bilink or not
+    
     std::vector<keyLink> aboveLinks;
     for (const auto& StartCluster : coord)
     {
@@ -470,18 +471,18 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
 
       QueryTree(_rtree_below,
           StartPhi - _neighbor_phi_width,
-          StartZ - _neighbor_eta_width,
+          StartZ - _neighbor_z_width,
           StartPhi + _neighbor_phi_width,
-          StartZ + _neighbor_eta_width,
+          StartZ + _neighbor_z_width,
           ClustersBelow);
         
       FillTupWinLink(_rtree_below, StartCluster, globalPositions);
 
       QueryTree(_rtree_above,
                 StartPhi - _neighbor_phi_width,
-                StartZ - _neighbor_eta_width,
+                StartZ - _neighbor_z_width,
                 StartPhi + _neighbor_phi_width,
-                StartZ + _neighbor_eta_width,
+                StartZ + _neighbor_z_width,
                 ClustersAbove);
 
       t_seed->stop();
@@ -519,8 +520,7 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
       // find the three clusters closest to a straight line
       // (by maximizing the cos of the angle between the (delta_eta,delta_phi) vectors)
       // double minSumLengths = 1e9;
-      keyList bestBelowClusters;
-      keyList bestAboveClusters;
+      std::unordered_set<TrkrDefs::cluskey> bestAboveClusters;
       for (size_t iAbove = 0; iAbove < delta_above.size(); ++iAbove)
       {
         for (size_t iBelow = 0; iBelow < delta_below.size(); ++iBelow)
@@ -542,8 +542,8 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
           {
             // maxCosPlaneAngle = cos(angle);
             // minSumLengths = belowLength+aboveLength;
-            bestBelowClusters.push_back(ClustersBelow[iBelow].second);
-            bestAboveClusters.push_back(ClustersAbove[iAbove].second);
+            curr_downlinks.insert({StartCluster.second, ClustersBelow[iBelow].second});
+            bestAboveClusters.insert(ClustersAbove[iAbove].second);
 
             // fill the tuples for plotting
             fill_tuple(_tupclus_links,  0, StartCluster.second, globalPositions.at(StartCluster.second));
@@ -560,11 +560,6 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
       t_seed->stop();
       compute_best_angle_time += t_seed->elapsed();
       t_seed->restart();
-
-      for (auto cluster : bestBelowClusters)
-      {
-        curr_downlinks.insert({StartCluster.second, cluster});
-      }
 
       for (auto cluster : bestAboveClusters)
       {
@@ -584,9 +579,32 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
           } else {
             bodyLinks[layer_index+1].push_back(std::make_pair(key_top,key_bot));
           }
+
         }
       }  // end loop over all up-links
     }    // end loop over start clusters
+
+              int fixme_ndown = (int) startLinks.size();
+              for (int k=0; k<(fixme_ndown-1);++k) {
+                for (int j=k+1; j<fixme_ndown; ++j) {
+                  if (startLinks[k].first == startLinks[j].first && startLinks[k].second == startLinks[j].second) {
+                    std::cout << " FIXME C1 found duplicate in startLinks" << std::endl;
+                    /* continue; */
+                  }
+                }
+              }
+    
+      // check for duplicate downlinks
+            const auto& BL = bodyLinks[layer_index+1];
+              fixme_ndown = (int) BL.size();
+              for (int k=0; k<(fixme_ndown-1);++k) {
+                for (int j=k+1; j<fixme_ndown; ++j) {
+                  if (BL[k].first == BL[j].first && BL[k].second == BL[j].second) {
+                    std::cout << " FIXME C3 found duplicate in bodyLinks" << std::endl;
+                    /* continue; */
+                  }
+                }
+              }
     t_seed->stop();
     set_insert_time += t_seed->elapsed();
     t_seed->restart();
@@ -672,6 +690,8 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
   std::vector<keyList> tempSeedKeyLists = trackSeedKeyLists;
   trackSeedKeyLists.clear();
 
+  int nsplit_chains = -1;
+
   while (tempSeedKeyLists.size() > 0)
   {
     if (Verbosity() > 0)
@@ -698,6 +718,7 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
       /* for (auto testlink = matched_links.first; testlink != matched_links.second; ++testlink) */
 
     bool did_seed_grow = false;
+    keyList links_added {}; 
     for (const auto& link : bilinks[trackHead_layer]) {
       if (link.first != trackHead) { continue; }
       // It appears that it is just faster to traverse the lists then it is to use a binary-sorted search
@@ -746,12 +767,14 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
         float new_d2phidr2 = new_dphi / (new_dr * new_dr) - dphi12 / (dr_12 * dr_12);
         if (fabs(d2phidr2 - new_d2phidr2) < _clusadd_delta_dphidr2_window)
         {
+          links_added.push_back(link.second);
           did_seed_grow = true;
           keyList newseed = seed;
           newseed.push_back(link.second);
           newtempSeedKeyLists.push_back(newseed);
         }
       } // end look over possible links to grow the seed
+      fill_split_chains(seed, links_added, globalPositions, nsplit_chains);
       if (did_seed_grow == false && seed.size() >= _min_clusters_per_seed) {
         // publish the seed
         trackSeedKeyLists.push_back(seed);
@@ -954,6 +977,7 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
   fitter->setFixedClusterError(0, _fixed_clus_err.at(0));
   fitter->setFixedClusterError(1, _fixed_clus_err.at(1));
   fitter->setFixedClusterError(2, _fixed_clus_err.at(2));
+
   
 #if defined(_PHCASEEDING_CLUSTERLOG_TUPOUT_)
   std::cout << " Writing _CLUSTER_LOG_TUPOUT.root file " << std::endl;
@@ -971,6 +995,9 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
 
   _search_windows = new TNtuple("search_windows","windows used in algorithm to seed clusters",
       "DelEta_ClSearch:DelPhi_ClSearch:start_layer:end_layer:dzdr_ClAdd:dphidr2_ClAdd");
+
+  _tup_chainfork  = new TNtuple("chainfork", "chain with multiple links, which if forking", "event:nchain:layer:x:y:z:dzdr:d2phidr2:nlink:nlinks"); // nlinks to add, 0 ... nlinks
+  _tup_chainbody  = new TNtuple("chainbody", "chain body with multiple link options", "event:nchain:layer:x:y:z:dzdr:d2phidr2:nlink:nlinks"); // nlinks in chain being added to will be 0, 1, 2 ... working backward from the fork -- dZ and dphi are dropped for final links as necessary
 #endif
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -986,6 +1013,98 @@ int PHCASeeding::End()
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+#if defined(_PHCASEEDING_CHAIN_FORKS_)
+
+void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCASeeding::keyList& add_links, const PHCASeeding::PositionMap& pos, int& n_tupchains) const 
+{
+  if (add_links.size() < 2) return;
+  n_tupchains += 1;
+
+  // fill the chain leading to the forks
+  int nlinks = seed.size();
+
+  bool has_0 = false;
+  float x0{0.}, y0{0.}, z0{0.}, r0{0.}, phi0{0.};
+
+  bool has_1 = false;
+  float /*x1, y1,*/ z1{0.}, r1{0.}, phi1{0.};
+
+  bool has_2 = false;
+  float /*x2, y2, z2,*/ r2{0.}, phi2{0.};
+
+  int index = seed.size(); // index will count backwards from the end of the chain
+                 // dR is not calculated for the final (outermost layer) link
+                 // dPhi is not calculated for the final two (outmost layer) link
+
+  float dphidr01=-1000.;
+  for (const auto& link : seed) {
+    index -= 1;
+    if (has_1) {
+      has_2 = true;
+      /*x2=x1; y2=y1; z2=z1;*/ r2=r1; phi2=phi1;
+    }
+    if (has_0) {
+      has_1 = true;
+      /*x1=x0; y1=y0;*/ z1=z0; r1=r0; phi1=phi0;
+    }
+    auto link_pos = pos.at(link);
+    has_0 = true;
+    x0 = link_pos.x();
+    y0 = link_pos.y();
+    z0 = link_pos.z();
+    phi0 = atan2(y0,x0);
+    r0 = sqrt(x0*x0+y0*y0);
+
+    if (!has_1) {
+      _tup_chainbody->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, -1000., -1000., index, nlinks);
+      continue;
+    } 
+    float dzdr = (z0-z1)/(r0-r1);
+    if (!has_2) {
+      _tup_chainbody->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, dzdr, -1000., index, nlinks);
+      continue;
+    }
+    float dphi01 = std::fmod(phi1-phi0, M_PI);
+    float dphi12 = std::fmod(phi2-phi1, M_PI);
+    float dr_01 = r1-r0;
+    float dr_12 = r2-r1;
+    dphidr01 = dphi01/dr_01/dr_01;
+    float d2phidr2 = dphidr01 - dphi12/dr_12/dr_12;
+    _tup_chainbody->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, dzdr, d2phidr2, index, nlinks);
+  } 
+  
+  // now fill a chain of the possible added seeds
+  index = -1;
+  nlinks = add_links.size();
+  TrkrDefs::cluskey fixme_lastlink = 0;
+
+  bool first_err_link = true;
+  for (const auto& link : add_links) {
+    if (first_err_link && link == fixme_lastlink) {
+       std::cout << " FIXME ERROR duplicate link! " << std::endl;
+    }
+    fixme_lastlink = link;
+    index += 1;
+    auto link_pos = pos.at(link);
+    float xt = link_pos.x();
+    float yt = link_pos.y();
+    float zt = link_pos.z();
+    float phit = atan2(yt,xt);
+    float rt = sqrt(xt*xt+yt*yt);
+    float dr_t0 = rt - r0;
+
+    float dzdr = (zt-z0)/(rt-r0);
+    float dphit0 = std::fmod(phit-phi0, M_PI);
+
+    float d2phidr2 = dphit0/dr_t0/dr_t0 - dphidr01;
+    _tup_chainfork->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, dzdr, d2phidr2, index, nlinks);
+  }
+}
+
+#else
+void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& /*chain*/, const PHCASeeding::keyList& /*links*/, const PHCASeeding::PositionMap& /*pos*/, int& /*nchains*/) const {};
+#endif
+
 #if defined(_PHCASEEDING_CLUSTERLOG_TUPOUT_)
 void PHCASeeding::write_tuples() {
   _f_clustering_process->cd();
@@ -999,6 +1118,8 @@ void PHCASeeding::write_tuples() {
   _tupwin_seed23     ->Write();
   _tupwin_seedL1     ->Write();
   _search_windows    ->Write();
+  _tup_chainbody ->Write();
+  _tup_chainfork ->Write();
   _f_clustering_process->Close();
 }
 
@@ -1018,7 +1139,7 @@ void PHCASeeding::fill_tuple_with_seed(TNtuple* tup, const PHCASeeding::keyList&
 void PHCASeeding::process_tupout_count() {
   _tupout_count += 1;
   if (_tupout_count!=0) return;
-  _search_windows->Fill(_neighbor_eta_width,_neighbor_phi_width,_start_layer,_end_layer,_clusadd_delta_dzdr_window,_clusadd_delta_dphidr2_window);
+  _search_windows->Fill(_neighbor_z_width,_neighbor_phi_width,_start_layer,_end_layer,_clusadd_delta_dzdr_window,_clusadd_delta_dphidr2_window);
 }
 
 void PHCASeeding::FillTupWinLink(bgi::rtree<PHCASeeding::pointKey,bgi::quadratic<16>>& _rtree_below, const PHCASeeding::coordKey& StartCluster, const PHCASeeding::PositionMap& globalPositions) const

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -10,6 +10,7 @@
 
 // Statements for if we want to save out the intermediary clustering steps
 #define _PHCASEEDING_CLUSTERLOG_TUPOUT_
+#define _PHCASEEDING_CHAIN_FORKS_
 /* #define _PHCASEEDING_TIMER_OUT_ */
 
 #include "ALICEKF.h"
@@ -67,7 +68,7 @@ class PHCASeeding : public PHTrackSeeding
 
    using point = bg::model::point<float, 2, bg::cs::cartesian>;
    using box = bg::model::box<point>;
-   using pointKey = std::pair<point, TrkrDefs::cluskey>; // phi and eta in the key
+   using pointKey = std::pair<point, TrkrDefs::cluskey>; // phi and z in the key
    using coordKey = std::pair<std::array<float, 2>, TrkrDefs::cluskey>; // just use phi and eta, no longer needs the layer
 
    using keyList = std::vector<TrkrDefs::cluskey>;
@@ -90,9 +91,10 @@ class PHCASeeding : public PHTrackSeeding
       const unsigned int nlayers_intt = 4,
       const unsigned int nlayers_tpc = 48,
       float neighbor_phi_width = .02,
-      float neighbor_eta_width = .01,
-      float maxSinPhi = 0.999,
-      float cosTheta_limit = -0.8);
+      float neighbor_z_width = .01,
+      float maxSinPhi = 0.999
+      /* float cosTheta_limit = -0.8 */
+      );
 
   ~PHCASeeding() override {}
   void SetLayerRange(unsigned int layer_low, unsigned int layer_up)
@@ -100,9 +102,9 @@ class PHCASeeding : public PHTrackSeeding
     _start_layer = layer_low;
     _end_layer = layer_up;
   }
-  void SetSearchWindow(float eta_width, float phi_width)
+  void SetSearchWindow(float z_width, float phi_width)
   {
-    _neighbor_eta_width = eta_width;
+    _neighbor_z_width = z_width;
     _neighbor_phi_width = phi_width;
   }
   void SetClusAdd_delta_window(float _dzdr_cutoff, float _dphidr2_cutoff) 
@@ -141,22 +143,26 @@ class PHCASeeding : public PHTrackSeeding
   int Setup(PHCompositeNode* topNode) override;
   int Process(PHCompositeNode* topNode) override;
   int InitializeGeometry(PHCompositeNode* topNode);
-  int FindSeedsLayerSkip(double cosTheta_limit);
+  /* int FindSeedsLayerSkip(double cosTheta_limit); */
   int End() override;
 
  private:
   bool _save_clus_proc = false;
 
   TFile* _f_clustering_process = nullptr;
-  int      _tupout_count=-1;
+  int _tupout_count = -1;
+  int _n_tupchains  = -1;
   // Save the steps of the clustering
   TNtuple* _tupclus_all         = nullptr; // all clusters
   TNtuple* _tupclus_links       = nullptr; //  clusters which are linked
   TNtuple* _tupclus_bilinks     = nullptr; // bi-linked clusters
   TNtuple* _tupclus_seeds       = nullptr; // seed (outermost three bi-linked chain
   TNtuple* _tupclus_grown_seeds = nullptr; // seeds saved out
+                                           //
+  TNtuple* _tup_chainbody  = nullptr;
+  TNtuple* _tup_chainfork  = nullptr;
 
-  TNtuple* _tupwin_link      = nullptr; // cluster pairs with dphi and deta (very wide windows) x0,x1,y0,y1,z0,z1
+  TNtuple* _tupwin_link      = nullptr; // cluster pairs with dphi and dz (very wide windows) x0,x1,y0,y1,z0,z1
   TNtuple* _tupwin_cos_angle = nullptr; // directed cosine (all cluster triples which are found) x0,x1,x2
   TNtuple* _tupwin_seed23    = nullptr; // from third to fourth link -- can only use passing seeds
   TNtuple* _tupwin_seedL1    = nullptr; // from third to fourth link -- can only use passing seeds
@@ -171,6 +177,7 @@ class PHCASeeding : public PHTrackSeeding
   void FillTupWinLink(bgi::rtree<pointKey,bgi::quadratic<16>>&, const coordKey&, const PositionMap&)const;
   void FillTupWinCosAngle(const TrkrDefs::cluskey, const TrkrDefs::cluskey, const TrkrDefs::cluskey, const PositionMap&, double cos_angle, bool isneg) const;
   void FillTupWinGrowSeed(const keyList& seed, const keyLink& link, const PositionMap& globalPositions) const;
+  void fill_split_chains(const keyList& chain, const keyList& keylinks, const PositionMap& globalPositions, int& nchains) const;
   /* void fill_tuple_with_seed(TN */
 
 
@@ -204,7 +211,7 @@ class PHCASeeding : public PHTrackSeeding
   std::vector<coordKey> FillTree(bgi::rtree<pointKey,bgi::quadratic<16>>&, const keyList&, const PositionMap&, int layer);
   int FindSeedsWithMerger(const PositionMap&, const keyListPerLayer&);
 
-  void QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>>& rtree, double phimin, double etamin, double phimax, double etamax, std::vector<pointKey>& returned_values) const;
+  void QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>>& rtree, double phimin, double zmin, double phimax, double zmax, std::vector<pointKey>& returned_values) const;
   std::vector<TrackSeed_v2> RemoveBadClusters(const std::vector<keyList>& seeds, const PositionMap& globalPositions) const;
   double getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b, TrkrDefs::cluskey c, const PositionMap& globalPositions) const;
 
@@ -226,11 +233,11 @@ class PHCASeeding : public PHTrackSeeding
   //  float _cluster_z_error;
   //  float _cluster_alice_y_error;
   float _neighbor_phi_width;
-  float _neighbor_eta_width;
+  float _neighbor_z_width;
   float _clusadd_delta_dzdr_window = 0.5;
   float _clusadd_delta_dphidr2_window = 0.005;
   float _max_sin_phi;
-  float _cosTheta_limit;
+  /* float _cosTheta_limit; */
   double _rz_outlier_threshold = 0.1;
   double _xy_outlier_threshold = 0.1;
   double _fieldDir = -1;

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -9,8 +9,8 @@
  */
 
 // Statements for if we want to save out the intermediary clustering steps
-#define _PHCASEEDING_CLUSTERLOG_TUPOUT_
-#define _PHCASEEDING_CHAIN_FORKS_
+/* #define _PHCASEEDING_CLUSTERLOG_TUPOUT_ */
+/* #define _PHCASEEDING_CHAIN_FORKS_ */
 /* #define _PHCASEEDING_TIMER_OUT_ */
 
 #include "ALICEKF.h"


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This fixes a bug that was duplicating links in the PHCASeeding which massively increased the size of seeds produced. The results are much smaller numbers of seeds and chains.
It also fixes a transition from old version of code from eta to Z (as well as the names)
It also contains some compile-time options to fill yet more tuples that show locations in which the chains fork
 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

