### PR TITLE
adding configurable tower prefix to jet reco

### DIFF
--- a/offline/packages/jetbackground/CopyAndSubtractJets.cc
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.cc
@@ -59,9 +59,27 @@ int CopyAndSubtractJets::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosOH3 = nullptr;
   if (m_use_towerinfo)
   {
-    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
-    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+    EMTowerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    IHTowerName = m_towerNodePrefix + "_HCALIN";
+    OHTowerName = m_towerNodePrefix + "_HCALOUT";
+    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
+    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
+    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, OHTowerName);
+    if(!towerinfosEM3)
+    {
+      std::cout << "CopyAndSubtractJets::process_event: Cannot find node "<<EMTowerName<<std::endl;
+      exit(1);
+    }
+    if(!towerinfosIH3)
+    {
+      std::cout << "CopyAndSubtractJets::process_event: Cannot find node "<<IHTowerName<<std::endl;
+      exit(1);
+    }
+    if(!towerinfosOH3)
+    {
+      std::cout << "CopyAndSubtractJets::process_event: Cannot find node "<<OHTowerName<<std::endl;
+      exit(1);
+    }
   }
   else
   {

--- a/offline/packages/jetbackground/CopyAndSubtractJets.h
+++ b/offline/packages/jetbackground/CopyAndSubtractJets.h
@@ -38,12 +38,21 @@ class CopyAndSubtractJets : public SubsysReco
   {
     m_use_towerinfo = use_towerinfo;
   }
+  void set_towerNodePrefix(const std::string &prefix)
+  {
+    m_towerNodePrefix = prefix;
+    return;
+  }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
 
   bool _use_flow_modulation{false};
   bool m_use_towerinfo{false};
+  std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
+  std::string EMTowerName;
+  std::string IHTowerName;
+  std::string OHTowerName;
 };
 
 #endif

--- a/offline/packages/jetbackground/DetermineTowerBackground.cc
+++ b/offline/packages/jetbackground/DetermineTowerBackground.cc
@@ -85,9 +85,27 @@ int DetermineTowerBackground::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosOH3 = nullptr;
   if (m_use_towerinfo)
   {
-    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
-    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+    EMTowerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    IHTowerName = m_towerNodePrefix + "_HCALIN";
+    OHTowerName = m_towerNodePrefix + "_HCALOUT";
+    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
+    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
+    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, OHTowerName);
+    if(!towerinfosEM3)
+    {
+      std::cout << "DetermineTowerBackground::process_event: Cannot find node "<<EMTowerName<<std::endl;
+      exit(1);
+    }
+    if(!towerinfosIH3)
+    {
+      std::cout << "DetermineTowerBackground::process_event: Cannot find node "<<IHTowerName<<std::endl;
+      exit(1);
+    }
+    if(!towerinfosOH3)
+    {
+      std::cout << "DetermineTowerBackground::process_event: Cannot find node "<<OHTowerName<<std::endl;
+      exit(1);
+    }
   }
   else
   {

--- a/offline/packages/jetbackground/DetermineTowerBackground.h
+++ b/offline/packages/jetbackground/DetermineTowerBackground.h
@@ -44,6 +44,11 @@ class DetermineTowerBackground : public SubsysReco
   {
     m_use_towerinfo = use_towerinfo;
   }
+  void set_towerNodePrefix(const std::string &prefix)
+  {
+    m_towerNodePrefix = prefix;
+    return;
+  }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
@@ -85,6 +90,11 @@ class DetermineTowerBackground : public SubsysReco
   Jet::PROPERTY _index_SeedItr{};
 
   bool m_use_towerinfo{false};
+
+  std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
+  std::string EMTowerName;
+  std::string IHTowerName;
+  std::string OHTowerName;
 };
 
 #endif

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -51,7 +51,13 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfosEM3 = nullptr;
   if (m_use_towerinfo)
   {
-    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC");
+    EMTowerName = m_towerNodePrefix + "_CEMC";
+    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
+    if(!towerinfosEM3)
+    {
+      std::cout << "RetowerCEMC::process_event: Cannot find node "<<EMTowerName<<std::endl;
+      exit(1);
+    }
   }
   else
   {
@@ -229,10 +235,11 @@ int RetowerCEMC::process_event(PHCompositeNode *topNode)
 
   if (m_use_towerinfo)
   {
-    TowerInfoContainer *emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+    EMRetowerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    TowerInfoContainer *emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, EMRetowerName);
     if (Verbosity() > 0)
     {
-      std::cout << "RetowerCEMC::process_event: filling TOWERINFO_CALIB_CEMC_RETOWER node" << std::endl;
+      std::cout << "RetowerCEMC::process_event: filling "<<EMRetowerName<<" node" << std::endl;
     }
     // create new towers
     for (int eta = 0; eta < _NETA; eta++)
@@ -310,22 +317,24 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
 
   if (m_use_towerinfo)
   {
-    TowerInfoContainer *test_emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-    TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+    EMRetowerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    IHTowerName = m_towerNodePrefix + "_HCALIN";
+    TowerInfoContainer *test_emcal_retower = findNode::getClass<TowerInfoContainer>(topNode, EMRetowerName);
+    TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
     if (!test_emcal_retower)
     {
       if (Verbosity() > 0)
       {
-        std::cout << "RetowerCEMC::CreateNode : creating TOWERINFO_CALIB_CEMC_RETOWER node " << std::endl;
+        std::cout << "RetowerCEMC::CreateNode : creating "<<EMRetowerName<<" node " << std::endl;
       }
 
       TowerInfoContainer *emcal_retower = dynamic_cast<TowerInfoContainer *>(hcal_towers->CloneMe());
-      PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_retower, "TOWERINFO_CALIB_CEMC_RETOWER", "PHObject");
+      PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_retower, EMRetowerName, "PHObject");
       emcalNode->addNode(emcalTowerNode);
     }
     else
     {
-      std::cout << "RetowerCEMC::CreateNode : TOWERINFO_CALIB_CEMC_RETOWER already exists! " << std::endl;
+      std::cout << "RetowerCEMC::CreateNode : "<<EMRetowerName<<" already exists! " << std::endl;
     }
   }
   else

