### PR TITLE
fix: intt and tpc slowdown

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -911,6 +911,8 @@ int Fun4AllStreamingInputManager::FillMvtx()
     for (auto iter : m_MvtxInputVector)
     {
       iter->CleanupUsedPackets(m_MvtxRawHitMap.begin()->first);
+
+      iter->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
     }
     timer2.stop();
     std::cout << "cleanup used packets " << timer2.elapsed() << std::endl;
@@ -1001,9 +1003,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       }
       feecounter++;
     }
-    // we just want to erase anything that is well before the current GL1
-    // so make an arbitrary cut of 40000.
-    p->clearFeeGTML1BCOMap(m_RefBCO - 40000);
+
   }
   int allfeestagged = 0;
   for (auto &[pid, feeset] : taggedPacketsFEEs)
@@ -1254,6 +1254,8 @@ int Fun4AllStreamingInputManager::FillTpc()
     for (auto iter : m_TpcInputVector)
     {
       iter->CleanupUsedPackets(m_TpcRawHitMap.begin()->first);
+      iter->clearPacketBClkStackMap(m_TpcRawHitMap.begin()->first);
+
     }
     m_TpcRawHitMap.begin()->second.TpcRawHitVector.clear();
     m_TpcRawHitMap.erase(m_TpcRawHitMap.begin());
@@ -1313,7 +1315,6 @@ int Fun4AllStreamingInputManager::FillTpc()
       iter->CleanupUsedPackets(m_TpcRawHitMap.begin()->first);
         // we just want to erase anything that is well away from the current GL1
   
-      iter->clearPacketBClkStackMap(m_RefBCO -m_tpc_negative_bco);
     }
     m_TpcRawHitMap.begin()->second.TpcRawHitVector.clear();
     m_TpcRawHitMap.erase(m_TpcRawHitMap.begin());

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -640,16 +640,11 @@ int Fun4AllStreamingInputManager::FillGl1()
 
 int Fun4AllStreamingInputManager::FillIntt()
 {
-    PHTimer timer("timer");
-  timer.stop();
-  timer.restart();
   int iret = FillInttPool();
   if (iret)
   {
     return iret;
   }
-    timer.stop();
-  std::cout << "fillmvtxpool " << timer.elapsed() << std::endl;
 
   // unsigned int alldone = 0;
   //     std::cout << "stashed intt BCOs: " << m_InttRawHitMap.size() << std::endl;
@@ -682,12 +677,9 @@ int Fun4AllStreamingInputManager::FillIntt()
               << " for ref BCO " << m_RefBCO
               << std::dec << std::endl;
   }
-    timer.restart();
 
   while (m_InttRawHitMap.begin()->first < m_RefBCO - m_intt_negative_bco)
-  {PHTimer timer2("timer2");
-    timer2.stop();
-    timer2.restart();
+  {
     if (Verbosity() > 2)
     {
       std::cout << "Intt BCO: 0x" << std::hex << m_InttRawHitMap.begin()->first
@@ -703,25 +695,16 @@ int Fun4AllStreamingInputManager::FillIntt()
       iter->clearPacketBClkStackMap(m_InttRawHitMap.begin()->first);
       iter->clearFeeGTML1BCOMap(m_InttRawHitMap.begin()->first);
     }
-    timer2.stop();
-    std::cout << "cleanup used packets " << timer2.elapsed() << std::endl;
-    timer2.restart();
+   
     m_InttRawHitMap.begin()->second.InttRawHitVector.clear();
     m_InttRawHitMap.erase(m_InttRawHitMap.begin());
-    timer2.stop();
-    std::cout << "erase vectors " << timer2.elapsed() << std::endl;
-    timer2.restart();
+    
     iret = FillInttPool();
     if (iret)
     {
       return iret;
     }
-    timer2.stop();
-    std::cout << "refill the pool " << timer2.elapsed() << std::endl;
   }
-timer.stop();
-  std::cout << "first loop time " << timer.elapsed()<<std::endl;
-    timer.restart();
 
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
   h_refbco_intt->Fill(refbcobitshift);
@@ -729,17 +712,13 @@ timer.stop();
   int allpacketsallfees = 0;
   for (auto &p : m_InttInputVector)
   {
-    PHTimer qatimer("qatimer");
-    qatimer.stop();
-    qatimer.restart();
+    
     // this is on a per packet basis
     auto bcl_stack = p->BclkStackMap();
     auto feebclstack = p->getFeeGTML1BCOMap();
     int packet_id = bcl_stack.begin()->first;
     int histo_to_fill = (packet_id % 10) - 1;
-  qatimer.stop();
-  std::cout << "grab maps time " << qatimer.elapsed() << std::endl;
-  qatimer.restart();
+  
     std::set<int> feeidset;
     int fee = 0;
     for (auto &[feeid, gtmbcoset] : feebclstack)
@@ -756,9 +735,7 @@ timer.stop();
       }
       fee++;
     }
