### PR TITLE
Add event skipping capability to single trigger input mgrs

### DIFF
--- a/offline/framework/fun4allraw/SingleCemcTriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleCemcTriggerInput.cc
@@ -91,6 +91,10 @@ void SingleCemcTriggerInput::FillPool(const unsigned int keep)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
+    if (EventSequence < SkipToEvent())
+    {
+      continue;
+    }
     std::vector<Packet *> pktvec = evt->getPacketVector();
     for (auto packet : pktvec)
     {

--- a/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggerInput.cc
@@ -85,6 +85,16 @@ void SingleGl1TriggerInput::FillPool(const unsigned int keep)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
+    if (EventSequence < SkipToEvent())
+    {
+      continue;
+    }
+    if (EventSequence > LastEvent())
+    {
+      std::cout << Name() << ": Last event " << LastEvent() << std::endl;
+      AllDone(1);
+      return;
+    }
     Packet *packet = evt->getPacket(14001);
     if (!packet)
     {
@@ -115,13 +125,13 @@ void SingleGl1TriggerInput::FillPool(const unsigned int keep)
           TriggerInputManager()->AddGl1DroppedEvent(EventSequence);
         }
 
-	static int icnt = 0;
-	if (icnt < 1000)
-	{
-	  std::cout << Name() << ": Found dropped Event at event " << EventSequence
-		    << " with Packet Number: " << packetnumber << std::endl;
-	  icnt++;
-	}
+        static int icnt = 0;
+        if (icnt < 1000)
+        {
+          std::cout << Name() << ": Found dropped Event at event " << EventSequence
+                    << " with Packet Number: " << packetnumber << std::endl;
+          icnt++;
+        }
         m_Gl1PacketNumberEventNumberDiff = gl1pktdiff;
       }
     }

--- a/offline/framework/fun4allraw/SingleHcalTriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleHcalTriggerInput.cc
@@ -29,15 +29,10 @@
 #include <set>
 #include <utility>  // for pair
 
-// it is 8 packets for the hcal, this number needs to be npackets+1
-// so it doesn't trigger the warning and exit. Setting it to 10
-static const int NHCALPACKETS = 10;
-
 SingleHcalTriggerInput::SingleHcalTriggerInput(const std::string &name)
   : SingleTriggerInput(name)
 {
   SubsystemEnum(InputManagerType::HCAL);
-  plist = new Packet *[NHCALPACKETS];  // eight packets for the hcal in each file
   LocalPoolDepth(3);
 }
 
@@ -51,7 +46,6 @@ SingleHcalTriggerInput::~SingleHcalTriggerInput()
   {
     m_EventStack.erase(m_EventStack.begin());
   }
-  delete[] plist;
 }
 
 void SingleHcalTriggerInput::FillPool(const unsigned int keep)
@@ -96,18 +90,14 @@ void SingleHcalTriggerInput::FillPool(const unsigned int keep)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
-    int npackets = evt->getPacketList(plist, NHCALPACKETS);
-    if (npackets >= NHCALPACKETS)
+    if (EventSequence < SkipToEvent())
     {
-      std::cout << PHWHERE << " Packets array size " << NHCALPACKETS
-                << " too small for " << Name()
-                << ", increase NHCALPACKETS and rebuild" << std::endl;
-      exit(1);
+      continue;
     }
