### PR TITLE
Adding a masking pixel class and a method to turn it on and off in of…

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -23,7 +23,9 @@ pkginclude_HEADERS = \
   MvtxNoiseMap.h \
   MvtxCombinedRawDataDecoder.h \
   CylinderGeom_Mvtx.h \
-  SegmentationAlpide.h
+  SegmentationAlpide.h \
+  MvtxPixelDefs.h \
+  MvtxPixelMask.h
 
 ROOTDICTS = \
   CylinderGeom_Mvtx_Dict.cc \
@@ -38,7 +40,9 @@ nobase_dist_pcm_DATA = \
 libmvtx_la_SOURCES = \
   MvtxClusterizer.cc \
   MvtxHitPruner.cc \
-  MvtxCombinedRawDataDecoder.cc
+  MvtxCombinedRawDataDecoder.cc \
+  MvtxPixelDefs.cc \
+  MvtxPixelMask.cc
 
 libmvtx_la_LIBADD = \
   libmvtx_io.la \

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "MvtxPixelMask.h"
+
 class MvtxEventInfo;
 class MvtxRawEvtHeader;
 class MvtxRawHitContainer;
@@ -48,6 +50,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   void writeMvtxEventHeader(bool write) { m_writeMvtxEventHeader = write; }
 
+  void doOfflineMasking(bool do_masking) { m_doOfflineMasking = do_masking; }
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
   void getStrobeLength();
@@ -63,7 +66,12 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
   float m_strobeWidth = 89.;  //! microseconds
   bool m_writeMvtxEventHeader = true;
-  std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
+  // std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
+
+  // mask hot pixels
+  bool m_doOfflineMasking{false};
+  MvtxPixelMask * m_hot_pixel_mask{nullptr};
+
 };
 
 #endif

--- a/offline/packages/mvtx/MvtxPixelDefs.cc
+++ b/offline/packages/mvtx/MvtxPixelDefs.cc
@@ -1,0 +1,68 @@
+#include "MvtxPixelDefs.h"
+
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <cstdint>
+
+
+// MvtPixelDefs namespace
+//==============================================================================
+MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey(const uint32_t hitset_key, const uint32_t hitkey)
+{
+    return ((uint64_t) hitset_key << MvtxPixelDefs::kBitShiftLadder) | ((uint64_t) hitkey & 0xFFFFFFFF);
+}
+
+uint32_t MvtxPixelDefs::get_hitsetkey(const MvtxPixelDefs::pixelkey pkey)
+{
+    return (uint32_t) (pkey >> MvtxPixelDefs::kBitShiftLadder);
+}
+
+uint32_t MvtxPixelDefs::get_hitkey(const MvtxPixelDefs::pixelkey pkey)
+{
+    return (uint32_t) pkey & 0xFFFFFFFF;
+}
+
+MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey_from_coors(const uint8_t layer, const uint8_t stave, const uint8_t chip, const uint16_t row, const uint16_t col)
+{
+    return MvtxPixelDefs::gen_pixelkey(MvtxDefs::genHitSetKey(layer, stave, chip, 0), MvtxDefs::genHitKey(col, row));
+}
+
+MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey(MvtxRawHit *hit)
+{
+    if(!hit) return MvtxPixelDefs::VOID_PIXEL;
+    const TrkrDefs::hitkey this_hitkey = MvtxDefs::genHitKey(hit->get_col(), hit->get_row());
+    const TrkrDefs::hitsetkey this_hitsetkey = MvtxDefs::genHitSetKey(hit->get_layer_id(), hit->get_stave_id(), hit->get_chip_id(), 0);
+    MvtxPixelDefs::pixelkey this_pixelkey = MvtxPixelDefs::gen_pixelkey(this_hitsetkey, this_hitkey);
+    return this_pixelkey;
+}
+
+unsigned int MvtxPixelDefs::get_layer(const MvtxPixelDefs::pixelkey pkey)
+{
+    uint32_t hitsetkey = get_hitsetkey(pkey);
+    return TrkrDefs::getLayer(hitsetkey);
+}
+
+unsigned int MvtxPixelDefs::get_stave(const MvtxPixelDefs::pixelkey pkey)
+{
+    uint32_t hitsetkey = get_hitsetkey(pkey);
+    return MvtxDefs::getStaveId(hitsetkey);
+}
+
+unsigned int MvtxPixelDefs::get_chip(const MvtxPixelDefs::pixelkey pkey)
+{
+    uint32_t hitsetkey = get_hitsetkey(pkey);
+    return MvtxDefs::getChipId(hitsetkey);
+}
+
+unsigned int MvtxPixelDefs::get_row(const MvtxPixelDefs::pixelkey pkey)
+{
+    uint32_t hitkey = get_hitkey(pkey);
+    return MvtxDefs::getRow(hitkey);
+}
+
+unsigned int MvtxPixelDefs::get_col(const MvtxPixelDefs::pixelkey pkey)
+{
+    uint32_t hitkey = get_hitkey(pkey);
+    return MvtxDefs::getCol(hitkey);
+}

