### PR TITLE
Added Background Determination flags to User

### DIFF
--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -264,6 +264,11 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
   _cutParams.set_int_param("failsHiEmJetCut", failsHiEm);
   _cutParams.set_int_param("failsIhJetCut", failsIhCut);
   _cutParams.set_int_param("failsAnyJetCut", failsAnyCut);
+  _cutParams.set_int_param("isDijet", isDijet);
+  _cutParams.set_double_param("frcem", frcem);
+  _cutParams.set_double_param("frcoh", frcoh);
+  _cutParams.set_double_param("maxJetET", maxJetET);
+  _cutParams.set_double_param("dPhi", dPhi);
   _cutParams.UpdateNodeTree(parNode, "JetCutParams");
 
   return Fun4AllReturnCodes::EVENT_OK;


### PR DESCRIPTION

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The jet background tagging is determined via: isDijet, frcem, frcoh, maxJetET, and dPhi so passing these variables to the user allows for verification of the thresholds used that tag the event as containing background.


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

