### PR TITLE
add isZS status getter and setter, and set it in the `calotowerbuilder`

### DIFF
--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -34,6 +34,8 @@ class TowerInfo : public PHObject
   virtual bool get_isNotInstr() const { return false; }
   virtual void set_isNoCalib(bool /*isNotInstr*/) { return; }
   virtual bool get_isNoCalib() const { return false; }
+  virtual void set_isZS(bool /*isZS*/) { return; }
+  virtual bool get_isZS() const { return false; }
   virtual bool get_isGood() const { return true; }
   virtual uint8_t get_status() const { return 0; }
   virtual void set_status(uint8_t /*status*/) { return; }

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -39,6 +39,9 @@ class TowerInfov2 : public TowerInfov1
   void set_isNoCalib(bool isNoCalib) override { set_status_bit(4, isNoCalib); }
   bool get_isNoCalib() const override { return get_status_bit(4); }
 
+  void set_isZS(bool isZS) override { set_status_bit(5, isZS); }
+  bool get_isZS() const override { return get_status_bit(5); }
+
   bool get_isGood() const override { return !((bool) _status); }
 
   uint8_t get_status() const override { return _status; }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -559,8 +559,16 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
     int n_samples = waveforms.at(i).size();
     if (n_samples == m_nzerosuppsamples)
     {
-      towerinfo->set_isNotInstr(true);
+      if(waveforms.at(i).at(0) == 0)
+      {
+        towerinfo->set_isNotInstr(true);
+      }
+      else
+      {
+        towerinfo->set_isZS(true);
+      }
     }
+    
     for (int j = 0; j < n_samples; j++)
     {
       towerinfo->set_waveform_value(j, waveforms.at(i).at(j));


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add ZS status getter(`get_isZS()` ) and setter ( `set_isZS(ZS)` ), and set it in `CaloTowerBuilder`, also the `isNotInstr` setting is obsolete and I updated it also ;)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