-
-    for (int i = 0; i < npackets; i++)
+    std::vector<Packet *> pktvec = evt->getPacketVector();
+    for (auto packet : pktvec)
     {
-      int packet_id = plist[i]->getIdentifier();
+      int packet_id = packet->getIdentifier();
       // The call to  EventNumberOffset(identifier) will initialize it to our default (zero) if it wasn't set already
       // if we encounter a misalignemt, the Fun4AllPrdfInputTriggerManager will adjust this. But the event
       // number of the adjustment depends on its pooldepth. Events in its pools will be moved to the correct slots
@@ -116,14 +106,14 @@ void SingleHcalTriggerInput::FillPool(const unsigned int keep)
       int CorrectedEventSequence = EventSequence + EventNumberOffset(packet_id);
       if (Verbosity() > 2)
       {
-        plist[i]->identify();
+        packet->identify();
       }
 
       // by default use previous bco clock for gtm bco
       CaloPacket *newhit = new CaloPacketv1();
-      int nr_modules = plist[i]->iValue(0, "NRMODULES");
-      int nr_channels = plist[i]->iValue(0, "CHANNELS");
-      int nr_samples = plist[i]->iValue(0, "SAMPLES");
+      int nr_modules = packet->iValue(0, "NRMODULES");
+      int nr_channels = packet->iValue(0, "CHANNELS");
+      int nr_samples = packet->iValue(0, "SAMPLES");
       if (nr_modules > newhit->getMaxNumModules())
       {
         std::cout << PHWHERE << " too many modules " << nr_modules << ", max is "
@@ -142,47 +132,47 @@ void SingleHcalTriggerInput::FillPool(const unsigned int keep)
                   << newhit->getMaxNumSamples() << ", need to adjust arrays" << std::endl;
         gSystem->Exit(1);
       }
-      uint64_t gtm_bco = plist[i]->lValue(0, "CLOCK");
+      uint64_t gtm_bco = packet->lValue(0, "CLOCK");
       newhit->setNrModules(nr_modules);
       newhit->setNrSamples(nr_samples);
       newhit->setNrChannels(nr_channels);
       newhit->setBCO(gtm_bco);
-      newhit->setPacketEvtSequence(plist[i]->iValue(0, "EVTNR"));
+      newhit->setPacketEvtSequence(packet->iValue(0, "EVTNR"));
       newhit->setIdentifier(packet_id);
-      newhit->setHitFormat(plist[i]->getHitFormat());
+      newhit->setHitFormat(packet->getHitFormat());
       newhit->setEvtSequence(EventSequence);
-      newhit->setEvenChecksum(plist[i]->iValue(0, "EVENCHECKSUM"));
-      newhit->setCalcEvenChecksum(plist[i]->iValue(0, "CALCEVENCHECKSUM"));
-      newhit->setOddChecksum(plist[i]->iValue(0, "ODDCHECKSUM"));
-      newhit->setCalcOddChecksum(plist[i]->iValue(0, "CALCODDCHECKSUM"));
-      newhit->setModuleAddress(plist[i]->iValue(0, "MODULEADDRESS"));
-      newhit->setDetId(plist[i]->iValue(0, "DETID"));
+      newhit->setEvenChecksum(packet->iValue(0, "EVENCHECKSUM"));
+      newhit->setCalcEvenChecksum(packet->iValue(0, "CALCEVENCHECKSUM"));
+      newhit->setOddChecksum(packet->iValue(0, "ODDCHECKSUM"));
+      newhit->setCalcOddChecksum(packet->iValue(0, "CALCODDCHECKSUM"));
+      newhit->setModuleAddress(packet->iValue(0, "MODULEADDRESS"));
+      newhit->setDetId(packet->iValue(0, "DETID"));
       for (int ifem = 0; ifem < nr_modules; ifem++)
       {
-        newhit->setFemClock(ifem, plist[i]->iValue(ifem, "FEMCLOCK"));
-        newhit->setFemEvtSequence(ifem, plist[i]->iValue(ifem, "FEMEVTNR"));
-        newhit->setFemSlot(ifem, plist[i]->iValue(ifem, "FEMSLOT"));
-        newhit->setChecksumLsb(ifem, plist[i]->iValue(ifem, "CHECKSUMLSB"));
-        newhit->setChecksumMsb(ifem, plist[i]->iValue(ifem, "CHECKSUMMSB"));
-        newhit->setCalcChecksumLsb(ifem, plist[i]->iValue(ifem, "CALCCHECKSUMLSB"));
-        newhit->setCalcChecksumMsb(ifem, plist[i]->iValue(ifem, "CALCCHECKSUMMSB"));
+        newhit->setFemClock(ifem, packet->iValue(ifem, "FEMCLOCK"));
+        newhit->setFemEvtSequence(ifem, packet->iValue(ifem, "FEMEVTNR"));
+        newhit->setFemSlot(ifem, packet->iValue(ifem, "FEMSLOT"));
+        newhit->setChecksumLsb(ifem, packet->iValue(ifem, "CHECKSUMLSB"));
+        newhit->setChecksumMsb(ifem, packet->iValue(ifem, "CHECKSUMMSB"));
+        newhit->setCalcChecksumLsb(ifem, packet->iValue(ifem, "CALCCHECKSUMLSB"));
+        newhit->setCalcChecksumMsb(ifem, packet->iValue(ifem, "CALCCHECKSUMMSB"));
       }
       for (int ipmt = 0; ipmt < nr_channels; ipmt++)
       {
         // store pre/post only for suppressed channels, the array in the packet routines is not
         // initialized so reading pre/post for not zero suppressed channels returns garbage
-        bool isSuppressed = plist[i]->iValue(ipmt, "SUPPRESSED");
+        bool isSuppressed = packet->iValue(ipmt, "SUPPRESSED");
         newhit->setSuppressed(ipmt, isSuppressed);
         if (isSuppressed)
         {
-          newhit->setPre(ipmt, plist[i]->iValue(ipmt, "PRE"));
-          newhit->setPost(ipmt, plist[i]->iValue(ipmt, "POST"));
+          newhit->setPre(ipmt, packet->iValue(ipmt, "PRE"));
+          newhit->setPost(ipmt, packet->iValue(ipmt, "POST"));
         }
         else
         {
           for (int isamp = 0; isamp < nr_samples; isamp++)
           {
-            newhit->setSample(ipmt, isamp, plist[i]->iValue(isamp, ipmt));
+            newhit->setSample(ipmt, isamp, packet->iValue(isamp, ipmt));
           }
         }
       }
@@ -197,9 +187,9 @@ void SingleHcalTriggerInput::FillPool(const unsigned int keep)
       m_EventStack.insert(CorrectedEventSequence);
       if (ddump_enabled())
       {
-        ddumppacket(plist[i]);
+        ddumppacket(packet);
       }
-      delete plist[i];
+      delete packet;
     }
     if (m_LocalPacketMap.size() >= LocalPoolDepth())
     {

--- a/offline/framework/fun4allraw/SingleHcalTriggerInput.h
+++ b/offline/framework/fun4allraw/SingleHcalTriggerInput.h
@@ -36,7 +36,6 @@ class SingleHcalTriggerInput : public SingleTriggerInput
   int ShiftEvents(int pktid, int offset);
   int m_ClockReferencePacket{0};
   bool m_FEMClockProblemFlag{false};
-  Packet **plist{nullptr};
   std::set<int> m_BadBCOPacketSet;
   std::map<int, std::vector<OfflinePacket *>> m_LocalPacketMap;
   std::map<int, uint64_t> m_EventRefBCO;

--- a/offline/framework/fun4allraw/SingleLL1TriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleLL1TriggerInput.cc
@@ -29,15 +29,10 @@
 #include <set>
 #include <utility>  // for pair
 
-// it is 8 packets for the ll1, this number needs to be npackets+1
-// so it doesn't trigger the warning and exit. Setting it to 10
-static const int NLL1PACKETS = 19;
-
 SingleLL1TriggerInput::SingleLL1TriggerInput(const std::string &name)
   : SingleTriggerInput(name)
 {
   SubsystemEnum(InputManagerType::LL1);
-  plist = new Packet *[NLL1PACKETS];  // eight packets for the ll1 in each file
 }
 
 SingleLL1TriggerInput::~SingleLL1TriggerInput()
@@ -49,7 +44,6 @@ SingleLL1TriggerInput::~SingleLL1TriggerInput()
   {
     m_EventStack.erase(m_EventStack.begin());
   }
-  delete[] plist;
 }
 
 void SingleLL1TriggerInput::FillPool(const unsigned int keep)
