### PR TITLE
fix: make laser event identifier skip rest of event

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -227,28 +227,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
   auto mvtxGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
   auto inttGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_INTT");
   auto mmGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS_FULL");
-  auto laserEventInfo = findNode::getClass<LaserEventInfo>(topNode, "LaserEventInfo");
-
-  if (m_rejectLaserEvent)
-  {
-    if (!laserEventInfo)
-    {
-      std::cout << "Missing LaserEventInfo node, can't continue" << std::endl;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-    else
-    {
-      if (laserEventInfo->isLaserEvent())
-      {
-        if (Verbosity() > 1)
-        {
-          std::cout << "This is a laser event!" << std::endl;
-        }
-        return Fun4AllReturnCodes::EVENT_OK;
-      }
-    }
-  }
-
+ 
   if (!mmGeom)
   {
     mmGeom = findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MICROMEGAS");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -62,8 +62,6 @@ class TrackResiduals : public SubsysReco
 
   void set_doMicromegasOnly( bool value ) { m_doMicromegasOnly = value; }
 
-  void set_rejectLaserEvent( bool value ) { m_rejectLaserEvent = value; }
-
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
                              TrkrCluster *cluster, ActsGeometry *geometry);
@@ -125,8 +123,6 @@ class TrackResiduals : public SubsysReco
   unsigned int m_min_cluster_size = 0;
 
   bool m_doMicromegasOnly = false;
-
-  bool m_rejectLaserEvent = true;
 
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();

--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -166,12 +166,12 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
   TF1 *f0 = new TF1("f0", "gausn(0)");
   f0->SetParameters(itMaxContent_0, itMax_0, 1);
   f0->SetParLimits(1, itMax_0 - 2, itMax_0 + 2);
-  m_itHist_0->Fit(f0, "B");
+  m_itHist_0->Fit(f0, "Bq0");
 
   TF1 *f1 = new TF1("f1", "gausn(0)");
   f1->SetParameters(itMaxContent_1, itMax_1, 1);
   f1->SetParLimits(1, itMax_1 - 2, itMax_1 + 2);
-  m_itHist_1->Fit(f1, "B");
+  m_itHist_1->Fit(f1, "Bq0");
 
 
   if ((itMaxContent_0 / itMeanContent_0 >= 7 && itMaxContent_0 > 1000) || (itMaxContent_1 / itMeanContent_1 >= 7 && itMaxContent_1 > 1000))

--- a/offline/packages/tpc/LaserEventIdentifier.cc
+++ b/offline/packages/tpc/LaserEventIdentifier.cc
@@ -187,6 +187,10 @@ int LaserEventIdentifier::process_event(PHCompositeNode *topNode)
     peakSample1 = (int) itMax_1;
     peakWidth0 = f0->GetParameter(2);
     peakWidth1 = f1->GetParameter(2);
+    if(m_rejectEvent)
+    {
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
   }
   else
   {

--- a/offline/packages/tpc/LaserEventIdentifier.h
+++ b/offline/packages/tpc/LaserEventIdentifier.h
@@ -32,7 +32,7 @@ class LaserEventIdentifier : public SubsysReco
 
   void set_debug(bool debug) { m_debug = debug; }
   void set_debug_name(const std::string &name) { m_debugFileName = name; }
-
+  void set_reject_event(bool reject) { m_rejectEvent = reject; }
  private:
   int m_time_samples_max=425;
 
@@ -41,7 +41,7 @@ class LaserEventIdentifier : public SubsysReco
   PHG4TpcCylinderGeomContainer *m_geom_container = nullptr;
 
   LaserEventInfo *m_laserEventInfo = nullptr ;
-
+  bool m_rejectEvent = true;
   bool m_debug = false;
   std::string m_debugFileName = "LaserEventIdentifier_debug.root";
   TFile *m_debugFile = nullptr;


### PR DESCRIPTION
This moves the reject event into the laser identifier itself, so that we avoid reconstructing full events with the laser pulse in it if chosen to do so.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

