### PR TITLE
Ffa return abortprocessing

### DIFF
--- a/offline/database/rundb/Makefile.am
+++ b/offline/database/rundb/Makefile.am
@@ -3,6 +3,8 @@ AUTOMAKE_OPTIONS = foreign
 lib_LTLIBRARIES = \
     libcalotemp.la
 
+bin_PROGRAMS = testODBC
+
 AM_LDFLAGS = \
   -L$(libdir) \
   -L$(OFFLINE_MAIN)/lib \
@@ -19,6 +21,9 @@ pkginclude_HEADERS = \
 
 libcalotemp_la_SOURCES = \
   CaloTemp.cc 
+
+testODBC_SOURCES = testODBC.cc
+testODBC_LDADD = libcalotemp.la
 
 libcalotemp_la_LDFLAGS = \
   -L$(libdir) \

--- a/offline/database/rundb/testODBC.cc
+++ b/offline/database/rundb/testODBC.cc
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <typeinfo>
+#include <odbc++/connection.h>
+#include <odbc++/drivermanager.h>
+#include <odbc++/resultset.h>
+#include <odbc++/resultsetmetadata.h>
+
+int main() {
+    try {
+
+
+      std::cout << "Testing ODBC." << std::endl;
+
+      odbc::Connection* conn = odbc::DriverManager::getConnection("DSN=spinDB");
+      std::cout << "Connected to spinDB." << std::endl;
+      
+      odbc::Statement* stmt = conn->createStatement();
+      std::string query = "SELECT mbdvtx FROM spin WHERE runnumber = 45876";
+      
+      odbc::ResultSet* rs = stmt->executeQuery(query);
+
+      while (rs->next()) {
+	// ======== Using getString() ============ //
+	std::cout << "getString method:" << std::endl;
+	std::string mbdvtx = rs->getString("mbdvtx");
+	std::cout << mbdvtx << std::endl;
+	// ======================================= //
+
+	// ======== Using getBytes() ============ //
+	std::cout << "getBytes method:" << std::endl;
+	odbc::Bytes bytes = rs->getBytes("mbdvtx");
+	const signed char* data = bytes.getData();
+	std::string strdata(reinterpret_cast<const char*>(data));
+	std::cout << strdata << std::endl;
+	// ======================================= //
+      }
+
+      delete rs;
+      delete stmt;
+      delete conn;
+    } catch (odbc::SQLException& e) {
+      std::cerr << "SQL Error: " << e.getMessage() << std::endl;
+    }
+    
+    return 0;
+}

--- a/offline/framework/fun4all/Fun4AllReturnCodes.h
+++ b/offline/framework/fun4all/Fun4AllReturnCodes.h
@@ -6,6 +6,7 @@
 // In general negative return codes signal some fatal condition where continuing is just a waste of cpu
 
 // SubsysReco module return codes:
+// ABORTPROCESSING: Aborts processing of events and proceeds to call EndRun and End
 // ABORTRUN: signals that processing should be aborted for this run, the process will exit with a non zero exit
 // ABORTEVENT: abort reconstruction of the current event, reset everything and process the next event
 // EVENT_OK: generic good return
@@ -22,6 +23,7 @@ namespace Fun4AllReturnCodes
 {
   enum
   {
+    ABORTPROCESSING = -4,
     ABORTRUN = -2,
     ABORTEVENT = -1,
     EVENT_OK = 0,

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -636,6 +636,13 @@ int Fun4AllServer::process_event()
         std::cout << "Fun4AllServer::Abort Run by " << Subsystem.first->Name() << std::endl;
         return Fun4AllReturnCodes::ABORTRUN;
       }
+      else if (RetCodes[icnt] == Fun4AllReturnCodes::ABORTPROCESSING)
+      {
+        eventbad = 1;
+        retcodesmap[Fun4AllReturnCodes::ABORTPROCESSING]++;
+        std::cout << "Fun4AllServer::Abort Processing by " << Subsystem.first->Name() << std::endl;
+        return Fun4AllReturnCodes::ABORTPROCESSING;
+      }
       else
       {
         std::cout << "Fun4AllServer::Unknown return code: "
@@ -1457,7 +1464,7 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
                 << (icnt + 1) << " from run " << runnumber << std::endl;
     }
 
-    if (icnt == 0 and Verbosity() > VERBOSITY_QUIET)
+    if (icnt == 0 && Verbosity() > VERBOSITY_QUIET)
     {
       // increase verbosity for the first event in verbose modes
       int iverb = Verbosity();
@@ -1466,7 +1473,7 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
 
     iret = process_event();
 
-    if (icnt == 0 and Verbosity() > VERBOSITY_QUIET)
+    if (icnt == 0 && Verbosity() > VERBOSITY_QUIET)
     {
       // increase verbosity for the first event in verbose modes
       int iverb = Verbosity();

--- a/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
+++ b/offline/packages/PHGenFitPkg/Example/minimumTestPHGenFit.cc
@@ -4,99 +4,99 @@
  *  \author		Haiwang Yu <yuhw@nmsu.edu>
  */
 
-//STL
+// STL
 #include <vector>
 
-//ROOT
-#include <TVector3.h>
+// ROOT
 #include <TMatrixDSym.h>
+#include <TVector3.h>
 
-//GenFit
+// GenFit
 #include <GenFit/AbsTrackRep.h>
 #include <GenFit/RKTrackRep.h>
 #include <GenFit/StateOnPlane.h>
 
-//PHGenFit
+// PHGenFit
 #include <phgenfit/Fitter.h>
-#include <phgenfit/Track.h>
 #include <phgenfit/Measurement.h>
 #include <phgenfit/PlanarMeasurement.h>
 #include <phgenfit/SpacepointMeasurement.h>
+#include <phgenfit/Track.h>
 
 #include <phfield/PHFieldUtility.h>
 
-#define LogDEBUG    std::cout<<"DEBUG: "<<__LINE__<<"\n"
+#define LogDEBUG std::cout << "DEBUG: " << __LINE__ << "\n"
 
 void get_seed(TVector3& seed_pos, TVector3& seed_mom, TMatrixDSym& seed_cov)
 {
-	seed_pos.SetXYZ(0,0,0);
-	seed_mom.SetXYZ(10,-5,0);
-	seed_cov.ResizeTo(6,6);
+  seed_pos.SetXYZ(0, 0, 0);
+  seed_mom.SetXYZ(10, -5, 0);
+  seed_cov.ResizeTo(6, 6);
 }
 
 std::vector<TVector3> get_raw_measurements()
 {
-	std::vector<TVector3> v_pos;
-	v_pos.push_back(TVector3(2.22459,-1.54767,-2.37792));
-	v_pos.push_back(TVector3(3.80050,-2.64444,-2.16561));
-	v_pos.push_back(TVector3(7.80344,-5.41815,-1.98928));
-	v_pos.push_back(TVector3(8.63214,-5.97797,-1.59626));
-	return v_pos;
+  std::vector<TVector3> v_pos;
+  v_pos.emplace_back(2.22459, -1.54767, -2.37792);
+  v_pos.emplace_back(3.80050, -2.64444, -2.16561);
+  v_pos.emplace_back(7.80344, -5.41815, -1.98928);
+  v_pos.emplace_back(8.63214, -5.97797, -1.59626);
+  return v_pos;
 }
 
-int main(int argc, char**argv) {
+int main(int /*argc*/, char** /*argv*/)
+{
+  //! Initiallize Geometry, Field, Fitter
+  PHGenFit::Fitter* fitter = new PHGenFit::Fitter("sPHENIX_Geo.root",
+                                                  PHFieldUtility::BuildFieldMap(PHFieldUtility::DefaultFieldConfig(), 1),
+                                                  "KalmanFitter", "RKTrackRep", false);
 
-	//! Initiallize Geometry, Field, Fitter
-	PHGenFit::Fitter* fitter = new PHGenFit::Fitter("sPHENIX_Geo.root",
-	    PHFieldUtility::BuildFieldMap(PHFieldUtility::DefaultFieldConfig(), 1),
-	    "KalmanFitter","RKTrackRep",false);
+  //! Build TrackRep from particle assumption
+  int pid = -13;  // mu+
+  genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pid);
 
-	//! Build TrackRep from particle assumption
-	int pid = -13; //mu+
-	genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pid);
+  //! Initiallize track with seed from pattern recognition
+  TVector3 seed_pos;
+  TVector3 seed_mom;
+  TMatrixDSym seed_cov;
+  get_seed(seed_pos, seed_mom, seed_cov);
+  PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos, seed_mom, seed_cov);
 
-	//! Initiallize track with seed from pattern recognition
-	TVector3 seed_pos;
-	TVector3 seed_mom;
-	TMatrixDSym seed_cov;
-	get_seed(seed_pos,seed_mom, seed_cov);
-	PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos,seed_mom, seed_cov);
+  //! Create measurements
+  std::vector<TVector3> v_pos = get_raw_measurements();
+  double res_phi = 0.005;  // cm
+  double res_z = 0.04;     // cm
+  std::vector<PHGenFit::Measurement*> measurements;
+  for (const auto& pos : v_pos)
+  {
+    TVector3 n(pos.x(), pos.Y(), 0);
+    PHGenFit::Measurement* meas = new PHGenFit::PlanarMeasurement(pos, n, res_phi, res_z);
+    // PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(pos,res_phi);
+    meas->getMeasurement()->Print();
+    measurements.push_back(meas);
+  }
 
-	//! Create measurements
-	std::vector<TVector3> v_pos = get_raw_measurements();
-	double res_phi = 0.005; //cm
-	double res_z = 0.04; //cm
-	std::vector<PHGenFit::Measurement*> measurements;
-	for (unsigned int imeasurement = 0; imeasurement < v_pos.size(); imeasurement++) {
-		TVector3 pos = v_pos[imeasurement];
-		TVector3 n(pos.x(),pos.Y(),0);
-		PHGenFit::Measurement* meas = new PHGenFit::PlanarMeasurement(pos,n,res_phi, res_z);
-		//PHGenFit::Measurement* meas = new PHGenFit::SpacepointMeasurement(pos,res_phi);
-		meas->getMeasurement()->Print();
-		measurements.push_back(meas);
-	}
+  //! Add measurements to track
+  track->addMeasurements(measurements);
 
-	//! Add measurements to track
-	track->addMeasurements(measurements);
+  //! Fit the track
+  fitter->processTrack(track, false);
 
-	//! Fit the track
-	fitter->processTrack(track, false);
+  //! Extrapolate to beam line
+  // genfit::MeasuredStateOnPlane* state = track->extrapolateToLine(TVector3(0, 0, 0), TVector3(0, 0, 1));
+  // genfit::MeasuredStateOnPlane* state = track->extrapolateToPoint(TVector3(0, 0, 0));
+  genfit::MeasuredStateOnPlane* state = track->extrapolateToCylinder(1., TVector3(0, 0, 0), TVector3(0, 0, 1));
+  state->Print();
+  delete state;
 
-	//! Extrapolate to beam line
-	//genfit::MeasuredStateOnPlane* state = track->extrapolateToLine(TVector3(0, 0, 0), TVector3(0, 0, 1));
-	//genfit::MeasuredStateOnPlane* state = track->extrapolateToPoint(TVector3(0, 0, 0));
-	genfit::MeasuredStateOnPlane* state = track->extrapolateToCylinder(1.,TVector3(0, 0, 0), TVector3(0, 0, 1));
-	state->Print();
-	delete state;
+  //! Event display, uncomment to use
+  // fitter->displayEvent();
 
-	//! Event display, uncomment to use
-	//fitter->displayEvent();
+  //! Comment off if want to keep event display.
 
-	//! Comment off if want to keep event display.
+  delete track;
 
-	delete track;
+  delete fitter;
 
-	delete fitter;
-
-	return 0;
+  return 0;
 }

--- a/offline/packages/PHGenFitPkg/Example/testPHGenFit.cc
+++ b/offline/packages/PHGenFitPkg/Example/testPHGenFit.cc
@@ -4,249 +4,256 @@
  *  \author		Haiwang Yu <yuhw@nmsu.edu>
  */
 
-//STL
+// STL
 #include <vector>
 
-//BOOST
-#include<boost/make_shared.hpp>
+// BOOST
+#include <boost/make_shared.hpp>
 
 #define SMART(expr) boost::shared_ptr<expr>
 #define NEW(expr) boost::make_shared<expr>
 
 #include <phfield/PHFieldUtility.h>
 
-//ROOT
-#include <TVector3.h>
-#include <TMatrixDSym.h>
+// ROOT
+#include <TCanvas.h>
 #include <TF1.h>
+#include <TFile.h>
 #include <TH1D.h>
 #include <TH2D.h>
-#include <TProfile.h>
-#include <TFile.h>
-#include <TTree.h>
-#include <TCanvas.h>
-#include <TROOT.h>
-#include <TStyle.h>
 #include <TMath.h>
+#include <TMatrixDSym.h>
+#include <TProfile.h>
+#include <TROOT.h>
 #include <TRandom.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <TVector3.h>
 
-//GenFit
+// GenFit
 #include <GenFit/AbsTrackRep.h>
 #include <GenFit/RKTrackRep.h>
 #include <GenFit/StateOnPlane.h>
 
-//PHGenFit
+// PHGenFit
 #include <phgenfit/Fitter.h>
-#include <phgenfit/Track.h>
 #include <phgenfit/Measurement.h>
 #include <phgenfit/PlanarMeasurement.h>
+#include <phgenfit/Track.h>
 
-#define LogDEBUG    std::cout<<"DEBUG: "<<__LINE__<<"\n"
+#define LogDEBUG std::cout << "DEBUG: " << __LINE__ << "\n"
 
-//void pause() {
-//  std::cout << "Press ENTER to continue..." << std::flush;
-//  std::cin.clear();  // use only if a human is involved
-//  std::cin.flush();  // use only if a human is involved
-//  std::cin.ignore( std::numeric_limits<std::streamsize>::max(), '\n' );
-//}
+// void pause() {
+//   std::cout << "Press ENTER to continue..." << std::flush;
+//   std::cin.clear();  // use only if a human is involved
+//   std::cin.flush();  // use only if a human is involved
+//   std::cin.ignore( std::numeric_limits<std::streamsize>::max(), '\n' );
+// }
 
