### PR TITLE
Tpot decoding update

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -46,7 +46,7 @@ Fun4AllStreamingInputManager::Fun4AllStreamingInputManager(const std::string &na
 {
   Fun4AllServer *se = Fun4AllServer::instance();
   m_topNode = se->topNode(TopNodeName());
-  
+
   return;
 }
 
@@ -434,6 +434,7 @@ void Fun4AllStreamingInputManager::registerStreamingInput(SingleStreamingInput *
     break;
   case InputManagerType::MICROMEGAS:
     m_micromegas_registered_flag = true;
+    static_cast<SingleMicromegasPoolInput*>(evtin)->createQAHistos();
     m_MicromegasInputVector.push_back(evtin);
     break;
   case InputManagerType::GL1:
@@ -804,16 +805,8 @@ int Fun4AllStreamingInputManager::FillMicromegas()
   }
 
   // fill all BCO statistics
-  bool first = true;
   for (const auto &iter : m_MicromegasInputVector)
-  {
-    if (first)
-    {
-      static_cast<SingleMicromegasPoolInput*>(iter)->createQAHistos();
-      first = false; 
-    }
-    static_cast<SingleMicromegasPoolInput*>(iter)->FillBcoQA(m_RefBCO);
-  }
+  { static_cast<SingleMicromegasPoolInput*>(iter)->FillBcoQA(m_RefBCO); }
 
 
   while ((m_MicromegasRawHitMap.begin()->first) <= select_crossings - m_micromegas_negative_bco)

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -193,7 +193,6 @@ bool MicromegasBcoMatchingInformation::find_reference( Packet* packet )
       if( get_bco_diff( gtm_bco_diff_list[i], fee_bco_diff ) < m_max_fee_bco_diff )
       {
         m_verified = true;
-        m_needs_synchronize = false;
         m_gtm_bco_first = gtm_bco_list[i];
         m_fee_bco_first = fee_bco_prev;
 
@@ -365,10 +364,6 @@ void MicromegasBcoMatchingInformation::update_multiplier_adjustment( uint64_t gt
     m_multiplier_adjustment_numerator = 0;
     m_multiplier_adjustment_denominator = 0;
     m_multiplier_adjustment_count = 0;
-
-    // also force resynchronization
-    m_needs_synchronize = true;
-
   }
 
 }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -49,6 +49,18 @@ namespace
     inline static constexpr T get_bco_diff( const T& first, const T& second )
   { return first < second ? (second-first):(first-second); }
 
+  // define limit for matching two fee_bco
+  static constexpr unsigned int m_max_multiplier_adjustment_count = 1000;
+
+  // define limit for matching two fee_bco
+  static constexpr unsigned int m_max_fee_bco_diff = 10;
+
+  // define limit for matching fee_bco to fee_bco_predicted
+  static constexpr unsigned int m_max_gtm_bco_diff = 100;
+
+  // needed to avoid memory leak. Assumes that we will not be assembling more than 50 events at the same time
+  static constexpr unsigned int m_max_matching_data_size = 50;
+
   //! copied from micromegas/MicromegasDefs.h, not available here
   static constexpr int m_nchannels_fee = 256;
 
@@ -181,6 +193,7 @@ bool MicromegasBcoMatchingInformation::find_reference( Packet* packet )
       if( get_bco_diff( gtm_bco_diff_list[i], fee_bco_diff ) < m_max_fee_bco_diff )
       {
         m_verified = true;
+        m_needs_synchronize = false;
         m_gtm_bco_first = gtm_bco_list[i];
         m_fee_bco_first = fee_bco_prev;
 
@@ -352,6 +365,10 @@ void MicromegasBcoMatchingInformation::update_multiplier_adjustment( uint64_t gt
     m_multiplier_adjustment_numerator = 0;
     m_multiplier_adjustment_denominator = 0;
     m_multiplier_adjustment_count = 0;
+
+    // also force resynchronization
+    m_needs_synchronize = true;
+
   }
 
 }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -33,10 +33,6 @@ class MicromegasBcoMatchingInformation
   bool is_verified() const
   { return m_verified; }
 
-  //! true if new synchronization is needed
-  bool needs_synchronize() const
-  { return m_needs_synchronize; }
-
   //! get predicted fee_bco from gtm_bco
   std::optional<uint32_t> get_predicted_fee_bco( uint64_t ) const;
 
@@ -88,9 +84,6 @@ class MicromegasBcoMatchingInformation
 
   //! verified
   bool m_verified = false;
-
-  //! true if needs to re-synchronize gtm_bco_first and fee_bco_first
-  bool m_needs_synchronize = false;
 
   //! first lvl1 bco (40 bits)
   uint64_t m_gtm_bco_first = 0;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -33,6 +33,10 @@ class MicromegasBcoMatchingInformation
   bool is_verified() const
   { return m_verified; }
 
+  //! true if new synchronization is needed
+  bool needs_synchronize() const
+  { return m_needs_synchronize; }
+
   //! get predicted fee_bco from gtm_bco
   std::optional<uint32_t> get_predicted_fee_bco( uint64_t ) const;
 
@@ -85,6 +89,9 @@ class MicromegasBcoMatchingInformation
   //! verified
   bool m_verified = false;
 
+  //! true if needs to re-synchronize gtm_bco_first and fee_bco_first
+  bool m_needs_synchronize = false;
+
   //! first lvl1 bco (40 bits)
   uint64_t m_gtm_bco_first = 0;
 
@@ -115,18 +122,6 @@ class MicromegasBcoMatchingInformation
 
   //! running count for multiplier adjustment
   unsigned int m_multiplier_adjustment_count = 0;
-
-  // define limit for matching two fee_bco
-  static constexpr unsigned int m_max_multiplier_adjustment_count = 1000;
-
-  // define limit for matching two fee_bco
-  static constexpr unsigned int m_max_fee_bco_diff = 10;
-
-  // define limit for matching fee_bco to fee_bco_predicted
-  static constexpr unsigned int m_max_gtm_bco_diff = 100;
-
-  // needed to avoid memory leak. Assumes that we will not be assembling more than 50 events at the same time
-  static constexpr unsigned int m_max_matching_data_size = 50;
 
 };
 

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -37,7 +37,7 @@ class MicromegasBcoMatchingInformation
   std::optional<uint32_t> get_predicted_fee_bco( uint64_t ) const;
 
   //! multiplier
