### PR TITLE
Minor bug fix for CentralityReco

### DIFF
--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -194,6 +194,7 @@ int CentralityReco::FillVars()
       std::cout << scale_factor << "*" << m_centrality_scale << std::endl;
     }
 
+  m_mbd_total_charge = 0; // Reset the total charge
   for (int i = 0; i < 128; i++)
     {
       

--- a/offline/packages/centrality/CentralityReco.cc
+++ b/offline/packages/centrality/CentralityReco.cc
@@ -194,7 +194,6 @@ int CentralityReco::FillVars()
       std::cout << scale_factor << "*" << m_centrality_scale << std::endl;
     }
 
-  m_mbd_total_charge = 0; // Reset the total charge
   for (int i = 0; i < 128; i++)
     {
       

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -83,7 +83,7 @@ class CentralityReco : public SubsysReco
 
   unsigned int m_key{std::numeric_limits<unsigned int>::max()};
 
-  float m_mbd_total_charge{std::numeric_limits<float>::quiet_NaN()};
+  float m_mbd_total_charge{0.}; // init to zero for use in first event
 
   double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
   std::vector<std::pair<std::pair<float, float>, float>>  m_vertex_scales{};

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -83,7 +83,7 @@ class CentralityReco : public SubsysReco
 
   unsigned int m_key{std::numeric_limits<unsigned int>::max()};
 
-  float m_mbd_total_charge{0};
+  float m_mbd_total_charge{std::numeric_limits<float>::quiet_NaN()};
 
   double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
   std::vector<std::pair<std::pair<float, float>, float>>  m_vertex_scales{};

--- a/offline/packages/centrality/CentralityReco.h
+++ b/offline/packages/centrality/CentralityReco.h
@@ -83,7 +83,7 @@ class CentralityReco : public SubsysReco
 
   unsigned int m_key{std::numeric_limits<unsigned int>::max()};
 
-  float m_mbd_total_charge{std::numeric_limits<float>::quiet_NaN()};
+  float m_mbd_total_charge{0};
 
   double m_centrality_scale{std::numeric_limits<double>::quiet_NaN()};
   std::vector<std::pair<std::pair<float, float>, float>>  m_vertex_scales{};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Initialize m_mbd_total_charge to 0 instead of NaN to prevent the first event processed by Fun4All from having m_mbd_total_charge=nan and CentBin=0 (since adding a float to nan results in nan.)
This minor bug does not affect subsequent events, as ResetEvent sets m_mbd_total_charge = 0.

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

