### PR TITLE
add 5 more histogram with wide range and narrow range for energy for the tower QA for cemc ihcal ohcal

### DIFF
--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -230,6 +230,12 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         bool isGood = tower->get_isGood();
         uint8_t status = tower->get_status();
         h_emcal_tower_e->Fill(offlineenergy);
+				h_emcal_tower_e_wide_range->Fill(offlineenergy);
+				h_ihcal_tower_e->Fill(offlineenergy);
+				h_ihcal_tower_e_wide_range->Fill(offlineenergy);
+				h_ohcal_tower_e->Fill(offlineenergy);
+				h_ohcal_tower_e_wide_range->Fill(offlineenergy);
+
         float pedestal = tower->get_pedestal();
         h_cemc_channel_pedestal[channel]->Fill(pedestal);
 
@@ -993,6 +999,26 @@ void CaloValid::createHistos()
   h_emcal_tower_e = new TH1F(boost::str(boost::format("%semcal_tower_e") % getHistoPrefix()).c_str(), "emcal_tower_e", 5000, -0.1, 1);
   h_emcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_emcal_tower_e);
+
+	h_emcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%semcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "emcal_tower_e_wide_range", 1000, -10., 40.);
+  h_emcal_tower_e_wide_range->SetDirectory(nullptr);
+  hm->registerHisto(h_emcal_tower_e_wide_range);
+
+	h_ihcal_tower_e = new TH1F(boost::str(boost::format("%sihcal_tower_e") % getHistoPrefix()).c_str(), "ihcal_tower_e", 5000, -0.1, 1);
+  h_ihcal_tower_e->SetDirectory(nullptr);
+  hm->registerHisto(h_ihcal_tower_e);
+
+	h_ihcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sihcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ihcal_tower_e_wide_range", 1000, -10., 40.);
+  h_ihcal_tower_e_wide_range->SetDirectory(nullptr);
+  hm->registerHisto(h_ihcal_tower_e_wide_range);
+
+	h_ohcal_tower_e = new TH1F(boost::str(boost::format("%sohcal_tower_e") % getHistoPrefix()).c_str(), "ohcal_tower_e", 5000, -0.1, 1);
+  h_ohcal_tower_e->SetDirectory(nullptr);
+  hm->registerHisto(h_ohcal_tower_e);
+
+	h_ohcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sohcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ohcal_tower_e_wide_range", 1000, -10., 40.);
+  h_ohcal_tower_e_wide_range->SetDirectory(nullptr);
+  hm->registerHisto(h_ohcal_tower_e_wide_range);
 
   // cluster QA
   h_etaphi_clus = new TH2F(boost::str(boost::format("%setaphi_clus") % getHistoPrefix()).c_str(), "", 140, -1.2, 1.2, 64, -1 * M_PI, M_PI);

--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -231,12 +231,8 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         uint8_t status = tower->get_status();
         h_emcal_tower_e->Fill(offlineenergy);
 				h_emcal_tower_e_wide_range->Fill(offlineenergy);
-				h_ihcal_tower_e->Fill(offlineenergy);
-				h_ihcal_tower_e_wide_range->Fill(offlineenergy);
-				h_ohcal_tower_e->Fill(offlineenergy);
-				h_ohcal_tower_e_wide_range->Fill(offlineenergy);
-
-        float pedestal = tower->get_pedestal();
+				
+				float pedestal = tower->get_pedestal();
         h_cemc_channel_pedestal[channel]->Fill(pedestal);
 
         for (int is = 0; is < 8; is++)
@@ -298,6 +294,8 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ihcal_status->Fill(tower->get_status());
         float pedestal = tower->get_pedestal();
         h_ihcal_channel_pedestal[channel]->Fill(pedestal);
+				h_ihcal_tower_e->Fill(offlineenergy);
+				h_ihcal_tower_e_wide_range->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)
@@ -353,6 +351,8 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ohcal_status->Fill(tower->get_status());
         float pedestal = tower->get_pedestal();
         h_ohcal_channel_pedestal[channel]->Fill(pedestal);
+				h_ohcal_tower_e->Fill(offlineenergy);
+				h_ohcal_tower_e_wide_range->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)

--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -230,9 +230,9 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         bool isGood = tower->get_isGood();
         uint8_t status = tower->get_status();
         h_emcal_tower_e->Fill(offlineenergy);
-				h_emcal_tower_e_wide_range->Fill(offlineenergy);
-				
-				float pedestal = tower->get_pedestal();
+        h_emcal_tower_e_wide_range->Fill(offlineenergy);
+        
+        float pedestal = tower->get_pedestal();
         h_cemc_channel_pedestal[channel]->Fill(pedestal);
 
         for (int is = 0; is < 8; is++)
