### PR TITLE
Tpot qa dropped waveforms

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1037,11 +1037,7 @@ int Fun4AllStreamingInputManager::FillMicromegas()
       << std::dec << std::endl;
   }
 
-  // cleanup all data that corresponds too early BCO
-  /*
-   * m_MicromegasRawHitMap.empty() does not need to be checked here, FillMicromegasPool returns non zero
-   * if this map is empty which is handled above
-   */
+  // cleanup all data that correspond too early BCO. Said data is effectively dropped
   while (m_MicromegasRawHitMap.begin()->first < first_bco)
   {
     if (Verbosity() > 2)
@@ -1053,10 +1049,9 @@ int Fun4AllStreamingInputManager::FillMicromegas()
     }
 
     for (auto iter : m_MicromegasInputVector)
-    {
-      iter->CleanupUsedPackets(m_MicromegasRawHitMap.begin()->first);
-    }
+    { static_cast<SingleMicromegasPoolInput*>(iter)->CleanupUsedPackets_with_qa(m_MicromegasRawHitMap.begin()->first, true); }
 
+    // also cleanup internal map
     m_MicromegasRawHitMap.begin()->second.MicromegasRawHitVector.clear();
     m_MicromegasRawHitMap.erase(m_MicromegasRawHitMap.begin());
     iret = FillMicromegasPool();
@@ -1085,6 +1080,7 @@ int Fun4AllStreamingInputManager::FillMicromegas()
       iter->CleanupUsedPackets(m_MicromegasRawHitMap.begin()->first);
     }
 
+    // also cleanup internal map
     m_MicromegasRawHitMap.begin()->second.MicromegasRawHitVector.clear();
     m_MicromegasRawHitMap.erase(m_MicromegasRawHitMap.begin());
     if (m_MicromegasRawHitMap.empty())

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -63,11 +63,21 @@ SingleMicromegasPoolInput::~SingleMicromegasPoolInput()
 {
   for( const auto& [packet,counts]:m_waveform_count_total )
   {
-    const auto& dropped = m_waveform_count_dropped[packet];
     std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - packet: " << packet << std::endl;
     std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - waveform_count_total: " << counts << std::endl;
-    std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - waveform_count_dropped: " << dropped << std::endl;
-    std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - ratio: " << double(dropped)/counts << std::endl;
+
+    {
+      const auto& dropped = m_waveform_count_dropped_bco[packet];
+      std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - waveform_count_dropped (bco): " << dropped << std::endl;
+      std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - ratio (bco): " << double(dropped)/counts << std::endl;
+    }
+
+    {
+      const auto& dropped = m_waveform_count_dropped_pool[packet];
+      std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - waveform_count_dropped (pool): " << dropped << std::endl;
+      std::cout << "SingleMicromegasPoolInput::~SingleMicromegasPoolInput - ratio (pool): " << double(dropped)/counts << std::endl;
+    }
+
     std::cout << std::endl;
   }
 }
@@ -199,8 +209,8 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
       if (!bco_matching_information.is_verified())
       {
         std::cout << "SingleMicromegasPoolInput::FillPool - bco_matching not verified, dropping packet" << std::endl;
-        m_waveform_count_dropped[packet_id] += nwf;
-        h_waveform_count_dropped->Fill( std::to_string(packet_id).c_str(), nwf );
+        m_waveform_count_dropped_bco[packet_id] += nwf;
+        h_waveform_count_dropped_bco->Fill( std::to_string(packet_id).c_str(), nwf );
         bco_matching_information.cleanup();
         continue;
       }
