### PR TITLE
Add histogram to check for a tower energy, if it is saturated

### DIFF
--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -231,7 +231,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         uint8_t status = tower->get_status();
         h_emcal_tower_e->Fill(offlineenergy);
         h_emcal_tower_e_wide_range->Fill(offlineenergy);
-        
+        if (tower->get_isSaturated()) h_emcal_tower_e_saturated->Fill(offlineenergy);
         float pedestal = tower->get_pedestal();
         h_cemc_channel_pedestal[channel]->Fill(pedestal);
 
@@ -296,6 +296,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ihcal_channel_pedestal[channel]->Fill(pedestal);
         h_ihcal_tower_e->Fill(offlineenergy);
         h_ihcal_tower_e_wide_range->Fill(offlineenergy);
+        if (tower->get_isSaturated()) h_ihcal_tower_e_saturated->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)
@@ -353,6 +354,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         h_ohcal_channel_pedestal[channel]->Fill(pedestal);
         h_ohcal_tower_e->Fill(offlineenergy);
         h_ohcal_tower_e_wide_range->Fill(offlineenergy);
+        if (tower->get_isSaturated()) h_ohcal_tower_e_saturated->Fill(offlineenergy);
 
         uint8_t status = tower->get_status();
         for (int is = 0; is < 8; is++)
@@ -1004,6 +1006,10 @@ void CaloValid::createHistos()
   h_emcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_emcal_tower_e_wide_range);
 
+  h_emcal_tower_e_saturated = new TH1F(boost::str(boost::format("%semcal_tower_e_saturated") % getHistoPrefix()).c_str(), "emcal_tower_e_saturated", 1000, -10., 40.);
+  h_emcal_tower_e_saturated->SetDirectory(nullptr);
+  hm->registerHisto(h_emcal_tower_e_saturated);
+
   h_ihcal_tower_e = new TH1F(boost::str(boost::format("%sihcal_tower_e") % getHistoPrefix()).c_str(), "ihcal_tower_e", 5000, -0.1, 1);
   h_ihcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_tower_e);
@@ -1012,6 +1018,10 @@ void CaloValid::createHistos()
   h_ihcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_ihcal_tower_e_wide_range);
 
+  h_ihcal_tower_e_saturated = new TH1F(boost::str(boost::format("%sihcal_tower_e_saturated") % getHistoPrefix()).c_str(), "ihcal_tower_e_saturated", 1000, -10., 40.);
+  h_ihcal_tower_e_saturated->SetDirectory(nullptr);
+  hm->registerHisto(h_ihcal_tower_e_saturated);
+
   h_ohcal_tower_e = new TH1F(boost::str(boost::format("%sohcal_tower_e") % getHistoPrefix()).c_str(), "ohcal_tower_e", 5000, -0.1, 1);
   h_ohcal_tower_e->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_tower_e);
@@ -1019,6 +1029,10 @@ void CaloValid::createHistos()
   h_ohcal_tower_e_wide_range = new TH1F(boost::str(boost::format("%sohcal_tower_e_wide_range") % getHistoPrefix()).c_str(), "ohcal_tower_e_wide_range", 1000, -10., 40.);
   h_ohcal_tower_e_wide_range->SetDirectory(nullptr);
   hm->registerHisto(h_ohcal_tower_e_wide_range);
+
+  h_ohcal_tower_e_saturated = new TH1F(boost::str(boost::format("%sohcal_tower_e_saturated") % getHistoPrefix()).c_str(), "ohcal_tower_e_saturated", 1000, -10., 40.);
+  h_ohcal_tower_e_saturated->SetDirectory(nullptr);
+  hm->registerHisto(h_ohcal_tower_e_saturated);
 
   // cluster QA
   h_etaphi_clus = new TH2F(boost::str(boost::format("%setaphi_clus") % getHistoPrefix()).c_str(), "", 140, -1.2, 1.2, 64, -1 * M_PI, M_PI);

--- a/offline/QA/Calorimeters/CaloValid.h
+++ b/offline/QA/Calorimeters/CaloValid.h
@@ -105,10 +105,13 @@ class CaloValid : public SubsysReco
   TH1* h_ohcaltime{nullptr};
   TH1* h_emcal_tower_e{nullptr};
   TH1* h_emcal_tower_e_wide_range{nullptr};
+  TH1* h_emcal_tower_e_saturated{nullptr};
   TH1* h_ihcal_tower_e{nullptr};
   TH1* h_ihcal_tower_e_wide_range{nullptr};
+  TH1* h_ihcal_tower_e_saturated{nullptr};
   TH1* h_ohcal_tower_e{nullptr};
   TH1* h_ohcal_tower_e_wide_range{nullptr};
+  TH1* h_ohcal_tower_e_saturated{nullptr};
   TH2* h_etaphi_clus{nullptr};
   TH1* h_clusE{nullptr};
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Add a new tower histogram for all the calorimeters to check its tower energy if it is saturated
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

