### PR TITLE
extended radians and interpolation flags to be distortion dependent.

### DIFF
--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -51,8 +51,12 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
   // look for distortion calibration object
   PHNodeIterator iter(topNode);
 
-  std::cout << "TpcLoadDistortionCorrection::InitRun - m_phi_hist_in_radians: " << m_phi_hist_in_radians << std::endl;
-
+  std::cout << "TpcLoadDistortionCorrection::InitRun - m_flags: (i,in_use,radians,interpolate_z):"
+  for (int i=0; i<4; i++)
+  {
+    std::cout << "("<< i <<", "<<m_correction_in_use[i] << ", " << m_phi_hist_in_radians[i] << ", " << m_interpolate_z[i] << ")"<< std::endl;
+  }
+  
   /// Get the RUN node and check
   auto runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
@@ -105,10 +109,10 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
     assert(distortion_correction_object->m_dimensions == 2 || distortion_correction_object->m_dimensions == 3);
 
     // assign whether phi corrections (DP) should be read as radians or mm
-    distortion_correction_object->m_phi_hist_in_radians = m_phi_hist_in_radians;
+    distortion_correction_object->m_phi_hist_in_radians = m_phi_hist_in_radians[i];
 
     // assign whether 2D corrections should be interpolated to zero at readout or not (has no effect on 3D corrections)
-    distortion_correction_object->m_interpolate_z = m_interpolate_z;
+    distortion_correction_object->m_interpolate_z = m_interpolate_z[i];
 
     if (Verbosity())
     {

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -51,7 +51,7 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
   // look for distortion calibration object
   PHNodeIterator iter(topNode);
 
-  std::cout << "TpcLoadDistortionCorrection::InitRun - m_flags: (i,in_use,radians,interpolate_z):"
+  std::cout << "TpcLoadDistortionCorrection::InitRun - m_flags: (i,in_use,radians,interpolate_z):";
   for (int i=0; i<4; i++)
   {
     std::cout << "("<< i <<", "<<m_correction_in_use[i] << ", " << m_phi_hist_in_radians[i] << ", " << m_interpolate_z[i] << ")"<< std::endl;

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -37,10 +37,12 @@ class TpcLoadDistortionCorrection : public SubsysReco
     DistortionType_ModuleEdge = 3
   };
 
+  const int nDistortionTypes = 4;
+
   //! correction filename
   void set_correction_filename(DistortionType i, const std::string& value)
   {
-    if (i < 0 || i >= 4) return;
+    if (i < 0 || i >= nDistortionTypes) return;
     m_correction_filename[i] = value;
     m_correction_in_use[i] = true;
   }
@@ -48,13 +50,21 @@ class TpcLoadDistortionCorrection : public SubsysReco
   //! set the phi histogram to be interpreted as radians.
   void set_read_phi_as_radians(bool flag)
   {
-    m_phi_hist_in_radians = flag;
+    m_phi_hist_in_radians[0] = flag;
+  }
+ void set_read_phi_as_radians(int i, bool flag)
+  {
+    m_phi_hist_in_radians[i] = flag;
   }
   //! set the histogram to interpolate between hist value and zero, depending on z position. (has no effect if m_dimensions is 3)
   void set_interpolate_2D_to_zero(bool flag)
   {
-    m_interpolate_z = flag;
+    m_interpolate_z[0] = flag;
   }
+  void set_interpolate_2D_to_zero(int i, bool flag)
+  {
+    m_interpolate_z[i] = flag;
+  } 
 
   //! node name
   void set_node_name(const std::string& value)
@@ -68,17 +78,17 @@ class TpcLoadDistortionCorrection : public SubsysReco
 
  private:
   //! correction filename
-  std::string m_correction_filename[4] = {"", "", "",""};
+  std::string m_correction_filename[nDistortionTypes] = {"", "", "",""};
 
   //! flag to indicate correction in use
-  bool m_correction_in_use[4] = {false, false, false,false};
+  bool m_correction_in_use[nDistortionTypes] = {false, false, false,false};
 
   //! set the phi histogram to be interpreted as radians rather than mm
-  bool m_phi_hist_in_radians = true;
-  bool m_interpolate_z = true;
+  bool m_phi_hist_in_radians[nDistortionTypes] = {true,true,true,true};
+  bool m_interpolate_z[nDistortionTypes] = {true,true,true,true};
 
   //! distortion object node name
-  std::string m_node_name[4] = {"TpcDistortionCorrectionContainerStatic", "TpcDistortionCorrectionContainerAverage", "TpcDistortionCorrectionContainerFluctuation","TpcDistortionCorrectionContainerModuleEdge"};
+  std::string m_node_name[nDistortionTypes] = {"TpcDistortionCorrectionContainerStatic", "TpcDistortionCorrectionContainerAverage", "TpcDistortionCorrectionContainerFluctuation","TpcDistortionCorrectionContainerModuleEdge"};
 };
 
 #endif

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -37,7 +37,7 @@ class TpcLoadDistortionCorrection : public SubsysReco
     DistortionType_ModuleEdge = 3
   };
 
-  const int nDistortionTypes = 4;
+  static const int nDistortionTypes = 4;
 
   //! correction filename
   void set_correction_filename(DistortionType i, const std::string& value)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This allows different corrections to have different settings (interpolation type, treatment of the phi axis units) instead of being required to all share the same pair of flags.  To use this correctly it also needs the matching macro PR which will have the same title.
Without this, the default static distortion and default edge corrections can not both work correctly simultaneously.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

Will post shortly in macros.  This compiles and runs regardless, but will not steer correctly without that pull req.

