### PR TITLE
Changing location of line lasers to match reality

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc
@@ -416,13 +416,13 @@ void PHG4TpcDirectLaser::SetupLasers()
     {
       laser.m_position.SetZ(position_base.z());
       laser.m_direction = -1;
-      laser.m_phi = M_PI / 2 * i + (15 * M_PI / 180);  // additional offset of 15 deg.
+      laser.m_phi = M_PI / 2 * i - (15 * M_PI / 180);  // additional offset of 15 deg.
     }
     else
     {
       laser.m_position.SetZ(-position_base.z());
       laser.m_direction = 1;
-      laser.m_phi = M_PI / 2 * i - (15 * M_PI / 180);  // additional offset of 15 deg.
+      laser.m_phi = M_PI / 2 * i + (15 * M_PI / 180);  // additional offset of 15 deg.
     }
 
     // rotate around z


### PR DESCRIPTION
**Files Affected:**

- simulation/g4simulation/g4tpc/PHG4TpcDirectLaser.cc

**Changes:**

- L419, 425 - adjusting the sign of the angle so that it rotates the laser locations to proper angles

**TODO:**

- check with Ross that SS is right
- rebuild macros and confirm that its right
