### PR TITLE
CD: Added code to run MVTX in triggered mode

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -65,6 +65,8 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   int FillTpcPool();
   void Streaming(bool b = true) { m_StreamingFlag = b; }
 
+  void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
+
  private:
   struct MvtxRawHitInfo
   {
@@ -121,6 +123,7 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   bool m_mvtx_registered_flag{false};
   bool m_StreamingFlag{false};
   bool m_tpc_registered_flag{false};
+  bool m_mvtx_is_triggered{false};
 
   std::vector<SingleStreamingInput *> m_Gl1InputVector;
   std::vector<SingleStreamingInput *> m_InttInputVector;

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -51,6 +51,9 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   void writeMvtxEventHeader(bool write) { m_writeMvtxEventHeader = write; }
 
   void doOfflineMasking(bool do_masking) { m_doOfflineMasking = do_masking; }
+
+  void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
+
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
   void getStrobeLength();
@@ -72,6 +75,7 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   bool m_doOfflineMasking{false};
   MvtxPixelMask * m_hot_pixel_mask{nullptr};
 
+  bool m_mvtx_is_triggered{false};
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
These changes allow the MVTX to run in triggered mode. In this mode, the strobe arrives after the GL1 and is offset by two BCOs.

Changes needed in an analysis macro are:

```c++
  bool mvtxTriggered = true;

  Fun4AllStreamingInputManager *in = new Fun4AllStreamingInputManager("Comb");
  in->runMvtxTriggered(mvtxTriggered);
  
    auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
    mvtxunpacker->Verbosity(0);
    mvtxunpacker->runMvtxTriggered(mvtxTriggered);
```

You can set the BCO range to 2 with
```c++
  for (auto& infile : infiles)
  {
    auto* sngl= new SingleMvtxPoolInput("MVTX_FLX" + to_string(i));
    int bcoRange = mvtxTriggered ? 2 : 10;
    sngl->SetBcoRange(bcoRange);
    sngl->AddListFile(infile);
    in->registerStreamingInput(sngl, InputManagerType::MVTX);
    i++;
  }
  se->registerInputManager(in);
  ```
which will match you to the GL1 but a large number here just means you'll pick up second collisions as well as the real collision 

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

