### PR TITLE
Enable use of `FastJetOpts` in FastJetAlgoSub

### DIFF
--- a/offline/packages/jetbackground/FastJetAlgoSub.cc
+++ b/offline/packages/jetbackground/FastJetAlgoSub.cc
@@ -15,13 +15,11 @@
 #include <memory>
 #include <vector>
 
-FastJetAlgoSub::FastJetAlgoSub(Jet::ALGO algo, float par, int verbosity)
-  : _verbosity(verbosity)
-  , _algo(algo)
-  , _par(par)
+FastJetAlgoSub::FastJetAlgoSub(const FastJetOptions& options)
+  : m_opt{options}
 {
   fastjet::ClusterSequence clusseq;
-  if (_verbosity > 0)
+  if (m_opt.verbosity > 0)
   {
     clusseq.print_banner();
   }
@@ -37,17 +35,17 @@ FastJetAlgoSub::FastJetAlgoSub(Jet::ALGO algo, float par, int verbosity)
 void FastJetAlgoSub::identify(std::ostream& os)
 {
   os << "   FastJetAlgoSub: ";
-  if (_algo == Jet::ANTIKT)
+  if (m_opt.algo == Jet::ANTIKT)
   {
-    os << "ANTIKT r=" << _par;
+    os << "ANTIKT r=" << m_opt.jet_R;
   }
-  else if (_algo == Jet::KT)
+  else if (m_opt.algo == Jet::KT)
   {
-    os << "KT r=" << _par;
+    os << "KT r=" << m_opt.jet_R;
   }
-  else if (_algo == Jet::CAMBRIDGE)
+  else if (m_opt.algo == Jet::CAMBRIDGE)
   {
-    os << "CAMBRIDGE r=" << _par;
+    os << "CAMBRIDGE r=" << m_opt.jet_R;
   }
   os << std::endl;
 }
@@ -58,7 +56,7 @@ void FastJetAlgoSub::identify(std::ostream& os)
 
 void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer* jetcont)
 {
-  if (_verbosity > 1)
+  if (m_opt.verbosity > 1)
   {
     std::cout << "FastJetAlgoSub::process_event -- entered" << std::endl;
   }
@@ -88,7 +86,7 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
       this_py = this_py * e_ratio;
       this_pz = this_pz * e_ratio;
 
-      if (_verbosity > 5)
+      if (m_opt.verbosity > 5)
       {
         std::cout << " FastJetAlgoSub input particle with negative-E, original kinematics px / py / pz / E = ";
         std::cout << particles[ipart]->get_px() << " / " << particles[ipart]->get_py() << " / " << particles[ipart]->get_pz() << " / " << particles[ipart]->get_e() << std::endl;
@@ -104,17 +102,17 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
 
   // run fast jet
   fastjet::JetDefinition* jetdef = nullptr;
-  if (_algo == Jet::ANTIKT)
+  if (m_opt.algo == Jet::ANTIKT)
   {
-    jetdef = new fastjet::JetDefinition(fastjet::antikt_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+    jetdef = new fastjet::JetDefinition(fastjet::antikt_algorithm, m_opt.jet_R, fastjet::E_scheme, fastjet::Best);
   }
-  else if (_algo == Jet::KT)
+  else if (m_opt.algo == Jet::KT)
   {
-    jetdef = new fastjet::JetDefinition(fastjet::kt_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+    jetdef = new fastjet::JetDefinition(fastjet::kt_algorithm, m_opt.jet_R, fastjet::E_scheme, fastjet::Best);
   }
-  else if (_algo == Jet::CAMBRIDGE)
+  else if (m_opt.algo == Jet::CAMBRIDGE)
   {
-    jetdef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, _par, fastjet::E_scheme, fastjet::Best);
+    jetdef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, m_opt.jet_R, fastjet::E_scheme, fastjet::Best);
   }
   else
   {
@@ -131,7 +129,7 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
   {
     auto jet = jetcont->add_jet();
 
-    if (_verbosity > 5 && fastjets[ijet].perp() > 15)
+    if (m_opt.verbosity > 5 && fastjets[ijet].perp() > 15)
     {
       std::cout << " FastJetAlgoSub : jet # " << ijet << " comes out of clustering with pt / eta / phi = " << fastjets[ijet].perp() << " / " << fastjets[ijet].eta() << " / " << fastjets[ijet].phi();
       std::cout << ", px / py / pz / e = " << fastjets[ijet].px() << " / " << fastjets[ijet].py() << " / " << fastjets[ijet].pz() << " / " << fastjets[ijet].e() << std::endl;
@@ -164,14 +162,14 @@ void FastJetAlgoSub::cluster_and_fill(std::vector<Jet*>& particles, JetContainer
     jet->set_e(total_e);
     jet->set_id(ijet);
 
-    if (_verbosity > 5 && fastjets[ijet].perp() > 15)
+    if (m_opt.verbosity > 5 && fastjets[ijet].perp() > 15)
     {
       std::cout << " FastJetAlgoSub : jet # " << ijet << " after correcting for proper constituent kinematics, pt / eta / phi = " << jet->get_pt() << " / " << jet->get_eta() << " / " << jet->get_phi();
       std::cout << ", px / py / pz / e = " << jet->get_px() << " / " << jet->get_py() << " / " << jet->get_pz() << " / " << jet->get_e() << std::endl;
     }
   }
 
-  if (_verbosity > 1)
+  if (m_opt.verbosity > 1)
   {
     std::cout << "FastJetAlgoSub::process_event -- exited" << std::endl;
   }

--- a/offline/packages/jetbackground/FastJetAlgoSub.h
+++ b/offline/packages/jetbackground/FastJetAlgoSub.h
@@ -1,6 +1,7 @@
 #ifndef JETBACKGROUND_FASTJETALGOSUB_H
 #define JETBACKGROUND_FASTJETALGOSUB_H
 
+#include <jetbase/FastJetOptions.h>
 #include <jetbase/Jet.h>
 #include <jetbase/JetAlgo.h>
 
@@ -12,20 +13,28 @@ class JetContainer;
 class FastJetAlgoSub : public JetAlgo
 {
  public:
-  FastJetAlgoSub(Jet::ALGO algo, float par, int verbosity = 0);
+  FastJetAlgoSub(const FastJetOptions& options);
   ~FastJetAlgoSub() override = default;
 
+  //----------------------------------------------------------------------
+  //  Legacy code interface. It is better to use FastJetOptions, but
+  //  there is no harm is using these, as well.
+  //----------------------------------------------------------------------
+  FastJetAlgoSub(Jet::ALGO algo, float par, int verbosity = 0)
+    : FastJetAlgoSub({{algo, JET_R, par, VERBOSITY, static_cast<float>(verbosity)}})
+  {
+  }
+  //--end-legacy-code-interface-------------------------------------------
+
   void identify(std::ostream& os = std::cout) override;
-  Jet::ALGO get_algo() override { return _algo; }
-  float get_par() override { return _par; }
+  Jet::ALGO get_algo() override { return m_opt.algo; }
+  float get_par() override { return m_opt.jet_R; }
 
   /* std::vector<Jet*> get_jets(std::vector<Jet*> particles) override; */
   void cluster_and_fill(std::vector<Jet*>& part_in, JetContainer* jets_out) override;
 
  private:
-  int _verbosity;
-  Jet::ALGO _algo;
-  float _par;
+  FastJetOptions m_opt{};
 };
 
 #endif


### PR DESCRIPTION
This PR extends the use of `FastJetOpts` to `FastJetAlgoSub`, following [coresoftware#2143](https://github.com/sPHENIX-Collaboration/coresoftware/pull/2143). Now both are symmetric in their handling of FastJet options.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## Links to other PRs in macros and calibration repositories (if applicable)

This PR is required to complete [macros#992](https://github.com/sPHENIX-Collaboration/macros/pull/992) which utilizes `FastJetOpts` to allow for greater flexibility to running jet reconstruction.