### PR TITLE
fix: turn off hit assoc

### DIFF
--- a/offline/packages/trackreco/PHTrackSeeding.h
+++ b/offline/packages/trackreco/PHTrackSeeding.h
@@ -58,7 +58,7 @@ class PHTrackSeeding : public SubsysReco
   TrkrClusterHitAssoc *_cluster_hit_map = nullptr;
   TrkrClusterIterationMapv1* _iteration_map;
   int _n_iteration;
-  bool do_hit_assoc = true;
+  bool do_hit_assoc = false;
   SvtxVertexMap *_vertex_map = nullptr;
   TrackSeedContainer *_track_map = nullptr;
   TrkrHitSetContainer  *_hitsets = nullptr;


### PR DESCRIPTION
When running over cluster DSTs, this lack of the clusterhit association node prints out an error message. This suppresses that, as the node is not used in our default track seeding

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

