### PR TITLE
fix: clang tidy simulation qa package

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: 'modernize-use-using, modernize-loop-convert, modernize-use-nullptr, modernize-use-emplace, modernize-redundant-void-arg, modernize-use-bool-literals, modernize-use-equals-default, performance-*, -clang-analyzer*, misc-*, bugprone-*, hicpp-braces-around-statements, hicpp-*,-hicpp-use-auto, -hicpp-no-array-decay, -hicpp-avoid-c-arrays, -bugprone-narrowing-conversions, -bugprone-easily-swappable-parameters'
+Checks: 'modernize-use-using, modernize-loop-convert, modernize-use-nullptr, modernize-use-emplace, modernize-redundant-void-arg, modernize-use-bool-literals, modernize-use-equals-default, performance-*, -clang-analyzer*, misc-*, bugprone-*, hicpp-braces-around-statements, hicpp-*,-hicpp-use-auto, -hicpp-no-array-decay, -hicpp-avoid-c-arrays, -bugprone-narrowing-conversions, -bugprone-easily-swappable-parameters, -performance-avoid-endl'
 # use this to find C math functions which should be replaced by std::
 #Checks: 'performance-type-promotion-in-math-fn, -clang-analyzer*'
 # use this to optimize string searching

--- a/offline/QA/SimulationModules/QAG4Decayer.cc
+++ b/offline/QA/SimulationModules/QAG4Decayer.cc
@@ -19,6 +19,8 @@
 #include <TStyle.h>
 #include <TVector3.h>
 
+#include <boost/format.hpp>
+
 #include <algorithm>
 
 #include <cassert>

--- a/offline/QA/SimulationModules/QAG4Decayer.cc
+++ b/offline/QA/SimulationModules/QAG4Decayer.cc
@@ -19,15 +19,14 @@
 #include <TStyle.h>
 #include <TVector3.h>
 
-
 #include <algorithm>
 
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
 
 const int NHFQA = 16;
 

--- a/offline/QA/SimulationModules/QAG4Decayer.cc
+++ b/offline/QA/SimulationModules/QAG4Decayer.cc
@@ -1,9 +1,9 @@
 #include "QAG4Decayer.h"
 
+#include <TTree.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <decayfinder/DecayFinder.h>
-#include <decayfinder/DecayFinderContainerBase.h>  // for DecayFinderContainerBase::Iter
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
@@ -12,34 +12,32 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
-#include <TDatabasePDG.h>
 #include <TF1.h>
 #include <TH1.h>
-#include <TH2.h>
-#include <TLatex.h>
 #include <TLorentzVector.h>
-#include <TNamed.h>
 #include <TROOT.h>
-#include <TString.h>
 #include <TStyle.h>
 #include <TVector3.h>
 
-#include <CLHEP/Vector/LorentzVector.h>
 
-#include <boost/format.hpp>
+#include <algorithm>
 
-#include <iostream>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
 #include <map>
+#include <vector>
+#include <string>
 
 const int NHFQA = 16;
 
-int QAVtxPDGID[NHFQA] = {411, 421, 431, 4122, 511, 521, 531, 443, 553, -411, -421, -431, -4122, -511, -521, -531};
+static int QAVtxPDGID[NHFQA] = {411, 421, 431, 4122, 511, 521, 531, 443, 553, -411, -421, -431, -4122, -511, -521, -531};
 
 // float MassMin[NHFQA] = {1.6,1.6,1.7,2.0,5.0,5.0,5.1,2.0,9.0};
-float MassMin[NHFQA] = {1.6, 1.6, 1.7, 2.0, 5.0, 5.0, 5.1, 1.2, 9.0, 1.6, 1.6, 1.7, 2.0, 5.0, 5.0, 5.1};
-float MassMax[NHFQA] = {2.0, 2.0, 2.1, 2.5, 5.5, 5.5, 5.6, 3.2, 10.0, 2.0, 2.0, 2.1, 2.5, 5.5, 5.5, 5.6};
+static float MassMin[NHFQA] = {1.6, 1.6, 1.7, 2.0, 5.0, 5.0, 5.1, 1.2, 9.0, 1.6, 1.6, 1.7, 2.0, 5.0, 5.0, 5.1};
+static float MassMax[NHFQA] = {2.0, 2.0, 2.1, 2.5, 5.5, 5.5, 5.6, 3.2, 10.0, 2.0, 2.0, 2.1, 2.5, 5.5, 5.5, 5.6};
 
-std::multimap<std::vector<int>, int> decaymap[NHFQA];
+static std::multimap<std::vector<int>, int> decaymap[NHFQA];
 
 /*
  *  QA module to check decay branching ratio, decay lifetime, and momentum conservation for inclusive heavy flavor hadron decay, which is handle by EvtGen as default
@@ -372,13 +370,13 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
 
   float CosTheta = -2;
 
-  PHG4TruthInfoContainer::ConstRange range = m_truth_info->GetParticleRange();
+  PHG4TruthInfoContainer::ConstRange const range = m_truth_info->GetParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second; ++iter)
   {
     PHG4Particle *g4particle = iter->second;
 
-    int gflavor = g4particle->get_pid();
+    int const gflavor = g4particle->get_pid();
 
     int ParentPDGID = -1;
     int GrandParentPDGID = -1;
@@ -420,8 +418,8 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
       }
     }
 
-    int NDig = (int) log10(abs(gflavor));
-    int firstDigit = (int) (abs(gflavor) / pow(10, NDig));
+    int const NDig = (int) log10(abs(gflavor));
+    int const firstDigit = (int) (abs(gflavor) / pow(10, NDig));
     if ((firstDigit == 4 || firstDigit == 5) && ParentPDGID == 0)
     {
       int HFFillIndex = -99;
@@ -444,7 +442,7 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
       }
     }
 
-    int VtxSize = ParentTrkInfo.size();
+    int const VtxSize = ParentTrkInfo.size();
 
     bool NewVtx = true;
     int Index = -1;
@@ -534,8 +532,8 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
 
     if (GrandParentPDGID == 0 && ParentVtx && VtxToQA)
     {
-      float ParentMass = sqrt(mother->get_e() * mother->get_e() - mother->get_px() * mother->get_px() - mother->get_py() * mother->get_py() - mother->get_pz() * mother->get_pz());
-      float ParP = sqrt(mother->get_px() * mother->get_px() + mother->get_py() * mother->get_py() + mother->get_pz() * mother->get_pz());
+      float const ParentMass = sqrt(mother->get_e() * mother->get_e() - mother->get_px() * mother->get_px() - mother->get_py() * mother->get_py() - mother->get_pz() * mother->get_pz());
+      float const ParP = sqrt(mother->get_px() * mother->get_px() + mother->get_py() * mother->get_py() + mother->get_pz() * mother->get_pz());
 
       HFProdVtx.SetXYZ(ParentVtx->get_x(), ParentVtx->get_y(), ParentVtx->get_z());
       HFDecayVtx.SetXYZ(vtx->get_x(), vtx->get_y(), vtx->get_z());
@@ -560,11 +558,11 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
   }
 
   // BR Working here
-  int VtxSizeFinal = TotalEPerVertex.size();
+  int const VtxSizeFinal = TotalEPerVertex.size();
 
   for (int q = 0; q < VtxSizeFinal; q++)
   {
-    int HFIndexToFill = HFIndexInfo[q];
+    int const HFIndexToFill = HFIndexInfo[q];
     //		int HFSign = HFIndexSignInfo[q];
 
     DevPx = (ParentPxInfo[q] - TotalPxPerVertex[q]) / ParentPxInfo[q];
@@ -572,7 +570,7 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
     DevPz = (ParentPzInfo[q] - TotalPzPerVertex[q]) / ParentPzInfo[q];
     DevE = (ParentEInfo[q] - TotalEPerVertex[q]) / ParentEInfo[q];
 
-    float ParMass = sqrt(TotalEPerVertex[q] * TotalEPerVertex[q] - ParentPxInfo[q] * ParentPxInfo[q] - ParentPyInfo[q] * ParentPyInfo[q] - ParentPzInfo[q] * ParentPzInfo[q]);
+    float const ParMass = sqrt(TotalEPerVertex[q] * TotalEPerVertex[q] - ParentPxInfo[q] * ParentPxInfo[q] - ParentPyInfo[q] * ParentPyInfo[q] - ParentPzInfo[q] * ParentPzInfo[q]);
 
     QAPx[HFIndexToFill]->Fill(DevPx);
     QAPy[HFIndexToFill]->Fill(DevPy);
@@ -807,7 +805,7 @@ int QAG4Decayer::process_event(PHCompositeNode *topNode)
       }
     }
 
-    int ChannelSize = ChannelID.size();
+    int const ChannelSize = ChannelID.size();
 
     for (int r = 0; r < ChannelSize; r++)
     {

--- a/offline/QA/SimulationModules/QAG4SimulationCalorimeter.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationCalorimeter.cc
@@ -32,7 +32,6 @@
 #include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TString.h>
 #include <TVector3.h>
 
@@ -44,6 +43,7 @@
 #include <iostream>
 #include <iterator>  // for reverse_iterator
 #include <map>
+#include <string>
 #include <utility>
 
 QAG4SimulationCalorimeter::QAG4SimulationCalorimeter(const std::string &calo_name,
@@ -174,7 +174,7 @@ int QAG4SimulationCalorimeter::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessG4Hit))
   {
-    int ret = process_event_G4Hit(topNode);
+    int const ret = process_event_G4Hit(topNode);
 
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
@@ -184,7 +184,7 @@ int QAG4SimulationCalorimeter::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessTower))
   {
-    int ret = process_event_Tower(topNode);
+    int const ret = process_event_Tower(topNode);
 
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
@@ -194,7 +194,7 @@ int QAG4SimulationCalorimeter::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessCluster))
   {
-    int ret = process_event_Cluster(topNode);
+    int const ret = process_event_Cluster(topNode);
 
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
@@ -285,7 +285,7 @@ int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode * /*topNode*/
 
   // get primary
   assert(_truth_container);
