### PR TITLE
KFP: Updates for QM25

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -53,6 +53,7 @@
 #include <TMatrixD.h>
 #include "KFParticle_truthAndDetTools.h"
 
+#include <TFile.h>
 #include <TMatrixDfwd.h>  // for TMatrixD
 #include <TMatrixT.h>     // for TMatrixT, operator*
 
@@ -315,6 +316,35 @@ std::vector<KFParticle> KFParticle_Tools::makeAllDaughterParticles(PHCompositeNo
   return daughterParticles;
 }
 
+void KFParticle_Tools::getTracksFromBC(PHCompositeNode *topNode, const int &bunch_crossing, const std::string &vertexMapName, int &nTracks, int &nPVs)
+{
+  if (m_use_mbd_vertex) //If you're using the MBD vertex then there is no way to know which tracks are associated to it
+  {
+    return;
+  }
+
+  std::string vtxMN;
+  if (vertexMapName.empty())
+  {
+    vtxMN = m_vtx_map_node_name;
+  }
+  else
+  {
+    vtxMN = vertexMapName;
+  }
+
+  m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vtxMN);
+  for (SvtxVertexMap::ConstIter iter = m_dst_vertexmap->begin(); iter != m_dst_vertexmap->end(); ++iter)
+  {
+    m_dst_vertex = iter->second;
+    if ((int) m_dst_vertex->get_beam_crossing() == bunch_crossing)
+    {
+      nTracks += m_dst_vertex->size_tracks();
+      ++nPVs;
+    }
+  }
+}
+
 int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFParticle &vertex, const std::string &vertexMapName)
 {
   if (m_use_mbd_vertex) //If you're using the MBD vertex then there is no way to know which tracks are associated to it
@@ -332,14 +362,10 @@ int KFParticle_Tools::getTracksFromVertex(PHCompositeNode *topNode, const KFPart
     vtxMN = vertexMapName;
   }
 
-  SvtxVertex *associatedVertex = nullptr;
-  m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vtxMN);
-  auto globalvertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
-  GlobalVertex *associatedgvertex = globalvertexmap->find(vertex.Id())->second;
-  auto svtxvtx_id = associatedgvertex->find_vtxids(GlobalVertex::SVTX)->second;
-  associatedVertex = m_dst_vertexmap->find(svtxvtx_id)->second;
+  m_dst_vertexmap = findNode::getClass<SvtxVertexMap>(topNode, vertexMapName);
+  SvtxVertex* associated_vertex = m_dst_vertexmap->get(vertex.Id());
 
-  return associatedVertex->size_tracks();
+  return associated_vertex->size_tracks();   
 }
 
 /*const*/ bool KFParticle_Tools::isGoodTrack(const KFParticle &particle, const std::vector<KFParticle> &primaryVertices)
@@ -681,7 +707,7 @@ float KFParticle_Tools::flightDistanceChi2(const KFParticle &particle, const KFP
 
 std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters[], int daughterOrder[],
                                                            bool isIntermediate, int intermediateNumber, int nTracks,
-                                                           bool constrainMass, float required_vertexID)
+                                                           bool constrainMass, float required_vertexID, PHCompositeNode* topNode)
 {
   KFParticle mother;
   KFParticle *inputTracks = new KFParticle[nTracks];
@@ -689,6 +715,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   mother.SetConstructMethod(2);
 
   bool daughterMassCheck = true;
+  int particlesWithPID[] = {211, 321, 2212};
   float unique_vertexID = 0;
 
   // Figure out if the decay has reco. tracks mixed with resonances
@@ -735,6 +762,24 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
                           vDaughters[i].CovarianceMatrix(),
                           (Int_t) vDaughters[i].GetQ(),
                           daughterMass);
+
+    //Run PID check
+    if (m_use_PID)
+    {
+      int track_PDG_ID = (Int_t) vDaughters[i].GetQ()*daughterOrder[i];
+      if (std::find(std::begin(particlesWithPID), std::end(particlesWithPID), std::abs(track_PDG_ID)) != std::end(particlesWithPID))
+      {
+        float calculated_dEdx_value = get_dEdx(topNode, vDaughters[i]);
+        double expected_dEdx_value = get_dEdx_fitValue((Int_t) vDaughters[i].GetQ() * vDaughters[i].GetP(), track_PDG_ID);
+        bool accept_dEdx = isInRange((1-m_dEdx_band_width)*expected_dEdx_value, calculated_dEdx_value, (1+m_dEdx_band_width)*expected_dEdx_value);
+        if(!accept_dEdx)
+        {
+         delete [] inputTracks;
+         return std::make_tuple(mother, false);
+        }
+      }
+    }
+
     mother.AddDaughter(inputTracks[i]);
     unique_vertexID += (Int_t) vDaughters[i].GetQ() * getParticleMass(daughterOrder[i]);
   }
