### PR TITLE
Split CylinderGeom_Mvtx functionality to helper class

### DIFF
--- a/offline/packages/TrackingDiagnostics/Makefile.am
+++ b/offline/packages/TrackingDiagnostics/Makefile.am
@@ -12,10 +12,10 @@ AM_LDFLAGS = \
 
 pkginclude_HEADERS = \
   BeamCrossingAnalysis.h \
-  KshortReconstruction.h \
   helixResiduals.h \
-  TrackResiduals.h \
+  KshortReconstruction.h \
   TrackContainerCombiner.h \
+  TrackResiduals.h \
   TrackSeedTrackMapConverter.h \
   TrkrNtuplizer.h
 
@@ -24,10 +24,10 @@ lib_LTLIBRARIES = \
 
 libTrackingDiagnostics_la_SOURCES = \
   BeamCrossingAnalysis.cc \
-  KshortReconstruction.cc \
   helixResiduals.cc \
-  TrackResiduals.cc \
+  KshortReconstruction.cc \
   TrackContainerCombiner.cc \
+  TrackResiduals.cc \
   TrackSeedTrackMapConverter.cc \
   TrkrNtuplizer.cc
 
@@ -38,15 +38,16 @@ libTrackingDiagnostics_la_LIBADD = \
   -lg4eval_io \
   -lphg4hit \
   -lg4detectors_io \
-  -ltrack_io \
-  -ltrackbase_historic_io \
-  -ltpc_io \
+  -lmvtx \
   -lmvtx_io \
   -lintt \
   -lintt_io \
   -lmicromegas_io \
   -lSubsysReco \
-  -ltrackeralign
+  -ltpc_io \
+  -ltrack_io \
+  -ltrackeralign \
+  -ltrackbase_historic_io
 
 BUILT_SOURCES = testexternals.cc
 

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -23,6 +23,7 @@
 #include <micromegas/MicromegasDefs.h>
 
 #include <mvtx/CylinderGeom_Mvtx.h>
+#include <mvtx/CylinderGeom_MvtxHelper.h>
 
 #include <trackbase_historic/ActsTransformations.h>
 #include <trackbase_historic/SvtxAlignmentState.h>
