### PR TITLE
Tpc residuals

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -783,8 +783,8 @@ int TrackResiduals::End(PHCompositeNode* /*unused*/)
   {
     m_hittree->Write();
   }
-  m_vertextree->Write();
-  m_failedfits->Write();
+  // m_vertextree->Write();
+  // m_failedfits->Write();
   m_outfile->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -2026,7 +2026,10 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
         }
       }
     }
-    m_tree->Fill();
+
+    if( m_nmms>0 || !m_doMicromegasOnly )
+    { m_tree->Fill(); }
+
   }  // end loop over tracks
 
   if (m_doFailedSeeds)

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -773,9 +773,6 @@ void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
 //____________________________________________________________________________..
 int TrackResiduals::End(PHCompositeNode* /*unused*/)
 {
-
-  std::cout << "TrackResiduals::End - m_goodtracks: " << m_goodtracks << std::endl;
-
   m_outfile->cd();
   m_tree->Write();
   if (m_doClusters)
@@ -1969,12 +1966,6 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
 
       // add the global positions to a vector to give to the cluster mover
       global_raw.emplace_back(std::make_pair(ckey, global));
-
-      std::cout << "TrackResiduals::fillResidualTreeKF -"
-        << " track id: " << m_trackid
-        << " layer: " << (int) TrkrDefs::getLayer(ckey)
-        << " position: " << global.x() << "," << global.y() << "," << global.z()
-        << std::endl;
     }
 
     // move the cluster positions back to the original readout surface in the fillClusterBranchesKF method
@@ -2038,11 +2029,6 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
 
     if( m_nmms>0 || !m_doMicromegasOnly )
     { m_tree->Fill(); }
-
-
-    // count good tracks
-    if( m_pt>0.2 && m_quality<100 && m_ntpc>20 && m_nmaps>2 && m_nintt>1 && m_nmms>0 )
-    { ++m_goodtracks; }
 
   }  // end loop over tracks
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -786,8 +786,8 @@ int TrackResiduals::End(PHCompositeNode* /*unused*/)
   {
     m_hittree->Write();
   }
-  // m_vertextree->Write();
-  // m_failedfits->Write();
+  m_vertextree->Write();
+  m_failedfits->Write();
   m_outfile->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -58,6 +58,8 @@ class TrackResiduals : public SubsysReco
   void failedTree() { m_doFailedSeeds = true; }
   void setSegment(const int segment) { m_segment = segment; }
 
+  void set_doMicromegasOnly( bool value ) { m_doMicromegasOnly = value; }
+
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
                              TrkrCluster *cluster, ActsGeometry *geometry);
@@ -98,6 +100,7 @@ class TrackResiduals : public SubsysReco
   bool m_doHits = false;
   bool m_zeroField = false;
   bool m_doFailedSeeds = false;
+  
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
   TpcClusterMover m_clusterMover;
 
@@ -112,6 +115,8 @@ class TrackResiduals : public SubsysReco
   bool m_convertSeeds = false;
   bool m_linefitTPCOnly = true;
   bool m_dropClustersNoState = false;
+
+  bool m_doMicromegasOnly = false;
 
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -100,7 +100,7 @@ class TrackResiduals : public SubsysReco
   bool m_doHits = false;
   bool m_zeroField = false;
   bool m_doFailedSeeds = false;
-  
+
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
   TpcClusterMover m_clusterMover;
 
@@ -117,6 +117,10 @@ class TrackResiduals : public SubsysReco
   bool m_dropClustersNoState = false;
 
   bool m_doMicromegasOnly = false;
+
+
+  /// count number of good tracks, for debugging
+  int m_goodtracks = 0;
 
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();
@@ -168,7 +172,7 @@ class TrackResiduals : public SubsysReco
   float m_dcaxy = std::numeric_limits<float>::quiet_NaN();
   float m_dcaz = std::numeric_limits<float>::quiet_NaN();
   float m_tracklength = std::numeric_limits<float>::quiet_NaN();
-  
+
   float m_silseedx = std::numeric_limits<float>::quiet_NaN();
   float m_silseedy = std::numeric_limits<float>::quiet_NaN();
   float m_silseedz = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -118,10 +118,6 @@ class TrackResiduals : public SubsysReco
 
   bool m_doMicromegasOnly = false;
 
-
-  /// count number of good tracks, for debugging
-  int m_goodtracks = 0;
-
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();
   int m_runnumber = std::numeric_limits<int>::quiet_NaN();

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -257,8 +257,7 @@ bool PHTpcResiduals::checkTrack(SvtxTrack* track) const
   {
     return false;
   }
