### PR TITLE
TPC Offline QA Improvements

### DIFF
--- a/offline/QA/Tpc/TpcRawHitQA.h
+++ b/offline/QA/Tpc/TpcRawHitQA.h
@@ -30,7 +30,12 @@ class TpcRawHitQA : public SubsysReco
   int EndRun(const int runnumber) override;
 
   int End(PHCompositeNode *topNode) override;
-  
+
+  void setPresample(bool value)
+  {
+    longPresample = value;
+  } 
+ 
  private:
   void createHistos();
   std::string getHistoPrefix() const;
@@ -41,6 +46,8 @@ class TpcRawHitQA : public SubsysReco
 
   TH1* h_nhits_sectors[24]{nullptr};
   TH2* h_nhits_sectors_fees[24]{nullptr};
+  TH1* h_nhits_sectors_laser[24]{nullptr};
+  TH2* h_nhits_sectors_fees_laser[24]{nullptr};
   TH1* h_nhits_sam[24][3]{{nullptr}};
   TH1* h_adc[24][3]{{nullptr}};
   TH2* h_xy_N{nullptr};
@@ -48,6 +55,8 @@ class TpcRawHitQA : public SubsysReco
 
   int FEE_R[26]{2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
   int FEE_map[26]{4, 5, 0, 2, 1, 11, 9, 10, 8, 7, 6, 0, 1, 3, 7, 6, 5, 4, 3, 2, 0, 2, 1, 3, 5, 4};
+ 
+  bool longPresample = false;
 };
 
 #endif  // TPCRAWHITQA_H

--- a/offline/QA/Tracking/TpcSiliconQA.cc
+++ b/offline/QA/Tracking/TpcSiliconQA.cc
@@ -89,7 +89,7 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
       h_yDiff[0]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[0]->Fill(m_tpcseedz - m_silseedz);
   
-      if (m_tpcseedz > 0 && m_silseedz > 0)
+      if (m_tpcseedeta > 0 && m_silseedeta > 0)
       {
         h_phiDiff[4]->Fill(m_tpcseedphi - m_silseedphi);
         h_etaDiff[4]->Fill(m_tpcseedeta - m_silseedeta);
@@ -97,7 +97,7 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
         h_yDiff[4]->Fill(m_tpcseedy - m_silseedy);
         h_zDiff[4]->Fill(m_tpcseedz - m_silseedz);
       }
