### PR TITLE
fix: memory leak in silicon seeding

### DIFF
--- a/offline/packages/trackbase_historic/TrackSeedContainer_v1.h
+++ b/offline/packages/trackbase_historic/TrackSeedContainer_v1.h
@@ -30,7 +30,6 @@ class TrackSeedContainer_v1 : public TrackSeedContainer
   TrackSeed* insert(const TrackSeed* seed) override;
   void erase(const std::size_t key) override
   {
-    delete m_seeds.at(key);
     m_seeds.at(key) = nullptr;
   }
 

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -115,48 +115,19 @@ int PHActsSiliconSeeding::process_event(PHCompositeNode* topNode)
     }
   }
 
-  auto eventTimer = std::make_unique<PHTimer>("eventTimer");
-  eventTimer->stop();
-  eventTimer->restart();
-
   if (Verbosity() > 0)
   {
     std::cout << "Processing PHActsSiliconSeeding event "
               << m_event << std::endl;
   }
 
-  std::vector<const SpacePoint*> spVec;
-  auto seedVector = runSeeder(spVec);
-
-  eventTimer->stop();
-  auto seederTime = eventTimer->get_accumulated_time();
-  eventTimer->restart();
-
-  makeSvtxTracks(seedVector);
-
-  eventTimer->stop();
-  auto circleFitTime = eventTimer->get_accumulated_time();
-
-  for (auto sp : spVec)
-  {
-    delete sp;
-  }
-  spVec.clear();
+  runSeeder();
+ 
 
   if (Verbosity() > 0)
   {
     std::cout << "Finished PHActsSiliconSeeding process_event"
               << std::endl;
-  }
-
-  if (Verbosity() > 0)
-  {
-    std::cout << "PHActsSiliconSeeding Acts seed time "
-              << seederTime << std::endl;
-    std::cout << "PHActsSiliconSeeding circle fit time "
-              << circleFitTime << std::endl;
-    std::cout << "PHActsSiliconSeeding total event time "
-              << circleFitTime + seederTime << std::endl;
   }
 
   m_event++;
@@ -182,12 +153,18 @@ int PHActsSiliconSeeding::End(PHCompositeNode* /*topNode*/)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
+void PHActsSiliconSeeding::runSeeder()
 {
   Acts::SeedFinder<SpacePoint> seedFinder(m_seedFinderCfg);
-  GridSeeds seedVector;
+
+  auto eventTimer = std::make_unique<PHTimer>("eventTimer");
+  eventTimer->stop();
+  int circleFitTime = 0;
+  int seederTime = 0;
+  int spTime = 0;
   for (int strobe = m_lowStrobeIndex; strobe < m_highStrobeIndex; strobe++)
   {
+    GridSeeds seedVector;
     /// Covariance converter functor needed by seed finder
     auto covConverter =
         [=](const SpacePoint& sp, float zAlign, float rAlign, float sigmaError)
@@ -201,9 +178,10 @@ GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
     };
 
     Acts::Extent rRangeSPExtent;
-
-    spVec = getSiliconSpacePoints(rRangeSPExtent, strobe);
-
+    eventTimer->restart();
+    auto spVec = getSiliconSpacePoints(rRangeSPExtent, strobe);
+    eventTimer->stop();
+    spTime += eventTimer->get_accumulated_time();
     if (m_seedAnalysis)
     {
       h_nInputMeas->Fill(spVec.size());
@@ -227,7 +205,10 @@ GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
     const Acts::Range1D<float> rMiddleSPRange(
         std::floor(rRangeSPExtent.min(Acts::binR) / 2) * 2 + 1.5,
         std::floor(rRangeSPExtent.max(Acts::binR) / 2) * 2 - 1.5);
+   
 
+
+    eventTimer->restart();
     SeedContainer seeds;
     seeds.clear();
     decltype(seedFinder)::SeedingState state;
@@ -243,11 +224,36 @@ GridSeeds PHActsSiliconSeeding::runSeeder(std::vector<const SpacePoint*>& spVec)
                                      top,
                                      rMiddleSPRange);
     }
