### PR TITLE
Step 2: fast storage for TPC time frame building and fast decoding #3238

### DIFF
--- a/offline/framework/ffarawobjects/Makefile.am
+++ b/offline/framework/ffarawobjects/Makefile.am
@@ -57,8 +57,10 @@ ROOTDICTS = \
   TpcRawHitContainer_Dict.cc \
   TpcRawHitContainerv1_Dict.cc \
   TpcRawHitContainerv2_Dict.cc \
+  TpcRawHitContainerv3_Dict.cc \
   TpcRawHitv1_Dict.cc \
-  TpcRawHitv2_Dict.cc
+  TpcRawHitv2_Dict.cc \
+  TpcRawHitv3_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
@@ -103,8 +105,10 @@ nobase_dist_pcm_DATA = \
   TpcRawHitContainer_Dict_rdict.pcm \
   TpcRawHitContainerv1_Dict_rdict.pcm \
   TpcRawHitContainerv2_Dict_rdict.pcm \
+  TpcRawHitContainerv3_Dict_rdict.pcm \
   TpcRawHitv1_Dict_rdict.pcm \
-  TpcRawHitv2_Dict_rdict.pcm
+  TpcRawHitv2_Dict_rdict.pcm \
+  TpcRawHitv3_Dict_rdict.pcm
 
 pkginclude_HEADERS = \
   CaloPacket.h \
@@ -148,8 +152,10 @@ pkginclude_HEADERS = \
   TpcRawHitContainer.h \
   TpcRawHitContainerv1.h \
   TpcRawHitContainerv2.h \
+  TpcRawHitContainerv3.h \
   TpcRawHitv1.h \
-  TpcRawHitv2.h
+  TpcRawHitv2.h \
+  TpcRawHitv3.h
 
 libffarawobjects_la_SOURCES = \
   $(ROOTDICTS) \

--- a/offline/framework/ffarawobjects/Makefile.am
+++ b/offline/framework/ffarawobjects/Makefile.am
@@ -184,7 +184,7 @@ libffarawobjects_la_SOURCES = \
   OfflinePacket.cc \
   OfflinePacketv1.cc \
   TpcRawHitContainerv1.cc \
-  TpcRawHitContainerv2.cc \\
+  TpcRawHitContainerv2.cc \
   TpcRawHitContainerv3.cc \
   TpcRawHitv1.cc \
   TpcRawHitv2.cc \

--- a/offline/framework/ffarawobjects/Makefile.am
+++ b/offline/framework/ffarawobjects/Makefile.am
@@ -184,9 +184,11 @@ libffarawobjects_la_SOURCES = \
   OfflinePacket.cc \
   OfflinePacketv1.cc \
   TpcRawHitContainerv1.cc \
-  TpcRawHitContainerv2.cc \
+  TpcRawHitContainerv2.cc \\
+  TpcRawHitContainerv3.cc \
   TpcRawHitv1.cc \
-  TpcRawHitv2.cc
+  TpcRawHitv2.cc \
+  TpcRawHitv3.cc
 
 BUILT_SOURCES = testexternals.cc
 

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
@@ -3,6 +3,8 @@
 
 #include <TClonesArray.h>
 
+#include <iostream>
+
 static const int NTPCHITS = 10000;
 
 TpcRawHitContainerv3::TpcRawHitContainerv3()
@@ -51,8 +53,20 @@ TpcRawHit *TpcRawHitContainerv3::AddHit()
 
 TpcRawHit *TpcRawHitContainerv3::AddHit(TpcRawHit *tpchit)
 {
-  TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3(tpchit);
-  return newhit;
+  if (dynamic_cast<TpcRawHitv3 *>(tpchit))
+  {
+    // fast add with move constructor to avoid ADC data copying
+
+    TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1])
+        TpcRawHitv3(std::move(*(dynamic_cast<TpcRawHitv3 *>(tpchit))));
+    return newhit;
+  }
+  else
+  {
+    std::cout << __PRETTY_FUNCTION__ << "WARNING: input hit is not of type TpcRawHitv3. This is slow, please avoid." << std::endl;
+    TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3(tpchit);
+    return newhit;
+  }
 }
 
 TpcRawHit *TpcRawHitContainerv3::get_hit(unsigned int index)

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
@@ -1,0 +1,61 @@
+#include "TpcRawHitContainerv3.h"
+#include "TpcRawHitv3.h"
+
+#include <TClonesArray.h>
+
+static const int NTPCHITS = 10000;
+
+TpcRawHitContainerv3::TpcRawHitContainerv3()
+{
+  TpcRawHitsTCArray = new TClonesArray("TpcRawHitv3", NTPCHITS);
+}
+
+TpcRawHitContainerv3::~TpcRawHitContainerv3()
+{
+  TpcRawHitsTCArray->Clear("C");
+  delete TpcRawHitsTCArray;
+}
+
+void TpcRawHitContainerv3::Reset()
+{
+  TpcRawHitsTCArray->Clear("C");
+  TpcRawHitsTCArray->Expand(NTPCHITS);
+}
+
+void TpcRawHitContainerv3::identify(std::ostream &os) const
+{
+  os << "TpcRawHitContainerv3" << std::endl;
+  os << "containing " << TpcRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
+  TpcRawHit *tpchit = static_cast<TpcRawHit *>(TpcRawHitsTCArray->At(0));
+  if (tpchit)
+  {
+    os << "for beam clock: " << std::hex << tpchit->get_bco() << std::dec << std::endl;
+  }
+}
+
+int TpcRawHitContainerv3::isValid() const
+{
+  return TpcRawHitsTCArray->GetSize();
+}
+
+unsigned int TpcRawHitContainerv3::get_nhits()
+{
+  return TpcRawHitsTCArray->GetEntriesFast();
+}
+
+TpcRawHit *TpcRawHitContainerv3::AddHit()
+{
+  TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3();
+  return newhit;
+}
+
+TpcRawHit *TpcRawHitContainerv3::AddHit(TpcRawHit *tpchit)
+{
+  TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3(tpchit);
+  return newhit;
+}
+
+TpcRawHit *TpcRawHitContainerv3::get_hit(unsigned int index)
+{
+  return (TpcRawHit *) TpcRawHitsTCArray->At(index);
+}

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.h
@@ -6,6 +6,7 @@
 class TpcRawHit;
 class TClonesArray;
 
