### PR TITLE
no skipping of zero hit events after initial syncing to gl1 bco

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -104,17 +104,20 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
     {
       exit(1);
     }
-    for (int i = 0; i < npackets; i++)
+    if (m_SkipEarlyEvents)
     {
-      int numBCOs = plist[i]->iValue(0, "NR_BCOS");
-      for (int j = 0; j < numBCOs; j++)
+      for (int i = 0; i < npackets; i++)
       {
-        uint64_t bco = plist[i]->lValue(j, "BCOLIST");
-        if (bco < minBCO)
-        {
-          continue;
-        }
-        m_SkipEarlyEvents = false;
+	int numBCOs = plist[i]->iValue(0, "NR_BCOS");
+	for (int j = 0; j < numBCOs; j++)
+	{
+	  uint64_t bco = plist[i]->lValue(j, "BCOLIST");
+	  if (bco < minBCO)
+	  {
+	    continue;
+	  }
+	  m_SkipEarlyEvents = false;
+	}
       }
     }
     if (m_SkipEarlyEvents)

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -86,7 +86,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
     if (evt->getEvtType() != DATAEVENT)
     {
       m_NumSpecialEvents++;
-      if(evt->getEvtType() == ENDRUNEVENT)
+      if (evt->getEvtType() == ENDRUNEVENT)
       {
         std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
         delete evt;
@@ -104,26 +104,24 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
     {
       exit(1);
     }
-    bool skipthis = true;
-
-    for (int i = 0 ; i< npackets; i++)
+    for (int i = 0; i < npackets; i++)
     {
-       int numBCOs = plist[i]->iValue(0, "NR_BCOS");
-       for (int j = 0; j < numBCOs; j++)
-       {
-	 uint64_t bco = plist[i]->lValue(j, "BCOLIST");
-	 if (bco < minBCO)
-	 {
-	   continue;
-	 }
-	 skipthis = false;
-       }
-    }
-    if (skipthis)
-    {
-      for (int i = 0 ; i< npackets; i++)
+      int numBCOs = plist[i]->iValue(0, "NR_BCOS");
+      for (int j = 0; j < numBCOs; j++)
       {
-	delete plist[i];
+        uint64_t bco = plist[i]->lValue(j, "BCOLIST");
+        if (bco < minBCO)
+        {
+          continue;
+        }
+        m_SkipEarlyEvents = false;
+      }
+    }
+    if (m_SkipEarlyEvents)
+    {
+      for (int i = 0; i < npackets; i++)
+      {
+        delete plist[i];
       }
       delete evt;
       continue;
@@ -164,87 +162,87 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
           std::cout << "Number of Hits: " << num_hits << " for packet "
                     << pool->getIdentifier() << std::endl;
         }
-        
-       int numBCOs = pool->iValue(0, "NR_BCOS");
-       uint64_t largest_bco = 0;
-         for (int j = 0; j < numBCOs; j++)
-         {
-           uint64_t bco = pool->lValue(j, "BCOLIST");
-	   if (largest_bco < bco)
-	   {
-	     largest_bco = bco;
-	   }
-	   if (bco < minBCO)
-	   {
-	     continue;
-	   }
-	   skipthis = false;
-           m_BclkStack.insert(bco);
-           m_BclkStackPacketMap[packet_id].insert(bco);
-         }
-	 if (skipthis)
-	 {
-	   if (Verbosity() > 1)
-	   {
-	     std::cout << "largest bco: 0x" << std::hex << largest_bco << ", minbco 0x" << minBCO
-		       << std::dec << ", evtno: " << EventSequence << std::endl;
-	   }
-	 }
-	 else
-	 {
-        for (int j = 0; j < num_hits; j++)
-        {
-          uint64_t gtm_bco = pool->lValue(j, "BCO");
-	  if (gtm_bco < minBCO)
-	  {
-	    // std::cout << "dropping hit with bco 0x" << std::hex
-	    // 	      << gtm_bco << ", min bco: 0x" << minBCO
-	    // 	      << std::endl;
-	     continue;
-	  }
-          InttRawHit *newhit = new InttRawHitv2();
-          int FEE = pool->iValue(j, "FEE");
-          newhit->set_packetid(pool->getIdentifier());
-          newhit->set_fee(FEE);
-          newhit->set_bco(gtm_bco);
-          newhit->set_adc(pool->iValue(j, "ADC"));
-          newhit->set_amplitude(pool->iValue(j, "AMPLITUDE"));
-          newhit->set_chip_id(pool->iValue(j, "CHIP_ID"));
-          newhit->set_channel_id(pool->iValue(j, "CHANNEL_ID"));
-          newhit->set_word(pool->iValue(j, "DATAWORD"));
-          newhit->set_FPHX_BCO(pool->iValue(j, "FPHX_BCO"));
-          newhit->set_full_FPHX(pool->iValue(j, "FULL_FPHX"));
-          newhit->set_full_ROC(pool->iValue(j, "FULL_ROC"));
-          newhit->set_event_counter(pool->iValue(j, "EVENT_COUNTER"));
 
-          gtm_bco += m_Rollover[FEE];
-          
-          if (gtm_bco < m_PreviousClock[FEE])
+        int numBCOs = pool->iValue(0, "NR_BCOS");
+        uint64_t largest_bco = 0;
+        bool skipthis{true};
+        for (int j = 0; j < numBCOs; j++)
+        {
+          uint64_t bco = pool->lValue(j, "BCOLIST");
+          if (largest_bco < bco)
           {
-            m_Rollover[FEE] += 0x10000000000;
-            gtm_bco += 0x10000000000;  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
+            largest_bco = bco;
           }
-          m_PreviousClock[FEE] = gtm_bco;
-          m_BeamClockFEE[gtm_bco].insert(FEE);
-          m_FEEBclkMap[FEE] = gtm_bco;
-          if (Verbosity() > 2)
+          if (bco < minBCO)
           {
-            std::cout << "evtno: " << EventSequence
-                      << ", hits: " << j
-                      << ", nr_hits: " << num_hits
-                      << ", FEE: " << FEE
-                      << ", bco: 0x" << std::hex << gtm_bco << std::dec
-		      << ", min bco: 0x" << std::hex << minBCO << std::dec
-                      << ", channel: " << newhit->get_channel_id()
-                      << ", evt_counter: " << newhit->get_event_counter() << std::endl;
+            continue;
           }
-          if (StreamingInputManager())
-          {
-            StreamingInputManager()->AddInttRawHit(gtm_bco, newhit);
-          }
-          m_InttRawHitMap[gtm_bco].push_back(newhit);
+          skipthis = false;
+          m_BclkStack.insert(bco);
+          m_BclkStackPacketMap[packet_id].insert(bco);
         }
-	 }
+        if (skipthis)
+        {
+          if (Verbosity() > 1)
+          {
+            std::cout << "largest bco: 0x" << std::hex << largest_bco << ", minbco 0x" << minBCO
+                      << std::dec << ", evtno: " << EventSequence << std::endl;
+          }
+        }
+        else
+        {
+          for (int j = 0; j < num_hits; j++)
+          {
+            uint64_t gtm_bco = pool->lValue(j, "BCO");
+            if (gtm_bco < minBCO)
+            {
+              // std::cout << "dropping hit with bco 0x" << std::hex
+              // 	      << gtm_bco << ", min bco: 0x" << minBCO
+              // 	      << std::endl;
+              continue;
+            }
+            InttRawHit *newhit = new InttRawHitv2();
+            int FEE = pool->iValue(j, "FEE");
+            newhit->set_packetid(pool->getIdentifier());
+            newhit->set_fee(FEE);
+            newhit->set_bco(gtm_bco);
+            newhit->set_adc(pool->iValue(j, "ADC"));
+            newhit->set_amplitude(pool->iValue(j, "AMPLITUDE"));
+            newhit->set_chip_id(pool->iValue(j, "CHIP_ID"));
+            newhit->set_channel_id(pool->iValue(j, "CHANNEL_ID"));
+            newhit->set_word(pool->iValue(j, "DATAWORD"));
+            newhit->set_FPHX_BCO(pool->iValue(j, "FPHX_BCO"));
+            newhit->set_full_FPHX(pool->iValue(j, "FULL_FPHX"));
+            newhit->set_full_ROC(pool->iValue(j, "FULL_ROC"));
+            newhit->set_event_counter(pool->iValue(j, "EVENT_COUNTER"));
+            gtm_bco += m_Rollover[FEE];
+
+            if (gtm_bco < m_PreviousClock[FEE])
+            {
+              m_Rollover[FEE] += 0x10000000000;
+              gtm_bco += 0x10000000000;  // rollover makes sure our bclks are ascending even if we roll over the 40 bit counter
+            }
+            m_PreviousClock[FEE] = gtm_bco;
+            m_BeamClockFEE[gtm_bco].insert(FEE);
+            m_FEEBclkMap[FEE] = gtm_bco;
+            if (Verbosity() > 2)
+            {
+              std::cout << "evtno: " << EventSequence
+                        << ", hits: " << j
+                        << ", nr_hits: " << num_hits
+                        << ", FEE: " << FEE
+                        << ", bco: 0x" << std::hex << gtm_bco << std::dec
+                        << ", min bco: 0x" << std::hex << minBCO << std::dec
+                        << ", channel: " << newhit->get_channel_id()
+                        << ", evt_counter: " << newhit->get_event_counter() << std::endl;
+            }
+            if (StreamingInputManager())
+            {
+              StreamingInputManager()->AddInttRawHit(gtm_bco, newhit);
+            }
+            m_InttRawHitMap[gtm_bco].push_back(newhit);
+          }
+        }
         //	    Print("FEEBCLK");
       }
       pool->next();
@@ -288,9 +286,9 @@ void SingleInttPoolInput::Print(const std::string &what) const
   }
   if (what == "ALL" || what == "STACK")
   {
-    for(auto& [packetid, bclkstack] : m_BclkStackPacketMap)
+    for (auto &[packetid, bclkstack] : m_BclkStackPacketMap)
     {
-      for(auto& bclk : bclkstack)
+      for (auto &bclk : bclkstack)
       {
         std::cout << "stacked bclk: 0x" << std::hex << bclk << std::dec << std::endl;
       }
@@ -323,7 +321,7 @@ void SingleInttPoolInput::CleanupUsedPackets(const uint64_t bclk)
   for (auto iter : toclearbclk)
   {
     m_BclkStack.erase(iter);
-    for(auto& [packetid , bclkstack] : m_BclkStackPacketMap)
+    for (auto &[packetid, bclkstack] : m_BclkStackPacketMap)
     {
       bclkstack.erase(iter);
     }
@@ -373,23 +371,23 @@ bool SingleInttPoolInput::GetSomeMoreEvents(const uint64_t ibclk)
   }
   if (poolmap.empty())
   {
-//      std::cout << "GetSomeMoreEvents poolmap empty, ret true" << std::endl;
+    //      std::cout << "GetSomeMoreEvents poolmap empty, ret true" << std::endl;
     return true;
   }
-    // for (auto iter : poolmap)
-    // {
-    //   if (!iter.second->depth_ok())
-    //   {
-    //   std::cout << "GetSomeMoreEvents depth not ok, ret true" << std::endl;
-    // 	return true;
-    //   }
-    // }
+  // for (auto iter : poolmap)
+  // {
+  //   if (!iter.second->depth_ok())
+  //   {
+  //   std::cout << "GetSomeMoreEvents depth not ok, ret true" << std::endl;
+  // 	return true;
+  //   }
+  // }
   uint64_t localbclk = ibclk;
   if (ibclk == 0)
   {
     if (m_InttRawHitMap.empty())
     {
-//      std::cout << "GetSomeMoreEvents hitmap empty, ret true" << std::endl;
+      //      std::cout << "GetSomeMoreEvents hitmap empty, ret true" << std::endl;
       return true;
     }
     localbclk = m_InttRawHitMap.begin()->first;
@@ -420,11 +418,11 @@ bool SingleInttPoolInput::GetSomeMoreEvents(const uint64_t ibclk)
       }
     }
   }
-  for(auto iter : toerase)
+  for (auto iter : toerase)
   {
     m_FEEBclkMap.erase(iter);
   }
-//  std::cout << "GetSomeMoreEvents ret false" << std::endl;
+  //  std::cout << "GetSomeMoreEvents ret false" << std::endl;
   return false;
 }
 

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -31,15 +31,15 @@ class SingleInttPoolInput : public SingleStreamingInput
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
-  const std::set<uint64_t>& BclkStack() const override { return m_BclkStack; }
-  const std::map<uint64_t, std::set<int>>& BeamClockFEE() const override { return m_BeamClockFEE; }
+  const std::set<uint64_t> &BclkStack() const override { return m_BclkStack; }
+  const std::map<uint64_t, std::set<int>> &BeamClockFEE() const override { return m_BeamClockFEE; }
 
  private:
   Packet **plist{nullptr};
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
-
+  bool m_SkipEarlyEvents{true};
   std::array<uint64_t, 14> m_PreviousClock{};
   std::array<uint64_t, 14> m_Rollover{};
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The aggressive skipping of events before filling the intt_pool had an unintended side effect. It now catches up quickly with the gl1 bco but we do have rcdaq events which contain only a packet fragment where hte decoder claims zero hits and no BCO. They still need to be fed into the intt_pool which recovers those data. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

