### PR TITLE
Added offline QA histograms to keep track of how dropped waveforms

### DIFF
--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -547,6 +547,7 @@ void SingleMicromegasPoolInput::createQAHistos()
   h_packet_stat->GetXaxis()->SetBinLabel(2, "5001" );
   h_packet_stat->GetXaxis()->SetBinLabel(3, "5002" );
   h_packet_stat->GetXaxis()->SetBinLabel(4, "All" );
+  h_packet_stat->GetYaxis()->SetTitle( "trigger count" );
 
   // total number of waveform per packet
   h_waveform_count_total = new TH1F( "h_MicromegasBCOQA_waveform_count_total", "Total number of waveforms per packet", m_npackets_active, 0, m_npackets_active );

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -559,6 +559,7 @@ void SingleMicromegasPoolInput::createQAHistos()
   {
     h->GetXaxis()->SetBinLabel(1, "5001" );
     h->GetXaxis()->SetBinLabel(2, "5002" );
+    h->GetXaxis()->SetTitle( "packet id" );
   }
 
   // register all histograms to histogram manager

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -559,6 +559,7 @@ void SingleMicromegasPoolInput::createQAHistos()
   {
     h->GetXaxis()->SetBinLabel(1, "5001" );
     h->GetXaxis()->SetBinLabel(2, "5002" );
+    h->GetYaxis()->SetTitle( "waveform count" );
     h->GetXaxis()->SetTitle( "packet id" );
   }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -167,7 +167,10 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
 
       // loop over waveforms
       const int nwf = packet->iValue(0, "NR_WF");
+
+      // increment counter and histogram
       m_waveform_count_total[packet_id] += nwf;
+      h_waveform_count_total->Fill( std::to_string(packet_id).c_str(), nwf );
 
       if (Verbosity())
       {
@@ -197,6 +200,7 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       {
         std::cout << "SingleMicromegasPoolInput::FillPool - bco_matching not verified, dropping packet" << std::endl;
         m_waveform_count_dropped[packet_id] += nwf;
+        h_waveform_count_dropped->Fill( std::to_string(packet_id).c_str(), nwf );
         bco_matching_information.cleanup();
         continue;
       }
@@ -227,8 +231,9 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
         }
         else
         {
-          // increment count
+          // increment counter and histogram
           ++m_waveform_count_dropped[packet_id];
+          h_waveform_count_dropped->Fill( std::to_string(packet_id).c_str(), 1 );
 
           // skip the waverform
           continue;
@@ -526,21 +531,38 @@ void SingleMicromegasPoolInput::createQAHistos()
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
-  h_packet = new TH1I( "h_MicromegasBCOQA_npacket_bco", "TPOT Packet Count per GTM BCO; Matching BCO tagger count; GL1 trigger count", 10, 0, 10 );
-  h_waveform = new TH1I( "h_MicromegasBCOQA_nwaveform_bco", "TPOT Waveform Count per GTM BCO; Matching Waveform count; GL1 trigger count", 4100, 0, 4100 );
+  // number of packets found with BCO from felix matching reference BCO
+  h_packet = new TH1F( "h_MicromegasBCOQA_npacket_bco", "TPOT Packet Count per GTM BCO; Matching BCO tagger count; GL1 trigger count", 10, 0, 10 );
+
+  // number of waveforms found with BCO from felix matching reference BCO
+  h_waveform = new TH1F( "h_MicromegasBCOQA_nwaveform_bco", "TPOT Waveform Count per GTM BCO; Matching Waveform count; GL1 trigger count", 4100, 0, 4100 );
 
   /*
    * first bin is the number of requested GL1 BCO, for reference
    * next two bins is the number of times the GL1 BCO is found in the taggers list for a given packet_id
    * last bin is the sum
    */
-  h_packet_stat = new TH1I( "h_MicromegasBCOQA_packet_stat", "Matching Tagger count per packet; packet id; GL1 trigger count", m_npackets_active+2, 0, m_npackets_active+2 );
+  h_packet_stat = new TH1F( "h_MicromegasBCOQA_packet_stat", "Matching Tagger count per packet; packet id; GL1 trigger count", m_npackets_active+2, 0, m_npackets_active+2 );
   h_packet_stat->GetXaxis()->SetBinLabel(1, "Reference" );
   h_packet_stat->GetXaxis()->SetBinLabel(2, "5001" );
   h_packet_stat->GetXaxis()->SetBinLabel(3, "5002" );
   h_packet_stat->GetXaxis()->SetBinLabel(4, "All" );
 
-  for( const auto& h:std::initializer_list<TH1*>{h_packet, h_waveform, h_packet_stat} )
+  // total number of waveform per packet
+  h_waveform_count_total = new TH1F( "h_MicromegasBCOQA_waveform_count_total", "Total number of waveforms per packet", m_npackets_active, 0, m_npackets_active );
+
+  // number of dropped waveform per packet
+  h_waveform_count_dropped = new TH1F( "h_MicromegasBCOQA_waveform_count_dropped", "Number of dropped waveforms per packet", m_npackets_active, 0, m_npackets_active );
+
+  // define axis
+  for( const auto& h:std::initializer_list<TH1*>{h_waveform_count_total, h_waveform_count_dropped} )
+  {
+    h->GetXaxis()->SetBinLabel(1, "5001" );
+    h->GetXaxis()->SetBinLabel(2, "5002" );
+  }
+
+  // register all histograms to histogram manager
+  for( const auto& h:std::initializer_list<TH1*>{h_packet, h_waveform, h_packet_stat, h_waveform_count_total, h_waveform_count_dropped} )
   {
     h->SetFillStyle(1001);
     h->SetFillColor(kYellow);

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -94,6 +94,13 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   //! keeps track of how many waveforms are found for a given BCO
   TH1 *h_waveform{nullptr};
 
+  //! total number of waveforms per packet
+  TH1 *h_waveform_count_total{nullptr};
+
+  //! total number of dropped waveforms per packet
+  /*! waveforms are dropped when their FEE-BCO cannot be associated to any global BCO */
+  TH1 *h_waveform_count_dropped{nullptr};
+
   //@}
 
 };


### PR DESCRIPTION
Added offline QA histograms to keep track of how many waveforms are dropped per packet because of not being able to associate their BCO to any GL1 BCO.
Also changed TH1I into TH1F, they are easier to manipulate and normalize.


![Screenshot_20240910_104504](https://github.com/user-attachments/assets/ac0fd10a-e0c0-47c5-aef6-4f204622f1d7)


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

