### PR TITLE
Fix get_strip_z_spacing method in CylinderGeomIntt

### DIFF
--- a/offline/packages/intt/CylinderGeomIntt.h
+++ b/offline/packages/intt/CylinderGeomIntt.h
@@ -67,9 +67,14 @@ class CylinderGeomIntt : public PHG4CylinderGeom
     return m_StripY;
   }
 
-  double get_strip_z_spacing() const override
+  // double get_strip_z_spacing() const override // Only return type-A 1.6 cm strip z size
+  // {
+  //   return m_StripZ[0];
+  // }
+
+  double get_strip_z_spacing(const int itype = 0) const
   {
-    return m_StripZ[0];
+    return (itype == 0 || itype == 1) ? m_StripZ[itype] : m_StripZ[0];
   }
 
   double get_strip_tilt() const override

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -643,11 +643,12 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
     // we have a single hitset, get the info that identifies the sensor
     int layer = TrkrDefs::getLayer(hitsetitr->first);
     int ladder_z_index = InttDefs::getLadderZId(hitsetitr->first);
+    int type = (ladder_z_index == 0 || ladder_z_index == 2) ? 0 : 1; // ladder ID 0 and 2 are type-A (1.6 cm), ladder ID 1 and 3 are type-B (2.0 cm)
 
     // we will need the geometry object for this layer to get the global position
     CylinderGeomIntt* geom = dynamic_cast<CylinderGeomIntt*>(geom_container->GetLayerGeom(layer));
     float pitch = geom->get_strip_y_spacing();
-    float length = geom->get_strip_z_spacing();
+    float length = geom->get_strip_z_spacing(type);
 
     // fill a vector of hits to make things easier - gets every hit in the hitset
     std::vector<RawHit*> hitvec;

--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -379,11 +379,12 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
     // we have a single hitset, get the info that identifies the sensor
     int layer = TrkrDefs::getLayer(hitsetitr->first);
     int ladder_z_index = InttDefs::getLadderZId(hitsetitr->first);
+    int type = (ladder_z_index == 0 || ladder_z_index == 2) ? 0 : 1; // ladder ID 0 and 2 are type-A (1.6 cm), ladder ID 1 and 3 are type-B (2.0 cm)
 
     // we will need the geometry object for this layer to get the global position
     CylinderGeomIntt* geom = dynamic_cast<CylinderGeomIntt*>(geom_container->GetLayerGeom(layer));
     float pitch = geom->get_strip_y_spacing();
-    float length = geom->get_strip_z_spacing();
+    float length = geom->get_strip_z_spacing(type);
 
     // fill a vector of hits to make things easier - gets every hit in the hitset
     std::vector<std::pair<TrkrDefs::hitkey, TrkrHit*>> hitvec;

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -475,10 +475,16 @@ int PHG4InttHitReco::process_event(PHCompositeNode *topNode)
           double location[3] = {-1, -1, -1};
           layergeom->find_strip_center_localcoords(ladder_z_index, iy, iz, location);
           // note that (y1,z1) is the top left corner, (y2,z2) is the bottom right corner of the pixel - circle_rectangle_intersection expects this ordering
+          int type = (ladder_z_index == 0 || ladder_z_index == 2) ? 0 : 1; // ladder ID 0 and 2 are type-A (1.6 cm), ladder ID 1 and 3 are type-B (2.0 cm)
           double y1 = location[1] - layergeom->get_strip_y_spacing() / 2.0;
           double y2 = location[1] + layergeom->get_strip_y_spacing() / 2.0;
