### PR TITLE
KFParticle updates

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -302,8 +302,19 @@ int KFParticle_Tools::calcMinIP(const KFParticle &track, const std::vector<KFPar
 
   for (const auto &PV : PVs)
   {
-    ip.push_back(track.GetDistanceFromVertex(PV));
-    float thisIPchi2 = track.GetDeviationFromVertex(PV);
+    float thisIPchi2 = 0;
+
+    if (m_use_2D_matching_tools) 
+    {
+      ip.push_back(track.GetDistanceFromVertex(PV));
+      track.GetDeviationFromVertex(PV);
+    }
+    else
+    {
+      ip.push_back(abs(track.GetDistanceFromVertexXY(PV)));
+      track.GetDeviationFromVertexXY(PV);
+    }
+
     if (thisIPchi2 < 0)
     {
       thisIPchi2 = 0;
@@ -346,12 +357,23 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
     {
       if (i_it < j_it)
       {
-        if (daughterParticles[*i_it].GetDistanceFromParticle(daughterParticles[*j_it]) <= m_comb_DCA)
+        float dca = 0;
+        if (m_use_2D_matching_tools)
+        {
+          daughterParticles[*i_it].GetDistanceFromParticleXY(daughterParticles[*j_it]);
+        }
+        else
+        {
+          daughterParticles[*i_it].GetDistanceFromParticle(daughterParticles[*j_it]);
+        }
+
+        if (dca <= m_comb_DCA)
         {
           KFVertex twoParticleVertex;
           twoParticleVertex += daughterParticles[*i_it];
           twoParticleVertex += daughterParticles[*j_it];
           float vertexchi2ndof = twoParticleVertex.GetChi2() / twoParticleVertex.GetNDF();
+          float sv_radial_position = sqrt(pow(twoParticleVertex.GetX(), 2) + pow(twoParticleVertex.GetY(), 2));
           std::vector<int> combination = {*i_it, *j_it};
 
           if (nTracks == 2 && vertexchi2ndof > m_vertex_chi2ndof)
@@ -360,7 +382,14 @@ std::vector<std::vector<int>> KFParticle_Tools::findTwoProngs(std::vector<KFPart
           }
           else
           {
-            goodTracksThatMeet.push_back(combination);
+            if (nTracks == 2 && sv_radial_position < m_min_radial_SV)
+            {
+              continue;
+            }
+            else
+            {
+              goodTracksThatMeet.push_back(combination);
+            }
           }
         }
       }
@@ -394,7 +423,17 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
         bool dcaMet = true;
         for (unsigned int i = 0; i < nProngs - 1; ++i)
         {
-          if (daughterParticles[i_it].GetDistanceFromParticle(daughterParticles[goodTracksThatMeet[i_prongs][i]]) > m_comb_DCA)
+          float dca = 0;
+          if (m_use_2D_matching_tools)
+          {
+            daughterParticles[i_it].GetDistanceFromParticleXY(daughterParticles[goodTracksThatMeet[i_prongs][i]]);
+          }
+          else
+          {
+            daughterParticles[i_it].GetDistanceFromParticle(daughterParticles[goodTracksThatMeet[i_prongs][i]]);          
+          }
+
+          if (dca > m_comb_DCA)
           {
             dcaMet = false;
           }
@@ -412,6 +451,7 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
             combination.push_back(goodTracksThatMeet[i_prongs][i]);
           }
           float vertexchi2ndof = particleVertex.GetChi2() / particleVertex.GetNDF();
+          float sv_radial_position = sqrt(pow(particleVertex.GetX(), 2) + pow(particleVertex.GetY(), 2));
 
           if ((unsigned int) nRequiredTracks == nProngs && vertexchi2ndof > m_vertex_chi2ndof)
           {
@@ -419,7 +459,14 @@ std::vector<std::vector<int>> KFParticle_Tools::findNProngs(std::vector<KFPartic
           }
           else
           {
-            goodTracksThatMeet.push_back(combination);
+            if ((unsigned int) nRequiredTracks == nProngs && sv_radial_position < m_min_radial_SV)
+            {
+              continue;
+            }
+            else
+            {
+              goodTracksThatMeet.push_back(combination);
+            }
           }
         }
       }
@@ -705,7 +752,16 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
 
   float calculated_fdchi2 = flightDistanceChi2(particle, vertex);
   float calculated_dira = eventDIRA(particle, vertex);
-  float calculated_ipchi2 = particle.GetDeviationFromVertex(vertex);
+
+  float calculated_ipchi2;
+  if (m_use_2D_matching_tools)
+  {
+    calculated_ipchi2 = particle.GetDeviationFromVertexXY(vertex);
+  }
+  else
+  {
+    calculated_ipchi2 = particle.GetDeviationFromVertex(vertex);
+  }
 
   goodCandidate = false;
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -173,6 +173,10 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   bool m_allowZeroMassTracks {false};
 
+  bool m_use_2D_matching_tools {false};
+
+  float m_min_radial_SV = -1.;
+
   std::string m_vtx_map_node_name;
   std::string m_trk_map_node_name;
   SvtxVertexMap *m_dst_vertexmap {nullptr};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -52,7 +52,7 @@ KFParticle_eventReconstruction::KFParticle_eventReconstruction()
 void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::vector<KFParticle>& selectedMother, std::vector<KFParticle>& selectedVertex,
                                                  std::vector<std::vector<KFParticle>>& selectedDaughters,
                                                  std::vector<std::vector<KFParticle>>& selectedIntermediates,
-                                                 int& nPVs, int& multiplicity)
+                                                 int& nPVs)
 {
   std::vector<KFParticle> primaryVertices;
   if (m_use_fake_pv)
@@ -67,7 +67,6 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
   std::vector<KFParticle> daughterParticles = makeAllDaughterParticles(topNode);
 
   nPVs = primaryVertices.size();
-  multiplicity = daughterParticles.size();
 
   std::vector<int> goodTrackIndex = findAllGoodTracks(daughterParticles, primaryVertices);
 
@@ -499,8 +498,22 @@ int KFParticle_eventReconstruction::selectBestCombination(bool PVconstraint, boo
   {
     if (PVconstraint && !isAnInterMother)
     {
-      if (possibleCandidates[i].GetDeviationFromVertex(possibleVertex[i]) <
-          smallestMassError.GetDeviationFromVertex(possibleVertex[bestCombinationIndex]))
+
+      float current_IPchi2 = 0;
+      float best_IPchi2 = 0;
+   
+      if (m_use_2D_matching_tools)
+      {
+        current_IPchi2 = possibleCandidates[i].GetDeviationFromVertexXY(possibleVertex[i]);
+        best_IPchi2 = smallestMassError.GetDeviationFromVertexXY(possibleVertex[bestCombinationIndex]);
+      }
+      else
+      {
+        current_IPchi2 = possibleCandidates[i].GetDeviationFromVertex(possibleVertex[i]);
+        best_IPchi2 = smallestMassError.GetDeviationFromVertex(possibleVertex[bestCombinationIndex]);
+      }
+
+      if (current_IPchi2 < best_IPchi2)
       {
         smallestMassError = possibleCandidates[i];
         bestCombinationIndex = i;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -43,7 +43,7 @@ KFParticle_Tools kfp_Tools_evtReco;
 
 /// KFParticle constructor
 KFParticle_eventReconstruction::KFParticle_eventReconstruction()
-  : m_constrain_to_vertex(true)
+  : m_constrain_to_vertex(false)
   , m_constrain_int_mass(false)
   , m_use_fake_pv(false)
 {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
@@ -48,7 +48,7 @@ class KFParticle_eventReconstruction : public KFParticle_Tools
   void createDecay(PHCompositeNode* topNode, std::vector<KFParticle>& selectedMother, std::vector<KFParticle>& selectedVertex,
                    std::vector<std::vector<KFParticle>>& selectedDaughters,
                    std::vector<std::vector<KFParticle>>& selectedIntermediates,
-                   int& nPVs, int& multiplicity);
+                   int& nPVs);
 
   /// Used to reconstruct simple decays with no intermediate states
   void buildBasicChain(std::vector<KFParticle>& selectedMotherBasic,

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -33,7 +33,6 @@ KFParticle_nTuple::KFParticle_nTuple()
   , m_truth_matching(false)
   , m_detector_info(false)
   , m_calo_info(false)
-  , m_use_intermediate_name(true)
   , m_get_charge_conjugate_nTuple(false)
   , m_use_fake_pv_nTuple(false)
   , m_tree(nullptr)
@@ -128,15 +127,7 @@ void KFParticle_nTuple::initializeBranches()
   {
     for (int i = 0; i < m_num_intermediate_states_nTuple; ++i)
     {
-      std::string intermediate_name;
-      if (!m_use_intermediate_name)
-      {
-        intermediate_name = "intermediate_" + std::to_string(i + 1);
-      }
-      else
-      {
-        intermediate_name = m_intermediate_name_ntuple[i];
-      }
+      std::string intermediate_name = m_intermediate_name_ntuple[i];
 
       // Note, TBranch will not allow the leaf to contain a forward slash as it is used to define the branch type. Causes problems with J/psi
       for (auto const& [badString, goodString] : forbiddenStrings)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -8,6 +8,7 @@
 #include <phool/getClass.h>
 
 #include <KFParticle.h>
+#include <KFVertex.h>
 
 #include <Rtypes.h>
 #include <TString.h>  // for TString, operator+
@@ -118,6 +119,7 @@ void KFParticle_nTuple::initializeBranches()
   m_tree->Branch(TString(mother_name) + "_vertex_volume", &m_calculated_mother_v, TString(mother_name) + "_vertex_volume/F");
   m_tree->Branch(TString(mother_name) + "_chi2", &m_calculated_mother_chi2, TString(mother_name) + "_chi2/F");
   m_tree->Branch(TString(mother_name) + "_nDoF", &m_calculated_mother_ndof, TString(mother_name) + "_nDoF/I");
+  m_tree->Branch(TString(mother_name) + "_SV_chi2_per_nDoF", &m_calculated_mother_SV_chi2_per_ndof, TString(mother_name) + "_SV_chi2_per_nDoF/F");
   m_tree->Branch(TString(mother_name) + "_PDG_ID", &m_calculated_mother_pdgID, TString(mother_name) + "_PDG_ID/I");
   m_tree->Branch(TString(mother_name) + "_Covariance", &m_calculated_mother_cov, TString(mother_name) + "_Covariance[21]/F", 21);
 
@@ -184,6 +186,7 @@ void KFParticle_nTuple::initializeBranches()
       m_tree->Branch(TString(intermediate_name) + "_vertex_volume", &m_calculated_intermediate_v[i], TString(intermediate_name) + "_vertex_volume/F");
       m_tree->Branch(TString(intermediate_name) + "_chi2", &m_calculated_intermediate_chi2[i], TString(intermediate_name) + "_chi2/F");
       m_tree->Branch(TString(intermediate_name) + "_nDoF", &m_calculated_intermediate_ndof[i], TString(intermediate_name) + "_nDoF/I");
+      m_tree->Branch(TString(intermediate_name) + "_SV_chi2_per_nDoF", &m_calculated_intermediate_SV_chi2_per_ndof[i], TString(intermediate_name) + "_SV_chi2_per_nDoF/F");
       m_tree->Branch(TString(intermediate_name) + "_PDG_ID", &m_calculated_intermediate_pdgID[i], TString(intermediate_name) + "_PDG_ID/I");
       m_tree->Branch(TString(intermediate_name) + "_Covariance", &m_calculated_intermediate_cov[i], TString(intermediate_name) + "_Covariance[21]/F", 21);
 
@@ -269,6 +272,11 @@ void KFParticle_nTuple::initializeBranches()
         std::string dca_branch_name = "track_" + std::to_string(i + 1) + "_track_" + std::to_string(j + 1) + "_DCA";
         std::string dca_leaf_name = dca_branch_name + "/F";
         m_tree->Branch(dca_branch_name.c_str(), &m_daughter_dca[iter], dca_leaf_name.c_str());
+
+        std::string dca_branch_name_xy = dca_branch_name + "_xy";
+        std::string dca_leaf_name_xy = dca_branch_name_xy + "/F";
+        m_tree->Branch(dca_branch_name_xy.c_str(), &m_daughter_dca_xy[iter], dca_leaf_name_xy.c_str());
+
         ++iter;
       }
     }
@@ -528,21 +536,38 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     }
   }
 
+  KFVertex motherDecayVertex;
+
+  if (m_num_intermediate_states_nTuple == 0)
+  {
+    for (int i = 0; i < m_num_tracks_nTuple; ++i)
+    {
+      motherDecayVertex += daughterArray[i];
+    }
+  }
+
   int iter = 0;
   // Calcualte jT wrt their own mother, not grandmother
   for (int k = 0; k < m_num_intermediate_states_nTuple; ++k)
   {
+    KFVertex intermediateDecayVertex;
     for (int j = 0; j < m_num_tracks_from_intermediate_nTuple[k]; ++j)
     {
       m_calculated_daughter_jt[iter] = kfpTupleTools.calculateJT(intermediateArray[k], daughterArray[iter]);
+      intermediateDecayVertex += daughterArray[iter];
       ++iter;
     }
+    m_calculated_intermediate_SV_chi2_per_ndof[k] = intermediateDecayVertex.GetChi2() / intermediateDecayVertex.GetNDF();
+    motherDecayVertex += intermediateArray[k];
   }
   for (int k = 0; k < num_remaining_tracks; k++)
   {
     m_calculated_daughter_jt[iter] = kfpTupleTools.calculateJT(motherParticle, daughterArray[iter]);
+    motherDecayVertex += daughterArray[iter];
     ++iter;
   }
+
+  m_calculated_mother_SV_chi2_per_ndof = motherDecayVertex.GetChi2() / motherDecayVertex.GetNDF();
 
   iter = 0;
   for (int i = 0; i < m_num_tracks_nTuple; ++i)
@@ -552,6 +577,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
       if (i < j)
       {
         m_daughter_dca[iter] = daughterArray[i].GetDistanceFromParticle(daughterArray[j]);
+        m_daughter_dca_xy[iter] = daughterArray[i].GetDistanceFromParticleXY(daughterArray[j]);
         ++iter;
       }
     }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -88,6 +88,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_mother_v = -1;
   float m_calculated_mother_chi2 = -1;
   int m_calculated_mother_ndof = -1;
+  float m_calculated_mother_SV_chi2_per_ndof = -1;
   int m_calculated_mother_pdgID = -1;
   // float *m_calculated_mother_cov;
   float m_calculated_mother_cov[21] = {0};
@@ -124,6 +125,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_intermediate_v[max_intermediates] = {0};
   float m_calculated_intermediate_chi2[max_intermediates] = {0};
   float m_calculated_intermediate_ndof[max_intermediates] = {0};
+  float m_calculated_intermediate_SV_chi2_per_ndof[max_intermediates] = {0};
   int m_calculated_intermediate_pdgID[max_intermediates] = {0};
   // float *m_calculated_intermediate_cov[max_intermediates];
   float m_calculated_intermediate_cov[max_intermediates][21] = {{0}, {0}};
@@ -159,6 +161,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_daughter_cov[max_tracks][21] = {{0}, {0}};
 
   float m_daughter_dca[99] = {0};
+  float m_daughter_dca_xy[99] = {0};
 
   float m_calculated_vertex_x = -1;
   float m_calculated_vertex_y = -1;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -148,7 +148,9 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
-  createDecay(topNode, mother, vertex_kfparticle, daughters, intermediates, nPVs, multiplicity);
+  multiplicity = check_trackmap->size();
+
+  createDecay(topNode, mother, vertex_kfparticle, daughters, intermediates, nPVs);
 
   if (!m_has_intermediates_sPHENIX)
   {
@@ -300,7 +302,7 @@ int KFParticle_sPHENIX::parseDecayDescriptor()
   if (checkForCC == "[]CC")
   {
     manipulateDecayDescriptor = manipulateDecayDescriptor.substr(1, manipulateDecayDescriptor.size() - 4);
-    getChargeConjugate(true);
+    getChargeConjugate();
   }
 
   // Find the initial particle
@@ -448,7 +450,7 @@ int KFParticle_sPHENIX::parseDecayDescriptor()
 
   if (intermediates_name.size() > 0)
   {
-    hasIntermediateStates(true);
+    hasIntermediateStates();
     setIntermediateStates(intermediate_list);
     setNumberOfIntermediateStates(intermediates_name.size());
     setNumberTracksFromIntermeditateState(m_nTracksFromIntermediates);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -90,14 +90,14 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     m_mother_name_Tools = mother_name;
   }
 
-  void useIntermediateName(bool use_intermediate_name) { m_use_intermediate_name = use_intermediate_name; }
+  void useIntermediateName() { m_use_intermediate_name = true; }
 
-  void hasIntermediateStates(bool has_intermediates)
+  void hasIntermediateStates()
   {
-    m_has_intermediates = has_intermediates;
-    m_has_intermediates_nTuple = has_intermediates;
-    m_has_intermediates_sPHENIX = has_intermediates;
-    m_has_intermediates_DST = has_intermediates;
+    m_has_intermediates = true;
+    m_has_intermediates_nTuple = true;
+    m_has_intermediates_sPHENIX = true;
+    m_has_intermediates_DST = true;
   }
 
   void setNumberOfTracks(int num_tracks)
@@ -121,10 +121,10 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     m_num_intermediate_states_nTuple = n_intermediates;
   }
 
-  void getChargeConjugate(bool get_charge_conjugate)
+  void getChargeConjugate()
   {
-    m_get_charge_conjugate_nTuple = get_charge_conjugate;
-    m_get_charge_conjugate = get_charge_conjugate;
+    m_get_charge_conjugate_nTuple = true;
+    m_get_charge_conjugate = true;
   }
 
   void setDaughters(std::vector<std::pair<std::string, int> /*unused*/> daughter_list)
@@ -180,6 +180,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumVertexchi2nDOF(float vertexchi2nDOF) { m_vertex_chi2ndof = vertexchi2nDOF; }
 
+  void setMinimumRadialSV(float min_rad_sv) { m_min_radial_SV = min_rad_sv; }
+
   void setFlightDistancechi2(float fdchi2) { m_fdchi2 = fdchi2; }
 
   void setMinDIRA(float dira_min) { m_dira_min = dira_min; }
@@ -192,28 +194,28 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumMotherVertexVolume(float vertexvol) { m_mother_vertex_volume = vertexvol; }
 
-  void constrainToPrimaryVertex(bool constrain_to_vertex)
+  void constrainToPrimaryVertex()
   {
-    m_constrain_to_vertex = constrain_to_vertex;
-    m_constrain_to_vertex_nTuple = constrain_to_vertex;
-    m_constrain_to_vertex_sPHENIX = constrain_to_vertex;
+    m_constrain_to_vertex = true;
+    m_constrain_to_vertex_nTuple = true;
+    m_constrain_to_vertex_sPHENIX = true;
   }
 
-  void useFakePrimaryVertex(bool use_fake)
+  void useFakePrimaryVertex()
   {
-    m_use_fake_pv = use_fake;
-    m_use_fake_pv_nTuple = use_fake;
+    m_use_fake_pv = true;
+    m_use_fake_pv_nTuple = true;
   }
 
-  void allowZeroMassTracks(bool allow) { m_allowZeroMassTracks = allow; }
+  void allowZeroMassTracks() { m_allowZeroMassTracks = true; }
 
-  void extraolateTracksToSV(bool extrapolate)
+  void extraolateTracksToSV()
   {
-    m_extrapolateTracksToSV = extrapolate;
-    m_extrapolateTracksToSV_nTuple = extrapolate;
+    m_extrapolateTracksToSV = true;
+    m_extrapolateTracksToSV_nTuple = true;
   }
 
-  void constrainIntermediateMasses(bool constrain_int_mass) { m_constrain_int_mass = constrain_int_mass; }
+  void constrainIntermediateMasses() { m_constrain_int_mass = true; }
 
   void setIntermediateMassRange(std::vector<std::pair<float, float> /*unused*/> intermediate_mass_range)
   {
@@ -268,7 +270,9 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     for (unsigned int i = 0; i < intermediate_max_vertexvol.size(); ++i) m_intermediate_vertex_volume.push_back(intermediate_max_vertexvol[i]);
   }
 
-  void useMVA(bool require_mva) { m_require_mva = require_mva; }
+  void use2Dmatching(){ m_use_2D_matching_tools = true; }
+
+  void useMVA() { m_require_mva = true; }
 
   void setNumMVAPars(unsigned int nPars) { m_nPars = nPars; }
 
@@ -283,25 +287,25 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMVACutValue(float cut_value) { m_mva_cut_value = cut_value; }
 
-  void saveDST(bool save) { m_save_dst = save; }
+  void saveDST() { m_save_dst = true; }
 
-  void saveTrackContainer(bool save) { m_write_track_container = save; }
+  void saveTrackContainer() { m_write_track_container = true; }
 
-  void saveParticleContainer(bool save) { m_write_particle_container = save; }
+  void saveParticleContainer() { m_write_particle_container = true; }
 
   void setContainerName(const std::string &name) { m_container_name = name; }
 
-  void saveOutput(bool save) { m_save_output = save; }
+  void saveOutput() { m_save_output = true; }
 
   void setOutputName(const std::string &name) { m_outfile_name = name; }
 
-  void doTruthMatching(bool truth) { m_truth_matching = truth; }
+  void doTruthMatching() { m_truth_matching = true; }
 
-  void getDetectorInfo(bool detinfo) { m_detector_info = detinfo; }
+  void getDetectorInfo() { m_detector_info = true; }
 
-  void getCaloInfo(bool caloinfo) { m_calo_info = caloinfo; }
+  void getCaloInfo() { m_calo_info = true; }
 
-  void getAllPVInfo(bool pvinfo) { m_get_all_PVs = pvinfo; }
+  void getAllPVInfo() { m_get_all_PVs = true; }
 
   /// Use alternate vertex and track fitters
   void setVertexMapNodeName(const std::string &vtx_map_node_name) { m_vtx_map_node_name = m_vtx_map_node_name_nTuple = vtx_map_node_name; }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -90,8 +90,6 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     m_mother_name_Tools = mother_name;
   }
 
-  void useIntermediateName() { m_use_intermediate_name = true; }
-
   void hasIntermediateStates()
   {
     m_has_intermediates = true;
@@ -209,10 +207,9 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void allowZeroMassTracks() { m_allowZeroMassTracks = true; }
 
-  void extraolateTracksToSV()
+  void dontExtraolateTracksToSV()
   {
-    m_extrapolateTracksToSV = true;
-    m_extrapolateTracksToSV_nTuple = true;
+    m_extrapolateTracksToSV = m_extrapolateTracksToSV_nTuple = false;
   }
 
   void constrainIntermediateMasses() { m_constrain_int_mass = true; }
@@ -289,13 +286,13 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void saveDST() { m_save_dst = true; }
 
-  void saveTrackContainer() { m_write_track_container = true; }
+  void dontSaveTrackContainer() { m_write_track_container = false; }
 
-  void saveParticleContainer() { m_write_particle_container = true; }
+  void dontSaveParticleContainer() { m_write_particle_container = false; }
 
   void setContainerName(const std::string &name) { m_container_name = name; }
 
-  void saveOutput() { m_save_output = true; }
+  void dontSaveOutput() { m_save_output = false; }
 
   void setOutputName(const std::string &name) { m_outfile_name = name; }
 


### PR DESCRIPTION
…cut options

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [x] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I added the ability to run reconstruction using 2D DCAs instead of 3D DCAs (this is a flag)

I also added a new secondary vertex radial cut option (useful for K-shorts/lambdas/conversions) for decays that have no associated PV

I also removed macro function calls that required the user to set them to true or false. All variables default to false so the functions now set them to true without specifying. Note, this will break old macros which have a true/false in the function call.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
[https://github.com/sPHENIX-Collaboration/macros/pull/930](https://github.com/sPHENIX-Collaboration/macros/pull/930)

