### PR TITLE
fix: matching tuple filling

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -451,13 +451,12 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       unsigned int siid = phtrk_iter_si;
   if(_test_windows)
   {
-      _tree->Fill((float) m_event,
-                  (float) si_phi, (float) si_eta, (float) si_x, (float) si_y, (float) si_z,
-                  (float) tpc_phi, (float) tpc_eta, (float) tpc_x, (float) tpc_y, (float) tpc_z,
-                  (float) siid, (float) tpcid);
-
-	  _tree->Fill((int) si_crossing, (int) si_q, (float) si_px, (float) si_py, (float) si_pz,
-                  (int) tpc_q,  (float) tpc_px, (float) tpc_py, (float) tpc_pz);
+    float data[] = {(float) m_event, (float) si_crossing, (float) si_q,
+                    (float) si_phi, (float) si_eta, (float) si_x, (float) si_y, (float) si_z, (float) si_px, (float) si_py, (float) si_pz,
+                    (float) tpc_q, (float) tpc_phi, (float) tpc_eta, (float) tpc_x, (float) tpc_y, (float) tpc_z,
+                    (float) tpc_px, (float) tpc_py, (float) tpc_pz,
+                    (float) tpcid, (float) siid};
+    _tree->Fill(data);
   }
       if (fabs(tpc_eta - si_eta) < _eta_search_win * mag)
       {


### PR DESCRIPTION
Fixes the filling of the silicon-tpc track matching tuple filling

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

