### PR TITLE
EPD reco update: replace the hardcoded equal distance phi value arrays with human readable calculation

### DIFF
--- a/offline/packages/epd/EpdGeom.h
+++ b/offline/packages/epd/EpdGeom.h
@@ -3,16 +3,12 @@
  Re-written by Ejiro Umaka 03/28/23
 */
 
-#ifndef EPD_GEOM_H
-#define EPD_GEOM_H
+#ifndef EPD_EPDGEOM_H
+#define EPD_EPDGEOM_H
 
 #include <phool/PHObject.h>
 
-#include <vector>
-#include <utility>
-#include <tuple>
-#include <iostream>
-#include <cmath>
+#include <limits>
 
 class EpdGeom : public PHObject
 {
@@ -24,13 +20,13 @@ class EpdGeom : public PHObject
     virtual void set_r(unsigned int /*key*/, float /*r*/) {return;}
     virtual void set_phi(unsigned int /*key*/, float /*f*/) {return;}
     virtual void set_phi0(unsigned int /*key*/, float /*f0*/) {return;} 
-    virtual float get_r(unsigned int /*key*/) const {return NAN;};
-    virtual float get_z(unsigned int /*key*/) const {return NAN;};
-    virtual float get_phi(unsigned int /*key*/) const {return NAN;};
+    virtual float get_r(unsigned int /*key*/) const {return std::numeric_limits<float>::quiet_NaN();};
+    virtual float get_z(unsigned int /*key*/) const {return std::numeric_limits<float>::quiet_NaN();};
+    virtual float get_phi(unsigned int /*key*/) const {return std::numeric_limits<float>::quiet_NaN();};
 
   private:
     ClassDefOverride(EpdGeom, 1);
 };
 
 
-#endif // EPD_GEOM_H
+#endif // EPD_EPDGEOM_H

--- a/offline/packages/epd/EpdGeomV1.cc
+++ b/offline/packages/epd/EpdGeomV1.cc
@@ -2,16 +2,6 @@
 
 #include <calobase/TowerInfoDefs.h>
 
