### PR TITLE
Various improvements to PHCASeeding

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -70,14 +70,6 @@
 #define LogDebug(exp) (void) 0
 #endif
 
-#if defined(_PHCASEEDING_TIMER_OUT_)
-#define PHCASEEDING_PRINT_TIME(timer, statement) \
-  timer->stop();                                 \
-  std::cout << " PHCASEEDING_PRINT_TIME: Time to " << statement << ": " << timer->elapsed() / 1000 << " s" << std::endl;
-#else
-#define PHCASEEDING_PRINT_TIME(timer, statement) (void) 0
-#endif
-
 // apparently there is no builtin STL hash function for a std::array
 // so to use std::unordered_set (essentially a hash table), we have to make our own hasher
 
@@ -125,24 +117,6 @@ namespace
     return x * x;
   }
 
-  /// phi angle of Acts::Vector3
-  inline double get_phi(const Acts::Vector3& position)
-  {
-    double phi = std::atan2(position.y(), position.x());
-    if (phi < 0)
-    {
-      phi += 2. * M_PI;
-    }
-    return phi;
-  }
-
-  /// pseudo rapidity of Acts::Vector3
-  /* inline double get_eta(const Acts::Vector3& position) */
-  /* { */
-  /*   const double norm = std::sqrt(square(position.x()) + square(position.y()) + square(position.z())); */
-  /*   return std::log((norm + position.z()) / (norm - position.z())) / 2; */
-  /* } */
-
   inline double breaking_angle(double x1, double y1, double z1, double x2, double y2, double z2)
   {
     double l1 = sqrt(x1 * x1 + y1 * y1 + z1 * z1);
@@ -156,7 +130,107 @@ namespace
     return 2 * atan2(sqrt(dx * dx + dy * dy + dz * dz), sqrt(sx * sx + sy * sy + sz * sz));
   }
 
+  inline float wrap_dphi(float a, float b) {
+    float   _dphi = b-a;
+    return (_dphi < -M_PI) ? _dphi += 2*M_PI
+         : (_dphi >  M_PI) ? _dphi -= 2*M_PI
+         : _dphi;
+  }
+
+  inline std::array<double,3> keyPointDiff(const PHCASeeding::keyPoint& a, const PHCASeeding::keyPoint& b) {
+    return {b.x-a.x, b.y-a.y, b.z-a.z};
+  }
+
+  void print_reset_time(std::unique_ptr<PHTimer>& timer, int verbosity, int threshhold, const std::string& msg) {
+    timer->stop();
+    if (verbosity>=threshhold) {
+      std::cout << " || " << timer->elapsed()/1000. << " s || " << msg << std::endl;
+    }
+    timer->restart();
+  }
+
 }  // namespace
+
+
+PHCASeeding::Checker_dphidz::Checker_dphidz(
+  const float& _clusadd_delta_z_window,
+  const float& _clusadd_delta_phi_window,
+  keyPtrList& seed)
+: delta_dzdr_window {_clusadd_delta_z_window},
+  delta_dphidr2_window {_clusadd_delta_phi_window}
+{
+  // add the last three clusters from the seed triplet
+  for (int i=0;i<3;++i) {
+    const auto&  p = *(seed.end()-3+i);
+    const float x = p->x;
+    const float y = p->y;
+    z[i] = p->z;
+    phi[i] = p->phi;
+    R[i] = sqrt(x*x+y*y);
+    if (i>0) {
+      dR[i] = R[i]-R[i-1];
+      dZdR[i] = (z[i]-z[i-1])/dR[i];
+      auto dphi = wrap_dphi(phi[i-1],phi[i]);
+      dphidR2[i] = dphi/dR[i]/dR[i];
+    }
+  }
+}
+
+bool PHCASeeding::Checker_dphidz::check_cluster(PHCASeeding::keyPtr p)
+{
+  update(p);
+  return 
+       (fabs(dZdR[i3]-dZdR[i2]) <= delta_dzdr_window)
+   &&  (fabs(dphidR2[i3]-2*dphidR2[i2]+dphidR2[i1]) <= delta_dphidr2_window);
+}
+
+void PHCASeeding::Checker_dphidz::update(const PHCASeeding::keyPtr p) {
+  const float x = p->x;
+  const float y = p->y;
+  z[i3] = p->z;
+  phi[i3] = p->phi;
+  R[i3] = sqrt(x*x+y*y);
+  dR[i3] = R[i3]-R[i2];
+  dZdR[i3] = (z[i3]-z[i2])/dR[i3];
+  auto dphi = wrap_dphi(phi[i2],phi[i3]);
+  dphidR2[i3] = dphi/dR[i3]/dR[i3];
+}
+
+void PHCASeeding::Checker_dphidz::update(const PHCASeeding::keyPtrList& ptrs) {
+  // get the average values of z, phi, R, and update with those
+  double _x = std::accumulate(ptrs.begin(), ptrs.end(), 0., 
+    [](double sum, const keyPtr& p) { return sum + p->x; });
+  double _y = std::accumulate(ptrs.begin(), ptrs.end(), 0., 
+    [](double sum, const keyPtr& p) { return sum + p->y; });
+  double _z = std::accumulate(ptrs.begin(), ptrs.end(), 0., 
+    [](double sum, const keyPtr& p) { return sum + p->z; });
+  double n = ptrs.size();
+  _x /= n;
+  _y /= n;
+  _z /= n;
+  z[i3] = _z;
+  phi[i3] = atan2(_y,_x);
+  R[i3] = sqrt(_x*_x+_y*_y);
+  dR[i3] = R[i3]-R[i2];
+  dZdR[i3] = (z[i3]-z[i2])/dR[i3];
+  dphidR2[i3] = (phi[i3]-phi[i2])/dR[i3]/dR[i3];
+}
+
+void PHCASeeding::Checker_dphidz::add_cluster(const PHCASeeding::keyPtr p) {
+  if (p) { update(p); }
+  ++index;
+  i1 = (index+1)%4;
+  i2 = (index+2)%4;
+  i3 = (index+3)%4;
+}
+
+void PHCASeeding::Checker_dphidz::add_clusters(const keyPtrList& ptrs) {
+  update(ptrs);
+  ++index;
+  i1 = (index+1)%4;
+  i2 = (index+2)%4;
+  i3 = (index+3)%4;
+}
 
 // using namespace ROOT::Minuit2;
 namespace bgi = boost::geometry::index;
@@ -208,35 +282,44 @@ Acts::Vector3 PHCASeeding::getGlobalPosition(TrkrDefs::cluskey key, TrkrCluster*
   return _pp_mode ? m_tGeometry->getGlobalPosition(key, cluster) : m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, 0);
 }
 
-void PHCASeeding::QueryTree(const bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& rtree, double phimin, double z_min, double phimax, double z_max, std::vector<pointKey>& returned_values) const
+void PHCASeeding::QueryTree(
+    const PHCASeeding::boost_rtree& rtree, 
+    const PHCASeeding::keyPtr& p, 
+    const double& dphi, const double& dz,  PHCASeeding::rtreePairList& returned_values) const
 {
+  double phimin = p->phi-dphi;
+  double phimax = p->phi+dphi;
+  double zmin = p->z-dz;
+  double zmax = p->z+dz;
   bool query_both_ends = false;
-  if (phimin < 0)
+  if (phimin < -M_PI)
   {
     query_both_ends = true;
     phimin += 2 * M_PI;
   }
-  if (phimax > 2 * M_PI)
+  if (phimax > M_PI)
   {
     query_both_ends = true;
     phimax -= 2 * M_PI;
   }
   if (query_both_ends)
   {
-    rtree.query(bgi::intersects(box(point(phimin, z_min), point(2 * M_PI, z_max))), std::back_inserter(returned_values));
-    rtree.query(bgi::intersects(box(point(0., z_min), point(phimax, z_max))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(phimin, zmin), point(M_PI, zmax))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(-M_PI, zmin), point(phimax, zmax))), std::back_inserter(returned_values));
   }
   else
   {
-    rtree.query(bgi::intersects(box(point(phimin, z_min), point(phimax, z_max))), std::back_inserter(returned_values));
+    rtree.query(bgi::intersects(box(point(phimin, zmin), point(phimax, zmax))), std::back_inserter(returned_values));
   }
 }
 
