### PR TITLE
fix: call distortion corrections in global position determination

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -32,9 +32,9 @@
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 
-#include <tpc/TpcGlobalPositionWrapper.h>
-#include <tpc/TpcDistortionCorrectionContainer.h>
 #include <ffarawobjects/Gl1RawHit.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
+#include <tpc/TpcGlobalPositionWrapper.h>
 
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
@@ -491,10 +491,10 @@ float TrackResiduals::calc_dedx(TrackSeed* tpcseed, TrkrClusterContainer* cluste
   for (unsigned long cluster_key : clusterKeys)
   {
     auto detid = TrkrDefs::getTrkrId(cluster_key);
-    if (detid != TrkrDefs::TrkrId::tpcId) 
-      {
-	continue;   // the micromegas clusters are added to the TPC seeds
-      }
+    if (detid != TrkrDefs::TrkrId::tpcId)
+    {
+      continue;  // the micromegas clusters are added to the TPC seeds
+    }
     unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
     TrkrCluster* cluster = clustermap->findCluster(cluster_key);
     float adc = cluster->getAdc();
@@ -597,7 +597,7 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
         if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::tpcId)
         {
           global = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(ckey, cluster, geometry, 0,
-                                                                                m_dccStatic, m_dccAverage, m_dccFluctuation);
+                                                                                  m_dccStatic, m_dccAverage, m_dccFluctuation);
         }
         else
         {
@@ -671,7 +671,7 @@ void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
           if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
           {
             clusglob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
-                                                                                  m_dccStatic, m_dccAverage, m_dccFluctuation);
+                                                                                      m_dccStatic, m_dccAverage, m_dccFluctuation);
           }
           else
           {
@@ -804,12 +804,13 @@ void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
         auto key = iter->first;
         auto cluster = clusters->findCluster(key);
         Acts::Vector3 glob;
-        if(TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+        if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
         {
           glob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
-          m_dccStatic, m_dccAverage, m_dccFluctuation);
+                                                                                m_dccStatic, m_dccAverage, m_dccFluctuation);
         }
