### PR TITLE
Fix NodeTree not found problem

### DIFF
--- a/offline/QA/Mvtx/MvtxRawHitQA.cc
+++ b/offline/QA/Mvtx/MvtxRawHitQA.cc
@@ -30,8 +30,7 @@ int MvtxRawHitQA::InitRun(PHCompositeNode *topNode)
 
   if (!rawhitcont)
   {
-    std::cout << PHWHERE << "Missing node(s), can't continue" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
+    std::cout << PHWHERE << "Missing MvtxRawHitContainer node!!!" << std::endl;
   }
 
   auto hm = QAHistManagerDef::getHistoManager();
@@ -80,27 +79,31 @@ int MvtxRawHitQA::process_event(PHCompositeNode * /*unused*/)
   rows.clear();
   cols.clear();
 
-  auto raw_hit_num = rawhitcont->get_nhits();
-  for (unsigned int i = 0; i < raw_hit_num; i++)
+  unsigned int raw_hit_num = 0;
+  if (rawhitcont)
   {
-    auto hit = rawhitcont->get_hit(i);
-    auto bco = hit->get_bco();
-    auto strobe_bc = hit->get_strobe_bc();
-    auto chip_bc = hit->get_chip_bc();
-    auto layer = hit->get_layer_id();
-    auto stave = hit->get_stave_id();
-    auto chip = hit->get_chip_id();
-    auto row = hit->get_row();
-    auto col = hit->get_col();
-    hits.push_back( hit );
-    bcos.push_back( bco );
-    strobe_bcs.push_back( strobe_bc );
-    chip_bcs.push_back( chip_bc );
-    layers.push_back( layer );
-    staves.push_back( stave );
-    chips.push_back( chip );
-    rows.push_back( row );
-    cols.push_back( col );
+    raw_hit_num = rawhitcont->get_nhits();
+    for (unsigned int i = 0; i < raw_hit_num; i++)
+    {
+      auto hit = rawhitcont->get_hit(i);
+      auto bco = hit->get_bco();
+      auto strobe_bc = hit->get_strobe_bc();
+      auto chip_bc = hit->get_chip_bc();
+      auto layer = hit->get_layer_id();
+      auto stave = hit->get_stave_id();
+      auto chip = hit->get_chip_id();
+      auto row = hit->get_row();
+      auto col = hit->get_col();
+      hits.push_back( hit );
+      bcos.push_back( bco );
+      strobe_bcs.push_back( strobe_bc );
+      chip_bcs.push_back( chip_bc );
+      layers.push_back( layer );
+      staves.push_back( stave );
+      chips.push_back( chip );
+      rows.push_back( row );
+      cols.push_back( col );
+    }
   }
 
   // if no raw hit is found, skip this event


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fix NodeTree not found problem
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
If data has no MVTX detector information, MvtxRawHitContainer NodeTree may not be found which will cause event aborting problem. I remove ``return Fun4AllReturnCodes::ABORTEVENT;`` to let this event continue processing, but histogram will no save any information.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