-    qatimer.stop();
-    std::cout << "filling feeidset time " << qatimer.elapsed() << std::endl;
-  qatimer.restart();
+    
     if (feeidset.size() == 14)
     {
       allpacketsallfees++;
@@ -766,14 +743,7 @@ timer.stop();
     }
     feeidset.clear();
     bool thispacket = false;
-    
-    // we just want to erase anything that is before the current GL1
-    qatimer.stop();
-    std::cout << "clear map first time " << qatimer.elapsed() << std::endl;
-    qatimer.restart();
-  qatimer.stop();
-    std::cout << "clear map time " << qatimer.elapsed() << std::endl;
-    qatimer.restart();
+        
     for (auto &[packetid, gtmbcoset] : bcl_stack)
     {
       for (auto &gtmbco : gtmbcoset)
@@ -787,9 +757,7 @@ timer.stop();
         }
       }
     }
-    qatimer.stop();
-    std::cout << "filling bcl stack time " << qatimer.elapsed() << std::endl;
-
+    
     if (thispacket == false)
     {
       allpackets = false;
@@ -803,9 +771,7 @@ timer.stop();
   {
     h_taggedAllFee_intt->Fill(refbcobitshift);
   }
-timer.stop();
-  std::cout << "Timer QA time " << timer.elapsed() << std::endl;
-  timer.restart();
+
   //  std::cout << "Checking diff " << (m_InttRawHitMap.begin()->first - (select_crossings - m_intt_negative_bco)) << std::endl;
   while (m_InttRawHitMap.begin()->first <= select_crossings - m_intt_negative_bco)
   {
@@ -822,9 +788,6 @@ timer.stop();
     for (auto iter : m_InttInputVector)
     {
       iter->CleanupUsedPackets(m_InttRawHitMap.begin()->first);
-
-
-
     }
     m_InttRawHitMap.begin()->second.InttRawHitVector.clear();
     m_InttRawHitMap.erase(m_InttRawHitMap.begin());
@@ -833,24 +796,17 @@ timer.stop();
       break;
     }
   }
-  timer.stop();
-  std::cout << "Resetting time " << timer.elapsed()<<std::endl;
-  std::cout << "total time to run mvtx " << timer.get_accumulated_time() << std::endl;
-  return 0;
+ return 0;
 }
 
 int Fun4AllStreamingInputManager::FillMvtx()
 {
-  PHTimer timer("timer");
-  timer.stop();
-  timer.restart();
+
   int iret = FillMvtxPool();
   if (iret)
   {
     return iret;
   }
-  timer.stop();
-  std::cout << "fillmvtxpool " << timer.elapsed() << std::endl;
 
   MvtxRawEvtHeader *mvtxEvtHeader = findNode::getClass<MvtxRawEvtHeader>(m_topNode, "MVTXRAWEVTHEADER");
   if (!mvtxEvtHeader)
@@ -891,19 +847,12 @@ int Fun4AllStreamingInputManager::FillMvtx()
               << " to 0x" << select_crossings - m_mvtx_bco_range
               << std::dec << std::endl;
   }
-  timer.restart();
   // m_MvtxRawHitMap.empty() does not need to be checked here, FillMvtxPool returns non zero
   // if this map is empty which is handled above
   // All three values used in the while loop evaluation are unsigned ints. If m_RefBCO is < m_mvtx_bco_range then we will overflow and delete all hits
