### PR TITLE
Minor feature additions for TPC time frame building

### DIFF
--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -62,9 +62,10 @@ int TpcRawHitQA::InitRun(PHCompositeNode *topNode)
                   << thisNode->getName() << std::endl;
 
         TpcRawHitContainer *rawhitcont = (TpcRawHitContainer *) thisNode->getData();
-        assert(rawhitcont);
-
-        rawhitcont_vec.push_back(rawhitcont);
+        if (rawhitcont);
+        {
+          rawhitcont_vec.push_back(rawhitcont);
+        }
       }
     }
   }

--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -62,7 +62,7 @@ int TpcRawHitQA::InitRun(PHCompositeNode *topNode)
                   << thisNode->getName() << std::endl;
 
         TpcRawHitContainer *rawhitcont = (TpcRawHitContainer *) thisNode->getData();
-        if (rawhitcont);
+        if (rawhitcont)
         {
           rawhitcont_vec.push_back(rawhitcont);
         }

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -8,6 +8,15 @@
 #include <ffarawobjects/TpcRawHitv3.h>
 
 #include <frog/FROG.h>
+#include <phool/PHTimer.h>  // for PHTimer
+
+#include <fun4all/Fun4AllHistoManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <qautils/QAHistManagerDef.h>
+
+#include <TAxis.h>
+#include <TH1.h>
+#include <TH2.h>
 
 #include <phool/PHCompositeNode.h>
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
@@ -28,6 +37,32 @@ SingleTpcTimeFrameInput::SingleTpcTimeFrameInput(const std::string &name)
   SubsystemEnum(InputManagerType::TPC);
   m_rawHitContainerName = "TPCRAWHIT";
   plist = new Packet *[NTPCPACKETS];
+
+  // cppcheck-suppress noCopyConstructor
+  // cppcheck-suppress noOperatorEq
+  m_FillPoolTimer = new PHTimer("SingleTpcTimeFrameInput_" + name + "_FillPool");
+  m_getNextEventTimer = new PHTimer("SingleTpcTimeFrameInput_" + name + "_getNextEvent");
+  m_ProcessPacketTimer = new PHTimer("SingleTpcTimeFrameInput_" + name + "_ProcessPacket");
+  m_getTimeFrameTimer = new PHTimer("SingleTpcTimeFrameInput_" + name + "_getTimeFrame");
+
+  Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
+  assert(hm);
+
+  m_hNorm = new TH1D(TString("SingleTpcTimeFrameInput_" + name) + "_Normalization",  //
+                     TString("SingleTpcTimeFrameInput_" + name) + " Normalization;Items;Count",
+                     20, .5, 20.5);
+  int i = 1;
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "FillPoolCount");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "FillPoolTime[ms]");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "getNextEventCount");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "getNextEventTime[ms]");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "ProcessPacketCount");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "ProcessPacketTime[ms]");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "getTimeFrameCount");
+  m_hNorm->GetXaxis()->SetBinLabel(i++, "getTimeFrameTime[ms]");
+  assert(i <= 20);
+  m_hNorm->GetXaxis()->LabelsOption("v");
+  hm->registerHisto(m_hNorm);
 }
 
 SingleTpcTimeFrameInput::~SingleTpcTimeFrameInput()
@@ -40,13 +75,52 @@ SingleTpcTimeFrameInput::~SingleTpcTimeFrameInput()
   }
 }
 
