### PR TITLE
fix: reconstruct tpc seeds outside physical z volume

### DIFF
--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -116,7 +116,7 @@ bool ALICEKF::TransportAndRotate(double old_radius, double new_radius, double& p
       return false;
     }
 
-    if(new_radius > 78. || fabs(kftrack.GetZ()) > 105.5)
+    if(new_radius > 78.)
     {
       if(Verbosity()>1) { std::cout << "outside TPC, exiting" << std::endl;
 }

--- a/offline/packages/trackreco/ALICEKF.cc
+++ b/offline/packages/trackreco/ALICEKF.cc
@@ -3,26 +3,28 @@
 #include "GPUTPCTrackLinearisation.h"
 #include "GPUTPCTrackParam.h"
 
+#include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrackFitUtils.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase_historic/ActsTransformations.h>
-#include <trackbase/ClusterErrorPara.h>
 
 #include <Geant4/G4SystemOfUnits.hh>
 
 #include <TMatrixFfwd.h>
-#include <TMatrixT.h>   
+#include <TMatrixT.h>
 #include <TMatrixTUtils.h>
 //#define _DEBUG_
 
 #if defined(_DEBUG_)
 #define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp
 #else
-#define LogDebug(exp) (void)0
+#define LogDebug(exp) (void) 0
 #endif
 
-#define LogError(exp) if(Verbosity()>0) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp
-#define LogWarning(exp) if(Verbosity()>0) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp
+#define LogError(exp) \
+  if (Verbosity() > 0) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp
+#define LogWarning(exp) \
+  if (Verbosity() > 0) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp
 
 using keylist = std::vector<TrkrDefs::cluskey>;
 
@@ -30,14 +32,21 @@ using keylist = std::vector<TrkrDefs::cluskey>;
 namespace
 {
   // square
-  template<class T> inline constexpr T square( const T& x ) { return x*x; }
-}
-
-bool ALICEKF::checknan(double val, const std::string &name, int num) const
-{
-  if(std::isnan(val))
+  template <class T>
+  inline constexpr T square(const T& x)
   {
-    if(Verbosity()>0) { std::cout << "WARNING: " << name << " is NaN for seed " << num << ". Aborting this seed.\n"; }
+    return x * x;
+  }
+}  // namespace
+
+bool ALICEKF::checknan(double val, const std::string& name, int num) const
+{
+  if (std::isnan(val))
+  {
+    if (Verbosity() > 0)
+    {
+      std::cout << "WARNING: " << name << " is NaN for seed " << num << ". Aborting this seed.\n";
+    }
   }
   return std::isnan(val);
 }
@@ -45,89 +54,114 @@ bool ALICEKF::checknan(double val, const std::string &name, int num) const
 double ALICEKF::get_Bz(double x, double y, double z) const
 {
   //  if(_use_const_field) return _const_field;
-  if(_use_const_field || fabs(z)>105.5) { return _const_field; }
-  double p[4] = {x*cm,y*cm,z*cm,0.*cm};
+  if (_use_const_field || fabs(z) > 105.5)
+  {
+    return _const_field;
+  }
+  double p[4] = {x * cm, y * cm, z * cm, 0. * cm};
   double bfield[3];
-  _B->GetFieldValue(p,bfield);
-  return bfield[2]/tesla;
+  _B->GetFieldValue(p, bfield);
+  return bfield[2] / tesla;
 }
 
 double ALICEKF::getClusterError(TrkrCluster* c, TrkrDefs::cluskey key, Acts::Vector3 global, int i, int j) const
 {
-  if(_use_fixed_clus_error) 
+  if (_use_fixed_clus_error)
   {
-     if(i==j) { return _fixed_clus_error.at(i)*_fixed_clus_error.at(i); }
-     else { return 0.; }
-  }
-  else 
+    if (i == j)
     {
-      TMatrixF localErr(3,3);
-    
-      double clusRadius = sqrt(global[0]*global[0] + global[1]*global[1]);
-      auto para_errors = _ClusErrPara->get_clusterv5_modified_error(c,clusRadius,key);
-      
-      localErr[0][0] = 0.;
-      localErr[0][1] = 0.;
-      localErr[0][2] = 0.;
-      localErr[1][0] = 0.;
-      localErr[1][1] = para_errors.first;
-      localErr[1][2] = 0.;
-      localErr[2][0] = 0.;
-      localErr[2][1] = 0.;
-      localErr[2][2] = para_errors.second;
-      
-      float clusphi = atan2(global(1), global(0));
-      TMatrixF ROT(3,3);
-      ROT[0][0] = cos(clusphi);
-      ROT[0][1] = -sin(clusphi);
-      ROT[0][2] = 0.0;
-      ROT[1][0] = sin(clusphi);
-      ROT[1][1] = cos(clusphi);
-      ROT[1][2] = 0.0;
-      ROT[2][0] = 0.0;
-      ROT[2][1] = 0.0;
-      ROT[2][2] = 1.0;
-      TMatrixF ROT_T(3,3);
-      ROT_T.Transpose(ROT);
-  
-      TMatrixF err(3,3);
-      err = ROT * localErr * ROT_T;
-      
-      return err[i][j];
+      return _fixed_clus_error.at(i) * _fixed_clus_error.at(i);
     }
+    else
+    {
+      return 0.;
+    }
+  }
+  else
+  {
+    TMatrixF localErr(3, 3);
+
+    double clusRadius = sqrt(global[0] * global[0] + global[1] * global[1]);
+    auto para_errors = _ClusErrPara->get_clusterv5_modified_error(c, clusRadius, key);
+
+    localErr[0][0] = 0.;
+    localErr[0][1] = 0.;
+    localErr[0][2] = 0.;
+    localErr[1][0] = 0.;
+    localErr[1][1] = para_errors.first;
+    localErr[1][2] = 0.;
+    localErr[2][0] = 0.;
+    localErr[2][1] = 0.;
+    localErr[2][2] = para_errors.second;
+
+    float clusphi = atan2(global(1), global(0));
+    TMatrixF ROT(3, 3);
+    ROT[0][0] = cos(clusphi);
+    ROT[0][1] = -sin(clusphi);
+    ROT[0][2] = 0.0;
+    ROT[1][0] = sin(clusphi);
+    ROT[1][1] = cos(clusphi);
+    ROT[1][2] = 0.0;
+    ROT[2][0] = 0.0;
+    ROT[2][1] = 0.0;
+    ROT[2][2] = 1.0;
+    TMatrixF ROT_T(3, 3);
+    ROT_T.Transpose(ROT);
+
+    TMatrixF err(3, 3);
+    err = ROT * localErr * ROT_T;
+
+    return err[i][j];
+  }
 }
 
 bool ALICEKF::TransportAndRotate(double old_radius, double new_radius, double& phi, GPUTPCTrackParam& kftrack, GPUTPCTrackParam::GPUTPCTrackFitParam& fp) const
 {
   const double transport_spacing = .05;
-  const int Ndivisions = floor(fabs(new_radius-old_radius)/transport_spacing);
-  if(Verbosity()>2) { std::cout << "old_radius: " << old_radius << ", new_radius: " << new_radius << std::endl;
-}
-  if(Verbosity()>2) { std::cout << "Ndivisions: " << Ndivisions << std::endl;
-}
-  for(int i=1; i<=Ndivisions+1; i++)
+  const int Ndivisions = floor(fabs(new_radius - old_radius) / transport_spacing);
+  if (Verbosity() > 2)
   {
-    if(std::isnan(kftrack.GetX()) ||
-       std::isnan(kftrack.GetY()) ||
-       std::isnan(kftrack.GetZ()))
+    std::cout << "old_radius: " << old_radius << ", new_radius: " << new_radius << std::endl;
+  }
+  if (Verbosity() > 2)
+  {
+    std::cout << "Ndivisions: " << Ndivisions << std::endl;
+  }
+  for (int i = 1; i <= Ndivisions + 1; i++)
+  {
+    if (std::isnan(kftrack.GetX()) ||
+        std::isnan(kftrack.GetY()) ||
+        std::isnan(kftrack.GetZ()))
     {
-      if(Verbosity()>0) { std::cout << "position is NaN, exiting" << std::endl;
-}
+      if (Verbosity() > 0)
+      {
+        std::cout << "position is NaN, exiting" << std::endl;
+      }
       return false;
     }
 
-    if(new_radius > 78.)
+    if (new_radius > 78.)
     {
-      if(Verbosity()>1) { std::cout << "outside TPC, exiting" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "outside TPC, exiting" << std::endl;
+      }
       return false;
     }
 
     double r_div;
-    if(i==Ndivisions+1) { r_div = new_radius;
-    } else if(old_radius<new_radius) { r_div = old_radius + transport_spacing*i;
-    } else { r_div = old_radius - transport_spacing*i;
-}
+    if (i == Ndivisions + 1)
+    {
+      r_div = new_radius;
+    }
+    else if (old_radius < new_radius)
+    {
+      r_div = old_radius + transport_spacing * i;
+    }
+    else
+    {
+      r_div = old_radius - transport_spacing * i;
+    }
 
     // track state position relative to radial direction
     const double tX = kftrack.GetX();
@@ -135,32 +169,36 @@ bool ALICEKF::TransportAndRotate(double old_radius, double new_radius, double& p
     const double tz = kftrack.GetZ();
 
     // track state global position (including tz above)
-    const double tx = tX*cos(phi) - tY*sin(phi);
-    const double ty = tX*sin(phi) + tY*cos(phi);
+    const double tx = tX * cos(phi) - tY * sin(phi);
+    const double ty = tX * sin(phi) + tY * cos(phi);
 
-    const double Bz = _Bzconst * get_Bz(tx,ty,tz);
+    const double Bz = _Bzconst * get_Bz(tx, ty, tz);
 
     kftrack.CalculateFitParameters(fp);
 
     // transport to radius
-    if(!kftrack.TransportToXWithMaterial(r_div, fp, Bz, 1.))
+    if (!kftrack.TransportToXWithMaterial(r_div, fp, Bz, 1.))
     {
-      if(Verbosity()>1) { std::cout << "transport failed" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "transport failed" << std::endl;
+      }
       return false;
     }
 
     // rotate track state reference frame
     const double new_tX = kftrack.GetX();
     const double new_tY = kftrack.GetY();
-    const double new_tx = new_tX*cos(phi) - new_tY*sin(phi);
-    const double new_ty = new_tX*sin(phi) + new_tY*cos(phi);
-    const double new_phi = atan2(new_ty,new_tx);
+    const double new_tx = new_tX * cos(phi) - new_tY * sin(phi);
+    const double new_ty = new_tX * sin(phi) + new_tY * cos(phi);
+    const double new_phi = atan2(new_ty, new_tx);
     const double alpha = new_phi - phi;
-    if(!kftrack.Rotate(alpha,1.))
+    if (!kftrack.Rotate(alpha, 1.))
     {
-      if(Verbosity()>1) { std::cout << "rotate failed" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "rotate failed" << std::endl;
+      }
       return false;
     }
     phi = new_phi;
@@ -168,11 +206,11 @@ bool ALICEKF::TransportAndRotate(double old_radius, double new_radius, double& p
 
   const double final_tX = kftrack.GetX();
   const double final_tY = kftrack.GetY();
-  const double final_tx = final_tX*cos(phi) - final_tY*sin(phi);
-  const double final_ty = final_tX*sin(phi) + final_tY*cos(phi);
+  const double final_tx = final_tX * cos(phi) - final_tY * sin(phi);
+  const double final_ty = final_tX * sin(phi) + final_tY * cos(phi);
   const double final_tz = kftrack.GetZ();
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track position after transport: (" << final_tx << ", " << final_ty << ", " << final_tz << ")" << std::endl;
   }
@@ -182,12 +220,14 @@ bool ALICEKF::TransportAndRotate(double old_radius, double new_radius, double& p
 bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_phi, GPUTPCTrackParam& kftrack, GPUTPCTrackParam::GPUTPCTrackFitParam& fp, const PositionMap& globalPositions) const
 {
   // give up if position vector has NaN for any component
-  if(std::isnan(kftrack.GetX()) ||
-     std::isnan(kftrack.GetY()) ||
-     std::isnan(kftrack.GetZ()))
+  if (std::isnan(kftrack.GetX()) ||
+      std::isnan(kftrack.GetY()) ||
+      std::isnan(kftrack.GetZ()))
   {
-    if(Verbosity()>0) { std::cout << "position is NaN, exiting" << std::endl;
-}
+    if (Verbosity() > 0)
+    {
+      std::cout << "position is NaN, exiting" << std::endl;
+    }
     return false;
   }
 
@@ -197,10 +237,10 @@ bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_
   const double tz = kftrack.GetZ();
 
   // track state global position (including tz above)
-  const double tx = tX*cos(current_phi) - tY*sin(current_phi);
-  const double ty = tX*sin(current_phi) + tY*cos(current_phi);
+  const double tx = tX * cos(current_phi) - tY * sin(current_phi);
+  const double ty = tX * sin(current_phi) + tY * cos(current_phi);
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << std::endl;
     std::cout << "current phi: " << current_phi << std::endl;
@@ -212,65 +252,84 @@ bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_
   const double cy = cluster_pos(1);
   const double cz = cluster_pos(2);
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "cluster position: (" << cx << ", " << cy << ", " << cz << ")" << std::endl;
   }
 
-  const double cX = sqrt(cx*cx+cy*cy);
+  const double cX = sqrt(cx * cx + cy * cy);
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "transporting to radius: " << cX << std::endl;
   }
 
-  if(fabs(tX-cX)<0.1 || !TransportAndRotate(tX,cX,current_phi,kftrack,fp))
+  if (fabs(tX - cX) < 0.1 || !TransportAndRotate(tX, cX, current_phi, kftrack, fp))
   {
-    if(std::isnan(kftrack.GetX()) ||
-       std::isnan(kftrack.GetY()) ||
-       std::isnan(kftrack.GetZ()))
+    if (std::isnan(kftrack.GetX()) ||
+        std::isnan(kftrack.GetY()) ||
+        std::isnan(kftrack.GetZ()))
     {
       return false;
     }
 
-    if(Verbosity()>1) { std::cout << "track turned around near X=" << kftrack.GetX() << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "track turned around near X=" << kftrack.GetX() << std::endl;
+    }
 
     // TransportAndRotate failure indicates that track has turned around before it reaches next layer
     // The track parameters don't update in that last step, so we're likely somewhere between two layers
     // So, first, we turn the track around ourselves, setting it to its next intersection at its current radius
 
     // basically circle project in xy, linear project in z
-    double pt = 1./fabs(kftrack.GetQPt());
-    double end_tx = kftrack.GetX()*cos(current_phi)-kftrack.GetY()*sin(current_phi);
-    double end_ty = kftrack.GetX()*sin(current_phi)+kftrack.GetY()*cos(current_phi);
+    double pt = 1. / fabs(kftrack.GetQPt());
+    double end_tx = kftrack.GetX() * cos(current_phi) - kftrack.GetY() * sin(current_phi);
+    double end_ty = kftrack.GetX() * sin(current_phi) + kftrack.GetY() * cos(current_phi);
     double end_tz = kftrack.GetZ();
-    if(Verbosity()>1) { std::cout << "current parameters: pt=" << pt << ", (x, y, z) = (" << end_tx << ", " << end_ty << ", " << end_tz << ")" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "current parameters: pt=" << pt << ", (x, y, z) = (" << end_tx << ", " << end_ty << ", " << end_tz << ")" << std::endl;
+    }
     // pt[GeV] = 0.3 B[T] R[m]
-    double R = 100.*pt/(0.3*get_Bz(end_tx,end_ty,end_tz));
-    if(Verbosity()>2) { std::cout << "R=" << R << std::endl;
-}
-    double pX = pt*kftrack.GetCosPhi();
-    double pY = pt*kftrack.GetSinPhi();
-    if(Verbosity()>2) { std::cout << "(pX, pY) = (" << pX << ", " << pY << ")" << std::endl;
-}
-    double px = pX*cos(current_phi)-pY*sin(current_phi);
-    double py = pX*sin(current_phi)+pY*cos(current_phi);
-    double tangent_phi = atan2(py,px);
+    double R = 100. * pt / (0.3 * get_Bz(end_tx, end_ty, end_tz));
+    if (Verbosity() > 2)
+    {
+      std::cout << "R=" << R << std::endl;
+    }
+    double pX = pt * kftrack.GetCosPhi();
+    double pY = pt * kftrack.GetSinPhi();
+    if (Verbosity() > 2)
+    {
+      std::cout << "(pX, pY) = (" << pX << ", " << pY << ")" << std::endl;
+    }
+    double px = pX * cos(current_phi) - pY * sin(current_phi);
+    double py = pX * sin(current_phi) + pY * cos(current_phi);
+    double tangent_phi = atan2(py, px);
     double center_phi;
-    if(kftrack.GetQPt()>0) { center_phi = tangent_phi + M_PI/2.;
-    } else { center_phi = tangent_phi - M_PI/2.;
-}
-    if(center_phi>M_PI) { center_phi -= 2.*M_PI;
-}
-    if(center_phi<-M_PI) { center_phi += 2.*M_PI;
-}
-    double xc = end_tx - R*cos(center_phi);
-    double yc = end_ty - R*sin(center_phi);
-    if(Verbosity()>2) { std::cout << "(xc, yc) = (" << xc << ", " << yc << ")" << std::endl;
-}
-    auto circle_output = TrackFitUtils::circle_circle_intersection(sqrt(pow(kftrack.GetX(),2.)+pow(kftrack.GetY(),2.)),R,xc,yc);
+    if (kftrack.GetQPt() > 0)
+    {
+      center_phi = tangent_phi + M_PI / 2.;
+    }
+    else
+    {
+      center_phi = tangent_phi - M_PI / 2.;
+    }
+    if (center_phi > M_PI)
+    {
+      center_phi -= 2. * M_PI;
+    }
+    if (center_phi < -M_PI)
+    {
+      center_phi += 2. * M_PI;
+    }
+    double xc = end_tx - R * cos(center_phi);
+    double yc = end_ty - R * sin(center_phi);
+    if (Verbosity() > 2)
+    {
+      std::cout << "(xc, yc) = (" << xc << ", " << yc << ")" << std::endl;
+    }
+    auto circle_output = TrackFitUtils::circle_circle_intersection(sqrt(pow(kftrack.GetX(), 2.) + pow(kftrack.GetY(), 2.)), R, xc, yc);
     // pick the furthest point from current track position
     double new_tx;
     double new_ty;
@@ -278,10 +337,12 @@ bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_
     double yplus = std::get<1>(circle_output);
     double xminus = std::get<2>(circle_output);
     double yminus = std::get<3>(circle_output);
-    if(Verbosity()>1) { std::cout << "circle-circle intersection: (" << xplus << ", " << yplus << "), (" << xminus << ", " << yminus << ")" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "circle-circle intersection: (" << xplus << ", " << yplus << "), (" << xminus << ", " << yminus << ")" << std::endl;
+    }
 
-    if(sqrt(pow(end_tx-xplus,2.)+pow(end_ty-yplus,2.))>sqrt(pow(end_tx-xminus,2.)+pow(end_ty-yminus,2.)))
+    if (sqrt(pow(end_tx - xplus, 2.) + pow(end_ty - yplus, 2.)) > sqrt(pow(end_tx - xminus, 2.) + pow(end_ty - yminus, 2.)))
     {
       new_tx = xplus;
       new_ty = yplus;
@@ -291,25 +352,29 @@ bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_
       new_tx = xminus;
       new_ty = yminus;
     }
-    double rot_phi = atan2(new_ty,new_tx);
-//    double rot_alpha = rot_phi - current_phi;
+    double rot_phi = atan2(new_ty, new_tx);
+    //    double rot_alpha = rot_phi - current_phi;
 
     // new track point is existing track point rotated by alpha
-    double new_tX = new_tx*cos(rot_phi)+new_ty*sin(rot_phi);
-    double new_tY = -new_tx*sin(rot_phi)+new_ty*cos(rot_phi);
-    double new_centerphi = atan2(new_ty-yc,new_tx-xc);
-    double dcenterphi = new_centerphi-center_phi;
-    if(dcenterphi>M_PI) { dcenterphi = 2.*M_PI - dcenterphi;
-}
-    if(dcenterphi<-M_PI) { dcenterphi = 2.*M_PI + dcenterphi;
-}
-    double ds = R*fabs(dcenterphi);
-    double dz = kftrack.GetDzDs()*ds;
+    double new_tX = new_tx * cos(rot_phi) + new_ty * sin(rot_phi);
+    double new_tY = -new_tx * sin(rot_phi) + new_ty * cos(rot_phi);
+    double new_centerphi = atan2(new_ty - yc, new_tx - xc);
+    double dcenterphi = new_centerphi - center_phi;
+    if (dcenterphi > M_PI)
+    {
+      dcenterphi = 2. * M_PI - dcenterphi;
+    }
+    if (dcenterphi < -M_PI)
+    {
+      dcenterphi = 2. * M_PI + dcenterphi;
+    }
+    double ds = R * fabs(dcenterphi);
+    double dz = kftrack.GetDzDs() * ds;
 
     current_phi = rot_phi;
     kftrack.SetX(new_tX);
     kftrack.SetY(new_tY);
-    kftrack.SetZ(end_tz+dz);
+    kftrack.SetZ(end_tz + dz);
     // no change to sinPhi
     // no change to DzDs
     // no change to Q/pt
@@ -317,92 +382,104 @@ bool ALICEKF::FilterStep(TrkrDefs::cluskey ckey, keylist& keys, double& current_
     kftrack.SetSignCosPhi(-kftrack.GetSignCosPhi());
 
     // now finish transport
-    if(!TransportAndRotate(kftrack.GetX(),cX,current_phi,kftrack,fp))
+    if (!TransportAndRotate(kftrack.GetX(), cX, current_phi, kftrack, fp))
     {
       return false;
     }
   }
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     const double new_tX = kftrack.GetX();
     const double new_tY = kftrack.GetY();
-    const double new_tx = new_tX*cos(current_phi) - new_tY*sin(current_phi);
-    const double new_ty = new_tX*sin(current_phi) + new_tY*cos(current_phi);
+    const double new_tx = new_tX * cos(current_phi) - new_tY * sin(current_phi);
+    const double new_ty = new_tX * sin(current_phi) + new_tY * cos(current_phi);
     const double new_tz = kftrack.GetZ();
     std::cout << "cluster position: (" << cx << ", " << cy << ", " << cz << ")" << std::endl;
     std::cout << "current phi: " << current_phi << std::endl;
     std::cout << "new track position: (" << new_tx << ", " << new_ty << ", " << new_tz << ")" << std::endl;
 
     const double tYerr = sqrt(kftrack.GetCov(0));
-    const double txerr = fabs(tYerr*sin(current_phi));
-    const double tyerr = fabs(tYerr*cos(current_phi));
+    const double txerr = fabs(tYerr * sin(current_phi));
+    const double tyerr = fabs(tYerr * cos(current_phi));
     const double tzerr = sqrt(kftrack.GetCov(5));
     std::cout << "track position error: (" << txerr << ", " << tyerr << ", " << tzerr << ")" << std::endl;
   }
 
   TrkrCluster* cluster = _cluster_map->findCluster(ckey);
-  const double cxerr = sqrt(getClusterError(cluster,ckey,cluster_pos,0,0));
-  const double cyerr = sqrt(getClusterError(cluster,ckey,cluster_pos,1,1));
-  const double czerr = sqrt(getClusterError(cluster,ckey,cluster_pos,2,2));
+  const double cxerr = sqrt(getClusterError(cluster, ckey, cluster_pos, 0, 0));
+  const double cyerr = sqrt(getClusterError(cluster, ckey, cluster_pos, 1, 1));
+  const double czerr = sqrt(getClusterError(cluster, ckey, cluster_pos, 2, 2));
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "cluster position error: (" << cxerr << ", " << cyerr << ", " << czerr << ")" << std::endl;
   }
 
-  const double cY = -cx*sin(current_phi) + cy*cos(current_phi);
-  const double cxycov2 = getClusterError(cluster,ckey,cluster_pos,0,1);
-  const double cYerr2 = cxerr*cxerr*sin(current_phi)*sin(current_phi) + cxycov2*sin(current_phi)*cos(current_phi) + cyerr*cyerr*cos(current_phi)*cos(current_phi);
-  const double czerr2 = czerr*czerr;
+  const double cY = -cx * sin(current_phi) + cy * cos(current_phi);
+  const double cxycov2 = getClusterError(cluster, ckey, cluster_pos, 0, 1);
+  const double cYerr2 = cxerr * cxerr * sin(current_phi) * sin(current_phi) + cxycov2 * sin(current_phi) * cos(current_phi) + cyerr * cyerr * cos(current_phi) * cos(current_phi);
+  const double czerr2 = czerr * czerr;
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "Filtering cluster with Y=" << cY << ", z=" << cz << ", Yerr2=" << cYerr2 << ", zerr2=" << czerr2 << std::endl;
   }
 
