### PR TITLE
feat: packet qa improvement

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -654,10 +654,10 @@ int Fun4AllStreamingInputManager::FillIntt()
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
   h_refbco_intt->Fill(refbcobitshift);
   bool allpackets = true;
-  for (size_t p = 0; p < m_InttInputVector.size(); p++)
+  for (auto & p : m_InttInputVector)
   {
-    auto bcl_stack = m_InttInputVector[p]->BclkStackMap();
-    auto feebclstack = m_InttInputVector[p]->BeamClockFEE();
+    auto bcl_stack = p->BclkStackMap();
+    auto feebclstack = p->BeamClockFEE();
     int packet_id = bcl_stack.begin()->first;
     int histo_to_fill = (packet_id % 10) - 1;
     for (auto &[bcl, feeidset] : feebclstack)
@@ -829,9 +829,9 @@ int Fun4AllStreamingInputManager::FillMvtx()
   }
 
 std::map<int, std::set<int>> taggedPacketsFEEs;
-for (size_t p = 0; p < m_MvtxInputVector.size(); p++)
+for (auto & p : m_MvtxInputVector)
 {
-  auto gtml1bcoset_perfee = static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p])->getFeeGTML1BCOMap();
+  auto gtml1bcoset_perfee = static_cast<SingleMvtxPoolInput *>(p)->getFeeGTML1BCOMap();
   int feecounter = 0;
   for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
   {
@@ -853,7 +853,7 @@ for (size_t p = 0; p < m_MvtxInputVector.size(); p++)
     feecounter++;
   }
 
-  (static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p]))->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
+  (static_cast<SingleMvtxPoolInput *>(p))->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
   }
   int allfeestagged = 0;
   for (auto &[pid, feeset] : taggedPacketsFEEs)

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -81,7 +81,7 @@ Fun4AllStreamingInputManager::~Fun4AllStreamingInputManager()
     {
       delete mvtxhititer;
     }
-    for ( auto mvtxFeeIdInfo : mapiter.second.MvtxFeeIdInfoVector )
+    for (auto mvtxFeeIdInfo : mapiter.second.MvtxFeeIdInfoVector)
     {
       delete mvtxFeeIdInfo;
     }
@@ -446,7 +446,7 @@ void Fun4AllStreamingInputManager::registerStreamingInput(SingleStreamingInput *
     break;
   case InputManagerType::MICROMEGAS:
     m_micromegas_registered_flag = true;
-    static_cast<SingleMicromegasPoolInput*>(evtin)->createQAHistos();
+    static_cast<SingleMicromegasPoolInput *>(evtin)->createQAHistos();
     m_MicromegasInputVector.push_back(evtin);
     break;
   case InputManagerType::GL1:
@@ -654,7 +654,7 @@ int Fun4AllStreamingInputManager::FillIntt()
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
   h_refbco_intt->Fill(refbcobitshift);
   bool allpackets = true;
-  for (auto & p : m_InttInputVector)
+  for (auto &p : m_InttInputVector)
   {
     auto bcl_stack = p->BclkStackMap();
     auto feebclstack = p->BeamClockFEE();
@@ -663,9 +663,9 @@ int Fun4AllStreamingInputManager::FillIntt()
     for (auto &[bcl, feeidset] : feebclstack)
     {
       auto diff = (m_RefBCO > bcl) ? m_RefBCO - bcl : bcl - m_RefBCO;
-      if (diff <2)  // diff is within 1 bco since gl1 and intt are offset by 1 sometimes
+      if (diff < 2)  // diff is within 1 bco since gl1 and intt are offset by 1 sometimes
       {
-        if(feeidset.size() == 14)
+        if (feeidset.size() == 14)
         {
           h_taggedAllFees_intt[histo_to_fill]->Fill(refbcobitshift);
         }
@@ -674,28 +674,27 @@ int Fun4AllStreamingInputManager::FillIntt()
           h_gl1taggedfee_intt[histo_to_fill][fee]->Fill(refbcobitshift);
         }
       }
-
     }
     bool thispacket = false;
 
-    for (auto& [packetid, gtmbcoset] : bcl_stack)
+    for (auto &[packetid, gtmbcoset] : bcl_stack)
     {
-        for(auto& gtmbco : gtmbcoset)
-        {
-      auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-      if (diff <2) // diff is within 1 bco since gl1 and intt are offset by 1 sometimes
+      for (auto &gtmbco : gtmbcoset)
       {
-        thispacket = true;
-        h_gl1tagged_intt[histo_to_fill]->Fill(refbcobitshift);
-      }
+        auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
+        if (diff < 2)  // diff is within 1 bco since gl1 and intt are offset by 1 sometimes
+        {
+          thispacket = true;
+          h_gl1tagged_intt[histo_to_fill]->Fill(refbcobitshift);
         }
+      }
     }
-    if(thispacket == false)
+    if (thispacket == false)
     {
       allpackets = false;
     }
   }
