### PR TITLE
Fix track cleaner handling of TPC only tracks in pp mode.

### DIFF
--- a/offline/packages/trackreco/PHTrackCleaner.cc
+++ b/offline/packages/trackreco/PHTrackCleaner.cc
@@ -106,51 +106,55 @@ int PHTrackCleaner::process_event(PHCompositeNode * /*topNode*/)
 
       if (_track)
       {
-        if (_pp_mode)
-        {
-          if (_track->get_crossing() == SHRT_MAX)
-          {
-	    // Tracks with no assigned crossing number in pp mode
-	    if (_track->get_chisq() / _track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
-	      {
-		best_id = track_id;
-		best_ndf = _track->get_ndf();	    
-		double qual = _track->get_chisq() / _track->get_ndf();
-
-		if (qual < quality_cut * 2)
-		  {
-		    // keep this TPC only track
-		    track_keep_list.insert(best_id);
-		    ok_track++;
-		    if (qual < quality_cut)
-		      {
-			good_track++;
-		      }
-
-		    if (Verbosity() > 1)
-		      {
-			std::cout << "        keep unmatched track tpc_id " << tpc_id << " given best_id " << best_id 
-				  << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;			
-		      }		    
-		  }
-	      }
-	    
-	    continue;
-          }
-
-        }
-	
-        // Find the remaining track with the best chisq/ndf
-	
         unsigned int si_index = UINT_MAX;
         auto si_seed = _track->get_silicon_seed();
         if (si_seed)
-        {
-          si_index = _silicon_seed_map->find(si_seed);
-        }
-
+	  {
+	    si_index = _silicon_seed_map->find(si_seed);
+	  }
+	else
+	  {
+	    std::cout << "      no silicon seed found " << std::endl;
+	  }
+	
+        if (_pp_mode)
+	  {
+	    if (!si_seed)
+	      {
+		// Tracks with no silicon seed in pp mode
+		if (_track->get_chisq() / _track->get_ndf() < min_chisq_df && _track->get_ndf() > min_ndf && _track->get_ndf() != UINT_MAX)
+		  {
+		    best_id = track_id;
+		    best_ndf = _track->get_ndf();	    
+		    double qual = _track->get_chisq() / _track->get_ndf();
+		    
+		    if (qual < quality_cut * 2)
+		      {
+			// keep this TPC only track
+			track_keep_list.insert(best_id);
+			ok_track++;
+			if (qual < quality_cut)
+			  {
+			    good_track++;
+			  }
+			
+			if (Verbosity() > 1)
+			  {
+			    std::cout << "        keep unmatched track tpc_id " << tpc_id << " given best_id " << best_id 
+				      << " best_ndf " << best_ndf << " chisq/ndf " << qual << std::endl;			
+			  }		    
+		      }
+		  }
+		
+		continue;
+	      }
+	    
+	  }
+	
+        // Find the remaining silicon matched track with the best chisq/ndf
+	
         if (Verbosity() > 1)
-        {
+	  {
           std::cout << "        track ID " << track_id << " tpc index " << tpc_id << " si index " << si_index << " crossing " << _track->get_crossing()
                     << " chisq " << _track->get_chisq() << " ndf " << _track->get_ndf() << " min_chisq_df " << min_chisq_df << std::endl;
         }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Fixes the identification of TPC-only tracks in pp mode following the change where unmatched TPC tracks are arbitrarily assigned to crossing zero.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

