### PR TITLE
RawCluster Shower Shape getter

### DIFF
--- a/offline/packages/CaloBase/RawCluster.h
+++ b/offline/packages/CaloBase/RawCluster.h
@@ -168,6 +168,12 @@ class RawCluster : public PHObject
     return std::numeric_limits<float>::signaling_NaN();
   }
 
+  virtual std::vector<float> get_shower_shapes(float /*tower_thresh*/) const
+  {
+    PHOOL_VIRTUAL_WARN("get_shower_shapes(float tower_thresh)");
+    return std::vector<float>();
+  }
+
   //  //! truth cluster's PHG4Particle ID
   //  virtual int get_truth_track_ID() const
   //  {

--- a/offline/packages/CaloBase/RawClusterv1.h
+++ b/offline/packages/CaloBase/RawClusterv1.h
@@ -70,6 +70,8 @@ class RawClusterv1 : public RawCluster
   float get_et_iso() const override { return get_property_float(prop_et_iso_calotower_R03); }
   //! isolation ET the radius and hueristic can be specified
   float get_et_iso(const int radiusx10, bool subtracted, bool clusterTower) const override;
+
+  std::vector<float> get_shower_shapes(float tower_thresh) const override;
   //  //! truth cluster's PHG4Particle ID
   //  virtual int get_truth_track_ID() const override { return get_property_int(prop_truth_track_ID); }
   //  //! truth cluster's PHG4Particle flavor


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduce a method to RawClusterv1 that calculate the shower shape variables which are used to calculate the cluster chi2 using the saved tower map within the object, without changing the memory layout of the RawCluster object(so no issue with DST read back). 

The method returns a vector of float contains:
```e1t, e2t, e3t, e4t, center_of_gravity_eta, center_of_gravity_phi, variance_eta, variance_phi, e1, e2, e3, e4, totalE```

This will give us an easy access to the shower shape vars for study like tunning the cluster prob calculation :)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

