### PR TITLE
Distortion scalefactors

### DIFF
--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -72,19 +72,24 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
     divisor = 1.0;
   }
 
+  //get the corrections from the histograms
+  auto dphi=phi; //to inherit the same type
+  auto dr=r;
+  auto dz=z;
+
   if (dcc->m_dimensions == 3)
   {
     if (dcc->m_hDPint[index] && (mask & COORD_PHI) && check_boundaries(dcc->m_hDPint[index], phi, r, z))
     {
-      phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi, r, z) / divisor;
+      dphi=dcc->m_hDPint[index]->Interpolate(phi, r, z) / divisor;
     }
     if (dcc->m_hDRint[index] && (mask & COORD_R) && check_boundaries(dcc->m_hDRint[index], phi, r, z))
     {
-      r_new = r - dcc->m_hDRint[index]->Interpolate(phi, r, z);
+      dr=dcc->m_hDRint[index]->Interpolate(phi, r, z);
     }
     if (dcc->m_hDZint[index] && (mask & COORD_Z) && check_boundaries(dcc->m_hDZint[index], phi, r, z))
     {
-      z_new = z - dcc->m_hDZint[index]->Interpolate(phi, r, z);
+      dz=dcc->m_hDZint[index]->Interpolate(phi, r, z);
     }
   }
   else if (dcc->m_dimensions == 2)
@@ -96,29 +101,34 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
     }
     if (dcc->m_hDPint[index] && (mask & COORD_PHI) && check_boundaries(dcc->m_hDPint[index], phi, r))
     {
-      phi_new = phi - dcc->m_hDPint[index]->Interpolate(phi, r) * zterm / divisor;
+      dphi=dcc->m_hDPint[index]->Interpolate(phi, r) * zterm / divisor;
     }
     if (dcc->m_hDRint[index] && (mask & COORD_R) && check_boundaries(dcc->m_hDRint[index], phi, r))
     {
-      r_new = r - dcc->m_hDRint[index]->Interpolate(phi, r) * zterm;
+      dr=dcc->m_hDRint[index]->Interpolate(phi, r) * zterm;
     }
     if (dcc->m_hDZint[index] && (mask & COORD_Z) && check_boundaries(dcc->m_hDZint[index], phi, r))
     {
-      z_new = z - dcc->m_hDZint[index]->Interpolate(phi, r) * zterm;
+      dz=dcc->m_hDZint[index]->Interpolate(phi, r) * zterm;
     }
     
   }
 
+//if we are scaling, apply the scale factor to each correction
+if(dcc->m_use_scalefactor)
+  {
+    dphi *= dcc->m_scalefactor;
+    dr *= dcc->m_scalefactor;
+    dz *= dcc->m_scalefactor;
+  }
+
+  phi_new=phi-dphi;
+  r_new=r-dr;
+  z_new=z-dz;
+
   // update cluster
   const auto x_new = r_new * std::cos(phi_new);
   const auto y_new = r_new * std::sin(phi_new);
-
-if (dcc->m_use_scalefactor)
-  {
-    x_new *= dcc->m_scalefactor;
-    y_new *= dcc->m_scalefactor;
-    z_new *= dcc->m_scalefactor;
-  }
 
   return {x_new, y_new, z_new};
 }

--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -113,5 +113,12 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
   const auto x_new = r_new * std::cos(phi_new);
   const auto y_new = r_new * std::sin(phi_new);
 
+if (dcc->m_use_scalefactor)
+  {
+    x_new *= dcc->m_scalefactor;
+    y_new *= dcc->m_scalefactor;
+    z_new *= dcc->m_scalefactor;
+  }
+
   return {x_new, y_new, z_new};
 }

--- a/offline/packages/tpc/TpcDistortionCorrectionContainer.h
+++ b/offline/packages/tpc/TpcDistortionCorrectionContainer.h
@@ -20,6 +20,9 @@ class TpcDistortionCorrectionContainer
   //! flag to tell us whether to read z data or just 2d data
   int m_dimensions = 3;
 