@@ -294,8 +294,8 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ihcal_status->Fill(tower->get_status());
         float pedestal = tower->get_pedestal();
         h_ihcal_channel_pedestal[channel]->Fill(pedestal);
-				h_ihcal_tower_e->Fill(offlineenergy);
-				h_ihcal_tower_e_wide_range->Fill(offlineenergy);
+        h_ihcal_tower_e->Fill(offlineenergy);
+        h_ihcal_tower_e_wide_range->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)
@@ -351,8 +351,8 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ohcal_status->Fill(tower->get_status());
         float pedestal = tower->get_pedestal();
         h_ohcal_channel_pedestal[channel]->Fill(pedestal);
-				h_ohcal_tower_e->Fill(offlineenergy);
-				h_ohcal_tower_e_wide_range->Fill(offlineenergy);
+        h_ohcal_tower_e->Fill(offlineenergy);
+        h_ohcal_tower_e_wide_range->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)
@@ -1000,23 +1000,23 @@ void CaloValid::createHistos()
   h_emcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_emcal_tower_e);
 
-	h_emcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%semcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "emcal_tower_e_wide_range", 1000, -10., 40.);
+  h_emcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%semcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "emcal_tower_e_wide_range", 1000, -10., 40.);
   h_emcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_emcal_tower_e_wide_range);
 
-	h_ihcal_tower_e = new TH1F(boost::str(boost::format("%sihcal_tower_e") % getHistoPrefix()).c_str(), "ihcal_tower_e", 5000, -0.1, 1);
+  h_ihcal_tower_e = new TH1F(boost::str(boost::format("%sihcal_tower_e") % getHistoPrefix()).c_str(), "ihcal_tower_e", 5000, -0.1, 1);
   h_ihcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_tower_e);
 
-	h_ihcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sihcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ihcal_tower_e_wide_range", 1000, -10., 40.);
+  h_ihcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sihcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ihcal_tower_e_wide_range", 1000, -10., 40.);
   h_ihcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_tower_e_wide_range);
 
-	h_ohcal_tower_e = new TH1F(boost::str(boost::format("%sohcal_tower_e") % getHistoPrefix()).c_str(), "ohcal_tower_e", 5000, -0.1, 1);
+  h_ohcal_tower_e = new TH1F(boost::str(boost::format("%sohcal_tower_e") % getHistoPrefix()).c_str(), "ohcal_tower_e", 5000, -0.1, 1);
   h_ohcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_tower_e);
 
-	h_ohcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sohcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ohcal_tower_e_wide_range", 1000, -10., 40.);
+  h_ohcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sohcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ohcal_tower_e_wide_range", 1000, -10., 40.);
   h_ohcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_tower_e_wide_range);
 

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -104,6 +104,11 @@ class CaloValid : public SubsysReco
   TH1* h_ihcaltime{nullptr};
   TH1* h_ohcaltime{nullptr};
   TH1* h_emcal_tower_e{nullptr};
+	TH1* h_emcal_tower_e_wide_range{nullptr};
+	TH1* h_ihcal_tower_e{nullptr};
+	TH1* h_ihcal_tower_e_wide_range{nullptr};
+	TH1* h_ohcal_tower_e{nullptr};
+	TH1* h_ohcal_tower_e_wide_range{nullptr};
   TH2* h_etaphi_clus{nullptr};
   TH1* h_clusE{nullptr};
 

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -104,11 +104,11 @@ class CaloValid : public SubsysReco
   TH1* h_ihcaltime{nullptr};
   TH1* h_ohcaltime{nullptr};
   TH1* h_emcal_tower_e{nullptr};
-	TH1* h_emcal_tower_e_wide_range{nullptr};
-	TH1* h_ihcal_tower_e{nullptr};
-	TH1* h_ihcal_tower_e_wide_range{nullptr};
-	TH1* h_ohcal_tower_e{nullptr};
-	TH1* h_ohcal_tower_e_wide_range{nullptr};
+  TH1* h_emcal_tower_e_wide_range{nullptr};
+  TH1* h_ihcal_tower_e{nullptr};
+  TH1* h_ihcal_tower_e_wide_range{nullptr};
+  TH1* h_ohcal_tower_e{nullptr};
+  TH1* h_ohcal_tower_e_wide_range{nullptr};
   TH2* h_etaphi_clus{nullptr};
   TH1* h_clusE{nullptr};
 


### PR DESCRIPTION
It just adds additional QA histograms to the class CaloValid. Previously it only had the narrow range histogram for the tower energy spectra, this will add wider range -10,40 Gev with 100 bins for all the calorimeters

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

