### PR TITLE
Add setter functions to CaloTowerCalib for mean time calibration and to only do calorimeter energy calibration

### DIFF
--- a/offline/packages/CaloReco/CaloTowerCalib.h
+++ b/offline/packages/CaloReco/CaloTowerCalib.h
@@ -78,6 +78,20 @@ class CaloTowerCalib : public SubsysReco
     m_doZScrosscalib = doZScrosscalib;
   }
 
+  void set_dotimecalib(bool dotimecalib)
+  {
+    m_dotimecalib = dotimecalib;
+  }
+
+  void set_doCalibOnly(bool docalib = true)
+  {
+    if (docalib) 
+    {
+      m_dotimecalib = false;
+      m_doZScrosscalib = false;
+    }
+  }
+
   void set_use_TowerInfov2(bool use) { m_use_TowerInfov2 = use; }
 
  private:


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Setter functions set_dotimecalib and set_doCalibOnly are implemented to allow for user to set member variables dotimecalib and doZScrosscalib from the module level.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

