### PR TITLE
Fix time between crossings

### DIFF
--- a/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
+++ b/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
@@ -17,6 +17,7 @@
 
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
+#include <phool/sphenix_constants.h>
 
 #include <TFile.h>
 #include <TH1.h>
@@ -31,12 +32,6 @@
 #include <sstream>
 #include <string>
 #include <utility>  // for pair
-
-namespace
-{
-  // time between crossings (ns)
-  static constexpr double m_time_between_crossing = 106.65237;
-}
 
 bool IsOverFrame(double r, double phi);
 
@@ -462,7 +457,7 @@ int readDigitalCurrents::process_event(PHCompositeNode *topNode)
           {
             if (z >= 0 && z < 1.055 * m)
             {
-              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
               if (z_ibf[iz] > 0 && z_ibf[iz] < 1.055 * m)
               {
                 f_fill_ibf[iz] = 1;
@@ -470,7 +465,7 @@ int readDigitalCurrents::process_event(PHCompositeNode *topNode)
             }
             if (z < 0 && z > -1.055 * m)
             {
-              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
               if (z_ibf[iz] < 0 && z_ibf[iz] > -1.055 * m)
               {
                 f_fill_ibf[iz] = 1;

--- a/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
+++ b/calibrations/tpc/fillDigitalCurrentMaps/readDigitalCurrents.cc
@@ -32,6 +32,12 @@
 #include <string>
 #include <utility>  // for pair
 
+namespace
+{
+  // time between crossings (ns)
+  static constexpr double m_time_between_crossing = 106.65237;
+}
+
 bool IsOverFrame(double r, double phi);
 
 bool IsOverFrame(double r, double phi)
@@ -456,7 +462,7 @@ int readDigitalCurrents::process_event(PHCompositeNode *topNode)
           {
             if (z >= 0 && z < 1.055 * m)
             {
-              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * 106 * vIon * ns;
+              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
               if (z_ibf[iz] > 0 && z_ibf[iz] < 1.055 * m)
               {
                 f_fill_ibf[iz] = 1;
@@ -464,7 +470,7 @@ int readDigitalCurrents::process_event(PHCompositeNode *topNode)
             }
             if (z < 0 && z > -1.055 * m)
             {
-              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * 106 * vIon * ns;
+              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
               if (z_ibf[iz] < 0 && z_ibf[iz] > -1.055 * m)
               {
                 f_fill_ibf[iz] = 1;

--- a/calibrations/tpc/fillSpaceChargeMaps/fillSpaceChargeMaps.cc
+++ b/calibrations/tpc/fillSpaceChargeMaps/fillSpaceChargeMaps.cc
@@ -11,6 +11,7 @@
 
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
+#include <phool/sphenix_constants.h>
 
 #include <TAxis.h>  // for TAxis
 #include <TFile.h>
@@ -31,12 +32,6 @@
 #include <string>
 #include <utility>  // for pair
 #include <vector>
-
-namespace
-{
-  // time between crossings (ns)
-  static constexpr double m_time_between_crossing = 106.65237;
-}
 
 //____________________________________________________________________________..
 fillSpaceChargeMaps::fillSpaceChargeMaps(const std::string &name, const std::string &filename)
@@ -368,8 +363,8 @@ int fillSpaceChargeMaps::process_event(PHCompositeNode *topNode)
             }
             else
             {
-              z_prim[iz] = _hit_z - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
-              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_prim[iz] = _hit_z - (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
+              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
             }
             if (z_prim[iz] > 0 && z_prim[iz] < 1.055 * m)
             {
@@ -400,8 +395,8 @@ int fillSpaceChargeMaps::process_event(PHCompositeNode *topNode)
             }
             else
             {
-              z_prim[iz] = _hit_z + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
-              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_prim[iz] = _hit_z + (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
+              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * sphenix_constants::time_between_crossings * vIon * ns;
             }
             if (z_prim[iz] < 0 && z_prim[iz] > -1.055 * m)
             {

--- a/calibrations/tpc/fillSpaceChargeMaps/fillSpaceChargeMaps.cc
+++ b/calibrations/tpc/fillSpaceChargeMaps/fillSpaceChargeMaps.cc
@@ -32,6 +32,12 @@
 #include <utility>  // for pair
 #include <vector>
 
+namespace
+{
+  // time between crossings (ns)
+  static constexpr double m_time_between_crossing = 106.65237;
+}
+
 //____________________________________________________________________________..
 fillSpaceChargeMaps::fillSpaceChargeMaps(const std::string &name, const std::string &filename)
   : SubsysReco(name)
@@ -362,8 +368,8 @@ int fillSpaceChargeMaps::process_event(PHCompositeNode *topNode)
             }
             else
             {
-              z_prim[iz] = _hit_z - (bX - _event_bunchXing) * 106 * vIon * ns;
-              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * 106 * vIon * ns;
+              z_prim[iz] = _hit_z - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_ibf[iz] = 1.055 * m - (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
             }
             if (z_prim[iz] > 0 && z_prim[iz] < 1.055 * m)
             {
@@ -394,8 +400,8 @@ int fillSpaceChargeMaps::process_event(PHCompositeNode *topNode)
             }
             else
             {
-              z_prim[iz] = _hit_z + (bX - _event_bunchXing) * 106 * vIon * ns;
-              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * 106 * vIon * ns;
+              z_prim[iz] = _hit_z + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
+              z_ibf[iz] = -1.055 * m + (bX - _event_bunchXing) * m_time_between_crossing * vIon * ns;
             }
             if (z_prim[iz] < 0 && z_prim[iz] > -1.055 * m)
             {

--- a/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
+++ b/generators/phhepmc/Fun4AllHepMCPileupInputManager.h
@@ -3,6 +3,8 @@
 
 #include "Fun4AllHepMCInputManager.h"
 
+#include <phool/sphenix_constants.h>
+
 #include <gsl/gsl_rng.h>
 
 #include <map>
@@ -46,13 +48,16 @@ class Fun4AllHepMCPileupInputManager : public Fun4AllHepMCInputManager
   gsl_rng *RandomGenerator = nullptr;
 
   int m_SignalEventNumber = 0;
+
   /// past times are negative, future times are positive
   double _min_integration_time = -17500.0;
   double _max_integration_time = 17500.0;
+
   /// collision rate in Hz
   double _collision_rate = 100.0e3;
+
   /// time between bunch crossing in ns
-  double _time_between_crossings = 106.0;
+  double _time_between_crossings = sphenix_constants::time_between_crossings;
 
   //derived parameters
   double _ave_coll_per_crossing = 1.;

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -25,6 +25,13 @@
 #include <memory>
 #include <set>
 
+namespace
+{
+  // time between crossings (microseconds)
+  static constexpr double m_time_between_crossing = 106.65237 / 1000;
+}
+
+
 SingleMvtxPoolInput::SingleMvtxPoolInput(const std::string &name)
   : SingleStreamingInput(name)
 {
@@ -157,7 +164,7 @@ void SingleMvtxPoolInput::FillPool(const uint64_t minBCO)
             auto num_hits = pool->get_TRG_NR_HITS(feeId, i_strb);
             m_BclkStack.insert(strb_bco);
             m_FEEBclkMap[feeId] = strb_bco;
-            
+
             if (strb_bco < minBCO - m_NegativeBco)
             {
               continue;
@@ -450,8 +457,8 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   }
   else // catchall for anyting else to set to a range based on the rhic clock
   {
-    m_BcoRange = std::ceil(m_strobeWidth / 0.1065);
-    m_NegativeBco = std::ceil(m_strobeWidth / 0.1065);
+    m_BcoRange = std::ceil(m_strobeWidth / m_time_between_crossing);
+    m_NegativeBco = std::ceil(m_strobeWidth / m_time_between_crossing);
   }
   if(Verbosity() > 1)
   {

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -14,6 +14,7 @@
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/sphenix_constants.h>
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
@@ -24,13 +25,6 @@
 #include <cassert>
 #include <memory>
 #include <set>
-
-namespace
-{
-  // time between crossings (microseconds)
-  static constexpr double m_time_between_crossing = 106.65237 / 1000;
-}
-
 
 SingleMvtxPoolInput::SingleMvtxPoolInput(const std::string &name)
   : SingleStreamingInput(name)
@@ -457,8 +451,8 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   }
   else // catchall for anyting else to set to a range based on the rhic clock
   {
-    m_BcoRange = std::ceil(m_strobeWidth / m_time_between_crossing);
-    m_NegativeBco = std::ceil(m_strobeWidth / m_time_between_crossing);
+    m_BcoRange = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
+    m_NegativeBco = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
   }
   if(Verbosity() > 1)
   {

--- a/offline/framework/phool/Makefile.am
+++ b/offline/framework/phool/Makefile.am
@@ -88,7 +88,8 @@ pkginclude_HEADERS =  \
   PHTimeServer.h \
   PHTimeStamp.h \
   PHTypedNodeIterator.h \
-  recoConsts.h
+  recoConsts.h \
+  sphenix_constants.h
 
 noinst_PROGRAMS = \
   testexternals_phool \

--- a/offline/framework/phool/sphenix_constants.h
+++ b/offline/framework/phool/sphenix_constants.h
@@ -1,0 +1,16 @@
+#ifndef PHOOL_SPHENIX_CONSTANTS_H
+#define PHOOL_SPHENIX_CONSTANTS_H
+/*!
+ * \file sphenix_constants.h
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ * \brief convenient namespace to store a number of sphenix specific constants and avoid magic numbers multiplication
+ */
+
+namespace sphenix_constants
+{
+
+  //! time between RHIC crossings (ns)
+  static constexpr double time_between_crossings = 106.65237;
+
+}
+#endif

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.cc
@@ -2,6 +2,8 @@
 
 #include "Mille.h"
 
+#include <tpc/TpcClusterZCrossingCorrection.h>
+
 /// Tracking includes
 #include <trackbase/InttDefs.h>
 #include <trackbase/MvtxDefs.h>
@@ -250,10 +252,10 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
     // store cluster global positions in a vector global_vec and cluskey_vec
 
     TrackFitUtils::getTrackletClusters(_tGeometry, _cluster_map, global_vec, cluskey_vec);
-     
+
     correctTpcGlobalPositions(global_vec, cluskey_vec);
 
- 
+
     std::vector<float> fitpars;
     if(straight_line_fit)
       {
@@ -266,7 +268,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 
 	if (Verbosity() > 1)
 	  {
-	    std::cout << " Track " << trackid << " xy slope " << fitpars[0] << " y intercept " << fitpars[1] 
+	    std::cout << " Track " << trackid << " xy slope " << fitpars[0] << " y intercept " << fitpars[1]
 		      << " zslope " << fitpars[2] << " Z0 " << fitpars[3] << std::endl;
 	  }
       }
@@ -278,7 +280,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	  }
 
 	fitpars = TrackFitUtils::fitClusters(global_vec, cluskey_vec);  // do helical fit
-      
+
 	if (fitpars.size() == 0)
 	  {
 	    continue;  // discard this track, not enough clusters to fit
@@ -290,7 +292,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 		      << " zslope " << fitpars[3] << " Z0 " << fitpars[4] << std::endl;
 	  }
       }
-    
+
 
     //// Create a track map for diagnostics
     SvtxTrack_v4 newTrack;
@@ -312,7 +314,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 
       if(straight_line_fit)
 	{
-	  std::tuple<double, double> linefit_xy(fitpars[0], fitpars[1]); 
+	  std::tuple<double, double> linefit_xy(fitpars[0], fitpars[1]);
 	  nsilicon = TrackFitUtils::addClustersOnLine(linefit_xy, true, dca_cut, _tGeometry, _cluster_map, global_vec, cluskey_vec, 0, 6);
 	}
       else
@@ -341,15 +343,15 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
       if(straight_line_fit)
 	{
 	  fitpars = TrackFitUtils::fitClustersZeroField(global_vec, cluskey_vec, use_intt_zfit);
-	    
+
 	  if (fitpars.size() == 0)
 	    {
 	      continue;  // discard this track, not enough clusters to fit
 	    }
-	  
+
 	  if (Verbosity() > 1)
 	    {
-	      std::cout << " Track " << trackid << " dy/dx " << fitpars[0] << " y intercept " << fitpars[1] 
+	      std::cout << " Track " << trackid << " dy/dx " << fitpars[0] << " y intercept " << fitpars[1]
 			<< " dx/dz " << fitpars[2] << " Z0 " << fitpars[3] << std::endl;
 	    }
 	}
@@ -412,12 +414,12 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
       {
 	someseed.set_qOverR(1.0);
 	someseed.set_phi(tracklet->get_phi());
-	
+
 	someseed.set_X0(fitpars[0]);
 	someseed.set_Y0(fitpars[1]);
 	someseed.set_Z0(fitpars[3]);
 	someseed.set_slope(fitpars[2]);
-	
+
 	auto tangent=get_line_tangent(fitpars, global_vec[0]);
 	newTrack.set_x(track_vtx(0));
 	newTrack.set_y(track_vtx(1));
@@ -431,14 +433,14 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
       {
 	someseed.set_qOverR(tracklet->get_charge() / fitpars[0]);
 	someseed.set_phi(tracklet->get_phi());
-	
+
 	someseed.set_X0(fitpars[1]);
 	someseed.set_Y0(fitpars[2]);
 	someseed.set_Z0(fitpars[4]);
 	someseed.set_slope(fitpars[3]);
-	
+
 	const auto position = TrackSeedHelper::get_xyz(&someseed);
-	
+
 	newTrack.set_x(position.x());
 	newTrack.set_y(position.y());
 	newTrack.set_z(position.z());
@@ -446,8 +448,8 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	newTrack.set_py(someseed.get_py());
 	newTrack.set_pz(someseed.get_pz());
 	newTrack.set_charge(tracklet->get_charge());
-      }	
-	    
+      }
+
     nclus = ntpc + nsilicon;
 
     // some basic track quality requirements
@@ -758,7 +760,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	      glbl_derivativeX[0], glbl_derivativeX[1], glbl_derivativeX[2], glbl_derivativeX[3], glbl_derivativeX[4], glbl_derivativeX[5],
 	      lcl_derivativeY[0], lcl_derivativeY[1], lcl_derivativeY[2], lcl_derivativeY[3],
 	      glbl_derivativeY[0], glbl_derivativeY[1], glbl_derivativeY[2], glbl_derivativeY[3], glbl_derivativeY[4], glbl_derivativeY[5]};
-	    
+
 	    ntp->Fill(ntp_data);
 	  }
 	else
@@ -783,7 +785,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	      glbl_derivativeX[0], glbl_derivativeX[1], glbl_derivativeX[2], glbl_derivativeX[3], glbl_derivativeX[4], glbl_derivativeX[5],
 	      lcl_derivativeY[0], lcl_derivativeY[1], lcl_derivativeY[2], lcl_derivativeY[3], lcl_derivativeY[4],
 	      glbl_derivativeY[0], glbl_derivativeY[1], glbl_derivativeY[2], glbl_derivativeY[3], glbl_derivativeY[4], glbl_derivativeY[5]};
-	    
+
 	    ntp->Fill(ntp_data);
 
 	    if (Verbosity() > 2)
@@ -796,7 +798,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	      }
 	  }
       }
-      
+
       if (!isnan(residual(0)) && clus_sigma(0) < 1.0)  // discards crazy clusters
       {
         _mille->mille(AlignmentDefs::NLC, lcl_derivativeX, AlignmentDefs::NGL, glbl_derivativeX, glbl_label, residual(0), errinf * clus_sigma(0));
@@ -821,7 +823,7 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	  {
 	    SvtxTrack *vtxtrack = m_trackmap->get(*trackiter);
 	    if (vtxtrack)
-	      {	    
+	      {
 		unsigned int vtxtrackid = vtxtrack->get_id();
 		if(trackid == vtxtrackid)
 		  {
@@ -837,10 +839,10 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 	      }
 	  }
       }
-    
+
     //  skip the common vertex requirement for this track unless there are 3 tracks in the event
     if(accepted_tracks < 3) {  continue; }
-    
+
     // The residual for the vtx case is (event vtx - track vtx)
     // that is -dca
     float dca3dxy = 0;
@@ -854,8 +856,8 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
     else
       {
 	get_dca_zero_field(newTrack, dca3dxy, dca3dz, dca3dxysigma, dca3dzsigma, event_vtx);
-      } 
-    
+      }
+
     // These are local coordinate residuals in the perigee surface
    Acts::Vector2 vtx_residual(-dca3dxy, -dca3dz);
 
@@ -941,9 +943,9 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 				glblvtx_derivativeX[0], glblvtx_derivativeX[1], glblvtx_derivativeX[2],
 				lclvtx_derivativeY[0], lclvtx_derivativeY[1], lclvtx_derivativeY[2], lclvtx_derivativeY[3],
 				glblvtx_derivativeY[0], glblvtx_derivativeY[1], glblvtx_derivativeY[2],
-				newTrack.get_x(), newTrack.get_y(), newTrack.get_z(), 
+				newTrack.get_x(), newTrack.get_y(), newTrack.get_z(),
 				(float) event_vtx(0), (float ) event_vtx(1), (float) event_vtx(2), track_phi, perigee_phi};
-	  
+
 	  track_ntp->Fill(ntp_data);
 	}
       else
@@ -953,9 +955,9 @@ int HelicalFitter::process_event(PHCompositeNode* /*unused*/)
 				glblvtx_derivativeX[0], glblvtx_derivativeX[1], glblvtx_derivativeX[2],
 				lclvtx_derivativeY[0], lclvtx_derivativeY[1], lclvtx_derivativeY[2], lclvtx_derivativeY[3], lclvtx_derivativeY[4],
 				glblvtx_derivativeY[0], glblvtx_derivativeY[1], glblvtx_derivativeY[2],
-				newTrack.get_x(), newTrack.get_y(), newTrack.get_z(), 
+				newTrack.get_x(), newTrack.get_y(), newTrack.get_z(),
 				(float) event_vtx(0), (float ) event_vtx(1), (float) event_vtx(2), track_phi, perigee_phi};
-	  
+
 	  track_ntp->Fill(ntp_data);
 	}
     }
@@ -1012,7 +1014,7 @@ Acts::Vector3 HelicalFitter::get_line_surface_intersection(const Surface& surf, 
   /*
   // we need the direction of the line
 
-  // consider a point some distance along the straight line. 
+  // consider a point some distance along the straight line.
   // Consider a value of x, calculate y, calculate radius, calculate z
   double x = 2;
   double y = fitpars[0]*x + fitpars[1];
@@ -1031,7 +1033,7 @@ Acts::Vector3 HelicalFitter::get_line_surface_intersection(const Surface& surf, 
 
   auto line = get_line_zero_field(fitpars);  // do not need the direction
   auto arb_point = line.first;
-  auto tangent = line.second;  
+  auto tangent = line.second;
 
   Acts::Vector3 intersection = get_line_plane_intersection(arb_point, tangent, sensorCenter, sensorNormal);
 
@@ -1082,7 +1084,7 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_tangent(const st
   float phi = atan2(global(1),global(0));
 
   // we need the direction of the line
-  // consider a point some distance along the straight line. 
+  // consider a point some distance along the straight line.
   // Consider a value of x, calculate y, calculate radius, calculate z
   double x = 0;
   double y = fitpars[0]*x + fitpars[1];
@@ -1102,8 +1104,8 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_tangent(const st
       tangent = arb_point - arb_point2;   // direction of line
     }
 
-  tangent /= tangent.norm();  
-  
+  tangent /= tangent.norm();
+
   std::pair<Acts::Vector3, Acts::Vector3> line = std::make_pair(arb_point, tangent);
 
   return line;
@@ -1113,7 +1115,7 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_tangent(const st
 std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_zero_field(const std::vector<float>& fitpars)
 {
   // Returns the line equation, but without the direction of the track
-  // consider a point some distance along the straight line. 
+  // consider a point some distance along the straight line.
   // Consider a value of x, calculate y, calculate z
   double x = 0;
   double y = fitpars[0]*x + fitpars[1];
@@ -1126,8 +1128,8 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_zero_field(const
   Acts::Vector3 arb_point2(x2, y2, z2);
 
   Acts::Vector3 tangent = arb_point2 - arb_point;   // +/- times direction of line
-  tangent /= tangent.norm();  
-  
+  tangent /= tangent.norm();
+
   std::pair<Acts::Vector3, Acts::Vector3> line = std::make_pair(arb_point, tangent);
 
   return line;
@@ -1137,7 +1139,7 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line_zero_field(const
 std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line(const std::vector<float>& fitpars)
 {
   // we need the direction of the line
-  // consider a point some distance along the straight line. 
+  // consider a point some distance along the straight line.
   // Consider a value of x, calculate y, calculate radius, calculate z
   double x = 0.0;
   double y = fitpars[0]*x + fitpars[1];
@@ -1152,8 +1154,8 @@ std::pair<Acts::Vector3, Acts::Vector3> HelicalFitter::get_line(const std::vecto
   Acts::Vector3 arb_point2(x2, y2, z2);
 
   Acts::Vector3 tangent = arb_point2 - arb_point;   // direction of line
-  tangent /= tangent.norm();  
-  
+  tangent /= tangent.norm();
+
   std::pair<Acts::Vector3, Acts::Vector3> line = std::make_pair(arb_point, tangent);
 
   return line;
@@ -1354,7 +1356,7 @@ void HelicalFitter::makeTpcGlobalCorrections(TrkrDefs::cluskey cluster_key, shor
 {
   // make all corrections to global position of TPC cluster
   unsigned int side = TpcDefs::getSide(cluster_key);
-  global.z() = m_clusterCrossingCorrection.correctZ(global.z(), side, crossing);
+  global.z() = TpcClusterZCrossingCorrection::correctZ(global.z(), side, crossing);
 
   // apply distortion corrections
   global = m_globalPositionWrapper.applyDistortionCorrections(global);
@@ -1719,7 +1721,7 @@ void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, const Acts::Vect
   unitr /= unitr.norm();
   float phi = atan2(center(1), center(0));
   Acts::Vector3 unitrphi(-sin(phi), cos(phi), 0.0);  // unit vector phi in polar coordinates
-  Acts::Vector3 unitz(0, 0, 1); 
+  Acts::Vector3 unitz(0, 0, 1);
 
   glbl_derivativeX[3] = unitr.dot(projX);
   glbl_derivativeX[4] = unitrphi.dot(projX);
@@ -1782,7 +1784,7 @@ void HelicalFitter::getGlobalDerivativesXY(const Surface& surf, const Acts::Vect
     {
       for (int ip = 0; ip < 6; ++ip)
 	{
-	  std::cout << " layer " << layer << " ip " << ip 
+	  std::cout << " layer " << layer << " ip " << ip
 		    << "  glbl_derivativeX " << glbl_derivativeX[ip] << "  "
 		    << " glbl_derivativeY " << glbl_derivativeY[ip] << std::endl;
 	}
@@ -1841,7 +1843,7 @@ void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::
   // get the plane of the surface
   Acts::Vector3 sensorCenter = surf->center(_tGeometry->geometry().getGeoContext()) / Acts::UnitConstants::cm;  // convert to cm
 
-  // We need the three unit vectors in the sensor local frame, transformed to the global frame 
+  // We need the three unit vectors in the sensor local frame, transformed to the global frame
   //====================================================================
   // sensorNormal is the Z vector in the global frame
   Acts::Vector3 Z = -surf->normal(_tGeometry->geometry().getGeoContext());
@@ -1853,23 +1855,23 @@ void HelicalFitter::get_projectionXY(const Surface& surf, const std::pair<Acts::
   Acts::Vector3 yloc(0.0, 1.0, 0.0);
   Acts::Vector3 yglob = surf->transform(_tGeometry->geometry().getGeoContext()) * (yloc * Acts::UnitConstants::cm);
   yglob /= Acts::UnitConstants::cm;
-  // These are the local frame unit vectors transformed to the global frame  
+  // These are the local frame unit vectors transformed to the global frame
   Acts::Vector3 X = (xglob - sensorCenter) / (xglob - sensorCenter).norm();
   Acts::Vector3 Y = (yglob - sensorCenter) / (yglob - sensorCenter).norm();
 
   // see equation 31 of the ATLAS paper (and discussion) for this
-  // The unit vector in the local frame transformed to the global frame (X), 
+  // The unit vector in the local frame transformed to the global frame (X),
   // minus Z scaled by the track vector overlap with X, divided by the track vector overlap with Z.
   projX = X - (tanvec.dot(X) / tanvec.dot(Z)) * Z;
   projY = Y - (tanvec.dot(Y) / tanvec.dot(Z)) * Z;
 
   if(Verbosity() > 1)
     {
-      std::cout << "    tanvec: " << std::endl << tanvec << std::endl;  
+      std::cout << "    tanvec: " << std::endl << tanvec << std::endl;
       std::cout << "    X: " << std::endl << X << std::endl;
       std::cout << "    Y: " << std::endl << Y << std::endl;
       std::cout << "    Z: " << std::endl << Z << std::endl;
-      
+
       std::cout << "    projX: " << std::endl << projX << std::endl;
       std::cout << "    projY: " << std::endl << projY << std::endl;
     }

--- a/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
+++ b/offline/packages/TrackerMillepedeAlignment/HelicalFitter.h
@@ -161,9 +161,6 @@ class HelicalFitter : public SubsysReco, public PHParameterInterface
   Acts::Vector3 globalvtxToLocalvtx(SvtxTrack& track, const Acts::Vector3& event_vertex, Acts::Vector3 PCA);
   Acts::Vector3 localvtxToGlobalvtx(SvtxTrack& track, const Acts::Vector3& event_vtx, const Acts::Vector3& PCA);
 
-  //! cluster z correction
-  TpcClusterZCrossingCorrection m_clusterCrossingCorrection;
-
   //! global position wrapper
   TpcGlobalPositionWrapper m_globalPositionWrapper;
 

--- a/offline/packages/TrackingDiagnostics/KshortReconstruction.h
+++ b/offline/packages/TrackingDiagnostics/KshortReconstruction.h
@@ -10,9 +10,6 @@
 #include <globalvertex/SvtxVertexMap.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
-#include <tpc/TpcClusterZCrossingCorrection.h>
-#include <tpc/TpcDistortionCorrection.h>
-
 #include <Acts/Definitions/Algebra.hpp>
 
 #include <Acts/EventData/TrackParameters.hpp>

--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -35,6 +35,12 @@
 #include <array>
 #include <cassert>
 
+namespace
+{
+  // time between crossings (microseconds)
+  static constexpr double m_time_between_crossing = 106.65237 / 1000;
+}
+
 //_________________________________________________________
 MvtxCombinedRawDataDecoder::MvtxCombinedRawDataDecoder(const std::string &name)
   : SubsysReco(name)
@@ -228,7 +234,7 @@ int MvtxCombinedRawDataDecoder::process_event(PHCompositeNode *topNode)
     col = mvtx_hit->get_col();
 
     int bcodiff = gl1 ? strobe - gl1bco : 0;
-    double timeElapsed = bcodiff * 0.1065;  // 106 ns rhic clock
+    double timeElapsed = bcodiff * m_time_between_crossing;
     int index = m_mvtx_is_triggered ? 0 : std::ceil(timeElapsed / m_strobeWidth);
 
     if (index < -16 || index > 15)

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
@@ -6,6 +6,8 @@
 
 #include "TpcClusterZCrossingCorrection.h"
 
+#include <phool/sphenix_constants.h>
+
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -14,7 +16,7 @@
 float TpcClusterZCrossingCorrection::_vdrift = 8.0e-03;
 
 // ns, same value as in pileup generator
-float TpcClusterZCrossingCorrection::_time_between_crossings = 106.65237;
+float TpcClusterZCrossingCorrection::_time_between_crossings = sphenix_constants::time_between_crossings;
 
 //______________________________________________________________________________________________
 float TpcClusterZCrossingCorrection::correctZ(float zinit, unsigned int side, short int crossing)

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <limits>
 
-// default value, override from macro
+// default value, override from macro (cm/ns)
 float TpcClusterZCrossingCorrection::_vdrift = 8.0e-03;
 
 // ns, same value as in pileup generator

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
@@ -11,10 +11,8 @@
 #include <limits>
 
 float TpcClusterZCrossingCorrection::_vdrift = 8.0e-03;  // default value, override from macro
-
-TpcClusterZCrossingCorrection::TpcClusterZCrossingCorrection() = default;
-
-float TpcClusterZCrossingCorrection::correctZ(float zinit, unsigned int side, short int crossing) const
+float TpcClusterZCrossingCorrection::_time_between_crossings = 106;  // ns, same value as in pileup generator
+float TpcClusterZCrossingCorrection::correctZ(float zinit, unsigned int side, short int crossing)
 {
   if (crossing == std::numeric_limits<short>::max())
   {

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.cc
@@ -10,8 +10,13 @@
 #include <iostream>
 #include <limits>
 
-float TpcClusterZCrossingCorrection::_vdrift = 8.0e-03;  // default value, override from macro
-float TpcClusterZCrossingCorrection::_time_between_crossings = 106;  // ns, same value as in pileup generator
+// default value, override from macro
+float TpcClusterZCrossingCorrection::_vdrift = 8.0e-03;
+
+// ns, same value as in pileup generator
+float TpcClusterZCrossingCorrection::_time_between_crossings = 106.65237;
+
+//______________________________________________________________________________________________
 float TpcClusterZCrossingCorrection::correctZ(float zinit, unsigned int side, short int crossing)
 {
   if (crossing == std::numeric_limits<short>::max())

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.h
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.h
@@ -39,6 +39,8 @@ class TpcClusterZCrossingCorrection
   //! drift velocity (cm/ns)
   static float _vdrift;
 
+  private:
+
   //! time between crossing (ns)
   static float _time_between_crossings;
 

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.h
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.h
@@ -11,13 +11,38 @@ class TpcClusterZCrossingCorrection
 {
   public:
 
-  TpcClusterZCrossingCorrection() = default;
+  //!@name accessors
+  //@{
 
+  //! drift velocity (cm/ns)
+  static float get_vdrift() { return _vdrift; }
+
+  //! time between crossing (ns)
+  static float get_time_between_crossings() { return _time_between_crossings; }
+
+  //! apply correction on a given z
   static float correctZ(float zinit, unsigned int side, short int crossing);
+  //@}
 
+  //!@name modifiers
+  //@{
+  //! drift velocity (cm/ns)
+  static void set_vdrift( float value ) { _vdrift = value; }
+
+  //! time between crossing (ns)
+  static void set_time_between_crossings( float value ) { _time_between_crossings = value; }
+  //@}
+
+  // TODO: move to private
+  //!@name parameters
+  //@{
+  //! drift velocity (cm/ns)
   static float _vdrift;
 
-  static float _time_between_crossings;  // ns, same value as in pileup generator
+  //! time between crossing (ns)
+  static float _time_between_crossings;
+
+  //@}
 
 };
 

--- a/offline/packages/tpc/TpcClusterZCrossingCorrection.h
+++ b/offline/packages/tpc/TpcClusterZCrossingCorrection.h
@@ -9,15 +9,16 @@
 
 class TpcClusterZCrossingCorrection
 {
- public:
-  TpcClusterZCrossingCorrection();
+  public:
 
-  float correctZ(float zinit, unsigned int side, short int crossing) const;
+  TpcClusterZCrossingCorrection() = default;
+
+  static float correctZ(float zinit, unsigned int side, short int crossing);
 
   static float _vdrift;
 
- private:
-  float _time_between_crossings = 106;  // ns, same value as in pileup generator
+  static float _time_between_crossings;  // ns, same value as in pileup generator
+
 };
 
 #endif

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -6,6 +6,7 @@
 
 #include "TpcGlobalPositionWrapper.h"
 
+#include "TpcClusterZCrossingCorrection.h"
 #include "TpcDistortionCorrectionContainer.h"
 
 #include <phool/getClass.h>
@@ -96,7 +97,7 @@ Acts::Vector3 TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(con
     }
 
     // apply crossing correction
-    global.z() = m_crossingCorrection.correctZ(global.z(), TpcDefs::getSide(key), crossing);
+    global.z() = TpcClusterZCrossingCorrection::correctZ(global.z(), TpcDefs::getSide(key), crossing);
 
     // apply distortion corrections
     global = applyDistortionCorrections(global);

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -6,7 +6,6 @@
  * \brief provides the tpc 3d global position with all distortion and crossing corrections applied
  * \author Joe Osborn <josborn1@bnl.gov>, Hugo Pereira Da Costa <hugo.pereira-da-costa@lanl.gov>
  */
-#include "TpcClusterZCrossingCorrection.h"
 #include "TpcDistortionCorrection.h"
 
 #include <trackbase/TrkrDefs.h>
@@ -53,9 +52,6 @@ class TpcGlobalPositionWrapper
 
   //! verbosity
   unsigned int m_verbosity = 0;
-
-  //! cluster z crossing correction interface
-  TpcClusterZCrossingCorrection m_crossingCorrection;
 
   //! distortion correction interface
   TpcDistortionCorrection m_distortionCorrection;

--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -11,70 +11,75 @@ class ActsGeometry
 {
  public:
   ActsGeometry() = default;
-  ~ActsGeometry() {}
+  ~ActsGeometry() = default;
 
-  void setGeometry(ActsTrackingGeometry& tGeometry)
+  void setGeometry(const ActsTrackingGeometry& tGeometry)
   {
     m_tGeometry = tGeometry;
   }
 
-  void setSurfMaps(ActsSurfaceMaps& surfMaps)
+  void setSurfMaps(const ActsSurfaceMaps& surfMaps)
   {
     m_surfMaps = surfMaps;
   }
 
+  //! const accessor
+  const ActsTrackingGeometry& geometry() const
+  {
+    return m_tGeometry;
+  }
+
+  //! mutable accessor
   ActsTrackingGeometry& geometry()
   {
     return m_tGeometry;
   }
+
+  //! const accessor
+  const ActsSurfaceMaps& maps() const
+  {
+    return m_surfMaps;
+  }
+
+  //! mutable accessor
   ActsSurfaceMaps& maps()
   {
     return m_surfMaps;
   }
 
   void set_drift_velocity(double vd) { _drift_velocity = vd; }
-  double get_drift_velocity() { return _drift_velocity; }
 
   void set_tpc_tzero(double tz) { _tpc_tzero = tz; }
-  double get_tpc_tzero() { return _tpc_tzero; }
+  double get_tpc_tzero() const { return _tpc_tzero; }
 
-  void set_crossing_period(double t) { _crossing_period = t; }
-  double get_crossing_period() { return _crossing_period; }
-
-  Eigen::Matrix<float, 3, 1> getGlobalPositionF(
-      TrkrDefs::cluskey key,
-      TrkrCluster* cluster);
+  double get_drift_velocity() const { return _drift_velocity; }
 
   Acts::Vector3 getGlobalPosition(
       TrkrDefs::cluskey key,
-      TrkrCluster* cluster);
+      TrkrCluster* cluster) const;
 
   Acts::Vector3 getGlobalPositionTpc(
       TrkrDefs::cluskey key,
-      TrkrCluster* cluster);
+      TrkrCluster* cluster) const;
 
   Acts::Vector3 getGlobalPositionTpc(
       const TrkrDefs::hitsetkey& hitsetkey, const TrkrDefs::hitkey& hitkey, const float& phi, const float& rad,
-      const float& clockPeriod);
+      const float& clockPeriod) const;
 
   Surface get_tpc_surface_from_coords(
       TrkrDefs::hitsetkey hitsetkey,
       Acts::Vector3 world,
-      TrkrDefs::subsurfkey& subsurfkey);
+      TrkrDefs::subsurfkey& subsurfkey) const ;
 
