### PR TITLE
fix: mvtx time bucket range

### DIFF
--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -157,7 +157,8 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto num_hits = pool->get_TRG_NR_HITS(feeId, i_strb);
             m_BclkStack.insert(strb_bco);
             m_FEEBclkMap[feeId] = strb_bco;
-            if (strb_bco < minBCO)
+            
+            if (strb_bco < minBCO - m_NegativeBco)
             {
               continue;
             }
@@ -435,7 +436,7 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   }
   else if (m_strobeWidth > 9 && m_strobeWidth < 11)
   {
-    m_BcoRange = 100;
+    m_BcoRange = 500;
     m_NegativeBco = 500;
   }
   else if (m_strobeWidth < 1) // triggered mode


### PR DESCRIPTION
This fixes the time bucket range of the MVTX to include hits of up to 5 strobes in either direction of the GL1 to be included into a streamed event processing. This should resolve the issue Tony brought up this weekend.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

