### PR TITLE
CNN photon classifier

### DIFF
--- a/offline/framework/phool/onnxlib.cc
+++ b/offline/framework/phool/onnxlib.cc
@@ -35,3 +35,29 @@ std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &inpu
 
   return outputTensorValuesN;
 }
+
+std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &input, int N, int Nx, int Ny, int Nz, int Nreturn)
+{
+  // Define the memory information for ONNX Runtime
+  Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault);
+
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  std::vector<int64_t> inputDims = {N, Nx, Ny, Nz};
+  std::vector<int64_t> outputDimsN = {N, Nreturn};
+
+  std::vector<float> outputTensorValues(N * Nreturn);
+
+  std::vector<Ort::Value> inputTensors, outputTensors;
+
+  inputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, input.data(), N * Nx * Ny * Nz, inputDims.data(), inputDims.size()));
+
+  outputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, outputTensorValues.data(), N * Nreturn, outputDimsN.data(), outputDimsN.size()));
+
+
+  std::vector<const char *> inputNames{session->GetInputName(0, allocator)};
+  std::vector<const char *> outputNames{session->GetOutputName(0, allocator)};
+  session->Run(Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), outputTensors.data(), 1);
+  return outputTensorValues;
+}
+

--- a/offline/framework/phool/onnxlib.cc
+++ b/offline/framework/phool/onnxlib.cc
@@ -22,11 +22,13 @@ std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &inpu
 
   std::vector<int64_t> inputDimsN = {N, Nsamp};
   std::vector<int64_t> outputDimsN = {N, Nreturn};
+  int inputlen = N * Nsamp;
+  int outputlen = N * Nreturn;
 
-  std::vector<float> outputTensorValuesN(N * Nreturn);
+  std::vector<float> outputTensorValuesN(outputlen);
 
-  inputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, input.data(), N * Nsamp, inputDimsN.data(), inputDimsN.size()));
-  outputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, outputTensorValuesN.data(), N * Nreturn, outputDimsN.data(), outputDimsN.size()));
+  inputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, input.data(), inputlen, inputDimsN.data(), inputDimsN.size()));
+  outputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, outputTensorValuesN.data(), outputlen, outputDimsN.data(), outputDimsN.size()));
 
   std::vector<const char *> inputNames{session->GetInputName(0, allocator)};
   std::vector<const char *> outputNames{session->GetOutputName(0, allocator)};
@@ -45,14 +47,16 @@ std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &inpu
 
   std::vector<int64_t> inputDims = {N, Nx, Ny, Nz};
   std::vector<int64_t> outputDimsN = {N, Nreturn};
+  int inputlen = N * Nx * Ny * Nz;
+  int outputlen = N * Nreturn;
 
-  std::vector<float> outputTensorValues(N * Nreturn);
+  std::vector<float> outputTensorValues(outputlen);
 
   std::vector<Ort::Value> inputTensors, outputTensors;
 
-  inputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, input.data(), N * Nx * Ny * Nz, inputDims.data(), inputDims.size()));
+  inputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, input.data(), inputlen, inputDims.data(), inputDims.size()));
 
-  outputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, outputTensorValues.data(), N * Nreturn, outputDimsN.data(), outputDimsN.size()));
+  outputTensors.push_back(Ort::Value::CreateTensor<float>(memoryInfo, outputTensorValues.data(), outputlen, outputDimsN.data(), outputDimsN.size()));
 
 
   std::vector<const char *> inputNames{session->GetInputName(0, allocator)};

--- a/offline/framework/phool/onnxlib.h
+++ b/offline/framework/phool/onnxlib.h
@@ -13,4 +13,6 @@ Ort::Session *onnxSession(std::string &modelfile);
 
 std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &input, int N, int Nsamp, int Nreturn);
 
+std::vector<float> onnxInference(Ort::Session *session, std::vector<float> &input, int N, int Nx, int Ny, int Nz, int Nreturn);
+
 #endif

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -55,6 +55,7 @@ pkginclude_HEADERS = \
   RawClusterBuilderGraph.h \
   RawClusterBuilderTopo.h \
   RawClusterBuilderTemplate.h \
