### PR TITLE
added verbosity flag.

### DIFF
--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -22,23 +22,23 @@ void TpcGlobalPositionWrapper::loadNodes( PHCompositeNode* topNode )
 
   // tpc distortion corrections
   m_dcc_module_edge = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerModuleEdge");
-  if (m_dcc_module_edge)
+  if (m_dcc_module_edge && m_verbosity > 0)
   {
     std::cout << "TpcGlobalPositionWrapper::loadNodes - found module edge TPC distortion correction container" << std::endl;
   }
 
   m_dcc_static = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerStatic");
-  if (m_dcc_static)
+  if (m_dcc_static && m_verbosity > 0)
   {
     std::cout << "TpcGlobalPositionWrapper::loadNodes - found static TPC distortion correction container" << std::endl;
   }
   m_dcc_average = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerAverage");
-  if (m_dcc_average)
+  if (m_dcc_average && m_verbosity > 0)
   {
     std::cout << "TpcGlobalPositionWrapper::loadNodes - found average TPC distortion correction container" << std::endl;
   }
   m_dcc_fluctuation = findNode::getClass<TpcDistortionCorrectionContainer>(topNode, "TpcDistortionCorrectionContainerFluctuation");
-  if (m_dcc_fluctuation)
+  if (m_dcc_fluctuation && m_verbosity > 0)
   {
     std::cout << "TpcGlobalPositionWrapper::loadNodes - found fluctuation TPC distortion correction container" << std::endl;
   }

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -24,6 +24,18 @@ class TpcGlobalPositionWrapper
   //! constructor
   explicit TpcGlobalPositionWrapper() = default;
 
+  //! verbosity
+  void set_verbosity(int value)
+  {
+    m_verbosity = value;
+  }
+
+  //! verbosity
+  int verbosity() const
+  {
+    return m_verbosity;
+  }
+
   //! load relevant nodes from tree
   void loadNodes(PHCompositeNode* /*topnode*/);
 
@@ -38,6 +50,9 @@ class TpcGlobalPositionWrapper
   Acts::Vector3 getGlobalPositionDistortionCorrected(const TrkrDefs::cluskey&, TrkrCluster*, short int /*crossing*/ ) const;
 
   private:
+
+  //! verbosity
+  unsigned int m_verbosity = 0;
 
   //! cluster z crossing correction interface
   TpcClusterZCrossingCorrection m_crossingCorrection;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
By default, this removes anoying per event output message about which distortion correction maps are found on the node tree. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

