### PR TITLE
Miscellaneous fixes to Structure in Jets QA

### DIFF
--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -15,6 +15,8 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/getClass.h>
 
+#include <qautils/QAHistManagerDef.h>
+
 #include <trackbase_historic/SvtxTrack.h>
 #include <trackbase_historic/SvtxTrackMap.h>
 #include <trackbase_historic/TrackSeed.h>
@@ -60,6 +62,7 @@ int StructureinJets::Init(PHCompositeNode* /*topNode*/)
   }
   delete m_analyzer;
   m_analyzer = new TriggerAnalyzer();
+  m_manager = QAHistManagerDef::getHistoManager();
 
   // make sure module name is lower case
   std::string smallModuleName = m_moduleName;

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -142,15 +142,19 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
   }
 
   // get event centrality
-  CentralityInfo* cent_node = findNode::getClass<CentralityInfo>(topNode, "CentralityInfo");
-  if (!cent_node)
+  int cent = -1;
+  if (isAAFlag)
   {
-    std::cout
-        << "StructureinJets::process_event - Error can not find centrality node "
-        << std::endl;
-    return Fun4AllReturnCodes::EVENT_OK;
+    CentralityInfo* cent_node = findNode::getClass<CentralityInfo>(topNode, "CentralityInfo");
+    if (!cent_node)
+    {
+      std::cout
+          << "StructureinJets::process_event - Error can not find centrality node "
+          << std::endl;
+      return Fun4AllReturnCodes::EVENT_OK;
+    }
+    cent = cent_node->get_centile(CentralityInfo::PROP::mbd_NS);
   }
-  int cent = cent_node->get_centile(CentralityInfo::PROP::mbd_NS);
 
   // Loop through jets
   for (auto jet : *jets)
@@ -201,8 +205,9 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
     // Fill histogram for the current jet
     assert(m_h_track_vs_calo_pt);
     assert(m_h_track_pt);
+
     // Fill TH3 histogram for Au+Au collisions
-    if (isAA())
+    if (isAAFlag)
     {
       m_h_track_vs_calo_pt->Fill(jet->get_pt(), sumtrk.Perp(), cent);
     }
@@ -212,6 +217,7 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
     {
       m_h_track_pt->Fill(jet->get_pt(), sumtrk.Perp());
     }
+
     // Reset sumtrk for the next jet
     sumtrk.SetXYZ(0, 0, 0);
   }
@@ -247,7 +253,7 @@ int StructureinJets::End(PHCompositeNode* /*topNode*/)
     std::cout << "StructureinJets::End - Output to histogram manager" << std::endl;
   }
 
-  if (isAA())
+  if (isAAFlag)
   {
     TH2* h_proj;
     for (int i = 0; i < m_h_track_vs_calo_pt->GetNbinsZ(); i++)

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -126,7 +126,7 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
     std::cout
         << "StructureInJets::process_event - Error can not find DST Reco JetContainer node "
         << m_recoJetName << std::endl;
-    exit(-1);
+    return Fun4AllReturnCodes::EVENT_OK;
   }
   // get reco tracks
   SvtxTrackMap* trackmap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxTrackMap");
@@ -137,7 +137,7 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
     {
       std::cout
           << "StructureinJets::process_event - Error can not find DST trackmap node SvtxTrackMap" << std::endl;
-      exit(-1);
+      return Fun4AllReturnCodes::EVENT_OK;
     }
   }
 
@@ -148,7 +148,7 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
     std::cout
         << "StructureinJets::process_event - Error can not find centrality node "
         << std::endl;
-    exit(-1);
+    return Fun4AllReturnCodes::EVENT_OK;
   }
   int cent = cent_node->get_centile(CentralityInfo::PROP::mbd_NS);
 

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -220,17 +220,28 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
       SvtxTrack* track = iter.second;
       float quality = track->get_quality();
       auto silicon_seed = track->get_silicon_seed();
