### PR TITLE
feat: add settable raw hit node names

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -28,6 +28,7 @@ SingleInttPoolInput::SingleInttPoolInput(const std::string &name)
 {
   SubsystemEnum(InputManagerType::INTT);
   plist = new Packet *[1];
+  m_rawHitContainerName = "INTTRAWHIT";
 }
 
 SingleInttPoolInput::~SingleInttPoolInput()
@@ -383,11 +384,11 @@ void SingleInttPoolInput::CreateDSTNode(PHCompositeNode *topNode)
     detNode = new PHCompositeNode("INTT");
     dstNode->addNode(detNode);
   }
-  InttRawHitContainer *intthitcont = findNode::getClass<InttRawHitContainer>(detNode, "INTTRAWHIT");
+  InttRawHitContainer *intthitcont = findNode::getClass<InttRawHitContainer>(detNode, m_rawHitContainerName);
   if (!intthitcont)
   {
     intthitcont = new InttRawHitContainerv2();
-    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(intthitcont, "INTTRAWHIT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(intthitcont, m_rawHitContainerName, "PHObject");
     detNode->addNode(newNode);
   }
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -55,6 +55,7 @@ SingleMicromegasPoolInput::SingleMicromegasPoolInput(const std::string& name)
   : SingleStreamingInput(name)
 {
   SubsystemEnum(InputManagerType::MICROMEGAS);
+  m_rawHitContainerName = "MICROMEGASRAWHIT";
 }
 
 //______________________________________________________________
@@ -464,11 +465,11 @@ void SingleMicromegasPoolInput::CreateDSTNode(PHCompositeNode* topNode)
     dstNode->addNode(detNode);
   }
 
-  auto container = findNode::getClass<MicromegasRawHitContainer>(detNode, "MICROMEGASRAWHIT");
+  auto container = findNode::getClass<MicromegasRawHitContainer>(detNode, m_rawHitContainerName);
   if (!container)
   {
     container = new MicromegasRawHitContainerv1();
-    auto newNode = new PHIODataNode<PHObject>(container, "MICROMEGASRAWHIT", "PHObject");
+    auto newNode = new PHIODataNode<PHObject>(container, m_rawHitContainerName, "PHObject");
     detNode->addNode(newNode);
   }
 }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -28,6 +28,7 @@ SingleMvtxPoolInput::SingleMvtxPoolInput(const std::string &name)
   : SingleStreamingInput(name)
 {
   plist = new Packet *[2];
+  m_rawHitContainerName = "MVTXRAWHIT";
 }
 
 SingleMvtxPoolInput::~SingleMvtxPoolInput()
@@ -401,19 +402,19 @@ void SingleMvtxPoolInput::CreateDSTNode(PHCompositeNode *topNode)
     dstNode->addNode(detNode);
   }
 
-  MvtxRawEvtHeader *mvtxEH = findNode::getClass<MvtxRawEvtHeader>(detNode, "MVTXRAWEVTHEADER");
+  MvtxRawEvtHeader *mvtxEH = findNode::getClass<MvtxRawEvtHeader>(detNode, m_rawEventHeaderName);
   if (!mvtxEH)
   {
     mvtxEH = new MvtxRawEvtHeaderv2();
-    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(mvtxEH, "MVTXRAWEVTHEADER", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(mvtxEH, m_rawEventHeaderName, "PHObject");
     detNode->addNode(newNode);
   }
 
-  MvtxRawHitContainer *mvtxhitcont = findNode::getClass<MvtxRawHitContainer>(detNode, "MVTXRAWHIT");
+  MvtxRawHitContainer *mvtxhitcont = findNode::getClass<MvtxRawHitContainer>(detNode, m_rawHitContainerName);
   if (!mvtxhitcont)
   {
     mvtxhitcont = new MvtxRawHitContainerv1();
-    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(mvtxhitcont, "MVTXRAWHIT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(mvtxhitcont, m_rawHitContainerName, "PHObject");
     detNode->addNode(newNode);
   }
 }

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -27,7 +27,7 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void SetBcoRange(const unsigned int i) { m_BcoRange = i; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
-
+  void setRawEventHeaderName(const std::string &name) { m_rawEventHeaderName = name; }
   const std::map<int, std::set<uint64_t>>& getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
 
   void clearFeeGTML1BCOMap(const uint64_t& bclk) {
@@ -55,6 +55,7 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
+  std::string m_rawEventHeaderName = "MVTXRAWEVTHEADER";
 
   std::map<uint64_t, std::vector<MvtxRawHit *>> m_MvtxRawHitMap;
   std::map<int, uint64_t> m_FEEBclkMap;

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -47,9 +47,11 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   virtual const std::map<int, std::set<uint64_t>>& BclkStackMap() const { return m_BclkStackPacketMap; }
   virtual const std::set<uint64_t>& BclkStack() const { return m_BclkStack; }
   virtual const std::map<uint64_t, std::set<int>>& BeamClockFEE() const { return m_BeamClockFEE; }
- 
+  void setHitContainerName(const std::string &name) { m_rawHitContainerName = name; }
+
  protected:
   std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
+  std::string m_rawHitContainerName = "";
 
  private:
   Eventiterator *m_EventIterator{nullptr};

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -28,6 +28,7 @@ SingleTpcPoolInput::SingleTpcPoolInput(const std::string &name)
 {
   SubsystemEnum(InputManagerType::TPC);
   plist = new Packet *[NTPCPACKETS];
+  m_rawHitContainerName = "TPCRAWHIT";
 }
 
 SingleTpcPoolInput::~SingleTpcPoolInput()
@@ -426,11 +427,11 @@ void SingleTpcPoolInput::CreateDSTNode(PHCompositeNode *topNode)
     detNode = new PHCompositeNode("TPC");
     dstNode->addNode(detNode);
   }
-  TpcRawHitContainer *tpchitcont = findNode::getClass<TpcRawHitContainer>(detNode, "TPCRAWHIT");
+  TpcRawHitContainer *tpchitcont = findNode::getClass<TpcRawHitContainer>(detNode, m_rawHitContainerName);
   if (!tpchitcont)
   {
     tpchitcont = new TpcRawHitContainerv1();
-    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(tpchitcont, "TPCRAWHIT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(tpchitcont, m_rawHitContainerName, "PHObject");
     detNode->addNode(newNode);
   }
 }


### PR DESCRIPTION
This allows us to set the raw hit node names of the poolers from the macro level, for potential highly parallelized running. The unpackers actually already have this feature available, so the poolers were the only module missing it. The node names are defaulted to their current names, so this does not change any of the current default behavior.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

