### PR TITLE
(INTT) Bug fix in calibrations module

### DIFF
--- a/calibrations/intt/inttcalib/InttCalib.cc
+++ b/calibrations/intt/inttcalib/InttCalib.cc
@@ -53,7 +53,7 @@ int InttCalib::InitRun(PHCompositeNode* /*unused*/)
   {
     for (int bco = 0; bco < 129; ++bco)
     {
-      m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][128] = 0;
+      m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][bco] = 0;
     }
   }
 
@@ -681,23 +681,6 @@ int InttCalib::ConfigureBcoMap()
 
   for (InttMap::RawData_s raw = InttMap::RawDataBegin; raw != InttMap::RawDataEnd; ++raw)
   {
-    double hitrate = m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][128] / m_evts;
-    InttMap::Offline_s ofl;
-    if (m_feemap.Convert(ofl, raw))
-    {
-      continue;
-    }
-
-    if (adjust_hitrate(ofl, hitrate))
-    {
-      continue;
-    }
-
-    if (hitrate <= m_min_hitrate || m_max_hitrate <= hitrate)
-    {
-      continue;
-    }
-
     for (int bco = 0; bco < 128; ++bco)
     {
       m_bcorates[raw][bco] += m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][bco];


### PR DESCRIPTION
The BCO related output was affected when I changed the hot-channel map logic and would put the peaks at 0. It correctly gets the peaks now.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

