### PR TITLE
Fix sync

### DIFF
--- a/offline/framework/ffaobjects/SyncObject.cc
+++ b/offline/framework/ffaobjects/SyncObject.cc
@@ -55,5 +55,9 @@ int SyncObject::Different(const SyncObject* other) const
   {
     iret |= 0x2;
   }
+  if (SegmentNumber() != other->SegmentNumber())
+  {
+    iret |= 0x4;
+  }
   return iret;
 }

--- a/offline/framework/ffaobjects/SyncObject.cc
+++ b/offline/framework/ffaobjects/SyncObject.cc
@@ -44,20 +44,20 @@ SyncObject::operator=(const SyncObject& source)
   return *this;
 }
 
-int SyncObject::Different(const SyncObject* other) const
+unsigned int SyncObject::Different(const SyncObject* other) const
 {
-  int iret = 0;
+  unsigned int iret = 0;
   if (EventNumber() != other->EventNumber())
   {
-    iret += 0x1;
+    iret += 0x1U;
   }
   if (RunNumber() != other->RunNumber())
   {
-    iret |= 0x2;
+    iret |= 0x2U;
   }
   if (SegmentNumber() != other->SegmentNumber())
   {
-    iret |= 0x4;
+    iret |= 0x4U;
   }
   return iret;
 }

--- a/offline/framework/ffaobjects/SyncObject.h
+++ b/offline/framework/ffaobjects/SyncObject.h
@@ -30,7 +30,7 @@ class SyncObject : public PHObject
 
   PHObject* CloneMe() const override;
   SyncObject& operator=(const SyncObject& source);
-  virtual int Different(const SyncObject* other) const;
+  virtual unsigned int Different(const SyncObject* other) const;
 
   /// set Event Counter
   virtual void EventCounter(const int /*ival*/) { return; }

--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -287,8 +287,8 @@ int Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
       {
         std::cout << "Need to Resync, mastersync evt no: " << mastersync->EventNumber()
                   << ", this Event no: " << syncobject->EventNumber() << std::endl;
-        std::cout << "mastersync evt counter: " << mastersync->EventCounter()
-                  << ", this Event counter: " << syncobject->EventCounter() << std::endl;
+        std::cout << "mastersync evt counter: " << mastersync->EventNumber()
+                  << ", this Event counter: " << syncobject->EventNumber() << std::endl;
         std::cout << "mastersync run number: " << mastersync->RunNumber()
                   << ", this run number: " << syncobject->RunNumber() << std::endl;
       }
@@ -338,14 +338,14 @@ int Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
       {
         igood = 0;
       }
-      while (syncobject->EventCounter() < mastersync->EventCounter() && igood)
+      while (syncobject->EventNumber() < mastersync->EventNumber() && igood)
       {
         events_skipped_during_sync++;
         if (Verbosity() > 2)
         {
           std::cout << Name()
-                    << ", EventCounter: " << syncobject->EventCounter()
-                    << ", master: " << mastersync->EventCounter()
+                    << ", EventNumber: " << syncobject->EventNumber()
+                    << ", master: " << mastersync->EventNumber()
                     << std::endl;
         }
         iret = ReadNextEventSyncObject();
@@ -355,14 +355,14 @@ int Fun4AllDstInputManager::SyncIt(const SyncObject *mastersync)
         }
       }
       // Since up to here we only read the sync object we need to push
-      // the current event back inot the root file (subtract one from the
+      // the current event back into the root file (subtract one from the
       // local root file event counter) so we can read the full event
       // if it syncs, if it does not sync we also read one event too many
       // (otherwise we cannot determine that we are "too far")
       // and also have to push this one back
       PushBackEvents(1);
       if (syncobject->RunNumber() > mastersync->RunNumber() ||        // check if run number too large
-          syncobject->EventCounter() > mastersync->EventCounter() ||  // check if event counter too large
+          syncobject->EventNumber() > mastersync->EventNumber() ||  // check if event counter too large
           syncobject->SegmentNumber() > mastersync->SegmentNumber())  // check segment number too large
       {
         // the event from first file which determines the mastersync


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The synchronization was still based on the PHENIX data. The underlying assumption here was that even though the events are written asynchronously and saved into 6 different files, all DSTs come from the same source. For this reason it employed an event counter (just the position of an event in its raw data file) and the segment number. This gave enough information to figure out what to skip to find the next matching event. Run number and actual event number were just the final crosscheck.

In sPHENIX we have different sources for the raw data and the event counters and segment numbers are not preserved across subsystems. But in sPHENIX events are sorted which makes this a lot simpler and finding the next match easy (the run number is still consulted, so we don't mix runs). For our simulations it's not that simple, every event generator starts at event one, so each of our simulation files has the same event numbers (or uses the one from hijing where we repeat after 10000 events). For that reason the synchronization uses the segment number which distinguishes the simulation events from different input files. In real data, the segment number is zero.

While working on this I discovered an issue that for simulations it was actually possible to read the 0th segment of one dst type and the first segment of another and the synchronisation happily combined those events. That's not happening anymore once this PR is merged

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