+// NOLINTNEXTLINE(hicpp-special-member-functions)
 class TpcRawHitContainerv3 : public TpcRawHitContainer
 {
  public:

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.h
@@ -1,0 +1,43 @@
+#ifndef FUN4ALLRAW_TPCHITRAWCONTAINERv3_H
+#define FUN4ALLRAW_TPCHITRAWCONTAINERv3_H
+
+#include "TpcRawHitContainer.h"
+
+class TpcRawHit;
+class TClonesArray;
+
+class TpcRawHitContainerv3 : public TpcRawHitContainer
+{
+ public:
+  TpcRawHitContainerv3();
+  ~TpcRawHitContainerv3() override;
+
+  /// Clear Event
+  void Reset() override;
+
+  /** identify Function from PHObject
+      @param os Output Stream
+   */
+  void identify(std::ostream &os = std::cout) const override;
+
+  /// isValid returns non zero if object contains vailid data
+  int isValid() const override;
+
+  TpcRawHit *AddHit() override;
+  TpcRawHit *AddHit(TpcRawHit *tpchit) override;
+  unsigned int get_nhits() override;
+  TpcRawHit *get_hit(unsigned int index) override;
+  void setStatus(const unsigned int i) override { status = i; }
+  unsigned int getStatus() const override { return status; }
+  void setBco(const uint64_t i) override { bco = i; }
+  uint64_t getBco() const override { return bco; }
+
+ private:
+  TClonesArray *TpcRawHitsTCArray{nullptr};
+  uint64_t bco{0};
+  unsigned int status{0};
+
+  ClassDefOverride(TpcRawHitContainerv3, 1)
+};
+
+#endif

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3LinkDef.h
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcRawHitContainerv3 + ;
+
+#endif

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -1,7 +1,7 @@
 #include "TpcRawHitv3.h"
 
-#include <iostream>
 #include <cassert>
+#include <iostream>
 
 TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
 {
@@ -54,14 +54,14 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
   , parityerror(std::move(other.parityerror))
   , m_adcData(std::move(other.m_adcData))
 {
-//   other.bco = std::numeric_limits<uint64_t>::max();
-//   other.packetid = std::numeric_limits<int32_t>::max();
+  //   other.bco = std::numeric_limits<uint64_t>::max();
+  //   other.packetid = std::numeric_limits<int32_t>::max();
   other.fee = std::numeric_limits<uint16_t>::max();
   other.channel = std::numeric_limits<uint16_t>::max();
-//   other.type = std::numeric_limits<uint16_t>::max();
-//   other.userword = std::numeric_limits<uint16_t>::max();
-//   other.checksum = std::numeric_limits<uint16_t>::max();
-//   other.data_parity = std::numeric_limits<uint16_t>::max();
+  //   other.type = std::numeric_limits<uint16_t>::max();
+  //   other.userword = std::numeric_limits<uint16_t>::max();
+  //   other.checksum = std::numeric_limits<uint16_t>::max();
+  //   other.data_parity = std::numeric_limits<uint16_t>::max();
   other.checksumerror = true;
   other.parityerror = true;
 }
@@ -77,7 +77,7 @@ uint16_t TpcRawHitv3::get_adc(const uint16_t /*sample*/) const
   std::cout << __PRETTY_FUNCTION__
             << " Error: This moethod is slow and should be avoided as much as possible!"
             << std::endl;
-  assert(0);          
+  assert(0);
   //   auto adc = adcmap.find(sample);
   //   if (adc != adcmap.end())
   //   {
@@ -94,6 +94,18 @@ void TpcRawHitv3::Clear(Option_t * /*unused*/)
   checksumerror = true;
   parityerror = true;
 
+  for (auto &waveform : m_adcData)
+  {
+    waveform.second.clear();
+    waveform.second.shrink_to_fit();
+  }
   m_adcData.clear();
-  m_adcData.reserve(0);
+  m_adcData.shrink_to_fit();
+
+  // std::cout << __PRETTY_FUNCTION__ << " - m_adcData.capacity = "<<m_adcData.capacity() << std::endl;
+}
+
+void TpcRawHitv3::move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc)
+{
+  m_adcData.emplace_back(start_time, adc);
 }

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -46,7 +46,7 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
   , fee(other.fee)
   , channel(other.channel)
   , type(other.type)
