### PR TITLE
Extrapolation to calorimeters

### DIFF
--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -35,23 +35,15 @@
 #include <CLHEP/Vector/ThreeVector.h>
 #include <math.h>
 
+namespace
+{
+  static const std::vector<std::string> m_caloNames = { "CEMC", "HCALIN", "HCALOUT", "OUTER_CEMC", "OUTER_HCALIN", "OUTER_HCALOUT" };
+  static const std::vector<SvtxTrack::CAL_LAYER> m_caloTypes = { SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT, SvtxTrack::OUTER_CEMC, SvtxTrack::OUTER_HCALIN, SvtxTrack::OUTER_HCALOUT };
+}
+
 PHActsTrackProjection::PHActsTrackProjection(const std::string& name)
   : SubsysReco(name)
-{
-  m_caloNames.push_back("CEMC");
-  m_caloNames.push_back("HCALIN");
-  m_caloNames.push_back("HCALOUT");
-  m_caloNames.push_back("OUTER_CEMC");
-  m_caloNames.push_back("OUTER_HCALIN");
-  m_caloNames.push_back("OUTER_HCALOUT");
-
-  m_caloTypes.push_back(SvtxTrack::CEMC);
-  m_caloTypes.push_back(SvtxTrack::HCALIN);
-  m_caloTypes.push_back(SvtxTrack::HCALOUT);
-  m_caloTypes.push_back(SvtxTrack::OUTER_CEMC);
-  m_caloTypes.push_back(SvtxTrack::OUTER_HCALIN);
-  m_caloTypes.push_back(SvtxTrack::OUTER_HCALOUT);
-}
+{}
 
 int PHActsTrackProjection::InitRun(PHCompositeNode* topNode)
 {
@@ -288,9 +280,9 @@ PHActsTrackProjection::propagateTrack(
 int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode* topNode,
                                                  const int caloLayer)
 {
-  std::string towerGeoNodeName = "TOWERGEOM_" + m_caloNames.at(caloLayer);
-  std::string towerNodeName = "TOWERINFO_CALIB_" + m_caloNames.at(caloLayer);
-  std::string clusterNodeName = "CLUSTER_" + m_caloNames.at(caloLayer);
+  const std::string towerGeoNodeName = "TOWERGEOM_" + m_caloNames.at(caloLayer);
+  const std::string towerNodeName = "TOWERINFO_CALIB_" + m_caloNames.at(caloLayer);
+  const std::string clusterNodeName = "CLUSTER_" + m_caloNames.at(caloLayer);
 
   m_towerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, towerGeoNodeName.c_str());
 
@@ -305,7 +297,8 @@ int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode* topNode,
     m_clusterContainer = findNode::getClass<RawClusterContainer>(topNode, nodeName.c_str());
   }
 
-  if((!m_clusterContainer) && (Verbosity() > 1))
+  if((!m_clusterContainer) )
+    // && (Verbosity() > 1))
   {
     std::cout << PHWHERE
               << "Calo cluster container for " << m_caloNames.at(caloLayer)

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -281,30 +281,29 @@ int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode* topNode,
                                                  const int caloLayer)
 {
   const std::string towerGeoNodeName = "TOWERGEOM_" + m_caloNames.at(caloLayer);
-  const std::string towerNodeName = "TOWERINFO_CALIB_" + m_caloNames.at(caloLayer);
-  const std::string clusterNodeName = "CLUSTER_" + m_caloNames.at(caloLayer);
-
   m_towerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, towerGeoNodeName.c_str());
 
+  const std::string towerNodeName = "TOWERINFO_CALIB_" + m_caloNames.at(caloLayer);
   m_towerContainer = findNode::getClass<TowerInfoContainer>(topNode, towerNodeName.c_str());
 
-  m_clusterContainer = findNode::getClass<RawClusterContainer>(topNode, clusterNodeName.c_str());
-
-  if (m_useCemcPosRecalib and
-      m_caloNames.at(caloLayer).compare("CEMC") == 0)
+  for( const std::string basename: {"CLUSTER_POS_COR_", "CLUSTERINFO_", "CLUSTER_" } )
   {
-    std::string nodeName = "CLUSTER_POS_COR_" + m_caloNames.at(caloLayer);
-    m_clusterContainer = findNode::getClass<RawClusterContainer>(topNode, nodeName.c_str());
+    const std::string clusterNodeName = basename + m_caloNames.at(caloLayer);
+    m_clusterContainer = findNode::getClass<RawClusterContainer>(topNode, clusterNodeName.c_str());
+    if( m_clusterContainer )
+    {
+      // std::cout << "PHActsTrackProjection::setCaloContainerNodes - found " << clusterNodeName << std::endl;
+      break;
+    }
   }
 
