### PR TITLE
Add flag to turn off output file writing

### DIFF
--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -32,8 +32,11 @@ JetSeedCount::JetSeedCount(const std::string &recojetname, const std::string &tr
 int JetSeedCount::Init(PHCompositeNode * /*topNode*/)
 {
   std::cout << "JetSeedCount::Init(PHCompositeNode *topNode) Initializing" << std::endl;
-  std::cout << "Opening output file named " << m_outputFileName << std::endl;
-  // PHTFileServer::get().open(m_outputFileName, "RECREATE");
+  if (m_writeToOutputFile)
+  {
+    std::cout << "Opening output file named " << m_outputFileName << std::endl;
+    PHTFileServer::get().open(m_outputFileName, "RECREATE");
+  }
   m_manager = QAHistManagerDef::getHistoManager();
   if (!m_manager)
   {
@@ -154,7 +157,10 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
 int JetSeedCount::End(PHCompositeNode * /*topNode*/)
 {
   std::cout << "JetSeedCount::End(PHCompositeNode *topNode) This is the End..." << std::endl;
-  PHTFileServer::get().cd(m_outputFileName);
+  if (m_writeToOutputFile)
+  {
+    PHTFileServer::get().cd(m_outputFileName);
+  }
 
   TH1 *hRawSeedCount = new TH1F("hRawSeedCount", "Raw Seed Count per Event", 100, 0.00, 50.00);
   hRawSeedCount->GetXaxis()->SetTitle("Raw Seed Count per Event");

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -57,7 +57,7 @@ class JetSeedCount : public SubsysReco
  private:
   Fun4AllHistoManager *m_manager{nullptr};
 
-  bool m_writeToOutputFile;
+  bool m_writeToOutputFile {false};
 
   int m_event{0};
   int m_seed_sub{std::numeric_limits<int>::max()};

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -37,6 +37,11 @@ class JetSeedCount : public SubsysReco
     m_ptRange.first = low;
     m_ptRange.second = high;
   }
+  void
+  setWriteToOutputFile(bool write)
+  {
+    m_writeToOutputFile = write;
+  }
 
   int Init(PHCompositeNode *topNode) override;
 
@@ -51,6 +56,8 @@ class JetSeedCount : public SubsysReco
 
  private:
   Fun4AllHistoManager *m_manager{nullptr};
+
+  bool m_writeToOutputFile;
 
   int m_event{0};
   int m_seed_sub{std::numeric_limits<int>::max()};

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -188,8 +188,18 @@ int StructureinJets::EndRun(const int runnumber)
 //____________________________________________________________________________..
 int StructureinJets::End(PHCompositeNode* /*topNode*/)
 {
-  std::cout << "StructureinJets::End - Output to " << m_outputFileName << std::endl;
-  PHTFileServer::get().cd(m_outputFileName);
+
+  // if flag is true, write to output file
+  // otherwise rely on histogram manager
+  if (writeToOutputFileFlag)
+  {
+    std::cout << "StructureinJets::End - Output to " << m_outputFileName << std::endl;
+    PHTFileServer::get().cd(m_outputFileName);
+  }
+  else
+  {
+    std::cout << "StructureinJets::End - Output to histogram manager" << std::endl;
+  }
 
   if (isAA())
   {
@@ -198,12 +208,19 @@ int StructureinJets::End(PHCompositeNode* /*topNode*/)
     {
       m_h_track_vs_calo_pt->GetZaxis()->SetRange(i + 1, i + 1);
       h_proj = (TH2*) m_h_track_vs_calo_pt->Project3D("yx");
-      h_proj->Write((boost::format("h_track_vs_calo_%1.0f") % m_h_track_vs_calo_pt->GetZaxis()->GetBinLowEdge(i + 1)).str().c_str());
+      h_proj->SetName((boost::format("h_track_vs_calo_%1.0f") % m_h_track_vs_calo_pt->GetZaxis()->GetBinLowEdge(i + 1)).str().c_str());
+      if (writeToOutputFileFlag)
+      {
+        h_proj->Write();
+      }
     }
   }
   else
   {
-    m_h_track_pt->Write();  // if pp, do not project onto centrality bins
+    if (writeToOutputFileFlag)
+    {
+      m_h_track_pt->Write();  // if pp, do not project onto centrality bins
+    }
   }
   std::cout << "StructureinJets::End(PHCompositeNode *topNode) This is the End..." << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -62,11 +62,15 @@ class StructureinJets : public SubsysReco
   bool isAA() const { return isAAFlag; }
   void isAA(bool b) { isAAFlag = b; }
 
+  bool writeToOutputFile() const { return writeToOutputFileFlag; }
+  void writeToOutputFile(bool b) { writeToOutputFileFlag = b; }
+
  private:
   std::string m_recoJetName;
   float m_trk_pt_cut{2};
   float m_jetRadius{0.4};
   bool isAAFlag{false};
+  bool writeToOutputFileFlag{false};
   std::string m_outputFileName;
   TH3 *m_h_track_vs_calo_pt{nullptr};
   TH2 *m_h_track_pt{nullptr};


### PR DESCRIPTION
This PR adds a flag to a couple jet QA modules to avoid accidentally trying to save to a file when not needed.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Bug fix: user will now be able to turn off writing to output files in relevant jet QA modules.

## Links to other PRs in macros and calibration repositories (if applicable)

This will let all modules be run by [macros#844](https://github.com/sPHENIX-Collaboration/macros/pull/844). 
