### PR TITLE
Method to add strange particles to simulation

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -36,8 +36,8 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
-#include <TLorentzVector.h>
 #include <TDatabasePDG.h>
+#include <TLorentzVector.h>
 
 #include <cassert>
 #include <cmath>
@@ -107,7 +107,6 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
   }
   gsl_rng_set(RandomGenerator, phseed);
 
-  // gaurd against addfraction is negative: 
   if (addfraction < 0.0)
   {
     std::cout << "[WARNING] addfraction is negative which is not allowed. Setting addfraction to 0." << std::endl;
@@ -115,52 +114,49 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
   }
 
   if (addfraction != 0.0)
-  { 
+  {
     fpt = new TF1("fpt", EMGFunction, -10, 10, 4);
-    fpt->SetParameter(0, 1); // normalization
-    fpt->SetParameter(1, 4.71648e-01); // mu
-    fpt->SetParameter(2, 1.89602e-01); // sigma
-    fpt->SetParameter(3, 2.26981e+00); // lambda
+    fpt->SetParameter(0, 1);            // normalization
+    fpt->SetParameter(1, 4.71648e-01);  // mu
+    fpt->SetParameter(2, 1.89602e-01);  // sigma
+    fpt->SetParameter(3, 2.26981e+00);  // lambda
 
     feta = new TF1("feta", DBGFunction, -1, 1, 4);
-    feta->SetParameter(0, 1); // normalization
-    feta->SetParameter(1, -4.08301e-01); // mu1
-    feta->SetParameter(2, 4.11930e-01); // mu2
-    feta->SetParameter(3, 3.59063e-01); // sigma
+    feta->SetParameter(0, 1);             // normalization
+    feta->SetParameter(1, -4.08301e-01);  // mu1
+    feta->SetParameter(2, 4.11930e-01);   // mu2
+    feta->SetParameter(3, 3.59063e-01);   // sigma
 
-    std::vector<std::pair<int,double>> l_PIDProb;
+    std::vector<std::pair<int, double>> l_PIDProb;
     for (size_t i = 0; i < list_strangePID.size(); i++)
     {
-      l_PIDProb.push_back(std::make_pair(list_strangePID[i], list_strangePIDprob[i]));
-    } 
+      l_PIDProb.emplace_back(list_strangePID[i], list_strangePIDprob[i]);
+    }
 
-    // set the list of strange particles and their probabilities
-    // first sort list_strangePID based on the probability from pair.second in ascending order
-    std::sort(l_PIDProb.begin(), l_PIDProb.end(), 
-              [](const std::pair<int, double>& a, const std::pair<int, double>& b) -> bool
+    std::sort(l_PIDProb.begin(), l_PIDProb.end(),
+              [](const std::pair<int, double> &a, const std::pair<int, double> &b) -> bool
               {
                 return a.second < b.second;
               });
 
     double sum = 0.0;
-    for (const auto& it : l_PIDProb)
+    for (const auto &it : l_PIDProb)
     {
       sum += it.second;
-      list_strangePID_probrange.push_back(std::make_pair(it.first, std::make_pair(sum - it.second, sum)));
+      list_strangePID_probrange.emplace_back(it.first, std::make_pair(sum - it.second, sum));
     }
 
-    // print the list of strange particles and their probability ranges for debugging
     if (Verbosity() > 0)
     {
       std::cout << "[INFO] Sorted list of strange particles and their probabilities: " << std::endl;
 
-      for (const auto& it : l_PIDProb)
+      for (const auto &it : l_PIDProb)
       {
         std::cout << "PID: " << it.first << " Probability: " << it.second << std::endl;
       }
 
       std::cout << "[INFO] List of strange particles and their probability ranges: " << std::endl;
-      for (const auto& it : list_strangePID_probrange)
+      for (const auto &it : list_strangePID_probrange)
       {
         std::cout << "PID: " << it.first << " Probability range: [" << it.second.first << "," << it.second.second << "]" << std::endl;
       }
@@ -317,9 +313,8 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
     std::list<HepMC::GenParticle *> finalstateparticles;
     std::list<HepMC::GenParticle *>::const_iterator fiter;
-    
-    std::map<int, int> particlePID_count;
-    int Nstrange = 0; // count the number of strange particles with PID in list_strangePID
+
+    int Nstrange = 0;  // count the number of strange particles with PID in list_strangePID per event
 
     // units in G4 interface are GeV and CM as in PHENIX convention
     const double mom_factor = HepMC::Units::conversion_factor(evt->momentum_unit(), HepMC::Units::GEV);
@@ -356,9 +351,6 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           }
           finalstateparticles.push_back(*p);
 
-          // count unique particle PDG
-          particlePID_count[(*p)->pdg_id()]++;
-          // count the number of strange particles with absolute PID in list_strangePID
           if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs((*p)->pdg_id())) != list_strangePID.end())
           {
             Nstrange++;
@@ -372,26 +364,13 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
             std::cout << "\tparticle failed " << std::endl;
           }
         }
