### PR TITLE
fix: clear all bcos

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -319,29 +319,9 @@ void SingleInttPoolInput::Print(const std::string &what) const
 
 void SingleInttPoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
-  std::vector<uint64_t> toclearbclk;
-  for (const auto &iter : m_InttRawHitMap)
-  {
-    if (iter.first <= bclk)
-    {
-      for (auto pktiter : iter.second)
-      {
-        delete pktiter;
-      }
-      toclearbclk.push_back(iter.first);
-    }
-    else
-    {
-      break;
-    }
-  }
-  for (auto iter : toclearbclk)
-  {
-    m_BclkStack.erase(iter);
-    m_BeamClockFEE.erase(iter);
-    m_InttRawHitMap.erase(iter);
-  }
- 
+  m_BclkStack.erase(m_BclkStack.begin(), m_BclkStack.upper_bound(bclk));
+  m_BeamClockFEE.erase(m_BeamClockFEE.begin(), m_BeamClockFEE.upper_bound(bclk));
+  m_InttRawHitMap.erase(m_InttRawHitMap.begin(), m_InttRawHitMap.upper_bound(bclk));
 }
 
 bool SingleInttPoolInput::CheckPoolDepth(const uint64_t bclk)

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -258,35 +258,14 @@ void SingleMvtxPoolInput::Print(const std::string &what) const
 
 void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
-  std::vector<uint64_t> toclearbclk;
-  for (const auto &iter : m_MvtxRawHitMap)
+  m_BclkStack.erase(m_BclkStack.begin(), m_BclkStack.upper_bound(bclk));
+  m_MvtxRawHitMap.erase(m_MvtxRawHitMap.begin(), m_MvtxRawHitMap.upper_bound(bclk));
+  m_FeeStrobeMap.erase(m_FeeStrobeMap.begin(), m_FeeStrobeMap.upper_bound(bclk));
+  for(auto& [feeid, gtmbcoset] : m_FeeGTML1BCOMap)
   {
-    if (iter.first <= bclk)
-    {
-      for (auto pktiter : iter.second)
-      {
-        delete pktiter;
-      }
-      toclearbclk.push_back(iter.first);
-    }
-    else
-    {
-      break;
-    }
+    gtmbcoset.erase(gtmbcoset.begin(), gtmbcoset.upper_bound(bclk));
   }
-
-  for (auto iter : toclearbclk)
-  {
-    m_BclkStack.erase(iter);
-    m_MvtxRawHitMap[iter].clear();
-    m_MvtxRawHitMap.erase(iter);
-    m_FeeStrobeMap.erase(iter);
-
-    for (auto &[feeid, gtmbcoset] : m_FeeGTML1BCOMap)
-    {
-      gtmbcoset.erase(iter);
-    }
-  }
+  
 }
 
 bool SingleMvtxPoolInput::CheckPoolDepth(const uint64_t bclk)


### PR DESCRIPTION
There are cases where BCOs are added to the stack that have no hits, and thus they don't get cleared out properly leading to a memory blow up. This PR fixes the container cleanup to be more succinct and erase all BCOs less than the reference BCO

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