-  if(allpackets && m_InttInputVector.size() == 8)
+  if (allpackets && m_InttInputVector.size() == 8)
   {
     h_taggedAll_intt->Fill(refbcobitshift);
   }
@@ -807,18 +806,18 @@ int Fun4AllStreamingInputManager::FillMvtx()
   for (auto &[strbbco, mvtxrawhitinfo] : m_MvtxRawHitMap)
   {
     auto diff = (m_RefBCO > strbbco) ? m_RefBCO - strbbco : strbbco - m_RefBCO;
-    if(diff>m_mvtx_bco_range)
+    if (diff > m_mvtx_bco_range)
     {
       continue;
     }
-    if(diff > (m_RefBCO + m_mvtx_bco_range)/2.) 
+    if (diff > (m_RefBCO + m_mvtx_bco_range) / 2.)
     {
       break;
     }
-    for(auto feeidinfo : mvtxrawhitinfo.MvtxFeeIdInfoVector)
+    for (auto feeidinfo : mvtxrawhitinfo.MvtxFeeIdInfoVector)
     {
       auto feeId = feeidinfo->get_feeId();
-   
+
       auto link = MvtxRawDefs::decode_feeid(feeId);
       auto [felix, endpoint] = MvtxRawDefs::get_flx_endpoint(link.layer, link.stave);
       int packetid = felix * 2 + endpoint;
@@ -828,32 +827,32 @@ int Fun4AllStreamingInputManager::FillMvtx()
     break;
   }
 
-std::map<int, std::set<int>> taggedPacketsFEEs;
-for (auto & p : m_MvtxInputVector)
-{
-  auto gtml1bcoset_perfee = static_cast<SingleMvtxPoolInput *>(p)->getFeeGTML1BCOMap();
-  int feecounter = 0;
-  for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
+  std::map<int, std::set<int>> taggedPacketsFEEs;
+  for (auto &p : m_MvtxInputVector)
   {
-    auto link = MvtxRawDefs::decode_feeid(feeid);
-    auto [felix, endpoint] = MvtxRawDefs::get_flx_endpoint(link.layer, link.stave);
-    int packetid = felix * 2 + endpoint;
-    for (auto &gtmbco : gtmbcoset)
+    auto gtml1bcoset_perfee = static_cast<SingleMvtxPoolInput *>(p)->getFeeGTML1BCOMap();
+    int feecounter = 0;
+    for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
     {
-      auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-
-      h_bcoGL1LL1diff[packetid]->Fill(diff);
-
-      if (diff < 3)
+      auto link = MvtxRawDefs::decode_feeid(feeid);
+      auto [felix, endpoint] = MvtxRawDefs::get_flx_endpoint(link.layer, link.stave);
+      int packetid = felix * 2 + endpoint;
+      for (auto &gtmbco : gtmbcoset)
       {
-        taggedPacketsFEEs[packetid].insert(feeid);
-        break;
-      }
-    }
-    feecounter++;
-  }
+        auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
 
-  (static_cast<SingleMvtxPoolInput *>(p))->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
+        h_bcoGL1LL1diff[packetid]->Fill(diff);
+
+        if (diff < 3)
+        {
+          taggedPacketsFEEs[packetid].insert(feeid);
+          break;
+        }
+      }
+      feecounter++;
+    }
+
+    (static_cast<SingleMvtxPoolInput *>(p))->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
   }
   int allfeestagged = 0;
   for (auto &[pid, feeset] : taggedPacketsFEEs)