-      } // for (HepMC::GenVertex::particle_iterator p = (*v)->particles_begin(HepMC::children); p != (*v)->particles_end(HepMC::children); ++p)
+      }  // for (HepMC::GenVertex::particle_iterator p = (*v)->particles_begin(HepMC::children); p != (*v)->particles_end(HepMC::children); ++p)
 
       // Add additional strange particles if addfraction is not zero; round up to the ceiling integer
       Nstrange_add = static_cast<int>(std::ceil(Nstrange * addfraction * 0.01));
 
-      if (Verbosity() > 0) //TODO: Change to 1 or a larger number to suppress the debug printout after debugging
+      if (Verbosity() > 1)
       {
-        std::cout << "[DEBUG] Particle count map (before adding strageness): " << std::endl;
-        for (std::map<int, int>::iterator it = particlePID_count.begin();
-            it != particlePID_count.end();
-            ++it)
-        {
-          std::cout << "PDG: " << it->first << " count: " << it->second;
-          // if is strange particle (absolute PID in list_strangePID), mark it
-          if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs(it->first)) != list_strangePID.end())
-          {
-            std::cout << " (strange)";
-          }
-          std::cout << std::endl;
-        }
         std::cout << "[DEBUG] Number of original strange particles: " << Nstrange << std::endl;
         std::cout << "[DEBUG] addfraction: " << addfraction << "%; Number of strange particles to be added: " << Nstrange_add << std::endl;
       }
@@ -503,9 +482,9 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           {
             ineve->AddEmbeddedParticle(particle, embed_flag);
           }
-        } // for (fiter = finalstateparticles.begin(); fiter != finalstateparticles.end(); ++fiter)
+        }  // for (fiter = finalstateparticles.begin(); fiter != finalstateparticles.end(); ++fiter)
 
