### PR TITLE
Micromegas decoding 4

### DIFF
--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -87,34 +87,13 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco(
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet )
+void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
 {
-  // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
-  const int n_tagger = packet->lValue(0, "N_TAGGER");
-  for (int t = 0; t < n_tagger; ++t)
+  if(!m_gtm_bco_list.empty())
   {
-    const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
-    if (is_lvl1)
-    {
-      const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
-      m_gtm_bco_list.push_back(gtm_bco);
-    }
-  }
-
-  if(verbosity() && !m_gtm_bco_list.empty())
-  {
-    // get packet id
-    const int packet_id = packet->getIdentifier();
 
     std::cout
       << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
-      << " packet: " << packet_id
-      << " n_tagger: " << n_tagger
-      << std::endl;
-
-    std::cout
-      << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
-      << " packet: " << packet_id
       << " gtm_bco: " << std::hex << m_gtm_bco_list << std::dec
       << std::endl;
 
@@ -130,9 +109,24 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
 
       std::cout
         << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
-        << " packet: " << packet_id
         << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
         << std::endl;
+    }
+  }
+}
+
+//___________________________________________________
+void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet )
+{
+  // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
+  const int n_tagger = packet->lValue(0, "N_TAGGER");
+  for (int t = 0; t < n_tagger; ++t)
+  {
+    const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
+    if (is_lvl1)
+    {
+      const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+      m_gtm_bco_list.push_back(gtm_bco);
     }
   }
 }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -64,6 +64,18 @@ namespace
   //! copied from micromegas/MicromegasDefs.h, not available here
   static constexpr int m_nchannels_fee = 256;
 
+  /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
+  enum SampaDataType
+  {
+    HEARTBEAT_T = 0b000,
+    TRUNCATED_DATA_T = 0b001,
+    TRUNCATED_TRIG_EARLY_DATA_T = 0b011,
+    NORMAL_DATA_T = 0b100,
+    LARGE_DATA_T = 0b101,
+    TRIG_EARLY_DATA_T = 0b110,
+    TRIG_EARLY_LARGE_DATA_T = 0b111,
+  };
+
 }
 
 // this is the clock multiplier from lvl1 to fee clock
@@ -161,6 +173,14 @@ bool MicromegasBcoMatchingInformation::find_reference( Packet* packet )
   const int n_waveform = packet->iValue(0, "NR_WF");
   for (int iwf = 0; iwf < n_waveform; ++iwf)
   {
+
+    // check type
+    const unsigned short type = packet->iValue(iwf, "TYPE" );
+
+    // skip heartbeat waveforms
+    if( type == HEARTBEAT_T ) continue;
+
+    // check channel
     const unsigned short channel = packet->iValue( iwf, "CHANNEL" );
 
     // bound check

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -143,11 +143,25 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
   const int n_tagger = packet->lValue(0, "N_TAGGER");
   for (int t = 0; t < n_tagger; ++t)
   {
+    // save level1 trigger bco
     const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
     if (is_lvl1)
     {
       const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
       m_gtm_bco_list.push_back(gtm_bco);
+    }
+
+    // also save hearbeat bco
+    const bool is_modebit = static_cast<uint8_t>(packet->lValue(t, "IS_MODEBIT"));
+    if( is_modebit )
+    {
+      // get modebits
+      uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
+      if( modebits&(1<<ELINK_HEARTBEAT_T) )
+      {
+        const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+        m_gtm_bco_list.push_back(gtm_bco);
+      }
     }
   }
 }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -144,6 +144,14 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
 }
 
 //___________________________________________________