-  if (m_useMicromegas && count_clusters<TrkrDefs::micromegasId>(cluster_keys) < 1)
-    // if (m_useMicromegas && count_clusters<TrkrDefs::micromegasId>(cluster_keys) < 2)
+  if (m_useMicromegas && count_clusters<TrkrDefs::micromegasId>(cluster_keys) < 2)
   {
     return false;
   }
@@ -547,16 +546,16 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
       std::cout << std::endl;
     }
 
-//     // check track angles and residuals agains cuts
-//     if (std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
-//     {
-//       continue;
-//     }
-//
-//     if (std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
-//     {
-//       continue;
-//     }
+    // check track angles and residuals agains cuts
+    if (std::abs(trackAlpha) > m_maxTAlpha || std::abs(drphi) > m_maxResidualDrphi)
+    {
+      continue;
+    }
+
+    if (std::abs(trackBeta) > m_maxTBeta || std::abs(dz) > m_maxResidualDz)
+    {
+      continue;
+    }
 
     // Fill distortion matrices
     m_matrix_container->add_to_lhs(index, 0, 0, clusR / erp);

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -18,7 +18,7 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
-#include <trackbase_historic/SvtxTrackState_v1.h>
+#include <trackbase_historic/SvtxTrackState_v2.h>
 
 #include <trackreco/ActsPropagator.h>
 
@@ -589,7 +589,7 @@ void PHTpcResiduals::addTrackState(SvtxTrack* track, TrkrDefs::cluskey key, floa
   /* this is essentially a copy of the code from trackbase_historic/ActsTransformations::fillSvtxTrackStates */
 
   // create track state
-  SvtxTrackState_v1 state(pathlength);
+  SvtxTrackState_v2 state(pathlength);
 
   // save global position
   const auto global = params.position(m_tGeometry->geometry().getGeoContext());

--- a/offline/packages/tpccalib/PHTpcResiduals.h
+++ b/offline/packages/tpccalib/PHTpcResiduals.h
@@ -140,6 +140,7 @@ class PHTpcResiduals : public SubsysReco
   TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
 
   // distortion corrections
+  TpcDistortionCorrectionContainer *m_dcc_module_edge = nullptr;
   TpcDistortionCorrectionContainer *m_dcc_static = nullptr;
   TpcDistortionCorrectionContainer *m_dcc_average = nullptr;
   TpcDistortionCorrectionContainer *m_dcc_fluctuation = nullptr;

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -1149,6 +1149,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
       // create new svtx state and add to track
       auto state = create_track_state(pathlength, &gf_state);
+      state.set_cluskey(cluster_key);
       out_track->insert_state(&state);
     }
   }

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -53,7 +53,7 @@
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackMap_v2.h>
 #include <trackbase_historic/SvtxTrackState.h>  // for SvtxTrackState
-#include <trackbase_historic/SvtxTrackState_v1.h>
+#include <trackbase_historic/SvtxTrackState_v2.h>
 #include <trackbase_historic/SvtxTrack_v4.h>
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
@@ -108,10 +108,10 @@ namespace
     return x * x;
   }
 
-  // convert gf state to SvtxTrackState_v1
-  SvtxTrackState_v1 create_track_state(float pathlength, const genfit::MeasuredStateOnPlane* gf_state)
+  // convert gf state to SvtxTrackState_v2
+  SvtxTrackState_v2 create_track_state(float pathlength, const genfit::MeasuredStateOnPlane* gf_state)
   {
-    SvtxTrackState_v1 out(pathlength);
+    SvtxTrackState_v2 out(pathlength);
     out.set_x(gf_state->getPos().x());
     out.set_y(gf_state->getPos().y());
     out.set_z(gf_state->getPos().z());
@@ -834,7 +834,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
     so that the track state list is never empty. Note that insert_state, despite taking a pointer as argument,
     does not take ownership of the state
     */
-    SvtxTrackState_v1 first(0.0);
+    SvtxTrackState_v2 first(0.0);
     out_track->insert_state(&first);
   }
 
@@ -1031,6 +1031,7 @@ std::shared_ptr<SvtxTrack> PHGenFitTrkFitter::MakeSvtxTrack(const SvtxTrack* svt
 
     // create new svtx state and add to track
     auto state = create_track_state(pathlength, gf_state);
+
     out_track->insert_state(&state);
 
 #ifdef _DEBUG_


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This pull request fixes the use of extrapolated TrackState in the TPC for GitHub and PHTpcResiduals, so that they are properly dealt with in the TrackResiduals evaluation module. 
In particular it makes use of SvtxTrackState_v2, and properly assign cluster keys to track state (needed to form residuals later on).
It also adds module_edge correction to PHTpcResiduals. There are other places where the module_edge correction is missing. It will be part of a separate commit once this one is merged.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

