### PR TITLE
KFP: Added option to require all daughter tracks come from the same b…

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -44,6 +44,8 @@
 #include <Rtypes.h>
 #include <TDatabasePDG.h>
 #include <TMatrixD.h>
+#include "KFParticle_truthAndDetTools.h"
+
 #include <TMatrixDfwd.h>  // for TMatrixD
 #include <TMatrixT.h>     // for TMatrixT, operator*
 
@@ -56,6 +58,8 @@
 #include <iterator>   // for end
 #include <map>        // for _Rb_tree_iterator, map
 #include <memory>     // for allocator_traits<>::va...
+
+KFParticle_truthAndDetTools toolSet;
 
 /// KFParticle constructor
 KFParticle_Tools::KFParticle_Tools()
@@ -716,6 +720,22 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
       calculated_pt >= min_pt && daughterMassCheck && chargeCheck && calculateEllipsoidVolume(mother) <= max_vertex_volume)
   {
     goodCandidate = true;
+  }
+
+  if (goodCandidate && m_require_bunch_crossing_match)
+  {
+    std::vector<int> crossings;
+    for (int i = 0; i < nTracks; ++i)
+    {
+      SvtxTrack *thisTrack = toolSet.getTrack(vDaughters[i].Id(), m_dst_trackmap);
+      crossings.push_back(thisTrack->get_crossing());
+      removeDuplicates(crossings);
+
+      if (crossings.size() !=1)
+      {
+        goodCandidate = false;
+      }
+    }
   }
 
   // Check the requirements of an intermediate states against this mother and re-do goodCandidate

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -729,12 +729,13 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     {
       SvtxTrack *thisTrack = toolSet.getTrack(vDaughters[i].Id(), m_dst_trackmap);
       crossings.push_back(thisTrack->get_crossing());
-      removeDuplicates(crossings);
+    }
 
-      if (crossings.size() !=1)
-      {
-        goodCandidate = false;
-      }
+    removeDuplicates(crossings);
+
+    if (crossings.size() !=1)
+    {
+      goodCandidate = false;
     }
   }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -207,6 +207,11 @@ std::vector<KFParticle> KFParticle_Tools::makeAllDaughterParticles(PHCompositeNo
   {
     m_dst_track = iter.second;
 
+    if (m_bunch_crossing_zero_only && (m_dst_track->get_crossing() != 0))
+    {
+      continue;
+    }
+
     // First check if we have the required number of MVTX and TPC hits
     TrackSeed *tpcseed = m_dst_track->get_tpc_seed();
     TrackSeed *silseed = m_dst_track->get_silicon_seed();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -177,6 +177,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_min_radial_SV = -1.;
 
+  bool m_bunch_crossing_zero_only {false};  
+
   bool m_require_bunch_crossing_match {true};
 
   std::string m_vtx_map_node_name;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -177,6 +177,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_min_radial_SV = -1.;
 
+  bool m_require_bunch_crossing_match {true};
+
   std::string m_vtx_map_node_name;
   std::string m_trk_map_node_name;
   SvtxVertexMap *m_dst_vertexmap {nullptr};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -149,6 +149,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_daughter_pt_err[max_tracks] = {0};
   float m_calculated_daughter_jt[max_tracks] = {0};
   char m_calculated_daughter_q[max_tracks] = {0};
+  int m_calculated_daughter_bunch_crossing[max_tracks] = {0};
   float m_calculated_daughter_eta[max_tracks] = {0};
   float m_calculated_daughter_rapidity[max_tracks] = {0};
   float m_calculated_daughter_theta[max_tracks] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -207,10 +207,10 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void allowZeroMassTracks(bool allow = true) { m_allowZeroMassTracks = allow; }
 
-  void dontExtraolateTracksToSV(bool dontExtrapolate = true)
+  void extraolateTracksToSV(bool extrapolate = true)
   {
-    m_extrapolateTracksToSV = !dontExtrapolate;
-    m_extrapolateTracksToSV_nTuple = !dontExtrapolate;
+    m_extrapolateTracksToSV = extrapolate;
+    m_extrapolateTracksToSV_nTuple = extrapolate;
   }
 
   void constrainIntermediateMasses(bool constrain_int_mass = true) { m_constrain_int_mass = constrain_int_mass; }
@@ -287,13 +287,13 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void saveDST(bool save = true) { m_save_dst = save; }
 
-  void dontSaveTrackContainer(bool dontSave = true) { m_write_track_container = !dontSave; }
+  void saveTrackContainer(bool save = true) { m_write_track_container = save; }
 
-  void dontSaveParticleContainer(bool dontSave = true) { m_write_particle_container = !dontSave; }
+  void saveParticleContainer(bool save = true) { m_write_particle_container = save; }
 
   void setContainerName(const std::string &name) { m_container_name = name; }
 
-  void dontSaveOutput(bool dontSave = true) { m_save_output = !dontSave; }
+  void saveOutput(bool save = true) { m_save_output = save; }
 
   void setOutputName(const std::string &name) { m_outfile_name = name; }
 
@@ -304,6 +304,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
   void getCaloInfo(bool caloinfo = true) { m_calo_info = caloinfo; }
 
   void getAllPVInfo(bool pvinfo = true) { m_get_all_PVs = pvinfo; }
+
+  void requireBunchCrossingMatch(bool require = true) { m_require_bunch_crossing_match = require; }
 
   /// Use alternate vertex and track fitters
   void setVertexMapNodeName(const std::string &vtx_map_node_name) { m_vtx_map_node_name = m_vtx_map_node_name_nTuple = vtx_map_node_name; }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -305,6 +305,8 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void getAllPVInfo(bool pvinfo = true) { m_get_all_PVs = pvinfo; }
 
+  void bunchCrossingZeroOnly(bool bcZeroOnly = true) { m_bunch_crossing_zero_only = bcZeroOnly; }
+
   void requireBunchCrossingMatch(bool require = true) { m_require_bunch_crossing_match = require; }
 
   /// Use alternate vertex and track fitters


### PR DESCRIPTION
…unch crossing (default is to require this)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I added a new selection that requires candidate daughter tracks to come from the same bunch crossing. This keeps us up to date with the tracking changes where streamed data is in the same F4A event

I also reverted some member functions to have a more logical name. This requires a change in macros

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
https://github.com/sPHENIX-Collaboration/macros/pull/961
