### PR TITLE
BCOOffset is loaded from CDB and set it in combiner in order to get p…

### DIFF
--- a/offline/packages/intt/InttBCOMap.h
+++ b/offline/packages/intt/InttBCOMap.h
@@ -18,7 +18,7 @@ class InttBCOMap
   virtual int LoadFromFile(std::string const &filename);
 
   virtual bool IsBad(int const &felix_server,
-                     int const &fexlix_channel,
+                     int const &felix_channel,
                      uint64_t const &bco_full,
                      const int &bco);
 
@@ -29,6 +29,7 @@ class InttBCOMap
 
  protected:
   int LoadFromCDBTTree(CDBTTree &cdbttree);
+  int GetFeeOffSet();
 
  private:
   typedef std::array<std::array<int, 14>, 8> BCOArray;

--- a/offline/packages/intt/InttCombinedRawDataDecoder.cc
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.cc
@@ -140,15 +140,19 @@ int InttCombinedRawDataDecoder::InitRun(PHCompositeNode* topNode)
   ///////////////////////////////////////
   std::cout << "calibinfo BCO : " << m_calibinfoBCO.first << " " << (m_calibinfoBCO.second == CDB ? "CDB" : "FILE") << std::endl;
   m_bcomap.Verbosity(Verbosity());
+  int temp_offset = 0;
   if (m_calibinfoBCO.second == CDB)
   {
-    m_bcomap.LoadFromCDB(m_calibinfoBCO.first);
+    temp_offset = m_bcomap.LoadFromCDB(m_calibinfoBCO.first);
   }
   else
   {
-    m_bcomap.LoadFromFile(m_calibinfoBCO.first);
+    temp_offset = m_bcomap.LoadFromFile(m_calibinfoBCO.first);
   }
-
+  if(m_triggeredMode)
+  {
+    set_inttFeeOffset(temp_offset);
+  }
   ///////////////////////////////////////
   //
   std::cout << "Intt BadChannelMap : size = " << m_HotChannelSet.size() << "  ";
@@ -257,7 +261,7 @@ int InttCombinedRawDataDecoder::process_event(PHCompositeNode* topNode)
 
     ////////////////////////
     // bco filter
-    if (m_bcomap.IsBad(raw, bco_full, bco))
+    if (m_bcomap.IsBad(raw, bco_full, bco) && m_bcoFilter)
     {
       // std::cout<<"bad bco removed : "<<raw.felix_server<<" "<<raw.felix_channel<<" "<<raw.chip<<" "<<raw.channel<<std::endl;
       continue;

--- a/offline/packages/intt/InttCombinedRawDataDecoder.h
+++ b/offline/packages/intt/InttCombinedRawDataDecoder.h
@@ -49,7 +49,7 @@ class InttCombinedRawDataDecoder : public SubsysReco
   void set_inttFeeOffset(int offset) { m_inttFeeOffset = offset; }
   void set_outputBcoDiff(bool flag) {m_outputBcoDiff = flag; }
   void set_triggeredMode(bool flag) {m_triggeredMode = flag; }
-
+  void set_bcoFilter(bool flag) {m_bcoFilter = flag; }
  private:
   InttEventInfo* intt_event_header = nullptr;
   std::string m_InttRawNodeName = "INTTRAWHIT";
@@ -57,7 +57,7 @@ class InttCombinedRawDataDecoder : public SubsysReco
   Set_t m_HotChannelSet;
   bool m_runStandAlone = false;
   bool m_writeInttEventHeader = false;
-
+  bool m_bcoFilter = false;
   std::pair<std::string, CalibRef> m_calibinfoDAC;
   std::pair<std::string, CalibRef> m_calibinfoBCO;
 


### PR DESCRIPTION
…roper time-bucket info in trigger mode

[comment]: <> (Please tell us something about this pull request)
1. Adding the feature to load BCOoffset from CDB database and applying to Combiner in order to get proper Timing OffSet.
2. BCOFiltering is set to OFF by default, since now that is one of offline analysis cut no longer necessary in general. Especially streaming and extended readout trigger mode should not filter the data based on BCO value.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