--- a/offline/packages/mvtx/MvtxPixelDefs.cc
+++ b/offline/packages/mvtx/MvtxPixelDefs.cc
@@ -5,64 +5,66 @@
 
 #include <cstdint>
 
-
 // MvtPixelDefs namespace
 //==============================================================================
 MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey(const uint32_t hitset_key, const uint32_t hitkey)
 {
-    return ((uint64_t) hitset_key << MvtxPixelDefs::kBitShiftLadder) | ((uint64_t) hitkey & 0xFFFFFFFF);
+  return ((uint64_t) hitset_key << MvtxPixelDefs::kBitShiftLadder) | ((uint64_t) hitkey & 0xFFFFFFFF);
 }
 
 uint32_t MvtxPixelDefs::get_hitsetkey(const MvtxPixelDefs::pixelkey pkey)
 {
-    return (uint32_t) (pkey >> MvtxPixelDefs::kBitShiftLadder);
+  return (uint32_t) (pkey >> MvtxPixelDefs::kBitShiftLadder);
 }
 
 uint32_t MvtxPixelDefs::get_hitkey(const MvtxPixelDefs::pixelkey pkey)
 {
-    return (uint32_t) pkey & 0xFFFFFFFF;
+  return (uint32_t) pkey & 0xFFFFFFFF;
 }
 
 MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey_from_coors(const uint8_t layer, const uint8_t stave, const uint8_t chip, const uint16_t row, const uint16_t col)
 {
-    return MvtxPixelDefs::gen_pixelkey(MvtxDefs::genHitSetKey(layer, stave, chip, 0), MvtxDefs::genHitKey(col, row));
+  return MvtxPixelDefs::gen_pixelkey(MvtxDefs::genHitSetKey(layer, stave, chip, 0), MvtxDefs::genHitKey(col, row));
 }
 
 MvtxPixelDefs::pixelkey MvtxPixelDefs::gen_pixelkey(MvtxRawHit *hit)
 {
-    if(!hit) return MvtxPixelDefs::VOID_PIXEL;
-    const TrkrDefs::hitkey this_hitkey = MvtxDefs::genHitKey(hit->get_col(), hit->get_row());
-    const TrkrDefs::hitsetkey this_hitsetkey = MvtxDefs::genHitSetKey(hit->get_layer_id(), hit->get_stave_id(), hit->get_chip_id(), 0);
-    MvtxPixelDefs::pixelkey this_pixelkey = MvtxPixelDefs::gen_pixelkey(this_hitsetkey, this_hitkey);
-    return this_pixelkey;
+  if (!hit)
+  {
+    return MvtxPixelDefs::VOID_PIXEL;
+  }
+  const TrkrDefs::hitkey this_hitkey = MvtxDefs::genHitKey(hit->get_col(), hit->get_row());
+  const TrkrDefs::hitsetkey this_hitsetkey = MvtxDefs::genHitSetKey(hit->get_layer_id(), hit->get_stave_id(), hit->get_chip_id(), 0);
+  MvtxPixelDefs::pixelkey this_pixelkey = MvtxPixelDefs::gen_pixelkey(this_hitsetkey, this_hitkey);
+  return this_pixelkey;
 }
 
 unsigned int MvtxPixelDefs::get_layer(const MvtxPixelDefs::pixelkey pkey)
 {
-    uint32_t hitsetkey = get_hitsetkey(pkey);
-    return TrkrDefs::getLayer(hitsetkey);
+  uint32_t hitsetkey = get_hitsetkey(pkey);
+  return TrkrDefs::getLayer(hitsetkey);
 }
 
 unsigned int MvtxPixelDefs::get_stave(const MvtxPixelDefs::pixelkey pkey)
 {
-    uint32_t hitsetkey = get_hitsetkey(pkey);
-    return MvtxDefs::getStaveId(hitsetkey);
+  uint32_t hitsetkey = get_hitsetkey(pkey);
+  return MvtxDefs::getStaveId(hitsetkey);
 }
 
 unsigned int MvtxPixelDefs::get_chip(const MvtxPixelDefs::pixelkey pkey)
 {
-    uint32_t hitsetkey = get_hitsetkey(pkey);
-    return MvtxDefs::getChipId(hitsetkey);
+  uint32_t hitsetkey = get_hitsetkey(pkey);
+  return MvtxDefs::getChipId(hitsetkey);
 }
 
 unsigned int MvtxPixelDefs::get_row(const MvtxPixelDefs::pixelkey pkey)
 {
-    uint32_t hitkey = get_hitkey(pkey);
-    return MvtxDefs::getRow(hitkey);
+  uint32_t hitkey = get_hitkey(pkey);
+  return MvtxDefs::getRow(hitkey);
 }
 
 unsigned int MvtxPixelDefs::get_col(const MvtxPixelDefs::pixelkey pkey)
 {
-    uint32_t hitkey = get_hitkey(pkey);
-    return MvtxDefs::getCol(hitkey);
+  uint32_t hitkey = get_hitkey(pkey);
+  return MvtxDefs::getCol(hitkey);
 }

