### PR TITLE
fix: Fixes to packet QA

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -37,6 +37,7 @@
 #include <boost/format.hpp>
 
 #include <TH1.h>
+#include <TH2.h>
 #include <TSystem.h>
 
 #include <algorithm>  // for max
@@ -694,7 +695,8 @@ int Fun4AllStreamingInputManager::FillIntt()
     if (feeidset.size() == 14)
     {
       allpacketsallfees++;
-      h_taggedAllFees_intt[histo_to_fill]->Fill(refbcobitshift);
+      unsigned mask = (1 << 40) - 1;
+      h_taggedAllFees_intt[histo_to_fill]->Fill(m_RefBCO & mask);
     }
     feeidset.clear();
     bool thispacket = false;
@@ -716,12 +718,13 @@ int Fun4AllStreamingInputManager::FillIntt()
     {
       allpackets = false;
     }
+    
   }
-  if (allpackets && m_InttInputVector.size() == 8)
+  if (allpackets)
   {
     h_taggedAll_intt->Fill(refbcobitshift);
   }
-  if (allpacketsallfees == 8)
+  if (allpacketsallfees == (int) m_InttInputVector.size())
   {
     h_taggedAllFee_intt->Fill(refbcobitshift);
   }
@@ -905,7 +908,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
   {
     h_taggedAllFelixesAllFees_mvtx->Fill(refbcobitshift);
   }
-  if (taggedPacketsFEEs.size() == 12)
+  if (taggedPacketsFEEs.size() == m_MvtxInputVector.size())
   {
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
@@ -1100,6 +1103,9 @@ int Fun4AllStreamingInputManager::FillTpc()
   {
     auto bcl_stack = m_TpcInputVector[p]->BclkStackMap();
     int packetnum = 0;
+    int histo_to_fill = (bcl_stack.begin()->first - 4000) / 10;
+    
+    
     for (auto &[packetid, bclset] : bcl_stack)
     {
       bool thispacket = false;
@@ -1109,7 +1115,7 @@ int Fun4AllStreamingInputManager::FillTpc()
         if (diff < 5)
         {
           thispacket = true;
-          h_gl1tagged_tpc[p][packetnum]->Fill(refbcobitshift);
+          h_gl1tagged_tpc[histo_to_fill][packetnum]->Fill(refbcobitshift);
         }
       }
       if (thispacket == false)
@@ -1119,7 +1125,7 @@ int Fun4AllStreamingInputManager::FillTpc()
       packetnum++;
     }
   }
-  if (allpackets && m_TpcInputVector.size() == 24)
+  if (allpackets)
   {
     h_taggedAll_tpc->Fill(refbcobitshift);
   }
@@ -1400,6 +1406,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
   }
   h_tagStBcoFEE_mvtx = new TH1I("h_MvtxPoolQA_TagStBcoFEEs", "", 10000, 0, 10000);
   hm->registerHisto(h_tagStBcoFEE_mvtx);
+
   // intt has 8 prdfs, one per felix
   for (int i = 0; i < 8; i++)
   {
@@ -1408,7 +1415,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h->SetTitle((boost::format("EBDC %i") % i).str().c_str());
     hm->registerHisto(h);
 
-    auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str(), "INTT trigger tagged BCO all servers", 1000, 0, 1000);
+    auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str(), "INTT trigger tagged BCO all servers", 1000000, 1000000, 2000000);
     h_all->GetXaxis()->SetTitle("GL1 BCO");
     h_all->SetTitle("GL1 Reference BCO");
     hm->registerHisto(h_all);

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -37,7 +37,6 @@
 #include <boost/format.hpp>
 
 #include <TH1.h>
-#include <TH2.h>
 #include <TSystem.h>
 
 #include <algorithm>  // for max
@@ -915,7 +914,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
   {
     h_taggedAllFelixesAllFees_mvtx->Fill(refbcobitshift);
   }
-  if (taggedPacketsFEEs.size() == m_MvtxInputVector.size())
+  if (taggedPacketsFEEs.size() == 12)
   {
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
@@ -1426,7 +1425,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h->SetTitle((boost::format("EBDC %i") % i).str().c_str());
     hm->registerHisto(h);
 
-    auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str(), "INTT trigger tagged BCO all servers", 1000000, 1000000, 2000000);
+    auto h_all = new TH1I((boost::format("h_InttPoolQA_TagBCOAllFees_Server%i") % i).str().c_str(), "INTT trigger tagged BCO all servers", 1000, 1000, 1000);
     h_all->GetXaxis()->SetTitle("GL1 BCO");
     h_all->SetTitle("GL1 Reference BCO");
     hm->registerHisto(h_all);

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -676,12 +676,11 @@ int Fun4AllStreamingInputManager::FillIntt()
     auto feebclstack = p->getFeeGTML1BCOMap();
     int packet_id = bcl_stack.begin()->first;
     int histo_to_fill = (packet_id % 10) - 1;