+SingleTpcTimeFrameInput::TimeTracker::TimeTracker(PHTimer *timer, const std::string &name, TH1 *hout)
+  : m_timer(timer)
+  , m_name(name.c_str())
+  , m_hNorm(hout)
+{
+  assert(m_timer);
+  assert(m_hNorm);
+
+  m_hNorm->Fill(m_name + "Count", 1);
+
+  m_timer->restart();
+}
+
+void SingleTpcTimeFrameInput::TimeTracker::stop()
+{
+  assert(m_timer);
+  assert(m_hNorm);
+
+  m_timer->stop();
+  m_hNorm->Fill(m_name + "Time[ms]", m_timer->elapsed());
+
+  stopped = true;
+}
+
+SingleTpcTimeFrameInput::TimeTracker::~TimeTracker()
+{
+  if (!stopped)
+  {
+    stop();
+  }
+}
+
 void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
 {
-  if (Verbosity() > 1)
+  TimeTracker fillPoolTimer(m_FillPoolTimer, "FillPool", m_hNorm);
+
+  if ( (Verbosity() >= 1 and targetBCO % 941 == 0) or Verbosity() >= 2)
   {
     std::cout << "SingleTpcTimeFrameInput::FillPool: " << Name()
-              << " Entry with targetBCO = 0x"<<std::hex << targetBCO
-              <<"("<<std::dec<<targetBCO<<")" << std::endl;
+              << " Entry with targetBCO = 0x" << std::hex << targetBCO
+              << "(" << std::dec << targetBCO << ")" << std::endl;
+
+    m_FillPoolTimer->print_stat();
+    m_getNextEventTimer->print_stat();
+    m_ProcessPacketTimer->print_stat();
+    m_getTimeFrameTimer->print_stat();
   }
 
   if (AllDone())  // no more files and all events read
@@ -86,9 +160,10 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
     {
       std::cout << "SingleTpcTimeFrameInput::FillPool: " << Name()
                 << " require_more_data for targetBCO 0x"
-                <<std::hex << targetBCO <<std::dec<< std::endl;
+                << std::hex << targetBCO << std::dec << std::endl;
     }
 
+    TimeTracker getNextEventTimer(m_getNextEventTimer, "getNextEvent", m_hNorm);
     std::unique_ptr<Event> evt(GetEventiterator()->getNextEvent());
     while (!evt)
     {
@@ -100,6 +175,7 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
       }
       evt.reset(GetEventiterator()->getNextEvent());
     }
+
     if (Verbosity() > 2)
     {
       std::cout << "Fetching next Event" << evt->getEvtSequence() << std::endl;
@@ -125,6 +201,8 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
       exit(1);
     }
 
+    getNextEventTimer.stop();
+    TimeTracker ProcessPacketTimer(m_ProcessPacketTimer, "ProcessPacket", m_hNorm);
     for (int i = 0; i < npackets; i++)
     {
       // keep pointer to local packet
@@ -157,27 +235,28 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
       delete packet;
       packet = nullptr;
     }  //     for (int i = 0; i < npackets; i++)
+    ProcessPacketTimer.stop();
 
     require_more_data = false;
-    for (auto & map_builder : m_TpcTimeFrameBuilderMap)
+    for (auto &map_builder : m_TpcTimeFrameBuilderMap)
     {
       require_more_data |= map_builder.second->isMoreDataRequired(targetBCO);
     }
 
     if (not require_more_data)
     {
-      for (auto & map_builder : m_TpcTimeFrameBuilderMap)
+      TimeTracker getTimeFrameTimer(m_getTimeFrameTimer, "getTimeFrame", m_hNorm);
+
+      for (auto &map_builder : m_TpcTimeFrameBuilderMap)
       {
-        auto & timeframe = map_builder.second->getTimeFrame(targetBCO);
+        auto &timeframe = map_builder.second->getTimeFrame(targetBCO);
 
         for (auto newhit : timeframe)
         {
-          StreamingInputManager()->AddTpcRawHit(targetBCO, newhit); 
+          StreamingInputManager()->AddTpcRawHit(targetBCO, newhit);
         }
-
-      }      
-    } 
-
+      }
+    }
   }
   //    Print("HITS");
   //  } while (m_TpcRawHitMap.size() < 10 || CheckPoolDepth(m_TpcRawHitMap.begin()->first));
@@ -199,9 +278,7 @@ void SingleTpcTimeFrameInput::CleanupUsedPackets(const uint64_t bclk)
   {
     iter.second->CleanupUsedPackets(bclk);
   }
-
 }
-
 
 void SingleTpcTimeFrameInput::ClearCurrentEvent()
 {
@@ -216,7 +293,6 @@ void SingleTpcTimeFrameInput::ClearCurrentEvent()
   // // m_BeamClockFEE.erase(currentbclk);
   return;
 }
