### PR TITLE
Name changes only -- legacy (and new) phi to Z

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -136,11 +136,11 @@ namespace
   }
 
   /// pseudo rapidity of Acts::Vector3
-  inline double get_eta(const Acts::Vector3& position)
-  {
-    const double norm = std::sqrt(square(position.x()) + square(position.y()) + square(position.z()));
-    return std::log((norm + position.z()) / (norm - position.z())) / 2;
-  }
+  /* inline double get_eta(const Acts::Vector3& position) */
+  /* { */
+  /*   const double norm = std::sqrt(square(position.x()) + square(position.y()) + square(position.z())); */
+  /*   return std::log((norm + position.z()) / (norm - position.z())) / 2; */
+  /* } */
 
   inline double breaking_angle(double x1, double y1, double z1, double x2, double y2, double z2)
   {
@@ -212,7 +212,7 @@ Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster*
   return globalpos;
 }
 
-void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& rtree, double phimin, double etamin, double phimax, double etamax, std::vector<pointKey>& returned_values) const
+void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& rtree, double phimin, double z_min, double phimax, double z_max, std::vector<pointKey>& returned_values) const
 {
   bool query_both_ends = false;
   if (phimin < 0)
@@ -227,12 +227,12 @@ void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadrat
   }
   if (query_both_ends)
   {
-    rtree.query(bgi::intersects(box(point(phimin, etamin), point(2 * M_PI, etamax))), std::back_inserter(returned_values));
-    rtree.query(bgi::intersects(box(point(0., etamin), point(phimax, etamax))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(phimin, z_min), point(2 * M_PI, z_max))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(0., z_min), point(phimax, z_max))), std::back_inserter(returned_values));
   }
   else
   {
-    rtree.query(bgi::intersects(box(point(phimin, etamin), point(phimax, etamax))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(phimin, z_min), point(phimax, z_max))), std::back_inserter(returned_values));
   }
 }
 
@@ -499,7 +499,7 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
       delta_above.clear();
       delta_below.resize(ClustersBelow.size());
       delta_above.resize(ClustersAbove.size());
