### PR TITLE
fix: minimum bco check

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -194,7 +194,11 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
           int nbcos = pool->iValue(fee, "FEE_BCOS");
           for (int k = 0; k < nbcos; k++)
           {
-            auto bco = pool->lValue(fee, k, "BCOVAL");
+            uint64_t bco = pool->lValue(fee, k, "BCOVAL");
+            if(bco < minBCO)
+            {
+              continue;
+            }
             m_FeeGTML1BCOMap[fee].insert(bco);
           }
         }


### PR DESCRIPTION
At least one instance of the INTT decoder memory spiking is from cases where suddenly there are many BCOs put into one of the QA maps that are way less than the reference BCO. It is unclear why this happens at all, but this PR adds a protection for this situation.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