-    
+
     std::set<int> feeidset;
     int fee = 0;
     for (auto &[feeid, gtmbcoset] : feebclstack)
     {
-      
       for (auto &bcl : gtmbcoset)
       {
         auto diff = (m_RefBCO > bcl) ? m_RefBCO - bcl : bcl - m_RefBCO;
@@ -693,12 +692,11 @@ int Fun4AllStreamingInputManager::FillIntt()
       }
       fee++;
     }
-    
+
     if (feeidset.size() == 14)
     {
       allpacketsallfees++;
       h_taggedAllFees_intt[histo_to_fill]->Fill(refbcobitshift);
-      
     }
     feeidset.clear();
     bool thispacket = false;
@@ -723,7 +721,6 @@ int Fun4AllStreamingInputManager::FillIntt()
     {
       allpackets = false;
     }
-    
   }
   if (allpackets)
   {
@@ -884,7 +881,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       for (auto &gtmbco : gtmbcoset)
       {
         auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-     
+
         h_bcoGL1LL1diff[packetid]->Fill(diff);
 
         if (diff < 3)
@@ -1105,13 +1102,12 @@ int Fun4AllStreamingInputManager::FillTpc()
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
   h_refbco_tpc->Fill(refbcobitshift);
   bool allpackets = true;
-  for (size_t p = 0; p < m_TpcInputVector.size(); p++)
+  for (auto &p : m_TpcInputVector)
   {
-    auto bcl_stack = m_TpcInputVector[p]->BclkStackMap();
+    auto bcl_stack = p->BclkStackMap();
     int packetnum = 0;
     int histo_to_fill = (bcl_stack.begin()->first - 4000) / 10;
-    
-    
+
     for (auto &[packetid, bclset] : bcl_stack)
     {
       bool thispacket = false;
@@ -1130,7 +1126,7 @@ int Fun4AllStreamingInputManager::FillTpc()
       }
       // we just want to erase anything that is well away from the current GL1
       // so make an arbitrary cut of 40000.
-      m_TpcInputVector[p]->clearPacketBClkStackMap(packetid, m_RefBCO - 40000);
+      p->clearPacketBClkStackMap(packetid, m_RefBCO - 40000);
 
       packetnum++;
     }
@@ -1217,7 +1213,6 @@ void Fun4AllStreamingInputManager::SetMvtxBcoRange(const unsigned int i)
 
 int Fun4AllStreamingInputManager::FillInttPool()
 {
-  
   uint64_t ref_bco_minus_range = 0;
   if (m_RefBCO > m_intt_negative_bco)
   {
@@ -1230,7 +1225,7 @@ int Fun4AllStreamingInputManager::FillInttPool()
       std::cout << "Fun4AllStreamingInputManager::FillInttPool - fill pool for " << iter->Name() << std::endl;
     }
     iter->FillPool(ref_bco_minus_range);
-    //iter->FillPool();
+    // iter->FillPool();
     if (m_RunNumber == 0)
     {
       m_RunNumber = iter->RunNumber();

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -703,7 +703,10 @@ int Fun4AllStreamingInputManager::FillIntt()
     }
     feeidset.clear();
     bool thispacket = false;
-    p->clearFeeGTML1BCOMap(*(bcl_stack.begin()->second.begin()));
+    // we just want to erase anything that is well before the current GL1
+    // so make an arbitrary cut of 40000.
+    p->clearFeeGTML1BCOMap(m_RefBCO - 40000);
+    p->clearPacketBClkStackMap(packet_id, m_RefBCO - 40000);
 
     for (auto &[packetid, gtmbcoset] : bcl_stack)
     {
@@ -874,7 +877,6 @@ int Fun4AllStreamingInputManager::FillMvtx()
   {
     auto gtml1bcoset_perfee = p->getFeeGTML1BCOMap();
     int feecounter = 0;
-    uint64_t lowestbco = std::numeric_limits<uint64_t>::max();
     for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
     {
       auto link = MvtxRawDefs::decode_feeid(feeid);
@@ -883,9 +885,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       for (auto &gtmbco : gtmbcoset)
       {
         auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-        if(gtmbco < lowestbco){
-          lowestbco = gtmbco;
-        }
+     
         h_bcoGL1LL1diff[packetid]->Fill(diff);
 
         if (diff < 3)
@@ -896,8 +896,9 @@ int Fun4AllStreamingInputManager::FillMvtx()
       }
       feecounter++;
     }
-
-    p->clearFeeGTML1BCOMap(lowestbco);
+    // we just want to erase anything that is well before the current GL1
+    // so make an arbitrary cut of 40000.
+    p->clearFeeGTML1BCOMap(m_RefBCO - 40000);
   }
   int allfeestagged = 0;
   for (auto &[pid, feeset] : taggedPacketsFEEs)
@@ -1128,6 +1129,10 @@ int Fun4AllStreamingInputManager::FillTpc()
       {
         allpackets = false;
       }
+      // we just want to erase anything that is well away from the current GL1
+      // so make an arbitrary cut of 40000.
+      m_TpcInputVector[p]->clearPacketBClkStackMap(packetid, m_RefBCO - 40000);
+
       packetnum++;
     }
   }

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -677,10 +677,12 @@ int Fun4AllStreamingInputManager::FillIntt()
     auto feebclstack = p->getFeeGTML1BCOMap();
     int packet_id = bcl_stack.begin()->first;
     int histo_to_fill = (packet_id % 10) - 1;
+    
     std::set<int> feeidset;
     int fee = 0;
     for (auto &[feeid, gtmbcoset] : feebclstack)
     {
+      
       for (auto &bcl : gtmbcoset)
       {
         auto diff = (m_RefBCO > bcl) ? m_RefBCO - bcl : bcl - m_RefBCO;
@@ -692,15 +694,16 @@ int Fun4AllStreamingInputManager::FillIntt()
       }
       fee++;
     }
+    
     if (feeidset.size() == 14)
     {
       allpacketsallfees++;
-      unsigned mask = (1 << 40) - 1;
-      h_taggedAllFees_intt[histo_to_fill]->Fill(m_RefBCO & mask);
+      h_taggedAllFees_intt[histo_to_fill]->Fill(refbcobitshift);
+      
     }
     feeidset.clear();
     bool thispacket = false;
-    p->clearFeeGTML1BCOMap(m_InttRawHitMap.begin()->first);
+    p->clearFeeGTML1BCOMap(*(bcl_stack.begin()->second.begin()));
 
     for (auto &[packetid, gtmbcoset] : bcl_stack)
     {
@@ -871,6 +874,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
   {
     auto gtml1bcoset_perfee = p->getFeeGTML1BCOMap();
     int feecounter = 0;
+    uint64_t lowestbco = std::numeric_limits<uint64_t>::max();
     for (auto &[feeid, gtmbcoset] : gtml1bcoset_perfee)
     {
       auto link = MvtxRawDefs::decode_feeid(feeid);
@@ -879,7 +883,9 @@ int Fun4AllStreamingInputManager::FillMvtx()
       for (auto &gtmbco : gtmbcoset)
       {
         auto diff = (m_RefBCO > gtmbco) ? m_RefBCO - gtmbco : gtmbco - m_RefBCO;
-
+        if(gtmbco < lowestbco){
+          lowestbco = gtmbco;
+        }
         h_bcoGL1LL1diff[packetid]->Fill(diff);
 
         if (diff < 3)
@@ -891,7 +897,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       feecounter++;
     }
 
-    p->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
+    p->clearFeeGTML1BCOMap(lowestbco);
   }
   int allfeestagged = 0;
   for (auto &[pid, feeset] : taggedPacketsFEEs)

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -21,7 +21,6 @@ class PHCompositeNode;
 class SyncObject;
 class TpcRawHit;
 class TH1;
-
 class Fun4AllStreamingInputManager : public Fun4AllInputManager
 {
  public:

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -51,6 +51,23 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   std::string getHitContainerName() const { return m_rawHitContainerName; }
   const std::map<int, std::set<uint64_t>> &getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
 
+  void clearPacketBClkStackMap(const int &packetid, const uint64_t& bclk)
+  {
+    std::set<uint64_t> to_erase;
+    auto set = m_BclkStackPacketMap.find(packetid)->second;
+      for(auto& bclk_to_erase : set)
+      {
+        if(bclk_to_erase <= bclk)
+        {
+          to_erase.insert(bclk_to_erase);
+        }
+      }
+      for(auto& bclk_to_erase : to_erase)
+      {
+        set.erase(bclk_to_erase);
+      }
+    }
+  
   void clearFeeGTML1BCOMap(const uint64_t &bclk)
   {
     std::set<uint64_t> toerase;

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -312,10 +312,6 @@ void SingleTpcPoolInput::CleanupUsedPackets(const uint64_t bclk)
     m_BclkStack.erase(iter);
     m_BeamClockFEE.erase(iter);
     m_TpcRawHitMap.erase(iter);
-    for (auto &[packetid, bclkset] : m_BclkStackPacketMap)
-    {
-      bclkset.erase(iter);
-    }
   }
 }
 


### PR DESCRIPTION
This PR adds a few changes to be able to process the packet QA on a single server/felix/ebdc basis.
It also fixes a bug in the way that the containers were cleared. Previously, the container bcos were cleared based on the first hit bco entry, similarly to all other containers in the input manager. While doing the single server/felix/ebdc development, there were cases that became more apparent where bcos were being cleared that should not have been. This is because there are instances where the lowest hit BCO is not actually the lowest valid BCO that was tagged in the container, and so BCOs that may have been associated to future GL1 BCOs were being inadvertently cleared. This fixes that problem by clearing out the BCOs from the containers that are less than `GL1BCO - 40000`, which is arbitrary and just needs to be large enough to not inadvertently erase BCOs that may be correlated to a future GL1.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

