### PR TITLE
Adding EMCal+HCal topoclusters as jet input

### DIFF
--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -116,6 +116,14 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       return std::vector<Jet *>();
     }
   }
+  else if (m_Input == Jet::ECAL_HCAL_TOPO_CLUSTER)
+  {
+    clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_EMCAL_HCAL");
+    if (!clusters)
+    {
+      return std::vector<Jet *>();
+    }
+  }
   else if (m_Input == Jet::FEMC_CLUSTER)
   {
     clusters = findNode::getClass<RawClusterContainer>(topNode, "CLUSTER_FEMC");

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -118,7 +118,7 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   }
   else if (m_Input == Jet::ECAL_HCAL_TOPO_CLUSTER)
   {
-    clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_EMCAL_HCAL");
+    clusters = findNode::getClass<RawClusterContainer>(topNode, "TOPOCLUSTER_ALLCALO");
     if (!clusters)
     {
       return std::vector<Jet *>();

--- a/offline/packages/jetbase/Jet.h
+++ b/offline/packages/jetbase/Jet.h
@@ -112,6 +112,7 @@ class Jet : public PHObject
     HCALOUT_TOWERINFO_EMBED = 36,
     HCALOUT_TOWERINFO_SIM = 37,
     JET_PROBE = 38,
+    ECAL_HCAL_TOPO_CLUSTER = 39,    /* EMCal+IHCal+OHCal 3-D topoCluster input */
   };
 
   enum PROPERTY


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Additional Jet::SRC constant for EMCal+HCal topo-clusters and corresponding modification in the ClusterJetInput module. Previously only the EMCal only and HCal only options were available as jet input.