-      int nmvtxhits = 0;
+      auto tpc_seed = track->get_tpc_seed();
+
+      // get no. of clusters in silicon seed
+      int nsiliconclusts = 0;
       if (silicon_seed)
       {
-        nmvtxhits = silicon_seed->size_cluster_keys();
+        nsiliconclusts = silicon_seed->size_cluster_keys();
+      }
+
+      // get no. of clusters in tpc seed
+      int ntpcclusts = 0;
+      if (tpc_seed)
+      {
+        ntpcclusts = tpc_seed->size_cluster_keys();
       }
 
       // do some basic quality selection on tracks
       const bool inTrkPtCut = (track->get_pt() >= m_trk_pt_cut);
       const bool inTrkQualCut = (quality <= m_trk_qual_cut);
-      const bool inTrkNMVtxCut = (nmvtxhits >= m_trk_nmvtx_cut);
-      if (!inTrkPtCut || !inTrkQualCut || !inTrkNMVtxCut)
+      const bool inTrkNSilCut = (nsiliconclusts >= m_trk_nsil_cut);
+      const bool inTrkNTPCCut = (ntpcclusts >= m_trk_ntpc_cut);
+      if (!inTrkPtCut || !inTrkQualCut || !inTrkNSilCut || !inTrkNTPCCut)
       {
         continue;
       }

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -110,7 +110,11 @@ int StructureinJets::Init(PHCompositeNode* /*topNode*/)
   m_hSumTrkOverJetPt->GetXaxis()->SetTitle("Sum track p_{T} / Jet p_{T}");
   m_hSumTrkOverJetPt->GetYaxis()->SetTitle("Counts");
   m_hSumTrkPt = new TH1F(vecHistNames[3].data(), "", 200, 0, 100);
-  m_manager->registerHisto(m_hSumTrkVsJetPtVsCent);
+
+  if (m_isAAFlag)
+  {
+    m_manager->registerHisto(m_hSumTrkVsJetPtVsCent);
+  }
   m_manager->registerHisto(m_hSumTrkVsJetPt);
   m_manager->registerHisto(m_hSumTrkOverJetPt);
   m_manager->registerHisto(m_hSumTrkPt);
@@ -335,17 +339,18 @@ int StructureinJets::End(PHCompositeNode* /*topNode*/)
     {
       // construct histogram name for projection
       std::string name = m_hSumTrkVsJetPtVsCent->GetName();
+      name.append("_centbin" + std::to_string(i + 1));
 
       m_hSumTrkVsJetPtVsCent->GetZaxis()->SetRange(i + 1, i + 1);
       h_proj = (TH2*) m_hSumTrkVsJetPtVsCent->Project3D("yx");
-      h_proj->SetName(
-          (
-              boost::format(name + "_%1.0f") % m_hSumTrkVsJetPtVsCent->GetZaxis()->GetBinLowEdge(i + 1))
-              .str()
-              .c_str());
+      h_proj->SetName(name.data());
       if (m_writeToOutputFileFlag)
       {
         h_proj->Write();
+      }
+      else
+      {
+        m_manager->registerHisto(h_proj);
       }
     }
   }

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -110,6 +110,8 @@ int StructureinJets::Init(PHCompositeNode* /*topNode*/)
   m_hSumTrkOverJetPt->GetXaxis()->SetTitle("Sum track p_{T} / Jet p_{T}");
   m_hSumTrkOverJetPt->GetYaxis()->SetTitle("Counts");
   m_hSumTrkPt = new TH1F(vecHistNames[3].data(), "", 200, 0, 100);
