### PR TITLE
(INTT) ifdef to suppress warning

### DIFF
--- a/offline/packages/intt/InttSurveyMap.h
+++ b/offline/packages/intt/InttSurveyMap.h
@@ -5,7 +5,14 @@
 
 #include <phool/PHObject.h>
 
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundefined-internal"
 #include <Eigen/Geometry>
+#pragma GCC diagnostic pop
+#else
+#include <Eigen/Geometry>
+#endif
 
 #include <cstddef>  // for size_t
 #include <iostream>


### PR DESCRIPTION
Added ifdef to suppress undefined internal message when class is included in ROOT macros

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

