### PR TITLE
Revert "fix: streaming event combining exit strategy"

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1352,12 +1352,11 @@ int Fun4AllStreamingInputManager::FillInttPool()
       }
     }
   }
-  if (m_InttRawHitMap.empty() && m_Gl1RawHitMap.empty())
+  if (m_InttRawHitMap.empty())
   {
-    std::cout << "InttRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
+    std::cout << "InttRawHitMap is empty - we are done" << std::endl;
     return -1;
   }
-
   return 0;
 }
 
@@ -1431,12 +1430,11 @@ int Fun4AllStreamingInputManager::FillMicromegasPool()
       }
     }
   }
-  if (m_MicromegasRawHitMap.empty() && m_Gl1RawHitMap.empty())
+  if (m_MicromegasRawHitMap.empty())
   {
-    std::cout << "MicromegasRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
+    std::cout << "MicromegasRawHitMap is empty - we are done" << std::endl;
     return -1;
   }
-
   return 0;
 }
 
@@ -1469,10 +1467,10 @@ int Fun4AllStreamingInputManager::FillMvtxPool()
       }
     }
   }
-  if (m_MvtxRawHitMap.empty() && m_Gl1RawHitMap.empty())
+  if (m_MvtxRawHitMap.empty())
   {
     
-    std::cout << "MvtxRawHitMap and Gl1RawHitMap are empty - we are done" << std::endl;
+    std::cout << "MvtxRawHitMap is empty - we are done" << std::endl;
     return -1;
   }
   return 0;


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/coresoftware#3520

This somehow breaks the ending functionality when there are no GL1 triggers left of some runs but not all runs, evidently, which was not apparent until running at further scale. Reverting for now so that it gets into the new build while I investigate