### PR TITLE
feat: Option to seed by strobe

### DIFF
--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -411,7 +411,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
 
       //! try to get a crossing value based on INTT
       trackSeed->set_crossing(getCrossingIntt(*trackSeed));
-     
+
       m_seedContainer->insert(trackSeed.get());
 
       fitTimer->stop();
@@ -423,7 +423,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       }
     }
     strobe++;
-    if(strobe > m_highStrobeIndex)
+    if (strobe > m_highStrobeIndex)
     {
       std::cout << PHWHERE << "Error: some how grid seed vector is not the same as the number of strobes" << std::endl;
     }
@@ -824,7 +824,7 @@ SpacePointPtr PHActsSiliconSeeding::makeSpacePoint(
 }
 
 std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts::Extent& rRangeSPExtent,
-  const int strobe)
+                                                                           const int strobe)
 {
   std::vector<const SpacePoint*> spVec;
   unsigned int numSiliconHits = 0;
@@ -838,13 +838,13 @@ std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts:
   {
     for (const auto& hitsetkey : m_clusterMap->getHitSetKeys(det))
     {
-      if(det == TrkrDefs::TrkrId::mvtxId)
+      if (det == TrkrDefs::TrkrId::mvtxId)
       {
-      auto strobeId = MvtxDefs::getStrobeId(hitsetkey);
-      if(strobeId != strobe)
-      {
-        continue;
-      }
+        auto strobeId = MvtxDefs::getStrobeId(hitsetkey);
+        if (strobeId != strobe)
+        {
+          continue;
+        }
       }
       auto range = m_clusterMap->getClusters(hitsetkey);
       for (auto clusIter = range.first; clusIter != range.second; ++clusIter)

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -255,7 +255,8 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
   int numSeeds = 0;
   int numGoodSeeds = 0;
   m_seedid = -1;
-  /// Loop over grid volumes
+  int strobe = m_lowStrobeIndex;
+  /// Loop over grid volumes. In our case this will be strobe
   for (auto& seeds : seedVector)
   {
     /// Loop over actual seeds in this grid volume
@@ -410,7 +411,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
 
       //! try to get a crossing value based on INTT
       trackSeed->set_crossing(getCrossingIntt(*trackSeed));
-
+     
       m_seedContainer->insert(trackSeed.get());
 
       fitTimer->stop();
@@ -420,6 +421,11 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
         std::cout << "Intt fit time " << circlefittime << " and svtx time "
                   << svtxtracktime << std::endl;
       }
+    }
+    strobe++;
+    if(strobe > m_highStrobeIndex)
+    {
+      std::cout << PHWHERE << "Error: some how grid seed vector is not the same as the number of strobes" << std::endl;
     }
   }
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -29,8 +29,8 @@
 #include <trackbase_historic/TrackSeed.h>
 #include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeedContainer_v1.h>
-#include <trackbase_historic/TrackSeed_v2.h>
 #include <trackbase_historic/TrackSeedHelper.h>
+#include <trackbase_historic/TrackSeed_v2.h>
 
 #ifndef __clang__
 #pragma GCC diagnostic push
@@ -185,65 +185,67 @@ int PHActsSiliconSeeding::End(PHCompositeNode* /*topNode*/)
 GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
 {
   Acts::SeedFinder<SpacePoint> seedFinder(m_seedFinderCfg);
-
-  /// Covariance converter functor needed by seed finder
-  auto covConverter =
-      [=](const SpacePoint& sp, float zAlign, float rAlign, float sigmaError)
-      -> std::pair<Acts::Vector3, Acts::Vector2>
-  {
-    Acts::Vector3 position{sp.x(), sp.y(), sp.z()};
-    Acts::Vector2 cov;
-    cov[0] = (sp.m_varianceR + rAlign * rAlign) * sigmaError;
-    cov[1] = (sp.m_varianceZ + zAlign * zAlign) * sigmaError;
-    return std::make_pair(position, cov);
-  };
-
-  Acts::Extent rRangeSPExtent;
-
-  spVec = getSiliconSpacePoints(rRangeSPExtent);
-
-  if (m_seedAnalysis)
-  {
-    h_nInputMeas->Fill(spVec.size());
-  }
-
-  auto grid =
-      Acts::SpacePointGridCreator::createGrid<SpacePoint>(m_gridCfg,
-                                                          m_gridOptions);
-
-  auto spGroup = Acts::BinnedSPGroup<SpacePoint>(spVec.begin(),
-                                                 spVec.end(),
-                                                 covConverter,
-                                                 m_bottomBinFinder,
-                                                 m_topBinFinder,
-                                                 std::move(grid),
-                                                 rRangeSPExtent,
-                                                 m_seedFinderCfg,
-                                                 m_seedFinderOptions);
-
-  /// variable middle SP radial region of interest
-  const Acts::Range1D<float> rMiddleSPRange(
-      std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 + 1.5,
-      std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 - 1.5);
-
   GridSeeds seedVector;
-  SeedContainer seeds;
-  seeds.clear();
-  decltype(seedFinder)::SeedingState state;
-  state.spacePointData.resize(spVec.size(),
-                              m_seedFinderCfg.useDetailedDoubleMeasurementInfo);
-  for (const auto [bottom, middle, top] : spGroup)
+  for (int strobe = m_lowStrobeIndex; strobe < m_highStrobeIndex; strobe++)
   {
-    seedFinder.createSeedsForGroup(m_seedFinderOptions,
-                                   state, spGroup.grid(),
-                                   std::back_inserter(seeds),
-                                   bottom,
-                                   middle,
-                                   top,
-                                   rMiddleSPRange);
-  }
+    /// Covariance converter functor needed by seed finder
+    auto covConverter =
+        [=](const SpacePoint& sp, float zAlign, float rAlign, float sigmaError)
+        -> std::pair<Acts::Vector3, Acts::Vector2>
+    {
+      Acts::Vector3 position{sp.x(), sp.y(), sp.z()};
+      Acts::Vector2 cov;
+      cov[0] = (sp.m_varianceR + rAlign * rAlign) * sigmaError;
+      cov[1] = (sp.m_varianceZ + zAlign * zAlign) * sigmaError;
+      return std::make_pair(position, cov);
+    };
 
-  seedVector.push_back(seeds);
+    Acts::Extent rRangeSPExtent;
+
+    spVec = getSiliconSpacePoints(rRangeSPExtent, strobe);
+
+    if (m_seedAnalysis)
+    {
+      h_nInputMeas->Fill(spVec.size());
+    }
+
+    auto grid =
+        Acts::SpacePointGridCreator::createGrid<SpacePoint>(m_gridCfg,
+                                                            m_gridOptions);
+
+    auto spGroup = Acts::BinnedSPGroup<SpacePoint>(spVec.begin(),
+                                                   spVec.end(),
+                                                   covConverter,
+                                                   m_bottomBinFinder,
+                                                   m_topBinFinder,
+                                                   std::move(grid),
+                                                   rRangeSPExtent,
+                                                   m_seedFinderCfg,
+                                                   m_seedFinderOptions);
+
+    /// variable middle SP radial region of interest
+    const Acts::Range1D<float> rMiddleSPRange(
+        std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 + 1.5,
+        std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 - 1.5);
+
+    SeedContainer seeds;
+    seeds.clear();
+    decltype(seedFinder)::SeedingState state;
+    state.spacePointData.resize(spVec.size(),
+                                m_seedFinderCfg.useDetailedDoubleMeasurementInfo);
+    for (const auto [bottom, middle, top] : spGroup)
+    {
+      seedFinder.createSeedsForGroup(m_seedFinderOptions,
+                                     state, spGroup.grid(),
+                                     std::back_inserter(seeds),
+                                     bottom,
+                                     middle,
+                                     top,
+                                     rMiddleSPRange);
+    }
+
+    seedVector.push_back(seeds);
+  }
 
   return seedVector;
 }
