### PR TITLE
fix: map clear in INTT triggered mode

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -788,6 +788,11 @@ int Fun4AllStreamingInputManager::FillIntt()
     for (auto iter : m_InttInputVector)
     {
       iter->CleanupUsedPackets(m_InttRawHitMap.begin()->first);
+      if(m_intt_negative_bco < 2) //triggered mode
+      {
+        iter->clearPacketBClkStackMap(m_InttRawHitMap.begin()->first);
+        iter->clearFeeGTML1BCOMap(m_InttRawHitMap.begin()->first);
+      }
     }
     m_InttRawHitMap.begin()->second.InttRawHitVector.clear();
     m_InttRawHitMap.erase(m_InttRawHitMap.begin());


### PR DESCRIPTION
In triggered mode there are no raw hits prior to the GL1, so there were some maps not getting cleared properly. This fixes this, which returns the decoder to running at normal speed in triggered mode.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

