### PR TITLE
fix compilation failure for local acts build

### DIFF
--- a/offline/packages/trackbase/ActsGsfTrackFittingAlgorithm.h
+++ b/offline/packages/trackbase/ActsGsfTrackFittingAlgorithm.h
@@ -12,7 +12,12 @@
 #include <Acts/TrackFitting/BetheHeitlerApprox.hpp>
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
+
+#pragma GCC diagnostic push // needed for local Act compilation
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #include <Acts/TrackFitting/GaussianSumFitter.hpp>
+#pragma GCC diagnostic pop
+
 #include <Acts/TrackFitting/GsfMixtureReduction.hpp>
 #include <Acts/Utilities/Helpers.hpp>
 

--- a/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
+++ b/offline/packages/trackbase/ActsTrackFittingAlgorithm.h
@@ -10,10 +10,12 @@
 #include <Acts/EventData/SourceLink.hpp>
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/EventData/VectorTrackContainer.hpp>
-
 #include <Acts/Geometry/TrackingGeometry.hpp>
 
+#pragma GCC diagnostic push // needed for local Act compilation
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #include <Acts/Propagator/MultiEigenStepperLoop.hpp>
+#pragma GCC diagnostic pop
 
 #include <Acts/TrackFitting/KalmanFitter.hpp>
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
If Acts is compiled locally, other packages fail to compile because some acts includes create warnings. This PR re-introduces pragmas to ignore the compiler warnings for those includes

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

