### PR TITLE
Fixed bug where tt sometimes had q, when it should be 0.

### DIFF
--- a/generators/sphstarlight/StarLight_To_HepMc.cc
+++ b/generators/sphstarlight/StarLight_To_HepMc.cc
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
 {
   if (argc != 3)
   {
-    std::cerr << "Usage: " << argv[0] << " <HepMC_output_file>" << std::endl;
+    std::cerr << "Usage: " << argv[0] << "<starlight_file> <HepMC_output_file>" << std::endl;
     return 1;
   }
 

--- a/offline/packages/mbd/MbdEvent.h
+++ b/offline/packages/mbd/MbdEvent.h
@@ -37,6 +37,7 @@ class MbdEvent
 #ifndef ONLINE
   int SetRawData(CaloPacketContainer *mbdraw, MbdPmtContainer *bbcpmts, Gl1Packet *gl1raw);
 #endif
+  void PostProcessChannels(MbdPmtContainer *bbcpmts);
   int Calculate(MbdPmtContainer *bbcpmts, MbdOut *bbcout);
   int InitRun();
   int End();
@@ -86,6 +87,8 @@ class MbdEvent
   int Read_TQ_CLK_Offsets(const std::string &t0cal_fname);
   int Read_TT_CLK_Offsets(const std::string &t0cal_fname);
   //int DoQuickClockOffsetCalib();
+
+  bool isbadtch(const int ipmtch);
 
   int _debugintt{0};
   void ReadSyncFile(const char *fname = "SYNC_INTTMBD.root");

--- a/offline/packages/mbd/MbdOutV2.h
+++ b/offline/packages/mbd/MbdOutV2.h
@@ -32,59 +32,59 @@ class MbdOutV2 : public MbdOut
   PHObject* CloneMe() const override { return new MbdOutV2(*this); }
   void CopyTo(MbdOut *mbd) override;
 
-  /// get ZVertex determined by Bbc
+  /// get ZVertex determined by MBD
   Float_t get_zvtx() const override { return bz; }
 
-  /// get Error on ZVertex determined by Bbc
+  /// get Error on ZVertex determined by MBD
   Float_t get_zvtxerr() const override { return bzerr; }
 
-  /// get T0 determined by Bbc
+  /// get T0 determined by MBD
   Float_t get_t0() const override { return bt0; }
 
-  /// get Error on T0 determined by Bbc
+  /// get Error on T0 determined by MBD
   Float_t get_t0err() const override { return bt0err; }
 
-  /** set T0 for Bbc
-      @param t0 Bbc T0
-      @param t0err Bbc T0 error
+  /** set T0 for MBD
+      @param t0 MBD T0
+      @param t0err MBD T0 error
    */
   void set_t0(const Float_t t0, const Float_t t0err = 0) override;
 
   //! set vertex
   void set_zvtx(const Float_t vtx, const Float_t vtxerr = 0) override;
 
-  /** set Vtx Error for Bbc
-      @param vtxerr Bbc Vtx Error
+  /** set Vtx Error for MBD
+      @param vtxerr MBD Vtx Error
   */
   void set_zvtxerr(const Float_t vtxerr) override;
 
-  /** Add Bbc North/South data containing Number of pmt's, Energy and Timing
+  /** Add MBD North/South data containing Number of pmt's, Energy and Timing
       @param npmt Number of PMT's fired
       @param energy Energy in North/South
       @param timing Timing of North/South
-      @param iarm  Arm, use Bbc::North and Bbc::South
+      @param iarm  Arm, use MBD::North and MBD::South
    */
   void set_arm(const int iarm, const Short_t npmt, const Float_t chargesum, const Float_t timing) override;
 
-  /** Add Bbc data containing evt, clk, and femclk
+  /** Add Mbd data containing evt, clk, and femclk
       @param ievt   Event number
       @param iclk    XMIT clock
       @param ifemclk FEM clock
    */
   virtual void set_clocks(const Int_t ievt, const UShort_t iclk, const UShort_t ifemclk) override;
 
-  /** get Number of PMT's fired in North/South Bbc
-      @param iarm  Arm, use Bbc::North and Bbc::South
+  /** get Number of PMT's fired in North/South MBD
+      @param iarm  Arm, use MBD::North and MBD::South
    */
   Short_t get_npmt(const int iarm) const override;
 
-  /** get Number of Charged Particles into North/South Bbc
-      @param iarm  Arm, use Bbc::North and Bbc::South
+  /** get Number of Charged Particles into North/South MBD
+      @param iarm  Arm, use MBD::North and MBD::South
    */
   Float_t get_q(const int iarm) const override;
 
-  /** get Timing of North/South Bbc
-      @param iarm  Arm, use Bbc::North and Bbc::South
+  /** get Timing of North/South MBD
+      @param iarm  Arm, use MBD::North and MBD::South
    */
   Float_t get_time(const int iarm) const override;
 

--- a/offline/packages/mbd/MbdSig.cc
+++ b/offline/packages/mbd/MbdSig.cc
@@ -93,13 +93,10 @@ void MbdSig::SetTemplateSize(const Int_t nptsx, const Int_t nptsy, const Double_
   Double_t ybinwid = (1.1 + 0.1) / template_npointsy;  // yscale... should we vary this?
   
   
-    delete h2Template;
+  delete h2Template;
   
+  delete h2Residuals;
   
-  
-    delete h2Residuals;
-  
-
   TString name = "h2Template";
   name += _ch;
   h2Template = new TH2F(name, name, template_npointsx, template_begintime - (xbinwid / 2.), template_endtime + (xbinwid / 2),
@@ -918,6 +915,23 @@ void MbdSig::Print()
     gpulse->GetPoint(isamp, x, y);
     std::cout << isamp << "\t" << x << "\t" << y << std::endl;
   }
+}
+
+void MbdSig::DrawWaveform()
+{
+  int orig_verbose = _verbose;
+  if ( _verbose <= 5 )
+  {
+    _verbose = 6;
+  }
+
+  gSubPulse->Draw("ap");
+  gSubPulse->GetHistogram()->SetTitle(gSubPulse->GetName());
+  gPad->SetGridy(1);
+  if ( template_fcn!=nullptr ) template_fcn->Draw("same");  // should check if fit was made
+  PadUpdate();
+
+  _verbose = orig_verbose;
 }
 
 void MbdSig::PadUpdate() const

--- a/offline/packages/mbd/MbdSig.h
+++ b/offline/packages/mbd/MbdSig.h
@@ -114,6 +114,7 @@ class MbdSig
 
   void WritePedHist();
 
+  void DrawWaveform();      /// Draw Subtracted Waveform
   void PadUpdate() const;
   void Print();
   void Verbose(const int v) { _verbose = v; }


### PR DESCRIPTION
[comment]: Fixed bug where sometimes the time from the timing channel would be nan, ie, there was no hit that triggered the threshold in the time channel, but the charge was still reconstructed (from the noise samples).

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: 


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