--- a/offline/packages/jetbackground/RetowerCEMC.h
+++ b/offline/packages/jetbackground/RetowerCEMC.h
@@ -40,6 +40,11 @@ class RetowerCEMC : public SubsysReco
   {
     _FRAC_CUT = frac_cut;
   }
+  void set_towerNodePrefix(const std::string &prefix)
+  {
+    m_towerNodePrefix = prefix;
+    return;
+  }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
@@ -52,6 +57,10 @@ class RetowerCEMC : public SubsysReco
   std::vector<std::vector<int> > _EMCAL_RETOWER_T;
   std::vector<std::vector<float> > _EMCAL_RETOWER_MASKED_A;
   std::vector<std::vector<float> > _EMCAL_RETOWER_TOTAL_A;
+  std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
+  std::string EMTowerName;
+  std::string IHTowerName;
+  std::string EMRetowerName;
 };
 
 #endif

--- a/offline/packages/jetbackground/SubtractTowers.cc
+++ b/offline/packages/jetbackground/SubtractTowers.cc
@@ -61,15 +61,18 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
 
   if (m_use_towerinfo)
   {
-    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
-    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
-    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+    EMTowerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    IHTowerName = m_towerNodePrefix + "_HCALIN";
+    OHTowerName = m_towerNodePrefix + "_HCALOUT";
+    towerinfosEM3 = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
+    towerinfosIH3 = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
+    towerinfosOH3 = findNode::getClass<TowerInfoContainer>(topNode, OHTowerName);
 
     if (Verbosity() > 0)
     {
-      std::cout << "SubtractTowers::process_event: " << towerinfosEM3->size() << " TOWER_CALIB_CEMC_RETOWER towers" << std::endl;
-      std::cout << "SubtractTowers::process_event: " << towerinfosIH3->size() << " TOWER_CALIB_HCALIN towers" << std::endl;
-      std::cout << "SubtractTowers::process_event: " << towerinfosOH3->size() << " TOWER_CALIB_HCALOUT towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: " << towerinfosEM3->size() << EMTowerName << " towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: " << towerinfosIH3->size() << IHTowerName << " towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: " << towerinfosOH3->size() << OHTowerName << " towers" << std::endl;
     }
   }
   else
@@ -98,15 +101,18 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *ohcal_towerinfos = nullptr;
   if (m_use_towerinfo)
   {
-    emcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
-    ihcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
-    ohcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+    EMTowerName = m_towerNodePrefix + "_CEMC_RETOWER_SUB1";
+    IHTowerName = m_towerNodePrefix + "_HCALIN_SUB1";
+    OHTowerName = m_towerNodePrefix + "_HCALOUT_SUB1";
+    emcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
+    ihcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
+    ohcal_towerinfos = findNode::getClass<TowerInfoContainer>(topNode, OHTowerName);
   }
   if (Verbosity() > 0)
   {
-    std::cout << "SubtractTowers::process_event: starting with " << emcal_towerinfos->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
-    std::cout << "SubtractTowers::process_event: starting with " << ihcal_towerinfos->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
-    std::cout << "SubtractTowers::process_event: starting with " << ohcal_towerinfos->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: starting with " << emcal_towerinfos->size() << EMTowerName<<" towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: starting with " << ihcal_towerinfos->size() << IHTowerName<<" towers" << std::endl;
+    std::cout << "SubtractTowers::process_event: starting with " << ohcal_towerinfos->size() << OHTowerName<<" towers" << std::endl;
   }
 
   else
