### PR TITLE
Added function to use only crossing zero tracks

### DIFF
--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -64,8 +64,8 @@ std::pair<float, float> ParticleFlowReco::get_expected_signature(int trk)
 //____________________________________________________________________________..
 ParticleFlowReco::ParticleFlowReco(const std::string &name)
   : SubsysReco(name)
-  , _energy_match_Nsigma(1.5)
   , _only_crossing_zero(true)
+  , _energy_match_Nsigma(1.5)
 {
 }
 

--- a/offline/packages/particleflow/ParticleFlowReco.cc
+++ b/offline/packages/particleflow/ParticleFlowReco.cc
@@ -65,6 +65,7 @@ std::pair<float, float> ParticleFlowReco::get_expected_signature(int trk)
 ParticleFlowReco::ParticleFlowReco(const std::string &name)
   : SubsysReco(name)
   , _energy_match_Nsigma(1.5)
+  , _only_crossing_zero(true)
 {
 }
 
@@ -175,6 +176,11 @@ int ParticleFlowReco::process_event(PHCompositeNode *topNode)
     for (auto &iter : *trackmap)
     {
       SvtxTrack *track = iter.second;
+
+      if(_only_crossing_zero && (track->get_crossing() != 0))
+      {
+        continue;
+      }
 
       if (track->get_pt() < 0.5)
       {

--- a/offline/packages/particleflow/ParticleFlowReco.h
+++ b/offline/packages/particleflow/ParticleFlowReco.h
@@ -35,11 +35,15 @@ class ParticleFlowReco : public SubsysReco
   }
   void set_track_map_name(std::string &name) { _track_map_name = name; }
 
+  void set_only_crossing_zero(bool b) { _only_crossing_zero = b; }
+
  private:
   int CreateNode(PHCompositeNode *topNode);
 
   float calculate_dR(float, float, float, float);
   std::pair<float, float> get_expected_signature(int);
+
+  bool _only_crossing_zero = true;
 
   float _energy_match_Nsigma;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Since particle flow requires matching tracks to calorimeter clusters, only crossing zero tracks should be used.
Added a function to set on/off the crossing zero requirement, but only crossing zero is the default.