### PR TITLE
Tpot bco statistics

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1,6 +1,7 @@
 #include "Fun4AllStreamingInputManager.h"
 
 #include "InputManagerType.h"
+#include "SingleMicromegasPoolInput.h"
 #include "SingleStreamingInput.h"
 
 #include <ffarawobjects/Gl1RawHit.h>
@@ -798,6 +799,13 @@ int Fun4AllStreamingInputManager::FillMicromegas()
       return iret;
     }
   }
+
+  // fill all BCO statistics
+  for (const auto &iter : m_MicromegasInputVector)
+  {
+    static_cast<SingleMicromegasPoolInput*>(iter)->FillBcoStatistics(m_RefBCO);
+  }
+
 
   while ((m_MicromegasRawHitMap.begin()->first) <= select_crossings - m_micromegas_negative_bco)
   {

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -79,7 +79,7 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
   const int n_tagger = packet->lValue(0, "N_TAGGER");
-  for (int t = 0; t < n_tagger; t++)
+  for (int t = 0; t < n_tagger; ++t)
   {
     const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
     if (is_lvl1)

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -81,10 +81,10 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
   const int n_tagger = packet->lValue(0, "N_TAGGER");
   for (int t = 0; t < n_tagger; t++)
   {
-    bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
+    const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
     if (is_lvl1)
     {
-      uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+      const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
       m_gtm_bco_list.push_back(gtm_bco);
     }
   }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -127,7 +127,7 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
 
       // save BCO from tagger internally
       const int n_tagger = packet->lValue(0, "N_TAGGER");
-      for (int t = 0; t < n_tagger; t++)
+      for (int t = 0; t < n_tagger; ++t)
       {
         const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
         if (is_lvl1)
@@ -300,7 +300,6 @@ void SingleMicromegasPoolInput::Print(const std::string& what) const
 //____________________________________________________________________________
 void SingleMicromegasPoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
-  std::vector<uint64_t> toclearbclk;
   for (const auto& iter : m_MicromegasRawHitMap)
   {
     if (iter.first <= bclk)
@@ -309,7 +308,6 @@ void SingleMicromegasPoolInput::CleanupUsedPackets(const uint64_t bclk)
       {
         delete pktiter;
       }
-
     }
     else
     {
@@ -329,7 +327,7 @@ void SingleMicromegasPoolInput::CleanupUsedPackets(const uint64_t bclk)
   }
 
   // generic map cleanup
-  auto cleanup = [bclk]( auto map )
+  auto cleanup = [bclk]( auto&& map )
   {
     for( auto iter = map.begin(); iter!= map.end(); )
     {
@@ -345,17 +343,13 @@ void SingleMicromegasPoolInput::CleanupUsedPackets(const uint64_t bclk)
   cleanup( m_BeamClockFEE );
   cleanup( m_BeamClockPacket );
   cleanup( m_MicromegasRawHitMap );
-//   for (const auto& bclk : toclearbclk)
-//   {
-//     m_BclkStack.erase(bclk);
-//     m_BeamClockFEE.erase(bclk);
-//     m_MicromegasRawHitMap.erase(bclk);
-//   }
 }
 
 //_______________________________________________________
 void SingleMicromegasPoolInput::ClearCurrentEvent()
 {
+  std::cout << "SingleMicromegasPoolInput::ClearCurrentEvent." << std::endl;
+
   uint64_t currentbclk = *m_BclkStack.begin();
   CleanupUsedPackets(currentbclk);
   return;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -458,7 +458,7 @@ void SingleMicromegasPoolInput::FillBcoStatistics( uint64_t gtm_bco)
   { m_npacket_bco_hist = new TH1I( "m_npacket_bco_hist", "packet count per GTM BCO; packets; A.U.", 10, 0, 10 ); }
 
   if( !m_nwaveform_bco_hist )
-  { m_nwaveform_bco_hist = new TH1I( "m_nwaveform_bco_hist", "waveform count per GTM BCO; waveforms; A.U.", 10, 0, 10 ); }
+  { m_nwaveform_bco_hist = new TH1I( "m_nwaveform_bco_hist", "waveform count per GTM BCO; waveforms; A.U.", 4100, 0, 4100 ); }
 
   unsigned int n_waveforms = 0;
   unsigned int n_packets = 0;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -14,6 +15,9 @@
 class Fun4AllEvtInputPoolManager;
 class MicromegasRawHit;
 class Packet;
+
+class TFile;
+class TH1;
 
 class SingleMicromegasPoolInput : public SingleStreamingInput
 {
@@ -31,8 +35,16 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
+  /// enable evaluation
+  void SetDoEvaluation(bool value)
+  { m_do_evaluation = value; }
+
+  /// output file name for evaluation histograms
+  void SetEvaluationOutputFilename(const std::string& outputfile)
+  { m_evaluation_filename = outputfile; }
+
   //! save some statistics for BCO statistics
-  void SaveBcoStatistics( uint64_t /*gtm_bco*/);
+  void FillBcoStatistics( uint64_t /*gtm_bco*/);
 
  private:
   std::array<Packet*,10> plist{};
@@ -77,7 +89,15 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   // keep track of dropped waveforms
   uint64_t m_waveform_count_dropped = 0;
 
-  //! gtm bco statistics
+  bool m_do_evaluation = false;
+  std::string m_evaluation_filename = "SingleMicromegasPoolInput.root";
+  std::unique_ptr<TFile> m_evaluation_file;
+
+  //!@name gtm bco statistics histogram
+  //@{
+  TH1* m_npacket_bco_hist = nullptr;
+  TH1* m_nwaveform_bco_hist = nullptr;
+  //@}
 
 };
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -31,16 +31,41 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
+  //! save some statistics for BCO statistics
+  void SaveBcoStatistics( uint64_t /*gtm_bco*/);
+
  private:
   std::array<Packet*,10> plist{};
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
 
+  //! store list of packets that have data for a given beam clock
+  /**
+   * all packets in taggers are stored,
+   * disregarding whether there is data associated to it or not
+   * this allows to keep track of dropped data, also in zero-suppression mode
+   */
+  std::map<uint64_t, std::set<int>> m_BeamClockPacket;
+
+  //! store list of FEE that have data for a given beam clock
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;
+
+  //! store list of raw hits matching a given bco
   std::map<uint64_t, std::vector<MicromegasRawHit *>> m_MicromegasRawHitMap;
+
+  //! store current list of BCO on a per fee basis.
+  /** only packets for which a given FEE have data are stored */
   std::map<int, uint64_t> m_FEEBclkMap;
+
+  //! store current list of BCO
+  /**
+   * all packets in taggers are stored,
+   * disregarding whether there is data associated to it or not
+   * this allows to keep track of dropped data, also in zero-suppression mode
+   */
   std::set<uint64_t> m_BclkStack;
+
 
   //! map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation>;
@@ -51,6 +76,8 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
 
   // keep track of dropped waveforms
   uint64_t m_waveform_count_dropped = 0;
+
+  //! gtm bco statistics
 
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This is a first shot at keeping track of dropped data for TPOT
A new method 'FillBcoStatistics' is added to SingleMicromegasInput, called from Fun4AllStreamingInputManager
It stores how many packets and waveforms are found in TPOT for a BCO (from tagger) matching the requested BCO, by, e.g. GL1.
In non ZS mode, the expected number of waveform is about 4096. Anything below is dropped data.
In both ZS and non ZS mode, the expected number of packets is 2. Anything below is dropped data.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