@@ -232,8 +242,8 @@ void SingleMicromegasPoolInput::FillPool(const unsigned int /*nbclks*/)
         else
         {
           // increment counter and histogram
-          ++m_waveform_count_dropped[packet_id];
-          h_waveform_count_dropped->Fill( std::to_string(packet_id).c_str(), 1 );
+          ++m_waveform_count_dropped_bco[packet_id];
+          h_waveform_count_dropped_bco->Fill( std::to_string(packet_id).c_str(), 1 );
 
           // skip the waverform
           continue;
@@ -552,11 +562,14 @@ void SingleMicromegasPoolInput::createQAHistos()
   // total number of waveform per packet
   h_waveform_count_total = new TH1F( "h_MicromegasBCOQA_waveform_count_total", "Total number of waveforms per packet", m_npackets_active, 0, m_npackets_active );
 
-  // number of dropped waveform per packet
-  h_waveform_count_dropped = new TH1F( "h_MicromegasBCOQA_waveform_count_dropped", "Number of dropped waveforms per packet", m_npackets_active, 0, m_npackets_active );
+  // number of dropped waveform per packet due to bco mismatch
+  h_waveform_count_dropped_bco = new TH1F( "h_MicromegasBCOQA_waveform_count_dropped_bco", "Number of dropped waveforms per packet (bco)", m_npackets_active, 0, m_npackets_active );
+
+  // number of dropped waveform per packet due to fun4all pool mismatch
+  h_waveform_count_dropped_pool = new TH1F( "h_MicromegasBCOQA_waveform_count_dropped_pool", "Number of dropped waveforms per packet (pool)", m_npackets_active, 0, m_npackets_active );
 
   // define axis
-  for( const auto& h:std::initializer_list<TH1*>{h_waveform_count_total, h_waveform_count_dropped} )
+  for( const auto& h:std::initializer_list<TH1*>{h_waveform_count_total, h_waveform_count_dropped_bco, h_waveform_count_dropped_pool} )
   {
     h->GetXaxis()->SetBinLabel(1, "5001" );
     h->GetXaxis()->SetBinLabel(2, "5002" );
@@ -565,7 +578,7 @@ void SingleMicromegasPoolInput::createQAHistos()
   }
 
   // register all histograms to histogram manager
-  for( const auto& h:std::initializer_list<TH1*>{h_packet, h_waveform, h_packet_stat, h_waveform_count_total, h_waveform_count_dropped} )
+  for( const auto& h:std::initializer_list<TH1*>{h_packet, h_waveform, h_packet_stat, h_waveform_count_total, h_waveform_count_dropped_bco, h_waveform_count_dropped_pool} )
   {
     h->SetFillStyle(1001);
     h->SetFillColor(kYellow);

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -79,8 +79,11 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   // keep track of total number of waveforms per packet
   std::map<int,uint64_t> m_waveform_count_total{};
 
-  // keep track of dropped waveforms per packet
-  std::map<int,uint64_t> m_waveform_count_dropped{};
+  // keep track of dropped waveforms per packet, due to BCO mismatched
+  std::map<int,uint64_t> m_waveform_count_dropped_bco{};
+
+  // keep track of dropped waveforms per packet, due to fun4all pool mismatch
+  std::map<int,uint64_t> m_waveform_count_dropped_pool{};
 
   //!@name QA histograms
   //@{
@@ -97,9 +100,12 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   //! total number of waveforms per packet
   TH1 *h_waveform_count_total{nullptr};
 
-  //! total number of dropped waveforms per packet
+  //! total number of dropped waveforms per packet due to bco mismatch
   /*! waveforms are dropped when their FEE-BCO cannot be associated to any global BCO */
-  TH1 *h_waveform_count_dropped{nullptr};
+  TH1 *h_waveform_count_dropped_bco{nullptr};
+
+  //! total number of dropped waveforms per packet due to fun4all pool mismatch
+  TH1 *h_waveform_count_dropped_pool{nullptr};
 
   //@}
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -24,7 +24,13 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   explicit SingleMicromegasPoolInput(const std::string &name = "SingleMicromegasPoolInput");
   ~SingleMicromegasPoolInput() override;
   void FillPool(const unsigned int nevents = 1) override;
-  void CleanupUsedPackets(const uint64_t bclk) override;
+
+  void CleanupUsedPackets(const uint64_t bclk) override
+  { CleanupUsedPackets_with_qa(bclk,false); }
+
+  //! specialized verion of cleaning up packets, with an extra flag about wheter the cleanup hits are dropped or not
+  void CleanupUsedPackets_with_qa(const uint64_t bclk, bool /*dropped */);
+
   void ClearCurrentEvent() override;
   bool GetSomeMoreEvents();
   void Print(const std::string &what = "ALL") const override;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR adds more offline QA histograms to keep track of how many TPOT waveforms are 'dropped' by fun4all because of not being associated to a given GL1 BCO, or because of being processed after a given GL1 trigger BCO has been processed (due to effective pool depth being too small)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

