### PR TITLE
TpcSiliconQA Update to Remove TrackMap Usage

### DIFF
--- a/offline/QA/Tracking/TpcSiliconQA.cc
+++ b/offline/QA/Tracking/TpcSiliconQA.cc
@@ -22,13 +22,13 @@
 #include <boost/format.hpp>
 
 //____________________________________________________________________________..
-TpcSiliconQA::TpcSiliconQA(const std::string &name)
+TpcSiliconQA::TpcSiliconQA(const std::string& name)
   : SubsysReco(name)
 {
 }
 
 //____________________________________________________________________________..
-int TpcSiliconQA::InitRun(PHCompositeNode * /*topNode*/)
+int TpcSiliconQA::InitRun(PHCompositeNode* /*topNode*/)
 {
   createHistos();
 
@@ -36,7 +36,7 @@ int TpcSiliconQA::InitRun(PHCompositeNode * /*topNode*/)
 }
 
 //____________________________________________________________________________..
-int TpcSiliconQA::process_event(PHCompositeNode *topNode)
+int TpcSiliconQA::process_event(PHCompositeNode* topNode)
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
@@ -45,38 +45,44 @@ int TpcSiliconQA::process_event(PHCompositeNode *topNode)
   if (!silseedmap)
   {
     std::cout << "Silicon seed map not found, aborting event" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT; 
+    return Fun4AllReturnCodes::ABORTEVENT;
   }
   auto tpcseedmap = findNode::getClass<TrackSeedContainer>(topNode, "TpcTrackSeedContainer");
   if (!tpcseedmap)
   {
     std::cout << "TPC seed map not found, aborting event" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT; 
+    return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   for (const auto& silseed : *silseedmap)
   {
-    if (!silseed) continue;
+    if (!silseed)
+    {
+      continue;
+    }
 
     m_crossing = (float) silseed->get_crossing();
     h_crossing->Fill(m_crossing);
-    
+
     m_silseedx = silseed->get_x();
     m_silseedy = silseed->get_y();
     m_silseedz = silseed->get_z();
     m_silseedphi = silseed->get_phi();
     m_silseedeta = silseed->get_eta();
 
-    for (const auto& tpcseed : *tpcseedmap) 
+    for (const auto& tpcseed : *tpcseedmap)
     {
-      if (!tpcseed) continue;      
+      if (!tpcseed)
+      {
+        continue;
+      }
 
       m_tpcseedx = tpcseed->get_x();
       m_tpcseedy = tpcseed->get_y();
       m_tpcseedz = tpcseed->get_z();
       m_tpcseedphi = tpcseed->get_phi();
       m_tpcseedeta = tpcseed->get_eta();
-      
+
       h_phiDiff->Fill(m_tpcseedphi - m_silseedphi);
       h_etaDiff->Fill(m_tpcseedeta - m_silseedeta);
       h_xDiff->Fill(m_tpcseedx - m_silseedx);
@@ -84,14 +90,13 @@ int TpcSiliconQA::process_event(PHCompositeNode *topNode)
       h_zDiff->Fill(m_tpcseedz - m_silseedz);
     }
   }
- 
+
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int TpcSiliconQA::EndRun(const int /*runnumber*/)
 {
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -104,16 +109,16 @@ void TpcSiliconQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
- 
+
   {
-  h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),
-                      "Track Crossing Value", 1000, -500, 500);
-  h_crossing->GetXaxis()->SetTitle("Track Crossing");
-  h_crossing->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_crossing);
+    h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),
+                          "Track Crossing Value", 1000, -500, 500);
+    h_crossing->GetXaxis()->SetTitle("Track Crossing");
+    h_crossing->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_crossing);
   }
   /*
-  { 
+  {
   h_trackMatch = new TH1F(std::string(getHistoPrefix() + "trackMatch").c_str(),
                       "TPC and Silicon Seed Exist", 2, -0.5, 1.5);
   h_trackMatch->GetXaxis()->SetTitle("1 - TPC+Sil Seed, 0 - Missing TPC and/or Sil");
@@ -122,40 +127,40 @@ void TpcSiliconQA::createHistos()
   }
   */
   {
-  h_phiDiff = new TH1F(std::string(getHistoPrefix() + "phiDiff").c_str(),
-                      "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
-  h_phiDiff->GetXaxis()->SetTitle("TPC Seed #phi - Silicon Seed #phi");
-  h_phiDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_phiDiff);
+    h_phiDiff = new TH1F(std::string(getHistoPrefix() + "phiDiff").c_str(),
+                         "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
+    h_phiDiff->GetXaxis()->SetTitle("TPC Seed #phi - Silicon Seed #phi");
+    h_phiDiff->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_phiDiff);
   }
   {
-  h_etaDiff = new TH1F(std::string(getHistoPrefix() + "etaDiff").c_str(),
-                      "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
-  h_etaDiff->GetXaxis()->SetTitle("TPC Seed #eta - Silicon Seed #eta");
-  h_etaDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_etaDiff);
+    h_etaDiff = new TH1F(std::string(getHistoPrefix() + "etaDiff").c_str(),
+                         "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
+    h_etaDiff->GetXaxis()->SetTitle("TPC Seed #eta - Silicon Seed #eta");
+    h_etaDiff->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_etaDiff);
   }
   {
-  h_xDiff = new TH1F(std::string(getHistoPrefix() + "xDiff").c_str(),
-                      "TPC-Silicon x Difference", 100, -2, 2);
-  h_xDiff->GetXaxis()->SetTitle("TPC Seed x - Silicon Seed x [cm]");
-  h_xDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_xDiff);
+    h_xDiff = new TH1F(std::string(getHistoPrefix() + "xDiff").c_str(),
+                       "TPC-Silicon x Difference", 100, -2, 2);
+    h_xDiff->GetXaxis()->SetTitle("TPC Seed x - Silicon Seed x [cm]");
+    h_xDiff->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_xDiff);
   }
   {
-  h_yDiff = new TH1F(std::string(getHistoPrefix() + "yDiff").c_str(),
-                      "TPC-Silicon y Difference", 100, -2, 2);
-  h_yDiff->GetXaxis()->SetTitle("TPC Seed y - Silicon Seed y [cm]");
-  h_yDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_yDiff);
+    h_yDiff = new TH1F(std::string(getHistoPrefix() + "yDiff").c_str(),
+                       "TPC-Silicon y Difference", 100, -2, 2);
+    h_yDiff->GetXaxis()->SetTitle("TPC Seed y - Silicon Seed y [cm]");
+    h_yDiff->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_yDiff);
   }
   {
-  h_zDiff = new TH1F(std::string(getHistoPrefix() + "zDiff").c_str(),
-                      "TPC-Silicon z Difference", 500, -100, 100);
-  h_zDiff->GetXaxis()->SetTitle("TPC Seed z - Silicon Seed z [cm]");
-  h_zDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_zDiff);
-  } 
+    h_zDiff = new TH1F(std::string(getHistoPrefix() + "zDiff").c_str(),
+                       "TPC-Silicon z Difference", 500, -100, 100);
+    h_zDiff->GetXaxis()->SetTitle("TPC Seed z - Silicon Seed z [cm]");
+    h_zDiff->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_zDiff);
+  }
 
   return;
 }

--- a/offline/QA/Tracking/TpcSiliconQA.h
+++ b/offline/QA/Tracking/TpcSiliconQA.h
@@ -28,7 +28,6 @@ class TpcSiliconQA : public SubsysReco
  private:
   void createHistos();
 
-  std::string m_trackMapName = "SvtxTrackMap"; 
   float m_crossing = std::numeric_limits<float>::quiet_NaN();
   float m_silseedx = std::numeric_limits<float>::quiet_NaN();
   float m_silseedy = std::numeric_limits<float>::quiet_NaN();
@@ -45,7 +44,6 @@ class TpcSiliconQA : public SubsysReco
   int m_event = 0;
 
   TH1 *h_crossing = nullptr;
-  TH1 *h_trackMatch = nullptr;
   TH1 *h_phiDiff = nullptr;
   TH1 *h_etaDiff = nullptr;
   TH1 *h_xDiff = nullptr;


### PR DESCRIPTION
Will now iterate over SiliconSeedMap and TpcSeedMap directly 
Histograms will check x, y, z, eta, and phi differences between all seeds, not just track matches

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

