### PR TITLE
Added gl1packet info so that only MBDNS triggered events are used in calibration

### DIFF
--- a/offline/packages/mbd/Makefile.am
+++ b/offline/packages/mbd/Makefile.am
@@ -41,6 +41,7 @@ pkginclude_HEADERS = \
   MbdEvent.h \
   MbdGeom.h \
   MbdGeomV1.h \
+  MbdGeomV2.h \
   MbdOut.h \
   MbdOutV1.h \
   MbdOutV2.h \
@@ -83,6 +84,7 @@ pkginclude_HEADERS = \
   BbcGeomV1.h \
   MbdGeom.h \
   MbdGeomV1.h \
+  MbdGeomV2.h \
   BbcReturnCodes.h \
   MbdReturnCodes.h \
   BbcVertex.h \
@@ -98,6 +100,7 @@ ROOTDICTS = \
   BbcGeomV1_Dict.cc \
   MbdGeom_Dict.cc \
   MbdGeomV1_Dict.cc \
+  MbdGeomV2_Dict.cc \
   MbdOut_Dict.cc \
   MbdOutV1_Dict.cc \
   MbdOutV2_Dict.cc \
@@ -128,6 +131,7 @@ ROOTDICTS = \
   MbdOutV2_Dict.cc \
   MbdGeom_Dict.cc \
   MbdGeomV1_Dict.cc \
+  MbdGeomV2_Dict.cc \
   MbdPmtHit_Dict.cc \
   MbdPmtHitV1_Dict.cc \
   MbdPmtSimHitV1_Dict.cc \
@@ -144,6 +148,7 @@ nobase_dist_pcm_DATA = \
   BbcGeomV1_Dict_rdict.pcm \
   MbdGeom_Dict_rdict.pcm \
   MbdGeomV1_Dict_rdict.pcm \
+  MbdGeomV2_Dict_rdict.pcm \
   MbdOut_Dict_rdict.pcm \
   MbdOutV1_Dict_rdict.pcm \
   MbdOutV2_Dict_rdict.pcm \
@@ -176,6 +181,7 @@ nobase_dist_pcm_DATA = \
   MbdOutV2_Dict_rdict.pcm \
   MbdGeom_Dict_rdict.pcm \
   MbdGeomV1_Dict_rdict.pcm \
+  MbdGeomV2_Dict_rdict.pcm \
   MbdPmtHit_Dict_rdict.pcm \
   MbdPmtHitV1_Dict_rdict.pcm \
   MbdPmtSimHitV1_Dict_rdict.pcm \
@@ -190,6 +196,7 @@ libmbd_io_la_SOURCES = \
   MbdEvent.cc \
   BbcGeomV1.cc \
   MbdGeomV1.cc \
+  MbdGeomV2.cc \
   MbdOut.cc \
   MbdOutV1.cc \
   MbdOutV2.cc \
@@ -214,6 +221,7 @@ libmbd_io_la_SOURCES = \
   BbcPmtInfoV1.cc \
   BbcPmtInfoContainerV1.cc \
   MbdGeomV1.cc \
+  MbdGeomV2.cc \
   MbdOut.cc \
   MbdOutV1.cc \
   MbdOutV2.cc \

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -24,6 +24,7 @@ class TF1;
 class TCanvas;
 #ifndef ONLINE
 class CaloPacketContainer;
+class Gl1Packet;
 #endif
 
 class MbdEvent
@@ -34,7 +35,7 @@ class MbdEvent
 
   int SetRawData(Event *event, MbdPmtContainer *mbdpmts);
 #ifndef ONLINE
-  int SetRawData(CaloPacketContainer *mbdraw, MbdPmtContainer *mbdpmts);
+  int SetRawData(CaloPacketContainer *mbdraw, MbdPmtContainer *mbdpmts, Gl1Packet *gl1raw);
 #endif
   int Calculate(MbdPmtContainer *mbdpmts, MbdOut *mbdout);
   int InitRun();

--- a/offline/packages/mbd/MbdGeom.h
+++ b/offline/packages/mbd/MbdGeom.h
@@ -31,6 +31,8 @@ class MbdGeom : public PHObject
     virtual int get_pmt(const unsigned int feech) const { return (feech / 16) * 8 + feech % 8; }
     virtual int get_type(const unsigned int feech) const { return (feech / 8) % 2; }  // 0=T-channel, 1=Q-channel
 
+    virtual void download_hv() {}
+
     virtual void Reset() override {}
 
   private:

