### PR TITLE
Change to ZS waveform default time and ZS towers with post sample = 0 to have bad chi2

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -250,7 +250,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
     }
-    if (std::fabs(time - mean_time) > time_cut && m_doTime)
+    if (!m_raw_towers->get_tower_at_channel(channel)->get_isZS() && std::fabs(time - mean_time) > time_cut && m_doTime)
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadTime(true);
     }

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -64,9 +64,16 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
     if (size1 == _nzerosuppresssamples)
     {
       v.push_back(v.at(1) - v.at(0));  // returns peak sample - pedestal sample
-      v.push_back(-1);                 // set time to -1 to indicate zero suppressed
+      v.push_back(-20);                 // set time to -20 to indicate zero suppressed
       v.push_back(v.at(0));
-      v.push_back(0);
+      if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
+      { 
+        v.push_back(1000000);
+      } 
+      else 
+      {
+        v.push_back(0);
+      }
       v.push_back(0);
     }
     else
@@ -98,9 +105,16 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
       if ( (_bdosoftwarezerosuppression && v.at(6) - v.at(0) < _nsoftwarezerosuppression) || (_maxsoftwarezerosuppression && maxheight-pedestal  < _nsoftwarezerosuppression)  )
       {
         v.push_back(v.at(6) - v.at(0));
-        v.push_back(-1);
+        v.push_back(-20);
         v.push_back(v.at(0));
-        v.push_back(0);
+        if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
+        { 
+          v.push_back(1000000);
+        } 
+        else 
+        {
+          v.push_back(0);
+        }
         v.push_back(0);
       }
       else
@@ -335,11 +349,16 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_fast(std::v
     float amp = 0;
     float time = 0;
     float ped = 0;
+    float chi2 = 0;
     if (nsamples == 2)
     {
       amp = v.at(1);
-      time = -1;
+      time = -20;
       ped = v.at(0);
+      if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
+      { 
+        chi2 = 1000000;
+      } 
     }
     else if (nsamples >= 3)
     {
@@ -373,7 +392,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_fast(std::v
       }
     }
     amp -= ped;
-    std::vector<float> val = {amp, time, ped, 0, 0};
+    std::vector<float> val = {amp, time, ped, chi2, 0};
     fit_values.push_back(val);
     val.clear();
   }
@@ -391,7 +410,12 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_nyquist(std
 
     if (nsamples == 2)
     {
-      fit_values.push_back({v.at(1) - v.at(0), -1, v.at(0), 0, 0});
+      float chi2 = 0;
+      if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
+      { 
+        chi2 = 1000000;
+      }
+      fit_values.push_back({v.at(1) - v.at(0), -20, v.at(0), chi2, 0});
       continue;
     }
     


### PR DESCRIPTION
Change in waveform fitting to set ZS waveforms with post sample = 0 to have a high chi2 (1E6) and change ZS waveform time from -1 to -20 to not interact with the normal timing fit range. Change in tower status to not set ZS waveforms to isBadTime.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR changes the default time value for the ZS waveforms to be -20 instead of -1. This makes sure that the default ZS timing value is outside of the expected fitted time value range. A small change to the tower status is needed to not set these ZS channels to isBadTime with the new default value. 
This PR also checks to see if a ZS waveform has a non-zero ADC pre sample and a zero ADC post sample and sets the chi2 for these waveforms to 1E6 as a method of setting these towers as hot. 

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

