### PR TITLE
Fixed Incorrect Names in t0corr calibrations

### DIFF
--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -446,24 +446,24 @@ int MbdCalib::Download_T0Corr(const std::string& dbase_location)
     }
     cdbttree->LoadCalibrations();
 
-    _t0corrmean = cdbttree->GetSingleFloatValue("t0meancorr");
-    _t0corrmeanerr = cdbttree->GetSingleFloatValue("t0meancorrerr");
-    _t0corr_fitmean[0] = cdbttree->GetSingleFloatValue("t0corr_fitmean0");
-    _t0corr_fitmeanerr[0] = cdbttree->GetSingleFloatValue("t0corr_fitmeanerr0");
-    _t0corr_fitsigma[0] = cdbttree->GetSingleFloatValue("t0corr_fitsigma0");
-    _t0corr_fitsigmaerr[0] = cdbttree->GetSingleFloatValue("t0corr_fitsigmaerr0");
-    _t0corr_fitmean[1] = cdbttree->GetSingleFloatValue("t1corr_fitmean1");
-    _t0corr_fitmeanerr[1] = cdbttree->GetSingleFloatValue("t1corr_fitmeanerr1");
-    _t0corr_fitsigma[1] = cdbttree->GetSingleFloatValue("t1corr_fitsigma1");
-    _t0corr_fitsigmaerr[1] = cdbttree->GetSingleFloatValue("t1corr_fitsigmaerr1");
-    _t0corr_hmean[0] = cdbttree->GetSingleFloatValue("t0corr_hmean0");
-    _t0corr_hmeanerr[0] = cdbttree->GetSingleFloatValue("t0corr_hmeanerr0");
-    _t0corr_hstddev[0] = cdbttree->GetSingleFloatValue("t0corr_hstddev0");
-    _t0corr_hstddeverr[0] = cdbttree->GetSingleFloatValue("t0corr_hstddeverr0");
-    _t0corr_hmean[1] = cdbttree->GetSingleFloatValue("t1corr_hmean1");
-    _t0corr_hmeanerr[1] = cdbttree->GetSingleFloatValue("t1corr_hmeanerr1");
-    _t0corr_hstddev[1] = cdbttree->GetSingleFloatValue("t1corr_hstddev1");
-    _t0corr_hstddeverr[1] = cdbttree->GetSingleFloatValue("t1corr_hstddeverr1");
+    _t0corrmean = cdbttree->GetSingleFloatValue("_t0corrmean");
+    _t0corrmeanerr = cdbttree->GetSingleFloatValue("_t0corrmeanerr");
+    _t0corr_fitmean[0] = cdbttree->GetSingleFloatValue("_t0corr_fitmean0");
+    _t0corr_fitmeanerr[0] = cdbttree->GetSingleFloatValue("_t0corr_fitmeanerr0");
+    _t0corr_fitsigma[0] = cdbttree->GetSingleFloatValue("_t0corr_fitsigma0");
+    _t0corr_fitsigmaerr[0] = cdbttree->GetSingleFloatValue("_t0corr_fitsigmaerr0");
+    _t0corr_fitmean[1] = cdbttree->GetSingleFloatValue("_t0corr_fitmean1");
+    _t0corr_fitmeanerr[1] = cdbttree->GetSingleFloatValue("_t0corr_fitmeanerr1");
+    _t0corr_fitsigma[1] = cdbttree->GetSingleFloatValue("_t0corr_fitsigma1");
+    _t0corr_fitsigmaerr[1] = cdbttree->GetSingleFloatValue("_t0corr_fitsigmaerr1");
+    _t0corr_hmean[0] = cdbttree->GetSingleFloatValue("_t0corr_hmean0");
+    _t0corr_hmeanerr[0] = cdbttree->GetSingleFloatValue("_t0corr_hmeanerr0");
+    _t0corr_hstddev[0] = cdbttree->GetSingleFloatValue("_t0corr_hstddev0");
+    _t0corr_hstddeverr[0] = cdbttree->GetSingleFloatValue("_t0corr_hstddeverr0");
+    _t0corr_hmean[1] = cdbttree->GetSingleFloatValue("_t0corr_hmean1");
+    _t0corr_hmeanerr[1] = cdbttree->GetSingleFloatValue("_t0corr_hmeanerr1");
+    _t0corr_hstddev[1] = cdbttree->GetSingleFloatValue("_t0corr_hstddev1");
+    _t0corr_hstddeverr[1] = cdbttree->GetSingleFloatValue("_t0corr_hstddeverr1");
 
     if (Verbosity() > 0)
     {

--- a/offline/packages/mbd/MbdCalib.cc
+++ b/offline/packages/mbd/MbdCalib.cc
@@ -1656,6 +1656,22 @@ int MbdCalib::Write_CDB_Gains(const std::string& dbfile)
 }
 #endif
 
+int MbdCalib::Write_Gains(const std::string& dbfile)
+{
+  std::ofstream cal_gains_file;
+  cal_gains_file.open(dbfile);
+  for (int ipmtch = 0; ipmtch < MbdDefs::MBD_N_PMT; ipmtch++)
+  {
+    cal_gains_file << ipmtch << "\t" << _qfit_integ[ipmtch] << "\t" << _qfit_mpv[ipmtch]
+      << "\t" << _qfit_sigma[ipmtch] << "\t" << _qfit_integerr[ipmtch]
+      << "\t" << _qfit_mpverr[ipmtch] << "\t" << _qfit_sigmaerr[ipmtch]
+      << "\t" << _qfit_chi2ndf[ipmtch] << std::endl;
+  }
+  cal_gains_file.close();
+
+  return 1;
+}
+
 #ifndef ONLINE
 int MbdCalib::Write_CDB_All()
 {

--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -29,8 +29,8 @@ class MbdCalib
   virtual ~MbdCalib() {}
 
   float get_qgain(const int ipmt) const { return _qfit_mpv[ipmt]; }
-  float get_tq0(const int ipmt) const { return _tqfit_t0mean[ipmt]; }
   float get_tt0(const int ipmt) const { return _ttfit_t0mean[ipmt]; }
+  float get_tq0(const int ipmt) const { return _tqfit_t0mean[ipmt]; }
   float get_t0corr() const { return _t0corrmean; }
   float get_ped(const int ifeech) const { return _pedmean[ifeech]; }
   float get_pedrms(const int ifeech) const { return _pedsigma[ifeech]; }
@@ -69,6 +69,8 @@ class MbdCalib
 
   void set_sampmax(const int ifeech, const int val) { _sampmax[ifeech] = val; }
   void set_ped(const int ifeech, const float m, const float merr, const float s, const float serr);
+  void set_tt0(const int ipmt, const float t0) { _ttfit_t0mean[ipmt] = t0; }
+  void set_tq0(const int ipmt, const float t0) { _tqfit_t0mean[ipmt] = t0; }
 
   int Download_Gains(const std::string& dbfile);
   int Download_TQT0(const std::string& dbfile);
@@ -99,6 +101,7 @@ class MbdCalib
   int Write_TTT0(const std::string& dbfile);
   int Write_T0Corr(const std::string& dbfile);
   int Write_Ped(const std::string& dbfile);
+  int Write_Gains(const std::string& dbfile);
 
   void Reset_TQT0();
   void Reset_TTT0();


### PR DESCRIPTION
[comment]: Names in t0corr were incorrect, resulting in failure retrieving from CDB

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: Names of t0corr variables were fixed.  Previously, it tried to find the calibrations and failed.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

