### PR TITLE
Use *32 instead of *12 in IB_num calculation for CaloValid

### DIFF
--- a/offline/QA/Calorimeters/CaloValid.cc
+++ b/offline/QA/Calorimeters/CaloValid.cc
@@ -613,9 +613,7 @@ int CaloValid::process_towers(PHCompositeNode* topNode)
         unsigned int lt_eta = recoCluster->get_lead_tower().first;
         unsigned int lt_phi = recoCluster->get_lead_tower().second;
 
-        int ld_ib_eta = lt_eta / 8;
-        int ld_ib_phi = lt_phi / 8;
-        int IB_num    = ld_ib_eta * 12 + ld_ib_phi;
+        int IB_num = (lt_eta / 8)*32 + (lt_phi / 8);
 
         for (int bit : scaledActiveBits)
         {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Fixing IB numbering in TH3 histogram
## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

