### PR TITLE
Micromegas decoding 5

### DIFF
--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -258,7 +258,8 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
   }
 
   // print all differences
-  std::cout << "MicromegasBcoMatchingInformation::find_reference - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl;
+  if( verbosity() )
+  { std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl; }
 
   uint32_t fee_bco_prev = 0;
   bool has_fee_bco_prev = false;
@@ -295,7 +296,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
     if( fee_bco_diff < m_max_fee_bco_diff )
     { continue; }
 
-    std::cout << "MicromegasBcoMatchingInformation::find_reference - fee_bco_diff: " << fee_bco_diff << std::endl;
+    std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - fee_bco_diff: " << fee_bco_diff << std::endl;
 
     // look for matching diff in gtm_bco array
     for( size_t i = 0; i < gtm_bco_diff_list.size(); ++i )
@@ -313,13 +314,13 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
 
           if( verbosity() )
           {
-            std::cout << "MicromegasBcoMatchingInformation::find_reference - matching is verified" << std::endl;
+            std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - matching is verified" << std::endl;
             std::cout
-              << "MicromegasBcoMatchingInformation::find_reference -"
+              << "MicromegasBcoMatchingInformation::find_reference_from_data -"
               << " m_gtm_bco_first: " << std::hex << m_gtm_bco_first << std::dec
               << std::endl;
             std::cout
-              << "MicromegasBcoMatchingInformation::find_reference -"
+              << "MicromegasBcoMatchingInformation::find_reference_from_data -"
               << " m_fee_bco_first: " << std::hex << m_fee_bco_first << std::dec
               << std::endl;
           }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -188,6 +188,7 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       {
         std::cout << "SingleMicromegasPoolInput::FillPool - bco_matching not verified, dropping packet" << std::endl;
         m_waveform_count_dropped[packet_id] += nwf;
+        bco_matching_information.cleanup();
         continue;
       }
 

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -120,6 +120,7 @@ int MicromegasRawDataTimingEvaluation::process_event(PHCompositeNode* topNode)
     {
       std::cout << "MicromegasRawDataTimingEvaluation::process_event - bco_matching not verified, dropping packet" << std::endl;
       m_waveform_count_dropped[packet_id] += n_waveform;
+      bco_matching_information.cleanup();
       continue;
     }
 


### PR DESCRIPTION
This PR cleans up internal lists/maps even when reference is not found to avoid ever-increasing, resulting in job crash.
Also hides some more printout behind a Verbosity statement.
Thanks to @jdosbo for pointin this out. 
Note: the run you are looking at (44681) will still bomb, because of not being able to assemble a single event for TPOT. 


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

