### PR TITLE
Handle read back of broken TPC RawHit waveform with zero length

### DIFF
--- a/offline/framework/ffarawobjects/TpcRawHitv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.cc
@@ -69,7 +69,17 @@ TpcRawHitv3::TpcRawHitv3(TpcRawHitv3 &&other) noexcept
 void TpcRawHitv3::identify(std::ostream &os) const
 {
   os << "BCO: 0x" << std::hex << bco << std::dec << std::endl;
-  os << "packet id: " << packetid << std::endl;
+  os << " packet id: " << packetid << std::endl;
+
+  for (const auto &waveform : m_adcData)
+  {
+    os << " start time: " << waveform.first << " | ADCs: ";
+    for (const auto &adc : waveform.second)
+    {
+      os << adc << " ";
+    }
+    os << std::endl;
+  }
 }
 
 uint16_t TpcRawHitv3::get_adc(const uint16_t /*sample*/) const

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -116,14 +116,28 @@ class TpcRawHitv3 : public TpcRawHit
     void Next() override
     {
       // NOLINTNEXTLINE(bugprone-branch-clone)
-      if (m_adc_position_in_waveform_index < m_adc[m_waveform_index].second.size() - 1)
+      if (m_adc_position_in_waveform_index + 1U < m_adc[m_waveform_index].second.size())
       {
         ++m_adc_position_in_waveform_index;
       }
       else
-      {
-        ++m_waveform_index;
+      { 
+        // advance to the next valid waveform
         m_adc_position_in_waveform_index = 0;
+
+        while (true)
+        {
+          ++m_waveform_index;
+
+          if (m_waveform_index >= m_adc.size())
+          {
+            break;
+          }
+          if (not m_adc[m_waveform_index].second.empty())
+          {
+            break;
+          }
+        }
       }
     }
 

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -115,6 +115,8 @@ class TpcRawHitv3 : public TpcRawHit
 
     void Next() override
     {
+      if (IsDone()) return;
+      
       // NOLINTNEXTLINE(bugprone-branch-clone)
       if (m_adc_position_in_waveform_index + 1U < m_adc[m_waveform_index].second.size())
       {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

@osbornjd and @bogui56 found in the production readback test that the ADC iterator would stuck in an infinity loop when encountered a rare broken TPC waveform that contains an ADC data segment of zero length. 

This PR update the ADC iterator handle such case. It should be invisible to the downstream RawHit user code, which always get the next valid non-zerosuppressed ADC bin. 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)


- #3258
- #3255
- #3254 
- #3248
- #3242 
- #3238 
- #3266