### PR TITLE
refactor: standardize use of TPC ADC clock

### DIFF
--- a/offline/QA/EventDisplay/TrackerEventDisplay.cc
+++ b/offline/QA/EventDisplay/TrackerEventDisplay.cc
@@ -55,7 +55,19 @@ int TrackerEventDisplay::Init(PHCompositeNode* /*topNode*/)
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
+int TrackerEventDisplay::InitRun(PHCompositeNode *topNode)
+{
+  auto geom =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
 
+  return Fun4AllReturnCodes::EVENT_OK;
+}
 int TrackerEventDisplay::process_event(PHCompositeNode* topNode)
 {
   makeJsonFile(topNode);

--- a/offline/QA/EventDisplay/TrackerEventDisplay.h
+++ b/offline/QA/EventDisplay/TrackerEventDisplay.h
@@ -22,6 +22,7 @@ class TrackerEventDisplay : public SubsysReco
   ~TrackerEventDisplay() override = default;
 
   int Init(PHCompositeNode *topNode) override;
+  int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 

--- a/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
+++ b/offline/packages/TrackingDiagnostics/TrkrNtuplizer.cc
@@ -268,7 +268,7 @@ TrkrNtuplizer::~TrkrNtuplizer()
   delete _timer;
 }
 
-int TrkrNtuplizer::Init(PHCompositeNode* /*topNode*/)
+int TrkrNtuplizer::Init(PHCompositeNode* topNode)
 {
   _ievent = 0;
 
@@ -331,6 +331,15 @@ int TrkrNtuplizer::Init(PHCompositeNode* /*topNode*/)
   _timer = new PHTimer("_eval_timer");
   _timer->stop();
   /**/
+  auto geom =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/packages/tpc/LaserClusterizer.cc
+++ b/offline/packages/tpc/LaserClusterizer.cc
@@ -448,9 +448,18 @@ int LaserClusterizer::InitRun(PHCompositeNode *topNode)
         new PHIODataNode<PHObject>(laserclusters, laserClusterNodeName, "PHObject");
     DetNode->addNode(LaserClusterContainerNode);
   }
-
-  m_tdriftmax = AdcClockPeriod * NZBinsSide;
   
+  m_geom_container =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!m_geom_container)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  // get the first layer to get the clock freq
+  AdcClockPeriod = m_geom_container->GetFirstLayerCellGeom()->get_zstep();
+  m_tdriftmax = AdcClockPeriod * NZBinsSide;
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -512,14 +521,6 @@ int LaserClusterizer::process_event(PHCompositeNode *topNode)
   if (!m_clusterlist)
   {
     std::cout << PHWHERE << " ERROR: Can't find " << laserClusterNodeName << "." << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
-  m_geom_container =
-      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-  if (!m_geom_container)
-  {
-    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 

--- a/offline/packages/tpc/Tpc3DClusterizer.cc
+++ b/offline/packages/tpc/Tpc3DClusterizer.cc
@@ -116,7 +116,18 @@ int Tpc3DClusterizer::InitRun(PHCompositeNode *topNode)
     m_outputFile = new TFile(m_outputFileName.c_str(), "RECREATE");
 
     m_clusterNT = new TNtuple("clus3D", "clus3D","event:seed:x:y:z:r:phi:phibin:tbin:adc:maxadc:layer:phielem:zelem:size:phisize:tsize:lsize");
-  } 
+  }
+  
+  m_geom_container =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!m_geom_container)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  AdcClockPeriod = m_geom_container->GetFirstLayerCellGeom()->get_zstep();
+
   m_tdriftmax = AdcClockPeriod * NZBinsSide;
 
   t_all = std::make_unique<PHTimer>("t_all");
@@ -162,14 +173,6 @@ int Tpc3DClusterizer::process_event(PHCompositeNode *topNode)
   if (!m_clusterlist)
   {
     std::cout << PHWHERE << " ERROR: Can't find LASER_CLUSTER." << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
-  m_geom_container =
-      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-  if (!m_geom_container)
-  {
-    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 

--- a/offline/packages/tpc/TpcClusterizer.cc
+++ b/offline/packages/tpc/TpcClusterizer.cc
@@ -1228,6 +1228,15 @@ int TpcClusterizer::InitRun(PHCompositeNode *topNode)
       DetNode->addNode(newNode);
     }
   }
+  auto geom =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  
+  AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -548,7 +548,7 @@ void TpcDirectLaserReconstruction::process_track(SvtxTrack* track)
 
     // maximum drift time.
     /* it is needed to calculate a given hit position from its drift time */
-    static constexpr double AdcClockPeriod = 53.0;  // ns
+    static constexpr double AdcClockPeriod = layergeom->get_zstep();  // ns
     const unsigned short NTBins = (unsigned short) layergeom->get_zbins();
     const float tdriftmax = AdcClockPeriod * NTBins / 2.0;
 

--- a/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
+++ b/offline/packages/tpccalib/TpcDirectLaserReconstruction.cc
@@ -548,7 +548,7 @@ void TpcDirectLaserReconstruction::process_track(SvtxTrack* track)
 
     // maximum drift time.
     /* it is needed to calculate a given hit position from its drift time */
