### PR TITLE
change trackmap name & lepton PDGID

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -183,7 +183,7 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, const KFPa
     }
   }
 
-  SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  SvtxTrackMap* originalTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_origin_track_map_node_name.c_str());
   KFParticle* daughterArray = &daughters[0];
 
   for (unsigned int k = 0; k < daughters.size(); ++k)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.h
@@ -46,6 +46,7 @@ class KFParticle_DST
   bool m_write_track_container = true;
   bool m_write_particle_container = true;
   std::string m_container_name;
+  std::string m_origin_track_map_node_name = "SvtxTrackMap";
 
  private:
   SvtxTrackMap* m_recoTrackMap = nullptr;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -301,6 +301,14 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                     {
                       slowTrackMass = kfp_Tools_evtReco.getParticleMass((Int_t) motherDecayProducts[trackArrayID].GetQ() * uniqueCombination[trackArrayID]);
                       slowTrackPDG = (Int_t) motherDecayProducts[trackArrayID].GetQ() * uniqueCombination[trackArrayID];
+                      // pi+ pdgid = 211, pi- pdgid = -211
+                      // e+ pdgid = -11, e- pdgid = 11
+                      // mu+ pdgid = -13, mu- pdgid = 13
+                      // tau+ pdgid = -15, tau- pdgid = 15
+                      if (abs(slowTrackPDG) == 11 || abs(slowTrackPDG) == 13 || abs(slowTrackPDG) == 15)
+                      {
+                        slowTrackPDG *= -1;
+                      }
                     }
                     else if ((Int_t) motherDecayProducts[trackArrayID].GetQ() == 0)
                     {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -434,6 +434,14 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
             {
               intParticleMass = kfp_Tools_evtReco.getParticleMass((Int_t) daughterTracks[i].GetQ() * PDGIDofFirstParticleInCombination[i]);
               intParticlePDG = (Int_t) daughterTracks[i].GetQ() * PDGIDofFirstParticleInCombination[i];
+              // pi+ pdgid = 211, pi- pdgid = -211
+              // e+ pdgid = -11, e- pdgid = 11
+              // mu+ pdgid = -13, mu- pdgid = 13
+              // tau+ pdgid = -15, tau- pdgid = 15
+              if (abs(intParticlePDG) == 11 || abs(intParticlePDG) == 13 || abs(intParticlePDG) == 15)
+              {
+                intParticlePDG *= -1;
+              }
             }
             else if ((Int_t) daughterTracks[i].GetQ() == 0)
             {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -307,7 +307,7 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void setVertexMapNodeName(const std::string &vtx_map_node_name) { m_vtx_map_node_name = m_vtx_map_node_name_nTuple = vtx_map_node_name; }
 
   /// Use alternate vertex and track fitters
-  void setTrackMapNodeName(const std::string &trk_map_node_name) { m_trk_map_node_name = m_trk_map_node_name_nTuple = trk_map_node_name; }
+  void setTrackMapNodeName(const std::string &trk_map_node_name) { m_trk_map_node_name = m_trk_map_node_name_nTuple = m_origin_track_map_node_name = trk_map_node_name; }
 
   void magFieldFile(const std::string &fname) { m_magField = fname; }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Two changes in this PR
1. In KFParticle_DST, we search for SvtxTrack by using track id which is the index in that track map. We should search in the input track map, rather than "SvtxTrackMap", because we can use track map different from SvtxTrackMap from default tracking software.
2. lepton PDG ID convention is different from charged hadrons. For example, pi+ --> 211, pi- --> -211, e+ --> -11, e- --> 11. I add a if statement to time an extra minus sign for lepton including e+/-, mu+/-, tau+/-.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

