### PR TITLE
modified t0corr calibrations format

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -423,7 +423,10 @@ int MbdCalib::Download_T0Corr(const std::string& dbase_location)
   _t0corr_hstddev.fill(std::numeric_limits<float>::quiet_NaN());
   _t0corr_hstddeverr.fill(std::numeric_limits<float>::quiet_NaN());
 
-  if ( dbase_location.size()==0 ) return 0;
+  if ( dbase_location.size()==0 )
+  {
+    return 0;
+  }
 
   if (Verbosity() > 0)
   {

--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -414,8 +414,16 @@ int MbdCalib::Download_T0Corr(const std::string& dbase_location)
   // Reset All Values
   _t0corrmean = 0.;
   _t0corrmeanerr = 0.;
-  _t0corrsigma = 0.;
-  _t0corrsigmaerr = 0.;
+  _t0corr_fitmean.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitmeanerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitsigma.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitsigmaerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hmean.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hmeanerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hstddev.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hstddeverr.fill(std::numeric_limits<float>::quiet_NaN());
+
+  if ( dbase_location.size()==0 ) return 0;
 
   if (Verbosity() > 0)
   {
@@ -437,8 +445,22 @@ int MbdCalib::Download_T0Corr(const std::string& dbase_location)
 
     _t0corrmean = cdbttree->GetSingleFloatValue("t0meancorr");
     _t0corrmeanerr = cdbttree->GetSingleFloatValue("t0meancorrerr");
-    _t0corrsigma = cdbttree->GetSingleFloatValue("t0corrsigma");
-    _t0corrsigmaerr = cdbttree->GetSingleFloatValue("t0corrsigmaerr");
+    _t0corr_fitmean[0] = cdbttree->GetSingleFloatValue("t0corr_fitmean0");
+    _t0corr_fitmeanerr[0] = cdbttree->GetSingleFloatValue("t0corr_fitmeanerr0");
+    _t0corr_fitsigma[0] = cdbttree->GetSingleFloatValue("t0corr_fitsigma0");
+    _t0corr_fitsigmaerr[0] = cdbttree->GetSingleFloatValue("t0corr_fitsigmaerr0");
+    _t0corr_fitmean[1] = cdbttree->GetSingleFloatValue("t1corr_fitmean1");
+    _t0corr_fitmeanerr[1] = cdbttree->GetSingleFloatValue("t1corr_fitmeanerr1");
+    _t0corr_fitsigma[1] = cdbttree->GetSingleFloatValue("t1corr_fitsigma1");
+    _t0corr_fitsigmaerr[1] = cdbttree->GetSingleFloatValue("t1corr_fitsigmaerr1");
+    _t0corr_hmean[0] = cdbttree->GetSingleFloatValue("t0corr_hmean0");
+    _t0corr_hmeanerr[0] = cdbttree->GetSingleFloatValue("t0corr_hmeanerr0");
+    _t0corr_hstddev[0] = cdbttree->GetSingleFloatValue("t0corr_hstddev0");
+    _t0corr_hstddeverr[0] = cdbttree->GetSingleFloatValue("t0corr_hstddeverr0");
+    _t0corr_hmean[1] = cdbttree->GetSingleFloatValue("t1corr_hmean1");
+    _t0corr_hmeanerr[1] = cdbttree->GetSingleFloatValue("t1corr_hmeanerr1");
+    _t0corr_hstddev[1] = cdbttree->GetSingleFloatValue("t1corr_hstddev1");
+    _t0corr_hstddeverr[1] = cdbttree->GetSingleFloatValue("t1corr_hstddeverr1");
 
     if (Verbosity() > 0)
     {
@@ -458,12 +480,15 @@ int MbdCalib::Download_T0Corr(const std::string& dbase_location)
       return _status;
     }
 
-    infile >> _t0corrmean >> _t0corrmeanerr >> _t0corrsigma >> _t0corrsigmaerr;
+    infile >> _t0corrmean >> _t0corrmeanerr
+      >> _t0corr_fitmean[0] >> _t0corr_fitmeanerr[0] >> _t0corr_fitsigma[0] >> _t0corr_fitsigmaerr[0]
+      >> _t0corr_fitmean[1] >> _t0corr_fitmeanerr[1] >> _t0corr_fitsigma[1] >> _t0corr_fitsigmaerr[1]
+      >> _t0corr_hmean[0] >> _t0corr_hmeanerr[0] >> _t0corr_hstddev[0] >> _t0corr_hstddeverr[0]
+      >> _t0corr_hmean[1] >> _t0corr_hmeanerr[1] >> _t0corr_hstddev[1] >> _t0corr_hstddeverr[1];
 
     if (Verbosity() > 0)
     {
-      std::cout << "T0Corr\t" << _t0corrmean << "\t" << _t0corrmeanerr
-          << "\t" << _t0corrsigma << "\t" << _t0corrsigmaerr << std::endl;
+      std::cout << "T0Corr\t" << _t0corrmean << "\t" << _t0corrmeanerr << std::endl;
     }
     infile.close();
   }
@@ -1297,22 +1322,34 @@ int MbdCalib::Write_CDB_T0Corr(const std::string& dbfile)
   std::cout << "Creating " << dbfile << std::endl;
   cdbttree = new CDBTTree( dbfile );
   cdbttree->SetSingleIntValue("version", 1);
-  cdbttree->CommitSingle();
 
   std::cout << "T0Corr" << std::endl;
-  for (size_t ipmt = 0; ipmt < MbdDefs::MBD_N_PMT; ipmt++)
-  {
-    // store in a CDBTree
-    cdbttree->SetSingleFloatValue("ttfit_t0corrmean", _t0corrmean);
-    cdbttree->SetSingleFloatValue("ttfit_t0corrmeanerr", _t0corrmeanerr);
-    cdbttree->SetSingleFloatValue("ttfit_t0corrsigma", _t0corrsigma);
-    cdbttree->SetSingleFloatValue("ttfit_t0corrsigmaerr", _t0corrsigmaerr);
 
-    std::cout << "T0Corr\t" << cdbttree->GetSingleFloatValue("_t0corrmean") << std::endl;
-  }
+  // store in a CDBTree
+  cdbttree->SetSingleFloatValue("_t0corrmean", _t0corrmean);
+  cdbttree->SetSingleFloatValue("_t0corrmeanerr", _t0corrmeanerr);
+  cdbttree->SetSingleFloatValue("_t0corr_fitmean0", _t0corr_fitmean[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitmeanerr0", _t0corr_fitmeanerr[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitsigma0", _t0corr_fitsigma[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitsigmaerr0", _t0corr_fitsigmaerr[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitmean1", _t0corr_fitmean[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitmeanerr1", _t0corr_fitmeanerr[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitsigma1", _t0corr_fitsigma[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_fitsigmaerr1", _t0corr_fitsigmaerr[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_hmean0", _t0corr_hmean[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_hmeanerr0", _t0corr_hmeanerr[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_hstddev0", _t0corr_hstddev[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_hstddeverr0", _t0corr_hstddeverr[0]);
+  cdbttree->SetSingleFloatValue("_t0corr_hmean1", _t0corr_hmean[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_hmeanerr1", _t0corr_hmeanerr[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_hstddev1", _t0corr_hstddev[1]);
+  cdbttree->SetSingleFloatValue("_t0corr_hstddeverr1", _t0corr_hstddeverr[1]);
 
-  cdbttree->Commit();
-  // cdbttree->Print();
+  std::cout << "T0Corr\t" << cdbttree->GetSingleFloatValue("_t0corrmean") << std::endl;
+
+  cdbttree->CommitSingle();
+  //cdbttree->Commit();
+  //cdbttree->Print();
 
   // for now we create the tree after reading it
   cdbttree->WriteCDBTTree();
@@ -1326,7 +1363,11 @@ int MbdCalib::Write_T0Corr(const std::string& dbfile)
 {
   std::ofstream cal_t0corr_file;
   cal_t0corr_file.open(dbfile);
-  cal_t0corr_file << _t0corrmean << "\t" << _t0corrmeanerr << "\t" << _t0corrsigma << "\t" << _t0corrsigmaerr << std::endl;
+  cal_t0corr_file << _t0corrmean << "\t" << _t0corrmeanerr << std::endl;
+  cal_t0corr_file << _t0corr_fitmean[0] << "\t" << _t0corr_fitmeanerr[0] << "\t" << _t0corr_fitsigma[0] << "\t" << _t0corr_fitsigmaerr[0] << std::endl;
+  cal_t0corr_file << _t0corr_fitmean[1] << "\t" << _t0corr_fitmeanerr[1] << "\t" << _t0corr_fitsigma[1] << "\t" << _t0corr_fitsigmaerr[1] << std::endl;
+  cal_t0corr_file << _t0corr_hmean[0] << "\t" << _t0corr_hmeanerr[0] << "\t" << _t0corr_hstddev[0] << "\t" << _t0corr_hstddeverr[0] << std::endl;
+  cal_t0corr_file << _t0corr_hmean[1] << "\t" << _t0corr_hmeanerr[1] << "\t" << _t0corr_hstddev[1] << "\t" << _t0corr_hstddeverr[1] << std::endl;
   cal_t0corr_file.close();
 
   return 1;
@@ -1340,7 +1381,6 @@ int MbdCalib::Write_CDB_Ped(const std::string& dbfile)
   std::cout << "Creating " << dbfile << std::endl;
   cdbttree = new CDBTTree( dbfile );
   cdbttree->SetSingleIntValue("version", 1);
-  cdbttree->CommitSingle();
 
   std::cout << "Ped" << std::endl;
   for (size_t ifeech = 0; ifeech < MbdDefs::MBD_N_FEECH; ifeech++)
@@ -1356,6 +1396,7 @@ int MbdCalib::Write_CDB_Ped(const std::string& dbfile)
       std::cout << ifeech << "\t" << cdbttree->GetFloatValue(ifeech, "pedmean") << std::endl;
     }
   }
+  cdbttree->CommitSingle();
 
   cdbttree->Commit();
   // cdbttree->Print();
@@ -1681,10 +1722,16 @@ void MbdCalib::Reset_TQT0()
 
 void MbdCalib::Reset_T0Corr()
 {
-  _t0corrmean = 0;
+  _t0corrmean = 0.;
   _t0corrmeanerr = 0.;
-  _t0corrsigma = std::numeric_limits<float>::quiet_NaN();
-  _t0corrsigmaerr = std::numeric_limits<float>::quiet_NaN();
+  _t0corr_fitmean.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitmeanerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitsigma.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_fitsigmaerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hmean.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hmeanerr.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hstddev.fill(std::numeric_limits<float>::quiet_NaN());
+  _t0corr_hstddeverr.fill(std::numeric_limits<float>::quiet_NaN());
 }
 
 void MbdCalib::Reset_Ped()
@@ -1713,6 +1760,7 @@ void MbdCalib::Reset()
   Reset_TQT0();
   Reset_Ped();
   Reset_Gains();
+  Reset_T0Corr();
 
   _sampmax.fill(-1);
 }

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -155,8 +155,14 @@ class MbdCalib
   // Overall T0 offset
   Float_t _t0corrmean{ 0. };
   Float_t _t0corrmeanerr{ 0. };
-  Float_t _t0corrsigma{ std::numeric_limits<float>::quiet_NaN() };
-  Float_t _t0corrsigmaerr{ std::numeric_limits<float>::quiet_NaN() };
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_fitmean{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_fitmeanerr{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_fitsigma{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_fitsigmaerr{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_hmean{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_hmeanerr{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_hstddev{};
+  std::array<float, MbdDefs::MBD_N_ARMS> _t0corr_hstddeverr{};
 
   // Pedestals
   std::array<float, MbdDefs::MBD_N_FEECH> _pedmean{};

--- a/offline/packages/mbd/MbdDefs.h
+++ b/offline/packages/mbd/MbdDefs.h
@@ -17,6 +17,7 @@ namespace MbdDefs
 
   const int MBD_N_PMT = 128;
   const int MBD_N_FEECH = 256;
+  const int MBD_N_ARMS = 2;
   const int BBC_N_PMT = 128;
   const int BBC_N_FEECH = 256;
   const int MAX_SAMPLES = 31;

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -789,7 +789,7 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
     if (_verbose >= 10 && !isnan(t_pmt) )
     {
-      std::cout << ipmt << "\t" << t_pmt << std::endl;
+      std::cout << ipmt << "\t" << t_pmt << "\t" << q_pmt << std::endl;
     }
 
     if (fabs(t_pmt) < 25. && q_pmt > 0.)
@@ -948,6 +948,7 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
     // correct t0
     m_bbct0 -= _mbdcal->get_t0corr();
+    std::cout << "correcting m_bbct0 with " << _mbdcal->get_t0corr() << std::endl;
 
     // hard code these for now
     // need study to determine muliplicity dependence

--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -948,7 +948,7 @@ int MbdEvent::Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout)
 
     // correct t0
     m_bbct0 -= _mbdcal->get_t0corr();
-    std::cout << "correcting m_bbct0 with " << _mbdcal->get_t0corr() << std::endl;
+    //std::cout << "correcting m_bbct0 with " << _mbdcal->get_t0corr() << std::endl;
 
     // hard code these for now
     // need study to determine muliplicity dependence


### PR DESCRIPTION
[comment]: Added more fields in the t0corr.  This is the calibration that corrects the time-zero peak to be centered at 0 ns.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: I added the fit values from the calibration, which are useful for debugging.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