-  bool filter_success = kftrack.Filter(cY,cz,cYerr2,czerr2,_max_sin_phi);
-  if(Verbosity()>1)
+  bool filter_success = kftrack.Filter(cY, cz, cYerr2, czerr2, _max_sin_phi);
+  if (Verbosity() > 1)
   {
-    std::cout << "position after filter: (" << kftrack.GetX()*cos(current_phi)-kftrack.GetY()*sin(current_phi) << ", " << kftrack.GetX()*sin(current_phi)+kftrack.GetY()*cos(current_phi) << ", " << kftrack.GetZ() << std::endl;
+    std::cout << "position after filter: (" << kftrack.GetX() * cos(current_phi) - kftrack.GetY() * sin(current_phi) << ", " << kftrack.GetX() * sin(current_phi) + kftrack.GetY() * cos(current_phi) << ", " << kftrack.GetZ() << std::endl;
     std::cout << "track current parameters:" << std::endl;
     std::cout << "(X, Y, Z) = (" << kftrack.GetX() << ", " << kftrack.GetY() << ", " << kftrack.GetZ() << ")" << std::endl;
-    std::cout << "pt = " << 1./fabs(kftrack.GetQPt()) << std::endl;
+    std::cout << "pt = " << 1. / fabs(kftrack.GetQPt()) << std::endl;
     std::cout << "QPt = " << kftrack.GetQPt() << std::endl;
     std::cout << "sinPhi = " << kftrack.GetSinPhi() << std::endl;
     std::cout << "cosPhi = " << kftrack.GetCosPhi() << std::endl;
     std::cout << "dzds = " << kftrack.GetDzDs() << std::endl;
   }
-  if(!filter_success) { keys.erase(std::find(keys.begin(),keys.end(),ckey));
-}
+  if (!filter_success)
+  {
+    keys.erase(std::find(keys.begin(), keys.end(), ckey));
+  }
   return true;
 }
 
-TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& trackSeedKeyLists,bool use_nhits_limit, const PositionMap& globalPositions, std::vector<float>& trackChi2) const
+TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& trackSeedKeyLists, bool use_nhits_limit, const PositionMap& globalPositions, std::vector<float>& trackChi2) const
 {
-//  TFile* f = new TFile("/sphenix/u/mjpeters/macros_hybrid/detectors/sPHENIX/pull.root", "RECREATE");
-//  TNtuple* ntp = new TNtuple("pull","pull","cx:cy:cz:xerr:yerr:zerr:tx:ty:tz:layer:xsize:ysize:phisize:phierr:zsize");
+  //  TFile* f = new TFile("/sphenix/u/mjpeters/macros_hybrid/detectors/sPHENIX/pull.root", "RECREATE");
+  //  TNtuple* ntp = new TNtuple("pull","pull","cx:cy:cz:xerr:yerr:zerr:tx:ty:tz:layer:xsize:ysize:phisize:phierr:zsize");
   std::vector<TrackSeed_v2> seeds_vector;
   std::vector<GPUTPCTrackParam> alice_seeds_vector;
   int nseeds = 0;
   int ncandidates = -1;
-  if(Verbosity()>0) { std::cout << "min clusters per track: " << _min_clusters_per_track << "\n"; }
-  for( auto trackKeyChain:trackSeedKeyLists )
+  if (Verbosity() > 0)
+  {
+    std::cout << "min clusters per track: " << _min_clusters_per_track << "\n";
+  }
+  for (auto trackKeyChain : trackSeedKeyLists)
   {
     ++ncandidates;
 
-    if(trackKeyChain.size()<2) { continue; }
-    if(use_nhits_limit && trackKeyChain.size() < _min_clusters_per_track) { continue; }
-//    if(TrkrDefs::getLayer(trackKeyChain.front())<TrkrDefs::getLayer(trackKeyChain.back())) { std::reverse(trackKeyChain.begin(),trackKeyChain.end()); }
+    if (trackKeyChain.size() < 2)
+    {
+      continue;
+    }
+    if (use_nhits_limit && trackKeyChain.size() < _min_clusters_per_track)
+    {
+      continue;
+    }
+    //    if(TrkrDefs::getLayer(trackKeyChain.front())<TrkrDefs::getLayer(trackKeyChain.back())) { std::reverse(trackKeyChain.begin(),trackKeyChain.end()); }
     // get starting cluster from key
     // Transform sPHENIX coordinates into ALICE-compatible coordinates
     const auto& globalpos = globalPositions.at(trackKeyChain.at(0));
     double x0 = globalpos(0);
     double y0 = globalpos(1);
-    double z0 = globalpos(2);;
+    double z0 = globalpos(2);
+    ;
     LogDebug("Initial (x,y,z): (" << x0 << "," << y0 << "," << z0 << ")" << std::endl);
     // ALICE x coordinate = distance from beampipe
-    double alice_x0 = sqrt(x0*x0+y0*y0);
+    double alice_x0 = sqrt(x0 * x0 + y0 * y0);
     double alice_y0 = 0;
     double alice_z0 = z0;
     // Initialize track and linearisation
@@ -418,242 +495,307 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     trackSeed.SetZ(alice_z0);
     double x = x0;
     double y = y0;
-    #if defined(_DEBUG_)
+#if defined(_DEBUG_)
     double z = z0;
-    double alice_x = sqrt(x0*x0+y0*y0);
-    #endif
+    double alice_x = sqrt(x0 * x0 + y0 * y0);
+#endif
     // Pre-set momentum-based parameters to improve numerical stability
     const auto& secondpos = globalPositions.at(trackKeyChain.at(1));
 
     const double second_x = secondpos(0);
     const double second_y = secondpos(1);
     const double second_z = secondpos(2);
-    const double first_phi = atan2(y0,x0);
-    const double second_alice_x = second_x*std::cos(first_phi)+second_y*std::sin(first_phi);
+    const double first_phi = atan2(y0, x0);
+    const double second_alice_x = second_x * std::cos(first_phi) + second_y * std::sin(first_phi);
     const double delta_alice_x = second_alice_x - alice_x0;
-    //double second_alice_y = (second_x/cos(first_phi)-second_y/sin(first_phi))/(sin(first_phi)/cos(first_phi)+cos(first_phi)/sin(first_phi));
-    const double second_alice_y = -second_x*std::sin(first_phi)+second_y*std::cos(first_phi);
+    // double second_alice_y = (second_x/cos(first_phi)-second_y/sin(first_phi))/(sin(first_phi)/cos(first_phi)+cos(first_phi)/sin(first_phi));
+    const double second_alice_y = -second_x * std::sin(first_phi) + second_y * std::cos(first_phi);
     double init_SinPhi = second_alice_y / std::sqrt(square(delta_alice_x) + square(second_alice_y));
     const double delta_z = second_z - z0;
     double init_DzDs = delta_z / std::sqrt(square(delta_alice_x) + square(second_alice_y));
-    if(delta_alice_x < 0.)
+    if (delta_alice_x < 0.)
     {
       init_SinPhi *= -1.;
       init_DzDs *= -1.;
     }
     trackSeed.SetSinPhi(init_SinPhi);
-    //trackSeed.SetSignCosPhi(delta_alice_x / std::sqrt(square(delta_alice_x) + square(second_alice_y)));
+    // trackSeed.SetSignCosPhi(delta_alice_x / std::sqrt(square(delta_alice_x) + square(second_alice_y)));
     LogDebug("Set initial SinPhi to " << init_SinPhi << std::endl);
     trackSeed.SetDzDs(init_DzDs);
     LogDebug("Set initial DzDs to " << init_DzDs << std::endl);
-    
+
     // get initial pt estimate
-    std::vector<std::pair<double,double>> pts;
-    std::transform( trackKeyChain.begin(), trackKeyChain.end(), std::back_inserter( pts ), [&globalPositions]( const TrkrDefs::cluskey& key )
-    {
+    std::vector<std::pair<double, double>> pts;
+    std::transform(trackKeyChain.begin(), trackKeyChain.end(), std::back_inserter(pts), [&globalPositions](const TrkrDefs::cluskey& key)
+                   {
       const auto& clpos = globalPositions.at(key);
-      return std::make_pair(clpos(0),clpos(1));
-    });
-    
-    const auto [R, x_center, y_center] = TrackFitUtils::circle_fit_by_taubin( pts );
-    if(Verbosity()>1) { std::cout << std::endl << "candidate " << ncandidates << " seed " <<  nseeds << " circle fit parameters: R=" << R << ", X0=" << x_center << ", Y0=" << y_center << std::endl; }
-    
+      return std::make_pair(clpos(0),clpos(1)); });
+
+    const auto [R, x_center, y_center] = TrackFitUtils::circle_fit_by_taubin(pts);
+    if (Verbosity() > 1)
+    {
+      std::cout << std::endl
+                << "candidate " << ncandidates << " seed " << nseeds << " circle fit parameters: R=" << R << ", X0=" << x_center << ", Y0=" << y_center << std::endl;
+    }
+
     // check circle fit success
     /* failed fit will result in infinite momentum for the track, which in turn will break the kalman filter */
-    if( std::isnan(R) ) {continue;   }
-    
-    double init_QPt = 1./(0.3*R/100.*get_Bz(x0,y0,z0));
-    // determine charge
-    double phi_first = atan2(y0,x0);
-    if(Verbosity()>1){ std::cout << "phi_first: " << phi_first << std::endl;}
-    double phi_second = atan2(second_y,second_x);
-    if(Verbosity()>1) {std::cout << "phi_second: " << phi_second << std::endl;}
-    double dphi = phi_second - phi_first;
-    if(Verbosity()>1) {std::cout << "dphi: " << dphi << std::endl;}
-    if(dphi>M_PI) {dphi = 2*M_PI - dphi;}
-    if(dphi<-M_PI) {dphi = 2*M_PI + dphi;}
-    if(Verbosity()>1) {std::cout << "corrected dphi: " << dphi << std::endl;}
-    if((dphi>0. && x0*x0+y0*y0<second_x*second_x+second_y*second_y) ||
-       (dphi<0. && x0*x0+y0*y0>second_x*second_x+second_y*second_y)) 
+    if (std::isnan(R))
     {
-      init_QPt = -1*init_QPt;
+      continue;
+    }
+
+    double init_QPt = 1. / (0.3 * R / 100. * get_Bz(x0, y0, z0));
+    // determine charge
+    double phi_first = atan2(y0, x0);
+    if (Verbosity() > 1)
+    {
+      std::cout << "phi_first: " << phi_first << std::endl;
+    }
+    double phi_second = atan2(second_y, second_x);
+    if (Verbosity() > 1)
+    {
+      std::cout << "phi_second: " << phi_second << std::endl;
+    }
+    double dphi = phi_second - phi_first;
+    if (Verbosity() > 1)
+    {
+      std::cout << "dphi: " << dphi << std::endl;
+    }
+    if (dphi > M_PI)
+    {
+      dphi = 2 * M_PI - dphi;
+    }
+    if (dphi < -M_PI)
+    {
+      dphi = 2 * M_PI + dphi;
+    }
+    if (Verbosity() > 1)
+    {
+      std::cout << "corrected dphi: " << dphi << std::endl;
+    }
+    if ((dphi > 0. && x0 * x0 + y0 * y0 < second_x * second_x + second_y * second_y) ||
+        (dphi < 0. && x0 * x0 + y0 * y0 > second_x * second_x + second_y * second_y))
+    {
+      init_QPt = -1 * init_QPt;
     }
     LogDebug("initial QPt: " << init_QPt << std::endl);
     trackSeed.SetQPt(init_QPt);
-/*
-    if (trackSeed.GetSignCosPhi() < 0) {
-      trackSeed.SetSignCosPhi(-trackSeed.GetSignCosPhi());
-      trackSeed.SetSinPhi(-trackSeed.GetSinPhi());
-      trackSeed.SetDzDs(-trackSeed.GetDzDs());
-      trackSeed.SetQPt(-trackSeed.GetQPt());
-      trackSeed.SetCov(3,-trackSeed.GetCov(3));
-      trackSeed.SetCov(4,-trackSeed.GetCov(4));
-      trackSeed.SetCov(6,-trackSeed.GetCov(6));
-      trackSeed.SetCov(7,-trackSeed.GetCov(7));
-      trackSeed.SetCov(10,-trackSeed.GetCov(10));
-      trackSeed.SetCov(11,-trackSeed.GetCov(11));
-    }
-*/
+    /*
+        if (trackSeed.GetSignCosPhi() < 0) {
+          trackSeed.SetSignCosPhi(-trackSeed.GetSignCosPhi());
+          trackSeed.SetSinPhi(-trackSeed.GetSinPhi());
+          trackSeed.SetDzDs(-trackSeed.GetDzDs());
+          trackSeed.SetQPt(-trackSeed.GetQPt());
+          trackSeed.SetCov(3,-trackSeed.GetCov(3));
+          trackSeed.SetCov(4,-trackSeed.GetCov(4));
+          trackSeed.SetCov(6,-trackSeed.GetCov(6));
+          trackSeed.SetCov(7,-trackSeed.GetCov(7));
+          trackSeed.SetCov(10,-trackSeed.GetCov(10));
+          trackSeed.SetCov(11,-trackSeed.GetCov(11));
+        }
+    */
     GPUTPCTrackLinearisation trackLine(trackSeed);
     GPUTPCTrackParam::GPUTPCTrackFitParam fp{};
     trackSeed.CalculateFitParameters(fp);
 
-    LogDebug(std::endl << std::endl << "------------------------" << std::endl << "seed size: " << trackKeyChain.size() << std::endl << std::endl << std::endl);
+    LogDebug(std::endl
+             << std::endl
+             << "------------------------" << std::endl
+             << "seed size: " << trackKeyChain.size() << std::endl
+             << std::endl
+             << std::endl);
     double current_phi = phi_first;
     bool filter_failed = false;
     keylist outputKeyChain = trackKeyChain;
-    for(auto clusterkey = std::next(trackKeyChain.begin()); clusterkey != trackKeyChain.end(); ++clusterkey)
+    for (auto clusterkey = std::next(trackKeyChain.begin()); clusterkey != trackKeyChain.end(); ++clusterkey)
     {
-      if(!FilterStep(*clusterkey,outputKeyChain,current_phi,trackSeed,fp,globalPositions))
+      if (!FilterStep(*clusterkey, outputKeyChain, current_phi, trackSeed, fp, globalPositions))
       {
-        if(Verbosity()>0) { std::cout << "Kalman filter failed, exiting" << std::endl; }
+        if (Verbosity() > 0)
+        {
+          std::cout << "Kalman filter failed, exiting" << std::endl;
+        }
         filter_failed = true;
         break;
       }
     }
-    if(filter_failed) { continue;
-}
-    if(Verbosity()>0) {std::cout << "finished track\n";}
+    if (filter_failed)
+    {
+      continue;
+    }
+    if (Verbosity() > 0)
+    {
+      std::cout << "finished track\n";
+    }
 
-    double track_phi = atan2(y,x);
+    double track_phi = atan2(y, x);
 
-    if(Verbosity()>1) { std::cout << "final QPt = " << trackSeed.GetQPt() << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "final QPt = " << trackSeed.GetQPt() << std::endl;
+    }
 
-    double track_pt = fabs(1./trackSeed.GetQPt());
-    #if defined(_DEBUG_)
-    double track_pY = track_pt*trackSeed.GetSinPhi();
-    double track_pX = sqrt(track_pt*track_pt-track_pY*track_pY);
-    double track_px = track_pX*cos(track_phi)-track_pY*sin(track_phi);
-    double track_py = track_pX*sin(track_phi)+track_pY*cos(track_phi);
-    double track_pz = track_pt*trackSeed.GetDzDs();
-    #endif
-    double track_pterr = sqrt(trackSeed.GetErr2QPt())/(trackSeed.GetQPt()*trackSeed.GetQPt());
+    double track_pt = fabs(1. / trackSeed.GetQPt());
+#if defined(_DEBUG_)
+    double track_pY = track_pt * trackSeed.GetSinPhi();
+    double track_pX = sqrt(track_pt * track_pt - track_pY * track_pY);
+    double track_px = track_pX * cos(track_phi) - track_pY * sin(track_phi);
+    double track_py = track_pX * sin(track_phi) + track_pY * cos(track_phi);
+    double track_pz = track_pt * trackSeed.GetDzDs();
+#endif
+    double track_pterr = sqrt(trackSeed.GetErr2QPt()) / (trackSeed.GetQPt() * trackSeed.GetQPt());
     // If Kalman filter doesn't do its job (happens often with short seeds), use the circle-fit estimate as the central value
     // if(trackKeyChain.size()<10) {track_pt = fabs(1./init_QPt);}
     LogDebug("track pt = " << track_pt << " +- " << track_pterr << std::endl);
     LogDebug("track ALICE p = (" << track_pX << ", " << track_pY << ", " << track_pz << ")" << std::endl);
     LogDebug("track p = (" << track_px << ", " << track_py << ", " << track_pz << ")" << std::endl);
 
-/*    
-    if(cluster_ctr!=1 && !trackSeed.CheckNumericalQuality())
-    {
-      std::cout << "ERROR: Track seed failed numerical quality check before conversion to sPHENIX coordinates! Skipping this one.\n";
-      aborted = true;
-      continue;
-    } 
-*/    
+    /*
+        if(cluster_ctr!=1 && !trackSeed.CheckNumericalQuality())
+        {
+          std::cout << "ERROR: Track seed failed numerical quality check before conversion to sPHENIX coordinates! Skipping this one.\n";
+          aborted = true;
+          continue;
+        }
+    */
     //    pt:z:dz:phi:dphi:c:dc
     // Fill NT with track parameters
     // double StartEta = -log(tan(atan(z0/sqrt(x0*x0+y0*y0))));
-//    if(aborted) continue;
-//    double track_pt = fabs( 1./(trackSeed.GetQPt()));
-    if(checknan(track_pt,"pT",nseeds)) { continue;
-}
-//    double track_pterr = sqrt(trackSeed.GetErr2QPt())/(trackSeed.GetQPt()*trackSeed.GetQPt());
-    if(checknan(track_pterr,"pT err",nseeds)) { continue;
-}
+    //    if(aborted) continue;
+    //    double track_pt = fabs( 1./(trackSeed.GetQPt()));
+    if (checknan(track_pt, "pT", nseeds))
+    {
+      continue;
+    }
+    //    double track_pterr = sqrt(trackSeed.GetErr2QPt())/(trackSeed.GetQPt()*trackSeed.GetQPt());
+    if (checknan(track_pterr, "pT err", nseeds))
+    {
+      continue;
+    }
     LogDebug("Track pterr = " << track_pterr << std::endl);
-    double track_x = trackSeed.GetX()*cos(track_phi)-trackSeed.GetY()*sin(track_phi);
-    double track_y = trackSeed.GetX()*sin(track_phi)+trackSeed.GetY()*cos(track_phi);
+    double track_x = trackSeed.GetX() * cos(track_phi) - trackSeed.GetY() * sin(track_phi);
+    double track_y = trackSeed.GetX() * sin(track_phi) + trackSeed.GetY() * cos(track_phi);
     double track_z = trackSeed.GetZ();
-    if(checknan(track_z,"z",nseeds)) { continue;
-}
+    if (checknan(track_z, "z", nseeds))
+    {
+      continue;
+    }
     double track_zerr = sqrt(trackSeed.GetErr2Z());
-    if(checknan(track_zerr,"zerr",nseeds)) { continue;
-}
+    if (checknan(track_zerr, "zerr", nseeds))
+    {
+      continue;
+    }
     auto lcluster = _cluster_map->findCluster(trackKeyChain.back());
     const auto& lclusterglob = globalPositions.at(trackKeyChain.back());
-    const float lclusterrad = sqrt(lclusterglob(0)*lclusterglob(0) + lclusterglob(1)*lclusterglob(1));
-    double last_cluster_phierr = lcluster->getRPhiError() / lclusterrad;;
+    const float lclusterrad = sqrt(lclusterglob(0) * lclusterglob(0) + lclusterglob(1) * lclusterglob(1));
+    double last_cluster_phierr = lcluster->getRPhiError() / lclusterrad;
+    ;
 
     // phi error assuming error in track radial coordinate is zero
-    double track_phierr = sqrt(pow(last_cluster_phierr,2)+(pow(trackSeed.GetX(),2)*trackSeed.GetErr2Y()) / 
-      pow(pow(trackSeed.GetX(),2)+pow(trackSeed.GetY(),2),2));
-    if(checknan(track_phierr,"phierr",nseeds)) { continue;
-}
-    LogDebug("Track phi = " << atan2(track_py,track_px) << std::endl);
+    double track_phierr = sqrt(pow(last_cluster_phierr, 2) + (pow(trackSeed.GetX(), 2) * trackSeed.GetErr2Y()) /
+                                                                 pow(pow(trackSeed.GetX(), 2) + pow(trackSeed.GetY(), 2), 2));
+    if (checknan(track_phierr, "phierr", nseeds))
+    {
+      continue;
+    }
+    LogDebug("Track phi = " << atan2(track_py, track_px) << std::endl);
     LogDebug("Track phierr = " << track_phierr << std::endl);
-    double track_curvature = trackSeed.GetKappa(_Bzconst*get_Bz(track_x,track_y,track_z));
-    if(checknan(track_curvature,"curvature",nseeds)) { continue;
-}
-    double track_curverr = sqrt(trackSeed.GetErr2QPt())*_Bzconst*get_Bz(track_x,track_y,track_z);
-    if(checknan(track_curverr,"curvature error",nseeds)) { continue;
-}
+    double track_curvature = trackSeed.GetKappa(_Bzconst * get_Bz(track_x, track_y, track_z));
+    if (checknan(track_curvature, "curvature", nseeds))
+    {
+      continue;
+    }
+    double track_curverr = sqrt(trackSeed.GetErr2QPt()) * _Bzconst * get_Bz(track_x, track_y, track_z);
+    if (checknan(track_curverr, "curvature error", nseeds))
+    {
+      continue;
+    }
     TrackSeed_v2 track;
-//    track.set_vertex_id(_vertex_ids[best_vtx]);
+    //    track.set_vertex_id(_vertex_ids[best_vtx]);
     for (unsigned long j : outputKeyChain)
     {
       track.insert_cluster_key(j);
     }
-  
+
     int track_charge = 0;
-    if(trackSeed.GetQPt()<0) { track_charge = -1 * trackSeed.GetSignCosPhi();// * _fieldDir;
-    } else { track_charge = 1 * trackSeed.GetSignCosPhi();// * _fieldDir;
-}
-    
-    double sinphi = sin(track_phi); // who had the idea to use s here?????
+    if (trackSeed.GetQPt() < 0)
+    {
+      track_charge = -1 * trackSeed.GetSignCosPhi();  // * _fieldDir;
+    }
+    else
+    {
+      track_charge = 1 * trackSeed.GetSignCosPhi();  // * _fieldDir;
+    }
+
+    double sinphi = sin(track_phi);  // who had the idea to use s here?????
     double c = cos(track_phi);
     double p = trackSeed.GetSinPhi();
-    
+
     /// Shows the transformation between ALICE and sPHENIX coordinates
-    //track.set_x(trackSeed.GetX()*c-trackSeed.GetY()*s);//_vertex_x[best_vtx]);  //track.set_x(cl->getX());
-    //track.set_y(trackSeed.GetX()*s+trackSeed.GetY()*c);//_vertex_y[best_vtx]);  //track.set_y(cl->getY());
-    //track.set_z(trackSeed.GetZ());//_vertex_z[best_vtx]);  //track.set_z(cl->getZ());
-    //if(Verbosity()>0) std::cout << "x " << track.get_x() << "\n";
-    //if(Verbosity()>0) std::cout << "y " << track.get_y() << "\n";
-    //if(Verbosity()>0) std::cout << "z " << track.get_z() << "\n";
-    //if(checknan(p,"ALICE sinPhi",nseeds)) continue;
+    // track.set_x(trackSeed.GetX()*c-trackSeed.GetY()*s);//_vertex_x[best_vtx]);  //track.set_x(cl->getX());
+    // track.set_y(trackSeed.GetX()*s+trackSeed.GetY()*c);//_vertex_y[best_vtx]);  //track.set_y(cl->getY());
+    // track.set_z(trackSeed.GetZ());//_vertex_z[best_vtx]);  //track.set_z(cl->getZ());
+    // if(Verbosity()>0) std::cout << "x " << track.get_x() << "\n";
+    // if(Verbosity()>0) std::cout << "y " << track.get_y() << "\n";
+    // if(Verbosity()>0) std::cout << "z " << track.get_z() << "\n";
+    // if(checknan(p,"ALICE sinPhi",nseeds)) continue;
     double d = trackSeed.GetDzDs();
-    if(checknan(d,"ALICE dz/ds",nseeds)) { continue;
-}
-     
+    if (checknan(d, "ALICE dz/ds", nseeds))
+    {
+      continue;
+    }
+
     /// Shows the transformation between ALICE and sPHENIX coordinates
-    //double pY = track_pt*p;
-    //double pX = sqrt(track_pt*track_pt-pY*pY);
+    // double pY = track_pt*p;
+    // double pX = sqrt(track_pt*track_pt-pY*pY);
     /// We set the qoverR to get the good charge estimate from the KF
     /// which helps the Acts fit
-    track.set_qOverR(trackSeed.GetQPt()*(0.3*_const_field)/100.);
-    //track.set_px(pX*c-pY*s);
-    //track.set_py(pX*s+pY*c);
-    //track.set_pz(track_pt * trackSeed.GetDzDs()); 
+    track.set_qOverR(trackSeed.GetQPt() * (0.3 * _const_field) / 100.);
+    // track.set_px(pX*c-pY*s);
+    // track.set_py(pX*s+pY*c);
+    // track.set_pz(track_pt * trackSeed.GetDzDs());
     const double* cov = trackSeed.GetCov();
     bool cov_nan = false;
-    for(int i=0;i<15;i++)
+    for (int i = 0; i < 15; i++)
     {
-      if(checknan(cov[i],"covariance element "+std::to_string(i),nseeds)) { cov_nan = true;
-}
+      if (checknan(cov[i], "covariance element " + std::to_string(i), nseeds))
+      {
+        cov_nan = true;
+      }
     }
-    if(cov_nan) { continue;
-}
+    if (cov_nan)
+    {
+      continue;
+    }
     // make this into an actual Eigen matrix
-    Eigen::Matrix<double,5,5> ecov;
-    ecov(0,0)=cov[0];
-    ecov(0,1)=cov[1];
-    ecov(0,2)=cov[2];
-    ecov(0,3)=cov[3];
-    ecov(0,4)=cov[4];
-    ecov(1,1)=cov[5];
-    ecov(1,2)=cov[6];
-    ecov(1,3)=cov[7];
-    ecov(1,4)=cov[8];
-    ecov(2,2)=cov[9];
-    ecov(2,3)=cov[10];
-    ecov(2,4)=cov[11];
-    ecov(3,3)=cov[12];
-    ecov(3,4)=cov[13];
-    ecov(4,4)=cov[14];
+    Eigen::Matrix<double, 5, 5> ecov;
+    ecov(0, 0) = cov[0];
+    ecov(0, 1) = cov[1];
+    ecov(0, 2) = cov[2];
+    ecov(0, 3) = cov[3];
+    ecov(0, 4) = cov[4];
+    ecov(1, 1) = cov[5];
+    ecov(1, 2) = cov[6];
+    ecov(1, 3) = cov[7];
+    ecov(1, 4) = cov[8];
+    ecov(2, 2) = cov[9];
+    ecov(2, 3) = cov[10];
+    ecov(2, 4) = cov[11];
+    ecov(3, 3) = cov[12];
+    ecov(3, 4) = cov[13];
+    ecov(4, 4) = cov[14];
     // symmetrize
-    ecov(1,0)=ecov(0,1);
-    ecov(2,0)=ecov(0,2);
-    ecov(3,0)=ecov(0,3);
-    ecov(4,0)=ecov(0,4);
-    ecov(2,1)=ecov(1,2);
-    ecov(3,1)=ecov(1,3);
-    ecov(4,1)=ecov(1,4);
-    ecov(3,2)=ecov(2,3);
-    ecov(4,2)=ecov(2,4);
-    ecov(4,3)=ecov(3,4);
+    ecov(1, 0) = ecov(0, 1);
+    ecov(2, 0) = ecov(0, 2);
+    ecov(3, 0) = ecov(0, 3);
+    ecov(4, 0) = ecov(0, 4);
+    ecov(2, 1) = ecov(1, 2);
+    ecov(3, 1) = ecov(1, 3);
+    ecov(4, 1) = ecov(1, 4);
+    ecov(3, 2) = ecov(2, 3);
+    ecov(4, 2) = ecov(2, 4);
+    ecov(4, 3) = ecov(3, 4);
     // make rotation matrix based on the following:
     // x = X*cos(track_phi) - Y*sin(track_phi)
     // y = X*sin(track_phi) + Y*cos(track_phi)
@@ -663,62 +805,62 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     // px = pX*cos(track_phi) - pY*sin(track_phi)
     // py = pX*sin(track_phi) + pY*cos(track_phi)
     // pz = pt*(dz/ds)
-    Eigen::Matrix<double,6,5> J;
-    J(0,0) = -sinphi; // dx/dY
-    J(0,1) = 0.; // dx/dZ
-    J(0,2) = 0.; // dx/d(sinphi)
-    J(0,3) = 0.; // dx/d(dz/ds)
-    J(0,4) = 0.; // dx/d(Q/pt)
+    Eigen::Matrix<double, 6, 5> J;
+    J(0, 0) = -sinphi;  // dx/dY
+    J(0, 1) = 0.;       // dx/dZ
+    J(0, 2) = 0.;       // dx/d(sinphi)
+    J(0, 3) = 0.;       // dx/d(dz/ds)
+    J(0, 4) = 0.;       // dx/d(Q/pt)
 
-    J(1,0) = c;  // dy/dY
-    J(1,1) = 0.; // dy/dZ
-    J(1,2) = 0.; // dy/d(sinphi)
-    J(1,3) = 0.; // dy/d(dz/ds)
-    J(1,4) = 0.; // dy/d(Q/pt)
+    J(1, 0) = c;   // dy/dY
+    J(1, 1) = 0.;  // dy/dZ
+    J(1, 2) = 0.;  // dy/d(sinphi)
+    J(1, 3) = 0.;  // dy/d(dz/ds)
+    J(1, 4) = 0.;  // dy/d(Q/pt)
 
-    J(2,0) = 0.; // dz/dY
-    J(2,1) = 1.; // dz/dZ
-    J(2,2) = 0.; // dz/d(sinphi)
-    J(2,3) = 0.; // dz/d(dz/ds)
-    J(2,4) = 0.; // dz/d(Q/pt)
+    J(2, 0) = 0.;  // dz/dY
+    J(2, 1) = 1.;  // dz/dZ
+    J(2, 2) = 0.;  // dz/d(sinphi)
+    J(2, 3) = 0.;  // dz/d(dz/ds)
+    J(2, 4) = 0.;  // dz/d(Q/pt)
 
-    J(3,0) = 0.; // dpx/dY
-    J(3,1) = 0.; // dpx/dZ
-    J(3,2) = -track_pt*(p*c/sqrt(1-p*p)+sinphi); // dpx/d(sinphi)
-    J(3,3) = 0.; // dpx/d(dz/ds)
-    J(3,4) = track_pt*track_pt*track_charge*(p*sinphi-c*sqrt(1-p*p)); // dpx/d(Q/pt)
+    J(3, 0) = 0.;                                                                       // dpx/dY
+    J(3, 1) = 0.;                                                                       // dpx/dZ
+    J(3, 2) = -track_pt * (p * c / sqrt(1 - p * p) + sinphi);                           // dpx/d(sinphi)
+    J(3, 3) = 0.;                                                                       // dpx/d(dz/ds)
+    J(3, 4) = track_pt * track_pt * track_charge * (p * sinphi - c * sqrt(1 - p * p));  // dpx/d(Q/pt)
 
-    J(4,0) = 0.; // dpy/dY
-    J(4,1) = 0.; // dpy/dZ
-    J(4,2) = track_pt*(c-p*sinphi/sqrt(1-p*p)); // dpy/d(sinphi)
-    J(4,3) = 0.; // dpy/d(dz/ds)
-    J(4,4) = -track_pt*track_pt*track_charge*(p*c+sinphi*sqrt(1-p*p)); // dpy/d(Q/pt)
+    J(4, 0) = 0.;                                                                        // dpy/dY
+    J(4, 1) = 0.;                                                                        // dpy/dZ
+    J(4, 2) = track_pt * (c - p * sinphi / sqrt(1 - p * p));                             // dpy/d(sinphi)
+    J(4, 3) = 0.;                                                                        // dpy/d(dz/ds)
+    J(4, 4) = -track_pt * track_pt * track_charge * (p * c + sinphi * sqrt(1 - p * p));  // dpy/d(Q/pt)
 
-    J(5,0) = 0.; // dpz/dY
-    J(5,1) = 0.; // dpz/dZ
-    J(5,2) = 0.; // dpz/d(sinphi)
-    J(5,3) = track_pt; // dpz/d(dz/ds)
-    J(5,4) = -track_pt*track_pt*track_charge*d; // dpz/d(Q/pt)
-/*    bool cov_rot_nan = false;
-    for(int i=0;i<6;i++)
-    {
-      for(int j=0;j<5;j++)
-      {
-        if(checknan(J(i,j),"covariance rotator element ("+std::to_string(i)+","+std::to_string(j)+")",nseeds))
-        {
-          cov_rot_nan = true;
-          continue;
-        }
-      }
-    }
-    if(cov_rot_nan) continue;
-*/
+    J(5, 0) = 0.;                                       // dpz/dY
+    J(5, 1) = 0.;                                       // dpz/dZ
+    J(5, 2) = 0.;                                       // dpz/d(sinphi)
+    J(5, 3) = track_pt;                                 // dpz/d(dz/ds)
+    J(5, 4) = -track_pt * track_pt * track_charge * d;  // dpz/d(Q/pt)
+                                                        /*    bool cov_rot_nan = false;
+                                                            for(int i=0;i<6;i++)
+                                                            {
+                                                              for(int j=0;j<5;j++)
+                                                              {
+                                                                if(checknan(J(i,j),"covariance rotator element ("+std::to_string(i)+","+std::to_string(j)+")",nseeds))
+                                                                {
+                                                                  cov_rot_nan = true;
+                                                                  continue;
+                                                                }
+                                                              }
+                                                            }
+                                                            if(cov_rot_nan) continue;
+                                                        */
     // the heavy lifting happens here
-    Eigen::Matrix<double,6,6> scov = J*ecov*J.transpose();
-    if(!covIsPosDef(scov))
-      {
-	repairCovariance(scov);
-      }
+    Eigen::Matrix<double, 6, 6> scov = J * ecov * J.transpose();
+    if (!covIsPosDef(scov))
+    {
+      repairCovariance(scov);
+    }
     /*
     // Derived from:
     // 1) Taking the Jacobian of the conversion from (Y,Z,SinPhi,DzDs,Q/Pt) to (x,y,z,px,py,pz)
@@ -762,91 +904,90 @@ TrackSeedAliceSeedMap ALICEKF::ALICEKalmanFilter(const std::vector<keylist>& tra
     track.set_error(5, 4, track.get_error(4, 5));
 */
 
-/*
-    for(int w=0;w<cx.size();w++)
-    {
-      ntp->Fill(cx[w],cy[w],cz[w],xerr[w],yerr[w],zerr[w],tx[w],ty[w],tz[w],layer[w],xsize[w],ysize[w],phisize[w],phierr[w],zsize[w]);
-    }
-    cx.clear();
-    cy.clear();
-    cz.clear();
-    tx.clear();
-    ty.clear();
-    tz.clear();
-    xerr.clear();
-    yerr.clear();
-    zerr.clear();
-    layer.clear();
-    xsize.clear();
-    ysize.clear();
-    phisize.clear();
-    phierr.clear();
-    zsize.clear();
-*/
+    /*
+        for(int w=0;w<cx.size();w++)
+        {
+          ntp->Fill(cx[w],cy[w],cz[w],xerr[w],yerr[w],zerr[w],tx[w],ty[w],tz[w],layer[w],xsize[w],ysize[w],phisize[w],phierr[w],zsize[w]);
+        }
+        cx.clear();
+        cy.clear();
+        cz.clear();
+        tx.clear();
+        ty.clear();
+        tz.clear();
+        xerr.clear();
+        yerr.clear();
+        zerr.clear();
+        layer.clear();
+        xsize.clear();
+        ysize.clear();
+        phisize.clear();
+        phierr.clear();
+        zsize.clear();
+    */
     seeds_vector.push_back(track);
     alice_seeds_vector.push_back(trackSeed);
     trackChi2.push_back(trackSeed.GetChi2() / trackSeed.GetNDF());
-    
+
     ++nseeds;
   }
-//  f->cd();
-//  ntp->Write();
-//  f->Close();
-  if(Verbosity()>0) { std::cout << "number of seeds: " << nseeds << "\n";
-}
+  //  f->cd();
+  //  ntp->Write();
+  //  f->Close();
+  if (Verbosity() > 0)
+  {
+    std::cout << "number of seeds: " << nseeds << "\n";
+  }
 
   return std::make_pair(seeds_vector, alice_seeds_vector);
-
 }
 
