### PR TITLE
set m_max_tpc_time_samples according to run number

### DIFF
--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -47,7 +47,7 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   virtual const std::map<int, std::set<uint64_t>>& BclkStackMap() const { return m_BclkStackPacketMap; }
   virtual const std::set<uint64_t>& BclkStack() const { return m_BclkStack; }
   virtual const std::map<uint64_t, std::set<int>>& BeamClockFEE() const { return m_BeamClockFEE; }
-  virtual void  SetRunParameters(const int runnumber) {return;}
+  virtual void  SetRunParameters(const int /*runnumber*/) {return;}
 
  protected:
   std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -47,7 +47,8 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   virtual const std::map<int, std::set<uint64_t>>& BclkStackMap() const { return m_BclkStackPacketMap; }
   virtual const std::set<uint64_t>& BclkStack() const { return m_BclkStack; }
   virtual const std::map<uint64_t, std::set<int>>& BeamClockFEE() const { return m_BeamClockFEE; }
- 
+  virtual void  SetRunParameters(const int runnumber) {return;}
+
  protected:
   std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
 

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -68,6 +68,7 @@ void SingleTpcPoolInput::FillPool(const unsigned int /*nbclks*/)
       std::cout << "Fetching next Event" << evt->getEvtSequence() << std::endl;
     }
     RunNumber(evt->getRunNumber());
+    SetRunParameters(RunNumber());
     if (GetVerbosity() > 1)
     {
       evt->identify();
@@ -441,6 +442,22 @@ void SingleTpcPoolInput::ConfigureStreamingInputManager()
   {
     StreamingInputManager()->SetTpcBcoRange(m_BcoRange);
     StreamingInputManager()->SetTpcNegativeBco(m_NegativeBco);
+  }
+  return;
+}
+
+void SingleTpcPoolInput::SetRunParameters(const int runnumber)
+{
+  if (m_max_tpc_time_samples == std::numeric_limits<unsigned int>::max())
+  {
+    if (runnumber < 41624)
+    {
+      m_max_tpc_time_samples = 420;
+    }
+    else
+    {
+      m_max_tpc_time_samples = 425;
+    }
   }
   return;
 }

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.h
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.h
@@ -30,13 +30,14 @@ class SingleTpcPoolInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
   const std::map<int, std::set<uint64_t>> &BclkStackMap() const override { return m_BclkStackPacketMap; }
+  void SetRunParameters(const int runnumber) override;
 
  private:
   Packet **plist{nullptr};
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
-  unsigned int m_max_tpc_time_samples = 425;
+  unsigned int m_max_tpc_time_samples {425};
   //! map bco to packet
   std::map<unsigned int, uint64_t> m_packet_bco;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This moves the run number dependent setting of tpc_time_samples to the tpc input manager when the run number is known

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

