### PR TITLE
Fixed an error in the CopyFrom Function in TrkrClusterv5 

### DIFF
--- a/offline/packages/trackbase/TrkrClusterv5.cc
+++ b/offline/packages/trackbase/TrkrClusterv5.cc
@@ -84,7 +84,7 @@ void TrkrClusterv5::CopyFrom(const TrkrCluster& source)
   setSubSurfKey(source.getSubSurfKey());
   setAdc(source.getAdc());
   setMaxAdc(source.getMaxAdc());
-  setPhiError(source.getPhiError());
+  setPhiError(source.getRPhiError());
   setZError(source.getZError());
   setPhiSize(source.getPhiSize());
   setZSize(source.getZSize());


### PR DESCRIPTION
CopyFrom Function in TrkrClusterv5 used getPhiError when the name of the function is getRPhiError. This only fixes the names used in CopyFrom but it could be worth looking into why the get and set functions have different naming schemes
