### PR TITLE
hide boost include from cling

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -23,9 +23,9 @@
 #include <Acts/Utilities/Logger.hpp>
 
 #include <ActsExamples/Detector/TGeoDetectorWithOptions.hpp>
-
+#ifndef __CLING__
 #include <boost/program_options.hpp>
-
+#endif
 #include <map>
 #include <memory>
 #include <string>
@@ -169,11 +169,12 @@ class MakeActsGeometry : public SubsysReco
   /// Function that mimics ActsExamples::GeometryExampleBase
   void makeGeometry(int argc, char *argv[],
                     ActsExamples::TGeoDetectorWithOptions &detector);
+#ifndef __CLING__
   std::pair<std::shared_ptr<const Acts::TrackingGeometry>,
             std::vector<std::shared_ptr<ActsExamples::IContextDecorator>>>
   build(const boost::program_options::variables_map &vm,
         ActsExamples::TGeoDetectorWithOptions &detector);
-
+#endif
   void readTGeoLayerBuilderConfigsFile(const std::string &path,
                                        ActsExamples::TGeoDetector::Config &config);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
the new root version with gcc 14 chokes on boost/program_options.hpp, hiding it from cling makes this work

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