+void MicromegasBcoMatchingInformation::set_reference( uint64_t gtm_bco_first, uint32_t fee_bco_first )
+{
+  m_gtm_bco_first = gtm_bco_first;
+  m_fee_bco_first = fee_bco_first;
+  m_verified = true;
+}
+
+//___________________________________________________
 bool MicromegasBcoMatchingInformation::find_reference( Packet* packet )
 {
   // store gtm bco and diff to previous in an array

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -40,6 +40,9 @@ class MicromegasBcoMatchingInformation
   static double get_gtm_clock_multiplier()
   { return m_multiplier; }
 
+  //! print gtm bco information
+  void print_gtm_bco_information() const;
+
   //@}
 
   //!@name modifiers

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -62,9 +62,6 @@ class MicromegasBcoMatchingInformation
   //! find clock references used to match FEE and GTM BCO clock from packet data
   bool find_reference( Packet* );
 
-  //! set BCO reference manually
-  void set_reference( uint64_t /* gtm_bco_first*/, uint32_t /* fee_bco_first */ );
-
   /**
    * matching information is verified if at least one match
    * between gtm_bco and fee_bco is found
@@ -78,6 +75,12 @@ class MicromegasBcoMatchingInformation
   //@}
 
   private:
+
+  //! find reference from modebits
+  bool find_reference_from_modebits( Packet* );
+
+  //! find reference from data
+  bool find_reference_from_data( Packet* );
 
   //! update multiplier adjustment
   void update_multiplier_adjustment( uint64_t /* gtm_bco */, uint32_t /* fee_bco */ );

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -62,6 +62,9 @@ class MicromegasBcoMatchingInformation
   //! find clock references used to match FEE and GTM BCO clock from packet data
   bool find_reference( Packet* );
 
+  //! set BCO reference manually
+  void set_reference( uint64_t /* gtm_bco_first*/, uint32_t /* fee_bco_first */ );
+
   /**
    * matching information is verified if at least one match
    * between gtm_bco and fee_bco is found

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -26,6 +26,7 @@
 #include <TH1.h>
 
 #include <algorithm>
+#include <bitset>
 
 namespace
 {
@@ -42,6 +43,15 @@ namespace
     LARGE_DATA_T = 0b101,
     TRIG_EARLY_DATA_T = 0b110,
     TRIG_EARLY_LARGE_DATA_T = 0b111,
+  };
+
+  enum ModeBitType
+  {
+    BX_COUNTER_SYNC_T = 0,
+    ELINK_HEARTBEAT_T = 1,
+    SAMPA_EVENT_TRIGGER_T = 2,
+    CLEAR_LV1_LAST_T = 6,
+    CLEAR_LV1_ENDAT_T = 7
   };
 
 }  // namespace
@@ -153,6 +163,19 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
           const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
           m_BeamClockPacket[gtm_bco].insert(packet_id);
           m_BclkStack.insert(gtm_bco);
+        }
+
+        const bool is_modebit = static_cast<uint8_t>(packet->lValue(t, "IS_MODEBIT"));
+        if( is_modebit )
+        {
+          // get modebits
+          uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
+          if( modebits&(1<<BX_COUNTER_SYNC_T) )
+          {
+            // get BCO, assign to bco_matching_information
+            const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+            bco_matching_information.set_reference( gtm_bco, 0 );
+          }
         }
       }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -45,15 +45,6 @@ namespace
     TRIG_EARLY_LARGE_DATA_T = 0b111,
   };
 
-  enum ModeBitType
-  {
-    BX_COUNTER_SYNC_T = 0,
-    ELINK_HEARTBEAT_T = 1,
-    SAMPA_EVENT_TRIGGER_T = 2,
-    CLEAR_LV1_LAST_T = 6,
-    CLEAR_LV1_ENDAT_T = 7
-  };
-
 }  // namespace
 
 //______________________________________________________________
@@ -163,19 +154,6 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
           const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
           m_BeamClockPacket[gtm_bco].insert(packet_id);
           m_BclkStack.insert(gtm_bco);
-        }
-
-        const bool is_modebit = static_cast<uint8_t>(packet->lValue(t, "IS_MODEBIT"));
-        if( is_modebit )
-        {
-          // get modebits
-          uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
-          if( modebits&(1<<BX_COUNTER_SYNC_T) )
-          {
-            // get BCO, assign to bco_matching_information
-            const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
-            bco_matching_information.set_reference( gtm_bco, 0 );
-          }
         }
       }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -197,13 +197,6 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
           continue;
         }
 
-        // get number of samples and check
-        const uint16_t samples = packet->iValue(wf, "SAMPLES");
-        if (samples < m_min_req_samples)
-        {
-          continue;
-        }
-
         // get fee bco
         const unsigned int fee_bco = packet->iValue(wf, "BCO");
 
@@ -228,6 +221,13 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
         // get type
         // ignore heartbeat waveforms
         if( packet->iValue(wf, "TYPE" ) == HEARTBEAT_T ) continue;
+
+        // get number of samples and check
+        const uint16_t samples = packet->iValue(wf, "SAMPLES");
+        if (samples < m_min_req_samples)
+        {
+          continue;
+        }
 
         // create new hit
         auto newhit = std::make_unique<MicromegasRawHitv1>();

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -190,16 +190,6 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
         // get fee id
         const int fee_id = packet->iValue(wf, "FEE");
 
-        // get type
-        const int type = packet->iValue(wf, "TYPE" );
-
-        // ignore heartbeat waveforms
-        /**
-         * TODO: in principle, since heartbeat data come at fixed GTM BCO interals,
-         * the corresponding FEE_BCO could be use to check FEE clock frequency
-         **/
-        if( type == HEARTBEAT_T ) continue;
-
         // get checksum_error and check
         const auto checksum_error = packet->iValue(wf, "CHECKSUMERROR");
         if (checksum_error)
