### PR TITLE
Adding Geometric Cut Histograms to TpcSilisonQA

### DIFF
--- a/offline/QA/Tracking/TpcSiliconQA.cc
+++ b/offline/QA/Tracking/TpcSiliconQA.cc
@@ -82,31 +82,40 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
       m_tpcseedz = tpcseed->get_z();
       m_tpcseedphi = tpcseed->get_phi();
       m_tpcseedeta = tpcseed->get_eta();
-      
+
       h_phiDiff[0]->Fill(m_tpcseedphi - m_silseedphi);
       h_etaDiff[0]->Fill(m_tpcseedeta - m_silseedeta);
       h_xDiff[0]->Fill(m_tpcseedx - m_silseedx);
       h_yDiff[0]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[0]->Fill(m_tpcseedz - m_silseedz);
- 
-      if(abs(m_tpcseedx - m_silseedx) > m_xcut || abs(m_tpcseedy - m_silseedy) > m_ycut) continue;
-        
+
+      if (abs(m_tpcseedx - m_silseedx) > m_xcut || abs(m_tpcseedy - m_silseedy) > m_ycut)
+      {
+        continue;
+      }
+
       h_phiDiff[1]->Fill(m_tpcseedphi - m_silseedphi);
       h_etaDiff[1]->Fill(m_tpcseedeta - m_silseedeta);
       h_xDiff[1]->Fill(m_tpcseedx - m_silseedx);
       h_yDiff[1]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[1]->Fill(m_tpcseedz - m_silseedz);
-      
-      if(abs(m_tpcseedeta - m_silseedeta) > m_etacut) continue;
-       
+
+      if (abs(m_tpcseedeta - m_silseedeta) > m_etacut)
+      {
+        continue;
+      }
+
       h_phiDiff[2]->Fill(m_tpcseedphi - m_silseedphi);
       h_etaDiff[2]->Fill(m_tpcseedeta - m_silseedeta);
       h_xDiff[2]->Fill(m_tpcseedx - m_silseedx);
       h_yDiff[2]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[2]->Fill(m_tpcseedz - m_silseedz);
-      
-      if(abs(m_tpcseedphi - m_silseedphi) > m_phicut) continue;
-       
+
+      if (abs(m_tpcseedphi - m_silseedphi) > m_phicut)
+      {
+        continue;
+      }
+
       h_phiDiff[3]->Fill(m_tpcseedphi - m_silseedphi);
       h_etaDiff[3]->Fill(m_tpcseedeta - m_silseedeta);
       h_xDiff[3]->Fill(m_tpcseedx - m_silseedx);
@@ -134,11 +143,11 @@ void TpcSiliconQA::createHistos()
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  std::vector<std::string> cutNames = {"", "_xyCut", "_etaCut", "_phiCut"}; 
- 
+  std::vector<std::string> cutNames = {"", "_xyCut", "_etaCut", "_phiCut"};
+
   {
     h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),
-                        "Track Crossing Value", 1000, -500, 500);
+                          "Track Crossing Value", 1000, -500, 500);
     h_crossing->GetXaxis()->SetTitle("Track Crossing");
     h_crossing->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_crossing);
