### PR TITLE
Add flag to raw hit unpacker

### DIFF
--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -150,6 +150,9 @@ int TpcCombinedRawDataUnpacker::InitRun(PHCompositeNode* topNode)
     m_ntup = new TNtuple("NT", "NT", "event:gtmbco:packid:ep:sector:side:fee:rx:entries:ped:width");
     m_ntup_hits = new TNtuple("NTH", "NTH", "event:gtmbco:packid:ep:sector:side:fee:chan:sampadd:sampch:phibin:tbin:layer:adc:ped:width");
     m_ntup_hits_corr = new TNtuple("NTC", "NTC", "event:gtmbco:packid:ep:sector:side:fee:chan:sampadd:sampch:phibin:tbin:layer:adc:ped:width:corr");
+    if(m_ChanHitsCut){
+      m_HitsinChan = new TH1F("HitsinChan","HitsinChan",451,-0.5,450.5);
+    }
   }
 
   if (Verbosity() >= 1)
@@ -225,8 +228,9 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
   uint64_t bco_max = 0;
 
   const auto nhits = tpccont->get_nhits();
-
+  
   int max_time_range = 0;
+  
   for (unsigned int i = 0; i < nhits; i++)
   {
     TpcRawHit* tpchit = tpccont->get_hit(i);
@@ -243,6 +247,7 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
 
     int fee = tpchit->get_fee();
     int channel = tpchit->get_channel();
+    
     int feeM = FEE_map[fee];
     if (FEE_R[fee] == 2)
     {
@@ -271,8 +276,8 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    //    uint16_t sampadd = tpchit->get_sampaaddress();
-    // uint16_t sampch = tpchit->get_sampachannel();
+    uint16_t sampadd = tpchit->get_sampaaddress();
+    uint16_t sampch = tpchit->get_sampachannel();
     //    uint16_t sam = tpchit->get_samples();
     max_time_range = tpchit->get_samples();
     varname = "phi";  // + std::to_string(key);
@@ -334,6 +339,26 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
 
     float threshold_cut = m_zs_threshold;
 
+    int nhitschan=0;
+    
+    if(m_ChanHitsCut){
+      for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());!adc_iterator->IsDone();adc_iterator->Next()){
+	const uint16_t s = adc_iterator->CurrentTimeBin();
+	const uint16_t adc = adc_iterator->CurrentAdc();
+	int t = s - m_presampleShift - m_t0;
+	if (t < 0) continue;
+	if (feehist != nullptr){
+	  if (adc > 0){
+	    if ((float(adc) - hpedestal) > threshold_cut){
+	      nhitschan++;
+	    }
+	  }
+	}
+      }
+      m_HitsinChan->Fill(nhitschan);
+      if(nhitschan>100) continue;
+    }
+    
     for (std::unique_ptr<TpcRawHit::AdcIterator> adc_iterator(tpchit->CreateAdcIterator());
          !adc_iterator->IsDone();
          adc_iterator->Next())
@@ -374,26 +399,26 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
 
         if (m_writeTree)
         {
-          float fXh[18];
-          int nh = 0;
-
-          fXh[nh++] = _ievent - 1;
-          fXh[nh++] = 0;                        // gtm_bco;
-          fXh[nh++] = 0;                        // packet_id;
-          fXh[nh++] = 0;                        // ep;
-          fXh[nh++] = mc_sectors[sector % 12];  // Sector;
-          fXh[nh++] = side;
-          fXh[nh++] = fee;
-          fXh[nh++] = 0;  // channel;
-          fXh[nh++] = 0;  // sampadd;
-          fXh[nh++] = 0;  // sampch;
-          fXh[nh++] = (float) phibin;
-          fXh[nh++] = (float) t;
-          fXh[nh++] = layer;
-          fXh[nh++] = (float(adc) - hpedestal);
-          fXh[nh++] = hpedestal;
-          fXh[nh++] = hpedwidth;
-          m_ntup_hits->Fill(fXh);
+	    float fXh[18];
+	    int nh = 0;
+	    
+	    fXh[nh++] = _ievent - 1;
+	    fXh[nh++] = gtm_bco;                        // gtm_bco;
+	    fXh[nh++] = packet_id;                        // packet_id;
+	    fXh[nh++] = ep;                        // ep;
+	    fXh[nh++] = mc_sectors[sector % 12];  // Sector;
+	    fXh[nh++] = side;
+	    fXh[nh++] = fee;
+	    fXh[nh++] = channel;  // channel;
+	    fXh[nh++] = sampadd;  // sampadd;
+	    fXh[nh++] = sampch;  // sampch;
+	    fXh[nh++] = (float) phibin;
+	    fXh[nh++] = (float) t;
+	    fXh[nh++] = layer;
+	    fXh[nh++] = (float(adc) - hpedestal);
+	    fXh[nh++] = hpedestal;
+	    fXh[nh++] = hpedwidth;
+	    m_ntup_hits->Fill(fXh);
         }
       }
     }
