### PR TITLE
feat: read MVTX survey shift from cdb

### DIFF
--- a/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxDetector.h
@@ -28,7 +28,8 @@ class PHG4MvtxDetector : public PHG4Detector
 {
  public:
   //! constructor
-  PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam);
+  PHG4MvtxDetector(PHG4Subsystem* subsys, PHCompositeNode* Node, const PHParametersContainer* _paramsContainer, const std::string& dnam,
+                   const bool applyMisalignment, const std::string& misalignmentfile);
 
   //! destructor
   ~PHG4MvtxDetector() override {}
@@ -97,6 +98,7 @@ class PHG4MvtxDetector : public PHG4Detector
 
   // For modified geometry
   bool apply_misalignment {false};
+  std::string m_misalignmentFile="";
   double m_GlobalDisplacementX = 0.0;
   double m_GlobalDisplacementY = 0.0;
   double m_GlobalDisplacementZ = 0.0;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxMisalignment.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxMisalignment.cc
@@ -14,7 +14,7 @@
 #include <utility>  // for pair, make_pair
 #include <vector>
 
-PHG4MvtxMisalignment::PHG4MvtxMisalignment() { LoadMvtxStaveAlignmentParameters(); }
+PHG4MvtxMisalignment::PHG4MvtxMisalignment() {}
 
 std::vector<double> PHG4MvtxMisalignment::get_GlobalDisplacement()
 {

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxMisalignment.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxMisalignment.h
@@ -24,6 +24,12 @@ class PHG4MvtxMisalignment
   virtual ~PHG4MvtxMisalignment() = default;
 
   std::vector<double> get_GlobalDisplacement();
+  void setAlignmentFile(const std::string &filename)
+  {
+    mvtxStaveAlignParamsFile = filename;
+  }
+
+  void LoadMvtxStaveAlignmentParameters();
 
  private:
   std::string mvtxStaveAlignParamsFile = "./MvtxStaveAlignmentParameters_Run2024.txt";  // TODO: either put this text file in CDB or create CDBTree)
@@ -31,7 +37,6 @@ class PHG4MvtxMisalignment
   double m_GlobalDisplacementY = 0.;
   double m_GlobalDisplacementZ = 0.;
 
-  void LoadMvtxStaveAlignmentParameters();
 };
 
 #endif

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.cc
@@ -76,12 +76,12 @@ int PHG4MvtxSubsystem::InitRunSubsystem(PHCompositeNode* topNode)
   {
     std::cout << "    create Mvtx detector with " << n_layers << " layers." << std::endl;
   }
-  m_Detector = new PHG4MvtxDetector(this, topNode, GetParamsContainer(), Name());
+  m_Detector = new PHG4MvtxDetector(this, topNode, GetParamsContainer(), Name(), m_ApplyMisalignment, m_misalignmentFile);
   m_Detector->Verbosity(Verbosity());
   m_Detector->SuperDetector(SuperDetector());
   m_Detector->Detector(detector_type);
   m_Detector->OverlapCheck(CheckOverlap());
-  m_Detector->ApplyMisalignment(m_ApplyMisalignment);
+
   if (Verbosity())
   {
     std::cout << "    ------ created detector " << Name() << std::endl;

--- a/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
+++ b/simulation/g4simulation/g4mvtx/PHG4MvtxSubsystem.h
@@ -46,6 +46,7 @@ class PHG4MvtxSubsystem : public PHG4DetectorGroupSubsystem
   PHG4DisplayAction* GetDisplayAction() const override { return m_DisplayAction; }
 
   void Apply_Misalignment(bool b) { m_ApplyMisalignment = b; }
+  void MisalignmentFile(const std::string& filename) { m_misalignmentFile = filename; }
 
  private:
   void SetDefaultParameters() override;
@@ -72,7 +73,7 @@ class PHG4MvtxSubsystem : public PHG4DetectorGroupSubsystem
   std::string detector_type;
   std::string m_HitNodeName;
   std::string m_SupportNodeName;
-
+  std::string m_misalignmentFile = "";
   bool m_ApplyMisalignment{false};
 };
 


### PR DESCRIPTION
This enables the mvtx large scale geometry shift to be read in from the survey file from the CDB that @hrjheng put together.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

