### PR TITLE
fix: qa segfault

### DIFF
--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -114,6 +114,10 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode * /*topNode*/)
     {
       unsigned int trackkey = (*iter).second;
       SvtxTrack *track = _track_map->get(trackkey);
+      if(!track)
+      {
+        continue;
+      }
       crossing_tracks->insertWithKey(track, trackkey);
     }
 


### PR DESCRIPTION
The vertexer segfaults in the seed->vertex qa because some seeds are removed. This just adds a check to skip a track in the vertexing if it was removed in the seeding procedure.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

