### PR TITLE
Micromegas decoding 6

### DIFF
--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -25,7 +25,7 @@ namespace
     }
     else
     {
-      const bool is_hex = (o.flags()&std::ios_base::hex);
+      const bool is_hex = (o.flags() & std::ios_base::hex);
       o << "{ ";
       bool first = true;
       for (const auto& value : list)
@@ -34,8 +34,10 @@ namespace
         {
           o << ", ";
         }
-        if( is_hex )
-        { o << "0x"; }
+        if (is_hex)
+        {
+          o << "0x";
+        }
         o << value;
         first = false;
       }
@@ -53,7 +55,7 @@ namespace
     }
     else
     {
-      const bool is_hex = (o.flags()&std::ios_base::hex);
+      const bool is_hex = (o.flags() & std::ios_base::hex);
       o << "{ ";
       bool first = true;
       for (const auto& value : list)
@@ -62,8 +64,10 @@ namespace
         {
           o << ", ";
         }
-        if( is_hex )
-        { o << "0x"; }
+        if (is_hex)
+        {
+          o << "0x";
+        }
         o << value;
         first = false;
       }
@@ -73,9 +77,11 @@ namespace
   }
 
   // get the difference between two BCO.
-  template<class T>
-    inline static constexpr T get_bco_diff( const T& first, const T& second )
-  { return first < second ? (second-first):(first-second); }
+  template <class T>
+  inline static constexpr T get_bco_diff(const T& first, const T& second)
+  {
+    return first < second ? (second - first) : (first - second);
+  }
 
   // define limit for matching two fee_bco
   static constexpr unsigned int m_max_multiplier_adjustment_count = 1000;
@@ -116,59 +122,60 @@ namespace
     CLEAR_LV1_LAST_T = 6,
     CLEAR_LV1_ENDAT_T = 7
   };
-}
+}  // namespace
 
 // this is the clock multiplier from lvl1 to fee clock
 /* todo: should replace with actual rational number for John K. */
 double MicromegasBcoMatchingInformation::m_multiplier = 4.262916255;
 
 //___________________________________________________
-std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco( uint64_t gtm_bco ) const
+std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco(uint64_t gtm_bco) const
 {
   // check proper initialization
-  if( !is_verified() ) { return std::nullopt; }
+  if (!is_verified())
+  {
+    return std::nullopt;
+  }
 
   // get gtm bco difference with proper rollover accounting
-  const uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
-    (gtm_bco - m_gtm_bco_first):
-    (gtm_bco + (1ULL<<40U) - m_gtm_bco_first);
+  const uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ? (gtm_bco - m_gtm_bco_first) : (gtm_bco + (1ULL << 40U) - m_gtm_bco_first);
 
   // convert to fee bco, and truncate to 20 bits
-  const uint64_t fee_bco_predicted = m_fee_bco_first + get_adjusted_multiplier()*gtm_bco_difference;
-  return  uint32_t(fee_bco_predicted & 0xFFFFFU);
+  const uint64_t fee_bco_predicted = m_fee_bco_first + get_adjusted_multiplier() * gtm_bco_difference;
+  return uint32_t(fee_bco_predicted & 0xFFFFFU);
 }
 
 //___________________________________________________
 void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
 {
-  if(!m_gtm_bco_list.empty())
+  if (!m_gtm_bco_list.empty())
   {
-
     std::cout
-      << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
-      << " gtm_bco: " << std::hex << m_gtm_bco_list << std::dec
-      << std::endl;
+        << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
+        << " gtm_bco: " << std::hex << m_gtm_bco_list << std::dec
+        << std::endl;
 
     // also print predicted fee bco
-    if( is_verified() )
+    if (is_verified())
     {
       std::list<uint32_t> fee_bco_predicted_list;
       std::transform(
-        m_gtm_bco_list.begin(),
-        m_gtm_bco_list.end(),
-        std::back_inserter(fee_bco_predicted_list),
-        [this](const uint64_t& gtm_bco ){ return get_predicted_fee_bco(gtm_bco).value(); } );
+          m_gtm_bco_list.begin(),
+          m_gtm_bco_list.end(),
+          std::back_inserter(fee_bco_predicted_list),
+          [this](const uint64_t& gtm_bco)
+          { return get_predicted_fee_bco(gtm_bco).value(); });
 
       std::cout
-        << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
-        << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
-        << std::endl;
+          << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
+          << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
+          << std::endl;
     }
   }
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet )
+void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
   const int n_tagger = packet->lValue(0, "N_TAGGER");
