### PR TITLE
feat: automate mvtx pooling bco range based on strobe length

### DIFF
--- a/offline/framework/fun4all/InputFileHandler.h
+++ b/offline/framework/fun4all/InputFileHandler.h
@@ -20,6 +20,7 @@ class InputFileHandler
   void IsOpen(const int i) { m_IsOpen = i; }
   void SetVerbosity(const int i) { m_Verbosity = i; }
   int GetVerbosity() const { return m_Verbosity; }
+  const std::list<std::string>& GetFileList() const { return m_FileList; }
   void UpdateFileList();
   void FileName(const std::string &fn) { m_FileName = fn; }
   const std::string FileName() const { return m_FileName; }

--- a/offline/framework/fun4allraw/Makefile.am
+++ b/offline/framework/fun4allraw/Makefile.am
@@ -63,6 +63,7 @@ libmvtx_decoder_la_SOURCES =\
   mvtx_decoder/GBTLink.cc \
   mvtx_decoder/GBTWord.cc \
   mvtx_decoder/InteractionRecord.cc \
+  mvtx_decoder/mvtx_utils.cc \
   mvtx_decoder/PayLoadCont.cc \
   mvtx_decoder/PixelData.cc \
   mvtx_decoder/StrobeData.cc
@@ -99,6 +100,10 @@ libfun4allraw_la_SOURCES = \
   SingleZdcTriggerInput.cc \
   tpc_pool.cc
 
+libmvtx_decoder_la_LIBADD = \
+  -lfun4all \
+  -lphoolraw
+  
 libfun4allraw_la_LIBADD = \
   libmvtx_decoder.la \
   -lffarawobjects \

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -433,7 +433,7 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
     m_BcoRange = 1000;
     m_NegativeBco = 1000;
   }
-  else if (strobeLength > 9)
+  else if (strobeLength > 9 && strobeLength < 11)
   {
     m_BcoRange = 100;
     m_NegativeBco = 500;
@@ -446,6 +446,11 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
     {
       StreamingInputManager()->runMvtxTriggered(true);
     }
+  }
+  else // catchall for anyting else to set to a range based on the rhic clock
+  {
+    m_BcoRange = std::ceil(strobeLength / 0.1065);
+    m_NegativeBco = std::ceil(strobeLength / 0.1065);
   }
   if(Verbosity() > 1)
   {

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -21,6 +21,7 @@
 #include <Event/Eventiterator.h>
 #include <Event/fileEventiterator.h>
 
+#include <cmath>
 #include <cassert>
 #include <memory>
 #include <set>
@@ -421,6 +422,11 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
 
   auto [runnumber, segment] = Fun4AllUtils::GetRunSegment(*(GetFileList().begin()));
   float strobeLength = mvtx_utils::getStrobeLength(runnumber);
+  if(std::isnan(strobeLength))
+  {
+    std::cout << PHWHERE << "ERROR: Strobe length is not defined for run " << runnumber << std::endl;
+    exit(1);
+  }
   if(strobeLength > 88.)
   {
     m_BcoRange = 1000;

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -424,8 +424,9 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   float strobeLength = mvtx_utils::getStrobeLength(runnumber);
   if(std::isnan(strobeLength))
   {
-    std::cout << PHWHERE << "ERROR: Strobe length is not defined for run " << runnumber << std::endl;
-    exit(1);
+    std::cout << PHWHERE << "WARNING: Strobe length is not defined for run " << runnumber << std::endl;
+    std::cout << "Defaulting to 89 mus strobe length" << std::endl;
+    strobeLength = 89.;
   }
   if(strobeLength > 88.)
   {

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -110,13 +110,9 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
         }
         poolmap[plist[i]->getIdentifier()] = new mvtx_pool();
       }
-      std::cout << "add packet"<<std::endl;
       poolmap[plist[i]->getIdentifier()]->addPacket(plist[i]);
-  std::cout << "delete plist"<<std::endl;
       delete plist[i];
-      std::cout << "end loop"<<std::endl;
     }
