### PR TITLE
Construct hitsetkey-surface map without making geometry assumptions

### DIFF
--- a/offline/packages/trackreco/MakeActsGeometry.cc
+++ b/offline/packages/trackreco/MakeActsGeometry.cc
@@ -1049,8 +1049,6 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
       continue;
     }
 
-    double ref_rad[3] = {2.556, 3.359, 4.134};
-
     if (m_mvtxapplymisalign)
     {
       std::cout << "MakeActsGeometry::makeMvtxMapPairs - apply misalignment" << std::endl;
@@ -1068,6 +1066,7 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
     for (auto &j : surfaceVector)
     {
       auto surf = j->getSharedPtr();
+
       auto vec3d = surf->center(m_geoCtxt);
       std::vector<double> world_center = {(vec3d(0) - v_globaldisplacement[0]) / 10.0, (vec3d(1) - v_globaldisplacement[1]) / 10.0, (vec3d(2) - v_globaldisplacement[2]) / 10.0};  // convert from mm to cm
       double layer_rad = sqrt(pow(world_center[0], 2) + pow(world_center[1], 2));
@@ -1076,32 +1075,39 @@ void MakeActsGeometry::makeMvtxMapPairs(TrackingVolumePtr &mvtxVolume)
         std::cout << "[DEBUG] MVTX surface center (before misalignment): (x,y,z)=(" << vec3d(0) / 10. << "," << vec3d(1) / 10. << "," << vec3d(2) / 10. << "), layer_rad=" << sqrt(pow(vec3d(0) / 10., 2) + pow(vec3d(1) / 10., 2)) << std::endl;
         std::cout << "[DEBUG] MVTX surface center: (x,y,z)=(" << world_center[0] << "," << world_center[1] << "," << world_center[2] << "), layer_rad=" << layer_rad << std::endl;
       }
-      unsigned int layer = 0;
-      for (unsigned int i2 = 0; i2 < 3; ++i2)
-      {
-        if (fabs(layer_rad - ref_rad[i2]) < 0.1)
-        {
-          layer = i2;
-        }
-      }
 
-      TrkrDefs::hitsetkey hitsetkey = getMvtxHitSetKeyFromCoords(layer, world_center);
+      auto detelement = surf->associatedDetectorElement();
+      if(!detelement)
+	{
+	  std::cout << PHWHERE << " Did not find associatedDetectorElement, have to quit! " << std::endl;
+	  exit(1);
+	}
+      
+      Acts::GeometryIdentifier id = detelement->surface().geometryId();
+      unsigned int volume = id.volume();
+      unsigned int actslayer = id.layer();
+      unsigned int sphlayer = base_layer_map.find(volume)->second + actslayer / 2 - 1;
+      unsigned int sensor = id.sensitive() - 1;  // Acts sensor ID starts at 1
+	  
+      int stave = sensor / 9;
+      int chip = sensor % 9;	  
+      int dummy_strobe = 0;
+      TrkrDefs::hitsetkey hitsetkey= MvtxDefs::genHitSetKey(sphlayer, stave, chip, dummy_strobe);
 
       // Add this surface to the map
-      std::pair<TrkrDefs::hitsetkey, Surface> tmp = make_pair(hitsetkey, surf);
-
+      std::pair<TrkrDefs::hitsetkey, Surface> tmp = make_pair(hitsetkey, surf);      
       m_clusterSurfaceMapSilicon.insert(tmp);
 
       if (Verbosity() > 10)
       {
-        unsigned int stave = MvtxDefs::getStaveId(hitsetkey);
-        unsigned int chip = MvtxDefs::getChipId(hitsetkey);
+	unsigned int stavecheck = MvtxDefs::getStaveId(hitsetkey);
+	unsigned int chipcheck = MvtxDefs::getChipId(hitsetkey);
 
         double surface_phi = atan2(vec3d(1), vec3d(0)); // for debugging
 
         // check it is in there
         std::cout << "hitsetkey " << hitsetkey << " Layer radius " << layer_rad << " Layer "
-                  << layer << " stave " << stave << " chip " << chip
+                  << sphlayer << " stave " << stavecheck << " chip " << chipcheck
                   << " surface phi " << surface_phi
                   << " recover surface from m_clusterSurfaceMapSilicon "
                   << std::endl;

--- a/offline/packages/trackreco/MakeActsGeometry.h
+++ b/offline/packages/trackreco/MakeActsGeometry.h
@@ -279,6 +279,8 @@ class MakeActsGeometry : public SubsysReco
   /// Structs to put on the node tree which carry around ActsGeom info
   ActsGeometry *m_actsGeometry = nullptr;
 
+  std::map<unsigned int, unsigned int> base_layer_map = {{10, 0}, {12, 3}, {14, 7}, {16, 55}};
+  
   /// Verbosity value handed from PHActsSourceLinks
   //  int m_verbosity = 0;
 


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR modifies the making of the MVTX hitsetkey-surface association map to use only information from the detector element associated with the surface. It no longer makes assumptions about the MVTX geometry.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

