### PR TITLE
Harmonize mvtx cosmics

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -678,7 +678,9 @@ void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
                                      ActsGeometry* geometry)
 {
   if (clusters->size()< m_min_cluster_size)
+  {
     return;
+  }
   for (auto& det : {TrkrDefs::TrkrId::mvtxId, TrkrDefs::TrkrId::inttId,
                     TrkrDefs::TrkrId::tpcId, TrkrDefs::TrkrId::micromegasId})
   {
@@ -691,14 +693,16 @@ void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
         auto key = iter->first;
         auto cluster = clusters->findCluster(key);
         Acts::Vector3 glob;
-        if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
-        {
-          glob = geometry->getGlobalPosition(key, cluster);  // corrections make no sense if crossing is not known
-        }
-        else
-        {
-          glob = geometry->getGlobalPosition(key, cluster);
-        }
+        // NOT IMPLEMENTED YET
+        // if (TrkrDefs::getTrkrId(key) == TrkrDefs::tpcId)
+        // {
+        //   glob = geometry->getGlobalPosition(key, cluster);  // corrections make no sense if crossing is not known
+        // }
+        // else
+        // {
+        //   glob = geometry->getGlobalPosition(key, cluster);
+        // }
+        glob = geometry->getGlobalPosition(key, cluster);
         m_sclusgx = glob.x();
         m_sclusgy = glob.y();
         m_sclusgz = glob.z();

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -298,8 +298,10 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
 
   fillVertexTree(topNode);
 
-  fillEventTree(topNode);
-
+  if (m_doEventTree)
+  {
+    fillEventTree(topNode);
+  }
   m_event++;
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -793,7 +795,10 @@ int TrackResiduals::End(PHCompositeNode* /*unused*/)
   }
   m_vertextree->Write();
   m_failedfits->Write();
-  m_eventtree->Write();
+  if (m_doEventTree)
+  {
+    m_eventtree->Write();
+  }
   m_outfile->Close();
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -1575,21 +1580,24 @@ void TrackResiduals::fillStatesWithLineFit(const TrkrDefs::cluskey& key,
 }
 void TrackResiduals::createBranches()
 {
-  m_eventtree = new TTree("eventtree", "A tree with all hits");
-  m_eventtree->Branch("run", &m_runnumber, "m_runnumber/I");
-  m_eventtree->Branch("segment", &m_segment, "m_segment/I");
-  m_eventtree->Branch("event", &m_event, "m_event/I");
-  m_eventtree->Branch("gl1bco", &m_bco, "m_bco/I");
-  m_eventtree->Branch("nmvtx", &m_nmvtx_all, "m_nmvtx_all/I");
-  m_eventtree->Branch("nintt", &m_nintt_all, "m_nintt_all/I");
-  m_eventtree->Branch("nhittpc0", &m_ntpc_hits0, "m_ntpc_hits0/I");
-  m_eventtree->Branch("nhittpc1", &m_ntpc_hits1, "m_ntpc_hits1/I");
-  m_eventtree->Branch("nclustpc0", &m_ntpc_clus0, "m_ntpc_clus0/I");
-  m_eventtree->Branch("nclustpc1", &m_ntpc_clus1, "m_ntpc_clus1/I");
-  m_eventtree->Branch("nmms", &m_nmms_all, "m_nmms_all/I");
-  m_eventtree->Branch("nsiseed", &m_nsiseed, "m_nsiseed/I");
-  m_eventtree->Branch("ntpcseed", &m_ntpcseed, "m_ntpcseed/I");
-  m_eventtree->Branch("ntracks", &m_ntracks_all, "m_ntracks_all/I");
+  if (m_doEventTree)
+  {
+    m_eventtree = new TTree("eventtree", "A tree with all hits");
+    m_eventtree->Branch("run", &m_runnumber, "m_runnumber/I");
+    m_eventtree->Branch("segment", &m_segment, "m_segment/I");
+    m_eventtree->Branch("event", &m_event, "m_event/I");
+    m_eventtree->Branch("gl1bco", &m_bco, "m_bco/I");
+    m_eventtree->Branch("nmvtx", &m_nmvtx_all, "m_nmvtx_all/I");
+    m_eventtree->Branch("nintt", &m_nintt_all, "m_nintt_all/I");
+    m_eventtree->Branch("nhittpc0", &m_ntpc_hits0, "m_ntpc_hits0/I");
+    m_eventtree->Branch("nhittpc1", &m_ntpc_hits1, "m_ntpc_hits1/I");
+    m_eventtree->Branch("nclustpc0", &m_ntpc_clus0, "m_ntpc_clus0/I");
+    m_eventtree->Branch("nclustpc1", &m_ntpc_clus1, "m_ntpc_clus1/I");
+    m_eventtree->Branch("nmms", &m_nmms_all, "m_nmms_all/I");
+    m_eventtree->Branch("nsiseed", &m_nsiseed, "m_nsiseed/I");
+    m_eventtree->Branch("ntpcseed", &m_ntpcseed, "m_ntpcseed/I");
+    m_eventtree->Branch("ntracks", &m_ntracks_all, "m_ntracks_all/I");
+  }
 
   m_failedfits = new TTree("failedfits", "tree with seeds from failed Acts fits");
   m_failedfits->Branch("run", &m_runnumber, "m_runnumber/I");
@@ -2169,16 +2177,19 @@ void TrackResiduals::fillEventTree(PHCompositeNode* topNode)
       }
     }
   }
