### PR TITLE
fix: don't abort in qa when node not found

### DIFF
--- a/offline/QA/Intt/InttRawHitQA.cc
+++ b/offline/QA/Intt/InttRawHitQA.cc
@@ -10,6 +10,7 @@
 #include <phool/PHPointerListIterator.h>
 #include <fun4all/Fun4AllHistoManager.h>  // for Fun4AllHistoManager
 #include <fun4all/Fun4AllReturnCodes.h>   // for EVENT_OK, ABORTEVENT
+#include <fun4all/Fun4AllServer.h>
 
 #include <phool/getClass.h>  // for getClass
 #include <phool/phool.h>     // for PHWHERE
@@ -64,8 +65,9 @@ int InttRawHitQA::InitRun(PHCompositeNode *topNode)
       trkr_itr.findFirst("PHCompositeNode", "INTT"));  
   if(!intt_node)
   {
-    std::cout << PHWHERE << " No INTT node found, exit" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    std::cout << PHWHERE << " No INTT node found, unregistering subsystem" << std::endl;
+    Fun4AllServer::instance()->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::EVENT_OK;
   }
   PHNodeIterator intt_itr(intt_node);
   PHPointerListIterator<PHNode> iter(intt_itr.ls());

--- a/offline/QA/Mvtx/MvtxRawHitQA.cc
+++ b/offline/QA/Mvtx/MvtxRawHitQA.cc
@@ -5,6 +5,8 @@
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
+
 #include <phool/PHPointerListIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
@@ -32,7 +34,8 @@ int MvtxRawHitQA::InitRun(PHCompositeNode *topNode)
   if(!mvtx_node)
   {
     std::cout << PHWHERE << " No MVTX node found, exit" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    Fun4AllServer::instance()->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::EVENT_OK;
   }
   PHNodeIterator mvtx_itr(mvtx_node);
   PHPointerListIterator<PHNode> iter(mvtx_itr.ls());

--- a/offline/QA/Tpc/TpcRawHitQA.cc
+++ b/offline/QA/Tpc/TpcRawHitQA.cc
@@ -5,6 +5,7 @@
 
 #include <fun4all/Fun4AllHistoManager.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllServer.h>
 
 #include <ffarawobjects/TpcRawHit.h>
 #include <ffarawobjects/TpcRawHitContainer.h>
@@ -38,8 +39,9 @@ int TpcRawHitQA::InitRun(PHCompositeNode *topNode)
   if (!tpc_node)
   {
     std::cout << __PRETTY_FUNCTION__ << " : ERROR : "
-              << "No TPC node found, exit" << std::endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+              << "No TPC node found, unregistering module" << std::endl;
+    Fun4AllServer::instance()->unregisterSubsystem(this);
+    return Fun4AllReturnCodes::EVENT_OK;
   }
 
   PHNodeIterator tpc_itr(tpc_node);


### PR DESCRIPTION
In the QA we should not abort run when a particular node is not found - rather we should just unregister the module. This allows the production to run more flexibly

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

