### PR TITLE
ycm - increase memory pointer in case of corrupt rdh, fix possible in…

### DIFF
--- a/offline/framework/fun4allraw/mvtx_decoder/GBTLink.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/GBTLink.h
@@ -257,6 +257,8 @@ inline GBTLink::CollectedDataStatus GBTLink::collectROFCableData(/*const Mapping
     rdh.decode(rdh_start);
     if (! rdh.checkRDH(true) )
     {
+      dataOffset = currRawPiece->size;
+      ++hbf_count;
       continue;
     }
 

--- a/offline/framework/fun4allraw/mvtx_pool.cc
+++ b/offline/framework/fun4allraw/mvtx_pool.cc
@@ -100,6 +100,8 @@ void mvtx_pool::setupLinks()
         rdh.decode(&payload[payload_position]);
         if ( ! rdh.checkRDH(true) )
         {
+          // In case of corrupt RDH, skip felix word and continue to next
+          payload_position += mvtx_utils::FLXWordLength;
           continue;
         }
         const size_t pageSizeInBytes = static_cast<size_t>((rdh.pageSize + 1) * mvtx_utils::FLXWordLength);


### PR DESCRIPTION
…finite loop

This PR adds a fix for a possible infinite loop bug in case of corrupt MVTX data b/c we skipped the loop without increasing the reference data pointer.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