-  PHG4TruthInfoContainer::ConstRange primary_range =
+  PHG4TruthInfoContainer::ConstRange const primary_range =
       _truth_container->GetPrimaryParticleRange();
   double total_primary_energy = 1e-9;  // make it zero energy epsilon samll so it can be used for denominator
   for (PHG4TruthInfoContainer::ConstIterator particle_iter = primary_range.first;
@@ -366,7 +366,7 @@ int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode * /*topNode*/
     assert(hlat);
 
     h_norm->Fill("G4Hit Active", _calo_hit_container->size());
-    PHG4HitContainer::ConstRange calo_hit_range =
+    PHG4HitContainer::ConstRange const calo_hit_range =
         _calo_hit_container->getHits();
     for (PHG4HitContainer::ConstIterator hit_iter = calo_hit_range.first;
          hit_iter != calo_hit_range.second; hit_iter++)
@@ -408,7 +408,7 @@ int QAG4SimulationCalorimeter::process_event_G4Hit(PHCompositeNode * /*topNode*/
   {
     h_norm->Fill("G4Hit Absor.", _calo_abs_hit_container->size());
 
-    PHG4HitContainer::ConstRange calo_abs_hit_range =
+    PHG4HitContainer::ConstRange const calo_abs_hit_range =
         _calo_abs_hit_container->getHits();
     for (PHG4HitContainer::ConstIterator hit_iter = calo_abs_hit_range.first;
          hit_iter != calo_abs_hit_range.second; hit_iter++)
@@ -530,11 +530,11 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
       get_histo_prefix() + "_Normalization"));
   assert(h_norm);
 
-  std::string towernodename = "TOWER_CALIB_" + detector;
+  std::string const towernodename = "TOWER_CALIB_" + detector;
   // Grab the towers
   RawTowerContainer *towers = findNode::getClass<RawTowerContainer>(topNode,
                                                                     towernodename);
-  std::string towerinfonodename = "TOWERINFO_CALIB_" + detector;
+  std::string const towerinfonodename = "TOWERINFO_CALIB_" + detector;
   TowerInfoContainer *towerinfos = findNode::getClass<TowerInfoContainer>(topNode, towerinfonodename);
   if (!towers && !flag(kProcessTowerinfo))
   {
@@ -548,7 +548,7 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
               << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
-  std::string towergeomnodename = "TOWERGEOM_" + detector;
+  std::string const towergeomnodename = "TOWERGEOM_" + detector;
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(
       topNode, towergeomnodename);
   if (!towergeom)
@@ -630,7 +630,7 @@ int QAG4SimulationCalorimeter::process_event_Tower(PHCompositeNode *topNode)
             }
             else
             {
-              unsigned int towerkey = _calo_name == "CEMC" ? TowerInfoDefs::encode_emcal(ieta, wrapphi) : TowerInfoDefs::encode_hcal(ieta, wrapphi);
+              unsigned int const towerkey = _calo_name == "CEMC" ? TowerInfoDefs::encode_emcal(ieta, wrapphi) : TowerInfoDefs::encode_hcal(ieta, wrapphi);
               TowerInfo *towerinfo = towerinfos->get_tower_at_key(towerkey);
               if (towerinfo)
               {
@@ -687,7 +687,7 @@ int QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
 
   Fun4AllHistoManager *hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  std::string towergeomnodename = "TOWERGEOM_" + _calo_name;
+  std::string const towergeomnodename = "TOWERGEOM_" + _calo_name;
   RawTowerGeomContainer *towergeom = findNode::getClass<RawTowerGeomContainer>(
       topNode, towergeomnodename);
   if (!towergeom)
@@ -700,7 +700,7 @@ int QAG4SimulationCalorimeter::process_event_Cluster(PHCompositeNode *topNode)
   TH1D *h_norm = dynamic_cast<TH1D *>(hm->getHisto(get_histo_prefix() + "_Normalization"));
   assert(h_norm);
 
-  std::string nodename = "CLUSTER_" + _calo_name;
+  std::string const nodename = "CLUSTER_" + _calo_name;
   RawClusterContainer *clusters = findNode::getClass<RawClusterContainer>(topNode, nodename);
   assert(clusters);
   h_norm->Fill("Cluster", clusters->size());

--- a/offline/QA/SimulationModules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationCalorimeterSum.cc
@@ -1,4 +1,5 @@
 #include "QAG4SimulationCalorimeterSum.h"
+#include <math.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <g4eval/CaloEvalStack.h>
@@ -26,7 +27,6 @@
 #include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TString.h>
 
 #include <cassert>
@@ -178,7 +178,7 @@ int QAG4SimulationCalorimeterSum::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessCluster))
   {
-    int ret = process_event_Cluster(topNode);
+    int const ret = process_event_Cluster(topNode);
 
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
@@ -188,7 +188,7 @@ int QAG4SimulationCalorimeterSum::process_event(PHCompositeNode *topNode)
 
   if (flag(kProcessTrackProj))
   {
-    int ret = process_event_TrackProj(topNode);
+    int const ret = process_event_TrackProj(topNode);
 
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
@@ -338,7 +338,7 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
   assert(h2_proj);
 
   // pull the tower geometry
-  std::string towergeonodename = "TOWERGEOM_" + detector;
+  std::string const towergeonodename = "TOWERGEOM_" + detector;
   RawTowerGeomContainer *towergeo = findNode::getClass<RawTowerGeomContainer>(
       topNode, towergeonodename);
   assert(towergeo);
@@ -348,7 +348,7 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
     towergeo->identify();
   }
   // pull the towers
-  std::string towernodename = "TOWER_CALIB_" + detector;
+  std::string const towernodename = "TOWER_CALIB_" + detector;
   RawTowerContainer *towerList = findNode::getClass<RawTowerContainer>(topNode,
                                                                        towernodename);
   assert(towerList);
@@ -385,16 +385,16 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
   assert(not std::isnan(point[1]));
   assert(not std::isnan(point[2]));
 
-  double x = point[0];
-  double y = point[1];
-  double z = point[2];
+  double const x = point[0];
+  double const y = point[1];
+  double const z = point[2];
 
-  double phi = atan2(y, x);
-  double eta = asinh(z / sqrt(x * x + y * y));
+  double const phi = atan2(y, x);
+  double const eta = asinh(z / sqrt(x * x + y * y));
 
   // calculate 3x3 tower energy
-  int binphi = towergeo->get_phibin(phi);
-  int bineta = towergeo->get_etabin(eta);
+  int const binphi = towergeo->get_phibin(phi);
+  int const bineta = towergeo->get_etabin(eta);
 
   double etabin_width = towergeo->get_etabounds(bineta).second - towergeo->get_etabounds(bineta).first;
   if (bineta > 1 and bineta < towergeo->get_etabins() - 1)
@@ -402,7 +402,7 @@ bool QAG4SimulationCalorimeterSum::eval_trk_proj(const std::string &detector, Sv
     etabin_width = (towergeo->get_etacenter(bineta + 1) - towergeo->get_etacenter(bineta - 1)) / 2.;
   }
 
-  double phibin_width = towergeo->get_phibounds(binphi).second - towergeo->get_phibounds(binphi).first;
+  double const phibin_width = towergeo->get_phibounds(binphi).second - towergeo->get_phibounds(binphi).first;
 
   assert(etabin_width > 0);
   assert(phibin_width > 0);

--- a/offline/QA/SimulationModules/QAG4SimulationCalorimeterSum.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationCalorimeterSum.cc
@@ -1,5 +1,5 @@
 #include "QAG4SimulationCalorimeterSum.h"
-#include <math.h>
+
 #include <qautils/QAHistManagerDef.h>
 
 #include <g4eval/CaloEvalStack.h>

--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
@@ -1,6 +1,8 @@
 
 #include "QAG4SimulationDistortions.h"
 
+#include <math.h>
+#include <fun4all/SubsysReco.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
@@ -10,30 +12,30 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <globalvertex/SvtxVertexMap.h>
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrCluster.h>
 #include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/SvtxTrackState.h>
 #include <trackbase_historic/TrackSeed.h>
 
-#include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TString.h>
 #include <TTree.h>
-#include <TVector3.h>
 
-#include <array>
+#include <Acts/Definitions/Algebra.hpp>
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <map>      // for map
+#include <iterator>
+#include <string>
 #include <utility>  // for pair
+#include <vector>
 
 namespace
 {
@@ -254,7 +256,7 @@ int QAG4SimulationDistortions::process_event(PHCompositeNode* /*unused*/)
         continue;
       }
 
-      TrkrDefs::cluskey ckey = std::stoll(state->get_name());
+      TrkrDefs::cluskey const ckey = std::stoll(state->get_name());
 
       auto cluster = m_clusterContainer->findCluster(ckey);
 

--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
@@ -2,7 +2,7 @@
 #include "QAG4SimulationDistortions.h"
 
 #include <fun4all/SubsysReco.h>
-#include <math.h>
+
 #include <qautils/QAHistManagerDef.h>
 
 #include <fun4all/Fun4AllHistoManager.h>

--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
@@ -1,8 +1,8 @@
 
 #include "QAG4SimulationDistortions.h"
 
-#include <math.h>
 #include <fun4all/SubsysReco.h>
+#include <math.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
@@ -11,7 +11,6 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
-
 
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/TrkrCluster.h>

--- a/offline/QA/SimulationModules/QAG4SimulationIntt.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationIntt.cc
@@ -26,6 +26,8 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
+#include <boost/format.hpp>
+
 #include <TH1.h>
 
 #include <cassert>

--- a/offline/QA/SimulationModules/QAG4SimulationIntt.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationIntt.cc
@@ -28,15 +28,14 @@
 
 #include <TH1.h>
 
-
 #include <cassert>
 #include <cmath>
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
-#include <string>
 #include <set>
-#include <utility>   // for pair, make_pair
+#include <string>
+#include <utility>  // for pair, make_pair
 
 //________________________________________________________________________
 QAG4SimulationIntt::QAG4SimulationIntt(const std::string& name)

--- a/offline/QA/SimulationModules/QAG4SimulationIntt.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationIntt.cc
@@ -28,13 +28,14 @@
 
 #include <TH1.h>
 
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <cmath>
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
+#include <string>
+#include <set>
 #include <utility>   // for pair, make_pair
 
 //________________________________________________________________________

--- a/offline/QA/SimulationModules/QAG4SimulationJet.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationJet.cc
@@ -1,5 +1,7 @@
 #include "QAG4SimulationJet.h"
 
+#include <TString.h>
+#include <math.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <g4eval/JetEvalStack.h>
@@ -22,15 +24,16 @@
 #include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <set>
+#include <string>
+#include <utility>
 
 QAG4SimulationJet::QAG4SimulationJet(const std::string& truth_jet,
                                      enu_flags flags)
@@ -52,7 +55,7 @@ int QAG4SimulationJet::InitRun(PHCompositeNode* topNode)
   {
     for (const auto& reco_jet : _reco_jets)
     {
-      jetevalstacks_map::iterator it_jetevalstack = _jetevalstacks.find(
+      jetevalstacks_map::iterator const it_jetevalstack = _jetevalstacks.find(
           reco_jet);
 
       if (it_jetevalstack == _jetevalstacks.end())
@@ -213,7 +216,7 @@ QAG4SimulationJet::get_eta_range_str(const char* eta_name) const
 bool QAG4SimulationJet::jet_acceptance_cut(const Jet* jet) const
 {
   assert(jet);
-  bool eta_cut = (jet->get_eta() >= eta_range.first) && (jet->get_eta() <= eta_range.second);
+  bool const eta_cut = (jet->get_eta() >= eta_range.first) && (jet->get_eta() <= eta_range.second);
   return eta_cut;
 }
 
@@ -425,9 +428,9 @@ int QAG4SimulationJet::process_Spectrum(PHCompositeNode* topNode,
 
     if (is_reco_jet)
     {  // this is a reco jet
-      jetevalstacks_map::iterator it_stack = _jetevalstacks.find(jet_name);
+      jetevalstacks_map::iterator const it_stack = _jetevalstacks.find(jet_name);
       assert(it_stack != _jetevalstacks.end());
-      std::shared_ptr<JetEvalStack> eval_stack = it_stack->second;
+      std::shared_ptr<JetEvalStack> const eval_stack = it_stack->second;
       assert(eval_stack);
       JetRecoEval* recoeval = eval_stack->get_reco_eval();
       assert(recoeval);
@@ -475,7 +478,7 @@ int QAG4SimulationJet::process_Spectrum(PHCompositeNode* topNode,
       double hcalin_e = 0;
       double bh_e = 0;
 
-      std::set<PHG4Shower*> showers = _jettrutheval->all_truth_showers(leading_jet);
+      std::set<PHG4Shower*> const showers = _jettrutheval->all_truth_showers(leading_jet);
 
       for (auto shower : showers)
       {
@@ -626,9 +629,9 @@ int QAG4SimulationJet::process_TruthMatching(PHCompositeNode* topNode,
       ));
   assert(Matching_dPhi);
 
-  jetevalstacks_map::iterator it_stack = _jetevalstacks.find(reco_jet_name);
+  jetevalstacks_map::iterator const it_stack = _jetevalstacks.find(reco_jet_name);
   assert(it_stack != _jetevalstacks.end());
-  std::shared_ptr<JetEvalStack> eval_stack = it_stack->second;
+  std::shared_ptr<JetEvalStack> const eval_stack = it_stack->second;
   assert(eval_stack);
   JetRecoEval* recoeval = eval_stack->get_reco_eval();
   assert(recoeval);

--- a/offline/QA/SimulationModules/QAG4SimulationJet.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationJet.cc
@@ -21,6 +21,8 @@
 
 #include <phool/getClass.h>
 
+#include <boost/format.hpp>
+
 #include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>

--- a/offline/QA/SimulationModules/QAG4SimulationJet.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationJet.cc
@@ -25,7 +25,6 @@
 #include <TH1.h>
 #include <TH2.h>
 
-
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
@@ -209,7 +208,7 @@ TString
 QAG4SimulationJet::get_eta_range_str(const char* eta_name) const
 {
   assert(eta_name);
-  return TString((boost::format("%.1f < %s < %.1f") %eta_range.first %eta_name %eta_range.second).str().c_str());
+  return TString((boost::format("%.1f < %s < %.1f") % eta_range.first % eta_name % eta_range.second).str().c_str());
 }
 
 //! acceptance cut on jet object
@@ -716,8 +715,8 @@ int QAG4SimulationJet::process_TruthMatching(PHCompositeNode* topNode,
         }  // if (fabs(dPhi) < 0.1)
 
       }  //       if (recojet)
-    }    // inclusive best energy match
-    {    // unique match
+    }  // inclusive best energy match
+    {  // unique match
 
       const Jet* recojet = recoeval->unique_reco_jet_from_truth(truthjet);
       if (recojet)
@@ -751,7 +750,7 @@ int QAG4SimulationJet::process_TruthMatching(PHCompositeNode* topNode,
         }  // if (fabs(dPhi) < 0.1)
 
       }  //       if (recojet)
-    }    // unique match
+    }  // unique match
 
   }  //  if (truthjet)
 
@@ -821,7 +820,7 @@ int QAG4SimulationJet::process_TruthMatching(PHCompositeNode* topNode,
         }  // if (fabs(dPhi) < 0.1)
 
       }  //      if (truthjet1)
-    }    // inclusive best energy match
+    }  // inclusive best energy match
 
     {  // unique match
       Jet* truthjet2 = recoeval->unique_truth_jet_from_reco(recojet);
@@ -848,7 +847,7 @@ int QAG4SimulationJet::process_TruthMatching(PHCompositeNode* topNode,
         }  // if (fabs(dPhi) < 0.1)
 
       }  //      if (truthjet2)
