### PR TITLE
Topo cluster change the initial sub_cluster E for fitting

### DIFF
--- a/offline/packages/CaloReco/RawClusterBuilderTopo.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTopo.cc
@@ -1367,8 +1367,8 @@ int RawClusterBuilderTopo::process_event(PHCompositeNode *topNode)
       int highest_pseudocluster_index = -1;
       int second_highest_pseudocluster_index = -1;
 
-      float highest_pseudocluster_E = -1;
-      float second_highest_pseudocluster_E = -2;
+      float highest_pseudocluster_E = -999;
+      float second_highest_pseudocluster_E = -999;
 
       for (unsigned int n = 0; n < pseudocluster_adjacency.size(); n++)
       {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Splitting part goes in infinite loop when pseudocluster contains large negative values. This PR change the initial energy smaller to guarantee the finding of neighbor clusters to split the tower energy. 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

