### PR TITLE
mlp - added a data member to the Gl1Packetv2; TriggerVector is deprecated

### DIFF
--- a/offline/framework/ffarawobjects/Gl1Packet.h
+++ b/offline/framework/ffarawobjects/Gl1Packet.h
@@ -19,8 +19,12 @@ class Gl1Packet : public OfflinePacketv1
   virtual uint64_t getBunchNumber() const { return 0; }
   virtual void setTriggerInput(const uint64_t /*i*/) { return; }
   virtual uint64_t getTriggerInput() const { return 0; }
-  virtual void setTriggerVector(const uint64_t /*i*/) { return; }
-  virtual uint64_t getTriggerVector() const { return 0; }
+  virtual void setLiveVector(const uint64_t /*i*/) { return; }
+  virtual uint64_t getLiveVector() const { return 0; }
+  virtual void setTriggerVector(const uint64_t /*i*/) { return; }  //deprecated
+  virtual uint64_t getTriggerVector() const { return 0; }          //deprecated
+  virtual void setScaledVector(const uint64_t /*i*/) { return; }
+  virtual uint64_t getScaledVector() const { return 0; }
   virtual void setGTMBusyVector(const uint64_t /*i*/) { return; }
   virtual uint64_t getGTMBusyVector() const { return 0; }
 

--- a/offline/framework/ffarawobjects/Gl1Packetv1.cc
+++ b/offline/framework/ffarawobjects/Gl1Packetv1.cc
@@ -67,10 +67,19 @@ long long Gl1Packetv1::lValue(const int /*i*/, const std::string &what) const
   {
     return getTriggerInput();
   }
-  if (what == "TriggerVector")
+  if (what == "LiveVector")
   {
-    return getTriggerVector();
+    return getLiveVector();
   }
