### PR TITLE
Fix KFParticle crash involving useFakePrimaryVertex and constrainToPrimaryVertex

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_nTuple.cc
@@ -597,7 +597,10 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
     m_calculated_vertex_chi2 = vertex_fillbranch.GetChi2();
     m_calculated_vertex_ndof = vertex_fillbranch.GetNDF();
 
-    m_calculated_vertex_ID = getPVID(topNode, vertex_fillbranch);
+    // it only makes sense to calculate PVID for non-fake vertex
+    // (this otherwise crashes if m_use_fake_pv_nTuple is true in an event with no real vertices)
+    if(m_use_fake_pv_nTuple) m_calculated_vertex_ID = -100; // error value returned by getPVID
+    else m_calculated_vertex_ID = getPVID(topNode, vertex_fillbranch);
     // m_calculated_vertex_cov          = &vertex_fillbranch.CovarianceMatrix()[0];
     for (int j = 0; j < 6; ++j)
     {
@@ -608,7 +611,8 @@ void KFParticle_nTuple::fillBranch(PHCompositeNode* topNode,
   m_sv_mass = calc_secondary_vertex_mass_noPID(daughters);
 
   kfpTupleTools.getTracksFromBC(topNode, m_calculated_daughter_bunch_crossing[0], m_vtx_map_node_name_nTuple, m_multiplicity, m_nPVs);  
-  if (m_constrain_to_vertex_nTuple)
+  // cannot retrieve vertex map info from fake PV, hence the second condition
+  if (m_constrain_to_vertex_nTuple && !m_use_fake_pv_nTuple)
   {
     m_multiplicity = kfpTupleTools.getTracksFromVertex(topNode, vertex_fillbranch, m_vtx_map_node_name_nTuple);
   }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

If both useFakePrimaryVertex and constrainToPrimaryVertex are enabled in KFParticle_sPHENIX, the KFParticle_nTuple module tries to retrieve information from the vertex map about a vertex that might not exist, which causes a crash in any event with no primary vertex id 0 (the fake PV isn't added to the vertex map, and has an id of 0). This PR introduces safeguards that prevent this crash: the bunch crossing for a fake vertex is set to the typical error value of -100, and the track multiplicity is retrieved from the bunch crossing, not from the vertex.

It may not seem to make much sense to have both these settings enabled at once (constraining to a vertex that's not where the tracks are coming from probably isn't doing anything good, after all), but currently the constrainToPrimaryVertex option needs to be true to generate some branches of the ntuple that are key for HF analyses, like mother decay length. This combination of settings, with effectively no cuts on the vertex constraint properties, remains a valid vertex-agnostic diagnostic for basic debugging purposes, so fixing this crash isn't entirely useless.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

