### PR TITLE
use uint64_t for verbosity so we can also use bits

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -73,7 +73,7 @@ class Fun4AllBase
   std::string m_ThisName;
 
   /// The verbosity level. 0 means not verbose at all.
-  int m_Verbosity = VERBOSITY_QUIET;
+  uint64_t m_Verbosity = VERBOSITY_QUIET;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR changes the Fun4All verbosity from int to uint64_t to enable a decent bitwise verbosity setting if needed

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

