### PR TITLE
protect against missing gl1 packet

### DIFF
--- a/offline/framework/fun4allraw/SingleGl1PoolInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1PoolInput.cc
@@ -95,7 +95,12 @@ void SingleGl1PoolInput::FillPool(const unsigned int /*nbclks*/)
     }
     int EventSequence = evt->getEvtSequence();
     Packet *packet = evt->getPacket(14001);
-
+    if (!packet)
+    {
+      std::cout << PHWHERE << "Packet 14001 is null ptr" << std::endl;
+      evt->identify();
+      continue;
+    }
     if (Verbosity() > 1)
     {
       packet->identify();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The gl1 streaming input manager crashes if packet 14001 is missing from the gl1 event. That shouldn't happen but I have seen this once in the triggered systems (which then means the streaming combiner will die as well). If a gl1 event without packet 14001 is encountered, this event will be skipped (and a message with the event->identify() will be printed out).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

