### PR TITLE
fix: zero size vector crash

### DIFF
--- a/offline/QA/Calorimeters/CaloFittingQA.cc
+++ b/offline/QA/Calorimeters/CaloFittingQA.cc
@@ -214,8 +214,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         }
         else 
         {
-          zs_energy = cemc_waveforms.at(channel).at(1) - cemc_waveforms.at(channel).at(0);
-          h_cemc_etaphi_pedestal->Fill(ieta, iphi, cemc_waveforms.at(channel).at(0));
+          if(cemc_waveforms.size() > 0)
+          {
+            zs_energy = cemc_waveforms.at(channel).at(1) - cemc_waveforms.at(channel).at(0);
+            h_cemc_etaphi_pedestal->Fill(ieta, iphi, cemc_waveforms.at(channel).at(0));
+          }
         }
         if (Verbosity() > 0) 
         {
@@ -248,8 +251,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         }
         else 
         {
-          zs_energy = ohcal_waveforms.at(channel).at(1) - ohcal_waveforms.at(channel).at(0);
-          h_ohcal_etaphi_pedestal->Fill(ieta, iphi, ohcal_waveforms.at(channel).at(0));
+          if(ohcal_waveforms.size() > 0)
+          {
+            zs_energy = ohcal_waveforms.at(channel).at(1) - ohcal_waveforms.at(channel).at(0);
+            h_ohcal_etaphi_pedestal->Fill(ieta, iphi, ohcal_waveforms.at(channel).at(0));
+          }
         }
         if (Verbosity() > 0) 
         {
@@ -282,8 +288,11 @@ int CaloFittingQA::process_towers(PHCompositeNode* topNode)
         }
         else 
         {
-          zs_energy = ihcal_waveforms.at(channel).at(1) - ihcal_waveforms.at(channel).at(0);
-          h_ihcal_etaphi_pedestal->Fill(ieta, iphi, ihcal_waveforms.at(channel).at(0));
+          if(ihcal_waveforms.size() > 0)
+          {
+            zs_energy = ihcal_waveforms.at(channel).at(1) - ihcal_waveforms.at(channel).at(0);
+            h_ihcal_etaphi_pedestal->Fill(ieta, iphi, ihcal_waveforms.at(channel).at(0));
+          }
         }
         if (Verbosity() > 0) 
         {


### PR DESCRIPTION
This fixes a bug in the calo fitting QA which occurs when a subsystem isn't in, so the waveform vector size is 0. Should allow us to test QA infrastructure now with ongoing cosmics

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