@@ -405,9 +411,9 @@ int SubtractTowers::process_event(PHCompositeNode *topNode)
     }
     else
     {
-      std::cout << "SubtractTowers::process_event: ending with " << emcal_towerinfos->size() << " TOWER_CALIB_CEMC_RETOWER_SUB1 towers" << std::endl;
-      std::cout << "SubtractTowers::process_event: ending with " << ihcal_towerinfos->size() << " TOWER_CALIB_HCALIN_SUB1 towers" << std::endl;
-      std::cout << "SubtractTowers::process_event: ending with " << ohcal_towerinfos->size() << " TOWER_CALIB_HCALOUT_SUB1 towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: ending with " << emcal_towerinfos->size() << m_towerNodePrefix << "_CEMC_RETOWER_SUB1 towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: ending with " << ihcal_towerinfos->size() << m_towerNodePrefix << "_HCALIN_SUB1 towers" << std::endl;
+      std::cout << "SubtractTowers::process_event: ending with " << ohcal_towerinfos->size() << m_towerNodePrefix << "_HCALOUT_SUB1 towers" << std::endl;
     }
   }
 
@@ -431,10 +437,11 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+  IHTowerName = m_towerNodePrefix + "_HCALIN";
+  TowerInfoContainer *hcal_towers = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
   if (m_use_towerinfo && !hcal_towers)
   {
-    std::cout << PHWHERE << "Cannot find TOWERINFO_CALIB_HCALIN for creating new tower containers. Exiting" << std::endl;
+    std::cout << PHWHERE << "Cannot find " << IHTowerName << " for creating new tower containers. Exiting" << std::endl;
     exit(1);
   }
 
@@ -447,21 +454,22 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   }
   if (m_use_towerinfo)
   {
-    TowerInfoContainer *test_emcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
+    EMTowerName = m_towerNodePrefix + "_CEMC_RETOWER_SUB1";
+    TowerInfoContainer *test_emcal_tower = findNode::getClass<TowerInfoContainer>(topNode, EMTowerName);
     if (!test_emcal_tower)
     {
       if (Verbosity() > 0)
       {
-        std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_CEMC_RETOWER_SUB1 node " << std::endl;
+        std::cout << "SubtractTowers::CreateNode : creating " << EMTowerName << " node " << std::endl;
       }
 
       TowerInfoContainer *emcal_towers = dynamic_cast<TowerInfoContainer *>(hcal_towers->CloneMe());
-      PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_towers, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1", "PHObject");
+      PHIODataNode<PHObject> *emcalTowerNode = new PHIODataNode<PHObject>(emcal_towers, EMTowerName, "PHObject");
       emcalNode->addNode(emcalTowerNode);
     }
     else
     {
-      std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_CEMC_RETOWER_SUB1 already exists! " << std::endl;
+      std::cout << "SubtractTowers::CreateNode : " << EMTowerName << " already exists! " << std::endl;
     }
   }
   else
@@ -492,21 +500,22 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   }
   if (m_use_towerinfo)
   {
-    TowerInfoContainer *test_ihcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
+    IHTowerName = m_towerNodePrefix + "_HCALIN_SUB1";
+    TowerInfoContainer *test_ihcal_tower = findNode::getClass<TowerInfoContainer>(topNode, IHTowerName);
     if (!test_ihcal_tower)
     {
       if (Verbosity() > 0)
       {
-        std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_HCALIN_SUB1 node " << std::endl;
+        std::cout << "SubtractTowers::CreateNode : creating " << IHTowerName <<" node " << std::endl;
       }
 
       TowerInfoContainer *ihcal_towers = dynamic_cast<TowerInfoContainer *>(hcal_towers->CloneMe());
-      PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(ihcal_towers, "TOWERINFO_CALIB_HCALIN_SUB1", "PHObject");
+      PHIODataNode<PHObject> *ihcalTowerNode = new PHIODataNode<PHObject>(ihcal_towers, IHTowerName, "PHObject");
       ihcalNode->addNode(ihcalTowerNode);
     }
     else
     {
-      std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_HCALIN_SUB1 already exists! " << std::endl;
+      std::cout << "SubtractTowers::CreateNode : " << IHTowerName << " already exists! " << std::endl;
     }
   }
   else
