### PR TITLE
Fix eta acceptance in `JetKinematicCheck`, adjust verbosity in `JetSeedCount`, and fix jet QA return codes.

### DIFF
--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -32,6 +32,7 @@ JetKinematicCheck::JetKinematicCheck(const std::string &moduleName,
   , m_recoJetNameR04(recojetnameR04)
   , m_recoJetNameR05(recojetnameR05)
   , m_histTag("AllTrig")
+  , m_restrictEtaRange(true)
   , m_etaRange(-1.1, 1.1)
   , m_ptRange(10, 100)
   , m_doTrgSelect(false)
@@ -232,6 +233,18 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
   // Loop over each reco jet radii from array
   for (int i = 0; i < n_radii; i++)
   {
+
+    // update eta range based on resolution parameter
+    std::pair<float, float> etaRangeUse;
+    if (m_restrictEtaRange)
+    {
+      etaRangeUse = {m_etaRange.first + m_radii[i], m_etaRange.second - m_radii[i]};
+    }
+    else
+    {
+      etaRangeUse = {m_etaRange.first, m_etaRange.second};
+    }
+
     std::string recoJetName = m_recoJetName_array[i];
 
     JetContainer *jets = findNode::getClass<JetContainer>(topNode, recoJetName);
@@ -246,7 +259,7 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
     // loop over jets
     for (auto jet : *jets)
     {
-      bool eta_cut = (jet->get_eta() >= m_etaRange.first) and (jet->get_eta() <= m_etaRange.second);
+      bool eta_cut = (jet->get_eta() >= etaRangeUse.first) and (jet->get_eta() <= etaRangeUse.second);
       bool pt_cut = (jet->get_pt() >= m_ptRange.first) and (jet->get_pt() <= m_ptRange.second);
       if ((not eta_cut) or (not pt_cut))
       {

--- a/offline/QA/Jet/JetKinematicCheck.cc
+++ b/offline/QA/Jet/JetKinematicCheck.cc
@@ -253,7 +253,7 @@ int JetKinematicCheck::process_event(PHCompositeNode *topNode)
       std::cout
           << "JetKinematicCheck::process_event - Error can not find DST Reco JetContainer node "
           << recoJetName << std::endl;
-      return Fun4AllReturnCodes::ABORTRUN;
+      return Fun4AllReturnCodes::EVENT_OK;
     }
 
     // loop over jets

--- a/offline/QA/Jet/JetKinematicCheck.h
+++ b/offline/QA/Jet/JetKinematicCheck.h
@@ -48,6 +48,12 @@ class JetKinematicCheck : public SubsysReco
     m_histTag = tag;
   }
 
+  // restrict eta range by rJet
+  void setRestrictEtaRange(const bool restrictEtaRange = true)
+  {
+    m_restrictEtaRange = restrictEtaRange;
+  }
+
   // specifies a trigger to require
   void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
   {
@@ -89,6 +95,9 @@ class JetKinematicCheck : public SubsysReco
   std::string m_recoJetNameR04;
   std::string m_recoJetNameR05;
   std::string m_histTag;
+
+  // cuts
+  bool m_restrictEtaRange;
   std::pair<double, double> m_etaRange;
   std::pair<double, double> m_ptRange;
 

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -38,7 +38,10 @@ JetSeedCount::JetSeedCount(const std::string &moduleName, const std::string &rec
 
 int JetSeedCount::Init(PHCompositeNode * /*topNode*/)
 {
-  std::cout << "JetSeedCount::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetSeedCount::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  }
   if (m_writeToOutputFile)
   {
     std::cout << "Opening output file named " << m_outputFileName << std::endl;
@@ -56,7 +59,10 @@ int JetSeedCount::Init(PHCompositeNode * /*topNode*/)
 //____________________________________________________________________________..
 int JetSeedCount::InitRun(PHCompositeNode * /*topNode*/)
 {
-  std::cout << "JetSeedCount::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetSeedCount::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -108,15 +114,18 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
   if (!vertexmap)
   {
     std::cout
-        << "JetKinematicCheck::process_event - Error can not find global vertex  node "
+        << "JetSeedCount::process_event - Error can not find global vertex  node "
         << std::endl;
     exit(-1);
   }
   if (vertexmap->empty())
   {
-    std::cout
-        << "JetKinematicCheck::process_event - global vertex node is empty "
-        << std::endl;
+    if (Verbosity() > 1)
+    {
+      std::cout
+          << "JetSeedCount::process_event - global vertex node is empty "
+          << std::endl;
+    }
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -187,7 +196,10 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int JetSeedCount::End(PHCompositeNode * /*topNode*/)
 {
-  std::cout << "JetSeedCount::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "JetSeedCount::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  }
   if (m_writeToOutputFile)
   {
     PHTFileServer::get().cd(m_outputFileName);

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -126,7 +126,7 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
           << "JetSeedCount::process_event - global vertex node is empty "
           << std::endl;
     }
-    return Fun4AllReturnCodes::ABORTEVENT;
+    return Fun4AllReturnCodes::EVENT_OK;
   }
 
   GlobalVertex *vtx = vertexmap->begin()->second;


### PR DESCRIPTION
This PR addresses three minor issues with the Jet QA:
1. It enables the user to restrict the eta range of analyzed jets by the resolution parameter in `JetKinematicCheck`;
2. It fixes the verbosity of debugging messages in `JetSeedCount`; and
3. It removes stray instances of `ABORTEVENT` and `ABORTRUN` event codes.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR is a small bug fix and does not introduce breaking changes.
