### PR TITLE
fix: add flag end run in INTT pooling

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -90,6 +90,7 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
       {
         std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
         delete evt;
+        AllDone(1);
         return;
       }
       delete evt;

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -81,10 +81,17 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
     {
       evt->identify();
     }
+
     // not interested in special events, really
     if (evt->getEvtType() != DATAEVENT)
     {
       m_NumSpecialEvents++;
+      if(evt->getEvtType() == ENDRUNEVENT)
+      {
+        std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
+        delete evt;
+        return;
+      }
       delete evt;
       continue;
     }


### PR DESCRIPTION
In discussion with @mpurschke and @hahahachiya , there are INTT pooling job where the job abruptly ends due to a mismatched run number. Martin traced this down and it appears that the end run event is filled and data after this is corrupted, due to some interplay between the INTT RCDAQ plugin and RCDAQ itself. Until further upstream changes in the firmware can be made to handle this, this PR puts a flag in that if the `ENDRUNEVENT` is found the INTT pooler exits gracefully.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

