### PR TITLE
WIP add creator G4 process to particle vertex point

### DIFF
--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -77,25 +77,7 @@ ROOTHITDICTS = \
 # this is a tweak to install files in $(libdir), automake refuses
 # to install other files in libdir, this construct gets around this
 pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-  EicEventHeader_Dict_rdict.pcm \
-  EicEventHeaderv1_Dict_rdict.pcm \
-  PHG4EventHeader_Dict_rdict.pcm \
-  PHG4EventHeaderv1_Dict_rdict.pcm \
-  PHG4Hit_Dict_rdict.pcm \
-  PHG4Hitv1_Dict_rdict.pcm \
-  PHG4HitEval_Dict_rdict.pcm \
-  PHG4HitContainer_Dict_rdict.pcm \
-  PHG4InEvent_Dict_rdict.pcm \
-  PHG4Particle_Dict_rdict.pcm \
-  PHG4Particlev1_Dict_rdict.pcm \
-  PHG4Particlev2_Dict_rdict.pcm \
-  PHG4Particlev3_Dict_rdict.pcm \
-  PHG4Shower_Dict_rdict.pcm \
-  PHG4Showerv1_Dict_rdict.pcm \
-  PHG4VtxPoint_Dict_rdict.pcm \
-  PHG4VtxPointv1_Dict_rdict.pcm \
-  PHG4TruthInfoContainer_Dict_rdict.pcm
+nobase_dist_pcm_DATA = $(ROOTHITDICTS:.cc=_rdict.pcm)
 
 libphg4hit_la_SOURCES = \
   $(ROOTHITDICTS) \
@@ -149,6 +131,8 @@ libg4testbench_la_SOURCES = \
   PHG4PhenixTrackingAction.cc \
   PHG4PileupGenerator.cc \
   PHG4PrimaryGeneratorAction.cc \
+  PHG4ProcessMap.cc \
+  PHG4ProcessMapPhysics.cc \
   PHG4Reco.cc \
   PHG4RegionInformation.cc \
   PHG4ScoringManager.cc \
@@ -188,6 +172,7 @@ pkginclude_HEADERS = \
   PHG4HitContainer.h \
   PHG4InEvent.h \
   PHG4IonGun.h \
+  PHG4MCProcessDefs.h \
   PHG4Particle.h \
   PHG4Particlev1.h \
   PHG4Particlev2.h \
@@ -201,6 +186,8 @@ pkginclude_HEADERS = \
   PHG4PhenixDetector.h \
   PHG4PileupGenerator.h \
   PHG4PrimaryGeneratorAction.h \
+  PHG4ProcessMap.h \
+  PHG4ProcessMapPhysics.h \
   PHG4Reco.h \
   PHG4RegionInformation.h \
   PHG4ScoringManager.h \

--- a/simulation/g4simulation/g4main/Makefile.am
+++ b/simulation/g4simulation/g4main/Makefile.am
@@ -72,6 +72,7 @@ ROOTHITDICTS = \
   PHG4Showerv1_Dict.cc \
   PHG4VtxPoint_Dict.cc \
   PHG4VtxPointv1_Dict.cc \
+  PHG4VtxPointv2_Dict.cc \
   PHG4TruthInfoContainer_Dict.cc
 
 # this is a tweak to install files in $(libdir), automake refuses
@@ -98,7 +99,8 @@ libphg4hit_la_SOURCES = \
   PHG4Showerv1.cc \
   PHG4TruthInfoContainer.cc \
   PHG4VtxPoint.cc \
-  PHG4VtxPointv1.cc
+  PHG4VtxPointv1.cc \
+  PHG4VtxPointv2.cc
 
 libg4testbench_la_SOURCES = \
   Fun4AllMessenger.cc \
@@ -206,6 +208,7 @@ pkginclude_HEADERS = \
   PHG4VertexSelection.h \
   PHG4VtxPoint.h \
   PHG4VtxPointv1.h \
+  PHG4VtxPointv2.h \
   ReadEICFiles.h \
   CosmicSpray.h \
   EcoMug.h

--- a/simulation/g4simulation/g4main/PHG4MCProcessDefs.h
+++ b/simulation/g4simulation/g4main/PHG4MCProcessDefs.h
@@ -1,28 +1,31 @@
 #ifndef G4MAIN_PHG4MCPROCESSDEFS_H
 #define G4MAIN_PHG4MCPROCESSDEFS_H
 
+#include <array>
 #include <cstdint>
+#include <string_view>
 
 const int kMaxMCProcess = 50;
 
 /// physics process codes (taken from VMC )
