### PR TITLE
BCO convention changed

### DIFF
--- a/calibrations/intt/inttcalib/InttCalib.cc
+++ b/calibrations/intt/inttcalib/InttCalib.cc
@@ -115,8 +115,9 @@ int InttCalib::process_event(PHCompositeNode* top_node)
         .chp = (intt_raw_hit->get_chip_id() + 25) % 26,  //
         .chn = intt_raw_hit->get_channel_id(),           //
     };
-
-    int bco_diff = ((intt_raw_hit->get_bco() & 0x7fU) - intt_raw_hit->get_FPHX_BCO() + 128) % 128;
+  //old convention 
+ //int bco_diff = ((intt_raw_hit->get_bco() & 0x7fU) - intt_raw_hit->get_FPHX_BCO() + 128) % 128;
+  int bco_diff = (intt_raw_hit->get_FPHX_BCO() -  (intt_raw_hit->get_bco() & 0x7fU) + 128) % 128; 
 
     ++m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][bco_diff];
     ++m_hitmap[raw.pid - 3001][raw.fee][raw.chp][raw.chn][128];


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> 
BCO convention changed from
    int bco_diff = ((intt_raw_hit->get_bco() & 0x7fU) - intt_raw_hit->get_FPHX_BCO() + 128) % 128;
to
   int bco_diff = (intt_raw_hit->get_FPHX_BCO() -  (intt_raw_hit->get_bco() & 0x7fU) + 128) % 128;
   

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

