### PR TITLE
Add Mvtx hit set helper

### DIFF
--- a/offline/framework/ffarawobjects/MvtxFeeIdInfo.h
+++ b/offline/framework/ffarawobjects/MvtxFeeIdInfo.h
@@ -8,17 +8,28 @@
 class MvtxFeeIdInfo : public PHObject
 {
  public:
+  //! ctor
   MvtxFeeIdInfo() = default;
-  virtual ~MvtxFeeIdInfo() = default;
+
+  //! cp/mv ctor
+  MvtxFeeIdInfo(const MvtxFeeIdInfo&) = default;
+  MvtxFeeIdInfo(MvtxFeeIdInfo&&) = default;
+
+  //! cp/mv assignment
+  MvtxFeeIdInfo& operator=(const MvtxFeeIdInfo&) = default;
+  MvtxFeeIdInfo& operator=(MvtxFeeIdInfo&&) = default;
+
+  //! dtor
+  ~MvtxFeeIdInfo() override = default;
 
   virtual uint16_t get_feeId() const { return std::numeric_limits<uint16_t>::max(); }
-  virtual void set_feeId(const uint16_t) { return; }
+  virtual void set_feeId(const uint16_t /*dummy*/) { return; }
 
   virtual uint32_t get_detField() const { return std::numeric_limits<uint32_t>::max(); }
-  virtual void set_detField(const uint32_t) { return; }
+  virtual void set_detField(const uint32_t /*dummy*/) { return; }
 
   virtual uint64_t get_bco() const { return std::numeric_limits<uint64_t>::max(); }
-  virtual void set_bco(const uint64_t) { return; }
+  virtual void set_bco(const uint64_t /*dummy*/) { return; }
 
  private:
   ClassDefOverride(MvtxFeeIdInfo, 1)

--- a/offline/framework/ffarawobjects/MvtxFeeIdInfov1.h
+++ b/offline/framework/ffarawobjects/MvtxFeeIdInfov1.h
@@ -8,9 +8,20 @@
 class MvtxFeeIdInfov1 : public MvtxFeeIdInfo
 {
  public:
-  MvtxFeeIdInfov1() {}
-  MvtxFeeIdInfov1(MvtxFeeIdInfo* info);
-  ~MvtxFeeIdInfov1() override{};
+  //! ctor
+  MvtxFeeIdInfov1() = default;
+  explicit MvtxFeeIdInfov1(MvtxFeeIdInfo* info);
+
+  //! cp/mv ctor
+  MvtxFeeIdInfov1(const MvtxFeeIdInfov1&) = default;
+  MvtxFeeIdInfov1(MvtxFeeIdInfov1&&) = default;
+
+  //! cp/mv assigment
+  MvtxFeeIdInfov1& operator=(const MvtxFeeIdInfov1&) = default;
+  MvtxFeeIdInfov1& operator=(MvtxFeeIdInfov1&&) = default;
+
+  //! dtor
+  ~MvtxFeeIdInfov1() override = default;
 
   /** identify Function from PHObject
       @param os Output Stream
@@ -29,7 +40,7 @@ class MvtxFeeIdInfov1 : public MvtxFeeIdInfo
   // cppcheck-suppress virtualCallInConstructor
   void set_bco(const uint64_t val) override { m_bco = val; }
 
- protected:
+ private:
   uint16_t m_feeId = std::numeric_limits<uint16_t>::max();
   uint32_t m_detField = std::numeric_limits<uint32_t>::max();
   uint64_t m_bco = std::numeric_limits<uint64_t>::max();

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeader.h
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeader.h
@@ -13,23 +13,34 @@ class MvtxFeeIdInfo;
 class MvtxRawEvtHeader : public PHObject
 {
  public:
+  //! ctor
   MvtxRawEvtHeader() = default;
-  virtual ~MvtxRawEvtHeader() = default;
 
-  virtual void AddFeeId(const int &) { return; }
-  virtual void AddL1Trg(const uint64_t &) { return; }
+  //! cp/mv ctor
+  MvtxRawEvtHeader(const MvtxRawEvtHeader &) = default;
+  MvtxRawEvtHeader(MvtxRawEvtHeader &&) = default;
 
-  virtual void AddFeeId(const std::set<uint16_t> &) { return; }
-  virtual void AddL1Trg(const std::set<uint64_t> &) { return; }
+  //! cp/mv assignment
+  MvtxRawEvtHeader &operator=(const MvtxRawEvtHeader &) = default;
+  MvtxRawEvtHeader &operator=(MvtxRawEvtHeader &&) = default;
+
+  //! dtor
+  ~MvtxRawEvtHeader() override = default;
+
+  virtual void AddFeeId(const int & /*dummy*/) { return; }
+  virtual void AddL1Trg(const uint64_t & /*dummy*/) { return; }
+
+  virtual void AddFeeId(const std::set<uint16_t> & /*dummy*/) { return; }
+  virtual void AddL1Trg(const std::set<uint64_t> & /*dummy*/) { return; }
 
   virtual std::set<uint16_t> &getMvtxFeeIdSet() { return dummySet16; }
   virtual std::set<uint64_t> &getMvtxLvL1BCO() { return dummySet64; }
 
   virtual MvtxFeeIdInfo *AddFeeIdInfo() { return nullptr; }
-  virtual MvtxFeeIdInfo *AddFeeIdInfo(MvtxFeeIdInfo *) { return nullptr; }
+  virtual MvtxFeeIdInfo *AddFeeIdInfo(MvtxFeeIdInfo * /*dummy*/) { return nullptr; }
 
   virtual uint64_t get_nFeeIdInfo() { return 100; }
-  virtual MvtxFeeIdInfo *get_feeIdInfo(unsigned int) { return nullptr; }
+  virtual MvtxFeeIdInfo *get_feeIdInfo(unsigned int /*dummy*/) { return nullptr; }
 
  private:
   std::set<uint16_t> dummySet16;

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeaderv1.h
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeaderv1.h
@@ -11,7 +11,18 @@
 class MvtxRawEvtHeaderv1 : public MvtxRawEvtHeader
 {
  public:
+  //! ctor
   MvtxRawEvtHeaderv1() = default;
+
+  //! cp/mv ctor
+  MvtxRawEvtHeaderv1(const MvtxRawEvtHeaderv1&) = default;
+  MvtxRawEvtHeaderv1(MvtxRawEvtHeaderv1&&) = default;
+
+  //! cp/mv assignment
+  MvtxRawEvtHeaderv1& operator=(const MvtxRawEvtHeaderv1&) = default;
+  MvtxRawEvtHeaderv1& operator=(MvtxRawEvtHeaderv1&&) = default;
+
+  //! dtor
   ~MvtxRawEvtHeaderv1() override = default;
 
   /// Clear Event

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeaderv2.h
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeaderv2.h
@@ -11,7 +11,18 @@ class TClonesArray;
 class MvtxRawEvtHeaderv2 : public MvtxRawEvtHeader
 {
  public:
+  //! ctor
   MvtxRawEvtHeaderv2();
+
+  //! cp/mv ctor
+  MvtxRawEvtHeaderv2(const MvtxRawEvtHeaderv2 &) = default;
+  MvtxRawEvtHeaderv2(MvtxRawEvtHeaderv2 &&) = default;
+
+  //! cp/mv assignment
+  MvtxRawEvtHeaderv2 &operator=(const MvtxRawEvtHeaderv2 &) = default;
+  MvtxRawEvtHeaderv2 &operator=(MvtxRawEvtHeaderv2 &&) = default;
+
+  //! dtor
   ~MvtxRawEvtHeaderv2() override;
 
   /// Clear Event

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -8,18 +8,20 @@
 
 #include <fun4allraw/MvtxRawDefs.h>
 #include <trackbase/MvtxDefs.h>
-#include <trackbase/MvtxEventInfov2.h>
+#include <trackbase/MvtxEventInfov3.h>
 #include <trackbase/TrkrHitSet.h>
+#include <trackbase/TrkrHitSetContMvtxHelperv1.h>
 #include <trackbase/TrkrHitSetContainerv1.h>
 #include <trackbase/TrkrHitv2.h>
 
 #include <fun4all/Fun4AllServer.h>
 
-#include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/Gl1Packet.h>
-#include <ffarawobjects/MvtxRawEvtHeader.h>
-#include <ffarawobjects/MvtxRawHit.h>
-#include <ffarawobjects/MvtxRawHitContainer.h>
+#include <ffarawobjects/Gl1RawHit.h>
+#include <ffarawobjects/MvtxFeeIdInfov1.h>
+#include <ffarawobjects/MvtxRawEvtHeaderv2.h>
+#include <ffarawobjects/MvtxRawHitContainerv1.h>
+#include <ffarawobjects/MvtxRawHitv1.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -33,8 +35,13 @@
 #include <ffamodules/CDBInterface.h>  // for accessing the MVTX hot pixel file from the CDB
 
 #include <algorithm>
-#include <array>
 #include <cassert>
+#include <iterator>
+
+namespace
+{
+  std::string MvtxHitSetHelperName("TRKR_MVTXHITSETHELPER");
+}
 
 //_________________________________________________________
 MvtxCombinedRawDataDecoder::MvtxCombinedRawDataDecoder(const std::string &name)
@@ -42,14 +49,8 @@ MvtxCombinedRawDataDecoder::MvtxCombinedRawDataDecoder(const std::string &name)
 {
 }
 
-//_____________________________________________________________________
-int MvtxCombinedRawDataDecoder::Init(PHCompositeNode * /*topNode*/)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-//____________________________________________________________________________..
-int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
+//___________________________________________________________________________
+void MvtxCombinedRawDataDecoder::CreateNodes(PHCompositeNode *topNode)
 {
   // get dst node
   PHNodeIterator iter(topNode);
@@ -61,6 +62,27 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
                  "doing nothing."
               << std::endl;
     exit(1);
+  }
+
+  // create mvtx hitset helper container if needed
+  mvtx_hit_set_helper =
+      findNode::getClass<TrkrHitSetContMvtxHelper>(topNode, MvtxHitSetHelperName.c_str());
+  if (!mvtx_hit_set_helper)
+  {
+    // find or create TRKR node
+    auto trkrNode = dynamic_cast<PHCompositeNode *>(
+        iter.findFirst("PHCompositeNode", "TRKR"));
+    if (!trkrNode)
+    {
+      trkrNode = new PHCompositeNode("TRKR");
+      dstNode->addNode(trkrNode);
+    }
+
+    // create container and add to the tree
+    mvtx_hit_set_helper = new TrkrHitSetContMvtxHelperv1;
+    auto newNode = new PHIODataNode<PHObject>(mvtx_hit_set_helper, MvtxHitSetHelperName.c_str(),
+                                              "PHObject");
+    trkrNode->addNode(newNode);
   }
 
   // create hitset container if needed
@@ -85,36 +107,101 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   }
 
   // Check if MVTX event header already exists
-  if (m_writeMvtxEventHeader)
+  auto mvtxNode = dynamic_cast<PHCompositeNode *>(
+      iter.findFirst("PHCompositeNode", "MVTX"));
+  if (!mvtxNode)
   {
-    auto mvtxNode = dynamic_cast<PHCompositeNode *>(
-        iter.findFirst("PHCompositeNode", "MVTX"));
-    if (!mvtxNode)
-    {
-      mvtxNode = new PHCompositeNode("MVTX");
-      dstNode->addNode(mvtxNode);
-    }
+    mvtxNode = new PHCompositeNode("MVTX");
+    dstNode->addNode(mvtxNode);
+  }
 
-    mvtx_event_header =
-        findNode::getClass<MvtxEventInfo>(mvtxNode, "MVTXEVENTHEADER");
-    if (!mvtx_event_header)
-    {
-      mvtx_event_header = new MvtxEventInfov2();
-      auto newHeader = new PHIODataNode<PHObject>(
-          mvtx_event_header, "MVTXEVENTHEADER", "PHObject");
-      mvtxNode->addNode(newHeader);
-    }
+  mvtx_event_header =
+      findNode::getClass<MvtxEventInfo>(mvtxNode, "MVTXEVENTHEADER");
+  if (!mvtx_event_header)
+  {
+    mvtx_event_header = new MvtxEventInfov3();
+    auto newHeader = new PHIODataNode<PHObject>(
+        mvtx_event_header, "MVTXEVENTHEADER", "PHObject");
+    mvtxNode->addNode(newHeader);
   }
 
   mvtx_raw_event_header =
       findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
 
+  mvtx_raw_hit_container =
+      findNode::getClass<MvtxRawHitContainer>(topNode, m_MvtxRawHitNodeName);
+}
+
+//_____________________________________________________________________
+void MvtxCombinedRawDataDecoder::GetNodes(PHCompositeNode *topNode)
+{
+  mvtx_raw_event_header =
+      findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
+  if (Verbosity() >= 3)
+  {
+    mvtx_raw_event_header->identify();
+  }
+
+  mvtx_raw_hit_container =
+      findNode::getClass<MvtxRawHitContainer>(topNode, m_MvtxRawHitNodeName);
+  if (Verbosity() >= 3)
+  {
+    mvtx_raw_hit_container->identify();
+  }
+
+  hit_set_container =
+      findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
+
+  mvtx_hit_set_helper =
+      findNode::getClass<TrkrHitSetContMvtxHelper>(topNode, MvtxHitSetHelperName.c_str());
+
+  mvtx_event_header =
+      findNode::getClass<MvtxEventInfo>(topNode, "MVTXEVENTHEADER");
+
+  // Could we just get the first strobe BCO instead of setting this to 0?
+  // Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
+  //  uint64_t gl1rawhitbco = gl1 ? gl1->get_bco() : 0;
+  auto gl1 = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
+  if (gl1)
+  {
+    gl1rawhitbco = gl1->lValue(0, "BCO");
+  }
+  else
+  {
+    auto oldgl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
+    if (oldgl1)
+    {
+      gl1rawhitbco = oldgl1->get_bco();
+    }
+  }
+  if (gl1rawhitbco == 0 && (Verbosity() >= 4))
+  {
+    std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
+  }
+}
+
+//_____________________________________________________________________
+int MvtxCombinedRawDataDecoder::Init(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
+{
+  CreateNodes(topNode);
+
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  if (!mvtx_raw_event_header)
+  if (!mvtx_raw_event_header || !mvtx_raw_hit_container)
   {
     se->unregisterSubsystem(this);
+    std::cout << PHWHERE << "::" << __func__ << ": Could not get \""
+              << m_MvtxRawHitNodeName << " or " << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
+    std::cout << "Have you built this yet?" << std::endl;
+    exit(1);
   }
+
   auto rc = recoConsts::instance();
   int runNumber = rc->get_IntFlag("RUNNUMBER");
 
@@ -122,17 +209,20 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
   {
     m_strobeWidth = MvtxRawDefs::getStrobeLength(runNumber);
   }
-  if(std::isnan(m_strobeWidth))
+  if (std::isnan(m_strobeWidth))
   {
     std::cout << "MvtxCombinedRawDataDecoder::InitRun - strobe width is undefined for this run, defaulting to 89 mus" << std::endl;
     m_strobeWidth = 89;
   }
-  if(m_strobeWidth < 1)
+  if (m_strobeWidth < 1)
   {
     runMvtxTriggered(true);
   }
+  //! save MVTX strobe width
+  rc->set_FloatFlag("MvtxStrobeWidth", m_strobeWidth);
+
   // Load the hot pixel map from the CDB
-  if(m_doOfflineMasking)
+  if (m_doOfflineMasking)
   {
     m_hot_pixel_mask = new MvtxPixelMask();
     m_hot_pixel_mask->load_from_CDB();
@@ -144,56 +234,35 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
 //___________________________________________________________________________
 int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
 {
-  mvtx_raw_event_header =
-      findNode::getClass<MvtxRawEvtHeader>(topNode, m_MvtxRawEvtHeaderNodeName);
-  if (Verbosity() >= 3)
-  {
-    mvtx_raw_event_header->identify();
-  }
-
-  hit_set_container =
-      findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
-
-  mvtx_hit_container =
-      findNode::getClass<MvtxRawHitContainer>(topNode, m_MvtxRawHitNodeName);
-
-  if (!mvtx_hit_container)
-  {
-    std::cout << PHWHERE << "::" << __func__ << ": Could not get \""
-              << m_MvtxRawHitNodeName << "\" from Node Tree" << std::endl;
-    std::cout << "Have you built this yet?" << std::endl;
-    exit(1);
-  }
-  // Could we just get the first strobe BCO instead of setting this to 0?
-  // Possible problem, what if the first BCO isn't the mean, then we'll shift tracker hit sets? Probably not a bad thing but depends on hit stripping
-  //  uint64_t gl1rawhitbco = gl1 ? gl1->get_bco() : 0;
-  auto gl1 = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
-  uint64_t gl1rawhitbco = 0;
-  if(gl1)
-  {
-    gl1rawhitbco = gl1->lValue(0, "BCO");
-  }
-  else
-  {
-    auto oldgl1 = findNode::getClass<Gl1RawHit>(topNode, "GL1RAWHIT");
-    if(oldgl1)
-    {
-      gl1rawhitbco = oldgl1->get_bco();
-    }
-  }
-  if (gl1rawhitbco == 0 && (Verbosity() >= 4))
-  {
-    std::cout << PHWHERE << "Could not get gl1 raw hit" << std::endl;
-  }
+  GetNodes(topNode);
 
   // get the last 40 bits by bit shifting left then right to match
   // to the mvtx bco
-  auto lbshift = gl1rawhitbco << 24U;
-  auto gl1bco = lbshift >> 24U;
+  // auto lbshift = gl1rawhitbco << 24U;
+  // auto gl1bco = lbshift >> 24U;
 
+  // std::vector<std::pair<uint64_t, uint32_t> > strobe_bc_pairs;
+  // std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
+  // auto mvtxbco = *l1BCOs.begin();
+  // if (gl1rawhitbco && (Verbosity() > 2))
+  // {
+  //   std::cout << "MVTX header BCO " << mvtxbco << " and GL1 BCO " << gl1bco
+  //             << std::endl;
+  // }
+  //
+  for (const auto &L1 : mvtx_raw_event_header->getMvtxLvL1BCO())
+  {
+    mvtx_event_header->add_L1_BCO(L1);
+  }
+  auto nMvtxFeeIdInfo = mvtx_raw_event_header->get_nFeeIdInfo();
+  for (size_t i{}; i < nMvtxFeeIdInfo; ++i)
+  {
+    auto feeIdInfo = mvtx_raw_event_header->get_feeIdInfo(i);
+    mvtx_event_header->add_strobe_BCO(feeIdInfo->get_bco());
+  }
   if (Verbosity() >= 3)
   {
-    mvtx_hit_container->identify();
+    mvtx_raw_hit_container->identify();
   }
 
   uint64_t strobe = -1;  // Initialise to -1 for debugging
@@ -202,102 +271,90 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
   uint8_t chip = 0;
   uint16_t row = 0;
   uint16_t col = 0;
-  std::vector<std::pair<uint64_t, uint32_t> > strobe_bc_pairs;
-  std::set<uint64_t> l1BCOs = mvtx_raw_event_header->getMvtxLvL1BCO();
-  auto mvtxbco = *l1BCOs.begin();
-  if (gl1 && (Verbosity() > 2))
+
+  const auto &strobe_list = mvtx_event_header->get_strobe_BCOs();
+  for (unsigned int i = 0; i < mvtx_raw_hit_container->get_nhits(); i++)
   {
-    std::cout << "MVTX header BCO " << mvtxbco << " and GL1 BCO " << gl1bco
-              << std::endl;
-  }
+    mvtx_rawhit = mvtx_raw_hit_container->get_hit(i);
+    strobe = mvtx_rawhit->get_bco();
+    layer = mvtx_rawhit->get_layer_id();
+    stave = mvtx_rawhit->get_stave_id();
+    chip = mvtx_rawhit->get_chip_id();
+    row = mvtx_rawhit->get_row();
+    col = mvtx_rawhit->get_col();
 
-  if (m_writeMvtxEventHeader)
-  {
-    mvtx_event_header =
-        findNode::getClass<MvtxEventInfo>(topNode, "MVTXEVENTHEADER");
-    assert(mvtx_event_header);
-  }
-
-  for (unsigned int i = 0; i < mvtx_hit_container->get_nhits(); i++)
-  {
-    mvtx_hit = mvtx_hit_container->get_hit(i);
-    strobe = mvtx_hit->get_bco();
-    layer = mvtx_hit->get_layer_id();
-    stave = mvtx_hit->get_stave_id();
-    chip = mvtx_hit->get_chip_id();
-    row = mvtx_hit->get_row();
-    col = mvtx_hit->get_col();
-
-    int bcodiff = gl1 ? strobe - gl1bco : 0;
-
-    // elapsed time (us, to match strobeWidth)
-    const double timeElapsed = bcodiff * sphenix_constants::time_between_crossings/1000;
-
-    // strobe index
-    const int index = m_mvtx_is_triggered ? 0 : std::ceil(timeElapsed / m_strobeWidth);
-
-    if (index < -16 || index > 15)
+    const auto it = strobe_list.find(strobe);
+    int32_t index = -1;
+    if (it == strobe_list.cend())
     {
-      continue; //Index is out of the 5-bit signed range
-    }
-
-    if (Verbosity() >= 10)
-    {
-      mvtx_hit->identify();
-    }
-
-    const TrkrDefs::hitsetkey hitsetkey =
-        MvtxDefs::genHitSetKey(layer, stave, chip, index);
-    if (!hitsetkey)
-    {
-      continue;
-    }
-
-    // get matching hitset
-    const auto hitset_it = hit_set_container->findOrAddHitSet(hitsetkey);
-
-    // generate hit key
-    const TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(col, row);
-
-    // find existing hit, or create
-    auto hit = hitset_it->second->getHit(hitkey);
-    if (hit)
-    {
-      if(Verbosity() > 1)
+      std::cout << "Warning: hit strobe BCO " << strobe << " is not found in evet combined strobe list:" << std::endl;
+      for (auto &strobe : strobe_list)
       {
-        std::cout << PHWHERE << "::" << __func__
-                  << " - duplicated hit, hitsetkey: " << hitsetkey
-                  << " hitkey: " << hitkey << std::endl;
-      }
-      continue;
-    }
-
-    if(m_doOfflineMasking)
-    {
-      if (!m_hot_pixel_mask->is_masked(mvtx_hit))
-      { // Check if the pixel is masked
-        hit = new TrkrHitv2;
-        hitset_it->second->addHitSpecificKey(hitkey, hit);
+        std::cout << "0x" << std::hex << strobe << std::dec << std::endl;
       }
     }
     else
     {
-      hit = new TrkrHitv2;
-      hitset_it->second->addHitSpecificKey(hitkey, hit);
+      index = std::distance(strobe_list.cbegin(), it);
     }
 
-  }
+    // int bcodiff = gl1rawhitbco ? strobe - gl1bco : 0;
+    //   double timeElapsed = bcodiff * 0.1065;  // 106 ns rhic clock
+    //   int index = m_mvtx_is_triggered ? 0 : std::ceil(timeElapsed / m_strobeWidth);
+    //
+    //   if (index < -16 || index > 15)
+    //   {
+    //     continue;  // Index is out of the 5-bit signed range
+    //   }
 
-  mvtx_event_header->set_strobe_BCO(strobe);
-  if (m_writeMvtxEventHeader)
-  {
-    for (auto &iter : l1BCOs)
+    if (Verbosity() >= 10)
     {
-      mvtx_event_header->set_strobe_BCO_L1_BCO(strobe, iter);
+      mvtx_rawhit->identify();
     }
-    if (Verbosity() >= 2)
+
+    if (index >= 0)
     {
-      mvtx_event_header->identify();
+      const TrkrDefs::hitsetkey hitsetkey =
+          MvtxDefs::genHitSetKey(layer, stave, chip, index);
+      if (!hitsetkey)
+      {
+        continue;
+      }
+
+      mvtx_hit_set_helper->addHitSetKey(index, hitsetkey);
+
+      // get matching hitset
+      const auto hitset_it = hit_set_container->findOrAddHitSet(hitsetkey);
+
+      // generate hit key
+      const TrkrDefs::hitkey hitkey = MvtxDefs::genHitKey(col, row);
+
+      // find existing hit, or create
+      auto hit = hitset_it->second->getHit(hitkey);
+      if (hit)
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << PHWHERE << "::" << __func__
+                    << " - duplicated hit, hitsetkey: " << hitsetkey
+                    << " hitkey: " << hitkey << std::endl;
+        }
+        continue;
+      }
+
+      if (m_doOfflineMasking)
+      {
+        if (!m_hot_pixel_mask->is_masked(mvtx_rawhit))
+        {  // Check if the pixel is masked
+          hit = new TrkrHitv2;
+          hitset_it->second->addHitSpecificKey(hitkey, hit);
+        }
+      }
+      else
+      {
+        hit = new TrkrHitv2;
+        hitset_it->second->addHitSpecificKey(hitkey, hit);
+      }
     }
   }
 

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -24,49 +24,53 @@ class MvtxRawHitContainer;
 class MvtxRawHit;
 class PHCompositeNode;
 class TrkrHitSetContainer;
+class TrkrHitSetContMvtxHelper;
 
 /// mvtx raw data decoder
 class MvtxCombinedRawDataDecoder : public SubsysReco
 {
  public:
   /// constructor
-  MvtxCombinedRawDataDecoder(const std::string& name = "MvtxCombinedRawDataDecoder");
+  explicit MvtxCombinedRawDataDecoder(const std::string& name = "MvtxCombinedRawDataDecoder");
 
   /// global initialization
-  int Init(PHCompositeNode*) override;
+  int Init(PHCompositeNode* /*dummy*/) override;
 
   /// run initialization
-  int InitRun(PHCompositeNode*) override;
+  int InitRun(PHCompositeNode* /*dummy*/) override;
 
   /// event processing
-  int process_event(PHCompositeNode*) override;
+  int process_event(PHCompositeNode* /*dummy*/) override;
 
   /// end of processing
-  int End(PHCompositeNode*) override;
+  int End(PHCompositeNode* /*dummy*/) override;
 
   void useRawHitNodeName(const std::string& name) { m_MvtxRawHitNodeName = name; }
 
   void useRawEvtHeaderNodeName(const std::string& name) { m_MvtxRawEvtHeaderNodeName = name; }
 
-  void writeMvtxEventHeader(bool write) { m_writeMvtxEventHeader = write; }
-
   void doOfflineMasking(bool do_masking) { m_doOfflineMasking = do_masking; }
 
   void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
 
-  void  SetReadStrWidthFromDB(const bool val){ m_readStrWidthFromDB = val; }
-  bool  GetReadStrWidthFromDB(){ return m_readStrWidthFromDB; }
-  void  SetStrobeWidth(const float val) { m_strobeWidth = val; }
+  void SetReadStrWidthFromDB(const bool val) { m_readStrWidthFromDB = val; }
+  bool GetReadStrWidthFromDB() { return m_readStrWidthFromDB; }
+  void SetStrobeWidth(const float val) { m_strobeWidth = val; }
   float GetStrobeWidth() { return m_strobeWidth; }
 
  private:
   void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
+  void CreateNodes(PHCompositeNode*);
+  void GetNodes(PHCompositeNode*);
+
+  uint64_t gl1rawhitbco = 0;
 
   TrkrHitSetContainer* hit_set_container = nullptr;
+  TrkrHitSetContMvtxHelper* mvtx_hit_set_helper = nullptr;
   MvtxEventInfo* mvtx_event_header = nullptr;
   MvtxRawEvtHeader* mvtx_raw_event_header = nullptr;
-  MvtxRawHitContainer* mvtx_hit_container = nullptr;
-  MvtxRawHit* mvtx_hit = nullptr;
+  MvtxRawHitContainer* mvtx_raw_hit_container = nullptr;
+  MvtxRawHit* mvtx_rawhit = nullptr;
 
   std::string m_MvtxRawHitNodeName = "MVTXRAWHIT";
   std::string m_MvtxRawEvtHeaderNodeName = "MVTXRAWEVTHEADER";
@@ -74,12 +78,9 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   bool m_readStrWidthFromDB = true;
   float m_strobeWidth = 89.;  //! microseconds
 
-  bool m_writeMvtxEventHeader = true;
-  // std::vector<std::pair<TrkrDefs::hitsetkey, TrkrDefs::hitkey>> m_hotPixelMap;
-
   // mask hot pixels
   bool m_doOfflineMasking{false};
-  MvtxPixelMask * m_hot_pixel_mask{nullptr};
+  MvtxPixelMask* m_hot_pixel_mask{nullptr};
 
   bool m_mvtx_is_triggered{false};
 };

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.h
@@ -54,12 +54,12 @@ class MvtxCombinedRawDataDecoder : public SubsysReco
   void runMvtxTriggered(bool b = true) { m_mvtx_is_triggered = b; }
 
   void SetReadStrWidthFromDB(const bool val) { m_readStrWidthFromDB = val; }
-  bool GetReadStrWidthFromDB() { return m_readStrWidthFromDB; }
+  bool GetReadStrWidthFromDB() const { return m_readStrWidthFromDB; }
   void SetStrobeWidth(const float val) { m_strobeWidth = val; }
-  float GetStrobeWidth() { return m_strobeWidth; }
+  float GetStrobeWidth() const { return m_strobeWidth; }
 
  private:
-  void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
+  // static void removeDuplicates(std::vector<std::pair<uint64_t, uint32_t>>& v);
   void CreateNodes(PHCompositeNode*);
   void GetNodes(PHCompositeNode*);
 

--- a/offline/packages/trackbase/Makefile.am
+++ b/offline/packages/trackbase/Makefile.am
@@ -72,6 +72,7 @@ pkginclude_HEADERS = \
   MvtxEventInfo.h \
   MvtxEventInfov1.h \
   MvtxEventInfov2.h \
+  MvtxEventInfov3.h \
   RawHit.h \
   RawHitSet.h \
   RawHitSetContainer.h \
@@ -112,6 +113,8 @@ pkginclude_HEADERS = \
   TrkrDefs.h \
   TrkrHit.h \
   TrkrHitSet.h \
+  TrkrHitSetContMvtxHelper.h \
+  TrkrHitSetContMvtxHelperv1.h \
   TrkrHitSetContainer.h \
   TrkrHitSetContainerv1.h \
   TrkrHitSetContainerv2.h \
@@ -145,6 +148,7 @@ ROOTDICTS = \
   MvtxEventInfo_Dict.cc \
   MvtxEventInfov1_Dict.cc \
   MvtxEventInfov2_Dict.cc \
+  MvtxEventInfov3_Dict.cc \
   RawHitSetContainer_Dict.cc \
   RawHitSetContainerv1_Dict.cc \
   RawHitSet_Dict.cc \
@@ -177,6 +181,8 @@ ROOTDICTS = \
   TrkrClusterv3_Dict.cc \
   TrkrClusterv4_Dict.cc \
   TrkrClusterv5_Dict.cc \
+  TrkrHitSetContMvtxHelper_Dict.cc \
+  TrkrHitSetContMvtxHelperv1_Dict.cc \
   TrkrHitSetContainer_Dict.cc \
   TrkrHitSetContainerv1_Dict.cc \
   TrkrHitSetContainerv2_Dict.cc \
@@ -192,72 +198,7 @@ ROOTDICTS = \
 
 
 pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-  CMFlashClusterContainer_Dict_rdict.pcm \
-  CMFlashClusterContainerv1_Dict_rdict.pcm \
-  CMFlashCluster_Dict_rdict.pcm \
-  CMFlashClusterv1_Dict_rdict.pcm \
-  CMFlashClusterv2_Dict_rdict.pcm \
-  CMFlashClusterv3_Dict_rdict.pcm \
-  CMFlashDifferenceContainer_Dict_rdict.pcm \
-  CMFlashDifferenceContainerv1_Dict_rdict.pcm \
-  CMFlashDifference_Dict_rdict.pcm \
-  CMFlashDifferencev1_Dict_rdict.pcm \
-  ClusHitsVerbose_Dict_rdict.pcm \
-  ClusHitsVerbosev1_Dict_rdict.pcm \
-  InttEventInfo_Dict_rdict.pcm \
-  InttEventInfov1_Dict_rdict.pcm \
-  LaserClusterContainer_Dict_rdict.pcm \
-  LaserClusterContainerv1_Dict_rdict.pcm \
-  LaserCluster_Dict_rdict.pcm \
-  LaserClusterv1_Dict_rdict.pcm \
-  MvtxEventInfo_Dict_rdict.pcm \
-  MvtxEventInfov1_Dict_rdict.pcm \
-  MvtxEventInfov2_Dict_rdict.pcm \
-  RawHitSetContainer_Dict_rdict.pcm \
-  RawHitSetContainerv1_Dict_rdict.pcm \
-  RawHitSet_Dict_rdict.pcm \
-  RawHitSetv1_Dict_rdict.pcm \
-  RawHitTpc_Dict_rdict.pcm \
-  RawHit_Dict_rdict.pcm \
-  RawHitv1_Dict_rdict.pcm \
-  TpcSeedTrackMap_Dict_rdict.pcm \
-  TpcSeedTrackMapv1_Dict_rdict.pcm \
-  TpcTpotEventInfo_Dict_rdict.pcm \
-  TpcTpotEventInfov1_Dict_rdict.pcm \
-  TrackVertexCrossingAssoc_Dict_rdict.pcm \
-  TrackVertexCrossingAssoc_v1_Dict_rdict.pcm \
-  TrkrClusterContainer_Dict_rdict.pcm \
-  TrkrClusterContainerv1_Dict_rdict.pcm \
-  TrkrClusterContainerv2_Dict_rdict.pcm \
-  TrkrClusterContainerv3_Dict_rdict.pcm \
-  TrkrClusterContainerv4_Dict_rdict.pcm \
-  TrkrClusterCrossingAssoc_Dict_rdict.pcm \
-  TrkrClusterCrossingAssocv1_Dict_rdict.pcm \
-  TrkrClusterHitAssoc_Dict_rdict.pcm \
-  TrkrClusterHitAssocv1_Dict_rdict.pcm \
-  TrkrClusterHitAssocv2_Dict_rdict.pcm \
-  TrkrClusterHitAssocv3_Dict_rdict.pcm \
-  TrkrClusterIterationMap_Dict_rdict.pcm \
-  TrkrClusterIterationMapv1_Dict_rdict.pcm \
-  TrkrCluster_Dict_rdict.pcm \
-  TrkrClusterv1_Dict_rdict.pcm \
-  TrkrClusterv2_Dict_rdict.pcm \
-  TrkrClusterv3_Dict_rdict.pcm \
-  TrkrClusterv4_Dict_rdict.pcm \
-  TrkrClusterv5_Dict_rdict.pcm \
-  TrkrHitSetContainer_Dict_rdict.pcm \
-  TrkrHitSetContainerv1_Dict_rdict.pcm \
-  TrkrHitSetContainerv2_Dict_rdict.pcm \
-  TrkrHitSet_Dict_rdict.pcm \
-  TrkrHitSetv1_Dict_rdict.pcm \
-  TrkrHitSetTpc_Dict_rdict.pcm \
-  TrkrHitSetTpcv1_Dict_rdict.pcm \
-  TrkrHitTruthAssoc_Dict_rdict.pcm \
-  TrkrHitTruthAssocv1_Dict_rdict.pcm \
-  TrkrHit_Dict_rdict.pcm \
-  TrkrHitv1_Dict_rdict.pcm \
-  TrkrHitv2_Dict_rdict.pcm
+nobase_dist_pcm_DATA = $(ROOTDICTS:.cc=_rdict.pcm)
 
 # sources for io library
 libtrack_la_SOURCES = \
@@ -292,6 +233,7 @@ libtrack_io_la_SOURCES = \
   MvtxEventInfo.cc \
   MvtxEventInfov1.cc \
   MvtxEventInfov2.cc \
+  MvtxEventInfov3.cc \
   RawHitSet.cc \
   RawHitSetContainer.cc \
   RawHitSetContainerv1.cc \
@@ -324,6 +266,8 @@ libtrack_io_la_SOURCES = \
   TrkrClusterv5.cc \
   TrkrDefs.cc \
   TrkrHitSet.cc \
+  TrkrHitSetContMvtxHelper.cc \
+  TrkrHitSetContMvtxHelperv1.cc \
   TrkrHitSetContainer.cc \
   TrkrHitSetContainerv1.cc \
   TrkrHitSetContainerv2.cc \

--- a/offline/packages/trackbase/MvtxEventInfo.h
+++ b/offline/packages/trackbase/MvtxEventInfo.h
@@ -22,10 +22,11 @@
 class MvtxEventInfo : public PHObject
 {
  public:
+  //! ctor
   MvtxEventInfo() = default;
 
-  /// dtor
-  virtual ~MvtxEventInfo() = default;
+  //! dtor
+  ~MvtxEventInfo() override = default;
 
   PHObject *CloneMe() const override;
 
@@ -58,12 +59,12 @@ class MvtxEventInfo : public PHObject
   void set_stringval(const std::string & /*name*/, const std::string & /*ival*/);
   std::string get_stringval(const std::string & /*name*/) const;
 
-  virtual void set_number_HB(const int /*ival*/){};
+  virtual void set_number_HB(const int /*ival*/) {};
   virtual int get_number_HB() const { return 0; };
 
-  virtual void set_strobe_BCO(const uint64_t /*strobe_BCO*/){};
+  virtual void set_strobe_BCO(const uint64_t /*strobe_BCO*/) {};
 
-  virtual void set_strobe_BCO_L1_BCO(const uint64_t /*strobe_BCO*/, const uint64_t /*L1_BCO*/){};
+  virtual void set_strobe_BCO_L1_BCO(const uint64_t /*strobe_BCO*/, const uint64_t /*L1_BCO*/) {};
 
   virtual unsigned int get_number_strobes() const { return 0; };
   virtual unsigned int get_number_L1s() const { return 0; };
@@ -71,8 +72,11 @@ class MvtxEventInfo : public PHObject
   virtual std::set<uint64_t> get_strobe_BCOs() const { return dummySet; };
   virtual std::set<uint64_t> get_L1_BCOs() const { return dummySet; };
 
-  virtual std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t /*ival*/) const { return dummySet; };
+  virtual std::set<uint64_t> get_strobe_BCO_from_L1_BCO(const uint64_t /*ival*/) const { return dummySet; }
   virtual std::set<uint64_t> get_L1_BCO_from_strobe_BCO(const uint64_t /*ival*/) const { return dummySet; };
+
+  virtual void add_strobe_BCO(const uint64_t & /*strb_val*/) {};
+  virtual void add_L1_BCO(const uint64_t & /*strb_val*/) {};
 
  protected:
   std::map<std::string, int32_t> m_IntEventProperties;

--- a/offline/packages/trackbase/MvtxEventInfov3.cc
+++ b/offline/packages/trackbase/MvtxEventInfov3.cc
@@ -1,0 +1,87 @@
+#include "MvtxEventInfov3.h"
+
+#include <phool/phool.h>
+
+PHObject* MvtxEventInfov3::CloneMe() const
+{
+  std::cout << PHWHERE << "::" << __func__ << " is not implemented in daughter class" << std::endl;
+  return nullptr;
+}
+
+void MvtxEventInfov3::Reset()
+{
+  m_strobe_BCOs.clear();
+  m_L1_BCOs.clear();
+  m_Int64EventProperties.clear();
+  m_IntEventProperties.clear();
+  m_Int64EventProperties.clear();
+  m_UintEventProperties.clear();
+  m_Uint64EventProperties.clear();
+  m_FloatEventProperties.clear();
+
+  return;
+}
+
+void MvtxEventInfov3::identify(std::ostream& out) const
+{
+  out << "MvtxEventInfov1 information" << std::endl;
+
+  for (const auto& m_StringEventPropertie : m_StringEventProperties)
+  {
+    out << m_StringEventPropertie.first << ": " << m_StringEventPropertie.second << std::endl;
+  }
+
+  if (get_number_strobes() > 0)
+  {
+    out << "List of strobe BCOs in this event" << std::endl;
+
+    for (unsigned long iterStrobe : m_strobe_BCOs)
+    {
+      out << "Strobe BCO: " << iterStrobe << std::endl;
+      out << std::endl;
+    }
+  }
+
+  if (get_number_L1s() > 0)
+  {
+    out << "List of L1 BCOs in this event" << std::endl;
+
+    for (unsigned long iterStrobe : m_L1_BCOs)
+    {
+      out << "L1 BCO: " << iterStrobe << std::endl;
+      out << std::endl;
+    }
+  }
+
+  for (const auto& m_IntEventPropertie : m_IntEventProperties)
+  {
+    out << m_IntEventPropertie.first << ": " << m_IntEventPropertie.second << std::endl;
+  }
+
+  for (const auto& m_Int64EventPropertie : m_Int64EventProperties)
+  {
+    out << m_Int64EventPropertie.first << ": " << m_Int64EventPropertie.second << std::endl;
+  }
+
+  for (const auto& m_UintEventPropertie : m_UintEventProperties)
+  {
+    out << m_UintEventPropertie.first << ": " << m_UintEventPropertie.second << std::endl;
+  }
+
+  for (const auto& m_Uint64EventPropertie : m_Uint64EventProperties)
+  {
+    out << m_Uint64EventPropertie.first << ": " << m_Uint64EventPropertie.second << std::endl;
+  }
+
+  for (const auto& m_FloatEventPropertie : m_FloatEventProperties)
+  {
+    out << m_FloatEventPropertie.first << ": " << m_FloatEventPropertie.second << std::endl;
+  }
+  return;
+}
+
+int MvtxEventInfov3::isValid() const
+{
+  std::cout << PHWHERE << " isValid not implemented by daughter class" << std::endl;
+  return 0;
+}

--- a/offline/packages/trackbase/MvtxEventInfov3.h
+++ b/offline/packages/trackbase/MvtxEventInfov3.h
@@ -1,0 +1,69 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef MVTXEVENTINFOV1_H
+#define MVTXEVENTINFOV1_H
+
+/***************************/
+/* MVTX event header class */
+/*       Cameron Dean      */
+/*   MIT (ctdean@mit.edu)  */
+/*          29/09/2023     */
+/***************************/
+
+#include <iostream>
+
+#include <set>
+
+#include "MvtxEventInfo.h"
+
+///
+class MvtxEventInfov3 : public MvtxEventInfo
+{
+ public:
+  //! ctor
+  MvtxEventInfov3() = default;
+
+  //! cp/mv ctor
+  MvtxEventInfov3(const MvtxEventInfov3 &) = default;
+  MvtxEventInfov3(MvtxEventInfov3 &&) = default;
+
+  //! cp/mv asignment
+  MvtxEventInfov3 &operator=(const MvtxEventInfov3 &) = default;
+  MvtxEventInfov3 &operator=(MvtxEventInfov3 &&) = default;
+
+  //! dtor
+  ~MvtxEventInfov3() override = default;
+
+  PHObject *CloneMe() const override;
+
+  /// Clear Event
+  void Reset() override;
+
+  /** identify Function from PHObject
+      @param os Output Stream
+   */
+  void identify(std::ostream &os = std::cout) const override;
+
+  /// isValid returns non zero if object contains valid data
+  int isValid() const override;
+
+  unsigned int get_number_strobes() const override { return m_strobe_BCOs.size(); }
+  unsigned int get_number_L1s() const override { return m_L1_BCOs.size(); }
+
+  std::set<uint64_t> get_strobe_BCOs() const override { return m_strobe_BCOs; }
+  std::set<uint64_t> get_L1_BCOs() const override { return m_L1_BCOs; }
+
+  void add_strobe_BCO(const uint64_t &strb_val) override { m_strobe_BCOs.insert(strb_val); }
+  void add_L1_BCO(const uint64_t &strb_val) override { m_L1_BCOs.insert(strb_val); }
+
+ protected:
+ private:
+  void warning(const std::string &func) const;
+
+  std::set<uint64_t> m_strobe_BCOs;
+  std::set<uint64_t> m_L1_BCOs;
+
+  ClassDefOverride(MvtxEventInfov3, 1)
+};
+
+#endif

--- a/offline/packages/trackbase/MvtxEventInfov3LinkDef.h
+++ b/offline/packages/trackbase/MvtxEventInfov3LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class MvtxEventInfov3 + ;
+
+#endif

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelper.cc
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelper.cc
@@ -1,0 +1,19 @@
+/**
+ * @file trackbase/TrkrHitSetContMvtxHelper.cc
+ * @author Yasser Corrales Morales <ycmorales@bnl.gov>
+ * @date Febraury 2025
+ * base class for Mvtx hitsetkey container per strobe
+ */
+
+#include "TrkrHitSetContMvtxHelper.h"
+
+#include <Rtypes.h>
+#include <TSystem.h>
+
+#include <cstdlib>
+
+void TrkrHitSetContMvtxHelper::Reset()
+{
+  std::cout << "TrkrHitSetContMvtxHelper: Reset() not implemented by daughter class" << std::endl;
+  gSystem->Exit(1);
+}

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelper.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelper.h
@@ -1,0 +1,74 @@
+/**
+ * @file trackbase/TrkrHitSetContMvtxHelper.h
+ * @author Yasser Corrales Morales <ycmorales@bnl.gov>
+ * @date Febraury 2025
+ * base class for Mvtx hitsetkey container per strobe
+ */
+
+#ifndef TRACKBASE_TRKRHITSETCONTMVTXHELPER_H
+#define TRACKBASE_TRKRHITSETCONTMVTXHELPER_H
+
+#include "TrkrDefs.h"  // for hitsetkey, TrkrId
+
+#include <phool/PHObject.h>
+
+#include <iostream>  // for cout, ostream
+#include <map>       // for map
+#include <memory>
+#include <set>      // for set
+#include <utility>  // for pair
+
+// class TrkrHitSetKey;
+
+/**
+ * Container for Mvtx hitsekey per strobe
+ */
+class TrkrHitSetContMvtxHelper : public PHObject
+{
+ public:
+  using map_tp_value = std::set<TrkrDefs::hitsetkey>;
+  using Map = std::map<uint32_t, map_tp_value>;
+  using Iterator = Map::iterator;
+  using ConstIterator = Map::const_iterator;
+
+  //! cp/mv ctor
+  TrkrHitSetContMvtxHelper(const TrkrHitSetContMvtxHelper &) = default;
+  TrkrHitSetContMvtxHelper(TrkrHitSetContMvtxHelper &&) = default;
+  //! cp/mv assignment
+  TrkrHitSetContMvtxHelper &operator=(const TrkrHitSetContMvtxHelper &) = default;
+  TrkrHitSetContMvtxHelper &operator=(TrkrHitSetContMvtxHelper &&) = default;
+
+  //! dtor
+  ~TrkrHitSetContMvtxHelper() override = default;
+
+  //! PHObject functions
+  void Reset() override;
+
+  virtual bool addHitSetKey(const uint32_t /*dummy*/, const TrkrDefs::hitsetkey /*dummy*/)
+  {
+    return false;
+  }
+
+  //! preferred removal method, key is currently the hit id
+  virtual bool removeHitSetKey(const uint32_t /*strobe*/, const TrkrDefs::hitsetkey /*dummy*/)
+  {
+    return false;
+  }
+
+  //! return all HitSetKeys
+  virtual const map_tp_value &getHitSetKeys(const uint32_t /*strobe*/) = 0;
+
+  virtual unsigned int size() const
+  {
+    return 0;
+  }
+
+ protected:
+  //! ctor
+  TrkrHitSetContMvtxHelper() = default;
+
+ private:
+  ClassDefOverride(TrkrHitSetContMvtxHelper, 1)
+};
+
+#endif  // TRACKBASE_TRKRHITSETCONTAINER_H

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelper.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelper.h
@@ -27,7 +27,7 @@ class TrkrHitSetContMvtxHelper : public PHObject
 {
  public:
   using map_tp_value = std::set<TrkrDefs::hitsetkey>;
-  using Map = std::map<uint32_t, map_tp_value>;
+  using Map = std::map<int32_t, map_tp_value>;
   using Iterator = Map::iterator;
   using ConstIterator = Map::const_iterator;
 
@@ -44,19 +44,19 @@ class TrkrHitSetContMvtxHelper : public PHObject
   //! PHObject functions
   void Reset() override;
 
-  virtual bool addHitSetKey(const uint32_t /*dummy*/, const TrkrDefs::hitsetkey /*dummy*/)
+  virtual bool addHitSetKey(const int32_t & /*dummy*/, const TrkrDefs::hitsetkey & /*dummy*/)
   {
     return false;
   }
 
   //! preferred removal method, key is currently the hit id
-  virtual bool removeHitSetKey(const uint32_t /*strobe*/, const TrkrDefs::hitsetkey /*dummy*/)
+  virtual bool removeHitSetKey(int32_t /*strobe*/, const TrkrDefs::hitsetkey /*dummy*/)
   {
     return false;
   }
 
   //! return all HitSetKeys
-  virtual const map_tp_value &getHitSetKeys(const uint32_t /*strobe*/) = 0;
+  virtual const map_tp_value &getHitSetKeys(int32_t /*strobe*/) = 0;
 
   virtual unsigned int size() const
   {

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperLinkDef.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrHitSetContMvtxHelper + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.cc
@@ -1,0 +1,30 @@
+/**
+ * @file trackbase/TrkrHitSetContMvtxHelper.cc
+ * @author Yasser Corrales Morales <ycmorales@bnl.gov>
+ * @date Febraury 2025
+ * base class for Mvtx hitsetkey container per strobe
+ */
+
+#include "TrkrHitSetContMvtxHelperv1.h"
+#include "TrkrHitSetContMvtxHelper.h"
+
+void TrkrHitSetContMvtxHelperv1::Reset()
+{
+  for (auto&& [strobe, hitsetkey_set] : m_strb_hitsetkey_map)
+  {
+    hitsetkey_set.clear();
+  }
+  m_strb_hitsetkey_map.clear();
+}
+
+bool TrkrHitSetContMvtxHelperv1::addHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey key)
+{
+  const auto ret = m_strb_hitsetkey_map[strobe].insert(key);
+  return ret.second;
+}
+
+const TrkrHitSetContMvtxHelper::map_tp_value&
+TrkrHitSetContMvtxHelperv1::getHitSetKeys(const uint32_t strobe)
+{
+  return m_strb_hitsetkey_map[strobe];
+}

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.cc
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.cc
@@ -17,14 +17,14 @@ void TrkrHitSetContMvtxHelperv1::Reset()
   m_strb_hitsetkey_map.clear();
 }
 
-bool TrkrHitSetContMvtxHelperv1::addHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey key)
+bool TrkrHitSetContMvtxHelperv1::addHitSetKey(const int32_t& strobe, const TrkrDefs::hitsetkey& key)
 {
   const auto ret = m_strb_hitsetkey_map[strobe].insert(key);
   return ret.second;
 }
 
 const TrkrHitSetContMvtxHelper::map_tp_value&
-TrkrHitSetContMvtxHelperv1::getHitSetKeys(const uint32_t strobe)
+TrkrHitSetContMvtxHelperv1::getHitSetKeys(const int32_t strobe)
 {
   return m_strb_hitsetkey_map[strobe];
 }

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.h
@@ -1,0 +1,63 @@
+/**
+ * @file trackbase/TrkrHitSetContMvtxHelperv1.h
+ * @author Yasser Corrales Morales <ycmorales@bnl.gov>
+ * @date Febraury 2025
+ * base class for Mvtx hitsetkey container per strobe
+ */
+
+#ifndef TRACKBASE_TRKRHITSETCONTMVTXHELPERV1_H
+#define TRACKBASE_TRKRHITSETCONTMVTXHELPERV1_H
+
+#include "TrkrHitSetContMvtxHelper.h"
+
+/**
+ * Container for Mvtx hitsekey per strobe
+ */
+class TrkrHitSetContMvtxHelperv1 : public TrkrHitSetContMvtxHelper
+{
+ public:
+  //! ctor
+  TrkrHitSetContMvtxHelperv1() = default;
+  //! cp/mv ctor
+  TrkrHitSetContMvtxHelperv1(const TrkrHitSetContMvtxHelperv1 &) = default;
+  TrkrHitSetContMvtxHelperv1(TrkrHitSetContMvtxHelperv1 &&) = default;
+  //! cp/mv assignment
+  TrkrHitSetContMvtxHelperv1 &operator=(const TrkrHitSetContMvtxHelperv1 &) = default;
+  TrkrHitSetContMvtxHelperv1 &operator=(TrkrHitSetContMvtxHelperv1 &&) = default;
+
+  //! dtor
+  ~TrkrHitSetContMvtxHelperv1() override = default;
+
+  //! PHObject functions
+  void Reset() override;
+
+  bool addHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey hitsetkey) override;
+
+  //! preferred removal method, key is currently the hit id
+  bool removeHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey hitsetkey) override
+  {
+    size_t ret = m_strb_hitsetkey_map[strobe].erase(hitsetkey);
+    if (!ret)
+    {
+      std::cout << "hitsetkey " << hitsetkey << " was not found in strobe " << strobe << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+  //! return all HitSetKeys
+  const TrkrHitSetContMvtxHelper::map_tp_value &getHitSetKeys(const uint32_t strobe) override;
+
+  unsigned int size() const override
+  {
+    return 0;
+  }
+
+ protected:
+ private:
+  Map m_strb_hitsetkey_map;
+
+  ClassDefOverride(TrkrHitSetContMvtxHelperv1, 1)
+};
+
+#endif  // TRACKBASE_TRKRHITSETCONTAINER_H

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1.h
@@ -31,10 +31,10 @@ class TrkrHitSetContMvtxHelperv1 : public TrkrHitSetContMvtxHelper
   //! PHObject functions
   void Reset() override;
 
-  bool addHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey hitsetkey) override;
+  bool addHitSetKey(const int32_t &strobe, const TrkrDefs::hitsetkey &hitsetkey) override;
 
   //! preferred removal method, key is currently the hit id
-  bool removeHitSetKey(const uint32_t strobe, const TrkrDefs::hitsetkey hitsetkey) override
+  bool removeHitSetKey(const int32_t strobe, const TrkrDefs::hitsetkey hitsetkey) override
   {
     size_t ret = m_strb_hitsetkey_map[strobe].erase(hitsetkey);
     if (!ret)
@@ -46,7 +46,7 @@ class TrkrHitSetContMvtxHelperv1 : public TrkrHitSetContMvtxHelper
   }
 
   //! return all HitSetKeys
-  const TrkrHitSetContMvtxHelper::map_tp_value &getHitSetKeys(const uint32_t strobe) override;
+  const TrkrHitSetContMvtxHelper::map_tp_value &getHitSetKeys(int32_t strobe) override;
 
   unsigned int size() const override
   {

--- a/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1LinkDef.h
+++ b/offline/packages/trackbase/TrkrHitSetContMvtxHelperv1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TrkrHitSetContMvtxHelperv1 + ;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
- **ycm - clean and merge MVTX event header**
- **ycm - add new Mvtx trkr hitset helper to map hitsetkey with strobe id**
- **ycm - add default ctors/assigment**
- **ycm - changes to add new mvtx hit set helper**

[comment]: <> (Please tell us something about this pull request)
 This PR add a map of hitsekey per strobe during the MVTX unpacking, this will allow to
run the clustering process for single strobe and Si seeding for a given range of strobes.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

