### PR TITLE
Resolved KFParticle issue where TPC-only tracks pass nmvtx cut

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -261,10 +261,10 @@ std::vector<KFParticle> KFParticle_Tools::makeAllDaughterParticles(PHCompositeNo
           ++MVTX_hits;
         }
       }
-      if (MVTX_hits < m_nMVTXHits)
-      {
-        continue;
-      }
+    }
+    if (MVTX_hits < m_nMVTXHits)
+    {
+      continue;
     }
     if (tpcseed)
     {
@@ -278,12 +278,13 @@ std::vector<KFParticle> KFParticle_Tools::makeAllDaughterParticles(PHCompositeNo
           ++TPC_hits;
         }
       }
-      if (TPC_hits < m_nTPCHits)
-      {
-        continue;
-      }
     }
-
+    if (TPC_hits < m_nTPCHits)
+    {
+      continue;
+    }
+    
+    std::cout << "adding track " << trackID << " with nMVTX = " << MVTX_hits << ", which should be at least " << m_nMVTXHits << std::endl;
     daughterParticles.push_back(makeParticle(topNode));  /// Turn all dst tracks in KFP tracks
     daughterParticles[trackID].SetId(iter.first);
     ++trackID;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR fixes a bug in KFParticle_Tools where a track missing a silicon seed entirely would never fail the minimum MVTX hits cut, and would be included in the daughter particles list. (It also fixes an analogous issue for silicon-only tracks and the minimum TPC hits cut.)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