@@ -871,7 +872,7 @@ void TrackResiduals::fillHitTree(TrkrHitSetContainer* hitmap,
         local.SetX(local_coords.X());
         local.SetY(local_coords.Z());
         auto surf = geometry->maps().getSiliconSurface(m_hitsetkey);
-        auto glob = layergeom->get_world_from_local_coords(surf, geometry, local);
+        auto glob = CylinderGeom_MvtxHelper::get_world_from_local_coords(surf, geometry, local);
         m_hitgx = glob.X();
         m_hitgy = glob.Y();
         m_hitgz = glob.Z();

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.cc
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.cc
@@ -2,8 +2,6 @@
 
 #include "SegmentationAlpide.h"
 
-#include <Acts/Definitions/Units.hpp>
-
 #include <TRotation.h>
 #include <TVector3.h>
 
@@ -74,25 +72,6 @@ CylinderGeom_Mvtx::CylinderGeom_Mvtx(
   return;
 }
 
-TVector3
-CylinderGeom_Mvtx::get_local_from_world_coords(const Surface& surface,
-                                               ActsGeometry* tGeometry,
-                                               TVector3 world)
-{
-  Acts::Vector3 global;
-  global(0) = world[0];
-  global(1) = world[1];
-  global(2) = world[2];
-
-  global *= Acts::UnitConstants::cm;
-
-  Acts::Vector3 local = surface->transform(tGeometry->geometry().getGeoContext()).inverse() * global;
-  local /= Acts::UnitConstants::cm;
-
-  /// The Acts transform swaps a few of the coordinates
-  return TVector3(local(0), local(2) * -1, local(1));
-}
-
 void CylinderGeom_Mvtx::get_sensor_indices_from_world_coords(std::vector<double>& world, unsigned int& stave_index, unsigned int& chip_index)
 {
   // stave number is fom phi
@@ -116,39 +95,6 @@ void CylinderGeom_Mvtx::get_sensor_indices_from_world_coords(std::vector<double>
   chip_index = chip_tmp;
 }
 
-TVector3
-CylinderGeom_Mvtx::get_world_from_local_coords(const Surface& surface, ActsGeometry* tGeometry, const TVector2& local)
-{
-  Acts::Vector2 actslocal;
-  actslocal(0) = local.X();
-  actslocal(1) = local.Y();
-  actslocal *= Acts::UnitConstants::cm;
-
-  Acts::Vector3 global;
-  /// Acts requires a dummy vector to be passed in the arg list
-  global = surface->localToGlobal(tGeometry->geometry().getGeoContext(),
-                                  actslocal, Acts::Vector3(1, 1, 1));
-  global /= Acts::UnitConstants::cm;
-
-  TVector3 res;
-  res[0] = global(0);
-  res[1] = global(1);
-  res[2] = global(2);
-
-  return res;
-}
-
-TVector3
-CylinderGeom_Mvtx::get_world_from_local_coords(const Surface& surface, ActsGeometry* tGeometry, const TVector3& local)
-{
-  Acts::Vector3 loc(local.x(), local.y(), local.z());
-  loc *= Acts::UnitConstants::cm;
-
-  Acts::Vector3 glob = surface->transform(tGeometry->geometry().getGeoContext()) * loc;
-  glob /= Acts::UnitConstants::cm;
-
-  return TVector3(glob(0), glob(1), glob(2));
-}
 bool CylinderGeom_Mvtx::get_pixel_from_local_coords(TVector3 sensor_local, int& iRow, int& iCol)
 {
   // YCM (2020-01-02): It seems that due some round issues, local coords of hits at the edge of the sensor volume
@@ -232,19 +178,6 @@ void CylinderGeom_Mvtx::identify(std::ostream& os) const
      << ", pixel_z: " << pixel_z
      << ", pixel_thickness: " << pixel_thickness
      << endl;
-  return;
-}
-
-void CylinderGeom_Mvtx::find_sensor_center(const Surface& surface, ActsGeometry* tGeometry, double location[])
-{
-  TVector2 sensor_local(0.0, 0.0);
-
-  TVector3 sensor_world = get_world_from_local_coords(surface, tGeometry, sensor_local);
-
-  location[0] = sensor_world.X();
-  location[1] = sensor_world.Y();
-  location[2] = sensor_world.Z();
-
   return;
 }
 

--- a/offline/packages/mvtx/CylinderGeom_Mvtx.h
+++ b/offline/packages/mvtx/CylinderGeom_Mvtx.h
@@ -2,8 +2,6 @@
 #define MVTX_CYLINDERGEOMMVTX_H
 
 #include <g4detectors/PHG4CylinderGeom.h>
-
-#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <TVector3.h>
@@ -47,11 +45,6 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
   double get_pixel_z() const override { return pixel_z; }  // length
   double get_pixel_thickness() const override { return pixel_thickness; }
 
-  // our own - no override
-  TVector3 get_local_from_world_coords(const Surface& surface, ActsGeometry* tGeometry, TVector3 world);
-  TVector3 get_world_from_local_coords(const Surface& surface, ActsGeometry* tGeometry, const TVector2& local);
-  TVector3 get_world_from_local_coords(const Surface& surface, ActsGeometry* tGeometry, const TVector3& local);
-
   void get_sensor_indices_from_world_coords(std::vector<double>& world, unsigned int& stave, unsigned int& chip);
 
   bool get_pixel_from_local_coords(TVector3 sensor_local, int& iRow, int& iCol);
@@ -71,8 +64,6 @@ class CylinderGeom_Mvtx : public PHG4CylinderGeom
 
   int get_ladder_phi_index(int stave, int /*half_stave*/, int /*chip*/) { return stave; }
   int get_ladder_z_index(int /*module*/, int chip) { return chip; }
-
-  void find_sensor_center(const Surface& surface, ActsGeometry* tGeometry, double location[]);
 
   int get_N_staves() const { return N_staves; }
   int get_N_half_staves() const { return N_half_staves; }

--- a/offline/packages/mvtx/CylinderGeom_MvtxHelper.cc
+++ b/offline/packages/mvtx/CylinderGeom_MvtxHelper.cc
@@ -1,0 +1,91 @@
+#include "CylinderGeom_MvtxHelper.h"
+
+#include "SegmentationAlpide.h"
+
+#include <Acts/Definitions/Units.hpp>
+
+#include <TRotation.h>
+#include <TVector3.h>
+
+#include <cmath>
+#include <ostream>  // for operator<<, basic_ostream::operator<<, basic_...
+
+TVector3
+CylinderGeom_MvtxHelper::get_local_from_world_coords (
+  const Surface& surface,
+  ActsGeometry* tGeometry,
+  TVector3 world
+) {
+  Acts::Vector3 global;
+  global(0) = world[0];
+  global(1) = world[1];
+  global(2) = world[2];
+
+  global *= Acts::UnitConstants::cm;
+
+  Acts::Vector3 local = surface->transform(tGeometry->geometry().getGeoContext()).inverse() * global;
+  local /= Acts::UnitConstants::cm;
+
+  /// The Acts transform swaps a few of the coordinates
+  return TVector3(local(0), local(2) * -1, local(1));
+}
+
+TVector3
+CylinderGeom_MvtxHelper::get_world_from_local_coords (
+  const Surface& surface,
+  ActsGeometry* tGeometry,
+  const TVector2& local
+) {
+  Acts::Vector2 actslocal;
+  actslocal(0) = local.X();
+  actslocal(1) = local.Y();
+  actslocal *= Acts::UnitConstants::cm;
+
+  Acts::Vector3 global;
+  /// Acts requires a dummy vector to be passed in the arg list
+  global = surface->localToGlobal (
+    tGeometry->geometry().getGeoContext(),
+    actslocal,
+    Acts::Vector3(1, 1, 1)
+  );
+  global /= Acts::UnitConstants::cm;
+
+  TVector3 res;
+  res[0] = global(0);
+  res[1] = global(1);
+  res[2] = global(2);
+
+  return res;
+}
+
+TVector3
+CylinderGeom_MvtxHelper::get_world_from_local_coords (
+  const Surface& surface,
+  ActsGeometry* tGeometry,
+  const TVector3& local
+) {
+  Acts::Vector3 loc(local.x(), local.y(), local.z());
+  loc *= Acts::UnitConstants::cm;
+
+  Acts::Vector3 glob = surface->transform(tGeometry->geometry().getGeoContext()) * loc;
+  glob /= Acts::UnitConstants::cm;
+
+  return TVector3(glob(0), glob(1), glob(2));
+}
+
+void CylinderGeom_MvtxHelper::find_sensor_center (
+		const Surface& surface,
+		ActsGeometry* tGeometry,
+		double* location
+) {
+  TVector2 sensor_local(0.0, 0.0);
+
+  TVector3 sensor_world = get_world_from_local_coords(surface, tGeometry, sensor_local);
+
+  location[0] = sensor_world.X();
+  location[1] = sensor_world.Y();
+  location[2] = sensor_world.Z();
+
+  return;
+}
+

--- a/offline/packages/mvtx/CylinderGeom_MvtxHelper.h
+++ b/offline/packages/mvtx/CylinderGeom_MvtxHelper.h
@@ -1,0 +1,48 @@
+#ifndef MVTX_CYLINDERGEOMMVTXHELPER_H
+#define MVTX_CYLINDERGEOMMVTXHELPER_H
+
+#include <g4detectors/PHG4CylinderGeom.h>
+
+#include <trackbase/ActsGeometry.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <TVector3.h>
+
+#include <iostream>
+
+class CylinderGeom_MvtxHelper
+{
+ public:
+
+  // our own - no override
+  TVector3 static
+  get_local_from_world_coords (
+    Surface const& surface,
+    ActsGeometry* tGeometry,
+    TVector3 world
+  );
+
+  TVector3 static
+  get_world_from_local_coords (
+    Surface const& surface,
+    ActsGeometry* tGeometry,
+    TVector2 const& local
+  );
+
+  TVector3 static
+  get_world_from_local_coords (
+    Surface const& surface,
+    ActsGeometry* tGeometry,
+    TVector3 const& local
+  );
+
+  void static
+  find_sensor_center (
+    Surface const& surface,
+    ActsGeometry* tGeometry,
+    double* location
+  );
+
+};
+
+#endif

--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -19,14 +19,15 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib64
 
 pkginclude_HEADERS = \
+  CylinderGeom_Mvtx.h \
+  CylinderGeom_MvtxHelper.h \
+  MvtxCombinedRawDataDecoder.h \
   MvtxClusterizer.h \
   MvtxHitPruner.h \
   MvtxNoiseMap.h \
-  MvtxCombinedRawDataDecoder.h \
-  CylinderGeom_Mvtx.h \
-  SegmentationAlpide.h \
   MvtxPixelDefs.h \
-  MvtxPixelMask.h
+  MvtxPixelMask.h \
+  SegmentationAlpide.h
 
 ROOTDICTS = \
   CylinderGeom_Mvtx_Dict.cc \
@@ -35,29 +36,31 @@ ROOTDICTS = \
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   CylinderGeom_Mvtx_Dict_rdict.pcm \
-	MvtxNoiseMap_Dict_rdict.pcm
+  MvtxNoiseMap_Dict_rdict.pcm
 
 # sources for mvtx library
 libmvtx_la_SOURCES = \
+  CylinderGeom_MvtxHelper.cc \
+  MvtxCombinedRawDataDecoder.cc \
   MvtxClusterizer.cc \
   MvtxHitPruner.cc \
-  MvtxCombinedRawDataDecoder.cc \
   MvtxPixelDefs.cc \
   MvtxPixelMask.cc
 
 libmvtx_la_LIBADD = \
   libmvtx_io.la \
+  -lActsCore \
   -lCLHEP \
-  -lfun4all \
-  -lffarawobjects \
-  -lfun4allraw \
+  -lcdbobjects \
   -lffamodules \
+  -lffarawobjects \
+  -lfun4all \
+  -lfun4allraw \
+  -lmvtx_decoder \
   -lphg4hit \
   -lSubsysReco \
   -ltrack_io \
-  -lmvtx_decoder \
-  -ltrackbase_historic_io \
-  -lcdbobjects
+  -ltrackbase_historic_io
 
 # sources for io library
 libmvtx_io_la_SOURCES = \
@@ -67,9 +70,8 @@ libmvtx_io_la_SOURCES = \
   SegmentationAlpide.cc
 
 libmvtx_io_la_LIBADD = \
-  -lActsCore \
-  -lphool \
-  -lg4detectors_io
+  -lg4detectors_io \
+  -lphool
 
 # Rule for generating table CINT dictionaries.
 %_Dict.cc: %.h %LinkDef.h

--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -187,6 +187,7 @@ libtrack_reco_la_LIBADD = \
   -lintt \
   -lintt_io \
   -lmicromegas_io \
+  -lmvtx \
   -lmvtx_io \
   -lphparameter_io \
   -lPHGenFit \

--- a/offline/packages/trackreco/PHGenFitTrkFitter.cc
+++ b/offline/packages/trackreco/PHGenFitTrkFitter.cc
@@ -21,6 +21,7 @@
 #include <micromegas/MicromegasDefs.h>
 
 #include <mvtx/CylinderGeom_Mvtx.h>
+#include <mvtx/CylinderGeom_MvtxHelper.h>
 
 #include <phfield/PHFieldUtility.h>
 
@@ -656,7 +657,7 @@ std::shared_ptr<PHGenFit::Track> PHGenFitTrkFitter::ReFitTrack(PHCompositeNode* 
       auto geom = static_cast<CylinderGeom_Mvtx*>(geom_container_mvtx->GetLayerGeom(layer));
       auto hitsetkey = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
       auto surf = m_tgeometry->maps().getSiliconSurface(hitsetkey);
-      geom->find_sensor_center(surf, m_tgeometry, ladder_location);
+	  CylinderGeom_MvtxHelper::find_sensor_center(surf, m_tgeometry, ladder_location);
 
       TVector3 n(ladder_location[0], ladder_location[1], 0);
       n.RotateZ(geom->get_stave_phi_tilt());

--- a/offline/packages/trackreco/PHTruthClustering.cc
+++ b/offline/packages/trackreco/PHTruthClustering.cc
@@ -29,6 +29,7 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <mvtx/CylinderGeom_Mvtx.h>
+#include <mvtx/CylinderGeom_MvtxHelper.h>
 #include <intt/CylinderGeomIntt.h>
 #include <intt/CylinderGeomInttHelper.h>
 
@@ -882,24 +883,22 @@ void PHTruthClustering::G4ClusterSize(TrkrDefs::cluskey& ckey,unsigned int layer
       layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
       auto ihitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto isurf = _tgeometry->maps().getSiliconSurface(ihitsetkey);
-      TVector3 local_inner = layergeom->get_local_from_world_coords(isurf,_tgeometry, world_inner);
+      TVector3 local_inner = CylinderGeom_MvtxHelper::get_local_from_world_coords(isurf,_tgeometry, world_inner);
 
       TVector3 world_outer = {outer_x, outer_y, outer_z};
       std::vector<double> world_outer_vec = { world_outer[0], world_outer[1], world_outer[2] };
       layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
       auto ohitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
       auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
-      TVector3 local_outer = layergeom->get_local_from_world_coords(osurf,_tgeometry, world_outer);
+      TVector3 local_outer = CylinderGeom_MvtxHelper::get_local_from_world_coords(osurf,_tgeometry, world_outer);
 
       double diff =  max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
-      if(local_outer[0] < local_inner[0]) 
-	diff = -diff;
+      if(local_outer[0] < local_inner[0]) {diff = -diff;}
       local_outer[0] += diff;
       local_inner[0] -= diff;
 
       double diff_outer = min_diffusion_radius * 0.6;
-      if(local_outer[2] < local_inner[2]) 
-	diff_outer = -diff_outer;
+      if(local_outer[2] < local_inner[2]) {diff_outer = -diff_outer;}
       local_outer[2] += diff_outer;
       local_inner[2] -= diff_outer;
 

--- a/simulation/g4simulation/g4eval/Makefile.am
+++ b/simulation/g4simulation/g4eval/Makefile.am
@@ -31,6 +31,7 @@ libg4eval_la_LIBADD = \
   -lintt \
   -lintt_io \
   -lmicromegas_io \
+  -lmvtx \
   -lmvtx_io \
   -lphhepmc_io \
   -lphg4hit \

--- a/simulation/g4simulation/g4eval/SvtxTruthEval.cc
+++ b/simulation/g4simulation/g4eval/SvtxTruthEval.cc
@@ -23,6 +23,7 @@
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
 
 #include <mvtx/CylinderGeom_Mvtx.h>
+#include <mvtx/CylinderGeom_MvtxHelper.h>
 
 #include <intt/CylinderGeomIntt.h>
 #include <intt/CylinderGeomInttHelper.h>
@@ -877,14 +878,14 @@ void SvtxTruthEval::G4ClusterSize(TrkrDefs::cluskey ckey, unsigned int layer, st
     layergeom->get_sensor_indices_from_world_coords(world_inner_vec, stave, chip);
     TrkrDefs::hitsetkey ihitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
     auto isurf = _tgeometry->maps().getSiliconSurface(ihitsetkey);
-    TVector3 local_inner = layergeom->get_local_from_world_coords(isurf, _tgeometry, world_inner);
+    TVector3 local_inner = CylinderGeom_MvtxHelper::get_local_from_world_coords(isurf, _tgeometry, world_inner);
 
     TVector3 world_outer = {outer_x, outer_y, outer_z};
     std::vector<double> world_outer_vec = {world_outer[0], world_outer[1], world_outer[2]};
     layergeom->get_sensor_indices_from_world_coords(world_outer_vec, stave_outer, chip_outer);
     TrkrDefs::hitsetkey ohitsetkey = TrkrDefs::getHitSetKeyFromClusKey(ckey);
     auto osurf = _tgeometry->maps().getSiliconSurface(ohitsetkey);
-    TVector3 local_outer = layergeom->get_local_from_world_coords(osurf, _tgeometry, world_outer);
+    TVector3 local_outer = CylinderGeom_MvtxHelper::get_local_from_world_coords(osurf, _tgeometry, world_outer);
 
     double diff = max_diffusion_radius * 0.6;  // factor of 0.6 gives decent agreement with low occupancy reco clusters
     if (local_outer[0] < local_inner[0])

--- a/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
+++ b/simulation/g4simulation/g4eval/TrkrClusterIsMatcher.cc
@@ -4,8 +4,11 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 #include <g4detectors/PHG4TpcCylinderGeom.h>
 #include <g4detectors/PHG4TpcCylinderGeomContainer.h>
+
 #include <intt/CylinderGeomIntt.h>
 #include <mvtx/CylinderGeom_Mvtx.h>
+
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 

--- a/simulation/g4simulation/g4eval/g4evaltools.cc
+++ b/simulation/g4simulation/g4eval/g4evaltools.cc
@@ -14,6 +14,7 @@
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
 
@@ -28,6 +29,7 @@
 #include <TObjString.h>
 
 #include <iostream>
+#include <numeric> // for std::accumulate
 
 namespace G4Eval
 {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.cc
@@ -3,8 +3,10 @@
 #include "PHG4MvtxHitReco.h"
 
 #include <mvtx/CylinderGeom_Mvtx.h>
+#include <mvtx/CylinderGeom_MvtxHelper.h>
 #include <mvtx/MvtxHitPruner.h>
 
+#include <trackbase/ActsGeometry.h>
 #include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase/TrkrHit.h>  // // make iwyu happy
@@ -357,7 +359,7 @@ int PHG4MvtxHitReco::process_event(PHCompositeNode* topNode)
         auto hskey = MvtxDefs::genHitSetKey(layer, stave_number, chip_number, 0);
         auto surf = tgeometry->maps().getSiliconSurface(hskey);
 
-        TVector3 local_in_check = layergeom->get_local_from_world_coords(surf, tgeometry, world_in);
+        TVector3 local_in_check = CylinderGeom_MvtxHelper::get_local_from_world_coords(surf, tgeometry, world_in);
         std::cout
             << " local coords of entry point from geom (a check) "
             << local_in_check.X() << " " << local_in_check.Y() << " " << local_in_check.Z() << "\n"


### PR DESCRIPTION
Split CylinderGeom_Mvtx functionality to helper class to avoid linking Acts in io library

Alphabetized some of the relevant makefiles

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