@@ -156,7 +165,7 @@ void TpcSiliconQA::createHistos()
   for (const std::string& name : cutNames)
   {
     h_phiDiff[i] = new TH1F(std::string(getHistoPrefix() + "phiDiff" + name).c_str(),
-                        "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
+                            "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
     h_phiDiff[i]->GetXaxis()->SetTitle("TPC Seed #phi - Silicon Seed #phi");
     h_phiDiff[i]->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_phiDiff[i]);
@@ -166,7 +175,7 @@ void TpcSiliconQA::createHistos()
   for (const std::string& name : cutNames)
   {
     h_etaDiff[i] = new TH1F(std::string(getHistoPrefix() + "etaDiff" + name).c_str(),
-                        "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
+                            "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
     h_etaDiff[i]->GetXaxis()->SetTitle("TPC Seed #eta - Silicon Seed #eta");
     h_etaDiff[i]->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_etaDiff[i]);
@@ -176,7 +185,7 @@ void TpcSiliconQA::createHistos()
   for (const std::string& name : cutNames)
   {
     h_xDiff[i] = new TH1F(std::string(getHistoPrefix() + "xDiff" + name).c_str(),
-                        "TPC-Silicon x Difference", 100, -2, 2);
+                          "TPC-Silicon x Difference", 100, -2, 2);
     h_xDiff[i]->GetXaxis()->SetTitle("TPC Seed x - Silicon Seed x [cm]");
     h_xDiff[i]->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_xDiff[i]);
@@ -186,7 +195,7 @@ void TpcSiliconQA::createHistos()
   for (const std::string& name : cutNames)
   {
     h_yDiff[i] = new TH1F(std::string(getHistoPrefix() + "yDiff" + name).c_str(),
-                       "TPC-Silicon y Difference", 100, -2, 2);
+                          "TPC-Silicon y Difference", 100, -2, 2);
     h_yDiff[i]->GetXaxis()->SetTitle("TPC Seed y - Silicon Seed y [cm]");
     h_yDiff[i]->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_yDiff[i]);
@@ -196,12 +205,12 @@ void TpcSiliconQA::createHistos()
   for (const std::string& name : cutNames)
   {
     h_zDiff[i] = new TH1F(std::string(getHistoPrefix() + "zDiff" + name).c_str(),
-                       "TPC-Silicon z Difference", 500, -100, 100);
+                          "TPC-Silicon z Difference", 500, -100, 100);
     h_zDiff[i]->GetXaxis()->SetTitle("TPC Seed z - Silicon Seed z [cm]");
     h_zDiff[i]->GetYaxis()->SetTitle("Entries");
     hm->registerHisto(h_zDiff[i]);
-    i++; 
-  } 
+    i++;
+  }
 
   return;
 }

--- a/offline/QA/Tracking/TpcSiliconQA.cc
+++ b/offline/QA/Tracking/TpcSiliconQA.cc
@@ -77,11 +77,35 @@ int TpcSiliconQA::process_event(PHCompositeNode *topNode)
       m_tpcseedphi = tpcseed->get_phi();
       m_tpcseedeta = tpcseed->get_eta();
       
-      h_phiDiff->Fill(m_tpcseedphi - m_silseedphi);
-      h_etaDiff->Fill(m_tpcseedeta - m_silseedeta);
-      h_xDiff->Fill(m_tpcseedx - m_silseedx);
-      h_yDiff->Fill(m_tpcseedy - m_silseedy);
-      h_zDiff->Fill(m_tpcseedz - m_silseedz);
+      h_phiDiff[0]->Fill(m_tpcseedphi - m_silseedphi);
+      h_etaDiff[0]->Fill(m_tpcseedeta - m_silseedeta);
+      h_xDiff[0]->Fill(m_tpcseedx - m_silseedx);
+      h_yDiff[0]->Fill(m_tpcseedy - m_silseedy);
+      h_zDiff[0]->Fill(m_tpcseedz - m_silseedz);
+ 
+      if(abs(m_tpcseedx - m_silseedx) > m_xcut || abs(m_tpcseedy - m_silseedy) > m_ycut) continue;
+        
+      h_phiDiff[1]->Fill(m_tpcseedphi - m_silseedphi);
+      h_etaDiff[1]->Fill(m_tpcseedeta - m_silseedeta);
+      h_xDiff[1]->Fill(m_tpcseedx - m_silseedx);
+      h_yDiff[1]->Fill(m_tpcseedy - m_silseedy);
+      h_zDiff[1]->Fill(m_tpcseedz - m_silseedz);
+      
+      if(abs(m_tpcseedeta - m_silseedeta) > m_etacut) continue;
+       
+      h_phiDiff[2]->Fill(m_tpcseedphi - m_silseedphi);
+      h_etaDiff[2]->Fill(m_tpcseedeta - m_silseedeta);
+      h_xDiff[2]->Fill(m_tpcseedx - m_silseedx);
+      h_yDiff[2]->Fill(m_tpcseedy - m_silseedy);
+      h_zDiff[2]->Fill(m_tpcseedz - m_silseedz);
+      
+      if(abs(m_tpcseedphi - m_silseedphi) > m_phicut) continue;
+       
+      h_phiDiff[3]->Fill(m_tpcseedphi - m_silseedphi);
+      h_etaDiff[3]->Fill(m_tpcseedeta - m_silseedeta);
+      h_xDiff[3]->Fill(m_tpcseedx - m_silseedx);
+      h_yDiff[3]->Fill(m_tpcseedy - m_silseedy);
+      h_zDiff[3]->Fill(m_tpcseedz - m_silseedz);
     }
   }
  