-  std::cout << "mvtx cleanup bco loop raw hit map size " << m_MvtxRawHitMap.size() << std::endl;
-  auto bcofirst = m_MvtxRawHitMap.begin()->first;
-  auto bcolast = m_MvtxRawHitMap.rbegin()->first;
-  std::cout << "bco diff " << bcolast - bcofirst << std::endl;
   while (m_MvtxRawHitMap.begin()->first < ref_bco_minus_range)
   {
-    PHTimer timer2("timer2");
-    timer2.stop();
-    timer2.restart();
+ 
     if (Verbosity() > 2)
     {
       std::cout << "ditching mvtx bco 0x" << std::hex << m_MvtxRawHitMap.begin()->first << ", ref: 0x" << m_RefBCO << std::dec << std::endl;
@@ -911,12 +860,8 @@ int Fun4AllStreamingInputManager::FillMvtx()
     for (auto iter : m_MvtxInputVector)
     {
       iter->CleanupUsedPackets(m_MvtxRawHitMap.begin()->first);
-
       iter->clearFeeGTML1BCOMap(m_MvtxRawHitMap.begin()->first);
     }
-    timer2.stop();
-    std::cout << "cleanup used packets " << timer2.elapsed() << std::endl;
-    timer2.restart();
     for (auto mvtxFeeIdInfo : m_MvtxRawHitMap.begin()->second.MvtxFeeIdInfoVector)
     {
       if (Verbosity() > 1)
@@ -925,33 +870,26 @@ int Fun4AllStreamingInputManager::FillMvtx()
       }
       delete mvtxFeeIdInfo;
     }
-    timer2.stop();
-    std::cout << "delete mvtx feeid info " << timer2.elapsed() << std::endl;
-    timer2.restart();
+    
     m_MvtxRawHitMap.begin()->second.MvtxFeeIdInfoVector.clear();
     m_MvtxRawHitMap.begin()->second.MvtxL1TrgBco.clear();
     m_MvtxRawHitMap.begin()->second.MvtxRawHitVector.clear();
     m_MvtxRawHitMap.erase(m_MvtxRawHitMap.begin());
-    timer2.stop();
-    std::cout << "erase vectors " << timer2.elapsed() << std::endl;
-    timer2.restart();
+    
     iret = FillMvtxPool();
     if (iret)
     {
       return iret;
     }
-    timer2.stop();
-    std::cout << "refill the pool " << timer2.elapsed() << std::endl;
+
   }
-  timer.stop();
-  std::cout << "first loop time " << timer.elapsed()<<std::endl;
   // again m_MvtxRawHitMap.empty() is handled by return of FillMvtxPool()
   if (Verbosity() > 2)
   {
     std::cout << "after ditching, mvtx bco: 0x" << std::hex << m_MvtxRawHitMap.begin()->first << ", ref: 0x" << m_RefBCO
               << std::dec << std::endl;
   }
-  timer.restart();
+  
 
   unsigned int refbcobitshift = m_RefBCO & 0x3FU;
   h_refbco_mvtx->Fill(refbcobitshift);
@@ -1025,10 +963,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
     h_taggedAllFelixes_mvtx->Fill(refbcobitshift);
   }
   taggedPacketsFEEs.clear();
-  timer.stop();
-  std::cout << "Timer QA time " << timer.elapsed() << std::endl;
-  timer.restart();
-std::cout << "raw hit map size " << m_MvtxRawHitMap.size() << std::endl;
+  
   if (m_mvtx_is_triggered)
   {
     while (select_crossings <= m_MvtxRawHitMap.begin()->first && m_MvtxRawHitMap.begin()->first <= select_crossings + m_mvtx_bco_range) //triggered
@@ -1115,11 +1050,7 @@ std::cout << "raw hit map size " << m_MvtxRawHitMap.size() << std::endl;
       }
     }
   }
