### PR TITLE
ycm - fix typo in Makefile that prevent pcm file generation

### DIFF
--- a/offline/database/pdbcal/base/Makefile.am
+++ b/offline/database/pdbcal/base/Makefile.am
@@ -27,7 +27,7 @@ ROOT_DICTS = \
 
 pcmdir = $(libdir)
 # more elegant way to create pcm files (without listing them)
-nobase_dist_pcm_DATA = $(ROOTDICTS:.cc=_rdict.pcm)
+nobase_dist_pcm_DATA = $(ROOT_DICTS:.cc=_rdict.pcm)
 
 #please add new classes sorted according to the roman alphabet
 libpdbcalBase_la_SOURCES = \


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR fix a typo in the database/pdbcal/base Makefile
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

