### PR TITLE
add downscale for event printouts

### DIFF
--- a/offline/framework/fun4all/Fun4AllBase.h
+++ b/offline/framework/fun4all/Fun4AllBase.h
@@ -56,13 +56,20 @@ class Fun4AllBase
   };
 
   /// Sets the verbosity of this module (0 by default=quiet).
-  virtual void Verbosity(const int ival) { m_Verbosity = ival; }
+  virtual void Verbosity(const uint64_t ival) { m_Verbosity = ival; }
 
   /// Sets the verbosity of this module (0 by default=quiet).
   virtual void Verbosity(enu_Verbosity ival) { m_Verbosity = ival; }
 
   /// Gets the verbosity of this module.
-  virtual int Verbosity() const { return m_Verbosity; }
+  virtual uint64_t Verbosity() const { return m_Verbosity; }
+
+  /// Gets the downscale of printouts for this module.
+  virtual uint32_t VerbosityDownscale() const { return m_VerbosityDownscale; }
+
+  /// Sets the downscale of printouts for this module.
+  /// Use (cnt%VerbosityDownscale()) in the code to apply
+  virtual void VerbosityDownscale(uint32_t ival) { m_VerbosityDownscale = std::max(1U,ival); }
 
  protected:
   /** ctor.
@@ -73,7 +80,9 @@ class Fun4AllBase
   std::string m_ThisName;
 
   /// The verbosity level. 0 means not verbose at all.
-  uint64_t m_Verbosity = VERBOSITY_QUIET;
+  uint64_t m_Verbosity {VERBOSITY_QUIET};
+  /// The frequency of printouts
+  uint32_t m_VerbosityDownscale {1};
 };
 
 #endif

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -1458,7 +1458,7 @@ int Fun4AllServer::run(const int nevnts, const bool require_nevents)
         BeginRun(runnumber);
       }
     }
-    if (Verbosity() >= 1)
+    if (Verbosity() >= 1 && ((icnt + 1)%VerbosityDownscale() == 0))
     {
       std::cout << "Fun4AllServer::run - processing event "
                 << (icnt + 1) << " from run " << runnumber << std::endl;

--- a/offline/framework/fun4allraw/Fun4AllEventOutputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllEventOutputManager.cc
@@ -114,7 +114,7 @@ void Fun4AllEventOutputManager::SetOutfileName(const std::string &fname)
   return;
 }
 
-void Fun4AllEventOutputManager::Verbosity(const int i)
+void Fun4AllEventOutputManager::Verbosity(const uint64_t i)
 {
   Fun4AllBase::Verbosity(i);
   if (m_OutStream)

--- a/offline/framework/fun4allraw/Fun4AllEventOutputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllEventOutputManager.h
@@ -27,7 +27,7 @@ class Fun4AllEventOutputManager : public Fun4AllOutputManager
   int AddPacketRange(const int ipktmin, const int ipktmax);
   int DropPacketRange(const int ipktmin, const int ipktmax);
   void SetOutfileName(const std::string &fname);
-  void Verbosity(const int i) override;
+  void Verbosity(const uint64_t i) override;
 
  protected:
   std::string m_OutFileRule;

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -602,7 +602,7 @@ void MakeActsGeometry::setMaterialResponseFile(std::string &responseFile,
                    ("/ACTS/sphenix-mm-material.json");
   }
 
-  if (Verbosity() > -1)
+//  if (Verbosity() > -1) // always on with this setting
   {
     std::cout << "using Acts material file : " << materialFile
               << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a downscale to the verbosity. It's first implementation is the event wise printout (it's just a eventcount%scaledown) but it can be used in all modules which inherit from Fun4AllBase

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