+  bool m_use_scalefactor = false;
+  float m_scalefactor = 1.0;
+
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians = true;
   //! flag to tell us how to handle 2d corrections: interpolate to 0 at readout or assume the correction has no z dependence

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.cc
@@ -114,6 +114,11 @@ int TpcLoadDistortionCorrection::InitRun(PHCompositeNode* topNode)
     // assign whether 2D corrections should be interpolated to zero at readout or not (has no effect on 3D corrections)
     distortion_correction_object->m_interpolate_z = m_interpolate_z[i];
 
+    //assign whether the correction should be scaled, and if so, by how much
+    distortion_correction_object->m_use_scalefactor = m_use_scalefactor[i];
+    distortion_correction_object->m_scalefactor = m_scalefactor[i];
+
+
     if (Verbosity())
     {
       for (const auto& h : {

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -48,7 +48,7 @@ class TpcLoadDistortionCorrection : public SubsysReco
   }
 
   //! set the scale factor to be applied to the correction
-  void set_scale_factor(int i, float value)
+  void set_scale_factor(DistortionType i, float value)
   {
     m_use_scalefactor[i] = true;
     m_scalefactor[i] = value;

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -47,14 +47,11 @@ class TpcLoadDistortionCorrection : public SubsysReco
     m_correction_in_use[i] = true;
   }
 
-//! set the scale factor to be applied to the correction
-void set_scale_factor(int i, float value){
-  m_use_scalefactor[i] = true;
-  m_scalefactor[i] = value;
-}
-
-  
-}
+  //! set the scale factor to be applied to the correction
+  void set_scale_factor(int i, float value){
+    m_use_scalefactor[i] = true;
+    m_scalefactor[i] = value;
+  }
 
   //! set the phi histogram to be interpreted as radians.
   void set_read_phi_as_radians(bool flag)

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -92,6 +92,10 @@ void set_scale_factor(int i, float value){
   //! flag to indicate correction in use
   bool m_correction_in_use[nDistortionTypes] = {false, false, false,false};
 
+//! flag and scalefactor to apply to correction
+  m_use_scalefactor[nDistortionTypes] = {false,false,false,false};
+  m_scalefactor[nDistortionTypes] = {1.0,1.0,1.0,1.0};
+
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians[nDistortionTypes] = {true,true,true,true};
   bool m_interpolate_z[nDistortionTypes] = {true,true,true,true};

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -47,6 +47,15 @@ class TpcLoadDistortionCorrection : public SubsysReco
     m_correction_in_use[i] = true;
   }
 
+//! set the scale factor to be applied to the correction
+void set_scale_factor(int i, float value){
+  m_use_scalefactor[i] = true;
+  m_scalefactor[i] = value;
+}
+
+  
+}
+
   //! set the phi histogram to be interpreted as radians.
   void set_read_phi_as_radians(bool flag)
   {

--- a/offline/packages/tpc/TpcLoadDistortionCorrection.h
+++ b/offline/packages/tpc/TpcLoadDistortionCorrection.h
@@ -48,7 +48,8 @@ class TpcLoadDistortionCorrection : public SubsysReco
   }
 
   //! set the scale factor to be applied to the correction
-  void set_scale_factor(int i, float value){
+  void set_scale_factor(int i, float value)
+  {
     m_use_scalefactor[i] = true;
     m_scalefactor[i] = value;
   }
@@ -89,9 +90,9 @@ class TpcLoadDistortionCorrection : public SubsysReco
   //! flag to indicate correction in use
   bool m_correction_in_use[nDistortionTypes] = {false, false, false,false};
 
-//! flag and scalefactor to apply to correction
-  m_use_scalefactor[nDistortionTypes] = {false,false,false,false};
-  m_scalefactor[nDistortionTypes] = {1.0,1.0,1.0,1.0};
+  //! flag and scalefactor to apply to correction
+  bool m_use_scalefactor[nDistortionTypes] = {false,false,false,false};
+  float m_scalefactor[nDistortionTypes] = {1.0,1.0,1.0,1.0};
 
   //! set the phi histogram to be interpreted as radians rather than mm
   bool m_phi_hist_in_radians[nDistortionTypes] = {true,true,true,true};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This allows you to scale a correction by a scalefactor set during the initial loading of the file.  A separate pull req to the macros directory will be needed to access this.  By default, for all corrections, the scale factor is set to one, and the 'using scalefactor' flag is set to false, so the actual stored values in the histograms are used.

## TODOs (if applicable)




## Links to other PRs in macros and calibration repositories (if applicable)

tbd.