### PR TITLE
Tpc micromegas matching

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -123,22 +123,22 @@ namespace
     }
     else
     {
-     
+
       double denom = nx + ny*m;
       if(denom == 0) {
         return false; // lines are parallel and there is no intersection
       }
- 
+
       double x = (nx*x0 + ny*y0 - ny*b)/denom;
       double y = m*x + b;
       // a straight line has a unique intersection point
       xplus = xminus = x;
       yplus = yminus = y;
- 
+
     }
 
     return true;
-  }  
+  }
 
   // streamer of TVector3
   [[maybe_unused]] inline std::ostream& operator<<(std::ostream& out, const TVector3& vector)
@@ -293,10 +293,10 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
         clusters.push_back(tpc_clus);
         // make necessary corrections to the global position
         clusGlobPos.push_back( m_globalPositionWrapper.getGlobalPositionDistortionCorrected(cluster_key, tpc_clus, crossing) );
-        
+
     }
 
-    double xy_m = 0, xy_b = 0;   
+    double xy_m = 0, xy_b = 0;
     double R = 0, X0 = 0, Y0 = 0;
     double A = 0, B = 0;
 
@@ -317,11 +317,11 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
         }
         continue;  // skip to the next TPC tracklet
       }
-      
+
       const auto params = TrackFitUtils::fitClustersZeroField(clusGlobPos, cluster_list, true); // This is for the intersection
       xy_m = params[0];
       xy_b = params[1];
- 
+
       // get the straight line representing the z trajectory in the form of z vs radius
       std::tie(A, B) = TrackFitUtils::line_fit(clusGlobPos);
       if (Verbosity() > 10)
@@ -364,7 +364,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       {
         std::cout << " non-zero field fitted line has A " << A << " B " << B << std::endl;
       }
-  
+
     } // end !_zero_field
 
     // loop over micromegas layer
@@ -377,10 +377,10 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 
       double xplus, yplus, xminus, yminus;
       if(_zero_field) { // start _zero_field
-      
+
         // method to find where the fitted line intersects this layer
         std::tie(xplus, yplus, xminus, yminus) = TrackFitUtils::line_circle_intersection(layer_radius, xy_m, xy_b);
-        
+
       } else { // start _zero_field!
 
         // method to find where fitted circle intersects this layer
@@ -393,7 +393,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
       {
         std::cout << "xplus: " << xplus << " yplus " << yplus << " xminus " << xminus << " yminus " << std::endl;
       }
- 
+
       if (!std::isfinite(xplus))
        {
          if (Verbosity() > 10)
@@ -402,7 +402,7 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
            std::cout << PHWHERE << " mm_radius " << layer_radius << " fitted R " << R << " fitted X0 " << X0 << " fitted Y0 " << Y0 << std::endl;
          }
 
-         continue; 
+         continue;
       }
       // we can figure out which solution is correct based on the last cluster position in the TPC
       const double last_clus_phi = std::atan2(clusGlobPos.back()(1), clusGlobPos.back()(0));

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.h
@@ -35,12 +35,14 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
   void set_rphi_search_window_lyr2(const double win) { _rphi_search_win[1] = win; }
   void set_z_search_window_lyr2(const double win) { _z_search_win[1] = win; }
   void set_min_tpc_layer(const unsigned int layer) { _min_tpc_layer = layer; }
+  void set_max_tpc_layer(const unsigned int layer) { _max_tpc_layer = layer; }
   void set_test_windows_printout(const bool test) { _test_windows = test; }
   void set_pp_mode(const bool mode) { _pp_mode = mode; }
+  void set_use_silicon( const bool value ) { _use_silicon = value; }
   void SetIteration(int iter) { _n_iteration = iter; }
 
   void zeroField(const bool flag) { _zero_field = flag; }
-
+  int Init(PHCompositeNode* topNode) override;
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
   int End(PHCompositeNode*) override;
@@ -57,9 +59,21 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   //! number of layers in the micromegas
   static constexpr unsigned int _n_mm_layers{2};
-  
+
   bool _use_truth_clusters = false;
+
+  //! if true, use straight fit instead of helical to extrapolate to TPOT
   bool _zero_field = false;
+
+  //! if true, use silicon clusters instead of TPC to extrapolate to TPOT
+  bool _use_silicon = false;
+
+  // range of TPC layers to use in projection to micromegas
+  unsigned int _min_tpc_layer = 39;
+
+  // range of TPC layers to use in projection to micromegas
+  unsigned int _max_tpc_layer = 55;
+
   TrkrClusterContainer* _cluster_map{nullptr};
   TrkrClusterContainer* _corrected_cluster_map{nullptr};
 
@@ -75,8 +89,6 @@ class PHMicromegasTpcTrackMatching : public SubsysReco
 
   // get the cluster list for zeroField
   std::vector<TrkrDefs::cluskey> getTrackletClusterList(TrackSeed* tracklet);
-  // range of TPC layers to use in projection to micromegas
-  unsigned int _min_tpc_layer{38};
 
   /// first micromegas layer
   /** it is reset in ::Setup using actual micromegas geometry */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR builds on the code changes from @pedroanietom to 
- simplify/streamline the straight line fit
- add a flag to extrapolate from the silicons (MVTX and INTT in r,phi; MVTX only in r,z) instead of the TPC
- add the possibility to select both lower and upper limits for the TPC layers used for the fit.
It was checked that with identical parameters the fit results are identical to before the change.
@pedroanietom: feel free to have a look, double check.
The changes might conflict with local changes that you have. I can help resolve if this is a problem. 
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

