### PR TITLE
fix: streaming event combining exit strategy

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1352,11 +1352,12 @@ int Fun4AllStreamingInputManager::FillInttPool()
       }
     }
   }
-  if (m_InttRawHitMap.empty())
+  if (m_InttRawHitMap.empty() && m_Gl1RawHitMap.empty())
   {
-    std::cout << "InttRawHitMap is empty - we are done" << std::endl;
+    std::cout << "InttRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
     return -1;
   }
+
   return 0;
 }
 
@@ -1430,11 +1431,12 @@ int Fun4AllStreamingInputManager::FillMicromegasPool()
       }
     }
   }
-  if (m_MicromegasRawHitMap.empty())
+  if (m_MicromegasRawHitMap.empty() && m_Gl1RawHitMap.empty())
   {
-    std::cout << "MicromegasRawHitMap is empty - we are done" << std::endl;
+    std::cout << "MicromegasRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
     return -1;
   }
+
   return 0;
 }
 
@@ -1467,10 +1469,10 @@ int Fun4AllStreamingInputManager::FillMvtxPool()
       }
     }
   }
-  if (m_MvtxRawHitMap.empty())
+  if (m_MvtxRawHitMap.empty() && m_Gl1RawHitMap.empty())
   {
     
-    std::cout << "MvtxRawHitMap is empty - we are done" << std::endl;
+    std::cout << "MvtxRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
     return -1;
   }
   return 0;


### PR DESCRIPTION
This changes the exit strategy of the event combiner for each subsystem to only exit if the subsystem raw hit map is empty AND the gl1 raw hit map is empty. This mimics the current behavior in the TPC. The rationale for this change is that there are cases where the ROC by ROC processing exits early because a particular ROC has no data in it. This means there are incomplete runs produced as there are more GL1s to process but the ROC has no more hits for the time being. The most frequent example seems to be when the MVTX has a mixed state, so a FELIX stops sending data for a short period of time before the mixed state is recovered.

The current change should still allow for processing without the GL1 because, in the event of processing a subsystem alone, the GL1 raw hit map will necessarily be empty.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

