### PR TITLE
fix: clean up gl1 pool vectors

### DIFF
--- a/offline/framework/fun4allraw/SingleGl1PoolInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1PoolInput.cc
@@ -205,7 +205,6 @@ void SingleGl1PoolInput::CleanupUsedPackets(const uint64_t bclk)
       {
         delete pktiter;
       }
-      iter.second.clear();
       toclearbclk.push_back(iter.first);
     }
     else

--- a/offline/framework/fun4allraw/SingleGl1PoolInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1PoolInput.cc
@@ -108,7 +108,6 @@ void SingleGl1PoolInput::FillPool(const unsigned int /*nbclks*/)
 
     Gl1Packet *newhit = new Gl1Packetv2();
     uint64_t gtm_bco = packet->lValue(0, "BCO");
-    m_BeamClockFEE.insert(gtm_bco);
     m_FEEBclkMap.insert(gtm_bco);
     newhit->setBCO(packet->lValue(0, "BCO"));
     newhit->setHitFormat(packet->getHitFormat());
@@ -165,13 +164,7 @@ void SingleGl1PoolInput::FillPool(const unsigned int /*nbclks*/)
 
 void SingleGl1PoolInput::Print(const std::string &what) const
 {
-  if (what == "ALL" || what == "FEE")
-  {
-    for (const auto &bcliter : m_BeamClockFEE)
-    {
-      std::cout << PHWHERE << "Beam clock 0x" << std::hex << bcliter << std::dec << std::endl;
-    }
-  }
+  
   if (what == "ALL" || what == "FEEBCLK")
   {
     for (auto bcliter : m_FEEBclkMap)
@@ -204,7 +197,7 @@ void SingleGl1PoolInput::Print(const std::string &what) const
 void SingleGl1PoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
   std::vector<uint64_t> toclearbclk;
-  for (const auto &iter : m_Gl1RawHitMap)
+  for (auto &iter : m_Gl1RawHitMap)
   {
     if (iter.first <= bclk)
     {
@@ -212,6 +205,7 @@ void SingleGl1PoolInput::CleanupUsedPackets(const uint64_t bclk)
       {
         delete pktiter;
       }
+      iter.second.clear();
       toclearbclk.push_back(iter.first);
     }
     else
@@ -219,15 +213,12 @@ void SingleGl1PoolInput::CleanupUsedPackets(const uint64_t bclk)
       break;
     }
   }
-  // for (auto iter :  m_BeamClockFEE)
-  // {
-  //   iter.second.clear();
-  // }
+
 
   for (auto iter : toclearbclk)
   {
+    m_FEEBclkMap.erase(iter);
     m_BclkStack.erase(iter);
-    m_BeamClockFEE.erase(iter);
     m_Gl1RawHitMap.erase(iter);
   }
 }
@@ -266,7 +257,6 @@ void SingleGl1PoolInput::ClearCurrentEvent()
   //  std::cout << PHWHERE << "clearing bclk 0x" << std::hex << currentbclk << std::dec << std::endl;
   CleanupUsedPackets(currentbclk);
   // m_BclkStack.erase(currentbclk);
-  // m_BeamClockFEE.erase(currentbclk);
   return;
 }
 

--- a/offline/framework/fun4allraw/SingleGl1PoolInput.h
+++ b/offline/framework/fun4allraw/SingleGl1PoolInput.h
@@ -35,7 +35,6 @@ class SingleGl1PoolInput : public SingleStreamingInput
   //! map bco to packet
   std::map<unsigned int, uint64_t> m_packet_bco;
 
-  std::set<uint64_t> m_BeamClockFEE;
   std::map<uint64_t, std::vector<Gl1Packet *>> m_Gl1RawHitMap;
   std::set<uint64_t> m_FEEBclkMap;
   std::set<uint64_t> m_BclkStack;


### PR DESCRIPTION
This cleans up the GL1 pool vectors/maps better than before, and appears to lead to more stable CPU processing time as reported in today's tracking meeting.

https://indico.bnl.gov/event/25251/

Marking draft as I don't totally understand *why* this makes the speed more stable...

@hupereir 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

