### PR TITLE
fix: global cluster position

### DIFF
--- a/offline/packages/trackbase/ResidualOutlierFinder.h
+++ b/offline/packages/trackbase/ResidualOutlierFinder.h
@@ -112,11 +112,15 @@ struct ResidualOutlierFinder
         Acts::detail::transformBoundToFreeParameters(state.referenceSurface(),
                                                      m_tGeometry->geometry().getGeoContext(),
                                                      predicted);
+    Acts::Vector2 local(fullCalibrated[Acts::eBoundLoc0], fullCalibrated[Acts::eBoundLoc1]);
+    Acts::Vector3 global = state.referenceSurface().localToGlobal(
+        m_tGeometry->geometry().getGeoContext(), local,
+        Acts::Vector3(1, 1, 1));
     float data[] = {
         (float) sphenixlayer, (float) layer, (float) volume, distance, chi2,
         (float) freeParams[Acts::eFreePos0], (float) freeParams[Acts::eFreePos1], (float) freeParams[Acts::eFreePos2],
         (float) predicted[Acts::eBoundLoc0], (float) predicted[Acts::eBoundLoc1],
-        (float) fullCalibrated[Acts::eFreePos0], (float) fullCalibrated[Acts::eFreePos1], (float) fullCalibrated[Acts::eFreePos2],
+        (float) global[Acts::eFreePos0], (float) global[Acts::eFreePos1], (float) global[Acts::eFreePos2],
         (float) fullCalibrated[Acts::eBoundLoc0], (float) fullCalibrated[Acts::eBoundLoc1]};
     tree->Fill(data);
 


### PR DESCRIPTION
The measurement parameters vector also doesn't work with the usual enums... unfortunately we can't get the distortion corrections into this but the surface transform will have to be sufficient.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

