### PR TITLE
Tpot standalone efficiency qa

### DIFF
--- a/offline/QA/Tracking/MicromegasClusterQA.cc
+++ b/offline/QA/Tracking/MicromegasClusterQA.cc
@@ -11,6 +11,9 @@
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>
+#include <trackbase/TrkrHit.h>
+#include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContainer.h>
 
 #include <qautils/QAHistManagerDef.h>
 #include <qautils/QAUtil.h>
@@ -27,6 +30,23 @@
 
 #include <boost/format.hpp>
 
+
+//_____________________________________________________________________
+namespace
+{
+
+  //! range adaptor to be able to use range-based for loop
+  template<class T> class range_adaptor
+  {
+    public:
+    range_adaptor( const T& range ):m_range(range){}
+    const typename T::first_type& begin() {return m_range.first;}
+    const typename T::second_type& end() {return m_range.second;}
+    private:
+    T m_range;
+  };
+}
+
 //____________________________________________________________________________..
 MicromegasClusterQA::MicromegasClusterQA(const std::string &name)
   : SubsysReco(name)
@@ -36,24 +56,49 @@ MicromegasClusterQA::MicromegasClusterQA(const std::string &name)
 //____________________________________________________________________________..
 int MicromegasClusterQA::InitRun(PHCompositeNode *topNode)
 {
-  auto geomContainer = findNode::getClass<
-      PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
-  if (!geomContainer)
-  {
-    std::cout << PHWHERE
-              << " CYLINDERGEOM_MICROMEGAS_FULL  node not found on node tree"
-              << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-  int layer = 0;
-  const auto range = geomContainer->get_begin_end();
+  // print configuration
+  std::cout << "MicromegasClusterQA::InitRun - m_use_default_pedestal: " << m_use_default_pedestal << std::endl;
+  std::cout << "MicromegasClusterQA::InitRun - m_default_pedestal: " << m_default_pedestal << std::endl;
+  std::cout
+    << "MicromegasClusterQA::InitRun -"
+    << " m_calibration_filename: "
+    << (m_calibration_filename.empty() ? "unspecified":m_calibration_filename )
+    << std::endl;
 
-  for (auto iter = range.first; iter != range.second; ++iter)
+  // read calibrations
+  if( !m_calibration_filename.empty() )
+  { m_calibration_data.read( m_calibration_filename ); }
+
+  // get geometry and keep track of tiles per layer
+  auto geomContainer = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
+  assert( geomContainer );
+
+  // get number of layers
+  m_nlayers = geomContainer->get_NLayers();
+
+  // loop over layers
+  bool first = true;
+  const auto range = geomContainer->get_begin_end();
+  for( const auto& [layer, layergeom]:range_adaptor( range ) )
   {
-    auto layergeom = static_cast<CylinderGeomMicromegas *>(iter->second);
-    int ntiles = layergeom->get_tiles_count();
-    m_layerTileMap.insert(std::make_pair(layer, ntiles));
-    layer++;
+    const auto layergeom_mm = static_cast<CylinderGeomMicromegas*>(layergeom);
+    const int ntiles = layergeom_mm->get_tiles_count();
+    const auto segmentation = layergeom_mm->get_segmentation_type();
+
+    for( int tile=0; tile<ntiles; ++tile )
+    {
+      // generate hitset key get detector name and save
+      const auto hitsetkey = MicromegasDefs::genHitSetKey(layer, segmentation, tile );
+      const auto detector_name = m_mapping.get_detname_sphenix_from_hitsetkey( hitsetkey );
+      m_detector_names.push_back(detector_name);
+    }
+
+    // keep track of first layer
+    if( first )
+    {
+      first=false;
+      m_firstlayer = layer;
+    }
   }
 
   createHistos();
@@ -63,70 +108,161 @@ int MicromegasClusterQA::InitRun(PHCompositeNode *topNode)
 //____________________________________________________________________________..
 int MicromegasClusterQA::process_event(PHCompositeNode *topNode)
 {
-  auto clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
-  if (!clusterContainer)
-  {
-    std::cout << PHWHERE << "No cluster container, bailing" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
 
-  auto tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-  if (!tGeometry)
-  {
-    std::cout << PHWHERE << "No acts geometry on node tree, bailing" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
+  // acts geometry
+  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
+  assert( m_tGeometry );
+
+  // hitset container
+  m_hitsetcontainer = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+  assert(m_hitsetcontainer);
+
+  // cluster map
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  assert( m_cluster_map );
+
+  // cluster hit association map
+  m_cluster_hit_map = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  assert( m_cluster_hit_map );
 
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  for (auto &hsk : clusterContainer->getHitSetKeys(TrkrDefs::TrkrId::micromegasId))
-  {
-    int numclusters = 0;
-    auto range = clusterContainer->getClusters(hsk);
-    auto layer = TrkrDefs::getLayer(hsk);
-    auto tile = MicromegasDefs::getTileId(hsk);
-    auto h = dynamic_cast<TH2 *>(hm->getHisto((boost::format("%sncluspertile%i_%i") % getHistoPrefix() % (((int) layer) - 55) % (int) tile).str()));
+  // keep track of how many good clusters per detector
+  std::array<int, MicromegasDefs::m_nfee> cluster_count = {};
+  std::array<int, MicromegasDefs::m_nfee> good_cluster_count = {};
 
-    for (auto iter = range.first; iter != range.second; ++iter)
+  // first loop over TPOT hitsets
+  for( const auto& [hitsetkey,hitset]:range_adaptor(m_hitsetcontainer->getHitSets(TrkrDefs::TrkrId::micromegasId)))
+  {
+    // get detector name, layer and tile associated to this hitset key
+    const int layer = TrkrDefs::getLayer(hitsetkey);
+    const int tile = MicromegasDefs::getTileId(hitsetkey);
+    const auto detector_name = m_mapping.get_detname_sphenix_from_hitsetkey(hitsetkey);
+
+    // detector id
+    const int detid = tile + MicromegasDefs::m_ntiles*(layer-m_firstlayer);
+
+    // get profile histogram
+    const auto h_profile = dynamic_cast<TH2 *>(hm->getHisto((boost::format("%sncluspertile%i_%i") % getHistoPrefix()%(layer-m_firstlayer)%tile).str()));
+
+    // get clusters
+    const auto cluster_range = m_cluster_map->getClusters(hitsetkey);
+    cluster_count[detid] = std::distance( cluster_range.first, cluster_range.second );
+
+    // loop over clusters
+    for( const auto& [ckey,cluster]:range_adaptor(cluster_range))
     {
-      // const auto cluskey = iter->first;
-      const auto cluster = iter->second;
-      h->Fill(cluster->getLocalY(), cluster->getLocalX());
-      m_totalClusters++;
-      numclusters++;
+      // fill profile
+      h_profile->Fill(cluster->getLocalY(), cluster->getLocalX());
+
+      // find associated hits
+      const auto hit_range = m_cluster_hit_map->getHits(ckey);
+
+      // store cluster size
+      // const int cluster_size = std::distance( hit_range.first, hit_range.second );
+
+      // calculate cluster charge
+      double cluster_charge = 0;
+      for( const auto& [ckey2, hitkey]:range_adaptor( hit_range ) )
+      {
+
+        // get strip
+        const auto strip = MicromegasDefs::getStrip( hitkey );
+
+        // get associated hit
+        const auto hit = hitset->getHit( hitkey );
+        assert( hit );
+
+        // get adc, remove pedestal, increment total charge
+        const auto adc = hit->getAdc();
+        const double pedestal = m_use_default_pedestal ?
+          m_default_pedestal:
+          m_calibration_data.get_pedestal_mapped(hitsetkey, strip);
+        cluster_charge += (adc-pedestal);
+      }
+
+      // increment good clusters
+      /*
+       * we cut on cluster charge > 200 to define good clusters.
+       * This is consistent with what has been done offline so far.
+       * other cuts considered could include cluster size, cluster strip, etc.
+       */
+      if( cluster_charge > 200 )
+      { ++good_cluster_count[detid]; }
     }
-    m_nclustersPerTile[((int) layer) - 55][(int) tile] += numclusters;
   }
 
-  m_event++;
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-int MicromegasClusterQA::EndRun(const int /*runnumber*/)
-{
-  
+  // fill reference and found cluster histograms
+  for( int layer = 0; layer < m_nlayers; ++layer )
+  {
+    for( int tile =0; tile < MicromegasDefs::m_ntiles; ++tile )
+    {
+      // get detector id
+      const int detid = tile+MicromegasDefs::m_ntiles*layer;
+
+      // get reference detector id. It corresponds to the same tile, but on the other layer
+      const int detid_ref = detid > MicromegasDefs::m_ntiles ?
+        detid-MicromegasDefs::m_ntiles:
+        detid+MicromegasDefs::m_ntiles;
+
+      // check if there is exactly one good cluster in the reference detector
+      if(good_cluster_count[detid_ref]==1)
+      {
+        // fill curent detector ref count
+        m_h_clustercount_ref->Fill(detid);
+
+        // if there is one or more cluster in the current detector, also fill good count
+        if(cluster_count[detid])
+        { m_h_clustercount_found->Fill(detid); }
+      }
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+//____________________________________________________________________________..
+int MicromegasClusterQA::EndRun(const int /*runnumber*/)
+{ return Fun4AllReturnCodes::EVENT_OK; }
+
+//____________________________________________________________________________..
 std::string MicromegasClusterQA::getHistoPrefix() const
-{
-  return std::string("h_") + Name() + std::string("_");
-}
+{ return std::string("h_") + Name() + std::string("_"); }
+
+//____________________________________________________________________________..
 void MicromegasClusterQA::createHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
- 
-  for (const auto &[layer, ntiles] : m_layerTileMap)
-  {
-    for (int tile = 0; tile < ntiles; tile++)
-    {
-      auto h = new TH2F((boost::format("%sncluspertile%i_%i") % getHistoPrefix() % layer % tile).str().c_str(),
-                        "Micromegas clusters per tile", 2000, -30, 30, 2000, -20, 20);
-      h->GetXaxis()->SetTitle("Local z [cm]");
-      h->GetYaxis()->SetTitle("Local rphi [cm]");
-      hm->registerHisto(h);
 
+  // cluster count histograms
+  const int n_detectors = m_detector_names.size();
+  m_h_clustercount_ref = new TH1F( (boost::format("%sclustercount_ref") % getHistoPrefix()).str().c_str(), "reference cluster count", n_detectors, 0, n_detectors );
+  m_h_clustercount_found = new TH1F( (boost::format("%sclustercount_found") % getHistoPrefix()).str().c_str(), "found cluster count", n_detectors, 0, n_detectors );
+
+  // cluster positions vs tile
+  for( int i = 0; i < n_detectors; ++i )
+  {
+    m_h_clustercount_ref->GetXaxis()->SetBinLabel(i+1, m_detector_names[i].c_str());
+    m_h_clustercount_found->GetXaxis()->SetBinLabel(i+1, m_detector_names[i].c_str());
+  }
+
+  // register
+  hm->registerHisto(m_h_clustercount_ref);
+  hm->registerHisto(m_h_clustercount_found);
+
+  // cluster positions vs tile
+  for( int layer = 0; layer < m_nlayers; ++layer )
+  {
+    for (int tile = 0; tile < MicromegasDefs::m_ntiles; tile++)
+    {
+      auto h = new TH2F(
+        (boost::format("%sncluspertile%i_%i") % getHistoPrefix() % layer% tile).str().c_str(),
+        "Micromegas clusters per tile", 2000, -30, 30, 2000, -20, 20);
+      h->GetXaxis()->SetTitle("Local x [cm]");
+      h->GetYaxis()->SetTitle("Local y [cm]");
+      hm->registerHisto(h);
     }
   }
 

--- a/offline/QA/Tracking/MicromegasClusterQA.cc
+++ b/offline/QA/Tracking/MicromegasClusterQA.cc
@@ -202,12 +202,12 @@ int MicromegasClusterQA::process_event(PHCompositeNode *topNode)
       const int detid = tile+MicromegasDefs::m_ntiles*layer;
 
       // get reference detector id. It corresponds to the same tile, but on the other layer
-      const int detid_ref = detid > MicromegasDefs::m_ntiles ?
+      const int detid_ref = detid >= MicromegasDefs::m_ntiles ?
         detid-MicromegasDefs::m_ntiles:
         detid+MicromegasDefs::m_ntiles;
 
       // check if there is exactly one good cluster in the reference detector
-      if(good_cluster_count[detid_ref]==1)
+      if(good_cluster_count[detid_ref]==1 && cluster_count[detid_ref]==1)
       {
         // fill curent detector ref count
         m_h_clustercount_ref->Fill(detid);

--- a/offline/QA/Tracking/MicromegasClusterQA.cc
+++ b/offline/QA/Tracking/MicromegasClusterQA.cc
@@ -39,7 +39,7 @@ namespace
   template<class T> class range_adaptor
   {
     public:
-    range_adaptor( const T& range ):m_range(range){}
+    explicit range_adaptor( const T& range ):m_range(range){}
     const typename T::first_type& begin() {return m_range.first;}
     const typename T::second_type& end() {return m_range.second;}
     private:

--- a/offline/QA/Tracking/MicromegasClusterQA.h
+++ b/offline/QA/Tracking/MicromegasClusterQA.h
@@ -4,10 +4,22 @@
 #define QA_TRACKING_MICROMEGASCLUSTERQA_H_
 
 #include <fun4all/SubsysReco.h>
+#include <micromegas/MicromegasDefs.h>
+#include <micromegas/MicromegasMapping.h>
+#include <micromegas/MicromegasCalibrationData.h>
 
+#include <array>
 #include <map>
 #include <set>
 #include <string>
+
+class ActsGeometry;
+class TrkrHitSetContainer;
+class TrkrClusterContainer;
+class TrkrClusterHitAssoc;
+
+class TH1;
+class TH2;
 
 class PHCompositeNode;
 
@@ -22,14 +34,75 @@ class MicromegasClusterQA : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int EndRun(const int runnumber) override;
 
- private:
+  /// set default pedestal
+  void set_default_pedestal( double value )
+  { m_default_pedestal = value; }
+
+  /// set whether default pedestal is used or not
+  void set_use_default_pedestal( bool value )
+  { m_use_default_pedestal = value; }
+
+  /// calibration file
+  void set_calibration_file( const std::string& value )
+  { m_calibration_filename = value; }
+
+  private:
   void createHistos();
 
+  /// micromegas mapping
+  MicromegasMapping m_mapping;
+
+  /// per detector reference cluster count histogram
+  /*! used for standalone efficiency calculation */
+  TH1* m_h_clustercount_ref = nullptr;
+
+  /// per detector found cluster count histogram
+  /** used for standalone efficiency calculation */
+  TH1* m_h_clustercount_found = nullptr;
+
   std::string getHistoPrefix() const;
-  std::map<int, int> m_layerTileMap;
-  int m_event = 0;
-  int m_totalClusters = 0;
-  int m_nclustersPerTile[2][8] = {{0}};
+
+  /// Acts tracking geometry for surface lookup
+  ActsGeometry *m_tGeometry = nullptr;
+
+  //! hits
+  TrkrHitSetContainer* m_hitsetcontainer = nullptr;
+
+  //! clusters
+  TrkrClusterContainer* m_cluster_map = nullptr;
+
+  //! cluster to hit association
+  TrkrClusterHitAssoc* m_cluster_hit_map = nullptr;
+
+  /// first micromegas layer
+  /* this is updated on the fly from geometry object */
+  int m_firstlayer = 55;
+
+  /// number of layers
+  int m_nlayers = 2;
+
+  /// keep track of detector names
+  std::vector<std::string> m_detector_names;
+
+
+  ///@name calibration filename
+  //@{
+
+  /// if true, use default pedestal to get hit charge. Relies on calibration data otherwise
+  bool m_use_default_pedestal = true;
+
+  /// default pedestal
+  double m_default_pedestal = 74.6;
+
+  /// calibration filename
+  std::string m_calibration_filename;
+
+  /// calibration data
+  MicromegasCalibrationData m_calibration_data;
+
+  //@}
+
+
 };
 
 #endif  // MicromegasClusterQA_H

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.cc
@@ -89,6 +89,8 @@ namespace
   // define limit for matching two fee_bco
   static constexpr unsigned int m_max_fee_bco_diff = 10;
 
+  // define limit for matching gtm_bco from lvl1 to enddat
+
   // define limit for matching fee_bco to fee_bco_predicted
   static constexpr unsigned int m_max_gtm_bco_diff = 100;
 
@@ -184,6 +186,20 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
     {
       const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
       m_gtm_bco_list.push_back(gtm_bco);
+      continue;
+    }
+
+    // also save ENDDAT bco
+    const bool is_endat = static_cast<uint8_t>(packet->lValue(t, "IS_ENDAT"));
+    if( is_endat )
+    {
+      const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
+
+      // add to list if difference to last entry is big enough
+      if( m_gtm_bco_list.empty() || (gtm_bco-m_gtm_bco_list.back()) > 10 )
+      {  m_gtm_bco_list.push_back(gtm_bco); }
+
+      continue;
     }
 
     // also save hearbeat bco
@@ -196,6 +212,7 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
       {
         const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
         m_gtm_bco_list.push_back(gtm_bco);
+        continue;
       }
     }
   }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -156,7 +156,8 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       for (int t = 0; t < n_tagger; ++t)
       {
         const bool is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
-        if (is_lvl1)
+        const bool is_endat = static_cast<uint8_t>(packet->lValue(t, "IS_ENDAT"));
+        if (is_lvl1||is_endat)
         {
           const uint64_t gtm_bco = static_cast<uint64_t>(packet->lValue(t, "BCO"));
           m_BeamClockPacket[gtm_bco].insert(packet_id);

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -82,10 +82,20 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   // keep track of dropped waveforms per packet
   std::map<int,uint64_t> m_waveform_count_dropped{};
 
-  // QA histograms
+  //!@name QA histograms
+  //@{
+
+  //! keeps track of how often a given (or all) packets are found for a given BCO
   TH1 *h_packet_stat{nullptr};
+
+  //! keeps track of how many packets are found for a given BCO
   TH1 *h_packet{nullptr};
+
+  //! keeps track of how many waveforms are found for a given BCO
   TH1 *h_waveform{nullptr};
+
+  //@}
+
 };
 
 #endif

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -121,7 +121,6 @@ namespace MicromegasDefs
   //! mark invalid ADC values
   static constexpr uint16_t m_adc_invalid = 65000;
 
-
   /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
   // TODO: should move to online_distribution
   enum SampaDataType

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -94,6 +94,9 @@ namespace MicromegasDefs
    s*/
   uint8_t getTileId(TrkrDefs::cluskey);
 
+  //! number of TPOT tiles
+  static constexpr int m_ntiles = 8;
+
   //! TPOT packet ids
   /**
    * note: TPOT only uses 2 packets.

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -109,6 +109,9 @@ namespace MicromegasDefs
   //! number of channels per fee board
   static constexpr int m_nchannels_fee = 256;
 
+  //! number of sampa chips per fee board
+  static constexpr int m_nsampa_fee = 8;
+
   //! number of fee boards
   static constexpr int m_nfee = 16;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR modifies the Micromegas cluster QA module to add histograms needed for a crude, standalone detection efficiency estimate, on a per run basis. More details in a coming tracking meeting.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