@@ -537,21 +546,22 @@ int SubtractTowers::CreateNode(PHCompositeNode *topNode)
   }
   if (m_use_towerinfo)
   {
-    TowerInfoContainer *test_ohcal_tower = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+    OHTowerName = m_towerNodePrefix + "_HCALOUT_SUB1";
+    TowerInfoContainer *test_ohcal_tower = findNode::getClass<TowerInfoContainer>(topNode, OHTowerName);
     if (!test_ohcal_tower)
     {
       if (Verbosity() > 0)
       {
-        std::cout << "SubtractTowers::CreateNode : creating TOWERINFO_CALIB_HCALOUT_SUB1 node " << std::endl;
+        std::cout << "SubtractTowers::CreateNode : creating " << OHTowerName << " node " << std::endl;
       }
 
       TowerInfoContainer *ohcal_towers = dynamic_cast<TowerInfoContainer *>(hcal_towers->CloneMe());
-      PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(ohcal_towers, "TOWERINFO_CALIB_HCALOUT_SUB1", "PHObject");
+      PHIODataNode<PHObject> *ohcalTowerNode = new PHIODataNode<PHObject>(ohcal_towers, OHTowerName, "PHObject");
       ohcalNode->addNode(ohcalTowerNode);
     }
     else
     {
-      std::cout << "SubtractTowers::CreateNode : TOWER_CALIB_HCALOUT_SUB1 already exists! " << std::endl;
+      std::cout << "SubtractTowers::CreateNode : " << OHTowerName << " already exists! " << std::endl;
     }
   }
   else

--- a/offline/packages/jetbackground/SubtractTowers.h
+++ b/offline/packages/jetbackground/SubtractTowers.h
@@ -36,12 +36,21 @@ class SubtractTowers : public SubsysReco
   {
     m_use_towerinfo = use_towerinfo;
   }
+  void set_towerNodePrefix(const std::string &prefix)
+  {
+    m_towerNodePrefix = prefix;
+    return;
+  }
 
  private:
   int CreateNode(PHCompositeNode *topNode);
 
   bool m_use_towerinfo{false};
   bool _use_flow_modulation{false};
+  std::string m_towerNodePrefix{"TOWERINFO_CALIB"};
+  std::string EMTowerName;
+  std::string IHTowerName;
+  std::string OHTowerName;
 };
 
 #endif

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -5,11 +5,11 @@
 
 #include <calobase/RawTower.h>
 #include <calobase/RawTowerContainer.h>
-#include <calobase/TowerInfo.h>
-#include <calobase/TowerInfoContainer.h>
-#include <calobase/RawTowerDefs.h>           // for encode_towerid
+#include <calobase/RawTowerDefs.h>  // for encode_towerid
 #include <calobase/RawTowerGeom.h>
 #include <calobase/RawTowerGeomContainer.h>
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
 
@@ -23,8 +23,8 @@
 #include <vector>
 
 TowerJetInput::TowerJetInput(Jet::SRC input, std::string prefix)
-: m_input(input),
-  m_towerNodePrefix(prefix)
+  : m_input(input)
+  , m_towerNodePrefix(std::move(prefix))
 {
 }
 
