### PR TITLE
Functionality in RawClusterBuilder to set peak threshold

### DIFF
--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.cc
@@ -76,6 +76,7 @@ void RawClusterBuilderTemplate::Detector(const std::string &d)
   bemc->SetVertex(vertex);
   // Set threshold
   bemc->SetTowerThreshold(_min_tower_e);
+  bemc->SetPeakThreshold(_min_peak_e);
   bemc->SetProbNoiseParam(fProbNoiseParam);
 }
 
@@ -347,6 +348,7 @@ int RawClusterBuilderTemplate::process_event(PHCompositeNode *topNode)
   bemc->SetVertex(vertex);
   // Set threshold
   bemc->SetTowerThreshold(_min_tower_e);
+  bemc->SetPeakThreshold(_min_peak_e);
 
   bemc->SetProbNoiseParam(fProbNoiseParam);
   bemc->SetProfileProb(bProfProb);

--- a/offline/packages/CaloReco/RawClusterBuilderTemplate.h
+++ b/offline/packages/CaloReco/RawClusterBuilderTemplate.h
@@ -30,6 +30,7 @@ class RawClusterBuilderTemplate : public SubsysReco
   void SetProbNoiseParam(float rn) { fProbNoiseParam = rn; }
 
   void set_threshold_energy(const float e) { _min_tower_e = e; }
+  void set_peakthreshold_energy(const float e) { _min_peak_e = e; }
   void setEnergyNorm(const float norm) { fEnergyNorm = norm; }
   void checkenergy(const int i = 1) { chkenergyconservation = i; }
   void LoadProfile(const std::string& fname);
@@ -83,6 +84,7 @@ class RawClusterBuilderTemplate : public SubsysReco
   float fEnergyNorm{1.};
 
   float _min_tower_e{0.020};
+  float _min_peak_e{0.200};
   int chkenergyconservation{0};
 
   std::string detector;


### PR DESCRIPTION
Functionality in RawClusterBuilder to set peak threshold for local maxima finder in EMCal sub-clustering. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

