### PR TITLE
Remove pT-dependent magnification of track matching windows

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -62,7 +62,7 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
                       "event:sicrossing:siq:siphi:sieta:six:siy:siz:sipx:sipy:sipz:tpcq:tpcphi:tpceta:tpcx:tpcy:tpcz:tpcpx:tpcpy:tpcpz:tpcid:siid");
   }
   // put these in the output file
-  cout << PHWHERE << " Search windows: phi " << _phi_search_win << " eta "
+  cout << PHWHERE << " Search windows: phi " << _phi_search_win_min<<"-"<< _phi_search_win_max << " eta "
        << _eta_search_win << " _pp_mode " << _pp_mode << " _use_intt_crossing " << _use_intt_crossing << endl;
 
   int ret = GetNodes(topNode);
@@ -414,7 +414,8 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
       tpc_q = _tracklet_tpc->get_charge();
     }
-    double mag = getMatchingInflationFactor(tpc_pt);
+    /* double mag = getMatchingInflationFactor(tpc_pt); */
+    double mag = 1.;
 
     if (Verbosity() > 8)
     {
@@ -537,15 +538,12 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       }
 
       bool phi_match = false;
-      if (fabs(tpc_phi - si_phi) < _phi_search_win * mag)
-      {
-        phi_match = true;
-      }
-      if (fabs(fabs(tpc_phi - si_phi) - 2.0 * M_PI) < _phi_search_win * mag)
-      {
-        phi_match = true;
-      }
-      if (!phi_match)
+      // 2025.01.16: if we reintroduce window magnification, update this code 
+      float delta_phi = tpc_phi-si_phi;
+      while (delta_phi>M_PI) delta_phi -= 2*M_PI;
+      while (delta_phi<-M_PI) delta_phi += 2*M_PI;
+      if (   (delta_phi < _phi_search_win_min)
+          && (delta_phi > _phi_search_win_max))
       {
         continue;
       }