-  Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation);
+  Acts::Transform3 makeAffineTransform(Acts::Vector3 rotation, Acts::Vector3 translation) const;
 
-  Acts::Vector2 getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster);
-
-  Acts::Vector2 getCrossingCorrectedLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster, int crossing);
+  Acts::Vector2 getLocalCoords(TrkrDefs::cluskey key, TrkrCluster* cluster) const;
 
  private:
   ActsTrackingGeometry m_tGeometry;
   ActsSurfaceMaps m_surfMaps;
-
   double _drift_velocity = 8.0e-3;  // cm/ns
   double _tpc_tzero = 0.0;  // ns
-  double _crossing_period = 106.0;  // ns
 };
 
 #endif

--- a/offline/packages/trackbase/ActsTrackingGeometry.h
+++ b/offline/packages/trackbase/ActsTrackingGeometry.h
@@ -52,6 +52,11 @@ struct ActsTrackingGeometry
   Acts::GeometryContext geoContext;
   Acts::MagneticFieldContext magFieldContext;
 
+  const Acts::GeometryContext& getGeoContext() const
+  {
+    return geoContext;
+  }
+
   Acts::GeometryContext& getGeoContext()
   {
     return geoContext;

--- a/offline/packages/trackreco/ActsAlignmentStates.h
+++ b/offline/packages/trackreco/ActsAlignmentStates.h
@@ -7,8 +7,6 @@
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 
-#include <tpc/TpcClusterZCrossingCorrection.h>
-
 #include <trackbase/ActsGeometry.h>
 #include <trackbase/ActsTrackFittingAlgorithm.h>
 #include <trackbase/ClusterErrorPara.h>

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -26,6 +26,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/sphenix_constants.h>
 
 #include <TF1.h>
 #include <TFile.h>
@@ -39,13 +40,6 @@
 #include <utility>  // for pair
 
 using namespace std;
-
-namespace
-{
-
-  //! time between crossing (ns)
-  static constexpr double time_between_crossings = 106.65237;
-}
 
 //____________________________________________________________________________..
 PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name)
