### PR TITLE
Use PHParameters instead of recoConsts in Beam-Background Filter module

### DIFF
--- a/offline/packages/jetbackground/BeamBackgroundFilterAndQA.h
+++ b/offline/packages/jetbackground/BeamBackgroundFilterAndQA.h
@@ -13,11 +13,15 @@
 #define BEAMBACKGROUNDFILTERANDQA_H
 
 // module components
+#include "BaseBeamBackgroundFilter.h"
 #include "NullFilter.h"
 #include "StreakSidebandFilter.h"
 
 // f4a libraries
 #include <fun4all/SubsysReco.h>
+
+// phparameters libraries
+#include <phparameter/PHParameters.h>
 
 // c++ utilities
 #include <map>
@@ -26,11 +30,13 @@
 #include <vector>
 
 // forward declarations
-class BaseBeamBackgroundFilter;
 class Fun4AllHistoManager;
 class PHCompositeNode;
-class recoConsts;
+class QAHistManagerHistDef;
 class TH1;
+class TowerInfoContainer;
+
+
 
 // ============================================================================
 //! Filter beam background events and create QA
@@ -41,71 +47,79 @@ class TH1;
  */
 class BeamBackgroundFilterAndQA : public SubsysReco
 {
- public:
-  // ========================================================================
-  //! User options for module
-  // =======================================================================
-  struct Config
-  {
-    // turn modes on/off
-    bool debug = true;
-    bool doQA = true;
-    bool doEvtAbort = false;
+  public:
 
-    ///! module name
-    std::string moduleName = "BeamBackgroundFilterAndQA";
+    // ========================================================================
+    //! User options for module
+    // =======================================================================
+    struct Config
+    {
+      // turn modes on/off
+      bool debug      = true;
+      bool doQA       = true;
+      bool doEvtAbort = false;
 
-    ///! histogram tags
-    std::string histTag = "";
+      ///! module name
+      std::string moduleName = "BeamBackgroundFilterAndQA";
 
-    ///! which filters to apply
-    std::vector<std::string> filtersToApply = {"Null", "StreakSideband"};
+      ///! flag prefix
+      std::string flagPrefix = "HasBeamBackground";
 
-    ///! filter configurations
-    NullFilter::Config null;
-    StreakSidebandFilter::Config sideband;
-    //... add other configurations here ...//
-  };
+      ///! histogram tags
+      std::string histTag = "";
 
-  // ctor/dtor
-  BeamBackgroundFilterAndQA(const std::string& name = "BeamBackgroundFilterAndQA");
-  BeamBackgroundFilterAndQA(const Config& config);
-  ~BeamBackgroundFilterAndQA() override;
+      ///! which filters to apply
+      std::vector<std::string> filtersToApply = {"Null", "StreakSideband"};
 
-  // setters
-  void SetConfig(const Config& config) { m_config = config; }
+      ///! filter configurations
+      NullFilter::Config null;
+      StreakSidebandFilter::Config sideband;
+      //... add other configurations here ...//
+    };
 
-  // getters
-  Config GetConfig() const { return m_config; }
+    // ctor/dtor
+    BeamBackgroundFilterAndQA(const std::string& name = "BeamBackgroundFilterAndQA", const bool debug = false);
+    BeamBackgroundFilterAndQA(const Config& config);
+    ~BeamBackgroundFilterAndQA() override;
 
-  // f4a methods
-  int Init(PHCompositeNode* /*topNode*/) override;
-  int process_event(PHCompositeNode* topNode) override;
-  int End(PHCompositeNode* /*topNode*/) override;
+    // setters
+    void SetConfig(const Config& config) {m_config = config;}
 
- private:
-  // private methods
-  void InitFilters();
-  void InitFlags();
-  void InitHistManager();
-  void BuildHistograms();
-  void RegisterHistograms();
-  bool ApplyFilters(PHCompositeNode* topNode);
+    // getters
+    Config GetConfig() const {return m_config;}
 
-  ///! histogram manager
-  Fun4AllHistoManager* m_manager{nullptr};
+    // f4a methods
+    int Init(PHCompositeNode* topNode) override;
+    int process_event(PHCompositeNode* topNode) override;
+    int End(PHCompositeNode* /*topNode*/) override;
 
-  ///! reco consts (for flags)
-  recoConsts* m_consts{nullptr};
+  private:
 
-  ///! module-wide histograms
-  std::map<std::string, TH1*> m_hists;
+    // private methods
+    void InitFilters();
+    void InitFlags(PHCompositeNode* topNode);
+    void InitHistManager();
+    void BuildHistograms();
+    void RegisterHistograms();
+    void SetDefaultFlags();
+    void UpdateFlags(PHCompositeNode* topNode);
+    bool ApplyFilters(PHCompositeNode* topNode);
+    std::string MakeFlagName(const std::string& filter = "");
 
-  ///! module configuration
-  Config m_config;
+    ///! histogram manager
+    Fun4AllHistoManager* m_manager;
 
-  ///! filters
-  std::map<std::string, std::unique_ptr<BaseBeamBackgroundFilter>> m_filters;
+    ///! background flags
+    PHParameters m_flags;
+
+    ///! module-wide histograms
+    std::map<std::string, TH1*> m_hists;
+
+    ///! module configuration
+    Config m_config;
+
+    ///! filters
+    std::map<std::string, std::unique_ptr<BaseBeamBackgroundFilter>> m_filters;
 
 };  // end BeamBackgroundFilterAndQA
 

--- a/offline/packages/jetbackground/Makefile.am
+++ b/offline/packages/jetbackground/Makefile.am
@@ -26,7 +26,9 @@ libjetbackground_la_LIBADD = \
   -lcalo_io \
   -lConstituentSubtractor \
   -ljetbase \
+  -lpdbcalBase \
   -lphg4hit \
+  -lphparameter \
   -lqautils \
   -lSubsysReco
 


### PR DESCRIPTION
This PR updates the `BeamBackgroundFilterAndQA` module to use `PHParameters` instead of `recoConsts`, and ensures that flags are updated _and_ reset event-to-event.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This resolves a bug where the flags generated by the module were never updated, so once an event was found with beam background, the corresponding flag is set to true but never _reset_. Thanks to @jnclement for catching this!

Furthermore, since `recoConsts` is intended for reconstruction parameters which change more on the scale of a run, `PHParameters` is the more appropriate tool.

Note that the example macro and reader module have been updated in [analysis](https://github.com/sPHENIX-Collaboration/analysis/tree/master/JS-Jet/BeamBackgroundFilterAndQA).
