### PR TITLE
stopgap measure, drop first gl1 event to stay in sync with triggered …

### DIFF
--- a/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
@@ -78,6 +78,12 @@ void SingleGl1TriggerInput::FillPool(const unsigned int /*nbclks*/)
       m_NumSpecialEvents++;
       continue;
     }
+    static bool firstevent = true;
+    if (firstevent)
+    {
+      firstevent = false;
+      continue;
+    }
     int EventSequence = evt->getEvtSequence();
     Packet *packet = evt->getPacket(14001);
 


### PR DESCRIPTION
…systems

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR drops the first event from the gl1 input for the triggered readout. We seem to have an additional event (or the calos drop the first event) so we are out of sync right off the start. This is just a stopgap to fix this until we come with a general solution for those pesky event misalignments

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