-    }    // unique match
+    }  // unique match
 
   }  // if (recojet)
 

--- a/offline/QA/SimulationModules/QAG4SimulationJet.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationJet.cc
@@ -1,7 +1,6 @@
 #include "QAG4SimulationJet.h"
 
 #include <TString.h>
-#include <math.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <g4eval/JetEvalStack.h>

--- a/offline/QA/SimulationModules/QAG4SimulationKFParticle.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationKFParticle.cc
@@ -50,7 +50,7 @@
 #include <utility>  // for pair
 #include <vector>
 
-KFParticle_Tools kfpTools;
+static KFParticle_Tools kfpTools;
 
 QAG4SimulationKFParticle::QAG4SimulationKFParticle(const std::string &name, const std::string &mother_name, double min_m, double max_m)
   : SubsysReco(name)
@@ -291,7 +291,7 @@ int QAG4SimulationKFParticle::process_event(PHCompositeNode *topNode)
 
         for (unsigned int i = 0; i < d_id.size(); ++i)
         {
-          std::map<unsigned int, KFParticle *> D_Map = m_kfpContainer->returnParticlesByPDGid(d_id[i]);
+          std::map<unsigned int, KFParticle *> const D_Map = m_kfpContainer->returnParticlesByPDGid(d_id[i]);
           for (auto &[key, part] : D_Map)
           {
             if (i == 0)
@@ -344,7 +344,7 @@ PHG4Particle *QAG4SimulationKFParticle::getTruthTrack(SvtxTrack *thisTrack)
     clustereval = m_svtxEvalStack->get_cluster_eval();
   }
 
-  TrkrDefs::cluskey clusKey = *thisTrack->begin_cluster_keys();
+  TrkrDefs::cluskey const clusKey = *thisTrack->begin_cluster_keys();
   PHG4Particle *particle = clustereval->max_truth_particle_by_cluster_energy(clusKey);
 
   return particle;

--- a/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
@@ -1,9 +1,7 @@
 #include "QAG4SimulationMicromegas.h"
 
 #include <qautils/QAHistManagerDef.h>
-#include <qautils/QAUtil.h>
 
-#include <g4detectors/PHG4CylinderGeom.h>  // for PHG4CylinderGeom
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <g4main/PHG4Hit.h>
@@ -43,13 +41,13 @@
 #include <TH1.h>
 #include <TVector3.h>
 
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <cmath>     // for cos, sin, NAN
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
+#include <string>
 #include <utility>   // for pair, make_pair
 #include <vector>    // for vector
 
@@ -373,7 +371,7 @@ void QAG4SimulationMicromegas::evaluate_hits()
 
     // get all of the hits from this hitset
     TrkrHitSet* hitset = hitsetiter->second;
-    TrkrHitSet::ConstRange hitrange = hitset->getHits();
+    TrkrHitSet::ConstRange const hitrange = hitset->getHits();
 
     // loop over hits
     for (auto hit_it = hitrange.first; hit_it != hitrange.second; ++hit_it)
@@ -422,17 +420,17 @@ void QAG4SimulationMicromegas::evaluate_clusters()
   }
   // get primary truth particles
 
