### PR TITLE
Avoid Name Clashes and Add Functionality to Select Triggers in Jet QA

### DIFF
--- a/offline/QA/Jet/ConstituentsinJets.cc
+++ b/offline/QA/Jet/ConstituentsinJets.cc
@@ -32,6 +32,7 @@
 #include <TH2.h>
 #include <TH1.h>
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <string>
@@ -44,6 +45,7 @@
 
 ConstituentsinJets::ConstituentsinJets(const std::string &moduleName, const std::string &recojetname, const std::string &towBkgdName, const std::string &histTag)
   : SubsysReco(moduleName)
+  , m_moduleName(moduleName)
   , m_recoJetName(recojetname)
   , m_towBkgdName(towBkgdName)
   , m_histTag(histTag)
@@ -97,19 +99,29 @@ int ConstituentsinJets::Init(PHCompositeNode * /*topNode*/)
     const int N_calo_layers = 3;
     Double_t calo_layers_bins[N_calo_layers+1] = {0.5, 1.5, 2.5, 3.5}; // emcal, ihcal, ohcal
 
+    // make sure module name is lower case
+    std::string smallModuleName = m_moduleName;
+    std::transform(
+      smallModuleName.begin(),
+      smallModuleName.end(),
+      smallModuleName.begin(),
+      ::tolower
+    );
+
     // construct histogram names
     std::vector<std::string> vecHistNames = {
-      "h1_ConstituentsinJets_total",
-      "h1_ConstituentsinJets_IHCAL",
-      "h1_ConstituentsinJets_OHCAL",
-      "h1_ConstituentsinJets_CEMC",
-      "h2_ConstituentsinJets_vs_caloLayer",
-      "h1_jetFracE_IHCAL",
-      "h1_jetFracE_OHCAL",
-      "h1_jetFracE_CEMC",
-      "h2_jetFracE_vs_caloLayer"
+      "ncsts_total",
+      "ncsts_ihcal",
+      "ncsts_ohcal",
+      "ncsts_cemc",
+      "ncstsvscalolayer",
+      "efracjet_ihcal",
+      "efracjet_ohcal",
+      "efracjet_cemc",
+      "efracjetvscalolayer"
     };
     for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+      vecHistNames[iHistName].insert(0, "h_" + smallModuleName + "_");
       vecHistNames[iHistName].append("_" + m_histTag);
     }
 

--- a/offline/QA/Jet/ConstituentsinJets.cc
+++ b/offline/QA/Jet/ConstituentsinJets.cc
@@ -42,8 +42,8 @@
 #include <map>
 #include <utility>
 
-ConstituentsinJets::ConstituentsinJets(const std::string &recojetname, const std::string &towBkgdName, const std::string &histTag)
-  : SubsysReco("ConstituentsinJets")
+ConstituentsinJets::ConstituentsinJets(const std::string &moduleName, const std::string &recojetname, const std::string &towBkgdName, const std::string &histTag)
+  : SubsysReco(moduleName)
   , m_recoJetName(recojetname)
   , m_towBkgdName(towBkgdName)
   , m_histTag(histTag)

--- a/offline/QA/Jet/ConstituentsinJets.cc
+++ b/offline/QA/Jet/ConstituentsinJets.cc
@@ -42,9 +42,10 @@
 #include <map>
 #include <utility>
 
-ConstituentsinJets::ConstituentsinJets(const std::string &recojetname )
+ConstituentsinJets::ConstituentsinJets(const std::string &recojetname, const std::string& histTag)
   : SubsysReco("ConstituentsinJets")
   , m_recoJetName(recojetname)
+  , m_histTag(histTag)
   // , m_outputFileName(outputfilename)  
   // these are all initialized but included here for clarity
   , m_etaRange(-1.1, 1.1)
@@ -93,40 +94,56 @@ int ConstituentsinJets::Init(PHCompositeNode * /*topNode*/)
     const int N_calo_layers = 3;
     Double_t calo_layers_bins[N_calo_layers+1] = {0.5, 1.5, 2.5, 3.5}; // emcal, ihcal, ohcal
 
+    // construct histogram names
+    std::vector<std::string> vecHistNames = {
+      "h1_ConstituentsinJets_total",
+      "h1_ConstituentsinJets_IHCAL",
+      "h1_ConstituentsinJets_OHCAL",
+      "h1_ConstituentsinJets_CEMC",
+      "h2_ConstituentsinJets_vs_caloLayer",
+      "h1_jetFracE_IHCAL",
+      "h1_jetFracE_OHCAL",
+      "h1_jetFracE_CEMC",
+      "h2_jetFracE_vs_caloLayer"
+    };
+    for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+      vecHistNames[iHistName].append("_" + m_histTag);
+    }
+
     // declare histograms and include x and y axis labels in the constructor
-    h1_ConstituentsinJets_total = new TH1D("h1_ConstituentsinJets_total", "Jet N constituents", N_const, N_const_bins);
+    h1_ConstituentsinJets_total = new TH1D(vecHistNames[0].data(), "Jet N constituents", N_const, N_const_bins);
     h1_ConstituentsinJets_total->GetXaxis()->SetTitle("N constituents");
     h1_ConstituentsinJets_total->GetYaxis()->SetTitle("Counts");
 
-    h1_ConstituentsinJets_IHCAL = new TH1D("h1_ConstituentsinJets_IHCAL", "Jet N constituents in IHCal", N_const, N_const_bins);
+    h1_ConstituentsinJets_IHCAL = new TH1D(vecHistNames[1].data(), "Jet N constituents in IHCal", N_const, N_const_bins);
     h1_ConstituentsinJets_IHCAL->GetXaxis()->SetTitle("N constituents");
     h1_ConstituentsinJets_IHCAL->GetYaxis()->SetTitle("Counts");
 
-    h1_ConstituentsinJets_OHCAL = new TH1D("h1_ConstituentsinJets_OHCAL", "Jet N constituents in OHCal", N_const, N_const_bins);
+    h1_ConstituentsinJets_OHCAL = new TH1D(vecHistNames[2].data(), "Jet N constituents in OHCal", N_const, N_const_bins);
     h1_ConstituentsinJets_OHCAL->GetXaxis()->SetTitle("N constituents");
     h1_ConstituentsinJets_OHCAL->GetYaxis()->SetTitle("Counts");
 
-    h1_ConstituentsinJets_CEMC = new TH1D("h1_ConstituentsinJets_CEMC", "Jet N constituents in CEMC", N_const, N_const_bins);
+    h1_ConstituentsinJets_CEMC = new TH1D(vecHistNames[3].data(), "Jet N constituents in CEMC", N_const, N_const_bins);
     h1_ConstituentsinJets_CEMC->GetXaxis()->SetTitle("N constituents");
     h1_ConstituentsinJets_CEMC->GetYaxis()->SetTitle("Counts");
 
-    h2_ConstituentsinJets_vs_caloLayer = new TH2D("h2_ConstituentsinJets_vs_caloLayer", "Jet N constituents vs Calo Layer", N_calo_layers, calo_layers_bins, N_const, N_const_bins);
+    h2_ConstituentsinJets_vs_caloLayer = new TH2D(vecHistNames[4].data(), "Jet N constituents vs Calo Layer", N_calo_layers, calo_layers_bins, N_const, N_const_bins);
     h2_ConstituentsinJets_vs_caloLayer->GetXaxis()->SetTitle("Calo Layer");
     h2_ConstituentsinJets_vs_caloLayer->GetYaxis()->SetTitle("N constituents");
 
-    h1_jetFracE_IHCAL = new TH1D("h1_jetFracE_IHCAL", "Jet E fraction in IHCal", N_frac, frac_bins);
+    h1_jetFracE_IHCAL = new TH1D(vecHistNames[5].data(), "Jet E fraction in IHCal", N_frac, frac_bins);
     h1_jetFracE_IHCAL->GetXaxis()->SetTitle("E fraction");
     h1_jetFracE_IHCAL->GetYaxis()->SetTitle("Counts");
 
-    h1_jetFracE_OHCAL = new TH1D("h1_jetFracE_OHCAL", "Jet E fraction in OHCal", N_frac, frac_bins);
+    h1_jetFracE_OHCAL = new TH1D(vecHistNames[6].data(), "Jet E fraction in OHCal", N_frac, frac_bins);
     h1_jetFracE_OHCAL->GetXaxis()->SetTitle("E fraction");
     h1_jetFracE_OHCAL->GetYaxis()->SetTitle("Counts");
 
-    h1_jetFracE_CEMC = new TH1D("h1_jetFracE_CEMC", "Jet E fraction in CEMC", N_frac, frac_bins);
+    h1_jetFracE_CEMC = new TH1D(vecHistNames[7].data(), "Jet E fraction in CEMC", N_frac, frac_bins);
     h1_jetFracE_CEMC->GetXaxis()->SetTitle("E fraction");
     h1_jetFracE_CEMC->GetYaxis()->SetTitle("Counts");
 
-    h2_jetFracE_vs_caloLayer = new TH2D("h2_jetFracE_vs_caloLayer", "Jet E fraction vs Calo Layer", N_calo_layers, calo_layers_bins, N_frac, frac_bins);
+    h2_jetFracE_vs_caloLayer = new TH2D(vecHistNames[8].data(), "Jet E fraction vs Calo Layer", N_calo_layers, calo_layers_bins, N_frac, frac_bins);
     h2_jetFracE_vs_caloLayer->GetXaxis()->SetTitle("Calo Layer");
     h2_jetFracE_vs_caloLayer->GetYaxis()->SetTitle("E fraction");
 

--- a/offline/QA/Jet/ConstituentsinJets.cc
+++ b/offline/QA/Jet/ConstituentsinJets.cc
@@ -42,9 +42,10 @@
 #include <map>
 #include <utility>
 
-ConstituentsinJets::ConstituentsinJets(const std::string &recojetname, const std::string& histTag)
+ConstituentsinJets::ConstituentsinJets(const std::string &recojetname, const std::string &towBkgdName, const std::string &histTag)
   : SubsysReco("ConstituentsinJets")
   , m_recoJetName(recojetname)
+  , m_towBkgdName(towBkgdName)
   , m_histTag(histTag)
   // , m_outputFileName(outputfilename)  
   // these are all initialized but included here for clarity
@@ -206,7 +207,7 @@ int ConstituentsinJets::process_event(PHCompositeNode *topNode)
   float background_v2 = 0;
   float background_Psi2 = 0;
   bool has_tower_background = false;
