### PR TITLE
add laser rejection flag

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -36,6 +36,7 @@
 #include <ffarawobjects/Gl1RawHit.h>
 #include <tpc/TpcDistortionCorrectionContainer.h>
 #include <tpc/TpcGlobalPositionWrapper.h>
+#include <tpc/LaserEventInfo.h>
 
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
@@ -226,6 +227,27 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   auto mvtxGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
   auto inttGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
   auto mmGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
+  auto laserEventInfo = findNode::getClass<LaserEventInfo>(topNode, "LaserEventInfo");
+
+  if (m_rejectLaserEvent)
+  {
+    if (!laserEventInfo)
+    {
+      std::cout << "Missing LaserEventInfo node, can't continue" << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+    else
+    {
+      if (laserEventInfo->isLaserEvent())
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "This is a laser event!" << std::endl;
+        }
+        return Fun4AllReturnCodes::EVENT_OK;
+      }
+    }
+  }
 
   if (!mmGeom)
   {

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -62,6 +62,8 @@ class TrackResiduals : public SubsysReco
 
   void set_doMicromegasOnly( bool value ) { m_doMicromegasOnly = value; }
 
+  void set_rejectLaserEvent( bool value ) { m_rejectLaserEvent = value; }
+
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
                              TrkrCluster *cluster, ActsGeometry *geometry);
@@ -123,6 +125,8 @@ class TrackResiduals : public SubsysReco
   unsigned int m_min_cluster_size = 0;
 
   bool m_doMicromegasOnly = false;
+
+  bool m_rejectLaserEvent = true;
 
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Laser event rejection flag is added. By default, flag is set to true, so it will require node tree existing and reject laser event. For specific laser study, need to set flag to false.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

