### PR TITLE
feat: intt bco dump

### DIFF
--- a/offline/framework/ffarawmodules/InttBcoDump.cc
+++ b/offline/framework/ffarawmodules/InttBcoDump.cc
@@ -1,0 +1,121 @@
+#include "InttBcoDump.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>  // for SubsysReco
+
+#include <fun4all/Fun4AllHistoManager.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/PHNode.h>          // for PHNode
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/getClass.h>
+
+#include <Event/Event.h>
+#include <Event/EventTypes.h>
+#include <Event/packet.h>
+
+#include <qautils/QAHistManagerDef.h>
+#include <qautils/QAUtil.h>
+
+#include <TFile.h>
+#include <TProfile2D.h>
+#include <TSystem.h>
+#include <TTree.h>
+
+#include <iostream>  // for operator<<, endl, basic_ost...
+#include <set>
+#include <utility>  // for pair
+#include <vector>   // for vector
+
+//____________________________________________________________________________..
+InttBcoDump::InttBcoDump(const std::string &name)
+  : SubsysReco(name)
+{
+}
+//____________________________________________________________________________..
+int InttBcoDump::InitRun(PHCompositeNode * /*topNode*/)
+{
+  auto hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  ntup = new TTree("bco", "bco");
+  ntup->Branch("id", &m_id);
+  ntup->Branch("evt", &m_evt);
+  ntup->Branch("nfees", &m_nfees);
+  ntup->Branch("bco", &m_bco);
+  ntup->Branch("bcodiff", &m_bcodiff);
+
+  hm->registerHisto(ntup);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int InttBcoDump::process_event(PHCompositeNode *topNode)
+{
+  Event *evt = findNode::getClass<Event>(topNode, "PRDF");
+  if (!evt)
+  {
+    std::cout << "No Event found" << std::endl;
+    exit(1);
+  }
+  if (evt->getEvtType() == ENDRUNEVENT)
+  {
+    std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
+    delete evt;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  //  evt->identify();
+  int EventSequence = evt->getEvtSequence();
+  std::vector<Packet *> pktvec = evt->getPacketVector();
+  std::map<int, std::set<uint64_t>> bcoset;
+  for (auto packet : pktvec)
+  {
+    int nbcos = packet->iValue(0, "NR_BCOS");
+    for (int i = 0; i < nbcos; i++)
+    {
+      uint64_t bco = packet->lValue(i, "BCOLIST");
+      int nfees = packet->iValue(i, "NR_FEES");
+      bcoTaggedFees[bco] = nfees;
+      for (int j = 0; j < nfees; j++)
+      {
+        int fee = packet->iValue(i, j, "FEELIST");
+        bcoset[fee].insert(bco);
+      }
+    }
+
+    delete packet;
+  }
+  for (auto &mapiter : bcoset)
+  {
+    if (!mapiter.second.empty())
+    {
+      for (auto &bco : mapiter.second)
+      {
+        uint64_t prevbco = lastbco[mapiter.first];
+        if (prevbco > 0 && prevbco != bco)
+        {
+          int64_t diffbco = bco - prevbco;
+
+          m_id = mapiter.first;
+          m_evt = EventSequence;
+          m_bco = bco;
+          m_nfees = bcoTaggedFees[bco];
+          m_bcodiff = diffbco;
+
+          ntup->Fill();
+        }
+        lastbco[mapiter.first] = bco;
+      }
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int InttBcoDump::End(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/framework/ffarawmodules/InttBcoDump.h
+++ b/offline/framework/ffarawmodules/InttBcoDump.h
@@ -1,0 +1,43 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef FFARAWMODULES_INTTBCODUMP_H
+#define FFARAWMODULES_INTTBCODUMP_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+
+class Fun4AllInputManager;
+class PHCompositeNode;
+class TFile;
+class TTree;
+
+class InttBcoDump : public SubsysReco
+{
+ public:
+  InttBcoDump(const std::string &name = "MvtxBcoDump");
+
+  ~InttBcoDump() override {}
+
+  int InitRun(PHCompositeNode *topNode) override;
+
+  int process_event(PHCompositeNode *topNode) override;
+
+  int End(PHCompositeNode *topNode) override;
+  //  int ResetEvent(PHCompositeNode *topNode) override;
+
+ private:
+  TTree *ntup = nullptr;
+  std::map<int, uint64_t> lastbco;
+  std::map<uint64_t, int> bcoTaggedFees;
+  int m_id{0};
+  int m_evt{0};
+  uint64_t m_bco{0};
+  int m_nfees{0};
+  int64_t m_bcodiff{0};
+};
+
+#endif  // FFARAWMODULES_INTTBCODUMP_H

--- a/offline/framework/ffarawmodules/Makefile.am
+++ b/offline/framework/ffarawmodules/Makefile.am
@@ -21,6 +21,7 @@ pkginclude_HEADERS = \
   Gl1Check.h \
   HcalCheck.h \
   InttCheck.h \
+  InttBcoDump.h \
   InttGl1Check.h \
   LL1Check.h \
   MbdCheck.h \
@@ -43,6 +44,7 @@ libffarawmodules_la_SOURCES = \
   Gl1BcoDump.cc \
   Gl1Check.cc \
   HcalCheck.cc \
+  InttBcoDump.cc \
   InttCheck.cc \
   InttGl1Check.cc \
   LL1Check.cc \


### PR DESCRIPTION
Fast INTT bco dump module that doesn't use the event combiner and allows you to plot things like bco diff and number of fees vs bco

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

