### PR TITLE
no abort if run is not found, fix run selection

### DIFF
--- a/offline/framework/frog/CreateDstList.pl
+++ b/offline/framework/frog/CreateDstList.pl
@@ -153,23 +153,23 @@ else
 sub creatfilelists
 {
     my $run = shift;
-foreach my $ds (sort keys %dsttype)
-{
-    $getfiles->execute($run,$ds);
-    if ($getfiles->rows == 0)
+    foreach my $ds (sort keys %dsttype)
     {
-	print "no run $run for dst type $ds and dataset $dataset\n";
-	exit(1);
+	$getfiles->execute($run,$ds);
+	if ($getfiles->rows == 0)
+	{
+	    print "no run $run for dst type $ds and dataset $dataset\n";
+	    next;
+	}
+	my $filename = sprintf("%s-%08d.list",lc $ds, $run);
+	print "creating list for run $run --> $filename\n";
+	open(F,">$filename");
+	while (my @res = $getfiles->fetchrow_array())
+	{
+	    print F "$res[0]\n";
+	}
+	close(F);
     }
-    my $filename = sprintf("%s-%08d.list",lc $ds, $run);
-    print "creating list for run $run --> $filename\n";
-    open(F,">$filename");
-    while (my @res = $getfiles->fetchrow_array())
-    {
-	print F "$res[0]\n";
-    }
-    close(F);
-}
 }
 
 sub printtags
@@ -211,8 +211,9 @@ sub printruns
     }
     if (defined $dataset)
     {
-	my $getruns =  $dbh->prepare("select distinct(runnumber) from datasets where dataset = '$dataset' order by runnumber\n");
+	my $getruns =  $dbh->prepare("select distinct(runnumber) from datasets where dataset = '$dataset' and dsttype='$ARGV[0]' order by runnumber\n");
 	$getruns->execute();
+#	print "cmd: select distinct(runnumber) from datasets where dataset = '$dataset' and dsttype='$ARGV[0]' order by runnumber\n";
 	if ($getruns->rows == 0)
 	{
 	    print "no run found for dataset $dataset\n";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
CreateDstList.pl now selects runs according to the selected dst type. It doesn't abort anymore if a run from a runlist is not found. jenkins does not check this: [skip-ci] 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