@@ -94,18 +88,14 @@ void SingleLL1TriggerInput::FillPool(const unsigned int keep)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
-    int npackets = evt->getPacketList(plist, NLL1PACKETS);
-    if (npackets >= NLL1PACKETS)
+    if (EventSequence < SkipToEvent())
     {
-      std::cout << PHWHERE << " Packets array size " << NLL1PACKETS
-                << " too small for " << Name()
-                << ", increase NLL1PACKETS and rebuild" << std::endl;
-      exit(1);
+      continue;
     }
-
-    for (int i = 0; i < npackets; i++)
+    std::vector<Packet *> pktvec = evt->getPacketVector();
+    for (auto packet : pktvec)
     {
-      int packet_id = plist[i]->getIdentifier();
+      int packet_id = packet->getIdentifier();
       // The call to  EventNumberOffset(identifier) will initialize it to our default (zero) if it wasn't set already
       // if we encounter a misalignemt, the Fun4AllPrdfInputTriggerManager will adjust this. But the event
       // number of the adjustment depends on its pooldepth. Events in its pools will be moved to the correct slots
@@ -114,30 +104,30 @@ void SingleLL1TriggerInput::FillPool(const unsigned int keep)
       int CorrectedEventSequence = EventSequence + EventNumberOffset(packet_id);
       if (Verbosity() > 2)
       {
-        plist[i]->identify();
+        packet->identify();
       }
 
       // by default use previous bco clock for gtm bco
       LL1Packet *newhit = new LL1Packetv1();
-      int nr_channels = plist[i]->iValue(0, "CHANNELS");
-      int nr_samples = plist[i]->iValue(0, "SAMPLES");
-      uint64_t gtm_bco = plist[i]->iValue(0, "CLOCK");
+      int nr_channels = packet->iValue(0, "CHANNELS");
+      int nr_samples = packet->iValue(0, "SAMPLES");
+      uint64_t gtm_bco = packet->iValue(0, "CLOCK");
       // offline packet content
       newhit->setEvtSequence(CorrectedEventSequence);
       newhit->setIdentifier(packet_id);
-      newhit->setHitFormat(plist[i]->getHitFormat());
+      newhit->setHitFormat(packet->getHitFormat());
       newhit->setBCO(gtm_bco);
-      newhit->setPacketEvtSequence(plist[i]->iValue(0, "EVTNR"));
+      newhit->setPacketEvtSequence(packet->iValue(0, "EVTNR"));
       // ll1 packet additions
       newhit->setNrSamples(nr_samples);
       newhit->setNrChannels(nr_channels);
-      newhit->setTriggerWords(plist[i]->iValue(0, "TRIGGERWORDS"));
-      newhit->setSlotNr(plist[i]->iValue(0, "SLOTNR"));
-      newhit->setCardNr(plist[i]->iValue(0, "CARDNR"));
-      newhit->setMonitor(plist[i]->iValue(0, "MONITOR"));
-      newhit->setFemWords(plist[i]->iValue(0, "FEMWORDS"));
-      newhit->setFibers(plist[i]->iValue(0, "FIBERS"));
-      newhit->setSums(plist[i]->iValue(0, "SUMS"));
+      newhit->setTriggerWords(packet->iValue(0, "TRIGGERWORDS"));
+      newhit->setSlotNr(packet->iValue(0, "SLOTNR"));
+      newhit->setCardNr(packet->iValue(0, "CARDNR"));
+      newhit->setMonitor(packet->iValue(0, "MONITOR"));
+      newhit->setFemWords(packet->iValue(0, "FEMWORDS"));
+      newhit->setFibers(packet->iValue(0, "FIBERS"));
+      newhit->setSums(packet->iValue(0, "SUMS"));
       for (int ichan = 0; ichan < nr_channels; ichan++)
       {
         for (int isamp = 0; isamp < nr_samples; isamp++)
@@ -151,7 +141,7 @@ void SingleLL1TriggerInput::FillPool(const unsigned int keep)
           }
           else
           {
-            newhit->setSample(ichan, isamp, plist[i]->iValue(isamp, ichan));
+            newhit->setSample(ichan, isamp, packet->iValue(isamp, ichan));
           }
         }
       }
