### PR TITLE
MVTX strobe index patch

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -213,9 +213,14 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     row = mvtx_hit->get_row();
     col = mvtx_hit->get_col();
 
-    uint64_t bcodiff = gl1 ? gl1bco - strobe : 0;
+    int bcodiff = gl1 ? gl1bco - strobe : 0;
     double timeElapsed = bcodiff * 0.106;  // 106 ns rhic clock
     int index = std::floor(timeElapsed / m_strobeWidth);
+
+    if (index < -16 || index > 15)
+    {
+      continue; //Index is out of the 5-bit signed range
+    }
 
     if (Verbosity() >= 10)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

MVTX strobe index (think of as timing info) was calculated as the difference between the GL1 BCO and strobe BCO. The variable used to store this was an unsigned int so if the strobe was larger than the GL1, we'd overflow.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

