### PR TITLE
Added dropping packets when clock difference does not match.

### DIFF
--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -96,7 +96,8 @@ int ClockDiffCheck::process_event(PHCompositeNode *topNode)
 	      CaloPacketContainer *container = findNode::getClass<CaloPacketContainer>(topNode, nodeiter);
 	      for (unsigned int i = 0; i < container->get_npackets(); i++)
 		{
-		  if (iter.first == container->getPacket(i)->getIdentifier())
+		  unsigned int packetID = container->getPacket(i)->getIdentifier();
+		  if (iter.first == packetID)
 		    {
 		      delete container->getPacket(i);
 		    }

--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -94,7 +94,7 @@ int ClockDiffCheck::process_event(PHCompositeNode *topNode)
 	  for (const auto &nodeiter : nodenames)
 	    {
 	      CaloPacketContainer *container = findNode::getClass<CaloPacketContainer>(topNode, nodeiter);
-	      for (unsigned int i = 0; i < container->get_npackets(i); i++)
+	      for (unsigned int i = 0; i < container->get_npackets(); i++)
 		{
 		  if (iter.first == container->getPacket(i)->getIdentifier())
 		    {

--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -91,6 +91,17 @@ int ClockDiffCheck::process_event(PHCompositeNode *topNode)
 	if ((refdiff&0xFFFFFFFFU) != (std::get<2>(iter.second)&0xFFFFFFFFU))
 	{
 	  static int nprint = 0;
+	  for (const auto &nodeiter : nodenames)
+	    {
+	      CaloPacketContainer *container = findNode::getClass<CaloPacketContainer>(topNode, nodeiter);
+	      for (unsigned int i = 0; i < container->get_npackets(i); i++)
+		{
+		  if (iter.first == container->getPacket(i)->getIdentifier())
+		    {
+		      delete container->getPacket(i);
+		    }
+		}
+	    }
 	  if (nprint < 1000 || Verbosity() > 1)
 	  {
 	    std::bitset<32> x(refdiff);

--- a/offline/framework/ffarawmodules/ClockDiffCheck.cc
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.cc
@@ -91,15 +91,18 @@ int ClockDiffCheck::process_event(PHCompositeNode *topNode)
 	if ((refdiff&0xFFFFFFFFU) != (std::get<2>(iter.second)&0xFFFFFFFFU))
 	{
 	  static int nprint = 0;
-	  for (const auto &nodeiter : nodenames)
+	  if (delBadPkts)
 	    {
-	      CaloPacketContainer *container = findNode::getClass<CaloPacketContainer>(topNode, nodeiter);
-	      for (unsigned int i = 0; i < container->get_npackets(); i++)
+	      for (const auto &nodeiter : nodenames)
 		{
-		  unsigned int packetID = container->getPacket(i)->getIdentifier();
-		  if (iter.first == packetID)
+		  CaloPacketContainer *container = findNode::getClass<CaloPacketContainer>(topNode, nodeiter);
+		  for (unsigned int i = 0; i < container->get_npackets(); i++)
 		    {
-		      delete container->getPacket(i);
+		      unsigned int packetID = container->getPacket(i)->getIdentifier();
+		      if (iter.first == packetID)
+			{
+			  delete container->getPacket(i);
+			}
 		    }
 		}
 	    }

--- a/offline/framework/ffarawmodules/ClockDiffCheck.h
+++ b/offline/framework/ffarawmodules/ClockDiffCheck.h
@@ -29,7 +29,18 @@ class ClockDiffCheck : public SubsysReco, public DumpPacket
   void FillCaloClockDiff(CaloPacketContainer *pktcont);
   void FillPacketDiff(OfflinePacket *pkt);
 
+  void set_delBadPkts(bool newDelBadPkts)
+  {
+    delBadPkts = newDelBadPkts;
+  }
+
+  bool get_delBadPkts()
+  {
+    return delBadPkts;
+  }
+  
  private:
+  bool delBadPkts = false;
   std::map<unsigned int, std::tuple<uint64_t, uint64_t, uint64_t, TH1 *, bool>> m_PacketStuffMap;
   /* std::string m_EvtNodeName = "CLOCKDIFFRAWHIT"; */
   /* std::set<uint64_t> bclk_seen; */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This change drops packets in ClockDiffCheck.cc when the clock difference of a given packet does not match the GL1 packet. Note that this will cause productions to fail as soon as the GL1 is out of sync - this is a stopgap before the event combiner can be fixed.
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