-std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::FillGlobalPositions()
-{
-  keyListPerLayer ckeys;
-  PositionMap cachedPositions;
-  cachedPositions.reserve(_cluster_map->size());  // avoid resizing mid-execution
+PHCASeeding::keyPtrArr PHCASeeding::GetKeyPoints() {
+  _cluster_pts.clear();
+  _cluster_pts.reserve(_cluster_map->size());
+
+  // Fill the vector entirely for all data_points
+  // make accessor to iterate over point in each layer
+  std::array<int, _NLAYERS_TPC> cnt_per_layer{};
 
   for (const auto& hitsetkey : _cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
   {
@@ -248,7 +331,7 @@ std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::F
       unsigned int layer = TrkrDefs::getLayer(ckey);
 
       if(cluster->getZSize()==1&&_reject_zsize1==true){
-	continue;
+        continue;
       }
       if (layer < _start_layer || layer >= _end_layer)
       {
@@ -268,49 +351,56 @@ std::pair<PHCASeeding::PositionMap, PHCASeeding::keyListPerLayer> PHCASeeding::F
 
       // get global position, convert to Acts::Vector3 and store in map
       const Acts::Vector3 globalpos_d = getGlobalPosition(ckey, cluster);
-      const Acts::Vector3 globalpos = {globalpos_d.x(), globalpos_d.y(), globalpos_d.z()};
-      cachedPositions.insert(std::make_pair(ckey, globalpos));
-
-      ckeys[layer - _FIRST_LAYER_TPC].push_back(ckey);
-      fill_tuple(_tupclus_all, 0, ckey, cachedPositions.at(ckey));
+      _cluster_pts.emplace_back(ckey, globalpos_d);
+      cnt_per_layer[layer-_FIRST_LAYER_TPC]++;
+      fill_tuple(_tupclus_all, 0, &_cluster_pts.back());
     }
   }
-  return std::make_pair(cachedPositions, ckeys);
+
+  keyPtrArr ptsPerLayer{};
+  for (int i=0;i<_NLAYERS_TPC;++i) {
+    ptsPerLayer[i].reserve(cnt_per_layer[i]);
+  }
+  for (auto& p : _cluster_pts) {
+    ptsPerLayer[TrkrDefs::getLayer(p.key)-_FIRST_LAYER_TPC].emplace_back(&p);
+  }
+  return ptsPerLayer;
 }
 
-std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& _rtree, const PHCASeeding::keyList& ckeys, const PHCASeeding::PositionMap& globalPositions, const int layer)
+
+PHCASeeding::keyPtrList PHCASeeding::FillTree(PHCASeeding::boost_rtree& _rtree, const PHCASeeding::keyPtrList& ptrs)
 {
-  // Fill _rtree with the clusters in ckeys; remove duplicates, and return a vector of the coordKeys
-  // Note that layer is only used for a cout statement
+  // Fill _rtree with locations in the pointKeys; skip duplicates; and return a vector pointKeyIterators
+  // Note: layer used only for cout statement
   int n_dupli = 0;
-  std::vector<coordKey> coords;
+  keyPtrList iters_out; // vector<keyPointIer>
+  iters_out.reserve(ptrs.size());
   _rtree.clear();
   /* _rtree.reserve(ckeys.size()); */
-  for (const auto& ckey : ckeys)
+  t_fill->restart();
+  for (const auto& p : ptrs)
   {
-    const auto& globalpos_d = globalPositions.at(ckey);
-    const double clus_phi = get_phi(globalpos_d);
-    const double clus_z = globalpos_d.z();
     if (Verbosity() > 5)
     {
-      /* int layer = TrkrDefs::getLayer(ckey); */
-      std::cout << "Found cluster " << ckey << " in layer " << layer << std::endl;
+      int layer = TrkrDefs::getLayer(p->key);
+      std::cout << "Found cluster " << p->key << " in layer " << layer << std::endl;
     }
-    std::vector<pointKey> testduplicate;
-    QueryTree(_rtree, clus_phi - 0.00001, clus_z - 0.00001, clus_phi + 0.00001, clus_z + 0.00001, testduplicate);
+    rtreePairList testduplicate;
+    QueryTree(_rtree, p, 0.00001, 0.00001, testduplicate);
     if (!testduplicate.empty())
     {
       ++n_dupli;
       continue;
     }
-    coords.push_back({{static_cast<float>(clus_phi), static_cast<float>(clus_z)}, ckey});
-    t_fill->restart();
-    _rtree.insert(std::make_pair(point(clus_phi, globalpos_d.z()), ckey));
-    t_fill->stop();
+    iters_out.push_back(p);
+    _rtree.insert(std::make_pair(point(p->phi, p->z), p));
   }
+  t_fill->stop();
   if (Verbosity() > 5)
   {
-    std::cout << "nhits in layer(" << layer << "): " << coords.size() << std::endl;
+    int layer = -1;
+    if (ptrs.size()>0) { TrkrDefs::getLayer(ptrs[0]->key); };
+    std::cout << "nhits in layer(" << layer << "): " << iters_out.size() << std::endl;
   }
   if (Verbosity() > 3)
   {
@@ -320,7 +410,7 @@ std::vector<PHCASeeding::coordKey> PHCASeeding::FillTree(bgi::rtree<PHCASeeding:
   {
     std::cout << "number of duplicates : " << n_dupli << std::endl;
   }
-  return coords;
+  return iters_out;
 }
 
 int PHCASeeding::Process(PHCompositeNode* /*topNode*/)
@@ -340,64 +430,96 @@ int PHCASeeding::Process(PHCompositeNode* /*topNode*/)
     }
   }
 
-  t_seed->restart();
-  t_makebilinks->restart();
+  static const int _PRINT_THRESHOLD = 0;
 
-  PositionMap globalPositions;
-  keyListPerLayer ckeys;
-  std::tie(globalPositions, ckeys) = FillGlobalPositions();
+  t_process->restart();
 
-  t_seed->stop();
-  if (Verbosity() > 0)
-  {
-    std::cout << "Initial RTree fill time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
+
+  keyPtrArr ptsPerLayer;
+  ptsPerLayer = GetKeyPoints();
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "create key-geometry points");
+  if (Verbosity()>0) {
+    std::cout << " n clusters: " << _cluster_pts.size() << std::endl;
   }
-  t_seed->restart();
-  int numberofseeds = 0;
-  numberofseeds += FindSeedsWithMerger(globalPositions, ckeys);
-  t_seed->stop();
+
+  // get the new links
+  linkIterList start_links;
+  linkIterArr  links; // array of lists, one for each layer
+  std::tie(start_links, links) = CreateBilinks(ptsPerLayer);
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "created bilinks");
+  if (Verbosity()>0) {
+    std::cout << " n start links: " << start_links.size() << std::endl;
+    int ntot=0;
+    for (const auto& arr : links) { ntot+=arr.size(); }
+    std::cout << " n body links: " << ntot << std::endl;
+  }
+
+  /*
+     Note: The following code segments could very likely use a new algorithm
+     Current alorithm:
+       Input: links of [layer+1]->[layer]
+            1. startlinks: vector<links>: 
+               links in which the top layer clusters are not pointed to by 
+               any layer above
+            2. bodylinks: array<vector<links>>: a sets of links in each layer
+               which *do* have an above layer link pointed to them.
+               
+        Process:
+           Start with each starting set of three links (A->B->C) going downward,
+           check that passes a curvature test. Use as "starting seed".
+
+           For each starting seed, grow it by links in the following layer.
+           Could use a map or make a double-linked list, but don't. We just
+           iterate and check.
+
+           In any case, if the seed has multiple matches we just ghost it.
+  */
+
+  keyPtrLists seeds  = MakeSeedTripletHeads(start_links, links);
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "made triplet heads");
+  if (Verbosity()>0) {
+    std::cout << " number of seed triplet heads: " << seeds.size() << std::endl;
+  }
+
+  GrowSeeds(seeds, links);
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "grown seeds");
+
+  auto v2_seeds = RemoveBadClusters(seeds);
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "removed bad clusters");
+  if (Verbosity()>0) {
+    std::cout << " number of seeds: " << v2_seeds.size() << std::endl;
+  }
+
+  PublishSeeds(v2_seeds);
+  print_reset_time(t_process, Verbosity(), _PRINT_THRESHOLD, "published seeds");
+
+  unsigned int numberofseeds = seeds.size();
+
   if (Verbosity() > 0)
   {
     std::cout << "number of seeds " << numberofseeds << std::endl;
   }
   if (Verbosity() > 0)
   {
-    std::cout << "Kalman filtering time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
+    std::cout << "PHCASeeding Time: " << t_process->get_accumulated_time() / 1000 << " s" << std::endl;
   }
