### PR TITLE
feat: take best intt measurements

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -711,7 +711,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
   {
     if(minResidLayer[ilayer] < std::numeric_limits<float>::max())
     {
-      if(layer < 3)
+      if(ilayer < 3)
       {
         matchedClusters.push_back(minResidckey[ilayer]);
         clusters.push_back(minResidGlobPos[ilayer]);

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -707,12 +707,44 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
     }
     
   }
-  for(int i=0; i<7; i++)
+  for(int ilayer=0; ilayer<7; ilayer++)
   {
-    if(minResidLayer[i] < std::numeric_limits<float>::max())
+    if(minResidLayer[ilayer] < std::numeric_limits<float>::max())
     {
-      matchedClusters.push_back(minResidckey[i]);
-      clusters.push_back(minResidGlobPos[i]);
+      if(layer < 3)
+      {
+        matchedClusters.push_back(minResidckey[ilayer]);
+        clusters.push_back(minResidGlobPos[ilayer]);
+      }
+      else // need to check which layer is smaller in two intt half layer
+      {
+        if(ilayer==3)
+        {
+          if(minResidLayer[3] < minResidLayer[4])
+          {
+            matchedClusters.push_back(minResidckey[3]);
+            clusters.push_back(minResidGlobPos[3]);
+          }
+          else
+          {
+            matchedClusters.push_back(minResidckey[4]);
+            clusters.push_back(minResidGlobPos[4]);
+          }
+        }
+        else if(ilayer==5)
+        {
+          if(minResidLayer[5] < minResidLayer[6])
+          {
+            matchedClusters.push_back(minResidckey[5]);
+            clusters.push_back(minResidGlobPos[5]);
+          }
+          else
+          {
+            matchedClusters.push_back(minResidckey[6]);
+            clusters.push_back(minResidGlobPos[6]);
+          }
+        }
+      }
     }
   }
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -19,11 +19,11 @@
 #include <g4detectors/PHG4CylinderGeom.h>
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
-#include <trackbase/TrkrClusterCrossingAssoc.h>
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterCrossingAssoc.h>
 #include <trackbase/TrkrClusterIterationMapv1.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/TrackSeed.h>
@@ -379,7 +379,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       trackSeed->circleFitByTaubin(positions, 0, 7);
       phi = trackSeed->get_phi(positions);
       trackSeed->set_phi(phi);
-      if(m_searchInIntt)
+      if (m_searchInIntt)
       {
         trackSeed->lineFit(positions, 0, 2);
       }
@@ -549,7 +549,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
     std::vector<TrkrDefs::cluskey>& keys,
     TrackSeed& seed)
 {
-  auto fitpars = TrackFitUtils::fitClusters(clusters, keys,true);
+  auto fitpars = TrackFitUtils::fitClusters(clusters, keys, true);
 
   float trackphi = seed.get_phi();
   /// Diagnostic
@@ -570,7 +570,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
   std::map<int, float> minResidLayer;
   std::map<int, TrkrDefs::cluskey> minResidckey;
   std::map<int, Acts::Vector3> minResidGlobPos;
-  for(int i=0; i<7; i++)
+  for (int i = 0; i < 7; i++)
   {
     minResidLayer.insert(std::make_pair(i, std::numeric_limits<float>::max()));
   }
@@ -606,15 +606,14 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
         auto surfcenter = surf->center(m_tGeometry->geometry().geoContext);
         float surfphi = atan2(surfcenter.y(), surfcenter.x());
         float dphi = normPhi2Pi(trackphi - surfphi);
- 
+
         /// Check that the projection is within some reasonable amount of the segment
         /// to reject e.g. looking at segments in the opposite hemisphere. This is about
         /// the size of one intt segment (256 * 80 micron strips in a segment)
         if (fabs(dphi) > 0.2)
         {
-         continue;
+          continue;
         }
-
 
         auto range = m_clusterMap->getClusters(hitsetkey);
         for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
@@ -674,21 +673,19 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
           /// we divide by two
           float rphiresid = fabs(local.x() - cluster->getLocalX());
           float zresid = fabs(local.y() - cluster->getLocalY());
-         
+
           if ((det == TrkrDefs::TrkrId::mvtxId && rphiresid < m_mvtxrPhiSearchWin &&
-              zresid < m_mvtxzSearchWin) 
-              ||
+               zresid < m_mvtxzSearchWin) ||
               (det == TrkrDefs::TrkrId::inttId && rphiresid < m_inttrPhiSearchWin && zresid < m_inttzSearchWin))
