### PR TITLE
fix: use new intt hit api for auto produced histos

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -132,7 +132,14 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
           std::cout << "Number of Hits: " << num_hits << " for packet "
                     << pool->getIdentifier() << std::endl;
         }
-        std::set<uint64_t> bclk_set;
+        
+        int numBCOs = pool->iValue(0, "NR_BCOS");
+        for (int j = 0; j < numBCOs; j++)
+        {
+          auto bco = pool->lValue(j, "BCOLIST");
+          m_BclkStack.insert(bco);
+        }
+
         for (int j = 0; j < num_hits; j++)
         {
           InttRawHit *newhit = new InttRawHitv2();
@@ -152,7 +159,6 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
           newhit->set_event_counter(pool->iValue(j, "EVENT_COUNTER"));
 
           gtm_bco += m_Rollover[FEE];
-          bclk_set.insert(gtm_bco);
           
           if (gtm_bco < m_PreviousClock[FEE])
           {
@@ -177,7 +183,6 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
             StreamingInputManager()->AddInttRawHit(gtm_bco, newhit);
           }
           m_InttRawHitMap[gtm_bco].push_back(newhit);
-          m_BclkStack.insert(gtm_bco);
         }
         //	    Print("FEEBCLK");
       }


### PR DESCRIPTION
This uses Martin's new INTT API to get the BCOs for each server without any hit requirement. The auto produced histos are filled in the same way

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

