### PR TITLE
fix: memory leak

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -321,6 +321,13 @@ void SingleInttPoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
   m_BclkStack.erase(m_BclkStack.begin(), m_BclkStack.upper_bound(bclk));
   m_BeamClockFEE.erase(m_BeamClockFEE.begin(), m_BeamClockFEE.upper_bound(bclk));
+  for(auto it = m_InttRawHitMap.begin(); it != m_InttRawHitMap.end() && (it->first <= bclk); it = m_InttRawHitMap.erase(it))
+  {
+    for( const auto& rawhit : it->second)
+    {
+      delete rawhit;
+    }
+  }
   m_InttRawHitMap.erase(m_InttRawHitMap.begin(), m_InttRawHitMap.upper_bound(bclk));
 }
 

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -259,6 +259,13 @@ void SingleMvtxPoolInput::Print(const std::string &what) const
 void SingleMvtxPoolInput::CleanupUsedPackets(const uint64_t bclk)
 {
   m_BclkStack.erase(m_BclkStack.begin(), m_BclkStack.upper_bound(bclk));
+  for(auto it = m_MvtxRawHitMap.begin(); it != m_MvtxRawHitMap.end() && (it->first <= bclk); it = m_MvtxRawHitMap.erase(it))
+  {
+    for( const auto& rawhit : it->second)
+    {
+      delete rawhit;
+    }
+  }
   m_MvtxRawHitMap.erase(m_MvtxRawHitMap.begin(), m_MvtxRawHitMap.upper_bound(bclk));
   m_FeeStrobeMap.erase(m_FeeStrobeMap.begin(), m_FeeStrobeMap.upper_bound(bclk));
   for(auto& [feeid, gtmbcoset] : m_FeeGTML1BCOMap)


### PR DESCRIPTION
I introduced a memory leak into the pool inputs that evaded Jenkins. It turns out that the default valgrind job on the streaming input is not actually running properly. See for example a log from a recent PR [here](https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-default-valgrind-StreamingProduction/1159/artifact/macros/StreamingProduction/Fun4All_Stream_Combiner.C.log/*view*/). Interestingly Jenkins marks it as successful even the job doesn't run properly. @blackcathj is there an easy way to fix this?

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