--- a/offline/packages/mvtx/MvtxPixelDefs.h
+++ b/offline/packages/mvtx/MvtxPixelDefs.h
@@ -1,0 +1,31 @@
+#ifndef MVTX_MVTXPIXELDEFS_H
+#define MVTX_MVTXPIXELDEFS_H
+
+
+#include <cstdint>
+#include <climits>
+#include <memory>
+
+#include <ffarawobjects/MvtxRawHit.h>
+
+namespace MvtxPixelDefs 
+{
+
+    typedef uint64_t pixelkey; // (hitsetkey << 32) | hitkey
+    static MvtxPixelDefs::pixelkey VOID_PIXEL __attribute__((unused)) = UINT64_MAX;
+    static const unsigned int kBitShiftLadder __attribute__((unused)) = 32;
+
+    MvtxPixelDefs::pixelkey gen_pixelkey(const uint32_t hitset_key, const uint32_t hitkey);
+    uint32_t get_hitsetkey(const MvtxPixelDefs::pixelkey key);
+    uint32_t get_hitkey(const MvtxPixelDefs::pixelkey key);
+    MvtxPixelDefs::pixelkey gen_pixelkey_from_coors(const uint8_t layer, const uint8_t stave, const uint8_t chip, const uint16_t row, const uint16_t col);
+    MvtxPixelDefs::pixelkey gen_pixelkey(MvtxRawHit *hit);
+
+    unsigned int get_layer(const MvtxPixelDefs::pixelkey key);
+    unsigned int get_stave(const MvtxPixelDefs::pixelkey key);
+    unsigned int get_chip(const MvtxPixelDefs::pixelkey key);
+    unsigned int get_row(const MvtxPixelDefs::pixelkey key);
+    unsigned int get_col(const MvtxPixelDefs::pixelkey key);
+}
+
+#endif // MVTX_MVTXPIXELDEFS_H

--- a/offline/packages/mvtx/MvtxPixelDefs.h
+++ b/offline/packages/mvtx/MvtxPixelDefs.h
@@ -1,31 +1,30 @@
 #ifndef MVTX_MVTXPIXELDEFS_H
 #define MVTX_MVTXPIXELDEFS_H
 
