### PR TITLE
Extend rho axes

### DIFF
--- a/offline/QA/Jet/RhosinEvent.cc
+++ b/offline/QA/Jet/RhosinEvent.cc
@@ -53,7 +53,7 @@ int RhosinEvent::Init(PHCompositeNode* /*topNode*/)
 
   // Initialize histograms
   const int N_rho_mult = 320;
-  const double rho_max_mult = 0.16
+  const double rho_max_mult = 0.16;
   Double_t N_rho_mult_bins[N_rho_mult + 1];
   for (int i = 0; i <= N_rho_mult; i++)
   {

--- a/offline/QA/Jet/RhosinEvent.cc
+++ b/offline/QA/Jet/RhosinEvent.cc
@@ -52,18 +52,20 @@ int RhosinEvent::Init(PHCompositeNode* /*topNode*/)
   }
 
   // Initialize histograms
-  const int N_rho_mult = 200;
+  const int N_rho_mult = 320;
+  const double rho_max_mult = 0.16
   Double_t N_rho_mult_bins[N_rho_mult + 1];
   for (int i = 0; i <= N_rho_mult; i++)
   {
-    N_rho_mult_bins[i] = (0.3 / 200.0) * i;
+    N_rho_mult_bins[i] = (rho_max_mult / 320.0) * i;
   }
 
-  const int N_rho_area = 200;
+  const int N_rho_area = 400;
+  const double rho_max_area = 200;
   Double_t N_rho_area_bins[N_rho_area + 1];
   for (int i = 0; i <= N_rho_area; i++)
   {
-    N_rho_area_bins[i] = (10.0 / 200.0) * i;
+    N_rho_area_bins[i] = (rho_max_area / 400.0) * i;
   }
 
   // make sure module name is lower case


### PR DESCRIPTION
This PR extends the axes of the histograms of the `RhosInEvent` Jet QA module.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

This addresses a bug noticed in Run24 Au+Au, namely that the axes of these histograms were optimized for p+p collisions.

