### PR TITLE
add CompressionSetting() to Fun4AllOutputManager base class

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -33,7 +33,7 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   int Write(PHCompositeNode *startNode) override;
   int WriteNode(PHCompositeNode *thisNode) override;
   std::string UsedOutFileName() const { return m_UsedOutFileName; }
-  void CompressionSetting(const int i) { m_CompressionSetting = i; }
+  void CompressionSetting(const int i) override { m_CompressionSetting = i; }
 
  private:
   int outfile_open_first_write();

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -98,6 +98,9 @@ class Fun4AllOutputManager : public Fun4AllBase
   virtual void SetEventsWritten(const unsigned int i) { m_NEvents = i; }
   //! get output file name
   virtual std::string OutFileName() const { return m_OutFileName; }
+  //! set compression level (if implemented)
+  virtual void CompressionSetting(const int /*i*/) { return; }
+
   void OutFileName(const std::string &name) { m_OutFileName = name; }
   void SetClosingScript(const std::string &script) { m_RunAfterClosingScript = script; }
   void SetClosingScriptArgs(const std::string &args) { m_ClosingArgs = args; }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the compression level setting to the Fun4AllOutputManager base class. It's just implemented for DSTs but maybe one day we'll compress other output as well

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

