### PR TITLE
Add setter functions for emcal/hcal thresholds for ZS cross calib factors and histogram for packet event number check in CaloFittingQA module

### DIFF
--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -184,7 +184,7 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         {
           std::cout << "EMCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
         }
-        if (raw_energy > m_adc_threshold && raw_energy < m_high_adc_threshold) 
+        if (raw_energy > m_cemc_adc_threshold && raw_energy < m_cemc_high_adc_threshold) 
         {
           h_cemc_etaphi_ZScrosscalib->Fill(ieta, iphi, zs_energy/raw_energy);
         }
@@ -216,7 +216,7 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         {
           std::cout << "IHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
         }
-        if (raw_energy > m_adc_threshold && raw_energy < m_high_adc_threshold)
+        if (raw_energy > m_hcal_adc_threshold && raw_energy < m_hcal_high_adc_threshold)
         {
           h_ohcal_etaphi_ZScrosscalib->Fill(ieta, iphi, zs_energy/raw_energy);
         }
@@ -248,7 +248,7 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         {
           std::cout << "OHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
         }
-        if (raw_energy > m_adc_threshold && raw_energy < m_high_adc_threshold)
+        if (raw_energy > m_hcal_adc_threshold && raw_energy < m_hcal_high_adc_threshold)
         {
           h_ihcal_etaphi_ZScrosscalib->Fill(ieta, iphi, zs_energy/raw_energy);
         }

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -341,6 +341,7 @@ int CaloFittingQA::process_data(PHCompositeNode *topNode, CaloTowerDefs::Detecto
   {
     if (packet)
     {
+      h_packet_events->Fill(pid);
       int nchannels = packet->iValue(0, "CHANNELS");
       unsigned int adc_skip_mask = 0;
 
@@ -529,5 +530,9 @@ void CaloFittingQA::createHistos()
   h_ohcal_etaphi_ZScrosscalib = new TProfile2D(boost::str(boost::format("%sohcal_etaphi_ZScrosscalib") % getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, -10, 10);
   h_ohcal_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_ZScrosscalib);
+
+  h_packet_events = new TH1I(boost::str(boost::format("%spacket_events") % getHistoPrefix()).c_str(), ";packet id", 6010, 6000, 12010);
+  h_packet_events->SetDirectory(nullptr);
+  hm->registerHisto(h_packet_events);
 
 }

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -70,6 +70,7 @@ class CaloFittingQA : public SubsysReco
   TProfile2D* h_cemc_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ihcal_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ohcal_etaphi_ZScrosscalib{nullptr};
+  TH1* h_packet_events{nullptr};
 
   int _eventcounter{0};
 

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -47,13 +47,21 @@ class CaloFittingQA : public SubsysReco
   {
     m_SimFlag = f;
   }
-  void set_lowadcthreshold(int lath)
+  void set_cemc_lowadcthreshold(int lath)
   {
-    m_adc_threshold = lath;
+    m_cemc_adc_threshold = lath;
   }
-  void set_highadcthreshold(int hath)
+  void set_cemc_highadcthreshold(int hath)
   {
-    m_high_adc_threshold = hath;
+    m_cemc_high_adc_threshold = hath;
+  }
+  void set_hcal_lowadcthreshold(int lath)
+  {
+    m_hcal_adc_threshold = lath;
+  }
+  void set_hcal_highadcthreshold(int hath)
+  {
+    m_hcal_high_adc_threshold = hath;
   }
 
  private:
@@ -69,8 +77,10 @@ class CaloFittingQA : public SubsysReco
   bool m_UseOfflinePacketFlag{true};
   bool m_SimFlag{false};
 
-  float m_adc_threshold = 100.;
-  float m_high_adc_threshold = 2000.;
+  float m_cemc_adc_threshold = 200.;
+  float m_cemc_high_adc_threshold = 2000.;
+  float m_hcal_adc_threshold = 100.;
+  float m_hcal_high_adc_threshold = 2000.;
 
   std::string m_outputFileName;
   std::string OutputFileName;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR adds separate setter functions for the EMCal and HCals for the ADC thresholds used to calculate ZS cross calibrations factors. This is necessary to account for different levels of noise between calorimeters and determining any other kind of energy dependence in the cross calibration factors. 
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