+    eventTimer->stop();
+    seederTime += eventTimer->get_accumulated_time();
+    eventTimer->restart();
 
     seedVector.push_back(seeds);
+
+    makeSvtxTracks(seedVector);
+
+    eventTimer->stop();
+    circleFitTime += eventTimer->get_accumulated_time();
+
+    for (auto sp : spVec)
+    {
+      delete sp;
+    }
+    spVec.clear();
   }
 
-  return seedVector;
+  if (Verbosity() > 0)
+  {
+    std::cout << "PHActsSiliconSeeding spacepoint time "
+              << spTime << std::endl;
+    std::cout << "PHActsSiliconSeeding Acts seed time "
+              << seederTime << std::endl;
+    std::cout << "PHActsSiliconSeeding circle fit time "
+              << circleFitTime << std::endl;
+    std::cout << "PHActsSiliconSeeding total event time "
+              << spTime + circleFitTime + seederTime << std::endl;
+  }
+  return;
 }
 
 void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -58,7 +58,27 @@ PHActsSiliconSeeding::PHActsSiliconSeeding(const std::string& name)
   : SubsysReco(name)
 {
 }
-
+PHActsSiliconSeeding::~PHActsSiliconSeeding()
+{
+  delete m_file;
+  delete m_tree;
+  delete h_nInttProj;
+  delete h_nMvtxHits;
+  delete h_nInttHits;
+  delete h_nMatchedClusters;
+  delete h_nHits;
+  delete h_nSeeds;
+  delete h_nActsSeeds;
+  delete h_nTotSeeds;
+  delete h_nInputMeas;
+  delete h_nInputMvtxMeas;
+  delete h_nInputInttMeas;
+  delete h_hits;
+  delete h_zhits;
+  delete h_projHits;
+  delete h_zprojHits;
+  delete h_resids;
+}
 int PHActsSiliconSeeding::Init(PHCompositeNode* /*topNode*/)
 {
   Acts::SeedFilterConfig sfCfg = configureSeedFilter();

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -167,7 +167,7 @@ class PHActsSiliconSeeding : public SubsysReco
   int getNodes(PHCompositeNode *topNode);
   int createNodes(PHCompositeNode *topNode);
 
-  GridSeeds runSeeder(std::vector<const SpacePoint *> &spVec);
+  void runSeeder();
 
   /// Configure the seeding parameters for Acts. There
   /// are a number of tunable parameters for the seeder here

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -44,6 +44,7 @@ class PHActsSiliconSeeding : public SubsysReco
 {
  public:
   PHActsSiliconSeeding(const std::string &name = "PHActsSiliconSeeding");
+  ~PHActsSiliconSeeding() override;
   int Init(PHCompositeNode *topNode) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;

--- a/offline/packages/trackreco/PHSiliconSeedMerger.cc
+++ b/offline/packages/trackreco/PHSiliconSeedMerger.cc
@@ -89,6 +89,8 @@ int PHSiliconSeedMerger::process_event(PHCompositeNode *)
 	    { continue; }
 
 	  TrackSeed* track2 = m_siliconTracks->get(track2ID);
+	  if(track2 == nullptr)
+	    { continue; }
 	  std::set<TrkrDefs::cluskey> mvtx2Keys;
 	  for (TrackSeed::ConstClusterKeyIter iter = track2->begin_cluster_keys();
 	       iter != track2->end_cluster_keys();


### PR DESCRIPTION
This PR fixes a few memory leaks that were introduced into the silicon seeding when we moved to strobe by strobe reconstruction. Thanks to @hupereir for helping me spot the actual leak. The resolution is to move all the seeding code into the strobe loop so that the seeds and their corresponding space points are destroyed on a strobe by strobe basis

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

