### PR TITLE
Added a Verbosity after the _zero_field bool

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -302,7 +302,10 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 
     if(_zero_field) { // start _zero_field
 
-      std::cout << "zero field is ON, starting TPC clusters linear fit" << std::endl;
+      if (Verbosity() > 10)
+      {
+        std::cout << "zero field is ON, starting TPC clusters linear fit" << std::endl;
+      }
       auto cluster_list = getTrackletClusterList(tracklet_tpc);
 
       // need at least 3 clusters to fit a line
@@ -327,9 +330,11 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       }
 
     } else { // start !_zero_field
- 
-      std::cout << "zero field is OFF, starting TPC clusters circle fit" << std::endl;
 
+      if(Verbosity() > 10)
+      {
+        std::cout << "zero field is OFF, starting TPC clusters circle fit" << std::endl;
+      }
       // need at least 3 clusters to fit a circle
       if (outer_clusters.size() < 3)
       {


### PR DESCRIPTION
Corrected a Verbosity for a cout after a _zero_field bool flag.

[comment]: <Just implemented a Verbosity> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

