### PR TITLE
(INTT) Class for getting streaming/triggered through odbc query

### DIFF
--- a/offline/packages/intt/InttOdbcQuery.cc
+++ b/offline/packages/intt/InttOdbcQuery.cc
@@ -1,0 +1,157 @@
+/// Originally imitated from coresoftware/offline/database/rundb/CaloTime.*
+
+#include "InttOdbcQuery.h"
+
+#include <phool/phool.h>
+
+#include <odbc++/connection.h>
+#include <odbc++/drivermanager.h>
+#include <odbc++/resultset.h>
+#include <odbc++/statement.h>
+
+#include <iostream>
+#include <sstream>
+
+/// For retrying connections
+#include <random>
+#include <chrono>
+#include <thread>
+
+InttOdbcQuery::InttOdbcQuery()
+{
+  //...
+}
+
+InttOdbcQuery::~InttOdbcQuery()
+{
+  //...
+}
+
+int InttOdbcQuery::Query(int runnumber)
+{
+  m_query_successful = false;
+
+  /// Replace the following block with Singleton accessor? Something like:
+  /// odbc::Connection* dbcon = ODBInterface::instance()->getConnection();
+  /// Then ODBInterface implements the following 
+  std::random_device ran_dev;
+  std::seed_seq seeds {ran_dev(), ran_dev(), ran_dev()}; //...
+  std::mt19937_64 mersenne_twister(seeds);
+  std::uniform_int_distribution<> uniform(m_MIN_SLEEP_DUR, m_MAX_SLEEP_DUR);
+
+  int num_tries = 0;
+  int total_slept_ms = 0;
+
+  odbc::Connection* dbcon = nullptr;
+  for(num_tries = 0; num_tries < m_MAX_NUM_RETRIES; ++num_tries)
+  {
+    try
+    {
+      dbcon = odbc::DriverManager::getConnection("daq", "", "");
+    }
+    catch (odbc::SQLException &e)
+    {
+      std::cerr << PHWHERE << "\n"
+                << "\tSQL Exception:\n"
+                << "\t" << e.getMessage() << std::endl;
+    }
+
+    if(dbcon)
+	{
+      ++num_tries;
+      break;
+	}
+
+    int sleep_time_ms = uniform(mersenne_twister);
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time_ms));
+	total_slept_ms += sleep_time_ms;
+
+	if(1 < m_verbosity)
+	{
+      std::cout << PHWHERE << "\n"
+                << "\tConnection unsuccessful\n"
+                << "\tSleeping for addtional " << sleep_time_ms << " ms" << std::endl;
+	}
+  }
+
+  if(m_verbosity)
+  {
+    std::cout << PHWHERE << "\n"
+              << "\tConnection successful (" << num_tries << " attempts, " << total_slept_ms << " ms)" << std::endl;
+  }
+  /// Replace the above block with Singleton accessor? Something like:
+  /// odbc::Connection* dbcon = ODBInterface::instance()->getConnection();
+  /// Then ODBInterface implements the above
+
+  if(!dbcon)
+  {
+    std::cerr << PHWHERE << "\n"
+              << "\tDB Conntion failed after " << m_MAX_NUM_RETRIES << " retries\n"
+              << "\tAbandoning query" << std::endl;
+    return 1;
+  }
+
+  std::string sql = "select sched_data from  gtm_scheduler where vgtm=1 and sched_entry = 1 and runnumber = " + std::to_string(runnumber) + ";";
+
+  odbc::Statement *statement = dbcon->createStatement();
+  odbc::ResultSet *result_set = statement->executeQuery(sql);
+  std::string sched_data;
+
+  if(result_set && result_set->next())
+  {
+	try
+    {
+      /// This can throw an odbc::SQLException if, for example, the column name is mistyped
+      /// (you'll never guess how I figured that one out...)
+      sched_data = result_set->getString("sched_data");
+    }
+    catch (odbc::SQLException &e)
+    {
+      std::cerr << PHWHERE << "\n"
+                << "\tSQL Exception:\n"
+                << "\t" << e.getMessage() << std::endl;
+      delete result_set;
+      delete statement;
+      delete dbcon;
+    
+      return 1;
+    }
+  }
+
+  if(m_verbosity)
+  {
+    std::cout << PHWHERE << "\n"
+              << "\tsched_data: '" << sched_data << "'" << std::endl;
+  }
+
+  if(std::string{"{17,55,24,54}"} == sched_data)
+  {
+    /// Streaming
+    m_query_successful = true;
+    m_is_streaming = true;
+  }
+  else if (std::string{"{0,54,91,53}"} == sched_data)
+  {
+    /// Triggered
+    m_query_successful = true;
+    m_is_streaming = false;
+  }
+
+  delete result_set;
+  delete statement;
+  delete dbcon;
+
+  return 0;
+}
+
+bool InttOdbcQuery::IsStreaming()
+{
+  if(!m_query_successful)
+  {
+    std::cerr << PHWHERE << "\n"
+              << "\tCall is not preceeded by successful database connection and query\n"
+              << "\tValue returned will not necessarily be correct" << std::endl;
+  }
+
+  return m_is_streaming;
+}

