### PR TITLE
More TrackResiduals changes for better distortions handling 

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -944,32 +944,32 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
 
-  // move the cluster positions back to the original readout surface
+  // move the corrected cluster positions back to the original readout surface
   auto global_moved = m_clusterMover.processTrack(global);
 
   ActsTransformations transformer;
   TrkrCluster* cluster = clustermap->findCluster(ckey);
 
-  //loop over global_moved vector and get this cluster
-  Acts::Vector3 clusglob;
-  for(auto pair : global_moved)
+  //loop over global vectors and get this cluster
+  Acts::Vector3 clusglob(0,0,0);
+  for(auto pair : global)
     {
       auto thiskey = pair.first;
       clusglob = pair.second;
       if(thiskey == ckey) break;
     }
 
-  Acts::Vector3 clusglob_unmoved;
-  for(auto pair : global)
+  Acts::Vector3 clusglob_moved(0,0,0);
+  for(auto pair : global_moved)
     {
       auto thiskey = pair.first;
-      clusglob_unmoved = pair.second;
+      clusglob_moved = pair.second; 
       if(thiskey == ckey) break;
     }
 
   if(Verbosity() > 1)
     {
-      std::cout << "Called :fillClusterBranchesKF for ckey " << ckey << " trackid " << track->get_id() << " clusglob x " << clusglob(0) << " y " << clusglob(1) << " z " << clusglob(2) << std::endl;
+      std::cout << "Called :fillClusterBranchesKF for ckey " << ckey << " trackid " << track->get_id() << " clusglob x " << clusglob(0) << " y " << clusglob(1) << " z " << clusglob(2) <<  std::endl;
     }
 
   switch (TrkrDefs::getTrkrId(ckey))
@@ -1024,7 +1024,7 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
     {
       TrkrDefs::hitsetkey hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       TrkrDefs::subsurfkey new_subsurfkey = 0;
-      surf = geometry->get_tpc_surface_from_coords(hitsetkey, clusglob, new_subsurfkey);
+      surf = geometry->get_tpc_surface_from_coords(hitsetkey, clusglob_moved, new_subsurfkey);
     }
   if (!surf)
     {
@@ -1035,10 +1035,10 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   
   // get local coordinates
   Acts::Vector2 loc;
-  clusglob *= Acts::UnitConstants::cm;  // we want mm for transformations
+  clusglob_moved *= Acts::UnitConstants::cm;  // we want mm for transformations
   Acts::Vector3 normal = surf->normal(geometry->geometry().getGeoContext());
   auto local = surf->globalToLocal(geometry->geometry().getGeoContext(),
-				   clusglob, normal);
+				   clusglob_moved, normal);
   if (local.ok())
     {
       loc = local.value() / Acts::UnitConstants::cm;
@@ -1047,27 +1047,27 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
     {
        // otherwise take the manual calculation for the TPC
       // doing it this way just avoids the bounds check that occurs in the surface class method
-      Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * clusglob;  // global is in mm
+      Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * clusglob_moved;  // global is in mm
       loct /= Acts::UnitConstants::cm;
       
       loc(0) = loct(0);
       loc(1) = loct(1);
     }
 
-  clusglob /= Acts::UnitConstants::cm;  // we want cm for the tree
+  clusglob_moved /= Acts::UnitConstants::cm;  // we want cm for the tree
   
   m_cluslx.push_back(loc.x());
   m_cluslz.push_back(loc.y());
 
-  float clusr = r(clusglob.x(), clusglob.y());
+  float clusr = r(clusglob_moved.x(), clusglob_moved.y());
   auto para_errors = m_clusErrPara.get_clusterv5_modified_error(cluster,
                                                                 clusr, ckey);
   m_cluselx.push_back(sqrt(para_errors.first));
   m_cluselz.push_back(sqrt(para_errors.second));
-  m_clusgx.push_back(clusglob.x());
-  m_clusgy.push_back(clusglob.y());
-  m_clusgr.push_back(clusglob.y() > 0 ? clusr : -1 * clusr);
-  m_clusgz.push_back(clusglob.z());
+  m_clusgx.push_back(clusglob_moved.x());
+  m_clusgy.push_back(clusglob_moved.y());
+  m_clusgr.push_back(clusglob_moved.y() > 0 ? clusr : -1 * clusr);
+  m_clusgz.push_back(clusglob_moved.z());
   m_clusgxunmoved.push_back(clusglob.x());
   m_clusgyunmoved.push_back(clusglob.y());
   m_clusgzunmoved.push_back(clusglob.z());
@@ -1083,7 +1083,7 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   {
     std::cout << "Track state/clus in layer "
               << (unsigned int) TrkrDefs::getLayer(ckey) << " with pos "
-              << clusglob.transpose() << std::endl;
+              << clusglob_moved.transpose() << std::endl;
   }
 
   auto misaligncenter = surf->center(geometry->geometry().getGeoContext());
@@ -1098,7 +1098,13 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   alignmentTransformationContainer::use_alignment = false;
   auto idealcenter = surf->center(geometry->geometry().getGeoContext());
   auto idealnorm = -1 * surf->normal(geometry->geometry().getGeoContext());
-  Acts::Vector3 ideal_local(loc.x(), loc.y(), 0.0);
+
+  // replace the corrected moved cluster local position with the readout position from ideal geometry for now
+  // This allows us to see the distortion corrections by subtracting this uncorrected position
+  // revisit this when looking at the alignment case
+  //  Acts::Vector3 ideal_local(loc.x(), loc.y(), 0.0);
+  auto nominal_loc = geometry->getLocalCoords(ckey, cluster);
+  Acts::Vector3 ideal_local(nominal_loc.x(), nominal_loc.y(), 0.0);
   Acts::Vector3 ideal_glob = surf->transform(geometry->geometry().getGeoContext()) * (ideal_local * Acts::UnitConstants::cm);
   auto idealrot = surf->transform(geometry->geometry().getGeoContext()).rotation();
 
@@ -1176,6 +1182,41 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   m_statepy.push_back(state->get_py());
   m_statepz.push_back(state->get_pz());
   m_statepl.push_back(state->get_pathlength());
+
+  if(Verbosity() > 2)
+    {
+      if(ideal_glob(2) > 0)
+	{
+	  double xideal = ideal_glob.x();
+	  double yideal = ideal_glob.y();
+	  double zideal = ideal_glob.z();
+	  
+	  double xunmoved = clusglob.x();
+	  double yunmoved = clusglob.y();
+	  double zunmoved = clusglob.z();
+	  
+	  double xmoved = clusglob_moved.x();
+	  double ymoved = clusglob_moved.y();
+	  double zmoved = clusglob_moved.z();
+	  
+	  
+	  double this_radius_ideal = sqrt(xideal*xideal + yideal*yideal); 
+	  double this_radius_unmoved = sqrt(xunmoved*xunmoved + yunmoved*yunmoved); 
+	  
+	  double this_phi_unmoved =  atan2(yunmoved, xunmoved);
+	  double this_phi_ideal =  atan2(yideal, xideal);
+	  double this_phi_moved =  atan2(ymoved, xmoved);
+	  
+	  std::cout << " global:  unmoved " <<  xunmoved << "  " << yunmoved << "  " << zunmoved << " this_phi " << this_phi_unmoved << " radius_unmoved " << this_radius_unmoved 
+		    << " r*phi " << this_radius_ideal * this_phi_unmoved << std::endl; 
+	  std::cout << "              global: ideal " <<  xideal << "  " << yideal << "  " << zideal << " this_phi_ideal " << this_phi_ideal << " radius_ideal " << this_radius_ideal
+		    <<  " r*phi " << this_radius_ideal*this_phi_ideal  << std::endl; 
+	  std::cout << "              global: moved " <<  xmoved << "  " << ymoved << "  " << zmoved << " phi_moved " << this_phi_moved 
+		    <<  " r*phi " << this_radius_ideal*this_phi_moved  << std::endl; 
+	  std::cout << "                        d_radius " << this_radius_unmoved - this_radius_ideal  << " clusgz " << zideal << " r*dphi " << this_radius_ideal *(this_phi_unmoved - this_phi_ideal) << std::endl;
+	}
+    }
+
 }
 
 void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey, // SvtxTrack* track,