-  , userword(other.userword)
+  // , userword(other.userword)
   , checksum(other.checksum)
   , data_parity(other.data_parity)
   , checksumerror(other.checksumerror)

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -1,7 +1,18 @@
 #include "TpcRawHitv3.h"
 
+#include <iostream>
+
 TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
 {
+  static bool once = true;
+  if (once)
+  {
+    once = false;
+    std::cout << "TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit) - "
+              << "WARNING: This moethod is slow and should be avoided as much as possible!"
+              << std::endl;
+  }
+
   TpcRawHitv3::set_bco(tpchit->get_bco());
   TpcRawHitv3::set_gtm_bco(tpchit->get_gtm_bco());
   TpcRawHitv3::set_packetid(tpchit->get_packetid());
@@ -35,15 +46,15 @@ void TpcRawHitv3::identify(std::ostream &os) const
 
 uint16_t TpcRawHitv3::get_adc(const uint16_t sample) const
 {
-  auto adc = adcmap.find(sample);
-  if (adc != adcmap.end())
-  {
-    return adc->second;
-  }
+  //   auto adc = adcmap.find(sample);
+  //   if (adc != adcmap.end())
+  //   {
+  //     return adc->second;
+  //   }
   return 0;
 }
 
 void TpcRawHitv3::Clear(Option_t * /*unused*/)
 {
-  adcmap.clear();
+  //   adcmap.clear();
 }

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -39,18 +39,19 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
   }
 }
 
+// cppcheck-suppress accessMoved
 TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
   : TpcRawHit(std::move(other))
-  , bco(other.bco)
-  , packetid(other.packetid)
-  , fee(other.fee)
-  , channel(other.channel)
-  , type(other.type)
+  , bco(std::move(other.bco))
+  , packetid(std::move(other.packetid))
+  , fee(std::move(other.fee))
+  , channel(std::move(other.channel))
+  , type(std::move(other.type))
   // , userword(other.userword)
