### PR TITLE
TrackSeedTrackMapConverter fixes

### DIFF
--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -1,11 +1,12 @@
 #include "TrackFitUtils.h"
 
-#include <trackbase/MvtxDefs.h>
 #include "ActsGeometry.h"
 #include "TpcDefs.h"
 #include "TrkrClusterContainerv4.h"
 #include "TrkrClusterv5.h"
 #include "TrkrDefs.h"  // for cluskey, getTrkrId, tpcId
+
+#include <trackbase/MvtxDefs.h>
 
 #include <cmath>
 
@@ -820,7 +821,8 @@ float TrackFitUtils::get_helix_pathlength(std::vector<float>& fitpars, const Act
   // - when pz is zero, the helix is degenerate, so this method assumes the pathlength is on the first loop around
   // - this method does not check whether the start and end points are actually compatible with the helix;
   //   the actual points that this method uses are those points on the helix with the same z and phi as start_point and end_point
-  if(fitpars.size()!=5) return -1e9;
+  if(fitpars.size()!=5) { return -1e9;
+}
   float R = fitpars[0];
   float x0 = fitpars[1];
   float y0 = fitpars[2];
@@ -834,15 +836,15 @@ float TrackFitUtils::get_helix_pathlength(std::vector<float>& fitpars, const Act
 
   // find number of turns
   float z_dist = end_point.z() - start_point.z();
-  int n_turns = floor(fabs(z_dist / half_turn_z_pathlength));
+  int n_turns = std::floor(std::fabs(z_dist / half_turn_z_pathlength));
 
   // phi relative to center of circle
   float phic_start = atan2(start_point.y()-y0,start_point.x()-x0);
   float phic_end = atan2(end_point.y()-y0,end_point.x()-x0);
-  float phic_dist = fabs(phic_end-phic_start) + n_turns*2*M_PI;
+  float phic_dist = std::fabs(phic_end-phic_start) + n_turns*2*M_PI;
   float xy_dist = R*phic_dist;
 
-  float pathlength = sqrt(xy_dist*xy_dist+z_dist*z_dist);
+  float pathlength = std::sqrt(xy_dist*xy_dist+z_dist*z_dist);
   return pathlength;
 }
 

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -119,6 +119,9 @@ namespace TrackFitUtils
   Acts::Vector2 get_line_point_pca(double slope, double intercept, Acts::Vector3 global);
   std::vector<float> fitClustersZeroField(std::vector<Acts::Vector3>& global_vec,
 						       std::vector<TrkrDefs::cluskey> cluskey_vec, bool use_intt);
+
+  float get_helix_pathlength(std::vector<float>& fitpars, const Acts::Vector3& start_point, const Acts::Vector3& end_point);
+  float get_helix_surface_pathlength(const Surface& surf, std::vector<float>& fitpars, const Acts::Vector3& start_point, ActsGeometry* tGeometry);
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Fixes several issues with TrackSeedTrackMapConverter:
- SvtxTrackState objects are now inserted into the output SvtxTrack for all surfaces on which the track has an associated cluster.
- Silicon seeds in particular will now no longer be assigned a crossing of 0 when their associated seed crossing is SHRT_MAX.
- The residuals (for chi2/ndf calculation) now use the intersection between the fit helix and the surface, rather than the PCA of the helix to the cluster.
- The cluster errors (for chi2/ndf calculation) are now sourced from a non-obsolete function (previously TrkrCluster::getActsLocalError, now TrkrCluster::getRPhiError and TrkrCluster::getZError), so give actual values instead of nan.
- The patch setting cluster errors to 0.01 when TrkrCluster::getActsLocalError returns nan has been removed.

In service of these changes, two new functions have been added to TrackFitUtils, relating to calculation of path length along the fit helix (which is needed for track state insertion).

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

