### PR TITLE
Fix distortion corrections for regions outside of the real TPC volume

### DIFF
--- a/offline/packages/tpc/TpcDistortionCorrection.cc
+++ b/offline/packages/tpc/TpcDistortionCorrection.cc
@@ -72,11 +72,17 @@ Acts::Vector3 TpcDistortionCorrection::get_corrected_position(const Acts::Vector
     divisor = 1.0;
   }
 
-  //get the corrections from the histograms
-  auto dphi=phi; //to inherit the same type
+  //set our default corrections to be zero:
+  //first inherit the same type
+  auto dphi=phi;
   auto dr=r;
   auto dz=z;
-
+  //then set them to zero:
+  dphi=0;
+  dr=0;
+  dz=0;
+  
+  //get the corrections from the histograms
   if (dcc->m_dimensions == 3)
   {
     if (dcc->m_hDPint[index] && (mask & COORD_PHI) && check_boundaries(dcc->m_hDPint[index], phi, r, z))


### PR DESCRIPTION
previously, the corrections are instantiated as dz=z, dr=r, dphi=phi in order to let 'auto' give the new objects the same type as the original.  I added lines to set these to zero, so that when the histogram interpolation fails, it returns zero rather than corrections exactly equal to the original position.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
fixes a bug in how distortions are calculated for coordinates that are outside the TPC volume (though we should talk about why we pass real z coordinates as the argument in this case...)

## TODOs (if applicable)




## Links to other PRs in macros and calibration repositories (if applicable)