-  timer.stop();
-  std::cout << "Resetting time " << timer.elapsed()<<std::endl;
-  std::cout << "total time to run mvtx " << timer.get_accumulated_time() << std::endl;
-  std::cout << "raw hit map size 2 " << m_MvtxRawHitMap.size() << std::endl;
-
+  
   return 0;
 }
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -163,7 +163,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto hits = pool->get_hits(feeId, i_strb);
             for (auto &&hit : hits)
             {
-              MvtxRawHit *newhit = new MvtxRawHitv1();
+              auto newhit = std::make_unique<MvtxRawHitv1>();
               newhit->set_bco(strb_bco);
               newhit->set_strobe_bc(strb_bc);
               newhit->set_chip_bc(hit->bunchcounter);

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -163,7 +163,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto hits = pool->get_hits(feeId, i_strb);
             for (auto &&hit : hits)
             {
-              auto newhit = std::make_unique<MvtxRawHitv1>();
+              MvtxRawHit *newhit = new MvtxRawHitv1();
               newhit->set_bco(strb_bco);
               newhit->set_strobe_bc(strb_bc);
               newhit->set_chip_bc(hit->bunchcounter);
@@ -178,6 +178,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
                 StreamingInputManager()->AddMvtxRawHit(strb_bco, newhit.get());
               }
               m_MvtxRawHitMap[strb_bco].push_back(newhit.release());
+
             }
             if (StreamingInputManager())
             {

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -163,7 +163,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto hits = pool->get_hits(feeId, i_strb);
             for (auto &&hit : hits)
             {
-              MvtxRawHit *newhit = new MvtxRawHitv1();
+              auto newhit = std::make_unique<MvtxRawHitv1>();
               newhit->set_bco(strb_bco);
               newhit->set_strobe_bc(strb_bc);
               newhit->set_chip_bc(hit->bunchcounter);
@@ -175,9 +175,9 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
               newhit->set_col(hit->col_pos);
               if (StreamingInputManager())
               {
-                StreamingInputManager()->AddMvtxRawHit(strb_bco, newhit);
+                StreamingInputManager()->AddMvtxRawHit(strb_bco, newhit.get());
               }
-              m_MvtxRawHitMap[strb_bco].push_back(newhit);
+              m_MvtxRawHitMap[strb_bco].push_back(newhit.release());
             }
             if (StreamingInputManager())
             {

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -67,41 +67,41 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   /** TODO: check whether necessary */
   virtual void FillBcoQA(uint64_t /*gtm_bco*/) {};
 
+  void clearPacketBClkStackMap(const uint64_t& bclk)
 
-  void clearPacketBClkStackMap(const int &packetid, const uint64_t& bclk)
   {
-    std::set<uint64_t> to_erase;
-    auto set = m_BclkStackPacketMap.find(packetid)->second;
-      for(auto& bclk_to_erase : set)
+    for(auto& [packetid, set] : m_BclkStackPacketMap)
+    {
+    
+      for(auto it = set.begin(); it != set.end();)
+    {
+      if(*it <= bclk)
       {
-        if(bclk_to_erase <= bclk)
-        {
-          to_erase.insert(bclk_to_erase);
-        }
+        it = set.erase(it);
       }
-      for(auto& bclk_to_erase : to_erase)
+      else
       {
-        set.erase(bclk_to_erase);
+        ++it;
       }
     }
-
+    }
+  }
   void clearFeeGTML1BCOMap(const uint64_t &bclk)
   {
-    std::set<uint64_t> toerase;
     for (auto &[key, set] : m_FeeGTML1BCOMap)
     {
-      for (auto &ll1bclk : set)
+      for(auto it = set.begin(); it != set.end();)
       {
-        if (ll1bclk <= bclk)
+        if(*it <= bclk)
         {
-          // to avoid invalid reads
-          toerase.insert(ll1bclk);
+          it = set.erase(it);
+        }
+        else
+        {
+          ++it;
         }
       }
-      for (auto &bclk_to_erase : toerase)
-      {
-        set.erase(bclk_to_erase);
-      }
+      
     }
   }
 

--- a/offline/framework/fun4allraw/SingleTpcPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcPoolInput.cc
@@ -193,7 +193,7 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
             continue;
           }
           bool parityerror = (packet->iValue(wf, "DATAPARITYERROR") > 0);
-          TpcRawHit *newhit = new TpcRawHitv2();
+          auto newhit = std::make_unique<TpcRawHitv2>();
           int FEE = packet->iValue(wf, "FEE");
           newhit->set_bco(packet->iValue(wf, "BCO"));
 
@@ -254,9 +254,9 @@ void SingleTpcPoolInput::FillPool(const uint64_t minBCO)
           // {
           if (StreamingInputManager())
           {
-            StreamingInputManager()->AddTpcRawHit(gtm_bco, newhit);
+            StreamingInputManager()->AddTpcRawHit(gtm_bco, newhit.get());
           }
-          m_TpcRawHitMap[gtm_bco].push_back(newhit);
+          m_TpcRawHitMap[gtm_bco].push_back(newhit.release());
           m_BclkStack.insert(gtm_bco);
           //	}
         }


### PR DESCRIPTION
This PR fixes the intt and tpc slowdown in the poolers. There was a map that was being cleared in the wrong place, so it was growing faster than it was being cleared. It also changes the creation of the hits to use smart pointers instead of raw pointers, which are in general easier/safer. The linear slowdown in the mvtx still remains a mystery but it is not as egregious as these cases.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

