### PR TITLE
Trigger analyser compatible with track DSTs. KFP bug fix

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_triggerInfo.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_triggerInfo.cc
@@ -16,10 +16,14 @@ KFParticle_triggerInfo::~KFParticle_triggerInfo() = default;  // Destructor
 bool KFParticle_triggerInfo::buildTriggerBranches(PHCompositeNode *topNode, TTree *m_tree)
 {
   //First, check whether we actually have the right information
-  auto gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+  auto gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
   if (!gl1packet)
   {
-    return false;
+    gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+    if (!gl1packet)
+    {
+      return false;
+    }
   }
 
   auto triggerruninfo = findNode::getClass<TriggerRunInfo>(topNode, "TriggerRunInfo");

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -279,7 +279,6 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
       std::cout << "Have a global vertex with no " << vtxType << " vertex... shouldn't happen in KFParticle_truthAndDetTools::fillTruthBranch..." << std::endl;
     }
 
-/*
     auto svtxvertexvector = svtxviter->second;
     MbdVertex *mbdvertex = nullptr;
     SvtxVertex *svtxvertex = nullptr;
@@ -295,10 +294,8 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
         svtxvertex = dst_vertexmap->find(vertex_iter->get_id())->second;
       }
     }
-*/
 
     PHG4VtxPoint *truePoint = nullptr;
-/*
     if (m_use_mbd_vertex_truth)
     {
       std::set<PHG4VtxPoint*> truePointSet = vertexeval->all_truth_points(mbdvertex);
@@ -308,13 +305,11 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
     {
       truePoint = vertexeval->max_truth_point_by_ntracks(svtxvertex);
     }
-*/
+
     if (truePoint == nullptr && isParticleValid)
     {
-std::cout << "g4particle->get_parent_id() = " << g4particle->get_parent_id() << std::endl;
-      PHG4Particle *g4mother = m_truthinfo->GetParticle(g4particle->get_parent_id());
-      //PHG4Particle *g4mother = m_truthinfo->GetPrimaryParticle(g4particle->get_parent_id());
-g4mother->identify();
+      //PHG4Particle *g4mother = m_truthinfo->GetParticle(g4particle->get_parent_id());
+      PHG4Particle *g4mother = m_truthinfo->GetPrimaryParticle(g4particle->get_parent_id());
       truePoint = m_truthinfo->GetVtx(g4mother->get_vtx_id());  // Note, this may not be the PV for a decay with tertiaries
     }
 
@@ -361,10 +356,6 @@ g4mother->identify();
     m_true_daughter_pv_x[daughter_id] = truePoint == nullptr ? -99. : truePoint->get_x();
     m_true_daughter_pv_y[daughter_id] = truePoint == nullptr ? -99. : truePoint->get_y();
     m_true_daughter_pv_z[daughter_id] = truePoint == nullptr ? -99. : truePoint->get_z();
-std::cout << "m_true_daughter_vertex_x[" << daughter_id << "] = " << m_true_daughter_vertex_x[daughter_id] << ", m_true_daughter_pv_x[" << daughter_id << "] = " << m_true_daughter_pv_x[daughter_id] << ", delta = " << m_true_daughter_vertex_x[daughter_id] - m_true_daughter_pv_x[daughter_id] << std::endl;
-std::cout << "m_true_daughter_vertex_y[" << daughter_id << "] = " << m_true_daughter_vertex_y[daughter_id] << ", m_true_daughter_pv_y[" << daughter_id << "] = " << m_true_daughter_pv_y[daughter_id] << ", delta = " << m_true_daughter_vertex_y[daughter_id] - m_true_daughter_pv_y[daughter_id] << std::endl;
-std::cout << "m_true_daughter_vertex_z[" << daughter_id << "] = " << m_true_daughter_vertex_z[daughter_id] << ", m_true_daughter_pv_z[" << daughter_id << "] = " << m_true_daughter_pv_z[daughter_id] << ", delta = " << m_true_daughter_vertex_z[daughter_id] - m_true_daughter_pv_z[daughter_id] << std::endl;
-
   }
 }
 

--- a/offline/packages/trigger/TriggerAnalyzer.cc
+++ b/offline/packages/trigger/TriggerAnalyzer.cc
@@ -4,7 +4,6 @@
 #include "TriggerRunInfo.h"
 
 #include <ffarawobjects/Gl1Packet.h>
-
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
@@ -24,8 +23,12 @@ int TriggerAnalyzer::decodeTriggers(PHCompositeNode* topNode)
   gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
   if (!gl1packet)
   {
-    std::cout << " no gl1 packet" << std::endl;
-    return 1;
+    gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT"); //Different term used in track production
+    if (!gl1packet)
+    {
+      std::cout << "no gl1 packet" << std::endl;
+      return 1;
+    }
   }
   triggerruninfo = findNode::getClass<TriggerRunInfo>(topNode, "TriggerRunInfo");
   if (!triggerruninfo)
@@ -39,10 +42,14 @@ int TriggerAnalyzer::decodeTriggers(PHCompositeNode* topNode)
     return 0;
   }
   gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
-  if (!gl1packet) 
+  if (!gl1packet)
   {
-    std::cout << " no gl1 packet" << std::endl;
-    return 1;
+    gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT"); //Different term used in track production
+    if (!gl1packet)
+    {
+      std::cout << "no gl1 packet" << std::endl;
+      return 1;
+    }
   }
   triggerruninfo = findNode::getClass<TriggerRunInfo>(topNode, "TriggerRunInfo");
   if (!triggerruninfo) 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

I noticed our trigger analyser module isn't compatible with the tracker GL1 packets. Theyre named differently to avoid conflicts with calo DSTs. Chris is aware of this. @danjlis does this look ok to you as a fix?

I also accidentally submitted some test code for debugging truth matching in KFParticle. The bug only affects simulated data that requests truth matching

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

