### PR TITLE
Setting ghost selection to highest values as default

### DIFF
--- a/offline/packages/trackreco/PHGhostRejection.h
+++ b/offline/packages/trackreco/PHGhostRejection.h
@@ -52,16 +52,21 @@ class PHGhostRejection
   void set_min_pt_cut(float _ptmin) { _min_pt= _ptmin; }
   void set_must_span_sectors(bool _setting) { _must_span_sectors = _setting; }
   void set_min_clusters (int _val) { _min_clusters = _val; }
+  void set_phi_cut(double d) { _phi_cut = d; }
+  void set_eta_cut(double d) { _eta_cut = d; }
+  void set_x_cut(double d) { _x_cut = d; }
+  void set_y_cut(double d) { _y_cut = d; }
+  void set_z_cut(double d) { _z_cut = d; }
 
  private:
   unsigned int m_verbosity;
   std::vector<TrackSeed_v2>& seeds;
   std::vector<bool> m_rejected {}; // id
-  double _phi_cut = 0.01;
-  double _eta_cut = 0.004;
-  double _x_cut = 0.3;
-  double _y_cut = 0.3;
-  double _z_cut = 0.4;
+  double _phi_cut = std::numeric_limits<double>::max();
+  double _eta_cut = std::numeric_limits<double>::max();
+  double _x_cut = std::numeric_limits<double>::max();
+  double _y_cut = std::numeric_limits<double>::max();
+  double _z_cut = std::numeric_limits<double>::max();
 
   // cuts on minimally interesting tracks --
   // here to remove noise

--- a/offline/packages/trackreco/PHSimpleKFProp.cc
+++ b/offline/packages/trackreco/PHSimpleKFProp.cc
@@ -1357,6 +1357,11 @@ void PHSimpleKFProp::rejectAndPublishSeeds(std::vector<TrackSeed_v2>& seeds, con
 {
   // testing with presets for rejection
   PHGhostRejection rejector(Verbosity(), seeds);
+  rejector.set_phi_cut(_ghost_phi_cut);
+  rejector.set_eta_cut(_ghost_eta_cut);
+  rejector.set_x_cut(_ghost_x_cut);
+  rejector.set_y_cut(_ghost_y_cut);
+  rejector.set_z_cut(_ghost_z_cut);
   // If you want to reject tracks (before they are are made) can set them here:
   // rejector.set_min_pt_cut(0.2);
   // rejector.set_must_span_sectors(true);

--- a/offline/packages/trackreco/PHSimpleKFProp.h
+++ b/offline/packages/trackreco/PHSimpleKFProp.h
@@ -24,6 +24,7 @@
 #include <Eigen/Core>
 
 // STL includes
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -82,6 +83,12 @@ class PHSimpleKFProp : public SubsysReco
   void setCF4Fraction(double frac) { CF4_frac = frac; };
   void setNitrogenFraction(double frac) { N2_frac = frac; };
   void setIsobutaneFraction(double frac) { isobutane_frac = frac; };
+
+  void set_ghost_phi_cut(double d) { _ghost_phi_cut = d; }
+  void set_ghost_eta_cut(double d) { _ghost_eta_cut = d; }
+  void set_ghost_x_cut(double d) { _ghost_x_cut = d; }
+  void set_ghost_y_cut(double d) { _ghost_y_cut = d; }
+  void set_ghost_z_cut(double d) { _ghost_z_cut = d; }
 
  private:
   bool _use_truth_clusters = false;
@@ -187,6 +194,12 @@ class PHSimpleKFProp : public SubsysReco
   double CF4_frac = 0.20;
   double N2_frac = 0.00;
   double isobutane_frac = 0.05;
+
+  double _ghost_phi_cut = std::numeric_limits<double>::max();
+  double _ghost_eta_cut = std::numeric_limits<double>::max();
+  double _ghost_x_cut = std::numeric_limits<double>::max();
+  double _ghost_y_cut = std::numeric_limits<double>::max();
+  double _ghost_z_cut = std::numeric_limits<double>::max();
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

These changes aim to improve the ghost tracks removal.

- Setting the track ghost selection to the highest values in order to bypass it and go directly to track cluster keys comparisons.
- Setter functions where added to PHGhostRejection and PHSimpleKFProp in order to allow changes in the cuts at macro level.