-int main(int argc, char**argv) {
+int main(int /*argc*/, char ** /*argv*/)
+{
+  TFile *fPHG4Hits = TFile::Open("AnaSvtxTracksForGenFit.root", "read");
+  if (!fPHG4Hits)
+  {
+    std::cout << "No TFile Openned: " << __LINE__ << "\n";
+    return -1;
+  }
+  TTree *T = (TTree *) fPHG4Hits->Get("tracks");
+  if (!T)
+  {
+    std::cout << "No TTree Found: " << __LINE__ << "\n";
+    return -1;
+  }
 
-	TFile *fPHG4Hits = TFile::Open("AnaSvtxTracksForGenFit.root", "read");
-	if (!fPHG4Hits) {
-		std::cout << "No TFile Openned: " << __LINE__ << "\n";
-		return -1;
-	}
-	TTree *T = (TTree*) fPHG4Hits->Get("tracks");
-	if (!T) {
-		std::cout << "No TTree Found: " << __LINE__ << "\n";
-		return -1;
-	}
+  //! Initiallize Geometry, Field, Fitter
+  PHGenFit::Fitter *fitter = new PHGenFit::Fitter("sPHENIX_Geo.root", PHFieldUtility::BuildFieldMap(PHFieldUtility::DefaultFieldConfig(), 1));
 
-	//! Initiallize Geometry, Field, Fitter
-	PHGenFit::Fitter* fitter = new PHGenFit::Fitter("sPHENIX_Geo.root",PHFieldUtility::BuildFieldMap(PHFieldUtility::DefaultFieldConfig(), 1));
+  double resolution_detector_xy = 0.005 / 3.;  // 50/3. micron
 
+  TH2D *hpT_residual_vs_pT = new TH2D("hpT_residual_vs_pT", "#Delta pT/pT; pT[GeV/c]; #Delta pT/pT", 40, 0.5, 40.5, 1000, -1, 1);
 
-	double resolution_detector_xy = 0.005/3.; //50/3. micron
-
-
-	TH2D *hpT_residual_vs_pT = new TH2D("hpT_residual_vs_pT", "#Delta pT/pT; pT[GeV/c]; #Delta pT/pT", 40, 0.5, 40.5, 1000, -1, 1);
-
-	TH2D *hDCAr_vs_pT = new TH2D("hDCAr_vs_pT", "DCAr vs. p; p [GeV/c]; DCAr [cm]", 40, 0.5, 40.5, 1000, -0.1, 0.1);
-
+  TH2D *hDCAr_vs_pT = new TH2D("hDCAr_vs_pT", "DCAr vs. p; p [GeV/c]; DCAr [cm]", 40, 0.5, 40.5, 1000, -0.1, 0.1);
 
 #define NLAYERS 7
 
+  Float_t Cluster_x[NLAYERS];
+  Float_t Cluster_y[NLAYERS];
+  Float_t Cluster_z[NLAYERS];
+  Float_t Cluster_size_dphi[NLAYERS];
+  Float_t Cluster_size_dz[NLAYERS];
+  Float_t True_px;
+  Float_t True_py;
+  Float_t True_pz;
+  Float_t True_vx;
+  Float_t True_vy;
+  Float_t True_vz;
+  Float_t AlanDion_px;
+  Float_t AlanDion_py;
+  Float_t AlanDion_pz;
+  Float_t AlanDion_dca2d;
+  Int_t nhits;
 
-	Float_t Cluster_x[NLAYERS];
-	Float_t Cluster_y[NLAYERS];
-	Float_t Cluster_z[NLAYERS];
-	Float_t Cluster_size_dphi[NLAYERS];
-	Float_t Cluster_size_dz[NLAYERS];
-	Float_t True_px;
-	Float_t True_py;
-	Float_t True_pz;
-	Float_t True_vx;
-	Float_t True_vy;
-	Float_t True_vz;
-	Float_t AlanDion_px;
-	Float_t AlanDion_py;
-	Float_t AlanDion_pz;
-	Float_t AlanDion_dca2d;
-	Int_t nhits;
+  T->SetBranchAddress("nhits", &nhits);
+  T->SetBranchAddress("gpx", &True_px);
+  T->SetBranchAddress("gpy", &True_py);
+  T->SetBranchAddress("gpz", &True_pz);
+  T->SetBranchAddress("gvx", &True_vx);
+  T->SetBranchAddress("gvy", &True_vy);
+  T->SetBranchAddress("gvz", &True_vz);
+  T->SetBranchAddress("px", &AlanDion_px);
+  T->SetBranchAddress("py", &AlanDion_py);
+  T->SetBranchAddress("pz", &AlanDion_pz);
+  T->SetBranchAddress("dca2d", &AlanDion_dca2d);
+  T->SetBranchAddress("x", Cluster_x);
+  T->SetBranchAddress("y", Cluster_y);
+  T->SetBranchAddress("z", Cluster_z);
+  T->SetBranchAddress("size_dphi", Cluster_size_dphi);
+  T->SetBranchAddress("size_dz", Cluster_size_dz);
 
-	T->SetBranchAddress("nhits", &nhits);
-	T->SetBranchAddress("gpx", &True_px);
-	T->SetBranchAddress("gpy", &True_py);
-	T->SetBranchAddress("gpz", &True_pz);
-	T->SetBranchAddress("gvx", &True_vx);
-	T->SetBranchAddress("gvy", &True_vy);
-	T->SetBranchAddress("gvz", &True_vz);
-	T->SetBranchAddress("px", &AlanDion_px);
-	T->SetBranchAddress("py", &AlanDion_py);
-	T->SetBranchAddress("pz", &AlanDion_pz);
-	T->SetBranchAddress("dca2d", &AlanDion_dca2d);
-	T->SetBranchAddress("x", Cluster_x);
-	T->SetBranchAddress("y", Cluster_y);
-	T->SetBranchAddress("z", Cluster_z);
-	T->SetBranchAddress("size_dphi", Cluster_size_dphi);
-	T->SetBranchAddress("size_dz", Cluster_size_dz);
+  double nentries = 10;
+  // double nentries = T->GetEntries();
+  for (unsigned int ientry = 0; ientry < nentries; ++ientry)
+  {
+    // T->GetEntry(atoi(argv[1]));
+    if (ientry % 1000 == 0)
+    {
+      std::cout << "Processing: " << 100. * ientry / nentries << "%"
+                << "\n";
+    }
 
-	double nentries = 10;
-	//double nentries = T->GetEntries();
-	for (unsigned int ientry = 0; ientry < nentries; ++ientry) {
-		//T->GetEntry(atoi(argv[1]));
-		if(ientry%1000==0) std::cout<<"Processing: "<<100.*ientry/nentries <<"%"<<"\n";
+    T->GetEntry(ientry);
 
-		T->GetEntry(ientry);
+    if (nhits < 0)
+    {
+      // LogDEBUG;
+      continue;
+    }
 
-		if (nhits < 0) {
-			//LogDEBUG;
-			continue;
-		}
+    // true start values
+    TVector3 init_pos(0, 0, 0);  // cm
+    TVector3 True_mom(True_px, True_py, True_pz);
 
-		// true start values
-		TVector3 init_pos(0, 0, 0); //cm
-		TVector3 True_mom(True_px, True_py, True_pz);
+    // Seed: use smeared values
+    const bool smearPosMom = true;                        // init the Reps with smeared init_pos and True_mom
+    const double posSmear = 10 * resolution_detector_xy;  // cm
+    const double momSmear = 3. / 180. * TMath::Pi();      // rad
+    const double momMagSmear = 0.1;                       // relative
 
-		// Seed: use smeared values
-		const bool smearPosMom = true; // init the Reps with smeared init_pos and True_mom
-		const double posSmear = 10 * resolution_detector_xy;     // cm
-		const double momSmear = 3. / 180. * TMath::Pi();     // rad
-		const double momMagSmear = 0.1;   // relative
+    TVector3 seed_pos(init_pos);
+    TVector3 seed_mom(True_mom);
+    if (smearPosMom)
+    {
+      seed_pos.SetX(gRandom->Gaus(seed_pos.X(), posSmear));
+      seed_pos.SetY(gRandom->Gaus(seed_pos.Y(), posSmear));
+      seed_pos.SetZ(gRandom->Gaus(seed_pos.Z(), posSmear));
 
-		TVector3 seed_pos(init_pos);
-		TVector3 seed_mom(True_mom);
-		if (smearPosMom) {
-			seed_pos.SetX(gRandom->Gaus(seed_pos.X(), posSmear));
-			seed_pos.SetY(gRandom->Gaus(seed_pos.Y(), posSmear));
-			seed_pos.SetZ(gRandom->Gaus(seed_pos.Z(), posSmear));
+      seed_mom.SetPhi(gRandom->Gaus(True_mom.Phi(), momSmear));
+      seed_mom.SetTheta(gRandom->Gaus(True_mom.Theta(), momSmear));
+      seed_mom.SetMag(
+          gRandom->Gaus(True_mom.Mag(),
+                        momMagSmear * True_mom.Mag()));
+    }
 
-			seed_mom.SetPhi(gRandom->Gaus(True_mom.Phi(), momSmear));
-			seed_mom.SetTheta(gRandom->Gaus(True_mom.Theta(), momSmear));
-			seed_mom.SetMag(
-					gRandom->Gaus(True_mom.Mag(),
-							momMagSmear * True_mom.Mag()));
-		}
+    // approximate covariance
+    TMatrixDSym seed_cov(6);
 
-		// approximate covariance
-		TMatrixDSym seed_cov(6);
+    for (int idim = 0; idim < 3; ++idim)
+    {
+      seed_cov(idim, idim) = resolution_detector_xy * resolution_detector_xy;
+    }
+    for (int idim = 3; idim < 6; ++idim)
+    {
+      seed_cov(idim, idim) = pow(
+          resolution_detector_xy / NLAYERS / sqrt(3), 2);
+    }
 
-		for (int idim = 0; idim < 3; ++idim)
-			seed_cov(idim, idim) = resolution_detector_xy
-					* resolution_detector_xy;
-		for (int idim = 3; idim < 6; ++idim)
-			seed_cov(idim, idim) = pow(
-					resolution_detector_xy / NLAYERS / sqrt(3), 2);
+    //! Build TrackRep from particle assumption
+    int pid = -13;  // mu+
+    // SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
+    genfit::AbsTrackRep *rep = new genfit::RKTrackRep(pid);
 
+    //! Initiallize track with seed from pattern recognition
+    PHGenFit::Track *track = new PHGenFit::Track(rep, seed_pos,
+                                                 seed_mom, seed_cov);
 
-		//! Build TrackRep from particle assumption
-		int pid = -13; //mu+
-		//SMART(genfit::AbsTrackRep) rep = NEW(genfit::RKTrackRep)(pid);
-		genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pid);
+    //! Create measurements
+    std::vector<PHGenFit::Measurement *> measurements;
+    for (int imeas = 0; imeas < NLAYERS; imeas++)
+    {
+      TVector3 pos(Cluster_x[imeas], Cluster_y[imeas], Cluster_z[imeas]);
+      TVector3 n(Cluster_x[imeas], Cluster_y[imeas], 0);
+      TVector3 v(0, 0, 1);
+      TVector3 u = v.Cross(n);
 
-		//! Initiallize track with seed from pattern recognition
-		PHGenFit::Track* track = new PHGenFit::Track(rep, seed_pos,
-				seed_mom, seed_cov);
+      PHGenFit::Measurement *meas = new PHGenFit::PlanarMeasurement(
+          pos, u, v,
+          Cluster_size_dphi[imeas], Cluster_size_dz[imeas]);
+      measurements.push_back(meas);
+    }
 
-		//! Create measurements
-		std::vector<PHGenFit::Measurement*> measurements;
-		for (int imeas = 0; imeas < NLAYERS; imeas++) {
-			TVector3 pos(Cluster_x[imeas],Cluster_y[imeas],Cluster_z[imeas]);
-			TVector3 n(Cluster_x[imeas],Cluster_y[imeas],0);
-			TVector3 v(0,0,1);
-			TVector3 u = v.Cross(n);
+    //! Add measurements to track
+    track->addMeasurements(measurements);
 
-			PHGenFit::Measurement* meas = new PHGenFit::PlanarMeasurement(
-					pos,u,v,
-					Cluster_size_dphi[imeas],Cluster_size_dz[imeas]);
-			measurements.push_back(meas);
-		}
+    //! Fit the track
+    fitter->processTrack(track, false);
 
-		//! Add measurements to track
-		track->addMeasurements(measurements);
+    //!
+    genfit::MeasuredStateOnPlane *state_at_beam_line = track->extrapolateToLine(
+        TVector3(0, 0, 0), TVector3(0, 0, 1));
+    // state_at_beam_line->Print();
 
-		//! Fit the track
-		fitter->processTrack(track, false);
+    //		genfit::MeasuredStateOnPlane* state_at_layer_6 = track->extrapolateToCylinder(80.,
+    //						TVector3(0, 0, 0), TVector3(0, 0, 1));
+    //		//state_at_layer_6->Print();
+    //		delete state_at_layer_6;
 
-		//!
-		genfit::MeasuredStateOnPlane* state_at_beam_line = track->extrapolateToLine(
-				TVector3(0, 0, 0), TVector3(0, 0, 1));
-		//state_at_beam_line->Print();
+    TVector3 GenFit_mom = state_at_beam_line->getMom();
 
-//		genfit::MeasuredStateOnPlane* state_at_layer_6 = track->extrapolateToCylinder(80.,
-//						TVector3(0, 0, 0), TVector3(0, 0, 1));
-//		//state_at_layer_6->Print();
-//		delete state_at_layer_6;
+    TVector3 AlanDion_mom(AlanDion_px, AlanDion_py, AlanDion_pz);
 
+    hpT_residual_vs_pT->Fill(True_mom.Pt(), (GenFit_mom.Pt() - True_mom.Pt()) / True_mom.Pt());
 
-		TVector3 GenFit_mom = state_at_beam_line->getMom();
+    hDCAr_vs_pT->Fill(True_mom.Mag(), state_at_beam_line->getState()[3]);
 
-		TVector3 AlanDion_mom(AlanDion_px,AlanDion_py,AlanDion_pz);
+    delete state_at_beam_line;
+    delete track;
+    measurements.clear();
+  }
 
-		hpT_residual_vs_pT->Fill(True_mom.Pt(),(GenFit_mom.Pt() - True_mom.Pt())/True_mom.Pt());
+  gStyle->SetOptFit();
+  gStyle->SetOptStat(000000000);
 
-		hDCAr_vs_pT->Fill(True_mom.Mag(),state_at_beam_line->getState()[3]);
+  TF1 *tf_pT_resolution = new TF1("tf_pT_resolution", "sqrt([0]*[0] + x*x*[1]*[1])", 0, 40);
+  tf_pT_resolution->SetParameters(0, 0);
+  TCanvas *c3 = new TCanvas("c3", "c3");
+  c3->Divide(2, 1);
+  c3->cd(1);
+  hpT_residual_vs_pT->FitSlicesY();
+  TH1D *hpT_resolution_vs_pT = (TH1D *) gDirectory->Get("hpT_residual_vs_pT_2");
+  hpT_resolution_vs_pT->SetTitle("PHGenFit: #sigma_{p_{T}}/p_{T}; p_{T}[GeV/c]; #sigma_{p_{T}}/p_{T}");
+  hpT_resolution_vs_pT->SetMarkerStyle(20);
+  hpT_resolution_vs_pT->Draw("e");
+  hpT_resolution_vs_pT->Fit(tf_pT_resolution);
+  c3->cd(2);
+  hDCAr_vs_pT->FitSlicesY();
+  TH1D *hDCAr_resolution_vs_pT = (TH1D *) gDirectory->Get("hDCAr_vs_pT_2");
+  hDCAr_resolution_vs_pT->SetTitle(
+      "PHGenFit: #sigma_{DCAr} [cm]; p [GeV/c]; #sigma_{DCAr}");
+  hDCAr_resolution_vs_pT->SetMarkerStyle(20);
+  hDCAr_resolution_vs_pT->Draw("e");
+  // hDCAr_resolution_vs_pT->Fit(tf_pT_resolution);
+  c3->Print("pT_DCA_resolution.root");
 
-		delete state_at_beam_line;
-		delete track;
-		measurements.clear();
-	}
+  //! Event display
+  // fitter->displayEvent();
 
-	gStyle->SetOptFit();
-	gStyle->SetOptStat(000000000);
+  fPHG4Hits->Close();
 
-	TF1 *tf_pT_resolution = new TF1("tf_pT_resolution","sqrt([0]*[0] + x*x*[1]*[1])", 0, 40);
-	tf_pT_resolution->SetParameters(0,0);
-	TCanvas *c3 = new TCanvas("c3","c3");
-	c3->Divide(2,1);
-	c3->cd(1);
-	hpT_residual_vs_pT->FitSlicesY();
-	TH1D *hpT_resolution_vs_pT = (TH1D*)gDirectory->Get("hpT_residual_vs_pT_2");
-	hpT_resolution_vs_pT->SetTitle("PHGenFit: #sigma_{p_{T}}/p_{T}; p_{T}[GeV/c]; #sigma_{p_{T}}/p_{T}");
-	hpT_resolution_vs_pT->SetMarkerStyle(20);
-	hpT_resolution_vs_pT->Draw("e");
-	hpT_resolution_vs_pT->Fit(tf_pT_resolution);
-	c3->cd(2);
-	hDCAr_vs_pT->FitSlicesY();
-	TH1D *hDCAr_resolution_vs_pT = (TH1D*) gDirectory->Get("hDCAr_vs_pT_2");
-	hDCAr_resolution_vs_pT->SetTitle(
-			"PHGenFit: #sigma_{DCAr} [cm]; p [GeV/c]; #sigma_{DCAr}");
-	hDCAr_resolution_vs_pT->SetMarkerStyle(20);
-	hDCAr_resolution_vs_pT->Draw("e");
-	//hDCAr_resolution_vs_pT->Fit(tf_pT_resolution);
-	c3->Print("pT_DCA_resolution.root");
+  delete fitter;
 
-	//! Event display
-	//fitter->displayEvent();
+  // pause();
 
-	fPHG4Hits->Close();
+  std::cout << "SUCCESS! \n";
 
-	delete fitter;
-
-	//pause();
-
-	std::cout<<"SUCCESS! \n";
-
-	return 0;
+  return 0;
 }

--- a/offline/packages/PHGenFitPkg/GenFitExp/Makefile.am
+++ b/offline/packages/PHGenFitPkg/GenFitExp/Makefile.am
@@ -2,8 +2,8 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
-  -I`root-config --incdir`
+  -isystem$(OFFLINE_MAIN)/include \
+  -isystem`root-config --incdir`
 
 AM_LDFLAGS = \
   -L$(libdir) \

--- a/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
+++ b/offline/packages/PHGenFitPkg/GenFitExp/configure.ac
@@ -9,7 +9,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 dnl   make warnings fatal errors: -Werror
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 fi
 
 dnl test for root 6

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -77,8 +77,8 @@ namespace PHGenFit
     {
       _fitter = new genfit::KalmanFitterRefTrack();
     }
