### PR TITLE
Add functions to pi0EtaByEta to require a z vertex and to set the vertex type used for cluster location.

### DIFF
--- a/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.cc
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.cc
@@ -196,14 +196,41 @@ int pi0EtaByEta::process_towers(PHCompositeNode* topNode)
     std::cout << "pi0EtaByEta GlobalVertexMap node is missing" << std::endl;
     // return Fun4AllReturnCodes::ABORTRUN;
   }
+  
   float vtx_z = 0;
-  if (vertexmap && !vertexmap->empty())
+  bool found_vertex = false;
+  if (vertexmap && !vertexmap->empty()) 
   {
-    GlobalVertex* vtx = vertexmap->begin()->second;
+    GlobalVertex *vtx = vertexmap->begin()->second;
     if (vtx)
     {
-      vtx_z = vtx->get_z();
+      if (m_use_vertextype) 
+      {
+        auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+        auto typeEndIter = vtx->end_vertexes();
+        for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+        {
+          const auto &[type, vertexVec] = *iter;
+          if (type != m_vertex_type) { continue; }
+          for (const auto *vertex : vertexVec)
+          {
+            if (!vertex) { continue; }
+            vtx_z = vertex->get_z();
+            found_vertex = true;
+          }
+        }
+      } 
+      else 
+      {
+        vtx_z = vtx->get_z();
+        found_vertex = true;
+      }
     }
+  }
+
+  if (!found_vertex && reqVertex) 
+  {
+    return Fun4AllReturnCodes::EVENT_OK;
   }
 
   TowerInfoContainer* towers = findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_CEMC");

--- a/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>  // for string
 #include <vector>
+#include <globalvertex/GlobalVertex.h>
 
 // Forward declarations
 class Fun4AllHistoManager;
@@ -111,6 +112,17 @@ class pi0EtaByEta : public SubsysReco
     return;
   }
 
+  void set_GlobalVertexType(GlobalVertex::VTXTYPE type) 
+  {
+    m_use_vertextype = true;
+    m_vertex_type = type;
+  }
+
+  void set_requireVertex(bool state)
+  {
+    reqVertex = state;
+    return;
+  }
 
  protected:
   int Getpeaktime(TH1* h);
@@ -118,9 +130,12 @@ class pi0EtaByEta : public SubsysReco
   std::string outfilename;
 
   bool reqMinBias = true;
+  bool reqVertex = false;
 
   bool doVtxCut = true;
   float vtx_z_cut = 20;
+  bool m_use_vertextype {false};
+  GlobalVertex::VTXTYPE m_vertex_type = GlobalVertex::UNDEFINED;
 
   float pt1BaseClusCut = 1.3;
   float pt2BaseClusCut = 0.7;

--- a/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
+++ b/calibrations/calorimeter/calo_emc_pi0_tbt/pi0EtaByEta.h
@@ -1,13 +1,14 @@
 #ifndef PIEbyE_H__
 #define PIEbyE_H__
 
+#include <globalvertex/GlobalVertex.h>
+
 #include <fun4all/SubsysReco.h>
 
 //#include <CLHEP/Vector/ThreeVector.h>  // for Hep3Vector
 #include <array>
 #include <string>  // for string
 #include <vector>
-#include <globalvertex/GlobalVertex.h>
 
 // Forward declarations
 class Fun4AllHistoManager;


### PR DESCRIPTION
This PR adds function set_requireVertex which allows the user to require that every event used in pi0 mass finding have a z vertex (previous/default behavior sets vtx_z = 0 in the case that a vertex is not found from the GlobalVertex Container). This PR also adds function set_GlobalVertexType which allows the user to choose the vertex type from the GlobalVertex Container to use allowing for direct comparison between calorimeter data in data and MC using the MBD vertex. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

