### PR TITLE
CD: Moved MVTX BCO range check to pooler

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1255,13 +1255,14 @@ int Fun4AllStreamingInputManager::FillMicromegasPool()
 
 int Fun4AllStreamingInputManager::FillMvtxPool()
 {
+  uint64_t ref_bco_minus_range = m_RefBCO < m_mvtx_bco_range ? 0 : m_RefBCO - m_mvtx_bco_range;
   for (auto iter : m_MvtxInputVector)
   {
     if (Verbosity() > 3)
     {
       std::cout << "Fun4AllStreamingInputManager::FillMvtxPool - fill pool for " << iter->Name() << std::endl;
     }
-    iter->FillPool();
+    iter->FillPool(ref_bco_minus_range);
     if (m_RunNumber == 0)
     {
       m_RunNumber = iter->RunNumber();

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -43,7 +43,7 @@ SingleMvtxPoolInput::~SingleMvtxPoolInput()
   }
 }
 
-void SingleMvtxPoolInput::FillPool(const unsigned int /*nbclks*/)
+void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
 {
   if (AllDone())  // no more files and all events read
   {
@@ -150,9 +150,18 @@ void SingleMvtxPoolInput::FillPool(const unsigned int /*nbclks*/)
           for (int i_strb{0}; i_strb < num_strobes; ++i_strb)
           {
             auto strb_detField = pool->iValue(feeId, i_strb, "TRG_DET_FIELD");
-            auto strb_bco = pool->lValue(feeId, i_strb, "TRG_IR_BCO");
+            uint64_t strb_bco = pool->lValue(feeId, i_strb, "TRG_IR_BCO");
             auto strb_bc = pool->iValue(feeId, i_strb, "TRG_IR_BC");
             auto num_hits = pool->iValue(feeId, i_strb, "TRG_NR_HITS");
+
+            m_BeamClockFEE[strb_bco].insert(feeId);
+            m_BclkStack.insert(strb_bco);
+            m_FEEBclkMap[feeId] = strb_bco;
+            if (strb_bco < minBCO)
+            {
+              continue;
+            }
+
             if (Verbosity() > 4)
             {
               std::cout << "evtno: " << EventSequence << ", Fee: " << feeId;
@@ -182,9 +191,6 @@ void SingleMvtxPoolInput::FillPool(const unsigned int /*nbclks*/)
             {
               StreamingInputManager()->AddMvtxFeeIdInfo(strb_bco, feeId, strb_detField);
             }
-            m_BeamClockFEE[strb_bco].insert(feeId);
-            m_BclkStack.insert(strb_bco);
-            m_FEEBclkMap[feeId] = strb_bco;
           }
         }
       }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -23,7 +23,7 @@ class SingleMvtxPoolInput : public SingleStreamingInput
  public:
   explicit SingleMvtxPoolInput(const std::string &name);
   ~SingleMvtxPoolInput() override;
-  void FillPool(const unsigned int nevents = 1) override;
+  void FillPool(const uint64_t minBCO) override;
   void CleanupUsedPackets(const uint64_t bclk) override;
   bool CheckPoolDepth(const uint64_t bclk) override;
   void ClearCurrentEvent() override;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Overloaded FillPool for SingleMvtxPoolInput so it rejects strobe frame hits that are below the current reference BCO window. This speeds up event processing with regards to the previous method that fills a pool then rejects these hits at the event combiner stage

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

