### PR TITLE
Adding TPC OnlMon Plots to TpcRawHitQA Module 

### DIFF
--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -14,11 +14,13 @@
 #include <TProfile.h>
 #include <TProfile2D.h>
 #include <cassert>
+#include <cmath>
 
 //____________________________________________________________________________..
 TpcRawHitQA::TpcRawHitQA(const std::string &name)
   : SubsysReco(name)
 {
+  M.setMapNames("AutoPad-R1-RevA.sch.ChannelMapping.csv", "AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv", "AutoPad-R3-RevA.sch.ChannelMapping.csv");
 }
 
 //____________________________________________________________________________..
@@ -40,9 +42,18 @@ int TpcRawHitQA::InitRun(PHCompositeNode *topNode)
   {
     h_nhits_sectors[s] = dynamic_cast<TH1 *>(hm->getHisto(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s)).c_str()));
     h_nhits_sectors_fees[s] = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s) + "_fees").c_str()));
+    for (int r = 0; r < 3; r++)
+    {
+      h_nhits_sam[s][r] = dynamic_cast<TH1 *>(hm->getHisto(std::string(getHistoPrefix() + "nhits_sample_sec" + std::to_string(s) 
+                                              + "_R" + std::to_string(r)).c_str()));
+      h_adc[s][r] = dynamic_cast<TH1 *>(hm->getHisto(std::string(getHistoPrefix() + "adc_sec" + std::to_string(s) 
+                                              + "_R" + std::to_string(r)).c_str()));
+    }
   }
 
   h_bco = dynamic_cast<TH1 *>(hm->getHisto(std::string(getHistoPrefix() + "bco").c_str()));
+  h_xy_N = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "xyPos_North").c_str()));
+  h_xy_S = dynamic_cast<TH2 *>(hm->getHisto(std::string(getHistoPrefix() + "xyPos_South").c_str()));
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -69,10 +80,80 @@ int TpcRawHitQA::process_event(PHCompositeNode * /*unused*/)
     {
       auto hit = rawhitcont->get_hit(i);
       uint64_t bco = hit->get_gtm_bco();
+      uint16_t sam = hit->get_samples();
       int32_t packet_id = hit->get_packetid();
       int ep = (packet_id - 4000) % 10;
       int sector = (packet_id - 4000 - ep) / 10;
       uint16_t fee = hit->get_fee();
+      int channel = hit->get_channel();
+      int region = FEE_R[fee];
+      int feeM = FEE_map[fee];
+      if(FEE_R[fee]==2) feeM += 6;
+      if(FEE_R[fee]==3) feeM += 14;
+      double R = M.getR(feeM, channel);
+      double phi = 0;
+      if( sector < 12 ) //NS
+      {
+        phi = M.getPhi(feeM, channel) + (sector) * M_PI / 6 ;
+      }
+      else if( sector >= 12 ) //SS
+      {
+        phi = M.getPhi(feeM, channel) + (18 - sector ) * M_PI / 6 ; 
+      }
+
+      std::vector<int> values;
+      for (int sampleN = 0; sampleN < sam; sampleN++)
+      {
+        values.push_back((int) hit->get_adc(sampleN));
+      }     
+      std::sort(values.begin(), values.end());    
+      size_t size = values.size(); 
+      float median;
+      if (size % 2 == 0) 
+      {
+        median = (values[size / 2 - 1] + values[size / 2]) / 2.0;
+      } 
+      else 
+      {
+        median = values[size / 2];
+      }
+      std::vector<int> selectedValues;
+      for (int value : values) 
+      {
+        if (value >= median - 40 && value <= median + 40) selectedValues.push_back(value);
+      }
+
+      float stdDev = 3;
+      if(selectedValues.size() > 0 )
+      {
+        float mean = 0.0;
+        for (int value : selectedValues) 
+        {
+          mean += value;
+        }
+        mean /= selectedValues.size();
+        float sumSquares = 0.0;
+        for (int value : selectedValues)
+        {
+          float diff = value - mean;
+          sumSquares += std::pow(diff, 2);
+        }
+        float variance = sumSquares / selectedValues.size();
+        stdDev = std::sqrt(variance);
+      }
+
+
+      for (int sampleN = 0; sampleN < sam; sampleN++)
+      {
+        float adc = hit->get_adc(sampleN);
+        if (adc - median <= (std::max(5*stdDev, (float) 20.))) continue; 
+        
+        if (sector < 12) h_xy_N->Fill(R*cos(phi),R*sin(phi)); 
+        if (sector >= 12) h_xy_S->Fill(R*cos(phi),R*sin(phi)); 
+        h_nhits_sam[sector][region-1]->Fill(sampleN); 
+        h_adc[sector][region-1]->Fill(adc); 
+      }
+
       //hits.push_back( hit );
       bcos.push_back( bco );
       sectors.push_back( sector );
@@ -129,16 +210,37 @@ void TpcRawHitQA::createHistos()
 
   for (int s = 0; s < 24; s++)
   {
-    auto h = new TH1F(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s)).c_str(), 
-                      std::string("Number of Hits in Sector " + std::to_string(s) + ";Number of Hits;Entries").c_str(),100,0,10000);
-    hm->registerHisto(h);
-    auto h2 = new TH2F(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s) + "_fees").c_str(),
-                       std::string("Sector " + std::to_string(s) + " Fee Hit Distribution;FEE;Number of Hits").c_str(),26,-0.5,25.5,100,0,1000);
-    hm->registerHisto(h2);
+    {
+      auto h = new TH1F(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s)).c_str(), 
+                        std::string("Number of Hits in Sector " + std::to_string(s) + ";Number of Hits;Entries").c_str(),100,0,10000);
+      hm->registerHisto(h);
+    }
+    {
+      auto h = new TH2F(std::string(getHistoPrefix() + "nhits_sec" + std::to_string(s) + "_fees").c_str(),
+                         std::string("Sector " + std::to_string(s) + " Fee Hit Distribution;FEE;Number of Hits").c_str(),26,-0.5,25.5,100,0,1000);
+      hm->registerHisto(h);
+    }
+    for (int r = 0; r < 3; r++)
+    {
+      auto h = new TH1F(std::string(getHistoPrefix() + "nhits_sample_sec" + std::to_string(s) + "_R" + std::to_string(r)).c_str(),
+                         std::string("Sector " + std::to_string(s) + " Sample Time Distribution;Time Bin [1/20 MHz];Entries").c_str(),400,-0.5,399.5);
+      hm->registerHisto(h);
+      auto h2 = new TH1F(std::string(getHistoPrefix() + "adc_sec" + std::to_string(s) + "_R" + std::to_string(r)).c_str(),
+                         std::string("Sector " + std::to_string(s) + " ADC Distribution;ADC-pedestal [ADU];Entries").c_str(),281,-100,1024);
+      hm->registerHisto(h2);
+    }
   }
   
   {
     auto h = new TH1F(std::string(getHistoPrefix() + "bco").c_str(), "BCO distribution;BCO;Entries",100,0,TMath::Power( 2, 40 ));
+    hm->registerHisto(h);
+  }
+  {
+    auto h = new TH2F(std::string(getHistoPrefix() + "xyPos_North").c_str(), "Hit XY distribution (North);X [mm];Y [mm]",400,-800,800,400,-800,800);
+    hm->registerHisto(h);
+  }
+  {
+    auto h = new TH2F(std::string(getHistoPrefix() + "xyPos_South").c_str(), "Hit XY distribution (South);X [mm];Y [mm]",400,-800,800,400,-800,800);
     hm->registerHisto(h);
   }
 }

