### PR TITLE
KFParticle dEdx

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -30,6 +30,11 @@
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrCluster.h>
+#include <g4detectors/PHG4TpcCylinderGeom.h>
+#include <g4detectors/PHG4TpcCylinderGeomContainer.h>
+
 #include <globalvertex/GlobalVertex.h>
 #include <globalvertex/GlobalVertexMap.h>
 #include <globalvertex/SvtxVertex.h>
@@ -94,6 +99,8 @@ KFParticle_Tools::KFParticle_Tools()
   , m_dst_track()
   , m_dst_vertexmap()
   , m_dst_vertex()
+  , m_cluster_map()
+  , m_geom_container()
 {
 }
 
@@ -1022,4 +1029,63 @@ void KFParticle_Tools::identify(const KFParticle &particle)
   std::cout << particle.GetY() << " +/- " << std::sqrt(particle.GetCovariance(1, 1)) << ", ";
   std::cout << particle.GetZ() << " +/- " << std::sqrt(particle.GetCovariance(2, 2)) << ") cm\n"
             << std::endl;
+}
+
+
+
+
+float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &daughter){
+  m_dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name.c_str());
+  m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  m_geom_container = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
+
+
+  SvtxTrack *daughter_track = toolSet.getTrack(daughter.Id(), m_dst_trackmap);
+  TrackSeed *tpcseed = daughter_track->get_tpc_seed();
+
+
+  std::vector<TrkrDefs::cluskey> clusterKeys;
+    clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(),
+		       tpcseed->end_cluster_keys());
+
+    std::vector<float> dedxlist;
+    for (unsigned long cluster_key : clusterKeys){
+      unsigned int layer_local = TrkrDefs::getLayer(cluster_key);
+      if(TrkrDefs::getTrkrId(cluster_key) != TrkrDefs::TrkrId::tpcId){
+	  continue;
+      }
+      TrkrCluster* cluster = m_cluster_map->findCluster(cluster_key);
+
+      float adc = cluster->getAdc();
+      PHG4TpcCylinderGeom* GeoLayer_local = m_geom_container->GetLayerCellGeom(layer_local);
+      float thick = GeoLayer_local->get_thickness();
+      
+      float r = GeoLayer_local->get_radius();
+      float alpha = (r * r) / (2 * r * TMath::Abs(1.0 / tpcseed->get_qOverR()));
+      float beta = atan(tpcseed->get_slope());
+      float alphacorr = cos(alpha);
+      if(alphacorr<0||alphacorr>4){
+	alphacorr=4;
+      }
+      float betacorr = cos(beta);
+      if(betacorr<0||betacorr>4){
+	betacorr=4;
+      }
+      adc/=thick;
+      adc*=alphacorr;
+      adc*=betacorr;
+      dedxlist.push_back(adc);
+      sort(dedxlist.begin(), dedxlist.end());
+    }
+    int trunc_min = 0;
+    int trunc_max = (int)dedxlist.size()*0.7;
+    float sumdedx = 0;
+    int ndedx = 0;
+    for(int j = trunc_min; j<=trunc_max;j++){
+      sumdedx+=dedxlist.at(j);
+      ndedx++;
+    }
+    sumdedx/=ndedx;
+    return sumdedx;
+
 }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -1038,7 +1038,10 @@ float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &dau
   m_dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name.c_str());
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   m_geom_container = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-
+  if(!m_cluster_map || !m_geom_container){
+    std::cout << "Can't continue in KFParticle_Tools::get_dEdx, returning -1" << std::endl;
+    return -1.0;
+  }
 
   SvtxTrack *daughter_track = toolSet.getTrack(daughter.Id(), m_dst_trackmap);
   TrackSeed *tpcseed = daughter_track->get_tpc_seed();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -41,6 +41,8 @@ class SvtxVertexMap;
 class SvtxTrackMap;
 class SvtxVertex;
 class SvtxTrack;
+class TrkrClusterContainer;
+class PHG4TpcCylinderGeomContainer;
 
 class KFParticle_Tools : protected KFParticle_MVA
 {
@@ -104,6 +106,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   float getParticleMass(const int PDGID);
 
   void identify(const KFParticle &particle);
+
+  float get_dEdx(PHCompositeNode *topNode, const KFParticle &daughter);
 
  protected:
   std::string m_mother_name_Tools;
@@ -194,6 +198,8 @@ class KFParticle_Tools : protected KFParticle_MVA
   SvtxTrack *m_dst_track {nullptr};
   SvtxVertexMap *m_dst_vertexmap {nullptr};
   SvtxVertex *m_dst_vertex {nullptr};
+  TrkrClusterContainer *m_cluster_map {nullptr};
+  PHG4TpcCylinderGeomContainer *m_geom_container {nullptr};
 
   void removeDuplicates(std::vector<double> &v);
   void removeDuplicates(std::vector<int> &v);

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -228,6 +228,7 @@ void KFParticle_nTuple::initializeBranches()
     m_tree->Branch(TString(daughter_number) + "_track_ID", &m_calculated_daughter_trid[i], TString(daughter_number) + "_track_ID/I");
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
+    m_tree->Branch(TString(daughter_number) + "_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_dEdx/F");
 
     if (m_calo_info)
     {
@@ -504,6 +505,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     SvtxTrackMap *thisTrackMap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name_nTuple.c_str());
     SvtxTrack *thisTrack = getTrack(daughterArray[i].Id(), thisTrackMap);
     m_calculated_daughter_bunch_crossing[i] = thisTrack->get_crossing(); 
+    m_calculated_daughter_dedx[i] = kfpTupleTools.get_dEdx(topNode, daughterArray[i]);
 
     if (m_calo_info)
     {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -161,6 +161,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools
   int m_calculated_daughter_pdgID[max_tracks] = {0};
   // float *m_calculated_daughter_cov[max_tracks];
   float m_calculated_daughter_cov[max_tracks][21] = {{0}, {0}};
+  float m_calculated_daughter_dedx[max_tracks] = {0};
 
   float m_daughter_dca[99] = {0};
   float m_daughter_dca_xy[99] = {0};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <This adds dEdx for daughter branches to KFParticle's output> ( What does this PR do? Linking to talk in software meeting encouraged )
This adds dEdx for daughter branches to KFParticle's output


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )
Implementing dEdx selection in KFParticle's candidate selection could be useful in future for background reduction. Currently this just saves it to output to allow for selection in plotting


## Links to other PRs in macros and calibration repositories (if applicable)

