### PR TITLE
remove default for run number, print run numbers if not given

### DIFF
--- a/offline/framework/frog/CreateFileList.pl
+++ b/offline/framework/frog/CreateFileList.pl
@@ -11,6 +11,7 @@ use List::Util qw(shuffle);
 sub commonfiletypes;
 sub fill_nocombine_files;
 sub print_single_types;
+sub print_runs;
 
 my $dbh = DBI->connect("dbi:ODBC:FileCatalog","argouser") || die $DBI::error;
 $dbh->{LongReadLen}=2000; # full file paths need to fit in here
@@ -80,7 +81,7 @@ my $start_segment;
 my $last_segment;
 my $randomize;
 my $prodtype;
-my $runnumber = 7;
+my $runnumber;
 my $verbose;
 my $nopileup;
 my $embed;
@@ -136,7 +137,12 @@ my $AuAu_pileupstring;
 my $pp_pileupstring;
 my $pAu_pileupstring;
 my $pileupstring;
-
+if (! defined $runnumber && $#newargs >= 0)
+{
+    print "\nyou need to give a runnumber with -run <runnumber>\n";
+    print_runs();
+    exit(1);
+}
 if (defined $embed && defined $nopileup)
 {
     print "--embed and --nopileup flags do not work together, it does not make sense\n";
@@ -725,7 +731,7 @@ if ($#ARGV < 0)
 	print "-n     : <number of events>\n";
 	print "-nopileup : without pileup\n";
 	print "-rand  : randomize segments used\n";
-	print "-run   : runnumber (default = $runnumber)\n";
+	print "-run   : runnumber (mandatory, no default anymore)\n";
 	print "-s     : starting segment (remember first segment is 0)\n";
 	print "\n-type  : production type\n";
 	foreach my $pd (sort { $a <=> $b } keys %proddesc)
@@ -1169,4 +1175,17 @@ sub print_special_types
     {
 	    print "$name\n";
     }
+}
+
+sub print_runs
+{
+    my $getrunnumbers = $dbh->prepare("select distinct(runnumber) from datasets where dataset = 'mdc2' order by runnumber");
+    $getrunnumbers->execute();
+    print "Available Runs (check our wiki for more details for each runnumber):\n";
+    while(my @res = $getrunnumbers->fetchrow_array())
+    {
+	print "$res[0]\n";
+    }
+    print "NB: Not all DSTs are available for all runs\n";
+    $getrunnumbers->finish();
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The default runnumber was still 7 which doesn't exist anymore. With the split of systems along run numbers a default doesn't make sense anymore and is misleading. The run number is now a require argument, if it is not given a list of available runs is printed out. Jenkins doesn't check this [skip-ci] 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

