### PR TITLE
Fit Saturated towers

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -121,7 +121,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
       else
       {
         auto h = new TH1F(std::string("h_" + std::to_string((int) round(v.at(size1)))).c_str(), "", size1, -0.5, size1 - 0.5);
-        
+
         int ndata = 0;
         for (int i = 0; i < size1; ++i)
         {
@@ -154,7 +154,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
         ROOT::Fit::FitResult fitres = fitter->Result();
         double chi2min = fitres.MinFcnValue();
         //chi2min /= size1 - 3;  // divide by the number of dof
-        chi2min /= size1 - 3;  // divide by the number of dof
+        chi2min /= ndata - 3;  // divide by the number of dof
         if (chi2min > _chi2threshold && (f->GetParameter(2) < _bfr_highpedestalthreshold || pedestal < _bfr_highpedestalthreshold) && (f->GetParameter(2) > _bfr_lowpedestalthreshold || pedestal > _bfr_lowpedestalthreshold) && _dobitfliprecovery) 
         {
           std::vector<float> rv; // temporary recovered waveform

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -139,6 +139,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
         //if too many are saturated don't do the saturation recovery need enough ndf
         if(ndata > (size1 - 4))
         {
+	 ndata = size1;
          for (int i = 0; i < size1; ++i)
          {
             h->SetBinContent(i + 1, v.at(i));

--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -154,6 +154,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
         ROOT::Fit::Chi2Function *EPChi2 = new ROOT::Fit::Chi2Function(data, *fitFunction);
         ROOT::Fit::Fitter *fitter = new ROOT::Fit::Fitter();
         fitter->Config().MinimizerOptions().SetMinimizerType("GSLMultiFit");
+        fitter->Config().MinimizerOptions().SetPrintLevel(-1);
         double params[] = {static_cast<double>(maxheight - pedestal), static_cast<double>(maxbin - m_peakTimeTemp), static_cast<double>(pedestal)};
         //double params[] = {static_cast<double>(maxheight - pedestal), 0, static_cast<double>(pedestal)};
         fitter->Config().SetParamsSettings(3, params);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

When the waveform is saturated we are not including the sample(and one sample after saturation) for the least square fit.
Revert the change for default setting of the timing position, not the initial peak time is at the peak sample.

Some examples shown below, from EMCal beam data:
![image](https://github.com/user-attachments/assets/21e0f571-a0cb-4ea3-867a-b97622619ccd)
![image](https://github.com/user-attachments/assets/5d82e1e1-9149-4ea2-8dc8-7afffce7e6f8)
![image](https://github.com/user-attachments/assets/57439313-9f77-4b8f-b837-527f8aa4dfa2)

From waveform simulation:

![image](https://github.com/user-attachments/assets/1c17e77e-adab-469f-b1fd-25a15c06b0a4)
![image](https://github.com/user-attachments/assets/4e9e2395-3b7d-4d41-b4cb-3704377bccf2)



## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

