### PR TITLE
yuxd: add dummy SiliconTrackSeedContainer

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -289,7 +289,7 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
   if (!_track_map_silicon)
   {
     cerr << PHWHERE << " ERROR: Can't find SiliconTrackSeedContainer " << endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
+    //return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   _track_map = findNode::getClass<TrackSeedContainer>(topNode, _track_map_name);
@@ -328,6 +328,15 @@ int PHSiliconTpcTrackMatching::GetNodes(PHCompositeNode *topNode)
     _svtx_seed_map = new TrackSeedContainer_v1();
     PHIODataNode<PHObject> *node = new PHIODataNode<PHObject>(_svtx_seed_map, "SvtxTrackSeedContainer", "PHObject");
     svtxNode->addNode(node);
+
+    // create a dummy SiliconTrackSeedContainer
+    if (!_track_map_silicon)
+    {
+      _track_map_silicon = new TrackSeedContainer_v1();
+      PHIODataNode<PHObject>* trackNode =
+          new PHIODataNode<PHObject>(_track_map_silicon, _silicon_track_map_name, "PHObject");
+      svtxNode->addNode(trackNode);
+    }
   }
 
   _cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Previous PHSiliconTpcTrackMatching.cc requires SiliconTrackSeedContainer must exist, otherwise, return abortevent. In this PR, abortevent is commented, and create a dummy SiliconTrackSeedContainer if there is no silicon seed, which allows TPC-only tracks reconstruction without silicon.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

