### PR TITLE
Zero field implementation for TPOT-TPC tracking matching

### DIFF
--- a/offline/packages/trackbase/TrackFitUtils.cc
+++ b/offline/packages/trackbase/TrackFitUtils.cc
@@ -293,8 +293,31 @@ TrackFitUtils::line_fit_output_t TrackFitUtils::line_fit_xy(const std::vector<Ac
 }
 
 //_________________________________________________________________________________
+TrackFitUtils::line_circle_intersection_output_t TrackFitUtils::line_circle_intersection(double r, double m, double b)
+{
+
+  const double a_coef = 1+square(m);
+  const double b_coef = 2*m*b;
+  const double c_coef = square(b)-square(r);
+  const double delta = square(b_coef)-4*a_coef*c_coef;
+
+  const double sqdelta = std::sqrt(delta);
+
+
+  const double xplus = (-b_coef + sqdelta) / (2. * a_coef);
+  const double xminus = (-b_coef - sqdelta) / (2. * a_coef);
+
+  const double yplus = m*xplus + b;
+  const double yminus = m*xminus + b;
+
+  return std::make_tuple(xplus, yplus, xminus, yminus);
+
+}
+
+//_________________________________________________________________________________
 TrackFitUtils::circle_circle_intersection_output_t TrackFitUtils::circle_circle_intersection(double r1, double r2, double x2, double y2)
 {
+
   const double D = square(r1) - square(r2) + square(x2) + square(y2);
   const double a = 1.0 + square(x2 / y2);
   const double b = -D * x2 / square(y2);
@@ -955,9 +978,8 @@ TrackFitUtils::zero_field_track_params(
   py -= y;
   pz -= z;
 
-  // scale momentum vector pT to 0.5 GeV/c
-  const double pt_zerofield = 0.5;
-  const double scale = sqrt(px*px+py*py)/pt_zerofield;
+  // scale momentum vector pT to 5. GeV/c
+  const double scale = sqrt(px*px+py*py)/5.;
   px /= scale;
   py /= scale;
   pz /= scale;
@@ -968,5 +990,5 @@ TrackFitUtils::zero_field_track_params(
     std::cout << "phi: " << phi << " eta: " << eta << " pT: 1" <<
     " x,y,z: " << x<<"<"<<y<<","<<z<<"  P: " << px<<","<<py<<","<<pz << std::endl;
   }
-  return std::make_tuple(true, phi, eta, pt_zerofield, Acts::Vector3(x,y,z), p);
+  return std::make_tuple(true, phi, eta, 1, Acts::Vector3(x,y,z), p);
 }

--- a/offline/packages/trackbase/TrackFitUtils.h
+++ b/offline/packages/trackbase/TrackFitUtils.h
@@ -67,6 +67,20 @@ namespace TrackFitUtils
   line_fit_output_t line_fit_xy(const std::vector<Acts::Vector3>& positions);
   line_fit_output_t line_fit_xz(const std::vector<Acts::Vector3>& positions);
 
+  /// line-circle intersection output. (xplus, yplus, xminus, yminus)
+  using line_circle_intersection_output_t = std::tuple<double, double, double, double>;
+  /**
+  * r is radius of sPHENIX layer
+  * m and b are parameters of line fitted to TPC clusters in the x-y plane (slope and intersection)
+  * the solutions are xplus, xminus, yplus, yminus
+  * The intersection of the line-circle occurs when
+  * y = m*x + b
+  * Here we assume that circle is an sPHENIX layer centered on x1=y1=0
+  * x^2 +y^2 = r^2
+  * substitute for y in equation of circle, solve for x, and then for y.
+  **/
+  line_circle_intersection_output_t line_circle_intersection(double r, double m, double b);
+
   /// circle-circle intersection output. (xplus, yplus, xminus, yminus)
   using circle_circle_intersection_output_t = std::tuple<double, double, double, double>;
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -16,7 +16,7 @@
 #include <trackbase/TrkrClusterIterationMapv1.h>
 #include <trackbase/TrkrClusterv3.h>  // for TrkrCluster
 #include <trackbase/TrkrDefs.h>       // for cluskey, getLayer, TrkrId
-
+#include <trackbase_historic/TrackSeedHelper.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
@@ -38,6 +38,7 @@
 #include <map>       // for map
 #include <set>       // for _Rb_tree_const_iterator
 #include <utility>   // for pair, make_pair
+#include <optional>  // for line-circle function
 
 namespace
 {
@@ -58,12 +59,12 @@ namespace
 
   /// calculate intersection from circle to line, in 2d. return true on success
   /**
-   * circle is defined as (x-xc)**2 + (y-yc)**2 = r**2
-   * line is defined as nx(x-x0) + ny(y-y0) = 0
-   * to solve we substitute y by y0 - nx/ny*(x-x0) in the circle equation and solve the 2nd order polynom
-   * there is the extra complication that ny can be 0 (vertical line) to prevent this, we multiply all terms of the polynom by ny**2
-   * and account for this special case when calculating x from y
-   */
+  * circle is defined as (x-xc)**2 + (y-yc)**2 = r**2
+  * line is defined as nx(x-x0) + ny(y-y0) = 0
+  * to solve we substitute y by y0 - nx/ny*(x-x0) in the circle equation and solve the 2nd order polynom
+  * there is the extra complication that ny can be 0 (vertical line) to prevent this, we multiply all terms of the polynom by ny**2
+  * and account for this special case when calculating x from y
+  */
   bool circle_line_intersection(
       double r, double xc, double yc,
       double x0, double y0, double nx, double ny,
@@ -107,6 +108,38 @@ namespace
     return true;
   }
 
+  bool line_line_intersection(
+      double m, double b,
+      double x0, double y0, double nx, double ny,
+      double& xplus, double& yplus, double& xminus, double& yminus)
+  {
+    if (ny == 0)
+    {
+      // vertical lines are defined by ny=0 and x = x0
+      xplus = xminus = x0;
+
+      // calculate y accordingly
+      yplus = yminus = m * x0 + b;
+    }
+    else
+    {
+     
+      double denom = nx + ny*m;
+      if(denom == 0) {
+        return false; // lines are parallel and there is no intersection
+      }
+ 
+      double x = (nx*x0 + ny*y0 - ny*b)/denom;
+      double y = m*x + b;
+      // a straight line has a unique intersection point
+      xplus = xminus = x;
+      yplus = yminus = y;
+ 
+    }
+
+    return true;
+  }  
+
   // streamer of TVector3
   [[maybe_unused]] inline std::ostream& operator<<(std::ostream& out, const TVector3& vector)
   {
@@ -125,6 +158,7 @@ PHMicromegasTpcTrackMatching::PHMicromegasTpcTrackMatching(const std::string& na
 //____________________________________________________________________________..
 int PHMicromegasTpcTrackMatching::InitRun(PHCompositeNode* topNode)
 {
+
   std::cout << std::endl
             << PHWHERE
             << " rphi_search_win inner layer " << _rphi_search_win[0]
@@ -237,62 +271,96 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 
     for (auto key_iter = tracklet_tpc->begin_cluster_keys(); key_iter != tracklet_tpc->end_cluster_keys(); ++key_iter)
     {
-      const auto& cluster_key = *key_iter;
-      unsigned int layer = TrkrDefs::getLayer(cluster_key);
+        const auto& cluster_key = *key_iter;
+        unsigned int layer = TrkrDefs::getLayer(cluster_key);
 
-      if (layer < _min_tpc_layer)
+        if (layer < _min_tpc_layer)
+        {
+          continue;
+        }
+        if (layer >= _min_mm_layer)
+        {
+          continue;
+        }
+
+        // get the cluster
+        TrkrCluster* tpc_clus = _cluster_map->findCluster(cluster_key);
+        if (!tpc_clus)
+        {
+          continue;
+        }
+        outer_clusters.insert(std::make_pair(layer, tpc_clus));
+        clusters.push_back(tpc_clus);
+        // make necessary corrections to the global position
+        clusGlobPos.push_back( m_globalPositionWrapper.getGlobalPositionDistortionCorrected(cluster_key, tpc_clus, crossing) );
+        
+    }
+
+    double xy_m = 0, xy_b = 0;   
+    double R = 0, X0 = 0, Y0 = 0;
+    double A = 0, B = 0;
+
+    if(_zero_field) { // start _zero_field
+
+      std::cout << "zero field is ON, starting TPC clusters linear fit" << std::endl;
+      auto cluster_list = getTrackletClusterList(tracklet_tpc);
+
+      // need at least 3 clusters to fit a line
+      if (outer_clusters.size() < 3)
+      {
+        if (Verbosity() > 3)
+        {
+          std::cout << PHWHERE << "  -- skip this tpc tracklet, not enough outer clusters " << std::endl;
+        }
+        continue;  // skip to the next TPC tracklet
+      }
+      
+      const auto params = TrackFitUtils::fitClustersZeroField(clusGlobPos, cluster_list, true); // This is for the intersection
+      xy_m = params[0];
+      xy_b = params[1];
+ 
+      // get the straight line representing the z trajectory in the form of z vs radius
+      std::tie(A, B) = TrackFitUtils::line_fit(clusGlobPos);
+      if (Verbosity() > 10)
+      {
+        std::cout << " zero field fitted line has A " << A << " B " << B << " xy_m " << xy_m << " xy_b " << xy_b << std::endl;
+      }
+
+    } else { // start !_zero_field
+ 
+      std::cout << "zero field is OFF, starting TPC clusters circle fit" << std::endl;
+
+      // need at least 3 clusters to fit a circle
+      if (outer_clusters.size() < 3)
+      {
+        if (Verbosity() > 3)
+        {
+          std::cout << PHWHERE << "  -- skip this tpc tracklet, not enough outer clusters " << std::endl;
+        }
+        continue;  // skip to the next TPC tracklet
+      }
+
+      // fit a circle to the clusters
+      std::tie(R, X0, Y0) = TrackFitUtils::circle_fit_by_taubin(clusGlobPos);
+      if (Verbosity() > 10)
+      {
+        std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
+      }
+
+      // toss tracks for which the fitted circle could not have come from the vertex
+      if (R < 40.0)
       {
         continue;
       }
-      if (layer >= _min_mm_layer)
+
+      // get the straight line representing the z trajectory in the form of z vs radius
+      std::tie(A, B) = TrackFitUtils::line_fit(clusGlobPos);
+      if (Verbosity() > 10)
       {
-        continue;
+        std::cout << " non-zero field fitted line has A " << A << " B " << B << std::endl;
       }
-
-      // get the cluster
-      TrkrCluster* tpc_clus = _cluster_map->findCluster(cluster_key);
-      if (!tpc_clus)
-      {
-        continue;
-      }
-
-      outer_clusters.insert(std::make_pair(layer, tpc_clus));
-      clusters.push_back(tpc_clus);
-
-      // make necessary corrections to the global position
-      clusGlobPos.push_back( m_globalPositionWrapper.getGlobalPositionDistortionCorrected(cluster_key, tpc_clus, crossing) );
-
-    }
-
-    // need at least 3 clusters to fit a circle
-    if (outer_clusters.size() < 3)
-    {
-      if (Verbosity() > 3)
-      {
-        std::cout << PHWHERE << "  -- skip this tpc tracklet, not enough outer clusters " << std::endl;
-      }
-      continue;  // skip to the next TPC tracklet
-    }
-
-    // fit a circle to the clusters
-    const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(clusGlobPos);
-    if (Verbosity() > 10)
-    {
-      std::cout << " Fitted circle has R " << R << " X0 " << X0 << " Y0 " << Y0 << std::endl;
-    }
-
-    // toss tracks for which the fitted circle could not have come from the vertex
-    if (R < 40.0)
-    {
-      continue;
-    }
-
-    // get the straight line representing the z trajectory in the form of z vs radius
-    const auto [A, B] = TrackFitUtils::line_fit(clusGlobPos);
-    if (Verbosity() > 10)
-    {
-      std::cout << " Fitted line has A " << A << " B " << B << std::endl;
-    }
+  
+    } // end !_zero_field
 
     // loop over micromegas layer
     for (unsigned int imm = 0; imm < _n_mm_layers; ++imm)
@@ -302,27 +370,41 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       const auto layergeom = static_cast<CylinderGeomMicromegas*>(_geomContainerMicromegas->GetLayerGeom(layer));
       const auto layer_radius = layergeom->get_radius();
 
-      // method to find where fitted circle intersects this layer
-      auto [xplus, yplus, xminus, yminus] = TrackFitUtils::circle_circle_intersection(layer_radius, R, X0, Y0);
+      double xplus, yplus, xminus, yminus;
+      if(_zero_field) { // start _zero_field
+      
+        // method to find where the fitted line intersects this layer
+        std::tie(xplus, yplus, xminus, yminus) = TrackFitUtils::line_circle_intersection(layer_radius, xy_m, xy_b);
+        
+      } else { // start _zero_field!
 
-      // finds the intersection of the fitted circle with the micromegas layer
-      if (!std::isfinite(xplus))
+        // method to find where fitted circle intersects this layer
+        std::tie(xplus, yplus, xminus, yminus) = TrackFitUtils::circle_circle_intersection(layer_radius, R, X0, Y0);
+
+        // finds the intersection of the fitted circle with the micromegas layer
+      } // end _zero_field!
+
+      if (Verbosity() > 10)
       {
-        if (Verbosity() > 10)
-        {
-          std::cout << PHWHERE << " circle/circle intersection calculation failed, skip this case" << std::endl;
-          std::cout << PHWHERE << " mm_radius " << layer_radius << " fitted R " << R << " fitted X0 " << X0 << " fitted Y0 " << Y0 << std::endl;
-        }
-
-        continue;
+        std::cout << "xplus: " << xplus << " yplus " << yplus << " xminus " << xminus << " yminus " << std::endl;
       }
+ 
+      if (!std::isfinite(xplus))
+       {
+         if (Verbosity() > 10)
+         {
+           std::cout << PHWHERE << " circle/circle intersection calculation failed, skip this case" << std::endl;
+           std::cout << PHWHERE << " mm_radius " << layer_radius << " fitted R " << R << " fitted X0 " << X0 << " fitted Y0 " << Y0 << std::endl;
+         }
 
+         continue; 
+      }
       // we can figure out which solution is correct based on the last cluster position in the TPC
       const double last_clus_phi = std::atan2(clusGlobPos.back()(1), clusGlobPos.back()(0));
       double phi_plus = std::atan2(yplus, xplus);
       double phi_minus = std::atan2(yminus, xminus);
 
-      // calculate z
+        // calculate z
       double r = layer_radius;
       double z = B + A * r;
 
@@ -349,14 +431,30 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       const double nx = tile_norm.x();
       const double ny = tile_norm.y();
 
-      // calculate intersection to tile
-      if (!circle_line_intersection(R, X0, Y0, x0, y0, nx, ny, xplus, yplus, xminus, yminus))
-      {
-        if (Verbosity() > 10)
+      if(_zero_field) {
+
+        // calculate intersection to tile
+        if (!line_line_intersection(xy_m, xy_b, x0, y0, nx, ny, xplus, yplus, xminus, yminus))
         {
-          std::cout << PHWHERE << "circle_line_intersection - failed" << std::endl;
+          if (Verbosity() > 10)
+          {
+            std::cout << PHWHERE << "line_line_intersection - failed" << std::endl;
+          }
+          continue;
         }
-        continue;
+
+      } else {
+
+        // calculate intersection to tile
+        if (!circle_line_intersection(R, X0, Y0, x0, y0, nx, ny, xplus, yplus, xminus, yminus))
+        {
+          if (Verbosity() > 10)
+          {
+            std::cout << PHWHERE << "circle_line_intersection - failed" << std::endl;
+          }
+          continue;
+        }
+
       }
 
       // select again angle closest to last cluster
@@ -574,3 +672,46 @@ int PHMicromegasTpcTrackMatching::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+std::vector<TrkrDefs::cluskey> PHMicromegasTpcTrackMatching::getTrackletClusterList(TrackSeed* tracklet)
+{
+  std::vector<TrkrDefs::cluskey> cluskey_vec;
+  for (auto clusIter = tracklet->begin_cluster_keys();
+       clusIter != tracklet->end_cluster_keys();
+       ++clusIter)
+  {
+    auto key = *clusIter;
+    auto cluster = _cluster_map->findCluster(key);
+    if (!cluster)
+    {
+      if(Verbosity() > 1)
+      {
+        std::cout << PHWHERE << "Failed to get cluster with key " << key << std::endl;
+      }
+      continue;
+    }
+
+    /// Make a safety check for clusters that couldn't be attached to a surface
+    auto surf = _tGeometry->maps().getSurface(key, cluster);
+    if (!surf)
+    {
+      continue;
+    }
+
+    // drop some bad layers in the TPC completely
+    unsigned int layer = TrkrDefs::getLayer(key);
+    if (layer == 7 || layer == 22 || layer == 23 || layer == 38 || layer == 39)
+    {
+      continue;
+    }
+
+    /* if (layer > 2 && layer < 7) */
+    /* { */
+      /* continue; */
+    /* } */
+
+
+
+    cluskey_vec.push_back(key);
+  }  // end loop over clusters for this track
+  return cluskey_vec;
+}

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -39,6 +39,8 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_pp_mode(const bool mode) { _pp_mode = mode; }
   void SetIteration(int iter) { _n_iteration = iter; }
 
+  void zeroField(const bool flag) { _zero_field = flag; }
+
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
   int End(PHCompositeNode*) override;
@@ -55,8 +57,9 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   //! number of layers in the micromegas
   static constexpr unsigned int _n_mm_layers{2};
-
+  
   bool _use_truth_clusters = false;
+  bool _zero_field = false;
   TrkrClusterContainer* _cluster_map{nullptr};
   TrkrClusterContainer* _corrected_cluster_map{nullptr};
 
@@ -70,6 +73,8 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   //! default z search window for each layer
   std::array<double, _n_mm_layers> _z_search_win{26.0, 0.25};
 
+  // get the cluster list for zeroField
+  std::vector<TrkrDefs::cluskey> getTrackletClusterList(TrackSeed* tracklet);
   // range of TPC layers to use in projection to micromegas
   unsigned int _min_tpc_layer{38};
 


### PR DESCRIPTION
[comment]: <Straight-line fit instead of a helical fit for TPC tracks, which simplifies the projection and reduces errors. Added a zeroField flag in the PHMicromegasTpcTrackMatching.> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