+  RawClusterCNNClassifier.h \
   RawClusterPositionCorrection.h \
   RawClusterZVertexRecorrect.h \
   RawTowerCalibration.h \
@@ -84,6 +85,7 @@ libcalo_reco_la_SOURCES = \
   RawClusterBuilderGraph.cc \
   RawClusterBuilderTopo.cc \
   RawClusterBuilderTemplate.cc \
+  RawClusterCNNClassifier.cc \
   RawClusterPositionCorrection.cc \
   RawClusterZVertexRecorrect.cc \
   RawTowerCombiner.cc \

--- a/offline/packages/CaloReco/RawClusterCNNClassifier.cc
+++ b/offline/packages/CaloReco/RawClusterCNNClassifier.cc
@@ -39,9 +39,7 @@ RawClusterCNNClassifier::RawClusterCNNClassifier(const std::string &name)
 {
 }
 
-RawClusterCNNClassifier::~RawClusterCNNClassifier()
-{
-}
+RawClusterCNNClassifier::~RawClusterCNNClassifier() = default;
 
 
 int RawClusterCNNClassifier::Init(PHCompositeNode */*topNode*/)
@@ -127,7 +125,9 @@ int RawClusterCNNClassifier::process_event(PHCompositeNode *topNode)
         //find the N by N tower around the max tower
         std::vector<float> input;
         //resize to inputDimx * inputDimy
