### PR TITLE
Add charged particles as a jet source

### DIFF
--- a/offline/packages/jetbase/Jet.h
+++ b/offline/packages/jetbase/Jet.h
@@ -113,6 +113,7 @@ class Jet : public PHObject
     HCALOUT_TOWERINFO_SIM = 37,
     JET_PROBE = 38,
     ECAL_HCAL_TOPO_CLUSTER = 39,    /* EMCal+IHCal+OHCal 3-D topoCluster input */
+    CHARGED_PARTICLE = 40  /* for truth-level track jets */
   };
 
   enum PROPERTY

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -51,6 +51,12 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     return std::vector<Jet *>();
   }
 
+  // FIXME
+  //   - This requires care: selecting only charged primary particles will
+  //     miss the decay products of resonances like D0, B0, etc.
+  //   - For charged particle input, it might be better to
+  //     (1) Loop on GetPrimaryParticleRange
+  //     (2) Or add a loop on GetSecondaryParticleRange
   std::vector<Jet *> pseudojets;
   PHG4TruthInfoContainer::ConstRange range = truthinfo->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
@@ -83,6 +89,9 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     // if looking at only charged particles, remove neutrals
     if (m_Input == Jet::CHARGED_PARTICLE)
     {
+      // FIXME
+      //   - Confirm if TDatabasePDG is needed
+      //   - Use epsilon comparison here
       if (part->get_IonCharge() == 0.0)
       {
         continue;

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -83,7 +83,10 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     // if looking at only charged particles, remove neutrals
     if (m_Input == Jet::CHARGED_PARTICLE)
     {
-      if (part->get_IonCharge() == 0.0) continue;
+      if (part->get_IonCharge() == 0.0)
+      {
+        continue;
+      }
     }
 
     // remove acceptance... _etamin,_etamax

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -83,7 +83,7 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
     // if looking at only charged particles, remove neutrals
     if (m_Input == Jet::CHARGED_PARTICLE)
     {
-      if (part->get_IonCharge == 0.0) continue;
+      if (part->get_IonCharge() == 0.0) continue;
     }
 
     // remove acceptance... _etamin,_etamax

--- a/simulation/g4simulation/g4jets/TruthJetInput.cc
+++ b/simulation/g4simulation/g4jets/TruthJetInput.cc
@@ -80,6 +80,12 @@ std::vector<Jet *> TruthJetInput::get_input(PHCompositeNode *topNode)
       continue;
     }
 
+    // if looking at only charged particles, remove neutrals
+    if (m_Input == Jet::CHARGED_PARTICLE)
+    {
+      if (part->get_IonCharge == 0.0) continue;
+    }
+
     // remove acceptance... _etamin,_etamax
     if ((part->get_px() == 0.0) && (part->get_py() == 0.0))
     {


### PR DESCRIPTION
This PR adds charged particles as a potential jet source.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR adds `CHARGED_PARTICLE` to the list of possible jet sources, and updates `TruthJetInput` to filter out neutral `PHG4Particle`s if this input is specified. This is the 1st step towards centralizing track jet reconstruction in the same way that tower jet reconstruction is, and in turn will allow for running Jet QA on reconstructed jets.

## Links to other PRs in macros and calibration repositories (if applicable)

Required for [macros#992](https://github.com/sPHENIX-Collaboration/macros/pull/992).

## To-Do
- [ ] Swap out `get_IonCharge` for `TParticlePDG::Charge()` if needed
- [ ] Use an epsilon comparison for comparing selecting on charge
- [ ] Confirm truth selection works for all
    - [ ] J/S TG
    - [ ] HF/Q TG
    - [ ] cQCD TG
- [ ] Ensure charged decays of neutral resonances are properly accounted for