### PR TITLE
Updated retowerCEMC to suppress the warning from trying to re-retower

### DIFF
--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -233,7 +233,8 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      if(Verbosity() > 0) {
+      if(Verbosity() > 0) 
+      {
         std::cout << "RetowerCEMC::CreateNode : " << EMRetowerName << " already exists! " << std::endl;
       }
     }
@@ -253,7 +254,8 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      if (Verbosity() > 0) {
+      if (Verbosity() > 0) 
+      {
         std::cout << "RetowerCEMC::CreateNode : TOWER_CALIB_CEMC_RETOWER already exists! " << std::endl;
       }
     }

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -233,7 +233,10 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      std::cout << "RetowerCEMC::CreateNode : " << EMRetowerName << " already exists! " << std::endl;
+      if(Verbosity() > 0)
+      {
+        std::cout << "RetowerCEMC::CreateNode : " << EMRetowerName << " already exists! " << std::endl;
+      }
     }
   }
   else
@@ -251,7 +254,10 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      std::cout << "RetowerCEMC::CreateNode : TOWER_CALIB_CEMC_RETOWER already exists! " << std::endl;
+      if (Verbosity() > 0)
+      {
+        std::cout << "RetowerCEMC::CreateNode : TOWER_CALIB_CEMC_RETOWER already exists! " << std::endl;
+      }
     }
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/offline/packages/jetbackground/RetowerCEMC.cc
+++ b/offline/packages/jetbackground/RetowerCEMC.cc
@@ -233,8 +233,7 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      if(Verbosity() > 0)
-      {
+      if(Verbosity() > 0) {
         std::cout << "RetowerCEMC::CreateNode : " << EMRetowerName << " already exists! " << std::endl;
       }
     }
@@ -254,8 +253,7 @@ int RetowerCEMC::CreateNode(PHCompositeNode *topNode)
     }
     else
     {
-      if (Verbosity() > 0)
-      {
+      if (Verbosity() > 0) {
         std::cout << "RetowerCEMC::CreateNode : TOWER_CALIB_CEMC_RETOWER already exists! " << std::endl;
       }
     }


### PR DESCRIPTION
[comment]: <Added a verbosity flag to the createnode which suppresses a warning> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