@@ -60,7 +60,8 @@ void TowerJetInput::identify(std::ostream &os)
 
 std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 {
-  if (Verbosity() > 0) std::cout << "TowerJetInput::process_event -- entered" << std::endl;
+  if (Verbosity() > 0) { std::cout << "TowerJetInput::process_event -- entered" << std::endl;
+}
 
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
@@ -80,29 +81,29 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
   /* std::string name =(m_input == Jet::CEMC_TOWER ? "CEMC_TOWER" */
   /*                        : m_input == Jet::CEMC_TOWERINFO ? "CEMC_TOWERINFO" */
-  /*                        : m_input == Jet::EEMC_TOWER ? "Jet::EEMC_TOWER" */ 
-  /*                        : m_input == Jet::HCALIN_TOWER ? "Jet::HCALIN_TOWER" */ 
-  /*                        : m_input == Jet::HCALIN_TOWERINFO ? "Jet::HCALIN_TOWERINFO" */ 
-  /*                        : m_input == Jet::HCALOUT_TOWER ? "Jet::HCALOUT_TOWER" */ 
-  /*                        : m_input == Jet::HCALOUT_TOWERINFO ? "Jet::HCALOUT_TOWERINFO" */ 
-  /*                        : m_input == Jet::FEMC_TOWER ? "Jet::FEMC_TOWER" */ 
-  /*                        : m_input == Jet::FHCAL_TOWER ? "Jet::FHCAL_TOWER" */ 
-  /*                        : m_input == Jet::CEMC_TOWER_RETOWER ? "Jet::CEMC_TOWER_RETOWER" */ 
-  /*                        : m_input == Jet::CEMC_TOWERINFO_RETOWER ? "Jet::CEMC_TOWERINFO_RETOWER" */ 
-  /*                        : m_input == Jet::CEMC_TOWER_SUB1 ? "Jet::CEMC_TOWER_SUB1" */ 
-  /*                        : m_input == Jet::CEMC_TOWERINFO_SUB1 ? "Jet::CEMC_TOWERINFO_SUB1" */ 
-  /*                        : m_input == Jet::HCALIN_TOWER_SUB1 ? "Jet::HCALIN_TOWER_SUB1" */ 
-  /*                        : m_input == Jet::HCALIN_TOWERINFO_SUB1 ? "Jet::HCALIN_TOWERINFO_SUB1" */ 
-  /*                        : m_input == Jet::HCALOUT_TOWER_SUB1 ? "Jet::HCALOUT_TOWER_SUB1" */ 
-  /*                        : m_input == Jet::HCALOUT_TOWERINFO_SUB1 ? "Jet::HCALOUT_TOWERINFO_SUB1" */ 
-  /*                        : m_input == Jet::CEMC_TOWER_SUB1CS ? "Jet::CEMC_TOWER_SUB1CS" */ 
-  /*                        : m_input == Jet::HCALIN_TOWER_SUB1CS ? "Jet::HCALIN_TOWER_SUB1CS" */ 
+  /*                        : m_input == Jet::EEMC_TOWER ? "Jet::EEMC_TOWER" */
+  /*                        : m_input == Jet::HCALIN_TOWER ? "Jet::HCALIN_TOWER" */
+  /*                        : m_input == Jet::HCALIN_TOWERINFO ? "Jet::HCALIN_TOWERINFO" */
+  /*                        : m_input == Jet::HCALOUT_TOWER ? "Jet::HCALOUT_TOWER" */
+  /*                        : m_input == Jet::HCALOUT_TOWERINFO ? "Jet::HCALOUT_TOWERINFO" */
+  /*                        : m_input == Jet::FEMC_TOWER ? "Jet::FEMC_TOWER" */
+  /*                        : m_input == Jet::FHCAL_TOWER ? "Jet::FHCAL_TOWER" */
+  /*                        : m_input == Jet::CEMC_TOWER_RETOWER ? "Jet::CEMC_TOWER_RETOWER" */
+  /*                        : m_input == Jet::CEMC_TOWERINFO_RETOWER ? "Jet::CEMC_TOWERINFO_RETOWER" */
+  /*                        : m_input == Jet::CEMC_TOWER_SUB1 ? "Jet::CEMC_TOWER_SUB1" */
+  /*                        : m_input == Jet::CEMC_TOWERINFO_SUB1 ? "Jet::CEMC_TOWERINFO_SUB1" */
+  /*                        : m_input == Jet::HCALIN_TOWER_SUB1 ? "Jet::HCALIN_TOWER_SUB1" */
+  /*                        : m_input == Jet::HCALIN_TOWERINFO_SUB1 ? "Jet::HCALIN_TOWERINFO_SUB1" */
+  /*                        : m_input == Jet::HCALOUT_TOWER_SUB1 ? "Jet::HCALOUT_TOWER_SUB1" */
+  /*                        : m_input == Jet::HCALOUT_TOWERINFO_SUB1 ? "Jet::HCALOUT_TOWERINFO_SUB1" */
+  /*                        : m_input == Jet::CEMC_TOWER_SUB1CS ? "Jet::CEMC_TOWER_SUB1CS" */
+  /*                        : m_input == Jet::HCALIN_TOWER_SUB1CS ? "Jet::HCALIN_TOWER_SUB1CS" */
   /*                        : m_input == Jet::HCALOUT_TOWER_SUB1CS ? "Jet::HCALOUT_TOWER_SUB1CS" */
   /*                        : "NO NAME"); */
   /* std::cout << " TowerJetInput (" << name << ")" << std::endl; */
 
   RawTowerContainer *towers = nullptr;
-  TowerInfoContainer *towerinfos = nullptr; 
+  TowerInfoContainer *towerinfos = nullptr;
   RawTowerGeomContainer *geom = nullptr;
   if (m_input == Jet::CEMC_TOWER)
   {
@@ -121,9 +122,9 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::CEMC_TOWERINFO_EMBED)
   {
@@ -133,9 +134,9 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::CEMC_TOWERINFO_SIM)
   {
@@ -145,40 +146,40 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::EEMC_TOWER)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_EEMC");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_EEMC");
+    if ((!towers && !towerinfos) || !geom)
     {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_EEMC");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_EEMC");
