### PR TITLE
fix: memory usage

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -811,7 +811,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
     {
       continue;
     }
-    if(diff > (m_RefBCO + m_mvtx_bco_range)/2.) 
+    if(diff > (m_RefBCO + m_mvtx_bco_range)) 
     {
       break;
     }
@@ -864,6 +864,7 @@ for (size_t p = 0; p < m_MvtxInputVector.size(); p++)
       allfeestagged++;
       h_tagBcoFelixAllFees_mvtx[pid]->Fill(refbcobitshift);
     }
+    feeset.clear();
   }
   if(allfeestagged == 12)
   {
@@ -873,6 +874,7 @@ for (size_t p = 0; p < m_MvtxInputVector.size(); p++)
   {
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
+  taggedPacketsFEEs.clear();
   while (m_MvtxRawHitMap.begin()->first <= select_crossings - m_mvtx_bco_range)
   {
     if (Verbosity() > 2)

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -136,14 +136,15 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   // QA histos
   TH1 *h_refbco_mvtx{nullptr};
   TH1 *h_taggedAllFelixes_mvtx{nullptr};
+  TH1 *h_taggedAllFelixesAllFees_mvtx{nullptr};
   TH1 *h_tagBcoFelix_mvtx[12]{nullptr};
 
   TH1 *h_bcoGL1LL1diff[12]{nullptr};
   TH1 *h_bcoLL1Strobediff[12]{nullptr};
   TH1 *h_tagStBcoFelix_mvtx[12]{nullptr};
   TH1 *h_tagBcoFelixAllFees_mvtx[12]{nullptr};
-  TH1 *h_tagBcoFelixFee_mvtx[12][12]{{nullptr}};
   TH1 *h_tagStBcoFEE_mvtx{nullptr};
+  
   TH1 *h_refbco_intt{nullptr};
   TH1 *h_taggedAll_intt{nullptr};
   TH1 *h_gl1tagged_intt[8]{nullptr};

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -11,7 +11,6 @@
 #include <ffarawobjects/MvtxRawHitv1.h>
 
 #include <frog/FROG.h>
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
@@ -25,7 +24,6 @@
 #include <cassert>
 #include <memory>
 #include <set>
-
 SingleMvtxPoolInput::SingleMvtxPoolInput(const std::string &name)
   : SingleStreamingInput(name)
 {
@@ -59,6 +57,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
       return;
     }
   }
+
   //  std::set<uint64_t> saved_beamclocks;
   while (GetSomeMoreEvents())
   {
@@ -130,18 +129,17 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
         {
           auto feeId = pool->iValue(i_fee, "FEEID");
           auto link = MvtxRawDefs::decode_feeid(feeId);
+
           //          auto hbfSize = plist[i]->iValue(feeId, "NR_HBF");
           auto num_strobes = pool->iValue(feeId, "NR_STROBES");
           auto num_L1Trgs = pool->iValue(feeId, "NR_PHYS_TRG");
-
           for (int iL1 = 0; iL1 < num_L1Trgs; ++iL1)
           {
             auto l1Trg_bco = pool->lValue(feeId, iL1, "L1_IR_BCO");
             //            auto l1Trg_bc  = plist[i]->iValue(feeId, iL1, "L1_IR_BC");
-            m_FeeGTML1BCOMap[i_fee].insert(l1Trg_bco);
+            m_FeeGTML1BCOMap[feeId].insert(l1Trg_bco);
             gtmL1BcoSet.emplace(l1Trg_bco);
           }
-
           m_FeeStrobeMap[feeId] += num_strobes;
           for (int i_strb{0}; i_strb < num_strobes; ++i_strb)
           {
@@ -166,7 +164,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
               std::cout << ", n_hits: " << num_hits << std::endl;
             }
             auto hits = pool->get_hits(feeId, i_strb);
-            for ( auto&& hit : hits )
+            for (auto &&hit : hits)
             {
               MvtxRawHit *newhit = new MvtxRawHitv1();
               newhit->set_bco(strb_bco);
@@ -306,7 +304,6 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
       gtmbcoset.erase(iter);
     }
   }
-
 }
 
 bool SingleMvtxPoolInput::CheckPoolDepth(const uint64_t bclk)
@@ -385,11 +382,10 @@ bool SingleMvtxPoolInput::GetSomeMoreEvents()
                   << (highest_bclk - m_MvtxRawHitMap.begin()->first)
                   << std::dec << std::endl;
         toerase.insert(bcliter.first);
-
       }
     }
   }