-bool ALICEKF::covIsPosDef(Eigen::Matrix<double,6,6>& cov) const
+bool ALICEKF::covIsPosDef(Eigen::Matrix<double, 6, 6>& cov) const
 {
   // attempt Cholesky decomposition
-  Eigen::LLT<Eigen::Matrix<double,6,6>> chDec(cov);
+  Eigen::LLT<Eigen::Matrix<double, 6, 6>> chDec(cov);
   // if Cholesky decomposition does not exist, matrix is not positive definite
   return (chDec.info() != Eigen::NumericalIssue);
 }
 
-void ALICEKF::repairCovariance(Eigen::Matrix<double,6,6>& cov) const
+void ALICEKF::repairCovariance(Eigen::Matrix<double, 6, 6>& cov) const
 {
-  Eigen::Matrix<double,6,6> repaircov = cov;
+  Eigen::Matrix<double, 6, 6> repaircov = cov;
   // find closest positive definite matrix
-  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double,6,6>> solver(repaircov);
-  const Eigen::Matrix<double,6,1>& D = solver.eigenvalues();
-  Eigen::Matrix<double,6,6> Q = solver.eigenvectors();
-  Eigen::Matrix<double,6,1> Dp = D.cwiseMax(1e-15);
-  Eigen::Matrix<double,6,6> Z = Q*Dp.asDiagonal()*Q.transpose();
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 6, 6>> solver(repaircov);
+  const Eigen::Matrix<double, 6, 1>& D = solver.eigenvalues();
+  Eigen::Matrix<double, 6, 6> Q = solver.eigenvectors();
+  Eigen::Matrix<double, 6, 1> Dp = D.cwiseMax(1e-15);
+  Eigen::Matrix<double, 6, 6> Z = Q * Dp.asDiagonal() * Q.transpose();
   // updates covariance matrix
-  for(int i=0;i<6;i++)
+  for (int i = 0; i < 6; i++)
   {
-    for(int j=0;j<6;j++)
+    for (int j = 0; j < 6; j++)
     {
-      cov(i,j) = Z(i,j);
+      cov(i, j) = Z(i, j);
     }
   }
-  
 }
 