-  TowerBackground *towBack = findNode::getClass<TowerBackground>(topNode, "TowerInfoBackground_Sub2");
+  TowerBackground *towBack = findNode::getClass<TowerBackground>(topNode, m_towBkgdName);
   if(!towBack)
   {
     std::cout <<"ConstituentsinJets::process_event - Error can not find tower background node " << std::endl;  

--- a/offline/QA/Jet/ConstituentsinJets.cc
+++ b/offline/QA/Jet/ConstituentsinJets.cc
@@ -49,6 +49,8 @@ ConstituentsinJets::ConstituentsinJets(const std::string &moduleName, const std:
   , m_histTag(histTag)
   // , m_outputFileName(outputfilename)  
   // these are all initialized but included here for clarity
+  , m_doTrgSelect(false)
+  , m_trgToSelect(JetQADefs::GL1::MBDNSJet1)
   , m_etaRange(-1.1, 1.1)
   , m_ptRange(1.0, 1000)
   , h1_ConstituentsinJets_total(nullptr)
@@ -174,6 +176,13 @@ int ConstituentsinJets::process_event(PHCompositeNode *topNode)
   if(Verbosity() > 1)
   {
     std::cout << "ConstituentsinJets::process_event - Process event..." << std::endl;
+  }
+
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
   }
 
   // get the jets

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -23,6 +23,7 @@ class ConstituentsinJets : public SubsysReco
 
         ConstituentsinJets(
             const std::string &recojetname = "AntiKt_Tower_r04",
+            const std::string &towBkgdName = "TowerInfoBackground_Sub2",
             const std::string &histTag = "AllTrig_AntiKt_Tower_R04"
         );
         ~ConstituentsinJets() override {};
@@ -57,6 +58,7 @@ class ConstituentsinJets : public SubsysReco
 
         //! Input Node strings and histogram tags
         std::string m_recoJetName { "AntiKt_Tower_r04"};
+        std::string m_towBkgdName { "TowerInfoBackground_Sub2" };
         std::string m_histTag { "AllTrig_AntiKt_Tower_R04" };
         // std::string m_outputFileName{ "ConstituentsinJets.root"};
 

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -64,7 +64,8 @@ class ConstituentsinJets : public SubsysReco
 
     private:
 
-        //! Input Node strings and histogram tags
+        //! Module name, input node strings, and histogram tags
+        std::string m_moduleName { "ConstituentsinJets" };
         std::string m_recoJetName { "AntiKt_Tower_r04"};
         std::string m_towBkgdName { "TowerInfoBackground_Sub2" };
         std::string m_histTag { "AllTrig_AntiKt_Tower_R04" };

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -10,6 +10,8 @@
 #include <utility>  // std::pair, std::make_pair
 #include <vector>
 
+#include "JetQADefs.h"
+
 class Fun4AllHistoManager;
 class PHCompositeNode;
 class TH1;
@@ -48,6 +50,11 @@ class ConstituentsinJets : public SubsysReco
             m_ptRange.first = low;
             m_ptRange.second = high;
         }
+        void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+        { // specifies a trigger to require
+          m_doTrgSelect = true;
+          m_trgToSelect = trig;
+        }
 
         // standard Fun4All functions
         int Init(PHCompositeNode *topNode) override;
@@ -63,11 +70,13 @@ class ConstituentsinJets : public SubsysReco
         std::string m_histTag { "AllTrig_AntiKt_Tower_R04" };
         // std::string m_outputFileName{ "ConstituentsinJets.root"};
 
+        //! Trigger selection
+        bool m_doTrgSelect { false };
+        uint32_t m_trgToSelect { JetQADefs::GL1::MBDNSJet1 };
 
         // ! Kinematic cuts and reco jet node name
         std::pair<double, double> m_etaRange = std::make_pair(-1.1, 1.1);
         std::pair<double, double> m_ptRange = std::make_pair(1.0, 1000.0);
-  
 
         // Jet N constituents
         Fun4AllHistoManager* m_manager{nullptr};
@@ -84,8 +93,6 @@ class ConstituentsinJets : public SubsysReco
         TH1 * h1_jetFracE_OHCAL{nullptr};
         TH1 * h1_jetFracE_CEMC{nullptr};
         TH2 * h2_jetFracE_vs_caloLayer{nullptr};
-
-
 
 };
 

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -22,12 +22,18 @@ class ConstituentsinJets : public SubsysReco
     public:
 
         ConstituentsinJets(
-            const std::string &recojetname = "AntiKt_Tower_r04");
+            const std::string &recojetname = "AntiKt_Tower_r04",
+            const std::string &histTag = "AntiKt_Tower_R04"
+        );
         ~ConstituentsinJets() override {};
 
         void setRecoJetNodeName(const std::string &name)
         { // set the name of the node containing the reco jets
             m_recoJetName = name;
+        }
+        void setHistTag(const std::string &tag)
+        {  // set the tag to be applied to histogram names
+            m_histTag = tag;
         }
 
         void setEtaRange(double low, double high)
@@ -49,8 +55,9 @@ class ConstituentsinJets : public SubsysReco
 
     private:
 
-        //! Input Node strings
+        //! Input Node strings and histogram tags
         std::string m_recoJetName { "AntiKt_Tower_r04"};