-  for(auto iter : toerase)
+  for (auto iter : toerase)
   {
     m_FEEBclkMap.erase(iter);
   }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -293,9 +293,12 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
 
   for (auto iter : toclearbclk)
   {
+    // these two are the culprits
     m_BclkStack.erase(iter);
     m_BeamClockFEE[iter].clear();
     m_BeamClockFEE.erase(iter);
+
+    m_MvtxRawHitMap[iter].clear();
     m_MvtxRawHitMap.erase(iter);
     m_FeeStrobeMap.erase(iter);
 
@@ -304,6 +307,20 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
       gtmbcoset.erase(iter);
     }
   }
+  std::cout << "Sizes are"<<std::endl;
+  std::cout << "  " << m_BclkStack.size() << ", " << m_BeamClockFEE.size()
+	    << ", " << m_MvtxRawHitMap.size() << ", " << m_FeeStrobeMap.size() 
+	    << ", " << m_FeeGTML1BCOMap.size() << std::endl;
+
+  for(auto [bbclk, hitvec] : m_MvtxRawHitMap)
+    {
+      std::cout << "hitvec size " << hitvec.size() << std::endl;
+    }
+  for(auto [ feeid, gtmbcoset] : m_FeeGTML1BCOMap)
+    {
+      std::cout << "gtmbcoset size " << gtmbcoset.size() << std::endl;
+    }
+
 }
 
 bool SingleMvtxPoolInput::CheckPoolDepth(const uint64_t bclk)

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -147,14 +147,13 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             uint64_t strb_bco = pool->lValue(feeId, i_strb, "TRG_IR_BCO");
             auto strb_bc = pool->iValue(feeId, i_strb, "TRG_IR_BC");
             auto num_hits = pool->iValue(feeId, i_strb, "TRG_NR_HITS");
-
             m_BclkStack.insert(strb_bco);
             m_FEEBclkMap[feeId] = strb_bco;
             if (strb_bco < minBCO)
             {
               continue;
             }
-
+            
             if (Verbosity() > 4)
             {
               std::cout << "evtno: " << EventSequence << ", Fee: " << feeId;
@@ -276,10 +275,8 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
     }
   }
 
-
   for (auto iter : toclearbclk)
   {
-    // these two are the culprits
     m_BclkStack.erase(iter);
     m_MvtxRawHitMap[iter].clear();
     m_MvtxRawHitMap.erase(iter);
@@ -290,19 +287,6 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
       gtmbcoset.erase(iter);
     }
   }
-  std::cout << "Sizes are"<<std::endl;
-  std::cout << "  " << m_BclkStack.size()
-	    << ", " << m_MvtxRawHitMap.size() << ", " << m_FeeStrobeMap.size() 
-	    << ", " << m_FeeGTML1BCOMap.size() << std::endl;
-
-  for(auto [bbclk, hitvec] : m_MvtxRawHitMap)
-    {
-      std::cout << "hitvec size " << hitvec.size() << std::endl;
-    }
-  for(auto [ feeid, gtmbcoset] : m_FeeGTML1BCOMap)
-    {
-      std::cout << "gtmbcoset size " << gtmbcoset.size() << std::endl;
-    }
 
 }
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -148,7 +148,6 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto strb_bc = pool->iValue(feeId, i_strb, "TRG_IR_BC");
             auto num_hits = pool->iValue(feeId, i_strb, "TRG_NR_HITS");
 
-            m_BeamClockFEE[strb_bco].insert(feeId);
             m_BclkStack.insert(strb_bco);
             m_FEEBclkMap[feeId] = strb_bco;
             if (strb_bco < minBCO)
