### PR TITLE
Restore readback from file

### DIFF
--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -260,7 +260,8 @@ PHNodeIOManager::getBranchClassName(TBranch* branch)
   {
     // For this one we need to go down a little before getting the
     // name...
-    TLeafObject* leaf = dynamic_cast<TLeafObject*>(branch->GetLeaf(branch->GetName()));
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    TLeafObject* leaf = static_cast<TLeafObject*>(branch->GetLeaf(branch->GetName()));
     assert(leaf != nullptr);
     return leaf->GetTypeName();
   }
@@ -442,8 +443,7 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
     // later if a class is not loaded
     assert(thisClass != nullptr);
 
-    PHIODataNode<TObject>* newIODataNode =
-        dynamic_cast<PHIODataNode<TObject>*>(nodeIter.findFirst("PHIODataNode", *splitvec.rbegin()));
+    PHIODataNode<TObject>* newIODataNode = static_cast<PHIODataNode<TObject>*>(nodeIter.findFirst("PHIODataNode", *splitvec.rbegin()));// NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     if (!newIODataNode)
     {
       TObject* newTObject = static_cast<TObject*>(thisClass->New());

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -40,17 +40,17 @@ int MbdReco::Init(PHCompositeNode *topNode)
 
   m_mbdevent = std::make_unique<MbdEvent>(_calpass);
 
-  if (createNodes(topNode) == Fun4AllReturnCodes::ABORTEVENT)
-  {
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int MbdReco::InitRun(PHCompositeNode *topNode)
 {
+  if (createNodes(topNode) == Fun4AllReturnCodes::ABORTEVENT)
+  {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
   int ret = getNodes(topNode);
 
   m_mbdevent->SetSim(_simflag);
@@ -199,7 +199,7 @@ int MbdReco::createNodes(PHCompositeNode *topNode)
     bbcNode->addNode(MbdOutNode);
   }
 
-  m_mbdpmts = findNode::getClass<MbdPmtContainer>(bbcNode, "MbdPmtContainer");
+  m_mbdpmts = findNode::getClass<MbdPmtSimContainerV1>(bbcNode, "MbdPmtContainer");
   if (!m_mbdpmts)
   {
     m_mbdpmts = new MbdPmtContainerV1();

--- a/offline/packages/mbd/MbdReco.cc
+++ b/offline/packages/mbd/MbdReco.cc
@@ -33,7 +33,7 @@ MbdReco::MbdReco(const std::string &name)
 }
 
 //____________________________________________________________________________..
-int MbdReco::Init(PHCompositeNode *topNode)
+int MbdReco::Init(PHCompositeNode * /*topNode*/)
 {
   m_gaussian = std::make_unique<TF1>("gaussian", "gaus", 0, 20);
   m_gaussian->FixParameter(2, m_tres);

--- a/offline/packages/mbd/MbdReco.h
+++ b/offline/packages/mbd/MbdReco.h
@@ -25,7 +25,7 @@ class MbdReco : public SubsysReco
 
   ~MbdReco() override = default;
 
-  int Init(PHCompositeNode *topNode) override;
+  int Init(PHCompositeNode * /*topNode*/) override;
   int InitRun(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
There was a subtle issue caused by using a dynamic cast instead of a static cast brought to light by the mbd. The mbd created its nodes in Init() and when a file containing those nodes was opened, they did not overwrite them if the type doesn't match (the mbd has a separate sim object for the pmts which takes the place of the real data object, this is working - only the node creation tickled the problem in our PHNodeIOManager).
This PR restores the previous behavior of the PHNodeIOManager (overwriting existing nodes which have a different content) and moves the node creation to InitRun() in the MBD reco so it can react to nodes which are read from file
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