-    // NOLINTNEXTLINE(bugprone-branch-clone)
     else if (fitter_choice.compare("KalmanFitter") == 0)
+// NOLINTNEXTLINE(bugprone-branch-clone)
     {
       _fitter = new genfit::KalmanFitter();
     }
@@ -91,6 +91,7 @@ namespace PHGenFit
       _fitter = new genfit::DAF(true);
     }
     else
+// NOLINTNEXTLINE(bugprone-branch-clone)
     {
       _fitter = new genfit::KalmanFitter();
     }

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.cc
@@ -5,16 +5,16 @@
  *  \author		Haiwang Yu <yuhw@nmsu.edu>
  */
 
-//PHGenFit
+// PHGenFit
 #include "Fitter.h"
 
 #include "Track.h"
 
-//ROOT
+// ROOT
+#include <RVersion.h>  // for ROOT_VERSION, ROOT_VERSION...
 #include <TGeoManager.h>
-#include <RVersion.h>                      // for ROOT_VERSION, ROOT_VERSION...
 
-//GenFit
+// GenFit
 #include <GenFit/AbsKalmanFitter.h>
 #include <GenFit/DAF.h>
 #include <GenFit/EventDisplay.h>
@@ -26,272 +26,321 @@
 #include <GenFit/TGeoMaterialInterface.h>
 #include <GenFit/Track.h>
 
-//GenFitExp
+// GenFitExp
 #include <genfitexp/Field.h>
 
 #include <cassert>
 #include <cstddef>
 #include <iostream>
 
-namespace genfit { class AbsTrackRep; }
+namespace genfit
+{
+  class AbsTrackRep;
+}
 
-#define LogDEBUG(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogERROR(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogWARNING(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+#define LogDEBUG(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogERROR(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogWARNING(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
 
 namespace PHGenFit
 {
-Fitter::Fitter(
-    const std::string& tgeo_file_name,
-    const PHField* field,
-    const std::string& fitter_choice,
-    const std::string& /*track_rep_choice*/,
-    const bool doEventDisplay)
-  : verbosity(1000)
-  , _doEventDisplay(doEventDisplay)
-{
-  _tgeo_manager = new TGeoManager("Default", "Geane geometry");
-  TGeoManager::Import(tgeo_file_name.data());
+  Fitter::Fitter(
+      const std::string& tgeo_file_name,
+      const PHField* field,
+      const std::string& fitter_choice,
+      const std::string& /*track_rep_choice*/,
+      const bool doEventDisplay)
+    : verbosity(1000)
+    , _doEventDisplay(doEventDisplay)
+  {
+    _tgeo_manager = new TGeoManager("Default", "Geane geometry");
+    TGeoManager::Import(tgeo_file_name.data());
 
-  assert(field);
-  genfit::Field* fieldMap = new genfit::Field(field);
+    assert(field);
+    genfit::Field* fieldMap = new genfit::Field(field);
 
-  genfit::FieldManager::getInstance()->init(
-      fieldMap);
-  genfit::MaterialEffects::getInstance()->init(
-      new genfit::TGeoMaterialInterface());
+    genfit::FieldManager::getInstance()->init(fieldMap);
+    genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
 
-  // init event display
-  if (_doEventDisplay)
-    _display = genfit::EventDisplay::getInstance();
-  else
-    _display = NULL;
+    // init event display
+    if (_doEventDisplay)
+    {
+      _display = genfit::EventDisplay::getInstance();
+    }
+    else
+    {
+      _display = nullptr;
+    }
 
-  // init fitter
-  if (fitter_choice.compare("KalmanFitterRefTrack") == 0)
-    _fitter = new genfit::KalmanFitterRefTrack();
-  else if (fitter_choice.compare("KalmanFitter") == 0)
-    _fitter = new genfit::KalmanFitter();
-  else if (fitter_choice.compare("DafSimple") == 0)
-    _fitter = new genfit::DAF(false);
-  else if (fitter_choice.compare("DafRef") == 0)
-    _fitter = new genfit::DAF(true);
-  else
-    _fitter = new genfit::KalmanFitter();
+    // init fitter
+    if (fitter_choice.compare("KalmanFitterRefTrack") == 0)
+    {
+      _fitter = new genfit::KalmanFitterRefTrack();
+    }
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    else if (fitter_choice.compare("KalmanFitter") == 0)
+    {
+      _fitter = new genfit::KalmanFitter();
+    }
+    else if (fitter_choice.compare("DafSimple") == 0)
+    {
+      _fitter = new genfit::DAF(false);
+    }
+    else if (fitter_choice.compare("DafRef") == 0)
+    {
+      _fitter = new genfit::DAF(true);
+    }
+    else
+    {
+      _fitter = new genfit::KalmanFitter();
+    }
 
-  genfit::Exception::quiet(true);
-}
+    genfit::Exception::quiet(true);
+  }
 
-Fitter::~Fitter()
-{
-  delete _fitter;
-  //delete _tgeo_manager;
-  //_tgeo_manager->Delete();
-  delete _display;
-}
+  Fitter::~Fitter()
+  {
+    delete _fitter;
+    // delete _tgeo_manager;
+    //_tgeo_manager->Delete();
+    delete _display;
+  }
 
-int Fitter::processTrack(PHGenFit::Track* track, const bool save_to_evt_disp)
-{
-  genfit::Track* fitTrack = track->getGenFitTrack();
+  int Fitter::processTrack(PHGenFit::Track* track, const bool save_to_evt_disp)
+  {
+    genfit::Track* fitTrack = track->getGenFitTrack();
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
-  try
-  {
-    fitTrack->checkConsistency();
-  }
-  catch (genfit::Exception& e)
-  {
-    if (verbosity >= 2)
+    try
     {
-      std::cerr << "genfit::Track::checkConsistency() failed!" << std::endl;
-      std::cerr << e.what();
+      fitTrack->checkConsistency();
     }
-    return -1;
-  }
+    catch (genfit::Exception& e)
+    {
+      if (verbosity >= 2)
+      {
+        std::cerr << "genfit::Track::checkConsistency() failed!" << std::endl;
+        std::cerr << e.what();
+      }
+      return -1;
+    }
 #else
-  if (!fitTrack->checkConsistency())
-  {
-    if (verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!");
-    return -1;
-  }
-#endif
-  try
-  {
-    _fitter->processTrack(fitTrack);
-  }
-  catch (genfit::Exception& e)
-  {
-    if (verbosity >= 1)
+    if (!fitTrack->checkConsistency())
     {
-      std::cerr << "PHGenFit::Fitter::processTrack::Exception: \n";
-      std::cerr << e.what();
-      std::cerr << "Exception, next track" << std::endl;
+      if (verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!");
+      return -1;
     }
-    return -1;
-  }
+#endif
+    try
+    {
+      _fitter->processTrack(fitTrack);
+    }
+    catch (genfit::Exception& e)
+    {
+      if (verbosity >= 1)
+      {
+        std::cerr << "PHGenFit::Fitter::processTrack::Exception: \n";
+        std::cerr << e.what();
+        std::cerr << "Exception, next track" << std::endl;
+      }
+      return -1;
+    }
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
-  try
-  {
-    fitTrack->checkConsistency();
-  }
-  catch (genfit::Exception& e)
-  {
-    if (verbosity >= 2)
+    try
     {
-      std::cerr << "genfit::Track::checkConsistency() failed!" << std::endl;
-      std::cerr << e.what();
+      fitTrack->checkConsistency();
     }
-    return -1;
-  }
+    catch (genfit::Exception& e)
+    {
+      if (verbosity >= 2)
+      {
+        std::cerr << "genfit::Track::checkConsistency() failed!" << std::endl;
+        std::cerr << e.what();
+      }
+      return -1;
+    }
 #else
 
-  if (!fitTrack->checkConsistency())
-  {
-    if (verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!");
-    return -1;
-  }
+    if (!fitTrack->checkConsistency())
+    {
+      if (verbosity >= 2) LogWARNING("genfit::Track::checkConsistency() failed!");
+      return -1;
+    }
 #endif
-  genfit::AbsTrackRep* rep = fitTrack->getCardinalRep();
-  if (!fitTrack->getFitStatus(rep)->isFitConverged())
-  {
-    if (verbosity >= 2) LogWARNING("Track could not be fitted successfully! Fit is not converged!");
-    return -1;
+    genfit::AbsTrackRep* rep = fitTrack->getCardinalRep();
+    if (!fitTrack->getFitStatus(rep)->isFitConverged())
+    {
+      if (verbosity >= 2)
+      {
+        LogWARNING("Track could not be fitted successfully! Fit is not converged!");
+      }
+      return -1;
+    }
+
+    if (_display and save_to_evt_disp)
+    {
+      _display->addEvent(track->getGenFitTrack());
+    }
+
+    return 0;
   }
 
-  if (_display and save_to_evt_disp)
-    _display->addEvent(track->getGenFitTrack());
-
-  return 0;
-}
-
-Fitter* Fitter::getInstance(const std::string& tgeo_file_name,
-                            const PHField* field,
-                            const std::string& fitter_choice, const std::string& track_rep_choice,
-                            const bool doEventDisplay)
-{
-  TGeoManager* tgeo_manager = TGeoManager::Import(tgeo_file_name.data(), "Default");
-  if (!tgeo_manager)
+  Fitter* Fitter::getInstance(const std::string& tgeo_file_name,
+                              const PHField* field,
+                              const std::string& fitter_choice, const std::string& track_rep_choice,
+                              const bool doEventDisplay)
   {
-    LogERROR("No TGeoManager found!");
-    return NULL;
+    TGeoManager* tgeo_manager = TGeoManager::Import(tgeo_file_name.data(), "Default");
+    if (!tgeo_manager)
+    {
+      LogERROR("No TGeoManager found!");
+      return nullptr;
+    }
+
+    assert(field);
+    genfit::Field* fieldMap = new genfit::Field(field);
+    return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
   }
 
-  assert(field);
-  genfit::Field* fieldMap = new genfit::Field(field);
-  return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
-}
-
-Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
-               const PHGenFit::Fitter::FitterType& fitter_choice,
-               const PHGenFit::Fitter::TrackRepType& /*track_rep_choice*/,
-               const bool doEventDisplay)
-  : verbosity(0)
-  , _tgeo_manager(tgeo_manager)
-  , _doEventDisplay(doEventDisplay)
-{
-  genfit::FieldManager::getInstance()->init(
-      fieldMap);
-  genfit::MaterialEffects::getInstance()->init(
-      new genfit::TGeoMaterialInterface());
-
-  // init event display
-  if (_doEventDisplay)
-    _display = genfit::EventDisplay::getInstance();
-  else
-    _display = NULL;
-
-  // init fitter
-  if (fitter_choice == PHGenFit::Fitter::KalmanFitter)
-    _fitter = new genfit::KalmanFitter();
-  else if (fitter_choice == PHGenFit::Fitter::KalmanFitterRefTrack)
-    _fitter = new genfit::KalmanFitterRefTrack();
-  if (fitter_choice == PHGenFit::Fitter::DafSimple)
-    _fitter = new genfit::DAF(false);
-  else if (fitter_choice == PHGenFit::Fitter::DafRef)
-    _fitter = new genfit::DAF(true);
-  else
+  Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
+                 const PHGenFit::Fitter::FitterType& fitter_choice,
+                 const PHGenFit::Fitter::TrackRepType& /*track_rep_choice*/,
+                 const bool doEventDisplay)
+    : verbosity(0)
+    , _tgeo_manager(tgeo_manager)
+    , _doEventDisplay(doEventDisplay)
   {
-    _fitter = nullptr;
-    LogERROR("This fitter not implemented!");
-  }
-}
+    genfit::FieldManager::getInstance()->init(
+        fieldMap);
+    genfit::MaterialEffects::getInstance()->init(
+        new genfit::TGeoMaterialInterface());
 
-Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
-                            const PHField* field,
-                            const std::string& fitter_choice, const std::string& track_rep_choice,
-                            const bool doEventDisplay)
-{
-  if (!tgeo_manager)
-  {
-    LogERROR("No TGeoManager found!");
-    return NULL;
+    // init event display
+    if (_doEventDisplay)
+    {
+      _display = genfit::EventDisplay::getInstance();
+    }
+    else
+    {
+      _display = nullptr;
+    }
+
+    // init fitter
+    if (fitter_choice == PHGenFit::Fitter::KalmanFitter)
+    {
+      _fitter = new genfit::KalmanFitter();
+    }
+    else if (fitter_choice == PHGenFit::Fitter::KalmanFitterRefTrack)
+    {
+      _fitter = new genfit::KalmanFitterRefTrack();
+    }
+    if (fitter_choice == PHGenFit::Fitter::DafSimple)
+    {
+      _fitter = new genfit::DAF(false);
+    }
+    else if (fitter_choice == PHGenFit::Fitter::DafRef)
+    {
+      _fitter = new genfit::DAF(true);
+    }
+    else
+    {
+      _fitter = nullptr;
+      LogERROR("This fitter not implemented!");
+    }
   }
 
-  assert(field);
-  genfit::Field* fieldMap = new genfit::Field(field);
-  return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
-}
-
-Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
-               const std::string& fitter_choice, const std::string& /*track_rep_choice*/,
-               const bool doEventDisplay)
-  : verbosity(0)
-  , _tgeo_manager(tgeo_manager)
-  , _doEventDisplay(doEventDisplay)
-{
-  genfit::FieldManager::getInstance()->init(
-      fieldMap);
-  genfit::MaterialEffects::getInstance()->init(
-      new genfit::TGeoMaterialInterface());
-
-  // init event display
-  if (_doEventDisplay)
-    _display = genfit::EventDisplay::getInstance();
-  else
-    _display = NULL;
-
-  // init fitter
-  if (fitter_choice.compare("KalmanFitterRefTrack") == 0)
-    _fitter = new genfit::KalmanFitterRefTrack();
-  else if (fitter_choice.compare("KalmanFitter") == 0)
-    _fitter = new genfit::KalmanFitter();
-  else if (fitter_choice.compare("DafSimple") == 0)
-    _fitter = new genfit::DAF(false);
-  else if (fitter_choice.compare("DafRef") == 0)
-    _fitter = new genfit::DAF(true);
-  else
+  Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
+                              const PHField* field,
+                              const std::string& fitter_choice, const std::string& track_rep_choice,
+                              const bool doEventDisplay)
   {
-    _fitter = nullptr;
-    LogERROR("This fitter not implemented!");
-  }
-}
+    if (!tgeo_manager)
+    {
+      LogERROR("No TGeoManager found!");
+      return nullptr;
+    }
 
-int Fitter::displayEvent()
-{
-  if (_display)
-    _display->open();
-  else if (verbosity >= 0)
-    LogERROR("No genfit::EventDisplay found!");
-
-  return 0;
-}
-
-Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
-                            const PHField* field,
-                            const PHGenFit::Fitter::FitterType& fitter_choice,
-                            const PHGenFit::Fitter::TrackRepType& track_rep_choice,
-                            const bool doEventDisplay)
-{
-  if (!tgeo_manager)
-  {
-    LogERROR("No TGeoManager found!");
-    return NULL;
+    assert(field);
+    genfit::Field* fieldMap = new genfit::Field(field);
+    return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
   }
 
-  assert(field);
-  genfit::Field* fieldMap = new genfit::Field(field);
+  Fitter::Fitter(TGeoManager* tgeo_manager, genfit::AbsBField* fieldMap,
+                 const std::string& fitter_choice, const std::string& /*track_rep_choice*/,
+                 const bool doEventDisplay)
+    : verbosity(0)
+    , _tgeo_manager(tgeo_manager)
+    , _doEventDisplay(doEventDisplay)
+  {
+    genfit::FieldManager::getInstance()->init(
+        fieldMap);
+    genfit::MaterialEffects::getInstance()->init(
+        new genfit::TGeoMaterialInterface());
 
-  return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
-}
+    // init event display
+    if (_doEventDisplay)
+    {
+      _display = genfit::EventDisplay::getInstance();
+    }
+    else
+    {
+      _display = nullptr;
+    }
+
+    // init fitter
+    if (fitter_choice.compare("KalmanFitterRefTrack") == 0)
+    {
+      _fitter = new genfit::KalmanFitterRefTrack();
+    }
+    else if (fitter_choice.compare("KalmanFitter") == 0)
+    {
+      _fitter = new genfit::KalmanFitter();
+    }
+    else if (fitter_choice.compare("DafSimple") == 0)
+    {
+      _fitter = new genfit::DAF(false);
+    }
+    else if (fitter_choice.compare("DafRef") == 0)
+    {
+      _fitter = new genfit::DAF(true);
+    }
+    else
+    {
+      _fitter = nullptr;
+      LogERROR("This fitter not implemented!");
+    }
+  }
+
+  int Fitter::displayEvent()
+  {
+    if (_display)
+    {
+      _display->open();
+    }
+    else if (verbosity >= 0)
+    {
+      LogERROR("No genfit::EventDisplay found!");
+    }
+
+    return 0;
+  }
+
+  Fitter* Fitter::getInstance(TGeoManager* tgeo_manager,
+                              const PHField* field,
+                              const PHGenFit::Fitter::FitterType& fitter_choice,
+                              const PHGenFit::Fitter::TrackRepType& track_rep_choice,
+                              const bool doEventDisplay)
+  {
+    if (!tgeo_manager)
+    {
+      LogERROR("No TGeoManager found!");
+      return nullptr;
+    }
+
+    assert(field);
+    genfit::Field* fieldMap = new genfit::Field(field);
+
+    return new Fitter(tgeo_manager, fieldMap, fitter_choice, track_rep_choice, doEventDisplay);
+  }
 
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Fitter.h
@@ -10,14 +10,14 @@
 
 // needed, it crashes on Ubuntu using singularity with local cvmfs install
 // shared pointer later on uses this, forward declaration does not cut it
