### PR TITLE
(TrackerMillepedeAlignment) Added member, handles for writing TTree output

### DIFF
--- a/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
+++ b/offline/packages/TrackerMillepedeAlignment/MakeMilleFiles.h
@@ -16,6 +16,7 @@
 #include <trackbase/ClusterErrorPara.h>
 #include <trackbase/TrkrDefs.h>
 #include <trackbase_historic/ActsTransformations.h>
+#include <trackbase_historic/SvtxAlignmentState.h>
 #include <trackbase_historic/SvtxAlignmentStateMap.h>
 
 #include <fun4all/SubsysReco.h>
@@ -34,6 +35,9 @@ class TrkrClusterContainer;
 class Mille;
 class ActsPropagator;
 
+class TFile;
+class TTree;
+
 using Trajectory = ActsExamples::Trajectories;
 
 class MakeMilleFiles : public SubsysReco
@@ -46,9 +50,14 @@ class MakeMilleFiles : public SubsysReco
   int End(PHCompositeNode* topNode) override;
 
   void set_binary(bool bin) { _binary = bin; }
+
+  void set_track_map_name(const std::string& name) {m_track_map_name = name;}
+  void set_state_map_name(const std::string& name) {m_state_map_name = name;}
   void set_constraintfile_name(const std::string& file) { m_constraintFileName = file; }
   void set_datafile_name(const std::string& file) { data_outfilename = file; }
   void set_steeringfile_name(const std::string& file) { steering_outfilename = file; }
+  void set_tfile_name(const std::string& file) { m_tfile_name = file; }
+
   void set_mvtx_grouping(int group) { mvtx_group = (AlignmentDefs::mvtxGrp) group; }
   void set_intt_grouping(int group) { intt_group = (AlignmentDefs::inttGrp) group; }
   void set_tpc_grouping(int group) { tpc_group = (AlignmentDefs::tpcGrp) group; }
@@ -126,11 +135,22 @@ class MakeMilleFiles : public SubsysReco
   std::string m_constraintFileName = "mp2con.txt";
   std::ofstream m_constraintFile;
 
+  std::string m_track_map_name{"SvtxTrackMap"};
   SvtxTrackMap* _track_map{nullptr};
+
+  std::string m_state_map_name{"SvtxAlignmentStateMap"};
   SvtxAlignmentStateMap* _state_map{nullptr};
+
   ActsGeometry* _tGeometry{nullptr};
   TrkrClusterContainer* _cluster_map{nullptr};
   ClusterErrorPara _ClusErrPara;
+
+  std::string m_tfile_name;
+  TFile* m_file{nullptr};
+  TTree* m_tree{nullptr};
+
+  float m_glbl_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NGL]{};
+  float m_lcl_derivative[SvtxAlignmentState::NRES][SvtxAlignmentState::NLOC]{};
 };
 
 #endif  // MAKEMILLEFILES_H


### PR DESCRIPTION
Added member and handles for writing TTree output with residual information
* Currently writes TTree with track local and global residual derivative information
* Will eventually add branches for other fields as they are desired

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