-std::vector<double> ALICEKF::GetCircleClusterResiduals(const std::vector<std::pair<double,double>>& points, double R, double X0, double Y0) const
+std::vector<double> ALICEKF::GetCircleClusterResiduals(const std::vector<std::pair<double, double>>& points, double R, double X0, double Y0) const
 {
   std::vector<double> residues;
-  std::transform( points.begin(), points.end(), std::back_inserter( residues ), [R,X0,Y0]( const std::pair<double,double>& point )
-  {
+  std::transform(points.begin(), points.end(), std::back_inserter(residues), [R, X0, Y0](const std::pair<double, double>& point)
+                 {
     double x = point.first;
     double y = point.second;
 
     // The shortest distance of a point from a circle is along the radial; line from the circle center to the point
-    return std::sqrt( square(x-X0) + square(y-Y0) )  -  R;  
-  } );
-  return residues;  
+    return std::sqrt( square(x-X0) + square(y-Y0) )  -  R; });
+  return residues;
 }
 
-std::vector<double> ALICEKF::GetLineClusterResiduals(const std::vector<std::pair<double,double>>& points, double A, double B) const
+std::vector<double> ALICEKF::GetLineClusterResiduals(const std::vector<std::pair<double, double>>& points, double A, double B) const
 {
   std::vector<double> residues;
   // calculate cluster residuals from the fitted circle
-  std::transform( points.begin(), points.end(), std::back_inserter( residues ), [A,B]( const std::pair<double,double>& point )
-  {
+  std::transform(points.begin(), points.end(), std::back_inserter(residues), [A, B](const std::pair<double, double>& point)
+                 {
     double r = point.first;
     double z = point.second;
     
@@ -855,7 +996,6 @@ std::vector<double> ALICEKF::GetLineClusterResiduals(const std::vector<std::pair
     double a = -A;
     double b = 1.0;
     double c = -B;
-    return std::abs(a*r+b*z+c)/sqrt(square(a)+square(b));
-  });
-  return residues;  
+    return std::abs(a*r+b*z+c)/sqrt(square(a)+square(b)); });
+  return residues;
 }

--- a/offline/packages/trackreco/ALICEKF.h
+++ b/offline/packages/trackreco/ALICEKF.h
@@ -1,40 +1,40 @@
 #ifndef ALICEKF_H
 #define ALICEKF_H
 
-#include "GPUTPCTrackParam.h"
-#include <trackbase/ClusterErrorPara.h>
-#include <trackbase_historic/TrackSeed_v2.h>
-#include <trackbase/TrkrDefs.h>
-#include <trackbase/TrkrClusterContainer.h>
-#include <trackbase/TrkrCluster.h>
 #include <phfield/PHField.h>
-#include <phfield/PHFieldUtility.h>
 #include <phfield/PHFieldConfigv1.h>
+#include <phfield/PHFieldUtility.h>
+#include <trackbase/ClusterErrorPara.h>
+#include <trackbase/TrkrCluster.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
+#include <trackbase_historic/TrackSeed_v2.h>
+#include "GPUTPCTrackParam.h"
 
 #include <Acts/Definitions/Algebra.hpp>
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
 
 using PositionMap = std::map<TrkrDefs::cluskey, Acts::Vector3>;
 using TrackSeedAliceSeedMap = std::pair<std::vector<TrackSeed_v2>, std::vector<GPUTPCTrackParam>>;
 
 class ALICEKF
 {
-  public:
-  ALICEKF(PHCompositeNode *topNode, 
-          TrkrClusterContainer* cmap, 
-	  PHField *B,
+ public:
+  ALICEKF(PHCompositeNode* topNode,
+          TrkrClusterContainer* cmap,
+          PHField* B,
           double fieldDir,
           unsigned int min_clusters,
           double max_sin_phi,
           int verbosity)
   {
-    if(!topNode) std::cout << "no topnode, too bad..." << std::endl;
+    if (!topNode) std::cout << "no topnode, too bad..." << std::endl;
     _B = B;
     //    _B = PHFieldUtility::GetFieldMapNode(nullptr,topNode);
     _cluster_map = cmap;
@@ -45,7 +45,7 @@ class ALICEKF
     _ClusErrPara = new ClusterErrorPara();
   }
 
-  ~ALICEKF() {delete _ClusErrPara;}
+  ~ALICEKF() { delete _ClusErrPara; }
 
   explicit ALICEKF(const ALICEKF&) = delete;
   ALICEKF& operator=(const ALICEKF&) = delete;
@@ -60,42 +60,44 @@ class ALICEKF
   bool FilterStep(TrkrDefs::cluskey ckey, std::vector<TrkrDefs::cluskey>& keys, double& current_phi, GPUTPCTrackParam& kftrack, GPUTPCTrackParam::GPUTPCTrackFitParam& fp, const PositionMap& globalPositions) const;
 
   TrackSeedAliceSeedMap ALICEKalmanFilter(const std::vector<std::vector<TrkrDefs::cluskey>>& chains, bool use_nhits_limit, const PositionMap& globalPositions, std::vector<float>& trackChi2) const;
-  bool covIsPosDef(Eigen::Matrix<double,6,6>& cov) const;
-  void repairCovariance(Eigen::Matrix<double,6,6>& cov) const;
-  bool checknan(double val, const std::string &msg, int num) const;
+  bool covIsPosDef(Eigen::Matrix<double, 6, 6>& cov) const;
+  void repairCovariance(Eigen::Matrix<double, 6, 6>& cov) const;
+  bool checknan(double val, const std::string& msg, int num) const;
   double get_Bz(double x, double y, double z) const;
-  void useConstBField(bool opt) {_use_const_field = opt;}
-  void setConstBField(float b) {_const_field = b; }
-  void useFixedClusterError(bool opt) {_use_fixed_clus_error = opt;}
-  void setFixedClusterError(int i,double val) {_fixed_clus_error.at(i)=val;}
+  void useConstBField(bool opt) { _use_const_field = opt; }
+  void setConstBField(float b) { _const_field = b; }
+  void useFixedClusterError(bool opt) { _use_fixed_clus_error = opt; }
+  void setFixedClusterError(int i, double val) { _fixed_clus_error.at(i) = val; }
   double getClusterError(TrkrCluster* c, TrkrDefs::cluskey key, Acts::Vector3 global, int i, int j) const;
-  std::vector<double> GetCircleClusterResiduals(const std::vector<std::pair<double,double>>& pts, double R, double X0, double Y0) const;
-  std::vector<double> GetLineClusterResiduals(const std::vector<std::pair<double,double>>& pts, double A, double B) const; 
+  std::vector<double> GetCircleClusterResiduals(const std::vector<std::pair<double, double>>& pts, double R, double X0, double Y0) const;
+  std::vector<double> GetLineClusterResiduals(const std::vector<std::pair<double, double>>& pts, double A, double B) const;
   double get_Bzconst() const { return _Bzconst; }
-  
-  ClusterErrorPara *_ClusErrPara;
-  private:
+
+  ClusterErrorPara* _ClusErrPara;
+
+ private:
   PHField* _B = nullptr;
   size_t _min_clusters_per_track = 20;
   TrkrClusterContainer* _cluster_map = nullptr;
   int Verbosity() const
-  { return _v; }
-  
+  {
+    return _v;
+  }
+
   int _v = 0;
-  double _Bzconst = 10.*0.000299792458f;
+  double _Bzconst = 10. * 0.000299792458f;
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _use_const_field = false;
   float _const_field = 1.4;
   bool _use_fixed_clus_error = true;
-  std::array<double,3> _fixed_clus_error = {.2,.2,.5};
+  std::array<double, 3> _fixed_clus_error = {.2, .2, .5};
 
   double Ne_frac = 0.00;
   double Ar_frac = 0.75;
   double CF4_frac = 0.20;
   double N2_frac = 0.00;
   double isobutane_frac = 0.05;
-
 };
 
 #endif

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -137,7 +137,7 @@ int PHSimpleKFProp::InitRun(PHCompositeNode* topNode)
 
 double PHSimpleKFProp::get_Bz(double x, double y, double z) const
 {
-  if (_use_const_field)
+  if (_use_const_field || fabs(z) > 105.5)
   {
     return _const_field;
   }

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -597,7 +597,7 @@ bool PHSimpleKFProp::TransportAndRotate(double old_radius, double new_radius, do
       return false;
     }
 
-    if(new_radius > 78. || fabs(kftrack.GetZ()) > 105.5)
+    if(new_radius > 78.)
     {
       if(Verbosity()>1) { std::cout << "outside TPC, exiting" << std::endl;
 }
@@ -847,7 +847,7 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
     Acts::Vector3 proj_pt(uncorr_tx,uncorr_ty,uncorr_tz);
 
     const double proj_radius = sqrt(square(uncorr_tx) + square(uncorr_ty));
-    if (proj_radius > 78.0 || abs(tz) > 105.5)
+    if (proj_radius > 78.0)
     {
       // projection is bad, no cluster will be found
       return false;

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -255,8 +255,10 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
     std::cout << "prepared KD trees" << std::endl;
   }
 
-  if(Verbosity()) { std::cout << "number of TPC seeds: " << _track_map->size() << std::endl;
-}
+  if (Verbosity())
+  {
+    std::cout << "number of TPC seeds: " << _track_map->size() << std::endl;
+  }
 
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
   std::vector<TrackSeed_v2> unused_tracks;
@@ -326,7 +328,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       {
         continue;
       }
-      //track->set_qOverR(seedpair.first.at(0).get_qOverR());
+      // track->set_qOverR(seedpair.first.at(0).get_qOverR());
       if (Verbosity())
       {
         std::cout << "is tpc track" << std::endl;
@@ -343,30 +345,30 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       auto preseed = PropagateTrack(track, PropagationDirection::Inward, seedpair.second.at(0), globalPositions);
       std::vector<std::vector<TrkrDefs::cluskey>> p;
       p.push_back(preseed);
-      //std::vector<float> pchi2;
-      //auto kfpair_preseed = fitter->ALICEKalmanFilter(p, false, globalPositions, pchi2);
-      //if(kfpair_preseed.first.size()==0 || kfpair_preseed.second.size()==0) continue;
+      // std::vector<float> pchi2;
+      // auto kfpair_preseed = fitter->ALICEKalmanFilter(p, false, globalPositions, pchi2);
+      // if(kfpair_preseed.first.size()==0 || kfpair_preseed.second.size()==0) continue;
 
-      //std::map<TrkrDefs::cluskey,Acts::Vector3> pmap;
-      //for(auto& cl : preseed) pmap.insert(std::make_pair(cl,globalPositions.at(cl)));
+      // std::map<TrkrDefs::cluskey,Acts::Vector3> pmap;
+      // for(auto& cl : preseed) pmap.insert(std::make_pair(cl,globalPositions.at(cl)));
 
-      //kfpair_preseed.first.at(0).circleFitByTaubin(pmap,7,55);
-      //kfpair_preseed.first.at(0).lineFit(pmap,7,55);
-      //float pseed_intermediate_phi = kfpair_preseed.first.at(0).get_phi(pmap);
-      //kfpair_preseed.first.at(0).set_phi(pseed_intermediate_phi);
+      // kfpair_preseed.first.at(0).circleFitByTaubin(pmap,7,55);
+      // kfpair_preseed.first.at(0).lineFit(pmap,7,55);
+      // float pseed_intermediate_phi = kfpair_preseed.first.at(0).get_phi(pmap);
+      // kfpair_preseed.first.at(0).set_phi(pseed_intermediate_phi);
 
-      //auto preseed_final = PropagateTrack(&kfpair_preseed.first.at(0), PropagationDirection::Outward, kfpair_preseed.second.at(0), globalPositions);
+      // auto preseed_final = PropagateTrack(&kfpair_preseed.first.at(0), PropagationDirection::Outward, kfpair_preseed.second.at(0), globalPositions);
 
       if (Verbosity())
       {
         std::cout << "preseed size " << preseed.size() << std::endl;
       }
 
-//      if (preseed.size() > 40)
-//      {
-//        new_chains.push_back(preseed);
-//        continue;
-//      }
+      //      if (preseed.size() > 40)
+      //      {
+      //        new_chains.push_back(preseed);
+      //        continue;
+      //      }
 
       std::vector<std::vector<TrkrDefs::cluskey>> kl;
       kl.push_back(preseed);
@@ -382,7 +384,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
         continue;
       }
 
-      std::reverse(kl.at(0).begin(),kl.at(0).end());
+      std::reverse(kl.at(0).begin(), kl.at(0).end());
 
       auto pretrack = prepair.first.at(0);
       std::vector<TrkrDefs::cluskey> dumvec2;
@@ -400,29 +402,34 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
       pretrack.lineFit(pretrackClusPositions, 7, 55);
       float pretrackphi = pretrack.get_phi(pretrackClusPositions);
       pretrack.set_phi(pretrackphi);  // make phi persistent
-      //pretrack.set_qOverR(prepair.first.at(0).get_qOverR());
+      // pretrack.set_qOverR(prepair.first.at(0).get_qOverR());
 
-      //auto intermediate_seed = PropagateTrack(&pretrack, PropagationDirection::Inward, prepair.second.at(0), globalPositions);
-      //std::vector<std::vector<TrkrDefs::cluskey>> iseed;
-      //iseed.push_back(intermediate_seed);
-      //std::vector<float> iseedchi2;
-      //auto kfpair_intermediate = fitter->ALICEKalmanFilter(iseed, false, globalPositions, iseedchi2);
+      // auto intermediate_seed = PropagateTrack(&pretrack, PropagationDirection::Inward, prepair.second.at(0), globalPositions);
+      // std::vector<std::vector<TrkrDefs::cluskey>> iseed;
+      // iseed.push_back(intermediate_seed);
+      // std::vector<float> iseedchi2;
+      // auto kfpair_intermediate = fitter->ALICEKalmanFilter(iseed, false, globalPositions, iseedchi2);
 
-      //if(kfpair_intermediate.first.size()==0 || kfpair_intermediate.second.size()==0) continue;
+      // if(kfpair_intermediate.first.size()==0 || kfpair_intermediate.second.size()==0) continue;
 
-      //std::map<TrkrDefs::cluskey,Acts::Vector3> imap;
-      //for(auto& cl : intermediate_seed) imap.insert(std::make_pair(cl,globalPositions.at(cl)));
-      //kfpair_intermediate.first.at(0).circleFitByTaubin(imap,7,55);
-      //kfpair_intermediate.first.at(0).lineFit(imap,7,55);
-      //float kfpairiphi = kfpair_intermediate.first.at(0).get_phi(imap);
-      //kfpair_intermediate.first.at(0).set_phi(kfpairiphi);
+      // std::map<TrkrDefs::cluskey,Acts::Vector3> imap;
+      // for(auto& cl : intermediate_seed) imap.insert(std::make_pair(cl,globalPositions.at(cl)));
+      // kfpair_intermediate.first.at(0).circleFitByTaubin(imap,7,55);
+      // kfpair_intermediate.first.at(0).lineFit(imap,7,55);
+      // float kfpairiphi = kfpair_intermediate.first.at(0).get_phi(imap);
+      // kfpair_intermediate.first.at(0).set_phi(kfpairiphi);
 
       prepair.second.at(0).SetDzDs(-prepair.second.at(0).GetDzDs());
       auto finalchain = PropagateTrack(&pretrack, kl.at(0), PropagationDirection::Outward, prepair.second.at(0), globalPositions);
 
-      if(finalchain.size()>kl.at(0).size()) { new_chains.push_back(finalchain);
-      } else { new_chains.push_back(kl.at(0));
-}
+      if (finalchain.size() > kl.at(0).size())
+      {
+        new_chains.push_back(finalchain);
+      }
+      else
+      {
+        new_chains.push_back(kl.at(0));
+      }
 
       timer.stop();
 
@@ -448,8 +455,10 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   timer.restart();
 
   std::vector<std::vector<TrkrDefs::cluskey>> clean_chains = RemoveBadClusters(new_chains, globalPositions);
-  if(Verbosity()>1) { std::cout << "clean_chains size: " << clean_chains.size() << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "clean_chains size: " << clean_chains.size() << std::endl;
+  }
   timer.stop();
 
   timer.stop();
@@ -467,10 +476,12 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   timer.restart();
   //  Move ghost rejection into publishSeeds, so that we don't publish
   //  rejected seeds
-  if (m_ghostrejection) 
+  if (m_ghostrejection)
   {
     rejectAndPublishSeeds(seeds.first, globalPositions, trackChi2, timer);
-  } else {
+  }
+  else
+  {
     publishSeeds(seeds.first);
   }
 
@@ -557,13 +568,13 @@ PositionMap PHSimpleKFProp::PrepareKDTrees()
   _kdtrees.resize(kdhits.size());
   for (size_t l = 0; l < kdhits.size(); ++l)
   {
-    if (Verbosity()>1)
+    if (Verbosity() > 1)
     {
       std::cout << "l: " << l << std::endl;
     }
     _ptclouds[l] = std::make_shared<KDPointCloud<double>>();
     _ptclouds[l]->pts.resize(kdhits[l].size());
-    if (Verbosity()>1)
+    if (Verbosity() > 1)
     {
       std::cout << "resized to " << kdhits[l].size() << std::endl;
     }
@@ -580,38 +591,56 @@ PositionMap PHSimpleKFProp::PrepareKDTrees()
 
 bool PHSimpleKFProp::TransportAndRotate(double old_radius, double new_radius, double& phi, GPUTPCTrackParam& kftrack, GPUTPCTrackParam::GPUTPCTrackFitParam& fp) const
 {
-  if(Verbosity()>2) { std::cout << "old_radius " << old_radius << ", new_radius " << new_radius << std::endl;
-}
-  const float transport_spacing = .05; // max radial distance between transport points
-  const int Ndivisions = floor(fabs(new_radius-old_radius)/transport_spacing);
-  if(Verbosity()>2) { std::cout << "Ndivisions: " << Ndivisions << std::endl;
-}
-  for(int i=1; i<=Ndivisions+1; i++)
+  if (Verbosity() > 2)
   {
-    if(std::isnan(kftrack.GetX()) || 
-       std::isnan(kftrack.GetY()) ||
-       std::isnan(kftrack.GetZ()))
+    std::cout << "old_radius " << old_radius << ", new_radius " << new_radius << std::endl;
+  }
+  const float transport_spacing = .05;  // max radial distance between transport points
+  const int Ndivisions = floor(fabs(new_radius - old_radius) / transport_spacing);
+  if (Verbosity() > 2)
+  {
+    std::cout << "Ndivisions: " << Ndivisions << std::endl;
+  }
+  for (int i = 1; i <= Ndivisions + 1; i++)
+  {
+    if (std::isnan(kftrack.GetX()) ||
+        std::isnan(kftrack.GetY()) ||
+        std::isnan(kftrack.GetZ()))
     {
-      if(Verbosity()>1) { std::cout << "position is NaN, exiting" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "position is NaN, exiting" << std::endl;
+      }
       return false;
     }
 
-    if(new_radius > 78.)
+    if (new_radius > 78.)
     {
-      if(Verbosity()>1) { std::cout << "outside TPC, exiting" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "outside TPC, exiting" << std::endl;
+      }
       return false;
     }
 
     double r_div;
-    if(i==Ndivisions+1) { r_div = new_radius;
-    } else if(old_radius<new_radius) { r_div = old_radius + transport_spacing*i;
-    } else { r_div = old_radius - transport_spacing*i;
-}
+    if (i == Ndivisions + 1)
+    {
+      r_div = new_radius;
+    }
+    else if (old_radius < new_radius)
+    {
+      r_div = old_radius + transport_spacing * i;
+    }
+    else
+    {
+      r_div = old_radius - transport_spacing * i;
+    }
 
-    if(Verbosity()>2) { std::cout << "transporting to intermediate radius " << r_div << std::endl;
-}
+    if (Verbosity() > 2)
+    {
+      std::cout << "transporting to intermediate radius " << r_div << std::endl;
+    }
 
     // track state position relative to radial direction
     const double tX = kftrack.GetX();
@@ -619,33 +648,37 @@ bool PHSimpleKFProp::TransportAndRotate(double old_radius, double new_radius, do
     const double tz = kftrack.GetZ();
 
     // track state global position (including tz above)
-    const double tx = tX*cos(phi) - tY*sin(phi);
-    const double ty = tX*sin(phi) + tY*cos(phi);
+    const double tx = tX * cos(phi) - tY * sin(phi);
+    const double ty = tX * sin(phi) + tY * cos(phi);
 
-    const double Bz = _Bzconst * get_Bz(tx,ty,tz);
+    const double Bz = _Bzconst * get_Bz(tx, ty, tz);
 
     kftrack.CalculateFitParameters(fp);
 
     // transport to radius
-    if(!kftrack.TransportToXWithMaterial(r_div, fp, Bz, 1.))
+    if (!kftrack.TransportToXWithMaterial(r_div, fp, Bz, 1.))
     {
-      if(Verbosity()>1) { std::cout << "transport failed" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "transport failed" << std::endl;
+      }
       return false;
     }
     // rotate track state reference frame
     const double new_tX = kftrack.GetX();
     const double new_tY = kftrack.GetY();
 
-    const double new_tx = new_tX*cos(phi) - new_tY*sin(phi);
-    const double new_ty = new_tX*sin(phi) + new_tY*cos(phi);
-    const double new_phi = atan2(new_ty,new_tx);
+    const double new_tx = new_tX * cos(phi) - new_tY * sin(phi);
+    const double new_ty = new_tX * sin(phi) + new_tY * cos(phi);
+    const double new_phi = atan2(new_ty, new_tx);
     const double alpha = new_phi - phi;
 
-    if(!kftrack.Rotate(alpha,1.))
+    if (!kftrack.Rotate(alpha, 1.))
     {
-      if(Verbosity()>1) { std::cout << "rotate failed" << std::endl;
-}
+      if (Verbosity() > 1)
+      {
+        std::cout << "rotate failed" << std::endl;
+      }
       return false;
     }
     phi = new_phi;
@@ -653,11 +686,11 @@ bool PHSimpleKFProp::TransportAndRotate(double old_radius, double new_radius, do
 
   const double final_tX = kftrack.GetX();
   const double final_tY = kftrack.GetY();
-  const double final_tx = final_tX*cos(phi) - final_tY*sin(phi);
-  const double final_ty = final_tX*sin(phi) + final_tY*cos(phi);
+  const double final_tx = final_tX * cos(phi) - final_tY * sin(phi);
+  const double final_ty = final_tX * sin(phi) + final_tY * cos(phi);
   const double final_tz = kftrack.GetZ();
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track position after transport: (" << final_tx << ", " << final_ty << ", " << final_tz << ")" << std::endl;
   }
@@ -667,35 +700,50 @@ bool PHSimpleKFProp::TransportAndRotate(double old_radius, double new_radius, do
 bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_phi, PropagationDirection& direction, std::vector<TrkrDefs::cluskey>& propagated_track, std::vector<TrkrDefs::cluskey>& ckeys, GPUTPCTrackParam& kftrack, GPUTPCTrackParam::GPUTPCTrackFitParam& fp, const PositionMap& globalPositions) const
 {
   // give up if position vector is NaN (propagation failed)
-  if(std::isnan(kftrack.GetX()) ||
-     std::isnan(kftrack.GetY()) ||
-     std::isnan(kftrack.GetZ()))
+  if (std::isnan(kftrack.GetX()) ||
+      std::isnan(kftrack.GetY()) ||
+      std::isnan(kftrack.GetZ()))
   {
-    if(Verbosity()>1) { std::cout << "position is NaN, exiting loop" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "position is NaN, exiting loop" << std::endl;
+    }
     return false;
   }
 
-  if(Verbosity()>1) { std::cout << "current layer: " << current_layer << std::endl;
-}
-  if(Verbosity()>5) { std::cout << "original seed size: " << ckeys.size() << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "current layer: " << current_layer << std::endl;
+  }
+  if (Verbosity() > 5)
+  {
+    std::cout << "original seed size: " << ckeys.size() << std::endl;
+  }
 
   // CosPhi is the projection of the pt onto the radial direction
   // based on the sign of CosPhi, decide whether to propagate outward or inward
   int next_layer;
-  if(direction == PropagationDirection::Outward) { next_layer = current_layer + 1;
-  } else { next_layer = current_layer - 1;
-}
+  if (direction == PropagationDirection::Outward)
+  {
+    next_layer = current_layer + 1;
+  }
+  else
+  {
+    next_layer = current_layer - 1;
+  }
 
-  if(Verbosity()>1) { std::cout << "next layer: " << next_layer << std::endl;
-}
+  if (Verbosity() > 1)
+  {
+    std::cout << "next layer: " << next_layer << std::endl;
+  }
 
   // give up if next layer is outside the TPC (propagation complete)
-  if(next_layer < 7 || next_layer > 54)
+  if (next_layer < 7 || next_layer > 54)
   {
-    if(Verbosity()>1) { std::cout << "reached end of TPC, exiting loop" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "reached end of TPC, exiting loop" << std::endl;
+    }
     return false;
   }
 
@@ -705,67 +753,86 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
   const double tz = kftrack.GetZ();
 
   // track state global position (including tz above)
-  const double tx = tX*cos(current_phi) - tY*sin(current_phi);
-  const double ty = tX*sin(current_phi) + tY*cos(current_phi);
+  const double tx = tX * cos(current_phi) - tY * sin(current_phi);
+  const double ty = tX * sin(current_phi) + tY * cos(current_phi);
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << std::endl;
     std::cout << "track position: (" << tx << ", " << ty << ", " << tz << ")" << std::endl;
   }
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
-    std::cout << "transporting to radius: " << radii[next_layer-7] << std::endl;
+    std::cout << "transporting to radius: " << radii[next_layer - 7] << std::endl;
   }
 
-  if(!TransportAndRotate(kftrack.GetX(),radii[next_layer-7],current_phi,kftrack,fp))
+  if (!TransportAndRotate(kftrack.GetX(), radii[next_layer - 7], current_phi, kftrack, fp))
   {
-    if(std::isnan(kftrack.GetX()) ||
-       std::isnan(kftrack.GetY()) ||
-       std::isnan(kftrack.GetZ()))
+    if (std::isnan(kftrack.GetX()) ||
+        std::isnan(kftrack.GetY()) ||
+        std::isnan(kftrack.GetZ()))
     {
       return false;
     }
 
-    if(Verbosity()>1) { std::cout << "track turned around near X=" << kftrack.GetX() << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "track turned around near X=" << kftrack.GetX() << std::endl;
+    }
 
     // TransportAndRotate failure indicates that track has turned around before it reaches next layer
     // The track parameters don't update in that last step, so we're likely somewhere between two layers
     // So, first, we turn the track around ourselves, setting it to its next intersection at its current radius
 
     // basically circle project in xy, linear project in z
-    double pt = 1./fabs(kftrack.GetQPt());
-    double end_tx = kftrack.GetX()*cos(current_phi)-kftrack.GetY()*sin(current_phi);
-    double end_ty = kftrack.GetX()*sin(current_phi)+kftrack.GetY()*cos(current_phi);
+    double pt = 1. / fabs(kftrack.GetQPt());
+    double end_tx = kftrack.GetX() * cos(current_phi) - kftrack.GetY() * sin(current_phi);
+    double end_ty = kftrack.GetX() * sin(current_phi) + kftrack.GetY() * cos(current_phi);
     double end_tz = kftrack.GetZ();
-    if(Verbosity()>1) { std::cout << "current parameters: pt=" << pt << ", (x, y, z) = (" << end_tx << ", " << end_ty << ", " << end_tz << ")" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "current parameters: pt=" << pt << ", (x, y, z) = (" << end_tx << ", " << end_ty << ", " << end_tz << ")" << std::endl;
+    }
     // pt[GeV] = 0.3 B[T] R[m]
-    double R = 100.*pt/(0.3*get_Bz(end_tx,end_ty,end_tz));
-    if(Verbosity()>1) { std::cout << "R=" << R << std::endl;
-}
-    double pX = pt*kftrack.GetCosPhi();
-    double pY = pt*kftrack.GetSinPhi();
-    if(Verbosity()>1) { std::cout << "(pX, pY) = (" << pX << ", " << pY << ")" << std::endl;
-}
-    double px = pX*cos(current_phi)-pY*sin(current_phi);
-    double py = pX*sin(current_phi)+pY*cos(current_phi);
-    double tangent_phi = atan2(py,px);
+    double R = 100. * pt / (0.3 * get_Bz(end_tx, end_ty, end_tz));
+    if (Verbosity() > 1)
+    {
+      std::cout << "R=" << R << std::endl;
+    }
+    double pX = pt * kftrack.GetCosPhi();
+    double pY = pt * kftrack.GetSinPhi();
+    if (Verbosity() > 1)
+    {
+      std::cout << "(pX, pY) = (" << pX << ", " << pY << ")" << std::endl;
+    }
+    double px = pX * cos(current_phi) - pY * sin(current_phi);
+    double py = pX * sin(current_phi) + pY * cos(current_phi);
+    double tangent_phi = atan2(py, px);
     double center_phi;
-    if(kftrack.GetQPt()>0) { center_phi = tangent_phi + M_PI/2.;
-    } else { center_phi = tangent_phi - M_PI/2.;
-}
-    if(center_phi>M_PI) { center_phi -= 2.*M_PI;
-}
-    if(center_phi<-M_PI) { center_phi += 2.*M_PI;
-}
-    double xc = end_tx - R*cos(center_phi);
-    double yc = end_ty - R*sin(center_phi);
-    if(Verbosity()>1) { std::cout << "(xc, yc) = (" << xc << ", " << yc << ")" << std::endl;
-}
-    auto circle_output = TrackFitUtils::circle_circle_intersection(sqrt(pow(kftrack.GetX(),2.)+pow(kftrack.GetY(),2.)),R,xc,yc);
+    if (kftrack.GetQPt() > 0)
+    {
+      center_phi = tangent_phi + M_PI / 2.;
+    }
+    else
+    {
+      center_phi = tangent_phi - M_PI / 2.;
+    }
+    if (center_phi > M_PI)
+    {
+      center_phi -= 2. * M_PI;
+    }
+    if (center_phi < -M_PI)
+    {
+      center_phi += 2. * M_PI;
+    }
+    double xc = end_tx - R * cos(center_phi);
+    double yc = end_ty - R * sin(center_phi);
+    if (Verbosity() > 1)
+    {
+      std::cout << "(xc, yc) = (" << xc << ", " << yc << ")" << std::endl;
+    }
+    auto circle_output = TrackFitUtils::circle_circle_intersection(sqrt(pow(kftrack.GetX(), 2.) + pow(kftrack.GetY(), 2.)), R, xc, yc);
     // pick the furthest point from current track position
     double new_tx;
     double new_ty;
@@ -773,10 +840,12 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
     double yplus = std::get<1>(circle_output);
     double xminus = std::get<2>(circle_output);
     double yminus = std::get<3>(circle_output);
-    if(Verbosity()>1) { std::cout << "circle-circle intersection: (" << xplus << ", " << yplus << "), (" << xminus << ", " << yminus << ")" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "circle-circle intersection: (" << xplus << ", " << yplus << "), (" << xminus << ", " << yminus << ")" << std::endl;
+    }
 
-    if(sqrt(pow(end_tx-xplus,2.)+pow(end_ty-yplus,2.))>sqrt(pow(end_tx-xminus,2.)+pow(end_ty-yminus,2.)))
+    if (sqrt(pow(end_tx - xplus, 2.) + pow(end_ty - yplus, 2.)) > sqrt(pow(end_tx - xminus, 2.) + pow(end_ty - yminus, 2.)))
     {
       new_tx = xplus;
       new_ty = yplus;
@@ -787,49 +856,59 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
       new_ty = yminus;
     }
 
-    if(Verbosity()>1) { std::cout << "track now at (" << new_tx << ", " << new_ty << ")" << std::endl;
-}
-    double rot_phi = atan2(new_ty,new_tx);
-    //double rot_alpha = rot_phi - current_phi;
-    
+    if (Verbosity() > 1)
+    {
+      std::cout << "track now at (" << new_tx << ", " << new_ty << ")" << std::endl;
+    }
+    double rot_phi = atan2(new_ty, new_tx);
+    // double rot_alpha = rot_phi - current_phi;
+
     // new track point is existing track point rotated by alpha
-    double new_tX = new_tx*cos(rot_phi)+new_ty*sin(rot_phi);
-    double new_tY = -new_tx*sin(rot_phi)+new_ty*cos(rot_phi);
-    double new_centerphi = atan2(new_ty-yc,new_tx-xc);
-    double dcenterphi = new_centerphi-center_phi;
-    if(dcenterphi>M_PI) { dcenterphi = 2.*M_PI - dcenterphi;
-}
-    if(dcenterphi<-M_PI) { dcenterphi = 2.*M_PI + dcenterphi;
-}
-    double ds = R*fabs(dcenterphi);
-    double dz = kftrack.GetDzDs()*ds;
+    double new_tX = new_tx * cos(rot_phi) + new_ty * sin(rot_phi);
+    double new_tY = -new_tx * sin(rot_phi) + new_ty * cos(rot_phi);
+    double new_centerphi = atan2(new_ty - yc, new_tx - xc);
+    double dcenterphi = new_centerphi - center_phi;
+    if (dcenterphi > M_PI)
+    {
+      dcenterphi = 2. * M_PI - dcenterphi;
+    }
+    if (dcenterphi < -M_PI)
+    {
+      dcenterphi = 2. * M_PI + dcenterphi;
+    }
+    double ds = R * fabs(dcenterphi);
+    double dz = kftrack.GetDzDs() * ds;
 
     current_phi = rot_phi;
     kftrack.SetX(new_tX);
     kftrack.SetY(new_tY);
-    kftrack.SetZ(end_tz+dz);
+    kftrack.SetZ(end_tz + dz);
 
     kftrack.SetSignCosPhi(-kftrack.GetSignCosPhi());
 
     // now finish transport back down to current layer
-    if(!TransportAndRotate(kftrack.GetX(),radii[current_layer-7],current_phi,kftrack,fp))
+    if (!TransportAndRotate(kftrack.GetX(), radii[current_layer - 7], current_phi, kftrack, fp))
     {
       return false;
     }
 
-    if(direction == PropagationDirection::Outward) { direction = PropagationDirection::Inward;
-    } else { direction = PropagationDirection::Outward;
-}
+    if (direction == PropagationDirection::Outward)
+    {
+      direction = PropagationDirection::Inward;
+    }
+    else
+    {
+      direction = PropagationDirection::Outward;
+    }
 
     // track landed in same layer for this step
     next_layer = current_layer;
   }
-  
-  // account for distortions
-  if(!_pp_mode && (m_dcc_static || m_dcc_average || m_dcc_fluctuation))
-  {
 
-    if(Verbosity()>1)
+  // account for distortions
+  if (!_pp_mode && (m_dcc_static || m_dcc_average || m_dcc_fluctuation))
+  {
+    if (Verbosity() > 1)
     {
       std::cout << "doing distortion correction" << std::endl;
     }
@@ -840,11 +919,11 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
 
     const double uncorr_tX = kftrack.GetX();
     const double uncorr_tY = kftrack.GetY();
-    const double uncorr_tx = uncorr_tX*cos(current_phi) - uncorr_tY*sin(current_phi);
-    const double uncorr_ty = uncorr_tX*sin(current_phi) + uncorr_tY*cos(current_phi);
+    const double uncorr_tx = uncorr_tX * cos(current_phi) - uncorr_tY * sin(current_phi);
+    const double uncorr_ty = uncorr_tX * sin(current_phi) + uncorr_tY * cos(current_phi);
     const double uncorr_tz = kftrack.GetZ();
 
-    Acts::Vector3 proj_pt(uncorr_tx,uncorr_ty,uncorr_tz);
+    Acts::Vector3 proj_pt(uncorr_tx, uncorr_ty, uncorr_tz);
 
     const double proj_radius = sqrt(square(uncorr_tx) + square(uncorr_ty));
     if (proj_radius > 78.0)
@@ -853,51 +932,60 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
       return false;
     }
 
-    if(Verbosity()>2) { std::cout << "distortion correction for (" << tx << ", " << ty << ", " << tz << "), layer " << next_layer << ", radius " << proj_radius << std::endl;
-}
+    if (Verbosity() > 2)
+    {
+      std::cout << "distortion correction for (" << tx << ", " << ty << ", " << tz << "), layer " << next_layer << ", radius " << proj_radius << std::endl;
+    }
 
     if (m_dcc_static)
     {
-      if(Verbosity()>2) { std::cout << "static correction" << std::endl;
-}
+      if (Verbosity() > 2)
+      {
+        std::cout << "static correction" << std::endl;
+      }
       proj_pt = m_distortionCorrection.get_corrected_position(proj_pt, m_dcc_static);
     }
     if (m_dcc_average)
     {
-      if(Verbosity()>2) { std::cout << "average correction" << std::endl;
-}
+      if (Verbosity() > 2)
+      {
+        std::cout << "average correction" << std::endl;
+      }
       proj_pt = m_distortionCorrection.get_corrected_position(proj_pt, m_dcc_average);
     }
     if (m_dcc_fluctuation)
     {
-      if(Verbosity()>2) { std::cout << "fluctuation correction" << std::endl;
-}
+      if (Verbosity() > 2)
+      {
+        std::cout << "fluctuation correction" << std::endl;
+      }
       proj_pt = m_distortionCorrection.get_corrected_position(proj_pt, m_dcc_fluctuation);
     }
 
     const double dist_radius = sqrt(square(proj_pt[0]) + square(proj_pt[1]));
 
-    if(Verbosity()>2) { std::cout << "after correction: (" << proj_pt[0] << ", " << proj_pt[1] << ", " << proj_pt[2] << "), radius " << dist_radius << std::endl;
-}
+    if (Verbosity() > 2)
+    {
+      std::cout << "after correction: (" << proj_pt[0] << ", " << proj_pt[1] << ", " << proj_pt[2] << "), radius " << dist_radius << std::endl;
+    }
 
-    if(!TransportAndRotate(kftrack.GetX(),dist_radius,current_phi,kftrack,fp))
+    if (!TransportAndRotate(kftrack.GetX(), dist_radius, current_phi, kftrack, fp))
     {
       return false;
     }
 
-    if(std::isnan(kftrack.GetX()) ||
-       std::isnan(kftrack.GetY()) ||
-       std::isnan(kftrack.GetZ()))
+    if (std::isnan(kftrack.GetX()) ||
+        std::isnan(kftrack.GetY()) ||
+        std::isnan(kftrack.GetZ()))
     {
       return false;
     }
-
   }
 
   const double new_tX = kftrack.GetX();
   const double new_tY = kftrack.GetY();
-  const double new_tx = new_tX*cos(current_phi) - new_tY*sin(current_phi);
-  const double new_ty = new_tX*sin(current_phi) + new_tY*cos(current_phi);
+  const double new_tx = new_tX * cos(current_phi) - new_tY * sin(current_phi);
+  const double new_ty = new_tX * sin(current_phi) + new_tY * cos(current_phi);
   const double new_tz = kftrack.GetZ();
 
   // search for closest available cluster within window
@@ -906,10 +994,12 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
   std::vector<double> distance_out(1);
   int n_results = _kdtrees[next_layer]->knnSearch(&query_pt[0], 1, &index_out[0], &distance_out[0]);
   // if no results, then no cluster to add, but propagation is not necessarily done
-  if(!n_results)
+  if (!n_results)
   {
-    if(Verbosity()>1) { std::cout << "no clusters found in search window, moving on" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "no clusters found in search window, moving on" << std::endl;
+    }
     current_layer = next_layer;
     return true;
   }
@@ -921,18 +1011,18 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
   const double cand_y = candidate_globalpos(1);
   const double cand_z = candidate_globalpos(2);
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "found closest cluster candidate at (" << cand_x << ", " << cand_y << ", " << cand_z << ")" << std::endl;
   }
 
   // get cluster and track state position errors
   const double tYerr = sqrt(kftrack.GetCov(0));
-  const double txerr = fabs(tYerr*sin(current_phi));
-  const double tyerr = fabs(tYerr*cos(current_phi));
+  const double txerr = fabs(tYerr * sin(current_phi));
+  const double tyerr = fabs(tYerr * cos(current_phi));
   const double tzerr = sqrt(kftrack.GetCov(5));
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track state position errors: (" << txerr << ", " << tyerr << ", " << tzerr << ")" << std::endl;
   }
@@ -941,51 +1031,53 @@ bool PHSimpleKFProp::PropagateStep(unsigned int& current_layer, double& current_
   const double cand_yerr = sqrt(fitter->getClusterError(clusterCandidate, closest_ckey, candidate_globalpos, 1, 1));
   const double cand_zerr = sqrt(fitter->getClusterError(clusterCandidate, closest_ckey, candidate_globalpos, 2, 2));
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "cluster position errors: (" << cand_xerr << ", " << cand_yerr << ", " << cand_zerr << ")" << std::endl;
   }
 
   // add cluster if its position is within error-based window
-  if(fabs(new_tx-cand_x) < _max_dist * sqrt(txerr*txerr + cand_xerr*cand_xerr) &&
-     fabs(new_ty-cand_y) < _max_dist * sqrt(tyerr*tyerr + cand_yerr*cand_yerr) &&
-     fabs(new_tz-cand_z) < _max_dist * sqrt(tzerr*tzerr + cand_zerr*cand_zerr))
+  if (fabs(new_tx - cand_x) < _max_dist * sqrt(txerr * txerr + cand_xerr * cand_xerr) &&
+      fabs(new_ty - cand_y) < _max_dist * sqrt(tyerr * tyerr + cand_yerr * cand_yerr) &&
+      fabs(new_tz - cand_z) < _max_dist * sqrt(tzerr * tzerr + cand_zerr * cand_zerr))
   {
-    if(Verbosity()>1) { std::cout << "added cluster" << std::endl;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << "added cluster" << std::endl;
+    }
     propagated_track.push_back(closest_ckey);
 
     // don't re-filter clusters that are already in original seed
-    if(std::find(ckeys.begin(),ckeys.end(),closest_ckey) == ckeys.end())
+    if (std::find(ckeys.begin(), ckeys.end(), closest_ckey) == ckeys.end())
     {
-      const double cand_Y = -cand_x*sin(current_phi) + cand_y*cos(current_phi);
+      const double cand_Y = -cand_x * sin(current_phi) + cand_y * cos(current_phi);
       const double cand_xycov2 = fitter->getClusterError(clusterCandidate, closest_ckey, candidate_globalpos, 0, 1);
-      const double cand_Yerr2 = cand_xerr*cand_xerr*sin(current_phi)*sin(current_phi) + cand_xycov2*sin(current_phi)*cos(current_phi) + cand_yerr*cand_yerr*cos(current_phi)*cos(current_phi);
-      const double cand_zerr2 = cand_zerr*cand_zerr;
+      const double cand_Yerr2 = cand_xerr * cand_xerr * sin(current_phi) * sin(current_phi) + cand_xycov2 * sin(current_phi) * cos(current_phi) + cand_yerr * cand_yerr * cos(current_phi) * cos(current_phi);
+      const double cand_zerr2 = cand_zerr * cand_zerr;
 
-      if(Verbosity()>1)
+      if (Verbosity() > 1)
       {
         std::cout << "Filtering cluster with Y=" << cand_Y << ", z=" << cand_z << ", Yerr2=" << cand_Yerr2 << ", zerr2=" << cand_zerr2 << std::endl;
       }
 
       kftrack.Filter(cand_Y, cand_z, cand_Yerr2, cand_zerr2, _max_sin_phi);
     }
-//    else
-//    {
-//      kftrack.SetX(cand_x*cos(current_phi)+cand_y*sin(current_phi));
-//      kftrack.SetY(-cand_x*sin(current_phi)+cand_y*cos(current_phi));
-//      kftrack.SetZ(cand_z);
-//    }
+    //    else
+    //    {
+    //      kftrack.SetX(cand_x*cos(current_phi)+cand_y*sin(current_phi));
+    //      kftrack.SetY(-cand_x*sin(current_phi)+cand_y*cos(current_phi));
+    //      kftrack.SetZ(cand_z);
+    //    }
   }
-  
+
   // update layer
   current_layer = next_layer;
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track current parameters:" << std::endl;
     std::cout << "(X, Y, Z) = (" << kftrack.GetX() << ", " << kftrack.GetY() << ", " << kftrack.GetZ() << ")" << std::endl;
-    std::cout << "pt = " << 1./fabs(kftrack.GetQPt()) << std::endl;
+    std::cout << "pt = " << 1. / fabs(kftrack.GetQPt()) << std::endl;
     std::cout << "sinPhi = " << kftrack.GetSinPhi() << std::endl;
     std::cout << "cosPhi = " << kftrack.GetCosPhi() << std::endl;
     std::cout << "dzds = " << kftrack.GetDzDs() << std::endl;
@@ -1002,18 +1094,17 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   std::vector<TrkrDefs::cluskey> ckeys;
   std::copy(track->begin_cluster_keys(), track->end_cluster_keys(), std::back_inserter(ckeys));
 
-  if(direction == PropagationDirection::Inward)
+  if (direction == PropagationDirection::Inward)
   {
-    std::reverse(ckeys.begin(),ckeys.end());
+    std::reverse(ckeys.begin(), ckeys.end());
   }
 
-  return PropagateTrack(track,ckeys,direction,aliceSeed,globalPositions);
-} 
+  return PropagateTrack(track, ckeys, direction, aliceSeed, globalPositions);
+}
 
 std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, std::vector<TrkrDefs::cluskey>& ckeys, PropagationDirection direction, GPUTPCTrackParam& aliceSeed, const PositionMap& globalPositions) const
 {
-
-  if(direction == PropagationDirection::Inward)
+  if (direction == PropagationDirection::Inward)
   {
     aliceSeed.SetDzDs(-aliceSeed.GetDzDs());
   }
@@ -1022,15 +1113,17 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   double track_y = track->get_y();
   double track_z = track->get_z();
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "layers:" << std::endl;
-    for(auto& c : ckeys) { std::cout << (int)TrkrDefs::getLayer(c) << ", ";
-}
+    for (auto& c : ckeys)
+    {
+      std::cout << (int) TrkrDefs::getLayer(c) << ", ";
+    }
     std::cout << std::endl;
   }
 
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track (x,y,z) = (" << track_x << ", " << track_y << ", " << track_z << ")" << std::endl;
   }
@@ -1053,7 +1146,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     track_pz = track->get_pz();
   }
 
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track (px,py,pz) = (" << track_px << ", " << track_py << ", " << track_pz << ")" << std::endl;
   }