-        // add strange particles given Nstrange_add 
+        // add strange particles given Nstrange_add
         if (addfraction > 0)
         {
           if (Verbosity() > 1)
@@ -516,12 +495,9 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           // Add strange particles given Nstrange_add
           for (int i = 0; i < Nstrange_add; i++)
           {
-            // the added strange particles are in the list_strangePID, the probability of each particle is in list_strangePIDprob
-            // sample a strange particle PID from the list_strangePID with the probability in list_strangePIDprob; considering there might be more than 2 strange particles
-            int pid = list_strangePID[0]; // default to the first PID in the list, i.e K_s0
+            int pid = list_strangePID[0];  // default to the first PID in the list, i.e K_s0
             double prob = gsl_rng_uniform_pos(RandomGenerator);
-            // assign the PID based on the probability range
-            for (const auto& it : list_strangePID_probrange)
+            for (const auto &it : list_strangePID_probrange)
             {
               if (prob >= it.second.first && prob < it.second.second)
               {
@@ -537,7 +513,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
             double mass = TDatabasePDG::Instance()->GetParticle(pid)->Mass();
 
             TLorentzVector lv;
-            lv.SetPtEtaPhiM(pt, eta, phi, mass); // Lambda or K_s0
+            lv.SetPtEtaPhiM(pt, eta, phi, mass);
 
             // create a new particle
             PHG4Particle *particle = new PHG4Particlev1();
@@ -545,36 +521,15 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
             particle->set_px(lv.Px());
             particle->set_py(lv.Py());
             particle->set_pz(lv.Pz());
-            particle->set_barcode(std::numeric_limits<int>::max() - i); // set the barcode to be distinct from the existing particles; backward counting from the maximum integer value
+            particle->set_barcode(std::numeric_limits<int>::max() - i);  // set the barcode to be distinct from the existing particles; backward counting from the maximum integer value
 
             ineve->AddParticle(vtxindex, particle);
-
-            particlePID_count[particle->get_pid()]++; // count unique particle PDG for debugging
           }
         }
 
       }  // if (!finalstateparticles.empty())
-    }  // for (HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
-
-    //TODO: Change to 1 or a larger number to suppress the debug printout after debugging
-    if (Verbosity() > 0)
-    {
-      std::cout << "Particle count map (after adding strangeness): " << std::endl;
-      for (std::map<int, int>::iterator it = particlePID_count.begin();
-           it != particlePID_count.end();
-           ++it)
-      {
-        std::cout << "PDG: " << it->first << " count: " << it->second;
-
-        // if is strange particle (absolute PID in list_strangePID), mark it
-        if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs(it->first)) != list_strangePID.end())
-        {
-          std::cout << " (strange)";
-        }
-        std::cout << std::endl;
-      }
-    }
-  }  // For pile-up simulation: loop end for PHHepMC event map
+    }    // for (HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
+  }      // For pile-up simulation: loop end for PHHepMC event map
   if (Verbosity() > 0)
   {
     ineve->identify();
@@ -635,10 +590,10 @@ double HepMCNodeReader::EMGFunction(double *x, double *par)
 {
   // parameterization: https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
 
-  double N = par[0]; // Normalization
-  double mu = par[1]; // Mean of the Gaussian
-  double sigma = par[2]; // Width of the Gaussian
-  double lambda = par[3]; // Decay constant of the Exponential
+  double N = par[0];       // Normalization
+  double mu = par[1];      // Mean of the Gaussian
+  double sigma = par[2];   // Width of the Gaussian
+  double lambda = par[3];  // Decay constant of the Exponential
 
   double t = x[0];
   double z = (mu + lambda * sigma * sigma - t) / (sqrt(2) * sigma);
@@ -652,10 +607,10 @@ double HepMCNodeReader::EMGFunction(double *x, double *par)
 
 double HepMCNodeReader::DBGFunction(double *x, double *par)
 {
-  double N = par[0]; // Normalization
-  double mu1 = par[1]; // Mean of the first Gaussian
-  double mu2 = par[2]; // Mean of the second Gaussian
-  double sigma = par[3]; // Width of the Gaussian
+  double N = par[0];      // Normalization
+  double mu1 = par[1];    // Mean of the first Gaussian
+  double mu2 = par[2];    // Mean of the second Gaussian
+  double sigma = par[3];  // Width of the Gaussian
 
   return N * (TMath::Gaus(x[0], mu1, sigma) + TMath::Gaus(x[0], mu2, sigma));
 }

--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -36,6 +36,9 @@
 #include <gsl/gsl_randist.h>
 #include <gsl/gsl_rng.h>
 
+#include <TLorentzVector.h>
+#include <TDatabasePDG.h>
+
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
@@ -103,6 +106,67 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
     std::cout << Name() << " override random seed: " << phseed << std::endl;
   }
   gsl_rng_set(RandomGenerator, phseed);
+
+  // gaurd against addfraction is negative: 
+  if (addfraction < 0.0)
+  {
+    std::cout << "[WARNING] addfraction is negative which is not allowed. Setting addfraction to 0." << std::endl;
+    addfraction = 0.0;
+  }
+
+  if (addfraction != 0.0)
+  { 
+    fpt = new TF1("fpt", EMGFunction, -10, 10, 4);
+    fpt->SetParameter(0, 1); // normalization
+    fpt->SetParameter(1, 4.71648e-01); // mu
+    fpt->SetParameter(2, 1.89602e-01); // sigma
+    fpt->SetParameter(3, 2.26981e+00); // lambda
+
+    feta = new TF1("feta", DBGFunction, -1, 1, 4);
+    feta->SetParameter(0, 1); // normalization
+    feta->SetParameter(1, -4.08301e-01); // mu1
+    feta->SetParameter(2, 4.11930e-01); // mu2
+    feta->SetParameter(3, 3.59063e-01); // sigma
+
+    std::vector<std::pair<int,double>> l_PIDProb;
+    for (size_t i = 0; i < list_strangePID.size(); i++)
+    {
+      l_PIDProb.push_back(std::make_pair(list_strangePID[i], list_strangePIDprob[i]));
+    } 
+
+    // set the list of strange particles and their probabilities
+    // first sort list_strangePID based on the probability from pair.second in ascending order
+    std::sort(l_PIDProb.begin(), l_PIDProb.end(), 
+              [](const std::pair<int, double>& a, const std::pair<int, double>& b) -> bool
+              {
+                return a.second < b.second;
+              });
+
+    double sum = 0.0;
+    for (const auto& it : l_PIDProb)
+    {
+      sum += it.second;
+      list_strangePID_probrange.push_back(std::make_pair(it.first, std::make_pair(sum - it.second, sum)));
+    }
+
+    // print the list of strange particles and their probability ranges for debugging
+    if (Verbosity() > 0)
+    {
+      std::cout << "[INFO] Sorted list of strange particles and their probabilities: " << std::endl;
+
+      for (const auto& it : l_PIDProb)
+      {
+        std::cout << "PID: " << it.first << " Probability: " << it.second << std::endl;
+      }
+
+      std::cout << "[INFO] List of strange particles and their probability ranges: " << std::endl;
+      for (const auto& it : list_strangePID_probrange)
+      {
+        std::cout << "PID: " << it.first << " Probability range: [" << it.second.first << "," << it.second.second << "]" << std::endl;
+      }
+    }
+  }
+
   return 0;
 }
 