+  if (what == "TriggerVector")  // compatibility
+  {
+    return getLiveVector();
+  }
+  if (what == "ScaledVector")  // to avoid the "not implemented" warning
+  {
+    return 0;
+  }
+
   if (what == "BunchNumber")
   {
     return getBunchNumber();
@@ -81,6 +90,8 @@ long long Gl1Packetv1::lValue(const int /*i*/, const std::string &what) const
 
 void Gl1Packetv1::dump(std::ostream &os) const
 {
+  // to avoid confusion, we continue to call it "Trigger Vector" here. 
+
   os << "packet nr:       " << iValue(0) << std::endl;
   os << "Beam Clock:      "
      << "0x" << std::hex << lValue(0, "BCO") << std::dec << "   " << lValue(0, "BCO") << std::endl;

--- a/offline/framework/ffarawobjects/Gl1Packetv2.cc
+++ b/offline/framework/ffarawobjects/Gl1Packetv2.cc
@@ -10,7 +10,8 @@ void Gl1Packetv2::Reset()
   packet_nr = 0;
   BunchNumber = std::numeric_limits<uint64_t>::max();
   TriggerInput = 0;
-  TriggerVector = 0;
+  LiveVector = 0;
+  ScaledVector = 0;
   GTMBusyVector = 0;
   for (auto &row : scaler)
   {
@@ -32,7 +33,8 @@ void Gl1Packetv2::FillFrom(const Gl1Packet *pkt)
   setBunchNumber(pkt->getBunchNumber());
   setPacketNumber(pkt->getPacketNumber());
   setTriggerInput(pkt->getTriggerInput());
-  setTriggerVector(pkt->getTriggerVector());
+  setLiveVector(pkt->getLiveVector());
+  setScaledVector(pkt->getScaledVector());
   setGTMBusyVector(pkt->getGTMBusyVector());
   for (int i = 0; i < 64; i++)
   {
@@ -81,6 +83,14 @@ long long Gl1Packetv2::lValue(const int i, const std::string &what) const
   {
     return getTriggerVector();
   }
+  if (what == "LiveVector")
+  {
+    return getLiveVector();
+  }
+  if (what == "ScaledVector")
+  {
+    return getScaledVector();
+  }
   if (what == "GTMBusyVector")
   {
     return getGTMBusyVector();
@@ -112,8 +122,10 @@ void Gl1Packetv2::dump(std::ostream &os) const
      << "0x" << std::hex << lValue(0, "BCO") << std::dec << "   " << lValue(0, "BCO") << std::endl;
   os << "Trigger Input:   "
      << "0x" << std::hex << lValue(0, "TriggerInput") << std::dec << "   " << lValue(0, "TriggerInput") << std::endl;
-  os << "Trigger Vector:  "
-     << "0x" << std::hex << lValue(0, "TriggerVector") << std::dec << "   " << lValue(0, "TriggerVector") << std::endl;
+  os << "Live Vector:  "
+     << "0x" << std::hex << lValue(0, "LiveVector") << std::dec << "   " << lValue(0, "LiveVector") << std::endl;
+  os << "Scaled Vector:  "
+     << "0x" << std::hex << lValue(0, "ScaledVector") << std::dec << "   " << lValue(0, "ScaledVector") << std::endl;
   os << "GTM Busy Vector: "
      << "0x" << std::hex << lValue(0, "GTMBusyVector") << std::dec << "   " << lValue(0, "GTMBusyVector") << std::endl;
   os << "Bunch Number:    " << lValue(0, "BunchNumber") << std::endl

--- a/offline/framework/ffarawobjects/Gl1Packetv2.h
+++ b/offline/framework/ffarawobjects/Gl1Packetv2.h
@@ -55,7 +55,7 @@ class Gl1Packetv2 : public Gl1Packet
   std::array<std::array<uint64_t, 3>, 16> gl1pscaler{{{0}}};
 
  private:
-  ClassDefOverride(Gl1Packetv2, 1)
+  ClassDefOverride(Gl1Packetv2, 2)
 };
 
 #endif

--- a/offline/framework/ffarawobjects/Gl1Packetv2.h
+++ b/offline/framework/ffarawobjects/Gl1Packetv2.h
@@ -23,8 +23,15 @@ class Gl1Packetv2 : public Gl1Packet
   uint64_t getBunchNumber() const override { return BunchNumber; }
   void setTriggerInput(const uint64_t i) override { TriggerInput = i; }
   uint64_t getTriggerInput() const override { return TriggerInput; }
-  void setTriggerVector(const uint64_t i) override { TriggerVector = i; }
-  uint64_t getTriggerVector() const override { return TriggerVector; }
+
+  void setLiveVector(const uint64_t i) override { LiveVector = i; }
+  void setTriggerVector(const uint64_t i) override { setLiveVector(i); } // backward compatibility
+  uint64_t getLiveVector() const override { return LiveVector; }
+  uint64_t getTriggerVector() const override { return getLiveVector(); } // backward compatibility
+
+  void setScaledVector(const uint64_t i) override { ScaledVector =i;}
+  uint64_t getScaledVector() const override { return ScaledVector; }
+
   void setGTMBusyVector(const uint64_t i) override { GTMBusyVector = i; }
   uint64_t getGTMBusyVector() const override { return GTMBusyVector; }
 
@@ -41,7 +48,8 @@ class Gl1Packetv2 : public Gl1Packet
   unsigned int packet_nr{0};
   uint64_t BunchNumber{std::numeric_limits<uint64_t>::max()};
   uint64_t TriggerInput{0};
-  uint64_t TriggerVector{0};
+  uint64_t LiveVector{0};
+  uint64_t ScaledVector{0};
   uint64_t GTMBusyVector{0};
   std::array<std::array<uint64_t, 3>, 64> scaler{{{0}}};
   std::array<std::array<uint64_t, 3>, 16> gl1pscaler{{{0}}};

--- a/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
@@ -102,7 +102,8 @@ void SingleGl1TriggerInput::FillPool(const unsigned int /*nbclks*/)
     newhit->setPacketNumber(packet->iValue(0));
     newhit->setBunchNumber(packet->lValue(0, "BunchNumber"));
     newhit->setTriggerInput(packet->lValue(0, "TriggerInput"));
-    newhit->setTriggerVector(packet->lValue(0, "TriggerVector"));
+    newhit->setLiveVector(packet->lValue(0, "LiveVector"));
+    newhit->setScaledVector(packet->lValue(0, "ScaledVector"));
     newhit->setGTMBusyVector(packet->lValue(0, "GTMBusyVector"));
     for (int i = 0; i < 64; i++)
     {


### PR DESCRIPTION

[comment]: <> (Please tell us something about this pull request)
added a data member to the Gl1Packetv2; TriggerVector is deprecated
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The new "IDGL1V1" packet provides a new data member, the "Scaled" trigger vector.

I added the new "ScaledVector" member to the Gl1Packetv2; deprecated the "TriggerVector" name in favor of "LiveVector"; Gl1Packetv1 returns 0 when asked for "ScaledVector" but doesn't emit a warning. 
The use of "TriggerVector" will continue to work.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

