### PR TITLE
update compiler flags for mvtx

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(OFFLINE_MAIN)/include  \
+  -isystem$(OFFLINE_MAIN)/include  \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/offline/packages/mvtx/configure.ac
+++ b/offline/packages/mvtx/configure.ac
@@ -9,7 +9,7 @@ LT_INIT([disable-static])
 dnl   no point in suppressing warnings people should 
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_prog_gxx = yes; then
-   CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra"
+   CXXFLAGS="$CXXFLAGS -Wall -Wshadow  -Wextra -Werror"
 fi
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-unknown-warning-option"


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR updates the compiler flags for the mvtx package. The standard -Wshadow which prevents shadowed variable use was missing. Also use -isystem for OFFLINE_MAIN/include to get rid of warnings from 3rd party includes. No need to run jenkins [skip-ci]

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