-
-#include <cstdint>
 #include <climits>
+#include <cstdint>
 #include <memory>
 
 #include <ffarawobjects/MvtxRawHit.h>
 
-namespace MvtxPixelDefs 
+namespace MvtxPixelDefs
 {
 
-    typedef uint64_t pixelkey; // (hitsetkey << 32) | hitkey
-    static MvtxPixelDefs::pixelkey VOID_PIXEL __attribute__((unused)) = UINT64_MAX;
-    static const unsigned int kBitShiftLadder __attribute__((unused)) = 32;
+  typedef uint64_t pixelkey;  // (hitsetkey << 32) | hitkey
+  static MvtxPixelDefs::pixelkey VOID_PIXEL __attribute__((unused)) = UINT64_MAX;
+  static const unsigned int kBitShiftLadder __attribute__((unused)) = 32;
 
-    MvtxPixelDefs::pixelkey gen_pixelkey(const uint32_t hitset_key, const uint32_t hitkey);
-    uint32_t get_hitsetkey(const MvtxPixelDefs::pixelkey key);
-    uint32_t get_hitkey(const MvtxPixelDefs::pixelkey key);
-    MvtxPixelDefs::pixelkey gen_pixelkey_from_coors(const uint8_t layer, const uint8_t stave, const uint8_t chip, const uint16_t row, const uint16_t col);
-    MvtxPixelDefs::pixelkey gen_pixelkey(MvtxRawHit *hit);
+  MvtxPixelDefs::pixelkey gen_pixelkey(const uint32_t hitset_key, const uint32_t hitkey);
+  uint32_t get_hitsetkey(const MvtxPixelDefs::pixelkey key);
+  uint32_t get_hitkey(const MvtxPixelDefs::pixelkey key);
+  MvtxPixelDefs::pixelkey gen_pixelkey_from_coors(const uint8_t layer, const uint8_t stave, const uint8_t chip, const uint16_t row, const uint16_t col);
+  MvtxPixelDefs::pixelkey gen_pixelkey(MvtxRawHit *hit);
 
-    unsigned int get_layer(const MvtxPixelDefs::pixelkey key);
-    unsigned int get_stave(const MvtxPixelDefs::pixelkey key);
-    unsigned int get_chip(const MvtxPixelDefs::pixelkey key);
-    unsigned int get_row(const MvtxPixelDefs::pixelkey key);
-    unsigned int get_col(const MvtxPixelDefs::pixelkey key);
-}
+  unsigned int get_layer(const MvtxPixelDefs::pixelkey key);
+  unsigned int get_stave(const MvtxPixelDefs::pixelkey key);
+  unsigned int get_chip(const MvtxPixelDefs::pixelkey key);
+  unsigned int get_row(const MvtxPixelDefs::pixelkey key);
+  unsigned int get_col(const MvtxPixelDefs::pixelkey key);
+}  // namespace MvtxPixelDefs
 
-#endif // MVTX_MVTXPIXELDEFS_H
+#endif  // MVTX_MVTXPIXELDEFS_H

--- a/offline/packages/mvtx/MvtxPixelMask.cc
+++ b/offline/packages/mvtx/MvtxPixelMask.cc
@@ -1,9 +1,8 @@
 #include "MvtxPixelMask.h"
 #include "MvtxPixelDefs.h"
 
-
-#include <ffamodules/CDBInterface.h> 
 #include <cdbobjects/CDBTTree.h>
+#include <ffamodules/CDBInterface.h>
 
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrDefs.h>
@@ -11,88 +10,88 @@
 #include <ffarawobjects/MvtxRawHit.h>
 #include <ffarawobjects/MvtxRawHitv1.h>
 
+#include <algorithm>
 #include <iostream>
 #include <set>
-#include <algorithm>
 #include <string>
