### PR TITLE
TPC Timeframe building to handle new clock frequencies in v46 FEE firmware

### DIFF
--- a/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
+++ b/offline/framework/fun4allraw/TpcTimeFrameBuilder.h
@@ -62,6 +62,8 @@ class TpcTimeFrameBuilder
 
   static const uint16_t GL1_BCO_MATCH_WINDOW = 256;  // BCOs
 
+  int m_hitFormat = -1;
+
   uint16_t reverseBits(const uint16_t x) const;
   std::pair<uint16_t, uint16_t> crc16_parity(const uint32_t fee, const uint16_t l) const;
 
@@ -302,9 +304,7 @@ class TpcTimeFrameBuilder
     static constexpr unsigned int m_FEE_CLOCK_BITS = 20;
     static constexpr unsigned int m_GTM_CLOCK_BITS = 40;
 
-    // this is the clock multiplier from lvl1 to fee clock
-    // Tested with Run24 data. Could be changable in future runs
-    double m_multiplier = 4.262916255;
+    double m_multiplier = 0;
 
     TH1 *m_hNorm = nullptr;
     TH1 *m_hFEEClockAdjustment_MatchedReference = nullptr;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

The newly installed TPC FELIX and FEE firmware V46 allow for phase lock SAMPA ADC and RHIC clock at a `30/16` ratio. This shows up as a new hit format (`IDTPCFEEV5`) in raw data

This pull request allow for TPC time frame building to handle the new hit format and map to the new clock frequency. 

There should be no change to the production macros


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )

More test

## Links to other PRs in macros and calibration repositories (if applicable)

https://github.com/sPHENIX-Collaboration/online_distribution/pull/194 