@@ -104,57 +128,65 @@ void TpcSiliconQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
+
+  std::vector<std::string> cutNames = {"", "_xyCut", "_etaCut", "_phiCut"}; 
  
   {
-  h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),
-                      "Track Crossing Value", 1000, -500, 500);
-  h_crossing->GetXaxis()->SetTitle("Track Crossing");
-  h_crossing->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_crossing);
+    h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),
+                        "Track Crossing Value", 1000, -500, 500);
+    h_crossing->GetXaxis()->SetTitle("Track Crossing");
+    h_crossing->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_crossing);
   }
-  /*
-  { 
-  h_trackMatch = new TH1F(std::string(getHistoPrefix() + "trackMatch").c_str(),
-                      "TPC and Silicon Seed Exist", 2, -0.5, 1.5);
-  h_trackMatch->GetXaxis()->SetTitle("1 - TPC+Sil Seed, 0 - Missing TPC and/or Sil");
-  h_trackMatch->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_trackMatch);
-  }
-  */
+  int i = 0;
+  for (const std::string& name : cutNames)
   {
-  h_phiDiff = new TH1F(std::string(getHistoPrefix() + "phiDiff").c_str(),
-                      "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
-  h_phiDiff->GetXaxis()->SetTitle("TPC Seed #phi - Silicon Seed #phi");
-  h_phiDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_phiDiff);
+    h_phiDiff[i] = new TH1F(std::string(getHistoPrefix() + "phiDiff" + name).c_str(),
+                        "TPC-Silicon #phi Difference", 100, -0.5, 0.5);
+    h_phiDiff[i]->GetXaxis()->SetTitle("TPC Seed #phi - Silicon Seed #phi");
+    h_phiDiff[i]->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_phiDiff[i]);
+    i++;
   }
+  i = 0;
+  for (const std::string& name : cutNames)
   {
-  h_etaDiff = new TH1F(std::string(getHistoPrefix() + "etaDiff").c_str(),
-                      "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
-  h_etaDiff->GetXaxis()->SetTitle("TPC Seed #eta - Silicon Seed #eta");
-  h_etaDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_etaDiff);
+    h_etaDiff[i] = new TH1F(std::string(getHistoPrefix() + "etaDiff" + name).c_str(),
+                        "TPC-Silicon #eta Difference", 100, -0.1, 0.1);
+    h_etaDiff[i]->GetXaxis()->SetTitle("TPC Seed #eta - Silicon Seed #eta");
+    h_etaDiff[i]->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_etaDiff[i]);
+    i++;
   }
+  i = 0;
+  for (const std::string& name : cutNames)
   {
-  h_xDiff = new TH1F(std::string(getHistoPrefix() + "xDiff").c_str(),
-                      "TPC-Silicon x Difference", 100, -2, 2);
-  h_xDiff->GetXaxis()->SetTitle("TPC Seed x - Silicon Seed x [cm]");
-  h_xDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_xDiff);
+    h_xDiff[i] = new TH1F(std::string(getHistoPrefix() + "xDiff" + name).c_str(),
+                        "TPC-Silicon x Difference", 100, -2, 2);
+    h_xDiff[i]->GetXaxis()->SetTitle("TPC Seed x - Silicon Seed x [cm]");
+    h_xDiff[i]->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_xDiff[i]);
+    i++;
   }
