### PR TITLE
Tpot new hit format

### DIFF
--- a/offline/framework/fun4allraw/Makefile.am
+++ b/offline/framework/fun4allraw/Makefile.am
@@ -23,6 +23,7 @@ pkginclude_HEADERS = \
   intt_pool.h \
   InputManagerType.h \
   MicromegasBcoMatchingInformation.h\
+  MicromegasBcoMatchingInformation_v1.h\
   MicromegasBcoMatchingInformation_v2.h\
   MvtxRawDefs.h \
   SingleCemcTriggerInput.h \
@@ -85,7 +86,7 @@ libfun4allraw_la_SOURCES = \
   Fun4AllRolloverFileOutStream.cc \
   Fun4AllStreamingInputManager.cc \
   intt_pool.cc \
-  MicromegasBcoMatchingInformation.cc\
+  MicromegasBcoMatchingInformation_v1.cc\
   MicromegasBcoMatchingInformation_v2.cc\
   mvtx_pool.cc \
   MvtxRawDefs.cc \

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation.h
@@ -1,0 +1,8 @@
+#ifndef FUN4ALLRAW_MICROMEGASBCOMATCHINGINFORMATION_H
+#define FUN4ALLRAW_MICROMEGASBCOMATCHINGINFORMATION_H
+
+#include "MicromegasBcoMatchingInformation_v1.h"
+#include "MicromegasBcoMatchingInformation_v2.h"
+
+using MicromegasBcoMatchingInformation = MicromegasBcoMatchingInformation_v2;
+#endif

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v1.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v1.cc
@@ -1,11 +1,11 @@
 
 /*!
- * \file MicromegasBcoMatchingInformation.cc
+ * \file MicromegasBcoMatchingInformation_v1.cc
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  * \brief handles matching between GTM and FEE BCO clock
  */
 
-#include "MicromegasBcoMatchingInformation.h"
+#include "MicromegasBcoMatchingInformation_v1.h"
 
 #include <Event/packet.h>
 
@@ -123,10 +123,10 @@ namespace
 
 // this is the clock multiplier from lvl1 to fee clock
 /* todo: should replace with actual rational number for John K. */
-double MicromegasBcoMatchingInformation::m_multiplier = 4.262916255;
+double MicromegasBcoMatchingInformation_v1::m_multiplier = 4.262916255;
 
 //___________________________________________________
