### PR TITLE
fix: clear sets in mvtx pooling

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -828,6 +828,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
     {
       h_tagBcoFelixAllFees_mvtx[p]->Fill(refbcobitshift);
     }
+    (static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p]))->clearFeeGTML1BCOMap();
     bool thispacket = false;
     for (auto &gtmbco : gtml1bcoset)
     {
@@ -844,6 +845,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       {
         allpackets = false;
       }
+      (static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p]))->clearGtmL1BcoSet();
   }
   if(allpackets)
   {

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -803,7 +803,6 @@ int Fun4AllStreamingInputManager::FillMvtx()
   for (size_t p = 0; p < m_MvtxInputVector.size(); p++)
   {
     auto gtml1bcoset = static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p])->getGtmL1BcoSet();
-    auto bcorange = static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p])->GetBcoRange();
     auto gtml1bcoset_perfee = static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p])->getFeeGTML1BCOMap();
     bool allfees = true;
     for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
@@ -812,7 +811,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       for (auto &gtmbco : gtmbcoset)
       {
         auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-        if (diff < bcorange)
+        if (diff < 3)
         {
           h_tagBcoFelixFee_mvtx[p][feeid]->Fill(refbcobitshift);
           thisfee = true;
@@ -833,7 +832,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
     for (auto &gtmbco : gtml1bcoset)
     {
       auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-      if (diff < bcorange)
+      if (diff < 3)
       {
         thispacket = true;
         h_tagBcoFelix_mvtx[p]->Fill(refbcobitshift);

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -39,6 +39,14 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   std::set<int> &getFeeIdSet(const uint64_t &bco) { return m_BeamClockFEE[bco]; };
   std::set<uint64_t>& getGtmL1BcoSet() { return m_gtmL1BcoSetRef; }
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
+  void clearGtmL1BcoSet() { m_gtmL1BcoSetRef.clear(); }
+  void clearFeeGTML1BCOMap() { 
+    for(auto& [key, set] : m_FeeGTML1BCOMap)
+    {
+      set.clear();
+    }
+    m_FeeGTML1BCOMap.clear(); 
+  }
  protected:
   LinkId_t DecodeFeeid(const uint16_t &feeid)
   {


### PR DESCRIPTION
@cdean-github found some more sets that grow in size with time for certain runs. This adds some clearing functions to reset them after each time the qa uses them. Also changes the bco matching to within 3, which per @ycorrales is the matching range for the gtm and gl1 bcos for the mvtx. Strobe bco matching histograms to be added in another development

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

