### PR TITLE
fix: misalignment factor setting

### DIFF
--- a/offline/packages/trackbase/AlignmentTransformation.cc
+++ b/offline/packages/trackbase/AlignmentTransformation.cc
@@ -408,6 +408,7 @@ int AlignmentTransformation::getNodes(PHCompositeNode* topNode)
 void AlignmentTransformation::misalignmentFactor(uint8_t layer, const double factor)
 {
   transformMap->setMisalignmentFactor(layer, factor);
+  transformMapTransient->setMisalignmentFactor(layer, factor);
 }
 void AlignmentTransformation::createAlignmentTransformContainer(PHCompositeNode* topNode)
 {

--- a/offline/packages/trackbase/AlignmentTransformation.h
+++ b/offline/packages/trackbase/AlignmentTransformation.h
@@ -103,6 +103,10 @@ class AlignmentTransformation
 
   void verbosity() { localVerbosity = 1; }
   void misalignmentFactor(uint8_t layer, const double factor);
+  double misalignmentFactor(uint8_t layer)
+  {
+    return transformMap->getMisalignmentFactor(layer);
+  }
   void useInttSurveyGeometry(bool sur) { use_intt_survey_geometry = sur; }
 
  private:


### PR DESCRIPTION
The introduction of the transient transform container meant that the misalignment factors applied to Acts were not properly propagated. This PR fixes this problem such that the measurement uncertainties are properly blown up based on some macro setting

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