-        else{
+        else
+        {
           glob = geometry->getGlobalPosition(key, cluster);
         }
         m_sclusgx = glob.x();
@@ -1129,7 +1130,7 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
   if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::tpcId)
   {
     clusglob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(ckey, cluster, geometry, 0,
-                                                                          m_dccStatic, m_dccAverage, m_dccFluctuation);
+                                                                              m_dccStatic, m_dccAverage, m_dccFluctuation);
   }
   else
   {
@@ -1556,20 +1557,20 @@ void TrackResiduals::createBranches()
   m_tree->Branch("segment", &m_segment, "m_segment/I");
   m_tree->Branch("event", &m_event, "m_event/I");
   m_tree->Branch("trackid", &m_trackid, "m_trackid/I");
-  m_tree->Branch("tpcid",&m_tpcid,"m_tpcid/I");
-  m_tree->Branch("silid",&m_silid,"m_silid/I");
+  m_tree->Branch("tpcid", &m_tpcid, "m_tpcid/I");
+  m_tree->Branch("silid", &m_silid, "m_silid/I");
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_tree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
-  m_tree->Branch("silseedx",&m_silseedx,"m_silseedx/F");
-  m_tree->Branch("silseedy",&m_silseedy,"m_silseedy/F");
-  m_tree->Branch("silseedz",&m_silseedz,"m_silseedz/F");
-  m_tree->Branch("silseedpx",&m_silseedpx,"m_silseedpx/F");
-  m_tree->Branch("silseedpy",&m_silseedpy,"m_silseedpy/F");
-  m_tree->Branch("silseedpz",&m_silseedpz,"m_silseedpz/F");
-  m_tree->Branch("silseedphi",&m_silseedphi,"m_silseedphi/F");
-  m_tree->Branch("silseedeta",&m_silseedeta,"m_silseedeta/F");
-  m_tree->Branch("silseedcharge",&m_silseedcharge,"m_silseedcharge/I");
+  m_tree->Branch("silseedx", &m_silseedx, "m_silseedx/F");
+  m_tree->Branch("silseedy", &m_silseedy, "m_silseedy/F");
+  m_tree->Branch("silseedz", &m_silseedz, "m_silseedz/F");
+  m_tree->Branch("silseedpx", &m_silseedpx, "m_silseedpx/F");
+  m_tree->Branch("silseedpy", &m_silseedpy, "m_silseedpy/F");
+  m_tree->Branch("silseedpz", &m_silseedpz, "m_silseedpz/F");
+  m_tree->Branch("silseedphi", &m_silseedphi, "m_silseedphi/F");
+  m_tree->Branch("silseedeta", &m_silseedeta, "m_silseedeta/F");
+  m_tree->Branch("silseedcharge", &m_silseedcharge, "m_silseedcharge/I");
   m_tree->Branch("tpcseedx", &m_tpcseedx, "m_tpcseedx/F");
   m_tree->Branch("tpcseedy", &m_tpcseedy, "m_tpcseedy/F");
   m_tree->Branch("tpcseedz", &m_tpcseedz, "m_tpcseedz/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -32,6 +32,8 @@
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 
+#include <tpc/TpcGlobalPositionWrapper.h>
+#include <tpc/TpcDistortionCorrectionContainer.h>
 #include <ffarawobjects/Gl1RawHit.h>
 
 #include <globalvertex/GlobalVertex.h>
@@ -91,11 +93,25 @@ int TrackResiduals::Init(PHCompositeNode* /*unused*/)
 }
 
 //____________________________________________________________________________..
-int TrackResiduals::InitRun(PHCompositeNode* /*unused*/)
+int TrackResiduals::InitRun(PHCompositeNode* topNode)
 {
   m_outfile = new TFile(m_outfileName.c_str(), "RECREATE");
   createBranches();
-
+  m_dccStatic = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerStatic");
+  if (m_dccStatic)
+  {
+    std::cout << PHWHERE << "  found static TPC distortion correction container" << std::endl;
+  }
+  m_dccAverage = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerAverage");
+  if (m_dccAverage)
+  {
+    std::cout << PHWHERE << "  found average TPC distortion correction container" << std::endl;
+  }
+  m_dccFluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerFluctuation");
+  if (m_dccFluctuation)
+  {
+    std::cout << PHWHERE << "  found fluctuation TPC distortion correction container" << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 void TrackResiduals::clearClusterStateVectors()
@@ -577,7 +593,16 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
       {
         auto ckey = *it;
         auto cluster = clustermap->findCluster(ckey);
-        auto global = geometry->getGlobalPosition(ckey, cluster);
+        Acts::Vector3 global;
+        if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::tpcId)
+        {
+          global = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(ckey, cluster, geometry, 0,
+                                                                                m_dccStatic, m_dccAverage, m_dccFluctuation);
+        }
+        else
+        {
+          global = geometry->getGlobalPosition(ckey, cluster);
+        }
         auto local = geometry->getLocalCoords(ckey, cluster);
         m_cluslx.push_back(local.x());
         m_cluslz.push_back(local.y());
@@ -641,7 +666,17 @@ void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
         for (const auto& ckey : get_cluster_keys(track))
         {
           TrkrCluster* cluster = clustermap->findCluster(ckey);
-          Acts::Vector3 clusglob = geometry->getGlobalPosition(ckey, cluster);
+
+          Acts::Vector3 clusglob;
+          if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+          {
+            clusglob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+                                                                                  m_dccStatic, m_dccAverage, m_dccFluctuation);
+          }
+          else
+          {
+            clusglob = geometry->getGlobalPosition(key, cluster);
+          }
           m_clusgx.push_back(clusglob.x());
           m_clusgy.push_back(clusglob.y());
           m_clusgz.push_back(clusglob.z());
@@ -768,7 +803,15 @@ void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
       {
         auto key = iter->first;
         auto cluster = clusters->findCluster(key);
-        auto glob = geometry->getGlobalPosition(key, cluster);
+        Acts::Vector3 glob;
+        if(TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+        {
+          glob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+          m_dccStatic, m_dccAverage, m_dccFluctuation);
+        }
+        else{
+          glob = geometry->getGlobalPosition(key, cluster);
+        }
         m_sclusgx = glob.x();
         m_sclusgy = glob.y();
         m_sclusgz = glob.z();
@@ -1082,7 +1125,16 @@ void TrackResiduals::fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack* trac
 
   ActsTransformations transformer;
   TrkrCluster* cluster = clustermap->findCluster(ckey);
-  Acts::Vector3 clusglob = geometry->getGlobalPosition(ckey, cluster);
+  Acts::Vector3 clusglob;
+  if (TrkrDefs::getTrkrId(ckey) == TrkrDefs::tpcId)
+  {
+    clusglob = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(ckey, cluster, geometry, 0,
+                                                                          m_dccStatic, m_dccAverage, m_dccFluctuation);
+  }
+  else
+  {
+    clusglob = geometry->getGlobalPosition(ckey, cluster);
+  }
   switch (TrkrDefs::getTrkrId(ckey))
   {
   case TrkrDefs::mvtxId:

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -29,6 +29,7 @@ class TrkrClusterContainer;
 class TrkrHitSetContainer;
 class PHG4TpcCylinderGeomContainer;
 class PHG4CylinderGeomContainer;
+class TpcDistortionCorrectionContainer;
 class TrackResiduals : public SubsysReco
 {
  public:
@@ -88,6 +89,8 @@ class TrackResiduals : public SubsysReco
   bool m_zeroField = false;
   bool m_doFailedSeeds = false;
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
+
+  TpcDistortionCorrectionContainer *m_dccStatic{nullptr}, *m_dccAverage{nullptr}, *m_dccFluctuation{nullptr};
 
   ClusterErrorPara m_clusErrPara;
   std::string m_alignmentMapName = "SvtxAlignmentStateMap";

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -145,7 +145,7 @@ class TrackResiduals : public SubsysReco
   float m_dcaxy = std::numeric_limits<float>::quiet_NaN();
   float m_dcaz = std::numeric_limits<float>::quiet_NaN();
 
-float m_silseedx = std::numeric_limits<float>::quiet_NaN();
+  float m_silseedx = std::numeric_limits<float>::quiet_NaN();
   float m_silseedy = std::numeric_limits<float>::quiet_NaN();
   float m_silseedz = std::numeric_limits<float>::quiet_NaN();
   float m_silseedpx = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/tpc/Makefile.am
+++ b/offline/packages/tpc/Makefile.am
@@ -46,6 +46,7 @@ pkginclude_HEADERS = \
   TpcCombinedRawDataUnpacker.h \
   TpcDistortionCorrection.h \
   TpcDistortionCorrectionContainer.h \
+  TpcGlobalPositionWrapper.h \
   TpcLoadDistortionCorrection.h \
   TpcMap.h \
   TpcRawWriter.h \
@@ -71,6 +72,7 @@ libtpc_la_SOURCES = \
   TpcClusterCleaner.cc \
   TpcClusterizer.cc \
   TpcCombinedRawDataUnpacker.cc \
+  TpcGlobalPositionWrapper.cc \
   TpcLoadDistortionCorrection.cc \
   TpcMap.cc \
   TpcRawWriter.cc \

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -1,0 +1,32 @@
+#include "TpcGlobalPositionWrapper.h"
+#include "TpcDistortionCorrection.h"
+#include "TpcDistortionCorrectionContainer.h"
+
+#include <trackbase/TpcDefs.h>
+#include <trackbase/TrkrCluster.h>
+
+Acts::Vector3 TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(const TrkrDefs::cluskey& key, TrkrCluster* cluster,
+                                                                   ActsGeometry* tGeometry, const short int& crossing, const TpcDistortionCorrectionContainer* staticCorrection,
+                                                                   const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection)
+{
+  TpcClusterZCrossingCorrection m_crossingCorrection;
+  TpcDistortionCorrection m_distortionCorrection;
+  Acts::Vector3 global = tGeometry->getGlobalPosition(key, cluster);
+  global[2] = m_crossingCorrection.correctZ(global.z(), TpcDefs::getSide(key), crossing);
+
+  // apply distortion corrections
+  if (staticCorrection)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, staticCorrection);
+  }
+  if (averageCorrection)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, averageCorrection);
+  }
+  if (fluctuationCorrection)
+  {
+    global = m_distortionCorrection.get_corrected_position(global, fluctuationCorrection);
+  }
+
+  return global;
+}

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -6,8 +6,8 @@
 #include <trackbase/TrkrCluster.h>
 
 Acts::Vector3 TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(const TrkrDefs::cluskey& key, TrkrCluster* cluster,
-                                                                   ActsGeometry* tGeometry, const short int& crossing, const TpcDistortionCorrectionContainer* staticCorrection,
-                                                                   const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection)
+                                                                             ActsGeometry* tGeometry, const short int& crossing, const TpcDistortionCorrectionContainer* staticCorrection,
+                                                                             const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection)
 {
   TpcClusterZCrossingCorrection m_crossingCorrection;
   TpcDistortionCorrection m_distortionCorrection;

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -1,0 +1,28 @@
+#ifndef TPC_TPCGLOBALPOSITIONWRAPPER_H
+#define TPC_TPCGLOBALPOSITIONWRAPPER_H
+
+/*
+ * \file TpcGlobalPositionWrapper.h
+ * \brief provides the tpc 3d global position with all distortion and crossing corrections applied
+ * \author Joe Osborn <josborn1@bnl.gov>
+ */
+#include "TpcClusterZCrossingCorrection.h"
+
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrDefs.h>
+#include <Acts/Definitions/Algebra.hpp>
+
+class TpcDistortionCorrection;
+class TpcDistortionCorrectionContainer;
+class TrkrCluster;
+
+class TpcGlobalPositionWrapper
+{
+    public:
+  static Acts::Vector3 getGlobalPositionDistortionCorrected(const TrkrDefs::cluskey& key, TrkrCluster* cluster, ActsGeometry* tGeometry, const short int& crossing,
+                                                  const TpcDistortionCorrectionContainer* staticCorrection, const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection);
+
+  
+};
+
+#endif

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -18,11 +18,9 @@ class TrkrCluster;
 
 class TpcGlobalPositionWrapper
 {
-    public:
+ public:
   static Acts::Vector3 getGlobalPositionDistortionCorrected(const TrkrDefs::cluskey& key, TrkrCluster* cluster, ActsGeometry* tGeometry, const short int& crossing,
-                                                  const TpcDistortionCorrectionContainer* staticCorrection, const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection);
-
-  
+                                                            const TpcDistortionCorrectionContainer* staticCorrection, const TpcDistortionCorrectionContainer* averageCorrection, const TpcDistortionCorrectionContainer* fluctuationCorrection);
 };
 
 #endif

--- a/offline/packages/trackreco/MakeSourceLinks.h
+++ b/offline/packages/trackreco/MakeSourceLinks.h
@@ -87,9 +87,6 @@ SourceLinkVec getSourceLinksClusterMover(
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   TpcClusterMover _clusterMover;
   
-  /// tpc distortion correction utility class
-  TpcDistortionCorrection _distortionCorrection;
-  
   ClusterErrorPara _ClusErrPara;
   
 

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -9,7 +9,7 @@
  */
 
 // Statements for if we want to save out the intermediary clustering steps
-#define _PHCASEEDING_CLUSTERLOG_TUPOUT_
+//#define _PHCASEEDING_CLUSTERLOG_TUPOUT_
 /* #define _PHCASEEDING_TIMER_OUT_ */
 
 #include "ALICEKF.h"


### PR DESCRIPTION
This introduces a wrapper class which applies the distortion corrections in one place when obtaining the global position of a tpc cluster. It leaves the other function alone so that we still have the ability to obtain only the uncorrected global position.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

