### PR TITLE
fix: intt bco dump memory  growth

### DIFF
--- a/offline/framework/ffarawmodules/InttBcoDump.cc
+++ b/offline/framework/ffarawmodules/InttBcoDump.cc
@@ -80,12 +80,16 @@ int InttBcoDump::process_event(PHCompositeNode *topNode)
       for (int j = 0; j < nfees; j++)
       {
         int fee = packet->iValue(i, j, "FEELIST");
+        lastbco.insert(std::make_pair(fee, 0));
+
         bcoset[fee].insert(bco);
       }
     }
 
     delete packet;
   }
+  pktvec.clear();
+
   for (auto &mapiter : bcoset)
   {
     if (!mapiter.second.empty())
@@ -107,9 +111,12 @@ int InttBcoDump::process_event(PHCompositeNode *topNode)
         }
         lastbco[mapiter.first] = bco;
       }
-    }
+      mapiter.second.clear();
+    } 
   }
-
+  bcoset.clear();
+  bcoTaggedFees.clear();
+  lastbco.clear();
   return Fun4AllReturnCodes::EVENT_OK;
 }
 


### PR DESCRIPTION
Fixes memory growth of this module

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