-      // calculate (delta_eta, delta_phi) vector for each neighboring cluster
+      // calculate (delta_z_, delta_phi) vector for each neighboring cluster
 
       std::transform(ClustersBelow.begin(), ClustersBelow.end(), delta_below.begin(),
                      [&](pointKey BelowCandidate)
@@ -522,7 +522,7 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
       t_seed->restart();
 
       // find the three clusters closest to a straight line
-      // (by maximizing the cos of the angle between the (delta_eta,delta_phi) vectors)
+      // (by maximizing the cos of the angle between the (delta_z_,delta_phi) vectors)
       // double minSumLengths = 1e9;
       std::unordered_set<TrkrDefs::cluskey> bestAboveClusters;
       for (size_t iAbove = 0; iAbove < delta_above.size(); ++iAbove)
@@ -789,33 +789,33 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
   {
     LogDebug(" seed " << i << ":" << std::endl);
 
-    double lasteta = -100;
+    double last_z = -100;
     double lastphi = -100;
     for (unsigned long& j : trackSeedKeyList)
     {
       const auto& globalpos = globalPositions.at(j);
       const double clus_phi = get_phi(globalpos);
-      const double clus_eta = get_eta(globalpos);
-      const double etajump = clus_eta - lasteta;
+      const double clus_z = globalpos.z();
+      const double z_jump = clus_z - last_z;
       const double phijump = clus_phi - lastphi;
 #if defined(_DEBUG_)
       unsigned int lay = TrkrDefs::getLayer(trackSeedKeyLists[i][j].second);
 #endif
-      if ((fabs(etajump) > 0.1 && lasteta != -100) || (fabs(phijump) > 1 && lastphi != -100))
+      if ((fabs(z_jump) > 0.1 && last_z != -100) || (fabs(phijump) > 1 && lastphi != -100))
       {
-        LogDebug(" Eta or Phi jump too large! " << std::endl);
+        LogDebug(" Z or Phi jump too large! " << std::endl);
         ++jumpcount;
       }
-      LogDebug(" (eta,phi,layer) = (" << clus_eta << "," << clus_phi << "," << lay << ") "
+      LogDebug(" (Z,phi,layer) = (" << clus_z << "," << clus_phi << "," << lay << ") "
                                       << " (x,y,z) = (" << globalpos(0) << "," << globalpos(1) << "," << globalpos(2) << ")" << std::endl);
 
       if (Verbosity() > 2)
       {
         unsigned int lay = TrkrDefs::getLayer(j);
-        std::cout << "  eta, phi, layer = (" << clus_eta << "," << clus_phi << "," << lay << ") "
+        std::cout << "  Z, phi, layer = (" << clus_z << "," << clus_phi << "," << lay << ") "
                   << " (x,y,z) = (" << globalpos(0) << "," << globalpos(1) << "," << globalpos(2) << ")" << std::endl;
       }
-      lasteta = clus_eta;
+      last_z = clus_z;
       lastphi = clus_phi;
     }
   }
@@ -823,7 +823,7 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
   t_seed->stop();
   if (Verbosity() > 1)
   {
-    std::cout << "eta-phi sanity check time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
+    std::cout << "z-phi sanity check time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
   }
   t_seed->restart();
   return trackSeedKeyLists;
@@ -982,7 +982,7 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
   std::cout << " Writing _CLUSTER_LOG_TUPOUT.root file " << std::endl;
   _f_clustering_process = new TFile("_CLUSTER_LOG_TUPOUT.root", "recreate");
   _tupclus_all         = new TNtuple("all",         "all clusters","event:layer:num:x:y:z");
-  _tupclus_links       = new TNtuple("links",       "links","event:layer:updown01:x:y:z:delta_eta:delta_phi");
+  _tupclus_links       = new TNtuple("links",       "links","event:layer:updown01:x:y:z:delta_z:delta_phi");
   _tupclus_bilinks     = new TNtuple("bilinks",     "bilinks","event:layer:topbot01:x:y:z");
   _tupclus_seeds       = new TNtuple("seeds",       "3 bilink seeds cores","event:layer:seed012:x:y:z");
   _tupclus_grown_seeds = new TNtuple("grown_seeds", "grown seeds", "event:layer:seednum05:x:y:z");
@@ -993,7 +993,7 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
       "event:layerL:xL:yL:zL:layer1:x1:y1:z1:dzdr_12:dzdr_L1:delta_dzdr_12_L1:d2phidr2_123:d2phidr2_L12:delta_d2phidr2");
 
   _search_windows = new TNtuple("search_windows","windows used in algorithm to seed clusters",
-      "DelEta_ClSearch:DelPhi_ClSearch:start_layer:end_layer:dzdr_ClAdd:dphidr2_ClAdd");
+      "DelZ_ClSearch:DelPhi_ClSearch:start_layer:end_layer:dzdr_ClAdd:dphidr2_ClAdd");
 
   _tup_chainfork  = new TNtuple("chainfork", "chain with multiple links, which if forking", "event:nchain:layer:x:y:z:dzdr:d2phidr2:nlink:nlinks"); // nlinks to add, 0 ... nlinks
   _tup_chainbody  = new TNtuple("chainbody", "chain body with multiple link options", "event:nchain:layer:x:y:z:dzdr:d2phidr2:nlink:nlinks"); // nlinks in chain being added to will be 0, 1, 2 ... working backward from the fork -- dZ and dphi are dropped for final links as necessary

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -69,7 +69,7 @@ class PHCASeeding : public PHTrackSeeding
    using point = bg::model::point<float, 2, bg::cs::cartesian>;
    using box = bg::model::box<point>;
    using pointKey = std::pair<point, TrkrDefs::cluskey>; // phi and z in the key
-   using coordKey = std::pair<std::array<float, 2>, TrkrDefs::cluskey>; // just use phi and eta, no longer needs the layer
+   using coordKey = std::pair<std::array<float, 2>, TrkrDefs::cluskey>; // just use phi and Z, no longer needs the layer
 
    using keyList = std::vector<TrkrDefs::cluskey>;
    using keyLists = std::vector<keyList>;


### PR DESCRIPTION
[comment]: <> 
Apologies for yet another commit. Some work that I had done updating the legacy (and some carryover into new) "phi" naming in variables and tuple tags to "z" was lost in one branch or another. This corrects that. Minus potential typo (I've run the code myself, and it all appears to be working fine) these don't change any numeric functionality in the code.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