@@ -865,11 +864,11 @@ for (auto & p : m_MvtxInputVector)
       h_tagBcoFelixAllFees_mvtx[pid]->Fill(refbcobitshift);
     }
   }
-  if(allfeestagged == 12)
+  if (allfeestagged == 12)
   {
     h_taggedAllFelixesAllFees_mvtx->Fill(refbcobitshift);
   }
-  if(taggedPacketsFEEs.size() == 12)
+  if (taggedPacketsFEEs.size() == 12)
   {
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
@@ -880,7 +879,7 @@ for (auto & p : m_MvtxInputVector)
       std::cout << "Adding 0x" << std::hex << m_MvtxRawHitMap.begin()->first
                 << " ref: 0x" << select_crossings << std::dec << std::endl;
     }
-    for ( auto mvtxFeeIdInfo : m_MvtxRawHitMap.begin()->second.MvtxFeeIdInfoVector )
+    for (auto mvtxFeeIdInfo : m_MvtxRawHitMap.begin()->second.MvtxFeeIdInfoVector)
     {
       if (Verbosity() > 1)
       {
@@ -964,7 +963,9 @@ int Fun4AllStreamingInputManager::FillMicromegas()
 
   // fill all BCO statistics
   for (const auto &iter : m_MicromegasInputVector)
-  { static_cast<SingleMicromegasPoolInput*>(iter)->FillBcoQA(m_RefBCO); }
+  {
+    static_cast<SingleMicromegasPoolInput *>(iter)->FillBcoQA(m_RefBCO);
+  }
 
   while ((m_MicromegasRawHitMap.begin()->first) <= select_crossings - m_micromegas_negative_bco)
   {
@@ -1049,17 +1050,17 @@ int Fun4AllStreamingInputManager::FillTpc()
           h_gl1tagged_tpc[p][packetnum]->Fill(refbcobitshift);
         }
       }
-      if(thispacket == false)
+      if (thispacket == false)
       {
         allpackets = false;
       }
       packetnum++;
     }
   }
