### PR TITLE
Change Status Check for StreakSidebandFilter

### DIFF
--- a/offline/packages/jetbackground/BeamBackgroundFilterAndQADefs.h
+++ b/offline/packages/jetbackground/BeamBackgroundFilterAndQADefs.h
@@ -56,12 +56,13 @@ namespace BeamBackgroundFilterAndQADefs
     // members
     uint8_t status = 0;
     double energy = -1.;
-
+    bool isGood = false;
     //! grab info from a TowerInfo object
     void SetInfo(TowerInfo* info)
     {
       status = info->get_status();
       energy = info->get_energy();
+      isGood = info->get_isGood();
       return;
     }
 

--- a/offline/packages/jetbackground/StreakSidebandFilter.cc
+++ b/offline/packages/jetbackground/StreakSidebandFilter.cc
@@ -189,7 +189,7 @@ bool StreakSidebandFilter::IsTowerNotStreaky(const BeamBackgroundFilterAndQADefs
     std::cout << "StreakSidebandFilter::IsTowerNotStreaky() Checking if tower not consistent w/ streak" << std::endl;
   }
 
-  const bool isBadStatus = (tower.status != 1);
+  const bool isBadStatus = (tower.status != 0 && tower.status != 32);
   const bool isBelowEneCut = (tower.energy < m_config.minStreakTwrEne);
   return (isBadStatus || isBelowEneCut);
 
@@ -206,7 +206,7 @@ bool StreakSidebandFilter::IsNeighborNotStreaky(const BeamBackgroundFilterAndQAD
     std::cout << "StreakSidebandFilter::IsNeighborNotStreaky() Checking if neighboring tower not consistent w/ streak" << std::endl;
   }
 
-  const bool isBadStatus = (tower.status != 1);
+  const bool isBadStatus = (tower.status != 0 && tower.status != 32);
   const bool isAboveEneCut = (tower.energy > m_config.maxAdjacentTwrEne);
   return (isBadStatus || isAboveEneCut);
 

--- a/offline/packages/jetbackground/StreakSidebandFilter.cc
+++ b/offline/packages/jetbackground/StreakSidebandFilter.cc
@@ -189,7 +189,7 @@ bool StreakSidebandFilter::IsTowerNotStreaky(const BeamBackgroundFilterAndQADefs
     std::cout << "StreakSidebandFilter::IsTowerNotStreaky() Checking if tower not consistent w/ streak" << std::endl;
   }
 
-  const bool isBadStatus = (tower.status != 0 && tower.status != 32);
+  const bool isBadStatus = !(tower.isGood);
   const bool isBelowEneCut = (tower.energy < m_config.minStreakTwrEne);
   return (isBadStatus || isBelowEneCut);
 
@@ -206,7 +206,7 @@ bool StreakSidebandFilter::IsNeighborNotStreaky(const BeamBackgroundFilterAndQAD
     std::cout << "StreakSidebandFilter::IsNeighborNotStreaky() Checking if neighboring tower not consistent w/ streak" << std::endl;
   }
 
-  const bool isBadStatus = (tower.status != 0 && tower.status != 32);
+  const bool isBadStatus = !(tower.isGood);
   const bool isAboveEneCut = (tower.energy > m_config.maxAdjacentTwrEne);
   return (isBadStatus || isAboveEneCut);
 

--- a/offline/packages/jetbackground/StreakSidebandFilter.h
+++ b/offline/packages/jetbackground/StreakSidebandFilter.h
@@ -45,7 +45,7 @@ class StreakSidebandFilter : public BaseBeamBackgroundFilter
     int verbosity{0};
     bool debug{true};
     float minStreakTwrEne{0.6};
-    float maxAdjacentTwrEne{0.08};
+    float maxAdjacentTwrEne{0.06};
     uint32_t minNumTwrsInStreak{5};
     std::string inNodeName{"TOWERINFO_CALIB_HCALOUT"};
   };

--- a/offline/packages/jetbackground/StreakSidebandFilter.h
+++ b/offline/packages/jetbackground/StreakSidebandFilter.h
@@ -45,7 +45,7 @@ class StreakSidebandFilter : public BaseBeamBackgroundFilter
     int verbosity{0};
     bool debug{true};
     float minStreakTwrEne{0.6};
-    float maxAdjacentTwrEne{0.06};
+    float maxAdjacentTwrEne{0.08};
     uint32_t minNumTwrsInStreak{5};
     std::string inNodeName{"TOWERINFO_CALIB_HCALOUT"};
   };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Changes the status that the streak filter checks to determine if a tower is good or bad. Previously, checked for 1 to determine goodness (wrong), now checks for 0 (good) or 32 (zero suppressed and good).
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This is a bug fix. As above, I have changed which statuses indicate that a tower is good to match the definitions currently in core software. Previously this file checked that the status was NOT 1 in order to determine that the tower was bad. It should check for NOT 0 and NOT 32, as these two statuses are good towers.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

