### PR TITLE
added controls to set n time samples in the LaserClusterizer

### DIFF
--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -97,9 +97,10 @@ int LaserClusterizer::InitRun(PHCompositeNode *topNode)
   {
     m_debugFile = new TFile(m_debugFileName.c_str(), "RECREATE");
   }
-
-  m_itHist_0 = new TH1I("m_itHist_0", "side 0;it", 360, -0.5, 359.5);
-  m_itHist_1 = new TH1I("m_itHist_1", "side 1;it", 360, -0.5, 359.5);
+float timeHistMax=m_time_samples_max;
+timeHistMax-=0.5;
+  m_itHist_0 = new TH1I("m_itHist_0", "side 0;it", m_time_samples_max, -0.5, timeHistMax);
+  m_itHist_1 = new TH1I("m_itHist_1", "side 1;it", m_time_samples_max, -0.5, timeHistMax);
 
   if (m_debug)
   {

--- a/offline/packages/tpc/LaserClusterizer.h
+++ b/offline/packages/tpc/LaserClusterizer.h
@@ -62,9 +62,11 @@ class LaserClusterizer : public SubsysReco
   void set_pedestal(float val) { m_pedestal = val; }
   void set_min_clus_size(float val) { min_clus_size = val; }
   void set_min_adc_sum(float val) { min_adc_sum = val; }
+  void set_max_time_samples(int val) { m_time_samples_max = val; }
 
  private:
   int m_event = -1;
+  int m_time_samples_max=360;
 
   TrkrHitSetContainer *m_hits = nullptr;
   RawHitSetContainer *m_rawhits = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This lets the user change the default range of where the diffuse laser clusterizer will look for the laser peak, in time bins.  It defaults to 360, the previous value, but may now be changed by adding a  LaserClusterizer->set_max_time_samples(int val) call in your macro somewhere before InitRun() takes place.

This runs, but does not seem to completely solve the boundary problem yet, since something is still preventing any hits from registering after t=370 or so.  See attached.  
<img width="686" alt="image" src="https://github.com/sPHENIX-Collaboration/coresoftware/assets/30266544/1a7f502d-e3c0-42f9-8f2f-fec7a916e087">


[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