-  //  fpara.cd();
-  //  fpara.Close();
-  //  if(Verbosity()>0) std::cout << "fpara OK\n";
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHCASeeding::FindSeedsWithMerger(const PHCASeeding::PositionMap& globalPositions, const PHCASeeding::keyListPerLayer& ckeys)
+std::pair<PHCASeeding::linkIterList, PHCASeeding::linkIterArr> PHCASeeding::CreateBilinks(PHCASeeding::keyPtrArr& key_arr)
 {
-  t_seed->restart();
 
-  keyLinks trackSeedPairs;
-  keyLinkPerLayer bodyLinks;
-  std::tie(trackSeedPairs, bodyLinks) = CreateBiLinks(globalPositions, ckeys);
-  PHCASEEDING_PRINT_TIME(t_makebilinks, "init and make bilinks");
+  linkIterList  startLinks; // bilinks at start of chains
+  linkIterArr   bodyLinks;  //  bilinks to build chains
 
-  t_makeseeds->restart();
-  keyLists trackSeedKeyLists = FollowBiLinks(trackSeedPairs, bodyLinks, globalPositions);
-  PHCASEEDING_PRINT_TIME(t_makeseeds, "make seeds");
-  if (Verbosity() > 0)
-  {
-    t_makeseeds->stop();
-    std::cout << "Time to make seeds: " << t_makeseeds->elapsed() / 1000 << " s" << std::endl;
+  unsigned int sum_size=0;
+  for (unsigned int i=0;i<bodyLinks.size();++i) {
+    const auto i_size = key_arr[i].size();
+    bodyLinks[i].reserve(i_size);
+    sum_size += i_size;
   }
-  std::vector<TrackSeed_v2> seeds = RemoveBadClusters(trackSeedKeyLists, globalPositions);
+  startLinks.reserve(sum_size / bodyLinks.size());
 
-  publishSeeds(seeds);
-  return seeds.size();
-}
-
-std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::CreateBiLinks(const PHCASeeding::PositionMap& globalPositions, const PHCASeeding::keyListPerLayer& ckeys)
-{
-  keyLinks startLinks;        // bilinks at start of chains
-  keyLinkPerLayer bodyLinks;  //  bilinks to build chains
-                              //
   double cluster_find_time = 0;
   double rtree_query_time = 0;
   double transform_time = 0;
@@ -405,11 +527,11 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
   double set_insert_time = 0;
 
   // there are three coord_array (only the current layer is used at a time,
-  // but it is filled the same time as the _rtrees, which are used two at
+  // but it is filled the same time as the _rtrees_old, which are used two at
   // a time -- the prior padplane row and the next padplain row
-  std::array<std::vector<coordKey>, 3> coord_arr;
-  std::array<std::unordered_set<keyLink>, 2> previous_downlinks_arr;
-  std::array<std::unordered_set<TrkrDefs::cluskey>, 2> bottom_of_bilink_arr;
+  std::array<keyPtrList, 3> iter_arr;
+  std::array<std::unordered_set<linkIter>, 2> previous_downlinks_arr;
+  std::array<std::set<keyPtr>, 2>  bottom_of_bilink_arr;
 
   // iterate from outer to inner layers
   const int inner_index = _start_layer - _FIRST_LAYER_TPC + 1;
@@ -418,8 +540,10 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
   // fill the current and prior row coord and ttrees for the first iteration
   int _index_above = (outer_index + 1) % 3;
   int _index_current = (outer_index) % 3;
-  coord_arr[_index_above] = FillTree(_rtrees[_index_above], ckeys[outer_index + 1], globalPositions, outer_index + 1);
-  coord_arr[_index_current] = FillTree(_rtrees[_index_current], ckeys[outer_index], globalPositions, outer_index);
+
+  // fill the booste trees and remove duplicate clusters
+  iter_arr[_index_above]   = FillTree(_rtrees[_index_above], key_arr[outer_index + 1]);
+  iter_arr[_index_current] = FillTree(_rtrees[_index_current], key_arr[outer_index]);
 
   for (int layer_index = outer_index; layer_index >= inner_index; --layer_index)
   {
@@ -427,16 +551,20 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
     // where the old lower becomes the new middle, the old middle the new upper,
     // and the old upper drops out and that _rtree is filled with the new lower
     const unsigned int LAYER = layer_index + _FIRST_LAYER_TPC;
+    const double dphi_win = dphi_per_layer[LAYER];
+    const double dz_win = dZ_per_layer[LAYER];
+    const double dphi_win_p1 = dphi_per_layer[LAYER+1];
+    const double dz_win_p1 = dZ_per_layer[LAYER+1];
     int index_above = (layer_index + 1) % 3;
     int index_current = (layer_index) % 3;
     int index_below = (layer_index - 1) % 3;
 
-    coord_arr[index_below] = FillTree(_rtrees[index_below], ckeys[layer_index - 1], globalPositions, layer_index - 1);
+    iter_arr[index_below] = FillTree(_rtrees[index_below], key_arr[layer_index - 1]);
 
-    // NO DUPLICATES FOUND IN COORD_ARR
+    // NO DUPLICATES FOUND IN iter_arr
 
     auto& _rtree_above = _rtrees[index_above];
-    const std::vector<coordKey>& coord = coord_arr[index_current];
+    const keyPtrList& ptrs = iter_arr[index_current];
     auto& _rtree_below = _rtrees[index_below];
 
     auto& curr_downlinks = previous_downlinks_arr[layer_index % 2];
@@ -448,145 +576,94 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
     curr_downlinks.clear();
     curr_bottom_of_bilink.clear();
 
-    // For all the clusters in coord, find nearest neighbors in the
+    // For all the clusters in ptrs, find nearest neighbors in the
     // above and below layers and make links
     // Any link to an above node which matches the same clusters
     // on the previous iteration (to a "below node") becomes a "bilink"
     // Check if this bilink links to a prior bilink or not
-
-    std::vector<keyLink> aboveLinks;
-    for (const auto& StartCluster : coord)
+    for (const auto& p : ptrs)
     {
-      double StartPhi = StartCluster.first[0];
-      const auto& globalpos = globalPositions.at(StartCluster.second);
-      double StartX = globalpos(0);
-      double StartY = globalpos(1);
-      double StartZ = globalpos(2);
-      t_seed->stop();
-      cluster_find_time += t_seed->elapsed();
-      t_seed->restart();
       LogDebug(" starting cluster:" << std::endl);
-      LogDebug(" z: " << StartZ << std::endl);
-      LogDebug(" phi: " << StartPhi << std::endl);
+      LogDebug(" z: " << p->z << std::endl);
+      LogDebug(" phi: " << p->phi << std::endl);
 
-      std::vector<pointKey> ClustersAbove;
-      std::vector<pointKey> ClustersBelow;
+      /* keyPtrList ClustersAbove; */
+      /* keyPtrList ClustersBelow; */
+      rtreePairList ClustersAbove;
+      rtreePairList ClustersBelow;
 
-      QueryTree(_rtree_below,
-                StartPhi - dphi_per_layer[LAYER],
-                StartZ - dZ_per_layer[LAYER],
-                StartPhi + dphi_per_layer[LAYER],
-                StartZ + dZ_per_layer[LAYER],
-                ClustersBelow);
+      QueryTree(_rtree_below, p, dphi_win, dz_win, ClustersBelow);
 
-      FillTupWinLink(_rtree_below, StartCluster, globalPositions);
+      FillTupWinLink(_rtree_below, p);
 
-      QueryTree(_rtree_above,
-                StartPhi - dphi_per_layer[LAYER + 1],
-                StartZ - dZ_per_layer[LAYER + 1],
-                StartPhi + dphi_per_layer[LAYER + 1],
-                StartZ + dZ_per_layer[LAYER + 1],
-                ClustersAbove);
+      QueryTree(_rtree_above, p, dphi_win_p1, dz_win_p1, ClustersAbove);
 
       t_seed->stop();
       rtree_query_time += t_seed->elapsed();
       t_seed->restart();
       LogDebug(" entries in below layer: " << ClustersBelow.size() << std::endl);
       LogDebug(" entries in above layer: " << ClustersAbove.size() << std::endl);
-      std::vector<std::array<double, 3>> delta_below;
-      std::vector<std::array<double, 3>> delta_above;
-      delta_below.clear();
-      delta_above.clear();
-      delta_below.resize(ClustersBelow.size());
-      delta_above.resize(ClustersAbove.size());
-      // calculate (delta_z_, delta_phi) vector for each neighboring cluster
 
-      std::transform(ClustersBelow.begin(), ClustersBelow.end(), delta_below.begin(),
-                     [&](pointKey BelowCandidate)
-                     {
-          const auto& belowpos = globalPositions.at(BelowCandidate.second);
-          return std::array<double,3>{belowpos(0)-StartX,
-          belowpos(1)-StartY,
-          belowpos(2)-StartZ}; });
-
-      std::transform(ClustersAbove.begin(), ClustersAbove.end(), delta_above.begin(),
-                     [&](pointKey AboveCandidate)
-                     {
-          const auto& abovepos = globalPositions.at(AboveCandidate.second);
-          return std::array<double,3>{abovepos(0)-StartX,
-          abovepos(1)-StartY,
-          abovepos(2)-StartZ}; });
-      t_seed->stop();
-      transform_time += t_seed->elapsed();
-      t_seed->restart();
-
+      std::vector<bool> new_dnlinks(ClustersBelow.size(), true);
       // find the three clusters closest to a straight line
       // (by maximizing the cos of the angle between the (delta_z_,delta_phi) vectors)
       // double minSumLengths = 1e9;
-      std::unordered_set<TrkrDefs::cluskey> bestAboveClusters;
-      for (size_t iAbove = 0; iAbove < delta_above.size(); ++iAbove)
+      for (const auto& it_above : ClustersAbove) 
       {
-        for (size_t iBelow = 0; iBelow < delta_below.size(); ++iBelow)
-        {
-          // test for straightness of line just by taking the cos(angle) between the two vectors
-          // use the sq as it is much faster than sqrt
-          const auto& A = delta_below[iBelow];
-          const auto& B = delta_above[iAbove];
-          // calculate normalized dot product between two vectors
+        const auto B = keyPointDiff(*p, *it_above.second);
+        bool new_uplink = true;
+
+        for (unsigned int i_below = 0; i_below<ClustersBelow.size(); ++i_below) {
+          if (!new_dnlinks[i_below] && !new_uplink) { continue; }
+
+          const auto& it_below = ClustersBelow[i_below].second;
+          const auto A = keyPointDiff(*p, *it_below);
+
           const double A_len_sq = (A[0] * A[0] + A[1] * A[1] + A[2] * A[2]);
           const double B_len_sq = (B[0] * B[0] + B[1] * B[1] + B[2] * B[2]);
           const double dot_prod = (A[0] * B[0] + A[1] * B[1] + A[2] * B[2]);
-          const double cos_angle_sq = dot_prod * dot_prod / A_len_sq / B_len_sq;  // also same as cos(angle), where angle is between two vectors
-          FillTupWinCosAngle(ClustersAbove[iAbove].second, StartCluster.second, ClustersBelow[iBelow].second, globalPositions, cos_angle_sq, (dot_prod < 0.));
+          const double cos_angle_sq = dot_prod * dot_prod / A_len_sq / B_len_sq;  
+          // also same as cos(angle), where angle is between two vectors
+
+          FillTupWinCosAngle(it_above.second, p, it_below, cos_angle_sq, (dot_prod < 0.));
 
           constexpr double maxCosPlaneAngle = -0.95;
           constexpr double maxCosPlaneAngle_sq = maxCosPlaneAngle * maxCosPlaneAngle;
           if ((dot_prod < 0.) && (cos_angle_sq > maxCosPlaneAngle_sq))
           {
-            // maxCosPlaneAngle = cos(angle);
-            // minSumLengths = belowLength+aboveLength;
-            curr_downlinks.insert({StartCluster.second, ClustersBelow[iBelow].second});
-            bestAboveClusters.insert(ClustersAbove[iAbove].second);
+            if (new_dnlinks[i_below]) {
+              new_dnlinks[i_below] = false;
+              curr_downlinks.insert({p, it_below}); // std::set, ignores doubles
+            }
+            if (new_uplink) {
+              new_uplink = false;
+              linkIter uplink = std::make_pair(it_above.second, p);
+              if (last_downlinks.find(uplink) != last_downlinks.end())
+              {
+                // This is a new bilink
+                curr_bottom_of_bilink.insert(p);
+                fill_tuple(_tupclus_bilinks, 0, it_above.second);
+                fill_tuple(_tupclus_bilinks, 1, p);
 
-            // fill the tuples for plotting
-            fill_tuple(_tupclus_links, 0, StartCluster.second, globalPositions.at(StartCluster.second));
-            fill_tuple(_tupclus_links, -1, ClustersBelow[iBelow].second, globalPositions.at(ClustersBelow[iBelow].second));
-            fill_tuple(_tupclus_links, 1, ClustersAbove[iAbove].second, globalPositions.at(ClustersAbove[iAbove].second));
-          }
-        }
-      }
-      // NOTE:
-      // There was some old commented-out code here for allowing layers to be skipped. This
-      // may be useful in the future. This chunk of code has been moved towards the
-      // end fo the file under the title: "---OLD CODE 0: SKIP_LAYERS---"
-      t_seed->stop();
-      compute_best_angle_time += t_seed->elapsed();
-      t_seed->restart();
+                if (last_bottom_of_bilink.find(it_above.second) == last_bottom_of_bilink.end())
+                {
+                  startLinks.emplace_back(uplink);
+                }
+                else
+                {
+                  bodyLinks[layer_index + 1].emplace_back(uplink);
+                }
+              }
+            }  // end new uplink
+          } // end check over triplet (cos-angle)
+        } // end loop over below matched clusters
+      } // end loop over above matched clusters
+    } // end loop over all clusters in current layer
 
-      for (auto cluster : bestAboveClusters)
-      {
-        keyLink uplink = std::make_pair(cluster, StartCluster.second);
-
-        if (last_downlinks.find(uplink) != last_downlinks.end())
-        {
-          // this is a bilink
-          const auto& key_top = uplink.first;
-          const auto& key_bot = uplink.second;
-          curr_bottom_of_bilink.insert(key_bot);
-          fill_tuple(_tupclus_bilinks, 0, key_top, globalPositions.at(key_top));
-          fill_tuple(_tupclus_bilinks, 1, key_bot, globalPositions.at(key_bot));
-
-          if (last_bottom_of_bilink.find(key_top) == last_bottom_of_bilink.end())
-          {
-            startLinks.push_back(std::make_pair(key_top, key_bot));
-          }
-          else
-          {
-            bodyLinks[layer_index + 1].push_back(std::make_pair(key_top, key_bot));
-          }
-        }
-      }  // end loop over all up-links
-    }    // end loop over start clusters
+    // NOTE:
+    // There was some old commented-out code here for allowing layers to be skipped. This
+    // may be useful in the future. This chunk of code has been moved towards the
+    // end fo the file under the title: "---OLD CODE 0: SKIP_LAYERS---"
 
     t_seed->stop();
     set_insert_time += t_seed->elapsed();
