### PR TITLE
fix: tpc unpacker invalid reads

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -543,7 +543,10 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
         std::map<unsigned int, std::vector<float>>::iterator fee_blm_it = feebaseline_map.find(fee_key);
         if (fee_blm_it != feebaseline_map.end())
         {
-          corr = (*fee_blm_it).second[tbin];
+          if(tbin < (int)(*fee_blm_it).second.size())
+          {
+            corr = (*fee_blm_it).second[tbin];
+          }
           hitr->second->setAdc(0);
           float nuadc = (float(adc) - corr);
           if (nuadc < 0)

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -279,7 +279,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     double phi = -1 * pow(-1, side) * m_cdbttree->GetDoubleValue(key, varname) + (sector % 12) * M_PI / 6;
     PHG4TpcCylinderGeom* layergeom = geom_container->GetLayerCellGeom(layer);
     unsigned int phibin = layergeom->get_phibin(phi);
-   
+
     hit_set_key = TpcDefs::genHitSetKey(layer, (mc_sectors[sector % 12]), side);
     hit_set_container_itr = trkr_hit_set_container->findOrAddHitSet(hit_set_key);
 
@@ -287,22 +287,24 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     float hpedwidth = 0;
 
     if (Verbosity() > 2)
-      {
-	std::cout << "TpcCombinedRawDataUnpacker:: do zero suppression" << std::endl;
-      }
+    {
+      std::cout << "TpcCombinedRawDataUnpacker:: do zero suppression" << std::endl;
+    }
     TH2C* feehist = nullptr;
     std::vector<int>::iterator fee_entries_vec_it;
     hpedestal = 60;
     hpedwidth = m_zs_threshold;
-        
+
     unsigned int pad_key = create_pad_key(side, layer, phibin);
-    
+
     std::map<unsigned int, chan_info>::iterator chan_it = chan_map.find(pad_key);
-    if (chan_it != chan_map.end()){
+    if (chan_it != chan_map.end())
+    {
       (*chan_it).second.ped = hpedestal;
       (*chan_it).second.width = hpedwidth;
     }
-    else{
+    else
+    {
       chan_info nucinfo;
       nucinfo.fee = fee;
       nucinfo.ped = hpedestal;
@@ -313,13 +315,15 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     unsigned int fee_key = create_fee_key(side, mc_sectors[sector % 12], rx, fee);
     // find or insert TH2C;
     std::map<unsigned int, TH2C*>::iterator fee_map_it;
-    std::map<unsigned int,std::vector<int> >::iterator fee_entries_it;
-    
+    std::map<unsigned int, std::vector<int>>::iterator fee_entries_it;
+
     fee_map_it = feeadc_map.find(fee_key);
-    if (fee_map_it != feeadc_map.end()){
+    if (fee_map_it != feeadc_map.end())
+    {
       feehist = (*fee_map_it).second;
     }
-    else{
+    else
+    {
       std::string histname = "h" + std::to_string(fee_key);
       feehist = new TH2C(histname.c_str(), "histname", max_time_range + 1, -0.5, max_time_range + 0.5, 501, -0.5, 1000.5);
       feeadc_map.insert(std::make_pair(fee_key, feehist));
@@ -327,270 +331,295 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       feeentries_map.insert(std::make_pair(fee_key, feeentries));
     }
     fee_entries_it = feeentries_map.find(fee_key);
-    if (fee_entries_it != feeentries_map.end()){
+    if (fee_entries_it != feeentries_map.end())
+    {
       fee_entries_vec_it = (*fee_entries_it).second.begin();
     }
-    
-    float threshold_cut =  m_zs_threshold;
-    
+
+    float threshold_cut = m_zs_threshold;
+
     for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());
-	 !adc_iterator->IsDone();
-	 adc_iterator->Next()){
+         !adc_iterator->IsDone();
+         adc_iterator->Next())
+    {
       const uint16_t s = adc_iterator->CurrentTimeBin();
       const uint16_t adc = adc_iterator->CurrentAdc();
       int t = s - m_presampleShift - m_t0;
-      if (t < 0){
-	continue;
+      if (t < 0)
+      {
+        continue;
       }
-      if (feehist != nullptr){
-	if (adc > 0){
-	  if ((float(adc) - hpedestal) > threshold_cut){
-	    feehist->Fill(t, adc - hpedestal);
-	    fee_entries_vec_it[t]++;
-	  }
-	}
+      if (feehist != nullptr)
+      {
+        if (adc > 0)
+        {
+          if ((float(adc) - hpedestal) > threshold_cut)
+          {
+            feehist->Fill(t, adc - hpedestal);
+            fee_entries_vec_it[t]++;
+          }
+        }
       }
- 
-      if ((float(adc) - hpedestal) > threshold_cut){
-	hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);
-	// find existing hit, or create new one
-	hit = hit_set_container_itr->second->getHit(hit_key);
-	if (!hit){
-	  hit = new TrkrHitv2();
-	  hit->setAdc(float(adc) - hpedestal);
-	  hit_set_container_itr->second->addHitSpecificKey(hit_key, hit);
-	}
-	
-	if (m_writeTree){
-	  float fXh[18];
-	  int nh = 0;
-	  
-	  fXh[nh++] = _ievent - 1;
-	  fXh[nh++] = 0;                        // gtm_bco;
-	  fXh[nh++] = 0;                        // packet_id;
-	  fXh[nh++] = 0;                        // ep;
-	  fXh[nh++] = mc_sectors[sector % 12];  // Sector;
-	  fXh[nh++] = side;
-	  fXh[nh++] = fee;
-	  fXh[nh++] = 0;  // channel;
-	  fXh[nh++] = 0;  // sampadd;
-	  fXh[nh++] = 0;  // sampch;
-	  fXh[nh++] = (float) phibin;
-	  fXh[nh++] = (float) t;
-	  fXh[nh++] = layer;
-	  fXh[nh++] = (float(adc) - hpedestal);
-	  fXh[nh++] = hpedestal;
-	  fXh[nh++] = hpedwidth;
-	  m_ntup_hits->Fill(fXh);
-	}
-	
+
+      if ((float(adc) - hpedestal) > threshold_cut)
+      {
+        hit_key = TpcDefs::genHitKey(phibin, (unsigned int) t);
+        // find existing hit, or create new one
+        hit = hit_set_container_itr->second->getHit(hit_key);
+        if (!hit)
+        {
+          hit = new TrkrHitv2();
+          hit->setAdc(float(adc) - hpedestal);
+          hit_set_container_itr->second->addHitSpecificKey(hit_key, hit);
+        }
+
+        if (m_writeTree)
+        {
+          float fXh[18];
+          int nh = 0;
+
+          fXh[nh++] = _ievent - 1;
+          fXh[nh++] = 0;                        // gtm_bco;
+          fXh[nh++] = 0;                        // packet_id;
+          fXh[nh++] = 0;                        // ep;
+          fXh[nh++] = mc_sectors[sector % 12];  // Sector;
+          fXh[nh++] = side;
+          fXh[nh++] = fee;
+          fXh[nh++] = 0;  // channel;
+          fXh[nh++] = 0;  // sampadd;
+          fXh[nh++] = 0;  // sampch;
+          fXh[nh++] = (float) phibin;
+          fXh[nh++] = (float) t;
+          fXh[nh++] = layer;
+          fXh[nh++] = (float(adc) - hpedestal);
+          fXh[nh++] = hpedestal;
+          fXh[nh++] = hpedwidth;
+          m_ntup_hits->Fill(fXh);
+        }
       }
     }
   }
 
-  if (m_do_baseline_corr == true){
+  if (m_do_baseline_corr == true)
+  {
     // Histos filled now process them for fee local baselines
-    
-    int nhistfilled =0;
+
+    int nhistfilled = 0;
     int nhisttotal = 0;
-    for (auto& hiter : feeadc_map){
-      if (hiter.second != nullptr){
-	unsigned int fee_key = hiter.first;
-	unsigned int side;
-	unsigned int sector; 
-	unsigned int rx;
-	unsigned int fee;
-	unpack_fee_key(side, sector, rx, fee, fee_key);
-	TH2C* hist2d = hiter.second;
-	std::map<unsigned int,std::vector<int> >::iterator fee_entries_it = feeentries_map.find(fee_key);
-	if (fee_entries_it == feeentries_map.end()){
-	  continue;
-	  //	  fee_entries_vec_it = (*fee_entries_it).second.begin();
-	}
-	std::vector<int>::iterator fee_entries_vec_it  = (*fee_entries_it).second.begin();
+    for (auto& hiter : feeadc_map)
+    {
+      if (hiter.second != nullptr)
+      {
+        unsigned int fee_key = hiter.first;
+        unsigned int side;
+        unsigned int sector;
+        unsigned int rx;
+        unsigned int fee;
+        unpack_fee_key(side, sector, rx, fee, fee_key);
+        TH2C* hist2d = hiter.second;
+        std::map<unsigned int, std::vector<int>>::iterator fee_entries_it = feeentries_map.find(fee_key);
+        if (fee_entries_it == feeentries_map.end())
+        {
+          continue;
+          //	  fee_entries_vec_it = (*fee_entries_it).second.begin();
+        }
+        std::vector<int>::iterator fee_entries_vec_it = (*fee_entries_it).second.begin();
 
+        std::vector<float> pedvec(hist2d->GetNbinsX(), 0);
+        feebaseline_map.insert(std::make_pair(hiter.first, pedvec));
+        std::map<unsigned int, std::vector<float>>::iterator fee_blm_it = feebaseline_map.find(hiter.first);
+        (*fee_blm_it).second.resize(hist2d->GetNbinsX(), 0);
+        for (int binx = 1; binx < hist2d->GetNbinsX(); binx++)
+        {
+          double timebin = ((TAxis*) hist2d->GetXaxis())->GetBinCenter(binx);
+          std::string histname1d = "h" + std::to_string(hiter.first) + "_" + std::to_string((int) timebin);
+          nhisttotal++;
+          float local_ped = 0;
+          float local_width = 0;
+          float entries = fee_entries_vec_it[timebin];
+          if (fee_entries_vec_it[timebin] > 100)
+          {
+            nhistfilled++;
 
-	std::vector<float> pedvec(hist2d->GetNbinsX(), 0);
-	feebaseline_map.insert(std::make_pair(hiter.first, pedvec));
-	std::map<unsigned int, std::vector<float>>::iterator fee_blm_it = feebaseline_map.find(hiter.first);
-	(*fee_blm_it).second.resize(hist2d->GetNbinsX(), 0);
-	for (int binx = 1; binx < hist2d->GetNbinsX(); binx++){
-	  double timebin = ((TAxis*) hist2d->GetXaxis())->GetBinCenter(binx);
-	  std::string histname1d = "h" + std::to_string(hiter.first) + "_" + std::to_string((int) timebin);
-	  nhisttotal++;
-	  float local_ped = 0;
-	  float local_width = 0;
-	  float entries = fee_entries_vec_it[timebin];
-	  if(fee_entries_vec_it[timebin]>100){
-	    nhistfilled++;
-	    
-	    TH1D* hist1d = hist2d->ProjectionY(histname1d.c_str(), binx, binx);
-	    if (hist1d->GetEntries()!=fee_entries_vec_it[timebin]){
-	      std::cout << " vec " << fee_entries_vec_it[timebin]
-			<< " hist " << hist1d->GetEntries()
-			<< std::endl;
-	    }
-	    if (hist1d->GetEntries() > 10){
-	      int maxbin = hist1d->GetMaximumBin();
-	      // calc peak position
-	      double hadc_sum = 0.0;
-	      double hibin_sum = 0.0;
-	      double hibin2_sum = 0.0;
-	      
-	      for (int isum = -3; isum <= 3; isum++){
-		float val = hist1d->GetBinContent(maxbin + isum);
-		float center = hist1d->GetBinCenter(maxbin + isum);
-		hibin_sum += center * val;
-		hibin2_sum += center * center * val;
-		hadc_sum += val;
-	      }
-	      local_ped = hibin_sum / hadc_sum;
-	      local_width = sqrt(hibin2_sum / hadc_sum - (local_ped * local_ped));
-	    }
-	    delete hist1d;
-	  }
-	  (*fee_blm_it).second[(int) timebin] = local_ped+m_baseline_nsigma*local_width;
-	
-	  if (m_writeTree){
-	    float fXh[11];
-	    int nh = 0;
-	    
-	    fXh[nh++] = _ievent - 1;
-	    fXh[nh++] = 0;                        // gtm_bco;
-	    fXh[nh++] = 0;                        // packet_id;
-	    fXh[nh++] = 0;                        // ep;
-	    fXh[nh++] = mc_sectors[sector % 12];  // Sector;
-	    fXh[nh++] = side;
-	    fXh[nh++] = fee;
-	    fXh[nh++] = rx;
-	    fXh[nh++] = entries;
-	    fXh[nh++] = local_ped;
-	    fXh[nh++] = local_width;
-	    m_ntup->Fill(fXh);
-	  }
-	}
+            TH1D* hist1d = hist2d->ProjectionY(histname1d.c_str(), binx, binx);
+            if (hist1d->GetEntries() != fee_entries_vec_it[timebin])
+            {
+              std::cout << " vec " << fee_entries_vec_it[timebin]
+                        << " hist " << hist1d->GetEntries()
+                        << std::endl;
+            }
+            if (hist1d->GetEntries() > 10)
+            {
+              int maxbin = hist1d->GetMaximumBin();
+              // calc peak position
+              double hadc_sum = 0.0;
+              double hibin_sum = 0.0;
+              double hibin2_sum = 0.0;
+
+              for (int isum = -3; isum <= 3; isum++)
+              {
+                float val = hist1d->GetBinContent(maxbin + isum);
+                float center = hist1d->GetBinCenter(maxbin + isum);
+                hibin_sum += center * val;
+                hibin2_sum += center * center * val;
+                hadc_sum += val;
+              }
+              local_ped = hibin_sum / hadc_sum;
+              local_width = sqrt(hibin2_sum / hadc_sum - (local_ped * local_ped));
+            }
+            delete hist1d;
+          }
+          (*fee_blm_it).second[(int) timebin] = local_ped + m_baseline_nsigma * local_width;
+
+          if (m_writeTree)
+          {
+            float fXh[11];
+            int nh = 0;
+
+            fXh[nh++] = _ievent - 1;
+            fXh[nh++] = 0;                        // gtm_bco;
+            fXh[nh++] = 0;                        // packet_id;
+            fXh[nh++] = 0;                        // ep;
+            fXh[nh++] = mc_sectors[sector % 12];  // Sector;
+            fXh[nh++] = side;
+            fXh[nh++] = fee;
+            fXh[nh++] = rx;
+            fXh[nh++] = entries;
+            fXh[nh++] = local_ped;
+            fXh[nh++] = local_width;
+            m_ntup->Fill(fXh);
+          }
+        }
       }
     }
-    if (Verbosity() >= 1){
+    if (Verbosity() >= 1)
+    {
       std::cout << " filled " << nhistfilled
-		<< " total " << nhisttotal
-		<< std::endl;
-      
+                << " total " << nhisttotal
+                << std::endl;
+
       std::cout << "second loop " << m_do_baseline_corr << std::endl;
     }
-    
+
     // second loop over hits to apply baseline correction
     TrkrHitSetContainer::ConstRange hitsetrange;
     hitsetrange = trkr_hit_set_container->getHitSets(TrkrDefs::TrkrId::tpcId);
-    
+
     for (TrkrHitSetContainer::ConstIterator hitsetitr = hitsetrange.first;
-	 hitsetitr != hitsetrange.second;
-	 ++hitsetitr){
+         hitsetitr != hitsetrange.second;
+         ++hitsetitr)
+    {
       // if(count>0)continue;
       TrkrHitSet* hitset = hitsetitr->second;
       unsigned int layer = TrkrDefs::getLayer(hitsetitr->first);
       int side = TpcDefs::getSide(hitsetitr->first);
       unsigned int sector = TpcDefs::getSectorId(hitsetitr->first);
-      
+
       TrkrHitSet::ConstRange hitrangei = hitset->getHits();
-      
+
       for (TrkrHitSet::ConstIterator hitr = hitrangei.first;
-	   hitr != hitrangei.second;
-	   ++hitr){
-	unsigned short phibin = TpcDefs::getPad(hitr->first);
-	unsigned short tbin = TpcDefs::getTBin(hitr->first);
-	unsigned short adc = (hitr->second->getAdc());
-	
-	unsigned int pad_key = create_pad_key(side, layer, phibin);
-	
-	float fee = 0;
-	std::map<unsigned int, chan_info>::iterator chan_it = chan_map.find(pad_key);
-	if (chan_it != chan_map.end()){
-	  chan_info cinfo = (*chan_it).second;
-	  fee = cinfo.fee;
-	  //hpedestal2 = cinfo.ped;
-	  //hpedwidth2 = cinfo.width;
-	}
-	
-	int rx = get_rx(layer);
-	float corr = 0;
-	
-	unsigned int fee_key = create_fee_key(side, sector, rx, fee);
-	std::map<unsigned int, std::vector<float>>::iterator fee_blm_it = feebaseline_map.find(fee_key);
-	if (fee_blm_it != feebaseline_map.end()){
-	  corr = (*fee_blm_it).second[tbin];
-	  hitr->second->setAdc(0);
-	  float nuadc = (float(adc) - corr);
-	  if (nuadc < 0){
-	    nuadc = 0;
-	  }
-	  hitr->second->setAdc(float(nuadc));
-	
-	  if (m_writeTree){
-	    float fXh[18];
-	    int nh = 0;
-	    
-	    fXh[nh++] = _ievent - 1;
-	    fXh[nh++] = 0;       // gtm_bco;
-	    fXh[nh++] = 0;       // packet_id;
-	    fXh[nh++] = 0;       // ep;
-	    fXh[nh++] = sector;  // mc_sectors[sector % 12];//Sector;
-	    fXh[nh++] = side;
-	    fXh[nh++] = fee;
-	    fXh[nh++] = 0;  // channel;
-	    fXh[nh++] = 0;  // sampadd;
-	    fXh[nh++] = 0;  // sampch;
-	    fXh[nh++] = (float) phibin;
-	    fXh[nh++] = (float) tbin;
-	    fXh[nh++] = layer;
-	    fXh[nh++] = float(adc);
-	    fXh[nh++] = 0;//hpedestal2;
-	    fXh[nh++] = 0;//hpedwidth2;
-	    fXh[nh++] = corr;
-	    
-	    m_ntup_hits_corr->Fill(fXh);
-	  }
-	}
+           hitr != hitrangei.second;
+           ++hitr)
+      {
+        unsigned short phibin = TpcDefs::getPad(hitr->first);
+        unsigned short tbin = TpcDefs::getTBin(hitr->first);
+        unsigned short adc = (hitr->second->getAdc());
+
+        unsigned int pad_key = create_pad_key(side, layer, phibin);
+
+        float fee = 0;
+        std::map<unsigned int, chan_info>::iterator chan_it = chan_map.find(pad_key);
+        if (chan_it != chan_map.end())
+        {
+          chan_info cinfo = (*chan_it).second;
+          fee = cinfo.fee;
+          // hpedestal2 = cinfo.ped;
+          // hpedwidth2 = cinfo.width;
+        }
+
+        int rx = get_rx(layer);
+        float corr = 0;
+
+        unsigned int fee_key = create_fee_key(side, sector, rx, fee);
+        std::map<unsigned int, std::vector<float>>::iterator fee_blm_it = feebaseline_map.find(fee_key);
+        if (fee_blm_it != feebaseline_map.end())
+        {
+          corr = (*fee_blm_it).second[tbin];
+          hitr->second->setAdc(0);
+          float nuadc = (float(adc) - corr);
+          if (nuadc < 0)
+          {
+            nuadc = 0;
+          }
+          hitr->second->setAdc(float(nuadc));
+
+          if (m_writeTree)
+          {
+            float fXh[18];
+            int nh = 0;
+
+            fXh[nh++] = _ievent - 1;
+            fXh[nh++] = 0;       // gtm_bco;
+            fXh[nh++] = 0;       // packet_id;
+            fXh[nh++] = 0;       // ep;
+            fXh[nh++] = sector;  // mc_sectors[sector % 12];//Sector;
+            fXh[nh++] = side;
+            fXh[nh++] = fee;
+            fXh[nh++] = 0;  // channel;
+            fXh[nh++] = 0;  // sampadd;
+            fXh[nh++] = 0;  // sampch;
+            fXh[nh++] = (float) phibin;
+            fXh[nh++] = (float) tbin;
+            fXh[nh++] = layer;
+            fXh[nh++] = float(adc);
+            fXh[nh++] = 0;  // hpedestal2;
+            fXh[nh++] = 0;  // hpedwidth2;
+            fXh[nh++] = corr;
+
+            m_ntup_hits_corr->Fill(fXh);
+          }
+        }
       }
     }
   }
   // reset histogramms
   for (auto& hiter2 : feeadc_map)
+  {
+    if (hiter2.second != nullptr)
     {
-      if (hiter2.second != nullptr)
-	{
-	  hiter2.second->Reset();
-	}
+      hiter2.second->Reset();
     }
-  feebaseline_map.clear();
-  for (auto& hiter_entries : feeentries_map){
-    hiter_entries.second.assign(hiter_entries.second.size(),0);
   }
-  
+  feebaseline_map.clear();
+  for (auto& hiter_entries : feeentries_map)
+  {
+    hiter_entries.second.assign(hiter_entries.second.size(), 0);
+  }
+
   if (Verbosity())
-    {
-      std::cout << " event BCO: " << bco_min << " - " << bco_max << std::endl;
-      std::cout << "TpcCombinedRawDataUnpacker:: done" << std::endl;
-    }
-  
+  {
+    std::cout << " event BCO: " << bco_min << " - " << bco_max << std::endl;
+    std::cout << "TpcCombinedRawDataUnpacker:: done" << std::endl;
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int TpcCombinedRawDataUnpacker::End(PHCompositeNode* /*topNode*/)
 {
   if (m_writeTree)
-    {
-      m_file->cd();
-      m_ntup->Write();
-      m_ntup_hits->Write();
-      m_ntup_hits_corr->Write();
-      m_file->Close();
-    }
+  {
+    m_file->cd();
+    m_ntup->Write();
+    m_ntup_hits->Write();
+    m_ntup_hits_corr->Write();
+    m_file->Close();
+  }
   if (Verbosity())
-    {
-      std::cout << "TpcCombinedRawDataUnpacker::End(PHCompositeNode *topNode) This is the End..." << std::endl;
-    }
+  {
+    std::cout << "TpcCombinedRawDataUnpacker::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  }
   // if(m_Debug==1) hm->dumpHistos(m_filename, "RECREATE");
-  
+
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -291,7 +291,6 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       std::cout << "TpcCombinedRawDataUnpacker:: do zero suppression" << std::endl;
     }
     TH2C* feehist = nullptr;
-    std::vector<int>::iterator fee_entries_vec_it;
     hpedestal = 60;
     hpedwidth = m_zs_threshold;
 
@@ -315,7 +314,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
     unsigned int fee_key = create_fee_key(side, mc_sectors[sector % 12], rx, fee);
     // find or insert TH2C;
     std::map<unsigned int, TH2C*>::iterator fee_map_it;
-    std::map<unsigned int, std::vector<int>>::iterator fee_entries_it;
+
 
     fee_map_it = feeadc_map.find(fee_key);
     if (fee_map_it != feeadc_map.end())
@@ -330,11 +329,8 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       std::vector<int> feeentries(feehist->GetNbinsX(), 0);
       feeentries_map.insert(std::make_pair(fee_key, feeentries));
     }
-    fee_entries_it = feeentries_map.find(fee_key);
-    if (fee_entries_it != feeentries_map.end())
-    {
-      fee_entries_vec_it = (*fee_entries_it).second.begin();
-    }
+    auto fee_entries_it = feeentries_map.find(fee_key);
+    std::vector<int>& fee_entries_vec = (*fee_entries_it).second;
 
     float threshold_cut = m_zs_threshold;
 
@@ -356,7 +352,10 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
           if ((float(adc) - hpedestal) > threshold_cut)
           {
             feehist->Fill(t, adc - hpedestal);
-            fee_entries_vec_it[t]++;
+            if(t < (int)fee_entries_vec.size())
+            {
+              fee_entries_vec[t]++;
+            }
           }
         }
       }


### PR DESCRIPTION
The tpc unpacker has some weird behavior sometimes with memory consumption. Valgrind reported some invalid reads and this PR fixes those. I also clang-formatted the file to make it more readable

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