-  PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetPrimaryParticleRange();  // only from primary particles
+  PHG4TruthInfoContainer::ConstRange const range = m_truthContainer->GetPrimaryParticleRange();  // only from primary particles
 
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second;
        ++iter)
   {
     PHG4Particle* g4particle = iter->second;
-    float gtrackID = g4particle->get_track_id();
-    float gflavor = g4particle->get_pid();
-    float gembed = trutheval->get_embed(g4particle);
-    float gprimary = trutheval->is_primary(g4particle);
+    float const gtrackID = g4particle->get_track_id();
+    float const gflavor = g4particle->get_pid();
+    float const gembed = trutheval->get_embed(g4particle);
+    float const gprimary = trutheval->is_primary(g4particle);
 
     if (Verbosity() > 0)
     {
@@ -454,9 +452,9 @@ void QAG4SimulationMicromegas::evaluate_clusters()
         continue;
       }
 
-      float gx = gclus->getX();
-      float gy = gclus->getY();
-      float gz = gclus->getZ();
+      float const gx = gclus->getX();
+      float const gy = gclus->getY();
+      float const gz = gclus->getZ();
 
       xy_pts.emplace_back(gx, gy);
       rz_pts.emplace_back(std::sqrt(gx * gx + gy * gy), gz);
@@ -508,8 +506,8 @@ void QAG4SimulationMicromegas::evaluate_clusters()
       const auto segmentation_type = MicromegasDefs::getSegmentationType(ckey);
 
       // get relevant cluster information
-      double rphi_error = cluster->getRPhiError();
-      double z_error = cluster->getZError();
+      double const rphi_error = cluster->getRPhiError();
+      double const z_error = cluster->getZError();
 
       // convert cluster position to local tile coordinates
       const TVector3 cluster_world(global(0), global(1), global(2));
@@ -526,12 +524,12 @@ void QAG4SimulationMicromegas::evaluate_clusters()
         for (int i = 0; i < 2; ++i)
         {
           // convert position to local
-          TVector3 g4hit_world(g4hit->get_x(i), g4hit->get_y(i), g4hit->get_z(i));
-          TVector3 g4hit_local = layergeom->get_local_from_world_coords(tileid, m_tGeometry, g4hit_world);
+          TVector3 const g4hit_world(g4hit->get_x(i), g4hit->get_y(i), g4hit->get_z(i));
+          TVector3 const g4hit_local = layergeom->get_local_from_world_coords(tileid, m_tGeometry, g4hit_world);
 
           // convert momentum to local
-          TVector3 momentum_world(g4hit->get_px(i), g4hit->get_py(i), g4hit->get_pz(i));
-          TVector3 momentum_local = layergeom->get_local_from_world_vect(tileid, m_tGeometry, momentum_world);
+          TVector3 const momentum_world(g4hit->get_px(i), g4hit->get_py(i), g4hit->get_pz(i));
+          TVector3 const momentum_local = layergeom->get_local_from_world_vect(tileid, m_tGeometry, momentum_world);
 
           hits.push_back({.position = g4hit_local, .momentum = momentum_local, .weight = weight});
         }

--- a/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
@@ -41,6 +41,8 @@
 #include <TH1.h>
 #include <TVector3.h>
 
+#include <boost/format.hpp>
+
 #include <cassert>
 #include <cmath>     // for cos, sin, NAN
 #include <iostream>  // for operator<<, basic...

--- a/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMicromegas.cc
@@ -41,15 +41,14 @@
 #include <TH1.h>
 #include <TVector3.h>
 
-
 #include <cassert>
 #include <cmath>     // for cos, sin, NAN
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
 #include <string>
-#include <utility>   // for pair, make_pair
-#include <vector>    // for vector
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector
 
 //_____________________________________________________________________
 namespace

--- a/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
@@ -28,13 +28,14 @@
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <cmath>     // for atan2
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
+#include <string>
+#include <set>
 #include <utility>   // for pair, make_pair
 
 //________________________________________________________________________
@@ -271,8 +272,8 @@ void QAG4SimulationMvtx::evaluate_clusters()
       const auto z_cluster = global(2);
       const auto phi_cluster = (float) std::atan2(global(1), global(0));
 
-      double phi_error = cluster->getRPhiError() / r_cluster;
-      double z_error = cluster->getZError();
+      double const phi_error = cluster->getRPhiError() / r_cluster;
+      double const z_error = cluster->getZError();
 
       // find associated g4hits
       const auto g4hits = find_g4hits(key);

--- a/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
@@ -28,15 +28,14 @@
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 
-
 #include <cassert>
 #include <cmath>     // for atan2
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
-#include <string>
 #include <set>
-#include <utility>   // for pair, make_pair
+#include <string>
+#include <utility>  // for pair, make_pair
 
 //________________________________________________________________________
 QAG4SimulationMvtx::QAG4SimulationMvtx(const std::string& name)

--- a/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
@@ -25,6 +25,8 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
+#include <boost/format.hpp>
+
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 

--- a/offline/QA/SimulationModules/QAG4SimulationTpc.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTpc.cc
@@ -34,16 +34,15 @@
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 
-
 #include <cassert>
 #include <cmath>     // for atan2
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
-#include <string>
 #include <set>
-#include <utility>   // for pair, make_pair
-#include <vector>    // for vector
+#include <string>
+#include <utility>  // for pair, make_pair
+#include <vector>   // for vector
 
 //________________________________________________________________________
 QAG4SimulationTpc::QAG4SimulationTpc(const std::string& name)

--- a/offline/QA/SimulationModules/QAG4SimulationTpc.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTpc.cc
@@ -34,13 +34,14 @@
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 
-#include <boost/format.hpp>
 
 #include <cassert>
 #include <cmath>     // for atan2
 #include <iostream>  // for operator<<, basic...
 #include <iterator>  // for distance
 #include <map>       // for map
+#include <string>
+#include <set>
 #include <utility>   // for pair, make_pair
 #include <vector>    // for vector
 
@@ -335,7 +336,7 @@ void QAG4SimulationTpc::evaluate_clusters()
   }
 
   // PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetParticleRange();  // all truth cluters
