### PR TITLE
TpcSeedsQA update

### DIFF
--- a/offline/QA/Tracking/TpcSeedsQA.cc
+++ b/offline/QA/Tracking/TpcSeedsQA.cc
@@ -1073,12 +1073,12 @@ void TpcSeedsQA::createHistos()
 
 std::pair<float, float> TpcSeedsQA::cal_tpc_eta_min_max(float vtxz)
 {
-  float R=780.;
-  float HalfZ=2110./2.;
-  float theta_max = atan2(R,HalfZ-vtxz);
-  float theta_min = atan2(R,-(vtxz+HalfZ));
-  float eta_max = -log(tan(theta_max/2));
-  float eta_min = -log(tan(theta_min/2));
+  float R = 780.;
+  float HalfZ = 2110. / 2.;
+  float theta_max = std::atan2(R, HalfZ - vtxz);
+  float theta_min = std::atan2(R, -(vtxz + HalfZ));
+  float eta_max = -log(std::tan(theta_max / 2));
+  float eta_min = -log(std::tan(theta_min / 2));
   std::pair<float, float> min_max = std::make_pair(eta_min, eta_max);
   return min_max;
 }

--- a/offline/QA/Tracking/TpcSeedsQA.h
+++ b/offline/QA/Tracking/TpcSeedsQA.h
@@ -65,6 +65,7 @@ class TpcSeedsQA : public SubsysReco
   std::string getHistoPrefix() const;
   std::set<int> m_layers;
   std::multimap<int, int> m_layerRegionMap;
+  std::pair<float, float> cal_tpc_eta_min_max(float vtxz);
 
   std::string m_clusterContainerName{"TRKR_CLUSTER"};
   std::string m_actsGeomName{"ActsGeometry"};
@@ -101,8 +102,10 @@ class TpcSeedsQA : public SubsysReco
   TProfile2D* h_avgnclus_eta_phi_neg{nullptr};
   // TH1* h_trackcrossing_pos{nullptr};
   // TH1* h_trackcrossing_neg{nullptr};
-  TH2* h_dcaxyorigin_phi_pos{nullptr};
-  TH2* h_dcaxyorigin_phi_neg{nullptr};
+  TH2* h_dcaxyorigin_phi_north_pos{nullptr};
+  TH2* h_dcaxyorigin_phi_south_pos{nullptr};
+  TH2* h_dcaxyorigin_phi_north_neg{nullptr};
+  TH2* h_dcaxyorigin_phi_south_neg{nullptr};
   TH2* h_dcaxyvtx_phi_pos{nullptr};
   TH2* h_dcaxyvtx_phi_neg{nullptr};
   TH2* h_dcazorigin_phi_pos{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
According to feedback from tracking software meeting, I make some updates on TpcSeedsQA
1.  Separate DCA_xy w.r.t. origin plot into north and south track (dca_z > 0 or dca_z < 0)
2. Enlarge DCA_xy w.r.t. origin 2D plot y-aixs region [-3,3] -> [10,-10]
3. For number of tpc clusters per track plot, require track within eta acceptance which considers z-vertex position

Example plots can be found in [QAhtmltest](https://sphenix-intra.sdcc.bnl.gov/WWW/subsystem/QAHtmlTest/mon.cgi?runnumber=51619&runtype=physics)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