-  static double multiplier()
+  static double get_gtm_clock_multiplier()
   { return m_multiplier; }
 
   //@}
@@ -73,6 +73,12 @@ class MicromegasBcoMatchingInformation
 
   private:
 
+  //! update multiplier adjustment
+  void update_multiplier_adjustment( uint64_t /* gtm_bco */, uint32_t /* fee_bco */ );
+
+  //! get adjusted multiplier
+  double get_adjusted_multiplier() const;
+
   //! verbosity
   unsigned int m_verbosity = 0;
 
@@ -97,6 +103,21 @@ class MicromegasBcoMatchingInformation
 
   //! gtm clock multiplier
   static double m_multiplier;
+
+  //! adjustment to multiplier
+  double m_multiplier_adjustment = 0;
+
+  //! running numerator for multiplier adjustment
+  double m_multiplier_adjustment_numerator = 0;
+
+  //! running denominator for multiplier adjustment
+  double m_multiplier_adjustment_denominator = 0;
+
+  //! running count for multiplier adjustment
+  unsigned int m_multiplier_adjustment_count = 0;
+
+  // define limit for matching two fee_bco
+  static constexpr unsigned int m_max_multiplier_adjustment_count = 1000;
 
   // define limit for matching two fee_bco
   static constexpr unsigned int m_max_fee_bco_diff = 10;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -73,7 +73,6 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
    */
   std::set<uint64_t> m_BclkStack;
 
-
   //! map bco_information_t to packet id
   using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation>;
   bco_matching_information_map_t m_bco_matching_information_map;

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -39,9 +39,14 @@ MicromegasRawDataTimingEvaluation::MicromegasRawDataTimingEvaluation(const std::
 int MicromegasRawDataTimingEvaluation::Init(PHCompositeNode* /*topNode*/)
 {
 
-  std::cout << "MicromegasRawDataTimingEvaluation::Init -"
-    << " MicromegasBcoMatchingInformation::multiplier: " << MicromegasBcoMatchingInformation::multiplier()
-    << std::endl;
+  {
+    const auto default_precision{std::cout.precision()};
+    std::cout << "MicromegasRawDataTimingEvaluation::Init -"
+      << std::setprecision(10)
+      << " MicromegasBcoMatchingInformation::multiplier: " << MicromegasBcoMatchingInformation::get_gtm_clock_multiplier()
+      << std::setprecision(default_precision)
+      << std::endl;
+    }
 
   m_evaluation_file.reset(new TFile(m_evaluation_filename.c_str(), "RECREATE"));
   m_evaluation_tree = new TTree("T", "T");


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR updates TPOT sub-event assembly to adjust FEE and GTM BCO clock multiplier on the fly, thus correcting from clock shift. 

It was tested on the 42 segments of run 00045288
Will test on more runs in the near future. 

Also @jdosbo @rosstom2232 this fixes broken code from https://github.com/sPHENIX-Collaboration/coresoftware/pull/2826


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

