### PR TITLE
add disable flag, to turn off cdb centrally

### DIFF
--- a/offline/framework/ffamodules/CDBInterface.cc
+++ b/offline/framework/ffamodules/CDBInterface.cc
@@ -115,6 +115,10 @@ void CDBInterface::Print(const std::string & /* what */) const
 
 std::string CDBInterface::getUrl(const std::string &domain, const std::string &filename)
 {
+  if (disable)
+  {
+    return "";
+  }
   recoConsts *rc = recoConsts::instance();
   if (!rc->FlagExist("CDB_GLOBALTAG"))
   {

--- a/offline/framework/ffamodules/CDBInterface.h
+++ b/offline/framework/ffamodules/CDBInterface.h
@@ -25,13 +25,16 @@ class CDBInterface : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
+  void Disable() {disable = true;}
+
   std::string getUrl(const std::string &domain, const std::string &filename = "");
 
  private:
   CDBInterface(const std::string &name = "CDBInterface");
 
   static CDBInterface *__instance;
-  SphenixClient *cdbclient = nullptr;
+  SphenixClient *cdbclient {nullptr};
+  bool disable {false};
   std::set<std::tuple<std::string, std::string, uint64_t>> m_UrlVector;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a flag to disable cdb accesses centrally. We do have some production passes which do not need the cdb (e.g. the calo event combining) and we plan to run those without a cdb tag to avoid confusion/non existing dependencies. For those passes we need to be able to turn the cdb access off so user modules cannot circumvent this. By default cdb access is enabled

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