@@ -606,276 +683,163 @@ std::pair<PHCASeeding::keyLinks, PHCASeeding::keyLinkPerLayer> PHCASeeding::Crea
   }
   t_seed->restart();
 
-  // sort the body links per layer so that links can be binary-searched per layer
+  // future optimization?
+  // Can sort the body links per layer so that links can be binary-searched per layer
+  // for now this doesn't seem any faster than just iterating and checking each link,
+  // but may become more important in Au+Au data
   /* for (auto& layer : bodyLinks) { std::sort(layer.begin(), layer.end()); } */
   return std::make_pair(startLinks, bodyLinks);
 }
 
-double PHCASeeding::getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b, TrkrDefs::cluskey c, const PHCASeeding::PositionMap& globalPositions) const
+double PHCASeeding::getMengerCurvature(PHCASeeding::keyPtr a, PHCASeeding::keyPtr b, PHCASeeding::keyPtr c) const
 {
   // Menger curvature = 1/R for circumcircle of triangle formed by most recent three clusters
   // We use here 1/R = 2*sin(breaking angle)/(hypotenuse of triangle)
-  auto& a_pos = globalPositions.at(a);
-  auto& b_pos = globalPositions.at(b);
-  auto& c_pos = globalPositions.at(c);
-  double hypot_length = sqrt(square<double>(c_pos.x() - a_pos.x()) + square<double>(c_pos.y() - a_pos.y()) + square<double>(c_pos.z() - a_pos.z()));
+  double hypot_length = sqrt(square<double>(c->x - a->x) + square<double>(c->y - a->y) + square<double>(c->z - a->z));
   double break_angle = breaking_angle(
-      a_pos.x() - b_pos.x(),
-      a_pos.y() - b_pos.y(),
-      a_pos.z() - b_pos.z(),
-      c_pos.x() - b_pos.x(),
-      c_pos.y() - b_pos.y(),
-      c_pos.z() - b_pos.z());
+      a->x - b->x,
+      a->y - b->y,
+      a->z - b->z,
+      c->x - b->x,
+      c->y - b->y,
+      c->z - b->z);
   return 2 * sin(break_angle) / hypot_length;
 }
 
-PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& trackSeedPairs, const PHCASeeding::keyLinkPerLayer& bilinks, const PHCASeeding::PositionMap& globalPositions) const
+PHCASeeding::keyPtrLists PHCASeeding::MakeSeedTripletHeads(
+  const PHCASeeding::linkIterList& start_links, 
+  const PHCASeeding::linkIterArr& bilinks) const
 {
   // form all possible starting 3-cluster tracks (we need that to calculate curvature)
-  keyLists seeds;
-  for (auto& startLink : trackSeedPairs)
+  keyPtrLists seeds;
+
+  // fixme! this is a combinatorial problem -- all copys of triplets will make
+  // *many* duplicate tracks from split clusters
+  for (auto& startLink : start_links)
   {
-    TrkrDefs::cluskey trackHead = startLink.second;
-    unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead) - _FIRST_LAYER_TPC;
+    const auto trackHead = startLink.second;
+    unsigned int trackHead_layer = TrkrDefs::getLayer(trackHead->key) - _FIRST_LAYER_TPC;
     // the following call with get iterators to all bilinks which match the head
     for (const auto& matchlink : bilinks[trackHead_layer])
     {
-      /* auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink()); */
-      /* for (auto matchlink = matched_links.first; matchlink != matched_links.second; ++matchlink) */
-      /* { */
-      if (matchlink.first != trackHead)
-      {
-        continue;
-      }
-      keyList trackSeedTriplet;
-      trackSeedTriplet.push_back(startLink.first);
-      trackSeedTriplet.push_back(startLink.second);
-      trackSeedTriplet.push_back(matchlink.second);
-      seeds.push_back(trackSeedTriplet);
+      if (matchlink.first == trackHead) {
+        seeds.push_back({startLink.first, startLink.second, matchlink.second});
+        /* keyPtrList trackSeedTriplet; */
+        /* trackSeedTriplet.push_back(startLink.first); */
+        /* trackSeedTriplet.push_back(startLink.second); */
+        /* trackSeedTriplet.push_back(matchlink.second); */
+        /* seeds.push_back(trackSeedTriplet); */
 
-      fill_tuple(_tupclus_seeds, 0, startLink.first, globalPositions.at(startLink.first));
-      fill_tuple(_tupclus_seeds, 1, startLink.second, globalPositions.at(startLink.second));
-      fill_tuple(_tupclus_seeds, 2, matchlink.second, globalPositions.at(matchlink.second));
+        fill_tuple(_tupclus_seeds, 0, startLink.first);
+        fill_tuple(_tupclus_seeds, 1, startLink.second);
+        fill_tuple(_tupclus_seeds, 2, matchlink.second);
+      }
     }
   }
-
-  // - grow every seed in the seedlist, up to the maximum number of clusters per seed
-  // - the algorithm is that every cluster is allowed to be used by any number of chains, so there is no penalty in which order they are added
-
-  t_seed->stop();
-  if (Verbosity() > 0)
-  {
-    std::cout << "starting cluster finding time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
-  }
-  t_seed->restart();
-  // assemble track cluster chains from starting cluster keys (ordered from outside in)
-
-  // std::cout << "STARTING SEED ASSEMBLY" << std::endl;
-
-  // The algorithm is to add keylinks to every chain of bilinks (seed) that wants them
-  // It is not first come first serve
-  // Therefore, follow each chain to the end
-  // If there are possible multiple links to add to a single chain, optionally split the chain to
-  // follow all possibile links (depending on the input parameter _split_seeds)
-
-  //  std::vector<keyList> seeds;
-  // std::vector<keyList> tempSeedKeyLists = seeds;
-  // seeds.clear();
-  if (seeds.size() == 0)
-  {
-    return seeds;
-  }
-
-  int nsplit_chains = -1;
-
-  // positions of the seed being following
-  std::array<float, 4> phi{}, R{}, Z{};
-  keyLists grown_seeds;
-
-  while (seeds.size() > 0)
-  {
-    keyLists split_seeds{};  // to collect when using split tracks
-    for (auto& seed : seeds)
-    {
-      // grow the seed to the maximum length allowed
-      bool first_link = true;
-      bool done_growing = (seed.size() >= _max_clusters_per_seed);
-      keyList head_keys = {seed.back()};
-      /* keyList head_keys = { seed.back() }; // heads of the seed */
-
-      while (!done_growing)
-      {
-        // Get all bilinks which fit to the head of the chain
-        unsigned int iL = TrkrDefs::getLayer(head_keys[0]) - _FIRST_LAYER_TPC;
-        keySet link_matches{};
-        for (const auto& head_key : head_keys)
-        {
-          // also possible to sort the links and use a sorted search like:
-          // auto matched_links = std::equal_range(bilinks[trackHead_layer].begin(), bilinks[trackHead_layer].end(), trackHead, CompKeyToBilink());
-          // for (auto link = matched_links.first; link != matched_links.second; ++link)
-          for (auto& link : bilinks[iL])
-          {  // iL for "Index of Layer"
-            if (link.first == head_key)
-            {
-              link_matches.insert(link.second);
-            }
-          }
-        }
-
-        // find which link_matches pass the dZdR and d2phidr2 cuts
-        keyList passing_links{};
-        for (const auto link : link_matches)
-        {  // iL for "Index of Layer"
-          // see if the link passes the growth cuts
-          if (first_link)
-          {
-            first_link = false;
-            for (int i = 1; i < 4; ++i)
-            {
-              const auto& pos = globalPositions.at(seed.rbegin()[i - 1]);
-              const auto x = pos.x();
-              const auto y = pos.y();
-              int index = (iL + i) % 4;
-              Z[index] = pos.z();
-              phi[index] = atan2(y, x);
-              R[index] = sqrt(x * x + y * y);
-            }
-          }
-
-          // get the data for the new link
-          const auto& pos = globalPositions.at(link);
-          const auto x = pos.x();
-          const auto y = pos.y();
-          const auto z = pos.z();
-
-          const int i0 = (iL + 0) % 4;
-          const int i1 = (iL + 1) % 4;
-          const int i2 = (iL + 2) % 4;
-          const int i3 = (iL + 3) % 4;
-
-          phi[i0] = atan2(y, x);
-          R[i0] = sqrt(x * x + y * y);
-          Z[i0] = z;
-
-          // see if it is possible matching link
-          if (_split_seeds)
-          {
-            FillTupWinGrowSeed(seed, {head_keys[0], link}, globalPositions);
-          }
-          const float dZ_12 = Z[i1] - Z[i2];
-          const float dZ_01 = Z[i0] - Z[i1];
-          const float dR_12 = R[i1] - R[i2];
-          const float dR_01 = R[i0] - R[i1];
-          const float dZdR_01 = dZ_01 / dR_01;
-          const float dZdR_12 = dZ_12 / dR_12;
-
-          if (fabs(dZdR_01 - dZdR_12) > _clusadd_delta_dzdr_window)
-          {
-            continue;
-          }
-          const float dphi_01 = phi[i0] - phi[i1];
-          const float dphi_12 = phi[i1] - phi[i2];
-          const float dphi_23 = phi[i2] - phi[i3];
-          const float dR_23 = R[i2] - R[i3];
-          const float d2phidr2_01 = dphi_01 / dR_01 / dR_01 - dphi_12 / dR_12 / dR_12;
-          const float d2phidr2_12 = dphi_12 / dR_12 / dR_12 - dphi_23 / dR_23 / dR_23;
-          if (fabs(d2phidr2_01 - d2phidr2_12) > _clusadd_delta_dphidr2_window)
-          {
-            continue;
-          }
-          passing_links.push_back(link);
-        }  // end loop over all bilinks in new layer
-
-        if (_split_seeds)
-        {
-          fill_split_chains(seed, passing_links, globalPositions, nsplit_chains);
-        }
-
-        // grow the chain appropriately
-        switch (passing_links.size())
-        {
-        case 0:
-          done_growing = true;
-          break;
-        case 1:
-          seed.push_back(passing_links[0]);
-          if (seed.size() >= _max_clusters_per_seed)
-          {
-            done_growing = true;
-          }  // this seed is done growing
-          head_keys = {passing_links[0]};
-          break;
-        default:  // more than one matched cluster
-          if (_split_seeds)
-          {
-            // there are multiple matching clusters
-            // if we are splitting seeds, then just push back each of the matched
-            // to the back of the seeds to grow on their own
-            for (unsigned int i = 1; i < passing_links.size(); ++i)
-            {
-              keyList newseed = {seed.begin(), seed.end()};
-              newseed.push_back(passing_links[i]);
-              split_seeds.push_back(newseed);
-            }
-            seed.push_back(passing_links[0]);
-            if (seed.size() >= _max_clusters_per_seed)
-            {
-              done_growing = true;
-            }
-            head_keys = {passing_links[0]};
-          }
-          else
-          {
-            // multiple seeds matched. get the average position to put into
-            // Z, phi, and R (of [iL]), and pass all the links to find the next cluster
-            float avg_x = 0;
-            float avg_y = 0;
-            float avg_z = 0;
-            for (const auto& link : passing_links)
-            {
-              const auto& pos = globalPositions.at(link);
-              avg_x += pos.x();
-              avg_y += pos.y();
-              avg_z += pos.z();
-            }
-            avg_x /= passing_links.size();
-            avg_y /= passing_links.size();
-            avg_z /= passing_links.size();
-            phi[iL % 4] = atan2(avg_y, avg_x);
-            R[iL % 4] = sqrt(avg_x * avg_x + avg_y * avg_y);
-            Z[iL % 4] = avg_z;
-            head_keys = passing_links;  // will try and grow from this position
-          }                             // end of logic for processing passing seeds
-          break;
-        }  // end of seed length switch
-      }    // end of seed growing loop: if (!done_growing)
-      if (seed.size() >= _min_clusters_per_seed)
-      {
-        grown_seeds.push_back(seed);
-        fill_tuple_with_seed(_tupclus_grown_seeds, seed, globalPositions);
-      }
-    }  // end of loop over seeds
-    seeds.clear();
-    for (const auto& seed : split_seeds)
-    {
-      seeds.push_back(seed);
-    }
-    /* seeds = split_seeds; */
-  }  // end of looping over all seeds
-
-  // old code block move to end of code under the title: "---OLD CODE 1: SKIP_LAYERS---"
-  t_seed->stop();
-  if (Verbosity() > 1)
-  {
-    std::cout << "keychain assembly time: " << t_seed->get_accumulated_time() / 1000 << " s" << std::endl;
-  }
-  t_seed->restart();
-  LogDebug(" track key chains assembled: " << trackSeedKeyLists.size() << std::endl);
-  LogDebug(" track key chain lengths: " << std::endl);
-  return grown_seeds;
+  return seeds;
 }
 
