### PR TITLE
hotfix: Fix poorly formatted boost string in jet QA

### DIFF
--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -363,7 +363,7 @@ int JetKinematicCheck::End(PHCompositeNode * /*unused*/)
   leg11->SetBorderSize(0);
   leg11->SetTextSize(0.06);
   leg11->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < p_{T} < %2% [GeV/c]") % m_ptRange.first%  m_ptRange.second).c_str(), "");
-  leg11->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %1.1f") % m_etaRange.first % m_etaRange.second).c_str(), "");
+  leg11->AddEntry((TObject *) nullptr, boost::str(boost::format("%1% < #eta < %2%") % m_etaRange.first % m_etaRange.second).c_str(), "");
   jet_mass_pt_r04->SetStats(false);
   jet_mass_pt_r04->SetTitle("Jet Mass vs p_{T} [R = 0.4]");
   jet_mass_pt_r04->GetListOfFunctions()->Add(leg11);


### PR DESCRIPTION
This PR resolves an exception thrown by a jet QA module.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This bug fix resolves an exception thrown in the `JetKinematicCheck` module: one histogram title was using a poorly formatted boost string.