@@ -1110,11 +1203,11 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   track_y = trkGlobPos.at(0)(1);
   track_z = trkGlobPos.at(0)(2);
 
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "new track (x,y,z) = " << track_x << ", " << track_y << ", " << track_z << ")" << std::endl;
   }
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "new track (px,py,pz) = " << track_px << ", " << track_py << ", " << track_pz << ")" << std::endl;
   }
@@ -1122,7 +1215,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   //    }
 
   double track_pt = sqrt(track_px * track_px + track_py * track_py);
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track pt: " << track_pt << std::endl;
   }
@@ -1137,7 +1230,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   kftrack.setIsobutaneFraction(isobutane_frac);
 
   float track_phi = atan2(track_y, track_x);
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "track phi: " << track_phi << std::endl;
     std::cout << "track charge: " << track->get_charge() << std::endl;
@@ -1149,91 +1242,92 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 
   kftrack.SetSignCosPhi(track_pX / track_pt);
   kftrack.SetSinPhi(track_pY / track_pt);
-  kftrack.SetDzDs(track_pz / sqrt(track_pt*track_pt+track_pz*track_pz));
+  kftrack.SetDzDs(track_pz / sqrt(track_pt * track_pt + track_pz * track_pz));
 
-  if(Verbosity()>1) { std::cout << "track pX = " << track_pX << ", pY = " << track_pY << ", CosPhi = " << track_pX / track_pt << ", signCosPhi = " << kftrack.GetSignCosPhi() << std::endl;
-}
-/*
-  // Y = y
-  // Z = z
-  // SinPhi = py/sqrt(px^2+py^2)
-  // DzDs = pz/sqrt(px^2+py^2)
-  // QPt = 1/sqrt(px^2+py^2)
-
-  const double track_pt3 = std::pow(track_pt, 3.);
-
-  Eigen::Matrix<double, 6, 5> Jrot;
-  Jrot(0, 0) = 0;  // dY/dx
-  Jrot(1, 0) = 1;  // dY/dy
-  Jrot(2, 0) = 0;  // dY/dz
-  Jrot(3, 0) = 0;  // dY/dpx
-  Jrot(4, 0) = 0;  // dY/dpy
-  Jrot(5, 0) = 0;  // dY/dpz
-
-  Jrot(0, 1) = 0;  // dZ/dx
-  Jrot(1, 1) = 0;  // dZ/dy
-  Jrot(2, 1) = 1;  // dZ/dz
-  Jrot(3, 1) = 0;  // dZ/dpx
-  Jrot(4, 1) = 0;  // dZ/dpy
-  Jrot(5, 1) = 0;  // dZ/dpz
-
-  Jrot(0, 2) = 0;                                 // dSinPhi/dx
-  Jrot(1, 2) = 0;                                 // dSinPhi/dy
-  Jrot(2, 2) = 0;                                 // dSinPhi/dz
-  Jrot(3, 2) = -track_py * track_px / track_pt3;  // dSinPhi/dpx
-  Jrot(4, 2) = track_px * track_px / track_pt3;   // dSinPhi/dpy
-  Jrot(5, 2) = 0;                                 // dSinPhi/dpz
-
-  Jrot(0, 3) = 0;                                 // dDzDs/dx
-  Jrot(1, 3) = 0;                                 // dDzDs/dy
-  Jrot(2, 3) = 0;                                 // dDzDs/dz
-  Jrot(3, 3) = -track_px * track_pz / track_pt3;  // dDzDs/dpx
-  Jrot(4, 3) = -track_py * track_pz / track_pt3;  // dDzDs/dpy
-  Jrot(5, 3) = 1. / track_pt;                     // dDzDs/dpz
-
-  Jrot(0, 4) = 0;                      // dQPt/dx
-  Jrot(1, 4) = 0;                      // dQPt/dy
-  Jrot(2, 4) = 0;                      // dQPt/dz
-  Jrot(3, 4) = -track_px / track_pt3;  // dQPt/dpx
-  Jrot(4, 4) = -track_py / track_pt3;  // dQPt/dpy
-  Jrot(5, 4) = 0;                      // dQPt/dpz
-
-  Eigen::Matrix<double, 5, 5> kfCov = Jrot.transpose() * xyzCov * Jrot;
-
-  int ctr = 0;
-  for (int i = 0; i < 5; i++)
+  if (Verbosity() > 1)
   {
-    for (int j = 0; j < 5; j++)
+    std::cout << "track pX = " << track_pX << ", pY = " << track_pY << ", CosPhi = " << track_pX / track_pt << ", signCosPhi = " << kftrack.GetSignCosPhi() << std::endl;
+  }
+  /*
+    // Y = y
+    // Z = z
+    // SinPhi = py/sqrt(px^2+py^2)
+    // DzDs = pz/sqrt(px^2+py^2)
+    // QPt = 1/sqrt(px^2+py^2)
+
+    const double track_pt3 = std::pow(track_pt, 3.);
+
+    Eigen::Matrix<double, 6, 5> Jrot;
+    Jrot(0, 0) = 0;  // dY/dx
+    Jrot(1, 0) = 1;  // dY/dy
+    Jrot(2, 0) = 0;  // dY/dz
+    Jrot(3, 0) = 0;  // dY/dpx
+    Jrot(4, 0) = 0;  // dY/dpy
+    Jrot(5, 0) = 0;  // dY/dpz
+
+    Jrot(0, 1) = 0;  // dZ/dx
+    Jrot(1, 1) = 0;  // dZ/dy
+    Jrot(2, 1) = 1;  // dZ/dz
+    Jrot(3, 1) = 0;  // dZ/dpx
+    Jrot(4, 1) = 0;  // dZ/dpy
+    Jrot(5, 1) = 0;  // dZ/dpz
+
+    Jrot(0, 2) = 0;                                 // dSinPhi/dx
+    Jrot(1, 2) = 0;                                 // dSinPhi/dy
+    Jrot(2, 2) = 0;                                 // dSinPhi/dz
+    Jrot(3, 2) = -track_py * track_px / track_pt3;  // dSinPhi/dpx
+    Jrot(4, 2) = track_px * track_px / track_pt3;   // dSinPhi/dpy
+    Jrot(5, 2) = 0;                                 // dSinPhi/dpz
+
+    Jrot(0, 3) = 0;                                 // dDzDs/dx
+    Jrot(1, 3) = 0;                                 // dDzDs/dy
+    Jrot(2, 3) = 0;                                 // dDzDs/dz
+    Jrot(3, 3) = -track_px * track_pz / track_pt3;  // dDzDs/dpx
+    Jrot(4, 3) = -track_py * track_pz / track_pt3;  // dDzDs/dpy
+    Jrot(5, 3) = 1. / track_pt;                     // dDzDs/dpz
+
+    Jrot(0, 4) = 0;                      // dQPt/dx
+    Jrot(1, 4) = 0;                      // dQPt/dy
+    Jrot(2, 4) = 0;                      // dQPt/dz
+    Jrot(3, 4) = -track_px / track_pt3;  // dQPt/dpx
+    Jrot(4, 4) = -track_py / track_pt3;  // dQPt/dpy
+    Jrot(5, 4) = 0;                      // dQPt/dpz
+
+    Eigen::Matrix<double, 5, 5> kfCov = Jrot.transpose() * xyzCov * Jrot;
+
+    int ctr = 0;
+    for (int i = 0; i < 5; i++)
     {
-      if (i >= j)
+      for (int j = 0; j < 5; j++)
       {
-        kftrack.SetCov(ctr, kfCov(i, j));
-        ctr++;
+        if (i >= j)
+        {
+          kftrack.SetCov(ctr, kfCov(i, j));
+          ctr++;
+        }
       }
     }
-  }
-*/
+  */
   std::vector<TrkrDefs::cluskey> propagated_track;
 
   kftrack.SetX(track_x * cos(track_phi) + track_y * sin(track_phi));
   kftrack.SetY(-track_x * sin(track_phi) + track_y * cos(track_phi));
   kftrack.SetZ(track_z);
 