@@ -234,6 +224,10 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
           // skip the waverform
           continue;
         }
+
+        // get type
+        // ignore heartbeat waveforms
+        if( packet->iValue(wf, "TYPE" ) == HEARTBEAT_T ) continue;
 
         // create new hit
         auto newhit = std::make_unique<MicromegasRawHitv1>();

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -163,10 +163,11 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       if (Verbosity())
       {
         std::cout
-            << "SingleMicromegasPoolInput::FillPool -"
-            << " packet: " << packet_id
-            << " n_waveform: " << nwf
-            << std::endl;
+          << "SingleMicromegasPoolInput::FillPool -"
+          << " packet: " << packet_id
+          << " n_waveform: " << nwf
+          << std::endl;
+        bco_matching_information.print_gtm_bco_information();
       }
 
       // try find reference

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -31,6 +31,19 @@ namespace
 {
   // minimum number of requested samples
   static constexpr int m_min_req_samples = 5;
+
+  /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
+  enum SampaDataType
+  {
+    HEARTBEAT_T = 0b000,
+    TRUNCATED_DATA_T = 0b001,
+    TRUNCATED_TRIG_EARLY_DATA_T = 0b011,
+    NORMAL_DATA_T = 0b100,
+    LARGE_DATA_T = 0b101,
+    TRIG_EARLY_DATA_T = 0b110,
+    TRIG_EARLY_LARGE_DATA_T = 0b111,
+  };
+
 }  // namespace
 
 //______________________________________________________________
@@ -174,6 +187,16 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       {
         // get fee id
         const int fee_id = packet->iValue(wf, "FEE");
+
+        // get type
+        const int type = packet->iValue(wf, "TYPE" );
+
+        // ignore heartbeat waveforms
+        /**
+         * TODO: in principle, since heartbeat data come at fixed GTM BCO interals,
+         * the corresponding FEE_BCO could be use to check FEE clock frequency
+         **/
+        if( type == HEARTBEAT_T ) continue;
 
         // get checksum_error and check
         const auto checksum_error = packet->iValue(wf, "CHECKSUMERROR");

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -121,6 +121,20 @@ namespace MicromegasDefs
   //! mark invalid ADC values
   static constexpr uint16_t m_adc_invalid = 65000;
 
+
+  /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
+  // TODO: should move to online_distribution
+  enum SampaDataType
+  {
+    HEARTBEAT_T = 0b000,
+    TRUNCATED_DATA_T = 0b001,
+    TRUNCATED_TRIG_EARLY_DATA_T = 0b011,
+    NORMAL_DATA_T = 0b100,
+    LARGE_DATA_T = 0b101,
+    TRIG_EARLY_DATA_T = 0b110,
+    TRIG_EARLY_LARGE_DATA_T = 0b111,
+  };
+
 }
 
 #endif