--- a/offline/packages/mbd/MbdGeomV2.cc
+++ b/offline/packages/mbd/MbdGeomV2.cc
@@ -1,0 +1,244 @@
+#include "MbdGeomV2.h"
+
+#include <cmath>
+
+// kludge where we have the hardcoded positions of the tubes
+// Should really be put in a database
+// These are the x,y for the south MBD (in cm).
+// The north inverts the x coordinate (x -> -x)
+static const float PmtLoc[64][2] = {
+    {-12.2976, 4.26},
+    {-12.2976, 1.42},
+    {-9.83805, 8.52},
+    {-9.83805, 5.68},
+    {-9.83805, 2.84},
+    {-7.37854, 9.94},
+    {-7.37854, 7.1},
+    {-7.37854, 4.26},
+    {-7.37854, 1.42},
+    {-4.91902, 11.36},
+    {-4.91902, 8.52},
+    {-4.91902, 5.68},
+    {-2.45951, 12.78},
+    {-2.45951, 9.94},
+    {-2.45951, 7.1},
+    {0, 11.36},
+    {0, 8.52},
+    {2.45951, 12.78},
+    {2.45951, 9.94},
+    {2.45951, 7.1},
+    {4.91902, 11.36},
+    {4.91902, 8.52},
+    {4.91902, 5.68},
+    {7.37854, 9.94},
+    {7.37854, 7.1},
+    {7.37854, 4.26},
+    {7.37854, 1.42},
+    {9.83805, 8.52},
+    {9.83805, 5.68},
+    {9.83805, 2.84},
+    {12.2976, 4.26},
+    {12.2976, 1.42},
+    {12.2976, -4.26},
+    {12.2976, -1.42},
+    {9.83805, -8.52},
+    {9.83805, -5.68},
+    {9.83805, -2.84},
+    {7.37854, -9.94},
+    {7.37854, -7.1},
+    {7.37854, -4.26},
+    {7.37854, -1.42},
+    {4.91902, -11.36},
+    {4.91902, -8.52},
+    {4.91902, -5.68},
+    {2.45951, -12.78},
+    {2.45951, -9.94},
+    {2.45951, -7.1},
+    {0, -11.36},
+    {0, -8.52},
+    {-2.45951, -12.78},
+    {-2.45951, -9.94},
+    {-2.45951, -7.1},
+    {-4.91902, -11.36},
+    {-4.91902, -8.52},
+    {-4.91902, -5.68},
+    {-7.37854, -9.94},
+    {-7.37854, -7.1},
+    {-7.37854, -4.26},
+    {-7.37854, -1.42},
+    {-9.83805, -8.52},
+    {-9.83805, -5.68},
+    {-9.83805, -2.84},
+    {-12.2976, -4.26},
+    {-12.2976, -1.42}};
+
+MbdGeomV2::MbdGeomV2()
+{
+  // Set the pmt locations
+  for (unsigned int ipmt = 0; ipmt < 128; ipmt++)
+  {
+    int arm = ipmt / 64;
+
+    float xsign = 1.;
+    float zsign = -1.;
+    if (arm == 1)  // north
+    {
+      xsign = -1.;
+      zsign = 1.;
+    }
+
+    float tube_x = xsign * PmtLoc[ipmt % 64][0];
+    float tube_y = PmtLoc[ipmt % 64][1];
+    float tube_z = zsign * 253.;
+
+    MbdGeomV2::set_xyz(ipmt, tube_x, tube_y, tube_z);
+  }
+
+  download_hv();
+}
+
+void MbdGeomV2::set_xyz(const unsigned int ipmt, const float x, const float y, const float z)
+{
+  pmt_x[ipmt] = x;
+  pmt_y[ipmt] = y;
+  pmt_z[ipmt] = z;
+  pmt_r[ipmt] = std::sqrt(x * x + y * y);
+  pmt_phi[ipmt] = std::atan2(y, x);
+}
+
+void MbdGeomV2::download_hv()
+{
+  // South HV Map
+  pmt_hv.insert(std::pair<int, int>( 0, 0 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 1 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 2 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 3 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 4 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 5 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 6 ));
+  pmt_hv.insert(std::pair<int, int>( 0, 10 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 9 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 12 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 13 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 15 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 17 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 18 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 20 ));
+  pmt_hv.insert(std::pair<int, int>( 1, 23 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 7 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 8 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 11 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 14 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 16 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 19 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 22 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 25 ));
+  pmt_hv.insert(std::pair<int, int>( 2, 26 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 21 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 24 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 27 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 28 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 29 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 30 ));
+  pmt_hv.insert(std::pair<int, int>( 3, 31 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 32 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 33 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 34 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 35 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 36 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 37 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 38 ));
+  pmt_hv.insert(std::pair<int, int>( 4, 42 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 41 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 44 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 45 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 47 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 49 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 50 ));
+  pmt_hv.insert(std::pair<int, int>( 5, 52 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 39 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 40 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 43 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 46 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 48 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 51 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 54 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 57 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 58 ));
+  pmt_hv.insert(std::pair<int, int>( 6, 60 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 53 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 55 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 56 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 59 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 61 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 62 ));
+  pmt_hv.insert(std::pair<int, int>( 7, 63 ));
+
+  // North HV Map
+  pmt_hv.insert(std::pair<int, int>( 8, 64 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 65 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 66 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 67 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 68 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 70 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 74 ));
+  pmt_hv.insert(std::pair<int, int>( 8, 77 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 76 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 81 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 84 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 87 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 91 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 94 ));
+  pmt_hv.insert(std::pair<int, int>( 9, 95 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 71 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 72 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 75 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 78 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 80 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 83 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 86 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 89 ));
+  pmt_hv.insert(std::pair<int, int>( 10, 90 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 69 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 73 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 79 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 82 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 85 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 88 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 92 ));
+  pmt_hv.insert(std::pair<int, int>( 11, 93 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 96 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 97 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 98 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 99 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 100 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 102 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 106 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 108 ));
+  pmt_hv.insert(std::pair<int, int>( 12, 109 ));
+  pmt_hv.insert(std::pair<int, int>( 13, 101 ));
+  pmt_hv.insert(std::pair<int, int>( 13, 105 ));
+  pmt_hv.insert(std::pair<int, int>( 13, 111 ));
+  pmt_hv.insert(std::pair<int, int>( 13, 119 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 103 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 104 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 107 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 110 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 112 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 115 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 116 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 118 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 121 ));
+  pmt_hv.insert(std::pair<int, int>( 14, 122 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 113 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 114 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 117 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 120 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 123 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 124 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 125 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 126 ));
+  pmt_hv.insert(std::pair<int, int>( 15, 127 ));
+
+}
+

