### PR TITLE
CD: KFP truth matching bug patch

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -15,7 +15,7 @@
 #include <trackbase/TrkrCluster.h>           // for TrkrCluster
 #include <trackbase/TrkrClusterContainer.h>  // for TrkrClusterContainer
 #include <trackbase/TrkrDefs.h>              // for getLayer, getTrkrId
-#include <trackbase_historic/SvtxPHG4ParticleMap_v1.h>
+#include <trackbase_historic/SvtxPHG4ParticleMap.h>
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack, SvtxTrack::...
 #include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, SvtxTrac...
 
@@ -120,12 +120,14 @@ PHG4Particle *KFParticle_truthAndDetTools::getTruthTrack(SvtxTrack *thisTrack, P
       std::cout << "KFParticle truth matching: G4TruthInfo does not exist" << std::endl;
     }
 
-    SvtxPHG4ParticleMap_v1 *dst_reco_truth_map = findNode::getClass<SvtxPHG4ParticleMap_v1>(topNode, "SvtxPHG4ParticleMap");
-
+    SvtxPHG4ParticleMap *dst_reco_truth_map = findNode::getClass<SvtxPHG4ParticleMap>(topNode, "SvtxPHG4ParticleMap");
     std::map<float, std::set<int>> truth_set = dst_reco_truth_map->get(thisTrack->get_id());
-    const auto &best_weight = truth_set.rbegin();
-    int best_truth_id = *best_weight->second.rbegin();
-    particle = m_truthinfo->GetParticle(best_truth_id);
+    if (truth_set.size() > 0)
+    {
+      std::pair<float, std::set<int>> best_weight = *truth_set.rbegin();
+      int best_truth_id = *best_weight.second.rbegin();
+      particle = m_truthinfo->GetParticle(best_truth_id);
+    }
   }
   else
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

There are some ghost tracks (I assume they're ghosts) that have no matching truth particles in the truth/reco map. When you try to associate them you access an array of size zero then KFParticle crashes

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