-        input.resize(inputDimx * inputDimy);
+        int vectorSize = inputDimx * inputDimy;
+        input.resize(vectorSize, 0);
+
         if (maxtowerE > 0)
         {
           int xlength = int((inputDimx - 1) / 2);
@@ -142,8 +142,8 @@ int RawClusterCNNClassifier::process_event(PHCompositeNode *topNode)
             {
               int mappediphi = iphi;
 
-              if (mappediphi < 0) mappediphi += 256;
-              if (mappediphi > 255) mappediphi -= 256;
+              if (mappediphi < 0){ mappediphi += 256; }
+              if (mappediphi > 255){ mappediphi -= 256; }
               unsigned int towerinfokey = TowerInfoDefs::encode_emcal(ieta, mappediphi);
               TowerInfo *towerinfo = emcTowerContainer->get_tower_at_key(towerinfokey);
               if (!towerinfo)

--- a/offline/packages/CaloReco/RawClusterCNNClassifier.cc
+++ b/offline/packages/CaloReco/RawClusterCNNClassifier.cc
@@ -1,0 +1,181 @@
+/*
+I trained a crappy CNN to classify EMCal clusters as photon or not photon. S.Li 8.16.2024
+*/
+
+
+#include "RawClusterCNNClassifier.h"
+
+#include <calobase/RawCluster.h>
+#include <calobase/RawClusterContainer.h>
+#include <calobase/RawClusterUtility.h>
+#include <calobase/RawTower.h>
+#include <calobase/RawTowerContainer.h>
+#include <calobase/RawTowerDefs.h>
+#include <calobase/RawTowerGeom.h>
+#include <calobase/RawTowerGeomContainer.h>
+
+// Tower stuff
+#include <calobase/TowerInfo.h>
+#include <calobase/TowerInfoContainer.h>
+#include <calobase/TowerInfoDefs.h>
+
+
+#include <ffaobjects/EventHeader.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>
+#include <phool/onnxlib.h>
+
+
+
+#include <iostream>
+#include <vector>
+
+RawClusterCNNClassifier::RawClusterCNNClassifier(const std::string &name)
+    : SubsysReco(name)
+{
+}
+
+RawClusterCNNClassifier::~RawClusterCNNClassifier()
+{
+}
+
+
+int RawClusterCNNClassifier::Init(PHCompositeNode */*topNode*/)
+{
+    //init the onnx model
+    std::string modelPath = "/sphenix/u/shuhang98/core_patch/coresoftware/offline/packages/CaloReco/functional_model.onnx";
+    onnxmodule = onnxSession(modelPath);
+    return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RawClusterCNNClassifier::process_event(PHCompositeNode *topNode)
+{
+    //get the cluster container
+    
+    std::string clusterNodeName = "CLUSTERINFO_CEMC";
+    RawClusterContainer *clusterContainer = findNode::getClass<RawClusterContainer>(topNode, clusterNodeName);
+    if (!clusterContainer)
+    {
+        std::cout << "Could not locate cluster node " << clusterNodeName << std::endl;
+        return Fun4AllReturnCodes::ABORTEVENT;
+    }
+    //I trained the model with the info from towerinfo container, raw tower should also work
+    std::string towerNodeName = "TOWERINFO_CALIB_CEMC";
+    TowerInfoContainer *emcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, towerNodeName);
+    if (!emcTowerContainer)
+    {
+        std::cout << "Could not locate tower node " << towerNodeName << std::endl;
+        return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    RawClusterContainer::ConstRange clusterEnd = clusterContainer->getClusters();
+    RawClusterContainer::ConstIterator clusterIter;
+    for (clusterIter = clusterEnd.first; clusterIter != clusterEnd.second; ++clusterIter) {
+    RawCluster *recoCluster = clusterIter->second;
+    //reset the prob inplace
+    recoCluster->set_prob(-1);
+    CLHEP::Hep3Vector vertex(0, 0, 0);
+    CLHEP::Hep3Vector E_vec_cluster_Full = RawClusterUtility::GetEVec(*recoCluster, vertex);
+    float ET = E_vec_cluster_Full.perp();
+    if (ET < minET)
+    {
+        continue;
+    }
+    const RawCluster::TowerConstRange tower_begin_end =
+            recoCluster->get_towers();
+
+    int maxtowerE = 0;
+    int maxtowerieta = -1;
+    int maxtoweriphi = -1;
+
+    for (RawCluster::TowerConstIterator tower_iter = tower_begin_end.first;
+             tower_iter != tower_begin_end.second; ++tower_iter) {
+          RawTowerDefs::keytype tower_key = tower_iter->first;
+         
+          // get ieta iphi
+          int ix = RawTowerDefs::decode_index2(tower_key); // iphi?
+          int iy = RawTowerDefs::decode_index1(tower_key); // ieta I  guess?(S.L.)
+          RawTowerDefs::CalorimeterId caloid =
+              RawTowerDefs::decode_caloid(tower_key);
+          // check if cemc, but I guess they shoul all be anyways lol
+          if (caloid != RawTowerDefs::CalorimeterId::CEMC) {
+            continue;
+          }
+          // get the towerinfo key
+          unsigned int towerinfokey = TowerInfoDefs::encode_emcal(
+              iy, ix); // this is the key for the towerinfo container get the towerinfo
+          TowerInfo *towerinfo =
+              emcTowerContainer->get_tower_at_key(towerinfokey);
+          if (!towerinfo) {
+            //should not happen
+            std::cout << "No towerinfo for tower key " << towerinfokey
+                      << std::endl;
+            continue;
+          }
+          float towerE = towerinfo->get_energy();
+          if (towerE > maxtowerE) {
+            maxtowerE = towerE;
+            maxtowerieta = iy;
+            maxtoweriphi = ix;
+          }
+
+        }
+        //find the N by N tower around the max tower
+        std::vector<float> input;
+        //resize to inputDimx * inputDimy
+        input.resize(inputDimx * inputDimy);
+        if (maxtowerE > 0)
+        {
+          int xlength = int((inputDimx - 1) / 2);
+          int ylength = int((inputDimy - 1) / 2);
+          if(maxtowerieta - ylength < 0 || maxtowerieta + ylength >= 96)
+          {
+            continue;
+          }
+          for (int ieta = maxtowerieta - ylength; ieta <= maxtowerieta + ylength; ieta++)
+          {
+            for (int iphi = maxtoweriphi - xlength; iphi <= maxtoweriphi + xlength; iphi++)
+            {
+              int mappediphi = iphi;
+
+              if (mappediphi < 0) mappediphi += 256;
+              if (mappediphi > 255) mappediphi -= 256;
+              unsigned int towerinfokey = TowerInfoDefs::encode_emcal(ieta, mappediphi);
+              TowerInfo *towerinfo = emcTowerContainer->get_tower_at_key(towerinfokey);
+              if (!towerinfo)
+              {
+                // should not happen
+                std::cout << "No towerinfo for tower key " << towerinfokey << std::endl;
+                std::cout << "ieta: " << ieta << " iphi: " << mappediphi << std::endl;
+                continue;
+              }
+              int index = (ieta - maxtowerieta + ylength) * inputDimx + iphi - maxtoweriphi + xlength;
+              input.at(index) = towerinfo->get_energy();
+            }
+          }
+        }
+        std::vector<float> prob = onnxInference(onnxmodule, input, 1, inputDimx, inputDimy, inputDimz, outputDim);
+        //std::cout << "new prob: " << prob[0] << "ET: " << ET << " original prob: " << recoCluster->get_prob() << std::endl;
+        //inplace change for the prob for now
+        recoCluster->set_prob(prob[0]);
+
+    }
+
+    return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RawClusterCNNClassifier::End(PHCompositeNode */*topNode*/)
+{
+    delete onnxmodule;
+    return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void RawClusterCNNClassifier::Print(const std::string &what) const
+{
+    std::cout << "RawClusterCNNClassifier::Print(const std::string &what) const Printing info for " << what << std::endl;
+    return;
+}

--- a/offline/packages/CaloReco/RawClusterCNNClassifier.h
+++ b/offline/packages/CaloReco/RawClusterCNNClassifier.h
@@ -23,7 +23,7 @@ class RawClusterCNNClassifier : public SubsysReco
   void Print(const std::string &what = "ALL") const override;
 
  private:
-  Ort::Session *onnxmodule;
+  Ort::Session *onnxmodule{nullptr};
   const int inputDimx = 5;
   const int inputDimy = 5;
   const int inputDimz = 1;

--- a/offline/packages/CaloReco/RawClusterCNNClassifier.h
+++ b/offline/packages/CaloReco/RawClusterCNNClassifier.h
@@ -1,0 +1,35 @@
+#ifndef RAWCLUSTERCNNCLASSIFIER_H
+#define RAWCLUSTERCNNCLASSIFIER_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <phool/onnxlib.h>
+
+class PHCompositeNode;
+
+class RawClusterCNNClassifier : public SubsysReco
+{
+ public:
+  RawClusterCNNClassifier(const std::string &name = "RawClusterCNNClassifier");
+
+  ~RawClusterCNNClassifier() override;
+
+  int Init(PHCompositeNode *topNode) override;
+
+  int process_event(PHCompositeNode *topNode) override;
+
+  int End(PHCompositeNode *topNode) override;
+
+  void Print(const std::string &what = "ALL") const override;
+
+ private:
+  Ort::Session *onnxmodule;
+  const int inputDimx = 5;
+  const int inputDimy = 5;
+  const int inputDimz = 1;
+  const int outputDim = 1;
+
+  const float minET = 3;
+};
+
+#endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I trained a toy CNN to classify EMCal photon clusters from non-photon showers.
### Training sample

The training sample is derived from Pythia 1M photon-jet sample and 10M Detroit jet sample. 
Cluster truth matching is done with the [g4eval](https://github.com/sPHENIX-Collaboration/coresoftware/tree/master/simulation/g4simulation/g4eval) module For clusters with ET>7GeV, I took the 5x5 tower_calib energy around the maximum energy tower. For both photon and non-photon sample I require the primary particle that matched to the cluster to contribute >99% energy in the 5x5 tower block. For truth photon sample, e+ e- converted photons are identified from shower history and excluded from the training sample. For non-photon samples, when the primary particle is pi0 and eta, we require the decayed photon to have delta R < 0.05 (otherwise we could have only one photon in the 5x5 tower block and have it labeled as non-photon shower), and require di-photon asymmetry < 0.8.

### Model

I implement a simple CNN with TensorFlow to train for the classification task, the model summary is as followed:
<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃<span style="font-weight: bold"> Layer (type)                    </span>┃<span style="font-weight: bold"> Output Shape           </span>┃<span style="font-weight: bold">       Param # </span>┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ conv2d_93 (<span style="color: #0087ff; text-decoration-color: #0087ff">Conv2D</span>)              │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">5</span>, <span style="color: #00af00; text-decoration-color: #00af00">5</span>, <span style="color: #00af00; text-decoration-color: #00af00">32</span>)       │           <span style="color: #00af00; text-decoration-color: #00af00">320</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ max_pooling2d_92 (<span style="color: #0087ff; text-decoration-color: #0087ff">MaxPooling2D</span>) │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">2</span>, <span style="color: #00af00; text-decoration-color: #00af00">2</span>, <span style="color: #00af00; text-decoration-color: #00af00">32</span>)       │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ conv2d_94 (<span style="color: #0087ff; text-decoration-color: #0087ff">Conv2D</span>)              │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">2</span>, <span style="color: #00af00; text-decoration-color: #00af00">2</span>, <span style="color: #00af00; text-decoration-color: #00af00">64</span>)       │        <span style="color: #00af00; text-decoration-color: #00af00">18,496</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ max_pooling2d_93 (<span style="color: #0087ff; text-decoration-color: #0087ff">MaxPooling2D</span>) │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>, <span style="color: #00af00; text-decoration-color: #00af00">64</span>)       │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ dropout_96 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dropout</span>)            │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>, <span style="color: #00af00; text-decoration-color: #00af00">64</span>)       │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ flatten_46 (<span style="color: #0087ff; text-decoration-color: #0087ff">Flatten</span>)            │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">64</span>)             │             <span style="color: #00af00; text-decoration-color: #00af00">0</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ dense_105 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)               │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">16</span>)             │         <span style="color: #00af00; text-decoration-color: #00af00">1,040</span> │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ dense_106 (<span style="color: #0087ff; text-decoration-color: #0087ff">Dense</span>)               │ (<span style="color: #00d7ff; text-decoration-color: #00d7ff">None</span>, <span style="color: #00af00; text-decoration-color: #00af00">1</span>)              │            <span style="color: #00af00; text-decoration-color: #00af00">17</span> │
└─────────────────────────────────┴────────────────────────┴───────────────┘
</pre>

The optimizer and loss are those common one for CNN model
```python
initial_learning_rate = 0.0001
lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
    initial_learning_rate,
    decay_steps=100000,
    decay_rate=0.96,
    staircase=True)
model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=lr_schedule),
              #loss='categorical_crossentropy',
              loss='binary_crossentropy',
              metrics=['accuracy'])
```
![af45f12832f1f821b7172584328cb9b](https://github.com/user-attachments/assets/4e48b856-f199-434a-b929-d74b970efb39)
For differentiate photons from non-photons, this CNN model seems to do a bit better job than just using the cluster prob, especially when we set to high probability threshold we can have a better non-photon rejection with will lead to a better signal background ratio for isolated photon study.

### Implementation in Fun4All

The model is exported as ONNX format and get applied with our [ONNX wrapper](https://github.com/sPHENIX-Collaboration/coresoftware/blob/master/offline/framework/phool/onnxlib.cc). I add a new function signature to make this work with models that require a higher dimensional input.

The `RawClusterCNNClassifier` model takes the cluster container and tower container, extract the 5x5 energy and feed it to the trained model, then modify the cluster prob based on the model output. The method is very flexible, so if you have your own trained model that you want to use instead of mine crappy CNN model, you can change the path to the ONNX session to yours and modify the model dimension accordingly and then it should just work.


## TODOs (if applicable)
In-place modification of the cluster prob is a bad idea(but that's what I'm doing now). In the future I will either add a new field to the rawcluster object (the complication is this might screw up the DST readback if I changed it in v1, so I need to make a new class), or make a new cluster node with different name on the node tree.

I need more systematic study to test this method and need more parameter optimization/better feature design, and finally put the model in CDB. 

But the framework is here and it works, so feel free to checkout this branch and play with it if you are interested.


## Links to other PRs in macros and calibration repositories (if applicable)

