### PR TITLE
Distortion extrapolation update

### DIFF
--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -330,7 +330,10 @@ CylinderGeomMicromegas::range_t CylinderGeomMicromegas::get_theta_range(uint til
       const auto strip_count = get_strip_count(tileid, geometry);
       const auto strip_length = get_strip_length(tileid, geometry);
       const auto mid_strip_center_local = get_local_coordinates(tileid, geometry, strip_count/2);
-      const auto mid_strip_begin = get_world_from_local_coords(tileid, geometry, mid_strip_center_local + TVector2(0,-strip_length/2));
+      // need to add special care for tile 0, whose half detector is disconnected
+      const auto mid_strip_begin = tileid == 0 ?
+        get_world_from_local_coords(tileid, geometry, mid_strip_center_local):
+        get_world_from_local_coords(tileid, geometry, mid_strip_center_local + TVector2(0,-strip_length/2));
       const auto mid_strip_end = get_world_from_local_coords( tileid, geometry, mid_strip_center_local + TVector2(0,strip_length/2));
       return {
         std::atan2(get_r(mid_strip_begin.x(), mid_strip_begin.y()), mid_strip_begin.z()),
@@ -342,7 +345,10 @@ CylinderGeomMicromegas::range_t CylinderGeomMicromegas::get_theta_range(uint til
     case MicromegasDefs::SegmentationType::SEGMENTATION_Z:
     {
       const auto strip_count = get_strip_count(tileid, geometry);
-      const auto first_strip_center = get_world_coordinates(tileid, geometry, 0);
+      // need to add special care for tile 0, whose half detector is disconnected
+      const auto first_strip_center = tileid == 0 ?
+        get_world_coordinates(tileid, geometry, 128):
+        get_world_coordinates(tileid, geometry, 0);
       const auto last_strip_center = get_world_coordinates(tileid, geometry, strip_count-1);
       return {
         std::atan2(get_r(first_strip_center.x(), first_strip_center.y()), first_strip_center.z()),

--- a/offline/packages/micromegas/CylinderGeomMicromegas.cc
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.cc
@@ -336,8 +336,8 @@ CylinderGeomMicromegas::range_t CylinderGeomMicromegas::get_theta_range(uint til
         get_world_from_local_coords(tileid, geometry, mid_strip_center_local + TVector2(0,-strip_length/2));
       const auto mid_strip_end = get_world_from_local_coords( tileid, geometry, mid_strip_center_local + TVector2(0,strip_length/2));
       return {
-        std::atan2(get_r(mid_strip_begin.x(), mid_strip_begin.y()), mid_strip_begin.z()),
-        std::atan2(get_r(mid_strip_end.x(), mid_strip_end.y()), mid_strip_end.z())
+        std::atan2(mid_strip_begin.z(), get_r(mid_strip_begin.x(), mid_strip_begin.y())),
+        std::atan2(mid_strip_end.z(), get_r(mid_strip_end.x(), mid_strip_end.y()))
       };
     }
 
@@ -351,8 +351,8 @@ CylinderGeomMicromegas::range_t CylinderGeomMicromegas::get_theta_range(uint til
         get_world_coordinates(tileid, geometry, 0);
       const auto last_strip_center = get_world_coordinates(tileid, geometry, strip_count-1);
       return {
-        std::atan2(get_r(first_strip_center.x(), first_strip_center.y()), first_strip_center.z()),
-        std::atan2(get_r(last_strip_center.x(), last_strip_center.y()), last_strip_center.z())
+        std::atan2(first_strip_center.z(), get_r(first_strip_center.x(), first_strip_center.y())),
+        std::atan2(last_strip_center.z(), get_r(last_strip_center.x(), last_strip_center.y()))
       };
     }
   }

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -117,7 +117,10 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   /// get the phi range, in global coordinates, corresponding to a given tile
   range_t get_phi_range(uint tileid, ActsGeometry* ) const;
 
-  /// get the theta range, in r,z plane, measured with respect to (0,0), in global coordinates, corresponding to a given tile
+  /**
+   * get the theta range, in r,z plane, measured with respect to (0,0), in global coordinates, corresponding to a given tile
+   * Note: theta is calculated with respect to the vertical axis, as theta = std::atan2(z, r).
+   */
   range_t get_theta_range(uint tileid, ActsGeometry* ) const;
 
   //@}

--- a/offline/packages/micromegas/CylinderGeomMicromegas.h
+++ b/offline/packages/micromegas/CylinderGeomMicromegas.h
@@ -111,6 +111,15 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   /// reference radius used in macro to convert tile size in azimuth into a angle range (cm)
   static constexpr double reference_radius = 82;
 
+  /// shortcut for min/max window
+  using range_t = std::pair<double, double>;
+
+  /// get the phi range, in global coordinates, corresponding to a given tile
+  range_t get_phi_range(uint tileid, ActsGeometry* ) const;
+
+  /// get the theta range, in r,z plane, measured with respect to (0,0), in global coordinates, corresponding to a given tile
+  range_t get_theta_range(uint tileid, ActsGeometry* ) const;
+
   //@}
 
   //!@name modifiers
@@ -159,9 +168,9 @@ class CylinderGeomMicromegas : public PHG4CylinderGeom
   double m_pitch = 0.1;
 
   //! tiles
-  /** 
-   * \brief tiles are only used in "find_tile_cylindrical". 
-   * For all other methods we use ACTS surfaces instead 
+  /**
+   * \brief tiles are only used in "find_tile_cylindrical".
+   * For all other methods we use ACTS surfaces instead
    */
   MicromegasTile::List m_tiles;
 

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.cc
@@ -36,38 +36,11 @@ namespace
     return phi;
   }
 
-  /// shortcut to angular window, needed to define TPOT acceptance
-  using range_t = std::pair<double, double>;
-
-  /// list of angular windows
-  using range_list_t = std::vector<range_t>;
-
   /// make sure angles in a given window are betwwen [0, 2PI]
-  range_t transform_range(const range_t& a)
+  TpcSpaceChargeReconstructionHelper::range_t transform_range(const TpcSpaceChargeReconstructionHelper::range_t& a)
   {
     return {get_bound_angle(a.first), get_bound_angle(a.second)};
   }
-
-  ///@name detector geometry
-  //@{
-  /// phi range for central sector (TPC sectors 9 and 21)
-  const range_t phi_range_central = transform_range({-1.742, -1.43979});
-
-  /// phi range for east sector (TPC sectors 8 and 20)
-  const range_t phi_range_east = transform_range({-2.27002, -1.9673});
-
-  /// phi range for west sector (TPC sectors 10 and 22)
-  const range_t phi_range_west = transform_range({-1.21452, -0.911172});
-
-  /// list of theta (polar) angles for each micromeas in central sector
-  const range_list_t theta_range_central = {{-0.918257, -0.613136}, {-0.567549, -0.031022}, {0.0332154, 0.570419}, {0.613631, 0.919122}};
-
-  /// list of theta (polar) angles for each micromeas in east sector
-  const range_list_t theta_range_east = {{-0.636926, -0.133603}, {0.140678, 0.642714}};
-
-  /// list of theta (polar) angles for each micromeas in west sector
-  const range_list_t theta_range_west = {{-0.643676, -0.141004}, {0.13485, 0.640695}};
-  //@}
 
   /// short class to check if a given value is in provided range
   class range_ftor_t
@@ -75,7 +48,7 @@ namespace
    public:
     explicit range_ftor_t(double value)
       : m_value(value){};
-    bool operator()(const range_t& range)
+    bool operator()(const TpcSpaceChargeReconstructionHelper::range_t& range)
     {
       return m_value > range.first && m_value < range.second;
     }
@@ -85,18 +58,33 @@ namespace
   };
 
   /// returns true if given value is in provided range
-  bool in_range(const double& value, const range_t& range)
-  {
-    return range_ftor_t(value)(range);
-  }
+  bool in_range(const double& value, const TpcSpaceChargeReconstructionHelper::range_t& range)
+  { return range_ftor_t(value)(range); }
 
   /// returns true if given value is in any of the provided range
-  bool in_range(const double& value, const range_list_t& range_list)
-  {
-    return std::any_of(range_list.begin(), range_list.end(), range_ftor_t(value));
-  }
+  bool in_range(const double& value, const TpcSpaceChargeReconstructionHelper::range_list_t& range_list)
+  { return std::any_of(range_list.begin(), range_list.end(), range_ftor_t(value)); }
 
 }  // namespace
+
+/// default TPOT geometry, hardcoded
+/// phi range for central sector (TPC sectors 9 and 21)
+TpcSpaceChargeReconstructionHelper::range_t TpcSpaceChargeReconstructionHelper::phi_range_central = transform_range({-1.742, -1.43979});
+
+/// phi range for east sector (TPC sectors 8 and 20)
+TpcSpaceChargeReconstructionHelper::range_t TpcSpaceChargeReconstructionHelper::phi_range_east = transform_range({-2.27002, -1.9673});
+
+/// phi range for west sector (TPC sectors 10 and 22)
+TpcSpaceChargeReconstructionHelper::range_t TpcSpaceChargeReconstructionHelper::phi_range_west = transform_range({-1.21452, -0.911172});
+
+/// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+TpcSpaceChargeReconstructionHelper::range_list_t TpcSpaceChargeReconstructionHelper::theta_range_central = {{-0.918257, -0.613136}, {-0.567549, -0.031022}, {0.0332154, 0.570419}, {0.613631, 0.919122}};
+
+/// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+TpcSpaceChargeReconstructionHelper::range_list_t TpcSpaceChargeReconstructionHelper::theta_range_east = {{-0.636926, -0.133603}, {0.140678, 0.642714}};
+
+/// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+TpcSpaceChargeReconstructionHelper::range_list_t TpcSpaceChargeReconstructionHelper::theta_range_west = {{-0.643676, -0.141004}, {0.13485, 0.640695}};
 
 //____________________________________________________________________________________
 void TpcSpaceChargeReconstructionHelper::create_tpot_mask(TH3* hmask)
@@ -611,3 +599,15 @@ TH3* TpcSpaceChargeReconstructionHelper::add_guarding_bins(const TH3* source, co
 
   return hout;
 }
+
+//___________________________________________________________________________________________________
+void TpcSpaceChargeReconstructionHelper::set_phi_range_central( const range_t& range)
+{ phi_range_central = transform_range(range); }
+
+//___________________________________________________________________________________________________
+void TpcSpaceChargeReconstructionHelper::set_phi_range_east( const range_t& range)
+{ phi_range_east = transform_range(range); }
+
+//___________________________________________________________________________________________________
+void TpcSpaceChargeReconstructionHelper::set_phi_range_west( const range_t& range)
+{ phi_range_west = transform_range(range); }

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstructionHelper.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstdint>
+#include <vector>
 
 // forward declarations
 class TH2;
@@ -75,6 +76,55 @@ class TpcSpaceChargeReconstructionHelper
    * to correct for the space charge distortions.
    */
   static TH3* add_guarding_bins(const TH3* /*source*/, const TString& /*name*/);
+
+  /// shortcut to angular window, needed to define TPOT acceptance
+  using range_t = std::pair<double, double>;
+
+  /// list of angular windows
+  using range_list_t = std::vector<range_t>;
+
+  //!@name define phi range for each TPOT sector
+  //@{
+  static void set_phi_range_central( const range_t& );
+  static void set_phi_range_east( const range_t& );
+  static void set_phi_range_west( const range_t& );
+  //@}
+
+  //!@name define theta range in each TPOT sector.
+  //@{
+  static void set_theta_range_central( const range_list_t& range_list )
+  { theta_range_central = range_list; }
+
+  static void set_theta_range_east( const range_list_t& range_list )
+  { theta_range_east = range_list; }
+
+  static void set_theta_range_west( const range_list_t& range_list )
+  { theta_range_west = range_list; }
+  //@}
+
+  private:
+
+  ///@name detector geometry
+  //@{
+  /// phi range for central sector (TPC sectors 9 and 21)
+  static range_t phi_range_central;
+
+  /// phi range for east sector (TPC sectors 8 and 20)
+  static range_t phi_range_east;
+
+  /// phi range for west sector (TPC sectors 10 and 22)
+  static range_t phi_range_west;
+
+  /// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+  static range_list_t theta_range_central;
+
+  /// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+  static range_list_t theta_range_east;
+
+  /// list of theta angles for each micromeas in central sector with theta defined as atan2(z,r)
+  static range_list_t theta_range_west;
+  //@}
+
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This adds some helper methods to facilitate the distortion extrapolation from TPOT acceptance to the full TPC acceptance 
1/ two new methods to calculate the phi and theta range of a given TPOT detector, using latest geometry+alignment correction
2/ the possibility to set the relevant theta and phi ranges (previously hard coded) to the TpcSpaceChargeReconstructionHelper class

@yudPKU (Xudong) I'll send you a separate email on how to use those.



## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