@@ -327,7 +321,7 @@ short int PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpci
 double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_mismatch)
 {
   const double vdrift = _tGeometry->get_drift_velocity();  // cm/ns
-  const double z_bunch_separation = time_between_crossings * vdrift; // cm
+  const double z_bunch_separation = sphenix_constants::time_between_crossings * vdrift; // cm
 
   // The sign of z_mismatch will depend on which side of the TPC the tracklet is in
   TrackSeed *track = _track_map->get(trid);

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -40,6 +40,13 @@
 
 using namespace std;
 
+namespace
+{
+
+  //! time between crossing (ns)
+  static constexpr double time_between_crossings = 106.65237;
+}
+
 //____________________________________________________________________________..
 PHSiliconTpcTrackMatching::PHSiliconTpcTrackMatching(const std::string &name)
   : SubsysReco(name)
@@ -175,7 +182,7 @@ bool PHSiliconTpcTrackMatching::WindowMatcher::in_window
     if (fabs_max_posQ) {
       return fabs(delta) < fn_exp(posHi, posHi_b0, pt);
     } else {
-      return (delta > fn_exp(posLo, posLo_b0, pt) 
+      return (delta > fn_exp(posLo, posLo_b0, pt)
            && delta < fn_exp(posHi, posHi_b0, pt));
     }
   } else {
@@ -183,7 +190,7 @@ bool PHSiliconTpcTrackMatching::WindowMatcher::in_window
     if (fabs_max_negQ) {
       return fabs(delta) < fn_exp(negHi, negHi_b0, pt);
     } else {
-      return (delta > fn_exp(negLo, negLo_b0, pt) 
+      return (delta > fn_exp(negLo, negLo_b0, pt)
            && delta < fn_exp(negHi, negHi_b0, pt));
     }
   }
@@ -194,7 +201,7 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
 {
   if(Verbosity() > 2)
   {
-    std::cout << " Warning: PHSiliconTpcTrackMatching " 
+    std::cout << " Warning: PHSiliconTpcTrackMatching "
       << ( _zero_field ? "zero field is ON" : " zero field is OFF") << std::endl;
   }
   // _track_map contains the TPC seed track stubs
@@ -319,15 +326,13 @@ short int PHSiliconTpcTrackMatching::findCrossingGeometrically(unsigned int tpci
 
 double PHSiliconTpcTrackMatching::getBunchCrossing(unsigned int trid, double z_mismatch)
 {
-  double vdrift = _tGeometry->get_drift_velocity();  // cm/ns
-  vdrift *= 1000.0;                                  // cm/microsecond
-  //  double vdrift = 8.00;  // cm /microsecond
-  // double z_bunch_separation = 0.106 * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
-  double z_bunch_separation = (crossing_period / 1000.0) * vdrift;  // 106 ns bunch crossing interval, as in pileup generator
+  const double vdrift = _tGeometry->get_drift_velocity();  // cm/ns
+  const double z_bunch_separation = time_between_crossings * vdrift; // cm
 
   // The sign of z_mismatch will depend on which side of the TPC the tracklet is in
   TrackSeed *track = _track_map->get(trid);
 
+  // crossing
   double crossings = z_mismatch / z_bunch_separation;
 
   // Check the TPC side for the first cluster in the track
@@ -496,7 +501,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       Acts::Vector3  mom;
       bool ok_track;
 
-      std::tie(ok_track, tpc_phi, tpc_eta, tpc_pt, tpc_pos, mom) = 
+      std::tie(ok_track, tpc_phi, tpc_eta, tpc_pt, tpc_pos, mom) =
         TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list);
       if (!ok_track) { continue; }
       tpc_px = mom.x();
@@ -581,7 +586,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       Acts::Vector3  mom;
       bool ok_track;
 
-      std::tie(ok_track, si_phi, si_eta, si_pt, si_pos, mom) = 
+      std::tie(ok_track, si_phi, si_eta, si_pt, si_pos, mom) =
         TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list);
       if (!ok_track) { continue; }
       si_px = mom.x();
@@ -623,7 +628,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       bool position_match = false;
       if (_pp_mode)
       {
-        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x()) 
+        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x())
          && window_dy.in_window(is_posQ, tpc_pt, tpc_pos.y(), si_pos.y()))
         {
           position_match = true;
@@ -631,7 +636,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       }
       else
       {
-        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x()) 
+        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x())
          && window_dy.in_window(is_posQ, tpc_pt, tpc_pos.y(), si_pos.y())
          && window_dz.in_window(is_posQ, tpc_pt, tpc_pos.z(), si_pos.z()))
         {
@@ -651,14 +656,14 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
         // if phi fails, account for case where |tpc_phi-si_phi|>PI
       } else if (fabs(tpc_phi-si_phi)>M_PI) {
         auto tpc_phi_wrap = tpc_phi;
-        if ((tpc_phi_wrap - si_phi) > M_PI) { 
-          tpc_phi_wrap -= 2*M_PI; 
+        if ((tpc_phi_wrap - si_phi) > M_PI) {
+          tpc_phi_wrap -= 2*M_PI;
         } else {
           tpc_phi_wrap += 2*M_PI;
         }
         phi_match = window_dphi.in_window(is_posQ, tpc_pt, tpc_phi_wrap, si_phi);
       }
-         
+
       if (!phi_match)
       {
         continue;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -31,10 +31,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   // legacy parameters
   // The legacy code matched tracks as:
-  //     |dX| < window * (a+b/pow(pT,c)) 
+  //     |dX| < window * (a+b/pow(pT,c))
   //   for pT < min_pT
   //   otherwise
-  //     |dX| < window 
+  //     |dX| < window
   bool _use_legacy_windowing = true;
   void set_use_legacy_windowing (bool set_par=true) { _use_legacy_windowing=set_par; }
 
@@ -58,9 +58,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     double leg_search_win = 1.; // use if use_legacy == true; set in InitRun
     /* PHSiliconTpcTrackMatching* parent_ptr {nullptr}; */
     void set_use_legacy(double _leg_search_win)
-    { 
-      use_legacy=true; 
-      leg_search_win=_leg_search_win; 
+    {
+      use_legacy=true;
+      leg_search_win=_leg_search_win;
     }
 
     // --- new method, comparing to a+b*exp(c/pT)
@@ -74,7 +74,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     Arr3D posHi { 100., 0., 0. }; // (above a3,b3,c3), 100 for use _use_legacy_windowing
     Arr3D negLo { 100., 0., 0. }; // (above a0,b0,c0), 100 for |dX|
     Arr3D negHi { 100., 0., 0. }; // (above a1,b1,c1), 100 for treat all tracks pos Q
-                                 
+
     // efficiency flags set during PHSiliconTpcTrackMatching::InitRun()
     bool fabs_max_posQ  = true;
     bool fabs_max_negQ  = true;
@@ -86,13 +86,13 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     double min_pt_negQ  = 0.25; // only grow function windows down to 150 MeV
 
     WindowMatcher(
-        const Arr3D _posLo={100.,0.,0.},  
-        const Arr3D _posHi={100.,0.,0.}, 
-        const Arr3D _negLo={100.,0.,0.}, 
-        const Arr3D _negHi={100.,0.,0.}, 
-        const double _min_pt_posQ=0.25, 
+        const Arr3D _posLo={100.,0.,0.},
+        const Arr3D _posHi={100.,0.,0.},
+        const Arr3D _negLo={100.,0.,0.},
+        const Arr3D _negHi={100.,0.,0.},
+        const double _min_pt_posQ=0.25,
         const double _min_pt_negQ=0.25)
-      : posLo{_posLo}, posHi{_posHi}, negLo{_negLo}, negHi{_negHi}, 
+      : posLo{_posLo}, posHi{_posHi}, negLo{_negLo}, negHi{_negHi},
       min_pt_posQ{_min_pt_posQ}, min_pt_negQ{_min_pt_negQ} {};
 
     inline double fn_exp(const Arr3D& arr, const bool& b_is_0, double pT) {
@@ -102,14 +102,14 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     void init_bools(const std::string& which_window="", const bool print=false);
 
     bool in_window(bool posQ, const double tpc_pt, const double tpc_X, const double si_X);
-    
+
     // initialize to fn_lo < deltaX < fn_hi for +Q, and fn_lo < deltaX < fn_hi for -Q
 
-    void reset_fns() { 
-      posLo={100.,0.,0.}; 
-      posHi={100.,0.,0.}; 
-      negLo={100.,0.,0.}; 
-      negHi={100.,0.,0.}; 
+    void reset_fns() {
+      posLo={100.,0.,0.};
+      posHi={100.,0.,0.};
+      negLo={100.,0.,0.};
+      negHi={100.,0.,0.};
     };
 
     // same max for |deltaX| for pos and neg Q
@@ -149,7 +149,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void print_windows(bool print=true) { _print_windows = print; }
 
   void zeroField(const bool flag) { _zero_field = flag; }
-  
+
   void set_use_old_matching(const bool flag) { _use_old_matching = flag; }
 
   void set_test_windows_printout(const bool test) { _test_windows = test; }
@@ -212,7 +212,6 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   //  double _collision_rate = 50e3;  // input rate for phi correction
   //  double _reference_collision_rate = 50e3;  // reference rate for phi correction
   //  double _si_vertex_dzmax = 0.25;  // mm
-  double crossing_period = 106.0;  // ns
   double fieldstrength{std::numeric_limits<double>::quiet_NaN()};
 
   bool _test_windows = false;

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -43,7 +43,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_x_search_window(const double win) { _x_search_win = win; }
   void set_y_search_window(const double win) { _y_search_win = win; }
   void set_z_search_window(const double win) { _z_search_win = win; }
-  void set_crossing_deltaz_max(const double dz) {_crossing_deltaz_max = dz ;} 
+  void set_crossing_deltaz_max(const double dz) {_crossing_deltaz_max = dz ;}
 
   float get_phi_search_window() const { return _phi_search_win; }
   float get_eta_search_window() const { return _eta_search_win; }
@@ -70,10 +70,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     // - only one curve if |dX|<fn_max, or two if like  fn_min<dX<fnmax
     using Arr3D = std::array<double,3>;
     std::string print_fn(const Arr3D&);
-    Arr3D posLo { 100., 0., 0. }; // (above a2,b2,c2), 100 for |dX|
-    Arr3D posHi { 100., 0., 0. }; // (above a3,b3,c3), 100 for use _use_legacy_windowing
-    Arr3D negLo { 100., 0., 0. }; // (above a0,b0,c0), 100 for |dX|
-    Arr3D negHi { 100., 0., 0. }; // (above a1,b1,c1), 100 for treat all tracks pos Q
+    Arr3D posLo { 100, 0, 0 }; // (above a2,b2,c2), 100 for |dX|
+    Arr3D posHi { 100, 0, 0 }; // (above a3,b3,c3), 100 for use _use_legacy_windowing
+    Arr3D negLo { 100, 0, 0 }; // (above a0,b0,c0), 100 for |dX|
+    Arr3D negHi { 100, 0, 0 }; // (above a1,b1,c1), 100 for treat all tracks pos Q
 
     // efficiency flags set during PHSiliconTpcTrackMatching::InitRun()
     bool fabs_max_posQ  = true;
@@ -86,10 +86,10 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     double min_pt_negQ  = 0.25; // only grow function windows down to 150 MeV
 
     WindowMatcher(
-        const Arr3D _posLo={100.,0.,0.},
-        const Arr3D _posHi={100.,0.,0.},
-        const Arr3D _negLo={100.,0.,0.},
-        const Arr3D _negHi={100.,0.,0.},
+        const Arr3D& _posLo={100,0,0},
+        const Arr3D& _posHi={100,0,0},
+        const Arr3D& _negLo={100,0,0},
+        const Arr3D& _negHi={100,0,0},
         const double _min_pt_posQ=0.25,
         const double _min_pt_negQ=0.25)
       : posLo{_posLo}, posHi{_posHi}, negLo{_negLo}, negHi{_negHi},
@@ -106,34 +106,34 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
     // initialize to fn_lo < deltaX < fn_hi for +Q, and fn_lo < deltaX < fn_hi for -Q
 
     void reset_fns() {
-      posLo={100.,0.,0.};
-      posHi={100.,0.,0.};
-      negLo={100.,0.,0.};
-      negHi={100.,0.,0.};
+      posLo={100,0,0};
+      posHi={100,0,0};
+      negLo={100,0,0};
+      negHi={100,0,0};
     };
 
     // same max for |deltaX| for pos and neg Q
-    void set_QoverpT_maxabs    (const Arr3D _posHi, const double _min_pt=0.25)
+    void set_QoverpT_maxabs    (const Arr3D& _posHi, const double _min_pt=0.25)
     { reset_fns(); posHi=_posHi; min_pt_posQ = _min_pt; };
 
     // same range for deltaX for pos and neg Q
-    void set_QoverpT_range     (const Arr3D _posLo, const Arr3D _posHi, const double _min_pt=0.25)
+    void set_QoverpT_range     (const Arr3D& _posLo, const Arr3D& _posHi, const double _min_pt=0.25)
     { reset_fns(); posLo=_posLo; posHi=_posHi; min_pt_posQ=_min_pt; };
 
     // max for |deltaX| for pos Q
-    void set_posQoverpT_maxabs (const Arr3D _posHi, const double _min_pt=0.25)
+    void set_posQoverpT_maxabs (const Arr3D& _posHi, const double _min_pt=0.25)
     { posLo={100.,0.,0.}; posHi=_posHi; min_pt_posQ = _min_pt; };
 
     // max for |deltaX| for neg Q
-    void set_negQoverpT_maxabs (const Arr3D _negHi, const double _min_pt=0.25)
+    void set_negQoverpT_maxabs (const Arr3D& _negHi, const double _min_pt=0.25)
     { posLo={100.,0.,0.}; negHi=_negHi; min_pt_negQ = _min_pt; };
 
     // range for deltaX for pos Q
-    void set_posQoverpT_range  (const Arr3D _posLo, const Arr3D _posHi, const double _min_pt=0.25)
+    void set_posQoverpT_range  (const Arr3D& _posLo, const Arr3D& _posHi, const double _min_pt=0.25)
     { posLo=_posLo; posHi=_posHi; min_pt_posQ = _min_pt; };
 
     // range for deltaX for neg Q
-    void set_negQoverpT_range  (const Arr3D _negLo, const Arr3D _negHi, const double _min_pt=0.25)
+    void set_negQoverpT_range  (const Arr3D& _negLo, const Arr3D& _negHi, const double _min_pt=0.25)
     { negLo=_negLo; negHi=_negHi; min_pt_negQ = _min_pt; };
 
   };
@@ -207,7 +207,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   std::map<unsigned int, double> _z_mismatch_map;
 
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
-  float _crossing_deltaz_max = 10.0; 
+  float _crossing_deltaz_max = 10.0;
 
   //  double _collision_rate = 50e3;  // input rate for phi correction
   //  double _reference_collision_rate = 50e3;  // reference rate for phi correction

--- a/offline/packages/trackreco/SecondaryVertexFinder.h
+++ b/offline/packages/trackreco/SecondaryVertexFinder.h
@@ -15,9 +15,6 @@
 #include <trackbase/TpcDefs.h>
 #include <trackbase/TrkrDefs.h>
 
-#include <tpc/TpcClusterZCrossingCorrection.h>
-#include <tpc/TpcDistortionCorrection.h>
-
 #include <Acts/Definitions/Algebra.hpp>
 
 //#pragma GCC diagnostic push

--- a/simulation/g4simulation/g4bbc/MbdDigitization.cc
+++ b/simulation/g4simulation/g4bbc/MbdDigitization.cc
@@ -21,6 +21,7 @@
 #include <phool/PHRandomSeed.h>
 #include <phool/getClass.h>
 #include <phool/phool.h>
+#include <phool/sphenix_constants.h>
 
 #include <TDatabasePDG.h>
 #include <TF1.h>
@@ -173,7 +174,7 @@ int MbdDigitization::process_event(PHCompositeNode * /*topNode*/)
     // get the first time
     if (this_hit->get_t(1) < first_time[ch])
     {
-      if (fabs(this_hit->get_t(1)) < 106.5)
+      if (fabs(this_hit->get_t(1)) < sphenix_constants::time_between_crossings)
       {
         first_time[ch] = this_hit->get_t(1) - vtxp->get_t();
         Float_t dt = gsl_ran_gaussian(m_RandomGenerator, _tres);  // get fluctuation in time

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -41,6 +41,7 @@
 #include <phool/PHObject.h>  // for PHObject
 #include <phool/getClass.h>
 #include <phool/phool.h>  // for PHWHERE
+#include <phool/sphenix_constants.h>
 
 #include <TSystem.h>
 
@@ -622,7 +623,7 @@ void PHG4InttHitReco::SetDefaultParameters()
   // provides for multiple layers/detector types
   set_default_double_param("tmax", 7020.0);  // max upper time window for extended readout
   set_default_double_param("tmin", -20.0);   // min lower time window for extended readout
-  set_default_double_param("beam_crossing_period", 106.65237);
+  set_default_double_param("beam_crossing_period", sphenix_constants::time_between_crossings);
 
   return;
 }

--- a/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
+++ b/simulation/g4simulation/g4intt/PHG4InttHitReco.cc
@@ -243,7 +243,7 @@ int PHG4InttHitReco::InitRun(PHCompositeNode *topNode)
   }
   else // use CDB file
   {
-    hotStripFile = std::filesystem::exists(m_hotStripFileName) ? m_hotStripFileName : CDBInterface::instance()->getUrl(m_hotStripFileName); 
+    hotStripFile = std::filesystem::exists(m_hotStripFileName) ? m_hotStripFileName : CDBInterface::instance()->getUrl(m_hotStripFileName);
   }
 
   std::cout << "PHG4InttHitReco::InitRun - Use local hot channel map file: " << m_useLocalHitMaskFile << std::endl
@@ -622,7 +622,7 @@ void PHG4InttHitReco::SetDefaultParameters()
   // provides for multiple layers/detector types
   set_default_double_param("tmax", 7020.0);  // max upper time window for extended readout
   set_default_double_param("tmin", -20.0);   // min lower time window for extended readout
-  set_default_double_param("beam_crossing_period", 106.0);
+  set_default_double_param("beam_crossing_period", 106.65237);
 
   return;
 }

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -13,6 +13,7 @@
 
 #include <phool/PHCompositeNode.h>  // for PHCompositeNode
 #include <phool/PHNodeIOManager.h>  // for PHNodeIOManager
+#include <phool/sphenix_constants.h>
 
 #include <gsl/gsl_rng.h>
 
@@ -102,7 +103,7 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   std::unique_ptr<PHNodeIOManager> m_IManager;
 
   //! time between crossings. This is a RHIC constant (ns)
-  double m_time_between_crossings = 106.65237;
+  double m_time_between_crossings = sphenix_constants::time_between_crossings;
 
   //! collision rate (Hz)
   double m_collision_rate = 5e4;

--- a/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllDstPileupInputManager.h
@@ -102,7 +102,7 @@ class Fun4AllDstPileupInputManager : public Fun4AllInputManager
   std::unique_ptr<PHNodeIOManager> m_IManager;
 
   //! time between crossings. This is a RHIC constant (ns)
-  double m_time_between_crossings = 106;
+  double m_time_between_crossings = 106.65237;
 
   //! collision rate (Hz)
   double m_collision_rate = 5e4;

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -13,6 +13,7 @@
 
 #include <phool/PHCompositeNode.h>  // for PHCompositeNode
 #include <phool/PHNodeIOManager.h>  // for PHNodeIOManager
+#include <phool/sphenix_constants.h>
 
 #include <gsl/gsl_rng.h>
 
@@ -98,7 +99,7 @@ class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
   std::unique_ptr<PHNodeIOManager> m_IManager_background;
 
   //! time between crossings. This is a RHIC constant (ns)
-  double m_time_between_crossings = 106.65237;
+  double m_time_between_crossings = sphenix_constants::time_between_crossings;
 
   //! collision rate (Hz)
   double m_collision_rate = 5e4;

--- a/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
+++ b/simulation/g4simulation/g4main/Fun4AllSingleDstPileupInputManager.h
@@ -98,7 +98,7 @@ class Fun4AllSingleDstPileupInputManager : public Fun4AllInputManager
   std::unique_ptr<PHNodeIOManager> m_IManager_background;
 
   //! time between crossings. This is a RHIC constant (ns)
-  double m_time_between_crossings = 106;
+  double m_time_between_crossings = 106.65237;
 
   //! collision rate (Hz)
   double m_collision_rate = 5e4;

--- a/simulation/g4simulation/g4main/PHG4PileupGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4PileupGenerator.h
@@ -40,7 +40,7 @@ class PHG4PileupGenerator : public PHG4ParticleGeneratorBase
   double _min_integration_time = -1000.;
   double _max_integration_time = 1000.;
   double _collision_rate = 100.;  // kHz
-  double _time_between_crossings = 106.;
+  double _time_between_crossings = 106.65237; // ns
 
   double _ave_coll_per_crossing = 1.;  // recalculated
   int _min_crossing = 0;               // recalculated

--- a/simulation/g4simulation/g4main/PHG4PileupGenerator.h
+++ b/simulation/g4simulation/g4main/PHG4PileupGenerator.h
@@ -5,6 +5,8 @@
 
 #include "PHG4ParticleGeneratorBase.h"
 
+#include <phool/sphenix_constants.h>
+
 #include <string>  // for string
 
 class PHCompositeNode;
@@ -40,7 +42,7 @@ class PHG4PileupGenerator : public PHG4ParticleGeneratorBase
   double _min_integration_time = -1000.;
   double _max_integration_time = 1000.;
   double _collision_rate = 100.;  // kHz
-  double _time_between_crossings = 106.65237; // ns
+  double _time_between_crossings = sphenix_constants::time_between_crossings; // ns
 
   double _ave_coll_per_crossing = 1.;  // recalculated
   int _min_crossing = 0;               // recalculated

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxHitReco.h
@@ -70,7 +70,6 @@ class PHG4MvtxHitReco : public SubsysReco, public PHParameterInterface
   double m_tmax;
   double m_strobe_width;
   double m_strobe_separation;
-  // double crossing_period = 106.0;
   double m_extended_readout_time = 0.0;
 
   bool m_in_sphenix_srdo = false;

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.cc
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.cc
@@ -14,5 +14,3 @@ TrkrTruthTrackContainer::Map& TrkrTruthTrackContainer::getMap()
 {
   return dummy_map;
 }
-
-// int TrkrTruthTrackContainer::nhw_cc() { return 106; };

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.cc
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.cc
@@ -15,4 +15,4 @@ TrkrTruthTrackContainer::Map& TrkrTruthTrackContainer::getMap()
   return dummy_map;
 }
 
-int TrkrTruthTrackContainer::nhw_cc() { return 106; };
+// int TrkrTruthTrackContainer::nhw_cc() { return 106; };

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.h
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.h
@@ -32,9 +32,12 @@ class TrkrTruthTrackContainer : public PHObject
   virtual ConstRange getTruthTrackRange() const;
   virtual bool hasTrackid(unsigned int /*trackid*/) const { return false; };
   virtual Map& getMap();
+
+  /*
   int nhw() { return 6; };
   int nhw_cc();
   virtual int nhw_virt() { return 60; };
+  */
 
   // PHObject virtual overload
   void identify(std::ostream& os = std::cout) const override

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.h
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainer.h
@@ -33,12 +33,6 @@ class TrkrTruthTrackContainer : public PHObject
   virtual bool hasTrackid(unsigned int /*trackid*/) const { return false; };
   virtual Map& getMap();
 
-  /*
-  int nhw() { return 6; };
-  int nhw_cc();
-  virtual int nhw_virt() { return 60; };
-  */
-
   // PHObject virtual overload
   void identify(std::ostream& os = std::cout) const override
   {

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainerv1.h
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainerv1.h
@@ -30,7 +30,7 @@ class TrkrTruthTrackContainerv1 : public TrkrTruthTrackContainer
   TrkrTruthTrackContainerv1() = default;
 
   void identify(std::ostream& os = std::cout) const override;
-  int nhw_virt() override { return 61; };
+  // int nhw_virt() override { return 61; };
 
  private:
   // the data

--- a/simulation/g4simulation/g4tracking/TrkrTruthTrackContainerv1.h
+++ b/simulation/g4simulation/g4tracking/TrkrTruthTrackContainerv1.h
@@ -30,7 +30,6 @@ class TrkrTruthTrackContainerv1 : public TrkrTruthTrackContainer
   TrkrTruthTrackContainerv1() = default;
 
   void identify(std::ostream& os = std::cout) const override;
-  // int nhw_virt() override { return 61; };
 
  private:
   // the data


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
We use time_between_crossings = 106ns in many places in our code. Discussing with Jin, this value is not quite correct, and impacts our ability to match TPC tracks to silicons (and TPOT) in extended readout mode. Jin quoted a more accurate value of 106.65237. This PR changes the value to everywhere relevant. 
Ultimately we would rather use a centraly defined value (using e.g some static constexpre float in a global header), to be agreed upon with @pinkenburg. 

For now, lets see if this compiles and if not everything is broken. 

Improvement to TPC-TPOT matching: 
![Screenshot_20250214_105504](https://github.com/user-attachments/assets/21f1d4d2-ba6c-45d7-922c-28d5e59dcc8c)


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

