### PR TITLE
New distortion correction type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ tmtags
 # For vim:
 *.swp
 
+#for vscode
+.vscode
+
 # For redcar:
 .redcar
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "__locale": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "__locale": "cpp"
-    }
-}

--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -106,9 +106,7 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
     {
       z_new = z - dcc->m_hDZint[index]->Interpolate(phi, r) * zterm;
     }
-
-    //if we are in interpolation mode, we need to apply the z interpolation to all terms
-
+    
   }
 
   // update cluster

--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -65,6 +65,7 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
 
   // if the phi correction hist units are cm, we must divide by r to get the dPhi in radians
   auto divisor = r;
+
   if (dcc->m_phi_hist_in_radians)
   {
     // if the phi correction hist units are radians, we must not divide by r.
@@ -88,7 +89,11 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
   }
   else if (dcc->m_dimensions == 2)
   {
-    const double zterm = (1. - std::abs(z) / 105.5);
+    double zterm = 1.0;
+
+    if (dcc->m_interpolate_z){
+      zterm=(1. - std::abs(z) / 105.5);
+    }
     if (dcc->m_hDPint[index] && (mask & COORD_PHI) && check_boundaries(dcc->m_hDPint[index], phi, r))
     {
       phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi, r) * zterm / divisor;
@@ -101,6 +106,9 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
     {
       z_new = z - dcc->m_hDZint[index]->Interpolate(phi, r) * zterm;
     }
+
+    //if we are in interpolation mode, we need to apply the z interpolation to all terms
+
   }
 
   // update cluster

--- a/offline/packages/tpc/TpcDistortionCorrection.h
+++ b/offline/packages/tpc/TpcDistortionCorrection.h
@@ -30,7 +30,7 @@ class TpcDistortionCorrection
     Volumetric = 0,
     PlanarInterpolateToZero= 1,
     PlanarFlat = 2
-  }
+  };
 
   enum CoordMask
   {

--- a/offline/packages/tpc/TpcDistortionCorrection.h
+++ b/offline/packages/tpc/TpcDistortionCorrection.h
@@ -21,7 +21,8 @@ class TpcDistortionCorrection
   {
     StaticOnly = 0,
     BeamInducedAverage = 1,
-    BeamInducedFluctuation = 2
+    BeamInducedFluctuation = 2,
+    ModuleEdge = 3
   };
 
   enum DistortionHandlingType

--- a/offline/packages/tpc/TpcDistortionCorrection.h
+++ b/offline/packages/tpc/TpcDistortionCorrection.h
@@ -24,6 +24,13 @@ class TpcDistortionCorrection
     BeamInducedFluctuation = 2
   };
 
+  enum DistortionHandlingType
+  {
+    Volumetric = 0,
+    PlanarInterpolateToZero= 1,
+    PlanarFlat = 2
+  }
+
   enum CoordMask
   {
     COORD_PHI = 1 << 0,

--- a/offline/packages/tpc/TpcDistortionCorrectionContainer.h
+++ b/offline/packages/tpc/TpcDistortionCorrectionContainer.h
@@ -17,11 +17,13 @@ class TpcDistortionCorrectionContainer
   //! constructor
   TpcDistortionCorrectionContainer() = default;
 
-  //! flag to tell us whether to read z data or just interpolate
+  //! flag to tell us whether to read z data or just 2d data
   int m_dimensions = 3;
 
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians = true;
+  //! flag to tell us how to handle 2d corrections: interpolate to 0 at readout or assume the correction has no z dependence
+  bool m_interpolate_z = true;
 
   //!@name space charge distortion histograms
   //@{

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -62,7 +62,7 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
   }
 
   // create and populate the nodes for each distortion, if present:
-  for (int i = 0; i < 3; i++)
+  for (int i = 0; i < 4; i++)
   {
     if (!m_correction_in_use[i])
     {
@@ -106,6 +106,9 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
 
     // assign whether phi corrections (DP) should be read as radians or mm
     distortion_correction_object->m_phi_hist_in_radians = m_phi_hist_in_radians;
+
+    // assign whether 2D corrections should be interpolated to zero at readout or not (has no effect on 3D corrections)
+    distortion_correction_object->m_interpolate_z = m_interpolate_z;
 
     if (Verbosity())
     {

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -34,7 +34,7 @@ class TpcLoadDistortionCorrection : public SubsysReco
     DistortionType_Static = 0,
     DistortionType_Average = 1,
     DistortionType_Fluctuation = 2,
-    DistortionTtype_ModuleEdge = 3
+    DistortionType_ModuleEdge = 3
   };
 
   //! correction filename
@@ -49,6 +49,11 @@ class TpcLoadDistortionCorrection : public SubsysReco
   void set_read_phi_as_radians(bool flag)
   {
     m_phi_hist_in_radians = flag;
+  }
+  //! set the histogram to interpolate between hist value and zero, depending on z position. (has no effect if m_dimensions is 3)
+  void set_interpolate_2D_to_zero(bool flag)
+  {
+    m_interpolate_z = flag;
   }
 
   //! node name
@@ -70,6 +75,7 @@ class TpcLoadDistortionCorrection : public SubsysReco
 
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians = true;
+  bool m_interpolate_z = true;
 
   //! distortion object node name
   std::string m_node_name[4] = {"TpcDistortionCorrectionContainerStatic", "TpcDistortionCorrectionContainerAverage", "TpcDistortionCorrectionContainerFluctuation","TpcDistortionCorrectionContainerModuleEdge"};

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -33,13 +33,14 @@ class TpcLoadDistortionCorrection : public SubsysReco
   {
     DistortionType_Static = 0,
     DistortionType_Average = 1,
-    DistortionType_Fluctuation = 2
+    DistortionType_Fluctuation = 2,
+    DistortionTtype_ModuleEdge = 3
   };
 
   //! correction filename
   void set_correction_filename(DistortionType i, const std::string& value)
   {
-    if (i < 0 || i >= 3) return;
+    if (i < 0 || i >= 4) return;
     m_correction_filename[i] = value;
     m_correction_in_use[i] = true;
   }
@@ -62,16 +63,16 @@ class TpcLoadDistortionCorrection : public SubsysReco
 
  private:
   //! correction filename
-  std::string m_correction_filename[3] = {"", "", ""};
+  std::string m_correction_filename[4] = {"", "", "",""};
 
   //! flag to indicate correction in use
-  bool m_correction_in_use[3] = {false, false, false};
+  bool m_correction_in_use[4] = {false, false, false,false};
 
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians = true;
 
   //! distortion object node name
-  std::string m_node_name[3] = {"TpcDistortionCorrectionContainerStatic", "TpcDistortionCorrectionContainerAverage", "TpcDistortionCorrectionContainerFluctuation"};
+  std::string m_node_name[4] = {"TpcDistortionCorrectionContainerStatic", "TpcDistortionCorrectionContainerAverage", "TpcDistortionCorrectionContainerFluctuation","TpcDistortionCorrectionContainerModuleEdge"};
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> This adds a 'module edge' distortion type, per Mariia's work.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)  This is a new feature.

[comment]: <> Up to four distortion corrections can now be applied.  2D corrections default to assuming they should be interpolated from stated values (at CM) to zero (at Readout), but the interpolation flag can also be set to false, which treats it as a z-independent distortion correction.  The module edge correction is expected to be z-independent for z more than ~few cm away from the readout.


## TODOs (if applicable)

It would be good to modify this to take 'n' distortions.  We can still hard-code that 'N', but '3' and now '4' appear in several places as a magic number.

## Links to other PRs in macros and calibration repositories (if applicable)

