### PR TITLE
Change caloTreeGen module ZDC tower node finder to not abort event if node is not found 

### DIFF
--- a/offline/QA/Calorimeters/caloTreeGen/caloTreeGen.cc
+++ b/offline/QA/Calorimeters/caloTreeGen/caloTreeGen.cc
@@ -167,7 +167,7 @@ int caloTreeGen::process_event(PHCompositeNode *topNode)
   RawClusterContainer *clusterContainer = findNode::getClass<RawClusterContainer>(topNode, m_clusterNode.c_str());
   if (!clusterContainer && storeClusters)
   {
-    std::cout << PHWHERE << "caloTreeGen::process_event: " << m_clusterNode << " node is missing. Output related to this node will be empty" << std::endl;
+    std::cout << PHWHERE << "caloTreeGen::process_event: Cluster " << m_clusterNode << " node is missing. Output related to this node will be empty" << std::endl;
     return 0;
   }
 
@@ -176,7 +176,7 @@ int caloTreeGen::process_event(PHCompositeNode *topNode)
   emcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, m_emcTowerNode.c_str());
   if (!emcTowerContainer && storeEMCal)
   {
-    std::cout << PHWHERE << "caloTreeGen::process_event: " << m_emcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
+    std::cout << PHWHERE << "caloTreeGen::process_event: EMCal " << m_emcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
   }
 
   // grab all the towers and fill their energies.
@@ -259,9 +259,9 @@ int caloTreeGen::process_event(PHCompositeNode *topNode)
   TowerInfoContainer *ohcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, m_ohcTowerNode);
   TowerInfoContainer *ihcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, m_ihcTowerNode.c_str());
 
-  if (!ohcTowerContainer || !ihcTowerContainer)
+  if ((!ohcTowerContainer || !ihcTowerContainer) && storeHCals)
   {
-    std::cout << PHWHERE << "caloTreeGen::process_event: " << m_ohcTowerNode << " or " << m_ohcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
+    std::cout << PHWHERE << "caloTreeGen::process_event: OHCal " << m_ohcTowerNode << " or IHCal " << m_ihcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
     return Fun4AllReturnCodes::ABORTEVENT;
   }
 
@@ -319,10 +319,9 @@ int caloTreeGen::process_event(PHCompositeNode *topNode)
   }
 
   TowerInfoContainer *zdcTowerContainer = findNode::getClass<TowerInfoContainer>(topNode, m_zdcTowerNode.c_str());
-  if (!zdcTowerContainer)
+  if (!zdcTowerContainer && storeZDC)
   {
-    std::cout << PHWHERE << "caloTreeGen::process_event: " << m_emcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
-    return Fun4AllReturnCodes::ABORTEVENT;
+    std::cout << PHWHERE << "caloTreeGen::process_event: ZDC " << m_zdcTowerNode << " node is missing. Output related to this node will be empty" << std::endl;
   }
 
   if (storeZDC && zdcTowerContainer)
@@ -355,7 +354,7 @@ int caloTreeGen::process_event(PHCompositeNode *topNode)
   Gl1Packet *gl1PacketInfo = findNode::getClass<Gl1Packet>(topNode, m_trigNode.c_str());
   if (!gl1PacketInfo && storeTrig)
   {
-    std::cout << PHWHERE << "caloTreeGen::process_event: " << m_trigNode << " node is missing. Output related to this node will be empty" << std::endl;
+    std::cout << PHWHERE << "caloTreeGen::process_event: Gl1 " << m_trigNode << " node is missing. Output related to this node will be empty" << std::endl;
   }
 
   if (storeTrig && gl1PacketInfo)


### PR DESCRIPTION
Change caloTreeGen module ZDC tower node finder to not abort event if node is not found for use in simulation. Small bug fixes to cout statements to return the correct node names associated with calorimeter dst nodes. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