+  i = 0;
+  for (const std::string& name : cutNames)
   {
-  h_yDiff = new TH1F(std::string(getHistoPrefix() + "yDiff").c_str(),
-                      "TPC-Silicon y Difference", 100, -2, 2);
-  h_yDiff->GetXaxis()->SetTitle("TPC Seed y - Silicon Seed y [cm]");
-  h_yDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_yDiff);
+    h_yDiff[i] = new TH1F(std::string(getHistoPrefix() + "yDiff" + name).c_str(),
+                       "TPC-Silicon y Difference", 100, -2, 2);
+    h_yDiff[i]->GetXaxis()->SetTitle("TPC Seed y - Silicon Seed y [cm]");
+    h_yDiff[i]->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_yDiff[i]);
+    i++;
   }
+  i = 0;
+  for (const std::string& name : cutNames)
   {
-  h_zDiff = new TH1F(std::string(getHistoPrefix() + "zDiff").c_str(),
-                      "TPC-Silicon z Difference", 500, -100, 100);
-  h_zDiff->GetXaxis()->SetTitle("TPC Seed z - Silicon Seed z [cm]");
-  h_zDiff->GetYaxis()->SetTitle("Entries");
-  hm->registerHisto(h_zDiff);
+    h_zDiff[i] = new TH1F(std::string(getHistoPrefix() + "zDiff" + name).c_str(),
+                       "TPC-Silicon z Difference", 500, -100, 100);
+    h_zDiff[i]->GetXaxis()->SetTitle("TPC Seed z - Silicon Seed z [cm]");
+    h_zDiff[i]->GetYaxis()->SetTitle("Entries");
+    hm->registerHisto(h_zDiff[i]);
+    i++; 
   } 
 
   return;

--- a/offline/QA/Tracking/TpcSiliconQA.h
+++ b/offline/QA/Tracking/TpcSiliconQA.h
@@ -25,6 +25,11 @@ class TpcSiliconQA : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
 
+  void setXCut(float cutVal) {m_xcut = cutVal;}
+  void setYCut(float cutVal) {m_ycut = cutVal;}
+  void setEtaCut(float cutVal) {m_etacut = cutVal;}
+  void setPhiCut(float cutVal) {m_phicut = cutVal;}
+
  private:
   void createHistos();
 
@@ -40,15 +45,20 @@ class TpcSiliconQA : public SubsysReco
   float m_tpcseedphi = std::numeric_limits<float>::quiet_NaN();
   float m_tpcseedeta = std::numeric_limits<float>::quiet_NaN();
 
+  float m_xcut = 1.0;
+  float m_ycut = 1.0;
+  float m_etacut = 0.05;
+  float m_phicut = 0.25;
+
   std::string getHistoPrefix() const;
   int m_event = 0;
 
   TH1 *h_crossing = nullptr;
-  TH1 *h_phiDiff = nullptr;
-  TH1 *h_etaDiff = nullptr;
-  TH1 *h_xDiff = nullptr;
-  TH1 *h_yDiff = nullptr;
-  TH1 *h_zDiff = nullptr; 
+  TH1 *h_phiDiff[4] = {nullptr};
+  TH1 *h_etaDiff[4] = {nullptr};
+  TH1 *h_xDiff[4] = {nullptr};
+  TH1 *h_yDiff[4] = {nullptr};
+  TH1 *h_zDiff[4] = {nullptr}; 
 };
 
 #endif  // QA_TRACKING_TPCSILICONQA_H


### PR DESCRIPTION
Adding histograms with progressive geometric cuts that the user can specify to narrow down the selection of TPC and Silicon seeds that get matched (now that we iterate over all TPC and Silicon seeds instead of only pulling from those placed together in a track)
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