-  if (kftrack.GetSignCosPhi() < 0) {
+  if (kftrack.GetSignCosPhi() < 0)
+  {
     kftrack.SetSinPhi(-kftrack.GetSinPhi());
     kftrack.SetDzDs(-kftrack.GetDzDs());
-    //kftrack.SetQPt(-kftrack.GetQPt());
-    kftrack.SetCov(3,-kftrack.GetCov(3));
-    kftrack.SetCov(4,-kftrack.GetCov(4));
-    kftrack.SetCov(6,-kftrack.GetCov(6));
-    kftrack.SetCov(7,-kftrack.GetCov(7));
-    kftrack.SetCov(10,-kftrack.GetCov(10));
-    kftrack.SetCov(11,-kftrack.GetCov(11));
+    // kftrack.SetQPt(-kftrack.GetQPt());
+    kftrack.SetCov(3, -kftrack.GetCov(3));
+    kftrack.SetCov(4, -kftrack.GetCov(4));
+    kftrack.SetCov(6, -kftrack.GetCov(6));
+    kftrack.SetCov(7, -kftrack.GetCov(7));
+    kftrack.SetCov(10, -kftrack.GetCov(10));
+    kftrack.SetCov(11, -kftrack.GetCov(11));
   }
 
-
-
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "initial track params:" << std::endl;
     std::cout << "X: " << kftrack.GetX() << std::endl;
@@ -1250,7 +1344,6 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
     std::cout << std::endl;
   }
 
