### PR TITLE
set ZS status for uniform software ZS tower, no magic number for timing and chi2

### DIFF
--- a/offline/packages/CaloBase/TowerInfov4.h
+++ b/offline/packages/CaloBase/TowerInfov4.h
@@ -4,6 +4,7 @@
 #include "TowerInfov1.h"
 
 #include <cmath>
+#include <limits>
 
 class TowerInfov4 : public TowerInfo
 {
@@ -30,7 +31,7 @@ class TowerInfov4 : public TowerInfo
     
     if (std::isnan(_chi2))
     {
-      lnChi2 = 1;
+      lnChi2 = 0;
     }
     else if (_chi2 <= 0)
     {
@@ -46,7 +47,11 @@ class TowerInfov4 : public TowerInfo
     }
     chi2 = static_cast<uint8_t>(std::round(lnChi2));
   }
-  float get_chi2() override { return (pow(1.08, (float) chi2) - 1.0); }
+  float get_chi2() override {
+    return (chi2 == 0)
+        ? std::numeric_limits<float>::quiet_NaN() 
+        : (pow(1.08, static_cast<float>(chi2)) - 1.0);
+  }
 
   void set_isHot(bool isHot) override { set_status_bit(0, isHot); }
   bool get_isHot() const override { return get_status_bit(0); }

