### PR TITLE
Write GL1P scalers to SpinDB

### DIFF
--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -429,16 +429,14 @@ int XingShiftCal::CommitToSpinDB()
 
 
   //=============== connect to daq db to get gl1p scalers ===============
-  std::string remoteConnStr =
-        "DRIVER={PostgreSQL};"
-        "SERVER=sphnxdaqdbreplica;"
-        "PORT=5432;"
-        "DATABASE=daq;"
-    "UID=phnxrc;";
+  std::string daqdbname = "daq";
+  std::string daqdbowner = "phnxrc";
+  std::string daqdbpasswd = "";
+
   odbc::Connection *conDAQ = nullptr;
   try
   {
-    conDAQ = odbc::DriverManager::getConnection(remoteConnStr);
+    conDAQ = odbc::DriverManager::getConnection(daqdbname.c_str(), daqdbowner.c_str(), daqdbpasswd.c_str());
   }
   catch (odbc::SQLException &eDAQ)
   {

--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -14,7 +14,6 @@
 
 #include <TCanvas.h>
 #include <TH1.h>
-#include <TFile.h>
 
 #include <boost/format.hpp>
 
@@ -41,7 +40,6 @@ XingShiftCal::XingShiftCal(const std::string &name, const int poverwriteSpinEntr
     }
   }
 
-  hbnchnum = new TH1I("hbnchnum","hbnchnum",120,-0.5,119.5);
 
   std::cout << "XingShiftCal::XingShiftCal(const std::string &name) Calling ctor" << std::endl;
 }
