### PR TITLE
Kinematic selections for adding strange particles

### DIFF
--- a/simulation/g4simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.cc
@@ -121,7 +121,8 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
     fpt->SetParameter(2, 1.89602e-01);  // sigma
     fpt->SetParameter(3, 2.26981e+00);  // lambda
 
-    feta = new TF1("feta", DBGFunction, -1, 1, 4);
+    std::cout << "[INFO] eta is sampled between [" << -1 * sel_eta << "," << sel_eta << "]" << std::endl;
+    feta = new TF1("feta", DBGFunction, -1*sel_eta, sel_eta, 4);
     feta->SetParameter(0, 1);             // normalization
     feta->SetParameter(1, -4.08301e-01);  // mu1
     feta->SetParameter(2, 4.11930e-01);   // mu2
@@ -353,7 +354,14 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
           if (std::find(list_strangePID.begin(), list_strangePID.end(), std::abs((*p)->pdg_id())) != list_strangePID.end())
           {
-            Nstrange++;
+            // count number of strange particles with PID in list_strangePID within the kinematic selection (sPHNEIX acceptance)
+            // |eta|<=1 and momentum within sel_ptmin and sel_ptmax
+            if ((fabs((*p)->momentum().eta()) <= sel_eta) && //
+                ((*p)->momentum().perp() >= sel_ptmin && (*p)->momentum().perp() <= sel_ptmax) //
+            )
+            {
+              Nstrange++;
+            }
           }
         }
         else
@@ -371,7 +379,7 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
 
       if (Verbosity() > 1)
       {
-        std::cout << "[DEBUG] Number of original strange particles: " << Nstrange << std::endl;
+        std::cout << "[DEBUG] Number of original strange particles with kinematic selection (abs(eta) cut: " << sel_eta << ", pT cut: " << sel_ptmin << " - " << sel_ptmax << "): " << Nstrange << std::endl;
         std::cout << "[DEBUG] addfraction: " << addfraction << "%; Number of strange particles to be added: " << Nstrange_add << std::endl;
       }
 

--- a/simulation/g4simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4simulation/g4main/HepMCNodeReader.h
@@ -84,6 +84,9 @@ class HepMCNodeReader : public SubsysReco
   std::vector<std::pair<int, std::pair<double, double>>> list_strangePID_probrange{};  // list of strange particles and their probability ranges
   float addfraction{0.0};                                                              // additional strangeness particles, in percent; default 0
   int Nstrange_add{0};                                                                 // number of strange particles to be added; default 0
+  float sel_eta{1.0};                                                                  // |eta| selection for additional strangeness particles; default 1
+  float sel_ptmin{0.0};                                                                // min pT selection for additional strangeness particles; default 0
+  float sel_ptmax{std::numeric_limits<float>::max()};                                  // max pT selection for additional strangeness particles; default infinity
   TF1 *fpt{nullptr};
   TF1 *feta{nullptr};
 };


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
This PR introduces kinematic selections for sampling strange particles within sPHENIX acceptance ($|\eta|\leq1$)
The default selections: $|\eta|\leq1$, $0\leq p_{T}\leq$ std::numeric_limits<float>::max() 

The current method of counting strangeness in the HepMC record does not apply any kinematic selection for sPHENIX acceptance (e.g., $|\eta|\leq1$). The number of added strange particles is calculated based on the total count, regardless of their kinematics. However, the added strange particles are sampled only within $|\eta|\leq1$. The consequence is that one ends up oversampling strange particles within the sPHENIX acceptance
One example here:
```
[DEBUG] Number of original strange particles: 181; Number of strange particles in |eta|<=1: 36
[DEBUG] addfraction: 40%; Number of strange particles to be added: 73
```
181 is the inclusive count of $K_s^{0}$ and $\Lambda$ without any kinematic selection
36 is the count within sPHENIX acceptance
73 is 40% of 181, which is the number of $K_s^{0}$ and $\Lambda$ added within $|\eta|\leq1$ in the current sample 
Effectively, this results in a 200% enhancement within $|\eta|\leq1$, rather than the intended 40% enhancement

(The effect is checked with the $dN_{ch}/d\eta$ measurement - this effective 200% enhancement within $|\eta|\leq1$ results in a 7% variation in the final $dN_{ch}/d\eta$)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