--- a/offline/packages/micromegas/MicromegasRawDataCalibration.cc
+++ b/offline/packages/micromegas/MicromegasRawDataCalibration.cc
@@ -72,9 +72,13 @@ int MicromegasRawDataCalibration::process_event(PHCompositeNode *topNode)
 
     for( int i=0; i<n_waveforms; ++i )
     {
-      auto channel = packet->iValue( i, "CHANNEL" );
-      int fee_id = m_mapping.get_old_fee_id(packet->iValue(i, "FEE"));
-      int samples = packet->iValue( i, "SAMPLES" );
+
+      const int type = packet->iValue(i, "TYPE");
+      if( type == MicromegasDefs::HEARTBEAT_T ) continue;
+
+      const auto channel = packet->iValue( i, "CHANNEL" );
+      const int fee_id = m_mapping.get_old_fee_id(packet->iValue(i, "FEE"));
+      const int samples = packet->iValue( i, "SAMPLES" );
       if( Verbosity() )
       {
         std::cout

--- a/offline/packages/micromegas/MicromegasRawDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasRawDataDecoder.cc
@@ -115,6 +115,11 @@ int MicromegasRawDataDecoder::process_event(PHCompositeNode* topNode)
     for (int iwf = 0; iwf < n_waveforms; ++iwf)
     {
       const int fee = m_mapping.get_old_fee_id(packet->iValue(iwf, "FEE"));
+      const int type = packet->iValue(iwf, "TYPE");
+
+      // ignore heartbeat waveforms
+      if( type == MicromegasDefs::HEARTBEAT_T ) continue;
+
       const auto channel = packet->iValue(iwf, "CHANNEL");
       const int samples = packet->iValue(iwf, "SAMPLES");
 

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -165,6 +165,10 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
 
       for (int iwf = 0; iwf < n_waveform; ++iwf)
       {
+
+        const int type = packet->iValue(iwf, "TYPE");
+        if( type == MicromegasDefs::HEARTBEAT_T ) continue;
+
         // create running sample, assign packet, fee, layer and tile id
         Sample sample;
         sample.packet_id = packet_id;

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -132,12 +132,6 @@ int MicromegasRawDataTimingEvaluation::process_event(PHCompositeNode* topNode)
       waveform.channel = packet->iValue( iwf, "CHANNEL" );
       waveform.type = packet->iValue(iwf, "TYPE");
 
-      // ignore heartbeat waveforms
-      if( waveform.type == MicromegasDefs::HEARTBEAT_T ) continue;
-
-      // ignore heartbeat waveforms
-      if( waveform.type == 0 ) continue;
-
       // bound check
       if( waveform.channel >= MicromegasDefs::m_nchannels_fee )
       {

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -128,6 +128,13 @@ int MicromegasRawDataTimingEvaluation::process_event(PHCompositeNode* topNode)
       waveform.packet_id = packet_id;
       waveform.fee_id = packet->iValue(iwf, "FEE");
       waveform.channel = packet->iValue( iwf, "CHANNEL" );
+      waveform.type = packet->iValue(iwf, "TYPE");
+
+      // ignore heartbeat waveforms
+      if( waveform.type == MicromegasDefs::HEARTBEAT_T ) continue;
+
+      // ignore heartbeat waveforms
+      if( waveform.type == 0 ) continue;
 
       // bound check
       if( waveform.channel >= MicromegasDefs::m_nchannels_fee )

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -104,10 +104,12 @@ int MicromegasRawDataTimingEvaluation::process_event(PHCompositeNode* topNode)
 
     if (Verbosity())
     {
-      std::cout << "MicromegasRawDataTimingEvaluation::process_event -"
-                << " packet: " << packet_id
-                << " n_waveform: " << n_waveform
-                << std::endl;
+      std::cout
+        << "MicromegasRawDataTimingEvaluation::process_event -"
+        << " packet: " << packet_id
+        << " n_waveform: " << n_waveform
+        << std::endl;
+      bco_matching_information.print_gtm_bco_information();
     }
 
     // try find reference

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.h
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.h
@@ -60,6 +60,10 @@ class MicromegasRawDataTimingEvaluation : public SubsysReco
     /// packet
     unsigned int packet_id = 0;
 
+    /// waveform type
+    /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
+    unsigned int type = 0;
+
     /// ll1 bco
     uint64_t gtm_bco = 0;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR
- ignores heartbeat in decoding, calibration, event assembly, etc.
- uses modebits tagger to set clock reference, when found. The old method, using data, is kept, so that one can still process non-zero file segment when necessary

With this: could fully assembled several entire runs of TPOT zero-suppressed data with a failure rate < 0.3% (FEE data not associated to a trigger).

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