@@ -553,7 +551,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       {
         cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt()
              << " and eta " << _tracklet_tpc->get_eta() << " with Si track " << siid << " with crossing " << _tracklet_si->get_crossing() << endl;
-        cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi << " phi search " << _phi_search_win * mag << " tpc_eta " << tpc_eta
+        cout << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi << " phi search [" << _phi_search_win_min * mag << "," << _phi_search_win_max*mag << "] tpc_eta " << tpc_eta
              << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " eta search " << _eta_search_win * mag << endl;
         std::cout << "      tpc x " << tpc_pos.x() << " si x " << si_pos.x() << " tpc y " << tpc_pos.y() << " si y " << si_pos.y() << " tpc_z " << tpc_pos.z() << " si z " << si_pos.z() << std::endl;
         std::cout << "      x search " << _x_search_win * mag << " y search " << _y_search_win * mag << " z search " << _z_search_win * mag << std::endl;
@@ -676,19 +674,19 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches(std::multimap<unsigned int,
   return;
 }
 
-double PHSiliconTpcTrackMatching::getMatchingInflationFactor(double tpc_pt)
-{
-  double mag = 1.0;
+/* double PHSiliconTpcTrackMatching::getMatchingInflationFactor(double tpc_pt) */
+/* { */
+/*   double mag = 1.0; */
 
-  if (tpc_pt > _match_function_ptmin)
-  {
-    mag = _match_function_a + _match_function_b / pow(tpc_pt, _match_function_pow);
-  }
+/*   if (tpc_pt > _match_function_ptmin) */
+/*   { */
+/*     mag = _match_function_a + _match_function_b / pow(tpc_pt, _match_function_pow); */
+/*   } */
 
-  // std::cout << "  tpc_pt = " << tpc_pt << " mag " << mag << " a " << _match_function_a << " b " << _match_function_b << std::endl;
+/*   // std::cout << "  tpc_pt = " << tpc_pt << " mag " << mag << " a " << _match_function_a << " b " << _match_function_b << std::endl; */
 
-  return mag;
-}
+/*   return mag; */
+/* } */
 
 std::vector<TrkrDefs::cluskey> PHSiliconTpcTrackMatching::getTrackletClusterList(TrackSeed* tracklet)
 {

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -28,13 +28,23 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   void SetDefaultParameters() override;
 
-  void set_phi_search_window(const double win) { _phi_search_win = win; }
+  void set_phi_search_window(const double _min, const double _max=-100.) { 
+    if (_max==-100) {
+      _phi_search_win_min = -_min;
+      _phi_search_win_max = _min;
+    } else {
+      _phi_search_win_min = _min;
+      _phi_search_win_max = _max;
+    }
+  }
+
   void set_eta_search_window(const double win) { _eta_search_win = win; }
   void set_x_search_window(const double win) { _x_search_win = win; }
   void set_y_search_window(const double win) { _y_search_win = win; }
   void set_z_search_window(const double win) { _z_search_win = win; }
 
-  float get_phi_search_window() const { return _phi_search_win; }
+  std::pair<float,float> get_phi_search_window() const 
+  { return {_phi_search_win_min, _phi_search_win_max}; }
   float get_eta_search_window() const { return _eta_search_win; }
   float get_x_search_window() const { return _x_search_win; }
   float get_y_search_window() const { return _y_search_win; }
@@ -42,12 +52,14 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   void zeroField(const bool flag) { _zero_field = flag; }
   
-  void set_match_window_function_pars(const double a, const double b, const double ptmin)
-  {
-    _match_function_a = a;
-    _match_function_b = b;
-    _match_function_ptmin = ptmin;
-  }
+  // 2025.01.16 : we will use constant search windows for now.
+  // This feature may be re-added when our residuals and distortions are better under control.
+  /* void set_match_window_function_pars(const double a, const double b, const double ptmin) */
+  /* { */
+  /*   _match_function_a = a; */
+  /*   _match_function_b = b; */
+  /*   _match_function_ptmin = ptmin; */
+  /* } */
   void set_use_old_matching(const bool flag) { _use_old_matching = flag; }
 
   void set_test_windows_printout(const bool test) { _test_windows = test; }
@@ -78,22 +90,26 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   // void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
   short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
   double getBunchCrossing(unsigned int trid, double z_mismatch);
-  double getMatchingInflationFactor(double tpc_pt);
+  // 2025.01.16 -- we won't inflate the search windows for now...
+  /* double getMatchingInflationFactor(double tpc_pt) { return 1.; }; */
 
   TFile *_file = nullptr;
   TNtuple *_tree = nullptr;
 
   // default values, can be replaced from the macro
-  double _phi_search_win = 0.01;
+  // 2025.01.16: update phi with an upper and lower bound
+  /* double _phi_search_win = 0.01; */
+  double _phi_search_win_min = -0.25;
+  double _phi_search_win_max = 0.05;
   double _eta_search_win = 0.004;
   double _x_search_win = 0.3;
   double _y_search_win = 0.3;
   double _z_search_win = 0.4;
 
-  double _match_function_a = 1.0;
-  double _match_function_b = 5.0;
-  double _match_function_pow = 1.0;
-  double _match_function_ptmin = 0.15;
+  /* double _match_function_a = 1.0; */
+  /* double _match_function_b = 5.0; */
+  /* double _match_function_pow = 1.0; */
+  /* double _match_function_ptmin = 0.15; */
   bool _use_old_matching = false;  // normally false
 
   bool _zero_field = false;     // fit straight lines if true


### PR DESCRIPTION
This is a simple change to set constant windows for the track matching between the Silicone and Tpc.
I can put in something more sophisticated, but think this is all that we want at this point.
The only point that I am a bit concerned about is the effect of the bit of code using the 
`silicon_match->set_use_old_matching(true)` in some macros, such as the `calibrations/tpc/TpcDVCalib/Fun4All_FieldOnAllTrackersCalos.C` -- for which the the phi window isn't enlarged.

- also set the phi search windows to use two parameters, an upper and lower bound. (All the other windows use a single bound for |DeltaVal|<bound)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