-#include <phgenfit/Track.h> 
+#include <phgenfit/Track.h>
 
 #include <GenFit/EventDisplay.h>
 #include "GenFit/Exception.h"
 
 #include <string>
 
-//BOOST
+// BOOST
 //#include<boost/make_shared.hpp>
 //
 //#define SMART(expr) boost::shared_ptr<expr>
@@ -28,124 +28,124 @@ class PHField;
 
 namespace genfit
 {
-class AbsKalmanFitter;
-class AbsBField;
+  class AbsKalmanFitter;
+  class AbsBField;
 }  // namespace genfit
 
 namespace PHGenFit
 {
 
-class Fitter
-{
- public:
-  enum FitterType
+  class Fitter
   {
-    KalmanFitter,
-    KalmanFitterRefTrack,
-    DafSimple,
-    DafRef
-  };
-  enum TrackRepType
-  {
-    RKTrackRep
-  };
+   public:
+    enum FitterType
+    {
+      KalmanFitter,
+      KalmanFitterRefTrack,
+      DafSimple,
+      DafRef
+    };
+    enum TrackRepType
+    {
+      RKTrackRep
+    };
 
-  //! Default constructor
-  Fitter(const std::string& tgeo_file_name,
-         const PHField* field,
-         const std::string& fitter_choice = "KalmanFitterRefTrack",
-         const std::string& track_rep_choice = "RKTrackRep",
-         const bool doEventDisplay = false);
+    //! Default constructor
+    Fitter(const std::string& tgeo_file_name,
+           const PHField* field,
+           const std::string& fitter_choice = "KalmanFitterRefTrack",
+           const std::string& track_rep_choice = "RKTrackRep",
+           const bool doEventDisplay = false);
 
-  Fitter(TGeoManager* tgeo_manager,
-         genfit::AbsBField* fieldMap,
-         const std::string& fitter_choice = "KalmanFitterRefTrack",
-         const std::string& track_rep_choice = "RKTrackRep",
-         const bool doEventDisplay = false);
+    Fitter(TGeoManager* tgeo_manager,
+           genfit::AbsBField* fieldMap,
+           const std::string& fitter_choice = "KalmanFitterRefTrack",
+           const std::string& track_rep_choice = "RKTrackRep",
+           const bool doEventDisplay = false);
 
-  Fitter(TGeoManager* tgeo_manager,
-         genfit::AbsBField* fieldMap,
-         const PHGenFit::Fitter::FitterType& fitter_choice = PHGenFit::Fitter::KalmanFitter,
-         const PHGenFit::Fitter::TrackRepType& track_rep_choice = PHGenFit::Fitter::RKTrackRep,
-         const bool doEventDisplay = false);
+    Fitter(TGeoManager* tgeo_manager,
+           genfit::AbsBField* fieldMap,
+           const PHGenFit::Fitter::FitterType& fitter_choice = PHGenFit::Fitter::KalmanFitter,
+           const PHGenFit::Fitter::TrackRepType& track_rep_choice = PHGenFit::Fitter::RKTrackRep,
+           const bool doEventDisplay = false);
 
-  //! Default destructor
-  ~Fitter();
-  explicit Fitter(const Fitter&) = delete;
-  Fitter& operator=(const Fitter&) = delete;
+    //! Default destructor
+    ~Fitter();
+    explicit Fitter(const Fitter&) = delete;
+    Fitter& operator=(const Fitter&) = delete;
 
-  static Fitter* getInstance(const std::string& tgeo_file_name,
-                             const PHField* field,
-                             const std::string& fitter_choice = "KalmanFitterRefTrack",
-                             const std::string& track_rep_choice = "RKTrackRep",
-                             const bool doEventDisplay = false);
+    static Fitter* getInstance(const std::string& tgeo_file_name,
+                               const PHField* field,
+                               const std::string& fitter_choice = "KalmanFitterRefTrack",
+                               const std::string& track_rep_choice = "RKTrackRep",
+                               const bool doEventDisplay = false);
 
-  static Fitter* getInstance(TGeoManager* tgeo_manager,
-                             const PHField* field,
-                             const std::string& fitter_choice = "KalmanFitterRefTrack",
-                             const std::string& track_rep_choice = "RKTrackRep",
-                             const bool doEventDisplay = false);
+    static Fitter* getInstance(TGeoManager* tgeo_manager,
+                               const PHField* field,
+                               const std::string& fitter_choice = "KalmanFitterRefTrack",
+                               const std::string& track_rep_choice = "RKTrackRep",
+                               const bool doEventDisplay = false);
 
-  static Fitter* getInstance(TGeoManager* tgeo_manager,
-                             const PHField* field,
-                             const PHGenFit::Fitter::FitterType& fitter_choice = PHGenFit::Fitter::KalmanFitter,
-                             const PHGenFit::Fitter::TrackRepType& track_rep_choice = PHGenFit::Fitter::RKTrackRep,
-                             const bool doEventDisplay = false);
+    static Fitter* getInstance(TGeoManager* tgeo_manager,
+                               const PHField* field,
+                               const PHGenFit::Fitter::FitterType& fitter_choice = PHGenFit::Fitter::KalmanFitter,
+                               const PHGenFit::Fitter::TrackRepType& track_rep_choice = PHGenFit::Fitter::RKTrackRep,
+                               const bool doEventDisplay = false);
 
-  int processTrack(PHGenFit::Track* track, const bool save_to_evt_disp = false);
+    int processTrack(PHGenFit::Track* track, const bool save_to_evt_disp = false);
 
-  int displayEvent();
+    int displayEvent();
 
-  bool is_do_Event_Display() const
-  {
-    return _doEventDisplay;
-  }
+    bool is_do_Event_Display() const
+    {
+      return _doEventDisplay;
+    }
 
-  void set_do_Event_Display(bool doEventDisplay)
-  {
-    _doEventDisplay = doEventDisplay;
-    if (!_display && _doEventDisplay)
-      _display = genfit::EventDisplay::getInstance();
-  }
+    void set_do_Event_Display(bool doEventDisplay)
+    {
+      _doEventDisplay = doEventDisplay;
+      if (!_display && _doEventDisplay)
+        _display = genfit::EventDisplay::getInstance();
+    }
 
-  genfit::EventDisplay* getEventDisplay()
-  {
-    return _display;
-  }
+    genfit::EventDisplay* getEventDisplay()
+    {
+      return _display;
+    }
 
-  int get_verbosity() const
-  {
-    return verbosity;
-  }
+    int get_verbosity() const
+    {
+      return verbosity;
+    }
 
-  void set_verbosity(int v)
-  {
-    this->verbosity = v;
-    if (verbosity >= 1)
-      genfit::Exception::quiet(false);
-    else
-      genfit::Exception::quiet(true);
-  }
+    void set_verbosity(int v)
+    {
+      this->verbosity = v;
+      if (verbosity >= 1)
+        genfit::Exception::quiet(false);
+      else
+        genfit::Exception::quiet(true);
+    }
 
- private:
-  /*!
-	 * Verbose control:
-	 * -1: Silient
-	 * 0: Minimum
-	 * 1: Errors only
-	 * 2: Errors and Warnings
-	 * 3: Verbose mode, long term debugging
-	 */
-  int verbosity;
+   private:
+    /*!
+     * Verbose control:
+     * -1: Silient
+     * 0: Minimum
+     * 1: Errors only
+     * 2: Errors and Warnings
+     * 3: Verbose mode, long term debugging
+     */
+    int verbosity;
 
-  TGeoManager* _tgeo_manager;
+    TGeoManager* _tgeo_manager;
 
-  bool _doEventDisplay;
+    bool _doEventDisplay;
 
-  genfit::EventDisplay* _display;
-  genfit::AbsKalmanFitter* _fitter;
+    genfit::EventDisplay* _display;
+    genfit::AbsKalmanFitter* _fitter;
 
-};  //class Fitter
+  };  // class Fitter
 
 }  // namespace PHGenFit
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem`root-config --incdir`
 
 AM_LDFLAGS = \

--- a/offline/packages/PHGenFitPkg/PHGenFit/Measurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Measurement.h
@@ -14,49 +14,48 @@
 
 namespace PHGenFit
 {
-class Measurement
-{
- public:
-  //!ctor
-  Measurement()
-    : _measurement(NULL)
-    , _clusterID(UINT_MAX){};
-
-  //!dtor
-  virtual ~Measurement() {}
-
-  //!
-  genfit::AbsMeasurement* getMeasurement()
+  class Measurement
   {
-    return _measurement;
-  }
+   public:
+    //! ctor
+    Measurement()
+      : _measurement(NULL)
+      , _clusterID(UINT_MAX){};
 
-  // old tracking
-  unsigned int get_cluster_ID() const
-  {
-    return _clusterID;
-  }
-  void set_cluster_ID(unsigned int clusterId)
-  {
-    _clusterID = clusterId;
-  }
+    //! dtor
+    virtual ~Measurement() {}
 
-  // new tracking
-  TrkrDefs::cluskey get_cluster_key() const
-  {
-    return _clusterkey;
-  }
-  void set_cluster_key(TrkrDefs::cluskey clusterkey)
-  {
-    _clusterkey = clusterkey;
-  }
+    //!
+    genfit::AbsMeasurement* getMeasurement()
+    {
+      return _measurement;
+    }
 
- protected:
-  genfit::AbsMeasurement* _measurement;
-  unsigned int _clusterID;
-  TrkrDefs::cluskey _clusterkey;
+    // old tracking
+    unsigned int get_cluster_ID() const
+    {
+      return _clusterID;
+    }
+    void set_cluster_ID(unsigned int clusterId)
+    {
+      _clusterID = clusterId;
+    }
 
-};
+    // new tracking
+    TrkrDefs::cluskey get_cluster_key() const
+    {
+      return _clusterkey;
+    }
+    void set_cluster_key(TrkrDefs::cluskey clusterkey)
+    {
+      _clusterkey = clusterkey;
+    }
+
+   protected:
+    genfit::AbsMeasurement* _measurement;
+    unsigned int _clusterID;
+    TrkrDefs::cluskey _clusterkey;
+  };
 }  // namespace PHGenFit
 
 #endif

--- a/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.cc
@@ -6,59 +6,59 @@
 
 #include "PlanarMeasurement.h"
 
-#include <GenFit/PlanarMeasurement.h>
 #include <GenFit/DetPlane.h>
-#include <GenFit/SharedPlanePtr.h>     // for SharedPlanePtr
+#include <GenFit/PlanarMeasurement.h>
+#include <GenFit/SharedPlanePtr.h>  // for SharedPlanePtr
 #include <GenFit/StateOnPlane.h>
 
-#include <TMatrixDSymfwd.h>            // for TMatrixDSym
-#include <TMatrixTSym.h>               // for TMatrixTSym
-#include <TVectorDfwd.h>               // for TVectorD
-#include <TVectorT.h>                  // for TVectorT
+#include <TMatrixDSymfwd.h>  // for TMatrixDSym
+#include <TMatrixTSym.h>     // for TMatrixTSym
 #include <TVector3.h>
+#include <TVectorDfwd.h>  // for TVectorD
+#include <TVectorT.h>     // for TVectorT
 
 namespace PHGenFit
 {
-void PlanarMeasurement::init(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv)
-{
-  int nDim = 2;
-  TVectorD hitCoords(nDim);
-  TMatrixDSym hitCov(nDim);
+  void PlanarMeasurement::init(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv)
+  {
+    int nDim = 2;
+    TVectorD hitCoords(nDim);
+    TMatrixDSym hitCov(nDim);
 
-  hitCoords(0) = 0;
-  hitCoords(1) = 0;
+    hitCoords(0) = 0;
+    hitCoords(1) = 0;
 
-  hitCov(0, 0) = du * du;
-  hitCov(1, 1) = dv * dv;
+    hitCov(0, 0) = du * du;
+    hitCov(1, 1) = dv * dv;
 
-  genfit::SharedPlanePtr plane(
-      new genfit::DetPlane(pos, u, v));
+    genfit::SharedPlanePtr plane(
+        new genfit::DetPlane(pos, u, v));
 
-  int measurementCounter_ = 0;
-  _measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, -1,
-                                               measurementCounter_,
-                                               nullptr);
+    int measurementCounter_ = 0;
+    _measurement = new genfit::PlanarMeasurement(hitCoords, hitCov, -1,
+                                                 measurementCounter_,
+                                                 nullptr);
 
-  static_cast<genfit::PlanarMeasurement*>(_measurement)->setPlane(plane, measurementCounter_);
-}
+    static_cast<genfit::PlanarMeasurement*>(_measurement)->setPlane(plane, measurementCounter_);
+  }
 
-PlanarMeasurement::PlanarMeasurement(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv)
-{
-  init(pos, u, v, du, dv);
-}
+  PlanarMeasurement::PlanarMeasurement(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv)
+  {
+    init(pos, u, v, du, dv);
+  }
 
-PlanarMeasurement::PlanarMeasurement(const TVector3& pos, const TVector3& n, const double du, const double dv)
-{
-  /*!
-	 *  Mainly for "n" in xy plane, or n.z() = 0;
-	 *  In this case, According to https://root.cern.ch/doc/master/TVector3_8h_source.html#l00301
-	 *  u = n.Orthogonal() is always in xy plane
-	 *  v = n x u, is along z direction.
-	 *  If z is not 0, but z <= x or y, then u will still be in xy plane, phi direction error, but v will not be along z axis.
-	 */
-  TVector3 u = n.Orthogonal();
-  TVector3 v = n.Cross(u);
-  init(pos, u, v, du, dv);
-}
+  PlanarMeasurement::PlanarMeasurement(const TVector3& pos, const TVector3& n, const double du, const double dv)
+  {
+    /*!
+     *  Mainly for "n" in xy plane, or n.z() = 0;
+     *  In this case, According to https://root.cern.ch/doc/master/TVector3_8h_source.html#l00301
+     *  u = n.Orthogonal() is always in xy plane
+     *  v = n x u, is along z direction.
+     *  If z is not 0, but z <= x or y, then u will still be in xy plane, phi direction error, but v will not be along z axis.
+     */
+    TVector3 u = n.Orthogonal();
+    TVector3 v = n.Cross(u);
+    init(pos, u, v, du, dv);
+  }
 
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/PlanarMeasurement.h
@@ -13,21 +13,21 @@ class TVector3;
 
 namespace PHGenFit
 {
-class PlanarMeasurement : public Measurement
-{
- public:
-  //!ctor
-  PlanarMeasurement(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv);
+  class PlanarMeasurement : public Measurement
+  {
+   public:
+    //! ctor
+    PlanarMeasurement(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv);
 
-  PlanarMeasurement(const TVector3& pos, const TVector3& n, const double du, const double dv);
+    PlanarMeasurement(const TVector3& pos, const TVector3& n, const double du, const double dv);
 
-  void init(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv);
+    void init(const TVector3& pos, const TVector3& u, const TVector3& v, const double du, const double dv);
 
-  //!dtor
-  ~PlanarMeasurement() override {}
+    //! dtor
+    ~PlanarMeasurement() override {}
 
- protected:
-};
+   protected:
+  };
 }  // namespace PHGenFit
 
 #endif

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.cc
@@ -8,7 +8,7 @@
 
 #include <GenFit/SpacepointMeasurement.h>
 
-#include <TMatrixDSymfwd.h>                // for TMatrixDSym
+#include <TMatrixDSymfwd.h>  // for TMatrixDSym
 #include <TMatrixTSym.h>
 #include <TVector3.h>
 #include <TVectorDfwd.h>