@@ -615,6 +640,9 @@ int TpcCombinedRawDataUnpacker::End(PHCompositeNode* /*topNode*/)
     m_ntup->Write();
     m_ntup_hits->Write();
     m_ntup_hits_corr->Write();
+    if(m_ChanHitsCut){
+      m_HitsinChan->Write();
+    }
     m_file->Close();
   }
   if (Verbosity())

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.cc
@@ -151,11 +151,7 @@ int TpcCombinedRawDataUnpacker::InitRun(PHCompositeNode* topNode)
     m_ntup_hits = new TNtuple("NTH", "NTH", "event:gtmbco:packid:ep:sector:side:fee:chan:sampadd:sampch:phibin:tbin:layer:adc:ped:width");
     m_ntup_hits_corr = new TNtuple("NTC", "NTC", "event:gtmbco:packid:ep:sector:side:fee:chan:sampadd:sampch:phibin:tbin:layer:adc:ped:width:corr");
     if(m_ChanHitsCut){
-<<<<<<< HEAD
       m_HitsinChan = new TH1F("HitsinChan","HitsinChan",451,-0.5,450.5);
-=======
-      m_HitsinChan = new TH1F("HitsinChan","HitsinChan",450,-0.5,449.5);
->>>>>>> 5ef4c1b272708b3cd9360636975533012ba002cb
     }
   }
 
@@ -359,7 +355,9 @@ int TpcCombinedRawDataUnpacker::process_event(PHCompositeNode* topNode)
 	  }
 	}
       }
-      m_HitsinChan->Fill(nhitschan);
+      if(m_writeTree){
+	m_HitsinChan->Fill(nhitschan);
+      }
       if(nhitschan>100) continue;
     }
     

--- a/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
+++ b/offline/packages/tpc/TpcCombinedRawDataUnpacker.h
@@ -16,6 +16,7 @@ class CDBInterface;
 class TH2I;
 class TH2C;
 class TFile;
+class TH1F;
 class TNtuple;
 
 class TpcCombinedRawDataUnpacker : public SubsysReco
@@ -28,6 +29,7 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   int process_event(PHCompositeNode *) override;
   int End(PHCompositeNode *topNode) override;
   void writeTree() { m_writeTree = true; }
+  void doChanHitsCut(bool cut){m_ChanHitsCut=cut;};
   void doBaselineCorr(bool val) { m_do_baseline_corr = val; }
   void doZSEmulation(bool val) { m_do_zs_emulation = val; }
   void ReadZeroSuppressedData() { 
@@ -105,6 +107,9 @@ class TpcCombinedRawDataUnpacker : public SubsysReco
   int mc_sectors[12]{5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 6};
   int FEE_map[26]{4, 5, 0, 2, 1, 11, 9, 10, 8, 7, 6, 0, 1, 3, 7, 6, 5, 4, 3, 2, 0, 2, 1, 3, 5, 4};
   int FEE_R[26]{2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
+
+  TH1F *m_HitsinChan{nullptr};
+  bool m_ChanHitsCut{false};
 
   float m_ped_sig_cut{4.0};
 


### PR DESCRIPTION
[comment]: <Adds flag to raw hit unpacker that places cut on number of hits allowed in FEE channels> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <This PR adds a flag to the raw hit unpacker that, when called, places a cut on the number of hits allowed in the TPC channels. If a channel has more hits than the threshold value set in TpcCombinedRawDataUnpacker then those hits are rejected. The purpose of this is to address noisy channels in the TPC that are always firing. When the writeTree flag is called, this new flag will also add a histogram to the output file that shows the distribution of hits in all channels.> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

