### PR TITLE
Add cross calibration for ZS towers in CaloTowerCalib

### DIFF
--- a/offline/packages/CaloReco/CaloTowerCalib.h
+++ b/offline/packages/CaloReco/CaloTowerCalib.h
@@ -67,6 +67,17 @@ class CaloTowerCalib : public SubsysReco
     m_directURL_time = url;
   }
 
+  void set_directURL_ZScrosscalib(const std::string &url)
+  {
+    m_giveDirectURL_ZScrosscalib = true;
+    m_directURL_ZScrosscalib = url;
+  }
+
+  void set_doZScrosscalib(bool doZScrosscalib)
+  {
+    m_doZScrosscalib = doZScrosscalib;
+  }
+
   void set_use_TowerInfov2(bool use) { m_use_TowerInfov2 = use; }
 
  private:
@@ -78,6 +89,8 @@ class CaloTowerCalib : public SubsysReco
   std::string m_calibName;
   std::string m_fieldname_time;
   std::string m_calibName_time;
+  std::string m_fieldname_ZScrosscalib;
+  std::string m_calibName_ZScrosscalib;
   bool m_overrideCalibName{false};
   bool m_overrideFieldName{false};
   std::string m_inputNodePrefix{"TOWERS_"};
@@ -94,8 +107,13 @@ class CaloTowerCalib : public SubsysReco
   std::string m_directURL_time = "";
   bool m_dotimecalib = true;
 
+  bool m_giveDirectURL_ZScrosscalib = false;
+  std::string m_directURL_ZScrosscalib = "";
+  bool m_doZScrosscalib = true;
+
   CDBTTree *cdbttree = nullptr;
   CDBTTree *cdbttree_time = nullptr;
+  CDBTTree *cdbttree_ZScrosscalib = nullptr;
   int m_runNumber;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Adds method to CaloTowerCalib to get ZS cross calibration factors from cdb and apply them to towers with flag is_ZS() during the calibration step from raw towers to calib towers. These cross calibration factors will need to be applied via run by run cdb trees created from the CaloFittingQA module. 
Also adds option to not apply these factors directly from CaloTowerCalib call. 

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