@@ -253,6 +317,9 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
     std::list<HepMC::GenParticle *> finalstateparticles;
     std::list<HepMC::GenParticle *>::const_iterator fiter;
+    
+    std::map<int, int> particlePID_count;
+    int Nstrange = 0; // count the number of strange particles with PID in list_strangePID
 
     // units in G4 interface are GeV and CM as in PHENIX convention
     const double mom_factor = HepMC::Units::conversion_factor(evt->momentum_unit(), HepMC::Units::GEV);
@@ -288,6 +355,14 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
             std::cout << "\tparticle passed " << std::endl;
           }
           finalstateparticles.push_back(*p);
+
+          // count unique particle PDG
+          particlePID_count[(*p)->pdg_id()]++;
+          // count the number of strange particles with absolute PID in list_strangePID
+          if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs((*p)->pdg_id())) != list_strangePID.end())
+          {
+            Nstrange++;
+          }
         }
         else
         {
@@ -297,6 +372,28 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
             std::cout << "\tparticle failed " << std::endl;
           }
         }
+      } // for (HepMC::GenVertex::particle_iterator p = (*v)->particles_begin(HepMC::children); p != (*v)->particles_end(HepMC::children); ++p)
+
+      // Add additional strange particles if addfraction is not zero; round up to the ceiling integer
+      Nstrange_add = static_cast<int>(std::ceil(Nstrange * addfraction * 0.01));
+
+      if (Verbosity() > 0) //TODO: Change to 1 or a larger number to suppress the debug printout after debugging
+      {
+        std::cout << "[DEBUG] Particle count map (before adding strageness): " << std::endl;
+        for (std::map<int, int>::iterator it = particlePID_count.begin();
+            it != particlePID_count.end();
+            ++it)
+        {
+          std::cout << "PDG: " << it->first << " count: " << it->second;
+          // if is strange particle (absolute PID in list_strangePID), mark it
+          if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs(it->first)) != list_strangePID.end())
+          {
+            std::cout << " (strange)";
+          }
+          std::cout << std::endl;
+        }
+        std::cout << "[DEBUG] Number of original strange particles: " << Nstrange << std::endl;
+        std::cout << "[DEBUG] addfraction: " << addfraction << "%; Number of strange particles to be added: " << Nstrange_add << std::endl;
       }
 
       if (!finalstateparticles.empty())
@@ -406,11 +503,77 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           {
             ineve->AddEmbeddedParticle(particle, embed_flag);
           }
