### PR TITLE
remove duplicate key matches in chain growth

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -698,18 +698,20 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
       // grow the seed to the maximum length allowed
       bool first_link = true; 
       bool done_growing = (seed.size() >= _max_clusters_per_seed);
-      keyList head_keys = { seed.back() }; // heads of the seed
+      keyList head_keys = { seed.back() };
+      /* keyList head_keys = { seed.back() }; // heads of the seed */
+                                           
       while (!done_growing) {
         // Get all bilinks which fit to the head of the chain
         unsigned int iL = TrkrDefs::getLayer(head_keys[0]) - _FIRST_LAYER_TPC;
-        keyList link_matches {};
+        keySet link_matches {};
         for (const auto& head_key : head_keys) {
             // also possible to sort the links and use a sorted search like:
             // auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); 
             // for (auto link = matched_links.first; link != matched_links.second; ++link)
           for (auto& link : bilinks[iL]) { // iL for "Index of Layer"
             if (link.first == head_key) { 
-              link_matches.push_back(link.second);
+              link_matches.insert(link.second);
             }
           }
         }

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -74,6 +74,7 @@ class PHCASeeding : public PHTrackSeeding
    using keyList = std::vector<TrkrDefs::cluskey>;
    using keyLists = std::vector<keyList>;
    using keyListPerLayer = std::array<keyList, _NLAYERS_TPC>;
+   using keySet = std::set<TrkrDefs::cluskey>;
 
    using keyLink = std::pair<TrkrDefs::cluskey, TrkrDefs::cluskey>;
    using keyLinks = std::vector<keyLink>;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fixes algorithm in `PHCASeeding` module to not match the same new "link" (matching cluster in next successive layer) to multiple previous links. (switch std::vector for std::set)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