@@ -773,6 +818,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     }
   }
 
+
   float calculated_mass, calculated_mass_err;
   mother.GetMass(calculated_mass, calculated_mass_err);
   float calculated_pt = mother.GetPt();
@@ -784,6 +830,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
   float max_vertex_volume = isIntermediate ? m_intermediate_vertex_volume[intermediateNumber] : m_mother_vertex_volume;
 
   bool goodCandidate = false;
+
   if (calculated_mass >= min_mass && calculated_mass <= max_mass &&
       calculated_pt >= min_pt && daughterMassCheck && chargeCheck && calculateEllipsoidVolume(mother) <= max_vertex_volume)
   {
@@ -868,12 +915,12 @@ void KFParticle_Tools::constrainToVertex(KFParticle &particle, bool &goodCandida
   }
 }
 
-std::tuple<KFParticle, bool> KFParticle_Tools::getCombination(KFParticle vDaughters[], int daughterOrder[], KFParticle vertex, bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID)
+std::tuple<KFParticle, bool> KFParticle_Tools::getCombination(KFParticle vDaughters[], int daughterOrder[], KFParticle vertex, bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID, PHCompositeNode* topNode)
 {
   KFParticle candidate;
   bool isGoodCandidate;
 
-  std::tie(candidate, isGoodCandidate) = buildMother(vDaughters, daughterOrder, isIntermediate, intermediateNumber, nTracks, constrainMass, required_vertexID);
+  std::tie(candidate, isGoodCandidate) = buildMother(vDaughters, daughterOrder, isIntermediate, intermediateNumber, nTracks, constrainMass, required_vertexID, topNode);
 
   if (constrain_to_vertex && isGoodCandidate && !isIntermediate)
   {
@@ -1059,7 +1106,6 @@ float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &dau
   m_dst_trackmap = findNode::getClass<SvtxTrackMap>(topNode, m_trk_map_node_name.c_str());
   m_cluster_map = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   m_geom_container = findNode::getClass<PHG4TpcCylinderGeomContainer>(topNode, "CYLINDERCELLGEOM_SVTX");
-
   if(!m_cluster_map || !m_geom_container)
   {
     std::cout << "Can't continue in KFParticle_Tools::get_dEdx, returning -1" << std::endl;
@@ -1071,7 +1117,6 @@ float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &dau
 
   std::vector<TrkrDefs::cluskey> clusterKeys;
   clusterKeys.insert(clusterKeys.end(), tpcseed->begin_cluster_keys(), tpcseed->end_cluster_keys());
-
   std::vector<float> dedxlist;
   for (unsigned long cluster_key : clusterKeys)
   {
@@ -1113,15 +1158,44 @@ float KFParticle_Tools::get_dEdx(PHCompositeNode *topNode, const KFParticle &dau
   int trunc_max = (int)dedxlist.size()*0.7;
   float sumdedx = 0;
   int ndedx = 0;
-
   for(int j = trunc_min; j<=trunc_max;j++)
   {
     sumdedx+=dedxlist.at(j);
     ndedx++;
   }
-
   sumdedx/=ndedx;
   return sumdedx;
+}
+
+void KFParticle_Tools::init_dEdx_fits()
+{
+  std::string dedx_fitparams = CDBInterface::instance()->getUrl("TPC_DEDX_FITPARAM");
+  TFile *filefit = TFile::Open(dedx_fitparams.c_str());
+
+  if (!filefit->IsOpen())
+  {
+      std::cerr << "Error opening filefit!" << std::endl;
+      return;
+  }
+
+  filefit->GetObject("f_piband", f_pion_plus);
+  filefit->GetObject("f_Kband", f_kaon_plus);
+  filefit->GetObject("f_pband", f_proton_plus);
+  filefit->GetObject("f_piminus_band", f_pion_minus);
+  filefit->GetObject("f_Kminus_band", f_kaon_minus);
+  filefit->GetObject("f_pbar_band", f_proton_minus);
+
+  pidMap.insert(std::pair<int, TF1*>( 211,  f_pion_plus));
+  pidMap.insert(std::pair<int, TF1*>( 321,  f_kaon_plus));
+  pidMap.insert(std::pair<int, TF1*>( 2212, f_proton_plus));
+  pidMap.insert(std::pair<int, TF1*>(-211,  f_pion_minus));
+  pidMap.insert(std::pair<int, TF1*>(-321,  f_kaon_minus));
+  pidMap.insert(std::pair<int, TF1*>(-2212, f_proton_minus));
+}
+
+double KFParticle_Tools::get_dEdx_fitValue(float momentum, int PID)
+{
+  return pidMap[PID]->Eval(momentum);
 }
 
 bool KFParticle_Tools::checkTrackAndVertexMatch(KFParticle vDaughters[], int nTracks, KFParticle vertex)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -42,6 +42,8 @@
 
 #include <phool/getClass.h>
 
+#include <ffamodules/CDBInterface.h>
+
 // KFParticle stuff
 #include <KFParticle.h>
 #include <KFVertex.h>

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -29,6 +29,8 @@
 
 #include <KFParticle.h>
 
+#include <TF1.h>
+
 #include <limits>
 #include <string>   // for string
 #include <tuple>    // for tuple
@@ -59,6 +61,8 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   std::vector<KFParticle> makeAllDaughterParticles(PHCompositeNode *topNode);
 
+  void getTracksFromBC(PHCompositeNode *topNode, const int &bunch_crossing, const std::string &vertexMapName, int &nTracks, int &nPVs);
+
   int getTracksFromVertex(PHCompositeNode *topNode, const KFParticle &vertex, const std::string &vertexMapName);
 
   /*const*/ bool isGoodTrack(const KFParticle &particle, const std::vector<KFParticle> &primaryVertices);
@@ -81,12 +85,12 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float flightDistanceChi2(const KFParticle &particle, const KFParticle &vertex);
 
-  std::tuple<KFParticle, bool> buildMother(KFParticle vDaughters[], int daughterOrder[], bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID);
+  std::tuple<KFParticle, bool> buildMother(KFParticle vDaughters[], int daughterOrder[], bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID, PHCompositeNode* topNode);
 
   void constrainToVertex(KFParticle &particle, bool &goodCandidate, KFParticle &vertex);
 
   std::tuple<KFParticle, bool> getCombination(KFParticle vDaughters[], int daughterOrder[], KFParticle vertex,
-                                              bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID);
+                                              bool constrain_to_vertex, bool isIntermediate, int intermediateNumber, int nTracks, bool constrainMass, float required_vertexID, PHCompositeNode* topNode);
 
   std::vector<std::vector<int>> findUniqueDaughterCombinations(int start, int end);
 
@@ -108,6 +112,10 @@ class KFParticle_Tools : protected KFParticle_MVA
   void identify(const KFParticle &particle);
 
   float get_dEdx(PHCompositeNode *topNode, const KFParticle &daughter);
+
+  void init_dEdx_fits();
+
+  double get_dEdx_fitValue(float momentum, int PID);
 
   bool checkTrackAndVertexMatch(KFParticle vDaughters[], int nTracks, KFParticle vertex);
 
@@ -131,6 +139,18 @@ class KFParticle_Tools : protected KFParticle_MVA
   std::vector<float> m_intermediate_min_ipchi2;
   std::vector<float> m_intermediate_max_ipchi2;
   std::vector<float> m_intermediate_vertex_volume;
+
+  bool m_use_PID{false};
+  float m_dEdx_band_width {0.2}; //Fraction of expected dE/dx
+  
+  TF1 *f_pion_plus{nullptr};
+  TF1 *f_kaon_plus{nullptr};
+  TF1 *f_proton_plus{nullptr};
+  TF1 *f_pion_minus{nullptr};
+  TF1 *f_kaon_minus{nullptr};
+  TF1 *f_proton_minus{nullptr};
+
+  std::map<int, TF1*> pidMap;
 
   float m_min_mass {-1};
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -78,11 +78,11 @@ void KFParticle_eventReconstruction::createDecay(PHCompositeNode* topNode, std::
 
   if (!m_has_intermediates)
   {
-    buildBasicChain(selectedMother, selectedVertex, selectedDaughters, daughterParticles, goodTrackIndex, primaryVertices);
+    buildBasicChain(selectedMother, selectedVertex, selectedDaughters, daughterParticles, goodTrackIndex, primaryVertices, topNode);
   }
   else
   {
-    buildChain(selectedMother, selectedVertex, selectedDaughters, selectedIntermediates, daughterParticles, goodTrackIndex, primaryVertices);
+    buildChain(selectedMother, selectedVertex, selectedDaughters, selectedIntermediates, daughterParticles, goodTrackIndex, primaryVertices, topNode);
   }
 }
 
@@ -94,7 +94,7 @@ void KFParticle_eventReconstruction::buildBasicChain(std::vector<KFParticle>& se
                                                      std::vector<std::vector<KFParticle>>& selectedDaughtersBasic,
                                                      const std::vector<KFParticle>& daughterParticlesBasic,
                                                      const std::vector<int>& goodTrackIndexBasic,
-                                                     const std::vector<KFParticle>& primaryVerticesBasic)
+                                                     const std::vector<KFParticle>& primaryVerticesBasic, PHCompositeNode* topNode)
 {
   std::vector<std::vector<int>> goodTracksThatMeet = findTwoProngs(daughterParticlesBasic, goodTrackIndexBasic, m_num_tracks);
   for (int p = 3; p < m_num_tracks + 1; ++p)
@@ -103,7 +103,7 @@ void KFParticle_eventReconstruction::buildBasicChain(std::vector<KFParticle>& se
   }
 
   getCandidateDecay(selectedMotherBasic, selectedVertexBasic, selectedDaughtersBasic, daughterParticlesBasic,
-                    goodTracksThatMeet, primaryVerticesBasic, 0, m_num_tracks, false, 0, true);
+                    goodTracksThatMeet, primaryVerticesBasic, 0, m_num_tracks, false, 0, true, topNode);
 }
 
 /*
@@ -115,7 +115,7 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                                                 std::vector<std::vector<KFParticle>>& selectedIntermediatesAdv,
                                                 const std::vector<KFParticle>& daughterParticlesAdv,
                                                 const std::vector<int>& goodTrackIndexAdv,
-                                                const std::vector<KFParticle>& primaryVerticesAdv)
+                                                const std::vector<KFParticle>& primaryVerticesAdv, PHCompositeNode* topNode)
 {
   int track_start = 0;
   int track_stop = m_num_tracks_from_intermediate[0];
@@ -137,7 +137,7 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
                                        m_num_tracks_from_intermediate[i], p);
     }
     getCandidateDecay(potentialIntermediates[i], vertices, potentialDaughters[i], daughterParticlesAdv,
-                      goodTracksThatMeet, primaryVerticesAdv, track_start, track_stop, true, i, m_constrain_int_mass);
+                      goodTracksThatMeet, primaryVerticesAdv, track_start, track_stop, true, i, m_constrain_int_mass, topNode);
     track_start += track_stop;
     track_stop += m_num_tracks_from_intermediate[i + 1];
   }
@@ -278,7 +278,7 @@ void KFParticle_eventReconstruction::buildChain(std::vector<KFParticle>& selecte
               for (const auto& i_pv : primaryVerticesAdv)
               {
                 std::tie(candidate, isGood) = getCombination(motherDecayProducts, &uniqueCombination[0], i_pv,
-                                                             m_constrain_to_vertex, false, 0, num_mother_decay_products, m_constrain_int_mass, required_unique_vertexID);
+                                                             m_constrain_to_vertex, false, 0, num_mother_decay_products, m_constrain_int_mass, required_unique_vertexID, topNode);
                 if (isGood)
                 {
 
@@ -416,7 +416,7 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
                                                        const std::vector<std::vector<int>>& goodTracksThatMeetCand,
                                                        const std::vector<KFParticle>& primaryVerticesCand,
                                                        int n_track_start, int n_track_stop,
-                                                       bool isIntermediate, int intermediateNumber, bool constrainMass)
+                                                       bool isIntermediate, int intermediateNumber, bool constrainMass, PHCompositeNode* topNode)
 {
   int nTracks = n_track_stop - n_track_start;
   std::vector<std::vector<int>> uniqueCombinations = findUniqueDaughterCombinations(n_track_start, n_track_stop);
@@ -447,7 +447,7 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
       {
         int* PDGIDofFirstParticleInCombination = &uniqueCombination[0];
         std::tie(candidate, isGood) = getCombination(daughterTracks, PDGIDofFirstParticleInCombination, primaryVerticesCand[i_pv], m_constrain_to_vertex,
-                                                     isIntermediate, intermediateNumber, nTracks, constrainMass, required_unique_vertexID);
+                                                     isIntermediate, intermediateNumber, nTracks, constrainMass, required_unique_vertexID, topNode);
         if (isIntermediate && isGood)
         {
           float min_ip = 0;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -537,7 +537,7 @@ int KFParticle_eventReconstruction::selectBestCombination(bool PVconstraint, boo
   int bestCombinationIndex = 0;
   for (unsigned int i = 1; i < possibleCandidates.size(); ++i)
   {
-    if (PVconstraint && !isAnInterMother && !m_require_track_and_vertex_match)
+    if (PVconstraint && !isAnInterMother)
     {
       float current_IPchi2 = 0;
       float best_IPchi2 = 0;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.h
@@ -56,7 +56,7 @@ class KFParticle_eventReconstruction : public KFParticle_Tools
                        std::vector<std::vector<KFParticle>>& selectedDaughtersBasic,
                        const std::vector<KFParticle>& daughterParticlesBasic,
                        const std::vector<int>& goodTrackIndexBasic,
-                       const std::vector<KFParticle>& primaryVerticesBasic);
+                       const std::vector<KFParticle>& primaryVerticesBasic, PHCompositeNode* topNode);
 
   /// Used to reconstruct more complicated decays with up to four intermediate states
   void buildChain(std::vector<KFParticle>& selectedMotherAdv,
@@ -65,7 +65,7 @@ class KFParticle_eventReconstruction : public KFParticle_Tools
                   std::vector<std::vector<KFParticle>>& selectedIntermediatesAdv,
                   const std::vector<KFParticle>& daughterParticlesAdv,
                   const std::vector<int>& goodTrackIndexAdv,
-                  const std::vector<KFParticle>& primaryVerticesAdv);
+                  const std::vector<KFParticle>& primaryVerticesAdv, PHCompositeNode* topNode);
 
   /// Basic building block for event reconstruction and selection
   void getCandidateDecay(std::vector<KFParticle>& selectedMotherCand,
@@ -75,7 +75,7 @@ class KFParticle_eventReconstruction : public KFParticle_Tools
                          const std::vector<std::vector<int>>& goodTracksThatMeetCand,
                          const std::vector<KFParticle>& primaryVerticesCand,
                          int n_track_start, int n_track_stop,
-                         bool isIntermediate, int intermediateNumber, bool constrainMass);
+                         bool isIntermediate, int intermediateNumber, bool constrainMass, PHCompositeNode* topNode);
 
   /// Method to chose best candidate from a selection of common SV's
   int selectBestCombination(bool PVconstraint, bool isAnInterMother,

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -2,7 +2,8 @@
 
 #include "KFParticle_Tools.h"
 
-#include <ffaobjects/EventHeaderv1.h>
+#include <ffaobjects/EventHeader.h>
+#include <ffarawobjects/Gl1Packet.h>
 
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
@@ -106,7 +107,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
   m_tree->Branch(TString(mother_name) + "_phi", &m_calculated_mother_phi, TString(mother_name) + "_phi/F");
   m_tree->Branch(TString(mother_name) + "_vertex_volume", &m_calculated_mother_v, TString(mother_name) + "_vertex_volume/F");
   m_tree->Branch(TString(mother_name) + "_chi2", &m_calculated_mother_chi2, TString(mother_name) + "_chi2/F");
-  m_tree->Branch(TString(mother_name) + "_nDoF", &m_calculated_mother_ndof, TString(mother_name) + "_nDoF/I");
+  m_tree->Branch(TString(mother_name) + "_nDoF", &m_calculated_mother_ndof, TString(mother_name) + "_nDoF/i");
   m_tree->Branch(TString(mother_name) + "_SV_chi2_per_nDoF", &m_calculated_mother_SV_chi2_per_ndof, TString(mother_name) + "_SV_chi2_per_nDoF/F");
   m_tree->Branch(TString(mother_name) + "_PDG_ID", &m_calculated_mother_pdgID, TString(mother_name) + "_PDG_ID/I");
   m_tree->Branch(TString(mother_name) + "_Covariance", &m_calculated_mother_cov, TString(mother_name) + "_Covariance[21]/F", 21);
@@ -165,7 +166,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
       m_tree->Branch(TString(intermediate_name) + "_phi", &m_calculated_intermediate_phi[i], TString(intermediate_name) + "_phi/F");
       m_tree->Branch(TString(intermediate_name) + "_vertex_volume", &m_calculated_intermediate_v[i], TString(intermediate_name) + "_vertex_volume/F");
       m_tree->Branch(TString(intermediate_name) + "_chi2", &m_calculated_intermediate_chi2[i], TString(intermediate_name) + "_chi2/F");
-      m_tree->Branch(TString(intermediate_name) + "_nDoF", &m_calculated_intermediate_ndof[i], TString(intermediate_name) + "_nDoF/I");
+      m_tree->Branch(TString(intermediate_name) + "_nDoF", &m_calculated_intermediate_ndof[i], TString(intermediate_name) + "_nDoF/i");
       m_tree->Branch(TString(intermediate_name) + "_SV_chi2_per_nDoF", &m_calculated_intermediate_SV_chi2_per_ndof[i], TString(intermediate_name) + "_SV_chi2_per_nDoF/F");
       m_tree->Branch(TString(intermediate_name) + "_PDG_ID", &m_calculated_intermediate_pdgID[i], TString(intermediate_name) + "_PDG_ID/I");
       m_tree->Branch(TString(intermediate_name) + "_Covariance", &m_calculated_intermediate_cov[i], TString(intermediate_name) + "_Covariance[21]/F", 21);
@@ -224,7 +225,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch(TString(daughter_number) + "_theta", &m_calculated_daughter_theta[i], TString(daughter_number) + "_theta/F");
     m_tree->Branch(TString(daughter_number) + "_phi", &m_calculated_daughter_phi[i], TString(daughter_number) + "_phi/F");
     m_tree->Branch(TString(daughter_number) + "_chi2", &m_calculated_daughter_chi2[i], TString(daughter_number) + "_chi2/F");
-    m_tree->Branch(TString(daughter_number) + "_nDoF", &m_calculated_daughter_ndof[i], TString(daughter_number) + "_nDoF/I");
+    m_tree->Branch(TString(daughter_number) + "_nDoF", &m_calculated_daughter_ndof[i], TString(daughter_number) + "_nDoF/i");
     m_tree->Branch(TString(daughter_number) + "_track_ID", &m_calculated_daughter_trid[i], TString(daughter_number) + "_track_ID/I");
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
@@ -269,7 +270,6 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch("primary_vertex_x", &m_calculated_vertex_x, "primary_vertex_x/F");
     m_tree->Branch("primary_vertex_y", &m_calculated_vertex_y, "primary_vertex_y/F");
     m_tree->Branch("primary_vertex_z", &m_calculated_vertex_z, "primary_vertex_z/F");
-    m_tree->Branch("primary_vertex_nTracks", &m_calculated_vertex_nTracks, "primary_vertex_nTracks/I");
     m_tree->Branch("primary_vertex_volume", &m_calculated_vertex_v, "primary_vertex_volume/F");
     m_tree->Branch("primary_vertex_chi2", &m_calculated_vertex_chi2, "primary_vertex_chi2/F");
     m_tree->Branch("primary_vertex_nDoF", &m_calculated_vertex_ndof, "primary_vertex_nDoF/i");
@@ -291,6 +291,7 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
 
   m_tree->Branch("runNumber", &m_runNumber, "runNumber/I");
   m_tree->Branch("eventNumber", &m_evtNumber, "eventNumber/I");
+  m_tree->Branch("BCO", &m_bco, "BCO/L");
 
   if (m_get_trigger_info)
   {
@@ -302,8 +303,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
                                    KFParticle motherParticle,
                                    const KFParticle& vertex_fillbranch,
                                    std::vector<KFParticle> daughters,
-                                   std::vector<KFParticle> intermediates,
-                                   int nPVs, int multiplicity)
+                                   std::vector<KFParticle> intermediates)
 {
   const float speedOfLight = 2.99792458e-2;
 
@@ -603,13 +603,15 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     {
       m_calculated_vertex_cov[j] = vertex_fillbranch.GetCovariance(j);
     }
-    m_calculated_vertex_nTracks = m_use_fake_pv_nTuple || m_use_mbd_vertex_truth ? 0 : kfpTupleTools.getTracksFromVertex(topNode, vertex_fillbranch, m_vtx_map_node_name_nTuple);
   }
 
   m_sv_mass = calc_secondary_vertex_mass_noPID(daughters);
 
-  m_nPVs = nPVs;
-  m_multiplicity = multiplicity;
+  kfpTupleTools.getTracksFromBC(topNode, m_calculated_daughter_bunch_crossing[0], m_vtx_map_node_name_nTuple, m_multiplicity, m_nPVs);  
+  if (m_constrain_to_vertex_nTuple)
+  {
+    m_multiplicity = kfpTupleTools.getTracksFromVertex(topNode, vertex_fillbranch, m_vtx_map_node_name_nTuple);
+  }
 
   PHNodeIterator nodeIter(topNode);
 
@@ -617,13 +619,20 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
 
   if (evtNode)
   {
-    EventHeaderv1* evtHeader = findNode::getClass<EventHeaderv1>(topNode, "EventHeader");
+    EventHeader* evtHeader = findNode::getClass<EventHeader>(topNode, "EventHeader");
     m_runNumber = evtHeader->get_RunNumber();
     m_evtNumber = evtHeader->get_EvtSequence();
+
+    auto gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1RAWHIT");
+    if (!gl1packet)
+    {
+      gl1packet = findNode::getClass<Gl1Packet>(topNode, "GL1Packet");
+    }
+    m_bco = m_trigger_info_available ? gl1packet->lValue(0, "BCO") + m_calculated_daughter_bunch_crossing[0] : 0;
   }
   else
   {
-    m_runNumber = m_evtNumber = -1;
+    m_runNumber = m_evtNumber = m_bco = -1;
   }
 
   if (m_trigger_info_available)

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -32,8 +32,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
                   KFParticle motherParticle,
                   const KFParticle &vertex,
                   std::vector<KFParticle> daughters,
-                  std::vector<KFParticle> intermediates,
-                  int nPVs, int multiplicity);
+                  std::vector<KFParticle> intermediates);
 
   float calc_secondary_vertex_mass_noPID(std::vector<KFParticle> kfp_daughters);
 
@@ -127,7 +126,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   float m_calculated_intermediate_phi[max_intermediates] = {0};
   float m_calculated_intermediate_v[max_intermediates] = {0};
   float m_calculated_intermediate_chi2[max_intermediates] = {0};
-  float m_calculated_intermediate_ndof[max_intermediates] = {0};
+  int m_calculated_intermediate_ndof[max_intermediates] = {0};
   float m_calculated_intermediate_SV_chi2_per_ndof[max_intermediates] = {0};
   int m_calculated_intermediate_pdgID[max_intermediates] = {0};
   // float *m_calculated_intermediate_cov[max_intermediates];
@@ -172,7 +171,6 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   float m_calculated_vertex_y = -1;
   float m_calculated_vertex_z = -1;
   float m_calculated_vertex_v = -1;
-  int m_calculated_vertex_nTracks = -1;
   float m_calculated_vertex_chi2 = -1;
   unsigned int m_calculated_vertex_ndof = -1;
   int m_calculated_vertex_ID = -1;
@@ -186,6 +184,7 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
 
   int m_runNumber = -1;
   int m_evtNumber = -1;
+  int64_t m_bco = -1;
 
   bool m_trigger_info_available {false};
 };

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -115,6 +115,11 @@ int KFParticle_sPHENIX::Init(PHCompositeNode *topNode)
     triggeranalyzer = new TriggerAnalyzer();
   }
 
+  if (m_use_PID)
+  {
+    init_dEdx_fits();
+  }
+
   return returnCode;
 }
 
@@ -201,7 +206,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
 
       if (m_save_output)
       {
-        fillBranch(topNode, mother[i], vertex_kfparticle[i], daughters[i], intermediates[i], nPVs, multiplicity);
+        fillBranch(topNode, mother[i], vertex_kfparticle[i], daughters[i], intermediates[i]);
       }
       if (m_save_dst)
       {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -321,6 +321,10 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void requireTrackVertexBunchCrossingMatch(bool require = true) { m_require_track_and_vertex_match = require; }
 
+  void usePID(bool use = true){ m_use_PID = use; }
+ 
+  void setPIDacceptFraction(float frac = 0.2){ m_dEdx_band_width = frac; }
+
   /// Use alternate vertex and track fitters
   void setVertexMapNodeName(const std::string &vtx_map_node_name) { m_vtx_map_node_name = m_vtx_map_node_name_nTuple = vtx_map_node_name; }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.cc
@@ -310,7 +310,16 @@ void KFParticle_truthAndDetTools::fillTruthBranch(PHCompositeNode *topNode, TTre
     {
       //PHG4Particle *g4mother = m_truthinfo->GetParticle(g4particle->get_parent_id());
       PHG4Particle *g4mother = m_truthinfo->GetPrimaryParticle(g4particle->get_parent_id());
-      truePoint = m_truthinfo->GetVtx(g4mother->get_vtx_id());  // Note, this may not be the PV for a decay with tertiaries
+      if (!g4mother)
+      {
+        std::cout << "KFParticle truth matching: True mother not found!\n";
+        std::cout << "Your truth track DCA will be measured wrt a reconstructed vertex!" << std::endl;
+        truePoint = nullptr;
+      }
+      else
+      {
+        truePoint = m_truthinfo->GetVtx(g4mother->get_vtx_id());  // Note, this may not be the PV for a decay with tertiaries
+      }
     }
 
     KFParticle trueKFParticleVertex;
@@ -571,22 +580,26 @@ void KFParticle_truthAndDetTools::initializeSubDetectorBranches(TTree *m_tree, c
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_staveID", &mvtx_staveID[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_chipID", &mvtx_chipID[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nHits", &detector_nHits_MVTX[daughter_id]);
+    m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nStates", &detector_nStates_MVTX[daughter_id]);
   }
   if (detectorName == "INTT")
   {
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_ladderZID", &intt_ladderZID[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_ladderPhiID", &intt_ladderPhiID[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nHits", &detector_nHits_INTT[daughter_id]);
+    m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nStates", &detector_nStates_INTT[daughter_id]);
   }
   if (detectorName == "TPC")
   {
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_sectorID", &tpc_sectorID[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_side", &tpc_side[daughter_id]);
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nHits", &detector_nHits_TPC[daughter_id]);
+    m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nStates", &detector_nStates_TPC[daughter_id]);
   }
   if (detectorName == "TPOT")
   {
     m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nHits", &detector_nHits_TPOT[daughter_id]);
+    m_tree->Branch(TString(daughter_number) + "_" + TString(detectorName) + "_nStates", &detector_nStates_TPOT[daughter_id]);
   }
 }
 
@@ -714,7 +727,28 @@ void KFParticle_truthAndDetTools::fillDetectorBranch(PHCompositeNode *topNode,
   
       residual_x[daughter_id].push_back(global.x() - tstate->get_x());
       residual_y[daughter_id].push_back(global.y() - tstate->get_y());
-      residual_z[daughter_id].push_back(global.z() - tstate->get_z()); 
+      residual_z[daughter_id].push_back(global.z() - tstate->get_z());
+
+      uint8_t id = TrkrDefs::getTrkrId(stateckey);
+    
+      switch (id)
+      {
+        case TrkrDefs::mvtxId:
+          ++detector_nStates_MVTX[daughter_id];
+          break;
+        case TrkrDefs::inttId:
+          ++detector_nStates_INTT[daughter_id];
+          break;
+        case TrkrDefs::tpcId:
+          ++detector_nStates_TPC[daughter_id];
+          break;
+        case TrkrDefs::micromegasId:
+          ++detector_nStates_TPOT[daughter_id];
+          break;
+        default:
+         std::cout << "Cluster key doesnt match a tracking system, this shouldn't happen" << std::endl;
+         break; 
+      }
     }
   }
 }
@@ -811,6 +845,11 @@ void KFParticle_truthAndDetTools::clearVectors()
     intt_ladderPhiID[i].clear();
     tpc_sectorID[i].clear();
     tpc_side[i].clear();
+
+    detector_nStates_MVTX[i] = 0;
+    detector_nStates_INTT[i] = 0;
+    detector_nStates_TPC[i] = 0;
+    detector_nStates_TPOT[i] = 0;
 
     // PV vectors
     allPV_daughter_IP[i].clear();

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_truthAndDetTools.h
@@ -146,6 +146,10 @@ class KFParticle_truthAndDetTools
   unsigned int detector_nHits_INTT[max_tracks] = {0};
   unsigned int detector_nHits_TPC[max_tracks] =  {0};
   unsigned int detector_nHits_TPOT[max_tracks] = {0};
+  unsigned int detector_nStates_MVTX[max_tracks] = {0};
+  unsigned int detector_nStates_INTT[max_tracks] = {0};
+  unsigned int detector_nStates_TPC[max_tracks] =  {0};
+  unsigned int detector_nStates_TPOT[max_tracks] = {0};
   std::vector<float> residual_x[max_tracks];
   std::vector<float> residual_y[max_tracks];
   std::vector<float> residual_z[max_tracks];


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
Several new KFParticle features:

1.     User can require the primary vertex used in the reconstruction has a bunch crossing that matches the candidate daughter tracks (reduced background)
2.     User can require PID of kaons, pions and protons using dE/dx information. Uses Michaels parameterization of dE/dx bands as requires a match in a user defined fraction (default is 20%).
3.     Number of track states from each tracking subsystem saved in nTuple
4.     Some bug fixes for saving nDoF branches
5.     New branch that saves tracks full BCO for duplicate rejection
6.     Updates branch to save number of PVs in a bunch crossing, and number of tracks from that PV

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