-if(allpackets && m_TpcInputVector.size() == 24)
-{
-  h_taggedAll_tpc->Fill(refbcobitshift);
-}
+  if (allpackets && m_TpcInputVector.size() == 24)
+  {
+    h_taggedAll_tpc->Fill(refbcobitshift);
+  }
   // again m_TpcRawHitMap.empty() is handled by return of FillTpcPool()
   while (m_TpcRawHitMap.begin()->first <= select_crossings - m_tpc_negative_bco)
   {
@@ -1333,30 +1334,30 @@ void Fun4AllStreamingInputManager::createQAHistos()
   // intt has 8 prdfs, one per felix
   for (int i = 0; i < 8; i++)
   {
-      auto h = new TH1I((boost::format("h_InttPoolQA_TagBCO_server%i") % i).str().c_str(), "INTT trigger tagged BCO", 1000, 0, 1000);
-      h->GetXaxis()->SetTitle("GL1 BCO");
-      h->SetTitle((boost::format("EBDC %i") % i).str().c_str());
-      hm->registerHisto(h);
+    auto h = new TH1I((boost::format("h_InttPoolQA_TagBCO_server%i") % i).str().c_str(), "INTT trigger tagged BCO", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("GL1 BCO");
+    h->SetTitle((boost::format("EBDC %i") % i).str().c_str());
+    hm->registerHisto(h);
 
-      auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") %i ).str().c_str(), "INTT trigger tagged BCO all servers", 1000, 0, 1000);
-      h_all->GetXaxis()->SetTitle("GL1 BCO");
-      h_all->SetTitle("GL1 Reference BCO");
-      hm->registerHisto(h_all);
-      for (int j = 0; j<14; j++)
-      {
-        auto h2 = new TH1I((boost::format("h_InttPoolQA_TagBCO_server%i_fee%i") % i % j).str().c_str(), "INTT trigger tagged BCO per FEE", 1000, 0, 1000);
-        h2->GetXaxis()->SetTitle("GL1 BCO");
-        h2->SetTitle((boost::format("EBDC %i FEE %i") % i % j).str().c_str());
-        hm->registerHisto(h2);
-      }
+    auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str(), "INTT trigger tagged BCO all servers", 1000, 0, 1000);
+    h_all->GetXaxis()->SetTitle("GL1 BCO");
+    h_all->SetTitle("GL1 Reference BCO");
+    hm->registerHisto(h_all);
+    for (int j = 0; j < 14; j++)
+    {
+      auto h2 = new TH1I((boost::format("h_InttPoolQA_TagBCO_server%i_fee%i") % i % j).str().c_str(), "INTT trigger tagged BCO per FEE", 1000, 0, 1000);
+      h2->GetXaxis()->SetTitle("GL1 BCO");
+      h2->SetTitle((boost::format("EBDC %i FEE %i") % i % j).str().c_str());
+      hm->registerHisto(h2);
+    }
   }
   for (int i = 0; i < 12; i++)
   {
     {
-    auto h = new TH1I((boost::format("h_MvtxPoolQA_TagBCO_felix%i") %i).str().c_str(), "MVTX trigger tagged BCO", 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("GL1 BCO");
-    h->SetTitle((boost::format("Felix %i") % i).str().c_str());
-    hm->registerHisto(h);
+      auto h = new TH1I((boost::format("h_MvtxPoolQA_TagBCO_felix%i") % i).str().c_str(), "MVTX trigger tagged BCO", 1000, 0, 1000);
+      h->GetXaxis()->SetTitle("GL1 BCO");
+      h->SetTitle((boost::format("Felix %i") % i).str().c_str());
+      hm->registerHisto(h);
     }
     {
       auto h = new TH1I((boost::format("h_MvtxPoolQA_TagStBco_felix%i") % i).str().c_str(), "", 1000, 0, 1000);
@@ -1367,59 +1368,56 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h_all->GetXaxis()->SetTitle("GL1 BCO");
     h_all->SetTitle("GL1 Reference BCO");
     hm->registerHisto(h_all);
-
   }
-    for (int i = 0; i < 24; i++)
+  for (int i = 0; i < 24; i++)
+  {
+    for (int j = 0; j < 2; j++)
     {
-      for (int j = 0; j < 2; j++)
       {
-        {
-          auto h = new TH1I((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str().c_str(), "TPC trigger tagged BCO", 1000, 0, 1000);
-          h->GetXaxis()->SetTitle("GL1 BCO");
-          h->SetTitle((boost::format("Packet %i and packet %i") % i % j).str().c_str());
-          hm->registerHisto(h);
-        }
+        auto h = new TH1I((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str().c_str(), "TPC trigger tagged BCO", 1000, 0, 1000);
+        h->GetXaxis()->SetTitle("GL1 BCO");
+        h->SetTitle((boost::format("Packet %i and packet %i") % i % j).str().c_str());
+        hm->registerHisto(h);
       }
     }
+  }
 
-  for(int i=0; i<12; i++)
+  for (int i = 0; i < 12; i++)
   {
     h_bcoGL1LL1diff[i] = new TH1I((boost::format("h_MvtxPoolQA_GL1LL1BCODiff_packet%i") % i).str().c_str(), "MVTX BCO diff;|GL1 BCO - LL1 BCO|", 5000, 0, 5000);
     hm->registerHisto(h_bcoGL1LL1diff[i]);
     h_bcoLL1Strobediff[i] = new TH1I((boost::format("h_MvtxPoolQA_LL1StrobeBCODiff_packet%i") % i).str().c_str(), "MVTX BCO diff; |LL1 BCO - Strobe BCO|", 100000, 0, 100000);
     hm->registerHisto(h_bcoLL1Strobediff[i]);
   }
-    // Get the global pointers
-    h_refbco_intt = dynamic_cast<TH1 *>(hm->getHisto("h_InttPoolQA_RefGL1BCO"));
-    h_taggedAll_intt = dynamic_cast<TH1 *>(hm->getHisto("h_InttPoolQA_TagBCOAllServers"));
-    for (int i = 0; i < 8; i++)
+  // Get the global pointers
+  h_refbco_intt = dynamic_cast<TH1 *>(hm->getHisto("h_InttPoolQA_RefGL1BCO"));
+  h_taggedAll_intt = dynamic_cast<TH1 *>(hm->getHisto("h_InttPoolQA_TagBCOAllServers"));
+  for (int i = 0; i < 8; i++)
+  {
+    h_gl1tagged_intt[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCO_server%i") % i).str().c_str()));
+    for (int j = 0; j < 14; j++)
     {
-      h_gl1tagged_intt[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCO_server%i") % i).str().c_str()));
-      for (int j = 0; j < 14; j++)
-      {
-
-        h_gl1taggedfee_intt[i][j] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCO_server%i_fee%i") % i % j).str().c_str()));
-      }
-      h_taggedAllFees_intt[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str()));
+      h_gl1taggedfee_intt[i][j] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCO_server%i_fee%i") % i % j).str().c_str()));
     }
+    h_taggedAllFees_intt[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str()));
+  }
 
-    h_refbco_mvtx = dynamic_cast<TH1 *>(hm->getHisto("h_MvtxPoolQA_RefGL1BCO"));
-    h_taggedAllFelixes_mvtx = dynamic_cast<TH1 *>(hm->getHisto("h_MvtxPoolQA_TagBCOAllFelixs"));
-    for(int i=0; i<12; i++)
+  h_refbco_mvtx = dynamic_cast<TH1 *>(hm->getHisto("h_MvtxPoolQA_RefGL1BCO"));
+  h_taggedAllFelixes_mvtx = dynamic_cast<TH1 *>(hm->getHisto("h_MvtxPoolQA_TagBCOAllFelixs"));
+  for (int i = 0; i < 12; i++)
+  {
+    h_tagBcoFelix_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCO_felix%i") % i).str().c_str()));
+    h_tagBcoFelixAllFees_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCOAllFees_Felix%i") % i).str().c_str()));
+  }
+
+  for (int i = 0; i < 24; i++)
+  {
+    for (int j = 0; j < 2; j++)
     {
-      h_tagBcoFelix_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCO_felix%i") % i).str().c_str()));
-      h_tagBcoFelixAllFees_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCOAllFees_Felix%i") % i).str().c_str()));
- 
+      h_gl1tagged_tpc[i][j] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str()));
     }
+  }
 
-    for (int i = 0; i < 24; i++)
-    {
-      for (int j = 0; j < 2; j++)
-      {
-        h_gl1tagged_tpc[i][j] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str()));
-      }
-    }
-
-    h_refbco_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_RefGL1BCO"));
-    h_taggedAll_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_TagBCOAllPackets"));
+  h_refbco_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_RefGL1BCO"));
+  h_taggedAll_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_TagBCOAllPackets"));
 }

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -656,8 +656,10 @@ int Fun4AllStreamingInputManager::FillIntt()
   bool allpackets = true;
   for (size_t p = 0; p < m_InttInputVector.size(); p++)
   {
-    auto bcl_stack = m_InttInputVector[p]->BclkStack();
+    auto bcl_stack = m_InttInputVector[p]->BclkStackMap();
     auto feebclstack = m_InttInputVector[p]->BeamClockFEE();
+    int packet_id = bcl_stack.begin()->first;
+    int histo_to_fill = (packet_id % 10) - 1;
     for (auto &[bcl, feeidset] : feebclstack)
     {
       auto diff = (m_RefBCO > bcl) ? m_RefBCO - bcl : bcl - m_RefBCO;
@@ -665,33 +667,35 @@ int Fun4AllStreamingInputManager::FillIntt()
       {
         if(feeidset.size() == 14)
         {
-          h_taggedAllFees_intt[p]->Fill(refbcobitshift);
+          h_taggedAllFees_intt[histo_to_fill]->Fill(refbcobitshift);
         }
         for (auto &fee : feeidset)
         {
-          h_gl1taggedfee_intt[p][fee]->Fill(refbcobitshift);
+          h_gl1taggedfee_intt[histo_to_fill][fee]->Fill(refbcobitshift);
         }
       }
 
     }
     bool thispacket = false;
 
-    for (auto& gtmbco : bcl_stack)
+    for (auto& [packetid, gtmbcoset] : bcl_stack)
     {
+        for(auto& gtmbco : gtmbcoset)
+        {
       auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
       if (diff <2) // diff is within 1 bco since gl1 and intt are offset by 1 sometimes
       {
         thispacket = true;
-        h_gl1tagged_intt[p]->Fill(refbcobitshift);
+        h_gl1tagged_intt[histo_to_fill]->Fill(refbcobitshift);
       }
-
+        }
     }
     if(thispacket == false)
     {
       allpackets = false;
     }
   }
