### PR TITLE
close TFiles from cdb after reading histo

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -26,12 +26,20 @@ double CaloWaveformFitting::template_function(double *x, double *par)
   return v1;
 }
 
+CaloWaveformFitting::~CaloWaveformFitting()
+{
+  delete h_template;
+}
+
 void CaloWaveformFitting::initialize_processing(const std::string &templatefile)
 {
   TFile *fin = TFile::Open(templatefile.c_str());
   assert(fin);
   assert(fin->IsOpen());
   h_template = static_cast<TProfile *>(fin->Get("waveform_template"));
+  h_template->SetDirectory(nullptr);
+  fin->Close();
+  delete fin;
   m_peakTimeTemp = h_template->GetBinCenter(h_template->GetMaximumBin());
   t = new ROOT::TThreadExecutor(_nthreads);
 }

--- a/offline/packages/CaloReco/CaloWaveformFitting.h
+++ b/offline/packages/CaloReco/CaloWaveformFitting.h
@@ -10,7 +10,7 @@ class CaloWaveformFitting
 {
  public:
   CaloWaveformFitting() = default;
-  ~CaloWaveformFitting() = default;
+  ~CaloWaveformFitting();
 
   void set_template_file(const std::string &template_input_file)
   {
@@ -67,26 +67,27 @@ class CaloWaveformFitting
   float stablepsinc(float t, std::vector<float> &vec_signal_samples);
 
   float psinc(float t, std::vector<float> &vec_signal_samples);
-  TProfile *h_template = nullptr;
   double template_function(double *x, double *par);
+
+  TProfile *h_template {nullptr};
+  double m_peakTimeTemp {0};
   int _nthreads{1};
   int _nzerosuppresssamples{2};
   int _nsoftwarezerosuppression{40};
 //  float _stepsize{0.001};
-  bool _bdosoftwarezerosuppression{false};
-  bool _maxsoftwarezerosuppression{false};
-  std::string m_template_input_file;
-  std::string url_template;
-  double m_peakTimeTemp = 0;
-  bool m_setTimeLim{false};
   float m_timeLim_low{-3.0};
   float m_timeLim_high{4.0};
-  float _chi2threshold = 100000;
-  float _chi2lowthreshold = 10000;
-  bool _dobitfliprecovery = false;
-  float _bfr_lowpedestalthreshold = 1200;
-  float _bfr_highpedestalthreshold = 4000;
+  float _chi2threshold {100000};
+  float _chi2lowthreshold {10000};
+  float _bfr_lowpedestalthreshold {1200};
+  float _bfr_highpedestalthreshold {4000};
+  bool _bdosoftwarezerosuppression{false};
+  bool _maxsoftwarezerosuppression{false};
+  bool m_setTimeLim{false};
+  bool _dobitfliprecovery {false};
 
+  std::string m_template_input_file;
+  std::string url_template;
   std::string url_onnx;
   std::string m_model_name;
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The waveform fitting never closed the files with the templates and therefore had always 3 files in cvmfs open. This PR now closes the files after copying the TProfile into memory

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

