### PR TITLE
ycm - change to check mvtx raw event header

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -19,6 +19,7 @@
 #include <ffarawobjects/Gl1Packet.h>
 #include <ffarawobjects/Gl1RawHit.h>
 #include <ffarawobjects/MvtxFeeIdInfov1.h>
+#include <ffarawobjects/MvtxRawEvtHeaderv1.h>
 #include <ffarawobjects/MvtxRawEvtHeaderv2.h>
 #include <ffarawobjects/MvtxRawHitContainerv1.h>
 #include <ffarawobjects/MvtxRawHitv1.h>
@@ -190,15 +191,20 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
 {
   CreateNodes(topNode);
 
-  Fun4AllServer *se = Fun4AllServer::instance();
-
   if (!mvtx_raw_event_header || !mvtx_raw_hit_container)
   {
-    se->unregisterSubsystem(this);
+    Fun4AllServer::instance()->unregisterSubsystem(this);
     std::cout << PHWHERE << "::" << __func__ << ": Could not get \""
               << m_MvtxRawHitNodeName << " or " << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
     std::cout << "Have you built this yet?" << std::endl;
     exit(1);
+  }
+  if (dynamic_cast<MvtxRawEvtHeaderv1 *>(mvtx_raw_event_header))
+  {
+    std::cout << "MvtxCombinedRawDataDecoder::GetNodes() !!!WARNING!!! using obsolete MvtxRawEvtHeaderv1.";
+    std::cout << " Unregistering MvtxCombinedRawDataDecoder SubsysReco." << std::endl;
+    Fun4AllServer::instance()->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   auto *rc = recoConsts::instance();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR try to abort/unregister MVTX unpacker reco system if we use old DST with obsolete MVTXRawEvtHeaderv1.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

