### PR TITLE
CD: MVTX event combining patch

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1009,7 +1009,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
   }
   else
   {
-    while (m_MvtxRawHitMap.begin()->first <= select_crossings - m_mvtx_bco_range) //streamed
+    while (select_crossings - m_mvtx_bco_range - m_mvtx_negative_bco <= m_MvtxRawHitMap.begin()->first && m_MvtxRawHitMap.begin()->first <= select_crossings) //streamed
     {
       if (Verbosity() > 2)
       {

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -227,9 +227,9 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     row = mvtx_hit->get_row();
     col = mvtx_hit->get_col();
 
-    int bcodiff = gl1 ? gl1bco - strobe : 0;
-    double timeElapsed = bcodiff * 0.106;  // 106 ns rhic clock
-    int index = m_mvtx_is_triggered ? 0 : std::floor(timeElapsed / m_strobeWidth);
+    int bcodiff = gl1 ? strobe - gl1bco : 0;
+    double timeElapsed = bcodiff * 0.1065;  // 106 ns rhic clock
+    int index = m_mvtx_is_triggered ? 0 : std::ceil(timeElapsed / m_strobeWidth);
 
     if (index < -16 || index > 15)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

We found that the MVTX hits in the track reconstruction dropped off after around 100 BCOs. Upon investigation, it looks like the MVTX pool was filled in reverse so there were no hits after the first strobe but several strobes filled from before GL1. There was also a bug in the unpacker that flipped the sign of the strobe index and then sent these hits from before the GL1 into INTT and TPC hits from after the GL1 by giving them a positive time sign. 

@jdosbo @pinkenburg @adfrawley @ycorrales we should probably check this PR against a test track reconstruction to ensure this actually fixes things before merging. There were lots of negatives and stuff to keep in the air to figure out the logic of what was going on.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

