### PR TITLE
Added Function to skip events with > 100k TPCseeds

### DIFF
--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -241,7 +241,7 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
     std::cout << "prepared KD trees" << std::endl;
   }
 
-  if (Verbosity()==0)
+  if (Verbosity())
   {
     std::cout << "number of TPC seeds: " << _track_map->size() << std::endl;
   }

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -245,10 +245,10 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
   {
     std::cout << "number of TPC seeds: " << _track_map->size() << std::endl;
   }
-  if(_max_seeds)
+  if(_max_seeds > 0)
   {
-    if(_track_map->size()>1e5){
-      std::cout << PHWHERE << "number of TPC seeds > 100,000. aborting event." << std::endl;
+    if(_track_map->size() > _max_seeds){
+      std::cout << PHWHERE << "number of TPC seeds > " << _max_seeds << " aborting event." << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
   }

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -241,11 +241,17 @@ int PHSimpleKFProp::process_event(PHCompositeNode* topNode)
     std::cout << "prepared KD trees" << std::endl;
   }
 
-  if (Verbosity())
+  if (Verbosity()==0)
   {
     std::cout << "number of TPC seeds: " << _track_map->size() << std::endl;
   }
-
+  if(_max_seeds)
+  {
+    if(_track_map->size()>1e5){
+      std::cout << PHWHERE << "number of TPC seeds > 100,000. aborting event." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
   std::vector<std::vector<TrkrDefs::cluskey>> new_chains;
   std::vector<TrackSeed_v2> unused_tracks;
   for (size_t track_it = 0; track_it != _track_map->size(); ++track_it)

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -70,6 +70,7 @@ class PHSimpleKFProp : public SubsysReco
   }
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_pp_mode(bool mode) { _pp_mode = mode; }
+  void set_max_seeds(bool abortEvt) { _max_seeds = abortEvt; }
   enum class PropagationDirection
   {
     Outward,
@@ -102,6 +103,7 @@ class PHSimpleKFProp : public SubsysReco
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
+  bool _max_seeds = false;
 
   TrkrClusterContainer* _cluster_map = nullptr;
 

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -70,7 +70,7 @@ class PHSimpleKFProp : public SubsysReco
   }
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_pp_mode(bool mode) { _pp_mode = mode; }
-  void set_max_seeds(bool abortEvt) { _max_seeds = abortEvt; }
+  void set_max_seeds(unsigned int ui) { _max_seeds = ui; }
   enum class PropagationDirection
   {
     Outward,
@@ -103,7 +103,7 @@ class PHSimpleKFProp : public SubsysReco
   double _fieldDir = -1;
   double _max_sin_phi = 1.;
   bool _pp_mode = false;
-  bool _max_seeds = false;
+  unsigned int _max_seeds = 0;
 
   TrkrClusterContainer* _cluster_map = nullptr;
 


### PR DESCRIPTION
[comment]: <I implemented the set_max_seeds function that aborts events with more than 100k TPC seeds.> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <If you call the function cprop->set_max_seeds(true); in the Fun4All_FieldOnAllTrackers.C macro, it aborts events that have more than 100k TPC seeds coming from the seeder process. Discussion in: https://indico.bnl.gov/event/25255/> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

