### PR TITLE
Add back global alignment rotation option

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -123,7 +123,7 @@ class AlignmentTransformation
 
   bool use_intt_survey_geometry = false;
 
-  Acts::Transform3 newMakeTransform(const Surface& surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, bool survey);
+  Acts::Transform3 newMakeTransform(const Surface& surf, Eigen::Vector3d& millepedeTranslation, Eigen::Vector3d& sensorAngles, Eigen::Vector3d& sensorAnglesGlobal, bool survey);
 
   alignmentTransformationContainer* transformMap = NULL;
   alignmentTransformationContainer* transformMapTransient = NULL;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This restores the option in AlignmentTransformation to apply a rotation of the surface in global coordinates after the Acts transformation. It allows the surface to be rotated around the x, y or z axis.

The code will now read files containing alignment parameters:
"hitsetkey  alpha, beta, gamma, dx, dy, dz, dgrx, dgry, dgrz"
Or, files containing only:
"hitsetkey  alpha, beta, gamma, dx, dy, dz"
In the latter case, it sets dgrx, dgry, dgrz to zero.

It should be kept in mind that the global rotation can also be obtained from a local frame rotation of the surface followed by a global translation, so allowing all 9 parameters to vary in millepede would not be a good idea. This change is intended to allow a fixed phi offset to be applied to the surface, so that small perturbations around that point can be applied using the first 6 parameters. It is aimed specifically at getting the TPC modules aligned in phi with the silicon.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

