### PR TITLE
ycm - add flag to manually force strobewidth settings

### DIFF
--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -421,24 +421,29 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
 {
 
   auto [runnumber, segment] = Fun4AllUtils::GetRunSegment(*(GetFileList().begin()));
-  float strobeLength = MvtxRawDefs::getStrobeLength(runnumber);
-  if(std::isnan(strobeLength))
+
+  if (m_readStrWidthFromDB)
+  {
+    m_strobeWidth = MvtxRawDefs::getStrobeLength(runnumber);
+  }
+
+  if(std::isnan(m_strobeWidth))
   {
     std::cout << PHWHERE << "WARNING: Strobe length is not defined for run " << runnumber << std::endl;
     std::cout << "Defaulting to 89 mus strobe length" << std::endl;
-    strobeLength = 89.;
+    m_strobeWidth = 89.;
   }
-  if(strobeLength > 88.)
+  if(m_strobeWidth > 88.)
   {
     m_BcoRange = 1000;
     m_NegativeBco = 1000;
   }
-  else if (strobeLength > 9 && strobeLength < 11)
+  else if (m_strobeWidth > 9 && m_strobeWidth < 11)
   {
     m_BcoRange = 100;
     m_NegativeBco = 500;
   }
-  else if (strobeLength < 1) // triggered mode
+  else if (m_strobeWidth < 1) // triggered mode
   {
     m_BcoRange = 2;
     m_NegativeBco = 0;
@@ -449,12 +454,12 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   }
   else // catchall for anyting else to set to a range based on the rhic clock
   {
-    m_BcoRange = std::ceil(strobeLength / 0.1065);
-    m_NegativeBco = std::ceil(strobeLength / 0.1065);
+    m_BcoRange = std::ceil(m_strobeWidth / 0.1065);
+    m_NegativeBco = std::ceil(m_strobeWidth / 0.1065);
   }
   if(Verbosity() > 1)
   {
-    std::cout << "Mvtx strobe length " << strobeLength << std::endl;
+    std::cout << "Mvtx strobe length " << m_strobeWidth << std::endl;
     std::cout << "Mvtx BCO range and negative bco range set based on strobe length " << m_BcoRange << ", " << m_NegativeBco << std::endl;
   }
   if (StreamingInputManager())

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -30,6 +30,11 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void setRawEventHeaderName(const std::string &name) { m_rawEventHeaderName = name; }
   std::string getRawEventHeaderName() const { return m_rawEventHeaderName; }
 
+  void  SetReadStrWidthFromDB(const bool val){ m_readStrWidthFromDB = val; }
+  bool  GetReadStrWidthFromDB(){ return m_readStrWidthFromDB; }
+  void  SetStrobeWidth(const float val) { m_strobeWidth = val; }
+  float GetStrobeWidth() { return m_strobeWidth; }
+
  protected:
  private:
   Packet **plist{nullptr};
@@ -44,6 +49,9 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   std::set<uint64_t> m_BclkStack;
   std::set<uint64_t> gtmL1BcoSet;  // GTM L1 BCO
   std::map<int, mvtx_pool *> poolmap;
+
+  bool m_readStrWidthFromDB = true;
+  float m_strobeWidth = 0;
 };
 
 #endif

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -116,7 +116,11 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   }
   recoConsts *rc = recoConsts::instance();
   int runNumber = rc->get_IntFlag("RUNNUMBER");
-  m_strobeWidth = MvtxRawDefs::getStrobeLength(runNumber);
+
+  if (m_readStrWidthFromDB)
+  {
+    m_strobeWidth = MvtxRawDefs::getStrobeLength(runNumber);
+  }
   if(std::isnan(m_strobeWidth))
   {
     std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is undefined for this run, defaulting to 89 mus" << std::endl;
@@ -212,7 +216,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
         findNode::getClass<MvtxEventInfo>(topNode, "MVTXEVENTHEADER");
     assert(mvtx_event_header);
   }
- 
+
   for (unsigned int i = 0; i < mvtx_hit_container->get_nhits(); i++)
   {
     mvtx_hit = mvtx_hit_container->get_hit(i);

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -54,6 +54,11 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
 
+  void  SetReadStrWidthFromDB(const bool val){ m_readStrWidthFromDB = val; }
+  bool  GetReadStrWidthFromDB(){ return m_readStrWidthFromDB; }
+  void  SetStrobeWidth(const float val) { m_strobeWidth = val; }
+  float GetStrobeWidth() { return m_strobeWidth; }
+
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
 
@@ -65,7 +70,10 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
 
   std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
   std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
+
+  bool m_readStrWidthFromDB = true;
   float m_strobeWidth = 89.;  //! microseconds
+
   bool m_writeMvtxEventHeader = true;
   // std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR added flags to force the MVTX strobe width setting in the (SingleMvtxPoolInput) and the unpacking modules (MvtxCombinedRawDataDecoder). We found that for some unknown reason, the information on the DB is not accurate and it mismatches with the real readout mode observed in the raw data.

However, since in most of the cases, the information read from the DB is correct, the automatic read from the DB was left as default. 
 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