-
 
 // MvtxPixelMask class
 //==============================================================================
 void MvtxPixelMask::load_from_CDB()
 {
-    if(!m_hot_pixel_map.empty()) clear();
+  if (!m_hot_pixel_map.empty())
+  {
+    clear();
+  }
 
+  // Load the hot pixel file from the CDB
+  std::string database = CDBInterface::instance()->getUrl("MVTX_HotPixelMap");  // This is specifically for MVTX Hot Pixels
+  CDBTTree* cdbttree = new CDBTTree(database);
+  int n_total_masked = cdbttree->GetSingleIntValue("TotalHotPixels");
 
-    // Load the hot pixel file from the CDB
-    std::string database = CDBInterface::instance()->getUrl("MVTX_HotPixelMap");  // This is specifically for MVTX Hot Pixels
-    CDBTTree *cdbttree = new CDBTTree(database);
-    int n_total_masked =  cdbttree->GetSingleIntValue("TotalHotPixels");
+  // Load the hot pixel map
+  std::set<MvtxPixelDefs::pixelkey> masked_pixels{};
+  for (int i = 0; i < n_total_masked; i++)
+  {
+    int layer = cdbttree->GetIntValue(i, "layer");
+    int stave = cdbttree->GetIntValue(i, "stave");
+    int chip = cdbttree->GetIntValue(i, "chip");
+    int row = cdbttree->GetIntValue(i, "row");
+    int col = cdbttree->GetIntValue(i, "col");
 
-    // Load the hot pixel map
-    std::set<MvtxPixelDefs::pixelkey> masked_pixels {};
-    for (int i = 0; i < n_total_masked; i++)
-    {
-        int layer = cdbttree->GetIntValue(i, "layer");
-        int stave = cdbttree->GetIntValue(i, "stave");
-        int chip = cdbttree->GetIntValue(i, "chip");
-        int row = cdbttree->GetIntValue(i, "row");
-        int col = cdbttree->GetIntValue(i, "col");
+    MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey_from_coors(layer, stave, chip, row, col);
+    masked_pixels.insert(this_pixel_key);
+  }
 
-        MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey_from_coors(layer, stave, chip, row, col);
-        masked_pixels.insert(this_pixel_key);
-    }
+  // Copy the masked pixels to the hot pixel map
+  // m_hot_pixel_map.assign(masked_pixels.begin(), masked_pixels.end());
+  for (unsigned long masked_pixel : masked_pixels)
+  {
+    m_hot_pixel_map.push_back(masked_pixel);
+  }
 
-    // Copy the masked pixels to the hot pixel map
-    // m_hot_pixel_map.assign(masked_pixels.begin(), masked_pixels.end());
-    for (auto it = masked_pixels.begin(); it != masked_pixels.end(); it++)
-    {
-        m_hot_pixel_map.push_back(*it);
-    }
-
-    return;
-
+  return;
 }
 
 void MvtxPixelMask::add_pixel(MvtxPixelDefs::pixelkey key)
 {
-    if (std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key) == m_hot_pixel_map.end())
-    {
-        m_hot_pixel_map.push_back(key);
-    }
+  if (std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key) == m_hot_pixel_map.end())
+  {
+    m_hot_pixel_map.push_back(key);
+  }
 
-    return;
+  return;
 }
 
 void MvtxPixelMask::remove_pixel(MvtxPixelDefs::pixelkey key)
 {
-    auto it = std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key);
-    if (it != m_hot_pixel_map.end())
-    {
-        m_hot_pixel_map.erase(it);
-    }
+  auto it = std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key);
+  if (it != m_hot_pixel_map.end())
+  {
+    m_hot_pixel_map.erase(it);
+  }
 
