### PR TITLE
Do not drop TPC-only tracks in pp mode

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -316,10 +316,12 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     short crossing = SHRT_MAX;
     if (siseed)
     {
+      // get the INTT crossing
       crossing = siseed->get_crossing();
     }
     else if (!m_pp_mode)
     {
+      // crossing always assumed to be zero if pp_mode = false
       crossing = 0;
     }
 
@@ -335,19 +337,6 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       // do not skip TPC only tracks, just set crossing to the nominal zero
       crossing = 0;
     }
-
-    /*
-    // if the crossing was not determined at all in pp running, skip this case completely
-    if (m_pp_mode && crossing == SHRT_MAX && crossing_estimate == SHRT_MAX)
-    {
-      // Skip this in the pp case.
-      if (Verbosity() > 3)
-      {
-        std::cout << "tpcid " << tpcid << " siid " << siid << " crossing and crossing_estimate not determined, skipping track" << std::endl;
-      }
-      continue;
-    }
-    */
 
     if (Verbosity() > 1)
     {
@@ -389,6 +378,7 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     if (crossing == SHRT_MAX)
     {
+      // this only happens if there is a silicon seed but no assigned INTT crossing
       // If there is no INTT crossing, start with the crossing_estimate value, vary up and down, fit, and choose the best chisq/ndf
       use_estimate = true;
       nvary = max_bunch_search;

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -311,13 +311,6 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       std::cout << " tpcid " << tpcid << " siid " << siid << std::endl;
     }
 
-    /// A track seed is made for every tpc seed. Not every tpc seed
-    /// has a silicon match, we skip those cases completely in pp running
-    if (m_pp_mode && siid == std::numeric_limits<unsigned int>::max())
-    {
-      continue;
-    }
-
     // get the INTT crossing number
     auto siseed = m_siliconSeeds->get(siid);
     short crossing = SHRT_MAX;
@@ -330,6 +323,20 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       crossing = 0;
     }
 
+    // Can't do SC case without INTT crossing
+    if (m_fitSiliconMMs && (crossing == SHRT_MAX))
+    {
+      continue;
+    }
+
+    /// A track seed is made for every tpc seed. Not every tpc seed has a silicon match
+    if (m_pp_mode && siid == std::numeric_limits<unsigned int>::max())
+    {
+      // do not skip TPC only tracks, just set crossing to the nominal zero
+      crossing = 0;
+    }
+
+    /*
     // if the crossing was not determined at all in pp running, skip this case completely
     if (m_pp_mode && crossing == SHRT_MAX && crossing_estimate == SHRT_MAX)
     {
@@ -340,16 +347,11 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
       }
       continue;
     }
+    */
 
     if (Verbosity() > 1)
     {
       std::cout << "tpc and si id " << tpcid << ", " << siid << " crossing " << crossing << " crossing estimate " << crossing_estimate << std::endl;
-    }
-
-    // Can't do SC case without INTT crossing
-    if (m_fitSiliconMMs && (crossing == SHRT_MAX))
-    {
-      continue;
     }
 
     auto tpcseed = m_tpcSeeds->get(tpcid);

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -80,15 +80,24 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode * /*topNode*/)
   for (const auto &[trackkey, track] : *_track_map)
   {
     auto crossing = track->get_crossing();
+    auto siseed = track->get_silicon_seed();
+
+    // crossing zero contains unmatched TPC tracks
+    // Here we skip those crossing = zero tracks that do not have silicon seeds
+    if( (crossing == 0) & !siseed)
+      {
+	continue;
+      }
+    
     crossings.insert(crossing);
-
     _track_vertex_crossing_map->addTrackAssoc(crossing, trackkey);
-
+    
     if (Verbosity() > 0)
-    {
-      std::cout << "trackkey " << trackkey << " crossing " << crossing << std::endl;
-    }
+      {
+	std::cout << "trackkey " << trackkey << " crossing " << crossing << std::endl;
+      }
   }
+  
 
   unsigned int vertex_id = 0;
 

--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -108,21 +108,40 @@ int PHTrackCleaner::process_event(PHCompositeNode * /*topNode*/)
       {
         if (_pp_mode)
         {
-          // skip tracks with no assigned crossing number in pp mode
           if (_track->get_crossing() == SHRT_MAX)
           {
-            if (Verbosity() > 0)
-            {
-              std::cout << "     skip  track ID " << track_id << " crossing " << _track->get_crossing() << " chisq " << _track->get_chisq()
-                        << " ndf " << _track->get_ndf() << std::endl;
-            }
+	    // Tracks with no assigned crossing number in pp mode
+	    if (_track->get_chisq() / _track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
+	      {
+		best_id = track_id;
+		best_ndf = _track->get_ndf();	    
+		double qual = _track->get_chisq() / _track->get_ndf();
 
-            continue;
+		if (qual < quality_cut * 2)
+		  {
+		    // keep this TPC only track
+		    track_keep_list.insert(best_id);
+		    ok_track++;
+		    if (qual < quality_cut)
+		      {
+			good_track++;
+		      }
+
+		    if (Verbosity() > 1)
+		      {
+			std::cout << "        keep unmatched track tpc_id " << tpc_id << " given best_id " << best_id 
+				  << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;			
+		      }		    
+		  }
+	      }
+	    
+	    continue;
           }
+
         }
-
+	
         // Find the remaining track with the best chisq/ndf
-
+	
         unsigned int si_index = UINT_MAX;
         auto si_seed = _track->get_silicon_seed();
         if (si_seed)

--- a/offline/packages/trackreco/PHTrackCleaner.h
+++ b/offline/packages/trackreco/PHTrackCleaner.h
@@ -46,7 +46,7 @@ class PHTrackCleaner : public SubsysReco
   TrackSeedContainer *_silicon_seed_map{nullptr};
 
   double min_ndf = 25;
-  float quality_cut = 15.0;
+  float quality_cut = 150.0;
   bool _pp_mode = false;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
In pp mode, do not drop TPC tracks that are not matched to the silicon. TPC-only tracks are assigned to crossing zero, so that their nominal z position is used in tracking. They are excluded from primary vertex finding.

TPC-only tracks can be identified by checking to see if the track has a silicon seed (nmaps > 0).



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

