### PR TITLE
JetReco: reset node before filling

### DIFF
--- a/offline/packages/jetbase/JetReco.cc
+++ b/offline/packages/jetbase/JetReco.cc
@@ -263,6 +263,7 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
 void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, const std::vector<Jet *> &jets)
 {
   JetMap *jetmap = findNode::getClass<JetMap>(topNode, _outputs[ipos]);
+  jetmap->Reset();
   if (!jetmap)
   {
     std::cout << PHWHERE << " ERROR: Can't find JetMap: " << _outputs[ipos] << std::endl;
@@ -287,6 +288,7 @@ void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, const std::vector<
 void JetReco::FillJetContainer(PHCompositeNode *topNode, int ipos, std::vector<Jet *> &inputs)
 {
   JetContainer *jetconn = findNode::getClass<JetContainer>(topNode, JC_name(_outputs[ipos]));
+  jetconn->Reset();
   if (!jetconn)
   {
     std::cout << PHWHERE << " ERROR: Can't find JetContainer: " << _outputs[ipos] << std::endl;

--- a/offline/packages/jetbase/JetReco.cc
+++ b/offline/packages/jetbase/JetReco.cc
@@ -263,13 +263,12 @@ int JetReco::CreateNodes(PHCompositeNode *topNode)
 void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, const std::vector<Jet *> &jets)
 {
   JetMap *jetmap = findNode::getClass<JetMap>(topNode, _outputs[ipos]);
-  jetmap->Reset();
   if (!jetmap)
   {
     std::cout << PHWHERE << " ERROR: Can't find JetMap: " << _outputs[ipos] << std::endl;
     exit(-1);
   }
-
+  jetmap->Reset();
   jetmap->set_algo(_algos[ipos]->get_algo());
   jetmap->set_par(_algos[ipos]->get_par());
   for (auto &_input : _inputs)
@@ -288,12 +287,12 @@ void JetReco::FillJetNode(PHCompositeNode *topNode, int ipos, const std::vector<
 void JetReco::FillJetContainer(PHCompositeNode *topNode, int ipos, std::vector<Jet *> &inputs)
 {
   JetContainer *jetconn = findNode::getClass<JetContainer>(topNode, JC_name(_outputs[ipos]));
-  jetconn->Reset();
   if (!jetconn)
   {
     std::cout << PHWHERE << " ERROR: Can't find JetContainer: " << _outputs[ipos] << std::endl;
     exit(-1);
   }
+  jetconn->Reset();
   _algos[ipos]->cluster_and_fill(inputs, jetconn);  // fills the jet container with clustered jets
   for (auto &_input : _inputs)
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Make sure the node is empty before filling in jets so you don't get duplicate jets


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

