### PR TITLE
replace illegal variable array by vector

### DIFF
--- a/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
+++ b/simulation/g4simulation/g4tpc/PHG4TpcCentralMembrane.cc
@@ -247,8 +247,8 @@ void PHG4TpcCentralMembrane::CalculateVertices(
 
   double theta = 0.0;
   // center coords
-  double cx[nStripes][nRadii];
-  double cy[nStripes][nRadii];
+  std::vector<std::vector<double>> cx(nStripes,std::vector<double>(nRadii));
+  std::vector<std::vector<double>> cy(nStripes,std::vector<double>(nRadii));
   // corner coords
   /* double tempX1a[nStripes][nRadii], tempY1a[nStripes][nRadii];
   double tempX1b[nStripes][nRadii], tempY1b[nStripes][nRadii];

--- a/simulation/g4simulation/g4tpc/configure.ac
+++ b/simulation/g4simulation/g4tpc/configure.ac
@@ -7,17 +7,11 @@ LT_INIT([disable-static])
 
 CXXFLAGS="$CXXFLAGS -Wall -Werror -Wextra -Wshadow"
 
-case $CXX in
- *analyzer)
-   CXXFLAGS="$CXXFLAGS -Wno-vla"
- ;;
- clang++)
-   CXXFLAGS="$CXXFLAGS -Wno-vla-extension -Wno-c11-extensions -Wno-deprecated-copy"
- ;;
- *g++)
-   CXXFLAGS="$CXXFLAGS -Wno-vla"
- ;;
-esac
+dnl case $CXX in
+dnl  clang++)
+dnl    CXXFLAGS="$CXXFLAGS -Wno-c11-extensions -Wno-deprecated-copy"
+dnl  ;;
+dnl esac
 
 CINTDEFS=" -noIncludePaths  -inlineInputHeader -Wno-inconsistent-missing-override "
 AC_SUBST(CINTDEFS)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
variable arrays are not part of the C++ standard and result in a warning. This PR replaces the last two cases of this in our code and re-enables the warning/Werror to prevent future re-introduction

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

