### PR TITLE
fix: option to look for old gl1 container

### DIFF
--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -10,7 +10,7 @@
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitv2.h>
 
-// #include <ffarawobjects/Gl1RawHit.h>
+#include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/Gl1Packet.h>
 #include <ffarawobjects/InttRawHit.h>
 #include <ffarawobjects/InttRawHitContainer.h>
@@ -186,18 +186,26 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
   }
   // Gl1RawHit* gl1 = nullptr;
   Gl1Packet* gl1 = nullptr;
+  uint64_t gl1rawhitbco = 0;
   if (!m_runStandAlone)
   {
     gl1 = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
-    if (!gl1)
+    if (gl1)
     {
-      std::cout << PHWHERE << " no gl1 container, exiting" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
+      gl1rawhitbco = gl1->lValue(0, "BCO");
+    }
+    else
+    {
+      auto oldgl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+      if(!oldgl1)
+      {
+        std::cout << PHWHERE << " no gl1 container, exiting" << std::endl;
+        return Fun4AllReturnCodes::ABORTEVENT;
+      }
+      gl1rawhitbco = oldgl1->get_bco();
     }
   }
 
-  // uint64_t gl1rawhitbco = m_runStandAlone ? 0 : gl1->get_bco();
-  uint64_t gl1rawhitbco = m_runStandAlone ? 0 : gl1->lValue(0, "BCO");
   // get the last 40 bits by bit shifting left then right to match
   // to the mvtx bco
   auto lbshift = gl1rawhitbco << 24U;  // clang-tidy: mark as unsigned

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -174,7 +174,10 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   }
   else{
     auto oldgl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
-    gl1rawhitbco = oldgl1->get_bco();
+    if(oldgl1)
+    {
+      gl1rawhitbco = oldgl1->get_bco();
+    }
   }
   if (gl1rawhitbco == 0 && (Verbosity() >= 4))
   {

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -14,7 +14,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 
-// #include <ffarawobjects/Gl1RawHit.h>
+#include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/Gl1Packet.h>
 #include <ffarawobjects/MvtxRawEvtHeader.h>
 #include <ffarawobjects/MvtxRawHit.h>
@@ -163,17 +163,24 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     std::cout << "Have you built this yet?" << std::endl;
     exit(1);
   }
-
-  // auto gl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+  // Could we just get the first strobe BCO instead of setting this to 0?
+  // Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
+  //  uint64_t gl1rawhitbco = gl1 ? gl1->get_bco() : 0;
   auto gl1 = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
-  if (!gl1 && (Verbosity() >= 4))
+  uint64_t gl1rawhitbco = 0;
+  if(gl1)
+  {
+    gl1rawhitbco = gl1->lValue(0, "BCO");
+  }
+  else{
+    auto oldgl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+    gl1rawhitbco = oldgl1->get_bco();
+  }
+  if (gl1rawhitbco == 0 && (Verbosity() >= 4))
   {
     std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
   }
-  //Could we just get the first strobe BCO instead of setting this to 0?
-  //Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
-  // uint64_t gl1rawhitbco = gl1 ? gl1->get_bco() : 0;
-  uint64_t gl1rawhitbco = gl1 ? gl1->lValue(0, "BCO") : 0;
+
   // get the last 40 bits by bit shifting left then right to match
   // to the mvtx bco
   auto lbshift = gl1rawhitbco << 24U;


### PR DESCRIPTION
To keep old DSTs reconstructible, we need to check for the `GL1RawHit` container which was used before `GL1Packet`. At some point this will become obsolete when we reprocess DSTs, but we aren't there yet.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

