### PR TITLE
Added minumum pool size in terms of number of stored BCO

### DIFF
--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -397,10 +397,14 @@ bool SingleMicromegasPoolInput::GetSomeMoreEvents()
   {
     return false;
   }
-  if (m_MicromegasRawHitMap.empty())
+
+  // check minimum pool size
+  if (m_MicromegasRawHitMap.size() < m_BcoPoolSize)
   {
     return true;
   }
+
+  // make sure that the latest BCO received by each FEEs is past the current BCO
   std::set<int> toerase;
   uint64_t lowest_bclk = m_MicromegasRawHitMap.begin()->first + m_BcoRange;
   for (auto bcliter : m_FEEBclkMap)
@@ -428,6 +432,13 @@ bool SingleMicromegasPoolInput::GetSomeMoreEvents()
   {
     m_FEEBclkMap.erase(fee);
   }
+
+  // print how many BCO are in the stack
+  std::cout << "SingleMicromegasPoolInput::GetSomeMoreEvents -"
+    << " m_MicromegasRawHitMap: " << m_MicromegasRawHitMap.size()
+    << " m_BeamClockPacket: " << m_BeamClockPacket.size()
+    << " m_BeamClockFEE: " << m_BeamClockFEE.size()
+    << std::endl;
 
   return false;
 }

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.cc
@@ -433,13 +433,6 @@ bool SingleMicromegasPoolInput::GetSomeMoreEvents()
     m_FEEBclkMap.erase(fee);
   }
 
-  // print how many BCO are in the stack
-  std::cout << "SingleMicromegasPoolInput::GetSomeMoreEvents -"
-    << " m_MicromegasRawHitMap: " << m_MicromegasRawHitMap.size()
-    << " m_BeamClockPacket: " << m_BeamClockPacket.size()
-    << " m_BeamClockFEE: " << m_BeamClockFEE.size()
-    << std::endl;
-
   return false;
 }
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput.h
@@ -40,6 +40,9 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
+  //! define minimum pool size in terms of how many BCO are stored
+  void SetBcoPoolSize(const unsigned int value) { m_BcoPoolSize = value; }
+
   //! save some statistics for BCO QA
   void FillBcoQA(uint64_t /*gtm_bco*/);
 
@@ -51,6 +54,9 @@ class SingleMicromegasPoolInput : public SingleStreamingInput
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
+
+  //! minimum number of BCO required in Micromegas Pools
+  unsigned int m_BcoPoolSize{1};
 
   //! store list of packets that have data for a given beam clock
   /**


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
@pinkenburg When processing the extended readout TPOT data it was found that a significant fraction (20%) of the FEE data is dropped because of being received _after_ a given BCO has already been processed by Fun4All. This is because the Fun4All pooling strategy in this configuration does not work for TPOT, in turn because FEE can send data for a given BCO in a locally unordered fashion.
This is addressed by also requiring that a large enough number of BCO's in in the pool stack before alowing to process a given BCO. 
For now the default pool size is set to 1, correspondign to no change in the current strategy. 
This will be adjusted to a working value on the macro side. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

