### PR TITLE
Fix to the EMCal<->HCal alignment

### DIFF
--- a/offline/packages/CaloReco/RawClusterBuilderTopo.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.h
@@ -112,7 +112,7 @@ class RawClusterBuilderTopo : public SubsysReco
 
   int get_matching_HCal_phi_from_EMCal(int index_emcal_phi)
   {
-    return [(index_emcal_phi + 251)/4] % _HCAL_NPHI;
+    return ((index_emcal_phi + 251)/4) % _HCAL_NPHI;
   }
 
   std::vector<int> get_adjacent_towers_by_ID(int ID);

--- a/offline/packages/CaloReco/RawClusterBuilderTopo.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.h
@@ -107,12 +107,12 @@ class RawClusterBuilderTopo : public SubsysReco
   // utility functions to express IHCal<->EMCal overlap in phi
   int get_first_matching_EMCal_phi_from_IHCal(int index_hcal_phi)
   {
-    return ((68 + 4 * (index_hcal_phi - 32) + _EMCAL_NPHI) % _EMCAL_NPHI);
+    return (4*index_hcal_phi + 5) % _EMCAL_NPHI;
   }
 
   int get_matching_HCal_phi_from_EMCal(int index_emcal_phi)
   {
-    return ((32 + (index_emcal_phi - 68 + _EMCAL_NPHI) / 4) % _HCAL_NPHI);
+    return [(index_emcal_phi + 251)/4] % _HCAL_NPHI;
   }
 
   std::vector<int> get_adjacent_towers_by_ID(int ID);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Fixing the towers alignment between EMCal and HCal for topo-clusters reconstructed using EMCal+HCal reconstruction mode.


