### PR TITLE
fix crash for null packet from empty gl1 event

### DIFF
--- a/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
@@ -84,15 +84,14 @@ void SingleGl1TriggerInput::FillPool(const unsigned int keep)
       m_NumSpecialEvents++;
       continue;
     }
-    // static bool firstevent = true;
-    // if (firstevent)
-    // {
-    //   firstevent = false;
-    //   continue;
-    // }
     int EventSequence = evt->getEvtSequence();
     Packet *packet = evt->getPacket(14001);
-
+    if (!packet)
+    {
+      std::cout << PHWHERE << "Packet 14001 is null ptr" << std::endl;
+      evt->identify();
+      continue;
+    }
     if (Verbosity() > 1)
     {
       packet->identify();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
We had at least one run where the last GL1 event didn't have a gl1 packet and then the production crashed

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

