### PR TITLE
feat: triggered mode setter

### DIFF
--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -33,6 +33,17 @@ class SingleInttPoolInput : public SingleStreamingInput
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
   const std::set<uint64_t> &BclkStack() const override { return m_BclkStack; }
   const std::map<uint64_t, std::set<int>> &BeamClockFEE() const override { return m_BeamClockFEE; }
+  void triggeredMode(const bool isTriggered)
+  {
+    if(isTriggered)
+    {
+      SetNegativeBco(1);
+      SetBcoRange(2);
+      return;
+    }
+    SetNegativeBco(120-23);
+    SetBcoRange(500);
+  }
 
  private:
   Packet **plist{nullptr};

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -9,7 +9,7 @@
 #include <set>
 #include <string>
 #include <vector>
-
+#include <iostream>
 class InttRawHit;
 class Packet;
 class PHCompositeNode;
@@ -33,16 +33,19 @@ class SingleInttPoolInput : public SingleStreamingInput
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
   const std::set<uint64_t> &BclkStack() const override { return m_BclkStack; }
   const std::map<uint64_t, std::set<int>> &BeamClockFEE() const override { return m_BeamClockFEE; }
-  void triggeredMode(const bool isTriggered)
+  void streamingMode(const bool isStreaming)
   {
-    if(isTriggered)
+    if(isStreaming)
     {
-      SetNegativeBco(1);
-      SetBcoRange(2);
+      SetNegativeBco(120 - 23);
+      SetBcoRange(500);
+      std::cout << "INTT set to streaming event combining"<<std::endl;
       return;
     }
-    SetNegativeBco(120-23);
-    SetBcoRange(500);
+
+    SetNegativeBco(1);
+    SetBcoRange(2);
+    std::cout << "INTT set to triggered event combining" << std::endl;
   }
 
  private:


### PR DESCRIPTION
This adds a triggered mode setter that sets the BCO ranges appropriately based on whether or not the INTT was in triggered or streaming mode. It can be set from the macro level with a db query similar to the hit unpacker.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

