### PR TITLE
Fix nopayloadclient

### DIFF
--- a/offline/database/sphenixnpc/CDBUtils.cc
+++ b/offline/database/sphenixnpc/CDBUtils.cc
@@ -9,6 +9,7 @@
 #include <set>
 #include <stdexcept>  // for out_of_range
 #include <tuple>
+#include <utility>  // for pair, make_pair
 
 CDBUtils::CDBUtils()
   : cdbclient(new SphenixClient())

--- a/offline/database/sphenixnpc/SphenixClient.cc
+++ b/offline/database/sphenixnpc/SphenixClient.cc
@@ -44,7 +44,11 @@ nlohmann::json SphenixClient::getUrl(const std::string& pl_type, long long iov)
   {
     return nopayloadclient::DataBaseException("No valid payload with type " + pl_type).jsonify();
   }
-  return makeResp(payload_iov["payload_url"]);
+  std::string payloadurl = payload_iov["payload_url"];
+  //  std::cout << "payload url: " << payloadurl << std::endl;
+  // the makeResp(T msg)  creates always problems when just doing
+  // makeResp(payload_iov["payload_url"] ) we get unresolved externals in non optimized code
+  return {{"code", 0}, {"msg", payloadurl}};
 }
 
 nlohmann::json SphenixClient::getUrlDict(long long iov)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes a long standing issue where using -O2 or no optimizer leads to unresolved externals. The underlying problem is a bad template definition in the NPPS client:
template<typename T>
json NoPayloadClient::makeResp(T msg) {
    return {{"code", 0}, {"msg", msg}};
}
using this in our code to return the payload url will lead to an unresolved json external. Contructing this ourselves without going through this template finally fixes this weird problem

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