@@ -16,54 +16,58 @@
 
 namespace PHGenFit
 {
-void SpacepointMeasurement::init(const TVector3& pos, const TMatrixDSym& cov)
-{
-  int nDim = 3;
-  TVectorD hitCoords(nDim);
-  TMatrixDSym hitCov(nDim);
+  void SpacepointMeasurement::init(const TVector3& pos, const TMatrixDSym& cov)
+  {
+    int nDim = 3;
+    TVectorD hitCoords(nDim);
+    TMatrixDSym hitCov(nDim);
 
-  hitCoords(0) = pos.X();
-  hitCoords(1) = pos.Y();
-  hitCoords(2) = pos.Z();
+    hitCoords(0) = pos.X();
+    hitCoords(1) = pos.Y();
+    hitCoords(2) = pos.Z();
 
-  for (int i = 0; i < 3; i++)
-    for (int j = 0; j < 3; j++)
-      hitCov(i, j) = cov(i, j);
+    for (int i = 0; i < 3; i++)
+    {
+      for (int j = 0; j < 3; j++)
+      {
+        hitCov(i, j) = cov(i, j);
+      }
+    }
 
-  int measurementCounter_ = 0;
-  _measurement = new genfit::SpacepointMeasurement(hitCoords, hitCov, -1,
-                                                   measurementCounter_,
-                                                   nullptr);
-}
+    int measurementCounter_ = 0;
+    _measurement = new genfit::SpacepointMeasurement(hitCoords, hitCov, -1,
+                                                     measurementCounter_,
+                                                     nullptr);
+  }
 
-SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const double resolution)
-{
-  TMatrixDSym cov(3);
-  cov.Zero();
-  cov(0, 0) = resolution * resolution;
-  cov(1, 1) = resolution * resolution;
-  cov(2, 2) = resolution * resolution;
-  init(pos, cov);
-}
+  SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const double resolution)
+  {
+    TMatrixDSym cov(3);
+    cov.Zero();
+    cov(0, 0) = resolution * resolution;
+    cov(1, 1) = resolution * resolution;
+    cov(2, 2) = resolution * resolution;
+    init(pos, cov);
+  }
 
-SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TVector3& resolution)
-{
-  TMatrixDSym cov(3);
-  cov.Zero();
-  cov(0, 0) = resolution.X() * resolution.X();
-  cov(1, 1) = resolution.Y() * resolution.Y();
-  cov(2, 2) = resolution.Z() * resolution.Z();
-  init(pos, cov);
-}
-  
-/*!
- * Ctor
- * \param pos measurement position
- * \param covariance matrix
- */
-SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov)
-{
-  init(pos, cov);
-}
+  SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TVector3& resolution)
+  {
+    TMatrixDSym cov(3);
+    cov.Zero();
+    cov(0, 0) = resolution.X() * resolution.X();
+    cov(1, 1) = resolution.Y() * resolution.Y();
+    cov(2, 2) = resolution.Z() * resolution.Z();
+    init(pos, cov);
+  }
+
+  /*!
+   * Ctor
+   * \param pos measurement position
+   * \param covariance matrix
+   */
+  SpacepointMeasurement::SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov)
+  {
+    init(pos, cov);
+  }
 
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/SpacepointMeasurement.h
@@ -15,35 +15,35 @@ class TVector3;
 
 namespace PHGenFit
 {
-class SpacepointMeasurement : public Measurement
-{
- public:
-  /*!
-	 * Ctor
-	 * \param pos measurement position
-	 * \param resolution standard dev for diagnal elements of the cov, other elements are zero
-	 */
-  SpacepointMeasurement(const TVector3& pos, const double resolution);
-  /*!
-	 * Ctor
-	 * \param pos measurement position
-	 * \param resolution standard dev for each diagnal element of the cov, other elements are zero
-	 */
-  SpacepointMeasurement(const TVector3& pos, const TVector3& resolution);
-  /*!
-	 * Ctor
-	 * \param pos measurement position
-	 * \param covariance matrix
-	 */
-  SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov);
+  class SpacepointMeasurement : public Measurement
+  {
+   public:
+    /*!
+     * Ctor
+     * \param pos measurement position
+     * \param resolution standard dev for diagnal elements of the cov, other elements are zero
+     */
+    SpacepointMeasurement(const TVector3& pos, const double resolution);
+    /*!
+     * Ctor
+     * \param pos measurement position
+     * \param resolution standard dev for each diagnal element of the cov, other elements are zero
+     */
+    SpacepointMeasurement(const TVector3& pos, const TVector3& resolution);
+    /*!
+     * Ctor
+     * \param pos measurement position
+     * \param covariance matrix
+     */
+    SpacepointMeasurement(const TVector3& pos, const TMatrixDSym& cov);
 
-  void init(const TVector3& pos, const TMatrixDSym& cov);
+    void init(const TVector3& pos, const TMatrixDSym& cov);
 
-  //!dtor
-  ~SpacepointMeasurement() override {}
+    //! dtor
+    ~SpacepointMeasurement() override {}
 
- protected:
-};
+   protected:
+  };
 }  // namespace PHGenFit
 
 #endif

--- a/offline/packages/PHGenFitPkg/PHGenFit/Tools.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Tools.cc
@@ -4,60 +4,59 @@
  *  \author		Haiwang Yu <yuhw@nmsu.edu>
  */
 
-//GenFit
-#include <GenFit/RKTrackRep.h>
+// GenFit
 #include <GenFit/AbsTrackRep.h>           // for AbsTrackRep
 #include <GenFit/Exception.h>             // for Exception
 #include <GenFit/MeasuredStateOnPlane.h>  // for MeasuredStateOnPlane
+#include <GenFit/RKTrackRep.h>
 
+#include <TVector3.h>  // for TVector3
 
-#include <TVector3.h>                     // for TVector3
-
-//STL
-#include <cassert>                       // for assert
-#include <iostream>                       // for operator<<, basic_ostream
+// STL
+#include <cassert>   // for assert
+#include <iostream>  // for operator<<, basic_ostream
 #include <limits>
 
-#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
 
 //#define _DEBUG_
 
 namespace PHGenFit
 {
-double extrapolateToCylinder(
-    genfit::MeasuredStateOnPlane* state,
-    double radius, TVector3 line_point, TVector3 line_direction,
-    const int pdg_code, const int direction,
-    const int verbosity)
-{
-  assert(direction == 1 or direction == -1);
-
-  assert(state);
-
-  double pathlenth = std::numeric_limits<double>::quiet_NaN();
-
-  genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pdg_code);
-  assert(rep);
-
-  state->setRep(rep);
-
-  try
+  double extrapolateToCylinder(
+      genfit::MeasuredStateOnPlane* state,
+      double radius, const TVector3& line_point, const TVector3& line_direction,
+      const int pdg_code, const int direction,
+      const int verbosity)
   {
-    pathlenth = rep->extrapolateToCylinder(*state, radius, line_point, line_direction);
-  }
-  catch (genfit::Exception& e)
-  {
-    if (verbosity > 1)
+    assert(direction == 1 or direction == -1);
+
+    assert(state);
+
+    double pathlenth = std::numeric_limits<double>::quiet_NaN();
+
+    genfit::AbsTrackRep* rep = new genfit::RKTrackRep(pdg_code);
+    assert(rep);
+
+    state->setRep(rep);
+
+    try
     {
-      LogWarning("Can't extrapolate track!");
-      std::cerr << e.what();
+      pathlenth = rep->extrapolateToCylinder(*state, radius, line_point, line_direction);
     }
+    catch (genfit::Exception& e)
+    {
+      if (verbosity > 1)
+      {
+        LogWarning("Can't extrapolate track!");
+        std::cerr << e.what();
+      }
+      return pathlenth;
+    }
+
     return pathlenth;
   }
-
-  return pathlenth;
-}
 
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/Tools.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Tools.h
@@ -7,26 +7,26 @@
 #ifndef PHGENFIT_TOOLS_H
 #define PHGENFIT_TOOLS_H
 
-//STL
+// STL
 #include <memory>
 #include <vector>
 
 namespace genfit
 {
-class AbsTrackRep;
-class StateOnPlane;
-class Track;
-class MeasuredStateOnPlane;
+  class AbsTrackRep;
+  class StateOnPlane;
+  class Track;
+  class MeasuredStateOnPlane;
 
 }  // namespace genfit
 
 namespace PHGenFit
 {
-double extrapolateToCylinder(
-    const genfit::MeasuredStateOnPlane* state,
-    double radius, TVector3 line_point, TVector3 line_direction,
-    const int pdg_code = 211, const int direction = 1,
-    const int verbosity = 0);
+  double extrapolateToCylinder(
+      const genfit::MeasuredStateOnPlane* state,
+      double radius, TVector3 line_point, TVector3 line_direction,
+      const int pdg_code = 211, const int direction = 1,
+      const int verbosity = 0);
 
 }  // namespace PHGenFit
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -4,13 +4,13 @@
  *  \author		Haiwang Yu <yuhw@nmsu.edu>
  */
 
-//PHGenFit
+// PHGenFit
 #include "Track.h"
 #include "Measurement.h"
 
 #include <trackbase/TrkrDefs.h>
 
-//GenFit
+// GenFit
 #include <GenFit/AbsFitterInfo.h>
 #include <GenFit/AbsHMatrix.h>
 #include <GenFit/AbsMeasurement.h>
@@ -27,26 +27,26 @@
 #include <GenFit/Track.h>
 #include <GenFit/TrackPoint.h>
 
-#include <TMatrixDfwd.h>                      // for TMatrixD
-#include <TMatrixDSymfwd.h>                   // for TMatrixDSym
-#include <TMatrixT.h>                         // for TMatrixT
-#include <TMatrixTSym.h>                      // for TMatrixTSym
-#include <TVectorDfwd.h>                      // for TVectorD
-#include <TVector3.h>                         // for TVector3
-#include <TVectorT.h>                         // for TVectorT, operator-
+#include <TMatrixDSymfwd.h>  // for TMatrixDSym
+#include <TMatrixDfwd.h>     // for TMatrixD
+#include <TMatrixT.h>        // for TMatrixT
+#include <TMatrixTSym.h>     // for TMatrixTSym
+#include <TVector3.h>        // for TVector3
+#include <TVectorDfwd.h>     // for TVectorD
+#include <TVectorT.h>        // for TVectorT, operator-
 
-//STL
+// STL
 #include <cassert>
 #include <cstddef>
-#include <limits>
 #include <iostream>
+#include <limits>
 #include <utility>
 
-#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
-#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << exp << std::endl
+#define LogDebug(exp) std::cout << "DEBUG: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogError(exp) std::cout << "ERROR: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
+#define LogWarning(exp) std::cout << "WARNING: " << __FILE__ << ": " << __LINE__ << ": " << (exp) << std::endl
 
-#define WILD_DOUBLE -999999
+#define WILD_DOUBLE (-999999)
 
 //#define _DEBUG_
 //#define _PRINT_MATRIX_
@@ -59,401 +59,413 @@ ofstream fout_matrix("matrix.txt");
 
 namespace PHGenFit
 {
-Track::Track(genfit::AbsTrackRep* rep, TVector3 seed_pos, TVector3 seed_mom, TMatrixDSym seed_cov, const int v)
-{
-  //TODO Add input param check
+  Track::Track(genfit::AbsTrackRep* rep, const TVector3& seed_pos, const TVector3& seed_mom, const TMatrixDSym& seed_cov, const int v)
+  {
+    // TODO Add input param check
 
-  verbosity = v;
+    verbosity = v;
 
-  genfit::MeasuredStateOnPlane seedMSoP(rep);
-  seedMSoP.setPosMomCov(seed_pos, seed_mom, seed_cov);
-  //const genfit::StateOnPlane seedSoP(seedMSoP);
+    genfit::MeasuredStateOnPlane seedMSoP(rep);
+    seedMSoP.setPosMomCov(seed_pos, seed_mom, seed_cov);
+    // const genfit::StateOnPlane seedSoP(seedMSoP);
 
-  TVectorD seedState(6);
-  TMatrixDSym seedCov(6);
-  seedMSoP.get6DStateCov(seedState, seedCov);
+    TVectorD seedState(6);
+    TMatrixDSym seedCov(6);
+    seedMSoP.get6DStateCov(seedState, seedCov);
 
-  _track = new genfit::Track(rep, seedState, seedCov);
-  //_track = NEW(genfit::Track)(rep, seedState, seedCov);
-}
+    _track = new genfit::Track(rep, seedState, seedCov);
+    //_track = NEW(genfit::Track)(rep, seedState, seedCov);
+  }
 
-Track::Track(const PHGenFit::Track& t)
-{
-  _track = new genfit::Track(*(t.getGenFitTrack()));
-  verbosity = t.verbosity;
-  _clusterIDs = t.get_cluster_IDs();
-  _clusterkeys = t.get_cluster_keys();
-  _vertex_id = t.get_vertex_id();
-}
+  Track::Track(const PHGenFit::Track& t)
+  {
+    _track = new genfit::Track(*(t.getGenFitTrack()));
+    verbosity = t.verbosity;
+    _clusterIDs = t.get_cluster_IDs();
+    _clusterkeys = t.get_cluster_keys();
+    _vertex_id = t.get_vertex_id();
+  }
 
-int Track::addMeasurement(PHGenFit::Measurement* measurement)
-{
-  std::vector<genfit::AbsMeasurement*> msmts;
-  msmts.push_back(measurement->getMeasurement());
-  _track->insertPoint(new genfit::TrackPoint(msmts, _track));
-
-  _clusterIDs.push_back(measurement->get_cluster_ID());
-  _clusterkeys.push_back(measurement->get_cluster_key());
-
-  delete measurement;
-
-  return 0;
-}
-
-int Track::addMeasurements(std::vector<PHGenFit::Measurement*>& measurements)
-{
-  for (PHGenFit::Measurement* measurement : measurements)
+  int Track::addMeasurement(PHGenFit::Measurement* measurement)
   {
     std::vector<genfit::AbsMeasurement*> msmts;
     msmts.push_back(measurement->getMeasurement());
-    _track->insertPoint(
-        new genfit::TrackPoint(msmts, _track));
+    _track->insertPoint(new genfit::TrackPoint(msmts, _track));
 
-    //_measurements.push_back(measurement);
     _clusterIDs.push_back(measurement->get_cluster_ID());
     _clusterkeys.push_back(measurement->get_cluster_key());
 
     delete measurement;
+
+    return 0;
   }
 
-  //measurements.clear();
-
-  return 0;
-}
-
-int Track::deleteLastMeasurement()
-{
-  _track->deletePoint(-1);
-
-  _clusterIDs.pop_back();
-  _clusterkeys.pop_back();
-
-  return 0;
-}
-
-Track::~Track()
-{
-  //	std::cout << "DTOR: " << __LINE__ <<std::endl;
-  delete _track;
-
-  //	for(PHGenFit::Measurement* measurement : _measurements)
-  //	{
-  //		delete measurement;
-  //	}
-  //	_measurements.clear();
-
-  _clusterIDs.clear();
-  _clusterkeys.clear();
-}
-
-double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id) const
-{
-  double pathlenth = WILD_DOUBLE;
-
-  genfit::SharedPlanePtr destPlane(new genfit::DetPlane(O, n));
-
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
-      tr_point_id, rep);
-  if (tp == NULL)
+  int Track::addMeasurements(std::vector<PHGenFit::Measurement*>& measurements)
   {
-    std::cout << "Track has no TrackPoint with fitterInfo! \n";
-    return WILD_DOUBLE;
-  }
-  std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
-      *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
-  // extrapolate back to reference plane.
-  try
-  {
-    pathlenth = rep->extrapolateToPlane(*kfsop, destPlane);
-  }
-  catch (genfit::Exception& e)
-  {
-    std::cerr << "Exception, next track" << std::endl;
-    std::cerr << e.what();
-    //delete kfsop;
-    return WILD_DOUBLE;
-  }
-
-  state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
-
-  //delete kfsop;
-
-  return pathlenth;
-}
-
-genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id) const
-{
-  genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-  double pathlenth = this->extrapolateToPlane(*state, O, n, tr_point_id);
-  if (pathlenth <= WILD_DOUBLE)
-  {
-    delete state;
-    return NULL;
-  }
-  else
-    return state;
-}
-
-double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
-{
-  double pathlenth = WILD_DOUBLE;
-
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
-      tr_point_id, rep);
-  if (tp == NULL)
-  {
-    std::cout << "Track has no TrackPoint with fitterInfo! \n";
-    return WILD_DOUBLE;
-  }
-  std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
-      *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
-  // extrapolate back to reference plane.
-  try
-  {
-    pathlenth = rep->extrapolateToLine(*kfsop, line_point, line_direction);
-  }
-  catch (genfit::Exception& e)
-  {
-    std::cerr << "Exception, next track" << std::endl;
-    std::cerr << e.what();
-    //delete kfsop;
-    return WILD_DOUBLE;
-  }
-
-  state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
-
-  //delete kfsop;
-
-  return pathlenth;
-}
-
-genfit::MeasuredStateOnPlane* Track::extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
-{
-  genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-  double pathlenth = this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
-  if (pathlenth <= WILD_DOUBLE)
-  {
-    delete state;
-    return NULL;
-  }
-  else
-    return state;
-}
-
-double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id, const int direction) const
-{
-#ifdef _DEBUG_
-  std::cout << __LINE__ << std::endl;
-  std::cout
-      << __LINE__
-      << ": tr_point_id: " << tr_point_id
-      << ": direction: " << direction
-      << std::endl;
-#endif
-  assert(direction == 1 or direction == -1);
-
-  double pathlenth = WILD_DOUBLE;
-
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-
-  //	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
-  //			tr_point_id, rep);
-  //	if (tp == NULL) {
-  //		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-  //		return WILD_DOUBLE;
-  //	}
-
-  bool have_tp_with_fit_info = false;
-  std::unique_ptr<genfit::MeasuredStateOnPlane> kfsop = NULL;
-  if (_track->getNumPointsWithMeasurement() > 0)
-  {
-#ifdef _DEBUG_
-//		std::cout<<__LINE__ <<std::endl;
-#endif
-    genfit::TrackPoint* tp = _track->getPointWithMeasurement(tr_point_id);
-    if (tp == NULL)
+    for (PHGenFit::Measurement* measurement : measurements)
     {
-      LogError("tp == NULL!");
+      std::vector<genfit::AbsMeasurement*> msmts;
+      msmts.push_back(measurement->getMeasurement());
+      _track->insertPoint(
+          new genfit::TrackPoint(msmts, _track));
+
+      //_measurements.push_back(measurement);
+      _clusterIDs.push_back(measurement->get_cluster_ID());
+      _clusterkeys.push_back(measurement->get_cluster_key());
+
+      delete measurement;
+    }
+
+    // measurements.clear();
+
+    return 0;
+  }
+
+  int Track::deleteLastMeasurement()
+  {
+    _track->deletePoint(-1);
+
+    _clusterIDs.pop_back();
+    _clusterkeys.pop_back();
+
+    return 0;
+  }
+
+  Track::~Track()
+  {
+    //	std::cout << "DTOR: " << __LINE__ <<std::endl;
+    delete _track;
+
+    //	for(PHGenFit::Measurement* measurement : _measurements)
+    //	{
+    //		delete measurement;
+    //	}
+    //	_measurements.clear();
+
+    _clusterIDs.clear();
+    _clusterkeys.clear();
+  }
+
+  double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, const TVector3& O, const TVector3& n, const int tr_point_id) const
+  {
+    double pathlenth = WILD_DOUBLE;
+
+    genfit::SharedPlanePtr destPlane(new genfit::DetPlane(O, n));
+
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
+        tr_point_id, rep);
+    if (tp == nullptr)
+    {
+      std::cout << "Track has no TrackPoint with fitterInfo! \n";
       return WILD_DOUBLE;
     }
