### PR TITLE
Add tpc tzero module

### DIFF
--- a/offline/packages/trackreco/Makefile.am
+++ b/offline/packages/trackreco/Makefile.am
@@ -79,6 +79,7 @@ pkginclude_HEADERS = \
   SecondaryVertexFinder.h \
   SvtxTrackStateRemoval.h \
   TrackingIterationCounter.h \
+  TpcClusterTzeroCorrection.h \
   TpcSeedFilter.h
 
 ROOTDICTS = \
@@ -166,6 +167,7 @@ libtrack_reco_la_SOURCES = \
   SecondaryVertexFinder.cc \
   SvtxTrackStateRemoval.cc \
   TrackingIterationCounter.cc \
+  TpcClusterTzeroCorrection.cc \
   TpcSeedFilter.cc
 
 libtrack_reco_io_la_LIBADD = \

--- a/offline/packages/trackreco/TpcClusterTzeroCorrection.cc
+++ b/offline/packages/trackreco/TpcClusterTzeroCorrection.cc
@@ -1,0 +1,95 @@
+#include "TpcClusterTzeroCorrection.h"
+
+/// Tracking includes
+
+#include <trackbase/TrkrCluster.h>            // for TrkrCluster
+#include <trackbase/TrkrClusterContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/getClass.h>
+#include <phool/phool.h>
+
+#include <iostream>                           // for operator<<, basic_ostream
+#include <map>                                // for map
+#include <set>                                // for _Rb_tree_const_iterator
+#include <utility>                            // for pair, make_pair
+#include <cassert>                          
+
+
+//____________________________________________________________________________..
+TpcClusterTzeroCorrection::TpcClusterTzeroCorrection(const std::string &name)
+  : SubsysReco(name)
+  , PHParameterInterface(name)
+{ InitializeParameters(); }
+
+
+//____________________________________________________________________________..
+int TpcClusterTzeroCorrection::InitRun(PHCompositeNode* /*unused*/)
+{
+  UpdateParametersWithMacro();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//____________________________________________________________________________..
+int TpcClusterTzeroCorrection::process_event(PHCompositeNode *topNode )
+{
+  // load nodes
+  const auto res = load_nodes(topNode);
+  if( res != Fun4AllReturnCodes::EVENT_OK ) { return res; }
+
+  process_clusters();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+int TpcClusterTzeroCorrection::End(PHCompositeNode* /*topNode*/ )
+{ return Fun4AllReturnCodes::EVENT_OK; }
+
+//_____________________________________________________________________
+void TpcClusterTzeroCorrection::SetDefaultParameters()
+{
+  // Data on gasses @20 C and 760 Torr from the following source:
+  // http://www.slac.stanford.edu/pubs/icfa/summer98/paper3/paper3.pdf
+  // diffusion and drift velocity for 400kV for NeCF4 50/50 from calculations:
+  // http://skipper.physics.sunysb.edu/~prakhar/tpc/HTML_Gases/split.html
+  return;
+}
+
+//_____________________________________________________________________
+int TpcClusterTzeroCorrection::load_nodes( PHCompositeNode* topNode )
+{
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, m_clusterContainerName);
+  assert(m_cluster_map);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________
+void TpcClusterTzeroCorrection::process_clusters()
+{
+  if( !m_cluster_map ) { return; }
+
+ for (const auto& hitsetkey : m_cluster_map->getHitSetKeys(TrkrDefs::TrkrId::tpcId))
+  {
+    auto range = m_cluster_map->getClusters(hitsetkey);
+    for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
+      {
+	TrkrDefs::cluskey cluster_key = clusIter->first;
+	
+	// consider TPC clusters only
+	if( TrkrDefs::getTrkrId(cluster_key) != TrkrDefs::tpcId ) { continue;}
+
+	TrkrCluster* cluster = clusIter->second;	
+	float initialLocalY = cluster->getLocalY();
+	cluster->setLocalY( cluster->getLocalY() - m_tzero);
+
+	if( Verbosity() )
+	  { 
+	    std::cout << "TpcClusterTzeroCorrection::process_cluster: " << cluster_key
+	    << " initial localY: " << initialLocalY << " m_tzero " << m_tzero 
+	    << " corrected localY " << cluster->getLocalY() << std::endl;
+	  }
+      }
+  }
+}

--- a/offline/packages/trackreco/TpcClusterTzeroCorrection.cc
+++ b/offline/packages/trackreco/TpcClusterTzeroCorrection.cc
@@ -49,10 +49,6 @@ int TpcClusterTzeroCorrection::End(PHCompositeNode* /*topNode*/ )
 //_____________________________________________________________________
 void TpcClusterTzeroCorrection::SetDefaultParameters()
 {
-  // Data on gasses @20 C and 760 Torr from the following source:
-  // http://www.slac.stanford.edu/pubs/icfa/summer98/paper3/paper3.pdf
-  // diffusion and drift velocity for 400kV for NeCF4 50/50 from calculations:
-  // http://skipper.physics.sunysb.edu/~prakhar/tpc/HTML_Gases/split.html
   return;
 }
 

--- a/offline/packages/trackreco/TpcClusterTzeroCorrection.h
+++ b/offline/packages/trackreco/TpcClusterTzeroCorrection.h
@@ -1,0 +1,54 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+
+/*!
+ *  \file TPCClusterTzeroCorrection.h
+ *  \brief Correct TPC cluster time for TPC ADC time zero
+ *  \author Tony Frawley <afrawley@fsu.edu>
+ */
+
+#ifndef TRACKRECO_TPCCLUSTERTZEROCORRECTION_H
+#define TRACKRECO_TPCCLUSTERTZEROCORRECTION_H
+
+#include <fun4all/SubsysReco.h>
+#include <phparameter/PHParameterInterface.h>
+#include <trackbase/TrkrDefs.h>
+
+class TrkrClusterContainer;
+
+class TpcClusterTzeroCorrection : public SubsysReco, public PHParameterInterface
+{
+ public:
+
+  /// constructor
+  TpcClusterTzeroCorrection(const std::string &name = "TpcClusterTzeroCorrection");
+
+  /// destructor
+  ~TpcClusterTzeroCorrection() override = default;
+
+  int InitRun(PHCompositeNode *topNode) override;
+  int process_event(PHCompositeNode *topNode) override;
+  int End(PHCompositeNode *topNode) override;
+  void SetDefaultParameters() override;
+  void setTrkrClusterContainerName(std::string &name){ m_clusterContainerName = name; }
+
+  void setTpcTzeroCorrection(const float tz) {m_tzero = tz  ;}
+
+  private:
+
+  /// load nodes
+  int load_nodes( PHCompositeNode* );
+
+  /// process clusters
+  void process_clusters();
+
+  /// cluster map
+  TrkrClusterContainer *m_cluster_map = nullptr;
+
+  //cluster container name
+  std::string m_clusterContainerName = "TRKR_CLUSTER";
+
+  float m_tzero = 0.0;
+};
+
+#endif // TpcClusterTzeroCorrection_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This adds a module which modifies all TPC clusters before track reconstruction by adding an offset to the cluster time. It is intended to be run after clustering and before seeding.  To use it, add (for example):

  auto tzero = new TpcClusterTzeroCorrection();
  tzero->setTpcTzeroCorrection(-5*50);   // ns
  se->registerSubsystem(tzero);

before TPC seeding.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

