### PR TITLE
suppress cling warning when including ActsTrackingGeometry.h

### DIFF
--- a/offline/packages/trackbase/ActsTrackingGeometry.h
+++ b/offline/packages/trackbase/ActsTrackingGeometry.h
@@ -1,15 +1,24 @@
 #ifndef TRACKBASE_ACTSTRACKINGGEOMETRY_H
 #define TRACKBASE_ACTSTRACKINGGEOMETRY_H
 
+
+#pragma GCC diagnostic push
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wundefined-internal"
 #include <Acts/Definitions/Algebra.hpp>
-#include <Acts/Utilities/BinnedArray.hpp>
-#include <Acts/Utilities/Logger.hpp>
-#include <memory>
+#endif
+#pragma GCC diagnostic pop
 
 #include <Acts/Geometry/TrackingGeometry.hpp>
+
 #include <Acts/MagneticField/MagneticFieldContext.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
+
+#include <Acts/Utilities/BinnedArray.hpp>
 #include <Acts/Utilities/CalibrationContext.hpp>
+#include <Acts/Utilities/Logger.hpp>
+
+#include <memory>
 
 /**
  * A struct to carry around Acts geometry on node tree, so as to not put


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR just gets rid of this annoying warning (by disabling the warnings via pragma for this include in the header file)
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/trackbase/ActsSurfaceMaps.h:9:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/trackbase/ActsTrackingGeometry.h:4:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/Acts/Definitions/Algebra.hpp:22:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/Eigen/Core:167:
/cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/Eigen/src/Core/util/IntegralConstant.h:189:36: warning: variable 'Eigen::fix<1>' has internal linkage but is not defined [-Wundefined-internal]
static const internal::FixedInt<N> fix{};
                                   ^
/cvmfs/sphenix.sdcc.bnl.gov/gcc-12.1.0/release/release_new/new.7/include/Eigen/src/Core/util/IndexedViewHelper.h:57:147: note: used here
static const symbolic::AddExpr<symbolic::SymbolExpr<internal::symbolic_last_tag>,symbolic::ValueExpr<Eigen::internal::FixedInt<1> > > lastp1(last+fix<1>());


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

