### PR TITLE
feat: Multiple nodes in raw hit qa

### DIFF
--- a/offline/QA/Intt/InttRawHitQA.cc
+++ b/offline/QA/Intt/InttRawHitQA.cc
@@ -6,6 +6,8 @@
 #include <ffarawobjects/InttRawHit.h>           // for InttRawHit
 #include <ffarawobjects/InttRawHitContainer.h>  // for InttRawHitContainer
 
+#include <phool/PHCompositeNode.h>
+#include <phool/PHPointerListIterator.h>
 #include <fun4all/Fun4AllHistoManager.h>  // for Fun4AllHistoManager
 #include <fun4all/Fun4AllReturnCodes.h>   // for EVENT_OK, ABORTEVENT
 
@@ -28,17 +30,17 @@ InttRawHitQA::InttRawHitQA(const std::string &name)
 {
 }
 
-std::vector<InttRawHit *> InttRawHitQA::GetHits()
+std::vector<InttRawHit *> InttRawHitQA::GetHits(InttRawHitContainer* container)
 {
   std::vector<InttRawHit *> hits;
-  if(node_inttrawhit_map_ == nullptr)
+  if(container == nullptr)
   {
     return hits;
   }
-  auto raw_hit_num = node_inttrawhit_map_->get_nhits();
+  auto raw_hit_num = container->get_nhits();
   for (unsigned int i = 0; i < raw_hit_num; i++)
   {
-    auto hit = node_inttrawhit_map_->get_hit(i);
+    auto hit = container->get_hit(i);
     hits.push_back(hit);
   }
 
@@ -56,15 +58,35 @@ int InttRawHitQA::InitRun(PHCompositeNode *topNode)
 
   /////////////////////////////////////////////////////////////////////////
   // INTT raw hit
-  std::string node_name_inttrawhit = "INTTRAWHIT";
-  node_inttrawhit_map_ =
-      findNode::getClass<InttRawHitContainer>(topNode, node_name_inttrawhit);
-
-  if (!node_inttrawhit_map_)
+  /////////////////////////////////////////////////////////////////////////
+  PHNodeIterator trkr_itr(topNode);
+  PHCompositeNode *intt_node = dynamic_cast<PHCompositeNode *>(
+      trkr_itr.findFirst("PHCompositeNode", "INTT"));  
+  if(!intt_node)
   {
-    std::cout << PHWHERE << node_name_inttrawhit << " node is missing." << std::endl;
+    std::cout << PHWHERE << " No INTT node found, exit" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
   }
-
+  PHNodeIterator intt_itr(intt_node);
+  PHPointerListIterator<PHNode> iter(intt_itr.ls());
+  PHNode *thisnode;
+  while((thisnode = iter()))
+  {
+    if(thisnode->getType() !="PHIODataNode")
+    {
+      continue;
+    }
+    PHIODataNode<InttRawHitContainer> *theNode = dynamic_cast<PHIODataNode<InttRawHitContainer> *>(thisnode);
+    if(theNode)
+    {
+      std::cout << PHWHERE << " Found INTT Raw hit container node " << theNode->getName() << std::endl;
+      auto cont = (InttRawHitContainer*)theNode->getData();
+      if(cont)
+      {
+        m_rawhit_containers.push_back(cont);
+      }
+    }
+  }
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
 
@@ -218,13 +240,16 @@ void InttRawHitQA::createHistos()
 
 int InttRawHitQA::process_event(PHCompositeNode * /*unused*/)
 {
-  auto hits = this->GetHits();
+  for(auto& cont : m_rawhit_containers)
+  {
+   
+  auto hits = GetHits(cont);
 
   auto raw_hit_num = hits.size();
   hist_nhit_->Fill(raw_hit_num);
 
   // if no raw hit is found, skip this event
-  if (raw_hit_num == 0 || node_inttrawhit_map_ == nullptr)
+  if (raw_hit_num == 0 || cont == nullptr)
   {
     return Fun4AllReturnCodes::EVENT_OK;
   }
@@ -234,13 +259,13 @@ int InttRawHitQA::process_event(PHCompositeNode * /*unused*/)
   //////////////////////////////////////////////////////////////////
   // processes for each event                                     //
   //////////////////////////////////////////////////////////////////
-  uint64_t bco_full = (node_inttrawhit_map_->get_hit(0)->get_bco());
+  uint64_t bco_full = (cont->get_hit(0)->get_bco());
   hist_bco_full_->Fill(bco_full);
 
   //////////////////////////////////////////////////////////////////
   // primary raw hit sweep to get some reference values           //
   //////////////////////////////////////////////////////////////////
-  uint32_t event_counter_ref = node_inttrawhit_map_->get_hit(0)->get_event_counter();
+  uint32_t event_counter_ref = cont->get_hit(0)->get_event_counter();
 
   //////////////////////////////////////////////////////////////////
   // processes for each raw hit                                   //
@@ -332,7 +357,7 @@ int InttRawHitQA::process_event(PHCompositeNode * /*unused*/)
   {
     previous_event_counter_ = -1;  // in the case of a crazy event counter
   }
-
+  }
   // cout << "-------------------------------------------------" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/QA/Intt/InttRawHitQA.cc
+++ b/offline/QA/Intt/InttRawHitQA.cc
@@ -76,7 +76,7 @@ int InttRawHitQA::InitRun(PHCompositeNode *topNode)
     {
       continue;
     }
-    PHIODataNode<InttRawHitContainer> *theNode = dynamic_cast<PHIODataNode<InttRawHitContainer> *>(thisnode);
+    PHIODataNode<InttRawHitContainer> *theNode = static_cast<PHIODataNode<InttRawHitContainer> *>(thisnode);
     if(theNode)
     {
       std::cout << PHWHERE << " Found INTT Raw hit container node " << theNode->getName() << std::endl;

--- a/offline/QA/Intt/InttRawHitQA.h
+++ b/offline/QA/Intt/InttRawHitQA.h
@@ -67,6 +67,7 @@ class InttRawHitQA : public SubsysReco
   static const int kChan_num_ = 128;    // the number of channel in a single chip
   static const int kFirst_pid_ = 3001;  // the first pid (packet ID), which means intt0
 
+    std::vector<InttRawHitContainer*> m_rawhit_containers;
   int previous_event_counter_ = -1;
   int last_event_counter_ = 0;
   int event_counter_by_myself_ = 0;  // because the event counter is not reliable, I count it by myself for histogram normalization
@@ -104,14 +105,9 @@ class InttRawHitQA : public SubsysReco
   TH1* hist_event_counter_diff_[kFelix_num_]{nullptr};
 
   ///////////////////////////////////////////
-  // nodes
-  ///////////////////////////////////////////
-  InttRawHitContainer* node_inttrawhit_map_{nullptr};
-
-  ///////////////////////////////////////////
   // functions
   ///////////////////////////////////////////
-  virtual std::vector<InttRawHit*> GetHits();
+  virtual std::vector<InttRawHit*> GetHits(InttRawHitContainer* container);
 };
 
 #endif  // INTTRAWHITQA_H

--- a/offline/QA/Intt/InttStreamQA.h
+++ b/offline/QA/Intt/InttStreamQA.h
@@ -12,7 +12,7 @@
 class PHCompositeNode;
 class TH1;
 class TH2;
-
+class InttRawHitContainer;
 /// Definition of this analysis module class
 class InttStreamQA : public SubsysReco
 {
@@ -39,6 +39,8 @@ class InttStreamQA : public SubsysReco
  private:
   void createHistos();
   std::string getHistoPrefix() const;
+  std::vector<InttRawHitContainer*> m_rawhit_containers;
+
   TH2* h_bco[8]{nullptr};
   TH2* h_hit[8]{nullptr};
 

--- a/offline/QA/Mvtx/MvtxRawHitQA.cc
+++ b/offline/QA/Mvtx/MvtxRawHitQA.cc
@@ -48,7 +48,7 @@ int MvtxRawHitQA::InitRun(PHCompositeNode *topNode)
     {
       continue;
     }
-    PHIODataNode<MvtxRawHitContainer> *theNode = dynamic_cast<PHIODataNode<MvtxRawHitContainer> *>(thisnode);
+    PHIODataNode<MvtxRawHitContainer> *theNode = static_cast<PHIODataNode<MvtxRawHitContainer> *>(thisnode);
     if(theNode)
     {
       std::cout << PHWHERE << " Found Mvtx Raw hit container node " << theNode->getName() << std::endl;

--- a/offline/QA/Mvtx/MvtxRawHitQA.cc
+++ b/offline/QA/Mvtx/MvtxRawHitQA.cc
@@ -5,7 +5,7 @@
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-
+#include <phool/PHPointerListIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
@@ -26,11 +26,38 @@ int MvtxRawHitQA::InitRun(PHCompositeNode *topNode)
 {
   createHistos();
 
-  rawhitcont = findNode::getClass<MvtxRawHitContainer>(topNode, "MVTXRAWHIT");
-
-  if (!rawhitcont)
+ PHNodeIterator trkr_itr(topNode);
+  PHCompositeNode *mvtx_node = dynamic_cast<PHCompositeNode *>(
+      trkr_itr.findFirst("PHCompositeNode", "MVTX"));  
+  if(!mvtx_node)
   {
-    std::cout << PHWHERE << "Missing MvtxRawHitContainer node!!!" << std::endl;
+    std::cout << PHWHERE << " No MVTX node found, exit" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  PHNodeIterator mvtx_itr(mvtx_node);
+  PHPointerListIterator<PHNode> iter(mvtx_itr.ls());
+  PHNode *thisnode;
+  while((thisnode = iter()))
+  {
+    if(thisnode->getType() !="PHIODataNode")
+    {
+      continue;
+    }
+    // only want the raw hits, not the header nodes
+    if((thisnode->getName()).find("HEADER") != std::string::npos)
+    {
+      continue;
+    }
+    PHIODataNode<MvtxRawHitContainer> *theNode = dynamic_cast<PHIODataNode<MvtxRawHitContainer> *>(thisnode);
+    if(theNode)
+    {
+      std::cout << PHWHERE << " Found Mvtx Raw hit container node " << theNode->getName() << std::endl;
+      auto cont = (MvtxRawHitContainer*)theNode->getData();
+      if(cont)
+      {
+        m_rawhit_containers.push_back(cont);
+      }
+    }
   }
 
   auto hm = QAHistManagerDef::getHistoManager();
@@ -76,6 +103,8 @@ int MvtxRawHitQA::process_event(PHCompositeNode * /*unused*/)
   cols.clear();
 
   unsigned int raw_hit_num = 0;
+  for(auto& rawhitcont : m_rawhit_containers)
+  {
   if (rawhitcont)
   {
     raw_hit_num = rawhitcont->get_nhits();
@@ -149,7 +178,7 @@ int MvtxRawHitQA::process_event(PHCompositeNode * /*unused*/)
       h_nhits_stave_chip_layer2->Fill(chips[i],staves[i]);
     }
   }
-
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/Mvtx/MvtxRawHitQA.h
+++ b/offline/QA/Mvtx/MvtxRawHitQA.h
@@ -32,8 +32,7 @@ class MvtxRawHitQA : public SubsysReco
  private:
   void createHistos();
   std::string getHistoPrefix() const;
-
-  MvtxRawHitContainer* rawhitcont{nullptr};
+  std::vector<MvtxRawHitContainer*> m_rawhit_containers;
 
   TH1* h_nhits_layer0{nullptr};
   TH1* h_nhits_layer1{nullptr};


### PR DESCRIPTION
This expands the silicon raw hit QA to be able to read multiple raw hit nodes in preparation for the single streaming jobs to properly produce qa output

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