+  m_hSumTrkPt->GetXaxis()->SetTitle("Sum track p_{T}");
+  m_hSumTrkPt->GetYaxis()->SetTitle("Counts");
 
   if (m_isAAFlag)
   {

--- a/offline/QA/Jet/StructureinJets.cc
+++ b/offline/QA/Jet/StructureinJets.cc
@@ -43,23 +43,34 @@ StructureinJets::StructureinJets(const std::string& moduleName, const std::strin
   , m_histTag(histTag)
   , m_outputFileName(outputfilename)
 {
-  std::cout << "StructureinJets::StructureinJets(const std::string &name) Calling ctor" << std::endl;
+  if(Verbosity() > 1 )
+  {
+    std::cout << "StructureinJets::StructureinJets(const std::string &name x 4) Calling ctor" << std::endl;
+  }
 }
 
 //____________________________________________________________________________..
 StructureinJets::~StructureinJets()
 {
-  std::cout << "StructureinJets::~StructureinJets() Calling dtor" << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "StructureinJets::~StructureinJets() Calling dtor" << std::endl;
+  }
 }
 
 //____________________________________________________________________________..
 int StructureinJets::Init(PHCompositeNode* /*topNode*/)
 {
-  std::cout << "StructureinJets::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "StructureinJets::Init(PHCompositeNode *topNode) Initializing" << std::endl;
+  }
+
   if (writeToOutputFileFlag)
   {
     PHTFileServer::get().open(m_outputFileName, "RECREATE");
   }
+
   delete m_analyzer;
   m_analyzer = new TriggerAnalyzer();
   m_manager = QAHistManagerDef::getHistoManager();
@@ -99,14 +110,21 @@ int StructureinJets::Init(PHCompositeNode* /*topNode*/)
 //____________________________________________________________________________..
 int StructureinJets::InitRun(PHCompositeNode* /*topNode*/)
 {
-  std::cout << "StructureinJets::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "StructureinJets::InitRun(PHCompositeNode *topNode) Initializing for Run XXX" << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int StructureinJets::process_event(PHCompositeNode* topNode)
 {
-  // std::cout << "StructureinJets::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+
+  if (Verbosity() > 1)
+  {
+    std::cout << "StructureinJets::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  }
 
   // if needed, check if selected trigger fired
   if (m_doTrgSelect)
@@ -161,7 +179,10 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
   {
     if (!jet)
     {
-      std::cout << "WARNING!!! Jet not found" << std::endl;
+      if (Verbosity() > 2)
+      {
+        std::cout << "WARNING!!! Jet not found" << std::endl;
+      }
       continue;
     }
     // sum up tracks in jet
@@ -227,14 +248,20 @@ int StructureinJets::process_event(PHCompositeNode* topNode)
 //____________________________________________________________________________..
 int StructureinJets::ResetEvent(PHCompositeNode* /*topNode*/)
 {
-  // std::cout << "StructureinJets::ResetEvent(PHCompositeNode *topNode) Resetting internal structures, prepare for next event" << std::endl;
+  if (Verbosity() > 1)
+  {
+    std::cout << "StructureinJets::ResetEvent(PHCompositeNode *topNode) Resetting internal structures, prepare for next event" << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int StructureinJets::EndRun(const int runnumber)
 {
+  if (Verbosity() > 0)
+  {
   std::cout << "StructureinJets::EndRun(const int runnumber) Ending Run for Run " << runnumber << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -245,12 +272,18 @@ int StructureinJets::End(PHCompositeNode* /*topNode*/)
   // otherwise rely on histogram manager
   if (writeToOutputFileFlag)
   {
-    std::cout << "StructureinJets::End - Output to " << m_outputFileName << std::endl;
+    if (Verbosity() > 1)
+    {
+      std::cout << "StructureinJets::End - Output to " << m_outputFileName << std::endl;
+    }
     PHTFileServer::get().cd(m_outputFileName);
   }
   else
   {
-    std::cout << "StructureinJets::End - Output to histogram manager" << std::endl;
+    if (Verbosity() > 1)
+    {
+      std::cout << "StructureinJets::End - Output to histogram manager" << std::endl;
+    }
   }
 
   if (isAAFlag)
@@ -281,14 +314,20 @@ int StructureinJets::End(PHCompositeNode* /*topNode*/)
       m_h_track_pt->Write();  // if pp, do not project onto centrality bins
     }
   }
-  std::cout << "StructureinJets::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "StructureinJets::End(PHCompositeNode *topNode) This is the End..." << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 //____________________________________________________________________________..
 int StructureinJets::Reset(PHCompositeNode* /*topNode*/)
 {
-  std::cout << "StructureinJets::Reset(PHCompositeNode *topNode) being Reset" << std::endl;
+  if (Verbosity() > 0)
+  {
+    std::cout << "StructureinJets::Reset(PHCompositeNode *topNode) being Reset" << std::endl;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -9,6 +9,7 @@
 #include <fun4all/SubsysReco.h>
 
 #include <string>
+#include <utility>
 
 class Fun4AllHistoManager;
 class PHCompositeNode;
@@ -19,10 +20,11 @@ class TriggerAnalyzer;
 class StructureinJets : public SubsysReco
 {
  public:
-  StructureinJets(const std::string &moduleName = "StructureInJets",
-                  const std::string &recojetname = "AntiKt_Tower_r04",
-                  const std::string &histTag = "AllTrig_AntiKt_Tower_r04",
-                  const std::string &outputfilename = "tracksinjets.root");
+  StructureinJets(const std::string& moduleName = "StructureInJets",
+                  const std::string& recojetname = "AntiKt_Tower_r04_Sub1",
+                  const std::string& trkNodeName = "SvtxTrackMap",
+                  const std::string& histTag = "AllTrig_AntiKt_Tower_r04",
+                  const std::string& outputfilename = "tracksinjets.root");
 
   ~StructureinJets() override;
 
@@ -59,32 +61,113 @@ class StructureinJets : public SubsysReco
 
   void Print(const std::string &what = "ALL") const override;
 
-  bool isAA() const { return isAAFlag; }
-  void isAA(bool b) { isAAFlag = b; }
+  bool isAA() const { return m_isAAFlag; }
+  void isAA(bool b) { m_isAAFlag = b; }
 
-  bool writeToOutputFile() const { return writeToOutputFileFlag; }
-  void writeToOutputFile(bool b) { writeToOutputFileFlag = b; }
+  bool writeToOutputFile() const { return m_writeToOutputFileFlag; }
+  void writeToOutputFile(bool b) { m_writeToOutputFileFlag = b; }
 
-  // set trigger to require
+  /// set the name of the node containing the reco jets
+  void setRecoJetNodeName(const std::string &name)
+  {
+    m_recoJetName = name;
+  }
+
+  /// set the name of the node containg the tracks
+  void setTrkNodeName(const std::string &name)
+  {
+    m_trkNodeName = name;
+  }
+
+  /// set the name of the output file
+  void setOutputFileName(const std::string &name)
+  {
+    m_outputFileName = name;
+  }
+
+  /// set the tag to be applied to the histogram names
+  void setHistTag(const std::string &tag)
+  {
+    m_histTag = tag;
+  }
+
+  /// set trigger to require
   void setTrgToSelect(const uint32_t trig = JetQADefs::GL1::MBDNSJet1)
   {
     m_doTrgSelect = true;
     m_trgToSelect = trig;
   }
 
+  /// set minimum track pt
+  void setTrkPtCut(const float cut)
+  {
+    m_trk_pt_cut = cut;
+  }
+
+  /// set max track quality
+  void setTrkQualityCut(const float cut)
+  {
+    m_trk_qual_cut = cut;
+  }
+
+  /// set min no. of mvtx hits
+  void setTrkNMVtxCut(const int cut)
+  {
+    m_trk_nmvtx_cut = cut;
+  }
+
+  /// set jet radius
+  void setJetRadius(const float radius)
+  {
+    m_jetRadius = radius;
+  }
+
+  /// set jet pt range
+  void setJetPtRange(const double low, const double high)
+  {
+    m_ptJetRange.first = low;
+    m_ptJetRange.second = high;
+  }
+
+  /// set jet eta range
+  void setJetEtaRange(const double low, const double high)
+  {
+    m_etaJetRange.first = low;
+    m_etaJetRange.second = high;
+  }
+
  private:
+
+  /// module name, input node strings, histogram tags, and output file name
   std::string m_moduleName;
   std::string m_recoJetName;
+  std::string m_trkNodeName;
   std::string m_histTag;
-  float m_trk_pt_cut{2};
-  float m_jetRadius{0.4};
-  bool isAAFlag{false};
-  bool writeToOutputFileFlag{false};
-  bool m_doTrgSelect{false};
-  uint32_t m_trgToSelect{JetQADefs::GL1::MBDNSJet1};
   std::string m_outputFileName;
+
+  /// track cuts
+  float m_trk_pt_cut{1.0};
+  float m_trk_qual_cut{6.0};
+  int m_trk_nmvtx_cut{2};
+  float m_jetRadius{0.4};
+
+  /// jet kinematic cuts
+  std::pair<double, double> m_etaJetRange{-1.1, 1.1};
+  std::pair<double, double> m_ptJetRange{1.0, 1000.0};
+
+  /// flags
+  bool m_isAAFlag{false};
+  bool m_writeToOutputFileFlag{false};
+  bool m_doTrgSelect{false};
+
+  /// trigger to select
+  uint32_t m_trgToSelect{JetQADefs::GL1::MBDNSJet1};
+
+  /// output histograms
   TH3 *m_h_track_vs_calo_pt{nullptr};
   TH2 *m_h_track_pt{nullptr};
+
+  /// fun4all members
   Fun4AllHistoManager *m_manager{nullptr};
   TriggerAnalyzer *m_analyzer{nullptr};
 };

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -111,10 +111,16 @@ class StructureinJets : public SubsysReco
     m_trk_qual_cut = cut;
   }
 
-  /// set min no. of mvtx hits
-  void setTrkNMVtxCut(const int cut)
+  /// set min no. of silicon clusters
+  void setTrkNSilCut(const int cut)
   {
-    m_trk_nmvtx_cut = cut;
+    m_trk_nsil_cut = cut;
+  }
+
+  /// set min no. of tpc clusters
+  void setTrkNTPCCut(const int cut)
+  {
+    m_trk_ntpc_cut = cut;
   }
 
   /// set jet radius
@@ -149,7 +155,8 @@ class StructureinJets : public SubsysReco
   /// track cuts
   float m_trk_pt_cut{1.0};
   float m_trk_qual_cut{6.0};
-  int m_trk_nmvtx_cut{2};
+  int m_trk_nsil_cut{4};
+  int m_trk_ntpc_cut{32};
   float m_jetRadius{0.4};
 
   /// jet kinematic cuts

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -153,10 +153,10 @@ class StructureinJets : public SubsysReco
   std::string m_outputFileName;
 
   /// track cuts
-  float m_trk_pt_cut{1.0};
+  float m_trk_pt_cut{0.1};
   float m_trk_qual_cut{6.0};
   int m_trk_nsil_cut{4};
-  int m_trk_ntpc_cut{32};
+  int m_trk_ntpc_cut{25};
   float m_jetRadius{0.4};
 
   /// jet kinematic cuts

--- a/offline/QA/Jet/StructureinJets.h
+++ b/offline/QA/Jet/StructureinJets.h
@@ -13,6 +13,7 @@
 
 class Fun4AllHistoManager;
 class PHCompositeNode;
+class TH1;
 class TH2;
 class TH3;
 class TriggerAnalyzer;
@@ -164,8 +165,10 @@ class StructureinJets : public SubsysReco
   uint32_t m_trgToSelect{JetQADefs::GL1::MBDNSJet1};
 
   /// output histograms
-  TH3 *m_h_track_vs_calo_pt{nullptr};
-  TH2 *m_h_track_pt{nullptr};
+  TH3 *m_hSumTrkVsJetPtVsCent{nullptr};
+  TH2 *m_hSumTrkVsJetPt{nullptr};
+  TH1 *m_hSumTrkOverJetPt{nullptr};
+  TH1 *m_hSumTrkPt{nullptr};
 
   /// fun4all members
   Fun4AllHistoManager *m_manager{nullptr};


### PR DESCRIPTION
This PR fixes a few bugs in the `StructureinJets` QA module.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Changes made:
- QA histogram manager is initialized before use
- `process_event` now returns `Fun4AllReturnCodes::EVENT_OK` instead of `exit(-1)` on errors
- Centrality calculation is now wrapped in the `isAA` flag
- All debugging statements are wrapped in verbosity checks
- All parameters (e.g. jet and track cuts) are now configurable, and several missing ones have been added
- An additional track cut on no. of tpc clusters in seed has been added
- 1D histograms for ptTrkSum and ptTrkSum/ptJet have now been added, histogram names are more reflective of content
- Projected ptTrkSum vs. ptJet vs. centrality histograms now registered with manager, have non-breaking names (no periods), and writing out centrality-dependent histograms is now consistent with other modules.