+        } // for (fiter = finalstateparticles.begin(); fiter != finalstateparticles.end(); ++fiter)
+
+        // add strange particles given Nstrange_add 
+        if (addfraction > 0)
+        {
+          if (Verbosity() > 1)
+          {
+            std::cout << "[INFO] Add strange particles. Number of strange particles to be added: " << Nstrange_add << std::endl;
+          }
+
+          // Add strange particles given Nstrange_add
+          for (int i = 0; i < Nstrange_add; i++)
+          {
+            // the added strange particles are in the list_strangePID, the probability of each particle is in list_strangePIDprob
+            // sample a strange particle PID from the list_strangePID with the probability in list_strangePIDprob; considering there might be more than 2 strange particles
+            int pid = list_strangePID[0]; // default to the first PID in the list, i.e K_s0
+            double prob = gsl_rng_uniform_pos(RandomGenerator);
+            // assign the PID based on the probability range
+            for (const auto& it : list_strangePID_probrange)
+            {
+              if (prob >= it.second.first && prob < it.second.second)
+              {
+                pid = it.first;
+                break;
+              }
+            }
+
+            // sample pt and eta from the EMG and DBG functions; phi between -pi and pi
+            double pt = fpt->GetRandom();
+            double eta = feta->GetRandom();
+            double phi = (gsl_rng_uniform_pos(RandomGenerator) * 2 * M_PI) - M_PI;
+            double mass = TDatabasePDG::Instance()->GetParticle(pid)->Mass();
+
+            TLorentzVector lv;
+            lv.SetPtEtaPhiM(pt, eta, phi, mass); // Lambda or K_s0
+
+            // create a new particle
+            PHG4Particle *particle = new PHG4Particlev1();
+            particle->set_pid(pid);
+            particle->set_px(lv.Px());
+            particle->set_py(lv.Py());
+            particle->set_pz(lv.Pz());
+            particle->set_barcode(std::numeric_limits<int>::max() - i); // set the barcode to be distinct from the existing particles; backward counting from the maximum integer value
+
+            ineve->AddParticle(vtxindex, particle);
+
+            particlePID_count[particle->get_pid()]++; // count unique particle PDG for debugging
+          }
         }
-      }  //      if (!finalstateparticles.empty())
 
-    }  //    for (HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
+      }  // if (!finalstateparticles.empty())
+    }  // for (HepMC::GenEvent::vertex_iterator v = evt->vertices_begin();
 