-      if ((!towers && !towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALIN_TOWER)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towers) || !geom)
     {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALIN_TOWERINFO)
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_HCALIN";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towerinfos) || !geom)
     {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_HCALIN";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALIN_TOWERINFO_EMBED)
   {
     m_use_towerinfo = true;
@@ -187,9 +188,9 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
     geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::HCALIN_TOWERINFO_SIM)
   {
@@ -199,31 +200,31 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
     geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::HCALOUT_TOWER)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    if ((!towers) || !geom)
     {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALOUT_TOWERINFO)
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_HCALOUT";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    if ((!towerinfos) || !geom)
     {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_HCALOUT";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALOUT_TOWERINFO_EMBED)
   {
     m_use_towerinfo = true;
@@ -232,9 +233,9 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
     geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
   else if (m_input == Jet::HCALOUT_TOWERINFO_SIM)
   {
@@ -244,21 +245,20 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
     geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
     if ((!towerinfos) || !geom)
-      {
-	return std::vector<Jet *>();
-      }
+    {
+      return std::vector<Jet *>();
+    }
   }
 
-
   else if (m_input == Jet::FEMC_TOWER)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_FEMC");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_FEMC");
+    if ((!towers) || !geom)
     {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_FEMC");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_FEMC");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::FHCAL_TOWER)
   {
     towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_FHCAL");
@@ -278,17 +278,17 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
   }
   else if (m_input == Jet::CEMC_TOWERINFO_RETOWER)
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_CEMC_RETOWER";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towerinfos) || !geom)
     {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_CEMC_RETOWER";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::CEMC_TOWER_SUB1)
   {
     towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER_SUB1");
@@ -299,19 +299,19 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
   }
   else if (m_input == Jet::CEMC_TOWERINFO_SUB1)
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_CEMC_RETOWER_SUB1";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towerinfos) || !geom)
     {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_CEMC_RETOWER_SUB1";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALIN_TOWER_SUB1)
-  {  
+  {
     towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN_SUB1");
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
     if ((!towers) || !geom)
@@ -320,17 +320,17 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
   }
   else if (m_input == Jet::HCALIN_TOWERINFO_SUB1)
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_HCALIN_SUB1";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towerinfos) || !geom)
     {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_HCALIN_SUB1";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
+      return std::vector<Jet *>();
     }
+  }
   else if (m_input == Jet::HCALOUT_TOWER_SUB1)
   {
     towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT_SUB1");
@@ -341,48 +341,48 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
   }
   else if (m_input == Jet::HCALOUT_TOWERINFO_SUB1)
-    {
-      m_use_towerinfo = true;
-      towerName = m_towerNodePrefix + "_HCALOUT_SUB1";
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
-      geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
-      if ((!towerinfos) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
-    }
-  else if (m_input == Jet::CEMC_TOWER_SUB1CS)
-    {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER_SUB1CS");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
-    }
-  else if (m_input == Jet::HCALIN_TOWER_SUB1CS)
-    {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN_SUB1CS");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
-    }
-  else if (m_input == Jet::HCALOUT_TOWER_SUB1CS)
-    {
-      towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT_SUB1CS");
-      geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
-      if ((!towers) || !geom)
-	{
-	  return std::vector<Jet *>();
-	}
-    }
-  else
+  {
+    m_use_towerinfo = true;
+    towerName = m_towerNodePrefix + "_HCALOUT_SUB1";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
+    geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    if ((!towerinfos) || !geom)
     {
       return std::vector<Jet *>();
     }
+  }
+  else if (m_input == Jet::CEMC_TOWER_SUB1CS)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_CEMC_RETOWER_SUB1CS");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towers) || !geom)
+    {
+      return std::vector<Jet *>();
+    }
+  }
+  else if (m_input == Jet::HCALIN_TOWER_SUB1CS)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALIN_SUB1CS");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
+    if ((!towers) || !geom)
+    {
+      return std::vector<Jet *>();
+    }
+  }
+  else if (m_input == Jet::HCALOUT_TOWER_SUB1CS)
+  {
+    towers = findNode::getClass<RawTowerContainer>(topNode, "TOWER_CALIB_HCALOUT_SUB1CS");
+    geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
+    if ((!towers) || !geom)
+    {
+      return std::vector<Jet *>();
+    }
+  }
+  else
+  {
+    return std::vector<Jet *>();
+  }
 
   // first grab the event vertex or bail
   GlobalVertex *vtx = vertexmap->begin()->second;
@@ -411,79 +411,82 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
   std::vector<Jet *> pseudojets;
   if (m_use_towerinfo)
+  {
+    if (!towerinfos)
     {
-      if (!towerinfos)
-	{
-	  return std::vector<Jet *>();
-	}
-
-      unsigned int nchannels = towerinfos->size();
-      for (unsigned int channel = 0; channel < nchannels;channel++)
-	{
-	  TowerInfo *tower = towerinfos->get_tower_at_channel(channel);
-	  assert(tower);
-
-	  unsigned int calokey = towerinfos->encode_key(channel);
-	  int ieta = towerinfos->getTowerEtaBin(calokey);
-	  int iphi = towerinfos->getTowerPhiBin(calokey);
-	  const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(geocaloid, ieta, iphi);
-	  //skip masked towers
-	  if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2()) continue;
-	  if(std::isnan(tower->get_energy())) continue;
-	  RawTowerGeom *tower_geom = geom->get_tower_geometry(key);
-	  assert(tower_geom);
-
-	  double r = tower_geom->get_center_radius();
-	  double phi = atan2(tower_geom->get_center_y(), tower_geom->get_center_x());
-	  double z0 = tower_geom->get_center_z();
-	  double z = z0 - vtxz;
-	  double eta = asinh(z / r);  // eta after shift from vertex
-	  double pt = tower->get_energy() / cosh(eta);
-	  double e = tower->get_energy();
-	  double px = pt * cos(phi);
-	  double py = pt * sin(phi);
-	  double pz = pt * sinh(eta);
-
-	  Jet *jet = new Jetv2();
-	  jet->set_px(px);
-	  jet->set_py(py);
-	  jet->set_pz(pz);
-	  jet->set_e(e);
-	  jet->insert_comp(m_input,channel);
-	  pseudojets.push_back(jet);
-	}
+      return std::vector<Jet *>();
     }
+
+    unsigned int nchannels = towerinfos->size();
+    for (unsigned int channel = 0; channel < nchannels; channel++)
+    {
+      TowerInfo *tower = towerinfos->get_tower_at_channel(channel);
+      assert(tower);
+
+      unsigned int calokey = towerinfos->encode_key(channel);
+      int ieta = towerinfos->getTowerEtaBin(calokey);
+      int iphi = towerinfos->getTowerPhiBin(calokey);
+      const RawTowerDefs::keytype key = RawTowerDefs::encode_towerid(geocaloid, ieta, iphi);
+      // skip masked towers
+      if (tower->get_isHot() || tower->get_isNoCalib() || tower->get_isNotInstr() || tower->get_isBadChi2()) { continue;
+}
+      if (std::isnan(tower->get_energy())) { continue;
+}
+      RawTowerGeom *tower_geom = geom->get_tower_geometry(key);
+      assert(tower_geom);
+
+      double r = tower_geom->get_center_radius();
+      double phi = atan2(tower_geom->get_center_y(), tower_geom->get_center_x());
+      double z0 = tower_geom->get_center_z();
+      double z = z0 - vtxz;
+      double eta = asinh(z / r);  // eta after shift from vertex
+      double pt = tower->get_energy() / cosh(eta);
+      double e = tower->get_energy();
+      double px = pt * cos(phi);
+      double py = pt * sin(phi);
+      double pz = pt * sinh(eta);
+
+      Jet *jet = new Jetv2();
+      jet->set_px(px);
+      jet->set_py(py);
+      jet->set_pz(pz);
+      jet->set_e(e);
+      jet->insert_comp(m_input, channel);
+      pseudojets.push_back(jet);
+    }
+  }
   else
+  {
+    RawTowerContainer::ConstRange begin_end = towers->getTowers();
+    RawTowerContainer::ConstIterator rtiter;
+    for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
     {
-      RawTowerContainer::ConstRange begin_end = towers->getTowers();
-      RawTowerContainer::ConstIterator rtiter;
-      for (rtiter = begin_end.first; rtiter != begin_end.second; ++rtiter)
-	{
-	  RawTower *tower = rtiter->second;
-	  
-	  RawTowerGeom *tower_geom = geom->get_tower_geometry(tower->get_key());
-	  assert(tower_geom);
-	  
-	  double r = tower_geom->get_center_radius();
-	  double phi = atan2(tower_geom->get_center_y(), tower_geom->get_center_x());
-	  double z0 = tower_geom->get_center_z();
-	  double z = z0 - vtxz;
-	  double eta = asinh(z / r);  // eta after shift from vertex
-	  double pt = tower->get_energy() / cosh(eta);
-	  double px = pt * cos(phi);
-	  double py = pt * sin(phi);
-	  double pz = pt * sinh(eta);
-	  
-	  Jet *jet = new Jetv2();
-	  jet->set_px(px);
-	  jet->set_py(py);
-	  jet->set_pz(pz);
-	  jet->set_e(tower->get_energy());
-	  jet->insert_comp(m_input, tower->get_id());
-	  pseudojets.push_back(jet);
-	}
+      RawTower *tower = rtiter->second;
+
+      RawTowerGeom *tower_geom = geom->get_tower_geometry(tower->get_key());
+      assert(tower_geom);
+
+      double r = tower_geom->get_center_radius();
+      double phi = atan2(tower_geom->get_center_y(), tower_geom->get_center_x());
+      double z0 = tower_geom->get_center_z();
+      double z = z0 - vtxz;
+      double eta = asinh(z / r);  // eta after shift from vertex
+      double pt = tower->get_energy() / cosh(eta);
+      double px = pt * cos(phi);
+      double py = pt * sin(phi);
+      double pz = pt * sinh(eta);
+
+      Jet *jet = new Jetv2();
+      jet->set_px(px);
+      jet->set_py(py);
+      jet->set_pz(pz);
+      jet->set_e(tower->get_energy());
+      jet->insert_comp(m_input, tower->get_id());
+      pseudojets.push_back(jet);
     }
-  if (Verbosity() > 0) std::cout << "TowerJetInput::process_event -- exited" << std::endl;
+  }
+  if (Verbosity() > 0) { std::cout << "TowerJetInput::process_event -- exited" << std::endl;
+}
 
   return pseudojets;
 }

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -22,8 +22,9 @@
 #include <utility>  // for pair
 #include <vector>
 
