### PR TITLE
Micromegas decoding 7

### DIFF
--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -205,20 +205,6 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference(Packet* packet)
-{
-  if (find_reference_from_modebits(packet))
-  {
-    return true;
-  }
-  if (find_reference_from_data(packet))
-  {
-    return true;
-  }
-  return false;
-}
-
-//___________________________________________________
 bool MicromegasBcoMatchingInformation::find_reference_from_modebits(Packet* packet)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -98,9 +98,6 @@ namespace
   //! copied from micromegas/MicromegasDefs.h, not available here
   static constexpr int m_nchannels_fee = 256;
 
-  //! max number of dropped waveforms before re-synching
-  static constexpr uint32_t m_waveform_count_dropped_max = 100;
-
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   enum SampaDataType
   {
@@ -422,17 +419,6 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t 
                     << " gtm_bco: none"
                     << " difference: " << fee_bco_diff
                     << std::endl;
-        }
-
-        // increment number of dropped fee
-        ++m_waveform_count_dropped;
-
-        // check against max allowed value
-        if (m_waveform_count_dropped > m_waveform_count_dropped_max)
-        {
-          m_waveform_count_dropped = 0;
-          m_verified_from_data = false;
-          std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco - too many dropped waveforms, forcing re-synchronization" << std::endl;
         }
       }
       return std::nullopt;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -31,6 +31,10 @@ class MicromegasBcoMatchingInformation
   }
 
   //! true if matching information is verified
+  /**
+   * matching information is verified if at least one match
+   * between gtm_bco and fee_bco is found
+   */
   bool is_verified() const
   {
     return m_verified_from_modebits || m_verified_from_data;
@@ -65,16 +69,15 @@ class MicromegasBcoMatchingInformation
     m_multiplier = value;
   }
 
+  //! find reference from modebits
+  bool find_reference_from_modebits(Packet*);
+
+  //! find reference from data
+  bool find_reference_from_data(Packet*);
+
   //! save all GTM BCO clocks from packet data
   void save_gtm_bco_information(Packet*);
 
-  //! find clock references used to match FEE and GTM BCO clock from packet data
-  bool find_reference(Packet*);
-
-  /**
-   * matching information is verified if at least one match
-   * between gtm_bco and fee_bco is found
-   */
   //! find gtm bco matching a given fee
   std::optional<uint64_t> find_gtm_bco(uint32_t /*fee_gtm*/);
 
@@ -84,11 +87,6 @@ class MicromegasBcoMatchingInformation
   //@}
 
  private:
-  //! find reference from modebits
-  bool find_reference_from_modebits(Packet*);
-
-  //! find reference from data
-  bool find_reference_from_data(Packet*);
 
   //! update multiplier adjustment
   void update_multiplier_adjustment(uint64_t /* gtm_bco */, uint32_t /* fee_bco */);

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -102,9 +102,6 @@ class MicromegasBcoMatchingInformation
 
   bool m_verified_from_data = false;
 
-  //! keep track of number of unassociated GTM bco
-  uint32_t m_waveform_count_dropped = 0;
-
   //! first lvl1 bco (40 bits)
   uint64_t m_gtm_bco_first = 0;
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -177,13 +177,20 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
         bco_matching_information.print_gtm_bco_information();
       }
 
-      // try find reference
+      // find reference from modebits, using BX_COUNTER_SYNC_T
+      /*
+       * This needs to be done even if the bco matching information is already verified
+       * because any BX_COUNTER_SYNC_T event will break past references
+       */
+      bco_matching_information.find_reference_from_modebits(packet.get());
+
+      // if bco matching information is not verified, try find reference from data
       if (!bco_matching_information.is_verified())
       {
-        bco_matching_information.find_reference(packet.get());
+        bco_matching_information.find_reference_from_data(packet.get());
       }
 
-      // drop packet if not found
+      // if bco matching information is still not verified, drop the packet
       if (!bco_matching_information.is_verified())
       {
         std::cout << "SingleMicromegasPoolInput::FillPool - bco_matching not verified, dropping packet" << std::endl;

--- a/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataEvaluation.cc
@@ -153,9 +153,18 @@ int MicromegasRawDataEvaluation::process_event(PHCompositeNode* topNode)
                 << std::endl;
     }
 
-    // try find reference
-    if( !bco_matching_information.is_verified() )
-    { bco_matching_information.find_reference( packet.get() ); }
+    // find reference from modebits, using BX_COUNTER_SYNC_T
+    /*
+     * This needs to be done even if the bco matching information is already verified
+     * because any BX_COUNTER_SYNC_T event will break past references
+     */
+    bco_matching_information.find_reference_from_modebits(packet.get());
+
+    // if bco matching information is not verified, try find reference from data
+    if (!bco_matching_information.is_verified())
+    {
+      bco_matching_information.find_reference_from_data(packet.get());
+    }
 
     if (m_flags & (EvalSample | EvalWaveform))
     {

--- a/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
+++ b/offline/packages/micromegas/MicromegasRawDataTimingEvaluation.cc
@@ -111,9 +111,18 @@ int MicromegasRawDataTimingEvaluation::process_event(PHCompositeNode* topNode)
       bco_matching_information.print_gtm_bco_information();
     }
 
-    // try find reference
-    if( !bco_matching_information.is_verified() )
-    { bco_matching_information.find_reference( packet.get() ); }
+    // find reference from modebits, using BX_COUNTER_SYNC_T
+    /*
+     * This needs to be done even if the bco matching information is already verified
+     * because any BX_COUNTER_SYNC_T event will break past references
+     */
+    bco_matching_information.find_reference_from_modebits(packet.get());
+
+    // if bco matching information is not verified, try find reference from data
+    if (!bco_matching_information.is_verified())
+    {
+      bco_matching_information.find_reference_from_data(packet.get());
+    }
 
     // drop packet if not found
     if( !bco_matching_information.is_verified() )


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
More changes to BCO synchronization logic:
- always check for BX_COUNTER_SYNC_T events even if bco matching is already verified, because any such event will break previous matching.
-  with this change, forcing re-sync for too many dropped channels becomes unnecessary <- remove

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

