### PR TITLE
Fix rare issue found in last night's test production and minor speed improvement 

### DIFF
--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
@@ -53,12 +53,12 @@ TpcRawHit *TpcRawHitContainerv3::AddHit()
 
 TpcRawHit *TpcRawHitContainerv3::AddHit(TpcRawHit *tpchit)
 {
-  if (dynamic_cast<TpcRawHitv3 *>(tpchit))
+  if (tpchit->IsA()==TpcRawHitv3::Class())
   {
     // fast add with move constructor to avoid ADC data copying
 
     TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1])
-        TpcRawHitv3(std::move(*(dynamic_cast<TpcRawHitv3 *>(tpchit))));
+        TpcRawHitv3(std::move(*(static_cast<TpcRawHitv3 *>(tpchit))));
     return newhit;
   }
   else

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -219,13 +219,13 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
         return;
       }
       evt.reset(GetEventiterator()->getNextEvent());
+      RunNumber(evt->getRunNumber());
     }
 
     if (Verbosity() > 2)
     {
       std::cout << "Fetching next Event" << evt->getEvtSequence() << std::endl;
     }
-    RunNumber(evt->getRunNumber());
     if (GetVerbosity() > 1)
     {
       evt->identify();

--- a/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
+++ b/offline/framework/fun4allraw/SingleTpcTimeFrameInput.cc
@@ -219,7 +219,18 @@ void SingleTpcTimeFrameInput::FillPool(const uint64_t targetBCO)
         return;
       }
       evt.reset(GetEventiterator()->getNextEvent());
+      RunNumber(0);
+    }
+
+    if (RunNumber() == 0)
+    {
       RunNumber(evt->getRunNumber());
+
+      if (Verbosity() >= 1)
+      {
+        std::cout << __PRETTY_FUNCTION__ << ": Fetching new file "<<FileName()
+        <<" for run "<<evt->getRunNumber()<<" with next Event # " << evt->getEvtSequence() << std::endl;
+      }
     }
 
     if (Verbosity() > 2)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

### Work around for data issue

Somehow the raw data file `TPC_ebdc02_physics-00051740-0013.evt` fetched a different run number of 11140 very late into the raw data file. This is the last raw data segment and likely corrupted at the end. This lead to a run number mismatch and crashed production for this run. 

This PR make a work around by fetching run number from first event in a segment 

### Speed improvement in RawHit container v3

@hupereir pointed out the `dynamic_cast` is slow and the `TpcRawHit *TpcRawHitContainerv3::AddHit(TpcRawHit *tpchit)` now use ROOT TClass to determine the RawHit class match. 

This improved this call time by more than 50% and 1% time overall

New callgrind graph: 
![callgrind out 18134](https://github.com/user-attachments/assets/2370845e-7601-47a4-88ed-8eb7de2e8082)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

- #3258
- #3255
- #3254 
- #3248
- #3242 
- #3238 