-  if(allpackets)
+  if(allpackets && m_InttInputVector.size() == 8)
   {
     h_taggedAll_intt->Fill(refbcobitshift);
   }
@@ -847,7 +851,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       }
       (static_cast<SingleMvtxPoolInput *>(m_MvtxInputVector[p]))->clearGtmL1BcoSet();
   }
-  if(allpackets)
+  if(allpackets && m_MvtxInputVector.size() == 6)
   {
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
@@ -1035,7 +1039,7 @@ int Fun4AllStreamingInputManager::FillTpc()
       packetnum++;
     }
   }
-if(allpackets)
+if(allpackets && m_TpcInputVector.size() == 24)
 {
   h_taggedAll_tpc->Fill(refbcobitshift);
 }

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -137,9 +137,13 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   TH1 *h_refbco_mvtx{nullptr};
   TH1 *h_taggedAllFelixes_mvtx{nullptr};
   TH1 *h_tagBcoFelix_mvtx[12]{nullptr};
+
+  TH1 *h_bcoGL1LL1diff[12]{nullptr};
+  TH1 *h_bcoLL1Strobediff[12]{nullptr};
+  TH1 *h_tagStBcoFelix_mvtx[12]{nullptr};
   TH1 *h_tagBcoFelixAllFees_mvtx[12]{nullptr};
   TH1 *h_tagBcoFelixFee_mvtx[12][12]{{nullptr}};