@@ -1249,7 +1290,7 @@ void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey, // SvtxTra
   m_cluslx.push_back(loc.x());
   m_cluslz.push_back(loc.y());
 
-  float clusr = r(clusglob.x(), clusglob.y());
+  float clusr = r(clusglob_moved.x(), clusglob_moved.y());
   auto para_errors = m_clusErrPara.get_clusterv5_modified_error(cluster,
                                                                 clusr, ckey);
   m_cluselx.push_back(sqrt(para_errors.first));
@@ -2101,7 +2142,7 @@ void TrackResiduals::fillResidualTreeSeeds( PHCompositeNode* topNode )
 	global_raw.emplace_back(std::make_pair(ckey, global));
       } 
 
-    // ---- we do not use the global positions moved back to the surface in the case of seeds
+    // ---- we move the global positions back to the surface in fillClusterBranchesSeeds
     
     if (!m_doAlignment)
       {

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -234,6 +234,9 @@ class TrackResiduals : public SubsysReco
   std::vector<float> m_clusgx;
   std::vector<float> m_clusgy;
   std::vector<float> m_clusgz;
+  std::vector<float> m_clusgxunmoved;
+  std::vector<float> m_clusgyunmoved;
+  std::vector<float> m_clusgzunmoved;
   std::vector<float> m_clusgr;
   std::vector<int> m_cluslayer;
   std::vector<int> m_clussize;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Modifies TrackResiduals by adding to residualtree the distortion corrected cluster position before the cluster mover puts it back on the surface. Now we have:

clusgxideal etc.        = cluster position with no corrections
clusgxunmoved etc. = cluster position after distortion corrections
clusgx etc.                = corrected cluster position moved to surface
stategx etc.               = track state at the cluster surface

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