@@ -170,7 +168,7 @@ int XingShiftCal::process_event(PHCompositeNode *topNode)
   {
     p = evt->getPacket(packet_GL1);
     int bunchnr = p->lValue(0, "BunchNumber");
-    hbnchnum->Fill(bunchnr);
+    
     for (int i = 0; i < NTRIG; i++)
     {
       // 2nd arg of lValue: 0 is raw trigger count, 1 is live trigger count, 2 is scaled trigger count
@@ -253,12 +251,6 @@ int XingShiftCal::End(PHCompositeNode * /*topNode*/)
   {
     std::cout << "Commit to SpinDB : FAILURE" << std::endl;
   }
-
-
-  TFile *outfile = new TFile("bnchnumhist.root","RECREATE");
-  hbnchnum->Write();
-  outfile->Write();
-  outfile->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/calibrations/xingshift/XingShiftCal.cc
+++ b/calibrations/xingshift/XingShiftCal.cc
@@ -486,7 +486,7 @@ int XingShiftCal::CommitToSpinDB()
     return 0;
   }
 
-  int arrayindex = 0;
+
   while (rsGL1P->next()) {
     int index = rsGL1P->getInt("index");
     int bunch = rsGL1P->getInt("bunch");
@@ -503,9 +503,7 @@ int XingShiftCal::CommitToSpinDB()
     {
       zdcns[bunch] = rsGL1P->getInt("scaled");
     }
-    //int64_t scaled = rsGL1P->getInt("scaled"); // Retrieve the value of the "scaled" column
-    //std::cout << "scaled: " << scaled << std::endl;
-    arrayindex++;
+
   }
   // =======================================================
   

--- a/calibrations/xingshift/XingShiftCal.h
+++ b/calibrations/xingshift/XingShiftCal.h
@@ -10,6 +10,7 @@
 
 class PHCompositeNode;
 class Packet;
+class TH1;
 
 class XingShiftCal : public SubsysReco
 {
@@ -95,6 +96,13 @@ class XingShiftCal : public SubsysReco
   int fillnumberYellow{0};
 
   uint64_t scalercounts[NTRIG][NBUNCHES]{};
+
+  int64_t mbdns[NBUNCHES]{0};
+  int64_t mbdvtx[NBUNCHES]{0};
+  int64_t zdcns[NBUNCHES]{0};
+
+  TH1 *hbnchnum;
+
 };
 
 #endif  // XINGSHIFT_XINGSHIFTCAL_H

--- a/calibrations/xingshift/XingShiftCal.h
+++ b/calibrations/xingshift/XingShiftCal.h
@@ -10,7 +10,6 @@
 
 class PHCompositeNode;
 class Packet;
-class TH1;
 
 class XingShiftCal : public SubsysReco
 {
@@ -101,7 +100,6 @@ class XingShiftCal : public SubsysReco
   int64_t mbdvtx[NBUNCHES]{0};
   int64_t zdcns[NBUNCHES]{0};
 
-  TH1 *hbnchnum;
 
 };
 

--- a/offline/packages/uspin/SpinDBInput.cc
+++ b/offline/packages/uspin/SpinDBInput.cc
@@ -306,9 +306,9 @@ int SpinDBInput::InitializeRunRow(SpinDBContent spin_cont)
   InitializeArray(runnum, qa_level, "polaryellowerrorsys", ncross);
   InitializeArray(runnum, qa_level, "spinpatternblue", ncross);
   InitializeArray(runnum, qa_level, "spinpatternyellow", ncross);
-  InitializeArray(runnum, qa_level, "mbdvertexcut", ncross);
-  InitializeArray(runnum, qa_level, "mbdwithoutcut", ncross);
-  InitializeArray(runnum, qa_level, "zdcnocut", ncross);
+  InitializeArray(runnum, qa_level, "mbdvtx", ncross);
+  InitializeArray(runnum, qa_level, "mbdns", ncross);
+  InitializeArray(runnum, qa_level, "zdcns", ncross);
   InitializeArray(runnum, qa_level, "badbunchqa", ncross);
 
   InitializeValue(runnum, qa_level, "transversxblue");
@@ -481,15 +481,15 @@ int SpinDBInput::UpdateDBContent(SpinDBContent spin_cont)
   }
   if (cmbd_vtxcut)
   {
-    UpdateArray(runnum, qa_level, "mbdvertexcut", mbd_vtxcut, ncross);
+    UpdateArray(runnum, qa_level, "mbdvtx", mbd_vtxcut, ncross);
   }
   if (cmbd_nocut)
   {
-    UpdateArray(runnum, qa_level, "mbdwithoutcut", mbd_nocut, ncross);
+    UpdateArray(runnum, qa_level, "mbdns", mbd_nocut, ncross);
   }
   if (czdc_nocut)
   {
-    UpdateArray(runnum, qa_level, "zdcnocut", zdc_nocut, ncross);
+    UpdateArray(runnum, qa_level, "zdcns", zdc_nocut, ncross);
   }
   if (cbad_bunch)
   {

--- a/offline/packages/uspin/SpinDBOutput.cc
+++ b/offline/packages/uspin/SpinDBOutput.cc
@@ -460,9 +460,9 @@ int SpinDBOutput::GetDBContent(SpinDBContent &spin_cont, odbc::ResultSet *rs)
   }
   GetArray(rs, "spinpatternblue", bpat, ncross);
   GetArray(rs, "spinpatternyellow", ypat, ncross);
-  GetArray(rs, "mbdvertexcut", mbd_vtxcut, ncross);
-  GetArray(rs, "mbdwithoutcut", mbd_nocut, ncross);
-  GetArray(rs, "zdcwithoutcut", zdc_nocut, ncross);
+  GetArray(rs, "mbdvtx", mbd_vtxcut, ncross);
+  GetArray(rs, "mbdns", mbd_nocut, ncross);
+  GetArray(rs, "zdcns", zdc_nocut, ncross);
   GetArray(rs, "badbunchqa", bad_bunch, ncross);
 
   for (int i = 0; i < ncross; i++)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR provides functionality for XingShiftCal to read gl1p scalers from the daq db and write them to the spin db. Additionally, the uspin package is updated to reflect a change in the naming convention of columns in the spin db.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

