### PR TITLE
update to area rho method

### DIFF
--- a/offline/packages/jetbackground/DetermineEventRho.cc
+++ b/offline/packages/jetbackground/DetermineEventRho.cc
@@ -2,6 +2,7 @@
 
 #include "EventRhov1.h"
 
+#include <fun4all/SubsysReco.h>
 #include <jetbase/JetInput.h>
 #include <jetbase/Jetv2.h>
 
@@ -11,25 +12,32 @@
 #include <phool/PHIODataNode.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
+#include <phool/PHNode.h>                  // for PHNode
 #include <phool/getClass.h>
+#include <phool/phool.h>
 
 // fastjet includes
+#include <fastjet/GhostedAreaSpec.hh>      // for GhostedAreaSpec
 #include <fastjet/AreaDefinition.hh>
 #include <fastjet/ClusterSequence.hh>
+#include <fastjet/ClusterSequenceArea.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/Selector.hh>
-#include <fastjet/tools/JetMedianBackgroundEstimator.hh>
 
 // standard includes
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cmath>
 
 DetermineEventRho::DetermineEventRho(const std::string &name)
   : SubsysReco(name)
 {
   // silence output from fastjet
-  fastjet::ClusterSequence clusseq;
+  fastjet::ClusterSequence const clusseq;
   if (Verbosity() > 0)
   {
     clusseq.print_banner();
@@ -46,7 +54,8 @@ DetermineEventRho::DetermineEventRho(const std::string &name)
 DetermineEventRho::~DetermineEventRho()
 {
   // clean up memory
-  for (auto &input : m_inputs) {
+  for (auto &input : m_inputs)
+  {
     delete input;
   }
   m_inputs.clear();
@@ -56,9 +65,6 @@ DetermineEventRho::~DetermineEventRho()
 
 int DetermineEventRho::InitRun(PHCompositeNode *topNode)
 {
-  // set algo
-
-
   // set jet_eta_range
   if (m_abs_jet_eta_range < 0)
   {
@@ -82,7 +88,7 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
   std::vector<Jet *> particles{};
   for (auto &input : m_inputs)
   {
-    std::vector<Jet *> parts = input->get_input(topNode);
+    std::vector<Jet *> const parts = input->get_input(topNode);
     for (auto &part : parts)
     {
       particles.push_back(part);
@@ -104,7 +110,7 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
 
     if (this_e < 0)
     {  // make energy = +1 MeV for purposes of clustering
-      float e_ratio = 0.001 / this_e;
+      float const e_ratio = 0.001 / this_e;
       this_e = this_e * e_ratio;
       this_px = this_px * e_ratio;
       this_py = this_py * e_ratio;
@@ -155,7 +161,7 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
       std::cout << PHWHERE << " EventRho node " << m_output_nodes.at(ipos) << " not found" << std::endl;
       continue;
     }
-    
+
     if (!m_jet_def)
     {
       std::cerr << PHWHERE << " jet definition not set" << std::endl;
@@ -164,14 +170,79 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
 
     if (rho_method == EventRho::Method::AREA)
     {
-      fastjet::AreaDefinition area_def(fastjet::active_area_explicit_ghosts,
-                                       fastjet::GhostedAreaSpec(m_abs_input_eta_range, 1, m_ghost_area));
+      fastjet::AreaDefinition const area_def(fastjet::active_area_explicit_ghosts,
+                                             fastjet::GhostedAreaSpec(m_abs_input_eta_range, 1, m_ghost_area));
+      auto m_cluseq = new fastjet::ClusterSequenceArea(calo_pseudojets, *m_jet_def, area_def);
+      auto fastjets = jet_selector(m_cluseq->inclusive_jets());
 
-      auto m_area_bge_rho = new fastjet::JetMedianBackgroundEstimator(jet_selector, *m_jet_def, area_def);
-      m_area_bge_rho->set_particles(calo_pseudojets);
-      rho = m_area_bge_rho->rho();
-      sigma = m_area_bge_rho->sigma();
-      delete m_area_bge_rho;
+      std::vector<float> pT_over_X{};
+      float total_X = 0;
+      float njets_used = 0.0;
+      float empty_X = 0;
+      float const njets_total = static_cast<float>(fastjets.size());
+
+      for (auto &fastjet : fastjets)
+      {
+        float const this_X = fastjet.area();
+        if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << PHWHERE << " ::WARNING: Discarding jet with zero area. Zero-area jets may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+          }
+          if (!std::isnan(this_X))
+          {
+            empty_X += this_X;
+          }
+          continue;  // skip this jet
+        }  // end of check on X
+
+        // add back the truth comp pT
+        float px_sum = 0, py_sum = 0;
+        for (auto &comp : fastjet.constituents())
+        {
+          if (comp.is_pure_ghost())
+          {  // skip pure ghosts
+            continue;
+          }
+
+          auto p = particles[comp.user_index()];  // get original particle
+          px_sum += p->get_px();
+          py_sum += p->get_py();
+
+        }  // end of loop over fastjet comps
+
+        // calculate pT and pT/X
+        float const this_pT_over_X = std::sqrt((px_sum * px_sum) + (py_sum * py_sum)) / this_X;
+        pT_over_X.push_back(this_pT_over_X);
+        total_X += this_X;
+        njets_used += 1.0;
+      }  // end of loop over fastjets
+
+      if (empty_X != 0.0)
+      {
+        std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+        total_X += empty_X;
+      }
+
+      float const n_empty_jets = njets_total - njets_used;
+      float mean_X = (1.0 * total_X) / (njets_total);
+      if (mean_X < 0)
+      {
+        std::cerr << PHWHERE << " mean_N < 0 , setting to 0" << std::endl;
+        mean_X = 0;
+      }
+
+      float tmp_med, tmp_std;
+      CalcMedianStd(pT_over_X, n_empty_jets, tmp_med, tmp_std);
+
+      sigma = std::sqrt(mean_X) * tmp_std;
+      rho = tmp_med;
+
+      // clean up
+      fastjets.clear();
+      pT_over_X.clear();
+      delete m_cluseq;
     }
     else if (rho_method == EventRho::Method::MULT)
     {
@@ -182,7 +253,7 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
       std::vector<float> pt_over_nconst{};
       int total_constituents = 0;
 
-      for ( auto &fastjet : fastjets )
+      for (auto &fastjet : fastjets)
       {
         auto comps = fastjet.constituents();
         if (comps.size() > 0)
@@ -196,32 +267,13 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
             total_py += particle->get_py();
             total_constituents++;
           }  // end of loop over constituents
-          float jet_avg_pt = (std::sqrt((total_px * total_px) + (total_py * total_py)) / (1.0 * comps.size()));
+          float const jet_avg_pt = (std::sqrt((total_px * total_px) + (total_py * total_py)) / (1.0 * comps.size()));
           pt_over_nconst.push_back(jet_avg_pt);
 
         }  // end of if comps.size() > 0
-      }    // end of loop over fastjets
+      }  // end of loop over fastjets
 
-      // {
-      //   // auto comps = fastjets[ijet].constituents();
-      //   if (comps.size() > 0)
-      //   {
-      //     float total_px = 0;
-      //     float total_py = 0;
-      //     for (auto &comp : comps)
-      //     {
-      //       auto particle = particles[comp.user_index()];
-      //       total_px += particle->get_px();
-      //       total_py += particle->get_py();
-      //       total_constituents++;
-      //     }  // end of loop over constituents
-      //     float jet_avg_pt = (std::sqrt((total_px * total_px) + (total_py * total_py)) / (1.0 * comps.size()));
-      //     pt_over_nconst.push_back(jet_avg_pt);
-
-      //   }  // end of if comps.size() > 0
-      // }    // end of loop over fastjets
-
-      float n_empty_jets = 1.0 * (fastjets.size() - pt_over_nconst.size());
+      float const n_empty_jets = 1.0 * (fastjets.size() - pt_over_nconst.size());
       float mean_N = (1.0 * total_constituents) / (1.0 * fastjets.size());
       if (mean_N < 0)
       {
@@ -260,7 +312,8 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
 
   delete m_jet_def;
   // clean up input vectors
-  for (auto &part : particles) {
+  for (auto &part : particles)
+  {
     delete part;
   }
   particles.clear();
@@ -272,7 +325,7 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
 void DetermineEventRho::add_method(EventRho::Method rho_method, std::string output_node)
 {
   // get method name ( also checks if method is valid )
-  std::string method_name = EventRhov1::get_method_string(rho_method);
+  std::string const method_name = EventRhov1::get_method_string(rho_method);
 
   // check if method already exists
   if (std::find(m_rho_methods.begin(), m_rho_methods.end(), rho_method) != m_rho_methods.end())
@@ -320,7 +373,7 @@ int DetermineEventRho::CreateNodes(PHCompositeNode *topNode)
         auto rhoDataNode = new PHIODataNode<PHObject>(eventrho, output, "PHObject");
         bkgNode->addNode(rhoDataNode);
       }  // end of if eventrho
-    }    // end of loop over output nodes
+    }  // end of loop over output nodes
 
   }  // end of if dstNode
 
@@ -332,8 +385,8 @@ float DetermineEventRho::CalcPercentile(const std::vector<float> &sorted_vec, co
   float result = 0;
   if (sorted_vec.size() > 0)
   {
-    int njets = sorted_vec.size();
-    float total_njets = njets + nempty;
+    int const njets = sorted_vec.size();
+    float const total_njets = njets + nempty;
     float perc_pos = (total_njets) *percentile - nempty - 0.5;
 
     if (perc_pos >= 0 && njets > 1)
@@ -370,14 +423,14 @@ void DetermineEventRho::CalcMedianStd(const std::vector<float> &vec, float n_emp
     std::vector<float> sorted_vec = vec;
     std::sort(sorted_vec.begin(), sorted_vec.end());
 
-    int njets = sorted_vec.size();
+    int const njets = sorted_vec.size();
     if (n_empty_jets > njets / 4.0)
     {
       std::cout << "WARNING: n_empty_jets = " << n_empty_jets << " is too large, setting to " << njets / 4.0 << std::endl;
       n_empty_jets = njets / 4.0;
     }
 
-    float posn[2] = {0.5, (1.0 - 0.6827) / 2.0};
+    float const posn[2] = {0.5, (1.0 - 0.6827) / 2.0};
     float res[2] = {0, 0};
     for (int i = 0; i < 2; i++)
     {
@@ -419,7 +472,7 @@ void DetermineEventRho::print_settings(std::ostream &os)
   }
 
   os << "Outputs: ";
-  for (const auto& output : m_output_nodes)
+  for (const auto &output : m_output_nodes)
   {
     os << output << ", ";
   }

--- a/offline/packages/jetbackground/DetermineEventRho.cc
+++ b/offline/packages/jetbackground/DetermineEventRho.cc
@@ -184,9 +184,10 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
       for (auto &fastjet : fastjets)
       {
         float const this_X = fastjet.area();
-        if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        // if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        if (this_X <= 0 || this_X != this_X )
         {
-          if (Verbosity() > 0)
+          if (Verbosity() > 2)
           {
             std::cout << PHWHERE << " ::WARNING: Discarding jet with zero area. Zero-area jets may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
           }
@@ -221,10 +222,12 @@ int DetermineEventRho::process_event(PHCompositeNode *topNode)
 
       if (empty_X != 0.0)
       {
-        std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
-        total_X += empty_X;
+        if ( Verbosity() > 0 ){
+          std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+        }
+          total_X += empty_X;
       }
-
+      
       float const n_empty_jets = njets_total - njets_used;
       float mean_X = (1.0 * total_X) / (njets_total);
       if (mean_X < 0)

--- a/offline/packages/jetbackground/DetermineTowerRho.cc
+++ b/offline/packages/jetbackground/DetermineTowerRho.cc
@@ -2,6 +2,7 @@
 
 #include "TowerRhov1.h"
 
+#include <fun4all/SubsysReco.h>
 #include <jetbase/JetInput.h>
 #include <jetbase/Jetv2.h>
 
@@ -12,24 +13,31 @@
 #include <phool/PHNodeIterator.h>
 #include <phool/PHObject.h>
 #include <phool/getClass.h>
+#include <phool/PHNode.h>                  // for PHNode
+#include <phool/phool.h>
 
 // fastjet includes
+#include <fastjet/GhostedAreaSpec.hh>      // for GhostedAreaSpec
 #include <fastjet/AreaDefinition.hh>
 #include <fastjet/ClusterSequence.hh>
+#include <fastjet/ClusterSequenceArea.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/Selector.hh>
-#include <fastjet/tools/JetMedianBackgroundEstimator.hh>
 
 // standard includes
 #include <algorithm>
 #include <cstdlib>
+#include <string>
+#include <iostream>
+#include <vector>
+#include <cmath>
 
 DetermineTowerRho::DetermineTowerRho(const std::string &name)
   : SubsysReco(name)
 {
   // silence output from fastjet
-  fastjet::ClusterSequence clusseq;
+  fastjet::ClusterSequence const clusseq;
   if (Verbosity() > 0)
   {
     clusseq.print_banner();
@@ -46,7 +54,8 @@ DetermineTowerRho::DetermineTowerRho(const std::string &name)
 DetermineTowerRho::~DetermineTowerRho()
 {
   // clean up memory
-  for (auto &input : m_inputs) {
+  for (auto &input : m_inputs)
+  {
     delete input;
   }
   m_inputs.clear();
@@ -57,7 +66,6 @@ DetermineTowerRho::~DetermineTowerRho()
 int DetermineTowerRho::InitRun(PHCompositeNode *topNode)
 {
   // set algo
-
 
   // set jet_eta_range
   if (m_abs_jet_eta_range < 0)
@@ -82,7 +90,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
   std::vector<Jet *> particles{};
   for (auto &input : m_inputs)
   {
-    std::vector<Jet *> parts = input->get_input(topNode);
+    std::vector<Jet *> const parts = input->get_input(topNode);
     for (auto &part : parts)
     {
       particles.push_back(part);
@@ -104,7 +112,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
 
     if (this_e < 0)
     {  // make energy = +1 MeV for purposes of clustering
-      float e_ratio = 0.001 / this_e;
+      float const e_ratio = 0.001 / this_e;
       this_e = this_e * e_ratio;
       this_px = this_px * e_ratio;
       this_py = this_py * e_ratio;
@@ -155,7 +163,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
       std::cout << PHWHERE << " TowerRho node " << m_output_nodes.at(ipos) << " not found" << std::endl;
       continue;
     }
-    
+
     if (!m_jet_def)
     {
       std::cerr << PHWHERE << " jet definition not set" << std::endl;
@@ -164,14 +172,79 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
 
     if (rho_method == TowerRho::Method::AREA)
     {
-      fastjet::AreaDefinition area_def(fastjet::active_area_explicit_ghosts,
+      fastjet::AreaDefinition const area_def(fastjet::active_area_explicit_ghosts,
                                        fastjet::GhostedAreaSpec(m_abs_input_eta_range, 1, m_ghost_area));
+      auto m_cluseq = new fastjet::ClusterSequenceArea(calo_pseudojets, *m_jet_def, area_def);
+      auto fastjets = jet_selector(m_cluseq->inclusive_jets());
 
-      auto m_area_bge_rho = new fastjet::JetMedianBackgroundEstimator(jet_selector, *m_jet_def, area_def);
-      m_area_bge_rho->set_particles(calo_pseudojets);
-      rho = m_area_bge_rho->rho();
-      sigma = m_area_bge_rho->sigma();
-      delete m_area_bge_rho;
+      std::vector<float> pT_over_X{};
+      float total_X = 0;
+      float njets_used = 0.0;
+      float empty_X = 0;
+      float const njets_total = static_cast<float>(fastjets.size());
+
+      for (auto &fastjet : fastjets)
+      {
+        float const this_X = fastjet.area();
+        if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        {
+          if (Verbosity() > 0)
+          {
+            std::cout << PHWHERE << " ::WARNING: Discarding jet with zero area. Zero-area jets may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+          }
+          if (!std::isnan(this_X))
+          {
+            empty_X += this_X;
+          }
+          continue;  // skip this jet
+        }  // end of check on X
+
+        // add back the truth comp pT
+        float px_sum = 0, py_sum = 0;
+        for (auto &comp : fastjet.constituents())
+        {
+          if (comp.is_pure_ghost())
+          {  // skip pure ghosts
+            continue;
+          }
+
+          auto p = particles[comp.user_index()];  // get original particle
+          px_sum += p->get_px();
+          py_sum += p->get_py();
+
+        }  // end of loop over fastjet comps
+
+        // calculate pT and pT/X
+        float const this_pT_over_X = std::sqrt((px_sum * px_sum) + (py_sum * py_sum)) / this_X;
+        pT_over_X.push_back(this_pT_over_X);
+        total_X += this_X;
+        njets_used += 1.0;
+      }  // end of loop over fastjets
+
+      if (empty_X != 0.0)
+      {
+        std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+        total_X += empty_X;
+      }
+
+      float const n_empty_jets = njets_total - njets_used;
+      float mean_X = (1.0 * total_X) / (njets_total);
+      if (mean_X < 0)
+      {
+        std::cerr << PHWHERE << " mean_N < 0 , setting to 0" << std::endl;
+        mean_X = 0;
+      }
+
+      float tmp_med, tmp_std;
+      CalcMedianStd(pT_over_X, n_empty_jets, tmp_med, tmp_std);
+
+      sigma = std::sqrt(mean_X) * tmp_std;
+      rho = tmp_med;
+
+      // clean up
+      fastjets.clear();
+      pT_over_X.clear();
+      delete m_cluseq;
     }
     else if (rho_method == TowerRho::Method::MULT)
     {
@@ -182,7 +255,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
       std::vector<float> pt_over_nconst{};
       int total_constituents = 0;
 
-      for ( auto &fastjet : fastjets )
+      for (auto &fastjet : fastjets)
       {
         auto comps = fastjet.constituents();
         if (comps.size() > 0)
@@ -196,11 +269,11 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
             total_py += particle->get_py();
             total_constituents++;
           }  // end of loop over constituents
-          float jet_avg_pt = (std::sqrt((total_px * total_px) + (total_py * total_py)) / (1.0 * comps.size()));
+          float const jet_avg_pt = (std::sqrt((total_px * total_px) + (total_py * total_py)) / (1.0 * comps.size()));
           pt_over_nconst.push_back(jet_avg_pt);
 
         }  // end of if comps.size() > 0
-      }    // end of loop over fastjets
+      }  // end of loop over fastjets
 
       // {
       //   // auto comps = fastjets[ijet].constituents();
@@ -221,7 +294,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
       //   }  // end of if comps.size() > 0
       // }    // end of loop over fastjets
 
-      float n_empty_jets = 1.0 * (fastjets.size() - pt_over_nconst.size());
+      float const n_empty_jets = 1.0 * (fastjets.size() - pt_over_nconst.size());
       float mean_N = (1.0 * total_constituents) / (1.0 * fastjets.size());
       if (mean_N < 0)
       {
@@ -260,7 +333,8 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
 
   delete m_jet_def;
   // clean up input vectors
-  for (auto &part : particles) {
+  for (auto &part : particles)
+  {
     delete part;
   }
   particles.clear();
@@ -272,7 +346,7 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
 void DetermineTowerRho::add_method(TowerRho::Method rho_method, std::string output_node)
 {
   // get method name ( also checks if method is valid )
-  std::string method_name = TowerRhov1::get_method_string(rho_method);
+  std::string const method_name = TowerRhov1::get_method_string(rho_method);
 
   // check if method already exists
   if (std::find(m_rho_methods.begin(), m_rho_methods.end(), rho_method) != m_rho_methods.end())
@@ -320,7 +394,7 @@ int DetermineTowerRho::CreateNodes(PHCompositeNode *topNode)
         auto rhoDataNode = new PHIODataNode<PHObject>(rho, output, "PHObject");
         bkgNode->addNode(rhoDataNode);
       }  // end of if TowerRho
-    }    // end of loop over output nodes
+    }  // end of loop over output nodes
 
   }  // end of if dstNode
 
@@ -332,8 +406,8 @@ float DetermineTowerRho::CalcPercentile(const std::vector<float> &sorted_vec, co
   float result = 0;
   if (sorted_vec.size() > 0)
   {
-    int njets = sorted_vec.size();
-    float total_njets = njets + nempty;
+    int const njets = sorted_vec.size();
+    float const total_njets = njets + nempty;
     float perc_pos = (total_njets) *percentile - nempty - 0.5;
 
     if (perc_pos >= 0 && njets > 1)
@@ -370,14 +444,14 @@ void DetermineTowerRho::CalcMedianStd(const std::vector<float> &vec, float n_emp
     std::vector<float> sorted_vec = vec;
     std::sort(sorted_vec.begin(), sorted_vec.end());
 
-    int njets = sorted_vec.size();
+    int const njets = sorted_vec.size();
     if (n_empty_jets > njets / 4.0)
     {
       std::cout << "WARNING: n_empty_jets = " << n_empty_jets << " is too large, setting to " << njets / 4.0 << std::endl;
       n_empty_jets = njets / 4.0;
     }
 
-    float posn[2] = {0.5, (1.0 - 0.6827) / 2.0};
+    float const posn[2] = {0.5, (1.0 - 0.6827) / 2.0};
     float res[2] = {0, 0};
     for (int i = 0; i < 2; i++)
     {
@@ -419,7 +493,7 @@ void DetermineTowerRho::print_settings(std::ostream &os)
   }
 
   os << "Outputs: ";
-  for (const auto& output : m_output_nodes)
+  for (const auto &output : m_output_nodes)
   {
     os << output << ", ";
   }

--- a/offline/packages/jetbackground/DetermineTowerRho.cc
+++ b/offline/packages/jetbackground/DetermineTowerRho.cc
@@ -186,9 +186,10 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
       for (auto &fastjet : fastjets)
       {
         float const this_X = fastjet.area();
-        if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        // if (this_X <= 0 || this_X != this_X || fastjet.is_pure_ghost())
+        if (this_X <= 0 || this_X != this_X )
         {
-          if (Verbosity() > 0)
+          if (Verbosity() > 2)
           {
             std::cout << PHWHERE << " ::WARNING: Discarding jet with zero area. Zero-area jets may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
           }
@@ -223,8 +224,10 @@ int DetermineTowerRho::process_event(PHCompositeNode *topNode)
 
       if (empty_X != 0.0)
       {
-        std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
-        total_X += empty_X;
+        if ( Verbosity() > 0 ){
+          std::cerr << PHWHERE << " ::WARNING: Found " << empty_X << " empty jets with zero area. This may be due to (i) too large a ghost area (ii) a jet being outside the ghost range (iii) the computation not being done using an appropriate algorithm (kt;C/A)." << std::endl;
+        }
+          total_X += empty_X;
       }
 
       float const n_empty_jets = njets_total - njets_used;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Removed fasjet::JetMedianBackgroundEstimator and replaced with a custom function to calculate area rho. Similar to multiplicity-based rho. Handles negative E towers correctly now
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

Fixed the way DetermineTowerRho/DetermineEventRho calculates area-based rho:
https://indico.bnl.gov/event/26524/#sc-87-6-ppg-04-ue-in-auau

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

