### PR TITLE
Saturation status bit for calo towers

### DIFF
--- a/offline/packages/CaloBase/TowerInfo.h
+++ b/offline/packages/CaloBase/TowerInfo.h
@@ -43,6 +43,8 @@ class TowerInfo : public PHObject
   virtual bool get_isZS() const { return false; }
   virtual void set_isRecovered(bool /*isRecovered*/) { return; }
   virtual bool get_isRecovered() const { return false; }
+  virtual void set_isSaturated(bool /*isSaturated*/) { return; }
+  virtual bool get_isSaturated() const { return false; }
   virtual bool get_isGood() const { return true; }
   virtual uint8_t get_status() const { return 0; }
   virtual void set_status(uint8_t /*status*/) { return; }

--- a/offline/packages/CaloBase/TowerInfov2.h
+++ b/offline/packages/CaloBase/TowerInfov2.h
@@ -46,6 +46,9 @@ class TowerInfov2 : public TowerInfov1
   void set_isRecovered(bool isRecovered) override { set_status_bit(6, isRecovered); }
   bool get_isRecovered() const override { return get_status_bit(6); }
 
+  void set_isSaturated(bool isSaturated) override { set_status_bit(7, isSaturated); }
+  bool get_isSaturated() const override { return get_status_bit(7); }
+
   bool get_isGood() const override { return !(get_isHot() || get_isBadChi2() || get_isNoCalib()); }
 
   uint8_t get_status() const override { return _status; }

--- a/offline/packages/CaloBase/TowerInfov4.h
+++ b/offline/packages/CaloBase/TowerInfov4.h
@@ -74,6 +74,9 @@ class TowerInfov4 : public TowerInfo
   void set_isRecovered(bool isRecovered) override { set_status_bit(6, isRecovered); }
   bool get_isRecovered() const override { return get_status_bit(6); }
 
+  void set_isSaturated(bool isSaturated) override { set_status_bit(7, isSaturated); }
+  bool get_isSaturated() const override { return get_status_bit(7); }
+
   bool get_isGood() const override { return !(get_isHot() || get_isBadChi2() || get_isNoCalib()); }
 
   uint8_t get_status() const override { return status; }

--- a/offline/packages/CaloReco/CaloTowerBuilder.cc
+++ b/offline/packages/CaloReco/CaloTowerBuilder.cc
@@ -227,6 +227,10 @@ int CaloTowerBuilder::process_sim()
     for (int j = 0; j < n_samples; j++)
     {
       towerinfo->set_waveform_value(j, waveforms.at(i).at(j));
+      if(std::round(waveforms.at(i).at(j)) >= m_saturation)
+      {
+        towerinfo->set_isSaturated(true);
+      }
     }
   }
   waveforms.clear();
@@ -449,6 +453,10 @@ int CaloTowerBuilder::process_event(PHCompositeNode *topNode)
     
     for (int j = 0; j < n_samples; j++)
     {
+      if(std::round(waveforms.at(i).at(j)) >= m_saturation)
+      {
+        towerinfo->set_isSaturated(true);
+      }
       towerinfo->set_waveform_value(j, waveforms.at(i).at(j));
     }
   }

--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -140,6 +140,8 @@ class CaloTowerBuilder : public SubsysReco
   float m_timeLim_high{4.0};
   bool m_dobitfliprecovery{false};
 
+  int m_saturation{16383};
+
   std::string m_fieldname;
   std::string m_calibName;
   std::string m_directURL;

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -56,7 +56,7 @@ CaloWaveformSim::~CaloWaveformSim()
   gsl_rng_free(m_RandomGenerator);
 }
 
-int CaloWaveformSim::Init(PHCompositeNode *topNode)
+int CaloWaveformSim::InitRun(PHCompositeNode *topNode)
 {
   m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   unsigned int seed = PHRandomSeed();  // fixed seed handled in PHRandomSeed()
@@ -349,11 +349,16 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
         {
           m_waveforms.at(i).at(j) += m_fixpedestal;
         }
-        // saturate at 2^14
-        if(m_waveforms.at(i).at(j) > 16384)
+        // saturate at 2^14 - 1
+        if(m_waveforms.at(i).at(j) > 16383)
         {
-          m_waveforms.at(i).at(j) = 16384;
+          m_waveforms.at(i).at(j) = 16383;
         }
+        if(m_waveforms.at(i).at(j) < 0)
+	      {
+	        m_waveforms.at(i).at(j) = 0;
+	      }
+        
         m_CaloWaveformContainer->get_tower_at_channel(i)->set_waveform_value(j, m_waveforms.at(i).at(j));
       }
     }

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -46,7 +46,7 @@ class CaloWaveformSim : public SubsysReco
     NOISE_TREE = 2
   };
 
-  int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
 
   /** Called for each event.
       This is where you do the real work.


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Add saturation status bit for both data and sim.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

