### PR TITLE
KFP: Reverted candidate selection and added new output branches

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.h
@@ -24,17 +24,19 @@ class KFParticle_DST
   int createParticleNode(PHCompositeNode* topNode);
 
   /// Simultaneously fills a KFParticle_Container and SvtxTrackMap if they are enabled
-  void fillParticleNode(PHCompositeNode* topNode, const KFParticle& motherParticle,
+  void fillParticleNode(PHCompositeNode* topNode, KFParticle& motherParticle,
+                        KFParticle& PV,
                         const std::vector<KFParticle>& daughters,
                         const std::vector<KFParticle>& intermediates);
 
   /// Called by fillParticleNode, fills an SvtxTrackMap
-  void fillParticleNode_Track(PHCompositeNode* topNode, const KFParticle& motherParticle,
+  void fillParticleNode_Track(PHCompositeNode* topNode, KFParticle& motherParticle,
                               std::vector<KFParticle> daughters,
                               std::vector<KFParticle> intermediates);
 
   /// Called by fillParticleNode, fills a KFParitcle_Container
-  void fillParticleNode_Particle(PHCompositeNode* topNode, const KFParticle& motherParticle,
+  void fillParticleNode_Particle(PHCompositeNode* topNode, KFParticle& motherParticle,
+                                 KFParticle& PV,
                                  std::vector<KFParticle> daughters,
                                  std::vector<KFParticle> intermediates);
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.cc
@@ -781,6 +781,7 @@ std::tuple<KFParticle, bool> KFParticle_Tools::buildMother(KFParticle vDaughters
     }
 
     mother.AddDaughter(inputTracks[i]);
+    mother.AddDaughterId(vDaughters[i].Id());
     unique_vertexID += (Int_t) vDaughters[i].GetQ() * getParticleMass(daughterOrder[i]);
   }
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -537,7 +537,7 @@ int KFParticle_eventReconstruction::selectBestCombination(bool PVconstraint, boo
   int bestCombinationIndex = 0;
   for (unsigned int i = 1; i < possibleCandidates.size(); ++i)
   {
-    if (PVconstraint && !isAnInterMother && !m_require_track_and_vertex_match)
+    if (PVconstraint && !isAnInterMother)// && !m_require_track_and_vertex_match)
     {
       float current_IPchi2 = 0;
       float best_IPchi2 = 0;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -537,7 +537,7 @@ int KFParticle_eventReconstruction::selectBestCombination(bool PVconstraint, boo
   int bestCombinationIndex = 0;
   for (unsigned int i = 1; i < possibleCandidates.size(); ++i)
   {
-    if (PVconstraint && !isAnInterMother)
+    if (PVconstraint && !isAnInterMother && !m_require_track_and_vertex_match)
     {
       float current_IPchi2 = 0;
       float best_IPchi2 = 0;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -76,6 +76,8 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch(TString(mother_name) + "_decayTimeErr", &m_calculated_mother_decaytime_err, TString(mother_name) + "_decayTimeErr/F");
     m_tree->Branch(TString(mother_name) + "_decayLength", &m_calculated_mother_decaylength, TString(mother_name) + "_decayLength/F");
     m_tree->Branch(TString(mother_name) + "_decayLengthErr", &m_calculated_mother_decaylength_err, TString(mother_name) + "_decayLengthErr/F");
+    m_tree->Branch(TString(mother_name) + "_decayLength_xy", &m_calculated_mother_decaylength_xy, TString(mother_name) + "_decayLength_xy/F");
+    m_tree->Branch(TString(mother_name) + "_decayLengthErr_xy", &m_calculated_mother_decaylength_xy_err, TString(mother_name) + "_decayLengthErr_xy/F");
     m_tree->Branch(TString(mother_name) + "_DIRA", &m_calculated_mother_dira, TString(mother_name) + "_DIRA/F");
     m_tree->Branch(TString(mother_name) + "_DIRA_xy", &m_calculated_mother_dira_xy, TString(mother_name) + "_DIRA_xy/F");
     m_tree->Branch(TString(mother_name) + "_FDchi2", &m_calculated_mother_fdchi2, TString(mother_name) + "_FDchi2/F");
@@ -134,6 +136,8 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
       m_tree->Branch(TString(intermediate_name) + "_decayTimeErr", &m_calculated_intermediate_decaytime_err[i], TString(intermediate_name) + "_decayTimeErr/F");
       m_tree->Branch(TString(intermediate_name) + "_decayLength", &m_calculated_intermediate_decaylength[i], TString(intermediate_name) + "_decayLength/F");
       m_tree->Branch(TString(intermediate_name) + "_decayLengthErr", &m_calculated_intermediate_decaylength_err[i], TString(intermediate_name) + "_decayLengthErr/F");
+      m_tree->Branch(TString(intermediate_name) + "_decayLength_xy", &m_calculated_intermediate_decaylength_xy[i], TString(intermediate_name) + "_decayLength_xy/F");
+      m_tree->Branch(TString(intermediate_name) + "_decayLengthErr_xy", &m_calculated_intermediate_decaylength_xy_err[i], TString(intermediate_name) + "_decayLengthErr_xy/F");
       m_tree->Branch(TString(intermediate_name) + "_DIRA", &m_calculated_intermediate_dira[i], TString(intermediate_name) + "_DIRA/F");
       m_tree->Branch(TString(intermediate_name) + "_FDchi2", &m_calculated_intermediate_fdchi2[i], TString(intermediate_name) + "_FDchi2/F");
       if (m_constrain_to_vertex_nTuple)
@@ -229,7 +233,10 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch(TString(daughter_number) + "_track_ID", &m_calculated_daughter_trid[i], TString(daughter_number) + "_track_ID/I");
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
-    m_tree->Branch(TString(daughter_number) + "_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_dEdx/F");
+    m_tree->Branch(TString(daughter_number) + "_calculated_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_calculated_dEdx/F");
+    m_tree->Branch(TString(daughter_number) + "_expected_pion_dEdx", &m_calculated_daughter_expected_dedx_pion[i], TString(daughter_number) + "_expected_pion_dEdx/F");
+    m_tree->Branch(TString(daughter_number) + "_expected_kaon_dEdx", &m_calculated_daughter_expected_dedx_kaon[i], TString(daughter_number) + "_expected_kaon_dEdx/F");
+    m_tree->Branch(TString(daughter_number) + "_expected_proton_dEdx", &m_calculated_daughter_expected_dedx_proton[i], TString(daughter_number) + "_expected_proton_dEdx/F");
 
     if (m_calo_info)
     {
@@ -465,6 +472,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
       intermediateArray[i].SetProductionVertex(motherParticle);
       intermediateArray[i].GetLifeTime(m_calculated_intermediate_decaytime[i], m_calculated_intermediate_decaytime_err[i]);
       intermediateArray[i].GetDecayLength(m_calculated_intermediate_decaylength[i], m_calculated_intermediate_decaylength_err[i]);
+      intermediateArray[i].GetDecayLengthXY(m_calculated_intermediate_decaylength_xy[i], m_calculated_intermediate_decaylength_xy_err[i]);
 
       m_calculated_intermediate_decaytime[i] /= speedOfLight;
       m_calculated_intermediate_decaytime_err[i] /= speedOfLight;
@@ -512,6 +520,9 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     SvtxTrack *thisTrack = getTrack(daughterArray[i].Id(), thisTrackMap);
     m_calculated_daughter_bunch_crossing[i] = thisTrack->get_crossing(); 
     m_calculated_daughter_dedx[i] = kfpTupleTools.get_dEdx(topNode, daughterArray[i]);
+    m_calculated_daughter_expected_dedx_pion[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 211);
+    m_calculated_daughter_expected_dedx_kaon[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 321);
+    m_calculated_daughter_expected_dedx_proton[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 2212);
 
     if (m_calo_info)
     {
@@ -586,6 +597,7 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     motherParticle.SetProductionVertex(vertex_fillbranch);
     motherParticle.GetLifeTime(m_calculated_mother_decaytime, m_calculated_mother_decaytime_err);
     motherParticle.GetDecayLength(m_calculated_mother_decaylength, m_calculated_mother_decaylength_err);
+    motherParticle.GetDecayLengthXY(m_calculated_mother_decaylength_xy, m_calculated_mother_decaylength_xy_err);
 
     m_calculated_mother_decaytime /= speedOfLight;
     m_calculated_mother_decaytime_err /= speedOfLight;

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -35,6 +35,8 @@ void KFParticle_nTuple::initializeVariables()
 
 void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
 {
+  //kfpTupleTools.init_dEdx_fits(); //Cant do this! Two trees open at once!
+
   delete m_tree;
   m_tree = new TTree("DecayTree", "DecayTree");
   m_tree->OptimizeBaskets();
@@ -234,9 +236,9 @@ void KFParticle_nTuple::initializeBranches(PHCompositeNode* topNode)
     m_tree->Branch(TString(daughter_number) + "_PDG_ID", &m_calculated_daughter_pdgID[i], TString(daughter_number) + "_PDG_ID/I");
     m_tree->Branch(TString(daughter_number) + "_Covariance", &m_calculated_daughter_cov[i], TString(daughter_number) + "_Covariance[21]/F", 21);
     m_tree->Branch(TString(daughter_number) + "_calculated_dEdx", &m_calculated_daughter_dedx[i], TString(daughter_number) + "_calculated_dEdx/F");
-    m_tree->Branch(TString(daughter_number) + "_expected_pion_dEdx", &m_calculated_daughter_expected_dedx_pion[i], TString(daughter_number) + "_expected_pion_dEdx/F");
-    m_tree->Branch(TString(daughter_number) + "_expected_kaon_dEdx", &m_calculated_daughter_expected_dedx_kaon[i], TString(daughter_number) + "_expected_kaon_dEdx/F");
-    m_tree->Branch(TString(daughter_number) + "_expected_proton_dEdx", &m_calculated_daughter_expected_dedx_proton[i], TString(daughter_number) + "_expected_proton_dEdx/F");
+    //m_tree->Branch(TString(daughter_number) + "_expected_pion_dEdx", &m_calculated_daughter_expected_dedx_pion[i], TString(daughter_number) + "_expected_pion_dEdx/F");
+    //m_tree->Branch(TString(daughter_number) + "_expected_kaon_dEdx", &m_calculated_daughter_expected_dedx_kaon[i], TString(daughter_number) + "_expected_kaon_dEdx/F");
+    //m_tree->Branch(TString(daughter_number) + "_expected_proton_dEdx", &m_calculated_daughter_expected_dedx_proton[i], TString(daughter_number) + "_expected_proton_dEdx/F");
 
     if (m_calo_info)
     {
@@ -520,9 +522,9 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     SvtxTrack *thisTrack = getTrack(daughterArray[i].Id(), thisTrackMap);
     m_calculated_daughter_bunch_crossing[i] = thisTrack->get_crossing(); 
     m_calculated_daughter_dedx[i] = kfpTupleTools.get_dEdx(topNode, daughterArray[i]);
-    m_calculated_daughter_expected_dedx_pion[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 211);
-    m_calculated_daughter_expected_dedx_kaon[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 321);
-    m_calculated_daughter_expected_dedx_proton[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 2212);
+    //m_calculated_daughter_expected_dedx_pion[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 211);
+    //m_calculated_daughter_expected_dedx_kaon[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 321);
+    //m_calculated_daughter_expected_dedx_proton[i] = kfpTupleTools.get_dEdx_fitValue((Int_t) daughterArray[i].GetQ() * daughterArray[i].GetP(), 2212);
 
     if (m_calo_info)
     {

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -64,6 +64,8 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   float m_calculated_mother_decaytime_err = -1;
   float m_calculated_mother_decaylength = -1;
   float m_calculated_mother_decaylength_err = -1;
+  float m_calculated_mother_decaylength_xy = -1;
+  float m_calculated_mother_decaylength_xy_err = -1;
   float m_calculated_mother_dira = -1;
   float m_calculated_mother_dira_xy = -1;
   float m_calculated_mother_fdchi2 = -1;
@@ -102,6 +104,8 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   float m_calculated_intermediate_decaytime_err[max_intermediates] = {0};
   float m_calculated_intermediate_decaylength[max_intermediates] = {0};
   float m_calculated_intermediate_decaylength_err[max_intermediates] = {0};
+  float m_calculated_intermediate_decaylength_xy[max_intermediates] = {0};
+  float m_calculated_intermediate_decaylength_xy_err[max_intermediates] = {0};
   float m_calculated_intermediate_dira[max_intermediates] = {0};
   float m_calculated_intermediate_fdchi2[max_intermediates] = {0};
   float m_calculated_intermediate_ip[max_intermediates] = {0};
@@ -163,6 +167,9 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   // float *m_calculated_daughter_cov[max_tracks];
   float m_calculated_daughter_cov[max_tracks][21] = {{0}, {0}};
   float m_calculated_daughter_dedx[max_tracks] = {0};
+  float m_calculated_daughter_expected_dedx_pion[max_tracks] = {0};
+  float m_calculated_daughter_expected_dedx_kaon[max_tracks] = {0};
+  float m_calculated_daughter_expected_dedx_proton[max_tracks] = {0};
 
   float m_daughter_dca[99] = {0};
   float m_daughter_dca_xy[99] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.h
@@ -167,9 +167,9 @@ class KFParticle_nTuple : public KFParticle_truthAndDetTools, public KFParticle_
   // float *m_calculated_daughter_cov[max_tracks];
   float m_calculated_daughter_cov[max_tracks][21] = {{0}, {0}};
   float m_calculated_daughter_dedx[max_tracks] = {0};
-  float m_calculated_daughter_expected_dedx_pion[max_tracks] = {0};
-  float m_calculated_daughter_expected_dedx_kaon[max_tracks] = {0};
-  float m_calculated_daughter_expected_dedx_proton[max_tracks] = {0};
+  //float m_calculated_daughter_expected_dedx_pion[max_tracks] = {0};
+  //float m_calculated_daughter_expected_dedx_kaon[max_tracks] = {0};
+  //float m_calculated_daughter_expected_dedx_proton[max_tracks] = {0};
 
   float m_daughter_dca[99] = {0};
   float m_daughter_dca_xy[99] = {0};

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.cc
@@ -210,7 +210,7 @@ int KFParticle_sPHENIX::process_event(PHCompositeNode *topNode)
       }
       if (m_save_dst)
       {
-        fillParticleNode(topNode, mother[i], daughters[i], intermediates[i]);
+        fillParticleNode(topNode, mother[i], vertex_kfparticle[i], daughters[i], intermediates[i]);
       }
 
       if (Verbosity() >= VERBOSITY_SOME)


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Reverted code that chose mothers based on best fit to IP rather than lowest mass error. Caused loss in statistics due increased mis ID (I assume).

Also added new output branches for decay length in x/y plane, and predicted dE/dx values for different PID hypotheses

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

