### PR TITLE
also use 'old' fee_id for calibrations.

### DIFF
--- a/offline/packages/micromegas/MicromegasRawDataCalibration.cc
+++ b/offline/packages/micromegas/MicromegasRawDataCalibration.cc
@@ -73,14 +73,14 @@ int MicromegasRawDataCalibration::process_event(PHCompositeNode *topNode)
     for( int i=0; i<n_waveforms; ++i )
     {
       auto channel = packet->iValue( i, "CHANNEL" );
-      int fee = packet->iValue(i, "FEE" );
+      int fee_id = m_mapping.get_old_fee_id(packet->iValue(i, "FEE"));
       int samples = packet->iValue( i, "SAMPLES" );
       if( Verbosity() )
       {
         std::cout
           << "MicromegasRawDataCalibration::process_event -"
           << " waveform: " << i
-          << " fee: " << fee
+          << " fee_id: " << fee_id
           << " channel: " << channel
           << " samples: " << samples
           << std::endl;
@@ -88,13 +88,13 @@ int MicromegasRawDataCalibration::process_event(PHCompositeNode *topNode)
 
       // find relevant profile histogram
       TProfile* profile = nullptr;
-      auto piter = m_profile_map.lower_bound( fee );
-      if( piter == m_profile_map.end() || fee < piter->first )
+      auto piter = m_profile_map.lower_bound( fee_id );
+      if( piter == m_profile_map.end() || fee_id < piter->first )
       {
         // create and insert
-        profile = new TProfile( Form( "h_adc_channel_%i", fee ), "ADC vs channel;channel;adc", MicromegasDefs::m_nchannels_fee, 0, MicromegasDefs::m_nchannels_fee );
+        profile = new TProfile( Form( "h_adc_channel_%i", fee_id ), "ADC vs channel;channel;adc", MicromegasDefs::m_nchannels_fee, 0, MicromegasDefs::m_nchannels_fee );
         profile->SetErrorOption( "s" );
-        m_profile_map.insert(  piter, std::make_pair( fee, profile ) );
+        m_profile_map.insert(  piter, std::make_pair( fee_id, profile ) );
       } else profile = piter->second;
 
       // fill
@@ -122,14 +122,14 @@ int MicromegasRawDataCalibration::End(PHCompositeNode* /*topNode*/ )
 
     // create calibration data object
     MicromegasCalibrationData calibration_data;
-    for( const auto& [fee, profile]:m_profile_map )
+    for( const auto& [fee_id, profile]:m_profile_map )
     {
       for( int i = 0; i < profile->GetNbinsX(); ++ i )
       {
         const auto pedestal = profile->GetBinContent(i+1);
         const auto rms = profile->GetBinError(i+1);
-        calibration_data.set_pedestal( fee, i, pedestal );
-        calibration_data.set_rms( fee, i, rms );
+        calibration_data.set_pedestal( fee_id, i, pedestal );
+        calibration_data.set_rms( fee_id, i, rms );
       }
     }
     calibration_data.write( m_calibration_filename );

--- a/offline/packages/micromegas/MicromegasRawDataCalibration.h
+++ b/offline/packages/micromegas/MicromegasRawDataCalibration.h
@@ -5,6 +5,9 @@
  * \file MicromegasRawDataCalibration.h
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  */
+
+#include "MicromegasMapping.h"
+
 #include <fun4all/SubsysReco.h>
 
 #include <map>
@@ -39,28 +42,31 @@ class MicromegasRawDataCalibration : public SubsysReco
 
   /// set min sample for noise estimation
   void set_sample_min( int value ) { m_sample_min = value; }
-  
+
   /// set min sample for noise estimation
   void set_sample_max( int value ) { m_sample_max = value; }
 
   /// set to true to store evaluation histograms and ntuples
   void set_calibration_file( const std::string& value ) { m_calibration_filename = value; }
-  
+
   private:
 
-  /// min sample for noise estimation 
+  //! mapping
+  MicromegasMapping m_mapping;
+
+  /// min sample for noise estimation
   int m_sample_min = 0;
-  
+
   /// max sample for noise estimation
   int m_sample_max = 100;
-  
+
   /// calibration output file
   std::string m_calibration_filename = "TPOT_Pedestal_000.root";
-    
+
   /// map fee id to Profile histogram
   using profile_map_t = std::map<int, TProfile*>;
   profile_map_t m_profile_map;
-  
+
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This fixes inconsistency between processing  old data with new calibration file, due to fiber swapping.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