--- a/offline/packages/intt/InttOdbcQuery.cc
+++ b/offline/packages/intt/InttOdbcQuery.cc
@@ -17,16 +17,6 @@
 #include <chrono>
 #include <thread>
 
-InttOdbcQuery::InttOdbcQuery()
-{
-  //...
-}
-
-InttOdbcQuery::~InttOdbcQuery()
-{
-  //...
-}
-
 int InttOdbcQuery::Query(int runnumber)
 {
   m_query_successful = false;

--- a/offline/packages/intt/InttOdbcQuery.h
+++ b/offline/packages/intt/InttOdbcQuery.h
@@ -1,0 +1,29 @@
+#ifndef INTT_ODBC_QUERY_H
+#define INTT_ODBC_QUERY_H
+
+class InttOdbcQuery
+{
+public:
+  InttOdbcQuery();
+  ~InttOdbcQuery();
+
+  int Verbosity() {return m_verbosity;}
+  int Verbosity(int verbosity) {return m_verbosity = verbosity;}
+
+  int Query(int);
+
+  bool IsStreaming();
+
+private:
+  static const int m_MAX_NUM_RETRIES = 3000;
+  static const int m_MIN_SLEEP_DUR =  200; // milliseconds
+  static const int m_MAX_SLEEP_DUR = 3000; // milliseconds
+
+  int m_verbosity{0};
+  bool m_query_successful{false};
+  bool m_is_streaming{false};
+};
+
+#endif//INTT_ODBC_QUERY_H
+
+

--- a/offline/packages/intt/InttOdbcQuery.h
+++ b/offline/packages/intt/InttOdbcQuery.h
@@ -4,8 +4,8 @@
 class InttOdbcQuery
 {
 public:
-  InttOdbcQuery();
-  ~InttOdbcQuery();
+  InttOdbcQuery() = default;
+  ~InttOdbcQuery() = default;
 
   int Verbosity() {return m_verbosity;}
   int Verbosity(int verbosity) {return m_verbosity = verbosity;}

--- a/offline/packages/intt/Makefile.am
+++ b/offline/packages/intt/Makefile.am
@@ -5,13 +5,15 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -isystem$(OFFLINE_MAIN)/include  \
-  -isystem$(ROOTSYS)/include
+  -isystem$(OFFLINE_MAIN)/include \
+  -isystem$(ROOTSYS)/include \
+  -isystem$(OPT_SPHENIX)/include
 
 AM_LDFLAGS = \
   -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
   -L$(ROOTSYS)/lib \
-  -L$(OFFLINE_MAIN)/lib
+  -L$(OPT_SPHENIX)/lib
 
 if USE_ONLINE
 
@@ -46,6 +48,7 @@ pkginclude_HEADERS = \
   InttFelixMap.h \
   InttMap.h \
   InttMapping.h \
+  InttOdbcQuery.h \
   InttSurveyMap.h \
   InttSurveyMapv1.h \
   InttXYVertexFinder.h \
@@ -102,6 +105,7 @@ libintt_la_SOURCES = \
   InttFeeMapv1.cc \
   InttFelixMap.cc \
   InttMapping.cc \
+  InttOdbcQuery.cc \
   InttMap.cc \
   InttSurveyMap.cc \
   InttSurveyMapv1.cc \
@@ -116,6 +120,7 @@ libintt_la_LIBADD = \
   -lcdbobjects \
   -lCLHEP \
   -lffarawobjects \
+  -lodbc++ \
   -lphg4hit \
   -lSubsysReco
 


### PR DESCRIPTION
 Implemented class for querying daq database to determine whether the INTT was in streaming/triggered for a given run

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