-          double z1 = location[2] + layergeom->get_strip_z_spacing() / 2.0;
-          double z2 = location[2] - layergeom->get_strip_z_spacing() / 2.0;
+          double z1 = location[2] + layergeom->get_strip_z_spacing(type) / 2.0;
+          double z2 = location[2] - layergeom->get_strip_z_spacing(type) / 2.0;
+
+          if (Verbosity() > 5)
+          {
+            std::cout << PHWHERE << " ladder_z_index " << ladder_z_index  << " strip size in z (from CylinderGeomIntt) " << fabs(z1 - z2) << " strip size in y (from CylinderGeomIntt) " << fabs(y1 - y2) << std::endl;
+          }
 
           // here m_SegmentVec.1 (Y) and m_SegmentVec.2 (Z) are the center of the circle, and diffusion_radius is the circle radius
           // circle_rectangle_intersection returns the overlap area of the circle and the pixel. It is very fast if there is no overlap.

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -234,8 +234,20 @@ int PHG4InttHitReco::InitRun(PHCompositeNode *topNode)
     }
   }
 
-  //Check for the hot channel map
-  std::string hotStripFile = std::filesystem::exists(m_hotStripFileName) ? m_hotStripFileName : CDBInterface::instance()->getUrl(m_hotStripFileName);
+  //Check for the hot channel map file
+  bool m_useLocalHitMaskFile = m_localHotStripFileName.empty() ? false : true;
+  std::string hotStripFile = "";
+  if (m_useLocalHitMaskFile)
+  {
+    hotStripFile = m_localHotStripFileName;
+  }
+  else // use CDB file
+  {
+    hotStripFile = std::filesystem::exists(m_hotStripFileName) ? m_hotStripFileName : CDBInterface::instance()->getUrl(m_hotStripFileName); 
+  }
+
+  std::cout << "PHG4InttHitReco::InitRun - Use local hot channel map file: " << m_useLocalHitMaskFile << std::endl
+            << "PHG4InttHitReco::InitRun - Hot channel map file: " << hotStripFile << std::endl;
 
   if (std::filesystem::exists(hotStripFile))
   {

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.h
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.h
@@ -43,6 +43,8 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
 
   void setHotStripMaskFile(const std::string& name) { m_hotStripFileName = name; }
 
+  void setLocalHotStripMaskFile(const std::string& name) { m_localHotStripFileName = name; }
+
  protected:
   std::string m_Detector = "INTT";
   std::string m_HitNodeName;
@@ -70,6 +72,7 @@ class PHG4InttHitReco : public SubsysReco, public PHParameterInterface
   std::map<TrkrDefs::hitsetkey, unsigned int> m_hitsetkey_cnt{};  // counter for making ckeys form hitsetkeys
 
   std::string m_hotStripFileName = "INTT_HotMap";
+  std::string m_localHotStripFileName = ""; // default to empty: only use local file for testing purpose; if empty, use CDB file
   typedef std::set<InttNameSpace::RawData_s, InttNameSpace::RawDataComparator> Set_t;
   Set_t m_HotChannelSet;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
- In the `get_strip_z_spacing method` of CylinderGeomIntt, a bug caused only type-A (1.6 cm) strip sizes to be returned, even when type-B (2.0 cm) strips were in use. This mismatch led to an underestimation of the number of strips intersected by the charge diffusion circle in digitization (PHG4InttHitReco), ultimately causing a loss in INTT acceptance. The first attached plot, created during the debugging process, shows PHG4Hit z0 distributions for all truth hits (black) and TrkrHit-matched truth hits (red). Gaps appear in the regions where type-B (2.0 cm) strips are located, indicating that type-B strip sizes were incorrectly assigned. The second plot was produced from a local build with the fix implemented (only simulated 1 event for local test)
- The method in CylinderGeomIntt is modified to return the size depending on the type and or default to the type-A size if the type is not given as an argument
- The relevant part in InttClusterizer is modified: mainly for the error calculation

![Screenshot 2024-11-01 at 12 15 52](https://github.com/user-attachments/assets/a99bf964-8250-453e-a2fa-9b62a80518cf)
![Screenshot 2024-11-01 at 12 37 06](https://github.com/user-attachments/assets/0fc95fae-f1f6-487c-9fa7-c216be556921)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)