+        std::string m_histTag { "AntiKt_Tower_R04" };
         // std::string m_outputFileName{ "ConstituentsinJets.root"};
 
 

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -22,6 +22,7 @@ class ConstituentsinJets : public SubsysReco
     public:
 
         ConstituentsinJets(
+            const std::string &moduleName = "ConstituentsInJets",
             const std::string &recojetname = "AntiKt_Tower_r04",
             const std::string &towBkgdName = "TowerInfoBackground_Sub2",
             const std::string &histTag = "AllTrig_AntiKt_Tower_R04"

--- a/offline/QA/Jet/ConstituentsinJets.h
+++ b/offline/QA/Jet/ConstituentsinJets.h
@@ -23,7 +23,7 @@ class ConstituentsinJets : public SubsysReco
 
         ConstituentsinJets(
             const std::string &recojetname = "AntiKt_Tower_r04",
-            const std::string &histTag = "AntiKt_Tower_R04"
+            const std::string &histTag = "AllTrig_AntiKt_Tower_R04"
         );
         ~ConstituentsinJets() override {};
 
@@ -57,7 +57,7 @@ class ConstituentsinJets : public SubsysReco
 
         //! Input Node strings and histogram tags
         std::string m_recoJetName { "AntiKt_Tower_r04"};
-        std::string m_histTag { "AntiKt_Tower_R04" };
+        std::string m_histTag { "AllTrig_AntiKt_Tower_R04" };
         // std::string m_outputFileName{ "ConstituentsinJets.root"};
 
 

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -32,7 +32,8 @@ JetKinematicCheck::JetKinematicCheck(const std::string &moduleName,
   , m_histTag("AllTrig")
   , m_etaRange(-1.1, 1.1)
   , m_ptRange(10, 100)
-
+  , m_doTrgSelect(false)
+  , m_trgToSelect(JetQADefs::GL1::MBDNSJet1)
 {
   if (Verbosity() > 1)
   {
@@ -200,6 +201,14 @@ int JetKinematicCheck::InitRun(PHCompositeNode * /*unused*/)
 //____________________________________________________________________________..
 int JetKinematicCheck::process_event(PHCompositeNode *topNode)
 {
+
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   std::vector<std::string> m_recoJetName_array = {m_recoJetNameR02, m_recoJetNameR03, m_recoJetNameR04};
   m_radii = {0.2, 0.3, 0.4};
   int n_radii = m_radii.size();

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -209,7 +209,7 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
     if (!jets)
     {
       std::cout
-          << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
+          << "JetKinematicCheck::process_event - Error can not find DST Reco JetContainer node "
           << recoJetName << std::endl;
       return Fun4AllReturnCodes::ABORTRUN;
     }

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -12,6 +12,7 @@
 #include <jetbase/Jetv2.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
+#include <algorithm>
 #include <cmath>
 #include <string>
 #include <vector>
@@ -25,6 +26,7 @@ JetKinematicCheck::JetKinematicCheck(const std::string &moduleName,
                                      const std::string &recojetnameR04,
                                      const std::string &recojetnameR05)
   : SubsysReco(moduleName)
+  , m_moduleName(moduleName)
   , m_recoJetNameR02(recojetnameR02)
   , m_recoJetNameR03(recojetnameR03)
   , m_recoJetNameR04(recojetnameR04)
@@ -56,34 +58,44 @@ int JetKinematicCheck::Init(PHCompositeNode * /*unused*/)
   hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
+  // make sure module name is lower case
+  std::string smallModuleName = m_moduleName;
+  std::transform(
+    smallModuleName.begin(),
+    smallModuleName.end(),
+    smallModuleName.begin(),
+    ::tolower
+  );
+
   // construct histogram names
   std::vector<std::string> vecHistNames = {
-    "h_spectra_r02",
-    "h_spectra_r03",
-    "h_spectra_r04",
-    "h_spectra_r05",
-    "h_eta_phi_r02",
-    "h_eta_phi_r03",
-    "h_eta_phi_r04",
-    "h_eta_phi_r05",
-    "h_jet_mass_pt_r02",
-    "h_jet_mass_pt_r03",
-    "h_jet_mass_pt_r04",
-    "h_jet_mass_pt_r05",
-    "h_jet_mass_eta_r02",
-    "h_jet_mass_eta_r03",
-    "h_jet_mass_eta_r04",
-    "h_jet_mass_eta_r05",
-    "h_jet_mass_pt_1D_r02",
-    "h_jet_mass_pt_1D_r03",
-    "h_jet_mass_pt_1D_r04",
-    "h_jet_mass_pt_1D_r05",
-    "h_jet_mass_eta_1D_r02",
-    "h_jet_mass_eta_1D_r03",
-    "h_jet_mass_eta_1D_r04",
-    "h_jet_Mass_eta_1D_r05"
+    "spectra_r02",
+    "spectra_r03",
+    "spectra_r04",
+    "spectra_r05",
+    "etavsphi_r02",
+    "etavsphi_r03",
+    "etavsphi_r04",
+    "etavsphi_r05",
+    "jetmassvspt_r02",
+    "jetmassvspt_r03",
+    "jetmassvspt_r04",
+    "jetmassvspt_r05",
+    "jetmassvseta_r02",
+    "jetmassvseta_r03",
+    "jetmassvseta_r04",
+    "jetmassvseta_r05",
+    "jetmassvsptprofile_r02",
+    "jetmassvsptprofile_r03",
+    "jetmassvsptprofile_r04",
+    "jetmassvsptprofile_r05",
+    "jetmassvsetaprofile_r02",
+    "jetmassvsetaprofile_r03",
+    "jetmassvsetaprofile_r04",
+    "jetmassvsetaprofile_r05"
   };
   for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+    vecHistNames[iHistName].insert(0, "h_" + smallModuleName + "_");
     vecHistNames[iHistName].append("_" + m_histTag);
   }
 

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -19,11 +19,13 @@
 #include <boost/format.hpp>
 //____________________________________________________________________________..
 
-JetKinematicCheck::JetKinematicCheck(const std::string &recojetnameR02, const std::string &recojetnameR03, const std::string &recojetnameR04)
+JetKinematicCheck::JetKinematicCheck(const std::string &recojetnameR02, const std::string &recojetnameR03, const std::string &recojetnameR04, const std::string &recojetnameR05)
   : SubsysReco("JetKinematicCheck")
   , m_recoJetNameR02(recojetnameR02)
   , m_recoJetNameR03(recojetnameR03)
   , m_recoJetNameR04(recojetnameR04)
+  , m_recoJetNameR05(recojetnameR05)
+  , m_histTag("AllTrig")
   , m_etaRange(-1.1, 1.1)
   , m_ptRange(10, 100)
 
@@ -49,76 +51,130 @@ int JetKinematicCheck::Init(PHCompositeNode * /*unused*/)
   hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
+  // construct histogram names
+  std::vector<std::string> vecHistNames = {
+    "h_spectra_r02",
+    "h_spectra_r03",
+    "h_spectra_r04",
+    "h_spectra_r05",
+    "h_eta_phi_r02",
+    "h_eta_phi_r03",
+    "h_eta_phi_r04",
+    "h_eta_phi_r05",
+    "h_jet_mass_pt_r02",
+    "h_jet_mass_pt_r03",
+    "h_jet_mass_pt_r04",
+    "h_jet_mass_pt_r05",
+    "h_jet_mass_eta_r02",
+    "h_jet_mass_eta_r03",
+    "h_jet_mass_eta_r04",
+    "h_jet_mass_eta_r05",
+    "h_jet_mass_pt_1D_r02",
+    "h_jet_mass_pt_1D_r03",
+    "h_jet_mass_pt_1D_r04",
+    "h_jet_mass_pt_1D_r05",
+    "h_jet_mass_eta_1D_r02",
+    "h_jet_mass_eta_1D_r03",
+    "h_jet_mass_eta_1D_r04",
+    "h_jet_Mass_eta_1D_r05"
+  };
+  for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+    vecHistNames[iHistName].append("_" + m_histTag);
+  }
+
   // initialize histograms
 
-  jet_spectra_r02 = new TH1D("h_spectra_r02", "", 19, 5, 100);
+  jet_spectra_r02 = new TH1D(vecHistNames[0].data(), "", 19, 5, 100);
   jet_spectra_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
 
-  jet_spectra_r03 = new TH1D("h_spectra_r03", "", 19, 5, 100);
+  jet_spectra_r03 = new TH1D(vecHistNames[1].data(), "", 19, 5, 100);
   jet_spectra_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
 
-  jet_spectra_r04 = new TH1D("h_spectra_r04", "", 19, 5, 100);
+  jet_spectra_r04 = new TH1D(vecHistNames[2].data(), "", 19, 5, 100);
   jet_spectra_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
 
-  jet_eta_phi_r02 = new TH2D("h_eta_phi_r02", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_spectra_r05 = new TH1D(vecHistNames[3].data(), "", 19, 5, 100);
+  jet_spectra_r05->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+
+  jet_eta_phi_r02 = new TH2D(vecHistNames[4].data(), "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r02->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r02->GetYaxis()->SetTitle("#Phi");
 
-  jet_eta_phi_r03 = new TH2D("h_eta_phi_r03", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r03 = new TH2D(vecHistNames[5].data(), "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r03->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r03->GetYaxis()->SetTitle("#Phi");
 
-  jet_eta_phi_r04 = new TH2D("h_eta_phi_r04", "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r04 = new TH2D(vecHistNames[6].data(), "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
   jet_eta_phi_r04->GetXaxis()->SetTitle("#eta");
   jet_eta_phi_r04->GetYaxis()->SetTitle("#Phi");
 
-  jet_mass_pt_r02 = new TH2D("h_jet_mass_pt_r02", "", 19, 5, 100, 15, 0, 15);
+  jet_eta_phi_r05 = new TH2D(vecHistNames[7].data(), "", 24, -1.1, 1.1, 64, -M_PI, M_PI);
+  jet_eta_phi_r05->GetXaxis()->SetTitle("#eta");
+  jet_eta_phi_r05->GetYaxis()->SetTitle("#Phi");
+
+  jet_mass_pt_r02 = new TH2D(vecHistNames[8].data(), "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_r03 = new TH2D("h_jet_mass_pt_r03", "", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r03 = new TH2D(vecHistNames[9].data(), "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_r04 = new TH2D("h_jet_mass_pt_r04", "", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r04 = new TH2D(vecHistNames[10].data(), "", 19, 5, 100, 15, 0, 15);
   jet_mass_pt_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_r02 = new TH2D("h_jet_mass_eta_r02", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_pt_r05 = new TH2D(vecHistNames[11].data(), "", 19, 5, 100, 15, 0, 15);
+  jet_mass_pt_r05->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_r05->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_r02 = new TH2D(vecHistNames[12].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r02->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r02->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_r03 = new TH2D("h_jet_mass_eta_r03", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r03 = new TH2D(vecHistNames[13].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r03->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r03->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_r04 = new TH2D("h_jet_mass_eta_r04", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r04 = new TH2D(vecHistNames[14].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_r04->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_r04->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_1D_r02 = new TH1D("h_jet_mass_pt_1D_r02", "", 19, 5, 100);
+  jet_mass_eta_r05 = new TH2D(vecHistNames[15].data(), "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_r05->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_r05->GetYaxis()->SetTitle("Jet Mass [GeV/c^{2}]");
+
+  jet_mass_pt_1D_r02 = new TH1D(vecHistNames[16].data(), "", 19, 5, 100);
   jet_mass_pt_1D_r02->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_1D_r03 = new TH1D("h_jet_mass_pt_1D_r03", "", 19, 5, 100);
+  jet_mass_pt_1D_r03 = new TH1D(vecHistNames[17].data(), "", 19, 5, 100);
   jet_mass_pt_1D_r03->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_pt_1D_r04 = new TH1D("h_jet_mass_pt_1D_r04", "", 19, 5, 100);
+  jet_mass_pt_1D_r04 = new TH1D(vecHistNames[18].data(), "", 19, 5, 100);
   jet_mass_pt_1D_r04->GetXaxis()->SetTitle("p_{T} [GeV/c]");
   jet_mass_pt_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_1D_r02 = new TH2D("h_jet_mass_eta_1D_r02", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_pt_1D_r05 = new TH1D(vecHistNames[19].data(), "", 19, 5, 100);
+  jet_mass_pt_1D_r05->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  jet_mass_pt_1D_r05->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_1D_r02 = new TH2D(vecHistNames[20].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r02->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r02->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_1D_r03 = new TH2D("h_jet_mass_eta_1D_r03", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r03 = new TH2D(vecHistNames[21].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r03->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r03->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
-  jet_mass_eta_1D_r04 = new TH2D("h_jet_mass_eta_1D_r04", "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r04 = new TH2D(vecHistNames[22].data(), "", 24, -1.1, 1.1, 15, 0, 15);
   jet_mass_eta_1D_r04->GetXaxis()->SetTitle("#eta");
   jet_mass_eta_1D_r04->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
+
+  jet_mass_eta_1D_r05 = new TH2D(vecHistNames[23].data(), "", 24, -1.1, 1.1, 15, 0, 15);
+  jet_mass_eta_1D_r05->GetXaxis()->SetTitle("#eta");
+  jet_mass_eta_1D_r05->GetYaxis()->SetTitle("Average Jet Mass [GeV/c^{2}]");
 
   if (Verbosity() > 1)
   {

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -19,8 +19,12 @@
 #include <boost/format.hpp>
 //____________________________________________________________________________..
 
-JetKinematicCheck::JetKinematicCheck(const std::string &recojetnameR02, const std::string &recojetnameR03, const std::string &recojetnameR04, const std::string &recojetnameR05)
-  : SubsysReco("JetKinematicCheck")
+JetKinematicCheck::JetKinematicCheck(const std::string &moduleName,
+                                     const std::string &recojetnameR02,
+                                     const std::string &recojetnameR03,
+                                     const std::string &recojetnameR04,
+                                     const std::string &recojetnameR05)
+  : SubsysReco(moduleName)
   , m_recoJetNameR02(recojetnameR02)
   , m_recoJetNameR03(recojetnameR03)
   , m_recoJetNameR04(recojetnameR04)

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "JetQADefs.h"
+
 class TH1;
 class TH2;
 class TH3;
@@ -44,6 +46,13 @@ class JetKinematicCheck : public SubsysReco
   void setHistTag(const std::string tag)
   {
     m_histTag = tag;
+  }
+
+  // specifies a trigger to require
+  void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+  {
+    m_doTrgSelect = true;
+    m_trgToSelect = trig;
   }
 
   /** Called during initialization.
@@ -81,6 +90,10 @@ class JetKinematicCheck : public SubsysReco
   std::string m_histTag;
   std::pair<double, double> m_etaRange;
   std::pair<double, double> m_ptRange;
+
+  // trigger selection
+  bool m_doTrgSelect;
+  uint32_t m_trgToSelect;
 
   // reconstructed jets
   std::vector<float> m_eta;

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -20,7 +20,8 @@ class JetKinematicCheck : public SubsysReco
  public:
   JetKinematicCheck(const std::string &recojetnameR02 = "AntiKt_Tower_r02",
                     const std::string &recojetnameR03 = "AntiKt_Tower_r03",
-                    const std::string &recojetnameR04 = "AntiKt_Tower_r04");
+                    const std::string &recojetnameR04 = "AntiKt_Tower_r04",
+                    const std::string &recojetnameR05 = "AntiKt_Tower_r05");
 
   ~JetKinematicCheck() override;
 
@@ -36,6 +37,12 @@ class JetKinematicCheck : public SubsysReco
   {
     m_ptRange.first = low;
     m_ptRange.second = high;
+  }
+
+  // set histogram tag
+  void setHistTag(const std::string tag)
+  {
+    m_histTag = tag;
   }
 
   /** Called during initialization.
@@ -69,7 +76,8 @@ class JetKinematicCheck : public SubsysReco
   std::string m_recoJetNameR02;
   std::string m_recoJetNameR03;
   std::string m_recoJetNameR04;
-  std::string m_outputFileName;
+  std::string m_recoJetNameR05;
+  std::string m_histTag;
   std::pair<double, double> m_etaRange;
   std::pair<double, double> m_ptRange;
 
@@ -83,21 +91,27 @@ class JetKinematicCheck : public SubsysReco
   TH1 *jet_spectra_r02 = nullptr;
   TH1 *jet_spectra_r03 = nullptr;
   TH1 *jet_spectra_r04 = nullptr;
+  TH1 *jet_spectra_r05 = nullptr;
   TH2 *jet_eta_phi_r02 = nullptr;
   TH2 *jet_eta_phi_r03 = nullptr;
   TH2 *jet_eta_phi_r04 = nullptr;
+  TH2 *jet_eta_phi_r05 = nullptr;
   TH2 *jet_mass_pt_r02 = nullptr;
   TH1 *jet_mass_pt_1D_r02 = nullptr;
   TH2 *jet_mass_pt_r03 = nullptr;
   TH1 *jet_mass_pt_1D_r03 = nullptr;
   TH2 *jet_mass_pt_r04 = nullptr;
   TH1 *jet_mass_pt_1D_r04 = nullptr;
+  TH2 *jet_mass_pt_r05 = nullptr;
+  TH1 *jet_mass_pt_1D_r05 = nullptr;
   TH2 *jet_mass_eta_r02 = nullptr;
   TH1 *jet_mass_eta_1D_r02 = nullptr;
   TH2 *jet_mass_eta_r03 = nullptr;
   TH1 *jet_mass_eta_1D_r03 = nullptr;
   TH2 *jet_mass_eta_r04 = nullptr;
   TH1 *jet_mass_eta_1D_r04 = nullptr;
+  TH2 *jet_mass_eta_r05 = nullptr;
+  TH1 *jet_mass_eta_1D_r05 = nullptr;
 };
 
 #endif  // JETKINEMATICCHECK_H

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -83,6 +83,7 @@ class JetKinematicCheck : public SubsysReco
  private:
   Fun4AllHistoManager *hm{nullptr};
 
+  std::string m_moduleName;
   std::string m_recoJetNameR02;
   std::string m_recoJetNameR03;
   std::string m_recoJetNameR04;

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -18,7 +18,8 @@ class PHCompositeNode;
 class JetKinematicCheck : public SubsysReco
 {
  public:
-  JetKinematicCheck(const std::string &recojetnameR02 = "AntiKt_Tower_r02",
+  JetKinematicCheck(const std::string &moduleName = "JetKinematicCheck",
+                    const std::string &recojetnameR02 = "AntiKt_Tower_r02",
                     const std::string &recojetnameR03 = "AntiKt_Tower_r03",
                     const std::string &recojetnameR04 = "AntiKt_Tower_r04",
                     const std::string &recojetnameR05 = "AntiKt_Tower_r05");

--- a/offline/QA/Jet/JetQADefs.h
+++ b/offline/QA/Jet/JetQADefs.h
@@ -19,6 +19,7 @@
 #include <ffarawobjects/Gl1Packet.h>
 #include <iostream>
 #include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
 #include <phool/phool.h>
 
 
@@ -123,7 +124,7 @@ namespace JetQADefs
   // --------------------------------------------------------------------------
   //! Check if a particular trigger fired
   // --------------------------------------------------------------------------
-  bool DidTriggerFire(const GL1 trg, PHCompositeNode* topNode)
+  inline bool DidTriggerFire(const uint32_t trg, PHCompositeNode* topNode)
   {
 
     // grab GL1 packet from node tree
@@ -139,7 +140,7 @@ namespace JetQADefs
 
     // loop through bits and check if specified one is set
     bool didTrgFire = false;
-    for (uint64_t iTrg = 0; iTrg < NMaxTrgIndex(); iTrg++)
+    for (uint32_t iTrg = 0; iTrg < NMaxTrgIndex(); iTrg++)
     {
 
       // only consider specified trigger
@@ -155,7 +156,7 @@ namespace JetQADefs
     }  // end index loop
     return didTrgFire;
 
-  }  // end 'DidTriggerFire(GL1 PHCompositeNode*)'
+  }  // end 'DidTriggerFire(uint32_t, PHCompositeNode*)'
 
 }  // end JetQADefs namespace
 

--- a/offline/QA/Jet/JetQADefs.h
+++ b/offline/QA/Jet/JetQADefs.h
@@ -1,0 +1,164 @@
+// ----------------------------------------------------------------------------
+/*! \file    JetQADefs.h
+ *  \authors Derek Anderson
+ *  \date    06.24.2024
+ *
+ *  A namespace to hold definitions of various
+ *  enums, helper methods, etc. relevant to
+ *  all jet QA modules.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef JETQADEFS_H
+#define JETQADEFS_H
+
+#include <bitset>
+#include <boost/dynamic_bitset.hpp>
+#include <cassert>
+#include <cmath>
+#include <ffarawobjects/Gl1Packet.h>
+#include <iostream>
+#include <phool/PHCompositeNode.h>
+#include <phool/phool.h>
+
+
+
+// ----------------------------------------------------------------------------
+//! Namespace to hold misc. definitions for the Jet QA
+// ----------------------------------------------------------------------------
+namespace JetQADefs
+{
+
+  // enums -------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  //! Trigger indices in GL1 packets
+  // -------------------------------------------------------------------------
+  /*! Gives indices of triggers as they are provided in the
+   *  GL1 packet. The list is:
+   *  | Index | Trigger                       |
+   *  | ----- | ----------------------------- |
+   *  | 0     | Clock                         |
+   *  | 1     | ZDC South                     |
+   *  | 2     | ZDC North                     |
+   *  | 3     | ZDC Coincidence               |
+   *  | 4     | Random                        |
+   *  | 5     | HCAL Singles                  |
+   *  | 8     | MBD S >= 1                    |
+   *  | 9     | MBD N >= 1                    |
+   *  | 10    | MBD N&S >= 1                  |
+   *  | 11    | MBD N&S >= 2                  |
+   *  | 12    | MBD N&S, vtx < 10 cm          |
+   *  | 13    | MBD N&S, vtx < 30 cm          |
+   *  | 14    | MBD N&S, vtx < 60 cm          |
+   *  | 15    | HCAL Singles + MBD NS >= 1    |
+   *  | 16    | Jet 1 + MBD NS >= 1           |
+   *  | 17    | Jet 2 + MBD NS >= 1           |
+   *  | 18    | Jet 3 + MBD NS >= 1           |
+   *  | 19    | Jet 4 + MBD NS >= 1           |
+   *  | 20    | Jet 1 (no MBD coincidence)    |
+   *  | 21    | Jet 2 (no MBD coincidence)    |
+   *  | 22    | Jet 3 (no MBD coincidence)    |
+   *  | 23    | Jet 4 (no MBD coincidence)    |
+   *  | 24    | Photon 1 + MBD NS >= 1        |
+   *  | 25    | Photon 2 + MBD NS >= 1        |
+   *  | 26    | Photon 3 + MBD NS >= 1        |
+   *  | 27    | Photon 4 + MBD NS >= 1        |
+   *  | 28    | Photon 1 (no MBD coincidence) |
+   *  | 29    | Photon 2 (no MBD coincidence) |
+   *  | 30    | Photon 3 (no MBD coincidence) |
+   *  | 31    | Photon 4 (no MBD coincidence) |
+   */ 
+  enum GL1
+  {
+    Clock = 0,
+    ZDCS = 1,
+    ZDCN = 2,
+    ZDCNS = 3,
+    Random = 4,
+    HCalSingle = 5,
+    MBDS = 8,
+    MBDN = 9,
+    MBDNS1 = 10,
+    MBDNS2 = 11,
+    MBDNSVtx10 = 12,
+    MBDNSVtx30 = 13,
+    MBDNSVtx60 = 14,
+    MBDNSHCalSingle = 15,
+    MBDNSJet1 = 16,
+    MBDNSJet2 = 17,
+    MBDNSJet3 = 18,
+    MBDNSJet4 = 19,
+    Jet1 = 20,
+    Jet2 = 21,
+    Jet3 = 22,
+    Jet4 = 23,
+    MBDNSPhoton1 = 24,
+    MBDNSPhoton2 = 25,
+    MBDNSPhoton3 = 26,
+    MBDNSPhoton4 = 27,
+    Photon1 = 28,
+    Photon2 = 29,
+    Photon3 = 30,
+    Photon4 = 31
+  };
+
+
+
+  // constants ----------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  //! Max no. of trigger indices
+  // --------------------------------------------------------------------------
+  inline uint32_t NMaxTrgIndex()
+  {
+    static const uint32_t nMaxTrgIndex = 32;
+    return nMaxTrgIndex;
+  }
+
+
+
+  // methods ------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  //! Check if a particular trigger fired
+  // --------------------------------------------------------------------------
+  bool DidTriggerFire(const GL1 trg, PHCompositeNode* topNode)
+  {
+
+    // grab GL1 packet from node tree
+    Gl1Packet* packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+    if (!packet)
+    {
+      std::cerr << PHWHERE << ": PANIC: not able to grab GL1 packet! aborting!" << std::endl;
+      assert(packet);
+    }
+
+    // grab trigger bits
+    boost::dynamic_bitset<> triggers(NMaxTrgIndex(), packet -> getTriggerInput());
+
+    // loop through bits and check if specified one is set
+    bool didTrgFire = false;
+    for (uint64_t iTrg = 0; iTrg < NMaxTrgIndex(); iTrg++)
+    {
+
+      // only consider specified trigger
+      if (iTrg != trg) continue;
+
+      // if trigger bit set, break and return true
+      if (triggers.test(iTrg))
+      {
+        didTrgFire = true;
+        break;
+      }
+
+    }  // end index loop
+    return didTrgFire;
+
+  }  // end 'DidTriggerFire(GL1 PHCompositeNode*)'
+
+}  // end JetQADefs namespace
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -28,6 +28,8 @@ JetSeedCount::JetSeedCount(const std::string &moduleName, const std::string &rec
   , m_histTag("AllTrig_AntiKt_Tower_r04_Sub1")
   , m_etaRange(-1, 1)
   , m_ptRange(5, 100)
+  , m_doTrgSelect(false)
+  , m_trgToSelect(JetQADefs::GL1::MBDNSJet1)
 {
   // std::cout << "JetSeedCount::JetSeedCount(const std::string &name) Calling ctor" << std::endl;
 }
@@ -59,6 +61,14 @@ int JetSeedCount::InitRun(PHCompositeNode * /*topNode*/)
 //____________________________________________________________________________..
 int JetSeedCount::process_event(PHCompositeNode *topNode)
 {
+
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   // std::cout << "JetSeedCount::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
   ++m_event;
   // Calling Raw Jet Seeds

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -88,14 +88,14 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
   if (!vertexmap)
   {
     std::cout
-        << "MyJetAnalysis::process_event - Error can not find global vertex  node "
+        << "JetKinematicCheck::process_event - Error can not find global vertex  node "
         << std::endl;
     exit(-1);
   }
   if (vertexmap->empty())
   {
     std::cout
-        << "MyJetAnalysis::process_event - global vertex node is empty "
+        << "JetKinematicCheck::process_event - global vertex node is empty "
         << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -18,9 +18,11 @@
 
 #include <iostream>
 
-JetSeedCount::JetSeedCount(const std::string &recojetname, const std::string &truthjetname, const std::string &outputfilename)
-  : SubsysReco("JetSeedCount_" + recojetname + "_" + truthjetname)
+JetSeedCount::JetSeedCount(const std::string &moduleName, const std::string &recojetname, const std::string &rawSeedName, const std::string &subSeedName, const std::string &truthjetname, const std::string &outputfilename)
+  : SubsysReco(moduleName)
   , m_recoJetName(recojetname)
+  , m_rawSeedName(rawSeedName)
+  , m_subSeedName(subSeedName)
   , m_truthJetName(truthjetname)
   , m_outputFileName(outputfilename)
   , m_histTag("AllTrig_AntiKt_Tower_r04_Sub1")
@@ -60,7 +62,7 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
   // std::cout << "JetSeedCount::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
   ++m_event;
   // Calling Raw Jet Seeds
-  JetContainer *seedjetsraw = findNode::getClass<JetContainer>(topNode, "AntiKt_TowerInfo_HIRecoSeedsRaw_r02");
+  JetContainer *seedjetsraw = findNode::getClass<JetContainer>(topNode, m_rawSeedName);
   if (!seedjetsraw)
   {
     std::cout << "JetSeedCount::process_event - Error can not find DST raw seed jets" << std::endl;
@@ -68,7 +70,7 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
   }
 
   // Calling Sub jet seeds
-  JetContainer *seedjetssub = findNode::getClass<JetContainer>(topNode, "AntiKt_TowerInfo_HIRecoSeedsSub_r02");
+  JetContainer *seedjetssub = findNode::getClass<JetContainer>(topNode, m_subSeedName);
   if (!seedjetssub)
   {
     std::cout << "JetSeedCount::process_event - Error can not find DST sub seed jets" << std::endl;

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -23,6 +23,7 @@ JetSeedCount::JetSeedCount(const std::string &recojetname, const std::string &tr
   , m_recoJetName(recojetname)
   , m_truthJetName(truthjetname)
   , m_outputFileName(outputfilename)
+  , m_histTag("AllTrig_AntiKt_Tower_r04_Sub1")
   , m_etaRange(-1, 1)
   , m_ptRange(5, 100)
 {
@@ -162,7 +163,27 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     PHTFileServer::get().cd(m_outputFileName);
   }
 
-  TH1 *hRawSeedCount = new TH1F("hRawSeedCount", "Raw Seed Count per Event", 100, 0.00, 50.00);
+  // construct histogram names
+  std::vector<std::string> vecHistNames = {
+    "hRawSeedCount",
+    "hRawPt",
+    "hRawPt_All",
+    "hRawEtaVsPhi",
+    "hSubSeedCount",
+    "hSubPt",
+    "hSubPt_All",
+    "hSubEtaVsPhi",
+    "hRawSeedEnergyVsCent",
+    "hSubSeedEnergyVsCent",
+    "hCentMbd",
+    "hRawSeedVsCent",
+    "hSubSeedVsCent"
+  };
+  for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+    vecHistNames[iHistName].append("_" + m_histTag);
+  }
+
+  TH1 *hRawSeedCount = new TH1F(vecHistNames[0].data(), "Raw Seed Count per Event", 100, 0.00, 50.00);
   hRawSeedCount->GetXaxis()->SetTitle("Raw Seed Count per Event");
   hRawSeedCount->GetYaxis()->SetTitle("Number of Entries");
   for (int m_raw_count : m_raw_counts)
@@ -170,7 +191,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawSeedCount->Fill(m_raw_count);
   }
 
-  TH1 *hRawPt = new TH1F("hRawPt", "Raw p_{T}", 1000, 0.00, 50.00);
+  TH1 *hRawPt = new TH1F(vecHistNames[1].data(), "Raw p_{T}", 1000, 0.00, 50.00);
   hRawPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   hRawPt->GetYaxis()->SetTitle("Number of Entries");
   for (double j : m_rawpt)
@@ -178,7 +199,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawPt->Fill(j);
   }
 
-  TH1 *hRawPt_All = new TH1F("hRawPt_All", "Raw p_{T} (all jet seeds)", 1000, 0.00, 50.00);
+  TH1 *hRawPt_All = new TH1F(vecHistNames[2].data(), "Raw p_{T} (all jet seeds)", 1000, 0.00, 50.00);
   hRawPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   hRawPt_All->GetYaxis()->SetTitle("Number of Entries");
   for (double j : m_rawpt_all)
@@ -186,7 +207,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawPt_All->Fill(j);
   }
 
-  TH2 *hRawEtaVsPhi = new TH2F("hRawEtaVsPhi", "Raw Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
+  TH2 *hRawEtaVsPhi = new TH2F(vecHistNames[3].data(), "Raw Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
   hRawEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
   hRawEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
   for (int j = 0; j < (int) m_RawEta.size(); j++)
@@ -194,7 +215,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawEtaVsPhi->Fill(m_RawEta.at(j), m_RawPhi.at(j));
   }
 
-  TH1 *hSubSeedCount = new TH1F("hSubSeedCount", "Sub Seed Count per Event", 100, 0.00, 50.00);
+  TH1 *hSubSeedCount = new TH1F(vecHistNames[4].data(), "Sub Seed Count per Event", 100, 0.00, 50.00);
   hSubSeedCount->GetXaxis()->SetTitle("Sub Seed Count per Event");
   hSubSeedCount->GetYaxis()->SetTitle("Number of Entries");
   for (int m_sub_count : m_sub_counts)
@@ -202,7 +223,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hSubSeedCount->Fill(m_sub_count);
   }
 
-  TH1 *hSubPt = new TH1F("hSubPt", "Sub. p_{T}", 1000, 0.00, 50.00);
+  TH1 *hSubPt = new TH1F(vecHistNames[5].data(), "Sub. p_{T}", 1000, 0.00, 50.00);
   hSubPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   hSubPt->GetYaxis()->SetTitle("Number of Entries");
   for (double j : m_subpt)
@@ -210,7 +231,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hSubPt->Fill(j);
   }
 
-  TH1 *hSubPt_All = new TH1F("hSubPt_All", "Sub. p_{T} (all jet seeds)", 1000, 0.00, 50.00);
+  TH1 *hSubPt_All = new TH1F(vecHistNames[6].data(), "Sub. p_{T} (all jet seeds)", 1000, 0.00, 50.00);
   hSubPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   hSubPt_All->GetYaxis()->SetTitle("Number of Entries");
   for (double j : m_subpt_all)
@@ -218,7 +239,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hSubPt->Fill(j);
   }
 
-  TH2 *hSubEtaVsPhi = new TH2F("hSubEtaVsPhi", "Sub. Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
+  TH2 *hSubEtaVsPhi = new TH2F(vecHistNames[7].data(), "Sub. Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
   hSubEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
   hSubEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
   for (int j = 0; j < (int) m_SubEta.size(); j++)
@@ -226,7 +247,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hSubEtaVsPhi->Fill(m_SubEta.at(j), m_SubPhi.at(j));
   }
 
-  TH2 *hRawSeedEnergyVsCent = new TH2F("hRawSeedEnergyVsCent", "Raw Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
+  TH2 *hRawSeedEnergyVsCent = new TH2F(vecHistNames[8].data(), "Raw Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
   hRawSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
   hRawSeedEnergyVsCent->GetYaxis()->SetTitle("RawSeedEnergy");
   for (int j = 0; j < (int) m_rawenergy.size(); j++)
@@ -234,7 +255,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawSeedEnergyVsCent->Fill(m_rawcent.at(j), m_rawenergy.at(j));
   }
 
-  TH2 *hSubSeedEnergyVsCent = new TH2F("hSubSeedEnergyVsCent", "Sub Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
+  TH2 *hSubSeedEnergyVsCent = new TH2F(vecHistNames[9].data(), "Sub Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
   hSubSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
   hSubSeedEnergyVsCent->GetYaxis()->SetTitle("SubSeedEnergy");
   for (int j = 0; j < (int) m_subenergy.size(); j++)
@@ -242,7 +263,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hSubSeedEnergyVsCent->Fill(m_subcent.at(j), m_subenergy.at(j));
   }
 
-  TH1 *hCentMbd = new TH1F("hCentMbd", "hCentMbd", 10, 0.00, 100.00);
+  TH1 *hCentMbd = new TH1F(vecHistNames[10].data(), "hCentMbd", 10, 0.00, 100.00);
   hCentMbd->GetXaxis()->SetTitle("Centrality (Mbd)");
   hCentMbd->GetYaxis()->SetTitle("Number of Entries");
   for (int j : m_centrality)
@@ -250,7 +271,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hCentMbd->Fill(j);
   }
 
-  TH2 *hRawSeedVsCent = new TH2F("hRawSeedVsCent", "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
+  TH2 *hRawSeedVsCent = new TH2F(vecHistNames[10].data(), "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
   hRawSeedVsCent->GetXaxis()->SetTitle("Centrality");
   hRawSeedVsCent->GetYaxis()->SetTitle("Raw Seed Count");
   for (int j = 0; j < (int) m_raw_counts.size(); j++)
@@ -258,7 +279,7 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     hRawSeedVsCent->Fill(m_centrality.at(j), m_raw_counts.at(j));
   }
 
-  TH2 *hSubSeedVsCent = new TH2F("hSubSeedVsCent", "Sub Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
+  TH2 *hSubSeedVsCent = new TH2F(vecHistNames[12].data(), "Sub Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
   hSubSeedVsCent->GetXaxis()->SetTitle("Centrality");
   hSubSeedVsCent->GetYaxis()->SetTitle("Sub Seed Count");
   for (int j = 0; j < (int) m_sub_counts.size(); j++)

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -16,10 +16,12 @@
 #include <TH1.h>
 #include <TH2.h>
 
+#include <algorithm>
 #include <iostream>
 
 JetSeedCount::JetSeedCount(const std::string &moduleName, const std::string &recojetname, const std::string &rawSeedName, const std::string &subSeedName, const std::string &truthjetname, const std::string &outputfilename)
   : SubsysReco(moduleName)
+  , m_moduleName(moduleName)
   , m_recoJetName(recojetname)
   , m_rawSeedName(rawSeedName)
   , m_subSeedName(subSeedName)
@@ -175,23 +177,33 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
     PHTFileServer::get().cd(m_outputFileName);
   }
 
+    // make sure module name is lower case
+    std::string smallModuleName = m_moduleName;
+    std::transform(
+      smallModuleName.begin(),
+      smallModuleName.end(),
+      smallModuleName.begin(),
+      ::tolower
+    );
+
   // construct histogram names
   std::vector<std::string> vecHistNames = {
-    "hRawSeedCount",
-    "hRawPt",
-    "hRawPt_All",
-    "hRawEtaVsPhi",
-    "hSubSeedCount",
-    "hSubPt",
-    "hSubPt_All",
-    "hSubEtaVsPhi",
-    "hRawSeedEnergyVsCent",
-    "hSubSeedEnergyVsCent",
-    "hCentMbd",
-    "hRawSeedVsCent",
-    "hSubSeedVsCent"
+    "rawseedcount",
+    "rawpt",
+    "rawptall",
+    "rawetavsphi",
+    "subseedcount",
+    "subpt",
+    "subptall",
+    "subetavsphi",
+    "rawseedenergyvscent",
+    "subseedenergyvscent",
+    "centmbd",
+    "rawseedvscent",
+    "subseedvscent"
   };
   for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+    vecHistNames[iHistName].insert(0, "h_" + smallModuleName + "_");
     vecHistNames[iHistName].append("_" + m_histTag);
   }
 

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -19,7 +19,10 @@ class PHCompositeNode;
 class JetSeedCount : public SubsysReco
 {
  public:
-  JetSeedCount(const std::string &recojetname = "AntiKt_Tower_r04",
+  JetSeedCount(const std::string &moduleName = "JetSeedCount",
+               const std::string &recojetname = "AntiKt_Tower_r04",
+               const std::string &rawSeedName = "AntiKt_TowerInfo_HIRecoSeedsRaw_r02",
+               const std::string &subSeedName = "AntiKt_TowerInfo_HIRecoSeedsSub_r02",
                const std::string &truthjetname = "AntiKt_Truth_r04",
                const std::string &outputfilename = "myjetanalysis.root");
 
@@ -70,6 +73,8 @@ class JetSeedCount : public SubsysReco
   double z_vtx{std::numeric_limits<double>::quiet_NaN()};
 
   std::string m_recoJetName;
+  std::string m_rawSeedName;
+  std::string m_subSeedName;
   std::string m_truthJetName;
   std::string m_outputFileName;
   std::string m_histTag;

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -42,6 +42,11 @@ class JetSeedCount : public SubsysReco
   {
     m_writeToOutputFile = write;
   }
+  void
+  setHistTag(const std::string &tag)
+  {
+    m_histTag = tag;
+  }
 
   int Init(PHCompositeNode *topNode) override;
 
@@ -67,6 +72,7 @@ class JetSeedCount : public SubsysReco
   std::string m_recoJetName;
   std::string m_truthJetName;
   std::string m_outputFileName;
+  std::string m_histTag;
 
   std::pair<double, double> m_etaRange;
   std::pair<double, double> m_ptRange;

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include "JetQADefs.h"
+
 class PHCompositeNode;
 
 class JetSeedCount : public SubsysReco
@@ -50,6 +52,12 @@ class JetSeedCount : public SubsysReco
   {
     m_histTag = tag;
   }
+  void
+  setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+  {
+    m_doTrgSelect = true;
+    m_trgToSelect = trig;
+  }
 
   int Init(PHCompositeNode *topNode) override;
 
@@ -81,6 +89,10 @@ class JetSeedCount : public SubsysReco
 
   std::pair<double, double> m_etaRange;
   std::pair<double, double> m_ptRange;
+
+  // trigger selection
+  bool m_doTrgSelect;
+  uint32_t m_trgToSelect;
 
   std::vector<double> m_RawEta;
   std::vector<double> m_RawPhi;

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -80,6 +80,7 @@ class JetSeedCount : public SubsysReco
   int m_seed_raw{std::numeric_limits<int>::max()};
   double z_vtx{std::numeric_limits<double>::quiet_NaN()};
 
+  std::string m_moduleName;
   std::string m_recoJetName;
   std::string m_rawSeedName;
   std::string m_subSeedName;

--- a/offline/QA/Jet/Makefile.am
+++ b/offline/QA/Jet/Makefile.am
@@ -15,6 +15,7 @@ AM_CPPFLAGS = \
 
 pkginclude_HEADERS = \
   ConstituentsinJets.h \
+  JetQADefs.h \
   StructureinJets.h \
   TrksInJetQA.h \
   TrksInJetQAHist.h \
@@ -56,6 +57,7 @@ libjetqa_la_LIBADD = \
   -lg4jets \
   -lcentrality_io \
   -lparticleflow_io \
+  -lffarawobjects \
   -lfun4all \
   -lphool \
   -lg4eval \

--- a/offline/QA/Jet/RhosinEvent.cc
+++ b/offline/QA/Jet/RhosinEvent.cc
@@ -22,8 +22,9 @@
 #include <cassert>
 #include <vector>
 
-RhosinEvent::RhosinEvent(const std::string &name)
+RhosinEvent::RhosinEvent(const std::string &name, const std::string &tag)
   : SubsysReco(name)
+  , m_histTag(tag)
   // , m_name(outputfilename)
   , m_do_mult_rho(true)
   , m_do_area_rho(true)
@@ -68,21 +69,32 @@ int RhosinEvent::Init(PHCompositeNode * /*topNode*/)
     {
         N_rho_area_bins[i] = (10.0/200.0)*i;
     }
-    
-    h1_mult_rho = new TH1D("h1_mult_rho", "h1_mult_rho", N_rho_mult, N_rho_mult_bins);
+
+    // construct histogram names
+    std::vector<std::string> vecHistNames = {
+      "h1_mult_rho",
+      "h1_mult_rho_sigma",
+      "h1_area_rho",
+      "h1_area_rho_sigma"
+    };
+    for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+      vecHistNames[iHistName].append("_" + m_histTag);
+    }
+
+    h1_mult_rho = new TH1D(vecHistNames[0].data(), "h1_mult_rho", N_rho_mult, N_rho_mult_bins);
     h1_mult_rho->GetXaxis()->SetTitle("rho_M");
     h1_mult_rho->GetYaxis()->SetTitle("Counts");
 
-    h1_mult_rho_sigma = new TH1D("h1_mult_rho_sigma", "h1_mult_rho_sigma", N_rho_mult, N_rho_mult_bins);
+    h1_mult_rho_sigma = new TH1D(vecHistNames[1].data(), "h1_mult_rho_sigma", N_rho_mult, N_rho_mult_bins);
     h1_mult_rho_sigma->GetXaxis()->SetTitle("sigma_M");
     h1_mult_rho_sigma->GetYaxis()->SetTitle("Counts");
 
         
-    h1_area_rho = new TH1D("h1_area_rho", "h1_area_rho", N_rho_area, N_rho_area_bins);
+    h1_area_rho = new TH1D(vecHistNames[2].data(), "h1_area_rho", N_rho_area, N_rho_area_bins);
     h1_area_rho->GetXaxis()->SetTitle("rho_A");
     h1_area_rho->GetYaxis()->SetTitle("Counts");
 
-    h1_area_rho_sigma = new TH1D("h1_area_rho_sigma", "h1_area_rho_sigma", N_rho_area, N_rho_area_bins);
+    h1_area_rho_sigma = new TH1D(vecHistNames[3].data(), "h1_area_rho_sigma", N_rho_area, N_rho_area_bins);
     h1_area_rho_sigma->GetXaxis()->SetTitle("sigma_A");
     h1_area_rho_sigma->GetYaxis()->SetTitle("Counts");
 

--- a/offline/QA/Jet/RhosinEvent.cc
+++ b/offline/QA/Jet/RhosinEvent.cc
@@ -30,6 +30,8 @@ RhosinEvent::RhosinEvent(const std::string &name, const std::string &tag)
   , m_do_area_rho(true)
   , m_mult_rho_node("TowerRho_MULT")
   , m_area_rho_node("TowerRho_AREA")
+  , m_doTrgSelect(false)
+  , m_trgToSelect(JetQADefs::GL1::MBDNSJet1)
   , h1_mult_rho(nullptr)
   , h1_mult_rho_sigma(nullptr)
   , h1_area_rho(nullptr)
@@ -113,6 +115,13 @@ int RhosinEvent::process_event(PHCompositeNode *topNode)
   if(Verbosity() > 1)
   {
     std::cout << "RhosinEvent::process_event - Process event..." << std::endl;
+  }
+
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
   }
 
   if(m_do_area_rho)

--- a/offline/QA/Jet/RhosinEvent.cc
+++ b/offline/QA/Jet/RhosinEvent.cc
@@ -17,13 +17,15 @@
 
 #include <TH1.h>
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <cassert>
 #include <vector>
 
-RhosinEvent::RhosinEvent(const std::string &name, const std::string &tag)
-  : SubsysReco(name)
+RhosinEvent::RhosinEvent(const std::string &moduleName, const std::string &tag)
+  : SubsysReco(moduleName)
+  , m_moduleName(moduleName)
   , m_histTag(tag)
   // , m_name(outputfilename)
   , m_do_mult_rho(true)
@@ -72,14 +74,24 @@ int RhosinEvent::Init(PHCompositeNode * /*topNode*/)
         N_rho_area_bins[i] = (10.0/200.0)*i;
     }
 
+    // make sure module name is lower case
+    std::string smallModuleName = m_moduleName;
+    std::transform(
+      smallModuleName.begin(),
+      smallModuleName.end(),
+      smallModuleName.begin(),
+      ::tolower
+    );
+
     // construct histogram names
     std::vector<std::string> vecHistNames = {
-      "h1_mult_rho",
-      "h1_mult_rho_sigma",
-      "h1_area_rho",
-      "h1_area_rho_sigma"
+      "rhomult",
+      "sigmamult",
+      "rhoarea",
+      "sigmaarea"
     };
     for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+      vecHistNames[iHistName].insert(0, "h_" + smallModuleName + "_");
       vecHistNames[iHistName].append("_" + m_histTag);
     }
 

--- a/offline/QA/Jet/RhosinEvent.h
+++ b/offline/QA/Jet/RhosinEvent.h
@@ -26,7 +26,7 @@ class RhosinEvent : public SubsysReco
     public:
 
         RhosinEvent(
-          const std::string &name = "RhosinEvent",
+          const std::string &moduleName = "RhosinEvent",
           const std::string &tag = "AllTrig"
         );
         ~RhosinEvent() override {};
@@ -55,7 +55,8 @@ class RhosinEvent : public SubsysReco
 
     private:
 
-        //! Input Node strings
+        //! Module name, and histogram tag
+        std::string m_moduleName{"RhosinEvent"};
         std::string m_histTag{"AllTrig"};
         // std::string m_outputFileName{"RhosinEvent.root"};
 

--- a/offline/QA/Jet/RhosinEvent.h
+++ b/offline/QA/Jet/RhosinEvent.h
@@ -23,7 +23,10 @@ class RhosinEvent : public SubsysReco
 
     public:
 
-        RhosinEvent(const std::string &name = "RhosinEvent");
+        RhosinEvent(
+          const std::string &name = "RhosinEvent",
+          const std::string &tag = "AllTrig"
+        );
         ~RhosinEvent() override {};
 
         void add_mult_rho_node(const std::string &name)
@@ -46,6 +49,7 @@ class RhosinEvent : public SubsysReco
     private:
 
         //! Input Node strings
+        std::string m_histTag{"AllTrig"};
         // std::string m_outputFileName{"RhosinEvent.root"};
 
         bool m_do_mult_rho{true};

--- a/offline/QA/Jet/RhosinEvent.h
+++ b/offline/QA/Jet/RhosinEvent.h
@@ -9,6 +9,8 @@
 #include <utility>  // std::pair, std::make_pair
 #include <vector>
 
+#include "JetQADefs.h"
+
 class Fun4AllHistoManager;
 class PHCompositeNode;
 class TH1;
@@ -39,6 +41,11 @@ class RhosinEvent : public SubsysReco
             m_do_area_rho = true;
             m_area_rho_node = name;
         }
+        void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+        {
+          m_doTrgSelect = true;
+          m_trgToSelect = trig;
+        }
 
         // standard Fun4All functions
         int Init(PHCompositeNode *topNode) override;
@@ -56,6 +63,10 @@ class RhosinEvent : public SubsysReco
         bool m_do_area_rho{true};
         std::string m_mult_rho_node{"TowerRho_MULT"};
         std::string m_area_rho_node{"TowerRho_AREA"};
+
+        // trigger selection
+        bool m_doTrgSelect;
+        uint32_t m_trgToSelect;
 
         Fun4AllHistoManager* m_manager{nullptr};
         //histos

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -35,6 +35,8 @@ StructureinJets::StructureinJets(const std::string &moduleName, const std::strin
   : SubsysReco(moduleName)
   , m_recoJetName(recojetname)
   , m_histTag(histTag)
+  , m_doTrgSelect(false)
+  , m_trgToSelect(JetQADefs::GL1::MBDNSJet1)
   , m_outputFileName(outputfilename)
 {
   std::cout << "StructureinJets::StructureinJets(const std::string &name) Calling ctor" << std::endl;
@@ -87,6 +89,14 @@ int StructureinJets::InitRun(PHCompositeNode* /*topNode*/)
 int StructureinJets::process_event(PHCompositeNode* topNode)
 {
   // std::cout << "StructureinJets::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   // interface to reco jets
   JetContainer* jets = findNode::getClass<JetContainer>(topNode, m_recoJetName);
   if (!jets)

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -31,8 +31,8 @@
 #include <utility>
 
 //____________________________________________________________________________..
-StructureinJets::StructureinJets(const std::string& recojetname, const std::string& histTag, const std::string& outputfilename)
-  : SubsysReco("StructureinJets_" + recojetname)
+StructureinJets::StructureinJets(const std::string &moduleName, const std::string& recojetname, const std::string& histTag, const std::string& outputfilename)
+  : SubsysReco(moduleName)
   , m_recoJetName(recojetname)
   , m_histTag(histTag)
   , m_outputFileName(outputfilename)

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -49,7 +49,11 @@ StructureinJets::~StructureinJets()
 int StructureinJets::Init(PHCompositeNode* /*topNode*/)
 {
   std::cout << "StructureinJets::Init(PHCompositeNode *topNode) Initializing" << std::endl;
-  PHTFileServer::get().open(m_outputFileName, "RECREATE");
+  if (writeToOutputFileFlag)
+  {
+    PHTFileServer::get().open(m_outputFileName, "RECREATE");
+  }
+
   m_h_track_vs_calo_pt = new TH3F("m_h_track_vs_calo_pt", "", 100, 0, 100, 500, 0, 100, 10, 0, 100);
   m_h_track_vs_calo_pt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
   m_h_track_vs_calo_pt->GetYaxis()->SetTitle("Sum track p_{T} [GeV]");

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -92,7 +92,7 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
   if (!jets)
   {
     std::cout
-        << "MyJetAnalysis::process_event - Error can not find DST Reco JetContainer node "
+        << "StructureInJets::process_event - Error can not find DST Reco JetContainer node "
         << m_recoJetName << std::endl;
     exit(-1);
   }

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -23,6 +23,7 @@
 #include <TH3.h>
 #include <TVector3.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
@@ -33,6 +34,7 @@
 //____________________________________________________________________________..
 StructureinJets::StructureinJets(const std::string &moduleName, const std::string& recojetname, const std::string& histTag, const std::string& outputfilename)
   : SubsysReco(moduleName)
+  , m_moduleName(moduleName)
   , m_recoJetName(recojetname)
   , m_histTag(histTag)
   , m_doTrgSelect(false)
@@ -58,12 +60,22 @@ int StructureinJets::Init(PHCompositeNode* /*topNode*/)
     PHTFileServer::get().open(m_outputFileName, "RECREATE");
   }
 
+  // make sure module name is lower case
+  std::string smallModuleName = m_moduleName;
+  std::transform(
+    smallModuleName.begin(),
+    smallModuleName.end(),
+    smallModuleName.begin(),
+    ::tolower
+  );
+
   // construct histogram names
   std::vector<std::string> vecHistNames = {
-    "h_track_vs_calo_pt",
-    "h_track_pt"
+    "trackvscalopt",
+    "trackpt"
   };
   for (size_t iHistName = 0; iHistName < vecHistNames.size(); ++iHistName) {
+    vecHistNames[iHistName].insert(0, "h_" + smallModuleName + "_");
     vecHistNames[iHistName].append("_" + m_histTag);
   }
 

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -22,6 +22,7 @@ class StructureinJets : public SubsysReco
 {
  public:
   StructureinJets(const std::string &recojetname = "AntiKt_Tower_r04",
+                  const std::string &histTag = "AllTrig_AntiKt_Tower_r04",
                   const std::string &outputfilename = "tracksinjets.root");
 
   ~StructureinJets() override;
@@ -67,6 +68,7 @@ class StructureinJets : public SubsysReco
 
  private:
   std::string m_recoJetName;
+  std::string m_histTag;
   float m_trk_pt_cut{2};
   float m_jetRadius{0.4};
   bool isAAFlag{false};

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -77,6 +77,7 @@ class StructureinJets : public SubsysReco
   }
 
  private:
+  std::string m_moduleName;
   std::string m_recoJetName;
   std::string m_histTag;
   float m_trk_pt_cut{2};

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -21,7 +21,8 @@ class TH3;
 class StructureinJets : public SubsysReco
 {
  public:
-  StructureinJets(const std::string &recojetname = "AntiKt_Tower_r04",
+  StructureinJets(const std::string &moduleName = "StructureInJets",
+                  const std::string &recojetname = "AntiKt_Tower_r04",
                   const std::string &histTag = "AllTrig_AntiKt_Tower_r04",
                   const std::string &outputfilename = "tracksinjets.root");
 

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -13,6 +13,8 @@
 
 #include <string>
 
+#include "JetQADefs.h"
+
 class Fun4AllHistoManager;
 class PHCompositeNode;
 class TH2;
@@ -67,6 +69,13 @@ class StructureinJets : public SubsysReco
   bool writeToOutputFile() const { return writeToOutputFileFlag; }
   void writeToOutputFile(bool b) { writeToOutputFileFlag = b; }
 
+  // set trigger to require
+  void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+  {
+    m_doTrgSelect = true;
+    m_trgToSelect = trig;
+  }
+
  private:
   std::string m_recoJetName;
   std::string m_histTag;
@@ -74,6 +83,8 @@ class StructureinJets : public SubsysReco
   float m_jetRadius{0.4};
   bool isAAFlag{false};
   bool writeToOutputFileFlag{false};
+  bool m_doTrgSelect{false};
+  uint32_t m_trgToSelect{JetQADefs::GL1::MBDNSJet1};
   std::string m_outputFileName;
   TH3 *m_h_track_vs_calo_pt{nullptr};
   TH2 *m_h_track_pt{nullptr};

--- a/offline/QA/Jet/TrksInJetQA.cc
+++ b/offline/QA/Jet/TrksInJetQA.cc
@@ -17,7 +17,8 @@
 TrksInJetQA::TrksInJetQA(const std::string& name)
   : SubsysReco(name)
 {
-  /* nothing to do */
+
+  m_moduleName = name;
 
 }  // end ctor
 
@@ -190,27 +191,48 @@ void TrksInJetQA::InitHistograms()
     std::cout << "TrksInJetQA::InitHistograms() Initializing histograms..." << std::endl;
   }
 
-  // make labels
-  std::string inJetLabel = "InJet";
-  std::string inclusiveLabel = "Inclusive";
+  // make sure module name is lower case
+  std::string smallModuleName = m_moduleName;
+  std::transform(
+    smallModuleName.begin(),
+    smallModuleName.end(),
+    smallModuleName.begin(),
+    ::tolower
+  );
+
+  // histograms are always prefixed by the module name
+  std::string prefix = "h_";
+  prefix += "_";
+  prefix += smallModuleName;
+
+  // if additional prefix provided, add it
+  if (m_histPrefix.has_value())
+  {
+    prefix += m_histPrefix.value();
+    prefix += "_";
+  }
+
+  // make suffixes
+  std::string inJetSuffix = "InJet";
+  std::string inclusiveSuffix = "Inclusive";
   if (m_histSuffix.has_value())
   {
-    inJetLabel += "_";
-    inJetLabel += m_histSuffix.value();
-    inclusiveLabel += "_";
-    inclusiveLabel += m_histSuffix.value();
+    inJetSuffix += "_";
+    inJetSuffix += m_histSuffix.value();
+    inclusiveSuffix += "_";
+    inclusiveSuffix += m_histSuffix.value();
   }
 
   // initialize submodules, as needed
   if (m_config.doInJet)
   {
     m_inJet = std::make_unique<TrksInJetQAInJetFiller>(m_config, m_hist);
-    m_inJet->MakeHistograms(inJetLabel);
+    m_inJet->MakeHistograms(prefix, inJetSuffix);
   }
   if (m_config.doInclusive)
   {
     m_inclusive = std::make_unique<TrksInJetQAInclusiveFiller>(m_config, m_hist);
-    m_inclusive->MakeHistograms(inclusiveLabel);
+    m_inclusive->MakeHistograms(prefix, inclusiveSuffix);
   }
   return;
 

--- a/offline/QA/Jet/TrksInJetQA.cc
+++ b/offline/QA/Jet/TrksInJetQA.cc
@@ -91,6 +91,13 @@ int TrksInJetQA::process_event(PHCompositeNode* topNode)
     std::cout << "TrksInJetQA::process_event(PHCompositeNode* topNode) Processing Event" << std::endl;
   }
 
+  // if needed, check if selected trigger fired
+  if (m_doTrgSelect)
+  {
+    bool hasTrigger = JetQADefs::DidTriggerFire(m_trgToSelect, topNode);
+    if (!hasTrigger) return Fun4AllReturnCodes::EVENT_OK;
+  }
+
   // run submodules
   if (m_config.doInJet)
   {

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -36,6 +36,9 @@
 #include <utility>
 #include <vector>
 
+// jet qa utilities
+#include "JetQADefs.h"
+
 // TrksInJetQA definition -----------------------------------------------------
 
 class TrksInJetQA : public SubsysReco
@@ -55,6 +58,11 @@ class TrksInJetQA : public SubsysReco
   // setters
   void SetOutFileName(const std::string& name) { m_outFileName = name; }
   void SetHistSuffix(const std::string& suffix) { m_histSuffix = suffix; }
+  void SetTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
+  {
+    m_doTrgSelect = true;
+    m_trgToSelect = trig;
+  }
 
   // public methods
   void Configure(
@@ -77,6 +85,10 @@ class TrksInJetQA : public SubsysReco
   TFile* m_outFile = NULL;
   std::string m_outFileName = "tracksInJetsQA.root";
   Fun4AllHistoManager* m_manager = NULL;
+
+  // trigger selection
+  bool m_doTrgSelect = false;
+  uint32_t m_trgToSelect = JetQADefs::GL1::MBDNSJet1;
 
   // optional suffix for histograms
   std::optional<std::string> m_histSuffix = std::nullopt;

--- a/offline/QA/Jet/TrksInJetQA.h
+++ b/offline/QA/Jet/TrksInJetQA.h
@@ -30,6 +30,7 @@
 #include <TFile.h>
 
 // c++ utilities
+#include <algorithm>
 #include <cassert>
 #include <optional>
 #include <string>
@@ -57,6 +58,7 @@ class TrksInJetQA : public SubsysReco
 
   // setters
   void SetOutFileName(const std::string& name) { m_outFileName = name; }
+  void SetHistPrefix(const std::string& prefix) { m_histPrefix = prefix; }
   void SetHistSuffix(const std::string& suffix) { m_histSuffix = suffix; }
   void SetTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
   {
@@ -83,6 +85,7 @@ class TrksInJetQA : public SubsysReco
   // io members
   //   - FIXME raw pointers should be smart ones!
   TFile* m_outFile = NULL;
+  std::string m_moduleName = "TrksInJetQA";
   std::string m_outFileName = "tracksInJetsQA.root";
   Fun4AllHistoManager* m_manager = NULL;
 
@@ -90,7 +93,8 @@ class TrksInJetQA : public SubsysReco
   bool m_doTrgSelect = false;
   uint32_t m_trgToSelect = JetQADefs::GL1::MBDNSJet1;
 
-  // optional suffix for histograms
+  // optional prefix, suffix for histograms
+  std::optional<std::string> m_histPrefix = std::nullopt;
   std::optional<std::string> m_histSuffix = std::nullopt;
 
   // submodules to run

--- a/offline/QA/Jet/TrksInJetQABaseFiller.cc
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.cc
@@ -41,24 +41,24 @@ TrksInJetQABaseFiller::TrksInJetQABaseFiller(
 
 // public methods -------------------------------------------------------------
 
-void TrksInJetQABaseFiller::MakeHistograms(const std::string& label)
+void TrksInJetQABaseFiller::MakeHistograms(const std::string& prefix, const std::string& suffix)
 {
   // initialize relevant submodules
   if (m_config.doHitQA)
   {
-    m_hitManager->MakeHistograms(label);
+    m_hitManager->MakeHistograms(prefix, suffix);
   }
   if (m_config.doClustQA)
   {
-    m_clustManager->MakeHistograms(label);
+    m_clustManager->MakeHistograms(prefix, suffix);
   }
   if (m_config.doTrackQA)
   {
-    m_trackManager->MakeHistograms(label);
+    m_trackManager->MakeHistograms(prefix, suffix);
   }
   if (m_config.doJetQA)
   {
-    m_jetManager->MakeHistograms(label);
+    m_jetManager->MakeHistograms(prefix, suffix);
   }
   return;
 

--- a/offline/QA/Jet/TrksInJetQABaseFiller.h
+++ b/offline/QA/Jet/TrksInJetQABaseFiller.h
@@ -48,7 +48,7 @@ class TrksInJetQABaseFiller
   virtual ~TrksInJetQABaseFiller() = default;
 
   // public methods
-  void MakeHistograms(const std::string& label = "");
+  void MakeHistograms(const std::string& prefix = "", const std::string& suffix = "");
   void SaveHistograms(TFile* outFile, const std::string& outDirName);
   void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
 

--- a/offline/QA/Jet/TrksInJetQABaseManager.cc
+++ b/offline/QA/Jet/TrksInJetQABaseManager.cc
@@ -34,10 +34,10 @@ TrksInJetQABaseManager::~TrksInJetQABaseManager()
 
 // public methods -------------------------------------------------------------
 
-void TrksInJetQABaseManager::MakeHistograms(const std::string& label)
+void TrksInJetQABaseManager::MakeHistograms(const std::string& prefix, const std::string& suffix)
 {
   DefineHistograms();
-  BuildHistograms(label);
+  BuildHistograms(prefix, suffix);
   return;
 
 }  // end 'MakeHistograms(std::string)'
@@ -94,7 +94,7 @@ void TrksInJetQABaseManager::GrabHistograms(
 
 // private methods ------------------------------------------------------------
 
-void TrksInJetQABaseManager::BuildHistograms(const std::string& label)
+void TrksInJetQABaseManager::BuildHistograms(const std::string& prefix, const std::string& suffix)
 {
   // build 1d histograms
   m_vecHist1D.resize(m_vecHistTypes.size());
@@ -103,11 +103,13 @@ void TrksInJetQABaseManager::BuildHistograms(const std::string& label)
     for (HistDef1D histDef1D : m_vecHistDef1D)
     {
       // make name
-      std::string sHistName("h");
+      std::string sHistName("h_");
+      sHistName += prefix;
+      sHistName += "_";
       sHistName += m_vecHistTypes.at(iType);
       sHistName += std::get<0>(histDef1D);
       sHistName += "_";
-      sHistName += label;
+      sHistName += suffix;
 
       // create histogram
       m_vecHist1D.at(iType).push_back(
@@ -127,11 +129,20 @@ void TrksInJetQABaseManager::BuildHistograms(const std::string& label)
     for (HistDef2D histDef2D : m_vecHistDef2D)
     {
       // make name
-      std::string sHistName("h");
+      std::string sHistName("h_");
+      sHistName += prefix;
+      sHistName += "_";
       sHistName += m_vecHistTypes.at(iType);
       sHistName += std::get<0>(histDef2D);
       sHistName += "_";
-      sHistName += label;
+      sHistName += suffix;
+
+      //const std::string sDoubleUnderscore("__");
+      std::regex_replace(
+        sHistName,
+        std::regex("__"),
+        "_"
+      );
 
       // create histogram
       m_vecHist2D.at(iType).push_back(

--- a/offline/QA/Jet/TrksInJetQABaseManager.h
+++ b/offline/QA/Jet/TrksInJetQABaseManager.h
@@ -25,6 +25,7 @@
 
 // c++ utilities
 #include <iostream>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,13 +40,13 @@ class TrksInJetQABaseManager
   virtual ~TrksInJetQABaseManager();
 
   // public methods
-  void MakeHistograms(const std::string& label = "");
+  void MakeHistograms(const std::string& prefix = "", const std::string& suffix = "");
   void SaveHistograms(TDirectory* outFile, const std::string& outDirName);
   void GrabHistograms(std::vector<TH1D*>& vecOutHist1D, std::vector<TH2D*>& vecOutHist2D);
 
  protected:
   // private methods
-  void BuildHistograms(const std::string& label = "");
+  void BuildHistograms(const std::string& prefix = "", const std::string& suffix = "");
   void ResetVectors();
 
   // private helper methods


### PR DESCRIPTION
This PR makes two major updates to the Jet QA:

1. Certain inputs and parameters have been made user-configurable in order to avoid name clashes across modules and histograms, and to allow for the same module to be run on different jet populations in parallel;
2. And functionality has been added to all modules to allow the user to select on a specific trigger by specifying the desired trigger's index in the GL1 trigger vector.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduces the new features described above. There have been modest changes to the API for certain modules (e.g. adding additional arguments to ctor's), and so users should update their downstream macros accordingly.
