### PR TITLE
Detailed calorimeter geometry

### DIFF
--- a/offline/packages/CaloBase/Makefile.am
+++ b/offline/packages/CaloBase/Makefile.am
@@ -48,6 +48,7 @@ pkginclude_HEADERS = \
   RawTowerGeomv2.h \
   RawTowerGeomv3.h \
   RawTowerGeomv4.h \
+  RawTowerGeomv5.h \
   RawTowerGeomContainer.h \
   RawTowerGeomContainerv1.h \
   RawTowerGeomContainer_Cylinderv1.h \
@@ -82,6 +83,7 @@ ROOTDICTS = \
   RawTowerGeomv2_Dict.cc \
   RawTowerGeomv3_Dict.cc \
   RawTowerGeomv4_Dict.cc \
+  RawTowerGeomv5_Dict.cc \
   RawTowerGeomContainer_Dict.cc \
   RawTowerGeomContainerv1_Dict.cc \
   RawTowerGeomContainer_Cylinderv1_Dict.cc \
@@ -116,6 +118,7 @@ nobase_dist_pcm_DATA = \
   RawTowerGeomv2_Dict_rdict.pcm \
   RawTowerGeomv3_Dict_rdict.pcm \
   RawTowerGeomv4_Dict_rdict.pcm \
+  RawTowerGeomv5_Dict_rdict.pcm \
   RawTowerGeomContainer_Dict_rdict.pcm \
   RawTowerGeomContainerv1_Dict_rdict.pcm \
   RawTowerGeomContainer_Cylinderv1_Dict_rdict.pcm \
@@ -150,6 +153,7 @@ libcalo_io_la_SOURCES = \
   RawTowerGeomv2.cc \
   RawTowerGeomv3.cc \
   RawTowerGeomv4.cc \
+  RawTowerGeomv5.cc \
   RawTowerGeomContainer.cc \
   RawTowerGeomContainerv1.cc \
   RawTowerGeomContainer_Cylinderv1.cc \

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -14,7 +14,7 @@ class RawTowerGeom : public PHObject
  public:
   ~RawTowerGeom() override {}
 
-  RawTowerGeom(const RawTowerGeom& /*geom*/) {};
+  RawTowerGeom(const RawTowerGeom& /*geom*/){};
 
   void identify(std::ostream& os = std::cout) const override;
 
@@ -101,193 +101,193 @@ class RawTowerGeom : public PHObject
   virtual double get_center_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_int_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_int_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_int_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_int_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_int_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_int_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
