### PR TITLE
fix for crash with extremely large z vertex

### DIFF
--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -76,7 +76,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
   if (vertexmap->empty())
   {
-    std::cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
+    if(Verbosity() > 0) std::cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
     return std::vector<Jet *>();
   }
   m_use_towerinfo = false;
@@ -410,6 +410,19 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
     return std::vector<Jet *>();
   }
+
+  if (abs(vtxz) > 1e3) //code crashes with very large z vertex, so skip these events
+    {
+      static bool once = true;
+      if (once)
+	{
+	  once = false;
+
+	  std::cout << "TowerJetInput::get_input - WARNING - vertex is "<<vtxz<<". Drop all tower inputs (further vertex warning will be suppressed)." << std::endl;
+	}
+
+      return std::vector<Jet *>();
+    }
 
   std::vector<Jet *> pseudojets;
   if (m_use_towerinfo)

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -411,7 +411,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     return std::vector<Jet *>();
   }
 
-  if (abs(vtxz) > 1e3) //code crashes with very large z vertex, so skip these events
+  if (std::abs(vtxz) > 1e3) //code crashes with very large z vertex, so skip these events
     {
       static bool once = true;
       if (once)


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Put a flag in TowerJetInput to skip events which have a z vertex > 1000. Very large z vertex values (appearing very rarely) were causing the code to crash. I also updated the error message that prints if the vertex container is empty to be Verbosity > 0, since the vertex is somewhat regularly not reconstructed and this causes confusion.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