-    return;
+  return;
 }
 
 void MvtxPixelMask::clear()
 {
-    m_hot_pixel_map.clear();
-    return;
+  m_hot_pixel_map.clear();
+  return;
 }
 
 bool MvtxPixelMask::is_masked(MvtxRawHit* hit) const
 {
-    uint8_t layer = hit->get_layer_id();
-    uint8_t stave = hit->get_stave_id();
-    uint8_t chip = hit->get_chip_id();
-    uint16_t row = hit->get_row();
-    uint16_t col = hit->get_col();
+  uint8_t layer = hit->get_layer_id();
+  uint8_t stave = hit->get_stave_id();
+  uint8_t chip = hit->get_chip_id();
+  uint16_t row = hit->get_row();
+  uint16_t col = hit->get_col();
 
-    // generate hit key and hitset key
-    const TrkrDefs::hitkey this_pixel_hitkey = MvtxDefs::genHitKey(col, row);
-    const TrkrDefs::hitsetkey this_pixel_hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
-    MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey(this_pixel_hitsetkey, this_pixel_hitkey);
+  // generate hit key and hitset key
+  const TrkrDefs::hitkey this_pixel_hitkey = MvtxDefs::genHitKey(col, row);
+  const TrkrDefs::hitsetkey this_pixel_hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
+  MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey(this_pixel_hitsetkey, this_pixel_hitkey);
 
-    return std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), this_pixel_key) != m_hot_pixel_map.end();
+  return std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), this_pixel_key) != m_hot_pixel_map.end();
 }

--- a/offline/packages/mvtx/MvtxPixelMask.cc
+++ b/offline/packages/mvtx/MvtxPixelMask.cc
@@ -1,0 +1,98 @@
+#include "MvtxPixelMask.h"
+#include "MvtxPixelDefs.h"
+
+
+#include <ffamodules/CDBInterface.h> 
+#include <cdbobjects/CDBTTree.h>
+
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <ffarawobjects/MvtxRawHit.h>
+#include <ffarawobjects/MvtxRawHitv1.h>
+
+#include <iostream>
+#include <set>
+#include <algorithm>
+#include <string>
+
+
+// MvtxPixelMask class
+//==============================================================================
+void MvtxPixelMask::load_from_CDB()
+{
+    if(!m_hot_pixel_map.empty()) clear();
+
+
+    // Load the hot pixel file from the CDB
+    std::string database = CDBInterface::instance()->getUrl("MVTX_HotPixelMap");  // This is specifically for MVTX Hot Pixels
+    CDBTTree *cdbttree = new CDBTTree(database);
+    int n_total_masked =  cdbttree->GetSingleIntValue("TotalHotPixels");
+
+    // Load the hot pixel map
+    std::set<MvtxPixelDefs::pixelkey> masked_pixels {};
+    for (int i = 0; i < n_total_masked; i++)
+    {
+        int layer = cdbttree->GetIntValue(i, "layer");
+        int stave = cdbttree->GetIntValue(i, "stave");
+        int chip = cdbttree->GetIntValue(i, "chip");
+        int row = cdbttree->GetIntValue(i, "row");
+        int col = cdbttree->GetIntValue(i, "col");
+
+        MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey_from_coors(layer, stave, chip, row, col);
+        masked_pixels.insert(this_pixel_key);
+    }
+
+    // Copy the masked pixels to the hot pixel map
+    // m_hot_pixel_map.assign(masked_pixels.begin(), masked_pixels.end());
+    for (auto it = masked_pixels.begin(); it != masked_pixels.end(); it++)
+    {
+        m_hot_pixel_map.push_back(*it);
+    }
+
+    return;
+
+}
+
+void MvtxPixelMask::add_pixel(MvtxPixelDefs::pixelkey key)
+{
+    if (std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key) == m_hot_pixel_map.end())
+    {
+        m_hot_pixel_map.push_back(key);
+    }
+
+    return;
+}
+
+void MvtxPixelMask::remove_pixel(MvtxPixelDefs::pixelkey key)
+{
+    auto it = std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), key);
+    if (it != m_hot_pixel_map.end())
+    {
+        m_hot_pixel_map.erase(it);
+    }
+
+    return;
+}
+
+void MvtxPixelMask::clear()
+{
+    m_hot_pixel_map.clear();
+    return;
+}
+
+bool MvtxPixelMask::is_masked(MvtxRawHit* hit) const
+{
+    uint8_t layer = hit->get_layer_id();
+    uint8_t stave = hit->get_stave_id();
+    uint8_t chip = hit->get_chip_id();
+    uint16_t row = hit->get_row();
+    uint16_t col = hit->get_col();
+
+    // generate hit key and hitset key
+    const TrkrDefs::hitkey this_pixel_hitkey = MvtxDefs::genHitKey(col, row);
+    const TrkrDefs::hitsetkey this_pixel_hitsetkey = MvtxDefs::genHitSetKey(layer, stave, chip, 0);
+    MvtxPixelDefs::pixelkey this_pixel_key = MvtxPixelDefs::gen_pixelkey(this_pixel_hitsetkey, this_pixel_hitkey);
+
+    return std::find(m_hot_pixel_map.begin(), m_hot_pixel_map.end(), this_pixel_key) != m_hot_pixel_map.end();
+}