-  PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetPrimaryParticleRange();  // only from primary particles
+  PHG4TruthInfoContainer::ConstRange const range = m_truthContainer->GetPrimaryParticleRange();  // only from primary particles
 
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
        iter != range.second;
@@ -343,10 +344,10 @@ void QAG4SimulationTpc::evaluate_clusters()
   {
     PHG4Particle* g4particle = iter->second;
 
-    float gtrackID = g4particle->get_track_id();
-    float gflavor = g4particle->get_pid();
-    float gembed = trutheval->get_embed(g4particle);
-    float gprimary = trutheval->is_primary(g4particle);
+    float const gtrackID = g4particle->get_track_id();
+    float const gflavor = g4particle->get_pid();
+    float const gembed = trutheval->get_embed(g4particle);
+    float const gprimary = trutheval->is_primary(g4particle);
 
     if (Verbosity() > 0)
     {
@@ -368,9 +369,9 @@ void QAG4SimulationTpc::evaluate_clusters()
         continue;
       }
 
-      float gx = gclus->getX();
-      float gy = gclus->getY();
-      float gz = gclus->getZ();
+      float const gx = gclus->getX();
+      float const gy = gclus->getY();
+      float const gz = gclus->getZ();
 
       xy_pts.emplace_back(gx, gy);
       rz_pts.emplace_back(std::sqrt(gx * gx + gy * gy), gz);
@@ -396,11 +397,11 @@ void QAG4SimulationTpc::evaluate_clusters()
         continue;
       }
 