-  
+
   virtual double get_center_ext_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_ext_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_ext_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_ext_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_ext_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_ext_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_eta_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_eta_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_eta_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_eta_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_eta_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_eta_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_eta_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_eta_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_eta_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_eta_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_eta_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_eta_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_phi_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_phi_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_phi_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_phi_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_low_phi_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_low_phi_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_phi_x() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_phi_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_phi_y() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_phi_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_high_phi_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_high_phi_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_vertex_x(int) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_vertex_y(int) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_vertex_z(int) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_size_x() const
   {
     PHOOL_VIRTUAL_WARN("get_size_x()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_size_y() const
   {
     PHOOL_VIRTUAL_WARN("get_size_y()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_size_z() const
   {
     PHOOL_VIRTUAL_WARN("get_size_z()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_volume() const
   {
     PHOOL_VIRTUAL_WARN("get_volume()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_center_radius() const
   {
     PHOOL_VIRTUAL_WARN("get_center_radius()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_eta() const
   {
     PHOOL_VIRTUAL_WARN("get_eta()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_theta() const
   {
     PHOOL_VIRTUAL_WARN("get_theta()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual double get_phi() const
   {
     PHOOL_VIRTUAL_WARN("get_phi()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual void set_tower_type(int)
@@ -304,17 +304,17 @@ class RawTowerGeom : public PHObject
   virtual double get_rotx() const
   {
     PHOOL_VIRTUAL_WARN("get_rotx()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
   virtual double get_roty() const
   {
     PHOOL_VIRTUAL_WARN("get_roty()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
   virtual double get_rotz() const
   {
     PHOOL_VIRTUAL_WARN("get_rotz()");
-    return std::numeric_limits<float>::signaling_NaN();
+    return std::numeric_limits<float>::quiet_NaN();
   }
 
   virtual void set_rotx(double)

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -14,6 +14,8 @@ class RawTowerGeom : public PHObject
  public:
   ~RawTowerGeom() override {}
 
+  RawTowerGeom(const RawTowerGeom& /*geom*/) {};
+
   void identify(std::ostream& os = std::cout) const override;
 
   virtual void set_id(RawTowerDefs::keytype) { PHOOL_VIRTUAL_WARN("set_id()"); }
@@ -72,6 +74,12 @@ class RawTowerGeom : public PHObject
     return;
   }
 
+  virtual void set_vertices(const std::vector<double>&)
+  {
+    PHOOL_VIRTUAL_WARN("set_vertices()");
+    return;
+  }
+
   virtual void set_size_x(double)
   {
     PHOOL_VIRTUAL_WARN("set_size_x()");
@@ -105,6 +113,132 @@ class RawTowerGeom : public PHObject
   virtual double get_center_z() const
   {
     PHOOL_VIRTUAL_WARN("get_center_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_int_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_int_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_int_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_int_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_int_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_int_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+  
+  virtual double get_center_ext_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_ext_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_ext_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_ext_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_ext_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_ext_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_eta_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_eta_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_eta_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_eta_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_eta_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_eta_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_eta_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_eta_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_eta_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_eta_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_eta_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_eta_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_phi_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_phi_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_phi_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_phi_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_low_phi_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_low_phi_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_phi_x() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_phi_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_phi_y() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_phi_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_center_high_phi_z() const
+  {
+    PHOOL_VIRTUAL_WARN("get_center_high_phi_z()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_vertex_x(int) const
+  {
+    PHOOL_VIRTUAL_WARN("get_vertex_x()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_vertex_y(int) const
+  {
+    PHOOL_VIRTUAL_WARN("get_vertex_y()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
+
+  virtual double get_vertex_z(int) const
+  {
+    PHOOL_VIRTUAL_WARN("get_vertex_z()");
     return std::numeric_limits<float>::signaling_NaN();
   }
 
@@ -167,6 +301,11 @@ class RawTowerGeom : public PHObject
     return -1;
   }
 
+  virtual double get_rotx() const
+  {
+    PHOOL_VIRTUAL_WARN("get_rotx()");
+    return std::numeric_limits<float>::signaling_NaN();
+  }
   virtual double get_roty() const
   {
     PHOOL_VIRTUAL_WARN("get_roty()");
@@ -178,6 +317,11 @@ class RawTowerGeom : public PHObject
     return std::numeric_limits<float>::signaling_NaN();
   }
 
+  virtual void set_rotx(double)
+  {
+    PHOOL_VIRTUAL_WARN("set_rotx()");
+    return;
+  }
   virtual void set_roty(double)
   {
     PHOOL_VIRTUAL_WARN("set_roty()");

--- a/offline/packages/CaloBase/RawTowerGeom.h
+++ b/offline/packages/CaloBase/RawTowerGeom.h
@@ -12,13 +12,13 @@
 class RawTowerGeom : public PHObject
 {
  public:
-  ~RawTowerGeom() override {}
+  ~RawTowerGeom() override = default;
 
-  RawTowerGeom(const RawTowerGeom& /*geom*/){};
+  //RawTowerGeom(const RawTowerGeom& /*geom*/){}
 
   void identify(std::ostream& os = std::cout) const override;
 
-  virtual void set_id(RawTowerDefs::keytype) { PHOOL_VIRTUAL_WARN("set_id()"); }
+  virtual void set_id(RawTowerDefs::keytype /*key*/) { PHOOL_VIRTUAL_WARN("set_id()"); }
 
   virtual RawTowerDefs::keytype get_id() const
   {
@@ -56,43 +56,43 @@ class RawTowerGeom : public PHObject
     return -1;
   }
 
-  virtual void set_center_x(double)
+  virtual void set_center_x(double /*x*/)
   {
     PHOOL_VIRTUAL_WARN("set_center_x()");
     return;
   }
 
-  virtual void set_center_y(double)
+  virtual void set_center_y(double /*y*/)
   {
     PHOOL_VIRTUAL_WARN("set_center_y()");
     return;
   }
 
-  virtual void set_center_z(double)
+  virtual void set_center_z(double /*z*/)
   {
     PHOOL_VIRTUAL_WARN("set_center_z()");
     return;
   }
 
-  virtual void set_vertices(const std::vector<double>&)
+  virtual void set_vertices(const std::vector<double>& /*vertices*/)
   {
     PHOOL_VIRTUAL_WARN("set_vertices()");
     return;
   }
 
-  virtual void set_size_x(double)
+  virtual void set_size_x(double /*dx*/)
   {
     PHOOL_VIRTUAL_WARN("set_size_x()");
     return;
   }
 
-  virtual void set_size_y(double)
+  virtual void set_size_y(double /*dy*/)
   {
     PHOOL_VIRTUAL_WARN("set_size_y()");
     return;
   }
 
-  virtual void set_size_z(double)
+  virtual void set_size_z(double /*dz*/)
   {
     PHOOL_VIRTUAL_WARN("set_size_z()");
     return;
@@ -224,19 +224,19 @@ class RawTowerGeom : public PHObject
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  virtual double get_vertex_x(int) const
+  virtual double get_vertex_x(int /*i*/) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_x()");
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  virtual double get_vertex_y(int) const
+  virtual double get_vertex_y(int /*i*/) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_y()");
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  virtual double get_vertex_z(int) const
+  virtual double get_vertex_z(int /*i*/) const
   {
     PHOOL_VIRTUAL_WARN("get_vertex_z()");
     return std::numeric_limits<float>::quiet_NaN();
@@ -290,7 +290,7 @@ class RawTowerGeom : public PHObject
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  virtual void set_tower_type(int)
+  virtual void set_tower_type(int /*tt*/)
   {
     PHOOL_VIRTUAL_WARN("set_tower_type()");
     return;
@@ -317,24 +317,24 @@ class RawTowerGeom : public PHObject
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  virtual void set_rotx(double)
+  virtual void set_rotx(double /*rotx*/)
   {
     PHOOL_VIRTUAL_WARN("set_rotx()");
     return;
   }
-  virtual void set_roty(double)
+  virtual void set_roty(double /*roty*/)
   {
     PHOOL_VIRTUAL_WARN("set_roty()");
     return;
   }
-  virtual void set_rotz(double)
+  virtual void set_rotz(double /*rotz*/)
   {
     PHOOL_VIRTUAL_WARN("set_rotz()");
     return;
   }
 
  protected:
-  RawTowerGeom() {}
+  RawTowerGeom() = default;
 
   ClassDefOverride(RawTowerGeom, 2)
 };

--- a/offline/packages/CaloBase/RawTowerGeomv5.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv5.cc
@@ -1,0 +1,215 @@
+#include "RawTowerGeomv5.h"
+
+#include <cmath>
+#include <iostream>
+
+RawTowerGeomv5::RawTowerGeomv5(RawTowerDefs::keytype id)
+  : _towerid(id)
+{
+}
+
+RawTowerGeomv5::RawTowerGeomv5(const RawTowerGeom& geom0)
+{
+  _towerid = geom0.get_id();
+
+  _rotx = geom0.get_rotx();
+  _roty = geom0.get_roty();
+  _rotz = geom0.get_rotz();
+  
+  _vertices.resize(_nVtx);
+  for (int i = 0; i < _nVtx; i++)
+  {
+    _vertices[i].x = geom0.get_vertex_x(i);
+    _vertices[i].y = geom0.get_vertex_y(i);
+    _vertices[i].z = geom0.get_vertex_z(i);
+  }
+
+  _center.x = geom0.get_center_x();
+  _center.y = geom0.get_center_y();
+  _center.z = geom0.get_center_z();
+
+  _center_int.x = geom0.get_center_int_x();
+  _center_int.y = geom0.get_center_int_y();
+  _center_int.z = geom0.get_center_int_z();
+  
+  _center_ext.x = geom0.get_center_ext_x();
+  _center_ext.y = geom0.get_center_ext_y();
+  _center_ext.z = geom0.get_center_ext_z();
+
+  _center_low_eta.x = geom0.get_center_low_eta_x();
+  _center_low_eta.y = geom0.get_center_low_eta_y();
+  _center_low_eta.z = geom0.get_center_low_eta_z();
+
+  _center_high_eta.x = geom0.get_center_high_eta_x();
+  _center_high_eta.y = geom0.get_center_high_eta_y();
+  _center_high_eta.z = geom0.get_center_high_eta_z();
+
+  _center_low_phi.x = geom0.get_center_low_phi_x();
+  _center_low_phi.y = geom0.get_center_low_phi_y();
+  _center_low_phi.z = geom0.get_center_low_phi_z();
+
+  _center_high_phi.x = geom0.get_center_high_phi_x();
+  _center_high_phi.y = geom0.get_center_high_phi_y();
+  _center_high_phi.z = geom0.get_center_high_phi_z();
+}
+
+void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
+{
+
+  /*       y                     
+           |                    7_______6
+           |                   /|      /|
+           |_______ z        8/_|_____/5|
+          /                   | |     | |
+         /                    |3|_____|_|2
+        /                     | /     | /
+     -x                      4|/______|/1
+  */
+
+  if ((int) vertices.size() != _nVtx * 3)
+  {
+    std::cerr
+      << "RawTowerGeomv5::set_vertices - input " << vertices.size() << " vertices given. Expected 8 x 3." << std::endl;
+    exit(1);
+  }
+
+  const bool face_outside[_nVtx] = {false, false, false, false, true, true, true, true};
+  const bool face_inside[_nVtx] = {true, true, true, true, false, false, false, false};
+  const bool face_low_eta[_nVtx] = {false, false, true, true, false, false, true, true};
+  const bool face_high_eta[_nVtx] = {true, true, false, false, true, true, false, false};
+  const bool face_low_phi[_nVtx] = {false, true, true, false, false, true, true, false};
+  const bool face_high_phi[_nVtx] = {true, false, false, true, true, false, false, true};
+
+  _center.x = 0;
+  _center.y = 0;
+  _center.z = 0;
+  _center_int.x = 0;
+  _center_int.y = 0;
+  _center_int.z = 0;
+  _center_ext.x = 0;
+  _center_ext.y = 0;
+  _center_ext.z = 0;
+  _center_low_eta.x = 0;
+  _center_low_eta.y = 0;
+  _center_low_eta.z = 0;
+  _center_high_eta.x = 0;
+  _center_high_eta.y = 0;
+  _center_high_eta.z = 0;
+  _center_low_phi.x = 0;
+  _center_low_phi.y = 0;
+  _center_low_phi.z = 0;
+  _center_high_phi.x = 0;
+  _center_high_phi.y = 0;
+  _center_high_phi.z = 0;
+  _vertices.resize(_nVtx);
+  for (int i = 0; i < _nVtx; i++)
+  {
+    _vertices[i].x = vertices[i*3+0];
+    _vertices[i].y = vertices[i*3+1];
+    _vertices[i].z = vertices[i*3+2];
+
+    _center.x += _vertices[i].x;
+    _center.y += _vertices[i].y;
+    _center.z += _vertices[i].z;
+
+    if (face_inside[i])
+    {
+      _center_int.x += _vertices[i].x;
+      _center_int.y += _vertices[i].y;
+      _center_int.z += _vertices[i].z;
+    }
+    if (face_outside[i])
+    {
+      _center_ext.x += _vertices[i].x;
+      _center_ext.y += _vertices[i].y;
+      _center_ext.z += _vertices[i].z;
+    }
+    if (face_low_eta[i])
+    {
+      _center_low_eta.x += _vertices[i].x;
+      _center_low_eta.y += _vertices[i].y;
+      _center_low_eta.z += _vertices[i].z;
+    }
+    if (face_high_eta[i])
+    {
+      _center_high_eta.x += _vertices[i].x;
+      _center_high_eta.y += _vertices[i].y;
+      _center_high_eta.z += _vertices[i].z;
+    }
+    if (face_low_phi[i])
+    {
+      _center_low_phi.x += _vertices[i].x;
+      _center_low_phi.y += _vertices[i].y;
+      _center_low_phi.z += _vertices[i].z;
+    }
+    if (face_high_phi[i])
+    {
+      _center_high_phi.x += _vertices[i].x;
+      _center_high_phi.y += _vertices[i].y;
+      _center_high_phi.z += _vertices[i].z;
+    }
+  }
+
+  _center.x /= (float) _nVtx;
+  _center.y /= (float) _nVtx;
+  _center.z /= (float) _nVtx;
+
+  _center_int.x /= (float) _nVtx / 2.;
+  _center_int.y /= (float) _nVtx / 2.;
+  _center_int.z /= (float) _nVtx / 2.;
+
+  _center_ext.x /= (float) _nVtx / 2.;
+  _center_ext.y /= (float) _nVtx / 2.;
+  _center_ext.z /= (float) _nVtx / 2.;
+  
+  _center_low_eta.x /= (float) _nVtx / 2.;
+  _center_low_eta.y /= (float) _nVtx / 2.;
+  _center_low_eta.z /= (float) _nVtx / 2.;
+
+  _center_high_eta.x /= (float) _nVtx / 2.;
+  _center_high_eta.y /= (float) _nVtx / 2.;
+  _center_high_eta.z /= (float) _nVtx / 2.;
+
+  _center_low_phi.x /= (float) _nVtx / 2.;
+  _center_low_phi.y /= (float) _nVtx / 2.;
+  _center_low_phi.z /= (float) _nVtx / 2.;
+
+  _center_high_phi.x /= (float) _nVtx / 2.;
+  _center_high_phi.y /= (float) _nVtx / 2.;
+  _center_high_phi.z /= (float) _nVtx / 2.;
+
+
+
+  return;
+} 
+
+double RawTowerGeomv5::get_center_radius() const
+{
+  return std::sqrt(_center.x * _center.x +
+                   _center.y * _center.y);
+}
+
+double RawTowerGeomv5::get_theta() const
+{
+  double radius = sqrt(_center.x * _center.x + _center.y * _center.y);
+  double theta = atan2(radius, _center.z);
+  return theta;
+}
+
+double RawTowerGeomv5::get_eta() const
+{
+  double theta = get_theta();
+  double eta = -log(tan(theta / 2.));
+
+  return eta;
+}
+
+double RawTowerGeomv5::get_phi() const
+{
+  return atan2(_center.y, _center.x);
+}
+
+void RawTowerGeomv5::identify(std::ostream& os) const
+{
+  os << "RawTowerGeomv5:  x: " << get_center_x() << "  y: " << get_center_y() << "  z: " << get_center_z() << std::endl;
+}

--- a/offline/packages/CaloBase/RawTowerGeomv5.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv5.cc
@@ -101,6 +101,7 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   _center_high_phi.y = 0;
   _center_high_phi.z = 0;
   _vertices.resize(_nVtx);
+
   for (int i = 0; i < _nVtx; i++)
   {
     _vertices[i].x = vertices[i * 3 + 0];

--- a/offline/packages/CaloBase/RawTowerGeomv5.cc
+++ b/offline/packages/CaloBase/RawTowerGeomv5.cc
@@ -15,7 +15,7 @@ RawTowerGeomv5::RawTowerGeomv5(const RawTowerGeom& geom0)
   _rotx = geom0.get_rotx();
   _roty = geom0.get_roty();
   _rotz = geom0.get_rotz();
-  
+
   _vertices.resize(_nVtx);
   for (int i = 0; i < _nVtx; i++)
   {
@@ -31,7 +31,7 @@ RawTowerGeomv5::RawTowerGeomv5(const RawTowerGeom& geom0)
   _center_int.x = geom0.get_center_int_x();
   _center_int.y = geom0.get_center_int_y();
   _center_int.z = geom0.get_center_int_z();
-  
+
   _center_ext.x = geom0.get_center_ext_x();
   _center_ext.y = geom0.get_center_ext_y();
   _center_ext.z = geom0.get_center_ext_z();
@@ -55,8 +55,7 @@ RawTowerGeomv5::RawTowerGeomv5(const RawTowerGeom& geom0)
 
 void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
 {
-
-  /*       y                     
+  /*       y
            |                    7_______6
            |                   /|      /|
            |_______ z        8/_|_____/5|
@@ -69,7 +68,7 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   if ((int) vertices.size() != _nVtx * 3)
   {
     std::cerr
-      << "RawTowerGeomv5::set_vertices - input " << vertices.size() << " vertices given. Expected 8 x 3." << std::endl;
+        << "RawTowerGeomv5::set_vertices - input " << vertices.size() << " vertices given. Expected 8 x 3." << std::endl;
     exit(1);
   }
 
@@ -104,9 +103,9 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   _vertices.resize(_nVtx);
   for (int i = 0; i < _nVtx; i++)
   {
-    _vertices[i].x = vertices[i*3+0];
-    _vertices[i].y = vertices[i*3+1];
-    _vertices[i].z = vertices[i*3+2];
+    _vertices[i].x = vertices[i * 3 + 0];
+    _vertices[i].y = vertices[i * 3 + 1];
+    _vertices[i].z = vertices[i * 3 + 2];
 
     _center.x += _vertices[i].x;
     _center.y += _vertices[i].y;
@@ -161,7 +160,7 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   _center_ext.x /= (float) _nVtx / 2.;
   _center_ext.y /= (float) _nVtx / 2.;
   _center_ext.z /= (float) _nVtx / 2.;
-  
+
   _center_low_eta.x /= (float) _nVtx / 2.;
   _center_low_eta.y /= (float) _nVtx / 2.;
   _center_low_eta.z /= (float) _nVtx / 2.;
@@ -178,10 +177,8 @@ void RawTowerGeomv5::set_vertices(const std::vector<double>& vertices)
   _center_high_phi.y /= (float) _nVtx / 2.;
   _center_high_phi.z /= (float) _nVtx / 2.;
 
-
-
   return;
-} 
+}
 
 double RawTowerGeomv5::get_center_radius() const
 {

--- a/offline/packages/CaloBase/RawTowerGeomv5.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5.h
@@ -1,0 +1,161 @@
+#ifndef CALOBASE_RAWTOWERGEOMV5_H
+#define CALOBASE_RAWTOWERGEOMV5_H
+
+#include "RawTowerGeom.h"
+
+#include "RawTowerDefs.h"
+
+#include <iostream>
+#include <limits>
+
+typedef std::pair<double,double> vertex_t;
+typedef std::vector<vertex_t> vertices_t;
+
+struct point_coordinates {
+  double R;
+  double eta;
+  double phi;
+  double x;
+  double y;
+  double z;
+};
+
+class RawTowerGeomv5 : public RawTowerGeom
+{
+ public:
+  RawTowerGeomv5() {}
+  RawTowerGeomv5(RawTowerDefs::keytype id);
+  RawTowerGeomv5(const RawTowerGeom& geom0);
+  ~RawTowerGeomv5() override {}
+
+  void identify(std::ostream& os = std::cout) const override;
+
+  void set_id(RawTowerDefs::keytype key) override { _towerid = key; }
+  RawTowerDefs::keytype get_id() const override { return _towerid; }
+
+  int get_bineta() const override { return RawTowerDefs::decode_index1(_towerid); }
+  int get_binphi() const override { return RawTowerDefs::decode_index2(_towerid); }
+  int get_column() const override { return RawTowerDefs::decode_index1(_towerid); }
+  int get_row() const override { return RawTowerDefs::decode_index2(_towerid); }
+
+  void set_center_x(double x) override
+  {
+    _center.x = x;
+    return;
+  }
+  void set_center_y(double y) override
+  {
+    _center.y = y;
+    return;
+  }
+  void set_center_z(double z) override
+  {
+    _center.z = z;
+    return;
+  }
+  void set_rotx(double rotx) override
+  {
+    _rotx = rotx;
+    return;
+  }
+  void set_roty(double roty) override
+  {
+    _roty = roty;
+    return;
+  }
+  void set_rotz(double rotz) override
+  {
+    _rotz = rotz;
+    return;
+  }
+
+  void set_vertices(const std::vector<double>&) override;
+
+  double get_center_x() const override { return _center.x; }
+  double get_center_y() const override { return _center.y; }
+  double get_center_z() const override { return _center.z; }
+  double get_center_int_x() const override { return _center_int.x; }
+  double get_center_int_y() const override { return _center_int.y; }
+  double get_center_int_z() const override { return _center_int.z; }
+  double get_center_ext_x() const override { return _center_ext.x; }
+  double get_center_ext_y() const override { return _center_ext.y; }
+  double get_center_ext_z() const override { return _center_ext.z; }
+  double get_center_low_eta_x() const override { return _center_low_eta.x; }
+  double get_center_low_eta_y() const override { return _center_low_eta.y; }
+  double get_center_low_eta_z() const override { return _center_low_eta.z; }
+  double get_center_high_eta_x() const override { return _center_high_eta.x; }
+  double get_center_high_eta_y() const override { return _center_high_eta.y; }
+  double get_center_high_eta_z() const override { return _center_high_eta.z; }
+  double get_center_low_phi_x() const override { return _center_low_phi.x; }
+  double get_center_low_phi_y() const override { return _center_low_phi.y; }
+  double get_center_low_phi_z() const override { return _center_low_phi.z; }
+  double get_center_high_phi_x() const override { return _center_high_phi.x; }
+  double get_center_high_phi_y() const override { return _center_high_phi.y; }
+  double get_center_high_phi_z() const override { return _center_high_phi.z; }
+  double get_rotx() const override { return _rotx; }
+  double get_roty() const override { return _roty; }
+  double get_rotz() const override { return _rotz; }
+  double get_vertex_x(int i) const override { return _vertices[i].x; }
+  double get_vertex_y(int i) const override { return _vertices[i].y; }
+  double get_vertex_z(int i) const override { return _vertices[i].z; }
+  double get_center_radius() const override;
+  double get_eta() const override;
+  double get_phi() const override;
+  double get_theta() const override;
+
+ protected:
+  RawTowerDefs::keytype _towerid{std::numeric_limits<RawTowerDefs::keytype>::max()};
+
+  static constexpr int _nVtx = 8;
+  point_coordinates _center{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_int{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_ext{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_low_eta{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_high_eta{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_low_phi{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center_high_phi{std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN(),
+                  std::numeric_limits<double>::signaling_NaN()};
+
+  std::vector<point_coordinates> _vertices;
+  double _rotx{std::numeric_limits<double>::signaling_NaN()};
+  double _roty{std::numeric_limits<double>::signaling_NaN()};
+  double _rotz{std::numeric_limits<double>::signaling_NaN()};
+  
+  ClassDefOverride(RawTowerGeomv5, 4)
+};
+
+#endif

--- a/offline/packages/CaloBase/RawTowerGeomv5.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5.h
@@ -11,10 +11,10 @@
 class RawTowerGeomv5 : public RawTowerGeom
 {
  public:
-  RawTowerGeomv5() {}
-  RawTowerGeomv5(RawTowerDefs::keytype id);
-  RawTowerGeomv5(const RawTowerGeom& geom0);
-  ~RawTowerGeomv5() override {}
+  RawTowerGeomv5() = default;
+  explicit RawTowerGeomv5(RawTowerDefs::keytype id);
+  explicit RawTowerGeomv5(const RawTowerGeom& geom0);
+  ~RawTowerGeomv5() override = default;
 
   void identify(std::ostream& os = std::cout) const override;
 
@@ -57,7 +57,7 @@ class RawTowerGeomv5 : public RawTowerGeom
     return;
   }
 
-  void set_vertices(const std::vector<double>&) override;
+  void set_vertices(const std::vector<double>& /*vertices*/) override;
 
   double get_center_x() const override { return _center.x; }
   double get_center_y() const override { return _center.y; }

--- a/offline/packages/CaloBase/RawTowerGeomv5.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5.h
@@ -8,18 +8,6 @@
 #include <iostream>
 #include <limits>
 
-typedef std::pair<double,double> vertex_t;
-typedef std::vector<vertex_t> vertices_t;
-
-struct point_coordinates {
-  double R;
-  double eta;
-  double phi;
-  double x;
-  double y;
-  double z;
-};
-
 class RawTowerGeomv5 : public RawTowerGeom
 {
  public:
@@ -103,58 +91,48 @@ class RawTowerGeomv5 : public RawTowerGeom
   double get_phi() const override;
   double get_theta() const override;
 
+  // This structure is only used by this class
+  struct point_coordinates
+  {
+    double x;
+    double y;
+    double z;
+  };
+
  protected:
+  using vertex_t = std::pair<double, double>;
+  using vertices_t = std::vector<vertex_t>;
+
   RawTowerDefs::keytype _towerid{std::numeric_limits<RawTowerDefs::keytype>::max()};
 
   static constexpr int _nVtx = 8;
-  point_coordinates _center{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_int{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_ext{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_low_eta{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_high_eta{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_low_phi{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
-  point_coordinates _center_high_phi{std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN(),
-                  std::numeric_limits<double>::signaling_NaN()};
+  point_coordinates _center{std::numeric_limits<double>::quiet_NaN(),
+                            std::numeric_limits<double>::quiet_NaN(),
+                            std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_int{std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_ext{std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN(),
+                                std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_low_eta{std::numeric_limits<double>::quiet_NaN(),
+                                    std::numeric_limits<double>::quiet_NaN(),
+                                    std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_high_eta{std::numeric_limits<double>::quiet_NaN(),
+                                     std::numeric_limits<double>::quiet_NaN(),
+                                     std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_low_phi{std::numeric_limits<double>::quiet_NaN(),
+                                    std::numeric_limits<double>::quiet_NaN(),
+                                    std::numeric_limits<double>::quiet_NaN()};
+  point_coordinates _center_high_phi{std::numeric_limits<double>::quiet_NaN(),
+                                     std::numeric_limits<double>::quiet_NaN(),
+                                     std::numeric_limits<double>::quiet_NaN()};
 
   std::vector<point_coordinates> _vertices;
-  double _rotx{std::numeric_limits<double>::signaling_NaN()};
-  double _roty{std::numeric_limits<double>::signaling_NaN()};
-  double _rotz{std::numeric_limits<double>::signaling_NaN()};
-  
+  double _rotx{std::numeric_limits<double>::quiet_NaN()};
+  double _roty{std::numeric_limits<double>::quiet_NaN()};
+  double _rotz{std::numeric_limits<double>::quiet_NaN()};
+
   ClassDefOverride(RawTowerGeomv5, 4)
 };
 

--- a/offline/packages/CaloBase/RawTowerGeomv5LinkDef.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5LinkDef.h
@@ -1,6 +1,5 @@
 #ifdef __CINT__
 
-// #pragma link C++ struct point_coordinates + ;
 #pragma link C++ class RawTowerGeomv5 + ;
 
 #endif /* __CINT__ */

--- a/offline/packages/CaloBase/RawTowerGeomv5LinkDef.h
+++ b/offline/packages/CaloBase/RawTowerGeomv5LinkDef.h
@@ -1,0 +1,6 @@
+#ifdef __CINT__
+
+// #pragma link C++ struct point_coordinates + ;
+#pragma link C++ class RawTowerGeomv5 + ;
+
+#endif /* __CINT__ */

--- a/offline/packages/CaloReco/CaloGeomMappingv2.cc
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.cc
@@ -5,10 +5,10 @@
 #include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/SubsysReco.h>                         // for SubsysReco
+#include <fun4all/SubsysReco.h>  // for SubsysReco
 
 #include <phool/PHCompositeNode.h>
-#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHIODataNode.h>  // for PHIODataNode
 #include <phool/PHNode.h>
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/PHObject.h>
@@ -21,18 +21,18 @@
 #include <calobase/RawTowerGeomContainer_Cylinderv1.h>
 #include <calobase/RawTowerGeomv5.h>
 
-#include <cstdlib>                                     // for exit
-#include <exception>                                    // for exception
-#include <iostream>                                     // for operator<<, endl
-#include <cmath>                                       // for fabs, atan, cos
-#include <stdexcept>                                    // for runtime_error
-#include <utility>                                      // for pair
+#include <cmath>      // for fabs, atan, cos
+#include <cstdlib>    // for exit
+#include <exception>  // for exception
+#include <iostream>   // for operator<<, endl
+#include <stdexcept>  // for runtime_error
+#include <utility>    // for pair
 
 //____________________________________________________________________________..
-CaloGeomMappingv2::CaloGeomMappingv2(const std::string &name):
- SubsysReco(name),
- m_Detector("CEMC"),
- m_RawTowerGeomContainer(nullptr)
+CaloGeomMappingv2::CaloGeomMappingv2(const std::string &name)
+  : SubsysReco(name)
+  , m_Detector("CEMC")
+  , m_RawTowerGeomContainer(nullptr)
 {
   std::cout << "CaloGeomMappingv2::CaloGeomMappingv2(const std::string &name) Calling ctor" << std::endl;
 }
@@ -64,22 +64,22 @@ int CaloGeomMappingv2::Init(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
+void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode *topNode)
 {
   PHNodeIterator iter(topNode);
   PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
   if (!runNode)
   {
-      std::cout << PHWHERE << "Run Node missing, doing nothing." << std::endl;
-      throw std::runtime_error("Failed to find Run node in CaloGeomMappingv2::CreateGeomNode");
+    std::cout << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+    throw std::runtime_error("Failed to find Run node in CaloGeomMappingv2::CreateGeomNode");
   }
 
   PHNodeIterator runIter(runNode);
   PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", m_Detector));
   if (!RunDetNode)
   {
-      RunDetNode = new PHCompositeNode(m_Detector);
-      runNode->addNode(RunDetNode);
+    RunDetNode = new PHCompositeNode(m_Detector);
+    runNode->addNode(RunDetNode);
   }
 
   const RawTowerDefs::CalorimeterId caloid = RawTowerDefs::convert_name_to_caloid(m_Detector);
@@ -100,8 +100,8 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
   // For the moment, the default geometry file is not yet in CDB
 
   // All towers' geome
-  std::string inName="/sphenix/user/virgilemahaut/geometry/macros/calo_geom_mapping_exact.root";
-  CDBTTree * cdbttree = new CDBTTree(inName);
+  std::string inName = "/sphenix/user/virgilemahaut/geometry/macros/calo_geom_mapping_exact.root";
+  CDBTTree *cdbttree = new CDBTTree(inName);
 
   std::string parBase;
   // Set the radius, thickness, number of eta and phi bins
@@ -141,42 +141,41 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
   {
     for (int iUniqueTower = 0; iUniqueTower < 192; iUniqueTower++)
     {
-
       // Vertices' coordinates of the corresponding unique block.
-      std::vector<double> vertices(18*3);
-      for (int i = 0; i < 8; i++) 
+      std::vector<double> vertices(18 * 3);
+      for (int i = 0; i < 8; i++)
       {
-        vertices[i*3+0] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_x") / 10; // Convert mm to cm
-        vertices[i*3+1] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_y") / 10;
-        vertices[i*3+2] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_z") / 10;
+        vertices[i * 3 + 0] = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "vtx_" + std::to_string(i) + "_x") / 10;  // Convert mm to cm
+        vertices[i * 3 + 1] = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "vtx_" + std::to_string(i) + "_y") / 10;
+        vertices[i * 3 + 2] = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "vtx_" + std::to_string(i) + "_z") / 10;
       }
 
       // Get the rotation vector of the block:
-      double rot_x = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_x");
-      double rot_y = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_y");
-      double rot_z = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_z");
+      double rot_x = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "rot_x");
+      double rot_y = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "rot_y");
+      double rot_z = cdbttree->GetDoubleValue(iUniqueTower * 32 + iSector + 1, "rot_z");
 
       // Divide each block into 4 equal towers.
-      for (int j = 0; j < 3; j++) 
+      for (int j = 0; j < 3; j++)
       {
         for (int i = 0; i < 4; i++)
         {
-          vertices[(8+i)*3+j]=(vertices[i*3+j] + vertices[((i+1)%4)*3+j]) / 2;
-          vertices[(8+i+4)*3+j]=(vertices[(i+4)*3+j] + vertices[((i+1)%4+4)*3+j]) / 2;
+          vertices[(8 + i) * 3 + j] = (vertices[i * 3 + j] + vertices[((i + 1) % 4) * 3 + j]) / 2;
+          vertices[(8 + i + 4) * 3 + j] = (vertices[(i + 4) * 3 + j] + vertices[((i + 1) % 4 + 4) * 3 + j]) / 2;
         }
-        vertices[(16)*3+j] = (vertices[0*3+j] + vertices[1*3+j] + vertices[2*3+j] + vertices[3*3+j]) / 4;
-        vertices[(17)*3+j] = (vertices[4*3+j] + vertices[5*3+j] + vertices[6*3+j] + vertices[7*3+j]) / 4;
+        vertices[(16) * 3 + j] = (vertices[0 * 3 + j] + vertices[1 * 3 + j] + vertices[2 * 3 + j] + vertices[3 * 3 + j]) / 4;
+        vertices[(17) * 3 + j] = (vertices[4 * 3 + j] + vertices[5 * 3 + j] + vertices[6 * 3 + j] + vertices[7 * 3 + j]) / 4;
       }
 
       int ietaBlock = iUniqueTower / 4;
-      int iphiBlock = iSector * 4 + iUniqueTower % 4; 
+      int iphiBlock = iSector * 4 + iUniqueTower % 4;
 
       // Vertices' indices for each of the 4 individual towers.
       double sub_tower[2][2][8];
-      double sub_tower_01[8] = {12,17,11,4,16,18,15,8}; // low eta high phi
-      double sub_tower_00[8] = {17,10,3,11,18,14,7,15}; // low eta low phi
-      double sub_tower_11[8] = {1,9,17,12,5,13,18,16}; // high eta high phi
-      double sub_tower_10[8] = {9,2,10,17,13,6,14,18}; // high eta low phi
+      double sub_tower_01[8] = {12, 17, 11, 4, 16, 18, 15, 8};  // low eta high phi
+      double sub_tower_00[8] = {17, 10, 3, 11, 18, 14, 7, 15};  // low eta low phi
+      double sub_tower_11[8] = {1, 9, 17, 12, 5, 13, 18, 16};   // high eta high phi
+      double sub_tower_10[8] = {9, 2, 10, 17, 13, 6, 14, 18};   // high eta low phi
       for (int ivtx = 0; ivtx < 8; ivtx++)
       {
         sub_tower[0][0][ivtx] = sub_tower_00[ivtx];
@@ -192,22 +191,21 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
           int ieta = ietaBlock * 2 + iTower;
           int iphi = iphiBlock * 2 + jTower;
 
-          std::vector<double> towerVertices(8*3);
+          std::vector<double> towerVertices(8 * 3);
           for (int ivtx = 0; ivtx < 8; ivtx++)
           {
-            for (int icoord = 0; icoord < 3; icoord++) 
+            for (int icoord = 0; icoord < 3; icoord++)
             {
-              towerVertices[ivtx*3+icoord] = vertices[(sub_tower[iTower][jTower][ivtx]-1)*3+icoord];
+              towerVertices[ivtx * 3 + icoord] = vertices[(sub_tower[iTower][jTower][ivtx] - 1) * 3 + icoord];
             }
           }
 
           // build tower geom here
           const RawTowerDefs::keytype key =
-            RawTowerDefs::encode_towerid(caloid, ieta, iphi);
-          
-      
+              RawTowerDefs::encode_towerid(caloid, ieta, iphi);
+
           RawTowerGeomv5 *tg0 = new RawTowerGeomv5(key);
-      
+
           tg0->set_vertices(towerVertices);
           tg0->set_rotx(rot_x);
           tg0->set_roty(rot_y);
@@ -216,11 +214,11 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
           const double x(tg0->get_center_x());
           const double y(tg0->get_center_y());
           const double z(tg0->get_center_z());
-          //std::cout << "tower " << key << ": (" << x << "," << y << "," << z << ")" << std::endl;
+          // std::cout << "tower " << key << ": (" << x << "," << y << "," << z << ")" << std::endl;
           /* const double x(0); */
           /* const double y(0); */
           /* const double z(0); */
-          
+
           RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
           if (tg)
           {
@@ -234,7 +232,7 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
             {
               std::cout << "CaloGeomMappingv2::CreateGeomNode - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
                         << std::endl;
-              
+
               exit(1);
             }
             if (fabs(tg->get_center_y() - y) > 1e-4)
@@ -256,7 +254,7 @@ void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
             {
               std::cout << "CaloGeomMappingv2::CreateGeomNode - building tower geometry " << key << "" << std::endl;
             }
-            
+
             tg = tg0;
             m_RawTowerGeomContainer->add_tower_geometry(tg);
           }
@@ -271,7 +269,7 @@ void CaloGeomMappingv2::set_detector_name(const std::string &name)
   m_Detector = name;
 }
 
-void CaloGeomMappingv2::setTowerGeomNodeName(const std::string& name)
+void CaloGeomMappingv2::setTowerGeomNodeName(const std::string &name)
 {
   m_TowerGeomNodeName = name;
 }

--- a/offline/packages/CaloReco/CaloGeomMappingv2.cc
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.cc
@@ -1,0 +1,282 @@
+#include "CaloGeomMappingv2.h"
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/SubsysReco.h>                         // for SubsysReco
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>    // for PHIODataNode
+#include <phool/PHNode.h>
+#include <phool/PHNodeIterator.h>  // for PHNodeIterator
+#include <phool/PHObject.h>
+#include <phool/getClass.h>
+#include <phool/phool.h>  // for PHWHERE
+
+#include <calobase/RawTowerDefs.h>           // for encode_towerid
+#include <calobase/RawTowerGeom.h>           // for RawTowerGeom
+#include <calobase/RawTowerGeomContainer.h>  // for RawTowerGeomC...
+#include <calobase/RawTowerGeomContainer_Cylinderv1.h>
+#include <calobase/RawTowerGeomv5.h>
+
+#include <cstdlib>                                     // for exit
+#include <exception>                                    // for exception
+#include <iostream>                                     // for operator<<, endl
+#include <cmath>                                       // for fabs, atan, cos
+#include <stdexcept>                                    // for runtime_error
+#include <utility>                                      // for pair
+
+//____________________________________________________________________________..
+CaloGeomMappingv2::CaloGeomMappingv2(const std::string &name):
+ SubsysReco(name),
+ m_Detector("CEMC"),
+ m_RawTowerGeomContainer(nullptr)
+{
+  std::cout << "CaloGeomMappingv2::CaloGeomMappingv2(const std::string &name) Calling ctor" << std::endl;
+}
+
+//____________________________________________________________________________..
+CaloGeomMappingv2::~CaloGeomMappingv2()
+{
+  std::cout << "CaloGeomMappingv2::~CaloGeomMappingv2() Calling dtor" << std::endl;
+}
+
+//____________________________________________________________________________..
+int CaloGeomMappingv2::Init(PHCompositeNode *topNode)
+{
+  std::cout << "CaloGeomMappingv2::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+
+  /* std::cout << "Printing node tree before new node creation:" << std::endl; */
+  /* topNode->print(); */
+  try
+  {
+    CreateGeomNode(topNode);
+  }
+  catch (std::exception &e)
+  {
+    std::cout << e.what() << std::endl;
+    exit(1);
+  }
+  /* std::cout << "Printing node tree after new node creation:" << std::endl; */
+  /* topNode->print(); */
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void CaloGeomMappingv2::CreateGeomNode(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode)
+  {
+      std::cout << PHWHERE << "Run Node missing, doing nothing." << std::endl;
+      throw std::runtime_error("Failed to find Run node in CaloGeomMappingv2::CreateGeomNode");
+  }
+
+  PHNodeIterator runIter(runNode);
+  PHCompositeNode *RunDetNode = dynamic_cast<PHCompositeNode *>(runIter.findFirst("PHCompositeNode", m_Detector));
+  if (!RunDetNode)
+  {
+      RunDetNode = new PHCompositeNode(m_Detector);
+      runNode->addNode(RunDetNode);
+  }
+
+  const RawTowerDefs::CalorimeterId caloid = RawTowerDefs::convert_name_to_caloid(m_Detector);
+  if (m_TowerGeomNodeName.empty())
+  {
+    m_TowerGeomNodeName = "TOWERGEOM_" + m_Detector;
+  }
+  m_RawTowerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, m_TowerGeomNodeName);
+  if (!m_RawTowerGeomContainer)
+  {
+    m_RawTowerGeomContainer = new RawTowerGeomContainer_Cylinderv1(caloid);
+    // add it to the node tree
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(m_RawTowerGeomContainer, m_TowerGeomNodeName, "PHObject");
+    RunDetNode->addNode(newNode);
+  }
+
+  // Get the geometry mapping file from the Conditions Database
+  // For the moment, the default geometry file is not yet in CDB
+
+  // All towers' geome
+  std::string inName="/sphenix/user/virgilemahaut/geometry/macros/calo_geom_mapping_exact.root";
+  CDBTTree * cdbttree = new CDBTTree(inName);
+
+  std::string parBase;
+  // Set the radius, thickness, number of eta and phi bins
+  if (m_Detector == "CEMC")
+  {
+    parBase = "cemc";
+    m_RawTowerGeomContainer->set_radius(93.5);
+    m_RawTowerGeomContainer->set_thickness(20.4997);
+    m_RawTowerGeomContainer->set_phibins(256);
+    m_RawTowerGeomContainer->set_etabins(96);
+    //  m_RawTowerGeomContainer->set_phistep(m_PhiStep);
+    //  m_RawTowerGeomContainer->set_phimin(m_PhiMin);
+  }
+  if (m_Detector == "HCALIN")
+  {
+    parBase = "hcalin";
+    m_RawTowerGeomContainer->set_radius(115);
+    m_RawTowerGeomContainer->set_thickness(25.005);
+    m_RawTowerGeomContainer->set_phibins(64);
+    m_RawTowerGeomContainer->set_etabins(24);
+    //  m_RawTowerGeomContainer->set_phistep(m_PhiStep);
+    //  m_RawTowerGeomContainer->set_phimin(m_PhiMin);
+  }
+  if (m_Detector == "HCALOUT")
+  {
+    parBase = "hcalout";
+    m_RawTowerGeomContainer->set_radius(177.423);
+    m_RawTowerGeomContainer->set_thickness(96.894);
+    m_RawTowerGeomContainer->set_phibins(64);
+    m_RawTowerGeomContainer->set_etabins(24);
+    //  m_RawTowerGeomContainer->set_phistep(m_PhiStep);
+    //  m_RawTowerGeomContainer->set_phimin(m_PhiMin);
+  }
+
+  // Populate container with RawTowerGeom objects
+  for (int iSector = 0; iSector < 32; iSector++)
+  {
+    for (int iUniqueTower = 0; iUniqueTower < 192; iUniqueTower++)
+    {
+
+      // Vertices' coordinates of the corresponding unique block.
+      std::vector<double> vertices(18*3);
+      for (int i = 0; i < 8; i++) 
+      {
+        vertices[i*3+0] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_x") / 10; // Convert mm to cm
+        vertices[i*3+1] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_y") / 10;
+        vertices[i*3+2] = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"vtx_" + std::to_string(i) + "_z") / 10;
+      }
+
+      // Get the rotation vector of the block:
+      double rot_x = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_x");
+      double rot_y = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_y");
+      double rot_z = cdbttree->GetDoubleValue(iUniqueTower*32+iSector+1,"rot_z");
+
+      // Divide each block into 4 equal towers.
+      for (int j = 0; j < 3; j++) 
+      {
+        for (int i = 0; i < 4; i++)
+        {
+          vertices[(8+i)*3+j]=(vertices[i*3+j] + vertices[((i+1)%4)*3+j]) / 2;
+          vertices[(8+i+4)*3+j]=(vertices[(i+4)*3+j] + vertices[((i+1)%4+4)*3+j]) / 2;
+        }
+        vertices[(16)*3+j] = (vertices[0*3+j] + vertices[1*3+j] + vertices[2*3+j] + vertices[3*3+j]) / 4;
+        vertices[(17)*3+j] = (vertices[4*3+j] + vertices[5*3+j] + vertices[6*3+j] + vertices[7*3+j]) / 4;
+      }
+
+      int ietaBlock = iUniqueTower / 4;
+      int iphiBlock = iSector * 4 + iUniqueTower % 4; 
+
+      // Vertices' indices for each of the 4 individual towers.
+      double sub_tower[2][2][8];
+      double sub_tower_01[8] = {12,17,11,4,16,18,15,8}; // low eta high phi
+      double sub_tower_00[8] = {17,10,3,11,18,14,7,15}; // low eta low phi
+      double sub_tower_11[8] = {1,9,17,12,5,13,18,16}; // high eta high phi
+      double sub_tower_10[8] = {9,2,10,17,13,6,14,18}; // high eta low phi
+      for (int ivtx = 0; ivtx < 8; ivtx++)
+      {
+        sub_tower[0][0][ivtx] = sub_tower_00[ivtx];
+        sub_tower[0][1][ivtx] = sub_tower_01[ivtx];
+        sub_tower[1][0][ivtx] = sub_tower_10[ivtx];
+        sub_tower[1][1][ivtx] = sub_tower_11[ivtx];
+      }
+
+      for (int iTower = 0; iTower < 2; iTower++)
+      {
+        for (int jTower = 0; jTower < 2; jTower++)
+        {
+          int ieta = ietaBlock * 2 + iTower;
+          int iphi = iphiBlock * 2 + jTower;
+
+          std::vector<double> towerVertices(8*3);
+          for (int ivtx = 0; ivtx < 8; ivtx++)
+          {
+            for (int icoord = 0; icoord < 3; icoord++) 
+            {
+              towerVertices[ivtx*3+icoord] = vertices[(sub_tower[iTower][jTower][ivtx]-1)*3+icoord];
+            }
+          }
+
+          // build tower geom here
+          const RawTowerDefs::keytype key =
+            RawTowerDefs::encode_towerid(caloid, ieta, iphi);
+          
+      
+          RawTowerGeomv5 *tg0 = new RawTowerGeomv5(key);
+      
+          tg0->set_vertices(towerVertices);
+          tg0->set_rotx(rot_x);
+          tg0->set_roty(rot_y);
+          tg0->set_rotz(rot_z);
+
+          const double x(tg0->get_center_x());
+          const double y(tg0->get_center_y());
+          const double z(tg0->get_center_z());
+          //std::cout << "tower " << key << ": (" << x << "," << y << "," << z << ")" << std::endl;
+          /* const double x(0); */
+          /* const double y(0); */
+          /* const double z(0); */
+          
+          RawTowerGeom *tg = m_RawTowerGeomContainer->get_tower_geometry(key);
+          if (tg)
+          {
+            delete tg0;
+            if (Verbosity() > 0)
+            {
+              std::cout << "CaloGeomMappingv2::CreateGeomNode - Tower geometry " << key << " already exists" << std::endl;
+            }
+
+            if (fabs(tg->get_center_x() - x) > 1e-4)
+            {
+              std::cout << "CaloGeomMappingv2::CreateGeomNode - Fatal Error - duplicated Tower geometry " << key << " with existing x = " << tg->get_center_x() << " and expected x = " << x
+                        << std::endl;
+              
+              exit(1);
+            }
+            if (fabs(tg->get_center_y() - y) > 1e-4)
+            {
+              std::cout << "CaloGeomMappingv2::CreateGeomNode - Fatal Error - duplicated Tower geometry " << key << " with existing y = " << tg->get_center_y() << " and expected y = " << y
+                        << std::endl;
+              exit(1);
+            }
+            if (fabs(tg->get_center_z() - z) > 1e-4)
+            {
+              std::cout << "CaloGeomMappingv2::CreateGeomNode - Fatal Error - duplicated Tower geometry " << key << " with existing z= " << tg->get_center_z() << " and expected z = " << z
+                        << std::endl;
+              exit(1);
+            }
+          }
+          else
+          {
+            if (Verbosity() > 0)
+            {
+              std::cout << "CaloGeomMappingv2::CreateGeomNode - building tower geometry " << key << "" << std::endl;
+            }
+            
+            tg = tg0;
+            m_RawTowerGeomContainer->add_tower_geometry(tg);
+          }
+        }
+      }
+    }
+  }  // end loop over eta, phi bins
+}  // end of building RawTowerGeomContainer
+
+void CaloGeomMappingv2::set_detector_name(const std::string &name)
+{
+  m_Detector = name;
+}
+
+void CaloGeomMappingv2::setTowerGeomNodeName(const std::string& name)
+{
+  m_TowerGeomNodeName = name;
+}
+
+std::string CaloGeomMappingv2::get_detector_name()
+{
+  return m_Detector;
+}

--- a/offline/packages/CaloReco/CaloGeomMappingv2.cc
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.cc
@@ -273,7 +273,7 @@ void CaloGeomMappingv2::setTowerGeomNodeName(const std::string &name)
   m_TowerGeomNodeName = name;
 }
 
-std::string CaloGeomMappingv2::get_detector_name()
+const std::string CaloGeomMappingv2::get_detector_name()
 {
   return m_Detector;
 }

--- a/offline/packages/CaloReco/CaloGeomMappingv2.h
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.h
@@ -56,7 +56,7 @@ class CaloGeomMappingv2 : public SubsysReco
   void setTowerGeomNodeName(const std::string& name);
 
   void set_detector_name(const std::string& name);
-  std::string get_detector_name();
+  const std::string get_detector_name();
 
  protected:
   std::string m_Detector;  // CEMC, HCALIN or HCALOUT

--- a/offline/packages/CaloReco/CaloGeomMappingv2.h
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.h
@@ -13,7 +13,7 @@ class RawTowerGeomContainer;
 class CaloGeomMappingv2 : public SubsysReco
 {
  public:
-  CaloGeomMappingv2(const std::string& name = "CaloGeomMappingv2");
+  explicit CaloGeomMappingv2(const std::string& name = "CaloGeomMappingv2");
 
   ~CaloGeomMappingv2() override;
 

--- a/offline/packages/CaloReco/CaloGeomMappingv2.h
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.h
@@ -1,0 +1,68 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+#ifndef CALOGEOMMAPPINGV2_H
+#define CALOGEOMMAPPINGV2_H
+
+#include <fun4all/SubsysReco.h>
+
+#include <string>
+
+class PHCompositeNode;
+class RawTowerGeomContainer;
+
+class CaloGeomMappingv2 : public SubsysReco
+{
+ public:
+
+  CaloGeomMappingv2(const std::string &name = "CaloGeomMappingv2");
+
+  ~CaloGeomMappingv2() override;
+
+  /** Called during initialization.
+      Typically this is where you can book histograms, and e.g.
+      register them to Fun4AllServer (so they can be output to file
+      using Fun4AllServer::dumpHistos() method).
+   */
+  int Init(PHCompositeNode *topNode) override;
+
+  /** Called for first event when run number is known.
+      Typically this is where you may want to fetch data from
+      database, because you know the run number. A place
+      to book histograms which have to know the run number.
+   */
+  /* int InitRun(PHCompositeNode *topNode) override; */
+
+  /** Called for each event.
+      This is where you do the real work.
+   */
+  /* int process_event(PHCompositeNode *topNode) override; */
+
+  /// Clean up internals after each event.
+  /* int ResetEvent(PHCompositeNode *topNode) override; */
+
+  /// Called at the end of each run.
+  /* int EndRun(const int runnumber) override; */
+
+  /// Called at the end of all processing.
+  /* int End(PHCompositeNode *topNode) override; */
+
+  /// Reset
+  /* int Reset(PHCompositeNode * topNode) override; */
+
+  /* void Print(const std::string &what = "ALL") const override; */
+
+  // Create tower geometry mapping node
+  void CreateGeomNode(PHCompositeNode* topNode);
+
+  void setTowerGeomNodeName(const std::string& name);
+
+  void set_detector_name(const std::string &name);
+  std::string get_detector_name();
+
+ protected:
+  std::string m_Detector; // CEMC, HCALIN or HCALOUT
+  std::string m_TowerGeomNodeName;
+  RawTowerGeomContainer* m_RawTowerGeomContainer; // Name of the output TOWERGEOM node
+};
+
+#endif // CALOGEOMMAPPING_H

--- a/offline/packages/CaloReco/CaloGeomMappingv2.h
+++ b/offline/packages/CaloReco/CaloGeomMappingv2.h
@@ -13,8 +13,7 @@ class RawTowerGeomContainer;
 class CaloGeomMappingv2 : public SubsysReco
 {
  public:
-
-  CaloGeomMappingv2(const std::string &name = "CaloGeomMappingv2");
+  CaloGeomMappingv2(const std::string& name = "CaloGeomMappingv2");
 
   ~CaloGeomMappingv2() override;
 
@@ -23,7 +22,7 @@ class CaloGeomMappingv2 : public SubsysReco
       register them to Fun4AllServer (so they can be output to file
       using Fun4AllServer::dumpHistos() method).
    */
-  int Init(PHCompositeNode *topNode) override;
+  int Init(PHCompositeNode* topNode) override;
 
   /** Called for first event when run number is known.
       Typically this is where you may want to fetch data from
@@ -56,13 +55,13 @@ class CaloGeomMappingv2 : public SubsysReco
 
   void setTowerGeomNodeName(const std::string& name);
 
-  void set_detector_name(const std::string &name);
+  void set_detector_name(const std::string& name);
   std::string get_detector_name();
 
  protected:
-  std::string m_Detector; // CEMC, HCALIN or HCALOUT
+  std::string m_Detector;  // CEMC, HCALIN or HCALOUT
   std::string m_TowerGeomNodeName;
-  RawTowerGeomContainer* m_RawTowerGeomContainer; // Name of the output TOWERGEOM node
+  RawTowerGeomContainer* m_RawTowerGeomContainer;  // Name of the output TOWERGEOM node
 };
 
-#endif // CALOGEOMMAPPING_H
+#endif  // CALOGEOMMAPPING_H

--- a/offline/packages/CaloReco/Makefile.am
+++ b/offline/packages/CaloReco/Makefile.am
@@ -45,6 +45,7 @@ pkginclude_HEADERS = \
 else
 pkginclude_HEADERS = \
   CaloGeomMapping.h \
+  CaloGeomMappingv2.h \
   CaloWaveformFitting.h \
   CaloWaveformProcessing.h \
   CaloRecoUtility.h \
@@ -76,6 +77,7 @@ libcalo_reco_la_SOURCES = \
   BEmcRec.cc \
   BEmcRecCEMC.cc \
   CaloGeomMapping.cc \
+  CaloGeomMappingv2.cc \
   CaloRecoUtility.cc \
   CaloWaveformFitting.cc \
   CaloWaveformProcessing.cc \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

This PR adds the possibility to use an alternative version of the EMCal geometry in the calorimeter reconstruction software. In this new version, the tower centers are identical to those in the GEANT4 simulation. In addition, the new geometry class allows to access easily the 8 vertices of the tower as well as the center of each face. This new geometry has been mentioned in this talk: https://indico.bnl.gov/event/26075/contributions/101054/attachments/59317/101905/Calorimeter_cluster_reconstruction_01062025.pdf.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

Implement the new geometry in the cluster reconstruction code without breaking the former geometry.

## Links to other PRs in macros and calibration repositories (if applicable)
This pull request has been done following this pull request (https://github.com/sPHENIX-Collaboration/coresoftware/pull/3374) which has been closed. The style is now generated with clang-format. Formerly global typedefs and struct have been redefined inside the class RawTowerGeomv5. "signaling_NaN()" have been replaced by "quiet_NaN()", both in RawTowerGeomv5.h and in RawTowerGeom.h 
