### PR TITLE
TPC to TPOT matching fix

### DIFF
--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -355,11 +355,14 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
 
     if( has_micromegas )
     {
-      std::cout
-        << "PHMicromegasTpcTrackMatching::process_event -"
-        << " Micromegas hits already associated to TPC seed. "
-        << " Skipping this track"
-        << std::endl;
+      if( Verbosity() )
+      {
+        std::cout
+          << "PHMicromegasTpcTrackMatching::process_event -"
+          << " Micromegas hits already associated to TPC seed."
+          << " Skipping this track"
+          << std::endl;
+      }
       continue;
     }
 

--- a/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHMicromegasTpcTrackMatching.cc
@@ -290,6 +290,8 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
     std::vector<Acts::Vector3> clusGlobPos_silicon;
     std::vector<Acts::Vector3> clusGlobPos_mvtx;
 
+    bool has_micromegas = false;
+
     // try extrapolate track to Micromegas and find corresponding tile
     /* this is all copied from PHMicromegasTpcTrackMatching */
     const auto cluster_keys = get_cluster_keys({tracklet_tpc,tracklet_si});
@@ -335,10 +337,30 @@ int PHMicromegasTpcTrackMatching::process_event(PHCompositeNode* topNode)
           break;
         }
 
+        case TrkrDefs::micromegasId:
+        {
+          /*
+           * micromegas clusters already associated to seed
+           * skip
+           */
+          has_micromegas = true;
+          break;
+        }
+
         default:
         break;
       }
 
+    }
+
+    if( has_micromegas )
+    {
+      std::cout
+        << "PHMicromegasTpcTrackMatching::process_event -"
+        << " Micromegas hits already associated to TPC seed. "
+        << " Skipping this track"
+        << std::endl;
+      continue;
     }
 
     // check number of clusters


### PR DESCRIPTION
When a given TPC seeds gets associated to two different tracks (or more), the association with TPOT is run multiple times. This results in more than 2 TPOT clusters being associated to a track (at the % level), which then confuses/break the ACTS fit. 

This PR Make sure that there are no TPOT clusters associated to a given tpc seed before performing the association, thus ensuring that there cannot be more than 2 TPOT clusters (one per layer) associated to a given track. 

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

