### PR TITLE
Performance tuning for TPC Time Frame building

### DIFF
--- a/offline/framework/ffarawobjects/TpcRawHit.h
+++ b/offline/framework/ffarawobjects/TpcRawHit.h
@@ -50,9 +50,11 @@ class TpcRawHit : public PHObject
   virtual uint16_t get_parity() const { return std::numeric_limits<uint16_t>::max(); }
   virtual void set_parity(const uint16_t /*i*/) { return; }
 
+  //! FEE waveform CRC check. If true, FEE data transmission from FEE to offline is broken
   virtual bool get_checksumerror() const { return false; }
   virtual void set_checksumerror(const bool /*b*/) { return; }
 
+  //! SAMPA data payload parity check. If true, data from SAMPA is broken, e.g. from SEU 
   virtual bool get_parityerror() const { return false; }
   virtual void set_parityerror(const bool /*b*/) { return; }
 

--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -23,8 +23,8 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHit *tpchit)
   TpcRawHitv3::set_sampachannel(tpchit->get_sampachannel());
   TpcRawHitv3::set_type(tpchit->get_type());
   TpcRawHitv3::set_userword(tpchit->get_userword());
-  TpcRawHitv3::set_checksum(tpchit->get_checksum());
-  TpcRawHitv3::set_parity(tpchit->get_parity());
+  // TpcRawHitv3::set_checksum(tpchit->get_checksum());
+  // TpcRawHitv3::set_parity(tpchit->get_parity());
   TpcRawHitv3::set_checksumerror(tpchit->get_checksumerror());
   TpcRawHitv3::set_parityerror(tpchit->get_parityerror());
   TpcRawHitv3::set_samples(tpchit->get_samples());
@@ -48,8 +48,8 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
   , channel(other.channel)
   , type(other.type)
   // , userword(other.userword)
-  , checksum(other.checksum)
-  , data_parity(other.data_parity)
+  // , checksum(other.checksum)
+  // , data_parity(other.data_parity)
   , checksumerror(other.checksumerror)
   , parityerror(other.parityerror)
   , m_adcData(std::move(other.m_adcData))

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -81,11 +81,11 @@ class TpcRawHitv3 : public TpcRawHit
   // uint16_t get_userword() const override { return userword; }
   // void set_userword(const uint16_t i) override { userword = i; }
 
-  uint16_t get_checksum() const override { return checksum; }
-  void set_checksum(const uint16_t i) override { checksum = i; }
+  // uint16_t get_checksum() const override { return checksum; }
+  // void set_checksum(const uint16_t i) override { checksum = i; }
 
-  uint16_t get_parity() const override { return data_parity; }
-  void set_parity(const uint16_t i) override { data_parity = i; }
+  // uint16_t get_parity() const override { return data_parity; }
+  // void set_parity(const uint16_t i) override { data_parity = i; }
 
   bool get_checksumerror() const override { return checksumerror; }
   void set_checksumerror(const bool b) override { checksumerror = b; }
@@ -163,8 +163,8 @@ class TpcRawHitv3 : public TpcRawHit
   uint16_t fee{std::numeric_limits<uint16_t>::max()};
   uint16_t channel{std::numeric_limits<uint16_t>::max()};
   uint16_t type{std::numeric_limits<uint16_t>::max()};
-  uint16_t checksum{std::numeric_limits<uint16_t>::max()};
-  uint16_t data_parity{std::numeric_limits<uint16_t>::max()};
+  // uint16_t checksum{std::numeric_limits<uint16_t>::max()};
+  // uint16_t data_parity{std::numeric_limits<uint16_t>::max()};
 
   bool checksumerror{true};
   bool parityerror{true};
@@ -172,7 +172,7 @@ class TpcRawHitv3 : public TpcRawHit
   //! adc waveform std::vector< uint16_t > for each start time uint16_t
   std::vector<std::pair<uint16_t, std::vector<uint16_t> > > m_adcData;
 