-    if (dynamic_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep)))
+    std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
+        *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
+    // extrapolate back to reference plane.
+    try
     {
-      if (direction == 1)
-      {
-        if (static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
-                                                       rep))
-                ->getForwardUpdate())
-        {
-          have_tp_with_fit_info = true;
-          kfsop =
-              std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::KalmanFittedStateOnPlane(
-                  *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
-                                                               rep))
-                        ->getForwardUpdate())));
-        }
-      }
-      else
-      {
-        if (static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
-                                                       rep))
-                ->getBackwardUpdate())
-        {
-          have_tp_with_fit_info = true;
-          kfsop =
-              std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::KalmanFittedStateOnPlane(
-                  *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
-                                                               rep))
-                        ->getBackwardUpdate())));
-        }
-      }
+      pathlenth = rep->extrapolateToPlane(*kfsop, destPlane);
     }
-  }
-
-  if (!have_tp_with_fit_info)
-  {
-#ifdef _DEBUG_
-    std::cout << __LINE__ << ": !have_tp_with_fit_info" << std::endl;
-#endif
-    kfsop = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
-    rep->setPosMomCov(*kfsop, _track->getStateSeed(), _track->getCovSeed());
-  }
-
-  if (!kfsop) return pathlenth;
-  // extrapolate back to reference plane.
-  try
-  {
-    //rep->extrapolateToLine(*kfsop, line_point, line_direction);
-    pathlenth = rep->extrapolateToCylinder(*kfsop, radius, line_point, line_direction);
-  }
-  catch (genfit::Exception& e)
-  {
-    if (verbosity > 1)
+    catch (genfit::Exception& e)
     {
-      LogWarning("Can't extrapolate to cylinder!");
+      std::cerr << "Exception, next track" << std::endl;
       std::cerr << e.what();
+      // delete kfsop;
+      return WILD_DOUBLE;
     }
-    return WILD_DOUBLE;
+
+    state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
+
+    // delete kfsop;
+
+    return pathlenth;
   }
 
-  state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
-
-  //delete kfsop;
-
-  return pathlenth;
-}
-
-genfit::MeasuredStateOnPlane* Track::extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id, const int direction) const
-{
-  assert(direction == 1 or direction == -1);
-  genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-  double pathlenth = this->extrapolateToCylinder(*state, radius, line_point, line_direction, tr_point_id, direction);
-  if (pathlenth <= WILD_DOUBLE)
+  genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(const TVector3& O, const TVector3& n, const int tr_point_id) const
   {
-    delete state;
-    return NULL;
-  }
-  else
-    return state;
-}
-
-int Track::updateOneMeasurementKalman(
-    const std::vector<PHGenFit::Measurement*>& measurements,
-    std::map<double, std::shared_ptr<PHGenFit::Track> >& incr_chi2s_new_tracks,
-    const int base_tp_idx,
-    const int direction,
-    const float blowup_factor,
-    const bool use_fitted_state) const
-{
-#ifdef _DEBUG_
-  std::cout
-      << __LINE__
-      << " : base_tp_idx: " << base_tp_idx
-      << " : direction: " << direction
-      << " : blowup_factor: " << blowup_factor
-      << " : use_fitted_state: " << use_fitted_state
-      << std::endl;
-#endif
-
-  if (measurements.size() == 0) return -1;
-
-  for (PHGenFit::Measurement* measurement : measurements)
-  {
-    std::shared_ptr<PHGenFit::Track> new_track = NULL;
-
-    new_track = std::shared_ptr<PHGenFit::Track>(new PHGenFit::Track(*this));
-
-    //		if(incr_chi2s_new_tracks.size() == 0)
-    //			new_track = const_cast<PHGenFit::Track*>(this);
-    //		else
-    //			new_track = new PHGenFit::Track(*this);
-
-    genfit::Track* track = new_track->getGenFitTrack();
-    genfit::AbsTrackRep* rep = track->getCardinalRep();
-
-    bool newFi(true);
-    genfit::TrackPoint* tp_base = NULL;
-    std::unique_ptr<genfit::MeasuredStateOnPlane> currentState = NULL;
-    genfit::SharedPlanePtr plane = NULL;
-
-    if (track->getNumPointsWithMeasurement() > 0)
+    genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+    double pathlenth = this->extrapolateToPlane(*state, O, n, tr_point_id);
+    if (pathlenth <= WILD_DOUBLE)
     {
-      tp_base = track->getPointWithMeasurement(base_tp_idx);
-      newFi = !(tp_base->hasFitterInfo(rep));
-      //tp_base->Print();
-    }
-#ifdef _DEBUG_
-    std::cout << __LINE__ << ": "
-              << "newFi: " << newFi << std::endl;
-#endif
-    if (newFi)
-    {
-      currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
-      rep->setPosMomCov(*currentState, track->getStateSeed(),
-                        track->getCovSeed());
+      delete state;
+      return nullptr;
     }
     else
     {
-      try
+      return state;
+    }
+  }
+
+  double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id) const
+  {
+    double pathlenth = WILD_DOUBLE;
+
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
+        tr_point_id, rep);
+    if (tp == nullptr)
+    {
+      std::cout << "Track has no TrackPoint with fitterInfo! \n";
+      return WILD_DOUBLE;
+    }
+    std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
+        *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
+    // extrapolate back to reference plane.
+    try
+    {
+      pathlenth = rep->extrapolateToLine(*kfsop, line_point, line_direction);
+    }
+    catch (genfit::Exception& e)
+    {
+      std::cerr << "Exception, next track" << std::endl;
+      std::cerr << e.what();
+      // delete kfsop;
+      return WILD_DOUBLE;
+    }
+
+    state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
+
+    // delete kfsop;
+
+    return pathlenth;
+  }
+
+  genfit::MeasuredStateOnPlane* Track::extrapolateToLine(const TVector3& line_point, const TVector3& line_direction, const int tr_point_id) const
+  {
+    genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+    double pathlenth = this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
+    if (pathlenth <= WILD_DOUBLE)
+    {
+      delete state;
+      return nullptr;
+    }
+    else
+    {
+      return state;
+    }
+  }
+
+  double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id, const int direction) const
+  {
+#ifdef _DEBUG_
+    std::cout << __LINE__ << std::endl;
+    std::cout
+        << __LINE__
+        << ": tr_point_id: " << tr_point_id
+        << ": direction: " << direction
+        << std::endl;
+#endif
+    assert(direction == 1 or direction == -1);
+
+    double pathlenth = WILD_DOUBLE;
+
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+
+    //	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
+    //			tr_point_id, rep);
+    //	if (tp == NULL) {
+    //		std::cout << "Track has no TrackPoint with fitterInfo! \n";
+    //		return WILD_DOUBLE;
+    //	}
+
+    bool have_tp_with_fit_info = false;
+    std::unique_ptr<genfit::MeasuredStateOnPlane> kfsop = nullptr;
+    if (_track->getNumPointsWithMeasurement() > 0)
+    {
+#ifdef _DEBUG_
+//		std::cout<<__LINE__ <<std::endl;
+#endif
+      genfit::TrackPoint* tp = _track->getPointWithMeasurement(tr_point_id);
+      if (tp == nullptr)
       {
-        genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
-        if (!kfi)
+        LogError("tp == NULL!");
+        return WILD_DOUBLE;
+      }
+      if (dynamic_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep)))
+      {
+        if (direction == 1)
         {
-#ifdef _DEBUG_
-          LogDebug("!kfi");
-#endif
-          continue;
-        }
-        //#ifdef _DEBUG_
-        //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
-        //				kfi->Print();
-        //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
-        //#endif
-        if (use_fitted_state)
-        {
-          const genfit::MeasuredStateOnPlane* tempFS = &(kfi->getFittedState(true));
-          if (!tempFS)
+          if (static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
+                                                         rep))
+                  ->getForwardUpdate())
           {
-#ifdef _DEBUG_
-            LogDebug("!tempFS");
-#endif
-            continue;
+            have_tp_with_fit_info = true;
+            kfsop =
+                std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::KalmanFittedStateOnPlane(
+                    *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
+                                                                 rep))
+                          ->getForwardUpdate())));
           }
-          currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(*tempFS));
         }
         else
         {
-          genfit::MeasuredStateOnPlane* tempUpdate = kfi->getUpdate(direction);
-          if (!tempUpdate)
+          if (static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
+                                                         rep))
+                  ->getBackwardUpdate())
+          {
+            have_tp_with_fit_info = true;
+            kfsop =
+                std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::KalmanFittedStateOnPlane(
+                    *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(
+                                                                 rep))
+                          ->getBackwardUpdate())));
+          }
+        }
+      }
+    }
+
+    if (!have_tp_with_fit_info)
+    {
+#ifdef _DEBUG_
+      std::cout << __LINE__ << ": !have_tp_with_fit_info" << std::endl;
+#endif
+      kfsop = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
+      rep->setPosMomCov(*kfsop, _track->getStateSeed(), _track->getCovSeed());
+    }
+
+    if (!kfsop)
+    {
+      return pathlenth;
+    }
+    // extrapolate back to reference plane.
+    try
+    {
+      // rep->extrapolateToLine(*kfsop, line_point, line_direction);
+      pathlenth = rep->extrapolateToCylinder(*kfsop, radius, line_point, line_direction);
+    }
+    catch (genfit::Exception& e)
+    {
+      if (verbosity > 1)
+      {
+        LogWarning("Can't extrapolate to cylinder!");
+        std::cerr << e.what();
+      }
+      return WILD_DOUBLE;
+    }
+
+    state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
+
+    // delete kfsop;
+
+    return pathlenth;
+  }
+
+  genfit::MeasuredStateOnPlane* Track::extrapolateToCylinder(double radius, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id, const int direction) const
+  {
+    assert(direction == 1 or direction == -1);
+    genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+    double pathlenth = this->extrapolateToCylinder(*state, radius, line_point, line_direction, tr_point_id, direction);
+    if (pathlenth <= WILD_DOUBLE)
+    {
+      delete state;
+      return nullptr;
+    }
+    else
+    {
+      return state;
+    }
+  }
+
+  int Track::updateOneMeasurementKalman(
+      const std::vector<PHGenFit::Measurement*>& measurements,
+      std::map<double, std::shared_ptr<PHGenFit::Track> >& incr_chi2s_new_tracks,
+      const int base_tp_idx,
+      const int direction,
+      const float blowup_factor,
+      const bool use_fitted_state) const
+  {
+#ifdef _DEBUG_
+    std::cout
+        << __LINE__
+        << " : base_tp_idx: " << base_tp_idx
+        << " : direction: " << direction
+        << " : blowup_factor: " << blowup_factor
+        << " : use_fitted_state: " << use_fitted_state
+        << std::endl;
+#endif
+
+    if (measurements.size() == 0)
+    {
+      return -1;
+    }
+
+    for (PHGenFit::Measurement* measurement : measurements)
+    {
+      std::shared_ptr<PHGenFit::Track> new_track = nullptr;
+
+      new_track = std::shared_ptr<PHGenFit::Track>(new PHGenFit::Track(*this));
+
+      //		if(incr_chi2s_new_tracks.size() == 0)
+      //			new_track = const_cast<PHGenFit::Track*>(this);
+      //		else
+      //			new_track = new PHGenFit::Track(*this);
+
+      genfit::Track* track = new_track->getGenFitTrack();
+      genfit::AbsTrackRep* rep = track->getCardinalRep();
+
+      bool newFi(true);
+      genfit::TrackPoint* tp_base = nullptr;
+      std::unique_ptr<genfit::MeasuredStateOnPlane> currentState = nullptr;
+      genfit::SharedPlanePtr plane = nullptr;
+
+      if (track->getNumPointsWithMeasurement() > 0)
+      {
+        tp_base = track->getPointWithMeasurement(base_tp_idx);
+        newFi = !(tp_base->hasFitterInfo(rep));
+        // tp_base->Print();
+      }
+#ifdef _DEBUG_
+      std::cout << __LINE__ << ": "
+                << "newFi: " << newFi << std::endl;
+#endif
+      if (newFi)
+      {
+        currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
+        rep->setPosMomCov(*currentState, track->getStateSeed(),
+                          track->getCovSeed());
+      }
+      else
+      {
+        try
+        {
+          genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
+          if (!kfi)
           {
 #ifdef _DEBUG_
-            LogDebug("!tempUpdate");
+            LogDebug("!kfi");
 #endif
             continue;
           }
-          currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(*tempUpdate));
-        }
+          //#ifdef _DEBUG_
+          //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
+          //				kfi->Print();
+          //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
+          //#endif
+          if (use_fitted_state)
+          {
+            const genfit::MeasuredStateOnPlane* tempFS = &(kfi->getFittedState(true));
+            if (!tempFS)
+            {
+#ifdef _DEBUG_
+              LogDebug("!tempFS");
+#endif
+              continue;
+            }
+            currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(*tempFS));
+          }
+          else
+          {
+            genfit::MeasuredStateOnPlane* tempUpdate = kfi->getUpdate(direction);
+            if (!tempUpdate)
+            {
+#ifdef _DEBUG_
+              LogDebug("!tempUpdate");
+#endif
+              continue;
+            }
+            currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(*tempUpdate));
+          }
 
 #ifdef _DEBUG_
 //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