-    static constexpr double AdcClockPeriod = layergeom->get_zstep();  // ns
+    const double AdcClockPeriod = layergeom->get_zstep();  // ns
     const unsigned short NTBins = (unsigned short) layergeom->get_zbins();
     const float tdriftmax = AdcClockPeriod * NTBins / 2.0;
 

--- a/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcElectronDrift.cc
@@ -434,15 +434,6 @@ int PHG4TpcElectronDrift::process_event(PHCompositeNode *topNode)
   PHG4TruthInfoContainer *truthinfo =
       findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
 
-  m_tGeometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
-  if (!m_tGeometry)
-  {
-    std::cout << PHWHERE
-              << "ActsGeometry not found on node tree. Exiting"
-              << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
-
   PHG4HitContainer::ConstRange hit_begin_end = g4hit->getHits();
   unsigned int count_g4hits = 0;
   //  int count_electrons = 0;

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadBaselineShift.cc
@@ -172,6 +172,15 @@ int PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  auto geom =
+      findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+  if (!geom)
+  {
+    std::cout << PHWHERE << "ERROR: Can't find node CYLINDERCELLGEOM_SVTX" << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+AdcClockPeriod = geom->GetFirstLayerCellGeom()->get_zstep();
+
   std::cout << "PHG4TpcPadBaselineShift::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -107,6 +107,7 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
   const std::string seggeonodename = "CYLINDERCELLGEOM_SVTX";
   GeomContainer = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, seggeonodename);
   assert(GeomContainer);
+  set_double_param("tpc_adc_clock", GeomContainer->GetFirstLayerCellGeom()->get_zstep());
 
   if(m_use_module_gain_weights)
     {

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -103,12 +103,6 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
     return reply;
   }
 
-  // load geo node
-  const std::string seggeonodename = "CYLINDERCELLGEOM_SVTX";
-  GeomContainer = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, seggeonodename);
-  assert(GeomContainer);
-  set_double_param("tpc_adc_clock", GeomContainer->GetFirstLayerCellGeom()->get_zstep());
-
   if(m_use_module_gain_weights)
     {
       int side, region, sector;
@@ -1042,7 +1036,7 @@ void PHG4TpcPadPlaneReadout::SetDefaultParameters()
 
   set_default_double_param("neffelectrons_threshold", 1.0);
   set_default_double_param("maxdriftlength", 105.5);     // cm
-  set_default_double_param("tpc_adc_clock", 53.0);       // ns, for 18.8 MHz clock
+  set_default_double_param("tpc_adc_clock", 53.326184);  // ns, for 18.8 MHz clock
   set_default_double_param("gem_cloud_sigma", 0.04);     // cm = 400 microns
   set_default_double_param("sampa_shaping_lead", 32.0);  // ns, for 80 ns SAMPA
   set_default_double_param("sampa_shaping_tail", 48.0);  // ns, for 80 ns SAMPA

--- a/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcPadPlaneReadout.cc
@@ -102,7 +102,9 @@ int PHG4TpcPadPlaneReadout::InitRun(PHCompositeNode *topNode)
   {
     return reply;
   }
-
+  const std::string seggeonodename = "CYLINDERCELLGEOM_SVTX";
+  GeomContainer = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, seggeonodename);
+  assert(GeomContainer);
   if(m_use_module_gain_weights)
     {
       int side, region, sector;

--- a/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcSubsystem.cc
@@ -217,7 +217,7 @@ void PHG4TpcSubsystem::SetDefaultParameters()
 
   set_default_double_param("maxdriftlength", 105.5);       // cm
   set_default_double_param("extended_readout_time", 0.0);  // ns
-  set_default_double_param("tpc_adc_clock", 53.0);         // ns, for 18.8 MHz clock
+  set_default_double_param("tpc_adc_clock", 53.326184);         // ns, for 18.8 MHz clock
 
   set_default_double_param("tpc_sector_phi_inner", 0.5024);  // 2 * M_PI / 12 );//sector size in phi for R1 sector
   set_default_double_param("tpc_sector_phi_mid", 0.5087);    // 2 * M_PI / 12 );//sector size in phi for R2 sector

--- a/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
+++ b/simulation/g4simulation/g4tpc/TpcClusterBuilder.cc
@@ -64,7 +64,7 @@ void TpcClusterBuilder::cluster_hits(TrkrTruthTrack* track)
     unsigned short NTBinsMin = 0;
     unsigned short PhiOffset = NPhiBinsSector * sector;
     unsigned short TOffset = NTBinsMin;
-
+    AdcClockPeriod = layergeom->get_zstep();
     double m_tdriftmax = AdcClockPeriod * NTBins / 2.0;
 
     unsigned short phibins = NPhiBinsSector;


### PR DESCRIPTION
This PR fixes the various places in the code that hardcode the TPC ADC clock to 53 ns to use the geometry objects definition of the ADC clock. This is in preparation for a new geometry file which uses the 50 ns clock that was actually used in run 24. The default value is left as 53ns as this was the design expectation and is what is expected to be the case in run 25. I will create a new geometry CDB file with the updated TPC geometry to be applicable for run 24.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

