### PR TITLE
Changing get_cluskey() to return max 64

### DIFF
--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -1,10 +1,11 @@
 #ifndef __SVTXTRACKSTATE_H__
 #define __SVTXTRACKSTATE_H__
 
-#include <phool/PHObject.h>
 #include <trackbase/TrkrDefs.h>
 
-#include <cmath>
+#include <phool/PHObject.h>
+
+#include <limits>
 
 class SvtxTrackState : public PHObject
 {
@@ -19,39 +20,39 @@ class SvtxTrackState : public PHObject
   int isValid() const override { return 0; }
   PHObject *CloneMe() const override { return nullptr; }
 
-  virtual float get_pathlength() const { return NAN; }
+  virtual float get_pathlength() const { return std::numeric_limits<float>::quiet_NaN(); }
 
-  virtual float get_x() const { return NAN; }
+  virtual float get_x() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_x(float) {}
 
-  virtual float get_y() const { return NAN; }
+  virtual float get_y() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_y(float) {}
 
-  virtual float get_z() const { return NAN; }
+  virtual float get_z() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z(float) {}
 
-  virtual float get_pos(unsigned int /*i*/) const { return NAN; }
+  virtual float get_pos(unsigned int /*i*/) const { return std::numeric_limits<float>::quiet_NaN(); }
 
-  virtual float get_px() const { return NAN; }
+  virtual float get_px() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_px(float) {}
 
-  virtual float get_py() const { return NAN; }
+  virtual float get_py() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_py(float) {}
 
-  virtual float get_pz() const { return NAN; }
+  virtual float get_pz() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_pz(float) {}
 
-  virtual float get_mom(unsigned int /*i*/) const { return NAN; }
+  virtual float get_mom(unsigned int /*i*/) const { return std::numeric_limits<float>::quiet_NaN(); }
 
-  virtual float get_p() const { return NAN; }
-  virtual float get_pt() const { return NAN; }
-  virtual float get_eta() const { return NAN; }
-  virtual float get_phi() const { return NAN; }
+  virtual float get_p() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float get_pt() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float get_eta() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float get_phi() const { return std::numeric_limits<float>::quiet_NaN(); }
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
 
-  virtual TrkrDefs::cluskey get_cluskey() const { return UINT64_MAX; }
+  virtual TrkrDefs::cluskey get_cluskey() const { return std::numeric_limits<TrkrDefs::cluskey>::max(); }
   virtual void set_cluskey(TrkrDefs::cluskey) {}
 
   virtual std::string get_name() const { return ""; }
@@ -63,19 +64,19 @@ class SvtxTrackState : public PHObject
   /// rphi error
   virtual float get_rphi_error() const
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   /// phi error
   virtual float get_phi_error() const
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   /// z error
   virtual float get_z_error() const
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   //@}

--- a/offline/packages/trackbase_historic/SvtxTrackState.h
+++ b/offline/packages/trackbase_historic/SvtxTrackState.h
@@ -51,7 +51,7 @@ class SvtxTrackState : public PHObject
   virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
   virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
 
-  virtual TrkrDefs::cluskey get_cluskey() const { return UINT32_MAX; }
+  virtual TrkrDefs::cluskey get_cluskey() const { return UINT64_MAX; }
   virtual void set_cluskey(TrkrDefs::cluskey) {}
 
   virtual std::string get_name() const { return ""; }

--- a/offline/packages/trackbase_historic/configure.ac
+++ b/offline/packages/trackbase_historic/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror"
+   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Small fix to the SvtxTrackState::get_cluskey() to return UINT64_MAX instead of UINT32_MAX. Returning UINT32_MAX while the cluster key is a uint64_t was making the track states in the origin and calorimeters to be misidentified as MVTX states.

