### PR TITLE
Fix globalvertex

### DIFF
--- a/offline/packages/globalvertex/GlobalVertex.cc
+++ b/offline/packages/globalvertex/GlobalVertex.cc
@@ -6,7 +6,7 @@ namespace
 {
   std::map<GlobalVertex::VTXTYPE, unsigned int> DummyGlobalVertex;
   std::map<GlobalVertex::VTXTYPE, GlobalVertex::VertexVector> dumVertexVector;
-}
+}  // namespace
 
 GlobalVertex::ConstVertexIter GlobalVertex::begin_vertexes() const
 {

--- a/offline/packages/globalvertex/GlobalVertex.cc
+++ b/offline/packages/globalvertex/GlobalVertex.cc
@@ -1,7 +1,12 @@
 #include "GlobalVertex.h"
 
-std::map<GlobalVertex::VTXTYPE, unsigned int> DummyGlobalVertex;
-std::map<GlobalVertex::VTXTYPE, GlobalVertex::VertexVector> dumVertexVector;
+#include <map>
+
+namespace
+{
+  std::map<GlobalVertex::VTXTYPE, unsigned int> DummyGlobalVertex;
+  std::map<GlobalVertex::VTXTYPE, GlobalVertex::VertexVector> dumVertexVector;
+}
 
 GlobalVertex::ConstVertexIter GlobalVertex::begin_vertexes() const
 {

--- a/offline/packages/globalvertex/GlobalVertex.h
+++ b/offline/packages/globalvertex/GlobalVertex.h
@@ -47,45 +47,45 @@ class GlobalVertex : public PHObject
   // vertex info
 
   virtual unsigned int get_id() const { return std::numeric_limits<unsigned int>::max(); }
-  virtual void set_id(unsigned int) {return;}
+  virtual void set_id(unsigned int) { return; }
 
   virtual float get_t() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_t(float) {return;}
+  virtual void set_t(float) { return; }
 
   virtual float get_t_err() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_t_err(float) {return;}
+  virtual void set_t_err(float) { return; }
 
   virtual float get_x() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_x(float) {return;}
+  virtual void set_x(float) { return; }
 
   virtual float get_y() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_y(float) {return;}
+  virtual void set_y(float) { return; }
 
   virtual float get_z() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_z(float) {return;}
+  virtual void set_z(float) { return; }
 
   virtual float get_chisq() const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_chisq(float) {return;}
+  virtual void set_chisq(float) { return; }
 
   virtual unsigned int get_ndof() const { return std::numeric_limits<unsigned int>::max(); }
-  virtual void set_ndof(unsigned int) {return;}
+  virtual void set_ndof(unsigned int) { return; }
 
   virtual float get_position(unsigned int /*coor*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {return;}
+  virtual void set_position(unsigned int /*coor*/, float /*xi*/) { return; }
 
   virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
-  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {return;}
+  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) { return; }
 
   virtual unsigned int get_beam_crossing() const { return std::numeric_limits<unsigned int>::max(); }
-  virtual void set_beam_crossing(unsigned int) {return;}
+  virtual void set_beam_crossing(unsigned int) { return; }
 
   virtual bool empty_vtxs() const { return true; }
   virtual size_t size_vtxs() const { return 0; }
   virtual size_t count_vtxs(VTXTYPE) const { return 0; }
-  virtual void clear_vtxs() {return;}
-  virtual void insert_vtx(VTXTYPE, const Vertex*) {return;}
+  virtual void clear_vtxs() { return; }
+  virtual void insert_vtx(VTXTYPE, const Vertex*) { return; }
   virtual size_t erase_vtxs(VTXTYPE) { return 0; }
-  virtual void erase_vtxs(VertexIter) {return;}
+  virtual void erase_vtxs(VertexIter) { return; }
 
   virtual ConstVertexIter begin_vertexes() const;
   virtual ConstVertexIter find_vertexes(VTXTYPE type) const;
@@ -104,11 +104,11 @@ class GlobalVertex : public PHObject
   virtual size_t size_vtxids() const { return 0; }
   virtual size_t count_vtxids(VTXTYPE /*type*/) const { return 0; }
 
-  virtual void clear_vtxids() {return;}
-  virtual void insert_vtxids(VTXTYPE /*type*/, unsigned int /*vtxid*/) {return;}
+  virtual void clear_vtxids() { return; }
+  virtual void insert_vtxids(VTXTYPE /*type*/, unsigned int /*vtxid*/) { return; }
   virtual size_t erase_vtxids(VTXTYPE /*type*/) { return 0; }
-  virtual void erase_vtxids(VtxIter /*iter*/) {return;}
-  virtual void erase_vtxids(VtxIter /*first*/, VtxIter /*last*/) {return;}
+  virtual void erase_vtxids(VtxIter /*iter*/) { return; }
+  virtual void erase_vtxids(VtxIter /*first*/, VtxIter /*last*/) { return; }
 
   virtual ConstVtxIter begin_vtxids() const;
   virtual ConstVtxIter find_vtxids(VTXTYPE type) const;

--- a/offline/packages/globalvertex/GlobalVertex.h
+++ b/offline/packages/globalvertex/GlobalVertex.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEX_H
-#define G4VERTEX_GLOBALVERTEX_H
+#ifndef GLOBALVERTEX_GLOBALVERTEX_H
+#define GLOBALVERTEX_GLOBALVERTEX_H
 
 #include <phool/PHObject.h>
 #include <cmath>

--- a/offline/packages/globalvertex/GlobalVertex.h
+++ b/offline/packages/globalvertex/GlobalVertex.h
@@ -84,6 +84,7 @@ class GlobalVertex : public PHObject
   virtual size_t count_vtxs(VTXTYPE) const { return 0; }
   virtual void clear_vtxs() { return; }
   virtual void insert_vtx(VTXTYPE, const Vertex*) { return; }
+  virtual void clone_insert_vtx(VTXTYPE, const Vertex*) { return; }
   virtual size_t erase_vtxs(VTXTYPE) { return 0; }
   virtual void erase_vtxs(VertexIter) { return; }
 

--- a/offline/packages/globalvertex/GlobalVertex.h
+++ b/offline/packages/globalvertex/GlobalVertex.h
@@ -3,11 +3,13 @@
 #ifndef GLOBALVERTEX_GLOBALVERTEX_H
 #define GLOBALVERTEX_GLOBALVERTEX_H
 
-#include <phool/PHObject.h>
-#include <cmath>
-#include <iostream>
-#include <map>
 #include "Vertex.h"
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <limits>
+#include <map>
 
 class GlobalVertex : public PHObject
 {
@@ -31,7 +33,7 @@ class GlobalVertex : public PHObject
   typedef std::map<GlobalVertex::VTXTYPE, unsigned int>::const_iterator ConstVtxIter;
   typedef std::map<GlobalVertex::VTXTYPE, unsigned int>::iterator VtxIter;
 
-  ~GlobalVertex() override {}
+  ~GlobalVertex() override = default;
 
   // PHObject virtual overloads
 
@@ -44,46 +46,46 @@ class GlobalVertex : public PHObject
 
   // vertex info
 
-  virtual unsigned int get_id() const { return 0xFFFFFFFF; }
-  virtual void set_id(unsigned int) {}
+  virtual unsigned int get_id() const { return std::numeric_limits<unsigned int>::max(); }
+  virtual void set_id(unsigned int) {return;}
 
-  virtual float get_t() const { return NAN; }
-  virtual void set_t(float) {}
+  virtual float get_t() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_t(float) {return;}
 
-  virtual float get_t_err() const { return NAN; }
-  virtual void set_t_err(float) {}
+  virtual float get_t_err() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_t_err(float) {return;}
 
-  virtual float get_x() const { return NAN; }
-  virtual void set_x(float) {}
+  virtual float get_x() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_x(float) {return;}
 
-  virtual float get_y() const { return NAN; }
-  virtual void set_y(float) {}
+  virtual float get_y() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_y(float) {return;}
 
-  virtual float get_z() const { return NAN; }
-  virtual void set_z(float) {}
+  virtual float get_z() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_z(float) {return;}
 
-  virtual float get_chisq() const { return NAN; }
-  virtual void set_chisq(float) {}
+  virtual float get_chisq() const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_chisq(float) {return;}
 
-  virtual unsigned int get_ndof() const { return 0xFFFFFFFF; }
-  virtual void set_ndof(unsigned int) {}
+  virtual unsigned int get_ndof() const { return std::numeric_limits<unsigned int>::max(); }
+  virtual void set_ndof(unsigned int) {return;}
 
-  virtual float get_position(unsigned int /*coor*/) const { return NAN; }
-  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
+  virtual float get_position(unsigned int /*coor*/) const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_position(unsigned int /*coor*/, float /*xi*/) {return;}
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
-  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
+  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {return;}
 
   virtual unsigned int get_beam_crossing() const { return std::numeric_limits<unsigned int>::max(); }
-  virtual void set_beam_crossing(unsigned int) {}
+  virtual void set_beam_crossing(unsigned int) {return;}
 
   virtual bool empty_vtxs() const { return true; }
   virtual size_t size_vtxs() const { return 0; }
   virtual size_t count_vtxs(VTXTYPE) const { return 0; }
-  virtual void clear_vtxs() {}
-  virtual void insert_vtx(VTXTYPE, const Vertex*) {}
+  virtual void clear_vtxs() {return;}
+  virtual void insert_vtx(VTXTYPE, const Vertex*) {return;}
   virtual size_t erase_vtxs(VTXTYPE) { return 0; }
-  virtual void erase_vtxs(VertexIter) {}
+  virtual void erase_vtxs(VertexIter) {return;}
 
   virtual ConstVertexIter begin_vertexes() const;
   virtual ConstVertexIter find_vertexes(VTXTYPE type) const;
@@ -102,11 +104,11 @@ class GlobalVertex : public PHObject
   virtual size_t size_vtxids() const { return 0; }
   virtual size_t count_vtxids(VTXTYPE /*type*/) const { return 0; }
 
-  virtual void clear_vtxids() {}
-  virtual void insert_vtxids(VTXTYPE /*type*/, unsigned int /*vtxid*/) {}
+  virtual void clear_vtxids() {return;}
+  virtual void insert_vtxids(VTXTYPE /*type*/, unsigned int /*vtxid*/) {return;}
   virtual size_t erase_vtxids(VTXTYPE /*type*/) { return 0; }
-  virtual void erase_vtxids(VtxIter /*iter*/) {}
-  virtual void erase_vtxids(VtxIter /*first*/, VtxIter /*last*/) {}
+  virtual void erase_vtxids(VtxIter /*iter*/) {return;}
+  virtual void erase_vtxids(VtxIter /*first*/, VtxIter /*last*/) {return;}
 
   virtual ConstVtxIter begin_vtxids() const;
   virtual ConstVtxIter find_vtxids(VTXTYPE type) const;
@@ -117,7 +119,7 @@ class GlobalVertex : public PHObject
   virtual VtxIter end_vtxids();
 
  protected:
-  GlobalVertex() {}
+  GlobalVertex() = default;
 
  private:
   ClassDefOverride(GlobalVertex, 1);

--- a/offline/packages/globalvertex/GlobalVertexMap.cc
+++ b/offline/packages/globalvertex/GlobalVertexMap.cc
@@ -1,6 +1,11 @@
 #include "GlobalVertexMap.h"
 
-std::map<unsigned int, GlobalVertex*> DummyGlobalVertexMap;
+#include <map>
+
+namespace
+{
+  std::map<unsigned int, GlobalVertex*> DummyGlobalVertexMap;
+}
 
 GlobalVertexMap::ConstIter GlobalVertexMap::begin() const
 {

--- a/offline/packages/globalvertex/GlobalVertexMap.cc
+++ b/offline/packages/globalvertex/GlobalVertexMap.cc
@@ -4,7 +4,7 @@
 
 namespace
 {
-  std::map<unsigned int, GlobalVertex*> DummyGlobalVertexMap;
+  std::map<unsigned int, GlobalVertex *> DummyGlobalVertexMap;
 }
 
 GlobalVertexMap::ConstIter GlobalVertexMap::begin() const

--- a/offline/packages/globalvertex/GlobalVertexMap.h
+++ b/offline/packages/globalvertex/GlobalVertexMap.h
@@ -20,7 +20,7 @@ class GlobalVertexMap : public PHObject
 
   void identify(std::ostream& os = std::cout) const override { os << "GlobalVertexMap base class" << std::endl; }
   int isValid() const override { return 0; }
-  virtual void CopyTo(GlobalVertexMap *) {return;}
+  virtual void CopyTo(GlobalVertexMap*) { return; }
 
   virtual bool empty() const { return true; }
   virtual size_t size() const { return 0; }

--- a/offline/packages/globalvertex/GlobalVertexMap.h
+++ b/offline/packages/globalvertex/GlobalVertexMap.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEXMAP_H
-#define G4VERTEX_GLOBALVERTEXMAP_H
+#ifndef GLOBALVERTEX_GLOBALVERTEXMAP_H
+#define GLOBALVERTEX_GLOBALVERTEXMAP_H
 
 #include <phool/PHObject.h>
 

--- a/offline/packages/globalvertex/GlobalVertexMapv1.cc
+++ b/offline/packages/globalvertex/GlobalVertexMapv1.cc
@@ -3,7 +3,6 @@
 #include "GlobalVertex.h"
 #include "GlobalVertexMap.h"
 
-#include <iterator>  // for reverse_iterator
 #include <utility>   // for pair, make_pair
 
 GlobalVertexMapv1::~GlobalVertexMapv1()

--- a/offline/packages/globalvertex/GlobalVertexMapv1.cc
+++ b/offline/packages/globalvertex/GlobalVertexMapv1.cc
@@ -3,7 +3,7 @@
 #include "GlobalVertex.h"
 #include "GlobalVertexMap.h"
 
-#include <utility>   // for pair, make_pair
+#include <utility>  // for pair, make_pair
 
 GlobalVertexMapv1::~GlobalVertexMapv1()
 {
@@ -57,11 +57,11 @@ GlobalVertex* GlobalVertexMapv1::insert(GlobalVertex* clus)
   return _map[index];
 }
 
-void GlobalVertexMapv1::CopyTo(GlobalVertexMap *to_global)
+void GlobalVertexMapv1::CopyTo(GlobalVertexMap* to_global)
 {
-  for (auto const &it : _map)
+  for (auto const& it : _map)
   {
-    GlobalVertex *glvtx = dynamic_cast<GlobalVertex *> (it.second->CloneMe());
+    GlobalVertex* glvtx = dynamic_cast<GlobalVertex*>(it.second->CloneMe());
     to_global->insert(glvtx);
   }
 }

--- a/offline/packages/globalvertex/GlobalVertexMapv1.h
+++ b/offline/packages/globalvertex/GlobalVertexMapv1.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEXMAPV1_H
-#define G4VERTEX_GLOBALVERTEXMAPV1_H
+#ifndef GLOBALVERTEX_GLOBALVERTEXMAPV1_H
+#define GLOBALVERTEX_GLOBALVERTEXMAPV1_H
 
 #include "GlobalVertexMap.h"
 

--- a/offline/packages/globalvertex/GlobalVertexMapv1.h
+++ b/offline/packages/globalvertex/GlobalVertexMapv1.h
@@ -21,7 +21,7 @@ class GlobalVertexMapv1 : public GlobalVertexMap
   void Reset() override { clear(); }
   int isValid() const override { return _map.size(); }
   PHObject* CloneMe() const override { return new GlobalVertexMapv1(*this); }
-  void CopyTo(GlobalVertexMap *) override;
+  void CopyTo(GlobalVertexMap*) override;
 
   bool empty() const override { return _map.empty(); }
   size_t size() const override { return _map.size(); }

--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -23,16 +23,13 @@
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
 
-#include <cfloat>
 #include <cmath>
 #include <cstdlib>  // for exit
 #include <iostream>
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 
-using namespace std;
-
-GlobalVertexReco::GlobalVertexReco(const string &name)
+GlobalVertexReco::GlobalVertexReco(const std::string &name)
   : SubsysReco(name)
 {
 }
@@ -41,8 +38,8 @@ int GlobalVertexReco::InitRun(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
-    cout << "======================= GlobalVertexReco::InitRun() =======================" << endl;
-    cout << "===========================================================================" << endl;
+    std::cout << "======================= GlobalVertexReco::InitRun() =======================" << std::endl;
+    std::cout << "===========================================================================" << std::endl;
   }
 
   return CreateNodes(topNode);
@@ -52,7 +49,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 {
   if (Verbosity() > 1)
   {
-    cout << "GlobalVertexReco::process_event -- entered" << endl;
+    std::cout << "GlobalVertexReco::process_event -- entered" << std::endl;
   }
 
   //---------------------------------
@@ -61,7 +58,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   GlobalVertexMap *globalmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!globalmap)
   {
-    cout << PHWHERE << "::ERROR - cannot find GlobalVertexMap" << endl;
+    std::cout << PHWHERE << "::ERROR - cannot find GlobalVertexMap" << std::endl;
     exit(-1);
   }
 
@@ -92,7 +89,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   {
     if (Verbosity())
     {
-      cout << "GlobalVertexReco::process_event - svtxmap && mbdmap" << endl;
+      std::cout << "GlobalVertexReco::process_event - svtxmap && mbdmap" << std::endl;
     }
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
@@ -102,7 +99,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       const SvtxVertex *svtx = svtxiter->second;
 
       const MbdVertex *mbd_best = nullptr;
-      float min_sigma = FLT_MAX;
+      float min_sigma = std::numeric_limits<float>::max();
       for (MbdVertexMap::ConstIter mbditer = mbdmap->begin();
            mbditer != mbdmap->end();
            ++mbditer)
@@ -158,7 +155,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   {
     if (Verbosity())
     {
-      cout << "GlobalVertexReco::process_event - svtxmap " << endl;
+      std::cout << "GlobalVertexReco::process_event - svtxmap " << std::endl;
     }
 
     for (SvtxVertexMap::ConstIter svtxiter = svtxmap->begin();
@@ -171,7 +168,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       {
         continue;
       }
-      if (isnan(svtx->get_z()))
+      if (std::isnan(svtx->get_z()))
       {
         continue;
       }
@@ -208,7 +205,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
   {
     if (Verbosity())
     {
-      cout << "GlobalVertexReco::process_event -  mbdmap" << endl;
+      std::cout << "GlobalVertexReco::process_event -  mbdmap" << std::endl;
     }
 
     for (MbdVertexMap::ConstIter mbditer = mbdmap->begin();
@@ -221,7 +218,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       {
         continue;
       }
-      if (isnan(mbd->get_z()))
+      if (std::isnan(mbd->get_z()))
       {
         continue;
       }
@@ -289,7 +286,7 @@ int GlobalVertexReco::CreateNodes(PHCompositeNode *topNode)
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 

--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -125,8 +125,8 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       GlobalVertex *vertex = new GlobalVertexv2();
       vertex->set_id(globalmap->size());
 
-      vertex->insert_vtx(GlobalVertex::SVTX, svtx);
-      vertex->insert_vtx(GlobalVertex::MBD, mbd_best);
+      vertex->clone_insert_vtx(GlobalVertex::SVTX, svtx);
+      vertex->clone_insert_vtx(GlobalVertex::MBD, mbd_best);
       used_svtx_vtxids.insert(svtx->get_id());
       used_mbd_vtxids.insert(mbd_best->get_id());
       vertex->set_id(globalmap->size());
@@ -179,7 +179,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
 
       vertex->set_id(globalmap->size());
 
-      vertex->insert_vtx(GlobalVertex::SVTX, svtx);
+      vertex->clone_insert_vtx(GlobalVertex::SVTX, svtx);
       used_svtx_vtxids.insert(svtx->get_id());
 
       //! Reset track ids to the new vertex object
@@ -227,7 +227,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       GlobalVertex *vertex = new GlobalVertexv2();
       vertex->set_id(globalmap->size());
 
-      vertex->insert_vtx(GlobalVertex::MBD, mbd);
+      vertex->clone_insert_vtx(GlobalVertex::MBD, mbd);
       used_mbd_vtxids.insert(mbd->get_id());
 
       globalmap->insert(vertex);

--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -108,7 +108,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
         const MbdVertex *mbd = mbditer->second;
 
         float combined_error = sqrt(svtx->get_error(2, 2) + pow(mbd->get_z_err(), 2));
-        float sigma = fabs(svtx->get_z() - mbd->get_z()) / combined_error;
+        float sigma = std::fabs(svtx->get_z() - mbd->get_z()) / combined_error;
         if (sigma < min_sigma)
         {
           min_sigma = sigma;
@@ -257,7 +257,7 @@ int GlobalVertexReco::process_event(PHCompositeNode *topNode)
       for (const auto &[vkey, vertex] : *globalmap)
       {
         float dz = track->get_z() - vertex->get_z();
-        if (fabs(dz) < maxdz)
+        if (std::fabs(dz) < maxdz)
         {
           maxdz = dz;
           vtxid = vkey;

--- a/offline/packages/globalvertex/GlobalVertexReco.cc
+++ b/offline/packages/globalvertex/GlobalVertexReco.cc
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdlib>  // for exit
 #include <iostream>
+#include <limits>
 #include <set>      // for _Rb_tree_const_iterator
 #include <utility>  // for pair
 

--- a/offline/packages/globalvertex/GlobalVertexReco.h
+++ b/offline/packages/globalvertex/GlobalVertexReco.h
@@ -48,12 +48,12 @@ class GlobalVertexReco : public SubsysReco
  private:
   int CreateNodes(PHCompositeNode *topNode);
 
-  float _xdefault = 0.;
-  float _xerr = 0.3;
-  float _ydefault = 0.;
-  float _yerr = 0.3;
-  float _tdefault = 0.;
-  float _terr = 0.2;
+  float _xdefault {0.};
+  float _xerr {0.3};
+  float _ydefault  {0.};
+  float _yerr {0.3};
+  float _tdefault {0.};
+  float _terr {0.2};
 };
 
-#endif  // G4VERTEX_GLOBALVERTEXRECO_H
+#endif  // GLOBALVERTEX_GLOBALVERTEXRECO_H

--- a/offline/packages/globalvertex/GlobalVertexReco.h
+++ b/offline/packages/globalvertex/GlobalVertexReco.h
@@ -48,12 +48,12 @@ class GlobalVertexReco : public SubsysReco
  private:
   int CreateNodes(PHCompositeNode *topNode);
 
-  float _xdefault {0.};
-  float _xerr {0.3};
-  float _ydefault  {0.};
-  float _yerr {0.3};
-  float _tdefault {0.};
-  float _terr {0.2};
+  float _xdefault{0.};
+  float _xerr{0.3};
+  float _ydefault{0.};
+  float _yerr{0.3};
+  float _tdefault{0.};
+  float _terr{0.2};
 };
 
 #endif  // GLOBALVERTEX_GLOBALVERTEXRECO_H

--- a/offline/packages/globalvertex/GlobalVertexReco.h
+++ b/offline/packages/globalvertex/GlobalVertexReco.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEXRECO_H
-#define G4VERTEX_GLOBALVERTEXRECO_H
+#ifndef GLOBALVERTEX_GLOBALVERTEXRECO_H
+#define GLOBALVERTEX_GLOBALVERTEXRECO_H
 
 //===========================================================
 /// \file GlobalVertexReco.h

--- a/offline/packages/globalvertex/GlobalVertexv1.cc
+++ b/offline/packages/globalvertex/GlobalVertexv1.cc
@@ -1,6 +1,8 @@
 #include "GlobalVertexv1.h"
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
 
 GlobalVertexv1::GlobalVertexv1(const GlobalVertex::VTXTYPE id)
   : _id(id)

--- a/offline/packages/globalvertex/GlobalVertexv1.h
+++ b/offline/packages/globalvertex/GlobalVertexv1.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEXV1_H
-#define G4VERTEX_GLOBALVERTEXV1_H
+#ifndef GLOBALVERTEX_GLOBALVERTEXV1_H
+#define GLOBALVERTEX_GLOBALVERTEXV1_H
 
 #include "GlobalVertex.h"
 

--- a/offline/packages/globalvertex/GlobalVertexv2.cc
+++ b/offline/packages/globalvertex/GlobalVertexv2.cc
@@ -12,9 +12,9 @@ GlobalVertexv2::~GlobalVertexv2()
 
 void GlobalVertexv2::Reset()
 {
-  for (ConstVertexIter iter = begin_vertexes(); iter != end_vertexes(); ++iter)
+  for (GlobalVertex::VertexIter iter = _vtxs.begin(); iter != _vtxs.end(); ++iter)
   {
-    for (auto& vertex : iter->second)
+    for (auto vertex : iter->second)
     {
       delete vertex;
     }
@@ -62,6 +62,20 @@ void GlobalVertexv2::insert_vtx(GlobalVertex::VTXTYPE type, const Vertex* vertex
   }
 
   it->second.push_back(vertex);
+}
+void GlobalVertexv2::clone_insert_vtx(GlobalVertex::VTXTYPE type, const Vertex* vertex)
+{
+  auto it = _vtxs.find(type);
+  Vertex *clone = dynamic_cast<Vertex *> (vertex->CloneMe());
+  if (it == _vtxs.end())
+  {
+    VertexVector vector;
+    vector.push_back(clone);
+    _vtxs.insert(std::make_pair(type, vector));
+    return;
+  }
+
+  it->second.push_back(clone);
 }
 size_t GlobalVertexv2::count_vtxs(GlobalVertex::VTXTYPE type) const
 {

--- a/offline/packages/globalvertex/GlobalVertexv2.cc
+++ b/offline/packages/globalvertex/GlobalVertexv2.cc
@@ -12,9 +12,9 @@ GlobalVertexv2::~GlobalVertexv2()
 
 void GlobalVertexv2::Reset()
 {
-  for (GlobalVertex::VertexIter iter = _vtxs.begin(); iter != _vtxs.end(); ++iter)
+  for (auto & _vtx : _vtxs)
   {
-    for (auto vertex : iter->second)
+    for (auto vertex : _vtx.second)
     {
       delete vertex;
     }

--- a/offline/packages/globalvertex/GlobalVertexv2.cc
+++ b/offline/packages/globalvertex/GlobalVertexv2.cc
@@ -12,14 +12,14 @@ GlobalVertexv2::~GlobalVertexv2()
 
 void GlobalVertexv2::Reset()
 {
-    for (ConstVertexIter iter = begin_vertexes(); iter != end_vertexes(); ++iter)
+  for (ConstVertexIter iter = begin_vertexes(); iter != end_vertexes(); ++iter)
   {
     for (auto& vertex : iter->second)
     {
       delete vertex;
     }
   }
-    _vtxs.clear();
+  _vtxs.clear();
 }
 
 void GlobalVertexv2::identify(std::ostream& os) const

--- a/offline/packages/globalvertex/GlobalVertexv2.cc
+++ b/offline/packages/globalvertex/GlobalVertexv2.cc
@@ -1,17 +1,25 @@
 #include "GlobalVertexv2.h"
 
-#include <cmath>
-
-GlobalVertexv2::GlobalVertexv2()
-  : _id(std::numeric_limits<unsigned int>::max())
-  , _bco(std::numeric_limits<unsigned int>::max())
+GlobalVertexv2::GlobalVertexv2(const unsigned int id)
+  : _id(id)
 {
 }
 
-GlobalVertexv2::GlobalVertexv2(const unsigned int id)
-  : _id(id)
-  , _bco(std::numeric_limits<unsigned int>::max())
+GlobalVertexv2::~GlobalVertexv2()
 {
+  GlobalVertexv2::Reset();
+}
+
+void GlobalVertexv2::Reset()
+{
+    for (ConstVertexIter iter = begin_vertexes(); iter != end_vertexes(); ++iter)
+  {
+    for (auto& vertex : iter->second)
+    {
+      delete vertex;
+    }
+  }
+    _vtxs.clear();
 }
 
 void GlobalVertexv2::identify(std::ostream& os) const
@@ -71,7 +79,7 @@ float GlobalVertexv2::get_t() const
   auto it = _vtxs.find(GlobalVertex::VTXTYPE::MBD);
   if (it == _vtxs.end())
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   return it->second[0]->get_t();
@@ -82,7 +90,7 @@ float GlobalVertexv2::get_t_err() const
   auto it = _vtxs.find(GlobalVertex::VTXTYPE::MBD);
   if (it == _vtxs.end())
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   return it->second[0]->get_t_err();
@@ -108,14 +116,14 @@ float GlobalVertexv2::get_position(unsigned int coor) const
     auto mbdit = _vtxs.find(GlobalVertex::VTXTYPE::MBD);
     if (mbdit == _vtxs.end())
     {
-      return NAN;
+      return std::numeric_limits<float>::quiet_NaN();
     }
     return mbdit->second[0]->get_position(coor);
   }
 
   GlobalVertex::VertexVector trackvertices = svtxit->second;
   size_t mosttracks = 0;
-  float pos = NAN;
+  float pos = std::numeric_limits<float>::quiet_NaN();
   for (auto vertex : trackvertices)
   {
     if (vertex->size_tracks() > mosttracks)
@@ -133,12 +141,12 @@ float GlobalVertexv2::get_chisq() const
   auto svtxit = _vtxs.find(GlobalVertex::VTXTYPE::SVTX);
   if (svtxit == _vtxs.end())
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   GlobalVertex::VertexVector trackvertices = svtxit->second;
   size_t mosttracks = 0;
-  float chisq = NAN;
+  float chisq = std::numeric_limits<float>::quiet_NaN();
   for (auto vertex : trackvertices)
   {
     if (vertex->size_tracks() > mosttracks)
@@ -182,7 +190,7 @@ float GlobalVertexv2::get_error(unsigned int i, unsigned int j) const
     auto mbdit = _vtxs.find(GlobalVertex::VTXTYPE::MBD);
     if (mbdit == _vtxs.end())
     {
-      return NAN;
+      return std::numeric_limits<float>::quiet_NaN();
     }
     // MBD only has z error defined
     if (i == 2 && j == 2)
@@ -191,13 +199,13 @@ float GlobalVertexv2::get_error(unsigned int i, unsigned int j) const
     }
     else
     {
-      return NAN;
+      return std::numeric_limits<float>::quiet_NaN();
     }
   }
 
   GlobalVertex::VertexVector trackvertices = svtxit->second;
   size_t mosttracks = 0;
-  float err = NAN;
+  float err = std::numeric_limits<float>::quiet_NaN();
   for (auto vertex : trackvertices)
   {
     if (vertex->size_tracks() > mosttracks)

--- a/offline/packages/globalvertex/GlobalVertexv2.h
+++ b/offline/packages/globalvertex/GlobalVertexv2.h
@@ -1,7 +1,7 @@
 // Tell emacs that this is a C++ source
 //  -*- C++ -*-.
-#ifndef G4VERTEX_GLOBALVERTEXV2_H
-#define G4VERTEX_GLOBALVERTEXV2_H
+#ifndef GLOBALVERTEX_GLOBALVERTEXV2_H
+#define GLOBALVERTEX_GLOBALVERTEXV2_H
 
 #include "GlobalVertex.h"
 

--- a/offline/packages/globalvertex/GlobalVertexv2.h
+++ b/offline/packages/globalvertex/GlobalVertexv2.h
@@ -52,6 +52,7 @@ class GlobalVertexv2 : public GlobalVertex
 
   void clear_vtxs() override { _vtxs.clear(); }
   void insert_vtx(GlobalVertex::VTXTYPE type, const Vertex* vertex) override;
+  void clone_insert_vtx(GlobalVertex::VTXTYPE type, const Vertex* vertex) override;
   size_t erase_vtxs(GlobalVertex::VTXTYPE type) override { return _vtxs.erase(type); }
   void erase_vtxs(GlobalVertex::VertexIter iter) override { _vtxs.erase(iter); }
 

--- a/offline/packages/globalvertex/GlobalVertexv2.h
+++ b/offline/packages/globalvertex/GlobalVertexv2.h
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <limits>
 #include <map>
-#include <utility>  // for pair, make_pair
 
 class PHObject;
 

--- a/offline/packages/globalvertex/GlobalVertexv2.h
+++ b/offline/packages/globalvertex/GlobalVertexv2.h
@@ -16,14 +16,14 @@ class PHObject;
 class GlobalVertexv2 : public GlobalVertex
 {
  public:
-  GlobalVertexv2();
+  GlobalVertexv2() = default;
   GlobalVertexv2(const unsigned int id);
-  ~GlobalVertexv2() override = default;
+  ~GlobalVertexv2() override;
 
   // PHObject virtual overloads
 
   void identify(std::ostream& os = std::cout) const override;
-  void Reset() override { *this = GlobalVertexv2(); }
+  void Reset() override;
   int isValid() const override;
   PHObject* CloneMe() const override { return new GlobalVertexv2(*this); }
 
@@ -65,8 +65,8 @@ class GlobalVertexv2 : public GlobalVertex
   GlobalVertex::VertexIter end_vertexes() override { return _vtxs.end(); }
 
  private:
-  unsigned int _id;
-  unsigned int _bco;                                    //< global bco
+  unsigned int _id {std::numeric_limits<unsigned int>::max()};
+  unsigned int _bco {std::numeric_limits<unsigned int>::max()};   //< global bco
   std::map<GlobalVertex::VTXTYPE, VertexVector> _vtxs;  //< list of vtxs
 
   ClassDefOverride(GlobalVertexv2, 2);

--- a/offline/packages/globalvertex/GlobalVertexv2.h
+++ b/offline/packages/globalvertex/GlobalVertexv2.h
@@ -64,9 +64,9 @@ class GlobalVertexv2 : public GlobalVertex
   GlobalVertex::VertexIter end_vertexes() override { return _vtxs.end(); }
 
  private:
-  unsigned int _id {std::numeric_limits<unsigned int>::max()};
-  unsigned int _bco {std::numeric_limits<unsigned int>::max()};   //< global bco
-  std::map<GlobalVertex::VTXTYPE, VertexVector> _vtxs;  //< list of vtxs
+  unsigned int _id{std::numeric_limits<unsigned int>::max()};
+  unsigned int _bco{std::numeric_limits<unsigned int>::max()};  //< global bco
+  std::map<GlobalVertex::VTXTYPE, VertexVector> _vtxs;          //< list of vtxs
 
   ClassDefOverride(GlobalVertexv2, 2);
 };

--- a/offline/packages/globalvertex/Makefile.am
+++ b/offline/packages/globalvertex/Makefile.am
@@ -2,8 +2,8 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include  \
-  -I`root-config --incdir`
+  -isystem$(OFFLINE_MAIN)/include  \
+  -isystem`root-config --incdir`
 
 lib_LTLIBRARIES = \
    libglobalvertex_io.la \
@@ -30,72 +30,57 @@ pkginclude_HEADERS = \
   GlobalVertexMap.h \
   GlobalVertexMapv1.h \
   GlobalVertexReco.h \
-  SvtxVertex.h \
-  SvtxVertex_v1.h \
-  SvtxVertex_v2.h \
-  SvtxVertexMap.h \
-  SvtxVertexMap_v1.h \
   MbdVertex.h \
   MbdVertexv1.h \
   MbdVertexv2.h \
   MbdVertexMap.h \
   MbdVertexMapv1.h \
+  SvtxVertex.h \
+  SvtxVertex_v1.h \
+  SvtxVertex_v2.h \
+  SvtxVertexMap.h \
+  SvtxVertexMap_v1.h \
   Vertex.h
 
 ROOTDICTS = \
-  Vertex_Dict.cc \
   GlobalVertex_Dict.cc \
   GlobalVertexv1_Dict.cc \
   GlobalVertexv2_Dict.cc \
   GlobalVertexMap_Dict.cc \
   GlobalVertexMapv1_Dict.cc \
+  MbdVertex_Dict.cc \
+  MbdVertexv1_Dict.cc \
+  MbdVertexv2_Dict.cc \
+  MbdVertexMap_Dict.cc \
+  MbdVertexMapv1_Dict.cc \
   SvtxVertex_Dict.cc \
   SvtxVertex_v1_Dict.cc \
   SvtxVertex_v2_Dict.cc \
   SvtxVertexMap_Dict.cc \
   SvtxVertexMap_v1_Dict.cc \
-  MbdVertex_Dict.cc \
-  MbdVertexv1_Dict.cc \
-  MbdVertexv2_Dict.cc \
-  MbdVertexMap_Dict.cc \
-  MbdVertexMapv1_Dict.cc
+  Vertex_Dict.cc
 
 pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-  Vertex_Dict_rdict.pcm \
-  GlobalVertex_Dict_rdict.pcm \
-  GlobalVertexv1_Dict_rdict.pcm \
-  GlobalVertexv2_Dict_rdict.pcm \
-  GlobalVertexMap_Dict_rdict.pcm \
-  GlobalVertexMapv1_Dict_rdict.pcm \
-  SvtxVertex_Dict_rdict.pcm \
-  SvtxVertex_v1_Dict_rdict.pcm \
-  SvtxVertex_v2_Dict_rdict.pcm \
-  SvtxVertexMap_Dict_rdict.pcm \
-  SvtxVertexMap_v1_Dict_rdict.pcm \
-  MbdVertex_Dict_rdict.pcm \
-  MbdVertexv1_Dict_rdict.pcm \
-  MbdVertexv2_Dict_rdict.pcm \
-  MbdVertexMap_Dict_rdict.pcm \
-  MbdVertexMapv1_Dict_rdict.pcm
+# more elegant way to create pcm files (without listing them)
+nobase_dist_pcm_DATA = $(ROOTDICTS:.cc=_rdict.pcm)
 
 libglobalvertex_io_la_SOURCES = \
   $(ROOTDICTS) \
-  Vertex.cc \
   GlobalVertex.cc \
   GlobalVertexv1.cc \
   GlobalVertexv2.cc \
   GlobalVertexMap.cc \
   GlobalVertexMapv1.cc \
+  MbdVertexv1.cc \
+  MbdVertexv2.cc \
+  MbdVertexMap.cc \
+  MbdVertexMapv1.cc \
   SvtxVertex.cc \
   SvtxVertex_v1.cc \
   SvtxVertex_v2.cc \
   SvtxVertexMap.cc \
   SvtxVertexMap_v1.cc \
-  MbdVertexv1.cc \
-  MbdVertexv2.cc \
-  MbdVertexMap.cc \
-  MbdVertexMapv1.cc
+  Vertex.cc
 
 libglobalvertex_la_SOURCES = \
   GlobalVertexReco.cc

--- a/offline/packages/globalvertex/MbdVertex.h
+++ b/offline/packages/globalvertex/MbdVertex.h
@@ -21,19 +21,19 @@ class MbdVertex : public Vertex
 
   // vertex info
 
-  virtual unsigned int get_id() const override { return 0xFFFFFFFF; }
+  virtual unsigned int get_id() const override { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_id(unsigned int) override {}
 
-  virtual float get_t() const override { return NAN; }
+  virtual float get_t() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_t(float) override {}
 
-  virtual float get_t_err() const override { return NAN; }
+  virtual float get_t_err() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_t_err(float) override {}
 
-  virtual float get_z() const override { return NAN; }
+  virtual float get_z() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z(float) override {}
 
-  virtual float get_z_err() const override { return NAN; }
+  virtual float get_z_err() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z_err(float) override {}
 
   virtual unsigned int get_beam_crossing() const override { return std::numeric_limits<unsigned int>::max(); }
@@ -41,8 +41,8 @@ class MbdVertex : public Vertex
 
   virtual void set_bbc_ns(int, int, float, float) override {}
   virtual int get_bbc_npmt(int) const override { return std::numeric_limits<int>::max(); }
-  virtual float get_bbc_q(int) const override { return NAN; }
-  virtual float get_bbc_t(int) const override { return NAN; }
+  virtual float get_bbc_q(int) const override { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float get_bbc_t(int) const override { return std::numeric_limits<float>::quiet_NaN(); }
 
  protected:
   MbdVertex() {}

--- a/offline/packages/globalvertex/MbdVertex.h
+++ b/offline/packages/globalvertex/MbdVertex.h
@@ -1,5 +1,7 @@
-#ifndef G4MBD_MBDVERTEX_H
-#define G4MBD_MBDVERTEX_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_MBDVERTEX_H
+#define GLOBALVERTEX_MBDVERTEX_H
 
 #include "Vertex.h"
 

--- a/offline/packages/globalvertex/MbdVertexMap.cc
+++ b/offline/packages/globalvertex/MbdVertexMap.cc
@@ -1,8 +1,13 @@
 #include "MbdVertexMap.h"
 
+#include <map>
+
 class MbdVertex;
 
-std::map<unsigned int, MbdVertex*> DummyMbdVertexMap;
+namespace
+{
+  std::map<unsigned int, MbdVertex*> DummyMbdVertexMap;
+}
 
 MbdVertexMap::ConstIter MbdVertexMap::begin() const
 {

--- a/offline/packages/globalvertex/MbdVertexMap.cc
+++ b/offline/packages/globalvertex/MbdVertexMap.cc
@@ -6,7 +6,7 @@ class MbdVertex;
 
 namespace
 {
-  std::map<unsigned int, MbdVertex*> DummyMbdVertexMap;
+  std::map<unsigned int, MbdVertex *> DummyMbdVertexMap;
 }
 
 MbdVertexMap::ConstIter MbdVertexMap::begin() const

--- a/offline/packages/globalvertex/MbdVertexMap.h
+++ b/offline/packages/globalvertex/MbdVertexMap.h
@@ -17,7 +17,7 @@ class MbdVertexMap : public PHObject
   typedef std::map<unsigned int, MbdVertex*>::const_iterator ConstIter;
   typedef std::map<unsigned int, MbdVertex*>::iterator Iter;
 
-  ~MbdVertexMap() override {}
+  ~MbdVertexMap() override = default;
 
   void identify(std::ostream& os = std::cout) const override { os << "MbdVertexMap base class" << std::endl; }
   int isValid() const override { return 0; }
@@ -41,7 +41,7 @@ class MbdVertexMap : public PHObject
   virtual Iter end();
 
  protected:
-  MbdVertexMap() {}
+  MbdVertexMap() = default;
 
  private:
   ClassDefOverride(MbdVertexMap, 1);

--- a/offline/packages/globalvertex/MbdVertexMap.h
+++ b/offline/packages/globalvertex/MbdVertexMap.h
@@ -1,5 +1,7 @@
-#ifndef G4MBD_MBDVERTEXMAP_H
-#define G4MBD_MBDVERTEXMAP_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_MBDVERTEXMAP_H
+#define GLOBALVERTEX_MBDVERTEXMAP_H
 
 #include <phool/PHObject.h>
 

--- a/offline/packages/globalvertex/MbdVertexMapv1.cc
+++ b/offline/packages/globalvertex/MbdVertexMapv1.cc
@@ -1,7 +1,6 @@
 #include "MbdVertexMapv1.h"
 
 #include "MbdVertex.h"
-#include "MbdVertexMap.h"
 
 #include <iterator>  // for reverse_iterator
 #include <utility>   // for pair, make_pair

--- a/offline/packages/globalvertex/MbdVertexMapv1.cc
+++ b/offline/packages/globalvertex/MbdVertexMapv1.cc
@@ -6,21 +6,14 @@
 #include <iterator>  // for reverse_iterator
 #include <utility>   // for pair, make_pair
 
-using namespace std;
-
-MbdVertexMapv1::MbdVertexMapv1()
-  : _map()
-{
-}
-
 MbdVertexMapv1::~MbdVertexMapv1()
 {
   MbdVertexMapv1::clear();
 }
 
-void MbdVertexMapv1::identify(ostream& os) const
+void MbdVertexMapv1::identify(std::ostream& os) const
 {
-  os << "MbdVertexMapv1: size = " << _map.size() << endl;
+  os << "MbdVertexMapv1: size = " << _map.size() << std::endl;
   return;
 }
 
@@ -61,7 +54,7 @@ MbdVertex* MbdVertexMapv1::insert(MbdVertex* clus)
   {
     index = _map.rbegin()->first + 1;
   }
-  _map.insert(make_pair(index, clus));
+  _map.insert(std::make_pair(index, clus));
   _map[index]->set_id(index);
   return _map[index];
 }

--- a/offline/packages/globalvertex/MbdVertexMapv1.h
+++ b/offline/packages/globalvertex/MbdVertexMapv1.h
@@ -14,7 +14,7 @@
 class MbdVertexMapv1 : public MbdVertexMap
 {
  public:
-  MbdVertexMapv1();
+  MbdVertexMapv1() = default;
   ~MbdVertexMapv1() override;
 
   void identify(std::ostream& os = std::cout) const override;

--- a/offline/packages/globalvertex/MbdVertexMapv1.h
+++ b/offline/packages/globalvertex/MbdVertexMapv1.h
@@ -1,5 +1,7 @@
-#ifndef G4MBD_MBDVERTEXMAPV1_H
-#define G4MBD_MBDVERTEXMAPV1_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_MBDVERTEXMAPV1_H
+#define GLOBALVERTEX_MBDVERTEXMAPV1_H
 
 #include "MbdVertexMap.h"
 

--- a/offline/packages/globalvertex/MbdVertexv1.cc
+++ b/offline/packages/globalvertex/MbdVertexv1.cc
@@ -1,5 +1,7 @@
 #include "MbdVertexv1.h"
 
+#include <cmath>
+
 void MbdVertexv1::identify(std::ostream& os) const
 {
   os << "---MbdVertexv1--------------------------------" << std::endl;

--- a/offline/packages/globalvertex/MbdVertexv1.cc
+++ b/offline/packages/globalvertex/MbdVertexv1.cc
@@ -1,50 +1,35 @@
 #include "MbdVertexv1.h"
 
-#include <cmath>
-
-using namespace std;
-
-MbdVertexv1::MbdVertexv1()
-  : _id(0xFFFFFFFF)
-  , _t(NAN)
-  , _t_err(NAN)
-  , _z(NAN)
-  , _z_err(NAN)
+void MbdVertexv1::identify(std::ostream& os) const
 {
-}
-
-MbdVertexv1::~MbdVertexv1() = default;
-
-void MbdVertexv1::identify(ostream& os) const
-{
-  os << "---MbdVertexv1--------------------------------" << endl;
-  os << "vertexid: " << get_id() << endl;
-  os << " t = " << get_t() << " +/- " << get_t_err() << endl;
-  os << " z =  " << get_z() << " +/- " << get_z_err() << endl;
-  os << "-----------------------------------------------" << endl;
+  os << "---MbdVertexv1--------------------------------" << std::endl;
+  os << "vertexid: " << get_id() << std::endl;
+  os << " t = " << get_t() << " +/- " << get_t_err() << std::endl;
+  os << " z =  " << get_z() << " +/- " << get_z_err() << std::endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
 
 int MbdVertexv1::isValid() const
 {
-  if (_id == 0xFFFFFFFF)
+  if (_id == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }
-  if (isnan(_t))
+  if (std::isnan(_t))
   {
     return 0;
   }
-  if (isnan(_t_err))
+  if (std::isnan(_t_err))
   {
     return 0;
   }
-  if (isnan(_z))
+  if (std::isnan(_z))
   {
     return 0;
   }
-  if (isnan(_z_err))
+  if (std::isnan(_z_err))
   {
     return 0;
   }

--- a/offline/packages/globalvertex/MbdVertexv1.h
+++ b/offline/packages/globalvertex/MbdVertexv1.h
@@ -6,12 +6,13 @@
 #include "MbdVertex.h"
 
 #include <iostream>
+#include <limits>
 
 class MbdVertexv1 : public MbdVertex
 {
  public:
-  MbdVertexv1();
-  ~MbdVertexv1() override;
+  MbdVertexv1() = default;
+  ~MbdVertexv1() override = default;
 
   // PHObject virtual overloads
 
@@ -38,11 +39,11 @@ class MbdVertexv1 : public MbdVertex
   void set_z_err(float z_err) override { _z_err = z_err; }
 
  private:
-  unsigned int _id;  //< unique identifier within container
-  float _t;          //< collision time
-  float _t_err;      //< collision time uncertainty
-  float _z;          //< collision position z
-  float _z_err;      //< collision position z uncertainty
+  unsigned int _id {std::numeric_limits<unsigned int>::max()};  //< unique identifier within container
+  float _t {std::numeric_limits<float>::quiet_NaN()};          //< collision time
+  float _t_err {std::numeric_limits<float>::quiet_NaN()};      //< collision time uncertainty
+  float _z {std::numeric_limits<float>::quiet_NaN()};          //< collision position z
+  float _z_err {std::numeric_limits<float>::quiet_NaN()};      //< collision position z uncertainty
 
   ClassDefOverride(MbdVertexv1, 1);
 };

--- a/offline/packages/globalvertex/MbdVertexv1.h
+++ b/offline/packages/globalvertex/MbdVertexv1.h
@@ -1,5 +1,7 @@
-#ifndef G4MBD_MBDVERTEXV1_H
-#define G4MBD_MBDVERTEXV1_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_MBDVERTEXV1_H
+#define GLOBALVERTEX_MBDVERTEXV1_H
 
 #include "MbdVertex.h"
 

--- a/offline/packages/globalvertex/MbdVertexv1.h
+++ b/offline/packages/globalvertex/MbdVertexv1.h
@@ -39,11 +39,11 @@ class MbdVertexv1 : public MbdVertex
   void set_z_err(float z_err) override { _z_err = z_err; }
 
  private:
-  unsigned int _id {std::numeric_limits<unsigned int>::max()};  //< unique identifier within container
-  float _t {std::numeric_limits<float>::quiet_NaN()};          //< collision time
-  float _t_err {std::numeric_limits<float>::quiet_NaN()};      //< collision time uncertainty
-  float _z {std::numeric_limits<float>::quiet_NaN()};          //< collision position z
-  float _z_err {std::numeric_limits<float>::quiet_NaN()};      //< collision position z uncertainty
+  unsigned int _id{std::numeric_limits<unsigned int>::max()};  //< unique identifier within container
+  float _t{std::numeric_limits<float>::quiet_NaN()};           //< collision time
+  float _t_err{std::numeric_limits<float>::quiet_NaN()};       //< collision time uncertainty
+  float _z{std::numeric_limits<float>::quiet_NaN()};           //< collision position z
+  float _z_err{std::numeric_limits<float>::quiet_NaN()};       //< collision position z uncertainty
 
   ClassDefOverride(MbdVertexv1, 1);
 };

--- a/offline/packages/globalvertex/MbdVertexv2.cc
+++ b/offline/packages/globalvertex/MbdVertexv2.cc
@@ -1,51 +1,35 @@
 #include "MbdVertexv2.h"
 
-#include <cmath>
-
-using namespace std;
-
-MbdVertexv2::MbdVertexv2()
-  : _id(0xFFFFFFFF)
-  , _bco(std::numeric_limits<unsigned int>::max())
-  , _t(NAN)
-  , _t_err(NAN)
-  , _z(NAN)
-  , _z_err(NAN)
+void MbdVertexv2::identify(std::ostream& os) const
 {
-}
-
-MbdVertexv2::~MbdVertexv2() = default;
-
-void MbdVertexv2::identify(ostream& os) const
-{
-  os << "---MbdVertexv2--------------------------------" << endl;
-  os << "vertexid: " << get_id() << endl;
-  os << " t = " << get_t() << " +/- " << get_t_err() << endl;
-  os << " z =  " << get_z() << " +/- " << get_z_err() << endl;
-  os << "-----------------------------------------------" << endl;
+  os << "---MbdVertexv2--------------------------------" << std::endl;
+  os << "vertexid: " << get_id() << std::endl;
+  os << " t = " << get_t() << " +/- " << get_t_err() << std::endl;
+  os << " z =  " << get_z() << " +/- " << get_z_err() << std::endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
 
 int MbdVertexv2::isValid() const
 {
-  if (_id == 0xFFFFFFFF)
+  if (_id == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }
-  if (isnan(_t))
+  if (std::isnan(_t))
   {
     return 0;
   }
-  if (isnan(_t_err))
+  if (std::isnan(_t_err))
   {
     return 0;
   }
-  if (isnan(_z))
+  if (std::isnan(_z))
   {
     return 0;
   }
-  if (isnan(_z_err))
+  if (std::isnan(_z_err))
   {
     return 0;
   }
@@ -69,6 +53,6 @@ float MbdVertexv2::get_position(unsigned int coor) const
   }
   else
   {
-    return NAN;
+    return std::numeric_limits<float>::quiet_NaN();
   }
 }

--- a/offline/packages/globalvertex/MbdVertexv2.cc
+++ b/offline/packages/globalvertex/MbdVertexv2.cc
@@ -1,5 +1,7 @@
 #include "MbdVertexv2.h"
 
+#include <cmath>
+
 void MbdVertexv2::identify(std::ostream& os) const
 {
   os << "---MbdVertexv2--------------------------------" << std::endl;

--- a/offline/packages/globalvertex/MbdVertexv2.h
+++ b/offline/packages/globalvertex/MbdVertexv2.h
@@ -1,5 +1,7 @@
-#ifndef G4MBD_MBDVERTEXV2_H
-#define G4MBD_MBDVERTEXV2_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_MBDVERTEXV2_H
+#define GLOBALVERTEX_MBDVERTEXV2_H
 
 #include "MbdVertex.h"
 

--- a/offline/packages/globalvertex/MbdVertexv2.h
+++ b/offline/packages/globalvertex/MbdVertexv2.h
@@ -10,8 +10,8 @@
 class MbdVertexv2 : public MbdVertex
 {
  public:
-  MbdVertexv2();
-  ~MbdVertexv2() override;
+  MbdVertexv2() = default;
+  ~MbdVertexv2() override = default;
 
   // PHObject virtual overloads
 
@@ -47,12 +47,12 @@ class MbdVertexv2 : public MbdVertex
   void set_beam_crossing(unsigned int bco) override { _bco = bco; }
 
  private:
-  unsigned int _id;   //< unique identifier within container
-  unsigned int _bco;  //< global bco
-  float _t;           //< collision time
-  float _t_err;       //< collision time uncertainty
-  float _z;           //< collision position z
-  float _z_err;       //< collision position z uncertainty
+  unsigned int _id {std::numeric_limits<unsigned int>::max()};   //< unique identifier within container
+  unsigned int _bco {std::numeric_limits<unsigned int>::max()};  //< global bco
+  float _t {std::numeric_limits<float>::quiet_NaN()};           //< collision time
+  float _t_err {std::numeric_limits<float>::quiet_NaN()};       //< collision time uncertainty
+  float _z {std::numeric_limits<float>::quiet_NaN()};           //< collision position z
+  float _z_err {std::numeric_limits<float>::quiet_NaN()};       //< collision position z uncertainty
 
   ClassDefOverride(MbdVertexv2, 1);
 };

--- a/offline/packages/globalvertex/MbdVertexv2.h
+++ b/offline/packages/globalvertex/MbdVertexv2.h
@@ -6,6 +6,7 @@
 #include "MbdVertex.h"
 
 #include <iostream>
+#include <limits>
 
 class MbdVertexv2 : public MbdVertex
 {

--- a/offline/packages/globalvertex/MbdVertexv2.h
+++ b/offline/packages/globalvertex/MbdVertexv2.h
@@ -48,12 +48,12 @@ class MbdVertexv2 : public MbdVertex
   void set_beam_crossing(unsigned int bco) override { _bco = bco; }
 
  private:
-  unsigned int _id {std::numeric_limits<unsigned int>::max()};   //< unique identifier within container
-  unsigned int _bco {std::numeric_limits<unsigned int>::max()};  //< global bco
-  float _t {std::numeric_limits<float>::quiet_NaN()};           //< collision time
-  float _t_err {std::numeric_limits<float>::quiet_NaN()};       //< collision time uncertainty
-  float _z {std::numeric_limits<float>::quiet_NaN()};           //< collision position z
-  float _z_err {std::numeric_limits<float>::quiet_NaN()};       //< collision position z uncertainty
+  unsigned int _id{std::numeric_limits<unsigned int>::max()};   //< unique identifier within container
+  unsigned int _bco{std::numeric_limits<unsigned int>::max()};  //< global bco
+  float _t{std::numeric_limits<float>::quiet_NaN()};            //< collision time
+  float _t_err{std::numeric_limits<float>::quiet_NaN()};        //< collision time uncertainty
+  float _z{std::numeric_limits<float>::quiet_NaN()};            //< collision position z
+  float _z_err{std::numeric_limits<float>::quiet_NaN()};        //< collision position z uncertainty
 
   ClassDefOverride(MbdVertexv2, 1);
 };

--- a/offline/packages/globalvertex/SvtxVertex.cc
+++ b/offline/packages/globalvertex/SvtxVertex.cc
@@ -1,6 +1,9 @@
 #include "SvtxVertex.h"
 
+namespace
+{
 SvtxVertex::TrackSet trackSet;
+}
 
 SvtxVertex::ConstTrackIter SvtxVertex::begin_tracks() const
 {

--- a/offline/packages/globalvertex/SvtxVertex.cc
+++ b/offline/packages/globalvertex/SvtxVertex.cc
@@ -2,7 +2,7 @@
 
 namespace
 {
-SvtxVertex::TrackSet trackSet;
+  SvtxVertex::TrackSet trackSet;
 }
 
 SvtxVertex::ConstTrackIter SvtxVertex::begin_tracks() const

--- a/offline/packages/globalvertex/SvtxVertex.h
+++ b/offline/packages/globalvertex/SvtxVertex.h
@@ -5,16 +5,15 @@
 
 #include "Vertex.h"
 
-#include <climits>
-#include <cmath>
 #include <iostream>
+#include <limits>
 #include <set>
 #include <vector>
 
 class SvtxVertex : public Vertex
 {
  public:
-  ~SvtxVertex() override {}
+  ~SvtxVertex() override = default;
 
   // PHObject virtual overloads
 
@@ -28,34 +27,34 @@ class SvtxVertex : public Vertex
 
   // vertex info
 
-  virtual unsigned int get_id() const override { return UINT_MAX; }
+  virtual unsigned int get_id() const override { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_id(unsigned int) override {}
 
   virtual float get_t0() const override { return get_t(); }
   virtual void set_t0(float t0) override { set_t(t0); }
 
-  virtual float get_t() const override { return NAN; }
+  virtual float get_t() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_t(float) override {}
 
-  virtual float get_x() const override { return NAN; }
+  virtual float get_x() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_x(float) override {}
 
-  virtual float get_y() const override { return NAN; }
+  virtual float get_y() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_y(float) override {}
 
-  virtual float get_z() const override { return NAN; }
+  virtual float get_z() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z(float) override {}
 
-  virtual float get_chisq() const override { return NAN; }
+  virtual float get_chisq() const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_chisq(float) override {}
 
-  virtual unsigned int get_ndof() const override { return UINT_MAX; }
+  virtual unsigned int get_ndof() const override { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_ndof(unsigned int) override {}
 
-  virtual float get_position(unsigned int) const override { return NAN; }
+  virtual float get_position(unsigned int) const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_position(unsigned int, float) override {}
 
-  virtual float get_error(unsigned int, unsigned int) const override { return NAN; }
+  virtual float get_error(unsigned int, unsigned int) const override { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_error(unsigned int, unsigned int, float) override {}
 
   //

--- a/offline/packages/globalvertex/SvtxVertex.h
+++ b/offline/packages/globalvertex/SvtxVertex.h
@@ -1,5 +1,7 @@
-#ifndef TRACKBASEHISTORIC_SVTXVERTEX_H
-#define TRACKBASEHISTORIC_SVTXVERTEX_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_SVTXVERTEX_H
+#define GLOBALVERTEX_SVTXVERTEX_H
 
 #include "Vertex.h"
 

--- a/offline/packages/globalvertex/SvtxVertex.h
+++ b/offline/packages/globalvertex/SvtxVertex.h
@@ -5,10 +5,9 @@
 
 #include "Vertex.h"
 
+#include <cstddef>
 #include <iostream>
 #include <limits>
-#include <set>
-#include <vector>
 
 class SvtxVertex : public Vertex
 {

--- a/offline/packages/globalvertex/SvtxVertexMap.h
+++ b/offline/packages/globalvertex/SvtxVertexMap.h
@@ -6,6 +6,8 @@
 #include "SvtxVertex.h"
 
 #include <phool/PHObject.h>
+
+#include <cstddef>
 #include <iostream>
 #include <map>
 

--- a/offline/packages/globalvertex/SvtxVertexMap.h
+++ b/offline/packages/globalvertex/SvtxVertexMap.h
@@ -1,5 +1,7 @@
-#ifndef TRACKBASEHISTORIC_SVTXVERTEXMAP_H
-#define TRACKBASEHISTORIC_SVTXVERTEXMAP_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_SVTXVERTEXMAP_H
+#define GLOBALVERTEX_SVTXVERTEXMAP_H
 
 #include "SvtxVertex.h"
 

--- a/offline/packages/globalvertex/SvtxVertexMap_v1.cc
+++ b/offline/packages/globalvertex/SvtxVertexMap_v1.cc
@@ -7,6 +7,7 @@
 #include <iterator>  // for reverse_iterator
 #include <utility>   // for pair, make_pair
 
+// NOLINTNEXTLINE(bugprone-copy-constructor-init)
 SvtxVertexMap_v1::SvtxVertexMap_v1(const SvtxVertexMap_v1& vertexmap)
   : _map()
 {

--- a/offline/packages/globalvertex/SvtxVertexMap_v1.cc
+++ b/offline/packages/globalvertex/SvtxVertexMap_v1.cc
@@ -7,20 +7,13 @@
 #include <iterator>  // for reverse_iterator
 #include <utility>   // for pair, make_pair
 
-using namespace std;
-
-SvtxVertexMap_v1::SvtxVertexMap_v1()
-  : _map()
-{
-}
-
 SvtxVertexMap_v1::SvtxVertexMap_v1(const SvtxVertexMap_v1& vertexmap)
   : _map()
 {
   for (auto iter : vertexmap)
   {
     SvtxVertex* vertex = dynamic_cast<SvtxVertex*>(iter.second->CloneMe());
-    _map.insert(make_pair(vertex->get_id(), vertex));
+    _map.insert(std::make_pair(vertex->get_id(), vertex));
   }
 }
 
@@ -30,14 +23,14 @@ SvtxVertexMap_v1& SvtxVertexMap_v1::operator=(const SvtxVertexMap_v1& vertexmap)
   for (auto iter : vertexmap)
   {
     SvtxVertex* vertex = dynamic_cast<SvtxVertex*>(iter.second->CloneMe());
-    _map.insert(make_pair(vertex->get_id(), vertex));
+    _map.insert(std::make_pair(vertex->get_id(), vertex));
   }
   return *this;
 }
 
 SvtxVertexMap_v1::~SvtxVertexMap_v1()
 {
-  Reset();
+  SvtxVertexMap_v1::Reset();
 }
 
 void SvtxVertexMap_v1::Reset()
@@ -50,9 +43,9 @@ void SvtxVertexMap_v1::Reset()
   _map.clear();
 }
 
-void SvtxVertexMap_v1::identify(ostream& os) const
+void SvtxVertexMap_v1::identify(std::ostream& os) const
 {
-  os << "SvtxVertexMap_v1: size = " << _map.size() << endl;
+  os << "SvtxVertexMap_v1: size = " << _map.size() << std::endl;
   return;
 }
 
@@ -83,7 +76,7 @@ SvtxVertex* SvtxVertexMap_v1::insert(SvtxVertex* vertex)
   {
     index = _map.rbegin()->first + 1;
   }
-  _map.insert(make_pair(index, vertex));
+  _map.insert(std::make_pair(index, vertex));
   _map[index]->set_id(index);
   return _map[index];
 }

--- a/offline/packages/globalvertex/SvtxVertexMap_v1.h
+++ b/offline/packages/globalvertex/SvtxVertexMap_v1.h
@@ -15,7 +15,7 @@ class PHObject;
 class SvtxVertexMap_v1 : public SvtxVertexMap
 {
  public:
-  SvtxVertexMap_v1();
+  SvtxVertexMap_v1() = default;
   SvtxVertexMap_v1(const SvtxVertexMap_v1& vertexmap);
   SvtxVertexMap_v1& operator=(const SvtxVertexMap_v1& vertexmap);
   ~SvtxVertexMap_v1() override;

--- a/offline/packages/globalvertex/SvtxVertexMap_v1.h
+++ b/offline/packages/globalvertex/SvtxVertexMap_v1.h
@@ -1,5 +1,7 @@
-#ifndef TRACKBASEHISTORIC_SVTXVERTEXMAPV1_H
-#define TRACKBASEHISTORIC_SVTXVERTEXMAPV1_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_SVTXVERTEXMAPV1_H
+#define GLOBALVERTEX_SVTXVERTEXMAPV1_H
 
 #include "SvtxVertex.h"
 #include "SvtxVertexMap.h"

--- a/offline/packages/globalvertex/SvtxVertex_v1.cc
+++ b/offline/packages/globalvertex/SvtxVertex_v1.cc
@@ -9,7 +9,7 @@ SvtxVertex_v1::SvtxVertex_v1()
   std::fill(std::begin(_err), std::end(_err), std::numeric_limits<float>::quiet_NaN());
 }
 
-void SvtxVertex_v1::identify(std::ostream& os) const
+void SvtxVertex_v1::identify(std::ostream &os) const
 {
   os << "---SvtxVertex_v1--------------------" << std::endl;
   os << "vertexid: " << get_id() << std::endl;

--- a/offline/packages/globalvertex/SvtxVertex_v1.cc
+++ b/offline/packages/globalvertex/SvtxVertex_v1.cc
@@ -3,71 +3,53 @@
 #include <cmath>
 #include <utility>  // for swap
 
-using namespace std;
-
 SvtxVertex_v1::SvtxVertex_v1()
-  : _id(0xFFFFFFFF)
-  , _t0(NAN)
-  , _pos()
-  , _chisq(NAN)
-  , _ndof(0xFFFFFFFF)
-  , _err()
-  , _track_ids()
 {
-  for (float& _po : _pos)
-  {
-    _po = NAN;
-  }
-  for (int j = 0; j < 3; ++j)
-  {
-    for (int i = j; i < 3; ++i)
-    {
-      set_error(i, j, NAN);
-    }
-  }
+  std::fill(std::begin(_pos), std::end(_pos), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(_err), std::end(_err), std::numeric_limits<float>::quiet_NaN());
 }
 
-void SvtxVertex_v1::identify(ostream& os) const
+void SvtxVertex_v1::identify(std::ostream& os) const
 {
-  os << "---SvtxVertex_v1--------------------" << endl;
-  os << "vertexid: " << get_id() << endl;
+  os << "---SvtxVertex_v1--------------------" << std::endl;
+  os << "vertexid: " << get_id() << std::endl;
 
-  os << " t0 = " << get_t() << endl;
+  os << " t0 = " << get_t() << std::endl;
 
   os << " (x,y,z) =  (" << get_position(0);
   os << ", " << get_position(1) << ", ";
-  os << get_position(2) << ") cm" << endl;
+  os << get_position(2) << ") cm" << std::endl;
 
   os << " chisq = " << get_chisq() << ", ";
-  os << " ndof = " << get_ndof() << endl;
+  os << " ndof = " << get_ndof() << std::endl;
 
   os << "         ( ";
   os << get_error(0, 0) << " , ";
   os << get_error(0, 1) << " , ";
-  os << get_error(0, 2) << " )" << endl;
+  os << get_error(0, 2) << " )" << std::endl;
   os << "  err  = ( ";
   os << get_error(1, 0) << " , ";
   os << get_error(1, 1) << " , ";
-  os << get_error(1, 2) << " )" << endl;
+  os << get_error(1, 2) << " )" << std::endl;
   os << "         ( ";
   os << get_error(2, 0) << " , ";
   os << get_error(2, 1) << " , ";
-  os << get_error(2, 2) << " )" << endl;
+  os << get_error(2, 2) << " )" << std::endl;
 
   os << " list of tracks ids: ";
   for (ConstTrackIter iter = begin_tracks(); iter != end_tracks(); ++iter)
   {
     os << *iter << " ";
   }
-  os << endl;
-  os << "-----------------------------------------------" << endl;
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
 
 int SvtxVertex_v1::isValid() const
 {
-  if (_id == 0xFFFFFFFF)
+  if (_id == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }
@@ -79,12 +61,12 @@ int SvtxVertex_v1::isValid() const
   {
     return 0;
   }
-  if (_ndof == 0xFFFFFFFF)
+  if (_ndof == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }
 
-  for (float _po : _pos)
+  for (const float &_po : _pos)
   {
     if (std::isnan(_po))
     {

--- a/offline/packages/globalvertex/SvtxVertex_v1.h
+++ b/offline/packages/globalvertex/SvtxVertex_v1.h
@@ -77,10 +77,10 @@ class SvtxVertex_v1 : public SvtxVertex
 
   unsigned int _id{std::numeric_limits<unsigned int>::max()};    //< unique identifier within container
   float _t0{std::numeric_limits<float>::quiet_NaN()};            //< collision time
-  float _pos[3];                                                 //< collision position x,y,z
+  float _pos[3]{};                                                 //< collision position x,y,z
   float _chisq{std::numeric_limits<float>::quiet_NaN()};         //< vertex fit chisq
   unsigned int _ndof{std::numeric_limits<unsigned int>::max()};  //< degrees of freedom
-  float _err[6];                                                 //< error covariance matrix (packed storage) (+/- cm^2)
+  float _err[6]{};                                                 //< error covariance matrix (packed storage) (+/- cm^2)
   std::set<unsigned int> _track_ids;                             //< list of track ids
 
   ClassDefOverride(SvtxVertex_v1, 1);

--- a/offline/packages/globalvertex/SvtxVertex_v1.h
+++ b/offline/packages/globalvertex/SvtxVertex_v1.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>  // for size_t
 #include <iostream>
+#include <limits>
 #include <set>
 
 class PHObject;
@@ -15,7 +16,7 @@ class SvtxVertex_v1 : public SvtxVertex
 {
  public:
   SvtxVertex_v1();
-  ~SvtxVertex_v1() override {}
+  ~SvtxVertex_v1() override = default;
 
   // PHObject virtual overloads
 

--- a/offline/packages/globalvertex/SvtxVertex_v1.h
+++ b/offline/packages/globalvertex/SvtxVertex_v1.h
@@ -1,5 +1,7 @@
-#ifndef TRACKBASEHISTORIC_SVTXVERTEXV1_H
-#define TRACKBASEHISTORIC_SVTXVERTEXV1_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_SVTXVERTEXV1_H
+#define GLOBALVERTEX_SVTXVERTEXV1_H
 
 #include "SvtxVertex.h"
 

--- a/offline/packages/globalvertex/SvtxVertex_v1.h
+++ b/offline/packages/globalvertex/SvtxVertex_v1.h
@@ -74,11 +74,11 @@ class SvtxVertex_v1 : public SvtxVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id;                   //< unique identifier within container
-  float _t0;                          //< collision time
+  unsigned int _id {std::numeric_limits<unsigned int>::max()};                   //< unique identifier within container
+  float _t0 {std::numeric_limits<float>::quiet_NaN()};                          //< collision time
   float _pos[3];                      //< collision position x,y,z
-  float _chisq;                       //< vertex fit chisq
-  unsigned int _ndof;                 //< degrees of freedom
+  float _chisq {std::numeric_limits<float>::quiet_NaN()};                       //< vertex fit chisq
+  unsigned int _ndof {std::numeric_limits<unsigned int>::max()};                 //< degrees of freedom
   float _err[6];                      //< error covariance matrix (packed storage) (+/- cm^2)
   std::set<unsigned int> _track_ids;  //< list of track ids
 

--- a/offline/packages/globalvertex/SvtxVertex_v1.h
+++ b/offline/packages/globalvertex/SvtxVertex_v1.h
@@ -75,13 +75,13 @@ class SvtxVertex_v1 : public SvtxVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id {std::numeric_limits<unsigned int>::max()};                   //< unique identifier within container
-  float _t0 {std::numeric_limits<float>::quiet_NaN()};                          //< collision time
-  float _pos[3];                      //< collision position x,y,z
-  float _chisq {std::numeric_limits<float>::quiet_NaN()};                       //< vertex fit chisq
-  unsigned int _ndof {std::numeric_limits<unsigned int>::max()};                 //< degrees of freedom
-  float _err[6];                      //< error covariance matrix (packed storage) (+/- cm^2)
-  std::set<unsigned int> _track_ids;  //< list of track ids
+  unsigned int _id{std::numeric_limits<unsigned int>::max()};    //< unique identifier within container
+  float _t0{std::numeric_limits<float>::quiet_NaN()};            //< collision time
+  float _pos[3];                                                 //< collision position x,y,z
+  float _chisq{std::numeric_limits<float>::quiet_NaN()};         //< vertex fit chisq
+  unsigned int _ndof{std::numeric_limits<unsigned int>::max()};  //< degrees of freedom
+  float _err[6];                                                 //< error covariance matrix (packed storage) (+/- cm^2)
+  std::set<unsigned int> _track_ids;                             //< list of track ids
 
   ClassDefOverride(SvtxVertex_v1, 1);
 };

--- a/offline/packages/globalvertex/SvtxVertex_v2.cc
+++ b/offline/packages/globalvertex/SvtxVertex_v2.cc
@@ -3,72 +3,53 @@
 #include <cmath>
 #include <utility>  // for swap
 
-using namespace std;
-
 SvtxVertex_v2::SvtxVertex_v2()
-  : _id(0xFFFFFFFF)
-  , _t0(NAN)
-  , _pos()
-  , _chisq(NAN)
-  , _ndof(0xFFFFFFFF)
-  , _err()
-  , _track_ids()
-  , _beamcrossing(UINT_MAX)
 {
-  for (float& _po : _pos)
-  {
-    _po = NAN;
-  }
-  for (int j = 0; j < 3; ++j)
-  {
-    for (int i = j; i < 3; ++i)
-    {
-      set_error(i, j, NAN);
-    }
-  }
+  std::fill(std::begin(_pos), std::end(_pos), std::numeric_limits<float>::quiet_NaN());
+  std::fill(std::begin(_err), std::end(_err), std::numeric_limits<float>::quiet_NaN());
 }
 
-void SvtxVertex_v2::identify(ostream& os) const
+void SvtxVertex_v2::identify(std::ostream& os) const
 {
-  os << "---SvtxVertex_v2--------------------" << endl;
-  os << "vertexid: " << get_id() << endl;
+  os << "---SvtxVertex_v2--------------------" << std::endl;
+  os << "vertexid: " << get_id() << std::endl;
 
-  os << " t0 = " << get_t() << endl;
-  os << " beam crossing = " << get_beam_crossing() << endl;
+  os << " t0 = " << get_t() << std::endl;
+  os << " beam crossing = " << get_beam_crossing() << std::endl;
   os << " (x,y,z) =  (" << get_position(0);
   os << ", " << get_position(1) << ", ";
-  os << get_position(2) << ") cm" << endl;
+  os << get_position(2) << ") cm" << std::endl;
 
   os << " chisq = " << get_chisq() << ", ";
-  os << " ndof = " << get_ndof() << endl;
+  os << " ndof = " << get_ndof() << std::endl;
 
   os << "         ( ";
   os << get_error(0, 0) << " , ";
   os << get_error(0, 1) << " , ";
-  os << get_error(0, 2) << " )" << endl;
+  os << get_error(0, 2) << " )" << std::endl;
   os << "  err  = ( ";
   os << get_error(1, 0) << " , ";
   os << get_error(1, 1) << " , ";
-  os << get_error(1, 2) << " )" << endl;
+  os << get_error(1, 2) << " )" << std::endl;
   os << "         ( ";
   os << get_error(2, 0) << " , ";
   os << get_error(2, 1) << " , ";
-  os << get_error(2, 2) << " )" << endl;
+  os << get_error(2, 2) << " )" << std::endl;
 
   os << " list of tracks ids: ";
   for (ConstTrackIter iter = begin_tracks(); iter != end_tracks(); ++iter)
   {
     os << *iter << " ";
   }
-  os << endl;
-  os << "-----------------------------------------------" << endl;
+  os << std::endl;
+  os << "-----------------------------------------------" << std::endl;
 
   return;
 }
 
 int SvtxVertex_v2::isValid() const
 {
-  if (_id == 0xFFFFFFFF)
+  if (_id == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }
@@ -80,7 +61,7 @@ int SvtxVertex_v2::isValid() const
   {
     return 0;
   }
-  if (_ndof == 0xFFFFFFFF)
+  if (_ndof == std::numeric_limits<unsigned int>::max())
   {
     return 0;
   }

--- a/offline/packages/globalvertex/SvtxVertex_v2.cc
+++ b/offline/packages/globalvertex/SvtxVertex_v2.cc
@@ -1,6 +1,8 @@
 #include "SvtxVertex_v2.h"
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <utility>  // for swap
 
 SvtxVertex_v2::SvtxVertex_v2()

--- a/offline/packages/globalvertex/SvtxVertex_v2.h
+++ b/offline/packages/globalvertex/SvtxVertex_v2.h
@@ -75,14 +75,14 @@ class SvtxVertex_v2 : public SvtxVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id {std::numeric_limits<unsigned int>::max()};                   //< unique identifier within container
-  float _t0 {std::numeric_limits<float>::quiet_NaN()};                          //< collision time
-  float _pos[3];                      //< collision position x,y,z
-  float _chisq {std::numeric_limits<float>::quiet_NaN()};                       //< vertex fit chisq
-  unsigned int _ndof {std::numeric_limits<unsigned int>::max()};                 //< degrees of freedom
-  float _err[6];                      //< error covariance matrix (packed storage) (+/- cm^2)
-  std::set<unsigned int> _track_ids;  //< list of track ids
-  unsigned int _beamcrossing {std::numeric_limits<unsigned int>::max()};
+  unsigned int _id{std::numeric_limits<unsigned int>::max()};    //< unique identifier within container
+  float _t0{std::numeric_limits<float>::quiet_NaN()};            //< collision time
+  float _pos[3];                                                 //< collision position x,y,z
+  float _chisq{std::numeric_limits<float>::quiet_NaN()};         //< vertex fit chisq
+  unsigned int _ndof{std::numeric_limits<unsigned int>::max()};  //< degrees of freedom
+  float _err[6];                                                 //< error covariance matrix (packed storage) (+/- cm^2)
+  std::set<unsigned int> _track_ids;                             //< list of track ids
+  unsigned int _beamcrossing{std::numeric_limits<unsigned int>::max()};
 
   ClassDefOverride(SvtxVertex_v2, 2);
 };

--- a/offline/packages/globalvertex/SvtxVertex_v2.h
+++ b/offline/packages/globalvertex/SvtxVertex_v2.h
@@ -1,5 +1,7 @@
-#ifndef TRACKBASEHISTORIC_SVTXVERTEXV1_H
-#define TRACKBASEHISTORIC_SVTXVERTEXV1_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_SVTXVERTEXV2_H
+#define GLOBALVERTEX_SVTXVERTEXV2_H
 
 #include "SvtxVertex.h"
 

--- a/offline/packages/globalvertex/SvtxVertex_v2.h
+++ b/offline/packages/globalvertex/SvtxVertex_v2.h
@@ -74,14 +74,14 @@ class SvtxVertex_v2 : public SvtxVertex
  private:
   unsigned int covar_index(unsigned int i, unsigned int j) const;
 
-  unsigned int _id;                   //< unique identifier within container
-  float _t0;                          //< collision time
+  unsigned int _id {std::numeric_limits<unsigned int>::max()};                   //< unique identifier within container
+  float _t0 {std::numeric_limits<float>::quiet_NaN()};                          //< collision time
   float _pos[3];                      //< collision position x,y,z
-  float _chisq;                       //< vertex fit chisq
-  unsigned int _ndof;                 //< degrees of freedom
+  float _chisq {std::numeric_limits<float>::quiet_NaN()};                       //< vertex fit chisq
+  unsigned int _ndof {std::numeric_limits<unsigned int>::max()};                 //< degrees of freedom
   float _err[6];                      //< error covariance matrix (packed storage) (+/- cm^2)
   std::set<unsigned int> _track_ids;  //< list of track ids
-  unsigned int _beamcrossing;
+  unsigned int _beamcrossing {std::numeric_limits<unsigned int>::max()};
 
   ClassDefOverride(SvtxVertex_v2, 2);
 };

--- a/offline/packages/globalvertex/SvtxVertex_v2.h
+++ b/offline/packages/globalvertex/SvtxVertex_v2.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>  // for size_t
 #include <iostream>
+#include <limits>
 #include <set>
 
 class PHObject;

--- a/offline/packages/globalvertex/SvtxVertex_v2.h
+++ b/offline/packages/globalvertex/SvtxVertex_v2.h
@@ -77,10 +77,10 @@ class SvtxVertex_v2 : public SvtxVertex
 
   unsigned int _id{std::numeric_limits<unsigned int>::max()};    //< unique identifier within container
   float _t0{std::numeric_limits<float>::quiet_NaN()};            //< collision time
-  float _pos[3];                                                 //< collision position x,y,z
+  float _pos[3]{};                                                 //< collision position x,y,z
   float _chisq{std::numeric_limits<float>::quiet_NaN()};         //< vertex fit chisq
   unsigned int _ndof{std::numeric_limits<unsigned int>::max()};  //< degrees of freedom
-  float _err[6];                                                 //< error covariance matrix (packed storage) (+/- cm^2)
+  float _err[6]{};                                                 //< error covariance matrix (packed storage) (+/- cm^2)
   std::set<unsigned int> _track_ids;                             //< list of track ids
   unsigned int _beamcrossing{std::numeric_limits<unsigned int>::max()};
 

--- a/offline/packages/globalvertex/Vertex.h
+++ b/offline/packages/globalvertex/Vertex.h
@@ -1,9 +1,11 @@
-#ifndef VERTEX_H
-#define VERTEX_H
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef GLOBALVERTEX_VERTEX_H
+#define GLOBALVERTEX_VERTEX_H
 
 #include <phool/PHObject.h>
-#include <climits>
-#include <cmath>
+
+#include <limits>
 #include <iostream>
 #include <set>
 #include <vector>
@@ -25,52 +27,52 @@ class Vertex : public PHObject
 
   // vertex info
 
-  virtual unsigned int get_id() const { return 0xFFFFFFFF; }
+  virtual unsigned int get_id() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_id(unsigned int) {}
 
-  virtual float get_t() const { return NAN; }
+  virtual float get_t() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_t(float) {}
 
   // Interface functions to maintain backwards compatibility with svtxvertex_v1
   virtual float get_t0() const { return get_t(); }
   virtual void set_t0(float t0) { set_t(t0); }
 
-  virtual float get_t_err() const { return NAN; }
+  virtual float get_t_err() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_t_err(float) {}
 
-  virtual float get_x() const { return NAN; }
+  virtual float get_x() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_x(float) {}
 
-  virtual float get_y() const { return NAN; }
+  virtual float get_y() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_y(float) {}
 
-  virtual float get_z() const { return NAN; }
+  virtual float get_z() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z(float) {}
 
-  virtual float get_chisq() const { return NAN; }
+  virtual float get_chisq() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_chisq(float) {}
 
-  virtual unsigned int get_ndof() const { return UINT_MAX; }
+  virtual unsigned int get_ndof() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_ndof(unsigned int) {}
 
-  virtual float get_position(unsigned int) const { return NAN; }
+  virtual float get_position(unsigned int) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_position(unsigned int /*coor*/, float /*xi*/) {}
 
-  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return NAN; }
+  virtual float get_error(unsigned int /*i*/, unsigned int /*j*/) const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_error(unsigned int /*i*/, unsigned int /*j*/, float /*value*/) {}
 
   // beam crossing methods
-  virtual unsigned int get_beam_crossing() const { return UINT_MAX; }
+  virtual unsigned int get_beam_crossing() const { return std::numeric_limits<unsigned int>::max(); }
   virtual void set_beam_crossing(unsigned int) {}
 
   // bbcvertex methods
   virtual void set_bbc_ns(int, int, float, float) {}
   virtual int get_bbc_npmt(int) const { return std::numeric_limits<int>::max(); }
-  virtual float get_z_err() const { return NAN; }
+  virtual float get_z_err() const { return std::numeric_limits<float>::quiet_NaN(); }
   virtual void set_z_err(float) {}
 
-  virtual float get_bbc_q(int) const { return NAN; }
-  virtual float get_bbc_t(int) const { return NAN; }
+  virtual float get_bbc_q(int) const { return std::numeric_limits<float>::quiet_NaN(); }
+  virtual float get_bbc_t(int) const { return std::numeric_limits<float>::quiet_NaN(); }
 
   // svtxvertex methods
   virtual void clear_tracks() {}

--- a/offline/packages/globalvertex/Vertex.h
+++ b/offline/packages/globalvertex/Vertex.h
@@ -5,10 +5,10 @@
 
 #include <phool/PHObject.h>
 
+#include <cstddef>
 #include <limits>
 #include <iostream>
 #include <set>
-#include <vector>
 
 class Vertex : public PHObject
 {

--- a/offline/packages/globalvertex/Vertex.h
+++ b/offline/packages/globalvertex/Vertex.h
@@ -6,8 +6,8 @@
 #include <phool/PHObject.h>
 
 #include <cstddef>
-#include <limits>
 #include <iostream>
+#include <limits>
 #include <set>
 
 class Vertex : public PHObject

--- a/offline/packages/globalvertex/Vertex.h
+++ b/offline/packages/globalvertex/Vertex.h
@@ -17,7 +17,7 @@ class Vertex : public PHObject
   typedef std::set<unsigned int>::const_iterator ConstTrackIter;
   typedef std::set<unsigned int>::iterator TrackIter;
 
-  ~Vertex() override {}
+  ~Vertex() override = default;
 
   // PHObject virtual overloads
 
@@ -86,6 +86,9 @@ class Vertex : public PHObject
   virtual TrackIter begin_tracks();
   virtual TrackIter find_track(unsigned int trackid);
   virtual TrackIter end_tracks();
+
+ protected:
+  Vertex() = default;
 
  private:
   ClassDefOverride(Vertex, 1);

--- a/offline/packages/globalvertex/configure.ac
+++ b/offline/packages/globalvertex/configure.ac
@@ -6,16 +6,17 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX(CC g++)
 LT_INIT([disable-static])
 
+CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -Werror"
 dnl leaving this here in case we want to play with different compiler 
 dnl specific flags
-case $CXX in
- clang++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
- *g++)
-  CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
- ;;
-esac
+dnl case $CXX in
+dnl  clang++)
+dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+dnl  ;;
+dnl  *g++)
+dnl   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+dnl  ;;
+dnl esac
 
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader "

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -133,14 +133,14 @@ int MbdReco::process_event(PHCompositeNode *topNode)
   // For multiple global vertex
   if (m_mbdevent->get_bbcn(0) > 0 && m_mbdevent->get_bbcn(1) > 0)
   {
-    auto vertex = std::make_unique<MbdVertexv2>();
+    auto vertex = new MbdVertexv2();
     vertex->set_t(m_mbdevent->get_bbct0());
     vertex->set_z(m_mbdevent->get_bbcz());
     vertex->set_z_err(0.6);
     vertex->set_t_err(m_tres);
     vertex->set_beam_crossing(0);
 
-    m_mbdvtxmap->insert(vertex.release());
+    m_mbdvtxmap->insert(vertex);
 
     // copy to globalvertex
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes a likely long standing memory leak in the global vertex object, allocated memory for the vertex objects was never freed. Modernized the code, clang-tidy, clang-format, remove using namespace std,...

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