-      float gx = gclus->getX();
-      float gy = gclus->getY();
-      float gz = gclus->getZ();
-      float gedep = gclus->getError(0, 0);
-      float ng4hits = gclus->getAdc();
+      float const gx = gclus->getX();
+      float const gy = gclus->getY();
+      float const gz = gclus->getZ();
+      float const gedep = gclus->getError(0, 0);
+      float const ng4hits = gclus->getAdc();
 
       const auto gr = QAG4Util::get_r(gclus->getX(), gclus->getY());
       const auto gphi = std::atan2(gclus->getY(), gclus->getX());
@@ -428,15 +429,15 @@ void QAG4SimulationTpc::evaluate_clusters()
         const auto z_cluster = global(2);
         const auto phi_cluster = (float) std::atan2(global(1), global(0));
 
-        double phi_error = rclus->getRPhiError() / r_cluster;
-        double z_error = rclus->getZError();
+        double const phi_error = rclus->getRPhiError() / r_cluster;
+        double const z_error = rclus->getZError();
 
         const auto dphi = QAG4Util::delta_phi(phi_cluster, gphi);
         const auto dz = z_cluster - gz;
 
         // get region from layer, fill histograms
         const auto it = m_layer_region_map.find(layer);
-        int region = it->second;
+        int const region = it->second;
 
         if (Verbosity() > 0)
         {

--- a/offline/QA/SimulationModules/QAG4SimulationTpc.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTpc.cc
@@ -34,6 +34,8 @@
 #include <TAxis.h>  // for TAxis
 #include <TH1.h>
 
+#include <boost/format.hpp>
+
 #include <cassert>
 #include <cmath>     // for atan2
 #include <iostream>  // for operator<<, basic...

--- a/offline/QA/SimulationModules/QAG4SimulationTracking.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTracking.cc
@@ -10,7 +10,6 @@
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
-#include <globalvertex/SvtxVertexMap.h>
 
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
@@ -35,16 +34,17 @@
 #include <TDatabasePDG.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TParticlePDG.h>  // for TParticlePDG
 #include <TString.h>
 #include <TVector3.h>
 
-#include <array>
+#include <Acts/Definitions/Algebra.hpp>
 #include <cassert>
 #include <cmath>
 #include <iostream>
 #include <map>      // for map
+#include <string>
+#include <set>
 #include <utility>  // for pair
 
 QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)
@@ -436,7 +436,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
             const double gpx = g4particle_match->get_px();
             const double gpy = g4particle_match->get_py();
-            TVector3 gv(gpx, gpy, 0);
+            TVector3 const gv(gpx, gpy, 0);
             const double gpt = gv.Pt();
 
             const double pt_ratio = (pt != 0) ? gpt / pt : 0;
@@ -458,7 +458,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }  // reco track loop
 
-  PHG4TruthInfoContainer::ConstRange range = m_truthContainer->GetPrimaryParticleRange();
+  PHG4TruthInfoContainer::ConstRange const range = m_truthContainer->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
   {
     // get the truth particle information
@@ -486,15 +486,15 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       }
     }
 
-    double gpx = g4particle->get_px();
-    double gpy = g4particle->get_py();
-    double gpz = g4particle->get_pz();
+    double const gpx = g4particle->get_px();
+    double const gpy = g4particle->get_py();
+    double const gpz = g4particle->get_pz();
     double gpt = 0;
     double geta = NAN;
 
     if (gpx != 0 && gpy != 0)
     {
-      TVector3 gv(gpx, gpy, gpz);
+      TVector3 const gv(gpx, gpy, gpz);
       gpt = gv.Pt();
       geta = gv.Eta();
       //      gphi = gv.Phi();
@@ -609,16 +609,16 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
         float dca3dzsigma = NAN;
         get_dca(track, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma);
 
-        double px = track->get_px();
-        double py = track->get_py();
-        double pz = track->get_pz();
+        double const px = track->get_px();
+        double const py = track->get_py();
+        double const pz = track->get_pz();
         double pt;
-        TVector3 v(px, py, pz);
+        TVector3 const v(px, py, pz);
         pt = v.Pt();
         //        eta = v.Pt();
         //      phi = v.Pt();
 
-        float pt_ratio = (gpt != 0) ? pt / gpt : 0;
+        float const pt_ratio = (gpt != 0) ? pt / gpt : 0;
         h_pTRecoGenRatio->Fill(pt_ratio);
         h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
         h_DCArPhi_pT->Fill(pt, dca3dxy);

--- a/offline/QA/SimulationModules/QAG4SimulationTracking.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTracking.cc
@@ -10,7 +10,6 @@
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
-
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getLayer
@@ -42,9 +41,9 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <map>      // for map
-#include <string>
+#include <map>  // for map
 #include <set>
+#include <string>
 #include <utility>  // for pair
 
 QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)

--- a/offline/QA/SimulationModules/QAG4SimulationTruthDecay.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTruthDecay.cc
@@ -1,5 +1,6 @@
 #include "QAG4SimulationTruthDecay.h"
 
+#include <phool/PHNode.h>
 #include <qautils/QAHistManagerDef.h>
 
 #include <fun4all/Fun4AllHistoManager.h>
@@ -7,21 +8,27 @@
 #include <fun4all/SubsysReco.h>
 
 #include <decayfinder/DecayFinder.h>
-#include <decayfinder/DecayFinderContainerBase.h>  // for DecayFinderContainerBase::Iter
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
 #include <CLHEP/Vector/LorentzVector.h>
 
 #include <TH1.h>
-#include <TH2.h>
-#include <TNamed.h>
 #include <TString.h>
-#include <TVector3.h>
 
-#include <TDatabasePDG.h>
+#include <string>
+#include <cassert>
+#include <vector>
+#include <iostream>
+#include <ostream>
+#include <algorithm>
+#include <iterator>
+#include <cstdlib>
+#include <cmath>
 
