### PR TITLE
Add number of states for each subsystem to residualtree

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -421,9 +421,13 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
     m_tpcseedcharge = tpcseed->get_qOverR() > 0 ? 1 : -1;
     m_dedx = calc_dedx(tpcseed, clustermap, tpcGeo);
     m_nmaps = 0;
+    m_nmapsstate = 0;
     m_nintt = 0;
+    m_ninttstate = 0;
     m_ntpc = 0;
+    m_ntpcstate = 0;
     m_nmms = 0;
+    m_nmmsstate = 0;
     clearClusterStateVectors();
     for (auto tseed : {silseed, tpcseed})
     {
@@ -1071,6 +1075,24 @@ if(Verbosity() > 1)
     {
       if(Verbosity() > 1)  {  std::cout << "   no state for cluster " << ckey << "  in layer " << layer << std::endl; }
     }
+  else
+    {
+      switch (TrkrDefs::getTrkrId(ckey))
+	{
+	case TrkrDefs::mvtxId:
+	  m_nmapsstate++;
+	  break;
+	case TrkrDefs::inttId:
+	  m_ninttstate++;
+	  break;
+	case TrkrDefs::tpcId:
+	  m_ntpcstate++;
+	  break;
+	case TrkrDefs::micromegasId:
+	  m_nmmsstate++;
+	  break;
+	}
+    }
   
   m_cluskeys.push_back(ckey);
 
@@ -1699,9 +1721,13 @@ void TrackResiduals::createBranches()
   m_tree->Branch("ndf", &m_ndf, "m_ndf/F");
   m_tree->Branch("nhits", &m_nhits, "m_nhits/I");
   m_tree->Branch("nmaps", &m_nmaps, "m_nmaps/I");
+  m_tree->Branch("nmapsstate", &m_nmapsstate, "m_nmapsstate/I");
   m_tree->Branch("nintt", &m_nintt, "m_nintt/I");
+  m_tree->Branch("ninttstate", &m_ninttstate, "m_ninttstate/I");
   m_tree->Branch("ntpc", &m_ntpc, "m_ntpc/I");
+  m_tree->Branch("ntpcstate", &m_ntpcstate, "m_ntpcstate/I");
   m_tree->Branch("nmms", &m_nmms, "m_nmms/I");
+  m_tree->Branch("nmmsstate", &m_nmmsstate, "m_nmmsstate/I");
   m_tree->Branch("tile", &m_tileid, "m_tileid/I");
   m_tree->Branch("vertexid", &m_vertexid, "m_vertexid/I");
   m_tree->Branch("vertex_crossing", &m_vertex_crossing, "m_vertex_crossing/I");
@@ -1849,9 +1875,13 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
     m_ndf = track->get_ndf();
 
     m_nmaps = 0;
+    m_nmapsstate = 0;
     m_nintt = 0;
+    m_ninttstate = 0;
     m_ntpc = 0;
+    m_ntpcstate = 0;
     m_nmms = 0;
+    m_nmmsstate = 0;
     m_silid = std::numeric_limits<unsigned int>::quiet_NaN();
     m_tpcid = std::numeric_limits<unsigned int>::quiet_NaN();
     m_silseedx = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -140,9 +140,13 @@ class TrackResiduals : public SubsysReco
   float m_ndf = std::numeric_limits<float>::quiet_NaN();
   int m_nhits = std::numeric_limits<int>::quiet_NaN();
   int m_nmaps = std::numeric_limits<int>::quiet_NaN();
+  int m_nmapsstate = std::numeric_limits<int>::quiet_NaN();
   int m_nintt = std::numeric_limits<int>::quiet_NaN();
+  int m_ninttstate = std::numeric_limits<int>::quiet_NaN();
   int m_ntpc = std::numeric_limits<int>::quiet_NaN();
+  int m_ntpcstate = std::numeric_limits<int>::quiet_NaN();
   int m_nmms = std::numeric_limits<int>::quiet_NaN();
+  int m_nmmsstate = std::numeric_limits<int>::quiet_NaN();
   unsigned int m_vertexid = std::numeric_limits<unsigned int>::quiet_NaN();
   int m_vertex_crossing = std::numeric_limits<int>::quiet_NaN();
   float m_vx = std::numeric_limits<float>::quiet_NaN();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adding the number of states to the residualtree for the KF case. Shows when the track seed contains clusters but the Acts fit did not use the measurement.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

