### PR TITLE
fix: unpacking strobe length

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -102,10 +102,17 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
 
   mvtx_raw_event_header =
       findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
   if (!mvtx_raw_event_header)
   {
-    Fun4AllServer* se = Fun4AllServer::instance();
     se->unregisterSubsystem(this);
+  }
+
+  if(se->RunNumber() > 42735)
+  {
+    m_strobeWidth = 10.;
   }
 
   // Mask Hot MVTX Pixels


### PR DESCRIPTION
This puts a check for the run number to determine the strobe length. We cannot access the database where this information is available in SDCC, so this will have to do for now so that we aren't producing nonsensical data in the offline. We need to return to this to get the information either into the CDB or into a db that is accessible in SDCC.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