-  if (Verbosity() > 1)
+  if (m_doEventTree)
   {
-    std::cout << " m_event:" << m_event << std::endl;
-    std::cout << " m_ntpc_clus0:" << m_ntpc_clus0 << std::endl;
-    std::cout << " m_ntpc_clus1: " << m_ntpc_clus1 << std::endl;
-    std::cout << " m_nmvtx_all:" << m_nmvtx_all << std::endl;
-    std::cout << " m_nintt_all: " << m_nintt_all << std::endl;
-    std::cout << " m_nmms_all: " << m_nmms_all << std::endl;
+    if (Verbosity() > 1)
+    {
+      std::cout << " m_event:" << m_event << std::endl;
+      std::cout << " m_ntpc_clus0:" << m_ntpc_clus0 << std::endl;
+      std::cout << " m_ntpc_clus1: " << m_ntpc_clus1 << std::endl;
+      std::cout << " m_nmvtx_all:" << m_nmvtx_all << std::endl;
+      std::cout << " m_nintt_all: " << m_nintt_all << std::endl;
+      std::cout << " m_nmms_all: " << m_nmms_all << std::endl;
+    }
+    m_eventtree->Fill();
   }
-  m_eventtree->Fill();
 }
 
 void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -675,6 +675,8 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
 void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
                                      ActsGeometry* geometry)
 {
+  if (clusters->size()< m_min_cluster_size)
+    return;
   for (auto& det : {TrkrDefs::TrkrId::mvtxId, TrkrDefs::TrkrId::inttId,
                     TrkrDefs::TrkrId::tpcId, TrkrDefs::TrkrId::micromegasId})
   {

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -118,7 +118,7 @@ class TrackResiduals : public SubsysReco
   bool m_convertSeeds = false;
   bool m_linefitTPCOnly = true;
   bool m_dropClustersNoState = false;
-  int m_min_cluster_size = 0;
+  unsigned int m_min_cluster_size = 0;
 
   bool m_doMicromegasOnly = false;
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -48,6 +48,7 @@ class TrackResiduals : public SubsysReco
   void trackmapName(const std::string &name) { m_trackMapName = name; }
   void clusterTree() { m_doClusters = true; }
   void hitTree() { m_doHits = true; }
+  void noEventTree() {m_doEventTree = false;}
   void ppmode() { m_ppmode = true; }
   void convertSeeds(bool flag) { m_convertSeeds = flag; }
   void dropClustersNoState(bool flag) { m_dropClustersNoState = flag; }
@@ -101,6 +102,7 @@ class TrackResiduals : public SubsysReco
 
   bool m_doClusters = false;
   bool m_doHits = false;
+  bool m_doEventTree = true;
   bool m_zeroField = false;
   bool m_doFailedSeeds = false;
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -55,7 +55,7 @@ class TrackResiduals : public SubsysReco
   void runnumber(const int run) { m_runnumber = run; }
   void segment(const int seg) { m_segment = seg; }
   void linefitAll() { m_linefitTPCOnly = false; }
-  void setClusterMinSize(int size) { m_min_cluster_size = size; }
+  void setClusterMinSize(unsigned int size) { m_min_cluster_size = size; }
   void failedTree() { m_doFailedSeeds = true; }
   void setSegment(const int segment) { m_segment = segment; }
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -55,6 +55,7 @@ class TrackResiduals : public SubsysReco
   void runnumber(const int run) { m_runnumber = run; }
   void segment(const int seg) { m_segment = seg; }
   void linefitAll() { m_linefitTPCOnly = false; }
+  void setClusterMinSize(int size) { m_min_cluster_size = size; }
   void failedTree() { m_doFailedSeeds = true; }
   void setSegment(const int segment) { m_segment = segment; }
 
@@ -117,6 +118,7 @@ class TrackResiduals : public SubsysReco
   bool m_convertSeeds = false;
   bool m_linefitTPCOnly = true;
   bool m_dropClustersNoState = false;
+  int m_min_cluster_size = 0;
 
   bool m_doMicromegasOnly = false;
 

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -437,7 +437,7 @@ PHCosmicSeeder::makeSeeds(PHCosmicSeeder::PositionMap& clusterPositions)
       float dist12_check = 2.;
       if (m_trackerId == TrkrDefs::TrkrId::mvtxId)
       {
-        dist12_check = 1.
+        dist12_check = 1.;
       }
       if (dist1 < dist2)
       {

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -452,7 +452,7 @@ PHCosmicSeeder::makeSeeds(PHCosmicSeeder::PositionMap& clusterPositions)
 
       float predy = dub.xyslope * pos.x() + dub.xyintercept;
       float predr = dub.rzslope * pos.z() + dub.rzintercept;
-      if (Verbosity() > 3)
+      if (Verbosity() > 2)
       {
         std::cout << "testing ckey " << key << " with box dca "
                   << predy << ", " << pos.transpose() << " and " << predr << ", " << r(pos.x(), pos.y())

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -122,7 +122,6 @@ int PHCosmicSeeder::process_event(PHCompositeNode*)
   }
   auto chainedSeeds = chainSeeds(finalSeeds, clusterPositions);
   // auto chainedSeeds = finalSeeds;
-
   if (Verbosity() > 1)
   {
     std::cout << "Total seeds found is " << chainedSeeds.size() << std::endl;
@@ -256,7 +255,7 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::chainSeeds(PHCosmicSeeder::SeedVector
       float pdiff3 = fabs((seed1.rzintercept - seed2.rzintercept) / longestrzint);
       float pdiff4 = fabs((seed1.rzslope - seed2.rzslope) / longestrzslope);
       if (pdiff < 1. && pdiff2 < 1. && pdiff3 < 1. && pdiff4 < 1.)
-      { 
+      {
         seedsToDelete.insert(j);
         for (auto& key : seed2.ckeys)
         {
@@ -335,7 +334,7 @@ PHCosmicSeeder::SeedVector PHCosmicSeeder::combineSeeds(PHCosmicSeeder::SeedVect
       }
     }
   }
-  if (Verbosity() > 2)
+  if (Verbosity() > 4)
   {
     std::cout << "seeds to delete size is " << seedsToDelete.size() << std::endl;
   }
@@ -435,14 +434,19 @@ PHCosmicSeeder::makeSeeds(PHCosmicSeeder::PositionMap& clusterPositions)
       // only look at the cluster that is within 2cm of the doublet clusters
       float dist1 = (pos1 - pos).norm();
       float dist2 = (pos2 - pos).norm();
+      float dist12_check = 2.;
+      if (m_trackerId == TrkrDefs::TrkrId::mvtxId)
+      {
+        dist12_check = 1.
+      }
       if (dist1 < dist2)
       {
-        if (dist1 > 1)
+        if (dist1 > dist12_check)
           continue;
       }
       else
       {
-        if (dist2 > 1)
+        if (dist2 > dist12_check)
           continue;
       }
 

--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -75,7 +75,7 @@ int PHCosmicSeeder::InitRun(PHCompositeNode* topNode)
 int PHCosmicSeeder::process_event(PHCompositeNode*)
 {
   PHCosmicSeeder::PositionMap clusterPositions;
-  for (const auto& hitsetkey : m_clusterContainer->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  for (const auto& hitsetkey : m_clusterContainer->getHitSetKeys(m_trackerId))
   {
     auto range = m_clusterContainer->getClusters(hitsetkey);
     for (auto citer = range.first; citer != range.second; ++citer)

--- a/offline/packages/trackreco/PHCosmicSeeder.h
+++ b/offline/packages/trackreco/PHCosmicSeeder.h
@@ -30,14 +30,14 @@ class PHCosmicSeeder : public SubsysReco
   using SeedVector = std::vector<seed>;
   PHCosmicSeeder(const std::string &name = "PHCosmicSeeder");
 
-  ~PHCosmicSeeder() override;
+  ~PHCosmicSeeder() override = default;
   int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   void xyTolerance(float tol) { m_xyTolerance = tol; }
   void seedAnalysis() { m_analysis = true; }
-  void trackMapName(std::string name) { m_trackMapName = name; }
+  void trackMapName(const std::string &name) { m_trackMapName = name; }
   void trackerId(TrkrDefs::TrkrId trackerId) { m_trackerId = trackerId; }
 
  private:

--- a/offline/packages/trackreco/PHCosmicSeeder.h
+++ b/offline/packages/trackreco/PHCosmicSeeder.h
@@ -37,6 +37,8 @@ class PHCosmicSeeder : public SubsysReco
   int End(PHCompositeNode *topNode) override;
   void xyTolerance(float tol) { m_xyTolerance = tol; }
   void seedAnalysis() { m_analysis = true; }
+  void trackMapName(std::string name) { m_trackMapName = name; }
+  void trackerId(TrkrDefs::TrkrId trackerId) { m_trackerId = trackerId; }
 
  private:
   int getNodes(PHCompositeNode *topNode);
@@ -50,6 +52,7 @@ class PHCosmicSeeder : public SubsysReco
   float m_xyTolerance = 2.;  //! cm
 //  float m_rzTolerance = 2.;  //! cm
   std::string m_trackMapName = "TpcTrackSeedContainer";
+  TrkrDefs::TrkrId m_trackerId = TrkrDefs::TrkrId::tpcId;
   ActsGeometry *m_tGeometry = nullptr;
   TrkrClusterContainer *m_clusterContainer = nullptr;
   TrackSeedContainer *m_seedContainer = nullptr;


### PR DESCRIPTION
[comment]: <> (PR to enable MVTX only running with cosmic seeder, and allow output from the TrackResiduals)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( Enables setters for various functions in the cosmic seeder that allow one to set the the seeder to work for the MVTX only cosmic seeding. These are mostly in the cosmicSeeder package, with a few small additions to the TrackResiduals module to control file size (if desired) by reducing events with too few clusters and disabling the event tree. By default, the code should remain the same unless the new options are enabled in a macro. )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