@@ -465,57 +477,57 @@ int Track::updateOneMeasurementKalman(
 //				std::cout << __LINE__ << "\n ###################################################################"<<std::endl;
 #endif
 
-        if (blowup_factor > 1)
+          if (blowup_factor > 1)
+          {
+            currentState->blowUpCov(blowup_factor, true, 1e6);
+          }
+        }
+        catch (genfit::Exception& e)
         {
-          currentState->blowUpCov(blowup_factor, true, 1e6);
+#ifdef _DEBUG_
+          std::cout
+              << __LINE__
+              << ": Fitted state not found!"
+              << std::endl;
+          std::cerr << e.what() << std::endl;
+#endif
+          currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
+          rep->setPosMomCov(*currentState, track->getStateSeed(),
+                            track->getCovSeed());
         }
       }
-      catch (genfit::Exception &e)
-      {
 #ifdef _DEBUG_
-        std::cout
-            << __LINE__
-            << ": Fitted state not found!"
-            << std::endl;
-        std::cerr << e.what() << std::endl;
+      std::cout << __LINE__ << std::endl;
 #endif
-        currentState = std::unique_ptr<genfit::MeasuredStateOnPlane>(new genfit::MeasuredStateOnPlane(rep));
-        rep->setPosMomCov(*currentState, track->getStateSeed(),
-                          track->getCovSeed());
-      }
-    }
-#ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
-#endif
-    //std::vector<genfit::AbsMeasurement*> msmts;
-    //msmts.push_back(measurement->getMeasurement());
+      // std::vector<genfit::AbsMeasurement*> msmts;
+      // msmts.push_back(measurement->getMeasurement());
 
-    //genfit::TrackPoint *tp = new genfit::TrackPoint(msmts, track);
-    //track->insertPoint(tp); // genfit
+      // genfit::TrackPoint *tp = new genfit::TrackPoint(msmts, track);
+      // track->insertPoint(tp); // genfit
 
-    /*!
-		 * A new TrackPoint created in addMeasurement
-		 * PHGenFit: clusterID also registerd
-		 */
-    new_track->addMeasurement(measurement);
+      /*!
+       * A new TrackPoint created in addMeasurement
+       * PHGenFit: clusterID also registerd
+       */
+      new_track->addMeasurement(measurement);
 
 #ifdef _DEBUG_
-    std::cout << __LINE__ << ": clusterIDs size: " << new_track->get_cluster_IDs().size() << std::endl;
-    std::cout << __LINE__ << ": clusterkeyss size: " << new_track->get_cluster_keys().size() << std::endl;
+      std::cout << __LINE__ << ": clusterIDs size: " << new_track->get_cluster_IDs().size() << std::endl;
+      std::cout << __LINE__ << ": clusterkeyss size: " << new_track->get_cluster_keys().size() << std::endl;
 #endif
 
-    //! Get the pointer of the TrackPoint just created
-    genfit::TrackPoint* tp = new_track->getGenFitTrack()->getPoint(-1);
+      //! Get the pointer of the TrackPoint just created
+      genfit::TrackPoint* tp = new_track->getGenFitTrack()->getPoint(-1);
 #ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
+      std::cout << __LINE__ << std::endl;
 #endif
-    genfit::KalmanFitterInfo* fi = new genfit::KalmanFitterInfo(tp, rep);
-    tp->setFitterInfo(fi);
+      genfit::KalmanFitterInfo* fi = new genfit::KalmanFitterInfo(tp, rep);
+      tp->setFitterInfo(fi);
 #ifdef _DEBUG_
-    std::cout
-        << __LINE__
-        << ": track->getPointWithMeasurement(): " << track->getPointWithMeasurement(-1)
-        << std::endl;
+      std::cout
+          << __LINE__
+          << ": track->getPointWithMeasurement(): " << track->getPointWithMeasurement(-1)
+          << std::endl;
 #endif
 //		if (track->getNumPointsWithMeasurement() > 0) {
 //			tp_base = track->getPointWithMeasurement(-1);
@@ -524,281 +536,340 @@ int Track::updateOneMeasurementKalman(
 //			}
 //		}
 #ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
-#endif
-    const std::vector<genfit::AbsMeasurement*>& rawMeasurements =
-        tp->getRawMeasurements();
-    // construct plane with first measurement
-    plane = rawMeasurements[0]->constructPlane(*currentState);
-
-    //double extLen = rep->extrapolateToPlane(*state, plane);
-
-    try
-    {
-      rep->extrapolateToPlane(*currentState, plane);
-    }
-    catch (...)
-    {
-      if (verbosity > 1)
-      {
-        LogWarning("Can not extrapolate to measuremnt with cluster_ID and cluster key: ") << measurement->get_cluster_ID() 
-									  << "    " << measurement->get_cluster_key() 
-									  << std::endl;
-      }
-      continue;
-    }
-#ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
-#endif
-    fi->setPrediction(currentState->clone(), direction);
-    genfit::MeasuredStateOnPlane* state = fi->getPrediction(direction);
-#ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
-#endif
-    TVectorD stateVector(state->getState());
-    TMatrixDSym cov(state->getCov());
-#ifdef _DEBUG_
-    {
       std::cout << __LINE__ << std::endl;
-      //			TMatrixDSym cov6d = state->get6DCov();
-      //			float err_rphi = sqrt(
-      //					cov6d[0][0] + cov6d[1][1] + cov6d[0][1] + cov6d[1][0]);
-      //			float err_z = sqrt(cov6d[2][2]);
-      //			std::cout << err_phi << "\t" << err_z << "\t";
-    }
 #endif
-    for (std::vector<genfit::AbsMeasurement*>::const_iterator it =
-             rawMeasurements.begin();
-         it != rawMeasurements.end(); ++it)
-    {
-      fi->addMeasurementsOnPlane(
-          (*it)->constructMeasurementsOnPlane(*state));
-    }
+      const std::vector<genfit::AbsMeasurement*>& rawMeasurements =
+          tp->getRawMeasurements();
+      // construct plane with first measurement
+      plane = rawMeasurements[0]->constructPlane(*currentState);
 
-    double chi2inc = 0;
-    double ndfInc = 0;
+      // double extLen = rep->extrapolateToPlane(*state, plane);
+
+      try
+      {
+        rep->extrapolateToPlane(*currentState, plane);
+      }
+      catch (...)
+      {
+        if (verbosity > 1)
+        {
+          LogWarning("Can not extrapolate to measuremnt with cluster_ID and cluster key: ") << measurement->get_cluster_ID()
+                                                                                            << "    " << measurement->get_cluster_key()
+                                                                                            << std::endl;
+        }
+        continue;
+      }
 #ifdef _DEBUG_
-    std::cout << __LINE__ << std::endl;
+      std::cout << __LINE__ << std::endl;
 #endif
-    // update(s)
-    const std::vector<genfit::MeasurementOnPlane*>& measurements_on_plane = fi->getMeasurementsOnPlane();
+      fi->setPrediction(currentState->clone(), direction);
+      genfit::MeasuredStateOnPlane* state = fi->getPrediction(direction);
 #ifdef _DEBUG_
-    std::cout
-        << __LINE__
-        << ": size of fi's MeasurementsOnPlane: " << measurements_on_plane.size()
-        << std::endl;
+      std::cout << __LINE__ << std::endl;
 #endif
-    for (std::vector<genfit::MeasurementOnPlane*>::const_iterator it =
-             measurements_on_plane.begin();
-         it != measurements_on_plane.end(); ++it)
-    {
-      const genfit::MeasurementOnPlane& mOnPlane = **it;
-      //const double weight = mOnPlane.getWeight();
-
-      const TVectorD& measurementA(mOnPlane.getState());
-      const genfit::AbsHMatrix* H(mOnPlane.getHMatrix());
-      // (weighted) cov
-      const TMatrixDSym& V(mOnPlane.getCov());  //Covariance of measurement noise v_{k}
-
-      TVectorD res(measurementA - H->Hv(stateVector));
+      TVectorD stateVector(state->getState());
+      TMatrixDSym cov(state->getCov());
 #ifdef _DEBUG_
       {
         std::cout << __LINE__ << std::endl;
-        //			std::cout
-        //			<<res(0) <<"\t"
-        //			<<res(1) <<"\t";
+        //			TMatrixDSym cov6d = state->get6DCov();
+        //			float err_rphi = sqrt(
+        //					cov6d[0][0] + cov6d[1][1] + cov6d[0][1] + cov6d[1][0]);
+        //			float err_z = sqrt(cov6d[2][2]);
+        //			std::cout << err_phi << "\t" << err_z << "\t";
       }
 #endif
-      // If hit, do Kalman algebra.
+      for (auto rawMeasurement : rawMeasurements)
       {
-        // calculate kalman gain ------------------------------
-        // calculate covsum (V + HCH^T) and invert
-        TMatrixDSym covSumInv(cov);
-        H->HMHt(covSumInv);
-        covSumInv += V;
+        fi->addMeasurementsOnPlane(
+            rawMeasurement->constructMeasurementsOnPlane(*state));
+      }
+
+      double chi2inc = 0;
+      double ndfInc = 0;
+#ifdef _DEBUG_
+      std::cout << __LINE__ << std::endl;
+#endif
+      // update(s)
+      const std::vector<genfit::MeasurementOnPlane*>& measurements_on_plane = fi->getMeasurementsOnPlane();
+#ifdef _DEBUG_
+      std::cout
+          << __LINE__
+          << ": size of fi's MeasurementsOnPlane: " << measurements_on_plane.size()
+          << std::endl;
+#endif
+      for (auto it : measurements_on_plane)
+      {
+        const genfit::MeasurementOnPlane& mOnPlane = *it;
+        // const double weight = mOnPlane.getWeight();
+
+        const TVectorD& measurementA(mOnPlane.getState());
+        const genfit::AbsHMatrix* H(mOnPlane.getHMatrix());
+        // (weighted) cov
+        const TMatrixDSym& V(mOnPlane.getCov());  // Covariance of measurement noise v_{k}
+
+        TVectorD res(measurementA - H->Hv(stateVector));
+#ifdef _DEBUG_
+        {
+          std::cout << __LINE__ << std::endl;
+          //			std::cout
+          //			<<res(0) <<"\t"
+          //			<<res(1) <<"\t";
+        }
+#endif
+        // If hit, do Kalman algebra.
+        {
+          // calculate kalman gain ------------------------------
+          // calculate covsum (V + HCH^T) and invert
+          TMatrixDSym covSumInv(cov);
+          H->HMHt(covSumInv);
+          covSumInv += V;
+          try
+          {
+            genfit::tools::invertMatrix(covSumInv);
+          }
+          catch (genfit::Exception& e)
+          {
+#ifdef _DEBUG_
+            LogDebug("cannot invert matrix.");
+#endif
+            continue;
+          }
+
+          TMatrixD CHt(H->MHt(cov));
+#ifdef _PRINT_MATRIX_
+          std::cout << __LINE__ << ": V_{k}:" << std::endl;
+          V.Print();
+          std::cout << __LINE__ << ": R_{k}^{-1}:" << std::endl;
+          covSumInv.Print();
+          std::cout << __LINE__ << ": C_{k|k-1}:" << std::endl;
+          cov.Print();
+          std::cout << __LINE__ << ": C_{k|k-1} H_{k}^{T} :" << std::endl;
+          CHt.Print();
+          std::cout << __LINE__ << ": K_{k} :" << std::endl;
+          TMatrixD Kk(CHt, TMatrixD::kMult, covSumInv);
+          Kk.Print();
+          std::cout << __LINE__ << ": res:" << std::endl;
+          res.Print();
+#endif
+          TVectorD update(
+              TMatrixD(CHt, TMatrixD::kMult, covSumInv) * res);
+          // TMatrixD(CHt, TMatrixD::kMult, covSumInv).Print();
+
+          stateVector += update;      // x_{k|k} = x_{k|k-1} + K_{k} r_{k|k-1}
+          covSumInv.Similarity(CHt);  // with (C H^T)^T = H C^T = H C  (C is symmetric)
+          cov -= covSumInv;           // C_{k|k}
+#ifdef _DEBUG_
+          {
+            std::cout << __LINE__ << std::endl;
+            //			TMatrixDSym cov6d = state->get6DCov();
+            //			float err_rphi     = sqrt(cov6d[0][0] + cov6d[1][1] + cov6d[0][1] + cov6d[1][0]);
+            //			float err_z   = sqrt(cov6d[2][2]);
+            //			std::cout
+            //			<<err_phi <<"\t"
+            //			<<err_z <<"\t";
+          }
+#endif
+        }
+
+        TVectorD resNew(measurementA - H->Hv(stateVector));
+
+        // Calculate chi2
+        TMatrixDSym HCHt(cov);  // C_{k|k}
+        H->HMHt(HCHt);
+        HCHt -= V;
+        HCHt *= -1;
+
         try
         {
-          genfit::tools::invertMatrix(covSumInv);
+          genfit::tools::invertMatrix(HCHt);
         }
-        catch (genfit::Exception &e)
+        catch (genfit::Exception& e)
         {
 #ifdef _DEBUG_
           LogDebug("cannot invert matrix.");
 #endif
           continue;
         }
+        chi2inc += HCHt.Similarity(resNew);
 
-        TMatrixD CHt(H->MHt(cov));
+        ndfInc += measurementA.GetNrows();
+
 #ifdef _PRINT_MATRIX_
-        std::cout << __LINE__ << ": V_{k}:" << std::endl;
-        V.Print();
-        std::cout << __LINE__ << ": R_{k}^{-1}:" << std::endl;
-        covSumInv.Print();
-        std::cout << __LINE__ << ": C_{k|k-1}:" << std::endl;
-        cov.Print();
-        std::cout << __LINE__ << ": C_{k|k-1} H_{k}^{T} :" << std::endl;
-        CHt.Print();
-        std::cout << __LINE__ << ": K_{k} :" << std::endl;
-        TMatrixD Kk(CHt, TMatrixD::kMult, covSumInv);
-        Kk.Print();
-        std::cout << __LINE__ << ": res:" << std::endl;
-        res.Print();
+        std::cout << __LINE__ << ": V - HCHt:" << std::endl;
+        HCHt.Print();
+        std::cout << __LINE__ << ": resNew:" << std::endl;
+        resNew.Print();
 #endif
-        TVectorD update(
-            TMatrixD(CHt, TMatrixD::kMult, covSumInv) * res);
-        //TMatrixD(CHt, TMatrixD::kMult, covSumInv).Print();
 
-        stateVector += update;      // x_{k|k} = x_{k|k-1} + K_{k} r_{k|k-1}
-        covSumInv.Similarity(CHt);  // with (C H^T)^T = H C^T = H C  (C is symmetric)
-        cov -= covSumInv;           //C_{k|k}
 #ifdef _DEBUG_
+        std::cout << __LINE__ << ": ndfInc:  " << ndfInc << std::endl;
+        std::cout << __LINE__ << ": chi2inc: " << chi2inc << std::endl;
+#endif
+
+        currentState->setStateCovPlane(stateVector, cov, plane);
+        currentState->setAuxInfo(state->getAuxInfo());
+
+        genfit::KalmanFittedStateOnPlane* updatedSOP =
+            new genfit::KalmanFittedStateOnPlane(*currentState, chi2inc,
+                                                 ndfInc);
+        fi->setUpdate(updatedSOP, direction);
+      }  // loop measurements_on_plane
+
+      // FIXME why chi2 could be smaller than 0?
+      if (chi2inc > 0)
+      {
+        incr_chi2s_new_tracks.insert(std::make_pair(chi2inc, new_track));
+      }
+
+    }  // loop measurments
+
+    return 0;
+  }
+
+  double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, const TVector3& P, const int tr_point_id) const
+  {
+    double pathlenth = WILD_DOUBLE;
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
+        tr_point_id, rep);
+    if (tp == nullptr)
+    {
+      std::cout << "Track has no TrackPoint with fitterInfo! \n";
+      return WILD_DOUBLE;
+    }
+    std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
+        *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
+    // extrapolate back to reference plane.
+    try
+    {
+      pathlenth = rep->extrapolateToPoint(*kfsop, P);
+    }
+    catch (genfit::Exception& e)
+    {
+      std::cerr << "Exception, next track" << std::endl;
+      std::cerr << e.what();
+      // delete kfsop;
+      return WILD_DOUBLE;
+    }
+
+    state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
+
+    // delete kfsop;
+
+    return pathlenth;
+  }
+
+  genfit::MeasuredStateOnPlane* Track::extrapolateToPoint(const TVector3& P, const int tr_point_id) const
+  {
+    genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+    double pathlenth = this->extrapolateToPoint(*state, P, tr_point_id);
+    if (pathlenth <= WILD_DOUBLE)
+    {
+      delete state;
+      return nullptr;
+    }
+    else
+    {
+      return state;
+    }
+  }
+
+  double Track::get_chi2() const
+  {
+    double chi2 = std::numeric_limits<double>::quiet_NaN();
+
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    if (rep)
+    {
+      genfit::FitStatus* fs = _track->getFitStatus(rep);
+      if (fs)
+      {
+        chi2 = fs->getChi2();
+      }
+    }
+    return chi2;
+  }
+
+  double Track::get_ndf() const
+  {
+    double ndf = std::numeric_limits<double>::quiet_NaN();
+
+    genfit::AbsTrackRep* rep = _track->getCardinalRep();
+    if (rep)
+    {
+      genfit::FitStatus* fs = _track->getFitStatus(rep);
+      if (fs)
+      {
+        ndf = fs->getNdf();
+      }
+    }
+    return ndf;
+  }
+
+  double Track::get_charge() const
+  {
+    double charge = std::numeric_limits<double>::quiet_NaN();
+
+    if (!_track)
+    {
+      return charge;
+    }
+
+    try
+    {
+      genfit::TrackPoint* tp_base = nullptr;
+
+      if (_track->getNumPointsWithMeasurement() > 0)
+      {
+        tp_base = _track->getPointWithMeasurement(0);
+      }
+
+      if (!tp_base)
+      {
+        return charge;
+      }
+
+      genfit::AbsTrackRep* rep = _track->getCardinalRep();
+      if (rep)
+      {
+        genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
+
+        if (!kfi)
         {
-          std::cout << __LINE__ << std::endl;
-          //			TMatrixDSym cov6d = state->get6DCov();
-          //			float err_rphi     = sqrt(cov6d[0][0] + cov6d[1][1] + cov6d[0][1] + cov6d[1][0]);
-          //			float err_z   = sqrt(cov6d[2][2]);
-          //			std::cout
-          //			<<err_phi <<"\t"
-          //			<<err_z <<"\t";
+          return charge;
         }
-#endif
+
+        const genfit::MeasuredStateOnPlane* state = &(kfi->getFittedState(true));
+
+        // std::unique_ptr<genfit::StateOnPlane> state (this->extrapolateToLine(TVector3(0, 0, 0), TVector3(1, 0, 0)));
+
+        if (state)
+        {
+          charge = rep->getCharge(*state);
+        }
       }
-
-      TVectorD resNew(measurementA - H->Hv(stateVector));
-
-      // Calculate chi2
-      TMatrixDSym HCHt(cov);  //C_{k|k}
-      H->HMHt(HCHt);
-      HCHt -= V;
-      HCHt *= -1;
-
-      try
+    }
+    catch (...)
+    {
+      if (verbosity >= 1)
       {
-        genfit::tools::invertMatrix(HCHt);
+        std::cerr << "Track::get_charge - Error - obtaining charge failed. Returning NAN as charge." << std::endl;
       }
-      catch (genfit::Exception &e)
-      {
-#ifdef _DEBUG_
-        LogDebug("cannot invert matrix.");
-#endif
-        continue;
-      }
-      chi2inc += HCHt.Similarity(resNew);
+    }
 
-      ndfInc += measurementA.GetNrows();
-
-#ifdef _PRINT_MATRIX_
-      std::cout << __LINE__ << ": V - HCHt:" << std::endl;
-      HCHt.Print();
-      std::cout << __LINE__ << ": resNew:" << std::endl;
-      resNew.Print();
-#endif
-
-#ifdef _DEBUG_
-      std::cout << __LINE__ << ": ndfInc:  " << ndfInc << std::endl;
-      std::cout << __LINE__ << ": chi2inc: " << chi2inc << std::endl;
-#endif
-
-      currentState->setStateCovPlane(stateVector, cov, plane);
-      currentState->setAuxInfo(state->getAuxInfo());
-
-      genfit::KalmanFittedStateOnPlane* updatedSOP =
-          new genfit::KalmanFittedStateOnPlane(*currentState, chi2inc,
-                                               ndfInc);
-      fi->setUpdate(updatedSOP, direction);
-    }  //loop measurements_on_plane
-
-    //FIXME why chi2 could be smaller than 0?
-    if (chi2inc > 0)
-      incr_chi2s_new_tracks.insert(std::make_pair(chi2inc, new_track));
-
-  }  //loop measurments
-
-  return 0;
-}
-
-double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id) const
-{
-  double pathlenth = WILD_DOUBLE;
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
-      tr_point_id, rep);
-  if (tp == NULL)
-  {
-    std::cout << "Track has no TrackPoint with fitterInfo! \n";
-    return WILD_DOUBLE;
-  }
-  std::unique_ptr<genfit::KalmanFittedStateOnPlane> kfsop(new genfit::KalmanFittedStateOnPlane(
-      *(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate())));
-  // extrapolate back to reference plane.
-  try
-  {
-    pathlenth = rep->extrapolateToPoint(*kfsop, P);
-  }
-  catch (genfit::Exception& e)
-  {
-    std::cerr << "Exception, next track" << std::endl;
-    std::cerr << e.what();
-    //delete kfsop;
-    return WILD_DOUBLE;
+    return charge;
   }
 
