### PR TITLE
Changes to handling of silicon-TPC matching for pp

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -304,43 +304,47 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
 
     unsigned int tpcid = track->get_tpc_seed_index();
     unsigned int siid = track->get_silicon_seed_index();
-    short int crossing_estimate = track->get_crossing_estimate();  // geometric crossing estimate
 
-    if (Verbosity() > 3)
-    {
-      std::cout << " tpcid " << tpcid << " siid " << siid << std::endl;
-    }
-
-    // get the INTT crossing number
+    // capture the input crossing value, and set crossing parameters
+    //==============================
+    short silicon_crossing =  SHRT_MAX;  
     auto siseed = m_siliconSeeds->get(siid);
-    short crossing = SHRT_MAX;
-    if (siseed)
-    {
-      // get the INTT crossing
-      crossing = siseed->get_crossing();
-    }
-    else if (!m_pp_mode)
-    {
-      // crossing always assumed to be zero if pp_mode = false
-      crossing = 0;
-    }
+    if(siseed) 
+      {
+	silicon_crossing = siseed->get_crossing(); 
+      }
+    short crossing = silicon_crossing;
+    short int crossing_estimate = crossing;
 
-    // Can't do SC case without INTT crossing
-    if (m_fitSiliconMMs && (crossing == SHRT_MAX))
-    {
-      continue;
-    }
+    if(m_enable_crossing_estimate)
+      {
+	crossing_estimate = track->get_crossing_estimate();  // geometric crossing estimate from matcher
+     }
+    //===============================
 
-    /// A track seed is made for every tpc seed. Not every tpc seed has a silicon match
-    if (m_pp_mode && siid == std::numeric_limits<unsigned int>::max())
-    {
-      // do not skip TPC only tracks, just set crossing to the nominal zero
-      crossing = 0;
-    }
 
+    // must have silicon seed with valid crossing if we are doing a SC calibration fit
+    if (m_fitSiliconMMs)
+      {
+	if( (siid == std::numeric_limits<unsigned int>::max()) || (silicon_crossing == SHRT_MAX))
+	  {
+	    continue;
+	  }
+      }
+
+    // do not skip TPC only tracks, just set crossing to the nominal zero
+    if(!siseed)
+      {
+	crossing = 0;
+      }
+    
     if (Verbosity() > 1)
     {
-      std::cout << "tpc and si id " << tpcid << ", " << siid << " crossing " << crossing << " crossing estimate " << crossing_estimate << std::endl;
+      if(siseed)
+	{
+	  std::cout << "tpc and si id " << tpcid << ", " << siid << " silicon_crossing " << silicon_crossing 
+		    << " crossing " << crossing << " crossing estimate " << crossing_estimate << std::endl;
+	}
     }
 
     auto tpcseed = m_tpcSeeds->get(tpcid);
@@ -356,14 +360,20 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     {
       if (siseed)
       {
-        std::cout << " silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
+        std::cout << "    silicon seed position is (x,y,z) = " << siseed->get_x() << "  " << siseed->get_y() << "  " << siseed->get_z() << std::endl;
+	std::cout << "    tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
       }
-      std::cout << " tpc seed position is (x,y,z) = " << tpcseed->get_x() << "  " << tpcseed->get_y() << "  " << tpcseed->get_z() << std::endl;
     }
 
     PHTimer trackTimer("TrackTimer");
     trackTimer.stop();
     trackTimer.restart();
+
+    if (Verbosity() > 1 && siseed)
+    {
+      std::cout << " m_pp_mode " << m_pp_mode << " m_enable_crossing_estimate " << m_enable_crossing_estimate 
+		<< " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
+    }
 
     short int this_crossing = crossing;
     bool use_estimate = false;
@@ -371,31 +381,38 @@ void PHActsTrkFitter::loopTracks(Acts::Logging::Level logLevel)
     std::vector<float> chisq_ndf;
     std::vector<SvtxTrack_v4> svtx_vec;
 
-    if (Verbosity() > 1)
-    {
-      std::cout << " INTT crossing " << crossing << " crossing_estimate " << crossing_estimate << std::endl;
-    }
-
-    if (crossing == SHRT_MAX)
-    {
-      // this only happens if there is a silicon seed but no assigned INTT crossing
-      // If there is no INTT crossing, start with the crossing_estimate value, vary up and down, fit, and choose the best chisq/ndf
-      use_estimate = true;
-      nvary = max_bunch_search;
-      if (Verbosity() > 1)
+    if(m_pp_mode)
       {
-        std::cout << " No INTT crossing: use crossing_estimate " << crossing_estimate << " with nvary " << nvary << std::endl;
+	if (m_enable_crossing_estimate && crossing == SHRT_MAX)
+	  {
+	    // this only happens if there is a silicon seed but no assigned INTT crossing, and only in pp_mode
+	    // If there is no INTT crossing, start with the crossing_estimate value, vary up and down, fit, and choose the best chisq/ndf
+	    use_estimate = true;
+	    nvary = max_bunch_search;
+	    if (Verbosity() > 1)
+	      {
+		std::cout << " No INTT crossing: use crossing_estimate " << crossing_estimate << " with nvary " << nvary << std::endl;
+	      }
+	  }
+	else
+	  {
+	    // use INTT crossing
+	    crossing_estimate = crossing;
+	  }
       }
-    }
     else
-    {
-      // use INTT crossing
-      crossing_estimate = crossing;
-    }
+      {
+	// non pp mode, we want only crossing zero, veto others
+	if(siseed && silicon_crossing != 0)
+	  {
+	    continue;
+	  }
+	crossing_estimate = crossing;
+      }
 
     // Fit this track assuming either:
     //    crossing = INTT value, if it exists (uses nvary = 0)
-    //    crossing = crossing_estimate +/- max_bunch_search, if no INTT value exists
+    //    crossing = crossing_estimate +/- max_bunch_search, if no INTT value exists and m_enable_crossing_estimate flag is set.
 
     for (short int ivary = -nvary; ivary <= nvary; ++ivary)
     {

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -124,6 +124,7 @@ class PHActsTrkFitter : public SubsysReco
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
 
+  void set_enable_geometric_crossing_estimate(bool flag) { m_enable_crossing_estimate = flag ; }
   void set_use_clustermover(bool use) { m_use_clustermover = use; }
   void ignoreLayer(int layer) { m_ignoreLayer.insert(layer); }
 
@@ -248,6 +249,8 @@ class PHActsTrkFitter : public SubsysReco
   SvtxAlignmentStateMap* m_alignmentStateMap = nullptr;
   ActsAlignmentStates m_alignStates;
   bool m_commissioning = false;
+
+  bool m_enable_crossing_estimate = false;
 
   PHG4TpcCylinderGeomContainer* _tpccellgeo = nullptr;
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -113,7 +113,9 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
     auto crossing = _tracklet_si->get_crossing();
     if (Verbosity() > 8)
     {
-      std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta() << " pt " << _tracklet_si->get_pt() << " si z " << _tracklet_si->get_z() << " crossing " << crossing << std::endl;
+      std::cout << " silicon stub: " << trackid << " eta " << _tracklet_si->get_eta() 
+		<< " pt " << _tracklet_si->get_pt() << " si z " << _tracklet_si->get_z() 
+		<< " crossing " << crossing << std::endl;
     }
 
     if (Verbosity() > 1)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Modifies the handling of matched silicon-TPC tracks in PHActsTrkFitter. Turns off by default the attempts to do geometric matching when no INTT crossing is available. Now, only matched tracks with INTT crossings are considered.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