-
   // get layer for each cluster
   std::vector<unsigned int> layers;
   std::transform(ckeys.begin(), ckeys.end(), std::back_inserter(layers), [](const TrkrDefs::cluskey& key)
@@ -1258,7 +1351,7 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
 
   double old_phi = track_phi;
   unsigned int old_layer = TrkrDefs::getLayer(ckeys[0]);
-  if (Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "first layer: " << old_layer << std::endl;
     std::cout << "cluster (x,y,z) = (" << globalPositions.at(ckeys[0])(0) << ", " << globalPositions.at(ckeys[0])(1) << ", " << globalPositions.at(ckeys[0])(2) << ")" << std::endl;
@@ -1270,19 +1363,27 @@ std::vector<TrkrDefs::cluskey> PHSimpleKFProp::PropagateTrack(TrackSeed* track, 
   GPUTPCTrackParam::GPUTPCTrackFitParam fp{};
   aliceSeed.CalculateFitParameters(fp);
 
-  for(int step = 0; step <= _max_propagation_steps; ++step)
+  for (int step = 0; step <= _max_propagation_steps; ++step)
   {
-    if(Verbosity()>1) { std::cout << std::endl << "------------------------" << std::endl << "step " << step << std::endl;
-}
-    if(!PropagateStep(old_layer,old_phi,direction,propagated_track,ckeys,aliceSeed,fp,globalPositions)) { break;
-}
+    if (Verbosity() > 1)
+    {
+      std::cout << std::endl
+                << "------------------------" << std::endl
+                << "step " << step << std::endl;
+    }
+    if (!PropagateStep(old_layer, old_phi, direction, propagated_track, ckeys, aliceSeed, fp, globalPositions))
+    {
+      break;
+    }
   }
 
-  if(Verbosity()>1)
+  if (Verbosity() > 1)
   {
     std::cout << "propagated track has " << propagated_track.size() << " clusters, at layers: ";
-    for(auto c : propagated_track) { std::cout << (int)TrkrDefs::getLayer(c) << ", ";
-}
+    for (auto c : propagated_track)
+    {
+      std::cout << (int) TrkrDefs::getLayer(c) << ", ";
+    }
     std::cout << std::endl;
   }
   return propagated_track;
@@ -1346,18 +1447,20 @@ std::vector<keylist> PHSimpleKFProp::RemoveBadClusters(const std::vector<keylist
 
 void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, const PositionMap& positions, std::vector<float>& trackChi2, PHTimer& timer)
 {
-
   // testing with presets for rejection
   PHGhostRejection rejector(Verbosity(), seeds);
   // If you want to reject tracks (before they are are made) can set them here:
   // rejector.set_min_pt_cut(0.2);
   // rejector.set_must_span_sectors(true);
   // rejector.set_min_clusters(8);
-  
-  for (unsigned int itrack=0; itrack < seeds.size(); ++itrack) 
+
+  for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
   {
     // cut tracks with too-few clusters (or that don;t span a sector boundary, if desired)
-    if (rejector.cut_from_clusters(itrack)) { continue; }
+    if (rejector.cut_from_clusters(itrack))
+    {
+      continue;
+    }
 
     auto& seed = seeds[itrack];
     /// The ALICEKF gives a better charge determination at high pT
@@ -1384,14 +1487,15 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
     std::cout << "ghost rejection find time " << timer.elapsed() << std::endl;
   }
 
-  for (unsigned int itrack=0; itrack < seeds.size(); ++itrack) 
+  for (unsigned int itrack = 0; itrack < seeds.size(); ++itrack)
   {
-    if (rejector.is_rejected(itrack)) {
+    if (rejector.is_rejected(itrack))
+    {
       if (Verbosity() > 0)
       {
-        std::cout << " Seed " << ((int)itrack) << " rejected. Not getting published." << std::endl;
+        std::cout << " Seed " << ((int) itrack) << " rejected. Not getting published." << std::endl;
       }
-      continue; 
+      continue;
     }
     auto& seed = seeds[itrack];
     _track_map->insert(&seed);
@@ -1399,7 +1503,7 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
     int q = seed.get_charge();
     if (Verbosity() > 0)
     {
-      std::cout << "Publishing seed " << ((int)itrack)
+      std::cout << "Publishing seed " << ((int) itrack)
                 << " q " << q
                 << " qOverR " << fabs(seed.get_qOverR()) * q
                 << " x " << seed.get_x()
@@ -1409,7 +1513,7 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
                 << " eta " << seed.get_eta()
                 << " phi " << seed.get_phi()
                 << std::endl;
-    } 
+    }
   }
 }
 

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -58,7 +58,7 @@ class PHSimpleKFProp : public SubsysReco
       _fieldDir = -1;
     }
   }
-  void ghostRejection(bool set_value=true) { m_ghostrejection = set_value; }
+  void ghostRejection(bool set_value = true) { m_ghostrejection = set_value; }
   void magFieldFile(const std::string& fname) { m_magField = fname; }
   void set_max_window(double s) { _max_dist = s; }
   void useConstBField(bool opt) { _use_const_field = opt; }
@@ -71,7 +71,11 @@ class PHSimpleKFProp : public SubsysReco
   }
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_pp_mode(bool mode) { _pp_mode = mode; }
-  enum class PropagationDirection { Outward, Inward };
+  enum class PropagationDirection
+  {
+    Outward,
+    Inward
+  };
 
   void setNeonFraction(double frac) { Ne_frac = frac; };
   void setArgonFraction(double frac) { Ar_frac = frac; };
@@ -186,7 +190,6 @@ class PHSimpleKFProp : public SubsysReco
   double CF4_frac = 0.20;
   double N2_frac = 0.00;
   double isobutane_frac = 0.05;
-
 };
 
 #endif


### PR DESCRIPTION
Changes to the propagator recently introduced some cuts on clusters inside the physical volume of the TPC. This means we don't reconstruct any seeds outside of the physical volume which is where the seeds exist in streaming data before they are matched to the silicon. This PR fixes that. Note that most of the line changes in this PR are from the clang-format commit to make the code more readable - the actual code changes are very minimal.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

