### PR TITLE
Apply TPC tzero offset in alignment transforms for TPC.

### DIFF
--- a/offline/packages/trackbase/ActsGeometry.h
+++ b/offline/packages/trackbase/ActsGeometry.h
@@ -35,6 +35,9 @@ class ActsGeometry
   void set_drift_velocity(double vd) { _drift_velocity = vd; }
   double get_drift_velocity() { return _drift_velocity; }
 
+  void set_tpc_tzero(double tz) { _tpc_tzero = tz; }
+  double get_tpc_tzero() { return _tpc_tzero; }
+
   void set_crossing_period(double t) { _crossing_period = t; }
   double get_crossing_period() { return _crossing_period; }
 
@@ -70,6 +73,7 @@ class ActsGeometry
   ActsSurfaceMaps m_surfMaps;
 
   double _drift_velocity = 8.0e-3;  // cm/ns
+  double _tpc_tzero = 0.0;  // ns
   double _crossing_period = 106.0;  // ns
 };
 

--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -212,6 +212,7 @@ int MakeActsGeometry::InitRun(PHCompositeNode *topNode)
   m_actsGeometry->setGeometry(trackingGeometry);
   m_actsGeometry->setSurfMaps(surfMaps);
   m_actsGeometry->set_drift_velocity(m_drift_velocity);
+  m_actsGeometry->set_tpc_tzero(m_tpc_tzero);
   // alignment_transformation.useInttSurveyGeometry(m_inttSurvey);
   if (Verbosity() > 1)
   {

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -138,6 +138,7 @@ class MakeActsGeometry : public SubsysReco
   double getSurfStepZ() { return m_surfStepZ; }
 
   void set_drift_velocity(double vd) { m_drift_velocity = vd; }
+  void set_tpc_tzero(double tz) { m_tpc_tzero = tz; }
 
   void set_nSurfPhi(unsigned int value)
   {
@@ -282,6 +283,7 @@ class MakeActsGeometry : public SubsysReco
   //  int m_verbosity = 0;
 
   double m_drift_velocity = 8.0e-03;  // cm/ns, override from macro
+  double m_tpc_tzero = 0.0;  // ns, override from macro
 
   /// Magnetic field components to set Acts magnetic field
   std::string m_magField = "1.4";


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This adds the TPC time zero correction as an additional z-offset in the alignment transformations for the TPC. This retains the as-recorded value of the TPC cluster time, and guarantees that TPC clusters get the correction in all circumstances when the position is transformed to global coordinates. The time zero correction is stored in the Acts geometry object alongside the TPC drift velocity, and is used only in AlignmentTransformation during TPC transform creation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

