### PR TITLE
fix: assign seed crossing to 0

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
+++ b/offline/packages/TrackingDiagnostics/TrackSeedTrackMapConverter.cc
@@ -141,7 +141,7 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
           svtxtrack->set_x(tpcseed->get_x());
           svtxtrack->set_y(tpcseed->get_y());
           svtxtrack->set_z(tpcseed->get_z());
-          svtxtrack->set_crossing(std::numeric_limits<short int>::max());
+          svtxtrack->set_crossing(0);
         }
         else
         {
@@ -284,6 +284,10 @@ int TrackSeedTrackMapConverter::process_event(PHCompositeNode* /*unused*/)
       double Z0 = trackSeed->get_Z0();
       double slope = trackSeed->get_slope();
       svtxtrack->set_crossing(trackSeed->get_crossing());
+      if(svtxtrack->get_crossing() == SHRT_MAX)
+      {
+        svtxtrack->set_crossing(0);
+      }
       std::vector<double> xy_error2;
       std::vector<double> rz_error2;
       std::vector<double> xy_residuals;


### PR DESCRIPTION
Assign the seed->track crossing to be 0 if it is not determined, similar to the track fitter

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