-    std::cout << "start pool map"<<std::endl;
     for (auto &iter : poolmap)
     {
       mvtx_pool *pool = iter.second;
@@ -422,11 +418,9 @@ void SingleMvtxPoolInput::CreateDSTNode(PHCompositeNode *topNode)
 
 void SingleMvtxPoolInput::ConfigureStreamingInputManager()
 {
-  std::cout << "Getting strobe length"<<std::endl;
-/*
+
   auto [runnumber, segment] = Fun4AllUtils::GetRunSegment(*(GetFileList().begin()));
   float strobeLength = mvtx_utils::getStrobeLength(runnumber);
-  std::cout << "got it " << strobeLength << std::endl;
   if(strobeLength > 88.)
   {
     m_BcoRange = 1000;
@@ -446,8 +440,11 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
       StreamingInputManager()->runMvtxTriggered(true);
     }
   }
-*/
-  std::cout << "BCO RANGE AND NEGATIVE BCO " << m_BcoRange << " " << m_NegativeBco << std::endl;
+  if(Verbosity() > 1)
+  {
+    std::cout << "Mvtx strobe length " << strobeLength << std::endl;
+    std::cout << "Mvtx BCO range and negative bco range set based on strobe length " << m_BcoRange << ", " << m_NegativeBco << std::endl;
+  }
   if (StreamingInputManager())
   {
     StreamingInputManager()->SetMvtxBcoRange(m_BcoRange);

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -1,10 +1,10 @@
 #include "SingleMvtxPoolInput.h"
 #include "mvtx_pool.h"
-
+#include "mvtx_decoder/mvtx_utils.h"
 #include "Fun4AllStreamingInputManager.h"
 
 #include "MvtxRawDefs.h"
-
+#include <fun4all/Fun4AllUtils.h>
 #include <ffarawobjects/MvtxFeeIdInfov1.h>
 #include <ffarawobjects/MvtxRawEvtHeaderv2.h>
 #include <ffarawobjects/MvtxRawHitContainerv1.h>
@@ -110,11 +110,13 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
         }
         poolmap[plist[i]->getIdentifier()] = new mvtx_pool();
       }
+      std::cout << "add packet"<<std::endl;
       poolmap[plist[i]->getIdentifier()]->addPacket(plist[i]);
-
+  std::cout << "delete plist"<<std::endl;
       delete plist[i];
+      std::cout << "end loop"<<std::endl;
     }