--- a/offline/QA/Tpc/TpcRawHitQA.h
+++ b/offline/QA/Tpc/TpcRawHitQA.h
@@ -6,6 +6,8 @@
 #include <fun4all/SubsysReco.h>
 #include <trackbase/TrkrDefs.h>
 
+#include <tpc/TpcMap.h>
+
 #include <ffarawobjects/TpcRawHitContainer.h>
 #include <ffarawobjects/TpcRawHit.h>
 
@@ -33,12 +35,20 @@ class TpcRawHitQA : public SubsysReco
   void createHistos();
   std::string getHistoPrefix() const;
 
+  TpcMap M;
+
   TpcRawHitContainer* rawhitcont{nullptr};
 
   TH1* h_nhits_sectors[24]{nullptr};
   TH2* h_nhits_sectors_fees[24]{nullptr};
+  TH1* h_nhits_sam[24][3]{{nullptr}};
+  TH1* h_adc[24][3]{{nullptr}};
   TH1* h_bco{nullptr};
+  TH2* h_xy_N{nullptr};
+  TH2* h_xy_S{nullptr};
 
+  int FEE_R[26]{2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
+  int FEE_map[26]{4, 5, 0, 2, 1, 11, 9, 10, 8, 7, 6, 0, 1, 3, 7, 6, 5, 4, 3, 2, 0, 2, 1, 3, 5, 4};
 };
 
 #endif  // TPCRAWHITQA_H


### PR DESCRIPTION
Adding plots for sector/region separated hit time sample distribution and adc distribution, and xy position for all hits iterated over. Note this does slow down the QA processing a little bit (we have to calculate the median and rms of each waveform), so if needed I can add in a flag to not create these histograms by default.
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