@@ -172,9 +162,9 @@ void SingleLL1TriggerInput::FillPool(const unsigned int keep)
       m_EventStack.insert(CorrectedEventSequence);
       if (ddump_enabled())
       {
-        ddumppacket(plist[i]);
+        ddumppacket(packet);
       }
-      delete plist[i];
+      delete packet;
     }
   }
 }

--- a/offline/framework/fun4allraw/SingleLL1TriggerInput.h
+++ b/offline/framework/fun4allraw/SingleLL1TriggerInput.h
@@ -4,7 +4,6 @@
 #include "SingleTriggerInput.h"
 
 #include <cstdint>
-#include <list>
 #include <map>
 #include <set>
 #include <string>
@@ -26,7 +25,6 @@ class SingleLL1TriggerInput : public SingleTriggerInput
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
  private:
-  Packet **plist{nullptr};
 };
 
 #endif

--- a/offline/framework/fun4allraw/SingleMbdTriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleMbdTriggerInput.cc
@@ -29,13 +29,10 @@
 #include <set>
 #include <utility>  // for pair
 
-static const int NMBDPACKETS = 2 + 1;  // one spare to get an error from getPacketList
-
 SingleMbdTriggerInput::SingleMbdTriggerInput(const std::string &name)
   : SingleTriggerInput(name)
 {
   SubsystemEnum(InputManagerType::MBD);
-  plist = new Packet *[NMBDPACKETS];  // two packets for the mbd in each file
 }
 
 SingleMbdTriggerInput::~SingleMbdTriggerInput()