-
+  TH1 *h_tagStBcoFEE_mvtx{nullptr};
   TH1 *h_refbco_intt{nullptr};
   TH1 *h_taggedAll_intt{nullptr};
   TH1 *h_gl1tagged_intt[8]{nullptr};

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -136,14 +136,15 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   // QA histos
   TH1 *h_refbco_mvtx{nullptr};
   TH1 *h_taggedAllFelixes_mvtx{nullptr};
+  TH1 *h_taggedAllFelixesAllFees_mvtx{nullptr};
   TH1 *h_tagBcoFelix_mvtx[12]{nullptr};
 
   TH1 *h_bcoGL1LL1diff[12]{nullptr};
   TH1 *h_bcoLL1Strobediff[12]{nullptr};
   TH1 *h_tagStBcoFelix_mvtx[12]{nullptr};
   TH1 *h_tagBcoFelixAllFees_mvtx[12]{nullptr};
-  TH1 *h_tagBcoFelixFee_mvtx[12][12]{{nullptr}};
   TH1 *h_tagStBcoFEE_mvtx{nullptr};
+  
   TH1 *h_refbco_intt{nullptr};
   TH1 *h_taggedAll_intt{nullptr};
   TH1 *h_gl1tagged_intt[8]{nullptr};

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -136,9 +136,9 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   // QA histos
   TH1 *h_refbco_mvtx{nullptr};
   TH1 *h_taggedAllFelixes_mvtx{nullptr};
-  TH1 *h_tagBcoFelix_mvtx[6]{nullptr};
-  TH1 *h_tagBcoFelixAllFees_mvtx[6]{nullptr};
-  TH1 *h_tagBcoFelixFee_mvtx[6][12]{{nullptr}};
+  TH1 *h_tagBcoFelix_mvtx[12]{nullptr};
+  TH1 *h_tagBcoFelixAllFees_mvtx[12]{nullptr};
+  TH1 *h_tagBcoFelixFee_mvtx[12][12]{{nullptr}};
 
   TH1 *h_refbco_intt{nullptr};
   TH1 *h_taggedAll_intt{nullptr};

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -147,10 +147,7 @@ void SingleInttPoolInput::FillPool(const unsigned int /*unused*/)
         {
           auto bco = pool->lValue(j, "BCOLIST");
           m_BclkStack.insert(bco);
-          if (m_BclkStackPacketMap.find(packet_id) == m_BclkStackPacketMap.end())
-          {
-            m_BclkStackPacketMap.insert(std::make_pair(packet_id, std::set<uint64_t>()));
-          }
+      
           m_BclkStackPacketMap[packet_id].insert(bco);
         }
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -11,7 +11,6 @@
 #include <ffarawobjects/MvtxRawHitv1.h>
 
 #include <frog/FROG.h>
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
@@ -25,7 +24,6 @@
 #include <cassert>
 #include <memory>
 #include <set>