-TowerJetInput::TowerJetInput(Jet::SRC input)
-  : m_input(input)
+TowerJetInput::TowerJetInput(Jet::SRC input, std::string prefix)
+: m_input(input),
+  m_towerNodePrefix(prefix)
 {
 }
 
@@ -115,7 +116,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC");
+    towerName = m_towerNodePrefix + "_CEMC";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
@@ -126,7 +128,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_EMBED)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_CEMC");
+    towerName = m_towerNodePrefix + "_EMBED_CEMC";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
@@ -137,7 +140,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_SIM)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_CEMC");
+    towerName = m_towerNodePrefix + "_SIM_CEMC";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     geocaloid = RawTowerDefs::CalorimeterId::CEMC;
     if ((!towerinfos) || !geom)
@@ -166,7 +170,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN");
+      towerName = m_towerNodePrefix + "_HCALIN";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -177,7 +182,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO_EMBED)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_HCALIN");
+    towerName = m_towerNodePrefix + "_EMBED_HCALIN";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
     geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
     if ((!towerinfos) || !geom)
@@ -188,7 +194,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO_SIM)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_HCALIN");
+    towerName = m_towerNodePrefix + "_SIM_HCALIN";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
     geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
     if ((!towerinfos) || !geom)
@@ -208,7 +215,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT");
+      towerName = m_towerNodePrefix + "_HCALOUT";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
       if ((!towerinfos) || !geom)
