### PR TITLE
Move cdb call to initrun function of CaloFittingQA. Add QA histograms for calorimeter single sample pedestal.

### DIFF
--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -68,6 +68,20 @@ int CaloFittingQA::Init(PHCompositeNode* /*unused*/)
 
   createHistos();
 
+  if (m_debug)
+  {
+    std::cout << "Leaving CaloFittingQA::Init" << std::endl;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CaloFittingQA::InitRun(PHCompositeNode* /*unused*/)
+{
+  if (m_debug)
+  {
+    std::cout << "In CaloFittingQA::InitRun" << std::endl;
+  }
+
   //===============
   // conditions DB flags
   //===============
@@ -83,7 +97,7 @@ int CaloFittingQA::Init(PHCompositeNode* /*unused*/)
 
   if (m_debug)
   {
-    std::cout << "Leaving CaloFittingQA::Init" << std::endl;
+    std::cout << "Leaving CaloFittingQA::InitRun" << std::endl;
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -68,6 +68,19 @@ int CaloFittingQA::Init(PHCompositeNode* /*unused*/)
 
   createHistos();
 
+  //===============
+  // conditions DB flags
+  //===============
+  m_calibName = "cemc_adcskipmask";
+  m_fieldname = "adcskipmask";
+  std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
+  if (calibdir.empty())
+  {
+    std::cout << PHWHERE << "ADC Skip mask not found in CDB, not even in the default... " << std::endl;
+    exit(1);
+  }
+  cdbttree = new CDBTTree(calibdir.c_str());
+
   if (m_debug)
   {
     std::cout << "Leaving CaloFittingQA::Init" << std::endl;
@@ -175,10 +188,12 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         if (m_SimFlag)
         {
           zs_energy = cemc_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(6) - cemc_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0);
+          h_cemc_etaphi_pedestal->Fill(ieta, iphi, cemc_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0));
         }
         else 
         {
           zs_energy = cemc_waveforms.at(channel).at(1) - cemc_waveforms.at(channel).at(0);
+          h_cemc_etaphi_pedestal->Fill(ieta, iphi, cemc_waveforms.at(channel).at(0));
         }
         if (m_debug) 
         {
@@ -207,14 +222,16 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         if (m_SimFlag)
         {
           zs_energy = ohcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(6) - ohcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0);
+          h_ohcal_etaphi_pedestal->Fill(ieta, iphi, ohcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0));
         }
         else 
         {
           zs_energy = ohcal_waveforms.at(channel).at(1) - ohcal_waveforms.at(channel).at(0);
+          h_ohcal_etaphi_pedestal->Fill(ieta, iphi, ohcal_waveforms.at(channel).at(0));
         }
         if (m_debug) 
         {
-          std::cout << "IHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
+          std::cout << "OHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
         }
         if (raw_energy > m_hcal_adc_threshold && raw_energy < m_hcal_high_adc_threshold)
         {
@@ -239,14 +256,16 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         if (m_SimFlag)
         {
           zs_energy = ihcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(6) - ihcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0);
+          h_ihcal_etaphi_pedestal->Fill(ieta, iphi, ihcal_sim_waveforms->get_tower_at_channel(channel)->get_waveform_value(0));
         }
         else 
         {
           zs_energy = ihcal_waveforms.at(channel).at(1) - ihcal_waveforms.at(channel).at(0);
+          h_ihcal_etaphi_pedestal->Fill(ieta, iphi, ihcal_waveforms.at(channel).at(0));
         }
         if (m_debug) 
         {
-          std::cout << "OHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
+          std::cout << "IHCal channel " << channel << " ieta " << ieta << " iphi " << iphi << " template E " << raw_energy << " ZS E " << zs_energy << std::endl;
         }
         if (raw_energy > m_hcal_adc_threshold && raw_energy < m_hcal_high_adc_threshold)
         {
@@ -266,25 +285,12 @@ int CaloFittingQA::process_data(PHCompositeNode *topNode, CaloTowerDefs::Detecto
   int packet_high = std::numeric_limits<int>::min();
   int m_nsamples = 2;
   int m_nchannels = 192;
-  //===============
-  // conditions DB flags
-  //===============
-  std::string m_calibName = "cemc_adcskipmask";
-  std::string m_fieldname = "adcskipmask";
-  CDBTTree *cdbttree = nullptr; 
 
   if (dettype == CaloTowerDefs::CEMC)
   {
     packet_low = 6001;
     packet_high = 6128;
     m_nchannels = 192;
-    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName);
-    if (calibdir.empty())
-    {
-      std::cout << PHWHERE << "ADC Skip mask not found in CDB, not even in the default... " << std::endl;
-      exit(1);
-    }
-    cdbttree = new CDBTTree(calibdir.c_str());
   }
   else if (dettype == CaloTowerDefs::HCALIN)
   {
@@ -310,7 +316,6 @@ int CaloFittingQA::process_data(PHCompositeNode *topNode, CaloTowerDefs::Detecto
     packet_high = 12001;
     m_nchannels = 128;
   }
-
 
   std::variant<CaloPacketContainer*, Event*> event;
   if (m_UseOfflinePacketFlag)
@@ -530,6 +535,21 @@ void CaloFittingQA::createHistos()
   h_ohcal_etaphi_ZScrosscalib = new TProfile2D(boost::str(boost::format("%sohcal_etaphi_ZScrosscalib") % getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, -10, 10);
   h_ohcal_etaphi_ZScrosscalib->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_etaphi_ZScrosscalib);
+
+  h_cemc_etaphi_pedestal = new TProfile2D(boost::str(boost::format("%scemc_etaphi_pedestal") % getHistoPrefix()).c_str(), ";eta;phi", 96, 0, 96, 256, 0, 256, 0, 16400);
+  h_cemc_etaphi_pedestal->SetErrorOption("G");
+  h_cemc_etaphi_pedestal->SetDirectory(nullptr);
+  hm->registerHisto(h_cemc_etaphi_pedestal);
+
+  h_ihcal_etaphi_pedestal = new TProfile2D(boost::str(boost::format("%sihcal_etaphi_pedestal") % getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, 0, 16400);
+  h_ihcal_etaphi_pedestal->SetErrorOption("G");
+  h_ihcal_etaphi_pedestal->SetDirectory(nullptr);
+  hm->registerHisto(h_ihcal_etaphi_pedestal);
+
+  h_ohcal_etaphi_pedestal = new TProfile2D(boost::str(boost::format("%sohcal_etaphi_pedestal") % getHistoPrefix()).c_str(), ";eta;phi", 24, 0, 24, 64, 0, 64, 0, 16400);
+  h_ohcal_etaphi_pedestal->SetErrorOption("G");
+  h_ohcal_etaphi_pedestal->SetDirectory(nullptr);
+  hm->registerHisto(h_ohcal_etaphi_pedestal);
 
   h_packet_events = new TH1I(boost::str(boost::format("%spacket_events") % getHistoPrefix()).c_str(), ";packet id", 6010, 6000, 12010);
   h_packet_events->SetDirectory(nullptr);

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -5,6 +5,8 @@
 
 #include <caloreco/CaloTowerDefs.h>
 
+#include <cdbobjects/CDBTTree.h>  // for CDBTTree
+
 #include <string>
 #include <vector>
 
@@ -70,7 +72,12 @@ class CaloFittingQA : public SubsysReco
   TProfile2D* h_cemc_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ihcal_etaphi_ZScrosscalib{nullptr};
   TProfile2D* h_ohcal_etaphi_ZScrosscalib{nullptr};
+  TProfile2D* h_cemc_etaphi_pedestal{nullptr};
+  TProfile2D* h_ihcal_etaphi_pedestal{nullptr};
+  TProfile2D* h_ohcal_etaphi_pedestal{nullptr};
   TH1* h_packet_events{nullptr};
+
+  CDBTTree *cdbttree = nullptr;
 
   int _eventcounter{0};
 
@@ -83,6 +90,8 @@ class CaloFittingQA : public SubsysReco
   float m_hcal_adc_threshold = 100.;
   float m_hcal_high_adc_threshold = 2000.;
 
+  std::string m_calibName;
+  std::string m_fieldname;
   std::string m_outputFileName;
   std::string OutputFileName;
 };

--- a/offline/QA/Calorimeters/CaloFittingQA.h
+++ b/offline/QA/Calorimeters/CaloFittingQA.h
@@ -28,6 +28,7 @@ class CaloFittingQA : public SubsysReco
 
   //! full initialization
   int Init(PHCompositeNode*) override;
+  int InitRun(PHCompositeNode *) override;
 
   //! event processing method
   int process_event(PHCompositeNode*) override;


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR moves the call to the CDB for the emcal adc skip mask to the init function from the process event function so that the CDB call happens only once. The PR also adds new QA histograms to monitor the calorimeter single sample pedestal. 
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

