### PR TITLE
ClusterIso: use isgood for tower selection

### DIFF
--- a/offline/packages/ClusterIso/ClusterIso.cc
+++ b/offline/packages/ClusterIso/ClusterIso.cc
@@ -513,22 +513,7 @@ int ClusterIso::End(PHCompositeNode * /*topNode*/)
 
 bool ClusterIso::IsAcceptableTower(TowerInfo *tower)
 {
-  if (tower->get_isBadTime())
-  {
-    return false;
-  }
-
-  if (tower->get_isHot())
-  {
-    return false;
-  }
-
-  if (tower->get_isBadChi2())
-  {
-    return false;
-  }
-
-  if (tower->get_isNotInstr())
+  if (!tower->get_isGood())
   {
     return false;
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

be consistent with good tower description in cluster builder. (Also since the timing calib is not working currently some good tower can be tag as bad time therefore get excluded from the iso calculation leading to abnormal negative iso ET).

I thought I changed that long time ago :(


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

