### PR TITLE
Fix out-of-bounds values being assigned valid strip indices in CylinderGeomIntt::find_strip_index_values

### DIFF
--- a/offline/packages/intt/CylinderGeomIntt.cc
+++ b/offline/packages/intt/CylinderGeomIntt.cc
@@ -210,11 +210,11 @@ void CylinderGeomIntt::find_strip_index_values(const int segment_z_bin, const do
 
   // get the strip z index
   double zup = (double) nstrips_z_sensor * strip_z / 2.0 + zpos;
-  strip_z_index = (int) (zup / strip_z);
+  strip_z_index = floor(zup / strip_z);
 
   // get the strip y index
   double yup = (double) nstrips_y_sensor * m_StripY / 2.0 + ypos;
-  strip_y_index = (int) (yup / m_StripY);
+  strip_y_index = floor(yup / m_StripY);
 
   /*
   std::cout << "segment_z_bin " << segment_z_bin << " ypos " << ypos << " zpos " << zpos << " zup " << zup << " yup " << yup << std::endl;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Currently, in `CylinderGeomIntt::find_strip_index_values`, local position on an INTT sensor surface is converted into strip indices by casting the ratio (distance along surface / strip length) to an int. This cast truncates the number, which in particular converts values like -0.1 (corresponding to a position that's not actually on the surface at all) to 0 (which is a valid strip index value). This means that positions not corresponding to any valid sensor for that surface are assigned valid strip indices.

This PR changes that int cast into a call to `floor()`, which does not have this issue; `floor(-0.1) = -1`, which is, as desired, not a valid strip index.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
Link to post in INTT Mattermost channel describing the issue and solution in more detail: https://chat.sdcc.bnl.gov/sphenix/pl/ac33dx368fyk8bxbeb95nhn9he
