### PR TITLE
Update SingleTpcPoolInput.cc

### DIFF
--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -168,8 +168,9 @@ void SingleTpcPoolInput::FillPool(const unsigned int /*nbclks*/)
         // samples
         // const uint16_t samples = packet->iValue(wf, "SAMPLES");
 
-        // Temp remedy as we set the time window as 360 for now
-        const uint16_t samples = 360;
+        // Temp remedy as we set the time window as 410 for now (extended from previous 360
+        // due to including of diffused laser flush)
+        const uint16_t samples = 410;
 
         newhit->set_samples(samples);
 


### PR DESCRIPTION
Time sample max extended from 360 to 410 so that diffused laser events are included

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

