### PR TITLE
CaloValid TH3 histogram addition and trigger software inclusion

### DIFF
--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -26,6 +26,7 @@
 
 #include <TH1.h>
 #include <TH2.h>
+#include <TH3F.h>
 #include <TLorentzVector.h>
 #include <TProfile.h>
 #include <TProfile2D.h>
@@ -72,7 +73,7 @@ int CaloValid::Init(PHCompositeNode* /*unused*/)
   }
 
   createHistos();
-
+  trigAna = new TriggerAnalyzer();
   if (m_debug)
   {
     std::cout << "Leaving CaloValid::Init" << std::endl;
@@ -150,6 +151,29 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
   }
 
   //--------------------------- trigger and GL1-------------------------------//
+  if (trigAna)
+  {
+    trigAna->decodeTriggers(topNode);
+  }
+  else
+  {
+    if (m_debug)
+    {
+    std::cout << "[ERROR] No TriggerAnalyzer pointer!\n";
+    }
+  }
+
+  std::vector<int> scaledActiveBits;
+  scaledActiveBits.reserve(triggerIndices.size());
+
+  for (int bit : triggerIndices)
+  {
+    if (trigAna->didTriggerFire(bit))
+    {
+    scaledActiveBits.push_back(bit);
+    }
+  }
+    
   bool scaledBits[64] = {false};
   long long int raw[64] = {0};
   long long int live[64] = {0};
@@ -180,7 +204,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
       }
       triggervec = (triggervec >> 1U) & 0xffffffffU;
     }
-    triggervec = gl1PacketInfo->getScaledVector();
+    //triggervec = gl1PacketInfo->getScaledVector(); commented out to get rid of never used warning using clang -tidy
   }
 
   //---------------------------calibrated towers-------------------------------//
@@ -574,9 +598,29 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         }
 
         TLorentzVector pi0 = photon1 + photon2;
-        h_InvMass->Fill(pi0.M());
+        float pi0Mass = pi0.M();
+        unsigned int lt_eta = recoCluster->get_lead_tower().first;
+        unsigned int lt_phi = recoCluster->get_lead_tower().second;
+
+        int ld_ib_eta = lt_eta / 8;
+        int ld_ib_phi = lt_phi / 8;
+        int IB_num    = ld_ib_eta * 12 + ld_ib_phi;
+
+        for (int bit : scaledActiveBits)
+        {
+          if (std::find(triggerIndices.begin(), triggerIndices.end(), bit)
+              == triggerIndices.end())
+          {
+            continue;
+          }
+          h_pi0_trigIB_mass->Fill(
+            static_cast<double>(bit),
+            static_cast<double>(IB_num),
+            static_cast<double>(pi0Mass));
+        }
+        h_InvMass->Fill(pi0Mass);
       }
-    }
+    } // end cluster loop
   }
 
   //----------------- Trigger / alignment ----------------------------//
@@ -735,7 +779,7 @@ TH2* CaloValid::LogYHist2D(const std::string& name, const std::string& title, in
   Double_t logymin = std::log10(ymin);
   Double_t logymax = std::log10(ymax);
   Double_t binwidth = (logymax - logymin) / ybins_in;
-  Double_t *ybins = new Double_t[ybins_in + 1];
+  Double_t *ybins = new Double_t[ybins_in + 2]; //allocate 1 extra bin to fix "malloc()L memory corruption crash
 
   for (Int_t i = 0; i <= ybins_in + 1; i++)
   {
@@ -1002,9 +1046,18 @@ void CaloValid::createHistos()
       h_ihcal_channel_energy[channel]->SetDirectory(nullptr);
     }
   }
-
+  h_pi0_trigIB_mass = new TH3F(
+    "h_pi0_trigIB_mass",
+    ";Trigger Bit; iIB (eta*32 + phi); #pi^{0} Mass (GeV/c^{2})",
+    64, -0.5, 63.5,    // triggers
+    384, -0.5, 383.5,  // IB index
+    120, 0.0, 1.2      // mass range
+  );
+  h_pi0_trigIB_mass->SetDirectory(nullptr);
+  hm->registerHisto(h_pi0_trigIB_mass);
+    
   // Trigger QA
-  h_triggerVec = new TH1F("h_CaloValid_triggerVec", "", 64, 0, 64);
+  // h_triggerVec = new TH1F("h_CaloValid_triggerVec", "", 64, 0, 64); commented out due to memory allocation issue w/ redef from line 1009
   pr_ldClus_trig =
       new TProfile("pr_CaloValid_ldClus_trig", "", 64, 0, 64, 0, 10);
   for (int i = 0; i < 64; i++)
@@ -1039,3 +1092,4 @@ void CaloValid::createHistos()
   hm->registerHisto(h_triggerVec);
   hm->registerHisto(pr_ldClus_trig);
 }
+

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -2,6 +2,7 @@
 #define CALOVALID_CALOVALID_H
 
 #include <fun4all/SubsysReco.h>
+#include <calotrigger/TriggerAnalyzer.h>
 
 #include <string>
 #include <vector>
@@ -10,6 +11,7 @@
 class PHCompositeNode;
 class TH1;
 class TH2;
+class TH3F;
 class TProfile2D;
 class TProfile;
 
@@ -46,6 +48,10 @@ class CaloValid : public SubsysReco
   void MirrorHistogram(TH1* histogram);
   std::string getHistoPrefix() const;
 
+  TriggerAnalyzer* trigAna{nullptr};
+  TH3F* h_pi0_trigIB_mass = nullptr;
+  std::vector<int> triggerIndices = {10, 28, 29, 30, 31}; //MBD NS>=1, Photon Triggers
+    
   TH1* h_cemc_channel_pedestal[128 * 192]{nullptr};
   TH1* h_ihcal_channel_pedestal[32 * 48]{nullptr};
   TH1* h_ohcal_channel_pedestal[32 * 48]{nullptr};
@@ -124,3 +130,4 @@ class CaloValid : public SubsysReco
 };
 
 #endif
+

--- a/offline/QA/Calorimeters/Makefile.am
+++ b/offline/QA/Calorimeters/Makefile.am
@@ -23,6 +23,7 @@ libcalovalid_la_SOURCES = \
 
 libcalovalid_la_LIBADD = \
   -lcalo_io \
+  -lcalotrigger \
   -lCLHEP \
   -lfun4all \
   -lglobalvertex_io \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Added TH3 h_pi0_trigIB_mass to hold pi0 mass for each IB board, for triggers 10, and 28-31 (photon triggers). Updated necessary code to use decodeTriggers for this triggered data going into TH3, included header file definition, and inclusion of line in Makefile. Updated a couple of bugs causing memory issues when testing histogram generation.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

