### PR TITLE
feat: add optional cluster adc cut to cosmic seeder

### DIFF
--- a/offline/packages/trackreco/PHCosmicSeeder.cc
+++ b/offline/packages/trackreco/PHCosmicSeeder.cc
@@ -15,6 +15,7 @@
 #include <trackbase_historic/TrackSeedContainer.h>
 #include <trackbase_historic/TrackSeedContainer_v1.h>
 #include <trackbase_historic/TrackSeed_v2.h>
+#include <trackbase/TrkrCluster.h>
 
 #include <TFile.h>
 #include <TNtuple.h>
@@ -92,6 +93,9 @@ int PHCosmicSeeder::process_event(PHCompositeNode* /*unused*/)
     {
       const auto ckey = citer->first;
       const auto cluster = citer->second;
+      if(cluster->getMaxAdc() < m_adcCut){
+        continue;
+      }
       const auto global = m_tGeometry->getGlobalPosition(ckey, cluster);
       clusterPositions.insert(std::make_pair(ckey, global));
     }

--- a/offline/packages/trackreco/PHCosmicSeeder.h
+++ b/offline/packages/trackreco/PHCosmicSeeder.h
@@ -38,6 +38,7 @@ class PHCosmicSeeder : public SubsysReco
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
+  void adcCut(float cut) { m_adcCut = cut; }
   void xyTolerance(float tol) { m_xyTolerance = tol; }
   void seedAnalysis() { m_analysis = true; }
   void trackMapName(const std::string &name) { m_trackMapName = name; }
@@ -57,6 +58,7 @@ class PHCosmicSeeder : public SubsysReco
   std::string m_trackMapName = "TpcTrackSeedContainer";
   TrkrDefs::TrkrId m_trackerId = TrkrDefs::TrkrId::tpcId;
   ActsGeometry *m_tGeometry = nullptr;
+  float m_adcCut = 0;
   TrkrClusterContainer *m_clusterContainer = nullptr;
   TrackSeedContainer *m_seedContainer = nullptr;
   TFile *m_outfile = nullptr;


### PR DESCRIPTION
Adds an option to only use clusters meeting a minimum ADC max cut to limit the number of clusters the seeder has to deal with. Set to 0 by default so nothing changes.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

