### PR TITLE
abort tpc reading when end of run event is seen, it is followed by co…

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllPrdfInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllPrdfInputManager.cc
@@ -20,6 +20,7 @@
 
 #include <Event/Event.h>
 #include <Event/Eventiterator.h>  // for Eventiterator
+#include <Event/EventTypes.h>
 #include <Event/fileEventiterator.h>
 
 #include <cassert>
@@ -129,13 +130,14 @@ readagain:
   {
     m_Event = m_EventIterator->getNextEvent();
   }
-  PrdfNode->setData(m_Event);
-  if (!m_Event)
+  if (!m_Event || m_Event->getEvtType() == ENDRUNEVENT)
   {
+    PrdfNode->setData(nullptr);
     fileclose();
     // NOLINTNEXTLINE(hicpp-avoid-goto)
     goto readagain;
   }
+  PrdfNode->setData(m_Event);
   if (Verbosity() > 1)
   {
     std::cout << Name() << " PRDF run " << m_Event->getRunNumber() << ", evt no: " << m_Event->getEvtSequence() << std::endl;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-class Fun4AllEvtInputPoolManager;
 class MicromegasRawHit;
 class Packet;
 

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -14,7 +14,6 @@
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
 #include <Event/Eventiterator.h>
-#include <Event/fileEventiterator.h>
 
 #include <memory>
 #include <set>
@@ -66,6 +65,12 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
     if (evt->getEvtType() != DATAEVENT)
     {
       m_NumSpecialEvents++;
+      if(evt->getEvtType() == ENDRUNEVENT)
+      {
+        std::cout << "End run flag for " << Name() << " found, remaining TPC data is corrupted" << std::endl;
+        AllDone(1);
+        return;
+      }
       continue;
     }
     int EventSequence = evt->getEvtSequence();


### PR DESCRIPTION
…rrupt data

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The tpc data contains data after the end run event which throws the decoding off. Especially runnumbers come back different which then triggers endrun/begin run sequences. Now the singletpcpoolinput and the old Fun4AllPrdfInput Managers close the input file if the eor event is encountered. If there are more files in the input list, they will still be opened and processed

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