@@ -335,7 +337,7 @@ void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
       fitTimer->restart();
 
       TrackSeedHelper::circleFitByTaubin(trackSeed.get(), positions, 0, 8);
-      const auto position( TrackSeedHelper::get_xyz(trackSeed.get()) );
+      const auto position(TrackSeedHelper::get_xyz(trackSeed.get()));
       if (std::abs(position.x()) > m_maxSeedPCA || std::abs(position.y()) > m_maxSeedPCA)
       {
         if (Verbosity() > 1)
@@ -731,19 +733,18 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
     matchedClusters.push_back(minResidckey[5]);
     clusters.push_back(minResidGlobPos[5]);
   }
-  else if(minResidLayer[6] < std::numeric_limits<float>::max())
+  else if (minResidLayer[6] < std::numeric_limits<float>::max())
   {
     matchedClusters.push_back(minResidckey[6]);
     clusters.push_back(minResidGlobPos[6]);
   }
 
+  if (m_seedAnalysis)
+  {
+    h_nMatchedClusters->Fill(matchedClusters.size());
+  }
 
-if (m_seedAnalysis)
-{
-  h_nMatchedClusters->Fill(matchedClusters.size());
-}
-
-return matchedClusters;
+  return matchedClusters;
 }
 
 SpacePointPtr PHActsSiliconSeeding::makeSpacePoint(
@@ -816,7 +817,8 @@ SpacePointPtr PHActsSiliconSeeding::makeSpacePoint(
   return spPtr;
 }
 
-std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts::Extent& rRangeSPExtent)
+std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts::Extent& rRangeSPExtent,
+  const int strobe)
 {
   std::vector<const SpacePoint*> spVec;
   unsigned int numSiliconHits = 0;
@@ -830,6 +832,14 @@ std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts:
   {
     for (const auto& hitsetkey : m_clusterMap->getHitSetKeys(det))
     {
+      if(det == TrkrDefs::TrkrId::mvtxId)
+      {
+      auto strobeId = MvtxDefs::getStrobeId(hitsetkey);
+      if(strobeId != strobe)
+      {
+        continue;
+      }
+      }
       auto range = m_clusterMap->getClusters(hitsetkey);
       for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
       {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -71,7 +71,7 @@ class PHActsSiliconSeeding : public SubsysReco
   {
     m_inttrPhiSearchWin = win;
   }
-  void setinttZSearchWindow(const float& win)
+  void setinttZSearchWindow(const float &win)
   {
     m_inttzSearchWin = win;
   }
@@ -146,7 +146,7 @@ class PHActsSiliconSeeding : public SubsysReco
   {
     m_helixcut = cut;
   }
-  void bfield(const float field) 
+  void bfield(const float field)
   {
     m_bField = field;
   }
@@ -187,14 +187,14 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Get all space points for the seeder
   std::vector<const SpacePoint *> getSiliconSpacePoints(Acts::Extent &rRangeSPExtent,
-    const int strobe);
+                                                        const int strobe);
   void printSeedConfigs(Acts::SeedFilterConfig &sfconfig);
 
   /// Projects circle fit to radii to find possible MVTX/INTT clusters
   /// belonging to track stub
   std::vector<TrkrDefs::cluskey> findMatches(
       std::vector<Acts::Vector3> &clusters,
-      std::vector<TrkrDefs::cluskey>& keys,
+      std::vector<TrkrDefs::cluskey> &keys,
       TrackSeed &seed);
 
   std::vector<TrkrDefs::cluskey> matchInttClusters(std::vector<Acts::Vector3> &clusters,
@@ -202,8 +202,8 @@ class PHActsSiliconSeeding : public SubsysReco
                                                    const double xProj[],
                                                    const double yProj[],
                                                    const double zProj[]);
-  short int getCrossingIntt(TrackSeed& si_track);
-  std::vector<short int> getInttCrossings(TrackSeed& si_track);
+  short int getCrossingIntt(TrackSeed &si_track);
+  std::vector<short int> getInttCrossings(TrackSeed &si_track);
 
   void createHistograms();
   void writeHistograms();
@@ -303,7 +303,7 @@ class PHActsSiliconSeeding : public SubsysReco
 
   /// Search window for phi to match intt clusters in cm
   double m_inttrPhiSearchWin = 0.1;
-  float m_inttzSearchWin = 0.8; // default to a half strip width
+  float m_inttzSearchWin = 0.8;  // default to a half strip width
   double m_mvtxrPhiSearchWin = 0.2;
   float m_mvtxzSearchWin = 0.5;
   /// Whether or not to use truth clusters in hit lookup

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -49,6 +49,11 @@ class PHActsSiliconSeeding : public SubsysReco
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
 
+  void setStrobeRange(const int low, const int high)
+  {
+    m_lowStrobeIndex = low;
+    m_highStrobeIndex = high;
+  }
   void setunc(float unc) { m_uncfactor = unc; }
   /// Set seeding with truth clusters
   void useTruthClusters(bool useTruthClusters)
@@ -181,7 +186,8 @@ class PHActsSiliconSeeding : public SubsysReco
       TrkrCluster *clus);
 
   /// Get all space points for the seeder
-  std::vector<const SpacePoint *> getSiliconSpacePoints(Acts::Extent &rRangeSPExtent);
+  std::vector<const SpacePoint *> getSiliconSpacePoints(Acts::Extent &rRangeSPExtent,
+    const int strobe);
   void printSeedConfigs(Acts::SeedFilterConfig &sfconfig);
 
   /// Projects circle fit to radii to find possible MVTX/INTT clusters
@@ -229,6 +235,8 @@ class PHActsSiliconSeeding : public SubsysReco
   TrkrClusterContainer *m_clusterMap = nullptr;
   PHG4CylinderGeomContainer *m_geomContainerIntt = nullptr;
 
+  int m_lowStrobeIndex = 0;
+  int m_highStrobeIndex = 1;
   /// Configuration classes for Acts seeding
   Acts::SeedFinderConfig<SpacePoint> m_seedFinderCfg;
   Acts::SpacePointGridConfig m_gridCfg;


### PR DESCRIPTION
This adds hooks to the silicon seeder to run the Acts seeding algorithm on a strobe by strobe basis. It can be improved with the helper object in https://github.com/sPHENIX-Collaboration/coresoftware/pull/3404, as currently all the hitsetkeys are looped over to obtain clusters and only those belonging to a certain strobe are added to the seeding algorithm. Witih the helper object, we can just look up all hitsetkeys associated to a particular strobe ID. This improves the silicon seeding as will be discussed in the tracking meeting today

https://indico.bnl.gov/event/26226/

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