-  if((!m_clusterContainer) )
-    // && (Verbosity() > 1))
-  {
-    std::cout << PHWHERE
-              << "Calo cluster container for " << m_caloNames.at(caloLayer)
-              << "not found on node tree. Track projections to calos WILL be filled."
-              << std::endl;
-  }
+//   if((!m_clusterContainer) )
+//   {
+//     std::cout << PHWHERE
+//               << "Calo cluster container for " << m_caloNames.at(caloLayer)
+//               << " not found on node tree. Track projections to calos will be filled."
+//               << std::endl;
+//   }
 
   if (!m_towerGeomContainer or !m_towerContainer)
   {

--- a/offline/packages/trackreco/PHActsTrackProjection.cc
+++ b/offline/packages/trackreco/PHActsTrackProjection.cc
@@ -37,8 +37,15 @@
 
 namespace
 {
-  static const std::vector<std::string> m_caloNames = { "CEMC", "HCALIN", "HCALOUT", "OUTER_CEMC", "OUTER_HCALIN", "OUTER_HCALOUT" };
-  static const std::vector<SvtxTrack::CAL_LAYER> m_caloTypes = { SvtxTrack::CEMC, SvtxTrack::HCALIN, SvtxTrack::HCALOUT, SvtxTrack::OUTER_CEMC, SvtxTrack::OUTER_HCALIN, SvtxTrack::OUTER_HCALOUT };
+  static const std::map<SvtxTrack::CAL_LAYER,std::string> m_caloNames =
+  {
+    {SvtxTrack::CEMC, "CEMC"},
+    {SvtxTrack::HCALIN, "HCALIN"},
+    {SvtxTrack::HCALOUT, "HCALOUT"},
+    {SvtxTrack::OUTER_CEMC, "OUTER_CEMC"},
+    {SvtxTrack::OUTER_HCALIN, "OUTER_HCALIN"},
+    {SvtxTrack::OUTER_HCALOUT, "OUTER_HCALOUT"}
+  };
 }
 
 PHActsTrackProjection::PHActsTrackProjection(const std::string& name)
@@ -54,9 +61,6 @@ int PHActsTrackProjection::InitRun(PHCompositeNode* topNode)
 
   int ret = makeCaloSurfacePtrs(topNode);
 
-  /// only need to print warning once
-  m_calosAvailable = false;
-
   if (getNodes(topNode) != Fun4AllReturnCodes::EVENT_OK)
   {
     ret = Fun4AllReturnCodes::ABORTEVENT;
@@ -70,46 +74,21 @@ int PHActsTrackProjection::InitRun(PHCompositeNode* topNode)
   return ret;
 }
 
-int PHActsTrackProjection::process_event(PHCompositeNode* topNode)
+int PHActsTrackProjection::process_event(PHCompositeNode* /*topNode*/)
 {
-  if (Verbosity() > 1)
+
+  for( const auto& [layer, name]:m_caloNames )
   {
-    std::cout << "PHActsTrackProjection : Starting process_event event "
-              << m_event << std::endl;
-  }
-
-  for (int layer = 0; layer < m_nCaloLayers; layer++)
-  {
-    if (Verbosity() > 1)
+    if (Verbosity())
     {
-      std::cout << "Processing calo layer "
-                << m_caloNames.at(layer) << std::endl;
+      std::cout << "Processing calo layer " << name << std::endl;
     }
-
-    if (setCaloContainerNodes(topNode, layer) != Fun4AllReturnCodes::EVENT_OK)
-    {
-      continue;
-    }
-
     int ret = projectTracks(layer);
     if (ret != Fun4AllReturnCodes::EVENT_OK)
     {
       return Fun4AllReturnCodes::ABORTEVENT;
     }
-    ret = projectTracks(layer+m_nCaloLayers);
-    if (ret != Fun4AllReturnCodes::EVENT_OK)
-    {
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
   }
-
-  if (Verbosity() > 1)
-  {
-    std::cout << "PHActsTrackProjection : Finished process_event event "
-              << m_event << std::endl;
-  }
-
-  m_event++;
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -124,7 +103,7 @@ int PHActsTrackProjection::End(PHCompositeNode* /*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHActsTrackProjection::projectTracks(const int caloLayer)
+int PHActsTrackProjection::projectTracks(SvtxTrack::CAL_LAYER caloLayer)
 {
   ActsPropagator prop(m_tGeometry);
   for (const auto& [key, track] : *m_trackMap)
@@ -134,10 +113,8 @@ int PHActsTrackProjection::projectTracks(const int caloLayer)
       {
 	continue;
       }
-    auto cylSurf =
-        m_caloSurfaces.find(m_caloNames.at(caloLayer))->second;
-
-    auto result = propagateTrack(params.value(), caloLayer, cylSurf);
+    const auto cylSurf = m_caloSurfaces.at(caloLayer);
+    const auto result = propagateTrack(params.value(), cylSurf);
     if (result.ok())
     {
       updateSvtxTrack(result.value(), track, caloLayer);
@@ -150,14 +127,14 @@ int PHActsTrackProjection::projectTracks(const int caloLayer)
 void PHActsTrackProjection::updateSvtxTrack(
     const ActsPropagator::BoundTrackParamPair& parameters,
     SvtxTrack* svtxTrack,
-    const int caloLayer)
+    SvtxTrack::CAL_LAYER caloLayer)
 {
-  float pathlength = parameters.first / Acts::UnitConstants::cm;
-  auto params = parameters.second;
-  float calorad = m_caloRadii.find(m_caloTypes.at(caloLayer))->second;
+  const float pathlength = parameters.first / Acts::UnitConstants::cm;
+  const auto params = parameters.second;
+  const float calorad = m_caloRadii.at(caloLayer);
   SvtxTrackState_v1 out(calorad);
 
-  auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
+  const auto projectionPos = params.position(m_tGeometry->geometry().getGeoContext());
   const auto momentum = params.momentum();
   out.set_x(projectionPos.x() / Acts::UnitConstants::cm);
   out.set_y(projectionPos.y() / Acts::UnitConstants::cm);
@@ -186,87 +163,9 @@ void PHActsTrackProjection::updateSvtxTrack(
   return;
 }
 
-void PHActsTrackProjection::getClusterProperties(double phi,
-                                                 double eta,
-                                                 double& minIndex,
-                                                 double& minDphi,
-                                                 double& minDeta,
-                                                 double& minE)
-{
-  double minR = DBL_MAX;
-  if(!m_clusterContainer)
-  {
-    if(Verbosity() > 1)
-    {
-      std::cout << PHWHERE
-                << "Calo cluster container "
-                << "not found. getClusterProperties will not return any information."
-                << std::endl;
-    }
-    return;
-  }
-  auto clusterMap = m_clusterContainer->getClustersMap();
-  for (const auto& [key, cluster] : clusterMap)
-  {
-    const auto clusterEta =
-        RawClusterUtility::GetPseudorapidity(*cluster,
-                                             CLHEP::Hep3Vector(0, 0, 0));
-    const auto dphi = deltaPhi(phi - cluster->get_phi());
-    const auto deta = eta - clusterEta;
-    const auto r = sqrt(pow(dphi, 2) + pow(deta, 2));
-
-    if (r < minR)
-    {
-      minIndex = key;
-      minR = r;
-      minDphi = dphi;
-      minDeta = deta;
-      minE = cluster->get_energy();
-    }
-  }
-
-  return;
-}
-
-void PHActsTrackProjection::getSquareTowerEnergies(int phiBin,
-                                                   int etaBin,
-                                                   double& energy3x3,
-                                                   double& energy5x5)
-{
-  for (int iphi = phiBin - 2; iphi <= phiBin + 2; ++iphi)
-  {
-    for (int ieta = etaBin - 2; ieta <= etaBin + 2; ++ieta)
-    {
-      /// Check the phi periodic boundary conditions
-      int wrapPhi = iphi;
-      if (wrapPhi < 0)
-        wrapPhi += m_towerGeomContainer->get_phibins();
-      if (wrapPhi >= m_towerGeomContainer->get_phibins())
-        wrapPhi -= m_towerGeomContainer->get_phibins();
-
-      /// Check the eta boundary conditions
-      if (ieta < 0 or ieta >= m_towerGeomContainer->get_etabins())
-        continue;
-
-      unsigned int towerkey = (ieta << 16U) + wrapPhi;
-      auto tower = m_towerContainer->get_tower_at_key(towerkey);
-
-      if (!tower)
-        continue;
-
-      energy5x5 += tower->get_energy();
-      if (abs(iphi - phiBin) <= 1 and abs(ieta - etaBin) <= 1)
-        energy3x3 += tower->get_energy();
-    }
-  }
-
-  return;
-}
-
 PHActsTrackProjection::BoundTrackParamResult
 PHActsTrackProjection::propagateTrack(
     const Acts::BoundTrackParameters& params,
-    const int /*caloLayer*/,
     const SurfacePtr& targetSurf)
 {
   ActsPropagator propagator(m_tGeometry);
@@ -277,83 +176,49 @@ PHActsTrackProjection::propagateTrack(
   return propagator.propagateTrackFast(params, targetSurf);
 }
 
-int PHActsTrackProjection::setCaloContainerNodes(PHCompositeNode* topNode,
-                                                 const int caloLayer)
-{
-  const std::string towerGeoNodeName = "TOWERGEOM_" + m_caloNames.at(caloLayer);
-  m_towerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, towerGeoNodeName.c_str());
-
-  const std::string towerNodeName = "TOWERINFO_CALIB_" + m_caloNames.at(caloLayer);
-  m_towerContainer = findNode::getClass<TowerInfoContainer>(topNode, towerNodeName.c_str());
-
-  for( const std::string basename: {"CLUSTER_POS_COR_", "CLUSTERINFO_", "CLUSTER_" } )
-  {
-    const std::string clusterNodeName = basename + m_caloNames.at(caloLayer);
-    m_clusterContainer = findNode::getClass<RawClusterContainer>(topNode, clusterNodeName.c_str());
-    if( m_clusterContainer )
-    {
-      // std::cout << "PHActsTrackProjection::setCaloContainerNodes - found " << clusterNodeName << std::endl;
-      break;
-    }
-  }
-
-//   if((!m_clusterContainer) )
-//   {
-//     std::cout << PHWHERE
-//               << "Calo cluster container for " << m_caloNames.at(caloLayer)
-//               << " not found on node tree. Track projections to calos will be filled."
-//               << std::endl;
-//   }
-
-  if (!m_towerGeomContainer or !m_towerContainer)
-  {
-    if (m_calosAvailable)
-    {
-      std::cout << PHWHERE
-                << "Calo geometry and/or cluster container for " << m_caloNames.at(caloLayer)
-                << "not found on node tree. Track projections to calos won't be filled."
-                << std::endl;
-    }
-
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
 int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode* topNode)
 {
-  for (int caloLayer = 0; caloLayer < m_nCaloLayers; caloLayer++)
+  using calo_pair_t = std::pair<SvtxTrack::CAL_LAYER,SvtxTrack::CAL_LAYER>;
+
+  for( const auto& [first, second]:std::initializer_list<calo_pair_t>{
+    {SvtxTrack::CEMC,SvtxTrack::OUTER_CEMC},
+    {SvtxTrack::HCALIN,SvtxTrack::OUTER_HCALIN },
+    {SvtxTrack::HCALOUT,SvtxTrack::OUTER_HCALOUT }} )
   {
-    if (setCaloContainerNodes(topNode, caloLayer) != Fun4AllReturnCodes::EVENT_OK)
+    const auto& caloname( m_caloNames.at(first) );
+
+    // get tower geometry node name
+    const std::string towerGeoNodeName = "TOWERGEOM_" + caloname;
+
+    // get tower geometry container
+    const auto towerGeomContainer = findNode::getClass<RawTowerGeomContainer>(topNode, towerGeoNodeName.c_str());
+
+    if( !towerGeomContainer )
     {
-      continue;
+      std::cout << PHWHERE
+        << "Calo tower geometry container for " << caloname
+        << "not found on node tree. Track projections to calos won't be filled."
+        << std::endl;
     }
 
-    /// Default to using calo radius
-    double caloRadius = m_towerGeomContainer->get_radius();
-    double caloOuterRadius = m_towerGeomContainer->get_radius() + m_towerGeomContainer->get_thickness();
-
-    if (m_caloRadii.find(m_caloTypes.at(caloLayer)) != m_caloRadii.end())
+    // get calorimeter inner radius and store
+    double caloRadius = towerGeomContainer->get_radius();
     {
-      caloRadius = m_caloRadii.find(m_caloTypes.at(caloLayer))->second;
-    }
-    else
-    {
-      m_caloRadii.insert(std::make_pair(m_caloTypes.at(caloLayer), caloRadius));
+      const auto iter = m_caloRadii.find(first);
+      if( iter == m_caloRadii.end() ) m_caloRadii.emplace(first,caloRadius);
+      else caloRadius = iter->second;
     }
 
+    // get calorimeter outer radius and store
+    double caloOuterRadius = towerGeomContainer->get_radius() + towerGeomContainer->get_thickness();
+    {
+      const auto iter = m_caloRadii.find(second);
+      if( iter == m_caloRadii.end() ) m_caloRadii.emplace(second,caloOuterRadius);
+      else caloOuterRadius = iter->second;
+    }
+
+    // convert to ACTS units
     caloRadius *= Acts::UnitConstants::cm;
-
-    if (m_caloRadii.find(m_caloTypes.at(caloLayer+m_nCaloLayers)) != m_caloRadii.end())
-    {
-      caloOuterRadius = m_caloRadii.find(m_caloTypes.at(caloLayer+m_nCaloLayers))->second;
-    }
-    else
-    {
-      m_caloRadii.insert(std::make_pair(m_caloTypes.at(caloLayer+m_nCaloLayers), caloOuterRadius));
-    }
-
     caloOuterRadius *= Acts::UnitConstants::cm;
 
     /// Extend farther so that there is at least surface there, for high
@@ -379,15 +244,15 @@ int PHActsTrackProjection::makeCaloSurfacePtrs(PHCompositeNode* topNode)
       std::cout << "Creating  cylindrical surface at " << caloRadius << std::endl;
       std::cout << "Creating  cylindrical surface at " << caloOuterRadius << std::endl;
     }
-    m_caloSurfaces.insert(std::make_pair(m_caloNames.at(caloLayer),surf));
-    m_caloSurfaces.insert(std::make_pair(m_caloNames.at(caloLayer+m_nCaloLayers), outer_surf));
+    m_caloSurfaces.emplace(first,surf);
+    m_caloSurfaces.emplace(second,outer_surf);
   }
 
   if (Verbosity() > 1)
   {
-    for (const auto& [name, surfPtr] : m_caloSurfaces)
+    for (const auto& [layer, surfPtr] : m_caloSurfaces)
     {
-      std::cout << "Cylinder " << name << " has center "
+      std::cout << "Cylinder " << m_caloNames.at(layer) << " has center "
                 << surfPtr.get()->center(m_tGeometry->geometry().getGeoContext()).transpose()
                 << std::endl;
     }
@@ -425,14 +290,4 @@ int PHActsTrackProjection::getNodes(PHCompositeNode* topNode)
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
-}
-
-double PHActsTrackProjection::deltaPhi(const double& phi)
-{
-  if (phi > M_PI)
-    return phi - 2. * M_PI;
-  else if (phi <= -M_PI)
-    return phi + 2. * M_PI;
-  else
-    return phi;
 }

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -100,7 +100,7 @@ class PHActsTrackProjection : public SubsysReco
                             double &minIndex, double &minDphi,
                             double &minDeta, double &minE);
   double deltaPhi(const double &phi);
- 
+
   /// Objects containing the Acts track fit results
   ActsGeometry *m_tGeometry = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
@@ -109,8 +109,6 @@ class PHActsTrackProjection : public SubsysReco
   /// Objects to hold calorimeter information. There are
   /// only 3 calo layers
   const static int m_nCaloLayers = 3;
-  std::vector<std::string> m_caloNames;
-  std::vector<SvtxTrack::CAL_LAYER> m_caloTypes;
   std::map<std::string, SurfacePtr> m_caloSurfaces;
   /// An optional map that allows projection to an arbitrary radius
   /// Results are written to the SvtxTrack based on the provided CAL_LAYER

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -16,6 +16,8 @@
 
 #include <ActsExamples/EventData/Trajectories.hpp>
 
+#include <map>
+
 class PHCompositeNode;
 class RawClusterContainer;
 class TowerInfoContainer;
@@ -55,32 +57,17 @@ class PHActsTrackProjection : public SubsysReco
   void setConstFieldVal(float b) { m_constFieldVal = b; }
 
   /// Set an arbitrary radius to project to, in cm
-  void setLayerRadius(SvtxTrack::CAL_LAYER layer,
-                      const float rad)
-  {
-    if (m_caloRadii.find(layer) != m_caloRadii.end())
-    {
-      m_caloRadii[layer] = rad;
-    }
-    else
-    {
-      m_caloRadii.insert(std::make_pair(layer, rad));
-    }
-  }
+  void setLayerRadius(SvtxTrack::CAL_LAYER layer, float rad)
+  { m_caloRadii[layer] = rad; }
 
  private:
   int getNodes(PHCompositeNode *topNode);
-  int projectTracks(int caloLayer);
+  int projectTracks(SvtxTrack::CAL_LAYER);
 
   /// Propagate the fitted track parameters to a surface with Acts
   BoundTrackParamResult propagateTrack(
       const Acts::BoundTrackParameters &params,
-      const int caloLayer,
       const SurfacePtr &targetSurf);
-
-  /// Set the particular calo nodes depending on which layer
-  int setCaloContainerNodes(PHCompositeNode *topNode,
-                            const int caloLayer);
 
   /// Make Acts::CylinderSurface objects corresponding to the calos
   int makeCaloSurfacePtrs(PHCompositeNode *topNode);
@@ -88,42 +75,28 @@ class PHActsTrackProjection : public SubsysReco
   /// Update the SvtxTrack object with the track-cluster match
   void updateSvtxTrack(const ActsPropagator::BoundTrackParamPair &params,
                        SvtxTrack *svtxTrack,
-                       const int caloLayer);
-
-  /// Get 3x3 and 5x5 tower sums matched to a track
-  void getSquareTowerEnergies(int phiBin, int etaBin,
-                              double &energy3x3,
-                              double &energy5x5);
-
-  /// Get the cluster values for a particular matched track
-  void getClusterProperties(double phi, double eta,
-                            double &minIndex, double &minDphi,
-                            double &minDeta, double &minE);
-  double deltaPhi(const double &phi);
+                       SvtxTrack::CAL_LAYER);
 
   /// Objects containing the Acts track fit results
   ActsGeometry *m_tGeometry = nullptr;
   SvtxTrackMap *m_trackMap = nullptr;
   SvtxVertexMap *m_vertexMap = nullptr;
 
-  /// Objects to hold calorimeter information. There are
-  /// only 3 calo layers
-  const static int m_nCaloLayers = 3;
-  std::map<std::string, SurfacePtr> m_caloSurfaces;
+  /// Objects to hold calorimeter information.
+  std::map<SvtxTrack::CAL_LAYER, SurfacePtr> m_caloSurfaces;
+
   /// An optional map that allows projection to an arbitrary radius
   /// Results are written to the SvtxTrack based on the provided CAL_LAYER
   std::map<SvtxTrack::CAL_LAYER, float> m_caloRadii;
 
-  RawTowerGeomContainer *m_towerGeomContainer = nullptr;
-  TowerInfoContainer *m_towerContainer = nullptr;
-  RawClusterContainer *m_clusterContainer = nullptr;
-
+  /// use constant field
   bool m_constField = true;
-  float m_constFieldVal = 1.4;
-  bool m_useCemcPosRecalib = false;
-  bool m_calosAvailable = true;
 
-  int m_event = 0;
+  /// constant field value
+  float m_constFieldVal = 1.4;
+
+  /// true if at least one calorimeter is available
+  bool m_calosAvailable = true;
 };
 
 #endif

--- a/offline/packages/trackreco/PHActsTrackProjection.h
+++ b/offline/packages/trackreco/PHActsTrackProjection.h
@@ -94,9 +94,6 @@ class PHActsTrackProjection : public SubsysReco
 
   /// constant field value
   float m_constFieldVal = 1.4;
-
-  /// true if at least one calorimeter is available
-  bool m_calosAvailable = true;
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR cleans-up track extrapolation to calorimeter
- unused methods are removed
- only TowerGeomertry objects are needed to determine calorimeters radii to which extrapolate and are only used once
- streamline calorimeter name to surface associations. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

