### PR TITLE
waveform sim pedestal scaling

### DIFF
--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.cc
@@ -334,12 +334,30 @@ int CaloWaveformSim::process_event(PHCompositeNode *topNode)
 
     for (int i = 0; i < m_nchannels; i++)
     {
+      std::vector<float> m_waveform_pedestal;
+      m_waveform_pedestal.resize(m_nsamples);
+      if(m_noiseType == NoiseType::NOISE_TREE)
+      {
+        TowerInfo *pedestal_tower = m_PedestalContainer->get_tower_at_channel(i);
+        float pedestal_mean = 0;
+        for(int j = 0; j < m_nsamples; j++)
+        {
+          m_waveform_pedestal.at(j) = (j < m_pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(m_pedestalsamples - 1);
+          pedestal_mean += m_waveform_pedestal.at(j);
+        }
+        pedestal_mean /= m_nsamples;
+        for(int j = 0; j < m_nsamples; j++)
+        {
+          m_waveform_pedestal.at(j)  = (m_waveform_pedestal.at(j) - pedestal_mean) * m_pedestal_scale + pedestal_mean;
+        }
+      }
       for (int j = 0; j < m_nsamples; j++)
       {
         if (m_noiseType == NoiseType::NOISE_TREE)
         {
-          TowerInfo *pedestal_tower = m_PedestalContainer->get_tower_at_channel(i);
-          m_waveforms.at(i).at(j) += (j < m_pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(m_pedestalsamples - 1);
+          //TowerInfo *pedestal_tower = m_PedestalContainer->get_tower_at_channel(i);
+          //m_waveforms.at(i).at(j) += (j < m_pedestalsamples) ? pedestal_tower->get_waveform_value(j) : pedestal_tower->get_waveform_value(m_pedestalsamples - 1);
+          m_waveforms.at(i).at(j) += m_waveform_pedestal.at(j);
         }
         if (m_noiseType == NoiseType::NOISE_GAUSSIAN)
         {

--- a/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
+++ b/simulation/g4simulation/g4waveformsim/CaloWaveformSim.h
@@ -137,6 +137,11 @@ class CaloWaveformSim : public SubsysReco
     m_highgain = _highgain;
     return;
   }
+  void set_pedestal_scale(float _pedestal_scale)
+  {
+    m_pedestal_scale = _pedestal_scale;
+    return;
+  }
   // for CEMC light yield correction
   LightCollectionModel &get_light_collection_model() { return light_collection_model; }
 
@@ -166,6 +171,7 @@ class CaloWaveformSim : public SubsysReco
   bool m_highgain{false};
   int m_gain{1};
   float m_peakpos{6.};
+  float m_pedestal_scale{1.};
   gsl_rng *m_RandomGenerator{nullptr};
 
   PHG4CylinderCellGeom_Spacalv1 *geo{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This PR introduce the pedestal scaling by set_pedestal_scale method(set to a smaller number for smaller noise scale).

This PR is for fine tuning or noise level to better match data. Currently since the pedestal file we used in our sim is taken after the pp running, therefore the pedestal is the worst case estimation, this PR make it possible to scale down the pedestal fluctuation to achieve better data/MC agreement :)  


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

