### PR TITLE
Changes to CaloTowerCalib to use direct URL for meantime and ZS cross calib when given before looking for CDBtree in run range

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -66,6 +66,12 @@ class CaloTowerBuilder : public SubsysReco
     m_bdosoftwarezerosuppression = usezerosuppression;
   }
 
+  void set_inputNodePrefix(const std::string &name)
+  {
+    m_inputNodePrefix = name;
+    return;
+  }
+
   void set_outputNodePrefix(const std::string &name)
   {
     m_outputNodePrefix = name;

--- a/offline/packages/CaloReco/CaloTowerCalib.cc
+++ b/offline/packages/CaloReco/CaloTowerCalib.cc
@@ -214,22 +214,22 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
   m_calibName_time = m_detector + "_meanTime";
   m_fieldname_time = "time";
 
-  std::string calibdir = CDBInterface::instance()->getUrl(m_calibName_time);
-  if (!calibdir.empty())
+  if (m_giveDirectURL_time)
   {
+    calibdir = m_directURL_time;
+    std::cout << "CaloTowerCalib::InitRun: Using setted url " << calibdir << std::endl;
     cdbttree_time = new CDBTTree(calibdir);
-    if (Verbosity() > 0)
-    {
-      std::cout << "CaloTowerCalib:InitRun Found " << m_calibName_time << " doing time calibration" << std::endl;
-    }
   }
   else
   {
-    if (m_giveDirectURL_time)
+    std::string calibdir = CDBInterface::instance()->getUrl(m_calibName_time);
+    if (!calibdir.empty())
     {
-      calibdir = m_directURL_time;
-      std::cout << "CaloTowerCalib::InitRun: Using setted url " << calibdir << std::endl;
       cdbttree_time = new CDBTTree(calibdir);
+      if (Verbosity() > 0)
+      {
+        std::cout << "CaloTowerCalib:InitRun Found " << m_calibName_time << " doing time calibration" << std::endl;
+      }
     }
     else
     {
@@ -245,24 +245,24 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
   m_calibName_ZScrosscalib = m_detector + "_ZSCrossCalib";
   m_fieldname_ZScrosscalib = "ratio";
 
-  if (m_doZScrosscalib) //possibly get rid of
-  { //possibly get rid of
-    calibdir = CDBInterface::instance()->getUrl(m_calibName_ZScrosscalib);
-    if (!calibdir.empty())
+  if (m_doZScrosscalib) 
+  { 
+    if (m_giveDirectURL_ZScrosscalib)
     {
+      calibdir = m_directURL_ZScrosscalib;
+      std::cout << "CaloTowerCalib::InitRun: Using setted url " << calibdir << std::endl;
       cdbttree_ZScrosscalib = new CDBTTree(calibdir);
-      if (Verbosity() > 0)
-      {
-        std::cout << "CaloTowerCalib:InitRun Found " << m_calibName_ZScrosscalib << " doing ZS cross calibration" << std::endl;
-      }
-    }
+    } 
     else
     {
-      if (m_giveDirectURL_ZScrosscalib)
+      calibdir = CDBInterface::instance()->getUrl(m_calibName_ZScrosscalib);
+      if (!calibdir.empty())
       {
-        calibdir = m_directURL_ZScrosscalib;
-        std::cout << "CaloTowerCalib::InitRun: Using setted url " << calibdir << std::endl;
         cdbttree_ZScrosscalib = new CDBTTree(calibdir);
+        if (Verbosity() > 0)
+        {
+          std::cout << "CaloTowerCalib:InitRun Found " << m_calibName_ZScrosscalib << " doing ZS cross calibration" << std::endl;
+        }
       }
       else
       {
@@ -273,7 +273,7 @@ int CaloTowerCalib::InitRun(PHCompositeNode *topNode)
         }
       }
     }
-  } //possibly get rid of
+  } 
 
   PHNodeIterator iter(topNode);
 
@@ -317,6 +317,7 @@ int CaloTowerCalib::process_event(PHCompositeNode *topNode)
     float raw_amplitude = caloinfo_raw->get_energy();
     float calibconst = cdbttree->GetFloatValue(key, m_fieldname);
     bool isZS = caloinfo_raw->get_isZS();
+
     if (isZS && m_doZScrosscalib)
     {
       float crosscalibconst = cdbttree_ZScrosscalib->GetFloatValue(key, m_fieldname_ZScrosscalib);


### PR DESCRIPTION
Changes to CaloTowerCalib to use direct URL for meantime and ZS cross calib when given before looking for CDBtree in run range. Additional change to CaloTowerBuilder to include setter for input node.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