--- a/offline/packages/mbd/MbdGeomV2.cc
+++ b/offline/packages/mbd/MbdGeomV2.cc
@@ -94,7 +94,6 @@ MbdGeomV2::MbdGeomV2()
     MbdGeomV2::set_xyz(ipmt, tube_x, tube_y, tube_z);
   }
 
-  download_hv();
 }
 
 void MbdGeomV2::set_xyz(const unsigned int ipmt, const float x, const float y, const float z)
@@ -104,6 +103,15 @@ void MbdGeomV2::set_xyz(const unsigned int ipmt, const float x, const float y, c
   pmt_z[ipmt] = z;
   pmt_r[ipmt] = std::sqrt(x * x + y * y);
   pmt_phi[ipmt] = std::atan2(y, x);
+}
+
+const std::multimap<int,int>& MbdGeomV2::get_hvmap()
+{
+  if ( pmt_hv.size()==0 )
+  {
+    download_hv();
+  }
+  return pmt_hv;
 }
 
 void MbdGeomV2::download_hv()

--- a/offline/packages/mbd/MbdGeomV2.h
+++ b/offline/packages/mbd/MbdGeomV2.h
@@ -19,7 +19,7 @@ class MbdGeomV2 : public MbdGeom
   void set_xyz(const unsigned int ipmt, const float x, const float y, const float z) override;
 
   void download_hv() override;
-  const std::multimap<int,int>& get_hvmap() { return pmt_hv; }
+  const std::multimap<int,int>& get_hvmap();
 
   virtual void Reset() override {}
 

