### PR TITLE
fix: check run number for number of presamples

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -159,6 +159,15 @@ int TpcCombinedRawDataUnpacker::InitRun(PHCompositeNode* topNode)
     std::cout << "TpcCombinedRawDataUnpacker:: startevt = " << startevt << std::endl;
     std::cout << "TpcCombinedRawDataUnpacker:: endevt = " << endevt << std::endl;
   }
+
+  // check run number if presamples need to be shifted, which went from 80 -> 120
+  // at 41624
+  Fun4AllServer* se = Fun4AllServer::instance();
+  if (se->RunNumber() < 41624)
+  {
+    m_presampleShift = 0;
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -302,7 +311,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       for (uint16_t s = 0; s < sam; s++)
       {
         uint16_t adc = tpchit->get_adc(s);
-        int t = s;
+        int t = s - m_presampleShift;
 
         hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);
         // find existing hit, or create new one


### PR DESCRIPTION
Adds a check to apply the presample shift to the offline hits based on the runnumber in fun4all. Allows correct processing of data before 41624 when the number of pre samples changed from 80 to 120.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