-              
+
           {
-            
-            if(rphiresid < minResidLayer[layer])
+            if (rphiresid < minResidLayer[layer])
             {
               minResidLayer[layer] = rphiresid;
               minResidckey[layer] = cluskey;
               minResidGlobPos[layer] = glob;
             }
-           
+
             if (Verbosity() > 4)
             {
               std::cout << "Matched INTT cluster with cluskey " << cluskey
@@ -705,55 +702,45 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
       }
       layer++;
     }
-    
   }
-  for(int ilayer=0; ilayer<7; ilayer++)
+  for (int ilayer = 0; ilayer < 3; ilayer++)
   {
-    if(minResidLayer[ilayer] < std::numeric_limits<float>::max())
+    if (minResidLayer[ilayer] < std::numeric_limits<float>::max())
     {
-      if(ilayer < 3)
-      {
-        matchedClusters.push_back(minResidckey[ilayer]);
-        clusters.push_back(minResidGlobPos[ilayer]);
-      }
-      else // need to check which layer is smaller in two intt half layer
-      {
-        if(ilayer==3)
-        {
-          if(minResidLayer[3] < minResidLayer[4])
-          {
-            matchedClusters.push_back(minResidckey[3]);
-            clusters.push_back(minResidGlobPos[3]);
-          }
-          else
-          {
-            matchedClusters.push_back(minResidckey[4]);
-            clusters.push_back(minResidGlobPos[4]);
-          }
-        }
-        else if(ilayer==5)
-        {
-          if(minResidLayer[5] < minResidLayer[6])
-          {
-            matchedClusters.push_back(minResidckey[5]);
-            clusters.push_back(minResidGlobPos[5]);
-          }
-          else
-          {
-            matchedClusters.push_back(minResidckey[6]);
-            clusters.push_back(minResidGlobPos[6]);
-          }
-        }
-      }
+      matchedClusters.push_back(minResidckey[ilayer]);
+      clusters.push_back(minResidGlobPos[ilayer]);
     }
   }
 
-  if (m_seedAnalysis)
+  if (minResidLayer[3] < minResidLayer[4] && minResidLayer[3] < std::numeric_limits<float>::max())
   {
-    h_nMatchedClusters->Fill(matchedClusters.size());
+    matchedClusters.push_back(minResidckey[3]);
+    clusters.push_back(minResidGlobPos[3]);
+  }
+  else if (minResidLayer[4] < std::numeric_limits<float>::max())
+  {
+    matchedClusters.push_back(minResidckey[4]);
+    clusters.push_back(minResidGlobPos[4]);
   }
 
-  return matchedClusters;
+  if (minResidLayer[5] < minResidLayer[6] && minResidLayer[5] < std::numeric_limits<float>::max())
+  {
+    matchedClusters.push_back(minResidckey[5]);
+    clusters.push_back(minResidGlobPos[5]);
+  }
+  else if(minResidLayer[6] < std::numeric_limits<float>::max())
+  {
+    matchedClusters.push_back(minResidckey[6]);
+    clusters.push_back(minResidGlobPos[6]);
+  }
+
+
+if (m_seedAnalysis)
+{
+  h_nMatchedClusters->Fill(matchedClusters.size());
+}
+
+return matchedClusters;
 }
 
 SpacePointPtr PHActsSiliconSeeding::makeSpacePoint(
@@ -1129,7 +1116,7 @@ double PHActsSiliconSeeding::normPhi2Pi(const double phi)
   {
     returnPhi += 2 * M_PI;
   }
-  if(returnPhi > M_PI)
+  if (returnPhi > M_PI)
   {
     returnPhi -= 2 * M_PI;
   }


### PR DESCRIPTION
This is a cleaned up branch/PR of the changes in the silicon seeder to take the best intt measurements in the two half layers on the track based on their residuals to the mvtx triplet, instead of taking each half layer on its own. This supersedes https://github.com/sPHENIX-Collaboration/coresoftware/pull/3171

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