@@ -47,7 +44,6 @@ SingleMbdTriggerInput::~SingleMbdTriggerInput()
   {
     m_EventStack.erase(m_EventStack.begin());
   }
-  delete[] plist;
 }
 
 void SingleMbdTriggerInput::FillPool(const unsigned int keep)
@@ -92,18 +88,14 @@ void SingleMbdTriggerInput::FillPool(const unsigned int keep)
       continue;
     }
     int EventSequence = evt->getEvtSequence();
-    int npackets = evt->getPacketList(plist, NMBDPACKETS);
-    if (npackets >= NMBDPACKETS)
+    if (EventSequence < SkipToEvent())
     {
-      std::cout << PHWHERE << " Packets array size " << NMBDPACKETS
-                << " too small for " << Name()
-                << ", increase NMBDPACKETS and rebuild" << std::endl;
-      exit(1);
+      continue;
     }
-
-    for (int i = 0; i < npackets; i++)
+    std::vector<Packet *> pktvec = evt->getPacketVector();
+    for (auto packet : pktvec)
     {
-      int packet_id = plist[i]->getIdentifier();
+      int packet_id = packet->getIdentifier();
       // The call to  EventNumberOffset(identifier) will initialize it to our default if it wasn't set already
       // if we encounter a misalignemt, the Fun4AllPrdfInputTriggerManager will adjust this. But the event
       // number of the adjustment depends on its pooldepth. Events in its pools will be moved to the correct slots
@@ -112,60 +104,60 @@ void SingleMbdTriggerInput::FillPool(const unsigned int keep)
       int CorrectedEventSequence = EventSequence + EventNumberOffset(packet_id);
       if (Verbosity() > 2)
       {
-        plist[i]->identify();
+        packet->identify();
       }
 
       CaloPacket *newhit = new CaloPacketv1();
-      int nr_modules = plist[i]->iValue(0, "NRMODULES");
-      int nr_channels = plist[i]->iValue(0, "CHANNELS");
-      int nr_samples = plist[i]->iValue(0, "SAMPLES");
+      int nr_modules = packet->iValue(0, "NRMODULES");
+      int nr_channels = packet->iValue(0, "CHANNELS");
+      int nr_samples = packet->iValue(0, "SAMPLES");
       if (nr_modules > 3)
       {
         std::cout << PHWHERE << " too many modules, need to adjust arrays" << std::endl;
         gSystem->Exit(1);
       }
 
-      uint64_t gtm_bco = plist[i]->lValue(0, "CLOCK");
+      uint64_t gtm_bco = packet->lValue(0, "CLOCK");
       newhit->setNrModules(nr_modules);
       newhit->setNrSamples(nr_samples);
       newhit->setNrChannels(nr_channels);
       newhit->setBCO(gtm_bco);
-      newhit->setPacketEvtSequence(plist[i]->iValue(0, "EVTNR"));
+      newhit->setPacketEvtSequence(packet->iValue(0, "EVTNR"));
       newhit->setIdentifier(packet_id);
-      newhit->setHitFormat(plist[i]->getHitFormat());
+      newhit->setHitFormat(packet->getHitFormat());
       newhit->setEvtSequence(CorrectedEventSequence);
-      newhit->setEvenChecksum(plist[i]->iValue(0, "EVENCHECKSUM"));
-      newhit->setCalcEvenChecksum(plist[i]->iValue(0, "CALCEVENCHECKSUM"));
-      newhit->setOddChecksum(plist[i]->iValue(0, "ODDCHECKSUM"));
-      newhit->setCalcOddChecksum(plist[i]->iValue(0, "CALCODDCHECKSUM"));
-      newhit->setModuleAddress(plist[i]->iValue(0, "MODULEADDRESS"));
-      newhit->setDetId(plist[i]->iValue(0, "DETID"));
+      newhit->setEvenChecksum(packet->iValue(0, "EVENCHECKSUM"));
+      newhit->setCalcEvenChecksum(packet->iValue(0, "CALCEVENCHECKSUM"));
+      newhit->setOddChecksum(packet->iValue(0, "ODDCHECKSUM"));
+      newhit->setCalcOddChecksum(packet->iValue(0, "CALCODDCHECKSUM"));
+      newhit->setModuleAddress(packet->iValue(0, "MODULEADDRESS"));
+      newhit->setDetId(packet->iValue(0, "DETID"));
       for (int ifem = 0; ifem < nr_modules; ifem++)
       {
-        newhit->setFemClock(ifem, plist[i]->iValue(ifem, "FEMCLOCK"));
-        newhit->setFemEvtSequence(ifem, plist[i]->iValue(ifem, "FEMEVTNR"));
-        newhit->setFemSlot(ifem, plist[i]->iValue(ifem, "FEMSLOT"));
-        newhit->setChecksumLsb(ifem, plist[i]->iValue(ifem, "CHECKSUMLSB"));
-        newhit->setChecksumMsb(ifem, plist[i]->iValue(ifem, "CHECKSUMMSB"));
-        newhit->setCalcChecksumLsb(ifem, plist[i]->iValue(ifem, "CALCCHECKSUMLSB"));
-        newhit->setCalcChecksumMsb(ifem, plist[i]->iValue(ifem, "CALCCHECKSUMMSB"));
+        newhit->setFemClock(ifem, packet->iValue(ifem, "FEMCLOCK"));
+        newhit->setFemEvtSequence(ifem, packet->iValue(ifem, "FEMEVTNR"));
+        newhit->setFemSlot(ifem, packet->iValue(ifem, "FEMSLOT"));
+        newhit->setChecksumLsb(ifem, packet->iValue(ifem, "CHECKSUMLSB"));
+        newhit->setChecksumMsb(ifem, packet->iValue(ifem, "CHECKSUMMSB"));
+        newhit->setCalcChecksumLsb(ifem, packet->iValue(ifem, "CALCCHECKSUMLSB"));
+        newhit->setCalcChecksumMsb(ifem, packet->iValue(ifem, "CALCCHECKSUMMSB"));
       }
       for (int ipmt = 0; ipmt < nr_channels; ipmt++)
       {
         // store pre/post only for suppressed channels, the array in the packet routines is not
         // initialized so reading pre/post for not zero suppressed channels returns garbage
-        bool isSuppressed = plist[i]->iValue(ipmt, "SUPPRESSED");
+        bool isSuppressed = packet->iValue(ipmt, "SUPPRESSED");
         newhit->setSuppressed(ipmt, isSuppressed);
         if (isSuppressed)
         {
-          newhit->setPre(ipmt, plist[i]->iValue(ipmt, "PRE"));
-          newhit->setPost(ipmt, plist[i]->iValue(ipmt, "POST"));
+          newhit->setPre(ipmt, packet->iValue(ipmt, "PRE"));
+          newhit->setPost(ipmt, packet->iValue(ipmt, "POST"));
         }
         else
         {
           for (int isamp = 0; isamp < nr_samples; isamp++)
           {
-            newhit->setSample(ipmt, isamp, plist[i]->iValue(isamp, ipmt));
+            newhit->setSample(ipmt, isamp, packet->iValue(isamp, ipmt));
           }
         }
       }
@@ -184,9 +176,9 @@ void SingleMbdTriggerInput::FillPool(const unsigned int keep)
       m_EventStack.insert(CorrectedEventSequence);
       if (ddump_enabled())
       {
-        ddumppacket(plist[i]);
+        ddumppacket(packet);
       }
-      delete plist[i];
+      delete packet;
     }
   }
 }

