### PR TITLE
fix: acts free params in outlier finder

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -137,6 +137,7 @@ int PHActsTrkFitter::InitRun(PHCompositeNode* topNode)
   m_outlierFinder.chi2Cuts = chi2Cuts;
   if (m_useOutlierFinder)
   {
+    m_outlierFinder.m_tGeometry = m_tGeometry;
     m_fitCfg.fit->outlierFinder(m_outlierFinder);
   }
 


### PR DESCRIPTION
The predicted state has to be transformed to get the free parameters, evidently, instead of the usual enum lookup.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