-  ClassDefOverride(TpcRawHitv3, 1)
+  ClassDefOverride(TpcRawHitv3, 2)
 };
 
 #endif

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -110,7 +110,7 @@ SingleTpcTimeFrameInput::TimeTracker::~TimeTracker()
 void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
 {
   {
-    bool first = true;
+    static bool first = true;
     if (first)
     {
       first = false;

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -212,6 +212,18 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
       // get packet id
       const auto packet_id = packet->getIdentifier();
 
+      if (m_SelectedPacketIDs.size() > 0 and m_SelectedPacketIDs.find(packet_id) == m_SelectedPacketIDs.end())
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << __PRETTY_FUNCTION__ << ": Skipping packet id: " << packet_id << std::endl;
+        }
+
+        delete packet;
+        packet = nullptr;
+        continue;
+      }
+
       if (m_TpcTimeFrameBuilderMap.find(packet_id) == m_TpcTimeFrameBuilderMap.end())
       {
         if (Verbosity() >= 1)

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -109,6 +109,24 @@ SingleTpcTimeFrameInput::TimeTracker::~TimeTracker()
 
 void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
 {
+  {
+    bool first = true;
+    if (first)
+    {
+      first = false;
+
+      if (m_SelectedPacketIDs.size())
+      {
+        std::cout << "SingleTpcTimeFrameInput::" << Name() <<" : note, only processing packets with ID: ";
+        for (const auto &id : m_SelectedPacketIDs)
+        {
+          std::cout << id << " ";
+        }
+        std::cout << std::endl;
+      }
+    }
+  }
+
   TimeTracker fillPoolTimer(m_FillPoolTimer, "FillPool", m_hNorm);
 
   if ( (Verbosity() >= 1 and targetBCO % 941 == 0) or Verbosity() >= 2)

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.h
@@ -37,6 +37,8 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
 
+  void AddPacketID(const int packetID) { m_SelectedPacketIDs.insert(packetID); }
+
  private:
   const int NTPCPACKETS = 3;
 
@@ -47,7 +49,7 @@ class SingleTpcTimeFrameInput : public SingleStreamingInput
 
   //! packet ID -> TimeFrame builder
   std::map<int, TpcTimeFrameBuilder *> m_TpcTimeFrameBuilderMap;
-
+  std::set<int> m_SelectedPacketIDs;
   
   TH1 *m_hNorm = nullptr;
 

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -623,7 +623,7 @@ int TpcTimeFrameBuilder::process_fee_data(unsigned int fee)
     assert(data_buffer[2] == FEE_PACKET_MAGIC_KEY_2);
 
     // valid packet
-    const uint16_t& pkt_length = data_buffer[0];  // this is indeed the number of 10-bit words + 5 in this packet
+    const uint16_t pkt_length = data_buffer[0];  // this is indeed the number of 10-bit words + 5 in this packet
     if (pkt_length > MAX_PACKET_LENGTH)
     {
       if (m_verbosity > 1)
@@ -1472,8 +1472,8 @@ std::optional<uint64_t> TpcTimeFrameBuilder::BcoMatchingInformation::find_refere
 
   for (const m_gtm_fee_bco_matching_pair_t& bco : m_bco_reference_candidate_list)
   {
-    const uint64_t& gtm_bco = bco.first;
-    const uint32_t& fee_bco_predicted = bco.second;
+    const uint64_t gtm_bco = bco.first;
+    const uint32_t fee_bco_predicted = bco.second;
 
     // check if the predicted fee bco matches the actual fee bco
     if (get_fee_bco_diff(fee_bco_predicted, fee_bco) < m_max_fee_bco_diff)

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.cc
@@ -993,7 +993,7 @@ std::pair<uint16_t, uint16_t> TpcTimeFrameBuilder::crc16_parity(const uint32_t f
   std::deque<uint16_t>::const_iterator it = data_buffer.begin();
 
   uint16_t crc = 0xffffU;
-  uint16_t data_parity = 1U;
+  uint16_t data_parity = 0U;
 
   for (int i = 0; i < l; ++i, ++it)
   {

--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -63,8 +63,7 @@ class TpcTimeFrameBuilder
   static const uint16_t GL1_BCO_MATCH_WINDOW = 256;  // BCOs
 
   uint16_t reverseBits(const uint16_t x) const;
-  uint16_t crc16(const uint32_t fee, const uint32_t index, const int l) const;
-  uint16_t check_data_parity(const unsigned int fee, const unsigned int index, const int l) const;
+  std::pair<uint16_t, uint16_t> crc16_parity(const uint32_t fee, const uint16_t l) const;
 
   //! DMA word structure
   struct dma_word
@@ -94,7 +93,6 @@ class TpcTimeFrameBuilder
   {
     uint16_t fee_id = 0;
     uint16_t adc_length = 0;
-    uint16_t data_parity = 0;
     uint16_t sampa_address = 0;
     uint16_t sampa_channel = 0;
     uint16_t channel = 0;
@@ -105,6 +103,9 @@ class TpcTimeFrameBuilder
 
     uint16_t data_crc = 0;
     uint16_t calc_crc = 0;
+    
+    uint16_t data_parity = 0;
+    uint16_t calc_parity = 0;
 
     std::vector<std::pair<uint16_t, std::vector<uint16_t>>> waveforms;
   };
@@ -240,7 +241,7 @@ class TpcTimeFrameBuilder
 
     // get the difference between two BCO with rollover corrections
     inline static constexpr uint32_t get_fee_bco_diff(
-        const uint32_t &first, const uint32_t &second) // NOLINT(misc-unused-parameters)
+        const uint32_t &first, const uint32_t &second)  // NOLINT(misc-unused-parameters)
     {
       const uint32_t diff_raw = get_bco_diff(first, second);
 
@@ -296,7 +297,7 @@ class TpcTimeFrameBuilder
     static constexpr unsigned int m_max_matching_data_size = 10;
 
     //! max time in GTM BCO for FEE data to sync over to datastream
-    static constexpr unsigned int m_max_fee_sync_time = 1024*8;
+    static constexpr unsigned int m_max_fee_sync_time = 1024 * 8;
 
     static constexpr unsigned int m_FEE_CLOCK_BITS = 20;
     static constexpr unsigned int m_GTM_CLOCK_BITS = 40;
@@ -356,7 +357,6 @@ class TpcTimeFrameBuilder
   TH1 *h_GTMClockDiff_Dropped = nullptr;
   TH1 *h_TimeFrame_Matched_Size = nullptr;
 
-  
   TH2 *h_ProcessPacket_Time = nullptr;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

More performance tuning for TPC Time Frame building: 
* Faster CRC calculation based on iterator access. This seems drop CRC time cost from 14% of run time to 10% of run time.
* Add parity calculation along with CRC 
* Allow process a subset of packets 
* Iterator based adc decoding for a faster buffer access
* bug fixes 

Updated callgrind 
![callgrind out 25340](https://github.com/user-attachments/assets/85263f90-bbae-498c-8f6a-5b7a94cca27d)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

- #3254 
- #3248
- #3242 
- #3238 

