### PR TITLE
Add a small module to filter TPC seeds for:

### DIFF
--- a/offline/packages/trackreco/TpcSeedFilter.cc
+++ b/offline/packages/trackreco/TpcSeedFilter.cc
@@ -1,0 +1,110 @@
+#include "TpcSeedFilter.h"
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>
+#include <phool/getClass.h>
+
+#include <trackbase_historic/SvtxTrack.h>
+#include <trackbase_historic/SvtxTrackMap.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+int TpcSeedFilter::process_event(PHCompositeNode* topNode)
+{
+  if (topNode == nullptr)
+  {
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  if (Verbosity() > 1000)
+  {
+    topNode->print(); 
+  }
+
+  // Get the map of all the input seeds
+  SvtxTrackMap* seeds = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
+  if (!seeds)
+  {
+    std::cout << "Could not locate SvtxTrackMap node when running "
+              << "\"TpcSeedFilter\" module." << std::endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  // iterate through the seeds and remove the ones that fail the cuts
+  for (SvtxTrackMap::Iter track_pair = seeds->begin();
+      track_pair != seeds->end(); ++track_pair)
+  {
+    auto& track = track_pair->second;
+    if (track == nullptr) continue;
+    
+    if (
+        ( _cut_on_min_pt && (track->get_pt() < _min_pt))
+     || ( _cut_on_max_pt && (track->get_pt() > _max_pt))
+     || ( _cut_on_min_eta && (track->get_eta() < _min_eta))
+     || ( _cut_on_max_eta && (track->get_eta() > _max_eta))
+     || ( track->size_cluster_keys() < _nclus_min )
+     ) {
+      if (Verbosity() > 4) {
+        std::cout << " Cutting track: id(" << static_cast<int>(track_pair->first)
+          << ")  nclusters: " // << std::static_cast<int>(track->size_cluster_keys() 
+          << "   pt: " << track->get_pt() << "  eta: " << track->get_eta() << std::endl;
+      }
+      seeds->erase(track_pair->first);
+      continue;
+    }
+    if (_must_span_sectors) {
+      // check that there are clusters in at least 2 of the three layers of sectors
+      bool in_0 = false;
+      bool in_1 = false;
+      bool in_2 = false;
+      unsigned int sec_cnt = 0;
+      for (auto key = track->begin_cluster_keys();
+          key != track->end_cluster_keys();
+          ++key)
+      {
+        unsigned int layer = TrkrDefs::getLayer(*key);
+        if (Verbosity() > 4)
+        {
+          std::cout << ((int) layer) << " ";
+        }
+
+        if (layer < 23 && !in_0)
+        {
+          in_0 = true; 
+          sec_cnt += 1;
+        }
+        else if (layer < 40 && !in_1)
+        { 
+          in_1 = true; 
+          sec_cnt += 1;
+        }
+        else if ( layer < 49 && !in_2) // CHECK
+        { 
+          in_2 = true; 
+          sec_cnt += 1;
+        }
+
+        if (sec_cnt >= _min_radial_sectors) break;
+      }
+      if (sec_cnt < _min_radial_sectors) {
+        //cut the track
+        seeds->erase(track_pair->first);
+
+        if (Verbosity() > 4) {
+          std::cout << " Cutting track: id(" << static_cast<int>(track_pair->first)
+            << ") :  clusters only in ";
+          if (in_0) std::cout << " inner ";
+          if (in_1) std::cout << " middle ";
+          if (in_2) std::cout << " outer ";
+          std::cout << " radial sectors but needs at least " 
+            << static_cast<int>(_min_radial_sectors) << std::endl;
+        }
+        continue;
+      }
+    }
+  }
+  if (Verbosity()>5) {
+    std::cout << " Done cutting on QA for tracks." << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/trackreco/TpcSeedFilter.h
+++ b/offline/packages/trackreco/TpcSeedFilter.h
@@ -1,0 +1,89 @@
+#ifndef TPCSEEDFILTER__H
+#define TPCSEEDFILTER__H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/TrackSeed.h>
+
+#include <iostream>
+#include <map>
+#include <vector>
+
+// This module, if put in an anayslis chain, will filter through the TpcSeeds (tracks made
+// of clusters in the TPC) and null out any tracks that don't pass the set cuts
+
+class SvtxTrack;
+class SvtxTrackMap;
+class PHCompositeNode;
+
+class TpcSeedFilter : public SubsysReco
+{
+  //--------------------------------------------------
+  // Standard public interface
+  //--------------------------------------------------
+ public:
+  int process_event(PHCompositeNode* topNode) override;
+  TpcSeedFilter( // Criteria to match a TrkrClusterContainer and track
+      /*-----------------------------------------------------------------------------------
+      * Input criteria for Truth Track (with nT clusters) to reco track (with nR clusters) :
+      *  - nclus_min   : minimum number of clusters in tpc
+      *  - min_pt      
+      *  - max_pt      : default -1 for no cut
+      *  - min_eta     : default to no eta cut
+      *  - max_eta     : default to no eta cut
+      *  - clusters_cross_boundaries : require clusters in at least two
+      *      different radial sectors.
+      *
+      * @Future cuts:
+      *   - cut on cluster values? (small clusters, etc...)
+      *   - cut on 
+      *--------------------------------------------------------*/
+        unsigned int _nclus_min_ = 10
+      , unsigned int _min_radial_sectors_ = 1
+      , float _min_pt_  = -1.0  // no cut default
+      , float _max_pt_  = -1.0  // no cut default
+      , float _min_eta_ = -100. // won't apply a cut
+      , float _max_eta_ = 100.  // won't apply a cut
+      )  
+      : _nclus_min { _nclus_min_ }
+      , _min_radial_sectors { _min_radial_sectors_ }
+      , _must_span_sectors { _min_radial_sectors > 1 }
+      , _min_pt { _min_pt_ }
+      , _max_pt { _max_pt_ }
+      , _min_eta { _min_eta_ }
+      , _max_eta { _max_eta_ }
+      , _cut_on_min_pt  { _min_pt  != -1.0  }
+      , _cut_on_max_pt  { _max_pt  != -1.0  }
+      , _cut_on_min_eta { _min_eta != -100. }
+      , _cut_on_max_eta { _max_eta != -100. }
+      {
+      };
+
+ public:
+
+  void set_min_radial_sectors (unsigned int nsec) { 
+    _min_radial_sectors = nsec; 
+    if (_min_radial_sectors > 1) { _must_span_sectors = true; }
+  };
+  
+  void setcut_min_pt(float val) { _min_pt = val; _cut_on_min_pt = true; };
+  void setcut_max_pt(float val) { _max_pt = val; _cut_on_max_pt = true; };
+
+  void setcut_min_eta(float val) { _min_eta = val; _cut_on_min_eta = true; };
+  void setcut_max_eta(float val) { _max_eta = val; _cut_on_max_eta = true; };
+
+ private:
+    unsigned int   _nclus_min;
+    unsigned int   _min_radial_sectors;
+    bool  _must_span_sectors { false };
+    float _min_pt        ;
+    float _max_pt        ;
+    float _min_eta       ;
+    float _max_eta       ;
+    bool  _cut_on_min_pt  {false};
+    bool  _cut_on_max_pt  {false};
+    bool  _cut_on_min_eta {false};
+    bool  _cut_on_max_eta {false};
+};
+
+#endif


### PR DESCRIPTION
1. minimum number of clusters
2. require clusters in multiple radial segements
3. min pt
4. max pt
6. min eta 7 max eta

The default behavior is to make no cuts at all, and the user can use either the arguments in the constructor or separate setters. All it does is delete tracks don't pass cuts.
Currently acts only on TPC segements (not TPC + Silicon).

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