-
 SingleMvtxPoolInput::SingleMvtxPoolInput(const std::string &name)
   : SingleStreamingInput(name)
 {
@@ -59,6 +57,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
       return;
     }
   }
+
   //  std::set<uint64_t> saved_beamclocks;
   while (GetSomeMoreEvents())
   {
@@ -130,18 +129,17 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
         {
           auto feeId = pool->iValue(i_fee, "FEEID");
           auto link = MvtxRawDefs::decode_feeid(feeId);
+
           //          auto hbfSize = plist[i]->iValue(feeId, "NR_HBF");
           auto num_strobes = pool->iValue(feeId, "NR_STROBES");
           auto num_L1Trgs = pool->iValue(feeId, "NR_PHYS_TRG");
-
           for (int iL1 = 0; iL1 < num_L1Trgs; ++iL1)
           {
             auto l1Trg_bco = pool->lValue(feeId, iL1, "L1_IR_BCO");
             //            auto l1Trg_bc  = plist[i]->iValue(feeId, iL1, "L1_IR_BC");
-            m_FeeGTML1BCOMap[i_fee].insert(l1Trg_bco);
+            m_FeeGTML1BCOMap[feeId].insert(l1Trg_bco);
             gtmL1BcoSet.emplace(l1Trg_bco);
           }
-
           m_FeeStrobeMap[feeId] += num_strobes;
           for (int i_strb{0}; i_strb < num_strobes; ++i_strb)
           {
@@ -166,7 +164,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
               std::cout << ", n_hits: " << num_hits << std::endl;
             }
             auto hits = pool->get_hits(feeId, i_strb);
-            for ( auto&& hit : hits )
+            for (auto &&hit : hits)
             {
               MvtxRawHit *newhit = new MvtxRawHitv1();
               newhit->set_bco(strb_bco);
@@ -306,7 +304,6 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
       gtmbcoset.erase(iter);
     }
   }
-
 }
 
 bool SingleMvtxPoolInput::CheckPoolDepth(const uint64_t bclk)
@@ -385,11 +382,10 @@ bool SingleMvtxPoolInput::GetSomeMoreEvents()
                   << (highest_bclk - m_MvtxRawHitMap.begin()->first)
                   << std::dec << std::endl;
         toerase.insert(bcliter.first);
-
       }
     }
   }
-  for(auto iter : toerase)
+  for (auto iter : toerase)
   {
     m_FEEBclkMap.erase(iter);
   }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -133,19 +133,13 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
           //          auto hbfSize = plist[i]->iValue(feeId, "NR_HBF");
           auto num_strobes = pool->iValue(feeId, "NR_STROBES");
           auto num_L1Trgs = pool->iValue(feeId, "NR_PHYS_TRG");
-// this should not be needed, the m_FeeGTML1BCOMap[i_fee].insert(l1Trg_bco)
-// will create the set if it doesn't exist
-          // if(m_FeeGTML1BCOMap.find(i_fee) == m_FeeGTML1BCOMap.end())
-          // {
-          //   m_FeeGTML1BCOMap[i_fee] = std::set<uint64_t>();
-          // }
+
           for (int iL1 = 0; iL1 < num_L1Trgs; ++iL1)
           {
             auto l1Trg_bco = pool->lValue(feeId, iL1, "L1_IR_BCO");
             //            auto l1Trg_bc  = plist[i]->iValue(feeId, iL1, "L1_IR_BC");
             m_FeeGTML1BCOMap[i_fee].insert(l1Trg_bco);
             gtmL1BcoSet.emplace(l1Trg_bco);
-            m_gtmL1BcoSetRef.emplace(l1Trg_bco);
           }
 
           m_FeeStrobeMap[feeId] += num_strobes;