-std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const std::vector<PHCASeeding::keyList>& chains, const PHCASeeding::PositionMap& globalPositions) const
+void PHCASeeding::GrowSeeds(PHCASeeding::keyPtrLists& seeds, const PHCASeeding::linkIterArr& bilinks)
+{
+  int nsplit_chains = -1;
+  unsigned int seed_index = 0;
+  while (seed_index < seeds.size()) {
+    auto& seed = seeds[seed_index];
+    seed_index++;
+
+    Checker_dphidz clus_checker(_clusadd_delta_dzdr_window, _clusadd_delta_dphidr2_window, seed);
+    keyPtrList head_keys = {seed.back()};
+
+    while (true) // iterate until break
+    {
+      // Get all bilinks which fit to the head of the chain
+      unsigned int layer = TrkrDefs::getLayer(head_keys[0]->key) - _FIRST_LAYER_TPC;
+      keyPtrSet matching_keys{};
+      for (const auto& head_key : head_keys)
+      {
+        // also possible to sort the links and use a sorted search
+        // for (auto link = matched_links.first; link != matched_links.second; ++link)
+        for (auto& link : bilinks[layer])
+        {  // layer for "Index of Layer"
+          if (link.first == head_key)
+          {
+            matching_keys.insert(link.second);
+          }
+        }
+      } // end loop over all bilinks in new layer
+
+      const unsigned int nmatched = matching_keys.size();
+      if (nmatched == 1) { // one matched key
+        const auto& new_cluster = *matching_keys.begin();
+        if (clus_checker.check_cluster(new_cluster)) {
+          // the 1 key is a good key
+          seed.emplace_back(new_cluster);
+          if (seed.size()>=_max_clusters_per_seed) { break; }
+          clus_checker.add_cluster();
+          head_keys = {new_cluster};
+          continue;
+        } else { // one matched cluster -- but is not good
+          break;
+        }
+      } else if (nmatched==0) {
+        break;
+      } 
+
+      // there are multiple matched links
+      //   find out which ones are good
+      keyPtrList passing_keys{};
+      for (const auto& p : matching_keys)
+      {  
+        // see if the link passes the growth cuts
+        if (_split_seeds)
+        { FillTupWinGrowSeed(seed, p); }
+
+        if (clus_checker.check_cluster(p)) 
+        { passing_keys.emplace_back(p); } 
+
+        if (_split_seeds)
+        { fill_split_chains(seed, passing_keys, nsplit_chains); }
+      } 
+
+      const unsigned int npass = passing_keys.size();
+      if (npass > 1) { // most likely case
+        if (_split_seeds) { // make new chains up to this link
+          for (unsigned int i = 1; i < passing_keys.size(); ++i)
+          {
+            keyPtrList newseed = {seed.begin(), seed.end()};
+            newseed.emplace_back(passing_keys[i]);
+            seeds.emplace_back(std::move(newseed));
+          }
+          seed.emplace_back(passing_keys[0]);
+          if (seed.size() >= _max_clusters_per_seed) { break; }
+          clus_checker.add_cluster(passing_keys[0]);
+          head_keys = {passing_keys[0]};
+          continue;
+        } else {
+          // instead of splitting track, add averaged matched cluster position
+          clus_checker.add_clusters(passing_keys);
+          head_keys = std::move(passing_keys);
+          continue;
+        }
+      } else if (npass == 0) {
+        break;
+      } else { // there is a single passing seed
+        seed.emplace_back(passing_keys[0]);
+        if (seed.size() >= _max_clusters_per_seed) { break; }
+        clus_checker.add_cluster(passing_keys[0]);
+        head_keys = {passing_keys[0]};
+        continue;
+      }
+    } // end growing single seed
+         
+    if (seed.size() >= _min_clusters_per_seed)
+    {
+      fill_tuple_with_seed(_tupclus_grown_seeds, seed);
+    }
+  }  // end of loop over seeds
+}
+
+std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const PHCASeeding::keyPtrLists& chains) const
 {
   if (Verbosity() > 0)
   {
@@ -885,7 +849,7 @@ std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const std::vector<PHCAS
 
   for (const auto& chain : chains)
   {
-    if (chain.size() < 3)
+    if (chain.size() < 3 || chain.size() < _min_clusters_per_track)
     {
       continue;
     }
@@ -894,12 +858,13 @@ std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const std::vector<PHCAS
       std::cout << "chain size: " << chain.size() << std::endl;
     }
 
-    TrackFitUtils::position_vector_t xy_pts;
-    for (const auto& cluskey : chain)
-    {
-      const auto& global = globalPositions.at(cluskey);
-      xy_pts.emplace_back(global.x(), global.y());
-    }
+    using pvec_t = TrackFitUtils::position_vector_t;
+
+    pvec_t xy_pts;
+    std::transform(chain.begin(), chain.end(), std::back_inserter(xy_pts),
+      [this](const keyPtr& p) -> pvec_t::value_type {
+        return {p->x, p->y};
+      });
 
     // fit a circle through x,y coordinates
     const auto [R, X0, Y0] = TrackFitUtils::circle_fit_by_taubin(xy_pts);
@@ -915,9 +880,9 @@ std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const std::vector<PHCAS
 
     // assign clusters to seed
     TrackSeed_v2 trackseed;
-    for (const auto& key : chain)
+    for (const auto& p : chain)
     {
-      trackseed.insert_cluster_key(key);
+      trackseed.insert_cluster_key(p->key);
     }
     clean_chains.push_back(trackseed);
     if (Verbosity() > 2)
@@ -929,7 +894,7 @@ std::vector<TrackSeed_v2> PHCASeeding::RemoveBadClusters(const std::vector<PHCAS
   return clean_chains;
 }
 
-void PHCASeeding::publishSeeds(const std::vector<TrackSeed_v2>& seeds) const
+void PHCASeeding::PublishSeeds(std::vector<TrackSeed_v2>& seeds)
 {
   for (const auto& seed : seeds)
   {
@@ -966,11 +931,8 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
   t_seed = std::make_unique<PHTimer>("t_seed");
   t_seed->stop();
 
-  t_makebilinks = std::make_unique<PHTimer>("t_makebilinks");
-  t_makebilinks->stop();
-
-  t_makeseeds = std::make_unique<PHTimer>("t_makeseeds");
-  t_makeseeds->stop();
+  t_process = std::make_unique<PHTimer>("t_seed");
+  t_process->stop();
 
   //  fcfg.set_rescale(1);
   std::unique_ptr<PHField> field_map;
@@ -1027,10 +989,10 @@ int PHCASeeding::Setup(PHCompositeNode* topNode)  // This is called by ::InitRun
   std::cout << " Writing _CLUSTER_LOG_TUPOUT.root file " << std::endl;
   _f_clustering_process = new TFile("_CLUSTER_LOG_TUPOUT.root", "recreate");
   _tupclus_all = new TNtuple("all", "all clusters", "event:layer:num:x:y:z");
-  _tupclus_links = new TNtuple("links", "links", "event:layer:updown01:x:y:z:delta_z:delta_phi");
+  /* _tupclus_links = new TNtuple("links", "links", "event:layer:updown01:x:y:z:delta_z:delta_phi"); */
   _tupclus_bilinks = new TNtuple("bilinks", "bilinks", "event:layer:topbot01:x:y:z");
   _tupclus_seeds = new TNtuple("seeds", "3 bilink seeds cores", "event:layer:seed012:x:y:z");
-  _tupclus_grown_seeds = new TNtuple("grown_seeds", "grown seeds", "event:layer:seednum05:x:y:z");
+  _tupclus_grown_seeds = new TNtuple("grown_seeds", "grown seeds", "event:layer:seednum05:x:y:z:dzdr:d2phidr2");
   _tupwin_link = new TNtuple("win_link", "neighbor clusters considered to make links", "event:layer0:x0:y0:z0:layer1:x1:y1:z1:dphi:dz");
   _tupwin_cos_angle = new TNtuple("win_cos_angle", "cos angle to make links", "event:layer0:x0:y0:z0:layer1:x1:y1:z1:layer2:x2:y2:z2:cos_angle");
   _tupwin_seed23 = new TNtuple("win_seed23", "xyL for points 1 and 2", "event:layer2:x2:y2:z2:layer3:x3:y3:z3");
@@ -1059,7 +1021,7 @@ int PHCASeeding::End()
 
 #if defined(_PHCASEEDING_CHAIN_FORKS_)
 
-void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCASeeding::keyList& add_links, const PHCASeeding::PositionMap& pos, int& n_tupchains) const
+void PHCASeeding::fill_split_chains(const PHCASeeding::keyPtrList& seed, const PHCASeeding::keyPtrList& add_links, int& n_tupchains) const
 {
   if (add_links.size() < 2) return;
   n_tupchains += 1;
@@ -1087,21 +1049,21 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
     if (has_1)
     {
       has_2 = true;
-      /*x2=x1; y2=y1; z2=z1;*/ r2 = r1;
+      r2 = r1;
       phi2 = phi1;
     }
     if (has_0)
     {
       has_1 = true;
-      /*x1=x0; y1=y0;*/ z1 = z0;
+      z1 = z0;
       r1 = r0;
       phi1 = phi0;
     }
-    auto link_pos = pos.at(link);
+    /* auto link_pos = pos.at(link); */
     has_0 = true;
-    x0 = link_pos.x();
-    y0 = link_pos.y();
-    z0 = link_pos.z();
+    x0 = link->x;
+    y0 = link->y;
+    z0 = link->z;
     phi0 = atan2(y0, x0);
     r0 = sqrt(x0 * x0 + y0 * y0);
 
@@ -1116,8 +1078,8 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
       _tup_chainbody->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), x0, y0, z0, dzdr, -1000., index, nlinks);
       continue;
     }
-    float dphi01 = std::fmod(phi1 - phi0, M_PI);
-    float dphi12 = std::fmod(phi2 - phi1, M_PI);
+    float dphi01 = wrap_dphi(phi0, phi1);
+    float dphi12 = wrap_dphi(phi1, phi2);
     float dr_01 = r1 - r0;
     float dr_12 = r2 - r1;
     dphidr01 = dphi01 / dr_01 / dr_01;
@@ -1132,16 +1094,16 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
   for (const auto& link : add_links)
   {
     index += 1;
-    auto link_pos = pos.at(link);
-    float xt = link_pos.x();
-    float yt = link_pos.y();
-    float zt = link_pos.z();
+    /* auto link_pos = pos.at(link); */
+    float xt = link->x;
+    float yt = link->y;
+    float zt = link->z;
     float phit = atan2(yt, xt);
     float rt = sqrt(xt * xt + yt * yt);
     float dr_t0 = rt - r0;
 
     float dzdr = (zt - z0) / (rt - r0);
-    float dphit0 = std::fmod(phit - phi0, M_PI);
+    float dphit0 = wrap_dphi(phi0, phit);
 
     float d2phidr2 = dphit0 / dr_t0 / dr_t0 - dphidr01;
     _tup_chainfork->Fill(_tupout_count, n_tupchains, TrkrDefs::getLayer(link), xt, yt, zt, dzdr, d2phidr2, index, nlinks);
@@ -1149,7 +1111,7 @@ void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& seed, const PHCA
 }
 
 #else
-void PHCASeeding::fill_split_chains(const PHCASeeding::keyList& /*chain*/, const PHCASeeding::keyList& /*links*/, const PHCASeeding::PositionMap& /*pos*/, int& /*nchains*/) const {};
+void PHCASeeding::fill_split_chains(const PHCASeeding::keyPtrList& /*chain*/, const PHCASeeding::keyPtrList& /*links*/, int& /*nchains*/) const {};
 #endif
 
 #if defined(_PHCASEEDING_CLUSTERLOG_TUPOUT_)
@@ -1157,7 +1119,7 @@ void PHCASeeding::write_tuples()
 {
   _f_clustering_process->cd();
   _tupclus_all->Write();
-  _tupclus_links->Write();
+  /* _tupclus_links->Write(); */
   _tupclus_bilinks->Write();
   _tupclus_seeds->Write();
   _tupclus_grown_seeds->Write();
@@ -1171,16 +1133,24 @@ void PHCASeeding::write_tuples()
   _f_clustering_process->Close();
 }
 
-void PHCASeeding::fill_tuple(TNtuple* tup, float val, TrkrDefs::cluskey key, const Acts::Vector3& pos) const
+void PHCASeeding::fill_tuple(TNtuple* tup, float val, PHCASeeding::keyPtr p) const
 {
-  tup->Fill(_tupout_count, TrkrDefs::getLayer(key), val, pos[0], pos[1], pos[2]);
+  tup->Fill(_tupout_count, TrkrDefs::getLayer(p->key), val, p->x, p->y, p->z);
 }
 
-void PHCASeeding::fill_tuple_with_seed(TNtuple* tup, const PHCASeeding::keyList& seed, const PHCASeeding::PositionMap& pos) const
+void PHCASeeding::fill_tuple_with_seed(TNtuple* tup, const PHCASeeding::keyPtrList& seed) const
 {
-  for (unsigned int i = 0; i < seed.size(); ++i)
-  {
-    fill_tuple(tup, (float) i, seed[i], pos.at(seed[i]));
+  keyPtrList trio {seed.begin(), seed.begin()+3};
+  Checker_dphidz checker(_clusadd_delta_dzdr_window, _clusadd_delta_dphidr2_window, trio);
+
+  int cnt = 0;
+  // also output the dR/dZ and dphi2/dR2
+  for (unsigned int i=0; i<seed.size(); ++i) {
+    if (i>2) {
+      checker.add_cluster(seed[i]);
+    }
+    tup->Fill(_tupout_count, TrkrDefs::getLayer(seed[i]->key), cnt, seed[i]->x, seed[i]->y, seed[i]->z, checker.calc_dzdr(), checker.calc_d2phidr2());
+    ++cnt;
   }
 }
 
@@ -1191,97 +1161,85 @@ void PHCASeeding::process_tupout_count()
   _search_windows->Fill(_neighbor_z_width, _neighbor_phi_width, _start_layer, _end_layer, _clusadd_delta_dzdr_window, _clusadd_delta_dphidr2_window);
 }
 
-void PHCASeeding::FillTupWinLink(bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& _rtree_below, const PHCASeeding::coordKey& StartCluster, const PHCASeeding::PositionMap& globalPositions) const
+void PHCASeeding::FillTupWinGrowSeed(const PHCASeeding::keyPtrList& seed, const PHCASeeding::keyPtr& p) const
 {
-  double StartPhi = StartCluster.first[0];
-  const auto& P0 = globalPositions.at(StartCluster.second);
-  double StartZ = P0(2);
-  // Fill TNTuple _tupwin_link
-  std::vector<pointKey> ClustersBelow;
-  QueryTree(_rtree_below,
-            StartPhi - 1.,
-            StartZ - 20.,
-            StartPhi + 1.,
-            StartZ + 20.,
-            ClustersBelow);
-
-  for (const auto& pkey : ClustersBelow)
-  {
-    const auto P1 = globalPositions.at(pkey.second);
-    double dphi = bg::get<0>(pkey.first) - StartPhi;
-    double dZ = P1(2) - StartZ;
-    _tupwin_link->Fill(_tupout_count, TrkrDefs::getLayer(StartCluster.second), P0(0), P0(1), P0(2), TrkrDefs::getLayer(pkey.second), P1(0), P1(1), P1(2), dphi, dZ);
-  }
-}
-
-void PHCASeeding::FillTupWinCosAngle(const TrkrDefs::cluskey A, const TrkrDefs::cluskey B, const TrkrDefs::cluskey C, const PHCASeeding::PositionMap& globalPositions, double cos_angle_sq, bool isneg) const
-{
-  // A is top cluster, B the middle, C the bottom
-  // a,b,c are the positions
-
-  auto a = globalPositions.at(A);
-  auto b = globalPositions.at(B);
-  auto c = globalPositions.at(C);
-
-  _tupwin_cos_angle->Fill(_tupout_count,
-                          TrkrDefs::getLayer(A), a[0], a[1], a[2],
-                          TrkrDefs::getLayer(B), b[0], b[1], b[2],
-                          TrkrDefs::getLayer(C), c[0], c[1], c[2],
-                          (isneg ? -1 : 1) * sqrt(cos_angle_sq));
-}
-
-void PHCASeeding::FillTupWinGrowSeed(const PHCASeeding::keyList& seed, const PHCASeeding::keyLink& link, const PHCASeeding::PositionMap& globalPositions) const
-{
-  TrkrDefs::cluskey trackHead = seed.back();
-  auto& head_pos = globalPositions.at(trackHead);
-  auto& prev_pos = globalPositions.at(seed.rbegin()[1]);
-  float x1 = head_pos.x();
-  float y1 = head_pos.y();
-  float z1 = head_pos.z();
-  float x2 = prev_pos.x();
-  float y2 = prev_pos.y();
-  float z2 = prev_pos.z();
+  keyPtr head = seed.back();
+  keyPtr prev = seed.rbegin()[1];
+  float x1 = head->x;
+  float y1 = head->y;
+  float z1 = head->z;
+  float x2 = prev->x;
+  float y2 = prev->y;
+  float z2 = prev->z;
   float dr_12 = sqrt(x1 * x1 + y1 * y1) - sqrt(x2 * x2 + y2 * y2);
   /* TrkrDefs::cluskey testCluster = link.second; */
-  auto& test_pos = globalPositions.at(link.second);
-  float xt = test_pos.x();
-  float yt = test_pos.y();
-  float zt = test_pos.z();
+  float xt = p->x;
+  float yt = p->y;
+  float zt = p->z;
   float dr_t1 = sqrt(xt * xt + yt * yt) - sqrt(x1 * x1 + y1 * y1);
   float dzdr_12 = (z1 - z2) / dr_12;
   float dzdr_t1 = (zt - z1) / dr_t1;
   // if (fabs(dzdr_12 - dzdr_t1) > _clusadd_delta_dzdr_window)) // then fail this link
 
-  auto& third_pos = globalPositions.at(seed.rbegin()[2]);
-  float x3 = third_pos.x();
-  float y3 = third_pos.y();
-  float z3 = third_pos.z();
+  auto& third_pos = seed.rbegin()[2];
+  float x3 = third_pos->x;
+  float y3 = third_pos->y;
+  float z3 = third_pos->z;
   float dr_23 = sqrt(x2 * x2 + y2 * y2) - sqrt(x3 * x3 + y3 * y3);
   float phi1 = atan2(y1, x1);
   float phi2 = atan2(y2, x2);
   float phi3 = atan2(y3, x3);
-  float dphi12 = std::fmod(phi1 - phi2, M_PI);
-  float dphi23 = std::fmod(phi2 - phi3, M_PI);
+  float dphi12 = wrap_dphi(phi2, phi1);
+  float dphi23 = wrap_dphi(phi3, phi2); 
   float d2phidr2_123 = dphi12 / (dr_12 * dr_12) - dphi23 / (dr_23 * dr_23);
   float dphit1 = std::fmod(atan2(yt, xt) - atan2(y1, x1), M_PI);
   float d2phidr2_t12 = dphit1 / (dr_t1 * dr_t1) - dphi12 / (dr_12 * dr_12);
   _tupwin_seed23->Fill(_tupout_count,
-                       (TrkrDefs::getLayer(seed.rbegin()[1])), x2, y2, z2,
-                       (TrkrDefs::getLayer(seed.rbegin()[2])), x3, y3, z3);
+                       (TrkrDefs::getLayer(seed.rbegin()[1]->key)), x2, y2, z2,
+                       (TrkrDefs::getLayer(seed.rbegin()[2]->key)), x3, y3, z3);
   _tupwin_seedL1->Fill(_tupout_count,
-                       (TrkrDefs::getLayer(link.second)), xt, yt, zt,
-                       (TrkrDefs::getLayer(seed.back())), x1, y1, z1,
+                       (TrkrDefs::getLayer(p->key)), xt, yt, zt, // ? not sure what orig
+                       (TrkrDefs::getLayer(seed.back()->key)), x1, y1, z1,
                        dzdr_12, dzdr_t1, fabs(dzdr_12 - dzdr_t1),
                        d2phidr2_123, d2phidr2_t12, fabs(d2phidr2_123 - d2phidr2_t12));
 }