-std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco(uint64_t gtm_bco) const
+std::optional<uint32_t> MicromegasBcoMatchingInformation_v1::get_predicted_fee_bco(uint64_t gtm_bco) const
 {
   // check proper initialization
   if (!is_verified())
@@ -143,12 +143,12 @@ std::optional<uint32_t> MicromegasBcoMatchingInformation::get_predicted_fee_bco(
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
+void MicromegasBcoMatchingInformation_v1::print_gtm_bco_information() const
 {
   if (!m_gtm_bco_list.empty())
   {
     std::cout
-        << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
+        << "MicromegasBcoMatchingInformation_v1::print_gtm_bco_information -"
         << " gtm_bco: " << std::hex << m_gtm_bco_list << std::dec
         << std::endl;
 
@@ -164,7 +164,7 @@ void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
           { return get_predicted_fee_bco(gtm_bco).value(); });
 
       std::cout
-          << "MicromegasBcoMatchingInformation::save_gtm_bco_information -"
+          << "MicromegasBcoMatchingInformation_v1::print_gtm_bco_information -"
           << " fee_bco_predicted: " << std::hex << fee_bco_predicted_list << std::dec
           << std::endl;
     }
@@ -172,7 +172,7 @@ void MicromegasBcoMatchingInformation::print_gtm_bco_information() const
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
+void MicromegasBcoMatchingInformation_v1::save_gtm_bco_information(Packet* packet)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
   const int n_tagger = packet->lValue(0, "N_TAGGER");
@@ -217,7 +217,7 @@ void MicromegasBcoMatchingInformation::save_gtm_bco_information(Packet* packet)
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference_from_modebits(Packet* packet)
+bool MicromegasBcoMatchingInformation_v1::find_reference_from_modebits(Packet* packet)
 {
   // append gtm_bco from taggers in this event to packet-specific list of available lv1_bco
   const int n_tagger = packet->lValue(0, "N_TAGGER");
@@ -230,7 +230,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_modebits(Packet* pack
       uint64_t modebits = static_cast<uint8_t>(packet->lValue(t, "MODEBITS"));
       if (modebits & (1U << BX_COUNTER_SYNC_T))
       {
-        std::cout << "MicromegasBcoMatchingInformation::find_reference_from_modebits"
+        std::cout << "MicromegasBcoMatchingInformation_v1::find_reference_from_modebits"
                   << " - packet: " << packet->getIdentifier()
                   << " found reference from modebits"
                   << std::endl;
@@ -249,7 +249,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_modebits(Packet* pack
 }
 
 //___________________________________________________
-bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
+bool MicromegasBcoMatchingInformation_v1::find_reference_from_data(Packet* packet)
 {
   // store gtm bco and diff to previous in an array
   std::vector<uint64_t> gtm_bco_list;
@@ -272,7 +272,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
   // print all differences
   if (verbosity())
   {
-    std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl;
+    std::cout << "MicromegasBcoMatchingInformation_v1::find_reference_from_data - gtm_bco_diff_list: " << gtm_bco_diff_list << std::endl;
   }
 
   uint32_t fee_bco_prev = 0;
@@ -316,7 +316,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
       continue;
     }
 
-    std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - fee_bco_diff: " << fee_bco_diff << std::endl;
+    std::cout << "MicromegasBcoMatchingInformation_v1::find_reference_from_data - fee_bco_diff: " << fee_bco_diff << std::endl;
 
     // look for matching diff in gtm_bco array
     for (size_t i = 0; i < gtm_bco_diff_list.size(); ++i)
@@ -333,13 +333,13 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
 
           if (verbosity())
           {
-            std::cout << "MicromegasBcoMatchingInformation::find_reference_from_data - matching is verified" << std::endl;
+            std::cout << "MicromegasBcoMatchingInformation_v1::find_reference_from_data - matching is verified" << std::endl;
             std::cout
-                << "MicromegasBcoMatchingInformation::find_reference_from_data -"
+                << "MicromegasBcoMatchingInformation_v1::find_reference_from_data -"
                 << " m_gtm_bco_first: " << std::hex << m_gtm_bco_first << std::dec
                 << std::endl;
             std::cout
-                << "MicromegasBcoMatchingInformation::find_reference_from_data -"
+                << "MicromegasBcoMatchingInformation_v1::find_reference_from_data -"
                 << " m_fee_bco_first: " << std::hex << m_fee_bco_first << std::dec
                 << std::endl;
           }
@@ -355,7 +355,7 @@ bool MicromegasBcoMatchingInformation::find_reference_from_data(Packet* packet)
 }
 
 //___________________________________________________
-std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t fee_bco)
+std::optional<uint64_t> MicromegasBcoMatchingInformation_v1::find_gtm_bco(uint32_t fee_bco)
 {
   // make sure the bco matching is properly initialized
   if (!is_verified())
@@ -391,7 +391,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t 
         const auto fee_bco_predicted = get_predicted_fee_bco(gtm_bco).value();
         const auto fee_bco_diff = get_bco_diff(fee_bco_predicted, fee_bco);
 
-        std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
+        std::cout << "MicromegasBcoMatchingInformation_v1::find_gtm_bco -"
                   << std::hex
                   << " fee_bco: 0x" << fee_bco
                   << " predicted: 0x" << fee_bco_predicted
@@ -427,7 +427,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t 
 
           const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ? get_bco_diff(get_predicted_fee_bco(*iter2).value(), fee_bco) : -1;
 
-          std::cout << "MicromegasBcoMatchingInformation::find_gtm_bco -"
+          std::cout << "MicromegasBcoMatchingInformation_v1::find_gtm_bco -"
                     << std::hex
                     << " fee_bco: 0x" << fee_bco
                     << std::dec
@@ -445,7 +445,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation::find_gtm_bco(uint32_t 
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::cleanup()
+void MicromegasBcoMatchingInformation_v1::cleanup()
 {
   // remove old gtm_bco and matching
   while (m_gtm_bco_list.size() > m_max_matching_data_size)
@@ -462,7 +462,7 @@ void MicromegasBcoMatchingInformation::cleanup()
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::cleanup(uint64_t ref_bco)
+void MicromegasBcoMatchingInformation_v1::cleanup(uint64_t ref_bco)
 {
   // erase all elements from bco_list that are less than or equal to ref_bco
   m_gtm_bco_list.erase( std::remove_if( m_gtm_bco_list.begin(), m_gtm_bco_list.end(), [ref_bco](const uint64_t& bco) { return bco<=ref_bco; }), m_gtm_bco_list.end() );
@@ -475,13 +475,13 @@ void MicromegasBcoMatchingInformation::cleanup(uint64_t ref_bco)
 }
 
 //___________________________________________________
-double MicromegasBcoMatchingInformation::get_adjusted_multiplier() const
+double MicromegasBcoMatchingInformation_v1::get_adjusted_multiplier() const
 {
   return m_multiplier + m_multiplier_adjustment;
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation::update_multiplier_adjustment(uint64_t gtm_bco, uint32_t fee_bco)
+void MicromegasBcoMatchingInformation_v1::update_multiplier_adjustment(uint64_t gtm_bco, uint32_t fee_bco)
 {
   // check that references are valid
   if (!is_verified())
@@ -506,7 +506,7 @@ void MicromegasBcoMatchingInformation::update_multiplier_adjustment(uint64_t gtm
   if (verbosity())
   {
     const auto default_precision{std::cout.precision()};
-    std::cout << "MicromegasBcoMatchingInformation::update_multiplier_adjustment -"
+    std::cout << "MicromegasBcoMatchingInformation_v1::update_multiplier_adjustment -"
               << " m_multiplier_adjustment_count: " << m_multiplier_adjustment_count
               << std::setprecision(10)
               << " m_multiplier: " << get_adjusted_multiplier()

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v1.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v1.h
@@ -1,8 +1,8 @@
-#ifndef MICROMEGAS_MicromegasBcoMatchingInformation_H
-#define MICROMEGAS_MicromegasBcoMatchingInformation_H
+#ifndef MICROMEGAS_MICROMEGASBCOMATCHINGINFORMATION_V1_H
+#define MICROMEGAS_MICROMEGASBCOMATCHINGINFORMATION_V1_H
 
 /*!
- * \file MicromegasBcoMatchingInformation.h
+ * \file MicromegasBcoMatchingInformation_v1.h
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  * \brief handles matching between GTM and FEE BCO clock
  */
@@ -15,11 +15,11 @@
 
 class Packet;
 
-class MicromegasBcoMatchingInformation
+class MicromegasBcoMatchingInformation_v1
 {
  public:
   //! constructor
-  MicromegasBcoMatchingInformation() = default;
+  MicromegasBcoMatchingInformation_v1() = default;
 
   //!@name accessor
   //@{

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -174,7 +174,7 @@ void MicromegasBcoMatchingInformation_v2::print_gtm_bco_information() const
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(const MicromegasBcoMatchingInformation_v2::gtm_payload& payload)
+void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int packet_id, const MicromegasBcoMatchingInformation_v2::gtm_payload& payload)
 {
   if ( payload.is_lvl1)
   {
@@ -182,6 +182,11 @@ void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(const Microme
     // save lvl1 BCO
     const auto& gtm_bco = payload.bco;
     m_gtm_bco_list.push_back(gtm_bco);
+
+    std::cout << "MicromegasBcoMatchingInformation_v2::save_gtm_bco_information -"
+      << " packet_id: " << packet_id
+      << " gtm_bco: 0x" << std::hex << gtm_bco << std::dec
+      << std::endl;
 
   } else if( payload.is_endat ) {
 
@@ -329,6 +334,7 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int pa
   {
     return std::nullopt;
   }
+
   // find matching gtm bco in map
   const auto bco_matching_iter = std::find_if(
       m_bco_matching_list.begin(),

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -118,7 +118,8 @@ namespace
 }  // namespace
 
 // this is the clock multiplier from lvl1 to fee clock
-double MicromegasBcoMatchingInformation_v2::m_multiplier = 4.262916255;
+bool MicromegasBcoMatchingInformation_v2::m_multiplier_is_set = false;
+double MicromegasBcoMatchingInformation_v2::m_multiplier = 0;
 
 // muliplier adjustment count
 /* controls how often the gtm multiplier is automatically adjusted */

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -322,7 +322,7 @@ bool MicromegasBcoMatchingInformation_v2::find_reference_from_data(const fee_pay
 }
 
 //___________________________________________________
-std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(uint32_t fee_bco)
+std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(int packet_id, unsigned int fee_id, uint32_t fee_bco)
 {
   // make sure the bco matching is properly initialized
   if (!is_verified())
@@ -359,6 +359,8 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(uint32
         const auto fee_bco_diff = get_bco_diff(fee_bco_predicted, fee_bco);
 
         std::cout << "MicromegasBcoMatchingInformation_v2::find_gtm_bco -"
+                  << " packet_id: " << packet_id
+                  << " fee_id: " << fee_id
                   << std::hex
                   << " fee_bco: 0x" << fee_bco
                   << " predicted: 0x" << fee_bco_predicted
@@ -395,6 +397,8 @@ std::optional<uint64_t> MicromegasBcoMatchingInformation_v2::find_gtm_bco(uint32
           const int fee_bco_diff = (iter2 != m_gtm_bco_list.end()) ? get_bco_diff(get_predicted_fee_bco(*iter2).value(), fee_bco) : -1;
 
           std::cout << "MicromegasBcoMatchingInformation_v2::find_gtm_bco -"
+                    << " packet_id: " << packet_id
+                    << " fee_id: " << fee_id
                     << std::hex
                     << " fee_bco: 0x" << fee_bco
                     << std::dec

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.cc
@@ -174,7 +174,7 @@ void MicromegasBcoMatchingInformation_v2::print_gtm_bco_information() const
 }
 
 //___________________________________________________
-void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int packet_id, const MicromegasBcoMatchingInformation_v2::gtm_payload& payload)
+void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int /*packet_id*/, const MicromegasBcoMatchingInformation_v2::gtm_payload& payload)
 {
   if ( payload.is_lvl1)
   {
@@ -182,11 +182,6 @@ void MicromegasBcoMatchingInformation_v2::save_gtm_bco_information(int packet_id
     // save lvl1 BCO
     const auto& gtm_bco = payload.bco;
     m_gtm_bco_list.push_back(gtm_bco);
-
-    std::cout << "MicromegasBcoMatchingInformation_v2::save_gtm_bco_information -"
-      << " packet_id: " << packet_id
-      << " gtm_bco: 0x" << std::hex << gtm_bco << std::dec
-      << std::endl;
 
   } else if( payload.is_endat ) {
 

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -93,6 +93,18 @@ class MicromegasBcoMatchingInformation_v2
   //! print gtm bco information
   void print_gtm_bco_information() const;
 
+  //! get first gtm bco
+  unsigned int get_fee_bco_first() const
+  { return m_fee_bco_first; }
+
+  //! get first gtm bco
+  uint64_t get_gtm_bco_first() const
+  { return m_gtm_bco_first; }
+
+  //! get last gtm bco
+  uint64_t get_gtm_bco_last() const
+  { return m_gtm_bco_list.empty() ? 0:*m_gtm_bco_list.rbegin(); }
+
   //@}
 
   //!@name modifiers

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -82,6 +82,12 @@ class MicromegasBcoMatchingInformation_v2
   std::optional<uint32_t> get_predicted_fee_bco(uint64_t) const;
 
   //! multiplier
+  static bool gtm_clock_multiplier_is_set()
+  {
+    return m_multiplier_is_set;
+  }
+
+  //! multiplier
   static double get_gtm_clock_multiplier()
   {
     return m_multiplier;
@@ -119,6 +125,7 @@ class MicromegasBcoMatchingInformation_v2
   /// set gtm clock multiplier
   static void set_gtm_clock_multiplier(double value)
   {
+    m_multiplier_is_set = true;
     m_multiplier = value;
   }
 
@@ -192,6 +199,9 @@ class MicromegasBcoMatchingInformation_v2
 
   //! keep track or  fee_bco for which no gtm_bco is found
   std::set<uint32_t> m_orphans;
+
+  //! true if multiplier is set
+  static bool m_multiplier_is_set;
 
   //! gtm clock multiplier
   static double m_multiplier;

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -130,7 +130,7 @@ class MicromegasBcoMatchingInformation_v2
   bool find_reference_from_data(const fee_payload&);
 
   //! save all GTM BCO clocks from packet data
-  void save_gtm_bco_information(const gtm_payload&);
+  void save_gtm_bco_information(int /* packet_id */, const gtm_payload&);
 
   //! find gtm bco matching a given fee
   /**

--- a/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
+++ b/offline/framework/fun4allraw/MicromegasBcoMatchingInformation_v2.h
@@ -133,7 +133,11 @@ class MicromegasBcoMatchingInformation_v2
   void save_gtm_bco_information(const gtm_payload&);
 
   //! find gtm bco matching a given fee
-  std::optional<uint64_t> find_gtm_bco(uint32_t /*fee_gtm*/);
+  /**
+   * packet and fee ids are not necessary to the calculation.
+   * They are pased here for the clarity of debugging messages
+   */
+  std::optional<uint64_t> find_gtm_bco(int /*packet_id*/, unsigned int /*fee_id*/, uint32_t /*fee_gtm*/);
 
   //! cleanup
   void cleanup();

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v1.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v1.h
@@ -1,7 +1,7 @@
 #ifndef FUN4ALLRAW_SINGLEMICROMEGASPOOLINPUT_V1_H
 #define FUN4ALLRAW_SINGLEMICROMEGASPOOLINPUT_V1_H
 
-#include "MicromegasBcoMatchingInformation.h"
+#include "MicromegasBcoMatchingInformation_v1.h"
 #include "SingleStreamingInput.h"
 
 #include <phool/PHTimer.h>
@@ -86,7 +86,7 @@ class SingleMicromegasPoolInput_v1 : public SingleStreamingInput
   std::set<uint64_t> m_BclkStack;
 
   //! map bco_information_t to packet id
-  using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation>;
+  using bco_matching_information_map_t = std::map<unsigned int, MicromegasBcoMatchingInformation_v1>;
   bco_matching_information_map_t m_bco_matching_information_map;
 
   // keep track of total number of waveforms per fee

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -651,7 +651,6 @@ void SingleMicromegasPoolInput_v2::process_fee_data( int packet_id, unsigned int
   auto& data_buffer = m_feeData[fee_id];
 
   // process header
-  // while (HEADER_LENGTH <= data_buffer.size())
   while (HEADER_LENGTH <= data_buffer.size())
   {
 
@@ -745,7 +744,7 @@ void SingleMicromegasPoolInput_v2::process_fee_data( int packet_id, unsigned int
 
     // find matching gtm bco
     uint64_t gtm_bco = 0;
-    const auto result = bco_matching_information.find_gtm_bco(fee_bco);
+    const auto result = bco_matching_information.find_gtm_bco(packet_id, fee_id, fee_bco);
     if (result)
     {
       // assign gtm bco

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -555,8 +555,26 @@ void SingleMicromegasPoolInput_v2::createQAHistos()
 void SingleMicromegasPoolInput_v2::process_packet(Packet* packet )
 {
   // check hit format
-  if (packet->getHitFormat() != IDTPCFEEV4)
+  const auto hitformat = packet->getHitFormat();
+  if (hitformat != IDTPCFEEV4 && hitformat != IDTPCFEEV5)
   { return; }
+
+  // set clock multipliers if not alsready
+  if( !MicromegasBcoMatchingInformation_v2::gtm_clock_multiplier_is_set() )
+  {
+    switch( hitformat )
+    {
+      case IDTPCFEEV4:
+      MicromegasBcoMatchingInformation_v2::set_gtm_clock_multiplier(4.262916255);
+      break;
+
+      case IDTPCFEEV5:
+      MicromegasBcoMatchingInformation_v2::set_gtm_clock_multiplier(30./8);
+      break;
+
+      default: break;
+    }
+  }
 
   // get packet id
   const int packet_id = packet->getIdentifier();

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -768,13 +768,11 @@ void SingleMicromegasPoolInput_v2::process_fee_data( int packet_id, unsigned int
     // store data from string
     // Format is (N sample) (start time), (1st sample)... (Nth sample)
     size_t pos = HEADER_LENGTH;
-    // while (pos < pkt_length )
-    while (pos < size_t(pkt_length+2) )
+    while (pos < pkt_length )
     {
       const uint16_t& samples = data_buffer[pos++];
       const uint16_t& start_t = data_buffer[pos++];
-      if (pos + samples > size_t(pkt_length+1) )
-      // if (pos + samples > size_t(pkt_length) )
+      if (pos + samples > size_t(pkt_length) )
       {
         if (Verbosity())
         {

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -536,6 +536,7 @@ void SingleMicromegasPoolInput_v2::createQAHistos()
   {
     m_evaluation_file.reset(new TFile(m_evaluation_filename.c_str(), "RECREATE"));
     m_evaluation_tree = new TTree("T", "T");
+    m_evaluation_tree->Branch("is_heartbeat", &m_waveform.is_heartbeat);
     m_evaluation_tree->Branch("packet_id", &m_waveform.packet_id);
     m_evaluation_tree->Branch("fee_id", &m_waveform.fee_id);
     m_evaluation_tree->Branch("channel", &m_waveform.channel);
@@ -805,6 +806,7 @@ void SingleMicromegasPoolInput_v2::process_fee_data( int packet_id, unsigned int
 
     if( m_do_evaluation )
     {
+      m_waveform.is_heartbeat = (payload.type == HEARTBEAT_T);
       m_waveform.fee_id = fee_id;
       m_waveform.channel = payload.channel;
       m_waveform.fee_bco = fee_bco;

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.cc
@@ -623,7 +623,7 @@ void SingleMicromegasPoolInput_v2::decode_gtm_data( int packet_id, const SingleM
 
   // save bco information
   auto& bco_matching_information = m_bco_matching_information_map[packet_id];
-  bco_matching_information.save_gtm_bco_information(payload);
+  bco_matching_information.save_gtm_bco_information(packet_id, payload);
 
   if(payload.is_lvl1||payload.is_endat)
   {
@@ -742,6 +742,15 @@ void SingleMicromegasPoolInput_v2::process_fee_data( int packet_id, unsigned int
     // try get gtm bco matching fee
     const auto& fee_bco = payload.bx_timestamp;
 
+    if( fee_id != 5 && payload.channel == 0 )
+    {
+      std::cout << "SingleMicromegasPoolInput_v2::process_fee_data - "
+        << " packet_id: " << packet_id
+        << " fee_id: " << fee_id
+        << " channel: " << payload.channel
+        << " fee_bco: 0x" << std::hex << fee_bco << std::dec
+        << std::endl;
+    }
     // find matching gtm bco
     uint64_t gtm_bco = 0;
     const auto result = bco_matching_information.find_gtm_bco(packet_id, fee_id, fee_bco);

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -188,6 +188,10 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   class Waveform
   {
    public:
+
+    /// true if measurement is hearbeat
+    bool is_heartbeat = false;
+
     /// packet
     unsigned int packet_id = 0;
 

--- a/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
+++ b/offline/framework/fun4allraw/SingleMicromegasPoolInput_v2.h
@@ -19,6 +19,7 @@ class MicromegasRawHit;
 class Packet;
 
 class TFile;
+class TTree;
 class TH1;
 
 class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
@@ -52,7 +53,13 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   // write the initial histograms for QA manager
   void createQAHistos() override;
 
- private:
+  /// do evalutation
+  void set_do_evaluation( bool value ) { m_do_evaluation = value; }
+
+  /// output file name for evaluation histograms
+  void set_evaluation_outputfile(const std::string& outputfile) { m_evaluation_filename = outputfile; }
+
+  private:
 
   //!@name decoding constants
   //@{
@@ -163,6 +170,59 @@ class SingleMicromegasPoolInput_v2 : public SingleStreamingInput
   TH1 *h_waveform_count_dropped_pool{nullptr};
 
   //@}
+
+  //!@name evaluation
+  //@{
+
+  //! evaluation
+  bool m_do_evaluation = false;
+
+  //! evaluation output filename
+  std::string m_evaluation_filename = "SingleMicromegasPoolInput.root";
+  std::unique_ptr<TFile> m_evaluation_file;
+
+  /**
+   * waveform is similar to sample except that there is only one of which per waveform,
+   * and that it stores the max adc and corresponding sample_id
+   */
+  class Waveform
+  {
+   public:
+    /// packet
+    unsigned int packet_id = 0;
+
+    /// waveform type
+    /* see: https://git.racf.bnl.gov/gitea/Instrumentation/sampa_data/src/branch/fmtv2/README.md */
+    unsigned int type = 0;
+
+    /// ll1 bco
+    uint64_t gtm_bco_first = 0;
+
+    /// ll1 bco
+    uint64_t gtm_bco = 0;
+
+    /// fee bco
+    unsigned int fee_bco_first = 0;
+
+    /// fee bco
+    unsigned int fee_bco = 0;
+
+    /// fee bco predicted (from gtm)
+    unsigned int fee_bco_predicted = 0;
+
+    /// fee
+    unsigned short fee_id = 0;
+
+    /// channel id
+    unsigned short channel = 0;
+  };
+
+  Waveform m_waveform;
+
+  //! tree
+  TTree* m_evaluation_tree = nullptr;
+
+  //*}
 
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This is the TPOT pendant to https://github.com/sPHENIX-Collaboration/coresoftware/pull/3502
Kept the possibility to manually adjust the clock multiplier from upstream steering macro
Also (re-added) some ntuple-based evaluation of the clock synchronization, on top of existing QA histograms, disabled by default, and cleaned-up multiple version of the MicromegasBcoMatchingInformation class

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

