### PR TITLE
corrections to pileup from waveforms in prev crossing polluting current one

### DIFF
--- a/offline/packages/mbd/MbdCalib.h
+++ b/offline/packages/mbd/MbdCalib.h
@@ -67,6 +67,24 @@ class MbdCalib
   std::vector<float> get_shape(const int ifeech) const { return _shape_y[ifeech]; }
   std::vector<float> get_sherr(const int ifeech) const { return _sherr_yerr[ifeech]; }
 
+  float get_pileup(const int ifeech, const int ipar) const {
+
+    if (ipar==0)
+    {
+      return _pileup_p0[ifeech];
+    }
+    else if (ipar==1)
+    {
+      return _pileup_p1[ifeech];
+    }
+    else if (ipar==2)
+    {
+      return _pileup_p2[ifeech];
+    }
+
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+
   void set_sampmax(const int ifeech, const int val) { _sampmax[ifeech] = val; }
   void set_ped(const int ifeech, const float m, const float merr, const float s, const float serr);
   void set_tt0(const int ipmt, const float t0) { _ttfit_t0mean[ipmt] = t0; }
@@ -81,6 +99,7 @@ class MbdCalib
   int Download_Shapes(const std::string& dbfile);
   int Download_TimeCorr(const std::string& dbfile);
   int Download_SlewCorr(const std::string& dbfile);
+  int Download_Pileup(const std::string& dbfile);
   int Download_All();
 
 #ifndef ONLINE
@@ -93,6 +112,7 @@ class MbdCalib
   int Write_CDB_TimeCorr(const std::string& dbfile);
   int Write_CDB_SlewCorr(const std::string& dbfile);
   int Write_CDB_Gains(const std::string& dbfile);
+  int Write_CDB_Pileup(const std::string& dbfile);
   int Write_CDB_All();
 #endif
 
@@ -102,12 +122,14 @@ class MbdCalib
   int Write_T0Corr(const std::string& dbfile);
   int Write_Ped(const std::string& dbfile);
   int Write_Gains(const std::string& dbfile);
+  int Write_Pileup(const std::string& dbfile);
 
   void Reset_TQT0();
   void Reset_TTT0();
   void Reset_T0Corr();
   void Reset_Ped();
   void Reset_Gains();
+  void Reset_Pileup();
 
   void Update_TQT0(const float dz, const float dt = 0.); // update with new z-vertex, t0
   void Update_TTT0(const float dz, const float dt = 0.);
@@ -175,6 +197,15 @@ class MbdCalib
 
   // SampMax (Peak of waveform)
   std::array<int, MbdDefs::MBD_N_FEECH> _sampmax{};
+
+  // Pileup waveform correction
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p0{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p0err{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p1{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p1err{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p2{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_p2err{};
+  std::array<float, MbdDefs::MBD_N_FEECH> _pileup_chi2ndf{};
 
   // Waveform Template
   int do_templatefit{0};

--- a/offline/packages/mbd/MbdPmtHitV1.cc
+++ b/offline/packages/mbd/MbdPmtHitV1.cc
@@ -7,7 +7,7 @@ void MbdPmtHitV1::Reset()
 
 void MbdPmtHitV1::Clear(Option_t* /*unused*/)
 {
-  // std::cout << "clearing " << bpmt << std::endl;
+  std::cout << "clearing " << bpmt << std::endl;
   bpmt = -1;
   bq = std::numeric_limits<float>::quiet_NaN();
   btt = std::numeric_limits<float>::quiet_NaN();

--- a/offline/packages/mbd/MbdPmtHitV1.h
+++ b/offline/packages/mbd/MbdPmtHitV1.h
@@ -51,10 +51,14 @@ class MbdPmtHitV1 : public MbdPmtHit
   }
 
  private:
-  Short_t bpmt{-1};
-  Float_t bq{std::numeric_limits<float>::quiet_NaN()};
-  Float_t btt{std::numeric_limits<float>::quiet_NaN()};
-  Float_t btq{std::numeric_limits<float>::quiet_NaN()};
+  //Short_t bpmt{-1};
+  //Float_t bq{std::numeric_limits<float>::quiet_NaN()};
+  //Float_t btt{std::numeric_limits<float>::quiet_NaN()};
+  //Float_t btq{std::numeric_limits<float>::quiet_NaN()};
+  Short_t bpmt;
+  Float_t bq;
+  Float_t btt;
+  Float_t btq;
 
   ClassDefOverride(MbdPmtHitV1, 1)
 };

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -131,7 +131,7 @@ int MbdReco::process_event(PHCompositeNode *topNode)
   m_mbdevent->Calculate(m_mbdpmts, m_mbdout);
 
   // For multiple global vertex
-  if (m_mbdevent->get_bbcn(0) > 0 && m_mbdevent->get_bbcn(1) > 0)
+  if (m_mbdevent->get_bbcn(0) > 0 && m_mbdevent->get_bbcn(1) > 0 && _calpass==0 )
   {
     auto vertex = new MbdVertexv2();
     vertex->set_t(m_mbdevent->get_bbct0());

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -7,14 +7,10 @@
 
 #include <fstream>
 #include <vector>
-#include <queue>
 
-
-class TFile;
 class TTree;
 class TGraphErrors;
 class TH2;
-// class THnSparse;
 class MbdCalib;
 
 /**
@@ -75,7 +71,8 @@ class MbdSig
 
   void CalcEventPed0(const Int_t minsamp, const Int_t maxsamp);
   void CalcEventPed0(const Double_t minx, const Double_t maxx);
-  void CalcEventPed0_PreSamp(const Int_t pre_samp, const Int_t nsamps = 1);
+  int CalcEventPed0_PreSamp(const Int_t pre_samp, const Int_t nsamps = 1);
+  void Remove_Pileup();
 
   TH1 *GetPedHist() { return hPed0; }
 
@@ -130,6 +127,10 @@ class MbdSig
 
   int _evt_counter{0};
   MbdCalib *_mbdcal{nullptr};
+  float _pileup_p0{0.};
+  float _pileup_p1{0.};
+  float _pileup_p2{0.};
+  TF1 *fit_pileup{nullptr};
 
   /** fit values*/
   // should make an array for the different methods
@@ -187,6 +188,10 @@ class MbdSig
   TF1 *template_fcn{nullptr};
   Double_t fit_min_time{};  //! min time for fit, in original units of waveform data
   Double_t fit_max_time{};  //! max time for fit, in original units of waveform data
+
+  std::ofstream *_pileupfile{nullptr};  // for writing out waveforms from prev. crossing pileup
+                                        // use for calibrating out the tail from these events
+
 
   int _verbose{0};
 };


### PR DESCRIPTION
[comment]: When there's an event from a previous crossing, the waveform from that crossing is now corrected out before fits to the waveform.  Occurred in only 1 in every ~10^4 events, depending on collision rate.  A new calibration is needed, mbd_pileup.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