+
+void PHCASeeding::FillTupWinLink(PHCASeeding::boost_rtree& rtree_below, const PHCASeeding::keyPtr p) const
+{
+  double StartPhi = p->phi;
+  double StartZ = p->z;
+  // Fill TNTuple _tupwin_link
+  rtreePairList ClustersBelow;
+  QueryTree(rtree_below, p, 1., 20, ClustersBelow);
+
+  for (const auto& pkey : ClustersBelow)
+  {
+    const auto new_phi = pkey.second->phi;
+    double dphi = wrap_dphi(StartPhi, new_phi);
+    double dZ = pkey.second->z - StartZ;
+    _tupwin_link->Fill(_tupout_count, TrkrDefs::getLayer(p->key), p->x,p->y,p->z, TrkrDefs::getLayer(pkey.second->key), pkey.second->x,pkey.second->y,pkey.second->z, dphi, dZ);
+  }
+}
+
+void PHCASeeding::FillTupWinCosAngle(const PHCASeeding::keyPtr A, const PHCASeeding::keyPtr B, const PHCASeeding::keyPtr C, double cos_angle_sq, bool isneg) const
+{
+  // A is top cluster, B the middle, C the bottom
+  // a,b,c are the positions
+
+  _tupwin_cos_angle->Fill(_tupout_count,
+                          TrkrDefs::getLayer(A->key), A->x, A->y, A->z,
+                          TrkrDefs::getLayer(B->key), B->x, B->y, B->z,
+                          TrkrDefs::getLayer(C->key), C->x, C->y, C->z,
+                          (isneg ? -1 : 1) * sqrt(cos_angle_sq));
+}
 #else
 void PHCASeeding::write_tuples(){};