-
+    std::cout << "start pool map"<<std::endl;
     for (auto &iter : poolmap)
     {
       mvtx_pool *pool = iter.second;
@@ -420,6 +422,32 @@ void SingleMvtxPoolInput::CreateDSTNode(PHCompositeNode *topNode)
 
 void SingleMvtxPoolInput::ConfigureStreamingInputManager()
 {
+  std::cout << "Getting strobe length"<<std::endl;
+/*
+  auto [runnumber, segment] = Fun4AllUtils::GetRunSegment(*(GetFileList().begin()));
+  float strobeLength = mvtx_utils::getStrobeLength(runnumber);
+  std::cout << "got it " << strobeLength << std::endl;
+  if(strobeLength > 88.)
+  {
+    m_BcoRange = 1000;
+    m_NegativeBco = 1000;
+  }
+  else if (strobeLength > 9)
+  {
+    m_BcoRange = 100;
+    m_NegativeBco = 500;
+  }
+  else if (strobeLength < 1) // triggered mode
+  {
+    m_BcoRange = 2;
+    m_NegativeBco = 0;
+    if(StreamingInputManager())
+    {
+      StreamingInputManager()->runMvtxTriggered(true);
+    }
+  }
+*/
+  std::cout << "BCO RANGE AND NEGATIVE BCO " << m_BcoRange << " " << m_NegativeBco << std::endl;
   if (StreamingInputManager())
   {
     StreamingInputManager()->SetMvtxBcoRange(m_BcoRange);

--- a/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.cc
+++ b/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.cc
@@ -1,0 +1,36 @@
+#include "mvtx_utils.h"
+
+
+
+float mvtx_utils::getStrobeLength()
+{
+  float strobeWidth = std::numeric_limits<float>::quiet_NaN();
+  recoConsts *rc = recoConsts::instance();
+  int runNumber = rc->get_IntFlag("RUNNUMBER");
+
+  std::string executable_command = "psql -h sphnxdaqdbreplica daq --csv -c \"SELECT strobe FROM mvtx_strobe WHERE hostname = \'mvtx0\' AND runnumber = ";
+  executable_command += std::to_string(runNumber);
+  executable_command += ";\" | tail -n 1";
+
+  std::array<char, 128> buffer = {};
+  std::string result;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(executable_command.c_str(), "r"), pclose);
+  if (!pipe)
+  {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
+  {
+    result += buffer.data();
+  }
+  try
+  {
+    strobeWidth = stof(result);
+  }
+  catch (std::invalid_argument const& ex)
+  {
+    std::cout << "mvtx_utils::getStrobeLength() Run number " << runNumber << " has no strobe length in the DAQ database, returning NAN" << std::endl;
+  }
+  
+  return strobeWidth;
+}

--- a/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.cc
+++ b/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.cc
@@ -2,11 +2,10 @@
 
 
 
-float mvtx_utils::getStrobeLength()
+
+float mvtx_utils::getStrobeLength(const int& runNumber)
 {
   float strobeWidth = std::numeric_limits<float>::quiet_NaN();
-  recoConsts *rc = recoConsts::instance();
-  int runNumber = rc->get_IntFlag("RUNNUMBER");
 
   std::string executable_command = "psql -h sphnxdaqdbreplica daq --csv -c \"SELECT strobe FROM mvtx_strobe WHERE hostname = \'mvtx0\' AND runnumber = ";
   executable_command += std::to_string(runNumber);

--- a/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
@@ -23,24 +23,24 @@ namespace mvtx_utils
   struct RdhExt_t
   {
     // FLX header
-    uint8_t flxId;    // [23]
-    uint16_t pageSize; // [25]
-    uint16_t gbtLink;
-    uint8_t  flxHdrSize;
-    uint16_t flxHdrVersion;
+    uint8_t flxId = std::numeric_limits<uint8_t>::quiet_NaN();    // [23]
+    uint16_t pageSize = std::numeric_limits<uint16_t>::quiet_NaN(); // [25]
+    uint16_t gbtLink = std::numeric_limits<uint16_t>::quiet_NaN();
+    uint8_t  flxHdrSize = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint16_t flxHdrVersion = std::numeric_limits<uint16_t>::quiet_NaN();
     // RU header
-    uint8_t rdhVersion;
-    uint8_t rdhSize;
-    uint16_t feeId;
-    uint8_t sourceId;
-    uint32_t detectorField;
-    uint16_t bc;
-    uint64_t orbit;
-    uint32_t trgType;
-    uint16_t packetCounter;
-    uint8_t  stopBit;
-    uint8_t  priority;
-    uint16_t rdhGBTcounter; // 10 bits
+    uint8_t rdhVersion = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint8_t rdhSize = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint16_t feeId = std::numeric_limits<uint16_t>::quiet_NaN();
+    uint8_t sourceId = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint32_t detectorField = std::numeric_limits<uint32_t>::quiet_NaN();
+    uint16_t bc = std::numeric_limits<uint16_t>::quiet_NaN();
+    uint64_t orbit  = std::numeric_limits<uint64_t>::quiet_NaN();
+    uint32_t trgType  = std::numeric_limits<uint32_t>::quiet_NaN();
+    uint16_t packetCounter = std::numeric_limits<uint16_t>::quiet_NaN();
+    uint8_t  stopBit = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint8_t  priority = std::numeric_limits<uint8_t>::quiet_NaN();
+    uint16_t rdhGBTcounter = std::numeric_limits<uint16_t>::quiet_NaN(); // 10 bits
 
     RdhExt_t() = default;
     ~RdhExt_t() = default;

--- a/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
@@ -118,7 +118,7 @@ namespace mvtx_utils
     return a.second < b.second;
   }
 
-float getStrobeLength();
+float getStrobeLength(const int& runNumber);
 
 
 } //namespace mvtx_utils

--- a/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
+++ b/offline/framework/fun4allraw/mvtx_decoder/mvtx_utils.h
@@ -7,6 +7,10 @@
 #include <cstdint>
 #include <cassert>
 #include <iostream>
+#include <limits>
+#include <array>
+#include <memory>
+#include <phool/recoConsts.h>
 
 namespace mvtx_utils
 {
@@ -113,6 +117,9 @@ namespace mvtx_utils
   {
     return a.second < b.second;
   }
+
+float getStrobeLength();
+
 
 } //namespace mvtx_utils
 

--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -54,6 +54,7 @@ libmvtx_la_LIBADD = \
   -lphg4hit \
   -lSubsysReco \
   -ltrack_io \
+  -lmvtx_decoder \
   -ltrackbase_historic_io \
   -lcdbobjects
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -6,6 +6,7 @@
 
 #include "MvtxCombinedRawDataDecoder.h"
 
+#include <mvtx_decoder/mvtx_utils.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/MvtxEventInfov2.h>
 #include <trackbase/TrkrHitSet.h>
@@ -114,8 +115,16 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
     se->unregisterSubsystem(this);
   }
 
-  getStrobeLength();
-
+  m_strobeWidth = mvtx_utils::getStrobeLength();
+  if(std::isnan(m_strobeWidth))
+  {
+    std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is NaN, exiting." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  if(m_strobeWidth < 1)
+  {
+    runMvtxTriggered(true);
+  }
   // Load the hot pixel map from the CDB
   if(m_doOfflineMasking)
   {
@@ -300,45 +309,4 @@ void MvtxCombinedRawDataDecoder::removeDuplicates(
     end = remove(it + 1, end, *it);
   }
   v.erase(end, v.end());
-}
-
-void MvtxCombinedRawDataDecoder::getStrobeLength()
-{
-  recoConsts *rc = recoConsts::instance();
-  int m_runNumber = rc->get_IntFlag("RUNNUMBER");
-
-  std::string executable_command = "psql -h sphnxdaqdbreplica daq --csv -c \"SELECT strobe FROM mvtx_strobe WHERE hostname = \'mvtx0\' AND runnumber = ";
-  executable_command += std::to_string(m_runNumber);
-  executable_command += ";\" | tail -n 1";
-
-  std::string strobe_query = exec(executable_command.c_str());
-
-  try
-  {
-    m_strobeWidth = stof(strobe_query);
-  }
-  catch (std::invalid_argument const& ex)
-  {
-    if (Verbosity() >= 1)
-    {
-      std::cout << PHWHERE << ":: Run number " << m_runNumber << " has no strobe length in the DAQ database, using " << m_strobeWidth << " microseconds" << std::endl;
-    }
-  }
-}
-
-// https://stackoverflow.com/questions/478898/how-do-i-execute-a-command-and-get-the-output-of-the-command-within-c-using-po
-std::string MvtxCombinedRawDataDecoder::exec(const char *cmd)
-{
-  std::array<char, 128> buffer = {};
-  std::string result;
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
-  if (!pipe)
-  {
-    throw std::runtime_error("popen() failed!");
-  }
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
-  {
-    result += buffer.data();
-  }
-  return result;
 }

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -114,8 +114,9 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   {
     se->unregisterSubsystem(this);
   }
-
-  m_strobeWidth = mvtx_utils::getStrobeLength();
+  recoConsts *rc = recoConsts::instance();
+  int runNumber = rc->get_IntFlag("RUNNUMBER");
+  m_strobeWidth = mvtx_utils::getStrobeLength(runNumber);
   if(std::isnan(m_strobeWidth))
   {
     std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is NaN, exiting." << std::endl;

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -119,8 +119,8 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   m_strobeWidth = mvtx_utils::getStrobeLength(runNumber);
   if(std::isnan(m_strobeWidth))
   {
-    std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is NaN, exiting." << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is undefined for this run, defaulting to 89 mus" << std::endl;
+    m_strobeWidth = 89;
   }
   if(m_strobeWidth < 1)
   {

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -56,8 +56,6 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
-  void getStrobeLength();
-  std::string exec(const char *cmd);
 
   TrkrHitSetContainer* hit_set_container = nullptr;
   MvtxEventInfo* mvtx_event_header = nullptr;


### PR DESCRIPTION
This PR generalizes the daq db strobe lookup to a helper class in the mvtx decoder such that both the SinglePoolInput and unpacker can call it. This way the strobe width can be accessed from the daqdb (as is already done in the unpacker) in the pooling, and the bco ranges can be set accordingly. This should completely automate the production of the MVTX data in any mode that currently exists - 89 or 10 mus streaming strobe, or in triggered mode.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