@@ -219,7 +227,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO_EMBED)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_EMBED_HCALOUT");
+    towerName = m_towerNodePrefix + "_EMBED_HCALOUT";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
     geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
     if ((!towerinfos) || !geom)
@@ -230,7 +239,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO_SIM)
   {
     m_use_towerinfo = true;
-    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SIM_HCALOUT");
+    towerName = m_towerNodePrefix + "_SIM_HCALOUT";
+    towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
     geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
     geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
     if ((!towerinfos) || !geom)
@@ -270,7 +280,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_RETOWER)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER");
+      towerName = m_towerNodePrefix + "_CEMC_RETOWER";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -290,7 +301,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::CEMC_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC_RETOWER_SUB1");
+      towerName = m_towerNodePrefix + "_CEMC_RETOWER_SUB1";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -310,7 +322,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALIN_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALIN_SUB1");
+      towerName = m_towerNodePrefix + "_HCALIN_SUB1";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALIN;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALIN");
       if ((!towerinfos) || !geom)
@@ -330,7 +343,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   else if (m_input == Jet::HCALOUT_TOWERINFO_SUB1)
     {
       m_use_towerinfo = true;
-      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_HCALOUT_SUB1");
+      towerName = m_towerNodePrefix + "_HCALOUT_SUB1";
+      towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerName);
       geocaloid = RawTowerDefs::CalorimeterId::HCALOUT;
       geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_HCALOUT");
       if ((!towerinfos) || !geom)

--- a/offline/packages/jetbase/TowerJetInput.h
+++ b/offline/packages/jetbase/TowerJetInput.h
@@ -14,7 +14,7 @@ class PHCompositeNode;
 class TowerJetInput : public JetInput
 {
  public:
-  TowerJetInput(Jet::SRC input);
+  TowerJetInput(Jet::SRC input, const std::string prefix = "TOWERINFO_CALIB");
   ~TowerJetInput() override {}
 
   void identify(std::ostream& os = std::cout) override;
@@ -27,6 +27,8 @@ class TowerJetInput : public JetInput
   Jet::SRC m_input;
   RawTowerDefs::CalorimeterId geocaloid;
   bool m_use_towerinfo = false;
+  std::string m_towerNodePrefix;
+  std::string towerName;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Updating the jet reconstruction code so that the tower node names aren't hard coded and a user can define a prefix for the nodes. It defaults to use "TOWERINFO_CALIB" as the prefix, which is what was previously hard coded in there. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

Update to HIJetReco.C so it takes in the user defined prefix: https://github.com/sPHENIX-Collaboration/macros/pull/861 Note that it should still work with the old version, this is just adding the functionality.