### PR TITLE
fix: filename in closeout script

### DIFF
--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -71,8 +71,16 @@ int Fun4AllHistoManager::RunAfterClosing()
       std::cout << PHWHERE << "RunAfterClosing() closing script " << m_RunAfterClosingScript << " is not owner executable" << std::endl;
       return -1;
     }
+  recoConsts *rc = recoConsts::instance();
+  int runnumber = 0;
+  std::string runseg = "";
+  if (rc->FlagExist("RUNNUMBER") && m_dumpHistoSegments)
+  {
+    runnumber = rc->get_IntFlag("RUNNUMBER");
+    runseg = (boost::format("-%08d-%05d.root") % runnumber % m_CurrentSegment).str();
 
-    std::string fullcmd = m_RunAfterClosingScript + " " + m_outfilename + " " + m_ClosingArgs;
+    }
+    std::string fullcmd = m_RunAfterClosingScript + " " + m_outfilename + runseg + " " + m_ClosingArgs;
     if (Verbosity() > 1)
     {
       std::cout << PHWHERE << " running " << fullcmd << std::endl;


### PR DESCRIPTION
Fixes the filename assignment for the closeout script, which wasn't apparent until testing in the production

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