-int candidateCounter = 0;
+#include <cmath>
+
+static int candidateCounter = 0;
 
 /*
  *  QA module to check that decayers obey laws of physics
@@ -58,8 +65,8 @@ int QAG4SimulationTruthDecay::Init(PHCompositeNode *topNode)
 
   TH1 *h(nullptr);
 
-  int m_mother_PDG_ID_nBins = (int) (m_mother_PDG_ID_max - m_mother_PDG_ID_min) * 1.2;
-  int m_daughter_PDG_ID_nBins = (int) (m_daughter_PDG_ID_max - m_daughter_PDG_ID_min) * 1.2;
+  int const m_mother_PDG_ID_nBins = (int) (m_mother_PDG_ID_max - m_mother_PDG_ID_min) * 1.2;
+  int const m_daughter_PDG_ID_nBins = (int) (m_daughter_PDG_ID_max - m_daughter_PDG_ID_min) * 1.2;
 
   h = new TH1I(TString(get_histo_prefix()) + "mother_PDG_ID",  //
                ";Mother PDG ID;Entries", m_mother_PDG_ID_nBins, m_mother_PDG_ID_min, m_mother_PDG_ID_max);
@@ -98,7 +105,7 @@ int QAG4SimulationTruthDecay::Init(PHCompositeNode *topNode)
 
   for (unsigned int i = 0; i < 4; ++i)
   {
-    std::string track_number = "track_" + std::to_string(i + 1);
+    std::string const track_number = "track_" + std::to_string(i + 1);
 
     h = new TH1I(TString(get_histo_prefix()) + TString(track_number) + "_PDG_ID",  //
                  ";Track PDG ID;Entries", m_daughter_PDG_ID_nBins, m_daughter_PDG_ID_min, m_daughter_PDG_ID_max);
@@ -364,7 +371,7 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
     float daughter_y = 0;
     float daughter_z = 0;
 
-    PHG4TruthInfoContainer::ConstRange range = m_truth_info->GetParticleRange();
+    PHG4TruthInfoContainer::ConstRange const range = m_truth_info->GetParticleRange();
     for (PHG4TruthInfoContainer::ConstIterator iter = range.first;
          iter != range.second; ++iter)
     {
@@ -379,7 +386,7 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
         m_mother_py = m_g4particle->get_py();
         m_mother_pz = m_g4particle->get_pz();
         m_mother_pE = m_g4particle->get_e();
-        CLHEP::HepLorentzVector motherLV(m_mother_px, m_mother_py, m_mother_pz, m_mother_pE);
+        CLHEP::HepLorentzVector const motherLV(m_mother_px, m_mother_py, m_mother_pz, m_mother_pE);
         m_mother_pT = motherLV.perp();
         m_mother_eta = motherLV.pseudoRapidity();
         m_mother_mass = motherLV.m();
@@ -410,7 +417,7 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
           m_track_py[trackCounter] = m_g4particle->get_py();
           m_track_pz[trackCounter] = m_g4particle->get_pz();
           m_track_pE[trackCounter] = m_g4particle->get_e();
-          CLHEP::HepLorentzVector daughterLV(m_track_px[trackCounter], m_track_py[trackCounter], m_track_pz[trackCounter], m_track_pE[trackCounter]);
+          CLHEP::HepLorentzVector const daughterLV(m_track_px[trackCounter], m_track_py[trackCounter], m_track_pz[trackCounter], m_track_pE[trackCounter]);
           daughterSumLV += daughterLV;
           m_track_pT[trackCounter] = daughterLV.perp();
           m_track_eta[trackCounter] = daughterLV.pseudoRapidity();
@@ -430,7 +437,7 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
           {
             m_accept_pT = false;
           }
-          bool in_eta_range = isInRange(m_track_eta[trackCounter], m_eta_min, m_eta_max);
+          bool const in_eta_range = isInRange(m_track_eta[trackCounter], m_eta_min, m_eta_max);
           if (!in_eta_range)
           {
             m_accept_eta = false;
@@ -443,10 +450,10 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
 
     m_daughter_sum_mass = daughterSumLV.m();
 
-    float diff_percent_px = fabs(m_delta_px / m_mother_px) * 100.;
-    float diff_percent_py = fabs(m_delta_py / m_mother_py) * 100.;
-    float diff_percent_pz = fabs(m_delta_pz / m_mother_pz) * 100.;
-    float diff_percent_pE = fabs(m_delta_pE / m_mother_pE) * 100.;
+    float const diff_percent_px = std::fabs(m_delta_px / m_mother_px) * 100.;
+    float const diff_percent_py = std::fabs(m_delta_py / m_mother_py) * 100.;
+    float const diff_percent_pz = std::fabs(m_delta_pz / m_mother_pz) * 100.;
+    float const diff_percent_pE = std::fabs(m_delta_pE / m_mother_pE) * 100.;
 
     m_accept_px_1percent = diff_percent_px <= 1. ? true : false;
     m_accept_py_1percent = diff_percent_py <= 1. ? true : false;
@@ -464,7 +471,7 @@ int QAG4SimulationTruthDecay::process_event(PHCompositeNode *topNode)
     m_accept_pE_15percent = diff_percent_pE <= 15. ? true : false;
 
     m_mother_decayLength = sqrt(pow(daughter_x - mother_x, 2) + pow(daughter_y - mother_y, 2) + pow(daughter_z - mother_z, 2));
-    float mother_p = sqrt(pow(m_mother_px, 2) + pow(m_mother_py, 2) + pow(m_mother_pz, 2));
+    float const mother_p = sqrt(pow(m_mother_px, 2) + pow(m_mother_py, 2) + pow(m_mother_pz, 2));
     m_mother_decayTime = m_mother_mass * m_mother_decayLength / mother_p;
 
     if (m_write_nTuple)
@@ -605,7 +612,7 @@ void QAG4SimulationTruthDecay::initializeBranches()
 
   for (unsigned int i = 0; i < m_nTracks; ++i)
   {
-    std::string track_number = "track_" + std::to_string(i + 1);
+    std::string const track_number = "track_" + std::to_string(i + 1);
 
     m_tree->Branch(TString(track_number) + "_PDG_ID", &m_track_pdg_id[i], TString(track_number) + "_PDG_ID/I");
     m_tree->Branch(TString(track_number) + "_px", &m_track_px[i], TString(track_number) + "_px/F");
@@ -646,7 +653,7 @@ void QAG4SimulationTruthDecay::getMotherPDG(PHCompositeNode *topNode)
 {
   PHNodeIterator nodeIter(topNode);
 
-  std::string node_name = m_df_module_name + "_DecayMap";
+  std::string const node_name = m_df_module_name + "_DecayMap";
 
   PHNode *findNode = dynamic_cast<PHNode *>(nodeIter.findFirst(node_name.c_str()));
   if (findNode)
@@ -665,9 +672,9 @@ std::vector<int> QAG4SimulationTruthDecay::getDecayFinderMothers(PHCompositeNode
 {
   std::vector<int> m_motherBarcodes;
 
-  PHNodeIterator nodeIter(topNode);
+  PHNodeIterator const nodeIter(topNode);
 
-  std::string node_name = m_df_module_name + "_DecayMap";
+  std::string const node_name = m_df_module_name + "_DecayMap";
 
   m_decayMap = findNode::getClass<DecayFinderContainer_v1>(topNode, node_name.c_str());
 

--- a/offline/QA/SimulationModules/QAG4SimulationTruthDecay.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTruthDecay.cc
@@ -16,15 +16,15 @@
 #include <TH1.h>
 #include <TString.h>
 
-#include <string>
-#include <cassert>
-#include <vector>
-#include <iostream>
-#include <ostream>
 #include <algorithm>
-#include <iterator>
-#include <cstdlib>
+#include <cassert>
 #include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
+#include <ostream>
+#include <string>
+#include <vector>
 
 #include <cmath>
 

--- a/offline/QA/SimulationModules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationUpsilon.cc
@@ -33,8 +33,8 @@
 #include <cmath>
 #include <cstdlib>  // for abs
 #include <iostream>
-#include <string>
 #include <set>
+#include <string>
 #include <utility>  // for pair
 
 QAG4SimulationUpsilon::QAG4SimulationUpsilon(const std::string &name)

--- a/offline/QA/SimulationModules/QAG4SimulationUpsilon.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationUpsilon.cc
@@ -22,7 +22,6 @@
 #include <TDatabasePDG.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TParticlePDG.h>  // for TParticlePDG
 #include <TString.h>
 #include <TVector3.h>
@@ -34,6 +33,8 @@
 #include <cmath>
 #include <cstdlib>  // for abs
 #include <iostream>
+#include <string>
+#include <set>
 #include <utility>  // for pair
 
 QAG4SimulationUpsilon::QAG4SimulationUpsilon(const std::string &name)
@@ -205,7 +206,7 @@ int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
-  PHG4TruthInfoContainer::ConstRange range = _truthContainer->GetPrimaryParticleRange();
+  PHG4TruthInfoContainer::ConstRange const range = _truthContainer->GetPrimaryParticleRange();
   for (PHG4TruthInfoContainer::ConstIterator iter = range.first; iter != range.second; ++iter)
   {
     // get the truth particle information
@@ -233,15 +234,15 @@ int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
       }
     }
 
-    double gpx = g4particle->get_px();
-    double gpy = g4particle->get_py();
-    double gpz = g4particle->get_pz();
+    double const gpx = g4particle->get_px();
+    double const gpy = g4particle->get_py();
+    double const gpz = g4particle->get_pz();
     double gpt = 0;
     double geta = NAN;
 
     if (gpx != 0 && gpy != 0)
     {
-      TVector3 gv(gpx, gpy, gpz);
+      TVector3 const gv(gpx, gpy, gpz);
       gpt = gv.Pt();
       geta = gv.Eta();
       //      gphi = gv.Phi();
@@ -309,16 +310,16 @@ int QAG4SimulationUpsilon::process_event(PHCompositeNode *topNode)
       h_nReco_etaGen->Fill(geta);
       h_nReco_pTGen->Fill(gpt);
 
-      double px = track->get_px();
-      double py = track->get_py();
-      double pz = track->get_pz();
+      double const px = track->get_px();
+      double const py = track->get_py();
+      double const pz = track->get_pz();
       double pt;
-      TVector3 v(px, py, pz);
+      TVector3 const v(px, py, pz);
       pt = v.Pt();
       //        eta = v.Pt();
       //      phi = v.Pt();
 
-      float pt_ratio = (gpt != 0) ? pt / gpt : 0;
+      float const pt_ratio = (gpt != 0) ? pt / gpt : 0;
       h_pTRecoGenRatio->Fill(pt_ratio);
       h_pTRecoGenRatio_pTGen->Fill(gpt, pt_ratio);
       h_norm->Fill("Reco Track", 1);

--- a/offline/QA/SimulationModules/QAG4SimulationVertex.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationVertex.cc
@@ -34,8 +34,8 @@
 #include <cmath>
 #include <iostream>
 #include <map>
-#include <string>
 #include <set>
+#include <string>
 #include <utility>  // for pair
 
 QAG4SimulationVertex::QAG4SimulationVertex(const std::string &name)

--- a/offline/QA/SimulationModules/QAG4SimulationVertex.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationVertex.cc
@@ -27,7 +27,6 @@
 
 #include <TH1.h>
 #include <TH2.h>
-#include <TNamed.h>
 #include <TString.h>
 #include <TVector3.h>
 
@@ -35,6 +34,8 @@
 #include <cmath>
 #include <iostream>
 #include <map>
+#include <string>
+#include <set>
 #include <utility>  // for pair
 
 QAG4SimulationVertex::QAG4SimulationVertex(const std::string &name)
@@ -217,7 +218,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
     for (auto iter = prange.first; iter != prange.second; ++iter)  // process all primary paricle
     {
       const int point_id = iter->second->get_vtx_id();
-      int gembed = m_truthInfo->isEmbededVtx(iter->second->get_vtx_id());
+      int const gembed = m_truthInfo->isEmbededVtx(iter->second->get_vtx_id());
       ++vertex_particle_count[point_id];
       ++embedvtxid_particle_count[gembed];
       PHG4Particle *g4particle = iter->second;
@@ -227,7 +228,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
         continue;
       }
 
-      std::set<TrkrDefs::cluskey> g4clusters = clustereval->all_clusters_from(g4particle);
+      std::set<TrkrDefs::cluskey> const g4clusters = clustereval->all_clusters_from(g4particle);
 
       unsigned int nglmaps = 0;
 
@@ -243,7 +244,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
 
       for (const TrkrDefs::cluskey g4cluster : g4clusters)
       {
-        unsigned int layer = TrkrDefs::getLayer(g4cluster);
+        unsigned int const layer = TrkrDefs::getLayer(g4cluster);
         // std::cout<<__LINE__<<": " << _ievent <<": " <<gtrackID << ": " << layer <<": " <<g4cluster->get_id() <<std::endl;
         if (_nlayers_maps > 0 && layer < _nlayers_maps)
         {
@@ -258,20 +259,20 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
         }
       }
 
-      float gpx = g4particle->get_px();
-      float gpy = g4particle->get_py();
-      float gpz = g4particle->get_pz();
+      float const gpx = g4particle->get_px();
+      float const gpy = g4particle->get_py();
+      float const gpz = g4particle->get_pz();
       float gpt = NAN;
       float geta = NAN;
 
       if (gpx != 0 && gpy != 0)
       {
-        TVector3 gv(gpx, gpy, gpz);
+        TVector3 const gv(gpx, gpy, gpz);
         gpt = gv.Pt();
         geta = gv.Eta();
         //          gphi = gv.Phi();
       }
-      if (nglmaps == 3 && fabs(geta) < 1.0 && gpt > 0.5)
+      if (nglmaps == 3 && std::fabs(geta) < 1.0 && gpt > 0.5)
       {
         ++embedvtxid_maps_particle_count[gembed];
       }
@@ -285,7 +286,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
     for (auto iter = vrange.first; iter != vrange.second; ++iter)  // process all primary vertexes
     {
       const int point_id = iter->first;
-      int gembed = m_truthInfo->isEmbededVtx(point_id);
+      int const gembed = m_truthInfo->isEmbededVtx(point_id);
       if (gembed <= 0)
       {
         continue;
@@ -322,10 +323,10 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
       ++n_recoSvtxVertex;
 
       PHG4VtxPoint *point = vertexeval->max_truth_point_by_ntracks(vertex);
-      float vx = vertex->get_x();
-      float vy = vertex->get_y();
-      float vz = vertex->get_z();
-      float ntracks = vertex->size_tracks();
+      float const vx = vertex->get_x();
+      float const vy = vertex->get_y();
+      float const vz = vertex->get_z();
+      float const ntracks = vertex->size_tracks();
       float gvx = NAN;
       float gvy = NAN;
       float gvz = NAN;
@@ -336,7 +337,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
 
       h_ntracks->Fill(ntracks);
 
-      int ntracks_with_cuts = 0;
+      int const ntracks_with_cuts = 0;
       for (SvtxVertex::TrackIter iter2 = vertex->begin_tracks();
            iter2 != vertex->end_tracks();
            ++iter2)
@@ -414,7 +415,7 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
 
         h_gntracks->Fill(gntracks);
 
-        if (embedvtxid_maps_particle_count[(int) gembed] > 0 && fabs(gvt) < 2000. && fabs(gvz) < 13.0)
+        if (embedvtxid_maps_particle_count[(int) gembed] > 0 && std::fabs(gvt) < 2000. && std::fabs(gvz) < 13.0)
         {
           gntracksmaps = embedvtxid_maps_particle_count[(int) gembed];
         }
@@ -422,9 +423,9 @@ int QAG4SimulationVertex::process_event(PHCompositeNode *topNode)
         h_gntracksmaps->Fill(gntracksmaps);
         h_norm->Fill("MVTXTrackOnVertex", gntracksmaps);
       }
-      float vx_res = vx - gvx;
-      float vy_res = vy - gvy;
-      float vz_res = vz - gvz;
+      float const vx_res = vx - gvx;
+      float const vy_res = vy - gvy;
+      float const vz_res = vz - gvz;
 
       h_vxRes_gvz->Fill(gvz, vx_res);
       h_vyRes_gvz->Fill(gvz, vy_res);


### PR DESCRIPTION
Adds an ignore to the `.clang-tidy` file to ignore the `std::endl` warnings, and applies clang-tidy to the simulation qa package

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

