### PR TITLE
Downstream plumbing to #3242 : use fast iterator for TPC ADC access

### DIFF
--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -6,6 +6,11 @@
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 
+
+#include <ffarawobjects/TpcRawHitContainer.h>
+#include <ffarawobjects/TpcRawHitContainerv3.h>
+#include <ffarawobjects/TpcRawHit.h>
+
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
@@ -28,11 +33,45 @@ int TpcRawHitQA::InitRun(PHCompositeNode *topNode)
 {
   createHistos();
 
-  rawhitcont = findNode::getClass<TpcRawHitContainer>(topNode, "TPCRAWHIT");
 
-  if (!rawhitcont)
+  PHNodeIterator trkr_itr(topNode);
+  PHCompositeNode* tpc_node = dynamic_cast<PHCompositeNode*>(
+    trkr_itr.findFirst("PHCompositeNode", "TPC"));
+  if (!tpc_node)
   {
-    std::cout << PHWHERE << "Missing TpcRawHitContainer node!!!" << std::endl;
+    std::cout << __PRETTY_FUNCTION__ << " : ERROR : " << "No TPC node found, exit" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  
+  PHNodeIterator tpc_itr(tpc_node);
+  {
+    PHPointerList<PHNode>& nodes = tpc_itr.ls();
+
+    for (size_t index =0; index < nodes.length(); ++index)
+    {
+        std::cout <<__PRETTY_FUNCTION__ << " : check TpcRawHitContainer Node "
+        <<nodes[index]->getName() <<" type " <<nodes[index]->getType()
+        <<" getClass = " <<nodes[index]->getClass()
+        <<" getObjectType = " <<nodes[index]->getObjectType()
+        <<" dynamic_cast<PHIODataNode<TpcRawHitContainer> *>(nodes[index]) = " <<
+        (dynamic_cast<PHIODataNode<TpcRawHitContainer> *>(nodes[index]))
+        <<" dynamic_cast<PHIODataNode<TpcRawHitContainerv3> *>(nodes[index]) = "<<
+        (dynamic_cast<PHIODataNode<TpcRawHitContainerv3> *>(nodes[index]))
+        << std::endl;
+      nodes[index]->print("");
+
+      PHIODataNode<TpcRawHitContainer> * thisNode = static_cast<PHIODataNode<TpcRawHitContainer> *>(nodes[index]);
+      if (thisNode)
+      {
+        std::cout <<__PRETTY_FUNCTION__ << " : Found TpcRawHitContainer Node "
+        <<thisNode->getName()  << std::endl;
+
+        TpcRawHitContainer* rawhitcont = (TpcRawHitContainer*) thisNode->getData();
+        assert(rawhitcont);
+
+        rawhitcont_vec.push_back(rawhitcont);
+      }
+    }
   }
 
   auto hm = QAHistManagerDef::getHistoManager();
@@ -70,7 +109,7 @@ int TpcRawHitQA::process_event(PHCompositeNode * /*unused*/)
   float nhit_sectors_fees_laser[24][26] = {{0}};
 
   unsigned int raw_hit_num = 0;
-  if (rawhitcont)
+  for (TpcRawHitContainer * & rawhitcont: rawhitcont_vec)
   {
     raw_hit_num = rawhitcont->get_nhits();
     for (unsigned int i = 0; i < raw_hit_num; i++)

--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -109,9 +109,13 @@ int TpcRawHitQA::process_event(PHCompositeNode * /*unused*/)
       {
         std::vector<int> values;
         values.reserve(sam);
-        for (int sampleN = 0; sampleN < sam; sampleN++)
+        // for (int sampleN = 0; sampleN < sam; sampleN++)
+        // {
+        for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(hit->CreateAdcIterator());
+             !adc_iterator->IsDone();
+             adc_iterator->Next())
         {
-          values.push_back((int) hit->get_adc(sampleN));
+          values.push_back((int) adc_iterator->CurrentAdc());
         }
         std::sort(values.begin(), values.end());
         size_t size = values.size();
@@ -151,9 +155,15 @@ int TpcRawHitQA::process_event(PHCompositeNode * /*unused*/)
         }
       }
 
-      for (int sampleN = 0; sampleN < sam; sampleN++)
+      // for (int sampleN = 0; sampleN < sam; sampleN++)
+      // {
+      //   float adc = hit->get_adc(sampleN);      
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(hit->CreateAdcIterator());
+            !adc_iterator->IsDone();
+            adc_iterator->Next())
       {
-        float adc = hit->get_adc(sampleN);
+        const uint16_t sampleN = adc_iterator->CurrentTimeBin();
+        const uint16_t adc = adc_iterator->CurrentAdc();
         if (adc - median <= (std::max(5 * stdDev, (float) 20.)))
         {
           continue;

--- a/offline/QA/Tpc/TpcRawHitQA.h
+++ b/offline/QA/Tpc/TpcRawHitQA.h
@@ -7,16 +7,15 @@
 #include <trackbase/TrkrDefs.h>
 
 #include <tpc/TpcMap.h>
-
-#include <ffarawobjects/TpcRawHitContainer.h>
-#include <ffarawobjects/TpcRawHit.h>
-
 #include <TH1.h>
 #include <TH2.h>
 #include <TProfile2D.h>
 
 #include <string>
 #include <vector>
+
+class TpcRawHitContainer;
+class TpcRawHit;
 
 class TpcRawHitQA : public SubsysReco
 {
@@ -42,7 +41,7 @@ class TpcRawHitQA : public SubsysReco
 
   TpcMap M;
 
-  TpcRawHitContainer* rawhitcont{nullptr};
+  std::vector<TpcRawHitContainer*> rawhitcont_vec;
 
   TH1* h_nhits_sectors[24]{nullptr};
   TH2* h_nhits_sectors_fees[24]{nullptr};

--- a/offline/framework/ffarawobjects/TpcRawHit.h
+++ b/offline/framework/ffarawobjects/TpcRawHit.h
@@ -59,7 +59,8 @@ class TpcRawHit : public PHObject
   class AdcIterator
   {
    public:
-    virtual ~AdcIterator() {} // Virtual destructor for polymorphism
+    AdcIterator() = default;
+    virtual ~AdcIterator() = default;
     virtual void First() = 0;
     virtual void Next() = 0;
     virtual bool IsDone() const = 0;

--- a/offline/framework/ffarawobjects/TpcRawHit.h
+++ b/offline/framework/ffarawobjects/TpcRawHit.h
@@ -56,6 +56,18 @@ class TpcRawHit : public PHObject
   virtual bool get_parityerror() const { return false; }
   virtual void set_parityerror(const bool /*b*/) { return; }
 
+  class AdcIterator
+  {
+   public:
+    virtual ~AdcIterator() {} // Virtual destructor for polymorphism
+    virtual void First() = 0;
+    virtual void Next() = 0;
+    virtual bool IsDone() const = 0;
+    virtual uint16_t CurrentTimeBin() const = 0;
+    virtual uint16_t CurrentAdc() const = 0;
+  };
+  virtual AdcIterator* CreateAdcIterator() const = 0;
+
  private:
   ClassDefOverride(TpcRawHit, 0)
 };

--- a/offline/framework/ffarawobjects/TpcRawHitv1.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv1.h
@@ -75,7 +75,7 @@ class TpcRawHitv1 : public TpcRawHit
       uint16_t m_index = 0;
 
      public:
-      AdcIteratorv1(const std::vector<uint16_t> & adc)
+      explicit AdcIteratorv1(const std::vector<uint16_t> & adc)
         : m_adc(adc)
       {
       }

--- a/offline/framework/ffarawobjects/TpcRawHitv1.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv1.h
@@ -12,15 +12,15 @@ class TpcRawHitv1 : public TpcRawHit
 {
  public:
   TpcRawHitv1() = default;
-  TpcRawHitv1(TpcRawHit *tpchit);
+  TpcRawHitv1(TpcRawHit* tpchit);
   ~TpcRawHitv1() override = default;
 
   /** identify Function from PHObject
       @param os Output Stream
    */
-  void identify(std::ostream &os = std::cout) const override;
+  void identify(std::ostream& os = std::cout) const override;
 
-  void Clear(Option_t *) override;
+  void Clear(Option_t*) override;
 
   uint64_t get_bco() const override { return bco; }
 
@@ -67,20 +67,55 @@ class TpcRawHitv1 : public TpcRawHit
     adc[sample] = val;
   }
 
- private:
-  uint64_t bco = std::numeric_limits<uint64_t>::max();
-  uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
-  int32_t packetid = std::numeric_limits<int32_t>::max();
-  uint16_t fee = std::numeric_limits<uint16_t>::max();
-  uint16_t channel = std::numeric_limits<uint16_t>::max();
-  uint16_t sampaaddress = std::numeric_limits<uint16_t>::max();
-  uint16_t sampachannel = std::numeric_limits<uint16_t>::max();
-  uint16_t samples = std::numeric_limits<uint16_t>::max();
 
-  //! adc value for each sample
-  std::vector<uint16_t> adc;
+  class AdcIteratorv1 : public AdcIterator
+    {
+     private:
+      const std::vector<uint16_t> & m_adc;
+      uint16_t m_index = 0;
 
-  ClassDefOverride(TpcRawHitv1, 1)
-};
+     public:
+      AdcIteratorv1(const std::vector<uint16_t> & adc)
+        : m_adc(adc)
+      {
+      }
+
+      void First() override { m_index = 0; }
+
+      void Next() override { ++m_index; }
+
+      bool IsDone() const override { return m_index >= m_adc.size(); }
+
+      uint16_t CurrentTimeBin() const override
+      {
+        return m_index;   
+      }
+      uint16_t CurrentAdc() const override
+      {
+        if (!IsDone())
+        {
+          return m_adc[m_index];
+        }
+        return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+      }
+    };
+
+    AdcIterator* CreateAdcIterator() const override { return new AdcIteratorv1(adc); }
+
+   private:
+    uint64_t bco = std::numeric_limits<uint64_t>::max();
+    uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
+    int32_t packetid = std::numeric_limits<int32_t>::max();
+    uint16_t fee = std::numeric_limits<uint16_t>::max();
+    uint16_t channel = std::numeric_limits<uint16_t>::max();
+    uint16_t sampaaddress = std::numeric_limits<uint16_t>::max();
+    uint16_t sampachannel = std::numeric_limits<uint16_t>::max();
+    uint16_t samples = std::numeric_limits<uint16_t>::max();
+
+    //! adc value for each sample
+    std::vector<uint16_t> adc;
+
+    ClassDefOverride(TpcRawHitv1, 1)
+  };
 
 #endif

--- a/offline/framework/ffarawobjects/TpcRawHitv2.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv2.h
@@ -85,6 +85,45 @@ class TpcRawHitv2 : public TpcRawHit
   bool get_parityerror() const override { return parityerror; }
   void set_parityerror(const bool b) override { parityerror = b; }
 
+  class AdcIteratorv2 : public AdcIterator
+  {
+   private:
+    const std::map<uint16_t, uint16_t> &m_adc;
+    std::map<uint16_t, uint16_t>::const_iterator m_iterator;
+
+   public:
+    AdcIteratorv2(const std::map<uint16_t, uint16_t> &adc)
+      : m_adc(adc)
+      , m_iterator(adc.begin())
+    {
+    }
+
+    void First() override { m_iterator = m_adc.begin(); }
+
+    void Next() override { ++m_iterator; }
+
+    bool IsDone() const override { return m_iterator == m_adc.end(); }
+
+    uint16_t CurrentTimeBin() const override
+    {
+      if (!IsDone())
+      {
+        return m_iterator->first;
+      }
+      return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+    }
+    uint16_t CurrentAdc() const override
+    {
+      if (!IsDone())
+      {
+        return m_iterator->second;
+      }
+      return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+    }
+  };
+
+  AdcIterator *CreateAdcIterator() const override { return new AdcIteratorv2(adcmap); }
+
  private:
   uint64_t bco{std::numeric_limits<uint64_t>::max()};
   uint64_t gtm_bco{std::numeric_limits<uint64_t>::max()};

--- a/offline/framework/ffarawobjects/TpcRawHitv2.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv2.h
@@ -92,7 +92,8 @@ class TpcRawHitv2 : public TpcRawHit
     std::map<uint16_t, uint16_t>::const_iterator m_iterator;
 
    public:
-    AdcIteratorv2(const std::map<uint16_t, uint16_t> &adc)
+    // NOLINTNEXTLINE(hicpp-member-init)
+    explicit AdcIteratorv2(const std::map<uint16_t, uint16_t> &adc)
       : m_adc(adc)
       , m_iterator(adc.begin())
     {

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -58,7 +58,7 @@ class TpcRawHitv3 : public TpcRawHit
   //   // cppcheck-suppress virtualCallInConstructor
   //   void set_sampachannel(const uint16_t val) override { sampachannel = val; }
 
-  //   uint16_t get_samples() const override { return samples; }
+  uint16_t get_samples() const override { return 1024U; }
   // cppcheck-suppress virtualCallInConstructor
   //   void set_samples(const uint16_t val) override
   //   {

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -17,7 +17,7 @@ class TpcRawHitv3 : public TpcRawHit
   TpcRawHitv3() = default;
   explicit TpcRawHitv3(TpcRawHit *tpchit);
   TpcRawHitv3(TpcRawHitv3 &&other) noexcept;
-  
+
   ~TpcRawHitv3() override = default;
 
   /** identify Function from PHObject
@@ -25,7 +25,7 @@ class TpcRawHitv3 : public TpcRawHit
    */
   void identify(std::ostream &os = std::cout) const override;
 
-  void Clear(Option_t */*unused*/) override;
+  void Clear(Option_t * /*unused*/) override;
 
   uint64_t get_bco() const override { return bco; }
   // cppcheck-suppress virtualCallInConstructor
@@ -92,6 +92,67 @@ class TpcRawHitv3 : public TpcRawHit
 
   bool get_parityerror() const override { return parityerror; }
   void set_parityerror(const bool b) override { parityerror = b; }
+
+  class AdcIteratorv3 : public AdcIterator
+  {
+   private:
+    const std::vector<std::pair<uint16_t, std::vector<uint16_t> > > &m_adc;
+    uint16_t m_waveform_index = 0;
+    uint16_t m_adc_position_in_waveform_index = 0;
+
+   public:
+    AdcIteratorv3(const std::vector<std::pair<uint16_t, std::vector<uint16_t> > > &adc)
+      : m_adc(adc)
+    {
+    }
+
+    void First() override
+    {
+      m_waveform_index = 0;
+      m_adc_position_in_waveform_index = 0;
+    }
+
+    void Next() override
+    {
+      if (m_adc_position_in_waveform_index < m_adc[m_waveform_index].second.size() - 1)
+      {
+        ++m_adc_position_in_waveform_index;
+      }
+      else
+      {
+        ++m_waveform_index;
+        m_adc_position_in_waveform_index = 0;
+      }
+    }
+
+    bool IsDone() const override { return m_waveform_index >= m_adc.size(); }
+
+    uint16_t CurrentTimeBin() const override
+    {
+      if (!IsDone())
+      {
+        return m_adc[m_waveform_index].first + m_adc_position_in_waveform_index;
+      }
+      return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+    }
+    uint16_t CurrentAdc() const override
+    {
+      if (!IsDone())
+      {
+        if (m_adc_position_in_waveform_index < m_adc[m_waveform_index].second.size())
+        {
+          return m_adc[m_waveform_index].second[m_adc_position_in_waveform_index];
+        }
+        else
+        {
+          return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+        }
+      }
+      return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+    }
+  };
+
+  AdcIterator *CreateAdcIterator() const override { return new AdcIteratorv3(m_adcData); }
 
  private:
   uint64_t bco{std::numeric_limits<uint64_t>::max()};

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -101,7 +101,8 @@ class TpcRawHitv3 : public TpcRawHit
     uint16_t m_adc_position_in_waveform_index = 0;
 
    public:
-    AdcIteratorv3(const std::vector<std::pair<uint16_t, std::vector<uint16_t> > > &adc)
+    // NOLINTNEXTLINE(hicpp-named-parameter)
+    explicit AdcIteratorv3(const std::vector<std::pair<uint16_t, std::vector<uint16_t> > > &adc)
       : m_adc(adc)
     {
     }
@@ -114,6 +115,7 @@ class TpcRawHitv3 : public TpcRawHit
 
     void Next() override
     {
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (m_adc_position_in_waveform_index < m_adc[m_waveform_index].second.size() - 1)
       {
         ++m_adc_position_in_waveform_index;
@@ -139,6 +141,7 @@ class TpcRawHitv3 : public TpcRawHit
     {
       if (!IsDone())
       {
+        // NOLINTNEXTLINE(bugprone-branch-clone)
         if (m_adc_position_in_waveform_index < m_adc[m_waveform_index].second.size())
         {
           return m_adc[m_waveform_index].second[m_adc_position_in_waveform_index];

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -39,8 +39,8 @@
 #include <cstdlib>   // for exit
 #include <iostream>  // for operator<<, endl, bas...
 #include <map>       // for _Rb_tree_iterator
-#include <utility>
 #include <memory>
+#include <utility>
 
 #define dEBUG
 
@@ -313,9 +313,9 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       {
         std::cout << "TpcCombinedRawDataUnpacker:: no zero suppression" << std::endl;
       }
-      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
-            !adc_iterator->IsDone(); 
-            adc_iterator->Next())
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());
+           !adc_iterator->IsDone();
+           adc_iterator->Next())
       {
         const uint16_t s = adc_iterator->CurrentTimeBin();
         const uint16_t adc = adc_iterator->CurrentAdc();
@@ -341,114 +341,117 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
         std::cout << "TpcCombinedRawDataUnpacker:: do zero suppression" << std::endl;
       }
       TH2I* feehist = nullptr;
-      if(!m_do_zs_emulation){
-	// for (uint16_t sampleNum = 0; sampleNum < sam; sampleNum++)
-	//   {
+      if (!m_do_zs_emulation)
+      {
+        // for (uint16_t sampleNum = 0; sampleNum < sam; sampleNum++)
+        //   {
 
-  for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
-        !adc_iterator->IsDone(); 
-        adc_iterator->Next())
-  {
-    // const uint16_t sampleNum = adc_iterator->CurrentTimeBin();
-    const uint16_t adc = adc_iterator->CurrentAdc();
+        for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());
+             !adc_iterator->IsDone();
+             adc_iterator->Next())
+        {
+          // const uint16_t sampleNum = adc_iterator->CurrentTimeBin();
+          const uint16_t adc = adc_iterator->CurrentAdc();
 
-	    if (adc > 0)
-	      {
-		pedhist.Fill(adc);
-	      }
-	  }
-	int hmax = 0;
-	int hmaxbin = 0;
-	for (int nbin = 1; nbin <= pedhist.GetNbinsX(); nbin++)
-	  {
-	    float val = pedhist.GetBinContent(nbin);
-	    if (val > hmax)
-	      {
-		hmaxbin = nbin;
-		hmax = val;
-	      }
-	  }
-	
-	// calculate pedestal mean and sigma
-	
-	if (pedhist.GetStdDev() == 0 || pedhist.GetEntries() == 0)
-	  {
-	    hpedestal = pedhist.GetBinCenter(pedhist.GetMaximumBin());
-	    hpedwidth = 999;
-	  }
-	else
-	  {
-	    // calc peak position
-	    double adc_sum = 0.0;
-	    double ibin_sum = 0.0;
-	    double ibin2_sum = 0.0;
-	    
-	    for (int isum = -3; isum <= 3; isum++)
-	      {
-		float val = pedhist.GetBinContent(hmaxbin + isum);
-		float center = pedhist.GetBinCenter(hmaxbin + isum);
-		ibin_sum += center * val;
-		ibin2_sum += center * center * val;
-		adc_sum += val;
-	      }
-	    
-	    hpedestal = ibin_sum / adc_sum;
-	    hpedwidth = sqrt(ibin2_sum / adc_sum - (hpedestal * hpedestal));
-	  }
-	if (m_do_baseline_corr)
-	  {
-	    unsigned int pad_key = create_pad_key(side, layer, phibin);
-	    
-	    std::map<unsigned int, chan_info>::iterator chan_it = chan_map.find(pad_key);
-	    if (chan_it != chan_map.end())
-	      {
-		(*chan_it).second.ped = hpedestal;
-		(*chan_it).second.width = hpedwidth;
-	      }
-	    else
-	      {
-		chan_info nucinfo;
-		nucinfo.fee = fee;
-		nucinfo.ped = hpedestal;
-		nucinfo.width = hpedwidth;
-		chan_map.insert(std::make_pair(pad_key, nucinfo));
-	      }
-	    int rx = get_rx(layer);
-	    unsigned int fee_key = create_fee_key(side, mc_sectors[sector % 12], rx, fee);
-	    // find or insert TH2I;
-	    std::map<unsigned int, TH2I*>::iterator fee_map_it;
-	    
-	    fee_map_it = feeadc_map.find(fee_key);
-	    if (fee_map_it != feeadc_map.end())
-	      {
-		feehist = (*fee_map_it).second;
-	      }
-	    else
-	      {
-		std::string histname = "h" + std::to_string(fee_key);
-		feehist = new TH2I(histname.c_str(), "histname", max_time_range + 1, -0.5, max_time_range + 0.5, 501, -0.5, 1000.5);
-		feeadc_map.insert(std::make_pair(fee_key, feehist));
-	      }
-	  }
-	ntotalchannels++;
-	if (m_do_noise_rejection && !m_do_baseline_corr)
-	  {
-	    if (hpedwidth < 0.5 || hpedestal < 10 || hpedwidth == 999)
-	      {
-		n_noisychannels++;
-		continue;
-	      }
-	  }
-      }else{
-	hpedestal = 60;
-	hpedwidth = m_zs_threshold;
+          if (adc > 0)
+          {
+            pedhist.Fill(adc);
+          }
+        }
+        int hmax = 0;
+        int hmaxbin = 0;
+        for (int nbin = 1; nbin <= pedhist.GetNbinsX(); nbin++)
+        {
+          float val = pedhist.GetBinContent(nbin);
+          if (val > hmax)
+          {
+            hmaxbin = nbin;
+            hmax = val;
+          }
+        }
+
+        // calculate pedestal mean and sigma
+
+        if (pedhist.GetStdDev() == 0 || pedhist.GetEntries() == 0)
+        {
+          hpedestal = pedhist.GetBinCenter(pedhist.GetMaximumBin());
+          hpedwidth = 999;
+        }
+        else
+        {
+          // calc peak position
+          double adc_sum = 0.0;
+          double ibin_sum = 0.0;
+          double ibin2_sum = 0.0;
+
+          for (int isum = -3; isum <= 3; isum++)
+          {
+            float val = pedhist.GetBinContent(hmaxbin + isum);
+            float center = pedhist.GetBinCenter(hmaxbin + isum);
+            ibin_sum += center * val;
+            ibin2_sum += center * center * val;
+            adc_sum += val;
+          }
+
+          hpedestal = ibin_sum / adc_sum;
+          hpedwidth = sqrt(ibin2_sum / adc_sum - (hpedestal * hpedestal));
+        }
+        if (m_do_baseline_corr)
+        {
+          unsigned int pad_key = create_pad_key(side, layer, phibin);
+
+          std::map<unsigned int, chan_info>::iterator chan_it = chan_map.find(pad_key);
+          if (chan_it != chan_map.end())
+          {
+            (*chan_it).second.ped = hpedestal;
+            (*chan_it).second.width = hpedwidth;
+          }
+          else
+          {
+            chan_info nucinfo;
+            nucinfo.fee = fee;
+            nucinfo.ped = hpedestal;
+            nucinfo.width = hpedwidth;
+            chan_map.insert(std::make_pair(pad_key, nucinfo));
+          }
+          int rx = get_rx(layer);
+          unsigned int fee_key = create_fee_key(side, mc_sectors[sector % 12], rx, fee);
+          // find or insert TH2I;
+          std::map<unsigned int, TH2I*>::iterator fee_map_it;
+
+          fee_map_it = feeadc_map.find(fee_key);
+          if (fee_map_it != feeadc_map.end())
+          {
+            feehist = (*fee_map_it).second;
+          }
+          else
+          {
+            std::string histname = "h" + std::to_string(fee_key);
+            feehist = new TH2I(histname.c_str(), "histname", max_time_range + 1, -0.5, max_time_range + 0.5, 501, -0.5, 1000.5);
+            feeadc_map.insert(std::make_pair(fee_key, feehist));
+          }
+        }
+        ntotalchannels++;
+        if (m_do_noise_rejection && !m_do_baseline_corr)
+        {
+          if (hpedwidth < 0.5 || hpedestal < 10 || hpedwidth == 999)
+          {
+            n_noisychannels++;
+            continue;
+          }
+        }
+      }
+      else
+      {
+        hpedestal = 60;
+        hpedwidth = m_zs_threshold;
       }
       // for (uint16_t s = 0; s < sam; s++)
       // {
-      
-      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
-            !adc_iterator->IsDone(); 
-            adc_iterator->Next())
+
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());
+           !adc_iterator->IsDone();
+           adc_iterator->Next())
       {
         const uint16_t s = adc_iterator->CurrentTimeBin();
         const uint16_t adc = adc_iterator->CurrentAdc();
@@ -457,18 +460,18 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
         {
           continue;
         }
-	if (m_do_baseline_corr && feehist != nullptr &&(!m_do_zs_emulation))
+        if (m_do_baseline_corr && feehist != nullptr && (!m_do_zs_emulation))
         {
           if (adc > 0)
           {
             feehist->Fill(t, adc - hpedestal + pedestal_offset);
           }
-	  
         }
-	float threshold_cut = (hpedwidth * m_ped_sig_cut);
-	if(m_do_zs_emulation){
-	  threshold_cut = m_zs_threshold;
-	}
+        float threshold_cut = (hpedwidth * m_ped_sig_cut);
+        if (m_do_zs_emulation)
+        {
+          threshold_cut = m_zs_threshold;
+        }
         if ((float(adc) - hpedestal) > threshold_cut)
         {
           hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -40,6 +40,7 @@
 #include <iostream>  // for operator<<, endl, bas...
 #include <map>       // for _Rb_tree_iterator
 #include <utility>
+#include <memory>
 
 #define dEBUG
 
@@ -312,9 +313,13 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       {
         std::cout << "TpcCombinedRawDataUnpacker:: no zero suppression" << std::endl;
       }
-      for (uint16_t s = 0; s < sam; s++)
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
+            !adc_iterator->IsDone(); 
+            adc_iterator->Next())
       {
-        uint16_t adc = tpchit->get_adc(s);
+        const uint16_t s = adc_iterator->CurrentTimeBin();
+        const uint16_t adc = adc_iterator->CurrentAdc();
+
         int t = s - m_presampleShift;
 
         hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);
@@ -337,9 +342,16 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       }
       TH2I* feehist = nullptr;
       if(!m_do_zs_emulation){
-	for (uint16_t sampleNum = 0; sampleNum < sam; sampleNum++)
-	  {
-	    uint16_t adc = tpchit->get_adc(sampleNum);
+	// for (uint16_t sampleNum = 0; sampleNum < sam; sampleNum++)
+	//   {
+
+  for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
+        !adc_iterator->IsDone(); 
+        adc_iterator->Next())
+  {
+    // const uint16_t sampleNum = adc_iterator->CurrentTimeBin();
+    const uint16_t adc = adc_iterator->CurrentAdc();
+
 	    if (adc > 0)
 	      {
 		pedhist.Fill(adc);
@@ -431,9 +443,15 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
 	hpedestal = 60;
 	hpedwidth = m_zs_threshold;
       }
-      for (uint16_t s = 0; s < sam; s++)
+      // for (uint16_t s = 0; s < sam; s++)
+      // {
+      
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator( tpchit->CreateAdcIterator() )  ; 
+            !adc_iterator->IsDone(); 
+            adc_iterator->Next())
       {
-        uint16_t adc = tpchit->get_adc(s);
+        const uint16_t s = adc_iterator->CurrentTimeBin();
+        const uint16_t adc = adc_iterator->CurrentAdc();
         int t = s - m_presampleShift;
         if (t < 0)
         {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Downstream plumbing to #3242 : use fast iterator for TPC hit access. This applies to **both** new and older version of `TpcRawHit`. Besides allowing unpacker & TPC QA to use `TpcRawHitv3`, we should see an immediate speed up of the unpacking of current DSTs of `TpcRawHitv2`

Thanks to help from Joe, who tested current RawHit DST readback. Furthermore, let's watch out for other unintended consequences.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Test - debug - bigger test again

## Links to other PRs in macros and calibration repositories (if applicable)

- #3242 
- #3238 