### PR TITLE
Fix fiber swap mess for TPOT

### DIFF
--- a/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
@@ -147,8 +147,8 @@ int MicromegasCombinedDataDecoder::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    // get fee id, apply mapping to original set, used downstream
-    const int fee = m_mapping.get_old_fee_id(rawhit->get_fee());
+    // get fee id, apply mapping to current fiber set, for backward compatibility
+    const int fee = m_mapping.get_new_fee_id(rawhit->get_fee());
     const auto channel = rawhit->get_channel();
     const int samples = rawhit->get_samples();
 

--- a/offline/packages/micromegas/MicromegasCombinedDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataEvaluation.cc
@@ -159,8 +159,8 @@ int MicromegasCombinedDataEvaluation::process_event(PHCompositeNode* topNode)
     Sample sample;
     sample.packet_id = packet_id;
 
-    // get fee id, apply mapping to original set
-    sample.fee_id = m_mapping.get_old_fee_id(rawhit->get_fee());
+    // get fee id, apply mapping to current fiber set, for backward compatibility
+    sample.fee_id = m_mapping.get_new_fee_id(rawhit->get_fee());
 
     const auto hitsetkey = m_mapping.get_hitsetkey(sample.fee_id);
     sample.layer = TrkrDefs::getLayer(hitsetkey);

--- a/offline/packages/micromegas/MicromegasMapping.cc
+++ b/offline/packages/micromegas/MicromegasMapping.cc
@@ -106,7 +106,9 @@ m_detectors( {
   {5001, 25, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   6 ), "sec22.1", "R3.8", "M6Z",  "SWIZ" },
 
   // north side
-  {5001, 11, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "sec8.0",  "R2.1", "M2P",  "NEIP" },
+  // on May 29 2024, fiber 11 was swapped to fiber 21
+  // {5001, 11, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "sec8.0",  "R2.1", "M2P",  "NEIP" },
+  {5002, 21, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 5 ), "sec8.0",  "R3.10", "M2P",  "NEIP" },
   {5001, 12, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   5 ), "sec8.1",  "R2.2", "M2Z",  "NEIZ" },
   {5001, 19, MicromegasDefs::genHitSetKey(55, MicromegasDefs::SegmentationType::SEGMENTATION_PHI, 3 ), "sec9.0",  "R2.3", "M10P", "NCOP" },
   {5001, 18, MicromegasDefs::genHitSetKey(56, MicromegasDefs::SegmentationType::SEGMENTATION_Z,   3 ), "sec9.1",  "R2.4", "M10Z", "NCOZ" },
@@ -561,14 +563,14 @@ void MicromegasMapping::construct_channel_mapping()
 }
 
 //_____________________________________________________________________
-int MicromegasMapping::get_old_fee_id( int fee_id ) const
+int MicromegasMapping::get_new_fee_id( int fee_id ) const
 {
   /*
   * on May 29 2024, we the fiber arriving on fee_id 11 was moved to fee_id 21
   * since fee_id 11 was not assigned before, we can internally convert all call to fee_id 21 to fee_id11,
   * while keeping backward compatibility
   */
-  static const std::map<int,int> internal_fee_id_map( {{21,11}} );
+  static const std::map<int,int> internal_fee_id_map( {{11,21}} );
   const auto& iter = internal_fee_id_map.find( fee_id );
   return iter == internal_fee_id_map.end() ? fee_id:iter->second;
 }

--- a/offline/packages/micromegas/MicromegasMapping.h
+++ b/offline/packages/micromegas/MicromegasMapping.h
@@ -56,14 +56,15 @@ class MicromegasMapping
   /// get fee id from hitset key
   int get_fee_id_from_hitsetkey(TrkrDefs::hitsetkey) const;
 
-  /// convert fee_id from data stream into old fee_id before fiber swapping */
+  /// convert fee_id from data stream into new fee_id after fiber swapping */
   /*
-   * this is used  to keep backward compatibility
+   * this is used  to keep being able to analyze older runs.
    * how it works is that every time a given fiber from the detector is connected to a new slot in the EBDC (a new FEE_ID),
-   * one must convert the new fee_id to the old one, that match the same detector
-   * in m_detectors. This works as long as fibers from the detectors are assigned to previously unsused slots/fee_id.
+   * one must convert the old fee_id to the new one, that match the same detector
+   * in m_detectors.
+   * This works as long as fibers from the detectors are assigned to previously unsused slots/fee_id.
    */
-  int get_old_fee_id( int /*fee_id*/ ) const;
+  int get_new_fee_id( int /*fee_id*/ ) const;
 
  private:
 

--- a/offline/packages/micromegas/MicromegasRawDataCalibration.cc
+++ b/offline/packages/micromegas/MicromegasRawDataCalibration.cc
@@ -76,8 +76,9 @@ int MicromegasRawDataCalibration::process_event(PHCompositeNode *topNode)
       const int type = packet->iValue(i, "TYPE");
       if( type == MicromegasDefs::HEARTBEAT_T ) continue;
 
+      // get fee id, apply mapping to current fiber set, for backward compatibility
       const auto channel = packet->iValue( i, "CHANNEL" );
-      const int fee_id = m_mapping.get_old_fee_id(packet->iValue(i, "FEE"));
+      const int fee_id = m_mapping.get_new_fee_id(packet->iValue(i, "FEE"));
       const int samples = packet->iValue( i, "SAMPLES" );
       if( Verbosity() )
       {

--- a/offline/packages/micromegas/MicromegasRawDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasRawDataDecoder.cc
@@ -114,7 +114,8 @@ int MicromegasRawDataDecoder::process_event(PHCompositeNode* topNode)
     }
     for (int iwf = 0; iwf < n_waveforms; ++iwf)
     {
-      const int fee = m_mapping.get_old_fee_id(packet->iValue(iwf, "FEE"));
+      // get fee id, apply mapping to current fiber set, for backward compatibility
+      const int fee = m_mapping.get_new_fee_id(packet->iValue(iwf, "FEE"));
       const int type = packet->iValue(iwf, "TYPE");
 
       // ignore heartbeat waveforms

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -172,7 +172,9 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
         // create running sample, assign packet, fee, layer and tile id
         Sample sample;
         sample.packet_id = packet_id;
-        sample.fee_id = m_mapping.get_old_fee_id(packet->iValue(iwf, "FEE"));
+
+        // get fee id, apply mapping to current fiber set, for backward compatibility
+        sample.fee_id = m_mapping.get_new_fee_id(packet->iValue(iwf, "FEE"));
         const auto hitsetkey = m_mapping.get_hitsetkey(sample.fee_id);
         sample.layer = TrkrDefs::getLayer( hitsetkey );
         sample.tile = MicromegasDefs::getTileId( hitsetkey );


### PR DESCRIPTION
This PR attempts to fix my proprietary mess resulting from the latest (May 29) fiber swaping:
- Use new fiber ID rather than old, everywhere, as it should be
- Attempt at keeping backward compatibility with old data (old fiber ID) and old calibration files. This will become unnecessary as time passes by.

A similar commit to online monitoring will follow. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

