### PR TITLE
fix: use wrapper in circle/line fits

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -411,11 +411,11 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
       }
       if (m_zeroField)
       {
-        lineFitClusters(keys, geometry, clustermap);
+        lineFitClusters(keys, geometry, clustermap, m_crossing);
       }
       else
       {
-        circleFitClusters(keys, geometry, clustermap);
+        circleFitClusters(keys, geometry, clustermap, m_crossing);
       }
       for (const auto& ckey : get_cluster_keys(track))
       {
@@ -712,7 +712,8 @@ float TrackResiduals::convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey c
 }
 void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
                                        ActsGeometry* geometry,
-                                       TrkrClusterContainer* clusters)
+                                       TrkrClusterContainer* clusters,
+                                       const short int& crossing)
 {
   std::vector<Acts::Vector3> clusPos, global_vec;
   for(auto& key : keys)
@@ -721,7 +722,7 @@ void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
     Acts::Vector3 pos;
     if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
     {
-      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, crossing,
                                                                             m_dccStatic, m_dccAverage, m_dccFluctuation);
     }
     else
@@ -765,7 +766,8 @@ void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
 
 void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
                                      ActsGeometry* geometry,
-                                     TrkrClusterContainer* clusters)
+                                     TrkrClusterContainer* clusters,
+                                     const short int& crossing)
 {
   std::vector<Acts::Vector3> clusPos;
   for (auto& key : keys)
@@ -774,7 +776,7 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
     Acts::Vector3 pos;
     if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
     {
-      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, crossing,
                                                                            m_dccStatic, m_dccAverage, m_dccFluctuation);
     }
     else

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -715,8 +715,21 @@ void TrackResiduals::circleFitClusters(std::vector<TrkrDefs::cluskey>& keys,
                                        TrkrClusterContainer* clusters)
 {
   std::vector<Acts::Vector3> clusPos, global_vec;
-  TrackFitUtils::getTrackletClusters(geometry, clusters,
-                                     clusPos, keys);
+  for(auto& key : keys)
+  {
+    auto cluster = clusters->findCluster(key);
+    Acts::Vector3 pos;
+    if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+    {
+      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+                                                                            m_dccStatic, m_dccAverage, m_dccFluctuation);
+    }
+    else
+    {
+      pos = geometry->getGlobalPosition(key, cluster);
+    }
+    clusPos.push_back(pos);
+  }
 
   for (auto& pos : clusPos)
   {
@@ -755,8 +768,21 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
                                      TrkrClusterContainer* clusters)
 {
   std::vector<Acts::Vector3> clusPos;
-  TrackFitUtils::getTrackletClusters(geometry, clusters,
-                                     clusPos, keys);
+  for (auto& key : keys)
+  {
+    auto cluster = clusters->findCluster(key);
+    Acts::Vector3 pos;
+    if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+    {
+      pos = TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(key, cluster, geometry, 0,
+                                                                           m_dccStatic, m_dccAverage, m_dccFluctuation);
+    }
+    else
+    {
+      pos = geometry->getGlobalPosition(key, cluster);
+    }
+    clusPos.push_back(pos);
+  }
   TrackFitUtils::position_vector_t xypoints, rzpoints, yzpoints;
   for (auto& pos : clusPos)
   {

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -67,9 +67,9 @@ class TrackResiduals : public SubsysReco
   void fillClusterBranches(TrkrDefs::cluskey ckey, SvtxTrack *track,
                            PHCompositeNode *topNode);
   void lineFitClusters(std::vector<TrkrDefs::cluskey> &keys, ActsGeometry *geometry,
-                       TrkrClusterContainer *clusters);
+                       TrkrClusterContainer *clusters, const short int& crossing);
   void circleFitClusters(std::vector<TrkrDefs::cluskey> &keys, ActsGeometry *geometry,
-                         TrkrClusterContainer *clusters);
+                         TrkrClusterContainer *clusters, const short int& crossing);
   void fillStatesWithCircleFit(const TrkrDefs::cluskey &key, TrkrCluster *cluster,
                                Acts::Vector3 &glob, ActsGeometry *geometry);
   void fillVertexTree(PHCompositeNode *topNode);


### PR DESCRIPTION
Uses the distortion wrapper in the circle/line fits of track residuals

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

