### PR TITLE
Fix memory usage in JetSeedCount

### DIFF
--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -145,7 +145,7 @@ int JetSeedCount::Init(PHCompositeNode * /*topNode*/)
     m_hCentMbd->GetYaxis()->SetTitle("Number of Entries");
     m_manager->registerHisto(m_hCentMbd);
 
-    m_hRawSeedVsCent = new TH2F(vecHistNames[10].data(), "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
+    m_hRawSeedVsCent = new TH2F(vecHistNames[11].data(), "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
     m_hRawSeedVsCent->GetXaxis()->SetTitle("Centrality");
     m_hRawSeedVsCent->GetYaxis()->SetTitle("Raw Seed Count");
     m_manager->registerHisto(m_hRawSeedVsCent);

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -306,6 +306,22 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
   if (m_writeToOutputFile)
   {
     PHTFileServer::get().cd(m_outputFileName);
+    m_hRawSeedCount->Write();
+    m_hRawPt->Write();
+    m_hRawPt_All->Write();
+    m_hRawEtaVsPhi->Write();
+    m_hSubSeedCount->Write();
+    m_hSubPt->Write();
+    m_hSubPt_All->Write();
+    m_hSubEtaVsPhi->Write();
+    if (!m_inPPMode)
+    {
+      m_hRawSeedEnergyVsCent->Write();
+      m_hSubSeedEnergyVsCent->Write();
+      m_hCentMbd->Write();
+      m_hRawSeedVsCent->Write();
+      m_hSubSeedVsCent->Write();
+    }
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/Jet/JetSeedCount.cc
+++ b/offline/QA/Jet/JetSeedCount.cc
@@ -53,6 +53,108 @@ int JetSeedCount::Init(PHCompositeNode * /*topNode*/)
     std::cout << "No m_manager" << std::endl;
     assert(m_manager);
   }
+  
+  // make sure module name is lower case
+  std::string smallModuleName = m_moduleName;
+  std::transform(
+      smallModuleName.begin(),
+      smallModuleName.end(),
+      smallModuleName.begin(),
+      ::tolower);
+
+  // construct histogram names
+  std::vector<std::string> vecHistNames = {
+      "rawseedcount",
+      "rawpt",
+      "rawptall",
+      "rawetavsphi",
+      "subseedcount",
+      "subpt",
+      "subptall",
+      "subetavsphi",
+      "rawseedenergyvscent",
+      "subseedenergyvscent",
+      "centmbd",
+      "rawseedvscent",
+      "subseedvscent"};
+  for (auto &vecHistName : vecHistNames)
+  {
+    vecHistName.insert(0, "h_" + smallModuleName + "_");
+    if (!m_histTag.empty())
+    {
+      vecHistName.append("_" + m_histTag);
+    }
+  }
+
+  // make histograms
+  m_hRawSeedCount = new TH1F(vecHistNames[0].data(), "Raw Seed Count per Event", 100, 0.00, 50.00);
+  m_hRawSeedCount->GetXaxis()->SetTitle("Raw Seed Count per Event");
+  m_hRawSeedCount->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hRawSeedCount);
+
+  m_hRawPt = new TH1F(vecHistNames[1].data(), "Raw p_{T}", 1000, 0.00, 50.00);
+  m_hRawPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
+  m_hRawPt->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hRawPt);
+
+  m_hRawPt_All = new TH1F(vecHistNames[2].data(), "Raw p_{T} (all jet seeds)", 1000, 0.00, 50.00);
+  m_hRawPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
+  m_hRawPt_All->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hRawPt_All);
+
+  m_hRawEtaVsPhi = new TH2F(vecHistNames[3].data(), "Raw Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
+  m_hRawEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
+  m_hRawEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
+  m_manager->registerHisto(m_hRawEtaVsPhi);
+
+  m_hSubSeedCount = new TH1F(vecHistNames[4].data(), "Sub Seed Count per Event", 100, 0.00, 50.00);
+  m_hSubSeedCount->GetXaxis()->SetTitle("Sub Seed Count per Event");
+  m_hSubSeedCount->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hSubSeedCount);
+
+  m_hSubPt = new TH1F(vecHistNames[5].data(), "Sub. p_{T}", 1000, 0.00, 50.00);
+  m_hSubPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
+  m_hSubPt->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hSubPt);
+
+  m_hSubPt_All = new TH1F(vecHistNames[6].data(), "Sub. p_{T} (all jet seeds)", 1000, 0.00, 50.00);
+  m_hSubPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
+  m_hSubPt_All->GetYaxis()->SetTitle("Number of Entries");
+  m_manager->registerHisto(m_hSubPt_All);
+
+  m_hSubEtaVsPhi = new TH2F(vecHistNames[7].data(), "Sub. Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
+  m_hSubEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
+  m_hSubEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
+  m_manager->registerHisto(m_hSubEtaVsPhi);
+
+  // If not in pp mode, plot quantities vs. centrality
+  if (!m_inPPMode)
+  {
+    m_hRawSeedEnergyVsCent = new TH2F(vecHistNames[8].data(), "Raw Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
+    m_hRawSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
+    m_hRawSeedEnergyVsCent->GetYaxis()->SetTitle("RawSeedEnergy");
+    m_manager->registerHisto(m_hRawSeedEnergyVsCent);
+
+    m_hSubSeedEnergyVsCent = new TH2F(vecHistNames[9].data(), "Sub Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
+    m_hSubSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
+    m_hSubSeedEnergyVsCent->GetYaxis()->SetTitle("SubSeedEnergy");
+    m_manager->registerHisto(m_hSubSeedEnergyVsCent);
+
+    m_hCentMbd = new TH1F(vecHistNames[10].data(), "hCentMbd", 10, 0.00, 100.00);
+    m_hCentMbd->GetXaxis()->SetTitle("Centrality (Mbd)");
+    m_hCentMbd->GetYaxis()->SetTitle("Number of Entries");
+    m_manager->registerHisto(m_hCentMbd);
+
+    m_hRawSeedVsCent = new TH2F(vecHistNames[10].data(), "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
+    m_hRawSeedVsCent->GetXaxis()->SetTitle("Centrality");
+    m_hRawSeedVsCent->GetYaxis()->SetTitle("Raw Seed Count");
+    m_manager->registerHisto(m_hRawSeedVsCent);
+
+    m_hSubSeedVsCent = new TH2F(vecHistNames[12].data(), "Sub Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
+    m_hSubSeedVsCent->GetXaxis()->SetTitle("Centrality");
+    m_hSubSeedVsCent->GetYaxis()->SetTitle("Sub Seed Count");
+    m_manager->registerHisto(m_hSubSeedVsCent);
+  }  // end if not in pp mode
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -129,19 +231,16 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   }
 
-  GlobalVertex *vtx = vertexmap->begin()->second;
-  z_vtx = vtx->get_z();
-
   // If not in pp mode, save centrailty info
   float cent_mbd = std::numeric_limits<float>::max();
   if (!m_inPPMode)
   {
     cent_mbd = cent_node->get_centile(CentralityInfo::PROP::bimp);
-    m_centrality.push_back(cent_mbd);
+    m_hCentMbd->Fill(cent_mbd);
   }
 
   // Raw Seed Count
-  m_seed_raw = 0;
+  uint64_t n_seed_raw = 0;
   //  float Counter = 0;
   // for (JetMap::Iter iter = seedjetsraw->begin(); iter != seedjetsraw->end(); ++iter){
   for (auto jet : *seedjetsraw)
@@ -149,24 +248,26 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
     // Jet* jet = iter->second;
     int passesCut = jet->get_property(seedjetsraw->property_index(Jet::PROPERTY::prop_SeedItr));
     // Counter += 1;
-    m_rawpt_all.push_back(jet->get_pt());
+    m_hRawPt_All->Fill(jet->get_pt());
     if (passesCut == 1)
     {
-      m_rawpt.push_back(jet->get_pt());
-      m_rawenergy.push_back(jet->get_e());
-      m_RawEta.push_back(jet->get_eta());
-      m_RawPhi.push_back(jet->get_phi());
+      m_hRawPt->Fill(jet->get_pt());
+      m_hRawEtaVsPhi->Fill(jet->get_eta(), jet->get_phi());
       if (!m_inPPMode)
       {
-        m_rawcent.push_back(cent_mbd);
+        m_hRawSeedEnergyVsCent->Fill(cent_mbd, jet->get_e());
       }
-      m_seed_raw++;
+      n_seed_raw++;
     }
   }
-  m_raw_counts.push_back(m_seed_raw);
+  m_hRawSeedCount->Fill(n_seed_raw);
+  if (!m_inPPMode)
+  {
+    m_hRawSeedVsCent->Fill(cent_mbd, n_seed_raw);
+  }
 
   // Sub Seed Count
-  m_seed_sub = 0;
+  uint64_t n_seed_sub = 0;
   //  Counter = 0;
   // for (unsigned int iter = 0; iter < seedjetssub->size(); ++iter){
   // Jet* jet = seedjetsub->get_jet(iter);
@@ -175,21 +276,23 @@ int JetSeedCount::process_event(PHCompositeNode *topNode)
     // Jet* jet = iter->second;
     int passesCut = jet->get_property(seedjetssub->property_index(Jet::PROPERTY::prop_SeedItr));
     //  Counter += 1;
-    m_subpt_all.push_back(jet->get_pt());
+    m_hSubPt_All->Fill(jet->get_pt());
     if (passesCut == 2)
     {
-      m_subpt.push_back(jet->get_pt());
-      m_subenergy.push_back(jet->get_e());
-      m_SubEta.push_back(jet->get_eta());
-      m_SubPhi.push_back(jet->get_phi());
+      m_hSubPt->Fill(jet->get_pt());
+      m_hSubEtaVsPhi->Fill(jet->get_eta(), jet->get_phi());
       if (!m_inPPMode)
       {
-        m_subcent.push_back(cent_mbd);
+        m_hSubSeedEnergyVsCent->Fill(cent_mbd, jet->get_e());
       }
-      m_seed_sub++;
+      n_seed_sub++;
     }
   }
-  m_sub_counts.push_back(m_seed_sub);
+  m_hSubSeedCount->Fill(n_seed_sub);
+  if (!m_inPPMode)
+  {
+    m_hSubSeedVsCent->Fill(cent_mbd, n_seed_sub);
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -204,159 +307,6 @@ int JetSeedCount::End(PHCompositeNode * /*topNode*/)
   {
     PHTFileServer::get().cd(m_outputFileName);
   }
-
-  // make sure module name is lower case
-  std::string smallModuleName = m_moduleName;
-  std::transform(
-      smallModuleName.begin(),
-      smallModuleName.end(),
-      smallModuleName.begin(),
-      ::tolower);
-
-  // construct histogram names
-  std::vector<std::string> vecHistNames = {
-      "rawseedcount",
-      "rawpt",
-      "rawptall",
-      "rawetavsphi",
-      "subseedcount",
-      "subpt",
-      "subptall",
-      "subetavsphi",
-      "rawseedenergyvscent",
-      "subseedenergyvscent",
-      "centmbd",
-      "rawseedvscent",
-      "subseedvscent"};
-  for (auto &vecHistName : vecHistNames)
-  {
-    vecHistName.insert(0, "h_" + smallModuleName + "_");
-    if (!m_histTag.empty())
-    {
-      vecHistName.append("_" + m_histTag);
-    }
-  }
-
-  TH1 *hRawSeedCount = new TH1F(vecHistNames[0].data(), "Raw Seed Count per Event", 100, 0.00, 50.00);
-  hRawSeedCount->GetXaxis()->SetTitle("Raw Seed Count per Event");
-  hRawSeedCount->GetYaxis()->SetTitle("Number of Entries");
-  for (int m_raw_count : m_raw_counts)
-  {
-    hRawSeedCount->Fill(m_raw_count);
-  }
-  m_manager->registerHisto(hRawSeedCount);
-
-  TH1 *hRawPt = new TH1F(vecHistNames[1].data(), "Raw p_{T}", 1000, 0.00, 50.00);
-  hRawPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
-  hRawPt->GetYaxis()->SetTitle("Number of Entries");
-  for (double j : m_rawpt)
-  {
-    hRawPt->Fill(j);
-  }
-  m_manager->registerHisto(hRawPt);
-
-  TH1 *hRawPt_All = new TH1F(vecHistNames[2].data(), "Raw p_{T} (all jet seeds)", 1000, 0.00, 50.00);
-  hRawPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
-  hRawPt_All->GetYaxis()->SetTitle("Number of Entries");
-  for (double j : m_rawpt_all)
-  {
-    hRawPt_All->Fill(j);
-  }
-  m_manager->registerHisto(hRawPt_All);
-
-  TH2 *hRawEtaVsPhi = new TH2F(vecHistNames[3].data(), "Raw Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
-  hRawEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
-  hRawEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
-  for (int j = 0; j < (int) m_RawEta.size(); j++)
-  {
-    hRawEtaVsPhi->Fill(m_RawEta.at(j), m_RawPhi.at(j));
-  }
-  m_manager->registerHisto(hRawEtaVsPhi);
-
-  TH1 *hSubSeedCount = new TH1F(vecHistNames[4].data(), "Sub Seed Count per Event", 100, 0.00, 50.00);
-  hSubSeedCount->GetXaxis()->SetTitle("Sub Seed Count per Event");
-  hSubSeedCount->GetYaxis()->SetTitle("Number of Entries");
-  for (int m_sub_count : m_sub_counts)
-  {
-    hSubSeedCount->Fill(m_sub_count);
-  }
-  m_manager->registerHisto(hSubSeedCount);
-
-  TH1 *hSubPt = new TH1F(vecHistNames[5].data(), "Sub. p_{T}", 1000, 0.00, 50.00);
-  hSubPt->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
-  hSubPt->GetYaxis()->SetTitle("Number of Entries");
-  for (double j : m_subpt)
-  {
-    hSubPt->Fill(j);
-  }
-  m_manager->registerHisto(hSubPt);
-
-  TH1 *hSubPt_All = new TH1F(vecHistNames[6].data(), "Sub. p_{T} (all jet seeds)", 1000, 0.00, 50.00);
-  hSubPt_All->GetXaxis()->SetTitle("Jet p_{T} [GeV]");
-  hSubPt_All->GetYaxis()->SetTitle("Number of Entries");
-  for (double j : m_subpt_all)
-  {
-    hSubPt_All->Fill(j);
-  }
-  m_manager->registerHisto(hSubPt_All);
-
-  TH2 *hSubEtaVsPhi = new TH2F(vecHistNames[7].data(), "Sub. Seed Eta Vs Phi", 220, -1.1, 1.1, 628, -3.14, 3.14);
-  hSubEtaVsPhi->GetXaxis()->SetTitle("Jet #eta [Rads.]");
-  hSubEtaVsPhi->GetYaxis()->SetTitle("Jet #phi [Rads.]");
-  for (int j = 0; j < (int) m_SubEta.size(); j++)
-  {
-    hSubEtaVsPhi->Fill(m_SubEta.at(j), m_SubPhi.at(j));
-  }
-  m_manager->registerHisto(hSubEtaVsPhi);
-
-  // If not in pp mode, plot quantities vs. centrality
-  if (!m_inPPMode)
-  {
-    TH2 *hRawSeedEnergyVsCent = new TH2F(vecHistNames[8].data(), "Raw Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
-    hRawSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
-    hRawSeedEnergyVsCent->GetYaxis()->SetTitle("RawSeedEnergy");
-    for (int j = 0; j < (int) m_rawenergy.size(); j++)
-    {
-      hRawSeedEnergyVsCent->Fill(m_rawcent.at(j), m_rawenergy.at(j));
-    }
-    m_manager->registerHisto(hRawSeedEnergyVsCent);
-
-    TH2 *hSubSeedEnergyVsCent = new TH2F(vecHistNames[9].data(), "Sub Seed Energy Vs Centrality", 10.00, 0.00, 100.00, 100, 0.00, 50.00);
-    hSubSeedEnergyVsCent->GetXaxis()->SetTitle("Centrality");
-    hSubSeedEnergyVsCent->GetYaxis()->SetTitle("SubSeedEnergy");
-    for (int j = 0; j < (int) m_subenergy.size(); j++)
-    {
-      hSubSeedEnergyVsCent->Fill(m_subcent.at(j), m_subenergy.at(j));
-    }
-    m_manager->registerHisto(hSubSeedEnergyVsCent);
-
-    TH1 *hCentMbd = new TH1F(vecHistNames[10].data(), "hCentMbd", 10, 0.00, 100.00);
-    hCentMbd->GetXaxis()->SetTitle("Centrality (Mbd)");
-    hCentMbd->GetYaxis()->SetTitle("Number of Entries");
-    for (int j : m_centrality)
-    {
-      hCentMbd->Fill(j);
-    }
-    m_manager->registerHisto(hCentMbd);
-
-    TH2 *hRawSeedVsCent = new TH2F(vecHistNames[10].data(), "Raw Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
-    hRawSeedVsCent->GetXaxis()->SetTitle("Centrality");
-    hRawSeedVsCent->GetYaxis()->SetTitle("Raw Seed Count");
-    for (int j = 0; j < (int) m_raw_counts.size(); j++)
-    {
-      hRawSeedVsCent->Fill(m_centrality.at(j), m_raw_counts.at(j));
-    }
-    m_manager->registerHisto(hRawSeedVsCent);
-
-    TH2 *hSubSeedVsCent = new TH2F(vecHistNames[12].data(), "Sub Seed Vs Centrality", 10, 0.00, 100.00, 101, -0.5, 100.5);
-    hSubSeedVsCent->GetXaxis()->SetTitle("Centrality");
-    hSubSeedVsCent->GetYaxis()->SetTitle("Sub Seed Count");
-    for (int j = 0; j < (int) m_sub_counts.size(); j++)
-    {
-      hSubSeedVsCent->Fill(m_centrality.at(j), m_sub_counts.at(j));
-    }
-    m_manager->registerHisto(hSubSeedVsCent);
-  }  // end if not in pp mode
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -3,6 +3,8 @@
 #ifndef JETSEEDCOUNT_H
 #define JETSEEDCOUNT_H
 
+#include "JetQADefs.h"
+
 #include <qautils/QAHistManagerDef.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
@@ -14,11 +16,10 @@
 #include <string>
 #include <vector>
 
-#include "JetQADefs.h"
 
 class PHCompositeNode;
-class TH1F;
-class TH2F;
+class TH1;
+class TH2;
 
 class JetSeedCount : public SubsysReco
 {
@@ -97,22 +98,22 @@ class JetSeedCount : public SubsysReco
   std::pair<double, double> m_ptRange;
 
   // trigger selection
-  bool m_doTrgSelect;
-  uint32_t m_trgToSelect;
+  bool m_doTrgSelect {false};
+  uint32_t m_trgToSelect {0};
 
-  TH1F* m_hRawSeedCount;
-  TH1F* m_hRawPt;
-  TH1F* m_hRawPt_All;
-  TH2F* m_hRawEtaVsPhi;
-  TH1F* m_hSubSeedCount;
-  TH1F* m_hSubPt;
-  TH1F* m_hSubPt_All;
-  TH2F* m_hSubEtaVsPhi;
-  TH2F* m_hRawSeedEnergyVsCent;
-  TH2F* m_hSubSeedEnergyVsCent;
-  TH1F* m_hCentMbd;
-  TH2F* m_hRawSeedVsCent;
-  TH2F* m_hSubSeedVsCent;
+  TH1* m_hRawSeedCount{nullptr};
+  TH1* m_hRawPt{nullptr};
+  TH1* m_hRawPt_All{nullptr};
+  TH2* m_hRawEtaVsPhi{nullptr};
+  TH1* m_hSubSeedCount{nullptr};
+  TH1* m_hSubPt{nullptr};
+  TH1* m_hSubPt_All{nullptr};
+  TH2* m_hSubEtaVsPhi{nullptr};
+  TH2* m_hRawSeedEnergyVsCent{nullptr};
+  TH2* m_hSubSeedEnergyVsCent{nullptr};
+  TH1* m_hCentMbd{nullptr};
+  TH2* m_hRawSeedVsCent{nullptr};
+  TH2* m_hSubSeedVsCent{nullptr};
 
 };
 

--- a/offline/QA/Jet/JetSeedCount.h
+++ b/offline/QA/Jet/JetSeedCount.h
@@ -17,6 +17,8 @@
 #include "JetQADefs.h"
 
 class PHCompositeNode;
+class TH1F;
+class TH2F;
 
 class JetSeedCount : public SubsysReco
 {
@@ -82,9 +84,6 @@ class JetSeedCount : public SubsysReco
   bool m_inPPMode{false};
 
   int m_event{0};
-  int m_seed_sub{std::numeric_limits<int>::max()};
-  int m_seed_raw{std::numeric_limits<int>::max()};
-  double z_vtx{std::numeric_limits<double>::quiet_NaN()};
 
   std::string m_moduleName;
   std::string m_recoJetName;
@@ -101,23 +100,20 @@ class JetSeedCount : public SubsysReco
   bool m_doTrgSelect;
   uint32_t m_trgToSelect;
 
-  std::vector<double> m_RawEta;
-  std::vector<double> m_RawPhi;
-  std::vector<double> m_SubEta;
-  std::vector<double> m_SubPhi;
-  std::vector<int> m_centrality;
-  std::vector<int> m_centrality_diff;
+  TH1F* m_hRawSeedCount;
+  TH1F* m_hRawPt;
+  TH1F* m_hRawPt_All;
+  TH2F* m_hRawEtaVsPhi;
+  TH1F* m_hSubSeedCount;
+  TH1F* m_hSubPt;
+  TH1F* m_hSubPt_All;
+  TH2F* m_hSubEtaVsPhi;
+  TH2F* m_hRawSeedEnergyVsCent;
+  TH2F* m_hSubSeedEnergyVsCent;
+  TH1F* m_hCentMbd;
+  TH2F* m_hRawSeedVsCent;
+  TH2F* m_hSubSeedVsCent;
 
-  std::vector<int> m_raw_counts;
-  std::vector<int> m_sub_counts;
-  std::vector<double> m_rawpt;
-  std::vector<double> m_subpt;
-  std::vector<double> m_rawpt_all;
-  std::vector<double> m_subpt_all;
-  std::vector<double> m_rawenergy;
-  std::vector<double> m_subenergy;
-  std::vector<double> m_rawcent;
-  std::vector<double> m_subcent;
 };
 
 #endif  // JETSEEDCOUNT_H


### PR DESCRIPTION
This PR resolves the excessive memory usage of the `jetqa/JetSeedCount` module which was causing AuAu Jet QA production jobs to fail.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This resolves a serious bug: as written, during `process_event()` the module would fill several `std::vector`s of the values to be filled into histograms during `End()`. For sparse events (such as in pp) where the numbers of seed jets per event is small, this wasn't an issue. However, the number of seed jets per event increases dramatically in AuAu.

This PR rewrites the module so that the histograms are filled in place rather than during `End()`.