### PR TITLE
CD: Run-dependent MVTX strobe length

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -113,11 +113,7 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
     se->unregisterSubsystem(this);
   }
 
-  float strobe_length_query = getStrobeLength();
-  if (strobe_length_query != 0 )
-  {
-    m_strobeWidth = strobe_length_query;
-  }
+  getStrobeLength();
 
   // Mask Hot MVTX Pixels
   std::string database = CDBInterface::instance()->getUrl(
@@ -298,7 +294,7 @@ void MvtxCombinedRawDataDecoder::removeDuplicates(
   v.erase(end, v.end());
 }
 
-float MvtxCombinedRawDataDecoder::getStrobeLength()
+void MvtxCombinedRawDataDecoder::getStrobeLength()
 {
   recoConsts *rc = recoConsts::instance();
   int m_runNumber = rc->get_IntFlag("RUNNUMBER");
@@ -308,7 +304,18 @@ float MvtxCombinedRawDataDecoder::getStrobeLength()
   executable_command += ";\" | tail -n 1";
 
   std::string strobe_query = exec(executable_command.c_str());
-  return stof(strobe_query);
+
+  try
+  {
+    m_strobeWidth = stof(strobe_query);
+  }
+  catch (std::invalid_argument const& ex)
+  {
+    if (Verbosity() >= 1)
+    {
+      std::cout << PHWHERE << ":: Run number " << m_runNumber << " has no strobe length in the DAQ database, using " << m_strobeWidth << " microseconds" << std::endl;
+    }
+  }
 }
 
 // https://stackoverflow.com/questions/478898/how-do-i-execute-a-command-and-get-the-output-of-the-command-within-c-using-po

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -50,7 +50,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
-  float getStrobeLength();
+  void getStrobeLength();
   std::string exec(const char *cmd);
 
   TrkrHitSetContainer* hit_set_container = nullptr;

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -50,6 +50,9 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
+  float getStrobeLength();
+  std::string exec(const char *cmd);
+
   TrkrHitSetContainer* hit_set_container = nullptr;
   MvtxEventInfo* mvtx_event_header = nullptr;
   MvtxRawEvtHeader* mvtx_raw_event_header = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This introduces a run-depended strobe length. This pulls from the read-only DB and only returns values as long as the info is there. We should default to 89 us in all other cases

Test results
```c++
Fun4AllServer::BeginRun: InitRun for MvtxCombinedRawDataDecoder
executable_command: 
psql -h sphnxdaqdbreplica daq --csv -c "SELECT strobe FROM mvtx_strobe WHERE hostname = 'mvtx0' AND runnumber = 45825;" | tail -n 1
strobe_query: 
9.9

The strobe length is 9.9
Registering Subsystem CDBInterface
```

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