-  , checksum(other.checksum)
-  , data_parity(other.data_parity)
-  , checksumerror(other.checksumerror)
-  , parityerror(other.parityerror)
+  , checksum(std::move(other.checksum))
+  , data_parity(std::move(other.data_parity))
+  , checksumerror(std::move(other.checksumerror))
+  , parityerror(std::move(other.parityerror))
   , m_adcData(std::move(other.m_adcData))
 {
 //   other.bco = std::numeric_limits<uint64_t>::max();

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -41,17 +41,17 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
 
 // cppcheck-suppress accessMoved
 TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
-  : TpcRawHit(std::move(other))
-  , bco(std::move(other.bco))
-  , packetid(std::move(other.packetid))
-  , fee(std::move(other.fee))
-  , channel(std::move(other.channel))
-  , type(std::move(other.type))
+  : TpcRawHit(other)
+  , bco(other.bco)
+  , packetid(other.packetid)
+  , fee(other.fee)
+  , channel(other.channel)
+  , type(other.type)
   // , userword(other.userword)
-  , checksum(std::move(other.checksum))
-  , data_parity(std::move(other.data_parity))
-  , checksumerror(std::move(other.checksumerror))
-  , parityerror(std::move(other.parityerror))
+  , checksum(other.checksum)
+  , data_parity(other.data_parity)
+  , checksumerror(other.checksumerror)
+  , parityerror(other.parityerror)
   , m_adcData(std::move(other.m_adcData))
 {
   //   other.bco = std::numeric_limits<uint64_t>::max();

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -1,6 +1,7 @@
 #include "TpcRawHitv3.h"
 
 #include <iostream>
+#include <cassert>
 
 TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
 {
@@ -70,8 +71,12 @@ void TpcRawHitv3::identify(std::ostream &os) const
   os << "packet id: " << packetid << std::endl;
 }
 
-uint16_t TpcRawHitv3::get_adc(const uint16_t sample) const
+uint16_t TpcRawHitv3::get_adc(const uint16_t /*sample*/) const
 {
+  std::cout << __PRETTY_FUNCTION__
+            << " Error: This moethod is slow and should be avoided as much as possible!"
+            << std::endl;
+  assert(0);          
   //   auto adc = adcmap.find(sample);
   //   if (adc != adcmap.end())
   //   {

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -9,7 +9,7 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
   {
     once = false;
     std::cout << "TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit) - "
-              << "WARNING: This moethod is slow and should be avoided as much as possible!"
+              << "WARNING: This moethod is slow and should be avoided as much as possible! Please use the move constructor."
               << std::endl;
   }
 
@@ -38,6 +38,32 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
   }
 }
 
+TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
+  : TpcRawHit(std::move(other))
+  , bco(other.bco)
+  , packetid(other.packetid)
+  , fee(other.fee)
+  , channel(other.channel)
+  , type(other.type)
+  , userword(other.userword)
+  , checksum(other.checksum)
+  , data_parity(other.data_parity)
+  , checksumerror(other.checksumerror)
+  , parityerror(other.parityerror)
+  , m_adcData(std::move(other.m_adcData))
+{
+//   other.bco = std::numeric_limits<uint64_t>::max();
+//   other.packetid = std::numeric_limits<int32_t>::max();
+  other.fee = std::numeric_limits<uint16_t>::max();
+  other.channel = std::numeric_limits<uint16_t>::max();
+//   other.type = std::numeric_limits<uint16_t>::max();
+//   other.userword = std::numeric_limits<uint16_t>::max();
+//   other.checksum = std::numeric_limits<uint16_t>::max();
+//   other.data_parity = std::numeric_limits<uint16_t>::max();
+  other.checksumerror = true;
+  other.parityerror = true;
+}
+
 void TpcRawHitv3::identify(std::ostream &os) const
 {
   os << "BCO: 0x" << std::hex << bco << std::dec << std::endl;
@@ -56,5 +82,12 @@ uint16_t TpcRawHitv3::get_adc(const uint16_t sample) const
 
 void TpcRawHitv3::Clear(Option_t * /*unused*/)
 {
-  //   adcmap.clear();
+  // quick reset
+  fee = std::numeric_limits<uint16_t>::max();
+  channel = std::numeric_limits<uint16_t>::max();
+  checksumerror = true;
+  parityerror = true;
+
+  m_adcData.clear();
+  m_adcData.reserve(0);
 }

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -1,0 +1,49 @@
+#include "TpcRawHitv3.h"
+
+TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
+{
+  TpcRawHitv3::set_bco(tpchit->get_bco());
+  TpcRawHitv3::set_gtm_bco(tpchit->get_gtm_bco());
+  TpcRawHitv3::set_packetid(tpchit->get_packetid());
+  TpcRawHitv3::set_fee(tpchit->get_fee());
+  TpcRawHitv3::set_channel(tpchit->get_channel());
+  TpcRawHitv3::set_sampaaddress(tpchit->get_sampaaddress());
+  TpcRawHitv3::set_sampachannel(tpchit->get_sampachannel());
+  TpcRawHitv3::set_type(tpchit->get_type());
+  TpcRawHitv3::set_userword(tpchit->get_userword());
+  TpcRawHitv3::set_checksum(tpchit->get_checksum());
+  TpcRawHitv3::set_parity(tpchit->get_parity());
+  TpcRawHitv3::set_checksumerror(tpchit->get_checksumerror());
+  TpcRawHitv3::set_parityerror(tpchit->get_parityerror());
+  TpcRawHitv3::set_samples(tpchit->get_samples());
+
+  for (size_t i = 0; i < tpchit->get_samples(); ++i)
+  {
+    uint16_t adcval = tpchit->get_adc(i);
+    if (adcval > 0)
+    {
+      TpcRawHitv3::set_adc(i, tpchit->get_adc(i));
+    }
+  }
+}
+
+void TpcRawHitv3::identify(std::ostream &os) const
+{
+  os << "BCO: 0x" << std::hex << bco << std::dec << std::endl;
+  os << "packet id: " << packetid << std::endl;
+}
+
+uint16_t TpcRawHitv3::get_adc(const uint16_t sample) const
+{
+  auto adc = adcmap.find(sample);
+  if (adc != adcmap.end())
+  {
+    return adc->second;
+  }
+  return 0;
+}
+
+void TpcRawHitv3::Clear(Option_t * /*unused*/)
+{
+  adcmap.clear();
+}

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -1,0 +1,111 @@
+#ifndef FUN4ALLRAW_TPCRAWTHITv3_H
+#define FUN4ALLRAW_TPCRAWTHITv3_H
+
+#include "TpcRawHit.h"
+
+#include <phool/PHObject.h>
+
+#include <cassert>
+#include <limits>
+#include <map>
+
+class TpcRawHitv3 : public TpcRawHit
+{
+ public:
+  TpcRawHitv3() = default;
+  TpcRawHitv3(TpcRawHit *tpchit);
+  ~TpcRawHitv3() override = default;
+
+  /** identify Function from PHObject
+      @param os Output Stream
+   */
+  void identify(std::ostream &os = std::cout) const override;
+
+  void Clear(Option_t *) override;
+
+  uint64_t get_bco() const override { return bco; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_bco(const uint64_t val) override { bco = val; }
+
+  uint64_t get_gtm_bco() const override { return gtm_bco; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_gtm_bco(const uint64_t val) override { gtm_bco = val; }
+
+  int32_t get_packetid() const override { return packetid; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_packetid(const int32_t val) override { packetid = val; }
+
+  uint16_t get_fee() const override { return fee; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_fee(const uint16_t val) override { fee = val; }
+
+  uint16_t get_channel() const override { return channel; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_channel(const uint16_t val) override { channel = val; }
+
+  uint16_t get_sampaaddress() const override { return sampaaddress; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_sampaaddress(const uint16_t val) override { sampaaddress = val; }
+
+  uint16_t get_sampachannel() const override { return sampachannel; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_sampachannel(const uint16_t val) override { sampachannel = val; }
+
+  uint16_t get_samples() const override { return samples; }
+  // cppcheck-suppress virtualCallInConstructor
+  void set_samples(const uint16_t val) override
+  {
+    // assign
+    samples = val;
+  }
+
+  uint16_t get_adc(const uint16_t sample) const override;
+
+  // cppcheck-suppress virtualCallInConstructor
+  void set_adc(const uint16_t sample, const uint16_t val) override
+  {
+    adcmap[sample] = val;
+  }
+
+  uint16_t get_type() const override { return type; }
+  void set_type(const uint16_t i) override { type = i; }
+
+  uint16_t get_userword() const override { return userword; }
+  void set_userword(const uint16_t i) override { userword = i; }
+
+  uint16_t get_checksum() const override { return checksum; }
+  void set_checksum(const uint16_t i) override { checksum = i; }
+
+  uint16_t get_parity() const override { return data_parity; }
+  void set_parity(const uint16_t i) override { data_parity = i; }
+
+  bool get_checksumerror() const override { return checksumerror; }
+  void set_checksumerror(const bool b) override { checksumerror = b; }
+
+  bool get_parityerror() const override { return parityerror; }
+  void set_parityerror(const bool b) override { parityerror = b; }
+
+ private:
+  uint64_t bco{std::numeric_limits<uint64_t>::max()};
+  uint64_t gtm_bco{std::numeric_limits<uint64_t>::max()};
+  int32_t packetid{std::numeric_limits<int32_t>::max()};
+  uint16_t fee{std::numeric_limits<uint16_t>::max()};
+  uint16_t channel{std::numeric_limits<uint16_t>::max()};
+  uint16_t sampaaddress{std::numeric_limits<uint16_t>::max()};
+  uint16_t sampachannel{std::numeric_limits<uint16_t>::max()};
+  uint16_t samples{std::numeric_limits<uint16_t>::max()};
+  uint16_t type{std::numeric_limits<uint16_t>::max()};
+  uint16_t userword{std::numeric_limits<uint16_t>::max()};
+  uint16_t checksum{std::numeric_limits<uint16_t>::max()};
+  uint16_t data_parity{std::numeric_limits<uint16_t>::max()};
+
+  bool checksumerror{true};
+  bool parityerror{true};
+
+  //! adc value for each sample
+  std::map<uint16_t, uint16_t> adcmap;
+
+  ClassDefOverride(TpcRawHitv3, 1)
+};
+
+#endif

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -80,8 +80,8 @@ class TpcRawHitv3 : public TpcRawHit
   uint16_t get_type() const override { return type; }
   void set_type(const uint16_t i) override { type = i; }
 
-  uint16_t get_userword() const override { return userword; }
-  void set_userword(const uint16_t i) override { userword = i; }
+  // uint16_t get_userword() const override { return userword; }
+  // void set_userword(const uint16_t i) override { userword = i; }
 
   uint16_t get_checksum() const override { return checksum; }
   void set_checksum(const uint16_t i) override { checksum = i; }
@@ -101,7 +101,6 @@ class TpcRawHitv3 : public TpcRawHit
   uint16_t fee{std::numeric_limits<uint16_t>::max()};
   uint16_t channel{std::numeric_limits<uint16_t>::max()};
   uint16_t type{std::numeric_limits<uint16_t>::max()};
-  uint16_t userword{std::numeric_limits<uint16_t>::max()};
   uint16_t checksum{std::numeric_limits<uint16_t>::max()};
   uint16_t data_parity{std::numeric_limits<uint16_t>::max()};
 

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -10,11 +10,12 @@
 #include <utility>
 #include <vector>
 
+// NOLINTNEXTLINE(hicpp-special-member-functions)
 class TpcRawHitv3 : public TpcRawHit
 {
  public:
   TpcRawHitv3() = default;
-  TpcRawHitv3(TpcRawHit *tpchit);
+  explicit TpcRawHitv3(TpcRawHit *tpchit);
   TpcRawHitv3(TpcRawHitv3 &&other) noexcept;
   
   ~TpcRawHitv3() override = default;
@@ -24,7 +25,7 @@ class TpcRawHitv3 : public TpcRawHit
    */
   void identify(std::ostream &os = std::cout) const override;
 
-  void Clear(Option_t *) override;
+  void Clear(Option_t */*unused*/) override;
 
   uint64_t get_bco() const override { return bco; }
   // cppcheck-suppress virtualCallInConstructor
@@ -73,7 +74,7 @@ class TpcRawHitv3 : public TpcRawHit
   //     adcmap[sample] = val;
   //   }
   void move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc);
-  
+
   uint16_t get_type() const override { return type; }
   void set_type(const uint16_t i) override { type = i; }
 

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -7,7 +7,8 @@
 
 #include <cassert>
 #include <limits>
-#include <map>
+#include <vector>
+#include <utility>
 
 class TpcRawHitv3 : public TpcRawHit
 {
@@ -27,9 +28,9 @@ class TpcRawHitv3 : public TpcRawHit
   // cppcheck-suppress virtualCallInConstructor
   void set_bco(const uint64_t val) override { bco = val; }
 
-  uint64_t get_gtm_bco() const override { return gtm_bco; }
-  // cppcheck-suppress virtualCallInConstructor
-  void set_gtm_bco(const uint64_t val) override { gtm_bco = val; }
+//   uint64_t get_gtm_bco() const override { return gtm_bco; }
+//   // cppcheck-suppress virtualCallInConstructor
+//   void set_gtm_bco(const uint64_t val) override { gtm_bco = val; }
 
   int32_t get_packetid() const override { return packetid; }
   // cppcheck-suppress virtualCallInConstructor
@@ -43,29 +44,29 @@ class TpcRawHitv3 : public TpcRawHit
   // cppcheck-suppress virtualCallInConstructor
   void set_channel(const uint16_t val) override { channel = val; }
 
-  uint16_t get_sampaaddress() const override { return sampaaddress; }
-  // cppcheck-suppress virtualCallInConstructor
-  void set_sampaaddress(const uint16_t val) override { sampaaddress = val; }
+//   uint16_t get_sampaaddress() const override { return sampaaddress; }
+//   // cppcheck-suppress virtualCallInConstructor
+//   void set_sampaaddress(const uint16_t val) override { sampaaddress = val; }
 
-  uint16_t get_sampachannel() const override { return sampachannel; }
-  // cppcheck-suppress virtualCallInConstructor
-  void set_sampachannel(const uint16_t val) override { sampachannel = val; }
+//   uint16_t get_sampachannel() const override { return sampachannel; }
+//   // cppcheck-suppress virtualCallInConstructor
+//   void set_sampachannel(const uint16_t val) override { sampachannel = val; }
 
-  uint16_t get_samples() const override { return samples; }
+//   uint16_t get_samples() const override { return samples; }
   // cppcheck-suppress virtualCallInConstructor
-  void set_samples(const uint16_t val) override
-  {
-    // assign
-    samples = val;
-  }
+//   void set_samples(const uint16_t val) override
+//   {
+//     // assign
+//     samples = val;
+//   }
 
   uint16_t get_adc(const uint16_t sample) const override;
 
   // cppcheck-suppress virtualCallInConstructor
-  void set_adc(const uint16_t sample, const uint16_t val) override
-  {
-    adcmap[sample] = val;
-  }
+//   void set_adc(const uint16_t sample, const uint16_t val) override
+//   {
+//     adcmap[sample] = val;
+//   }
 
   uint16_t get_type() const override { return type; }
   void set_type(const uint16_t i) override { type = i; }
@@ -87,13 +88,9 @@ class TpcRawHitv3 : public TpcRawHit
 
  private:
   uint64_t bco{std::numeric_limits<uint64_t>::max()};
-  uint64_t gtm_bco{std::numeric_limits<uint64_t>::max()};
   int32_t packetid{std::numeric_limits<int32_t>::max()};
   uint16_t fee{std::numeric_limits<uint16_t>::max()};
   uint16_t channel{std::numeric_limits<uint16_t>::max()};
-  uint16_t sampaaddress{std::numeric_limits<uint16_t>::max()};
-  uint16_t sampachannel{std::numeric_limits<uint16_t>::max()};
-  uint16_t samples{std::numeric_limits<uint16_t>::max()};
   uint16_t type{std::numeric_limits<uint16_t>::max()};
   uint16_t userword{std::numeric_limits<uint16_t>::max()};
   uint16_t checksum{std::numeric_limits<uint16_t>::max()};
@@ -102,8 +99,8 @@ class TpcRawHitv3 : public TpcRawHit
   bool checksumerror{true};
   bool parityerror{true};
 
-  //! adc value for each sample
-  std::map<uint16_t, uint16_t> adcmap;
+  //! adc waveform std::vector< uint16_t > for each start time uint16_t
+  std::vector< std::pair< uint16_t , std::vector< uint16_t > > > m_adcData;
 
   ClassDefOverride(TpcRawHitv3, 1)
 };

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -72,11 +72,8 @@ class TpcRawHitv3 : public TpcRawHit
   //   {
   //     adcmap[sample] = val;
   //   }
-  void move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc)
-  {
-    m_adcData.emplace_back(start_time, std::move(adc));
-  }
-
+  void move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc);
+  
   uint16_t get_type() const override { return type; }
   void set_type(const uint16_t i) override { type = i; }
 

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -7,14 +7,16 @@
 
 #include <cassert>
 #include <limits>
-#include <vector>
 #include <utility>
+#include <vector>
 
 class TpcRawHitv3 : public TpcRawHit
 {
  public:
   TpcRawHitv3() = default;
   TpcRawHitv3(TpcRawHit *tpchit);
+  TpcRawHitv3(TpcRawHitv3 &&other) noexcept;
+  
   ~TpcRawHitv3() override = default;
 
   /** identify Function from PHObject
@@ -28,9 +30,9 @@ class TpcRawHitv3 : public TpcRawHit
   // cppcheck-suppress virtualCallInConstructor
   void set_bco(const uint64_t val) override { bco = val; }
 
-//   uint64_t get_gtm_bco() const override { return gtm_bco; }
-//   // cppcheck-suppress virtualCallInConstructor
-//   void set_gtm_bco(const uint64_t val) override { gtm_bco = val; }
+  //   uint64_t get_gtm_bco() const override { return gtm_bco; }
+  //   // cppcheck-suppress virtualCallInConstructor
+  //   void set_gtm_bco(const uint64_t val) override { gtm_bco = val; }
 
   int32_t get_packetid() const override { return packetid; }
   // cppcheck-suppress virtualCallInConstructor
@@ -44,29 +46,36 @@ class TpcRawHitv3 : public TpcRawHit
   // cppcheck-suppress virtualCallInConstructor
   void set_channel(const uint16_t val) override { channel = val; }
 
-//   uint16_t get_sampaaddress() const override { return sampaaddress; }
-//   // cppcheck-suppress virtualCallInConstructor
-//   void set_sampaaddress(const uint16_t val) override { sampaaddress = val; }
+  uint16_t get_sampaaddress() const override
+  {
+    return static_cast<uint16_t>(channel >> 5U) & 0xfU;
+  }
+  //   // cppcheck-suppress virtualCallInConstructor
+  //   void set_sampaaddress(const uint16_t val) override { sampaaddress = val; }
 
-//   uint16_t get_sampachannel() const override { return sampachannel; }
-//   // cppcheck-suppress virtualCallInConstructor
-//   void set_sampachannel(const uint16_t val) override { sampachannel = val; }
+  uint16_t get_sampachannel() const override { return channel & 0x1fU; }
+  //   // cppcheck-suppress virtualCallInConstructor
+  //   void set_sampachannel(const uint16_t val) override { sampachannel = val; }
 
-//   uint16_t get_samples() const override { return samples; }
+  //   uint16_t get_samples() const override { return samples; }
   // cppcheck-suppress virtualCallInConstructor
-//   void set_samples(const uint16_t val) override
-//   {
-//     // assign
-//     samples = val;
-//   }
+  //   void set_samples(const uint16_t val) override
+  //   {
+  //     // assign
+  //     samples = val;
+  //   }
 
   uint16_t get_adc(const uint16_t sample) const override;
 
   // cppcheck-suppress virtualCallInConstructor
-//   void set_adc(const uint16_t sample, const uint16_t val) override
-//   {
-//     adcmap[sample] = val;
-//   }
+  //   void set_adc(const uint16_t sample, const uint16_t val) override
+  //   {
+  //     adcmap[sample] = val;
+  //   }
+  void move_adc_waveform(const uint16_t start_time, std::vector<uint16_t> &&adc)
+  {
+    m_adcData.emplace_back(start_time, std::move(adc));
+  }
 
   uint16_t get_type() const override { return type; }
   void set_type(const uint16_t i) override { type = i; }
@@ -100,7 +109,7 @@ class TpcRawHitv3 : public TpcRawHit
   bool parityerror{true};
 
   //! adc waveform std::vector< uint16_t > for each start time uint16_t
-  std::vector< std::pair< uint16_t , std::vector< uint16_t > > > m_adcData;
+  std::vector<std::pair<uint16_t, std::vector<uint16_t> > > m_adcData;
 
   ClassDefOverride(TpcRawHitv3, 1)
 };

--- a/offline/framework/ffarawobjects/TpcRawHitv3LinkDef.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcRawHitv3 + ;
+
+#endif

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -4,8 +4,8 @@
 #include "Fun4AllStreamingInputManager.h"
 #include "InputManagerType.h"
 
-#include <ffarawobjects/TpcRawHitContainerv2.h>
-#include <ffarawobjects/TpcRawHitv2.h>
+#include <ffarawobjects/TpcRawHitContainerv3.h>
+#include <ffarawobjects/TpcRawHitv3.h>
 
 #include <frog/FROG.h>
 
@@ -42,7 +42,7 @@ SingleTpcTimeFrameInput::~SingleTpcTimeFrameInput()
 
 void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
 {
-  if (Verbosity() > 0)
+  if (Verbosity() > 1)
   {
     std::cout << "SingleTpcTimeFrameInput::FillPool: " << Name()
               << " Entry with targetBCO = 0x"<<std::hex << targetBCO
@@ -237,7 +237,7 @@ void SingleTpcTimeFrameInput::CreateDSTNode(PHCompositeNode *topNode)
   TpcRawHitContainer *tpchitcont = findNode::getClass<TpcRawHitContainer>(detNode, m_rawHitContainerName);
   if (!tpchitcont)
   {
-    tpchitcont = new TpcRawHitContainerv2();
+    tpchitcont = new TpcRawHitContainerv3();
     PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(tpchitcont, m_rawHitContainerName, "PHObject");
     detNode->addNode(newNode);
   }

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -156,7 +156,7 @@ TpcTimeFrameBuilder::TpcTimeFrameBuilder(const int packet_id)
   h_ProcessPacket_Time = new TH2I(TString(m_HistoPrefix.c_str()) + "_ProcessPacket_Time",  //
                               TString(m_HistoPrefix.c_str()) +
                                   " Time cost to run ProcessPacket();Call counts;Time elapsed per call [ms];Count",
-                              100, 0, 30e6, 100,0,10);
+                              1000, 0, 30e6, 100,0,10);
   hm->registerHisto(h_ProcessPacket_Time);
 }
 

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -235,13 +235,16 @@ std::vector<TpcRawHit*>& TpcTimeFrameBuilder::getTimeFrame(const uint64_t& gtm_b
                   << " and bclk_rollover_corrected 0x" << std::hex
                   << bclk_rollover_corrected << std::dec << ". m_timeFrameMap:" << std::endl;
 
-        for (const auto& timeframe : m_timeFrameMap)
+        if (m_verbosity >= 2)
         {
-          std::cout << "- BCO in map: 0x" << std::hex << timeframe.first << std::dec
-                    << "(Diff:" << int64_t(timeframe.first) - int64_t(bclk_rollover_corrected)
-                    << ")"
-                    << " size: " << timeframe.second.size()
-                    << std::endl;
+          for (const auto& timeframe : m_timeFrameMap)
+          {
+            std::cout << "- BCO in map: 0x" << std::hex << timeframe.first << std::dec
+                      << "(Diff:" << int64_t(timeframe.first) - int64_t(bclk_rollover_corrected)
+                      << ")"
+                      << " size: " << timeframe.second.size()
+                      << std::endl;
+          }
         }
       }
 
@@ -295,10 +298,13 @@ std::vector<TpcRawHit*>& TpcTimeFrameBuilder::getTimeFrame(const uint64_t& gtm_b
               << "and bclk_rollover_corrected 0x" << std::hex
               << bclk_rollover_corrected << std::dec << ". m_timeFrameMap:" << std::endl;
 
-    for (const auto& timeframe : m_timeFrameMap)
+    if (m_verbosity >= 2)
     {
-      std::cout << "- BCO in map: 0x" << std::hex << timeframe.first << std::dec
-                << "(Diff:" << int64_t(timeframe.first) - int64_t(bclk_rollover_corrected) << ")" << std::endl;
+      for (const auto& timeframe : m_timeFrameMap)
+      {
+        std::cout << "- BCO in map: 0x" << std::hex << timeframe.first << std::dec
+                  << "(Diff:" << int64_t(timeframe.first) - int64_t(bclk_rollover_corrected) << ")" << std::endl;
+      }
     }
   }
 

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -152,6 +152,12 @@ TpcTimeFrameBuilder::TpcTimeFrameBuilder(const int packet_id)
                                           " Time frame size for Matched Time Frame ;Size [TPC raw hits];Count",
                                       3328, -.5, 3328 - .5);
   hm->registerHisto(h_TimeFrame_Matched_Size);
+
+  h_ProcessPacket_Time = new TH2I(TString(m_HistoPrefix.c_str()) + "_ProcessPacket_Time",  //
+                              TString(m_HistoPrefix.c_str()) +
+                                  " Time cost to run ProcessPacket();Call counts;Time elapsed per call [ms];Count",
+                              100, 0, 30e6, 100,0,10);
+  hm->registerHisto(h_ProcessPacket_Time);
 }
 
 TpcTimeFrameBuilder::~TpcTimeFrameBuilder()
@@ -540,6 +546,8 @@ int TpcTimeFrameBuilder::ProcessPacket(Packet* packet)
   }
 
   m_packetTimer->stop();
+  assert(h_ProcessPacket_Time);
+  h_ProcessPacket_Time -> Fill(call_count, m_packetTimer->elapsed());
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -354,6 +354,9 @@ class TpcTimeFrameBuilder
   TH1 *h_GTMClockDiff_Unmatched = nullptr;
   TH1 *h_GTMClockDiff_Dropped = nullptr;
   TH1 *h_TimeFrame_Matched_Size = nullptr;
+
+  
+  TH2 *h_ProcessPacket_Time = nullptr;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
As mentioned in #3238, the v2 TPC raw hit filling was dominating the CPU usage. It copies ADC value around a few times, and uses map indexing 

This PR introduce v3 TPC Rawhit, which uses move constructor to avoid ADC data copying after decoding stage. It also maintain the SAMPA sparse encoding and uses `std::vector` instead of `map`. This is introduced in parallel to the current processing chain.

This improve DST hit processing by about two orders of magnitude, from 4x decoding time to negligible (3% of decoding time).  

New callgrind map show similar CPU usage between time frame building (41%) and ROOT file output gzip compression (39%)
![callgrind out 29729](https://github.com/user-attachments/assets/ef0afe12-ca5e-44e3-b373-ec81436778fa)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

* Update down stream unpacker to use new RawHit
* Debug dropped packet in time frame building 
* More testing , more debugging

## Links to other PRs in macros and calibration repositories (if applicable)
* #3238
* Example macro: https://github.com/blackcathj/macros/blob/TPCTimeFrameBuilder2/StreamingProduction/Fun4All_TPC_SingleStream_Combiner.C
