### PR TITLE
new processing option to turn of the saturation handling

### DIFF
--- a/offline/packages/CaloReco/CaloWaveformFitting.cc
+++ b/offline/packages/CaloReco/CaloWaveformFitting.cc
@@ -126,7 +126,7 @@ std::vector<std::vector<float>> CaloWaveformFitting::calo_processing_templatefit
         int ndata = 0;
         for (int i = 0; i < size1; ++i)
         {
-          if (v.at(i) == 16383)
+          if ((v.at(i) == 16383) && _handleSaturation)
           {
             continue;
           }

--- a/offline/packages/CaloReco/CaloWaveformFitting.h
+++ b/offline/packages/CaloReco/CaloWaveformFitting.h
@@ -52,6 +52,11 @@ class CaloWaveformFitting
     _dobitfliprecovery = dobitfliprecovery;
   }
 
+  void set_handleSaturation(bool handleSaturation = true)
+  {
+    _handleSaturation = handleSaturation;
+  }
+
   std::vector<std::vector<float>> process_waveform(std::vector<std::vector<float>> waveformvector);
   std::vector<std::vector<float>> calo_processing_templatefit(std::vector<std::vector<float>> chnlvector);
   static std::vector<std::vector<float>> calo_processing_fast(const std::vector<std::vector<float>> &chnlvector);
@@ -86,6 +91,7 @@ class CaloWaveformFitting
   bool _maxsoftwarezerosuppression{false};
   bool m_setTimeLim{false};
   bool _dobitfliprecovery{false};
+  bool _handleSaturation{true};
 
   std::string m_template_input_file;
   std::string url_template;

--- a/offline/packages/CaloReco/CaloWaveformProcessing.cc
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.cc
@@ -26,12 +26,16 @@ void CaloWaveformProcessing::initialize_processing()
 {
   char *calibrationsroot = getenv("CALIBRATIONROOT");
   assert(calibrationsroot);
-  if (m_processingtype == CaloWaveformProcessing::TEMPLATE)
+  if (m_processingtype == CaloWaveformProcessing::TEMPLATE || m_processingtype == CaloWaveformProcessing::TEMPLATE_NOSAT)
   {
     std::string calibrations_repo_template = std::string(calibrationsroot) + "/WaveformProcessing/templates/" + m_template_input_file;
     url_template = CDBInterface::instance()->getUrl(m_template_name, calibrations_repo_template);
     m_Fitter = new CaloWaveformFitting();
     m_Fitter->initialize_processing(url_template);
+    if(m_processingtype == CaloWaveformProcessing::TEMPLATE_NOSAT)
+    {
+      m_Fitter->set_handleSaturation(false);
+    }
     m_Fitter->set_nthreads(get_nthreads());
     if (m_setTimeLim)
     {

--- a/offline/packages/CaloReco/CaloWaveformProcessing.h
+++ b/offline/packages/CaloReco/CaloWaveformProcessing.h
@@ -18,6 +18,7 @@ class CaloWaveformProcessing : public SubsysReco
     ONNX = 2,
     FAST = 3,
     NYQUIST = 4,
+    TEMPLATE_NOSAT = 5,
   };
 
   CaloWaveformProcessing() = default;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

TEMPLATE_NOSAT processing option fit the saturation waveform as is.

Just in case that we need to run the MC with the old waveform processing method...hope this flag is never used:)


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