@@ -302,10 +296,10 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
   for (auto iter : toclearbclk)
   {
     m_BclkStack.erase(iter);
+    m_BeamClockFEE[iter].clear();
     m_BeamClockFEE.erase(iter);
     m_MvtxRawHitMap.erase(iter);
     m_FeeStrobeMap.erase(iter);
-    m_gtmL1BcoSetRef.erase(iter);
 
     for (auto &[feeid, gtmbcoset] : m_FeeGTML1BCOMap)
     {

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -25,17 +25,21 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
   void SetBcoRange(const unsigned int i) { m_BcoRange = i; }
-  unsigned int GetBcoRange() const { return m_BcoRange; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
-  void clearFeeGTML1BCOMap() { 
+  void clearFeeGTML1BCOMap(const uint64_t& bclk) { 
     for(auto& [key, set] : m_FeeGTML1BCOMap)
     {
-      set.clear();
+      for(auto& ll1bclk : set)
+      {
+        if(ll1bclk < bclk)
+        {
+          set.erase(ll1bclk);
+        }
+      }
     }
-    m_FeeGTML1BCOMap.clear(); 
   }
  protected:
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -30,14 +30,20 @@ class SingleMvtxPoolInput : public SingleStreamingInput
 
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
   void clearFeeGTML1BCOMap(const uint64_t& bclk) { 
-    for(auto& [key, set] : m_FeeGTML1BCOMap)
+    std::set<uint64_t> toerase;
+    for (auto &[key, set] : m_FeeGTML1BCOMap)
     {
       for(auto& ll1bclk : set)
       {
-        if(ll1bclk < bclk)
+        if(ll1bclk <= bclk)
         {
-          set.erase(ll1bclk);
+          // to avoid invalid reads
+          toerase.insert(ll1bclk);
         }
+      }
+      for(auto& bclk_to_erase : toerase)
+      {
+        set.erase(bclk_to_erase);
       }
     }
   }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -29,10 +29,7 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
-  std::set<int> &getFeeIdSet(const uint64_t &bco) { return m_BeamClockFEE[bco]; };
-  std::set<uint64_t>& getGtmL1BcoSet() { return m_gtmL1BcoSetRef; }
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
-  void clearGtmL1BcoSet() { m_gtmL1BcoSetRef.clear(); }
   void clearFeeGTML1BCOMap() { 
     for(auto& [key, set] : m_FeeGTML1BCOMap)
     {
@@ -54,7 +51,6 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   std::map<int, uint64_t> m_FeeStrobeMap;
   std::set<uint64_t> m_BclkStack;
   std::set<uint64_t> gtmL1BcoSet;  // GTM L1 BCO
-  std::set<uint64_t> m_gtmL1BcoSetRef;
   std::map<int, std::set<uint64_t>> m_FeeGTML1BCOMap;
   std::map<int, mvtx_pool *> poolmap;
 };

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -47,6 +47,9 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   virtual const std::map<int, std::set<uint64_t>>& BclkStackMap() const { return m_BclkStackPacketMap; }
   virtual const std::set<uint64_t>& BclkStack() const { return m_BclkStack; }
   virtual const std::map<uint64_t, std::set<int>>& BeamClockFEE() const { return m_BeamClockFEE; }
+ 
+ protected:
+  std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
 
  private:
   Eventiterator *m_EventIterator{nullptr};
@@ -61,7 +64,6 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;
   std::map<int, uint64_t> m_FEEBclkMap;
   std::set<uint64_t> m_BclkStack;
-  std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
 };
 
 #endif

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.h
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.h
@@ -44,7 +44,6 @@ class SingleTpcPoolInput : public SingleStreamingInput
   std::map<uint64_t, std::vector<TpcRawHit *>> m_TpcRawHitMap;
   std::map<int, uint64_t> m_FEEBclkMap;
   std::set<uint64_t> m_BclkStack;
-  std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
 };
 
 #endif


### PR DESCRIPTION
This PR improves the packet QA to deal with missing prdfs in the silicon. It also improves the mvtx packet qa greatly by properly associating the LL1 to GL1 BCOs and also adding histograms for relating the strobe BCO to the GL1

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

