### PR TITLE
save numerator and denominator of one pad fraction in TpcSeedsQA root…

### DIFF
--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -574,10 +574,14 @@ int TpcSeedsQA::EndRun(const int /*runnumber*/)
       if (num_track_side0_pt[region][index_pt]>0)
       {
         h_cluster_phisize1_fraction_mean_side0[region]->SetBinContent(index_pt+1,frac_side0_pt[region][index_pt] / num_track_side0_pt[region][index_pt]);
+        h_cluster_phisize1_fraction_mean_numerator_side0[region]->SetBinContent(index_pt+1,frac_side0_pt[region][index_pt]);
+        h_cluster_phisize1_fraction_mean_denominator_side0[region]->SetBinContent(index_pt+1,num_track_side0_pt[region][index_pt]);
       }
       if (num_track_side1_pt[region][index_pt]>0)
       {
         h_cluster_phisize1_fraction_mean_side1[region]->SetBinContent(index_pt+1,frac_side1_pt[region][index_pt] / num_track_side1_pt[region][index_pt]);
+        h_cluster_phisize1_fraction_mean_numerator_side1[region]->SetBinContent(index_pt+1,frac_side1_pt[region][index_pt]);
+        h_cluster_phisize1_fraction_mean_denominator_side1[region]->SetBinContent(index_pt+1,num_track_side1_pt[region][index_pt]);
       }
     }
   }
@@ -880,5 +884,30 @@ void TpcSeedsQA::createHistos()
     h_cluster_phisize1_fraction_mean_side1[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
     h_cluster_phisize1_fraction_mean_side1[region]->GetYaxis()->SetTitle("Fraction");
     hm->registerHisto(h_cluster_phisize1_fraction_mean_side1[region]);
+
+    h_cluster_phisize1_fraction_mean_numerator_side0[region] = new TH1F((boost::format("%sclusphisize1frac_mean_numerator_side0_%i") % getHistoPrefix() % region).str().c_str(),
+                                                         (boost::format("Pt vs. Average fraction mean_numerator (sum of fraction) of TPC Cluster Phi Size == 1, side 0, region_%i") % region).str().c_str(), 4, 1, 3.2);
+    h_cluster_phisize1_fraction_mean_numerator_side0[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+    h_cluster_phisize1_fraction_mean_numerator_side0[region]->GetYaxis()->SetTitle("Fraction");
+    hm->registerHisto(h_cluster_phisize1_fraction_mean_numerator_side0[region]);
+
+    h_cluster_phisize1_fraction_mean_numerator_side1[region] = new TH1F((boost::format("%sclusphisize1frac_mean_numerator_side1_%i") % getHistoPrefix() % region).str().c_str(),
+                                                         (boost::format("Pt vs. Average fraction mean_numerator (sum of fraction) of TPC Cluster Phi Size == 1, side 1, region_%i") % region).str().c_str(), 4, 1, 3.2);
+    h_cluster_phisize1_fraction_mean_numerator_side1[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+    h_cluster_phisize1_fraction_mean_numerator_side1[region]->GetYaxis()->SetTitle("Fraction");
+    hm->registerHisto(h_cluster_phisize1_fraction_mean_numerator_side1[region]);
+
+    h_cluster_phisize1_fraction_mean_denominator_side0[region] = new TH1F((boost::format("%sclusphisize1frac_mean_denominator_side0_%i") % getHistoPrefix() % region).str().c_str(),
+                                                         (boost::format("Pt vs. Average fraction mean_denominator (sum of track) of TPC Cluster Phi Size == 1, side 0, region_%i") % region).str().c_str(), 4, 1, 3.2);
+    h_cluster_phisize1_fraction_mean_denominator_side0[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+    h_cluster_phisize1_fraction_mean_denominator_side0[region]->GetYaxis()->SetTitle("Fraction");
+    hm->registerHisto(h_cluster_phisize1_fraction_mean_denominator_side0[region]);
+
+    h_cluster_phisize1_fraction_mean_denominator_side1[region] = new TH1F((boost::format("%sclusphisize1frac_mean_denominator_side1_%i") % getHistoPrefix() % region).str().c_str(),
+                                                         (boost::format("Pt vs. Average fraction mean_denominator (sum of track) of TPC Cluster Phi Size == 1, side 1, region_%i") % region).str().c_str(), 4, 1, 3.2);
+    h_cluster_phisize1_fraction_mean_denominator_side1[region]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+    h_cluster_phisize1_fraction_mean_denominator_side1[region]->GetYaxis()->SetTitle("Fraction");
+    hm->registerHisto(h_cluster_phisize1_fraction_mean_denominator_side1[region]);
+
   }
 }

--- a/offline/QA/Tracking/TpcSeedsQA.h
+++ b/offline/QA/Tracking/TpcSeedsQA.h
@@ -134,6 +134,12 @@ class TpcSeedsQA : public SubsysReco
   TH1* h_cluster_phisize1_fraction_mean_side0[3] = {nullptr};
   TH1* h_cluster_phisize1_fraction_mean_side1[3] = {nullptr};
 
+  TH1* h_cluster_phisize1_fraction_mean_numerator_side0[3] = {nullptr};
+  TH1* h_cluster_phisize1_fraction_mean_numerator_side1[3] = {nullptr};
+
+  TH1* h_cluster_phisize1_fraction_mean_denominator_side0[3] = {nullptr};
+  TH1* h_cluster_phisize1_fraction_mean_denominator_side1[3] = {nullptr};
+
   double frac_side0_pt[3][4] = {{0}};
   double frac_side1_pt[3][4] = {{0}};
 


### PR DESCRIPTION
… files

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Save numerator and denominator of one pad faction which are additive, and can work in aggregation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

