### PR TITLE
feat: add ignore silicon flag to track fit

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -433,6 +433,8 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       {
         if (siseed)
         {
+          if(!m_ignoreSilicon)
+          {
           sourceLinks = makeSourceLinks.getSourceLinksClusterMover(
               siseed,
               measurements,
@@ -440,6 +442,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
               m_tGeometry,
               _dcc_module_edge, _dcc_static, _dcc_average, _dcc_fluctuation,
               this_crossing);
+          }
         }
         const auto tpcSourceLinks = makeSourceLinks.getSourceLinksClusterMover(
             tpcseed,
@@ -455,15 +458,18 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       {
         if (siseed)
         {
-          sourceLinks = makeSourceLinks.getSourceLinks(
-              siseed,
-              measurements,
-              m_clusterContainer,
-              m_tGeometry,
-              _dcc_module_edge, _dcc_static, _dcc_average, _dcc_fluctuation,
-              m_alignmentTransformationMapTransient,
-              m_transient_id_set,
-              this_crossing);
+          if (!m_ignoreSilicon)
+          {
+            sourceLinks = makeSourceLinks.getSourceLinks(
+                siseed,
+                measurements,
+                m_clusterContainer,
+                m_tGeometry,
+                _dcc_module_edge, _dcc_static, _dcc_average, _dcc_fluctuation,
+                m_alignmentTransformationMapTransient,
+                m_transient_id_set,
+                this_crossing);
+          }
         }
         const auto tpcSourceLinks = makeSourceLinks.getSourceLinks(
             tpcseed,
@@ -488,7 +494,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
         position(1) = siseed->get_y() * Acts::UnitConstants::cm;
         position(2) = siseed->get_z() * Acts::UnitConstants::cm;
       }
-      if(!siseed || !is_valid(position))
+      if(!siseed || !is_valid(position) || m_ignoreSilicon)
       {
         position(0) = tpcseed->get_x() * Acts::UnitConstants::cm;
         position(1) = tpcseed->get_y() * Acts::UnitConstants::cm;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -88,7 +88,10 @@ class PHActsTrkFitter : public SubsysReco
   {
     m_useMicromegas = value;
   }
-
+  void ignoreSilicon()
+  {
+    m_ignoreSilicon = true;
+  }
   void setUpdateSvtxTrackStates(bool fillSvtxTrackStates)
   {
     m_fillSvtxTrackStates = fillSvtxTrackStates;
@@ -197,6 +200,9 @@ class PHActsTrkFitter : public SubsysReco
 
   /// A bool to update the SvtxTrackState information (or not)
   bool m_fillSvtxTrackStates = true;
+  
+  /// bool to ignore the silicon clusters in the fit
+  bool m_ignoreSilicon = false;
 
   /// A bool to use the chi2 outlier finder in the track fitting
   bool m_useOutlierFinder = false;


### PR DESCRIPTION
Adds a flag to ignore the silicon clusters/seed in the track fit, for distortion development

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

