### PR TITLE
fix: do not exit mvtx unpacker

### DIFF
--- a/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
+++ b/offline/packages/mvtx/MvtxCombinedRawDataDecoder.cc
@@ -196,15 +196,14 @@ int MvtxCombinedRawDataDecoder::InitRun(PHCompositeNode *topNode)
     Fun4AllServer::instance()->unregisterSubsystem(this);
     std::cout << PHWHERE << "::" << __func__ << ": Could not get \""
               << m_MvtxRawHitNodeName << " or " << m_MvtxRawEvtHeaderNodeName << "\" from Node Tree" << std::endl;
-    std::cout << "Have you built this yet?" << std::endl;
-    exit(1);
+    std::cout << "Unregistering subsystem and continuing on" << std::endl;
+
   }
   if (dynamic_cast<MvtxRawEvtHeaderv1 *>(mvtx_raw_event_header))
   {
-    std::cout << "MvtxCombinedRawDataDecoder::GetNodes() !!!WARNING!!! using obsolete MvtxRawEvtHeaderv1.";
+    std::cout << PHWHERE <<  "MvtxCombinedRawDataDecoder::GetNodes() !!!WARNING!!! using obsolete MvtxRawEvtHeaderv1.";
     std::cout << " Unregistering MvtxCombinedRawDataDecoder SubsysReco." << std::endl;
     Fun4AllServer::instance()->unregisterSubsystem(this);
-    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   auto *rc = recoConsts::instance();


### PR DESCRIPTION
While producing some cluster DSTs for tpc calibration runs, we found that the mvtx unpacker exits if the nodes are not found. This shouldn't happen and this PR instead reverts the behavior back to just unregistering the module so that the job can proceed even in the absence of the proper node.


## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