+    //TODO: Change to 1 or a larger number to suppress the debug printout after debugging
+    if (Verbosity() > 0)
+    {
+      std::cout << "Particle count map (after adding strangeness): " << std::endl;
+      for (std::map<int, int>::iterator it = particlePID_count.begin();
+           it != particlePID_count.end();
+           ++it)
+      {
+        std::cout << "PDG: " << it->first << " count: " << it->second;
+
+        // if is strange particle (absolute PID in list_strangePID), mark it
+        if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs(it->first)) != list_strangePID.end())
+        {
+          std::cout << " (strange)";
+        }
+        std::cout << std::endl;
+      }
+    }
   }  // For pile-up simulation: loop end for PHHepMC event map
   if (Verbosity() > 0)
   {
@@ -466,6 +629,35 @@ void HepMCNodeReader::SmearVertex(const double s_x, const double s_y,
   width_vy = s_y;
   width_vz = s_z;
   return;
+}
+
+double HepMCNodeReader::EMGFunction(double *x, double *par)
+{
+  // parameterization: https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
+
+  double N = par[0]; // Normalization
+  double mu = par[1]; // Mean of the Gaussian
+  double sigma = par[2]; // Width of the Gaussian
+  double lambda = par[3]; // Decay constant of the Exponential
+
+  double t = x[0];
+  double z = (mu + lambda * sigma * sigma - t) / (sqrt(2) * sigma);
+
+  double prefactor = lambda / 2.0;
+  double exp_part = exp((lambda / 2.0) * (2.0 * mu + lambda * sigma * sigma - 2.0 * t));
+  double erfc_part = TMath::Erfc(z);
+
+  return N * prefactor * exp_part * erfc_part;
+}
+
+double HepMCNodeReader::DBGFunction(double *x, double *par)
+{
+  double N = par[0]; // Normalization
+  double mu1 = par[1]; // Mean of the first Gaussian
+  double mu2 = par[2]; // Mean of the second Gaussian
+  double sigma = par[3]; // Width of the Gaussian
+
+  return N * (TMath::Gaus(x[0], mu1, sigma) + TMath::Gaus(x[0], mu2, sigma));
 }
 
 void HepMCNodeReader::Embed(const int /*unused*/)

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -3,12 +3,15 @@
 #ifndef G4MAIN_HEPMCNODEREADER_H
 #define G4MAIN_HEPMCNODEREADER_H
 
+#include <TF1.h>
+
 #include <fun4all/SubsysReco.h>
 
 // rootcint barfs with this header so we need to hide it
 #include <gsl/gsl_rng.h>
 
 #include <string>
+#include <vector>
 
 class PHCompositeNode;
 
@@ -16,59 +19,73 @@ class PHCompositeNode;
 //! For HepMC subevent which is already simulated, they will not be simulated again in Geant4.
 class HepMCNodeReader : public SubsysReco
 {
- public:
-  HepMCNodeReader(const std::string &name = "HepMCNodeReader");
-  ~HepMCNodeReader() override;
+  public:
+    HepMCNodeReader(const std::string &name = "HepMCNodeReader");
+    ~HepMCNodeReader() override;
 
-  int Init(PHCompositeNode *topNode) override;
-  int process_event(PHCompositeNode *topNode) override;
+    int Init(PHCompositeNode *topNode) override;
+    int process_event(PHCompositeNode *topNode) override;
 
-  void pythia(const bool pythia)
-  {
-    is_pythia = pythia;
-  }
+    void pythia(const bool pythia) { is_pythia = pythia; }
 
-  //! this function is depreciated.
-  //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-  void Embed(const int i = 1);
+    //! this function is depreciated.
+    //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+    void Embed(const int i = 1);
 
-  //! this function is depreciated.
-  //! HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location.
-  //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-  void VertexPosition(const double v_x, const double v_y, const double v_z);
+    //! this function is depreciated.
+    //! HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location.
+    //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+    void VertexPosition(const double v_x, const double v_y, const double v_z);
 
-  //! HepMCNodeReader::SmearVertex - WARNING - this function is depreciated.
-  //! HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location.
-  //! And the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-  //! Positive value is Gauss smear, and negative values are flat smear
-  void SmearVertex(const double s_x, const double s_y, const double s_z);
+    //! HepMCNodeReader::SmearVertex - WARNING - this function is depreciated.
+    //! HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location.
+    //! And the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+    //! Positive value is Gauss smear, and negative values are flat smear
+    void SmearVertex(const double s_x, const double s_y, const double s_z);
 
-  //! Arbitary time shift for all sub-events.
-  //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-  void SetT0(const double t0) { vertex_t0 = t0; }
-  //
-  //! Override seed
-  void SetSeed(const unsigned int i)
-  {
-    seed = i;
-    use_seed = 1;
-  }
+    //! Arbitary time shift for all sub-events.
+    //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+    void SetT0(const double t0) { vertex_t0 = t0; }
+    //
+    //! Override seed
+    void SetSeed(const unsigned int i)
+    {
+        seed = i;
+        use_seed = 1;
+    }
 
- private:
-  double smeargauss(const double width);
-  double smearflat(const double width);
+    // Method to add strangeness content of the event: f is the fraction of additional strangeness particles, in percent
+    void AddStrangeness(const float f) { addfraction = f; }
 
-  gsl_rng *RandomGenerator{nullptr};
-  bool is_pythia{false};
-  int use_seed{0};
-  unsigned int seed{0};
-  double vertex_pos_x{0.0};
-  double vertex_pos_y{0.0};
-  double vertex_pos_z{0.0};
-  double vertex_t0{0.0};
-  double width_vx{0.0};
-  double width_vy{0.0};
-  double width_vz{0.0};
+  private:
+    double smeargauss(const double width);
+    double smearflat(const double width);
+
+    // Exponentially modified Gaussian distribution function, modelling pT
+    static double EMGFunction(double *x, double *par);
+    // Double Gaussian function: simplfied model, fraction is fixed to 0.5, gaussian widths are the same for both Gaussians; modelling eta
+    static double DBGFunction(double *x, double *par);
+
+    gsl_rng *RandomGenerator{nullptr};
+    bool is_pythia{false};
+    int use_seed{0};
+    unsigned int seed{0};
+    double vertex_pos_x{0.0};
+    double vertex_pos_y{0.0};
+    double vertex_pos_z{0.0};
+    double vertex_t0{0.0};
+    double width_vx{0.0};
+    double width_vy{0.0};
+    double width_vz{0.0};
+
+    // Method to change the strangeness content of the event
+    std::vector<int> list_strangePID = {310, 3122, -3122};                              // K_s0 (PID=310), Lambda (PID=3122)
+    std::vector<double> list_strangePIDprob = {1 - 0.333, 0.333 / 2., 0.333 / 2.};      // K_s0 (PID=310) has 2/3 probability, Lambda (PID=3122) has 1/3 probability
+    std::vector<std::pair<int, std::pair<double, double>>> list_strangePID_probrange{}; // list of strange particles and their probability ranges
+    float addfraction{0.0};                                                             // additional strangeness particles, in percent; default 0
+    int Nstrange_add{0};                                                                // number of strange particles to be added; default 0
+    TF1 *fpt{nullptr};
+    TF1 *feta{nullptr};
 };
 
 #endif

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -19,73 +19,73 @@ class PHCompositeNode;
 //! For HepMC subevent which is already simulated, they will not be simulated again in Geant4.
 class HepMCNodeReader : public SubsysReco
 {
-  public:
-    HepMCNodeReader(const std::string &name = "HepMCNodeReader");
-    ~HepMCNodeReader() override;
+ public:
+  HepMCNodeReader(const std::string &name = "HepMCNodeReader");
+  ~HepMCNodeReader() override;
 
-    int Init(PHCompositeNode *topNode) override;
-    int process_event(PHCompositeNode *topNode) override;
+  int Init(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
 
-    void pythia(const bool pythia) { is_pythia = pythia; }
+  void pythia(const bool pythia) { is_pythia = pythia; }
 
-    //! this function is depreciated.
-    //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-    void Embed(const int i = 1);
+  //! this function is depreciated.
+  //! Embedding IDs are controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+  void Embed(const int i = 1);
 
-    //! this function is depreciated.
-    //! HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location.
-    //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-    void VertexPosition(const double v_x, const double v_y, const double v_z);
+  //! this function is depreciated.
+  //! HepMCNodeReader::VertexPosition() move all HEPMC subevents to a new vertex location.
+  //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+  void VertexPosition(const double v_x, const double v_y, const double v_z);
 
-    //! HepMCNodeReader::SmearVertex - WARNING - this function is depreciated.
-    //! HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location.
-    //! And the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-    //! Positive value is Gauss smear, and negative values are flat smear
-    void SmearVertex(const double s_x, const double s_y, const double s_z);
+  //! HepMCNodeReader::SmearVertex - WARNING - this function is depreciated.
+  //! HepMCNodeReader::SmearVertex() smear each HEPMC subevents to a new vertex location.
+  //! And the vertex smears are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+  //! Positive value is Gauss smear, and negative values are flat smear
+  void SmearVertex(const double s_x, const double s_y, const double s_z);
 
-    //! Arbitary time shift for all sub-events.
-    //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
-    void SetT0(const double t0) { vertex_t0 = t0; }
-    //
-    //! Override seed
-    void SetSeed(const unsigned int i)
-    {
-        seed = i;
-        use_seed = 1;
-    }
+  //! Arbitary time shift for all sub-events.
+  //! And the vertex shifts are better controlled for individually HEPMC subevents in Fun4AllHepMCInputManagers and event generators.
+  void SetT0(const double t0) { vertex_t0 = t0; }
+  //
+  //! Override seed
+  void SetSeed(const unsigned int i)
+  {
+    seed = i;
+    use_seed = 1;
+  }
 
-    // Method to add strangeness content of the event: f is the fraction of additional strangeness particles, in percent
-    void AddStrangeness(const float f) { addfraction = f; }
+  // Method to add strangeness content of the event: f is the fraction of additional strangeness particles, in percent
+  void AddStrangeness(const float f) { addfraction = f; }
 
-  private:
-    double smeargauss(const double width);
-    double smearflat(const double width);
+ private:
+  double smeargauss(const double width);
+  double smearflat(const double width);
 
-    // Exponentially modified Gaussian distribution function, modelling pT
-    static double EMGFunction(double *x, double *par);
-    // Double Gaussian function: simplfied model, fraction is fixed to 0.5, gaussian widths are the same for both Gaussians; modelling eta
-    static double DBGFunction(double *x, double *par);
+  // Exponentially modified Gaussian distribution function, modelling pT
+  static double EMGFunction(double *x, double *par);
+  // Double Gaussian function, modelling eta
+  static double DBGFunction(double *x, double *par);
 
-    gsl_rng *RandomGenerator{nullptr};
-    bool is_pythia{false};
-    int use_seed{0};
-    unsigned int seed{0};
-    double vertex_pos_x{0.0};
-    double vertex_pos_y{0.0};
-    double vertex_pos_z{0.0};
-    double vertex_t0{0.0};
-    double width_vx{0.0};
-    double width_vy{0.0};
-    double width_vz{0.0};
+  gsl_rng *RandomGenerator{nullptr};
+  bool is_pythia{false};
+  int use_seed{0};
+  unsigned int seed{0};
+  double vertex_pos_x{0.0};
+  double vertex_pos_y{0.0};
+  double vertex_pos_z{0.0};
+  double vertex_t0{0.0};
+  double width_vx{0.0};
+  double width_vy{0.0};
+  double width_vz{0.0};
 
-    // Method to change the strangeness content of the event
-    std::vector<int> list_strangePID = {310, 3122, -3122};                              // K_s0 (PID=310), Lambda (PID=3122)
-    std::vector<double> list_strangePIDprob = {1 - 0.333, 0.333 / 2., 0.333 / 2.};      // K_s0 (PID=310) has 2/3 probability, Lambda (PID=3122) has 1/3 probability
-    std::vector<std::pair<int, std::pair<double, double>>> list_strangePID_probrange{}; // list of strange particles and their probability ranges
-    float addfraction{0.0};                                                             // additional strangeness particles, in percent; default 0
-    int Nstrange_add{0};                                                                // number of strange particles to be added; default 0
-    TF1 *fpt{nullptr};
-    TF1 *feta{nullptr};
+  // Method to change the strangeness content of the event
+  std::vector<int> list_strangePID = {310, 3122, -3122};                               // K_s0 (PID=310), Lambda (PID=3122)
+  std::vector<double> list_strangePIDprob = {1 - 0.333, 0.333 / 2., 0.333 / 2.};       // K_s0 (PID=310) has 2/3 probability, Lambda (PID=3122) has 1/3 probability
+  std::vector<std::pair<int, std::pair<double, double>>> list_strangePID_probrange{};  // list of strange particles and their probability ranges
+  float addfraction{0.0};                                                              // additional strangeness particles, in percent; default 0
+  int Nstrange_add{0};                                                                 // number of strange particles to be added; default 0
+  TF1 *fpt{nullptr};
+  TF1 *feta{nullptr};
 };
 
 #endif

--- a/simulation/g4simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4simulation/g4main/PHG4Reco.cc
@@ -100,7 +100,7 @@
 #include <cstdlib>
 #include <exception>  // for exception
 #include <filesystem>
-#include <iostream>   // for operator<<, endl
+#include <iostream>  // for operator<<, endl
 #include <memory>
 
 class G4EmSaturation;
@@ -294,7 +294,7 @@ int PHG4Reco::InitField(PHCompositeNode *topNode)
     if (std::filesystem::path(m_FieldMapFile).extension() != ".root")
     {
       // loading from database
-      m_FieldMapFile  = CDBInterface::instance()->getUrl(m_FieldMapFile);
+      m_FieldMapFile = CDBInterface::instance()->getUrl(m_FieldMapFile);
     }
     if (std::filesystem::exists(m_FieldMapFile))
     {

--- a/simulation/g4simulation/g4main/PHG4Reco.h
+++ b/simulation/g4simulation/g4main/PHG4Reco.h
@@ -152,7 +152,7 @@ class PHG4Reco : public SubsysReco
   void DefineMaterials();
   void DefineRegions();
 
-  float m_MagneticField {std::numeric_limits<float>::signaling_NaN()};
+  float m_MagneticField{std::numeric_limits<float>::signaling_NaN()};
   float m_MagneticFieldRescale = 1.0;
   double m_WorldSize[3]{1000., 1000., 1000.};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR introduces modifications and extensions to the HepMCNodeReader to enable the addition of strange particles to the original collection of HepMC particles, which are subsequently used in the GEANT simulation. Below is a summary of the key changes and additions: 
- std::vectors to specify a list of strange particle PIDs to be added and their corresponding probabilities based on measured ratios 
- A public method to set the enhancement fraction (default set to 0)
- A counter to track the number of original strange particles in the HepMC record. This count is used to calculate the number of additional strange particles to intorduce in PHG4InEvent.
- Kinematics of the additional strange particles are sampled from analytic functions (an exponentially-modified Gaussian for pT and a double Gaussian for eta), with parameters constrained from generator-level pT and eta spectra of K_s0 from Pythia simulations

In this implementation, the list of strangeness PIDs to be added includes only lambda and K_s0. This list can be easily modified to accommodate other particles in the future.

---

The primary objective of this PR is to enable systematic studies to quantify the impact of varying the fraction of strange particles on the dN/deta measurement. A set of slides for additional studies could be found at https://indico.bnl.gov/event/26258/#3-mit-update

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

No PRs to macros are needed. 
If users want to change the enhancement fraction (say, 100%), in G4_Input.C simply add
```C
// copy HepMC records into G4
HepMCNodeReader *hr = new HepMCNodeReader();
hr->AddStrangeness(100);
se->registerSubsystem(hr);
```