--- a/offline/packages/CaloBase/TowerInfov4.h
+++ b/offline/packages/CaloBase/TowerInfov4.h
@@ -27,7 +27,12 @@ class TowerInfov4 : public TowerInfo
   void set_chi2(float _chi2) override
   {
     float lnChi2;
-    if (_chi2 <= 0)
+    
+    if (std::isnan(_chi2))
+    {
+      lnChi2 = 1;
+    }
+    else if (_chi2 <= 0)
     {
       lnChi2 = 1;
     }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -485,7 +485,8 @@ bool CaloTowerBuilder::skipChannel(int ich, int pid)
 
 bool CaloTowerBuilder::isSZS(float time, float chi2)
 {
-  if (time == -20 && chi2 == 0)
+  //isfinite
+  if (!std::isfinite(time) && !std::isfinite(chi2))
   {
     return true;
   }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -205,6 +205,7 @@ int CaloTowerBuilder::process_sim()
     towerinfo->set_time_float(processed_waveforms.at(i).at(1));
     towerinfo->set_pedestal(processed_waveforms.at(i).at(2));
     towerinfo->set_chi2(processed_waveforms.at(i).at(3));
+    bool SZS = isSZS(processed_waveforms.at(i).at(1), processed_waveforms.at(i).at(3));
     if (processed_waveforms.at(i).at(4) == 0) 
     {
       towerinfo->set_isRecovered(false);
@@ -214,7 +215,7 @@ int CaloTowerBuilder::process_sim()
       towerinfo->set_isRecovered(true);
     }
     int n_samples = waveforms.at(i).size();
-    if (n_samples == m_nzerosuppsamples)
+    if (n_samples == m_nzerosuppsamples || SZS)
     {
       towerinfo->set_isZS(true);
     }
@@ -419,6 +420,7 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
     towerinfo->set_time_float(processed_waveforms.at(i).at(1));
     towerinfo->set_pedestal(processed_waveforms.at(i).at(2));
     towerinfo->set_chi2(processed_waveforms.at(i).at(3));
+    bool SZS = isSZS(processed_waveforms.at(i).at(1), processed_waveforms.at(i).at(3));
     if (processed_waveforms.at(i).at(4) == 0) 
     {
       towerinfo->set_isRecovered(false);
@@ -428,7 +430,7 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
       towerinfo->set_isRecovered(true);
     }
     int n_samples = waveforms.at(i).size();
-    if (n_samples == m_nzerosuppsamples)
+    if (n_samples == m_nzerosuppsamples || SZS)
     {
       if(waveforms.at(i).at(0) == 0)
       {
@@ -478,6 +480,15 @@ bool CaloTowerBuilder::skipChannel(int ich, int pid)
      }
   }
     
+  return false;
+}
+
+bool CaloTowerBuilder::isSZS(float time, float chi2)
+{
+  if (time == -20 && chi2 == 0)
+  {
+    return true;
+  }
   return false;
 }
 

--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -105,6 +105,7 @@ class CaloTowerBuilder : public SubsysReco
  private:
   int process_sim();
   bool skipChannel(int ich, int pid);
+  bool isSZS(float time, float chi2);
   CaloWaveformProcessing *WaveformProcessing{nullptr};
   TowerInfoContainer *m_CaloInfoContainer{nullptr};      //! Calo info
   TowerInfoContainer *m_CalowaveformContainer{nullptr};  // waveform from simulation

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -18,6 +18,7 @@
 #include <pthread.h>
 #include <iostream>
 #include <string>
+#include <limits>
 
 ROOT::TThreadExecutor *t = new ROOT::TThreadExecutor(1);
 double CaloWaveformFitting::template_function(double *x, double *par)
@@ -64,7 +65,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
     if (size1 == _nzerosuppresssamples)
     {
       v.push_back(v.at(1) - v.at(0));  // returns peak sample - pedestal sample
-      v.push_back(-20);                 // set time to -20 to indicate zero suppressed
+      v.push_back(std::numeric_limits<float>::quiet_NaN());                 // set time to qnan for ZS
       v.push_back(v.at(0));
       if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
       { 
@@ -72,7 +73,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
       } 
       else 
       {
-        v.push_back(0);
+        v.push_back(std::numeric_limits<float>::quiet_NaN());
       }
       v.push_back(0);
     }
@@ -105,7 +106,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
       if ( (_bdosoftwarezerosuppression && v.at(6) - v.at(0) < _nsoftwarezerosuppression) || (_maxsoftwarezerosuppression && maxheight-pedestal  < _nsoftwarezerosuppression)  )
       {
         v.push_back(v.at(6) - v.at(0));
-        v.push_back(-20);
+        v.push_back(std::numeric_limits<float>::quiet_NaN());
         v.push_back(v.at(0));
         if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
         { 
@@ -113,7 +114,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
         } 
         else 
         {
-          v.push_back(0);
+          v.push_back(std::numeric_limits<float>::quiet_NaN());
         }
         v.push_back(0);
       }
@@ -349,11 +350,11 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_fast(std::v
     float amp = 0;
     float time = 0;
     float ped = 0;
-    float chi2 = 0;
+    float chi2 = std::numeric_limits<float>::quiet_NaN();
     if (nsamples == 2)
     {
       amp = v.at(1);
-      time = -20;
+      time = std::numeric_limits<float>::quiet_NaN();
       ped = v.at(0);
       if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
       { 
@@ -410,12 +411,12 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_nyquist(std
 
     if (nsamples == 2)
     {
-      float chi2 = 0;
+      float chi2 = std::numeric_limits<float>::quiet_NaN();
       if (v.at(0) != 0 && v.at(1) == 0) // check if post-sample is 0, if so set high chi2
       { 
         chi2 = 1000000;
       }
-      fit_values.push_back({v.at(1) - v.at(0), -20, v.at(0), chi2, 0});
+      fit_values.push_back({v.at(1) - v.at(0), std::numeric_limits<float>::quiet_NaN(), v.at(0), chi2, 0});
       continue;
     }
     


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Currently if we are doing the uniform software ZS, the suppression is done in *CaloWaveformFitting* and after suppression the time of the tower will be set to -20 without setting the ZS status. However, the calotower status will check the timing for non-ZS tower.

This PR change the calotowerbuilder and waveformfitting, so the hardware and software ZS towers are set with time and chi2 equals to qnan. Also let calotowerbuilder to check for if the timing and chi2 is qnan(for SZS) to set the ZS status for software zero suppressed towers.

This PR also add case handling for Towerinfov4 where the chi2 is set into log scale, for quite nan case the lnchi2 is set to 0 and we can get the quite nan back while getting chi2.

Something to note that if we change the time for ZS tower this fix will stop working(but I don't think we plan to change it). 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

