### PR TITLE
added th3 option for merging efficiency

### DIFF
--- a/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
@@ -58,7 +58,9 @@ class pi0EtaByEta : public SubsysReco
 
 	void fitEtaPhiTowers(const std::string& infile, const std::string& fitOutFile, const std::string& cdbFile); // for tbt pi0 fit
 
-  void set_use_pdc(bool state)
+  void Split3DHist(const std::string& infile, const std::string& outfile);
+
+	void set_use_pdc(bool state)
   {
     use_pdc = state;
     return;
@@ -88,11 +90,18 @@ class pi0EtaByEta : public SubsysReco
     convLev=val;
     return;
   }
-  void set_RunTowByTow(bool state) // to decide if we want to run tbt (default is false)
+  void set_RunTowByTow(bool state) // to decide if we want to run tbt (default is true)
   {
     runTowByTow=state;
     return;
   }
+
+	void set_RunTBTCompactMode(bool state) // to decide if we want to run in TBT in compact mode (default is true)
+  {
+    runTBTCompactMode=state;
+    return;
+  }
+
 
   void set_massTargetHistFile(const std::string& file);
   bool checkOutput(const std::string& file);
@@ -150,8 +159,9 @@ class pi0EtaByEta : public SubsysReco
   bool dynMaskClus{false};
   bool doMix{false};
   bool use_pdc{false};
-  bool runTowByTow{false}; // default set not to run tbt
-  
+  bool runTowByTow{true}; // default set not to run tbt
+  bool runTBTCompactMode{true}; // default set to run in compact mode 
+
   std::vector<std::vector<std::vector<CLHEP::Hep3Vector>>>* clusMix;
   TH1* h_nclus_bin{nullptr};
   const int NBinsClus = 10;
@@ -183,6 +193,7 @@ class pi0EtaByEta : public SubsysReco
   TH2* h_hcalout_etaphi_wQA{nullptr};
   TH1* h_totalzdc_e{nullptr};
   TH3* h_pipT_Nclus_mass{nullptr};
+	TH3* h_ieta_iphi_invmass{nullptr};
 
   TProfile2D* h_cemc_etaphi_time{nullptr};
   TProfile2D* h_hcalin_etaphi_time{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

gives option to save the 24,576 tower inv mass histograms as single TH3F instead of individual 24576 TH1F's, and associated functions to switch between TH1F's and TH3F modes.  Using the TH3F's until right before fitting, speeds up merging by a large factor.  


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