@@ -184,11 +191,11 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
 
     // also save hearbeat bco
     const bool is_modebit = static_cast<uint8_t>(packet->lValue(t, "IS_MODEBIT"));
-    if( is_modebit )
+    if (is_modebit)
     {
       // get modebits
       uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
-      if( modebits&(1<<ELINK_HEARTBEAT_T) )
+      if (modebits & (1U << ELINK_HEARTBEAT_T))
       {
         const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
         m_gtm_bco_list.push_back(gtm_bco);
@@ -198,31 +205,37 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information( Packet* packet 
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference( Packet* packet )
+bool MicromegasBcoMatchingInformation::find_reference(Packet* packet)
 {
-  if( find_reference_from_modebits( packet ) ) return true;
-  if( find_reference_from_data( packet ) ) return true;
+  if (find_reference_from_modebits(packet))
+  {
+    return true;
+  }
+  if (find_reference_from_data(packet))
+  {
+    return true;
+  }
   return false;
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference_from_modebits( Packet* packet )
+bool MicromegasBcoMatchingInformation::find_reference_from_modebits(Packet* packet)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
   const int n_tagger = packet->lValue(0, "N_TAGGER");
   for (int t = 0; t < n_tagger; ++t)
   {
     const bool is_modebit = static_cast<uint8_t>(packet->lValue(t, "IS_MODEBIT"));
-    if( is_modebit )
+    if (is_modebit)
     {
       // get modebits
       uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
-      if( modebits&(1<<BX_COUNTER_SYNC_T) )
+      if (modebits & (1U << BX_COUNTER_SYNC_T))
       {
         std::cout << "MicromegasBcoMatchingInformation::find_reference_from_modebits"
-          << " - packet: " << packet->getIdentifier()
-          << " found reference from modebits"
-          << std::endl;
+                  << " - packet: " << packet->getIdentifier()
+                  << " found reference from modebits"
+                  << std::endl;
 
         // get BCO and assign
         const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
@@ -238,31 +251,31 @@ bool MicromegasBcoMatchingInformation::find_reference_from_modebits( Packet* pac
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet )
+bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
 {
   // store gtm bco and diff to previous in an array
   std::vector<uint64_t> gtm_bco_list;
   std::vector<uint64_t> gtm_bco_diff_list;
-  for( const auto& gtm_bco:m_gtm_bco_list )
+  for (const auto& gtm_bco : m_gtm_bco_list)
   {
-    if( !gtm_bco_list.empty() )
+    if (!gtm_bco_list.empty())
     {
       // add difference to last
       // get gtm bco difference with proper rollover accounting
-      const uint64_t gtm_bco_difference = (gtm_bco >= gtm_bco_list.back()) ?
-        (gtm_bco -  gtm_bco_list.back()):
-        (gtm_bco + (1ULL<<40U) - gtm_bco_list.back());
+      const uint64_t gtm_bco_difference = (gtm_bco >= gtm_bco_list.back()) ? (gtm_bco - gtm_bco_list.back()) : (gtm_bco + (1ULL << 40U) - gtm_bco_list.back());
 
-      gtm_bco_diff_list.push_back(get_adjusted_multiplier()*gtm_bco_difference);
+      gtm_bco_diff_list.push_back(get_adjusted_multiplier() * gtm_bco_difference);
     }
 
     // append to list
-    gtm_bco_list.push_back( gtm_bco );
+    gtm_bco_list.push_back(gtm_bco);
   }
 
   // print all differences
-  if( verbosity() )
-  { std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl; }
+  if (verbosity())
+  {
+    std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl;
+  }
 
   uint32_t fee_bco_prev = 0;
   bool has_fee_bco_prev = false;
@@ -271,61 +284,66 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
   const int n_waveform = packet->iValue(0, "NR_WF");
   for (int iwf = 0; iwf < n_waveform; ++iwf)
   {
-
     // check type
-    const unsigned short type = packet->iValue(iwf, "TYPE" );
+    const unsigned short type = packet->iValue(iwf, "TYPE");
 
     // skip heartbeat waveforms
-    if( type == HEARTBEAT_T ) continue;
+    if (type == HEARTBEAT_T)
+    {
+      continue;
+    }
 
     // check channel
-    const unsigned short channel = packet->iValue( iwf, "CHANNEL" );
+    const unsigned short channel = packet->iValue(iwf, "CHANNEL");
 
     // bound check
-    if( channel >= m_nchannels_fee )
-    { continue; }
+    if (channel >= m_nchannels_fee)
+    {
+      continue;
+    }
 
     const uint32_t fee_bco = static_cast<uint32_t>(packet->iValue(iwf, "BCO"));
-    if( !has_fee_bco_prev )
+    if (!has_fee_bco_prev)
     {
       fee_bco_prev = fee_bco;
       has_fee_bco_prev = true;
     }
 
     // calculate difference
-    const uint64_t fee_bco_diff = get_bco_diff( fee_bco, fee_bco_prev );
+    const uint64_t fee_bco_diff = get_bco_diff(fee_bco, fee_bco_prev);
 
     // discard identical fee_bco
-    if( fee_bco_diff < m_max_fee_bco_diff )
-    { continue; }
+    if (fee_bco_diff < m_max_fee_bco_diff)
+    {
+      continue;
+    }
 
     std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - fee_bco_diff: " << fee_bco_diff << std::endl;
 
     // look for matching diff in gtm_bco array
-    for( size_t i = 0; i < gtm_bco_diff_list.size(); ++i )
+    for (size_t i = 0; i < gtm_bco_diff_list.size(); ++i)
     {
-
       uint64_t sum = 0;
-      for( size_t j=i; j<gtm_bco_diff_list.size(); ++j )
+      for (size_t j = i; j < gtm_bco_diff_list.size(); ++j)
       {
         sum += gtm_bco_diff_list[j];
-        if( get_bco_diff( sum, fee_bco_diff ) < m_max_fee_bco_diff )
+        if (get_bco_diff(sum, fee_bco_diff) < m_max_fee_bco_diff)
         {
           m_verified_from_data = true;
           m_gtm_bco_first = gtm_bco_list[i];
           m_fee_bco_first = fee_bco_prev;
 
-          if( verbosity() )
+          if (verbosity())
           {
             std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - matching is verified" << std::endl;
             std::cout
-              << "MicromegasBcoMatchingInformation::find_reference_from_data -"
-              << " m_gtm_bco_first: " << std::hex << m_gtm_bco_first << std::dec
-              << std::endl;
+                << "MicromegasBcoMatchingInformation::find_reference_from_data -"
+                << " m_gtm_bco_first: " << std::hex << m_gtm_bco_first << std::dec
+                << std::endl;
             std::cout
-              << "MicromegasBcoMatchingInformation::find_reference_from_data -"
-              << " m_fee_bco_first: " << std::hex << m_fee_bco_first << std::dec
-              << std::endl;
+                << "MicromegasBcoMatchingInformation::find_reference_from_data -"
+                << " m_fee_bco_first: " << std::hex << m_fee_bco_first << std::dec
+                << std::endl;
           }
           return true;
         }
@@ -338,38 +356,36 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
   return false;
 }
 
-
 //___________________________________________________
-std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t fee_bco )
+std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t fee_bco)
 {
   // make sure the bco matching is properly initialized
-  if( !is_verified() )
+  if (!is_verified())
   {
     return std::nullopt;
   }
   // find matching gtm bco in map
   const auto bco_matching_iter = std::find_if(
-    m_bco_matching_list.begin(),
-    m_bco_matching_list.end(),
-    [fee_bco]( const m_bco_matching_pair_t& pair )
-    { return get_bco_diff( pair.first, fee_bco ) < m_max_fee_bco_diff; } );
+      m_bco_matching_list.begin(),
+      m_bco_matching_list.end(),
+      [fee_bco](const m_bco_matching_pair_t& pair)
+      { return get_bco_diff(pair.first, fee_bco) < m_max_fee_bco_diff; });
 
-  if( bco_matching_iter != m_bco_matching_list.end() )
+  if (bco_matching_iter != m_bco_matching_list.end())
   {
-
     return bco_matching_iter->second;
-
-  } else {
-
+  }
+  else
+  {
     // find element for which predicted fee_bco matches fee_bco, within limit
     const auto iter = std::find_if(
-      m_gtm_bco_list.begin(),
-      m_gtm_bco_list.end(),
-      [this, fee_bco]( const uint64_t& gtm_bco )
-      { return get_bco_diff( get_predicted_fee_bco(gtm_bco).value(), fee_bco ) <  m_max_gtm_bco_diff; } );
+        m_gtm_bco_list.begin(),
+        m_gtm_bco_list.end(),
+        [this, fee_bco](const uint64_t& gtm_bco)
+        { return get_bco_diff(get_predicted_fee_bco(gtm_bco).value(), fee_bco) < m_max_gtm_bco_diff; });
 
     // check
-    if( iter != m_gtm_bco_list.end() )
+    if (iter != m_gtm_bco_list.end())
     {
       const auto gtm_bco = *iter;
       if (verbosity())
@@ -378,13 +394,13 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t
         const auto fee_bco_diff = get_bco_diff(fee_bco_predicted, fee_bco);
 
         std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
-          << std::hex
-          << " fee_bco: 0x" << fee_bco
-          << " predicted: 0x" << fee_bco_predicted
-          << " gtm_bco: 0x" << gtm_bco
-          << std::dec
-          << " difference: " << fee_bco_diff
-          << std::endl;
+                  << std::hex
+                  << " fee_bco: 0x" << fee_bco
+                  << " predicted: 0x" << fee_bco_predicted
+                  << " gtm_bco: 0x" << gtm_bco
+                  << std::dec
+                  << " difference: " << fee_bco_diff
+                  << std::endl;
       }
 
       // save fee_bco and gtm_bco matching in map
@@ -394,46 +410,44 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t
       m_gtm_bco_list.erase(iter);
 
       // update clock adjustment
-      update_multiplier_adjustment( gtm_bco, fee_bco );
+      update_multiplier_adjustment(gtm_bco, fee_bco);
 
       return gtm_bco;
-    } else {
-
-      if( m_orphans.insert(fee_bco).second)
+    }
+    else
+    {
+      if (m_orphans.insert(fee_bco).second)
       {
-
-        if( verbosity() )
+        if (verbosity())
         {
           // find element for which predicted fee_bco is the closest to request
           const auto iter2 = std::min_element(
-            m_gtm_bco_list.begin(),
-            m_gtm_bco_list.end(),
-            [this, fee_bco]( const uint64_t& first, const uint64_t& second )
-            { return get_bco_diff( get_predicted_fee_bco(first).value(), fee_bco ) <  get_bco_diff( get_predicted_fee_bco(second).value(), fee_bco ); } );
+              m_gtm_bco_list.begin(),
+              m_gtm_bco_list.end(),
+              [this, fee_bco](const uint64_t& first, const uint64_t& second)
+              { return get_bco_diff(get_predicted_fee_bco(first).value(), fee_bco) < get_bco_diff(get_predicted_fee_bco(second).value(), fee_bco); });
 
-          const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ?
-            get_bco_diff( get_predicted_fee_bco(*iter2).value(), fee_bco ):-1;
+          const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ? get_bco_diff(get_predicted_fee_bco(*iter2).value(), fee_bco) : -1;
 
           std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
-            << std::hex
-            << " fee_bco: 0x" << fee_bco
-            << std::dec
-            << " gtm_bco: none"
-            << " difference: " << fee_bco_diff
-            << std::endl;
+                    << std::hex
+                    << " fee_bco: 0x" << fee_bco
+                    << std::dec
+                    << " gtm_bco: none"
+                    << " difference: " << fee_bco_diff
+                    << std::endl;
         }
 
         // increment number of dropped fee
         ++m_waveform_count_dropped;
 
         // check against max allowed value
-        if( m_waveform_count_dropped > m_waveform_count_dropped_max )
+        if (m_waveform_count_dropped > m_waveform_count_dropped_max)
         {
           m_waveform_count_dropped = 0;
           m_verified_from_data = false;
           std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco - too many dropped waveforms, forcing re-synchronization" << std::endl;
         }
-
       }
       return std::nullopt;
     }
@@ -441,65 +455,73 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t
 
   // never reached
   return std::nullopt;
-
 }
 
 //___________________________________________________
 void MicromegasBcoMatchingInformation::cleanup()
 {
   // remove old gtm_bco and matching
-  while( m_gtm_bco_list.size() > m_max_matching_data_size ) { m_gtm_bco_list.pop_front(); }
-  while( m_bco_matching_list.size() > m_max_matching_data_size ) { m_bco_matching_list.pop_front(); }
+  while (m_gtm_bco_list.size() > m_max_matching_data_size)
+  {
+    m_gtm_bco_list.pop_front();
+  }
+  while (m_bco_matching_list.size() > m_max_matching_data_size)
+  {
+    m_bco_matching_list.pop_front();
+  }
 
   // clear orphans
   m_orphans.clear();
 }
 
-
 //___________________________________________________
 double MicromegasBcoMatchingInformation::get_adjusted_multiplier() const
-{ return m_multiplier + m_multiplier_adjustment; }
+{
+  return m_multiplier + m_multiplier_adjustment;
+}
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::update_multiplier_adjustment( uint64_t gtm_bco, uint32_t fee_bco )
+void MicromegasBcoMatchingInformation::update_multiplier_adjustment(uint64_t gtm_bco, uint32_t fee_bco)
 {
   // check that references are valid
-  if( !is_verified() ) return;
+  if (!is_verified())
+  {
+    return;
+  }
 
   // skip if trivial
-  if( gtm_bco == m_gtm_bco_first ) return;
+  if (gtm_bco == m_gtm_bco_first)
+  {
+    return;
+  }
 
-  const uint32_t fee_bco_predicted = get_predicted_fee_bco( gtm_bco ).value();
-  const double delta_fee_bco = double(fee_bco)-double(fee_bco_predicted);
-  const double gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
-    (gtm_bco - m_gtm_bco_first):
-    (gtm_bco + (1ULL<<40U) - m_gtm_bco_first);
+  const uint32_t fee_bco_predicted = get_predicted_fee_bco(gtm_bco).value();
+  const double delta_fee_bco = double(fee_bco) - double(fee_bco_predicted);
+  const double gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ? (gtm_bco - m_gtm_bco_first) : (gtm_bco + (1ULL << 40U) - m_gtm_bco_first);
 
-  m_multiplier_adjustment_numerator += gtm_bco_difference*delta_fee_bco;
-  m_multiplier_adjustment_denominator += gtm_bco_difference*gtm_bco_difference;
+  m_multiplier_adjustment_numerator += gtm_bco_difference * delta_fee_bco;
+  m_multiplier_adjustment_denominator += gtm_bco_difference * gtm_bco_difference;
   ++m_multiplier_adjustment_count;
 
-  if( verbosity() )
+  if (verbosity())
   {
-
     const auto default_precision{std::cout.precision()};
     std::cout << "MicromegasBcoMatchingInformation::update_multiplier_adjustment -"
-      << " m_multiplier_adjustment_count: " << m_multiplier_adjustment_count
-      << std::setprecision(10)
-      << " m_multiplier: " << get_adjusted_multiplier()
-      << " adjustment: " << m_multiplier_adjustment_numerator/m_multiplier_adjustment_denominator
-      << " m_multiplier_adjusted: " << get_adjusted_multiplier() + m_multiplier_adjustment_numerator/m_multiplier_adjustment_denominator
-      << std::setprecision(default_precision)
-      << std::endl;
+              << " m_multiplier_adjustment_count: " << m_multiplier_adjustment_count
+              << std::setprecision(10)
+              << " m_multiplier: " << get_adjusted_multiplier()
+              << " adjustment: " << m_multiplier_adjustment_numerator / m_multiplier_adjustment_denominator
+              << " m_multiplier_adjusted: " << get_adjusted_multiplier() + m_multiplier_adjustment_numerator / m_multiplier_adjustment_denominator
+              << std::setprecision(default_precision)
+              << std::endl;
   }
 
   // update multiplier
-  if( m_multiplier_adjustment_count > m_max_multiplier_adjustment_count )
+  if (m_multiplier_adjustment_count > m_max_multiplier_adjustment_count)
   {
-    m_multiplier_adjustment += m_multiplier_adjustment_numerator/m_multiplier_adjustment_denominator;
+    m_multiplier_adjustment += m_multiplier_adjustment_numerator / m_multiplier_adjustment_denominator;
     m_multiplier_adjustment_numerator = 0;
     m_multiplier_adjustment_denominator = 0;
     m_multiplier_adjustment_count = 0;
   }
-
 }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -126,7 +126,7 @@ double MicromegasBcoMatchingInformation::m_multiplier = 4.262916255;
 std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco( uint64_t gtm_bco ) const
 {
   // check proper initialization
-  if( !m_verified ) { return std::nullopt; }
+  if( !is_verified() ) { return std::nullopt; }
 
   // get gtm bco difference with proper rollover accounting
   const uint64_t gtm_bco_difference = (gtm_bco >= m_gtm_bco_first) ?
@@ -150,7 +150,7 @@ void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
       << std::endl;
 
     // also print predicted fee bco
-    if( m_verified )
+    if( is_verified() )
     {
       std::list<uint32_t> fee_bco_predicted_list;
       std::transform(
@@ -228,7 +228,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_modebits( Packet* pac
         const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
         m_gtm_bco_first = gtm_bco;
         m_fee_bco_first = 0;
-        m_verified = true;
+        m_verified_from_modebits = true;
         return true;
       }
     }
@@ -311,7 +311,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
         sum += gtm_bco_diff_list[j];
         if( get_bco_diff( sum, fee_bco_diff ) < m_max_fee_bco_diff )
         {
-          m_verified = true;
+          m_verified_from_data = true;
           m_gtm_bco_first = gtm_bco_list[i];
           m_fee_bco_first = fee_bco_prev;
 
@@ -343,7 +343,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data( Packet* packet 
 std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t fee_bco )
 {
   // make sure the bco matching is properly initialized
-  if( !m_verified )
+  if( !is_verified() )
   {
     return std::nullopt;
   }
@@ -430,7 +430,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t
         if( m_waveform_count_dropped > m_waveform_count_dropped_max )
         {
           m_waveform_count_dropped = 0;
-          m_verified = false;
+          m_verified_from_data = false;
           std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco - too many dropped waveforms, forcing re-synchronization" << std::endl;
         }
 
@@ -464,7 +464,7 @@ double MicromegasBcoMatchingInformation::get_adjusted_multiplier() const
 void MicromegasBcoMatchingInformation::update_multiplier_adjustment( uint64_t gtm_bco, uint32_t fee_bco )
 {
   // check that references are valid
-  if( !m_verified ) return;
+  if( !is_verified() ) return;
 
   // skip if trivial
   if( gtm_bco == m_gtm_bco_first ) return;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -92,6 +92,9 @@ namespace
   //! copied from micromegas/MicromegasDefs.h, not available here
   static constexpr int m_nchannels_fee = 256;
 
+  //! max number of dropped waveforms before re-synching
+  static constexpr uint32_t m_waveform_count_dropped_max = 100;
+
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
   {
@@ -396,26 +399,41 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco( uint32_t
       return gtm_bco;
     } else {
 
-      if(verbosity() && m_orphans.insert(fee_bco).second)
+      if( m_orphans.insert(fee_bco).second)
       {
 
-        // find element for which predicted fee_bco is the closest to request
-        const auto iter2 = std::min_element(
-          m_gtm_bco_list.begin(),
-          m_gtm_bco_list.end(),
-          [this, fee_bco]( const uint64_t& first, const uint64_t& second )
-          { return get_bco_diff( get_predicted_fee_bco(first).value(), fee_bco ) <  get_bco_diff( get_predicted_fee_bco(second).value(), fee_bco ); } );
+        if( verbosity() )
+        {
+          // find element for which predicted fee_bco is the closest to request
+          const auto iter2 = std::min_element(
+            m_gtm_bco_list.begin(),
+            m_gtm_bco_list.end(),
+            [this, fee_bco]( const uint64_t& first, const uint64_t& second )
+            { return get_bco_diff( get_predicted_fee_bco(first).value(), fee_bco ) <  get_bco_diff( get_predicted_fee_bco(second).value(), fee_bco ); } );
 
-        const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ?
-          get_bco_diff( get_predicted_fee_bco(*iter2).value(), fee_bco ):-1;
+          const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ?
+            get_bco_diff( get_predicted_fee_bco(*iter2).value(), fee_bco ):-1;
 
-        std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
-          << std::hex
-          << " fee_bco: 0x" << fee_bco
-          << std::dec
-          << " gtm_bco: none"
-          << " difference: " << fee_bco_diff
-          << std::endl;
+          std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
+            << std::hex
+            << " fee_bco: 0x" << fee_bco
+            << std::dec
+            << " gtm_bco: none"
+            << " difference: " << fee_bco_diff
+            << std::endl;
+        }
+
+        // increment number of dropped fee
+        ++m_waveform_count_dropped;
+
+        // check against max allowed value
+        if( m_waveform_count_dropped > m_waveform_count_dropped_max )
+        {
+          m_waveform_count_dropped = 0;
+          m_verified = false;
+          std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco - too many dropped waveforms, forcing re-synchronization" << std::endl;
+        }
+
       }
       return std::nullopt;
     }

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -17,8 +17,7 @@ class Packet;
 
 class MicromegasBcoMatchingInformation
 {
-  public:
-
+ public:
   //! constructor
   MicromegasBcoMatchingInformation() = default;
 
@@ -27,18 +26,24 @@ class MicromegasBcoMatchingInformation
 
   //! verbosity
   int verbosity() const
-  { return m_verbosity; }
+  {
+    return m_verbosity;
+  }
 
   //! true if matching information is verified
   bool is_verified() const
-  { return m_verified_from_modebits||m_verified_from_data; }
+  {
+    return m_verified_from_modebits || m_verified_from_data;
+  }
 
   //! get predicted fee_bco from gtm_bco
-  std::optional<uint32_t> get_predicted_fee_bco( uint64_t ) const;
+  std::optional<uint32_t> get_predicted_fee_bco(uint64_t) const;
 
   //! multiplier
   static double get_gtm_clock_multiplier()
-  { return m_multiplier; }
+  {
+    return m_multiplier;
+  }
 
   //! print gtm bco information
   void print_gtm_bco_information() const;
@@ -49,41 +54,44 @@ class MicromegasBcoMatchingInformation
   //@{
 
   //! verbosity
-  void set_verbosity( int value )
-  { m_verbosity = value; }
+  void set_verbosity(int value)
+  {
+    m_verbosity = value;
+  }
 
   /// set gtm clock multiplier
-  static void set_gtm_clock_multiplier( double value )
-  { m_multiplier = value; }
+  static void set_gtm_clock_multiplier(double value)
+  {
+    m_multiplier = value;
+  }
 
   //! save all GTM BCO clocks from packet data
-  void save_gtm_bco_information( Packet* );
+  void save_gtm_bco_information(Packet*);
 
   //! find clock references used to match FEE and GTM BCO clock from packet data
-  bool find_reference( Packet* );
+  bool find_reference(Packet*);
 
   /**
    * matching information is verified if at least one match
    * between gtm_bco and fee_bco is found
    */
   //! find gtm bco matching a given fee
-  std::optional<uint64_t> find_gtm_bco( uint32_t /*fee_gtm*/ );
+  std::optional<uint64_t> find_gtm_bco(uint32_t /*fee_gtm*/);
 
   //! cleanup
   void cleanup();
 
   //@}
 
-  private:
-
+ private:
   //! find reference from modebits
-  bool find_reference_from_modebits( Packet* );
+  bool find_reference_from_modebits(Packet*);
 
   //! find reference from data
-  bool find_reference_from_data( Packet* );
+  bool find_reference_from_data(Packet*);
 
   //! update multiplier adjustment
-  void update_multiplier_adjustment( uint64_t /* gtm_bco */, uint32_t /* fee_bco */ );
+  void update_multiplier_adjustment(uint64_t /* gtm_bco */, uint32_t /* fee_bco */);
 
   //! get adjusted multiplier
   double get_adjusted_multiplier() const;
@@ -129,7 +137,6 @@ class MicromegasBcoMatchingInformation
 
   //! running count for multiplier adjustment
   unsigned int m_multiplier_adjustment_count = 0;
-
 };
 
 #endif

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -94,6 +94,9 @@ class MicromegasBcoMatchingInformation
   //! verified
   bool m_verified = false;
 
+  //! keep track of number of unassociated GTM bco
+  uint32_t m_waveform_count_dropped = 0;
+  
   //! first lvl1 bco (40 bits)
   uint64_t m_gtm_bco_first = 0;
 

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -31,7 +31,7 @@ class MicromegasBcoMatchingInformation
 
   //! true if matching information is verified
   bool is_verified() const
-  { return m_verified; }
+  { return m_verified_from_modebits||m_verified_from_data; }
 
   //! get predicted fee_bco from gtm_bco
   std::optional<uint32_t> get_predicted_fee_bco( uint64_t ) const;
@@ -92,11 +92,13 @@ class MicromegasBcoMatchingInformation
   unsigned int m_verbosity = 0;
 
   //! verified
-  bool m_verified = false;
+  bool m_verified_from_modebits = false;
+
+  bool m_verified_from_data = false;
 
   //! keep track of number of unassociated GTM bco
   uint32_t m_waveform_count_dropped = 0;
-  
+
   //! first lvl1 bco (40 bits)
   uint64_t m_gtm_bco_first = 0;
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -517,27 +517,24 @@ void SingleMicromegasPoolInput::createQAHistos()
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  auto h_npacket_bco_hist = new TH1I( "h_MicromegasBCOQA_npacket_bco", "TPOT Packet Count per GTM BCO; Matching BCO tagger count; GL1 trigger count", 10, 0, 10 );
-  auto h_nwaveform_bco_hist = new TH1I( "h_MicromegasBCOQA_nwaveform_bco", "TPOT Waveform Count per GTM BCO; Matching Waveform count; GL1 trigger count", 4100, 0, 4100 );
+  h_packet = new TH1I( "h_MicromegasBCOQA_npacket_bco", "TPOT Packet Count per GTM BCO; Matching BCO tagger count; GL1 trigger count", 10, 0, 10 );
+  h_waveform = new TH1I( "h_MicromegasBCOQA_nwaveform_bco", "TPOT Waveform Count per GTM BCO; Matching Waveform count; GL1 trigger count", 4100, 0, 4100 );
 
   /*
    * first bin is the number of requested GL1 BCO, for reference
    * next two bins is the number of times the GL1 BCO is found in the taggers list for a given packet_id
    * last bin is the sum
    */
-  auto h_packet_stat_hist = new TH1I( "h_MicromegasBCOQA_packet_stat", "Matching Tagger count per packet; packet id; GL1 trigger count", m_npackets_active+2, 0, m_npackets_active+2 );
-  h_packet_stat_hist->GetXaxis()->SetBinLabel(1, "Reference" );
-  h_packet_stat_hist->GetXaxis()->SetBinLabel(2, "5001" );
-  h_packet_stat_hist->GetXaxis()->SetBinLabel(3, "5002" );
-  h_packet_stat_hist->GetXaxis()->SetBinLabel(4, "All" );
+  h_packet_stat = new TH1I( "h_MicromegasBCOQA_packet_stat", "Matching Tagger count per packet; packet id; GL1 trigger count", m_npackets_active+2, 0, m_npackets_active+2 );
+  h_packet_stat->GetXaxis()->SetBinLabel(1, "Reference" );
+  h_packet_stat->GetXaxis()->SetBinLabel(2, "5001" );
+  h_packet_stat->GetXaxis()->SetBinLabel(3, "5002" );
+  h_packet_stat->GetXaxis()->SetBinLabel(4, "All" );
 
-  for( const auto& h:std::initializer_list<TH1*>{h_npacket_bco_hist, h_nwaveform_bco_hist, h_packet_stat_hist} )
+  for( const auto& h:std::initializer_list<TH1*>{h_packet, h_waveform, h_packet_stat} )
   {
     h->SetFillStyle(1001);
     h->SetFillColor(kYellow);
     hm->registerHisto(h);
   }
-  h_packet_stat = dynamic_cast<TH1*>(hm->getHisto("h_MicromegasBCOQA_packet_stat"));
-  h_packet = dynamic_cast<TH1*>(hm->getHisto("h_MicromegasBCOQA_npacket_bco"));
-  h_waveform = dynamic_cast<TH1*>(hm->getHisto("h_MicromegasBCOQA_nwaveform_bco"));
 }

--- a/offline/packages/micromegas/MicromegasClusterizer.h
+++ b/offline/packages/micromegas/MicromegasClusterizer.h
@@ -31,6 +31,9 @@ class MicromegasClusterizer : public SubsysReco
   //! event processing
   int process_event(PHCompositeNode*) override;
 
+  /// end of processing
+  int End(PHCompositeNode*) override;
+
   /// set default pedestal
   void set_default_pedestal( double value )
   { m_default_pedestal = value; }
@@ -68,6 +71,10 @@ class MicromegasClusterizer : public SubsysReco
 
   //@}
 
+
+  /// keep track of number of clusters per hitsetid
+  using clustercountmap_t = std::map<TrkrDefs::hitsetkey, int>;
+  clustercountmap_t m_clustercounts;
 
 };
 

--- a/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
+++ b/offline/packages/micromegas/MicromegasCombinedDataDecoder.cc
@@ -269,7 +269,7 @@ int MicromegasCombinedDataDecoder::End(PHCompositeNode* /*topNode*/)
   {
     for (const auto& [hitsetkey, count] : m_hitcounts)
     {
-      std::cout << "MicromegasCombinedDataDecoder::End - hitsetkey: " << hitsetkey << ", count: " << count << std::endl;
+      std::cout << "MicromegasCombinedDataDecoder::End - hitsetkey: " << hitsetkey << ", hit count: " << count << std::endl;
     }
   }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
By default clock synchronization is now done via the fee clock reset event sent to the TPOT/TPC FEE at begin of run. 
However, this does not work when running in local mode. One has to keep relying on synchronizing from data. 
This PR attempts at improving the robustness of data synchronization. 

In addition: 
- added some statitics to micromegas clusterizer
- simplified dropping of size 1 clusters
- simplified QA histogram creation in MicromegasSingleInput

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

