### PR TITLE
TPOT decoding, again

### DIFF
--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -86,13 +86,7 @@ namespace
   }
 
   // define limit for matching two fee_bco
-  static constexpr unsigned int m_max_multiplier_adjustment_count = 1000;
-
-  // define limit for matching two fee_bco
   static constexpr unsigned int m_max_fee_bco_diff = 10;
-
-  // define limit for matching fee_bco to fee_bco_predicted
-  static constexpr unsigned int m_max_gtm_bco_diff = 100;
 
   // needed to avoid memory leak. Assumes that we will not be assembling more than 50 events at the same time
   static constexpr unsigned int m_max_matching_data_size = 50;
@@ -124,8 +118,14 @@ namespace
 }  // namespace
 
 // this is the clock multiplier from lvl1 to fee clock
-/* todo: should replace with actual rational number for John K. */
 double MicromegasBcoMatchingInformation_v2::m_multiplier = 4.262916255;
+
+// muliplier adjustment count
+/* controls how often the gtm multiplier is automatically adjusted */
+unsigned int MicromegasBcoMatchingInformation_v2::m_max_multiplier_adjustment_count = 200;
+
+// define limit for matching fee_bco to fee_bco_predicted
+unsigned int MicromegasBcoMatchingInformation_v2::m_max_gtm_bco_diff = 100;
 
 //___________________________________________________
 std::optional<uint32_t> MicromegasBcoMatchingInformation_v2::get_predicted_fee_bco(uint64_t gtm_bco) const

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -110,6 +110,19 @@ class MicromegasBcoMatchingInformation_v2
     m_multiplier = value;
   }
 
+  /// muliplier adjustment count
+  /** controls how often the gtm multiplier is automatically adjusted */
+  static void set_max_multiplier_adjustment_count( unsigned int value )
+  {
+    m_max_multiplier_adjustment_count = value;
+  }
+
+  // define limit for matching fee_bco to fee_bco_predicted from gtm_bco
+  static void set_gtm_bco_diff( unsigned int value )
+  {
+    m_max_gtm_bco_diff = value;
+  }
+
   //! find reference from modebits
   bool find_reference_from_modebits(const gtm_payload&);
 
@@ -166,6 +179,13 @@ class MicromegasBcoMatchingInformation_v2
 
   //! gtm clock multiplier
   static double m_multiplier;
+
+  //! multiplier adjustment count
+  /* controls how often the gtm multiplier is automatically adjusted */
+  static unsigned int m_max_multiplier_adjustment_count;
+
+  // define limit for matching fee_bco to fee_bco_predicted
+  static unsigned int m_max_gtm_bco_diff;
 
   //! adjustment to multiplier
   double m_multiplier_adjustment = 0;


### PR DESCRIPTION
Changed frequency at which gtm multiplier is adjusted.
Make it a static adjustable parameter
Also make gtm_bco matching window a static adjustable parameter.

@osbornjd apparently the event decoding/assembling for TPOT cosmics is not working presently, due to incorrect gtm clock multiplier. This should fix it in a robust manner (while waiting for a firmware fix)

I'll post before/after offline QA plots as soon as I have them.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

