### PR TITLE
fix: only fill offline qa with endat

### DIFF
--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -126,7 +126,7 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
         const auto is_lvl1 = static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER"));
        
         const auto is_endat = static_cast<uint8_t>(packet->lValue(t, "IS_ENDAT"));
-        if (is_lvl1 || is_endat)
+        if (is_lvl1)
         {
           gtm_bco = packet->lValue(t, "BCO");
           if (largest_bco < gtm_bco)
@@ -150,6 +150,15 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
           }
           m_BclkStackPacketMap[packet_id].insert(gtm_bco);
         }
+          if(is_endat)
+          {
+            auto endatbco = packet->lValue(t, "BCO");
+            if (m_BclkStackPacketMap.find(packet_id) == m_BclkStackPacketMap.end())
+            {
+              m_BclkStackPacketMap.insert(std::make_pair(packet_id, std::set<uint64_t>()));
+            }
+            m_BclkStackPacketMap[packet_id].insert(endatbco);
+          }
       }
       if (skipthis)
       {


### PR DESCRIPTION
This should address @pinkenburg concern, this change now only affects the qa histogram filling with the endat instead of the possibility of actually starting the whole show with the endat bco
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

