### PR TITLE
Apply distortion corrections in distortion QA evaluation module

### DIFF
--- a/offline/QA/SimulationModules/Makefile.am
+++ b/offline/QA/SimulationModules/Makefile.am
@@ -26,6 +26,7 @@ libsimqa_modules_la_LIBADD = \
   -ljetbase \
   -lphg4hit \
   -ltrackbase_historic_io \
+  -ltpc \
   -lCLHEP \
   -ldecayfinder_io \
   -lphhepmc \
@@ -45,7 +46,7 @@ pkginclude_HEADERS = \
   QAG4SimulationVertex.h \
   QAG4SimulationUpsilon.h \
   QAG4SimulationTruthDecay.h \
-  QAG4Decayer.h 
+  QAG4Decayer.h
 
 libsimqa_kfparticle_la_SOURCES = \
   QAG4SimulationKFParticle.cc
@@ -63,7 +64,7 @@ libsimqa_modules_la_SOURCES = \
   QAG4SimulationVertex.cc \
   QAG4SimulationUpsilon.cc \
   QAG4SimulationTruthDecay.cc \
-  QAG4Decayer.cc 
+  QAG4Decayer.cc
 
 ################################################
 # linking tests

--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.h
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.h
@@ -4,6 +4,7 @@
 #define QAG4SIMULATIONDISTORTIONS_H
 
 #include <fun4all/SubsysReco.h>
+#include <tpc/TpcGlobalPositionWrapper.h>
 #include <trackbase/TrkrDefs.h>
 
 #include <math.h>
@@ -38,6 +39,9 @@ class QAG4SimulationDistortions : public SubsysReco
   SvtxTrackMap* m_trackMap = nullptr;
   TrkrClusterContainer* m_clusterContainer = nullptr;
   ActsGeometry* m_tGeometry = nullptr;
+
+  //! tpc global position wrapper
+  TpcGlobalPositionWrapper m_globalPositionWrapper;
 
   int m_event = 0;
   float m_tanAlpha = NAN;


### PR DESCRIPTION
Load and apply distortion corrections when forming unbiased residuals in the TPC.
This should address why Xudong sees no effect on applying distortion corrections in https://indico.bnl.gov/event/26185/contributions/101494/attachments/59434/102129/20250114_yuxd_TPC_distortion.pdf

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