--- a/offline/packages/mvtx/MvtxPixelMask.h
+++ b/offline/packages/mvtx/MvtxPixelMask.h
@@ -1,0 +1,38 @@
+#ifndef MVTX_MVTXPIXELMASK_H
+#define MVTX_MVTXPIXELMASK_H
+
+#include "MvtxPixelDefs.h"
+
+#include <vector>
+#include <climits>
+#include <memory>
+
+class MvtxRawHit;
+
+class MvtxPixelMask
+{
+    public:
+
+        MvtxPixelMask(){}
+        ~MvtxPixelMask(){ clear();}
+
+        typedef std::vector<MvtxPixelDefs::pixelkey> hot_pixel_map_t;
+
+        void load_from_CDB();
+
+        void add_pixel(MvtxPixelDefs::pixelkey key);
+        void remove_pixel(MvtxPixelDefs::pixelkey key);
+        
+        void clear();
+
+        bool is_masked(MvtxRawHit* hit) const;
+
+        hot_pixel_map_t get_hot_pixel_map() const { return m_hot_pixel_map; }
+
+    private:
+
+        hot_pixel_map_t m_hot_pixel_map {};
+
+};
+
+#endif // MVTX_MVTXPIXELMASK_H

--- a/offline/packages/mvtx/MvtxPixelMask.h
+++ b/offline/packages/mvtx/MvtxPixelMask.h
@@ -3,36 +3,33 @@
 
 #include "MvtxPixelDefs.h"
 
-#include <vector>
 #include <climits>
 #include <memory>
+#include <vector>
 
 class MvtxRawHit;
 
 class MvtxPixelMask
 {
-    public:
+ public:
+  MvtxPixelMask() {}
+  ~MvtxPixelMask() { clear(); }
 
-        MvtxPixelMask(){}
-        ~MvtxPixelMask(){ clear();}
+  typedef std::vector<MvtxPixelDefs::pixelkey> hot_pixel_map_t;
 
-        typedef std::vector<MvtxPixelDefs::pixelkey> hot_pixel_map_t;
+  void load_from_CDB();
 
-        void load_from_CDB();
+  void add_pixel(MvtxPixelDefs::pixelkey key);
+  void remove_pixel(MvtxPixelDefs::pixelkey key);
 
-        void add_pixel(MvtxPixelDefs::pixelkey key);
-        void remove_pixel(MvtxPixelDefs::pixelkey key);
-        
-        void clear();
+  void clear();
 
-        bool is_masked(MvtxRawHit* hit) const;
+  bool is_masked(MvtxRawHit* hit) const;
 
-        hot_pixel_map_t get_hot_pixel_map() const { return m_hot_pixel_map; }
+  hot_pixel_map_t get_hot_pixel_map() const { return m_hot_pixel_map; }
 
-    private:
-
-        hot_pixel_map_t m_hot_pixel_map {};
-
+ private:
+  hot_pixel_map_t m_hot_pixel_map{};
 };
 
-#endif // MVTX_MVTXPIXELMASK_H
+#endif  // MVTX_MVTXPIXELMASK_H


### PR DESCRIPTION
…fline analysis

[comment]: <> (Please tell us something about this pull request)
Adding the following changes:
- Turned off the automatic offline pixel mask form the 2023 pixel mask.
- Added method to turn this function on/off
- Added a class to mask `MvtxRawHits` called `MvtxPixelMask`. This class can load a pixel mask from CDB
- Added a class to deal with MVTX pixels directly (`MvtxPixelDefs`)
 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

