### PR TITLE
Max chi2 threshold for tower status setter

### DIFF
--- a/offline/packages/CaloReco/CaloTowerStatus.cc
+++ b/offline/packages/CaloReco/CaloTowerStatus.cc
@@ -258,7 +258,7 @@ int CaloTowerStatus::process_event(PHCompositeNode * /*topNode*/)
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isHot(true);
     }
-    if (chi2 > std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic))
+    if (chi2 > std::min(std::max(badChi2_treshold_const, adc * adc * badChi2_treshold_quadratic),badChi2_treshold_max))
     {
       m_raw_towers->get_tower_at_channel(channel)->set_isBadChi2(true);
     }

--- a/offline/packages/CaloReco/CaloTowerStatus.h
+++ b/offline/packages/CaloReco/CaloTowerStatus.h
@@ -52,6 +52,11 @@ class CaloTowerStatus : public SubsysReco
     fraction_badChi2_threshold = threshold;
     return;
   }
+  void set_badChi2_max_threshold(float threshold)
+  {
+    badChi2_treshold_max = threshold;
+    return;
+  }
   void set_time_cut(float threshold)
   {
     time_cut = threshold;
@@ -113,6 +118,7 @@ class CaloTowerStatus : public SubsysReco
 
   float badChi2_treshold_const = {1e4};
   float badChi2_treshold_quadratic = {1./100};
+  float badChi2_treshold_max = {1e8};
   float fraction_badChi2_threshold = {0.01};
   float time_cut = 2;  // number of samples from the mean time for the channel in the run
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

`TowerInfov4` saturate chi2 around 3e8, so some towers with very large energy(1E6) won't get flagged by the status setter, this PR adds an maximum chi2 threshold(1E8 by default).


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