--- a/offline/packages/mbd/MbdGeomV2.h
+++ b/offline/packages/mbd/MbdGeomV2.h
@@ -1,0 +1,38 @@
+#ifndef __MBD_GEOM_V2_H__
+#define __MBD_GEOM_V2_H__
+
+#include "MbdGeom.h"
+#include <map>
+
+class MbdGeomV2 : public MbdGeom
+{
+ public:
+  MbdGeomV2();
+  ~MbdGeomV2() override = default;
+
+  float get_x(const unsigned int pmtch) const override { return pmt_x[pmtch]; }
+  float get_y(const unsigned int pmtch) const override { return pmt_y[pmtch]; }
+  float get_z(const unsigned int pmtch) const override { return pmt_z[pmtch]; }
+  float get_r(const unsigned int pmtch) const override { return pmt_r[pmtch]; }
+  float get_phi(const unsigned int pmtch) const override { return pmt_phi[pmtch]; }
+
+  void set_xyz(const unsigned int ipmt, const float x, const float y, const float z) override;
+
+  void download_hv() override;
+  const std::multimap<int,int>& get_hvmap() { return pmt_hv; }
+
+  virtual void Reset() override {}
+
+ private:
+  float pmt_x[128]{};
+  float pmt_y[128]{};
+  float pmt_z[128]{};
+  float pmt_r[128]{};
+  float pmt_phi[128]{};
+
+  std::multimap<int,int> pmt_hv;
+
+  ClassDefOverride(MbdGeomV2, 1)
+};
+
+#endif  // __MBD_GEOM_V2_H__

--- a/offline/packages/mbd/MbdGeomV2LinkDef.h
+++ b/offline/packages/mbd/MbdGeomV2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class MbdGeomV2+;
+
+#endif /* __CINT__ */

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -22,6 +22,7 @@
 #include <phool/phool.h>
 
 #include <ffarawobjects/CaloPacketContainer.h>
+#include <ffarawobjects/Gl1Packet.h>
 
 #include <TF1.h>
 
@@ -87,7 +88,7 @@ int MbdReco::process_event(PHCompositeNode *topNode)
     }
     else if ( m_mbdraw!=nullptr )
     {
-      status = m_mbdevent->SetRawData(m_mbdraw, m_mbdpmts);
+      status = m_mbdevent->SetRawData(m_mbdraw, m_mbdpmts,m_gl1raw);
     }
 
     if (status == Fun4AllReturnCodes::DISCARDEVENT )
@@ -95,10 +96,20 @@ int MbdReco::process_event(PHCompositeNode *topNode)
       static int counter = 0;
       if ( counter<3 )
       {
-        std::cout << PHWHERE << " ERROR, no good data in MBD" << std::endl;
+        std::cout << PHWHERE << " Warning, MBD discarding event " << std::endl;
         counter++;
       }
       return Fun4AllReturnCodes::DISCARDEVENT;
+    }
+    else if (status == Fun4AllReturnCodes::ABORTEVENT )
+    {
+      static int counter = 0;
+      if ( counter<3 )
+      {
+        std::cout << PHWHERE << " Warning, MBD aborting event " << std::endl;
+        counter++;
+      }
+      return Fun4AllReturnCodes::ABORTEVENT;
     }
     else if ( status == -1001 )
     {
@@ -134,7 +145,7 @@ int MbdReco::process_event(PHCompositeNode *topNode)
     // copy to globalvertex
   }
 
-  //if (Verbosity() > 0)
+  if (Verbosity() > 0)
   {
     std::cout << "mbd vertex z and t0 " << m_mbdevent->get_bbcz() << ", " << m_mbdevent->get_bbct0() << std::endl;
   }
@@ -247,6 +258,9 @@ int MbdReco::getNodes(PHCompositeNode *topNode)
       counter++;
     }
   }
+
+  // Get the raw gl1 data from event combined DST
+  m_gl1raw = findNode::getClass<Gl1Packet>(topNode, "Gl1Packet");
 
   // MbdPmtContainer
   m_mbdpmts = findNode::getClass<MbdPmtContainer>(topNode, "MbdPmtContainer");

--- a/offline/packages/mbd/MbdReco.h
+++ b/offline/packages/mbd/MbdReco.h
@@ -14,6 +14,7 @@ class MbdOut;
 class MbdGeom;
 class Event;
 class CaloPacketContainer;
+class Gl1Packet;
 class TF1;
 class TH1;
 
@@ -43,6 +44,7 @@ class MbdReco : public SubsysReco
   std::unique_ptr<MbdEvent> m_mbdevent{nullptr};
   Event *m_event{nullptr};
   CaloPacketContainer *m_mbdraw{nullptr};
+  Gl1Packet *m_gl1raw{nullptr};
   MbdOut *m_mbdout{nullptr};
   MbdPmtContainer *m_mbdpmts{nullptr};
   MbdGeom *m_mbdgeom{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: reads in gl1packet from DST_TRIGGERED_EVENT, uses only MBDNS triggered events for calibration.  Also added hv map to MbdGeom (in v2 class). 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

