### PR TITLE
KFParticle updates for intermedite resonances

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -563,17 +563,18 @@ std::vector<std::vector<int>> KFParticle_Tools::appendTracksToIntermediates(KFPa
   return goodTracksThatMeetIntermediates;
 }
 
-float KFParticle_Tools::eventDIRA(const KFParticle &particle, const KFParticle &vertex)
+float KFParticle_Tools::eventDIRA(const KFParticle &particle, const KFParticle &vertex, bool do3D)
 {
-  TMatrixD flightVector(3, 1);
-  TMatrixD momVector(3, 1);
+  const int nDimensions = do3D ? 3 : 2;
+  TMatrixD flightVector(nDimensions, 1);
+  TMatrixD momVector(nDimensions, 1);
   flightVector(0, 0) = particle.GetX() - vertex.GetX();
   flightVector(1, 0) = particle.GetY() - vertex.GetY();
-  flightVector(2, 0) = particle.GetZ() - vertex.GetZ();
+  if (do3D) flightVector(2, 0) = particle.GetZ() - vertex.GetZ();
 
   momVector(0, 0) = particle.GetPx();
   momVector(1, 0) = particle.GetPy();
-  momVector(2, 0) = particle.GetPz();
+  if (do3D) momVector(2, 0) = particle.GetPz();
 
   TMatrixD momDotFD(1, 1);  // Calculate momentum dot flight distance
   momDotFD = TMatrixD(momVector, TMatrixD::kTransposeMult, flightVector);
@@ -777,16 +778,18 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
   particleCopy.GetDecayLength(calculated_decayLength, calculated_decayLengthErr);
 
   float calculated_fdchi2 = flightDistanceChi2(particle, vertex);
-  float calculated_dira = eventDIRA(particle, vertex);
+  float calculated_dira;
 
   float calculated_ipchi2;
   if (m_use_2D_matching_tools)
   {
     calculated_ipchi2 = particle.GetDeviationFromVertexXY(vertex);
+    calculated_dira = eventDIRA(particle, vertex, false);
   }
   else
   {
     calculated_ipchi2 = particle.GetDeviationFromVertex(vertex);
+    calculated_dira = eventDIRA(particle, vertex);
   }
 
   goodCandidate = false;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -734,7 +734,10 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     for (int i = 0; i < nTracks; ++i)
     {
       SvtxTrack *thisTrack = toolSet.getTrack(vDaughters[i].Id(), m_dst_trackmap);
-      crossings.push_back(thisTrack->get_crossing());
+      if (thisTrack)//This protects against intermediates which have no track but I need a way to assign the bunch crossing to an interemdiate as this was already checked when it was actually built
+      {
+        crossings.push_back(thisTrack->get_crossing());
+      }
     }
 
     removeDuplicates(crossings);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -188,7 +188,6 @@ class KFParticle_Tools : protected KFParticle_MVA
   SvtxVertex *m_dst_vertex {nullptr};
   SvtxTrack *m_dst_track {nullptr};
 
- private:
   void removeDuplicates(std::vector<double> &v);
   void removeDuplicates(std::vector<int> &v);
   void removeDuplicates(std::vector<std::vector<int>> &v);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -72,7 +72,7 @@ class KFParticle_Tools : protected KFParticle_MVA
   std::vector<std::vector<int>> appendTracksToIntermediates(KFParticle intermediateResonances[], std::vector<KFParticle> daughterParticles, const std::vector<int> &goodTrackIndex, int num_remaining_tracks);
 
   /// Calculates the cosine of the angle betweent the flight direction and momentum
-  float eventDIRA(const KFParticle &particle, const KFParticle &vertex);
+  float eventDIRA(const KFParticle &particle, const KFParticle &vertex, bool do3D = true);
 
   float flightDistanceChi2(const KFParticle &particle, const KFParticle &vertex);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -27,6 +27,10 @@
 
 #include "KFParticle_eventReconstruction.h"
 #include "KFParticle_Tools.h"
+#include "KFParticle_truthAndDetTools.h"
+
+//sPHENIX stuff
+#include <trackbase_historic/SvtxTrack.h>
 
 // KFParticle stuff
 #include <KFParticle.h>
@@ -277,6 +281,38 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                                                              m_constrain_to_vertex, false, 0, num_mother_decay_products, m_constrain_int_mass, required_unique_vertexID);
                 if (isGood)
                 {
+
+                  if (m_require_bunch_crossing_match)
+                  {
+                    KFParticle_truthAndDetTools toolSet;
+                    std::vector<int> crossings;
+                    for (int i = 0; i < num_tracks_used_by_intermediates; ++i)
+                    {
+                      SvtxTrack *thisTrack = toolSet.getTrack(finalTracks[i].Id(), m_dst_trackmap);
+                      if (thisTrack)
+                      {
+                        crossings.push_back(thisTrack->get_crossing());
+                      }
+                    }
+                
+                    for (int k = 0; k < num_remaining_tracks; ++k)
+                    {
+                      int trackArrayID = k + m_num_intermediate_states;
+                      SvtxTrack *thisTrack = toolSet.getTrack(motherDecayProducts[trackArrayID].Id(), m_dst_trackmap);
+                      if (thisTrack)
+                      {
+                        crossings.push_back(thisTrack->get_crossing());
+                      }
+                    }
+                
+                    removeDuplicates(crossings);
+                
+                    if (crossings.size() !=1)
+                    {
+                      continue;
+                    }
+                  }
+
                   goodCandidates.push_back(candidate);
                   if (m_constrain_to_vertex)
                   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -38,6 +38,8 @@
 #include <string>   // for string
 #include <tuple>    // for tie, tuple
 
+#include <iostream>
+
 /// Create necessary objects
 KFParticle_Tools kfp_Tools_evtReco;
 
@@ -113,18 +115,15 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
 {
   int track_start = 0;
   int track_stop = m_num_tracks_from_intermediate[0];
-
   std::vector<KFParticle> goodCandidates;
   std::vector<KFParticle> goodVertex;
   std::vector<KFParticle> goodDaughters[m_num_tracks];
   std::vector<KFParticle> goodIntermediates[m_num_intermediate_states];
   std::vector<KFParticle> potentialIntermediates[m_num_intermediate_states];
   std::vector<std::vector<KFParticle>> potentialDaughters[m_num_intermediate_states];
-
   for (int i = 0; i < m_num_intermediate_states; ++i)
   {
     std::vector<KFParticle> vertices;
-
     std::vector<std::vector<int>> goodTracksThatMeet = findTwoProngs(daughterParticlesAdv, goodTrackIndexAdv, m_num_tracks_from_intermediate[i]);
     for (int p = 3; p <= m_num_tracks_from_intermediate[i]; ++p)
     {
@@ -133,14 +132,11 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                                        goodTracksThatMeet,
                                        m_num_tracks_from_intermediate[i], p);
     }
-
     getCandidateDecay(potentialIntermediates[i], vertices, potentialDaughters[i], daughterParticlesAdv,
                       goodTracksThatMeet, primaryVerticesAdv, track_start, track_stop, true, i, m_constrain_int_mass);
-
     track_start += track_stop;
     track_stop += m_num_tracks_from_intermediate[i + 1];
   }
-
   int num_tracks_used_by_intermediates = 0;
   for (int i = 0; i < m_num_intermediate_states; ++i)
   {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -76,6 +76,7 @@ void KFParticle_nTuple::initializeBranches()
     m_tree->Branch(TString(mother_name) + "_decayLength", &m_calculated_mother_decaylength, TString(mother_name) + "_decayLength/F");
     m_tree->Branch(TString(mother_name) + "_decayLengthErr", &m_calculated_mother_decaylength_err, TString(mother_name) + "_decayLengthErr/F");
     m_tree->Branch(TString(mother_name) + "_DIRA", &m_calculated_mother_dira, TString(mother_name) + "_DIRA/F");
+    m_tree->Branch(TString(mother_name) + "_DIRA_xy", &m_calculated_mother_dira_xy, TString(mother_name) + "_DIRA_xy/F");
     m_tree->Branch(TString(mother_name) + "_FDchi2", &m_calculated_mother_fdchi2, TString(mother_name) + "_FDchi2/F");
     m_tree->Branch(TString(mother_name) + "_IP", &m_calculated_mother_ip, TString(mother_name) + "_IP/F");
     m_tree->Branch(TString(mother_name) + "_IPchi2", &m_calculated_mother_ipchi2, TString(mother_name) + "_IPchi2/F");
@@ -378,6 +379,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
   if (m_constrain_to_vertex_nTuple)
   {
     m_calculated_mother_dira = kfpTupleTools.eventDIRA(motherParticle, vertex_fillbranch);
+    m_calculated_mother_dira_xy = kfpTupleTools.eventDIRA(motherParticle, vertex_fillbranch, false);
     m_calculated_mother_fdchi2 = kfpTupleTools.flightDistanceChi2(motherParticle, vertex_fillbranch);
     m_calculated_mother_ip = motherParticle.GetDistanceFromVertex(vertex_fillbranch);
     m_calculated_mother_ipchi2 = motherParticle.GetDeviationFromVertex(vertex_fillbranch);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -64,6 +64,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   float m_calculated_mother_decaylength = -1;
   float m_calculated_mother_decaylength_err = -1;
   float m_calculated_mother_dira = -1;
+  float m_calculated_mother_dira_xy = -1;
   float m_calculated_mother_fdchi2 = -1;
   float m_calculated_mother_ip = -1;
   float m_calculated_mother_ip_xy = -1;

--- a/offline/packages/decayfinder/DecayFinder.cc
+++ b/offline/packages/decayfinder/DecayFinder.cc
@@ -1146,7 +1146,19 @@ void DecayFinder::multiplyVectorByScalarAndSort(std::vector<int>& v, int k)
 {
   // https://slaystudy.com/c-multiply-vector-by-scalar/
   std::transform(v.begin(), v.end(), v.begin(), [k](const int& c)
-                 { return c * k; });
+  {
+    int particlesWithNoCC[] = {111, 113, 115, 130, 220, 221, 223, 225, 310, 330, 331, 333, 335, 440, 441, 443, 
+                               445, 551, 553, 555, 10111, 10113, 10221, 10223, 10331, 10333, 10441, 10443, 
+                               10551, 10553, 20113, 20223, 20333, 20443, 20553, 100443, 100553};
+    if (std::find(std::begin(particlesWithNoCC), std::end(particlesWithNoCC), c) != std::end(particlesWithNoCC))
+    {
+      return c;
+    }
+    else
+    {
+      return c * k;
+    }
+  });
   std::sort(v.begin(), v.end());
 }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

Previous updates to KFParticle for bunch crossing matching between daughter candidates caused a crash when intermediate states were reconstructed. This patch fixes that crash, and extends matching correctly to intermediate states. Similar intermediate patch is added for DecayFinder

Also, I've added a 2D diretion angle calculation between the flight direction and monetum of mothers which should help with reconstruction when we can fully reconstruct tracks to the right z position

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