-
 
 void SingleTpcTimeFrameInput::CreateDSTNode(PHCompositeNode *topNode)
 {

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
@@ -3,6 +3,8 @@
 
 #include "SingleStreamingInput.h"
 
+#include <TString.h>
+
 #include <array>
 #include <list>
 #include <map>
@@ -13,6 +15,9 @@
 class TpcRawHit;
 class Packet;
 class TpcTimeFrameBuilder;
+class PHTimer;
+class TH1;
+class TH2;
 
 //! Provide TpcTimeFrameBuilder as a unified interface for Fun4AllStreamingInputManager
 // NOLINTNEXTLINE(hicpp-special-member-functions)
@@ -42,6 +47,29 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
 
   //! packet ID -> TimeFrame builder
   std::map<int, TpcTimeFrameBuilder *> m_TpcTimeFrameBuilderMap;
+
+  
+  TH1 *m_hNorm = nullptr;
+
+  PHTimer *m_FillPoolTimer = nullptr;
+  PHTimer *m_getNextEventTimer = nullptr;
+  PHTimer *m_ProcessPacketTimer = nullptr;
+  PHTimer *m_getTimeFrameTimer = nullptr;
+
+  class TimeTracker
+  {    
+   public:
+    TimeTracker(PHTimer * timer, const std::string & name, TH1* hout) ;
+    virtual ~TimeTracker() ;
+    void stop();
+
+   private:
+    PHTimer * m_timer = nullptr;
+    TString m_name;
+    TH1 *m_hNorm = nullptr;
+    bool stopped = false;
+  };
+
 };
 
 #endif

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
@@ -56,6 +56,7 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
   PHTimer *m_ProcessPacketTimer = nullptr;
   PHTimer *m_getTimeFrameTimer = nullptr;
 
+  // NOLINTNEXTLINE(hicpp-special-member-functions)
   class TimeTracker
   {    
    public:

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -242,7 +242,7 @@ std::vector<TpcRawHit*>& TpcTimeFrameBuilder::getTimeFrame(const uint64_t& gtm_b
                   << " and bclk_rollover_corrected 0x" << std::hex
                   << bclk_rollover_corrected << std::dec << ". m_timeFrameMap:" << std::endl;
 
-        if (m_verbosity >= 3)
+        // if (m_verbosity >= 3)
         {
           for (const auto& timeframe : m_timeFrameMap)
           {
@@ -587,7 +587,7 @@ int TpcTimeFrameBuilder::process_fee_data(unsigned int fee)
 {
   assert(m_hFEEDataStream);
 
-  if (m_verbosity > 1)
+  if (m_verbosity > 2)
   {
     cout << __PRETTY_FUNCTION__ << "\t- : processing FEE " << fee << "\t- with " << m_feeData[fee].size() << "\t- words" << endl;
   }

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -296,7 +296,7 @@ class TpcTimeFrameBuilder
     static constexpr unsigned int m_max_matching_data_size = 10;
 
     //! max time in GTM BCO for FEE data to sync over to datastream
-    static constexpr unsigned int m_max_fee_sync_time = 1024;
+    static constexpr unsigned int m_max_fee_sync_time = 1024*8;
 
     static constexpr unsigned int m_FEE_CLOCK_BITS = 20;
     static constexpr unsigned int m_GTM_CLOCK_BITS = 40;

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -329,6 +329,7 @@ class TpcTimeFrameBuilder
   //! This is used to organize hits into time frames based on their BCO values
   std::map<uint64_t, std::vector<TpcRawHit *>> m_timeFrameMap;
   static const size_t kMaxRawHitLimit = 10000;  // 10k hits per event > 256ch/fee * 26fee
+  std::queue<uint64_t> m_UsedTimeFrameSet;
 
   //! fast skip mode when searching for particular GL1 BCO over long segment of files
   bool m_fastBCOSkip = false;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
* Improve QA of dropped TPC hits
* Add QA of time consumption of each step of TPC input
* Allow for more than Raw Hit on `DST/TPC` node

Current `callgrind` time consumption stat., which is about half-half split of CPU usage of TPC timeframe buidling and ROOT DST output: 
![callgrind out 10249](https://github.com/user-attachments/assets/52ced5ba-5914-4bd8-abee-8ce2f5275834)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Test production, -> debug -> test more

## Links to other PRs in macros and calibration repositories (if applicable)

- #3248
- #3242 
- #3238 