-enum PHG4MCProcess : uint8_t {
-  kPPrimary = 0,             ///< Primary interaction
+enum PHG4MCProcess : uint8_t
+{
+  kPPrimary = 0,  ///< Primary interaction
 
-  kPMultipleScattering = 1,  ///< multiple scattering
-  kPCoulombScattering = 45,  ///< single Coulomb scattering
-  kPEnergyLoss = 2,          ///< continuous energy loss
-  kPMagneticFieldL = 3,      ///< bending in mag. field
-  kPDecay = 4,               ///< particle decay
-  kPPair = 5,                ///< photon pair production or
-                             ///< muon direct pair production
-  kPCompton = 6,             ///< Compton scattering
-  kPPhotoelectric = 7,       ///< photoelectric effect
-  kPBrem = 8,                ///< bremsstrahlung
-  kPDeltaRay = 9,            ///< delta-ray production
-  kPAnnihilation = 10,       ///< positron annihilation
-  kPAnnihilationRest = 11,   ///< positron annihilation at rest
-  kPAnnihilationFlight = 12, ///< positron annihilation in flight
+  kPMultipleScattering = 1,   ///< multiple scattering
+  kPCoulombScattering = 45,   ///< single Coulomb scattering
+  kPEnergyLoss = 2,           ///< continuous energy loss
+  kPMagneticFieldL = 3,       ///< bending in mag. field
+  kPDecay = 4,                ///< particle decay
+  kPPair = 5,                 ///< photon pair production or
+                              ///< muon direct pair production
+  kPCompton = 6,              ///< Compton scattering
+  kPPhotoelectric = 7,        ///< photoelectric effect
+  kPBrem = 8,                 ///< bremsstrahlung
+  kPDeltaRay = 9,             ///< delta-ray production
+  kPAnnihilation = 10,        ///< positron annihilation
+  kPAnnihilationRest = 11,    ///< positron annihilation at rest
+  kPAnnihilationFlight = 12,  ///< positron annihilation in flight
 
   kPHadronic = 13,           ///< hadronic interaction
   kPEvaporation = 14,        ///< nuclear evaporation
@@ -37,95 +40,93 @@ enum PHG4MCProcess : uint8_t {
   kPHInhelastic = 23,        ///< hadronic inelastic scattering
   kPPhotonInhelastic = 24,   ///< photon inelastic scattering
 
-  kPMuonNuclear = 25,        ///< muon nuclear interaction
-  kPElectronNuclear = 26,    ///< electron nuclear interaction
-  kPPositronNuclear = 27,    ///< positron nuclear interaction
-  kPPhotoNuclear = 46,       ///< photo nuclear interaction
+  kPMuonNuclear = 25,      ///< muon nuclear interaction
+  kPElectronNuclear = 26,  ///< electron nuclear interaction
+  kPPositronNuclear = 27,  ///< positron nuclear interaction
+  kPPhotoNuclear = 46,     ///< photo nuclear interaction
 
-  kPTOFlimit = 28,           ///< exceeded time of flight cut
-  kPPhotoFission = 29,       ///< nuclear photofission
+  kPTOFlimit = 28,      ///< exceeded time of flight cut
+  kPPhotoFission = 29,  ///< nuclear photofission
 
-  kPRayleigh = 30,           ///< Rayleigh scattering
+  kPRayleigh = 30,  ///< Rayleigh scattering
 
-  kPNull = 31,               ///< no mechanism is active, usually at the entrance
-                             ///< of a new volume
-  kPStop = 32,               ///< particle has fallen below energy threshold
-                             ///< and tracking stops
+  kPNull = 31,  ///< no mechanism is active, usually at the entrance
+                ///< of a new volume
+  kPStop = 32,  ///< particle has fallen below energy threshold
+                ///< and tracking stops
 
-  kPLightAbsorption = 33,    ///< Cerenkov photon absorption
-  kPLightDetection = 34,     ///< Optical photon detection (absorption + photoelectron production)
-  kPLightScattering = 35,    ///< Cerenkov photon reflection/refraction
-  kPLightWLShifting = 48,    ///< Optical photon wavelength shifting
-  kStepMax = 36,             ///< step limited by STEMAX
+  kPLightAbsorption = 33,  ///< Cerenkov photon absorption
+  kPLightDetection = 34,   ///< Optical photon detection (absorption + photoelectron production)
+  kPLightScattering = 35,  ///< Cerenkov photon reflection/refraction
+  kPLightWLShifting = 48,  ///< Optical photon wavelength shifting
+  kStepMax = 36,           ///< step limited by STEMAX
 
-  kPCerenkov = 37,           ///< Cerenkov photon generation
-  kPFeedBackPhoton = 38,     ///< Feed back photon in RICH -- ALICE specific
-  kPLightReflection = 39,    ///< Cerenkov photon reflection
-  kPLightRefraction = 40,    ///< Cerenkov photon refraction or
-                              /// dichroic mirror transmission
-  kPSynchrotron = 41,        ///< synchrotron radiation generation
-  kPScintillation = 42,      ///< scintillation
-  kPTransitionRadiation = 49,///< transition radiation
+  kPCerenkov = 37,             ///< Cerenkov photon generation
+  kPFeedBackPhoton = 38,       ///< Feed back photon in RICH -- ALICE specific
+  kPLightReflection = 39,      ///< Cerenkov photon reflection
+  kPLightRefraction = 40,      ///< Cerenkov photon refraction or
+                               /// dichroic mirror transmission
+  kPSynchrotron = 41,          ///< synchrotron radiation generation
+  kPScintillation = 42,        ///< scintillation
+  kPTransitionRadiation = 49,  ///< transition radiation
 
-  kPTransportation = 43,     ///< Transportation
-  kPUserDefined = 47,        ///< User defined process
+  kPTransportation = 43,  ///< Transportation
+  kPUserDefined = 47,     ///< User defined process
 
-  kPNoProcess = 44           ///< unknown process
+  kPNoProcess = 44  ///< unknown process
 };
 
-static const char *const PHG4MCProcessName[kMaxMCProcess] = {
-  "Primary particle emission",
-  "Multiple scattering",
-  "Energy loss",
-  "Bending in magnetic field",
-  "Decay",
-  "Lepton pair production",
-  "Compton scattering",
-  "Photoelectric effect",
-  "Bremstrahlung",
-  "Delta ray",
-  "Positron annihilation",
-  "Positron annihilation at rest",
-  "Positron annihilation in flight",
-  "Hadronic interaction",
-  "Nuclear evaporation",
-  "Nuclear fission",
-  "Nuclear absorbtion",
-  "Antiproton annihilation",
-  "Antineutron annihilation",
-  "Neutron capture",
-  "Hadronic elastic",
-  "Hadronic incoherent elastic",
-  "Hadronic coherent elastic",
-  "Hadronic inelastic",
-  "Photon inelastic",
-  "Muon nuclear interaction",
-  "Electron nuclear interaction",
-  "Positron nuclear interaction",
-  "Time of flight limit",
-  "Nuclear photofission",
-  "Rayleigh effect",
-  "No active process",
-  "Energy threshold",
-  "Light absorption",
-  "Light detection",
-  "Light scattering",
-  "Maximum allowed step",
-  "Cerenkov production",
-  "Cerenkov feed back photon",
-  "Cerenkov photon reflection",
-  "Cerenkov photon refraction",
-  "Synchrotron radiation",
-  "Scintillation",
-  "Transportation",
-  "Unknown process",
-  "Coulomb scattering",
-  "Photo nuclear interaction",
-  "User defined process",
-  "Optical photon wavelength shifting",
-  "Transition radiation"
-};
+static const std::array<std::string_view, kMaxMCProcess> PHG4MCProcessName =
+    {
+        {"Primary particle emission",
+         "Multiple scattering",
+         "Energy loss",
+         "Bending in magnetic field",
+         "Decay",
+         "Lepton pair production",
+         "Compton scattering",
+         "Photoelectric effect",
+         "Bremstrahlung",
+         "Delta ray",
+         "Positron annihilation",
+         "Positron annihilation at rest",
+         "Positron annihilation in flight",
+         "Hadronic interaction",
+         "Nuclear evaporation",
+         "Nuclear fission",
+         "Nuclear absorbtion",
+         "Antiproton annihilation",
+         "Antineutron annihilation",
+         "Neutron capture",
+         "Hadronic elastic",
+         "Hadronic incoherent elastic",
+         "Hadronic coherent elastic",
+         "Hadronic inelastic",
+         "Photon inelastic",
+         "Muon nuclear interaction",
+         "Electron nuclear interaction",
+         "Positron nuclear interaction",
+         "Time of flight limit",
+         "Nuclear photofission",
+         "Rayleigh effect",
+         "No active process",
+         "Energy threshold",
+         "Light absorption",
+         "Light detection",
+         "Light scattering",
+         "Maximum allowed step",
+         "Cerenkov production",
+         "Cerenkov feed back photon",
+         "Cerenkov photon reflection",
+         "Cerenkov photon refraction",
+         "Synchrotron radiation",
+         "Scintillation",
+         "Transportation",
+         "Unknown process",
+         "Coulomb scattering",
+         "Photo nuclear interaction",
+         "User defined process",
+         "Optical photon wavelength shifting",
+         "Transition radiation"}};
 
 #endif  //  G4MAIN_PHG4MCPROCESSDEFS_H
-
-

--- a/simulation/g4simulation/g4main/PHG4MCProcessDefs.h
+++ b/simulation/g4simulation/g4main/PHG4MCProcessDefs.h
@@ -1,0 +1,131 @@
+#ifndef G4MAIN_PHG4MCPROCESSDEFS_H
+#define G4MAIN_PHG4MCPROCESSDEFS_H
+
+#include <cstdint>
+
+const int kMaxMCProcess = 50;
+
+/// physics process codes (taken from VMC )
+enum PHG4MCProcess : uint8_t {
+  kPPrimary = 0,             ///< Primary interaction
+
+  kPMultipleScattering = 1,  ///< multiple scattering
+  kPCoulombScattering = 45,  ///< single Coulomb scattering
+  kPEnergyLoss = 2,          ///< continuous energy loss
+  kPMagneticFieldL = 3,      ///< bending in mag. field
+  kPDecay = 4,               ///< particle decay
+  kPPair = 5,                ///< photon pair production or
+                             ///< muon direct pair production
+  kPCompton = 6,             ///< Compton scattering
+  kPPhotoelectric = 7,       ///< photoelectric effect
+  kPBrem = 8,                ///< bremsstrahlung
+  kPDeltaRay = 9,            ///< delta-ray production
+  kPAnnihilation = 10,       ///< positron annihilation
+  kPAnnihilationRest = 11,   ///< positron annihilation at rest
+  kPAnnihilationFlight = 12, ///< positron annihilation in flight
+
+  kPHadronic = 13,           ///< hadronic interaction
+  kPEvaporation = 14,        ///< nuclear evaporation
+  kPNuclearFission = 15,     ///< nuclear fission
+  kPNuclearAbsorption = 16,  ///< nuclear absorption
+  kPPbarAnnihilation = 17,   ///< antiproton annihilation
+  kPNbarAnnihilation = 18,   ///< antineutron annihilation
+  kPNCapture = 19,           ///< neutron capture
+  kPHElastic = 20,           ///< hadronic elastic scattering
+  kPHIElastic = 21,          ///< hadronic elastic incoherent scattering
+  kPHCElastic = 22,          ///< hadronic elastic coherent scattering
+  kPHInhelastic = 23,        ///< hadronic inelastic scattering
+  kPPhotonInhelastic = 24,   ///< photon inelastic scattering
+
+  kPMuonNuclear = 25,        ///< muon nuclear interaction
+  kPElectronNuclear = 26,    ///< electron nuclear interaction
+  kPPositronNuclear = 27,    ///< positron nuclear interaction
+  kPPhotoNuclear = 46,       ///< photo nuclear interaction
+
+  kPTOFlimit = 28,           ///< exceeded time of flight cut
+  kPPhotoFission = 29,       ///< nuclear photofission
+
+  kPRayleigh = 30,           ///< Rayleigh scattering
+
+  kPNull = 31,               ///< no mechanism is active, usually at the entrance
+                             ///< of a new volume
+  kPStop = 32,               ///< particle has fallen below energy threshold
+                             ///< and tracking stops
+
+  kPLightAbsorption = 33,    ///< Cerenkov photon absorption
+  kPLightDetection = 34,     ///< Optical photon detection (absorption + photoelectron production)
+  kPLightScattering = 35,    ///< Cerenkov photon reflection/refraction
+  kPLightWLShifting = 48,    ///< Optical photon wavelength shifting
+  kStepMax = 36,             ///< step limited by STEMAX
+
+  kPCerenkov = 37,           ///< Cerenkov photon generation
+  kPFeedBackPhoton = 38,     ///< Feed back photon in RICH -- ALICE specific
+  kPLightReflection = 39,    ///< Cerenkov photon reflection
+  kPLightRefraction = 40,    ///< Cerenkov photon refraction or
+                              /// dichroic mirror transmission
+  kPSynchrotron = 41,        ///< synchrotron radiation generation
+  kPScintillation = 42,      ///< scintillation
+  kPTransitionRadiation = 49,///< transition radiation
+
+  kPTransportation = 43,     ///< Transportation
+  kPUserDefined = 47,        ///< User defined process
+
+  kPNoProcess = 44           ///< unknown process
+};
+
+static const char *const PHG4MCProcessName[kMaxMCProcess] = {
+  "Primary particle emission",
+  "Multiple scattering",
+  "Energy loss",
+  "Bending in magnetic field",
+  "Decay",
+  "Lepton pair production",
+  "Compton scattering",
+  "Photoelectric effect",
+  "Bremstrahlung",
+  "Delta ray",
+  "Positron annihilation",
+  "Positron annihilation at rest",
+  "Positron annihilation in flight",
+  "Hadronic interaction",
+  "Nuclear evaporation",
+  "Nuclear fission",
+  "Nuclear absorbtion",
+  "Antiproton annihilation",
+  "Antineutron annihilation",
+  "Neutron capture",
+  "Hadronic elastic",
+  "Hadronic incoherent elastic",
+  "Hadronic coherent elastic",
+  "Hadronic inelastic",
+  "Photon inelastic",
+  "Muon nuclear interaction",
+  "Electron nuclear interaction",
+  "Positron nuclear interaction",
+  "Time of flight limit",
+  "Nuclear photofission",
+  "Rayleigh effect",
+  "No active process",
+  "Energy threshold",
+  "Light absorption",
+  "Light detection",
+  "Light scattering",
+  "Maximum allowed step",
+  "Cerenkov production",
+  "Cerenkov feed back photon",
+  "Cerenkov photon reflection",
+  "Cerenkov photon refraction",
+  "Synchrotron radiation",
+  "Scintillation",
+  "Transportation",
+  "Unknown process",
+  "Coulomb scattering",
+  "Photo nuclear interaction",
+  "User defined process",
+  "Optical photon wavelength shifting",
+  "Transition radiation"
+};
+
+#endif  //  G4MAIN_PHG4MCPROCESSDEFS_H
+
+

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.cc
@@ -1,11 +1,11 @@
 
 #include "PHG4ProcessMap.h"
-
-#include <G4VProcess.hh>
 #include "PHG4MCProcessDefs.h"
 
-#include <iostream>
+#include <G4VProcess.hh>
+
 #include <iomanip>
+#include <iostream>
 #include <string>
 
 //
@@ -25,7 +25,6 @@ bool PHG4ProcessMap::IsDefined(int subType)
 //_____________________________________________________________________________
 bool PHG4ProcessMap::Add(int subType, PHG4MCProcess mcProcess)
 {
-
   if (!IsDefined(subType))
   {
     // insert into map
@@ -39,19 +38,19 @@ bool PHG4ProcessMap::Add(int subType, PHG4MCProcess mcProcess)
 //_____________________________________________________________________________
 void PHG4ProcessMap::PrintAll() const
 {
-
   if (fMap.empty())
   {
     return;
   }
 
   std::cout << "Dump of PHG4ProcessMap - " << fMap.size()
-         << " entries:" << std::endl;
+            << " entries:" << std::endl;
   int counter = 0;
-  for (auto [subType, codes] : fMap) {
+  for (auto [subType, codes] : fMap)
+  {
     // TO DO: get process sub-type name
     std::cout << "Map element " << std::setw(3) << counter++ << "   "
-           << subType << "   " << PHG4MCProcessName[codes] << std::endl;
+              << subType << "   " << PHG4MCProcessName[codes] << std::endl;
   }
 }
 
@@ -68,14 +67,14 @@ void PHG4ProcessMap::Clear()
 PHG4MCProcess
 PHG4ProcessMap::GetMCProcess(const G4VProcess* process) const
 {
-
   if (!process)
   {
     return kPNoProcess;
   }
 
   auto i = fMap.find(process->GetProcessSubType());
-  if (i == fMap.end()) {
+  if (i == fMap.end())
+  {
     std::string text = "Unknown process code for ";
     text += process->GetProcessName();
     std::cerr << "PHG4ProcessMap::GetCodes " << text.c_str() << std::endl;
@@ -88,7 +87,7 @@ PHG4ProcessMap::GetMCProcess(const G4VProcess* process) const
 }
 
 //_____________________________________________________________________________
-std::string PHG4ProcessMap::GetMCProcessName(const G4VProcess* process) const
+std::string_view PHG4ProcessMap::GetMCProcessName(const G4VProcess* process) const
 {
   if (!process)
   {

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.cc
@@ -2,7 +2,7 @@
 #include "PHG4ProcessMap.h"
 #include "PHG4MCProcessDefs.h"
 
-#include <G4VProcess.hh>
+#include <Geant4/G4VProcess.hh>
 
 #include <iomanip>
 #include <iostream>

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.cc
@@ -1,0 +1,99 @@
+
+#include "PHG4ProcessMap.h"
+
+#include <G4VProcess.hh>
+#include "PHG4MCProcessDefs.h"
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+//
+// private methods
+//
+
+//_____________________________________________________________________________
+bool PHG4ProcessMap::IsDefined(int subType)
+{
+  return !(fMap.find(subType) == fMap.end());
+}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+bool PHG4ProcessMap::Add(int subType, PHG4MCProcess mcProcess)
+{
+
+  if (!IsDefined(subType))
+  {
+    // insert into map
+    // only in case it is not yet here
+    fMap[subType] = mcProcess;
+    return true;
+  }
+  return false;
+}
+
+//_____________________________________________________________________________
+void PHG4ProcessMap::PrintAll() const
+{
+
+  if (fMap.empty())
+  {
+    return;
+  }
+
+  std::cout << "Dump of PHG4ProcessMap - " << fMap.size()
+         << " entries:" << std::endl;
+  int counter = 0;
+  for (auto [subType, codes] : fMap) {
+    // TO DO: get process sub-type name
+    std::cout << "Map element " << std::setw(3) << counter++ << "   "
+           << subType << "   " << PHG4MCProcessName[codes] << std::endl;
+  }
+}
+
+//_____________________________________________________________________________
+void PHG4ProcessMap::Clear()
+{
+  if (fMap.size())
+  {
+    fMap.clear();
+  }
+}
+
+//_____________________________________________________________________________
+PHG4MCProcess
+PHG4ProcessMap::GetMCProcess(const G4VProcess* process) const
+{
+
+  if (!process)
+  {
+    return kPNoProcess;
+  }
+
+  auto i = fMap.find(process->GetProcessSubType());
+  if (i == fMap.end()) {
+    std::string text = "Unknown process code for ";
+    text += process->GetProcessName();
+    std::cerr << "PHG4ProcessMap::GetCodes " << text.c_str() << std::endl;
+    return kPNoProcess;
+  }
+  else
+  {
+    return (*i).second;
+  }
+}
+
+//_____________________________________________________________________________
+std::string PHG4ProcessMap::GetMCProcessName(const G4VProcess* process) const
+{
+  if (!process)
+  {
+    return PHG4MCProcessName[kPNoProcess];
+  }
+
+  return PHG4MCProcessName[GetMCProcess(process)];
+}

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.h
@@ -4,15 +4,15 @@
 #include "PHG4MCProcessDefs.h"
 
 #include <cstdint>
-#include <string>
 #include <map>
+#include <string_view>
 
 class G4VProcess;
 
 class PHG4ProcessMap
 {
  public:
-  PHG4ProcessMap()= default;
+  PHG4ProcessMap() = default;
   PHG4ProcessMap(const PHG4ProcessMap& rhs) = default;
   PHG4ProcessMap(PHG4ProcessMap&& rhs) = delete;
   PHG4ProcessMap& operator=(const PHG4ProcessMap& rhs) = delete;
@@ -33,7 +33,7 @@ class PHG4ProcessMap
 
   // get methods
   PHG4MCProcess GetMCProcess(const G4VProcess* process) const;
-  std::string GetMCProcessName(const G4VProcess* process) const;
+  std::string_view GetMCProcessName(const G4VProcess* process) const;
 
  private:
   // methods

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.h
@@ -1,0 +1,46 @@
+#ifndef G4MAIN_PHG4PROCESSMAP_H
+#define G4MAIN_PHG4PROCESSMAP_H
+
+#include "PHG4MCProcessDefs.h"
+
+#include <cstdint>
+#include <string>
+#include <map>
+
+class G4VProcess;
+
+class PHG4ProcessMap
+{
+ public:
+  PHG4ProcessMap()= default;
+  PHG4ProcessMap(const PHG4ProcessMap& rhs) = default;
+  PHG4ProcessMap(PHG4ProcessMap&& rhs) = delete;
+  PHG4ProcessMap& operator=(const PHG4ProcessMap& rhs) = delete;
+  PHG4ProcessMap& operator=(PHG4ProcessMap&& rhs) = delete;
+  ~PHG4ProcessMap() = default;
+
+  // static access method
+  static PHG4ProcessMap& Instance()
+  {
+    static PHG4ProcessMap fgInstance;
+    return fgInstance;
+  };
+
+  // methods
+  bool Add(int subType, PHG4MCProcess mcProcess);
+  void PrintAll() const;
+  void Clear();
+
+  // get methods
+  PHG4MCProcess GetMCProcess(const G4VProcess* process) const;
+  std::string GetMCProcessName(const G4VProcess* process) const;
+
+ private:
+  // methods
+  bool IsDefined(int subType);
+
+  // data members
+  std::map<int, PHG4MCProcess> fMap;
+};
+
+#endif  // G4MAIN_PHG4PROCESSMAP_H

--- a/simulation/g4simulation/g4main/PHG4ProcessMap.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMap.h
@@ -13,11 +13,11 @@ class PHG4ProcessMap
 {
  public:
   PHG4ProcessMap() = default;
-  PHG4ProcessMap(const PHG4ProcessMap& rhs) = default;
+  PHG4ProcessMap(const PHG4ProcessMap& rhs) = delete;
   PHG4ProcessMap(PHG4ProcessMap&& rhs) = delete;
   PHG4ProcessMap& operator=(const PHG4ProcessMap& rhs) = delete;
   PHG4ProcessMap& operator=(PHG4ProcessMap&& rhs) = delete;
-  ~PHG4ProcessMap() = default;
+  ~PHG4ProcessMap() { Clear(); }
 
   // static access method
   static PHG4ProcessMap& Instance()

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
@@ -1,0 +1,137 @@
+#include "PHG4ProcessMapPhysics.h"
+
+#include "PHG4ProcessMap.h"
+
+// G4 process code headers
+#include <G4DecayProcessType.hh>
+#include <G4EmProcessSubType.hh>
+#include <G4FastSimulationProcessType.hh>
+#include <G4HadronicProcessType.hh>
+#include <G4OpProcessSubType.hh>
+#include <G4ProcessType.hh>
+#include <G4TransportationProcessType.hh>
+
+PHG4ProcessMapPhysics::PHG4ProcessMapPhysics()
+{
+  FillMap();
+}
+
+PHG4ProcessMapPhysics& Instance()
+{
+  static PHG4ProcessMapPhysics fgInstance;
+  return fgInstance;
+}
+
+void PHG4ProcessMapPhysics::FillMap()
+{
+  auto pMap = PHG4ProcessMap::Instance();
+
+  // clang-format off
+  // G4EmProcessSubType: 1 - 26; 40; 49
+  pMap.Add(fCoulombScattering, kPCoulombScattering);      // G4 value:  1
+  pMap.Add(fIonisation, kPEnergyLoss);                  // G4 value:  2
+  pMap.Add(fBremsstrahlung, kPBrem);                     // G4 value:  3
+  pMap.Add(fPairProdByCharged, kPPair);                   // G4 value:  4
+  pMap.Add(fAnnihilation, kPAnnihilation);                // G4 value:  5
+  pMap.Add(fAnnihilationToMuMu, kPAnnihilation);          // G4 value:  6
+    // Add code
+  pMap.Add(fAnnihilationToHadrons, kPAnnihilation);       // G4 value:  7
+    // Add code
+  pMap.Add(fNuclearStopping, kPCoulombScattering);        // G4 value:  8
+    // CHECK ??
+  pMap.Add(fElectronGeneralProcess, kPNull);      // G4 value:  9
+
+  pMap.Add(fMultipleScattering, kPMultipleScattering);    // G4 value: 10
+
+  pMap.Add(fRayleigh, kPRayleigh);                        // G4 value: 11
+  pMap.Add(fPhotoElectricEffect, kPPhotoelectric);        // G4 value: 12
+  pMap.Add(fComptonScattering, kPCompton);                // G4 value: 13
+  pMap.Add(fGammaConversion, kPPair);                     // G4 value: 14
+  pMap.Add(fGammaConversionToMuMu, kPPair);               // G4 value: 15
+    // Add code
+  pMap.Add(fGammaGeneralProcess, kPNull);          // G4 value: 16
+  pMap.Add(fPositronGeneralProcess, kPNull);       // G4 value: 17
+  // pMap.Add(fAnnihilationToTauTau, kPAnnihilation);         // G4 value: 18
+    // Add code
+
+  pMap.Add(fCerenkov, kPCerenkov);                         // G4 value: 21
+  pMap.Add(fScintillation, kPScintillation);       // G4 value: 22
+  pMap.Add(fSynchrotronRadiation, kPSynchrotron);          // G4 value: 23
+  pMap.Add(fTransitionRadiation, kPTransitionRadiation); // G4 value: 24
+
+  pMap.Add(fSurfaceReflection, kPNull);            // G4 value: 25
+     // low energy G4MicroElecSurface process
+  // pMap.Add(fGammaReflection, kPNull);              // G4 value: 26 (added in Geant4 v11.0.0, sphenix version 10.7.4)
+
+  // G4OpProcessSubType: 31 .36
+  pMap.Add(fOpAbsorption, kPLightAbsorption);              // G4 value: 31
+  pMap.Add(fOpBoundary, kPLightScattering);                // G4 value: 32
+  pMap.Add(fOpRayleigh, kPRayleigh);                       // G4 value: 33
+  pMap.Add(fOpWLS, kPLightWLShifting);             // G4 value: 34
+  pMap.Add(fOpMieHG, kPLightScattering);           // G4 value: 35
+    // Add code
+  pMap.Add(fOpWLS2, kPLightWLShifting);            // G4 value: 36
+    // Add code
+
+  // G4EmProcessSubType: 40; 49
+  // pMap.Add(fDarkBremsstrahlung, kPNull);           // G4 value: 40 (added in Geant4 v11.1.0, sphenix version 10.7.4)
+  // pMap.Add(fMuonPairProdByCharged, kPNull);        // G4 value: 49 (added in Geant4 v11.1.0, sphenix version 10.7.4)
+
+  // G4HadronicProcessType: 111 .161; 210; 310
+  pMap.Add(fHadronElastic, kPHElastic);                    // G4 value: 111
+  // pMap.Add(fNeutronGeneral, kPNull);               // G4 value: 116 (added in Geant4 v11.1.0, sphenix version 10.7.4)
+  pMap.Add(fHadronInelastic, kPHInhelastic);               // G4 value: 121
+  pMap.Add(fCapture, kPNCapture);                          // G4 value: 131
+  pMap.Add(fMuAtomicCapture, kPHadronic);                  // G4 value: 132
+    // Add code
+    // was: kPNCapture, kHADR
+  pMap.Add(fFission, kPNuclearFission);                    // G4 value: 141
+  pMap.Add(fHadronAtRest, kPHadronic);                     // G4 value: 151
+    // Add code .G4HadronStoppingProcess, "hadronCaptureAtRest"
+    // was: kPNCapture, kHADR
+  pMap.Add(fLeptonAtRest, kPHadronic);                     // G4 value: 152
+    // No process defined with this code
+  pMap.Add(fChargeExchange, kPHadronic);                   // G4 value: 161
+  // pMap.Add(fNuOscillation, kPHadronic);                    // G4 value: 165 (added in Geant4 v11.2.0, sphenix version 10.7.4)
+  // pMap.Add(fNuElectron, kPHadronic);                       // G4 value: 166 (added in Geant4 v11.2.0, sphenix version 10.7.4)
+  // pMap.Add(fNuNucleus, kPHadronic);                        // G4 value: 167 (added in Geant4 v11.2.0, sphenix version 10.7.4)
+  pMap.Add(fRadioactiveDecay, kPDecay);                    // G4 value: 210
+  // pMap.Add(fEMDissociation, kPHadronic);                   // G4 value: 310 (no found in sPHENIX)
+    // No process defined with this code
+
+  // TG4HadronicProcessType: 171 .174 (VMC Hadronic process, VMC is not available in sPHENIX)
+  // pMap.Add(fElectronNuclear, kPElectronNuclear);           // TG4 value: 171
+  // pMap.Add(fPositronNuclear, kPPositronNuclear);           // TG4 value: 172
+  // pMap.Add(fMuonNuclear, kPMuonNuclear);                   // TG4 value: 173
+  // pMap.Add(fPhotoNuclear, kPPhotoNuclear);                 // TG4 value: 174
+
+  // G4DecayProcessType: 201 .231
+  pMap.Add(DECAY, kPDecay);                                // G4 value: 201
+  pMap.Add(DECAY_WithSpin, kPDecay);                       // G4 value: 202
+  pMap.Add(DECAY_PionMakeSpin, kPDecay);                   // G4 value: 203
+  // DECAY_Radioactive ( G4 value: 210) .already added with G4HadronicProcessType
+  pMap.Add(DECAY_Unknown, kPDecay);                        // G4 value: 211
+  pMap.Add(DECAY_MuAtom, kPDecay);                         // G4 value: 221
+  pMap.Add(DECAY_External, kPDecay);                       // G4 value: 231
+
+  // G4TransportationProcessType: 91, 92
+  pMap.Add(TRANSPORTATION, kPTransportation);         // G4 value: 91
+  pMap.Add(COUPLED_TRANSPORTATION, kPTransportation); // G4 value: 92
+
+  // G4FastSimulationProcessType: 301
+  pMap.Add(FASTSIM_ManagerProcess, kPNull);        // G4 value: 301
+
+  // G4TransportationProcessType: 401 .491
+  // following processes belong to 'General' type
+  pMap.Add(STEP_LIMITER, kStepMax);                // G4 value: 401
+  pMap.Add(USER_SPECIAL_CUTS, kPStop);             // G4 value: 402
+  pMap.Add(NEUTRON_KILLER, kPStop);                // G4 value: 403
+    // was kPHadronic, kHADR
+  // pMap.Add(PARALLEL_WORLD_PROCESS, kPNull);        // G4 value: 491 (added in Geant4 v11.0.0, sphenix version 10.7.4)
+
+  // TG4BiasingProcessType: 501
+  // pMap.Add(fBiasing, kPNull);                      // TG4 value: 501 (VMC Hadronic process, VMC is not available in sPHENIX)
+
+  // TG4StackPopperProcessType: 601
+  // pMap.Add(fStackPopper, kPNull);                  // TG4 value: 601 (VMC Hadronic process, VMC is not available in sPHENIX)
+}

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
@@ -19,7 +19,7 @@ PHG4ProcessMapPhysics::PHG4ProcessMapPhysics()
 
 void PHG4ProcessMapPhysics::FillMap()
 {
-  auto pMap = PHG4ProcessMap::Instance();
+  auto& pMap = PHG4ProcessMap::Instance();
 
   // clang-format off
   // G4EmProcessSubType: 1 - 26; 40; 49

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.cc
@@ -1,25 +1,20 @@
 #include "PHG4ProcessMapPhysics.h"
 
+#include "PHG4MCProcessDefs.h"
 #include "PHG4ProcessMap.h"
 
 // G4 process code headers
-#include <G4DecayProcessType.hh>
-#include <G4EmProcessSubType.hh>
-#include <G4FastSimulationProcessType.hh>
-#include <G4HadronicProcessType.hh>
-#include <G4OpProcessSubType.hh>
-#include <G4ProcessType.hh>
-#include <G4TransportationProcessType.hh>
+#include <Geant4/G4DecayProcessType.hh>
+#include <Geant4/G4EmProcessSubType.hh>
+#include <Geant4/G4FastSimulationProcessType.hh>
+#include <Geant4/G4HadronicProcessType.hh>
+#include <Geant4/G4OpProcessSubType.hh>
+#include <Geant4/G4ProcessType.hh>
+#include <Geant4/G4TransportationProcessType.hh>
 
 PHG4ProcessMapPhysics::PHG4ProcessMapPhysics()
 {
   FillMap();
-}
-
-PHG4ProcessMapPhysics& Instance()
-{
-  static PHG4ProcessMapPhysics fgInstance;
-  return fgInstance;
 }
 
 void PHG4ProcessMapPhysics::FillMap()
@@ -134,4 +129,13 @@ void PHG4ProcessMapPhysics::FillMap()
 
   // TG4StackPopperProcessType: 601
   // pMap.Add(fStackPopper, kPNull);                  // TG4 value: 601 (VMC Hadronic process, VMC is not available in sPHENIX)
+}
+
+PHG4MCProcess PHG4ProcessMapPhysics::GetMCProcess(const G4VProcess* process) const
+{
+  return PHG4ProcessMap::Instance().GetMCProcess(process);
+}
+  std::string_view PHG4ProcessMapPhysics::GetMCProcessName(const G4VProcess* process) const
+{
+  return PHG4ProcessMap::Instance().GetMCProcessName(process);
 }

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
@@ -1,13 +1,15 @@
 #ifndef G4MAIN_PHG4PROCESSMAPPHYSICS_H
 #define G4MAIN_PHG4PROCESSMAPPHYSICS_H
 
-#include <cstdint>
-#include <string>
+#include "PHG4MCProcessDefs.h"
+
 #include <map>
+#include <string>
 
 class G4VProcess;
 
-class PHG4ProcessMapPhysics {
+class PHG4ProcessMapPhysics
+{
  public:
   // explicit constructor
   PHG4ProcessMapPhysics();
@@ -22,7 +24,16 @@ class PHG4ProcessMapPhysics {
   /// default destructor
   ~PHG4ProcessMapPhysics() = default;
 
-  PHG4ProcessMapPhysics& Instance();
+  // static access method
+  static PHG4ProcessMapPhysics& Instance()
+  {
+    static PHG4ProcessMapPhysics fgInstance;
+    return fgInstance;
+  }
+
+  // get methods
+  PHG4MCProcess GetMCProcess(const G4VProcess* process) const;
+  std::string_view GetMCProcessName(const G4VProcess* process) const;
 
  private:
   void FillMap();

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
@@ -1,0 +1,31 @@
+#ifndef G4MAIN_PHG4PROCESSMAPPHYSICS_H
+#define G4MAIN_PHG4PROCESSMAPPHYSICS_H
+
+#include <cstdint>
+#include <string>
+#include <map>
+
+class G4VProcess;
+
+class PHG4ProcessMapPhysics {
+ public:
+  // explicit constructor
+  PHG4ProcessMapPhysics();
+  /// default copy constructor
+  PHG4ProcessMapPhysics(const PHG4ProcessMapPhysics& rhs);
+  /// default copy asigment
+  PHG4ProcessMapPhysics& operator=(const PHG4ProcessMapPhysics& rhs) = delete;
+  /// default move constructor
+  PHG4ProcessMapPhysics(PHG4ProcessMapPhysics&& rhs) = delete;
+  /// default move assigment constructor
+  PHG4ProcessMapPhysics& operator=(PHG4ProcessMapPhysics&& rhs) = delete;
+  /// default destructor
+  ~PHG4ProcessMapPhysics() = default;
+
+  PHG4ProcessMapPhysics& Instance();
+
+ private:
+  void FillMap();
+};
+
+#endif  // G4MAIN_PHG4PROCESSMAPPHYSICS_H

--- a/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
+++ b/simulation/g4simulation/g4main/PHG4ProcessMapPhysics.h
@@ -14,7 +14,7 @@ class PHG4ProcessMapPhysics
   // explicit constructor
   PHG4ProcessMapPhysics();
   /// default copy constructor
-  PHG4ProcessMapPhysics(const PHG4ProcessMapPhysics& rhs);
+  PHG4ProcessMapPhysics(const PHG4ProcessMapPhysics& rhs) = delete;
   /// default copy asigment
   PHG4ProcessMapPhysics& operator=(const PHG4ProcessMapPhysics& rhs) = delete;
   /// default move constructor

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -3,13 +3,14 @@
 #include "PHG4Particle.h"  // for PHG4Particle
 #include "PHG4Particlev2.h"
 #include "PHG4Particlev3.h"
+#include "PHG4ProcessMapPhysics.h"
 #include "PHG4Shower.h"  // for PHG4Shower
 #include "PHG4Showerv1.h"
 #include "PHG4TrackUserInfoV1.h"
 #include "PHG4TruthEventAction.h"
 #include "PHG4TruthInfoContainer.h"
 #include "PHG4UserPrimaryParticleInformation.h"
-#include "PHG4VtxPointv1.h"
+#include "PHG4VtxPointv2.h"
 
 #include <phool/getClass.h>
 
@@ -24,7 +25,6 @@
 #include <Geant4/G4VUserTrackInformation.hh>  // for G4VUserTrackInformation
 
 #include <cmath>     // for sqrt
-#include <cstddef>   // for size_t
 #include <iostream>  // for operator<<, endl
 #include <utility>   // for pair
 
@@ -289,8 +289,12 @@ PHG4VtxPoint* PHG4TruthTrackingAction::AddVertex(PHG4TruthInfoContainer& truth, 
   {
     return truth.GetVtxMap().find(iter->second)->second;
   }
+  // get G4Track creator process
+  const auto g4Process = track.GetCreatorProcess();
+  // convert G4 Process to MC process
+  const auto process = PHG4ProcessMapPhysics::Instance().GetMCProcess(g4Process);
   // otherwise, create and add a new one
-  PHG4VtxPoint* vtxpt = new PHG4VtxPointv1(v[0] / cm, v[1] / cm, v[2] / cm, track.GetGlobalTime() / ns, vtxindex);
+  PHG4VtxPoint* vtxpt = new PHG4VtxPointv2(v[0] / cm, v[1] / cm, v[2] / cm, track.GetGlobalTime() / ns, vtxindex, process);
 
   return truth.AddVertex(vtxindex, vtxpt)->second;
 }

--- a/simulation/g4simulation/g4main/PHG4VtxPointv2.cc
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv2.cc
@@ -1,0 +1,13 @@
+#include "PHG4VtxPointv2.h"
+
+using namespace std;
+
+void PHG4VtxPointv2::identify(ostream& os) const
+{
+  os << "vtx position: x: " << get_x()
+     << ", y: " << get_y()
+     << ", z: " << get_z()
+     << ", t: " << get_t()
+     << ", prodProcess: " << getProdProcessAsString().data()
+     << endl;
+}

--- a/simulation/g4simulation/g4main/PHG4VtxPointv2.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv2.h
@@ -1,0 +1,88 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef G4MAIN_PHG4VTXPOINTV2_H
+#define G4MAIN_PHG4VTXPOINTV2_H
+
+#include "PHG4VtxPointv1.h"
+
+#include "PHG4MCProcessDefs.h"
+
+#include <climits>   // for INT_MIN
+#include <cmath>     // def of NAN
+#include <iostream>  // for cout, ostream
+
+class PHG4VtxPointv2 : public PHG4VtxPointv1
+{
+ public:
+  PHG4VtxPointv2() = default;
+  PHG4VtxPointv2(const PHG4VtxPointv2& rhs) = default;
+  PHG4VtxPointv2& operator=(const PHG4VtxPointv2&) = default;
+  PHG4VtxPointv2(PHG4VtxPointv2&& rhs) = default;
+  PHG4VtxPointv2& operator=(PHG4VtxPointv2&&) = default;
+  explicit PHG4VtxPointv2(const PHG4VtxPoint* vtx)
+    : PHG4VtxPointv1(vtx)
+  {
+  }
+
+  PHG4VtxPointv2(const double x, const double y, const double z, const double t,
+                 const int id_value = std::numeric_limits<int>::min(),
+                 const PHG4MCProcess process = PHG4MCProcess::kPNoProcess)
+    : PHG4VtxPointv1(x, y, z, t, id_value)
+  {
+    setProcess(process);
+  };
+
+  ~PHG4VtxPointv2() override = default;
+
+  // from PHObject
+  void identify(std::ostream& os = std::cout) const override;
+
+  /// set process property
+  void setProcess(int proc)
+  {
+    auto prop = ((PropEncoding) mProp);
+    prop.properties.process = proc;
+    mProp = prop.i;
+  }
+
+  /// get the production process (id) of this track
+  int getProcess() const { return ((PropEncoding) mProp).properties.process; }
+  std::string_view getProdProcessAsString() const;
+
+ protected:
+  // internal structure to allow convenient manipulation
+  // of properties as bits on an int
+  union PropEncoding
+  {
+    explicit PropEncoding(int a)
+      : i(a)
+    {
+    }
+    int i;
+    struct
+    {
+      int storage : 1;           // encoding whether to store this track to the output
+      unsigned int process : 6;  // encoding process that created this track (enough to store TMCProcess from ROOT)
+    } properties;
+  };
+
+ private:
+  int mProp = 0;
+
+  ClassDefOverride(PHG4VtxPointv2, 1)
+};
+
+inline std::string_view PHG4VtxPointv2::getProdProcessAsString() const
+{
+  auto procID = getProcess();
+  if (procID >= 0)
+  {
+    return PHG4MCProcessName[procID];
+  }
+  else
+  {
+    return PHG4MCProcessName[PHG4MCProcess::kPNoProcess];
+  }
+}
+
+#endif

--- a/simulation/g4simulation/g4main/PHG4VtxPointv2LinkDef.h
+++ b/simulation/g4simulation/g4main/PHG4VtxPointv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PHG4VtxPointv2 + ;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
- **ycm - Add G4 process information:**
- **ycm - create PHG4VtxPointv2**
- **ycm - fill PHG4VtxPointv2 with G4track process**

[comment]: <> (Please tell us something about this pull request)
WIP, This is a first attempt to include G4 creator process to secondaries particles.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
New feature to MC simulation
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
It get the G4Track creator process and propagate it to the PHG4VtxPointv2 

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicab,gg,,le)