@@ -221,17 +220,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
 void SingleMvtxPoolInput::Print(const std::string &what) const
 {
   // TODO: adapt to MVTX case
-  if (what == "ALL" || what == "FEE")
-  {
-    for (const auto &bcliter : m_BeamClockFEE)
-    {
-      std::cout << "Beam clock 0x" << std::hex << bcliter.first << std::dec << std::endl;
-      for (const auto feeiter : bcliter.second)
-      {
-        std::cout << "FEM: " << feeiter << std::endl;
-      }
-    }
-  }
+
   if (what == "ALL" || what == "FEEBCLK")
   {
     for (auto bcliter : m_FEEBclkMap)
@@ -286,18 +275,12 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
       break;
     }
   }
-  // for (auto iter :  m_BeamClockFEE)
-  // {
-  //   iter.second.clear();
-  // }
+
 
   for (auto iter : toclearbclk)
   {
     // these two are the culprits
     m_BclkStack.erase(iter);
-    m_BeamClockFEE[iter].clear();
-    m_BeamClockFEE.erase(iter);
-
     m_MvtxRawHitMap[iter].clear();
     m_MvtxRawHitMap.erase(iter);
     m_FeeStrobeMap.erase(iter);
@@ -308,7 +291,7 @@ void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
     }
   }
   std::cout << "Sizes are"<<std::endl;
-  std::cout << "  " << m_BclkStack.size() << ", " << m_BeamClockFEE.size()
+  std::cout << "  " << m_BclkStack.size()
 	    << ", " << m_MvtxRawHitMap.size() << ", " << m_FeeStrobeMap.size() 
 	    << ", " << m_FeeGTML1BCOMap.size() << std::endl;
 
@@ -359,7 +342,6 @@ void SingleMvtxPoolInput::ClearCurrentEvent()
   //  std::cout << "clearing bclk 0x" << std::hex << currentbclk << std::dec << std::endl;
   CleanupUsedPackets(currentbclk);
   // m_BclkStack.erase(currentbclk);
-  // m_BeamClockFEE.erase(currentbclk);
   return;
 }
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -25,17 +25,21 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
   void SetBcoRange(const unsigned int i) { m_BcoRange = i; }
-  unsigned int GetBcoRange() const { return m_BcoRange; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
-  void clearFeeGTML1BCOMap() { 
+  void clearFeeGTML1BCOMap(const uint64_t& bclk) { 
     for(auto& [key, set] : m_FeeGTML1BCOMap)
     {
-      set.clear();
+      for(auto& ll1bclk : set)
+      {
+        if(ll1bclk < bclk)
+        {
+          set.erase(ll1bclk);
+        }
+      }
     }
-    m_FeeGTML1BCOMap.clear(); 
   }
  protected:
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -29,15 +29,21 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
-  void clearFeeGTML1BCOMap(const uint64_t& bclk) { 
-    for(auto& [key, set] : m_FeeGTML1BCOMap)
+  void clearFeeGTML1BCOMap(const uint64_t& bclk) {
+    std::set<uint64_t> toerase;
+    for (auto &[key, set] : m_FeeGTML1BCOMap)
     {
       for(auto& ll1bclk : set)
       {
-        if(ll1bclk < bclk)
+        if(ll1bclk <= bclk)
         {
-          set.erase(ll1bclk);
+          // to avoid invalid reads
+          toerase.insert(ll1bclk);
         }
+      }
+      for(auto& bclk_to_erase : toerase)
+      {
+        set.erase(bclk_to_erase);
       }
     }
   }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -56,7 +56,6 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
 
-  std::map<uint64_t, std::set<int>> m_BeamClockFEE;
   std::map<uint64_t, std::vector<MvtxRawHit *>> m_MvtxRawHitMap;
   std::map<int, uint64_t> m_FEEBclkMap;
   std::map<int, uint64_t> m_FeeStrobeMap;


### PR DESCRIPTION
This reduces the memory growth of the mvtx pooler. There is still one set that needs to be improved upon but this at least gets us going, I think. Memory profile results before and after for 100 events
![memorybefore](https://github.com/user-attachments/assets/58989045-ab16-4bf6-b13f-31253d3c2380)
![memoryafter](https://github.com/user-attachments/assets/4a1ae58e-2e28-4cc3-9a5a-b86889fcfda1)


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