-#include <phool/PHObject.h>
-
-#include <map>
-#include <utility>
-#include <tuple>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-
-
 float EpdGeomV1::get_r(unsigned int key) const
 {
   return tile_r[TowerInfoDefs::get_epd_rbin(key)];
@@ -55,4 +45,3 @@ void EpdGeomV1::set_phi0(unsigned int key, float f0)
 {
   tile_phi0[TowerInfoDefs::get_epd_phibin(key)] = f0;
 }
-

--- a/offline/packages/epd/EpdGeomV1.h
+++ b/offline/packages/epd/EpdGeomV1.h
@@ -1,12 +1,7 @@
-#ifndef EPD_GEOM_V1_H
-#define EPD_GEOM_V1_H
+#ifndef EPD_EPDGEOMV1_H
+#define EPD_EPDGEOMV1_H
 
 #include "EpdGeom.h"
-
-#include <utility>
-#include <tuple>
-#include <iostream>
-
 
 class EpdGeomV1 : public EpdGeom {
 
@@ -34,4 +29,4 @@ private:
 
 };
 
-#endif // EPD_GEOM_V1_H
+#endif // EPD_EPDGEOMV1_H

--- a/offline/packages/epd/EpdGeomV2.cc
+++ b/offline/packages/epd/EpdGeomV2.cc
@@ -1,0 +1,53 @@
+#include "EpdGeomV2.h"
+
+#include <calobase/TowerInfoDefs.h>
+
+#include <phool/PHObject.h>
+
+#include <array>
+
+
+float EpdGeomV2::get_r(unsigned int key) const
+{
+  return tile_r.at(TowerInfoDefs::get_epd_rbin(key));
+}
+
+float EpdGeomV2::get_z(unsigned int key) const
+{
+  return tile_z.at(TowerInfoDefs::get_epd_arm(key));
+}
+
+float EpdGeomV2::get_phi(unsigned int key) const
+{
+
+  if(TowerInfoDefs::get_epd_rbin(key) == 0)
+  {
+    return tile_phi0.at(TowerInfoDefs::get_epd_phibin(key));
+  }
+  else
+  {
+    return tile_phi.at(TowerInfoDefs::get_epd_phibin(key));
+  }
+
+}
+ 
+void EpdGeomV2::set_z(unsigned int key, float z)
+{
+  tile_z.at(TowerInfoDefs::get_epd_arm(key)) = z;
+}
+
+void EpdGeomV2::set_r(unsigned int key, float r)
+{
+  tile_r.at(TowerInfoDefs::get_epd_rbin(key)) = r;
+}
+
+void EpdGeomV2::set_phi(unsigned int key, float f)
+{
+  tile_phi.at(TowerInfoDefs::get_epd_phibin(key)) = f;
+}
+
+void EpdGeomV2::set_phi0(unsigned int key, float f0)
+{
+  tile_phi0.at(TowerInfoDefs::get_epd_phibin(key)) = f0;
+}
+

--- a/offline/packages/epd/EpdGeomV2.h
+++ b/offline/packages/epd/EpdGeomV2.h
@@ -1,0 +1,34 @@
+#ifndef EPD_EPDGEOMV2_H
+#define EPD_EPDGEOMV2_H
+
+#include "EpdGeom.h"
+
+#include <array>
+
+class EpdGeomV2 : public EpdGeom {
+
+public:
+  EpdGeomV2() = default;
+  ~EpdGeomV2() override = default;
+  
+  float get_r(unsigned int key) const override;
+  float get_z(unsigned int key) const override;
+  float get_phi(unsigned int key) const override;
+  void set_z(unsigned int key, float z) override;
+  void set_r(unsigned int key, float r) override;
+  void set_phi(unsigned int key, float f) override;
+  void set_phi0(unsigned int key, float f0) override;
+
+
+private:
+  
+  std::array<float,16> tile_r {};
+  std::array<float,2> tile_z {};
+  std::array<float,24> tile_phi {};
+  std::array<float,12> tile_phi0 {};
+
+  ClassDefOverride(EpdGeomV2, 1)
+
+};
+
+#endif // EPD_EPDGEOMV2_H

--- a/offline/packages/epd/EpdGeomV2LinkDef.h
+++ b/offline/packages/epd/EpdGeomV2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EpdGeomV2 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/epd/EpdReco.cc
+++ b/offline/packages/epd/EpdReco.cc
@@ -191,9 +191,9 @@ void EpdReco::CreateNodes(PHCompositeNode *topNode) {
 void EpdReco::FillTilePhiArray()
 {
   size_t i = 0;
-  for (auto iter = tilephi.begin(); iter != tilephi.end(); ++iter)
+  for (float & iter : tilephi)
   {
-    *iter = ((2 * i + 1) * M_PI) / 24;
+    iter = ((2 * i + 1) * M_PI) / 24;
     i++;
   }
   return;
@@ -202,9 +202,9 @@ void EpdReco::FillTilePhiArray()
 void EpdReco::FillTilePhi0Array()
 {
   size_t i = 0;
-  for (auto iter = tilephi0.begin(); iter != tilephi0.end(); ++iter)
+  for (float & iter : tilephi0)
   {
-    *iter = ((2 * i + 1) * M_PI) / 12;
+    iter = ((2 * i + 1) * M_PI) / 12;
     i++;
   }
   return;

--- a/offline/packages/epd/EpdReco.cc
+++ b/offline/packages/epd/EpdReco.cc
@@ -143,10 +143,22 @@ int EpdReco::End(PHCompositeNode * /*topNode*/) {
 }
 
 float EpdReco::GetTilePhi(int thisphi) {
+  if (thisphi < 0 || thisphi > 23)
+  {
+    std::cout << PHWHERE << " index " << thisphi
+	      << " out of range (0-23), fix your code exiting" << std::endl;
+    gSystem->Exit(1);
+  }
   return ((2 * thisphi + 1) * M_PI) / 24;
 }
 
 float EpdReco::GetTilePhi0(int thisphi0) {
+  if (thisphi0 < 0 || thisphi0 > 11)
+  {
+    std::cout << PHWHERE << " index " << thisphi0
+	      << " out of range (0-11), fix your code exiting" << std::endl;
+    gSystem->Exit(1);
+  }
   return ((2 * thisphi0 + 1) * M_PI) / 12;
 }
 

--- a/offline/packages/epd/EpdReco.cc
+++ b/offline/packages/epd/EpdReco.cc
@@ -143,19 +143,11 @@ int EpdReco::End(PHCompositeNode * /*topNode*/) {
 }
 
 float EpdReco::GetTilePhi(int thisphi) {
-  static const float tilephi[24] = {
-      0.13089969, 0.39269908, 0.65449847, 0.91629786, 1.17809725, 1.43989663,
-      1.70169602, 1.96349541, 2.2252948,  2.48709418, 2.74889357, 3.01069296,
-      3.27249235, 3.53429174, 3.79609112, 4.05789051, 4.3196899,  4.58148929,
-      4.84328867, 5.10508806, 5.36688745, 5.62868684, 5.89048623, 6.15228561};
-  return tilephi[thisphi];
+  return ((2 * thisphi + 1) * M_PI) / 24;
 }
 
 float EpdReco::GetTilePhi0(int thisphi0) {
-  static const float tilephi0[12] = {
-      0.26179939, 0.78539816, 1.30899694, 1.83259571, 2.35619449, 2.87979327,
-      3.40339204, 3.92699082, 4.45058959, 4.97418837, 5.49778714, 6.02138592};
-  return tilephi0[thisphi0];
+  return ((2 * thisphi0 + 1) * M_PI) / 12;
 }
 
 float EpdReco::GetTileR(int thisr) {

--- a/offline/packages/epd/EpdReco.h
+++ b/offline/packages/epd/EpdReco.h
@@ -1,21 +1,18 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef __EPDRECO_H__
-#define __EPDRECO_H__
+#ifndef EPD_EPDRECO_H__
+#define EPD_EPDRECO_H__
 
 //===========================================================
 /// \author Ejiro Umaka
 //===========================================================
 
-#include <cdbobjects/CDBTTree.h>
-
 #include <fun4all/SubsysReco.h>
 
-#include <gsl/gsl_const_cgsm.h>
-
+#include <array>
 #include <string> // for string
-#include <vector> // for vector
 
+class CDBTTree;
 class PHCompositeNode;
 
 class EpdReco : public SubsysReco {
@@ -24,21 +21,27 @@ public:
   ~EpdReco() override = default;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
-  int End(PHCompositeNode * /*topNode*/) override;
 
 private:
-  CDBTTree *cdbttree{nullptr};
-  std::string m_fieldname;
-  std::string m_calibName;
-  bool m_overrideCalibName{false};
-  bool m_overrideFieldName{false};
-  std::string m_Detector = "SEPD";
-  std::string m_TowerInfoNodeName_calib = "TOWERINFO_CALIB_SEPD";
+  void CreateNodes(PHCompositeNode *topNode);
   float GetTilePhi(int thisphi);
   float GetTilePhi0(int thisphi0);
   float GetTileR(int thisr);
   float GetTileZ(int thisz);
-  void CreateNodes(PHCompositeNode *topNode);
+  void FillTilePhiArray();
+  void FillTilePhi0Array();
+
+  CDBTTree *cdbttree{nullptr};
+  bool m_overrideCalibName{false};
+  bool m_overrideFieldName{false};
+
+  std::string m_fieldname;
+  std::string m_calibName;
+  std::string m_Detector {"SEPD"};
+  std::string m_TowerInfoNodeName_calib {"TOWERINFO_CALIB_SEPD"};
+
+  std::array<float,24> tilephi;
+  std::array<float,12> tilephi0;
 };
 
-#endif // EPDRECO_H
+#endif // EPD_EPDRECO_H

--- a/offline/packages/epd/EpdReco.h
+++ b/offline/packages/epd/EpdReco.h
@@ -40,8 +40,8 @@ private:
   std::string m_Detector {"SEPD"};
   std::string m_TowerInfoNodeName_calib {"TOWERINFO_CALIB_SEPD"};
 
-  std::array<float,24> tilephi;
-  std::array<float,12> tilephi0;
+  std::array<float,24> tilephi{};
+  std::array<float,12> tilephi0{};
 };
 
 #endif // EPD_EPDRECO_H

--- a/offline/packages/epd/Makefile.am
+++ b/offline/packages/epd/Makefile.am
@@ -27,20 +27,24 @@ pkginclude_HEADERS = \
   EPDDefs.h \
   EpdGeom.h \
   EpdGeomV1.h \
+  EpdGeomV2.h \
   EpdReco.h
 
 ROOTDICTS = \
   EpdGeom_Dict.cc \
-  EpdGeomV1_Dict.cc
+  EpdGeomV1_Dict.cc \
+  EpdGeomV2_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
  EpdGeom_Dict_rdict.pcm \
- EpdGeomV1_Dict_rdict.pcm 
+ EpdGeomV1_Dict_rdict.pcm \
+ EpdGeomV2_Dict_rdict.pcm
 
 libepd_io_la_SOURCES = \
   $(ROOTDICTS) \
-  EpdGeomV1.cc
+  EpdGeomV1.cc \
+  EpdGeomV2.cc
 
 
 libepd_la_SOURCES = \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I believe

```cpp
float EpdReco::GetTilePhi(int thisphi) {
  static const float tilephi[24] = {
      0.13089969, 0.39269908, 0.65449847, 0.91629786, 1.17809725, 1.43989663,
      1.70169602, 1.96349541, 2.2252948,  2.48709418, 2.74889357, 3.01069296,
      3.27249235, 3.53429174, 3.79609112, 4.05789051, 4.3196899,  4.58148929,
      4.84328867, 5.10508806, 5.36688745, 5.62868684, 5.89048623, 6.15228561};
  return tilephi[thisphi];
}
```

is (almost)equivalent to:

```cpp
float EpdReco::GetTilePhi(int thisphi) {
  return ((2 * thisphi + 1) * M_PI) / 24;
}
```

The later also doesn't segfault if you give some index out of range...

I think this could be a potential improvement of the code 👀


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

