### PR TITLE
Fig but in PHCASeeding

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -136,6 +136,16 @@ namespace
     return phi;
   }
 
+  // note: assumes that a and b are in same range of phi;
+  // this will fail if a\in[-2 pi,0] and b\in[0,2 pi] 
+  // in this case is ok, as all are atan2 which [-pi,pi]
+  inline float wrap_dphi(float a, float b) {
+    float   _dphi = b-a;
+    return (_dphi < -M_PI) ? _dphi += 2*M_PI
+         : (_dphi >  M_PI) ? _dphi -= 2*M_PI
+         : _dphi;
+  }
+
   /// pseudo rapidity of Acts::Vector3
   /* inline double get_eta(const Acts::Vector3& position) */
   /* { */
@@ -773,9 +783,9 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
           {
             continue;
           }
-          const float dphi_01 = phi[i0] - phi[i1];
-          const float dphi_12 = phi[i1] - phi[i2];
-          const float dphi_23 = phi[i2] - phi[i3];
+          const float dphi_01 = wrap_dphi(phi[i1], phi[i0]);
+          const float dphi_12 = wrap_dphi(phi[i2], phi[i1]);
+          const float dphi_23 = wrap_dphi(phi[i3], phi[i2]);
           const float dR_23 = R[i2] - R[i3];
           const float d2phidr2_01 = dphi_01 / dR_01 / dR_01 - dphi_12 / dR_12 / dR_12;
           const float d2phidr2_12 = dphi_12 / dR_12 / dR_12 - dphi_23 / dR_23 / dR_23;


### PR DESCRIPTION
The calculation of dphi from point A to point B was atan2(By,Bx) - atan2(Ay,By). This fails for values at -Ax and -Bx, where Ay and By change sign (the periodic boundary). This is now fixed.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