--- a/offline/framework/fun4allraw/SingleMbdTriggerInput.h
+++ b/offline/framework/fun4allraw/SingleMbdTriggerInput.h
@@ -4,7 +4,6 @@
 #include "SingleTriggerInput.h"
 
 #include <cstdint>
-#include <list>
 #include <map>
 #include <set>
 #include <string>
@@ -26,7 +25,6 @@ class SingleMbdTriggerInput : public SingleTriggerInput
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
  private:
-  Packet **plist{nullptr};
 };
 
 #endif

--- a/offline/framework/fun4allraw/SingleTriggerInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggerInput.cc
@@ -298,7 +298,7 @@ bool SingleTriggerInput::GetSomeMoreEvents(const unsigned int keep)
               << ", keep: " << keep
               << std::endl;
   }
-// how many events should be stored upstream (keep) plus number of events kept locally
+  // how many events should be stored upstream (keep) plus number of events kept locally
   if (m_PacketMap.size() < std::max(2U, keep + m_LocalPoolDepth))  // at least 2 events in pool
   {
     return true;

--- a/offline/framework/fun4allraw/SingleTriggerInput.h
+++ b/offline/framework/fun4allraw/SingleTriggerInput.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>  // for uint64_t
 #include <fstream>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -48,9 +49,14 @@ class SingleTriggerInput : public Fun4AllBase, public InputFileHandler
   virtual void DefaultEventNumberOffset(const int i) { m_DefaultEventNumberOffset = i; }
   virtual int AdjustPacketMap(int pktid, int evtoffset);
   virtual bool GetSomeMoreEvents(const unsigned int keep);
-  virtual int AdjustEventOffset(int evtoffset);  // {return;}
-  virtual void LocalPoolDepth(unsigned int i) {m_LocalPoolDepth = i;}
-  virtual unsigned int LocalPoolDepth() const {return m_LocalPoolDepth;}
+  virtual int AdjustEventOffset(int evtoffset);
+  virtual void LocalPoolDepth(unsigned int i) { m_LocalPoolDepth = i; }
+  virtual unsigned int LocalPoolDepth() const { return m_LocalPoolDepth; }
+  virtual void SkipToEvent(const int i) { m_SkipToEvent = i; }
+  virtual int SkipToEvent() const { return m_SkipToEvent; }
+  virtual void LastEvent(const int i) { m_LastEvent = i; }
+  virtual int LastEvent() const { return m_LastEvent; }
+
   // these ones are used directly by the derived classes, maybe later
   // move to cleaner accessors
  protected:
@@ -69,6 +75,8 @@ class SingleTriggerInput : public Fun4AllBase, public InputFileHandler
   int m_AllDone{0};
   int m_SubsystemEnum{0};
   int m_DefaultEventNumberOffset{0};
+  int m_SkipToEvent{0};  // we may have negative event numbers but lets not go there right now
+  int m_LastEvent{std::numeric_limits<int>::max()};
   unsigned int m_LocalPoolDepth{0};
   std::map<uint64_t, std::set<int>> m_BeamClockFEE;
   std::map<int, uint64_t> m_FEEBclkMap;

--- a/offline/framework/fun4allraw/SingleZdcTriggerInput.h
+++ b/offline/framework/fun4allraw/SingleZdcTriggerInput.h
@@ -4,7 +4,6 @@
 #include "SingleTriggerInput.h"
 
 #include <cstdint>
-#include <list>
 #include <map>
 #include <set>
 #include <string>
@@ -35,7 +34,6 @@ class SingleZdcTriggerInput : public SingleTriggerInput
   int ShiftEvents(int pktid, int offset);
   int m_ClockReferencePacket{0};
   bool m_FEMClockProblemFlag{false};
-  Packet **plist{nullptr};
   std::set<int> m_BadBCOPacketSet;
   std::map<int, std::vector<OfflinePacket *>> m_LocalPacketMap;
   std::map<int, std::vector<OfflinePacket *>> m_LocalPacketMap_Unchecked;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the capability to skip events to the single trigger input managers. Still need to think about fast buffer skipping without unpacking to deal with the slow speed (2 hours for a set of the triggered input files to get over 20GB of data)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

