### PR TITLE
feat: skip tpc bcos way behind the gl1

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -485,7 +485,6 @@ void Fun4AllStreamingInputManager::AddGl1RawHit(uint64_t bclk, Gl1Packet *hit)
 {
   if (Verbosity() > 1)
   {
-    std::cout << "gl1 bclock is " << bclk << std::endl;
     std::cout << "Adding gl1 hit to bclk 0x"
               << std::hex << bclk << std::dec << std::endl;
   }
@@ -551,9 +550,8 @@ void Fun4AllStreamingInputManager::AddTpcRawHit(uint64_t bclk, TpcRawHit *hit)
 {
   if (Verbosity() > 1)
   {
-    std::cout << "adding tpchit " << bclk << std::endl;
     std::cout << "Adding tpc hit to bclk 0x"
-              << std::dec << bclk << std::dec << std::endl;
+              << std::hex << bclk << std::dec << std::endl;
   }
   m_TpcRawHitMap[bclk].TpcRawHitVector.push_back(hit);
 }
@@ -1088,13 +1086,11 @@ int Fun4AllStreamingInputManager::FillMicromegas()
 
 int Fun4AllStreamingInputManager::FillTpc()
 {
-  std::cout << "Ref BCO: " << m_RefBCO << std::endl;
   int iret = FillTpcPool();
   if (iret)
   {
     return iret;
   }
-  std::cout << "first tpc bco " << m_TpcRawHitMap.begin()->first << std::endl;
   TpcRawHitContainer *tpccont = findNode::getClass<TpcRawHitContainer>(m_topNode, "TPCRAWHIT");
   if (!tpccont)
   {
@@ -1116,15 +1112,12 @@ int Fun4AllStreamingInputManager::FillTpc()
   select_crossings += m_RefBCO;
   if (Verbosity() > 2)
   {
-    /*
+    
     std::cout << "select TPC crossings"
               << " from 0x" << std::hex << m_RefBCO - m_tpc_negative_bco
               << " to 0x" << select_crossings - m_tpc_negative_bco
-              << std::dec << std::endl;*/
-      std::cout << "Select TPC crossings from " << m_RefBCO - m_tpc_negative_bco
-                << " to " << select_crossings - m_tpc_negative_bco << std::endl;
-    std::cout << "Ref is " << m_RefBCO << std::endl;
-    std::cout << "tpcraw hit first fill is " << m_TpcRawHitMap.begin()->first << std::endl;
+              << std::dec << std::endl;
+
   }
   // m_TpcRawHitMap.empty() does not need to be checked here, FillTpcPool returns non zero
   // if this map is empty which is handled above

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -485,6 +485,7 @@ void Fun4AllStreamingInputManager::AddGl1RawHit(uint64_t bclk, Gl1Packet *hit)
 {
   if (Verbosity() > 1)
   {
+    std::cout << "gl1 bclock is " << bclk << std::endl;
     std::cout << "Adding gl1 hit to bclk 0x"
               << std::hex << bclk << std::dec << std::endl;
   }
@@ -550,8 +551,9 @@ void Fun4AllStreamingInputManager::AddTpcRawHit(uint64_t bclk, TpcRawHit *hit)
 {
   if (Verbosity() > 1)
   {
+    std::cout << "adding tpchit " << bclk << std::endl;
     std::cout << "Adding tpc hit to bclk 0x"
-              << std::hex << bclk << std::dec << std::endl;
+              << std::dec << bclk << std::dec << std::endl;
   }
   m_TpcRawHitMap[bclk].TpcRawHitVector.push_back(hit);
 }
@@ -1086,12 +1088,13 @@ int Fun4AllStreamingInputManager::FillMicromegas()
 
 int Fun4AllStreamingInputManager::FillTpc()
 {
+  std::cout << "Ref BCO: " << m_RefBCO << std::endl;
   int iret = FillTpcPool();
   if (iret)
   {
     return iret;
   }
-
+  std::cout << "first tpc bco " << m_TpcRawHitMap.begin()->first << std::endl;
   TpcRawHitContainer *tpccont = findNode::getClass<TpcRawHitContainer>(m_topNode, "TPCRAWHIT");
   if (!tpccont)
   {
@@ -1113,10 +1116,15 @@ int Fun4AllStreamingInputManager::FillTpc()
   select_crossings += m_RefBCO;
   if (Verbosity() > 2)
   {
+    /*
     std::cout << "select TPC crossings"
               << " from 0x" << std::hex << m_RefBCO - m_tpc_negative_bco
               << " to 0x" << select_crossings - m_tpc_negative_bco
-              << std::dec << std::endl;
+              << std::dec << std::endl;*/
+      std::cout << "Select TPC crossings from " << m_RefBCO - m_tpc_negative_bco
+                << " to " << select_crossings - m_tpc_negative_bco << std::endl;
+    std::cout << "Ref is " << m_RefBCO << std::endl;
+    std::cout << "tpcraw hit first fill is " << m_TpcRawHitMap.begin()->first << std::endl;
   }
   // m_TpcRawHitMap.empty() does not need to be checked here, FillTpcPool returns non zero
   // if this map is empty which is handled above
@@ -1292,13 +1300,19 @@ int Fun4AllStreamingInputManager::FillInttPool()
 
 int Fun4AllStreamingInputManager::FillTpcPool()
 {
+  uint64_t ref_bco_minus_range = 0;
+  if(m_RefBCO > m_tpc_negative_bco)
+  {
+    ref_bco_minus_range = m_RefBCO - m_tpc_negative_bco;
+  }
+
   for (auto iter : m_TpcInputVector)
   {
     if (Verbosity() > 0)
     {
       std::cout << "Fun4AllStreamingInputManager::FillTpcPool - fill pool for " << iter->Name() << std::endl;
     }
-    iter->FillPool();
+    iter->FillPool(ref_bco_minus_range);
     if (m_RunNumber == 0)
     {
       m_RunNumber = iter->RunNumber();

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -108,16 +108,16 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
     {
       for (int i = 0; i < npackets; i++)
       {
-	int numBCOs = plist[i]->iValue(0, "NR_BCOS");
-	for (int j = 0; j < numBCOs; j++)
-	{
-	  uint64_t bco = plist[i]->lValue(j, "BCOLIST");
-	  if (bco < minBCO)
-	  {
-	    continue;
-	  }
-	  m_SkipEarlyEvents = false;
-	}
+        int numBCOs = plist[i]->iValue(0, "NR_BCOS");
+        for (int j = 0; j < numBCOs; j++)
+        {
+          uint64_t bco = plist[i]->lValue(j, "BCOLIST");
+          if (bco < minBCO)
+          {
+            continue;
+          }
+          m_SkipEarlyEvents = false;
+        }
       }
     }
     if (m_SkipEarlyEvents)

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -6,8 +6,6 @@
 #include <ffarawobjects/TpcRawHitContainerv1.h>
 #include <ffarawobjects/TpcRawHitv1.h>
 
-#include <frog/FROG.h>
-
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
@@ -21,19 +19,11 @@
 #include <memory>
 #include <set>
 
-const int NTPCPACKETS = 3;
-
 SingleTpcPoolInput::SingleTpcPoolInput(const std::string &name)
   : SingleStreamingInput(name)
 {
   SubsystemEnum(InputManagerType::TPC);
-  plist = new Packet *[NTPCPACKETS];
   m_rawHitContainerName = "TPCRAWHIT";
-}
-
-SingleTpcPoolInput::~SingleTpcPoolInput()
-{
-  delete[] plist;
 }
 
 void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
@@ -79,26 +69,18 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
-    int npackets = evt->getPacketList(plist, NTPCPACKETS);
-
-    if (npackets >= NTPCPACKETS)
-    {
-      std::cout << PHWHERE << " Packets array size " << NTPCPACKETS
-                << " too small for " << Name()
-                << ", increase NTPCPACKETS and rebuild" << std::endl;
-      exit(1);
-    }
+    std::vector<Packet *> pktvec = evt->getPacketVector();
     if (m_skipEarlyEvents)
     {
-      for (int i = 0; i < npackets; i++)
+      for (auto packet : pktvec)
       {
-        int numBCOs = plist[i]->lValue(0, "N_TAGGER");
+        int numBCOs = packet->lValue(0, "N_TAGGER");
         for (int j = 0; j < numBCOs; j++)
         {
-          const auto is_lvl1 = static_cast<uint8_t>(plist[i]->lValue(j, "IS_LEVEL1_TRIGGER"));
+          const auto is_lvl1 = static_cast<uint8_t>(packet->lValue(j, "IS_LEVEL1_TRIGGER"));
           if (is_lvl1)
           {
-            uint64_t bco = plist[i]->lValue(j, "BCO");
+            uint64_t bco = packet->lValue(j, "BCO");
             if (bco < minBCO)
             {
               continue;
@@ -110,17 +92,14 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
     }
     if (m_skipEarlyEvents)
     {
-      for (int i = 0; i < npackets; i++)
+      for (auto packet : pktvec)
       {
-        delete plist[i];
+        delete packet;
       }
       continue;
     }
-    for (int i = 0; i < npackets; i++)
+    for (auto packet : pktvec)
     {
-      // keep pointer to local packet
-      auto &packet = plist[i];
-
       // get packet id
       const auto packet_id = packet->getIdentifier();
 
@@ -143,11 +122,11 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
         if (is_lvl1)
         {
           gtm_bco = packet->lValue(t, "BCO");
-          if(largest_bco < gtm_bco)
+          if (largest_bco < gtm_bco)
           {
             largest_bco = gtm_bco;
           }
-          if(gtm_bco < minBCO)
+          if (gtm_bco < minBCO)
           {
             continue;
           }
@@ -165,109 +144,109 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
           m_BclkStackPacketMap[packet_id].insert(gtm_bco);
         }
       }
-      if(skipthis)
+      if (skipthis)
       {
-        if(Verbosity() > 1)
+        if (Verbosity() > 1)
         {
-          std::cout << "Largest bco: 0x"<<std::hex << largest_bco << ", minbco 0x"
-          << minBCO <<std::dec << ", evtno: " << EventSequence << std::endl;
+          std::cout << "Largest bco: 0x" << std::hex << largest_bco << ", minbco 0x"
+                    << minBCO << std::dec << ", evtno: " << EventSequence << std::endl;
         }
       }
       else
       {
-      int m_nWaveFormInFrame = packet->iValue(0, "NR_WF");
-      static int once = 0;
-      for (int wf = 0; wf < m_nWaveFormInFrame; wf++)
-      {
-        if (m_TpcRawHitMap[gtm_bco].size() > 20000)
+        int m_nWaveFormInFrame = packet->iValue(0, "NR_WF");
+        static int once = 0;
+        for (int wf = 0; wf < m_nWaveFormInFrame; wf++)
         {
-          if (!once)
+          if (m_TpcRawHitMap[gtm_bco].size() > 20000)
           {
-            std::cout << "too many hits" << std::endl;
-          }
-          once++;
-          continue;
-        }
-        else
-        {
-          if (once)
-          {
-            std::cout << "many more hits: " << once << std::endl;
-          }
-          once = 0;
-        }
-
-        if (packet->iValue(wf, "CHECKSUMERROR") == 1)
-        {
-          continue;
-        }
-
-        TpcRawHit *newhit = new TpcRawHitv1();
-        int FEE = packet->iValue(wf, "FEE");
-        newhit->set_bco(packet->iValue(wf, "BCO"));
-
-        // store gtm bco in hit
-        newhit->set_gtm_bco(gtm_bco);
-
-        newhit->set_packetid(packet->getIdentifier());
-        newhit->set_fee(FEE);
-        newhit->set_channel(packet->iValue(wf, "CHANNEL"));
-        newhit->set_sampaaddress(packet->iValue(wf, "SAMPAADDRESS"));
-        newhit->set_sampachannel(packet->iValue(wf, "CHANNEL"));
-
-        //         // checksum and checksum error
-        //         newhit->set_checksum( packet->iValue(iwf, "CHECKSUM") );
-        //         newhit->set_checksum_error( packet->iValue(iwf, "CHECKSUMERROR") );
-
-        // samples
-        // const uint16_t samples = packet->iValue(wf, "SAMPLES");
-
-        // Temp remedy as we set the time window as 425 for now (extended from previous 360
-        // due to including of diffused laser flush)
-        const uint16_t samples = m_max_tpc_time_samples;
-
-        newhit->set_samples(samples);
-
-        // adc values
-        for (uint16_t is = 0; is < samples; ++is)
-        {
-          uint16_t adval = packet->iValue(wf, is);
-
-          // This is temporary fix for decoder change. Will be changed again for real ZS data decoding.
-          // if(adval >= 64000){ newhit->set_samples(is); break;}
-
-          // With this, the hit is unseen from clusterizer
-          if (adval >= 64000)
-          {
-            newhit->set_adc(is, 0);
+            if (!once)
+            {
+              std::cout << "too many hits" << std::endl;
+            }
+            once++;
+            continue;
           }
           else
           {
-            newhit->set_adc(is, adval);
+            if (once)
+            {
+              std::cout << "many more hits: " << once << std::endl;
+            }
+            once = 0;
           }
-        }
 
-        m_BeamClockFEE[gtm_bco].insert(FEE);
-        m_FEEBclkMap[FEE] = gtm_bco;
-        if (Verbosity() > 2)
-        {
-          std::cout << "evtno: " << EventSequence
-                    << ", hits: " << wf
-                    << ", num waveforms: " << m_nWaveFormInFrame
-                    << ", bco: 0x" << std::hex << gtm_bco << std::dec
-                    << ", FEE: " << FEE << std::endl;
+          if (packet->iValue(wf, "CHECKSUMERROR") == 1)
+          {
+            continue;
+          }
+
+          TpcRawHit *newhit = new TpcRawHitv1();
+          int FEE = packet->iValue(wf, "FEE");
+          newhit->set_bco(packet->iValue(wf, "BCO"));
+
+          // store gtm bco in hit
+          newhit->set_gtm_bco(gtm_bco);
+
+          newhit->set_packetid(packet->getIdentifier());
+          newhit->set_fee(FEE);
+          newhit->set_channel(packet->iValue(wf, "CHANNEL"));
+          newhit->set_sampaaddress(packet->iValue(wf, "SAMPAADDRESS"));
+          newhit->set_sampachannel(packet->iValue(wf, "CHANNEL"));
+
+          //         // checksum and checksum error
+          //         newhit->set_checksum( packet->iValue(iwf, "CHECKSUM") );
+          //         newhit->set_checksum_error( packet->iValue(iwf, "CHECKSUMERROR") );
+
+          // samples
+          // const uint16_t samples = packet->iValue(wf, "SAMPLES");
+
+          // Temp remedy as we set the time window as 425 for now (extended from previous 360
+          // due to including of diffused laser flush)
+          const uint16_t samples = m_max_tpc_time_samples;
+
+          newhit->set_samples(samples);
+
+          // adc values
+          for (uint16_t is = 0; is < samples; ++is)
+          {
+            uint16_t adval = packet->iValue(wf, is);
+
+            // This is temporary fix for decoder change. Will be changed again for real ZS data decoding.
+            // if(adval >= 64000){ newhit->set_samples(is); break;}
+
+            // With this, the hit is unseen from clusterizer
+            if (adval >= 64000)
+            {
+              newhit->set_adc(is, 0);
+            }
+            else
+            {
+              newhit->set_adc(is, adval);
+            }
+          }
+
+          m_BeamClockFEE[gtm_bco].insert(FEE);
+          m_FEEBclkMap[FEE] = gtm_bco;
+          if (Verbosity() > 2)
+          {
+            std::cout << "evtno: " << EventSequence
+                      << ", hits: " << wf
+                      << ", num waveforms: " << m_nWaveFormInFrame
+                      << ", bco: 0x" << std::hex << gtm_bco << std::dec
+                      << ", FEE: " << FEE << std::endl;
+          }
+          //          packet->convert();
+          // if (m_TpcRawHitMap[gtm_bco].size() < 50000)
+          // {
+          if (StreamingInputManager())
+          {
+            StreamingInputManager()->AddTpcRawHit(gtm_bco, newhit);
+          }
+          m_TpcRawHitMap[gtm_bco].push_back(newhit);
+          m_BclkStack.insert(gtm_bco);
+          //	}
         }
-        //          packet->convert();
-        // if (m_TpcRawHitMap[gtm_bco].size() < 50000)
-        // {
-        if (StreamingInputManager())
-        {
-          StreamingInputManager()->AddTpcRawHit(gtm_bco, newhit);
-        }
-        m_TpcRawHitMap[gtm_bco].push_back(newhit);
-        m_BclkStack.insert(gtm_bco);
-        //	}
-      }
       }
       delete packet;
     }
@@ -412,9 +391,9 @@ bool SingleTpcPoolInput::GetSomeMoreEvents(const uint64_t ibclk)
     return true;
   }
   uint64_t localbclk = ibclk;
-  if(ibclk == 0)
+  if (ibclk == 0)
   {
-    if(m_TpcRawHitMap.empty())
+    if (m_TpcRawHitMap.empty())
     {
       return true;
     }

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.h
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.h
@@ -18,11 +18,12 @@ class SingleTpcPoolInput : public SingleStreamingInput
  public:
   explicit SingleTpcPoolInput(const std::string &name);
   ~SingleTpcPoolInput() override;
-  void FillPool(const unsigned int) override;
+  void FillPool(const uint64_t) override;
   void CleanupUsedPackets(const uint64_t bclk) override;
   bool CheckPoolDepth(const uint64_t bclk) override;
   void ClearCurrentEvent() override;
-  bool GetSomeMoreEvents();
+  bool GetSomeMoreEvents(const uint64_t bclk);
+  
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNode(PHCompositeNode *topNode) override;
   void SetBcoRange(const unsigned int i) { m_BcoRange = i; }
@@ -37,6 +38,7 @@ class SingleTpcPoolInput : public SingleStreamingInput
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
   unsigned int m_max_tpc_time_samples = 425;
+  bool m_skipEarlyEvents = true;
   //! map bco to packet
   std::map<unsigned int, uint64_t> m_packet_bco;
 

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.h
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.h
@@ -17,13 +17,13 @@ class SingleTpcPoolInput : public SingleStreamingInput
 {
  public:
   explicit SingleTpcPoolInput(const std::string &name);
-  ~SingleTpcPoolInput() override;
+  ~SingleTpcPoolInput() override = default;
   void FillPool(const uint64_t) override;
   void CleanupUsedPackets(const uint64_t bclk) override;
   bool CheckPoolDepth(const uint64_t bclk) override;
   void ClearCurrentEvent() override;
   bool GetSomeMoreEvents(const uint64_t bclk);
-  
+
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNode(PHCompositeNode *topNode) override;
   void SetBcoRange(const unsigned int i) { m_BcoRange = i; }
@@ -33,12 +33,11 @@ class SingleTpcPoolInput : public SingleStreamingInput
   const std::map<int, std::set<uint64_t>> &BclkStackMap() const override { return m_BclkStackPacketMap; }
 
  private:
-  Packet **plist{nullptr};
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
-  unsigned int m_max_tpc_time_samples = 425;
-  bool m_skipEarlyEvents = true;
+  unsigned int m_max_tpc_time_samples{425};
+  bool m_skipEarlyEvents{true};
   //! map bco to packet
   std::map<unsigned int, uint64_t> m_packet_bco;
 


### PR DESCRIPTION
First attempt at skipping tpc bcos that are way behind the gl1. Needs work/additional testing @pinkenburg 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