-  state = *dynamic_cast<genfit::MeasuredStateOnPlane*>(kfsop.get());
-
-  //delete kfsop;
-
-  return pathlenth;
-}
-
-genfit::MeasuredStateOnPlane* Track::extrapolateToPoint(TVector3 P, const int tr_point_id) const
-{
-  genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-  double pathlenth = this->extrapolateToPoint(*state, P, tr_point_id);
-  if (pathlenth <= WILD_DOUBLE)
+  TVector3 Track::get_mom() const
   {
-    delete state;
-    return NULL;
-  }
-  else
-    return state;
-}
+    TVector3 mom(0, 0, 0);
 
-double Track::get_chi2() const
-{
-  double chi2 = std::numeric_limits<double>::quiet_NaN();
+    if (!_track)
+    {
+      return mom;
+    }
 
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  if (rep)
-  {
-    genfit::FitStatus* fs = _track->getFitStatus(rep);
-    if (fs)
-      chi2 = fs->getChi2();
-  }
-  return chi2;
-}
-
-double Track::get_ndf() const
-{
-  double ndf = std::numeric_limits<double>::quiet_NaN();
-
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  if (rep)
-  {
-    genfit::FitStatus* fs = _track->getFitStatus(rep);
-    if (fs)
-      ndf = fs->getNdf();
-  }
-  return ndf;
-}
-
-double Track::get_charge() const
-{
-  double charge = std::numeric_limits<double>::quiet_NaN();
-
-  if (!_track) return charge;
-
-  try
-  {
     genfit::TrackPoint* tp_base = nullptr;
 
     if (_track->getNumPointsWithMeasurement() > 0)
@@ -806,61 +877,30 @@ double Track::get_charge() const
       tp_base = _track->getPointWithMeasurement(0);
     }
 
-    if (!tp_base) return charge;
+    if (!tp_base)
+    {
+      return mom;
+    }
 
     genfit::AbsTrackRep* rep = _track->getCardinalRep();
     if (rep)
     {
       genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
 
-      if (!kfi) return charge;
+      if (!kfi)
+      {
+        return mom;
+      }
 
       const genfit::MeasuredStateOnPlane* state = &(kfi->getFittedState(true));
 
-      //std::unique_ptr<genfit::StateOnPlane> state (this->extrapolateToLine(TVector3(0, 0, 0), TVector3(1, 0, 0)));
-
       if (state)
-        charge = rep->getCharge(*state);
+      {
+        return state->getMom();
+      }
     }
+
+    return mom;
   }
-  catch (...)
-  {
-    if (verbosity >= 1)
-      std::cerr << "Track::get_charge - Error - obtaining charge failed. Returning NAN as charge." << std::endl;
-  }
-
-  return charge;
-}
-
-TVector3 Track::get_mom() const
-{
-  TVector3 mom(0, 0, 0);
-
-  if (!_track) return mom;
-
-  genfit::TrackPoint* tp_base = nullptr;
-
-  if (_track->getNumPointsWithMeasurement() > 0)
-  {
-    tp_base = _track->getPointWithMeasurement(0);
-  }
-
-  if (!tp_base) return mom;
-
-  genfit::AbsTrackRep* rep = _track->getCardinalRep();
-  if (rep)
-  {
-    genfit::KalmanFitterInfo* kfi = static_cast<genfit::KalmanFitterInfo*>(tp_base->getFitterInfo(rep));
-
-    if (!kfi) return mom;
-
-    const genfit::MeasuredStateOnPlane* state = &(kfi->getFittedState(true));
-
-    if (state)
-      return state->getMom();
-  }
-
-  return mom;
-}
 
 }  // namespace PHGenFit

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -12,143 +12,141 @@
 #include <TMatrixDSymfwd.h>
 #include <TVector3.h>
 
-//STL
+// STL
+#include <iostream>
 #include <limits>
 #include <map>
 #include <memory>
 #include <vector>
-#include <iostream>
 
-//GenFit
+// GenFit
 
 namespace genfit
 {
-class AbsTrackRep;
-class MeasuredStateOnPlane;
-class Track;
+  class AbsTrackRep;
+  class MeasuredStateOnPlane;
+  class Track;
 }  // namespace genfit
 
 namespace PHGenFit
 {
-class Measurement;
+  class Measurement;
 
-class Track
-{
- public:
-  //! Default ctor
-  Track(genfit::AbsTrackRep* rep, TVector3 seed_pos, TVector3 seed_mom, TMatrixDSym seed_cov, const int v = 0);
-
-  //! Copy constructor
-  Track(const PHGenFit::Track& t);
-
-  //! Default dtor
-  ~Track();
-
-  //! Add measurement
-  int addMeasurement(PHGenFit::Measurement* measurement);
-  int addMeasurements(std::vector<PHGenFit::Measurement*>& measurements);
-
-  int deleteLastMeasurement();
-
-  //!
-  int updateOneMeasurementKalman(
-      const std::vector<PHGenFit::Measurement*>& measurements,
-      std::map<double, std::shared_ptr<PHGenFit::Track> >& incr_chi2s_new_tracks,
-      const int base_tp_idx = -1,
-      const int direction = 1,
-      const float blowup_factor = 1.,
-      const bool use_fitted_state = false) const;
-
-  /*!
-	 * track_point 0 is the first one, and -1 is the last one
-	 */
-  double extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id = 0) const;
-  //!
-  double extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
-  //!
-  double extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0, const int direction = 1) const;
-  //!
-  double extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id = 0) const;
-
-  //!
-  genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = 0) const;
-  //!
-  genfit::MeasuredStateOnPlane* extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
-  //!
-  genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0, const int direction = 1) const;
-  //!
-  genfit::MeasuredStateOnPlane* extrapolateToPoint(TVector3 P, const int tr_point_id = 0) const;
-  //!
-  genfit::Track* getGenFitTrack() { return _track; }
-
-  genfit::Track* getGenFitTrack() const { return _track; }
-
-  double get_chi2() const;
-
-  double get_ndf() const;
-
-  double get_charge() const;
-
-  TVector3 get_mom() const;
-
-  // old tracking
-  const std::vector<unsigned int>& get_cluster_IDs() const
+  class Track
   {
-    return _clusterIDs;
-  }
-  void set_cluster_IDs(const std::vector<unsigned int>& clusterIDs)
-  {
-    _clusterIDs = clusterIDs;
-  }
+   public:
+    //! Default ctor
+    Track(genfit::AbsTrackRep* rep, const TVector3& seed_pos, const TVector3& seed_mom, const TMatrixDSym& seed_cov, const int v = 0);
 
-  // new tracking
-  const std::vector<TrkrDefs::cluskey>& get_cluster_keys() const
-  {
-    return _clusterkeys;
-  }
-  void set_cluster_keys(const std::vector<TrkrDefs::cluskey>& clusterkeys)
-  {
-    _clusterkeys = clusterkeys;
-  }
+    //! Copy constructor
+    Track(const PHGenFit::Track& t);
 
-  void set_vertex_id(const unsigned int vert_id)
-  {
-    _vertex_id = vert_id;
-  }
+    //! Default dtor
+    ~Track();
 
-  unsigned int get_vertex_id() const
-  {
-    //std::cout << " Track: returning vertex_id = " << _vertex_id << std::endl;
-    return _vertex_id;
-  }
+    //! Add measurement
+    int addMeasurement(PHGenFit::Measurement* measurement);
+    int addMeasurements(std::vector<PHGenFit::Measurement*>& measurements);
 
+    int deleteLastMeasurement();
 
-  int get_verbosity() const
-  {
-    return verbosity;
-  }
+    //!
+    int updateOneMeasurementKalman(
+        const std::vector<PHGenFit::Measurement*>& measurements,
+        std::map<double, std::shared_ptr<PHGenFit::Track> >& incr_chi2s_new_tracks,
+        const int base_tp_idx = -1,
+        const int direction = 1,
+        const float blowup_factor = 1.,
+        const bool use_fitted_state = false) const;
 
-  void set_verbosity(int v)
-  {
-    this->verbosity = v;
-  }
+    /*!
+     * track_point 0 is the first one, and -1 is the last one
+     */
+    double extrapolateToPlane(genfit::MeasuredStateOnPlane& state, const TVector3& O, const TVector3& n, const int tr_point_id = 0) const;
+    //!
+    double extrapolateToLine(genfit::MeasuredStateOnPlane& state, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id = 0) const;
+    //!
+    double extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id = 0, const int direction = 1) const;
+    //!
+    double extrapolateToPoint(genfit::MeasuredStateOnPlane& state, const TVector3& P, const int tr_point_id = 0) const;
 
-  //SMART(genfit::Track) getGenFitTrack() {return _track;}
+    //!
+    genfit::MeasuredStateOnPlane* extrapolateToPlane(const TVector3& O, const TVector3& n, const int tr_point_id = 0) const;
+    //!
+    genfit::MeasuredStateOnPlane* extrapolateToLine(const TVector3& line_point, const TVector3& line_direction, const int tr_point_id = 0) const;
+    //!
+    genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, const TVector3& line_point, const TVector3& line_direction, const int tr_point_id = 0, const int direction = 1) const;
+    //!
+    genfit::MeasuredStateOnPlane* extrapolateToPoint(const TVector3& P, const int tr_point_id = 0) const;
+    //!
+    genfit::Track* getGenFitTrack() { return _track; }
 
- private:
-  Track operator=(Track &trk) = delete; 
+    genfit::Track* getGenFitTrack() const { return _track; }
 
-  int verbosity;
+    double get_chi2() const;
 
-  genfit::Track* _track;
-  //std::vector<PHGenFit::Measurement*> _measurements;
-  std::vector<unsigned int> _clusterIDs;
-  std::vector<TrkrDefs::cluskey> _clusterkeys;
-  unsigned int _vertex_id {std::numeric_limits<unsigned int>::max()};
+    double get_ndf() const;
 
+    double get_charge() const;
 
-  //SMART(genfit::Track) _track;
-};
+    TVector3 get_mom() const;
+
+    // old tracking
+    const std::vector<unsigned int>& get_cluster_IDs() const
+    {
+      return _clusterIDs;
+    }
+    void set_cluster_IDs(const std::vector<unsigned int>& clusterIDs)
+    {
+      _clusterIDs = clusterIDs;
+    }
+
+    // new tracking
+    const std::vector<TrkrDefs::cluskey>& get_cluster_keys() const
+    {
+      return _clusterkeys;
+    }
+    void set_cluster_keys(const std::vector<TrkrDefs::cluskey>& clusterkeys)
+    {
+      _clusterkeys = clusterkeys;
+    }
+
+    void set_vertex_id(const unsigned int vert_id)
+    {
+      _vertex_id = vert_id;
+    }
+
+    unsigned int get_vertex_id() const
+    {
+      // std::cout << " Track: returning vertex_id = " << _vertex_id << std::endl;
+      return _vertex_id;
+    }
+
+    int get_verbosity() const
+    {
+      return verbosity;
+    }
+
+    void set_verbosity(int v)
+    {
+      this->verbosity = v;
+    }
+
+    // SMART(genfit::Track) getGenFitTrack() {return _track;}
+
+   private:
+    Track operator=(Track& trk) = delete;
+
+    int verbosity;
+
+    genfit::Track* _track;
+    // std::vector<PHGenFit::Measurement*> _measurements;
+    std::vector<unsigned int> _clusterIDs;
+    std::vector<TrkrDefs::cluskey> _clusterkeys;
+    unsigned int _vertex_id{std::numeric_limits<unsigned int>::max()};
+
+    // SMART(genfit::Track) _track;
+  };
 }  // namespace PHGenFit
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
We will need a new return code to be able to abort the processing gracefully (close and save the output files). The current ABORTRUN is a hard exit which does not close the output files properly. This is meant to be used in a fatal condition which invalidates a run and better a corrupt file than a "good" file with wrong data

clang-tidy fixed for genfit implementation (which is likely not being used anymore anyway) to reduce the jenkins noise
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

