### PR TITLE
PHCASeeding seed volume mitigation update

### DIFF
--- a/offline/packages/trackreco/PHCASeeding.cc
+++ b/offline/packages/trackreco/PHCASeeding.cc
@@ -390,7 +390,7 @@ int PHCASeeding::FindSeedsWithMerger(const PHCASeeding::PositionMap& globalPosit
   PHCASEEDING_PRINT_TIME(t_makebilinks, "init and make bilinks");
 
   t_makeseeds->restart();
-  keyLists trackSeedKeyLists = FollowBiLinks(trackSeedPairs, bodyLinks, globalPositions);
+  keyLists trackSeedKeyLists = removeDuplicates(FollowBiLinks(trackSeedPairs, bodyLinks, globalPositions));
   PHCASEEDING_PRINT_TIME(t_makeseeds, "make seeds");
   if (Verbosity() > 0)
   {
@@ -639,6 +639,66 @@ double PHCASeeding::getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b,
   return 2 * sin(break_angle) / hypot_length;
 }
 
+PHCASeeding::keyLists PHCASeeding::removeDuplicates(PHCASeeding::keyLists seeds)
+{
+  // Removes duplicate seeds (those that are subsets of another seed, with up to [differences_to_merge] allowed differences)
+  PHCASeeding::keyLists newseeds;
+  //size_t differences_to_merge = 2;
+  for(auto& seed_a : seeds)
+  {
+    //std::cout << "seed A: " << std::endl;
+    //for(auto c : seed_a) std::cout << c << " layer " << (int)TrkrDefs::getLayer(c) << std::endl;
+    bool merged = false;
+    for(auto &newseed : newseeds)
+    {
+      //std::cout << "newseed: " << std::endl;
+      //for(auto c : newseed) std::cout << c << " layer " << (int)TrkrDefs::getLayer(c) << std::endl;
+      std::vector<TrkrDefs::cluskey> intersection;
+      std::set<TrkrDefs::cluskey> seed_a_set(seed_a.begin(),seed_a.end());
+      std::set<TrkrDefs::cluskey> seed_b_set(newseed.begin(),newseed.end());
+      std::set_intersection(seed_a_set.begin(),seed_a_set.end(),seed_b_set.begin(),seed_b_set.end(),std::back_inserter(intersection));
+      // intersection comes out in the opposite direction, so reverse it
+      std::reverse(intersection.begin(),intersection.end());
+      //std::cout << "intersection: " << std::endl;
+      //for(auto c : intersection) std::cout << c << " layer " << (int)TrkrDefs::getLayer(c) << std::endl;
+      if(intersection.size() >= seed_a.size() - _differences_to_merge)
+      {
+        //std::cout << "merging" << std::endl;
+        merged = true;
+	auto minmax_pair = std::minmax_element(intersection.begin(),intersection.end(),
+          [](const TrkrDefs::cluskey& a,const TrkrDefs::cluskey& b){ return TrkrDefs::getLayer(a) < TrkrDefs::getLayer(b); });
+	size_t min_layer = TrkrDefs::getLayer(*(minmax_pair.first));
+	size_t max_layer = TrkrDefs::getLayer(*(minmax_pair.second));
+        //std::cout << "merging from layer " << min_layer << " to " << max_layer << std::endl;
+        std::vector<size_t> to_remove;
+	for(size_t index = 0; index < newseed.size(); index++)
+        {
+          //std::cout << "checking newseed " << newseed[index] << std::endl;
+          size_t layer = TrkrDefs::getLayer(newseed[index]);
+          if(layer>=min_layer && layer<=max_layer &&
+             std::find(intersection.begin(),intersection.end(),newseed[index])==intersection.end())
+          {
+            //std::cout << "discrepancy, removing" << std::endl;
+            to_remove.push_back(index);
+          }
+        }
+        for(int r = to_remove.size()-1; r>=0; r--)
+        {
+          newseed.erase(newseed.begin()+to_remove[r]);
+        }
+        //std::cout << "newseed is now: " << std::endl;
+        //for(auto c : newseed) std::cout << c << " layer " << (int)TrkrDefs::getLayer(c) << std::endl;
+      }
+    }
+    if(!merged)
+    {
+      newseeds.push_back(seed_a);
+    }
+  }
+  // std::cout << "originally " << seeds.size() << " seeds, now " << newseeds.size() << " seeds" << std::endl;
+  return newseeds;
+}
+
 PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& trackSeedPairs, const PHCASeeding::keyLinkPerLayer& bilinks, const PHCASeeding::PositionMap& globalPositions) const
 {
   // form all possible starting 3-cluster tracks (we need that to calculate curvature)
@@ -709,7 +769,7 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
     {
       // grow the seed to the maximum length allowed
       bool first_link = true;
-      bool done_growing = (seed.size() >= _max_clusters_per_seed);
+      bool done_growing = false; //(seed.size() >= _max_clusters_per_seed);
       keyList head_keys = {seed.back()};
       /* keyList head_keys = { seed.back() }; // heads of the seed */
 
@@ -734,6 +794,9 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
 
         // find which link_matches pass the dZdR and d2phidr2 cuts
         keyList passing_links{};
+	TrkrDefs::cluskey best_ckey = 0;
+	float best_deltaslope = 1e9;
+	float best_deltacurv = 1e9;
         for (const auto link : link_matches)
         {  // iL for "Index of Layer"
           // see if the link passes the growth cuts
@@ -761,7 +824,7 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
           const int i0 = (iL + 0) % 4;
           const int i1 = (iL + 1) % 4;
           const int i2 = (iL + 2) % 4;
-          const int i3 = (iL + 3) % 4;
+          //const int i3 = (iL + 3) % 4;
 
           phi[i0] = atan2(y, x);
           R[i0] = sqrt(x * x + y * y);
@@ -779,22 +842,33 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
           const float dZdR_01 = dZ_01 / dR_01;
           const float dZdR_12 = dZ_12 / dR_12;
 
-          if (fabs(dZdR_01 - dZdR_12) > _clusadd_delta_dzdr_window)
+          if (fabs(dZdR_01 - dZdR_12) > best_deltaslope)
           {
             continue;
           }
-          const float dphi_01 = wrap_dphi(phi[i1], phi[i0]);
-          const float dphi_12 = wrap_dphi(phi[i2], phi[i1]);
-          const float dphi_23 = wrap_dphi(phi[i3], phi[i2]);
-          const float dR_23 = R[i2] - R[i3];
-          const float d2phidr2_01 = dphi_01 / dR_01 / dR_01 - dphi_12 / dR_12 / dR_12;
-          const float d2phidr2_12 = dphi_12 / dR_12 / dR_12 - dphi_23 / dR_23 / dR_23;
-          if (fabs(d2phidr2_01 - d2phidr2_12) > _clusadd_delta_dphidr2_window)
+          //const float dphi_01 = wrap_dphi(phi[i1], phi[i0]);
+          //const float dphi_12 = wrap_dphi(phi[i2], phi[i1]);
+          //const float dphi_23 = wrap_dphi(phi[i3], phi[i2]);
+          //const float dR_23 = R[i2] - R[i3];
+          //const float d2phidr2_01 = dphi_01 / dR_01 / dR_01 - dphi_12 / dR_12 / dR_12;
+          //const float d2phidr2_12 = dphi_12 / dR_12 / dR_12 - dphi_23 / dR_23 / dR_23;
+	  const float newcurv = getMengerCurvature(link,seed.rbegin()[0],seed.rbegin()[1],globalPositions);
+	  const float currentcurv = getMengerCurvature(seed.rbegin()[0],seed.rbegin()[1],seed.rbegin()[2],globalPositions);
+          //if (fabs(d2phidr2_01 - d2phidr2_12) > _clusadd_delta_dphidr2_window)
+	  if(fabs(currentcurv-newcurv) > best_deltacurv)
           {
             continue;
           }
-          passing_links.push_back(link);
+          best_ckey = link;
+	  best_deltaslope = fabs(dZdR_01 - dZdR_12);
+	  best_deltacurv = fabs(newcurv - currentcurv);
+          // passing_links.push_back(link);
         }  // end loop over all bilinks in new layer
+
+        if(best_ckey != 0)
+	{
+	  passing_links.push_back(best_ckey);
+	}
 
         if (_split_seeds)
         {
@@ -809,10 +883,10 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
           break;
         case 1:
           seed.push_back(passing_links[0]);
-          if (seed.size() >= _max_clusters_per_seed)
-          {
-            done_growing = true;
-          }  // this seed is done growing
+          //if (seed.size() >= _max_clusters_per_seed)
+          //{
+          //  done_growing = true;
+          //}  // this seed is done growing
           head_keys = {passing_links[0]};
           break;
         default:  // more than one matched cluster
@@ -828,10 +902,10 @@ PHCASeeding::keyLists PHCASeeding::FollowBiLinks(const PHCASeeding::keyLinks& tr
               split_seeds.push_back(newseed);
             }
             seed.push_back(passing_links[0]);
-            if (seed.size() >= _max_clusters_per_seed)
-            {
-              done_growing = true;
-            }
+            //if (seed.size() >= _max_clusters_per_seed)
+            //{
+            //  done_growing = true;
+            //}
             head_keys = {passing_links[0]};
           }
           else

--- a/offline/packages/trackreco/PHCASeeding.h
+++ b/offline/packages/trackreco/PHCASeeding.h
@@ -117,6 +117,7 @@ class PHCASeeding : public PHTrackSeeding
   }
   void SetMinHitsPerCluster(unsigned int minHits) { _min_nhits_per_cluster = minHits; }
   void SetMinClustersPerTrack(unsigned int minClus) { _min_clusters_per_track = minClus; }
+  void SetNDifferencesToMerge(size_t nDiff) { _differences_to_merge = nDiff; }
   void SetNClustersPerSeedRange(unsigned int minClus, unsigned int maxClus)
   {
     _min_clusters_per_seed = minClus;
@@ -224,6 +225,7 @@ class PHCASeeding : public PHTrackSeeding
   void QueryTree(const bgi::rtree<pointKey, bgi::quadratic<16>>& rtree, double phimin, double zmin, double phimax, double zmax, std::vector<pointKey>& returned_values) const;
   std::vector<TrackSeed_v2> RemoveBadClusters(const std::vector<keyList>& seeds, const PositionMap& globalPositions) const;
   double getMengerCurvature(TrkrDefs::cluskey a, TrkrDefs::cluskey b, TrkrDefs::cluskey c, const PositionMap& globalPositions) const;
+  PHCASeeding::keyLists removeDuplicates(PHCASeeding::keyLists seeds);
 
   void publishSeeds(const std::vector<TrackSeed_v2>& seeds) const;
 
@@ -247,6 +249,7 @@ class PHCASeeding : public PHTrackSeeding
   float _clusadd_delta_dzdr_window = 0.5;
   float _clusadd_delta_dphidr2_window = 0.005;
   float _max_sin_phi;
+  size_t _differences_to_merge = 2;
   /* float _cosTheta_limit; */
   double _rz_outlier_threshold = 0.1;
   double _xy_outlier_threshold = 0.1;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
These updates to the PHCASeeding module greatly reduce the number of seeds produced by the TPC seeding process, which in turn greatly improves the runtime of PHSimpleKFProp in exchange for a slight increase in the runtime of PHCASeeding.

A summary of the details and some low-statistics test results will be presented at the March 7 tracking meeting; slides will be linked here afterward.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