-void PHCASeeding::fill_tuple(TNtuple* /**/, float /**/, TrkrDefs::cluskey /**/, const Acts::Vector3& /**/) const {};
-void PHCASeeding::fill_tuple_with_seed(TNtuple* /**/, const PHCASeeding::keyList& /**/, const PHCASeeding::PositionMap& /**/) const {};
+void PHCASeeding::fill_tuple(TNtuple* /**/, float /**/, PHCASeeding::keyPtr /**/) const {};
+void PHCASeeding::fill_tuple_with_seed(TNtuple* /**/, const PHCASeeding::keyPtrList& /**/) const {};
 void PHCASeeding::process_tupout_count(){};
-void PHCASeeding::FillTupWinLink(bgi::rtree<PHCASeeding::pointKey, bgi::quadratic<16>>& /**/, const PHCASeeding::coordKey& /**/, const PHCASeeding::PositionMap& /**/) const {};
-void PHCASeeding::FillTupWinCosAngle(const TrkrDefs::cluskey /**/, const TrkrDefs::cluskey /**/, const TrkrDefs::cluskey /**/, const PHCASeeding::PositionMap& /**/, double /**/, bool /**/) const {};
-void PHCASeeding::FillTupWinGrowSeed(const PHCASeeding::keyList& /**/, const PHCASeeding::keyLink& /**/, const PHCASeeding::PositionMap& /**/) const {};
+void PHCASeeding::FillTupWinGrowSeed(const PHCASeeding::keyPtrList& /**/, const PHCASeeding::keyPtr& /**/) const {};
+void PHCASeeding::FillTupWinLink(PHCASeeding::boost_rtree& /**/, const PHCASeeding::keyPtr /**/) const {};
+void PHCASeeding::FillTupWinCosAngle(PHCASeeding::keyPtr /**/, PHCASeeding::keyPtr /**/, PHCASeeding::keyPtr /**/, double /**/, bool /**/) const {}; 
 #endif  // defined _PHCASEEDING_CLUSTERLOG_TUPOUT_
 
 // ---OLD CODE 1: SKIP_LAYERS---
@@ -1346,7 +1304,7 @@ if(mode == skip_layers::on)
     // if no triplet is sufficiently linear, then it's likely that there's a missing cluster
     // repeat search but skip one layer below
     std::vector<pointKey> clustersTwoLayersBelow;
-    QueryTree(_rtree,
+    QueryTree_old(_rtree,
             StartPhi-_neighbor_phi_width,
             StartEta-_neighbor_eta_width,
             (double) StartLayer - 2.5,
@@ -1383,7 +1341,7 @@ if(mode == skip_layers::on)
     if(maxCosPlaneAngle > _cosTheta_limit)
     {
       std::vector<pointKey> clustersTwoLayersAbove;
-      QueryTree(_rtree,
+      QueryTree_old(_rtree,
               StartPhi-_neighbor_phi_width,
               StartEta-_neighbor_eta_width,
               (double) StartLayer + 1.5,


### PR DESCRIPTION
- Functionally fixes the `PHCASeeding->SetSplitSeeds(false);` to work as expected.
- Removes the separate map<TrkrDefs::cluskey,vector3> to just making a single vector list of the {cluskey,vector} data with pointers in the links. This is for efficiency, and works nicely. This also saves recalculating phi many times.
- When adding clusters, don't continually recalculate phi, dphi, R, dR, dzdR, d2phidr2, but only as needed. Again this is for efficiency.

Still needed:
- The cluster still makes all combinations of all triplets to start tracks. This should be either ignored (start further
    down the chain) or squashed into average clusters.
- Have the seeds start in the middle, grow inward, then outward

Given that the default Fun4All macro splits the tracks, this shouldn't change the QA. I'll wait to see them before asking for the PR merge.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