-      else if (m_tpcseedz < 0 && m_silseedz < 0)
+      else if (m_tpcseedeta < 0 && m_silseedeta < 0)
       {
         h_phiDiff[5]->Fill(m_tpcseedphi - m_silseedphi);
         h_etaDiff[5]->Fill(m_tpcseedeta - m_silseedeta);
@@ -139,7 +139,7 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
       h_yDiff[3]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[3]->Fill(m_tpcseedz - m_silseedz);
       
-      if (m_tpcseedz > 0 && m_silseedz > 0)
+      if (m_tpcseedeta > 0 && m_silseedeta > 0)
       {
         h_phiDiff[6]->Fill(m_tpcseedphi - m_silseedphi);
         h_etaDiff[6]->Fill(m_tpcseedeta - m_silseedeta);
@@ -147,7 +147,7 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
         h_yDiff[6]->Fill(m_tpcseedy - m_silseedy);
         h_zDiff[6]->Fill(m_tpcseedz - m_silseedz);
       }
-      else if (m_tpcseedz < 0 && m_silseedz < 0)
+      else if (m_tpcseedeta < 0 && m_silseedeta < 0)
       {
         h_phiDiff[7]->Fill(m_tpcseedphi - m_silseedphi);
         h_etaDiff[7]->Fill(m_tpcseedeta - m_silseedeta);

--- a/offline/QA/Tracking/TpcSiliconQA.cc
+++ b/offline/QA/Tracking/TpcSiliconQA.cc
@@ -88,6 +88,23 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
       h_xDiff[0]->Fill(m_tpcseedx - m_silseedx);
       h_yDiff[0]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[0]->Fill(m_tpcseedz - m_silseedz);
+  
+      if (m_tpcseedz > 0 && m_silseedz > 0)
+      {
+        h_phiDiff[4]->Fill(m_tpcseedphi - m_silseedphi);
+        h_etaDiff[4]->Fill(m_tpcseedeta - m_silseedeta);
+        h_xDiff[4]->Fill(m_tpcseedx - m_silseedx);
+        h_yDiff[4]->Fill(m_tpcseedy - m_silseedy);
+        h_zDiff[4]->Fill(m_tpcseedz - m_silseedz);
+      }
+      else if (m_tpcseedz < 0 && m_silseedz < 0)
+      {
+        h_phiDiff[5]->Fill(m_tpcseedphi - m_silseedphi);
+        h_etaDiff[5]->Fill(m_tpcseedeta - m_silseedeta);
+        h_xDiff[5]->Fill(m_tpcseedx - m_silseedx);
+        h_yDiff[5]->Fill(m_tpcseedy - m_silseedy);
+        h_zDiff[5]->Fill(m_tpcseedz - m_silseedz);
+      }
 
       if (abs(m_tpcseedx - m_silseedx) > m_xcut || abs(m_tpcseedy - m_silseedy) > m_ycut)
       {
@@ -121,6 +138,23 @@ int TpcSiliconQA::process_event(PHCompositeNode* topNode)
       h_xDiff[3]->Fill(m_tpcseedx - m_silseedx);
       h_yDiff[3]->Fill(m_tpcseedy - m_silseedy);
       h_zDiff[3]->Fill(m_tpcseedz - m_silseedz);
+      
+      if (m_tpcseedz > 0 && m_silseedz > 0)
+      {
+        h_phiDiff[6]->Fill(m_tpcseedphi - m_silseedphi);
+        h_etaDiff[6]->Fill(m_tpcseedeta - m_silseedeta);
+        h_xDiff[6]->Fill(m_tpcseedx - m_silseedx);
+        h_yDiff[6]->Fill(m_tpcseedy - m_silseedy);
+        h_zDiff[6]->Fill(m_tpcseedz - m_silseedz);
+      }
+      else if (m_tpcseedz < 0 && m_silseedz < 0)
+      {
+        h_phiDiff[7]->Fill(m_tpcseedphi - m_silseedphi);
+        h_etaDiff[7]->Fill(m_tpcseedeta - m_silseedeta);
+        h_xDiff[7]->Fill(m_tpcseedx - m_silseedx);
+        h_yDiff[7]->Fill(m_tpcseedy - m_silseedy);
+        h_zDiff[7]->Fill(m_tpcseedz - m_silseedz);
+      }
     }
   }
 
@@ -149,11 +183,15 @@ void TpcSiliconQA::createHistos()
   stream3 << std::fixed << std::setprecision(2) << m_etacut;
   stream4 << std::fixed << std::setprecision(2) << m_phicut;
 
-  std::vector<std::string> cutNames = {"", "_xyCut", "_etaCut", "_phiCut"};
-  std::vector<std::string> cutVals = {"", 
-                         std::string("|xdiff| < " + stream1.str() + ", |ydiff| < " + stream2.str()),
+  std::vector<std::string> cutNames = {"", "_xyCut", "_etaCut", "_phiCut", "North", "South", "NorthAllCuts", "SouthAllCuts"};
+  std::vector<std::string> cutVals = {"All Track Seeds", 
+                         std::string("|xdiff| < " + stream1.str() + "cm , |ydiff| < " + stream2.str() + "cm"),
                          std::string("xy cuts and |etadiff| < " + stream3.str()), 
-                         std::string("xy, eta cuts and |phidiff| < " + stream4.str())};
+                         std::string("xy, eta cuts and |phidiff| < " + stream4.str()),
+                         "All Track Seeds (North Only)",
+                         "All Track Seeds (South Only)",
+                         "North All Cuts (x,y,eta,phi)",
+                         "South All Cuts (x,y,eta,phi)"};
 
   {
     h_crossing = new TH1F(std::string(getHistoPrefix() + "crossing").c_str(),

--- a/offline/QA/Tracking/TpcSiliconQA.h
+++ b/offline/QA/Tracking/TpcSiliconQA.h
@@ -54,11 +54,11 @@ class TpcSiliconQA : public SubsysReco
   int m_event = 0;
 
   TH1 *h_crossing = nullptr;
-  TH1 *h_phiDiff[4] = {nullptr};
-  TH1 *h_etaDiff[4] = {nullptr};
-  TH1 *h_xDiff[4] = {nullptr};
-  TH1 *h_yDiff[4] = {nullptr};
-  TH1 *h_zDiff[4] = {nullptr}; 
+  TH1 *h_phiDiff[8] = {nullptr};
+  TH1 *h_etaDiff[8] = {nullptr};
+  TH1 *h_xDiff[8] = {nullptr};
+  TH1 *h_yDiff[8] = {nullptr};
+  TH1 *h_zDiff[8] = {nullptr}; 
 };
 
 #endif  // QA_TRACKING_TPCSILICONQA_H


### PR DESCRIPTION
Adding new North/South separated plots to TpcSiliconQA module
Also separating the laser pulse hits from other hits in the TpcRawHitQA module, as well as improving that module to more accurately determine the pedestal and std value for a given channel (was calculating on a channel-by-channel basis before incorrectly because we no longer have a resample)
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

