### PR TITLE
Add setter function to TowerJetInput and ClusterJetInput to allow for user-specified z vertex type 

### DIFF
--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -157,10 +157,10 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
       for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
       {
         const auto &[type, vertexVec] = *iter;
-        if (type != m_vertex_type) continue;
+        if (type != m_vertex_type) { continue; }
         for (const auto *v : vertexVec)
         {
-          if (!v) continue; 
+          if (!v) { continue; }
           vertex.set(v->get_x(), v->get_y(), v->get_z());
         }
       }

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -147,12 +147,35 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
 
   // first grab the event vertex or bail
   GlobalVertex *vtx = vertexmap->begin()->second;
-  CLHEP::Hep3Vector vertex;
+  CLHEP::Hep3Vector vertex(0, 0, std::nan(""));
   if (vtx)
   {
-    vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+    if (m_use_vertextype) 
+    {
+      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+      auto typeEndIter = vtx->end_vertexes();
+      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+      {
+        const auto &[type, vertexVec] = *iter;
+        if (type != m_vertex_type) continue;
+        for (const auto *v : vertexVec)
+        {
+          if (!v) continue; 
+          vertex.set(v->get_x(), v->get_y(), v->get_z());
+        }
+      }
+    } 
+    else 
+    {
+      vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+    }
   }
   else
+  {
+    return std::vector<Jet *>();
+  }
+
+  if (std::isnan(vertex.z()))
   {
     return std::vector<Jet *>();
   }

--- a/offline/packages/jetbase/ClusterJetInput.h
+++ b/offline/packages/jetbase/ClusterJetInput.h
@@ -7,12 +7,15 @@
 // then other local incudes
 #include "Jet.h"
 
+#include <globalvertex/GlobalVertex.h>
+
 // finally system includes
 #include <iostream>  // for cout, ostream
 #include <vector>
 
 // forward declarations
 class PHCompositeNode;
+class GlobalVertex;
 
 class ClusterJetInput : public JetInput
 {
@@ -26,9 +29,17 @@ class ClusterJetInput : public JetInput
 
   std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
+  void set_GlobalVertexType(GlobalVertex::VTXTYPE type) 
+  {
+    m_use_vertextype = true;
+    m_vertex_type = type;
+  }
+
  private:
   int m_Verbosity = 0;
   Jet::SRC m_Input = Jet::VOID;
+  bool m_use_vertextype {false};
+  GlobalVertex::VTXTYPE m_vertex_type = GlobalVertex::UNDEFINED;
 };
 
 #endif

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -403,14 +403,31 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     }
   }
 
-
-
   // first grab the event vertex or bail
   GlobalVertex *vtx = vertexmap->begin()->second;
   float vtxz = NAN;
+  
   if (vtx)
   {
-    vtxz = vtx->get_z();
+    if (m_use_vertextype) 
+    {
+      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+      auto typeEndIter = vtx->end_vertexes();
+      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+      {
+        const auto &[type, vertexVec] = *iter;
+        if (type != m_vertex_type) continue;
+        for (const auto *vertex : vertexVec)
+        {
+          if (!vertex) continue; 
+          vtxz = vertex->get_z();
+        }
+      }
+    } 
+    else 
+    {
+      vtxz = vtx->get_z();
+    }
   }
   else
   {

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -416,10 +416,10 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
       for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
       {
         const auto &[type, vertexVec] = *iter;
-        if (type != m_vertex_type) continue;
+        if (type != m_vertex_type) { continue; }
         for (const auto *vertex : vertexVec)
         {
-          if (!vertex) continue; 
+          if (!vertex) { continue; }
           vtxz = vertex->get_z();
         }
       }

--- a/offline/packages/jetbase/TowerJetInput.h
+++ b/offline/packages/jetbase/TowerJetInput.h
@@ -5,12 +5,14 @@
 #include "JetInput.h"
 
 #include <calobase/RawTowerDefs.h>
+#include <globalvertex/GlobalVertex.h>
 
 #include <iostream>  // for cout, ostream
 
 #include <vector>
 // forward declarations
 class PHCompositeNode;
+class GlobalVertex;
 class TowerJetInput : public JetInput
 {
  public:
@@ -23,12 +25,20 @@ class TowerJetInput : public JetInput
 
   std::vector<Jet*> get_input(PHCompositeNode* topNode) override;
 
+  void set_GlobalVertexType(GlobalVertex::VTXTYPE type) 
+  {
+    m_use_vertextype = true;
+    m_vertex_type = type;
+  }
+
  private:
   Jet::SRC m_input;
   RawTowerDefs::CalorimeterId geocaloid{RawTowerDefs::CalorimeterId::NONE};
   bool m_use_towerinfo {false};
   std::string m_towerNodePrefix;
   std::string towerName;
+  bool m_use_vertextype {false};
+  GlobalVertex::VTXTYPE m_vertex_type = GlobalVertex::UNDEFINED;
 };
 
 #endif


### PR DESCRIPTION
Allows user to select the type of global vertex used for jet reconstruction with either calorimeter towers or calorimeter clusters. Uses the GlobalVertex enum types to determine which global vertex to use. When global vertex type not specified, default behavior is still to use the "best" vertex from GlobalVertex. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)
PR in macros repo to implement this option in HIJetReco macro. Macros repo [PR 1028](https://github.com/sPHENIX-Collaboration/macros/pull/1028)
