### PR TITLE
refactor: crossing assignment into silicon seeding

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -283,7 +283,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
       double Y0 = trackSeed->get_Y0();
       double Z0 = trackSeed->get_Z0();
       double slope = trackSeed->get_slope();
-      svtxtrack->set_crossing(0);
+      svtxtrack->set_crossing(trackSeed->get_crossing());
       std::vector<double> xy_error2;
       std::vector<double> rz_error2;
       std::vector<double> xy_residuals;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -19,6 +19,7 @@
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
+#include <trackbase/TrkrClusterCrossingAssoc.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrCluster.h>
@@ -402,6 +403,9 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
         trackSeed->identify();
       }
 
+      //! try to get a crossing value based on INTT
+      trackSeed->set_crossing(getCrossingIntt(*trackSeed));
+
       m_seedContainer->insert(trackSeed.get());
 
       fitTimer->stop();
@@ -438,6 +442,106 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
   }
 
   return;
+}
+
+short int PHActsSiliconSeeding::getCrossingIntt(TrackSeed& si_track)
+{
+  // If the Si track contains an INTT hit, use it to get the bunch crossing offset
+
+  std::vector<short int> intt_crossings = getInttCrossings(si_track);
+
+  bool keep_it = true;
+  short int crossing_keep = 0;
+  if (intt_crossings.size() == 0)
+  {
+    keep_it = false;
+  }
+  else
+  {
+    crossing_keep = intt_crossings[0];
+    for (unsigned int ic = 1; ic < intt_crossings.size(); ++ic)
+    {
+      if (intt_crossings[ic] != crossing_keep)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << " Warning: INTT crossings not all the same "
+                    << " crossing_keep " << crossing_keep << " new crossing " << intt_crossings[ic] << " keep the first one in the list" << std::endl;
+        }
+      }
+    }
+  }
+
+  if (keep_it)
+  {
+    return crossing_keep;
+  }
+
+  return SHRT_MAX;
+}
+
+std::vector<short int> PHActsSiliconSeeding::getInttCrossings(TrackSeed& si_track)
+{
+  std::vector<short int> intt_crossings;
+
+  // If the Si track contains an INTT hit, use it to get the bunch crossing offset
+  // loop over associated clusters to get keys for silicon cluster
+  for (TrackSeed::ConstClusterKeyIter iter = si_track.begin_cluster_keys();
+       iter != si_track.end_cluster_keys();
+       ++iter)
+  {
+    TrkrDefs::cluskey cluster_key = *iter;
+    const unsigned int trkrid = TrkrDefs::getTrkrId(cluster_key);
+
+    if (Verbosity() > 1)
+    {
+      unsigned int layer = TrkrDefs::getLayer(cluster_key);
+
+      if (trkrid == TrkrDefs::mvtxId)
+      {
+        TrkrCluster* cluster = m_clusterMap->findCluster(cluster_key);
+        if (!cluster)
+        {
+          continue;
+        }
+
+        Acts::Vector3 global = m_tGeometry->getGlobalPosition(cluster_key, cluster);
+
+        std::cout << "Checking  si Track with cluster " << cluster_key
+                  << " in layer " << layer << " position " << global(0) << "  " << global(1) << "  " << global(2)
+                  << " eta " << si_track.get_eta() << std::endl;
+      }
+      else
+      {
+        std::cout << "Checking  si Track with cluster " << cluster_key
+                  << " in layer " << layer << " with eta " << si_track.get_eta() << std::endl;
+      }
+    }
+
+    if (trkrid == TrkrDefs::inttId)
+    {
+      TrkrCluster* cluster = m_clusterMap->findCluster(cluster_key);
+      if (!cluster)
+      {
+        continue;
+      }
+
+      unsigned int layer = TrkrDefs::getLayer(cluster_key);
+
+      // get the bunch crossings for all hits in this cluster
+      auto crossings = _cluster_crossing_map->getCrossings(cluster_key);
+      for (auto iter1 = crossings.first; iter1 != crossings.second; ++iter1)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "                si Track with cluster " << iter1->first << " layer " << layer << " crossing " << iter1->second << std::endl;
+        }
+        intt_crossings.push_back(iter1->second);
+      }
+    }
+  }
+
+  return intt_crossings;
 }
 
 std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
@@ -820,6 +924,13 @@ void PHActsSiliconSeeding::configureSeeder()
 
 int PHActsSiliconSeeding::getNodes(PHCompositeNode* topNode)
 {
+  _cluster_crossing_map = findNode::getClass<TrkrClusterCrossingAssoc>(topNode, "TRKR_CLUSTERCROSSINGASSOC");
+  if (!_cluster_crossing_map)
+  {
+    std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERCROSSINGASSOC " << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   m_geomContainerIntt = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
   if (!m_geomContainerIntt)
   {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -30,6 +30,7 @@ class TrackSeedContainer;
 class TrkrCluster;
 class TrkrClusterContainer;
 class TrkrClusterIterationMapv1;
+class TrkrClusterCrossingAssoc;
 
 using GridSeeds = std::vector<std::vector<Acts::Seed<SpacePoint>>>;
 
@@ -195,11 +196,15 @@ class PHActsSiliconSeeding : public SubsysReco
                                                    const double xProj[],
                                                    const double yProj[],
                                                    const double zProj[]);
+  short int getCrossingIntt(TrackSeed& si_track);
+  std::vector<short int> getInttCrossings(TrackSeed& si_track);
 
   void createHistograms();
   void writeHistograms();
   double normPhi2Pi(const double phi);
   void clearTreeVariables();
+
+  TrkrClusterCrossingAssoc *_cluster_crossing_map = nullptr;
   TTree *m_tree = nullptr;
   int m_seedid = std::numeric_limits<int>::quiet_NaN();
   std::vector<float> m_mvtxgx = {};


### PR DESCRIPTION
This puts the assignment of the crossing number for silicon seeding into the actual silicon seeding algorithm, rather than in the matching. Will allow us to monitor crossing assignment for silicon seeds

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

