### PR TITLE
Adding Cluster Phi Size and Clusters/Track Histograms to QA Output

### DIFF
--- a/offline/QA/Tracking/TpcClusterQA.h
+++ b/offline/QA/Tracking/TpcClusterQA.h
@@ -8,8 +8,10 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 class PHCompositeNode;
+class TpcDistortionCorrectionContainer;
 
 class TpcClusterQA : public SubsysReco
 {
@@ -21,10 +23,28 @@ class TpcClusterQA : public SubsysReco
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
+
+  void makeResidQAHistos (bool value)
+  {
+    m_residQA = value;
+  }
  
  private:
   void createHistos();
-    
+
+  bool m_residQA = false;
+
+  std::string m_trackMapName = "SvtxTrackMap";
+  TpcDistortionCorrectionContainer *m_dccStatic{nullptr}, *m_dccAverage{nullptr}, *m_dccFluctuation{nullptr};
+  float m_px = std::numeric_limits<float>::quiet_NaN();
+  float m_py = std::numeric_limits<float>::quiet_NaN();
+  float m_pt = std::numeric_limits<float>::quiet_NaN();    
+  int m_ntpc = std::numeric_limits<int>::quiet_NaN();
+  std::vector<float> m_clusgz;
+  std::vector<int> m_cluslayer;
+  std::vector<int> m_clusphisize;
+  std::vector<int> m_cluszsize;
+  std::vector<int> m_region;
 
   std::string getHistoPrefix() const;
   std::set<int> m_layers;


### PR DESCRIPTION
Adds region-separated histograms for computing fraction of clusters with phi size equal to 1 as a function of pT, and number of clusters per track histogram.
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

