### PR TITLE
feat: outlier finder diagnostic ntuple

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -269,7 +269,10 @@ int PHActsTrkFitter::End(PHCompositeNode* /*topNode*/)
   {
     m_evaluator->End();
   }
-
+  if(m_useOutlierFinder)
+  {
+    m_outlierFinder.Write();
+  }
   if (Verbosity() > 0)
   {
     std::cout << "Finished PHActsTrkFitter" << std::endl;

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -114,7 +114,10 @@ class PHActsTrkFitter : public SubsysReco
   void commissioning(bool com) { m_commissioning = com; }
 
   void useOutlierFinder(bool outlier) { m_useOutlierFinder = outlier; }
-
+  void setOutlierFinderOutfile(const std::string& outfilename)
+  {
+    m_outlierFinder.outfileName(outfilename);
+  }
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
 


### PR DESCRIPTION

 @adfrawley 

This PR adds a diagnostic tool to the outlier finder for trying to help understand what the KF is actually doing and/or seeing. You can enable it by setting 
```
    actsFit->useOutlierFinder(true);
```
 in your macro. Right now it just puts the predicted local/global state position, local/global cluster position, chi2, and residual distance into an ntuple. We can always add more branches.
 
 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

