### PR TITLE
Variable type in TTree branch in TrackResiduals & method to set pp mode in PHSimpleVertexFinder

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1602,7 +1602,7 @@ void TrackResiduals::createBranches()
   m_vertextree->Branch("gl1BunchCrossing", &m_gl1BunchCrossing, "m_gl1BunchCrossing/l");
   m_vertextree->Branch("gl1bco", &m_bco, "m_bco/l");
   m_vertextree->Branch("trbco", &m_bcotr, "m_bcotr/l");
-  m_vertextree->Branch("vertexid", &m_vertexid, "m_vertexid/I");
+  m_vertextree->Branch("vertexid", &m_vertexid);
   m_vertextree->Branch("vertex_crossing", &m_vertex_crossing, "m_vertex_crossing/I");
   m_vertextree->Branch("vx", &m_vx, "m_vx/F");
   m_vertextree->Branch("vy", &m_vy, "m_vy/F");
@@ -1731,7 +1731,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("nmms", &m_nmms, "m_nmms/I");
   m_tree->Branch("nmmsstate", &m_nmmsstate, "m_nmmsstate/I");
   m_tree->Branch("tile", &m_tileid, "m_tileid/I");
-  m_tree->Branch("vertexid", &m_vertexid, "m_vertexid/I");
+  m_tree->Branch("vertexid", &m_vertexid);
   m_tree->Branch("vertex_crossing", &m_vertex_crossing, "m_vertex_crossing/I");
   m_tree->Branch("vx", &m_vx, "m_vx/F");
   m_tree->Branch("vy", &m_vy, "m_vy/F");

--- a/offline/packages/trackreco/PHSimpleVertexFinder.cc
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.cc
@@ -48,6 +48,11 @@ PHSimpleVertexFinder::PHSimpleVertexFinder(const std::string &name)
 //____________________________________________________________________________..
 int PHSimpleVertexFinder::InitRun(PHCompositeNode *topNode)
 {
+  if (Verbosity() > 0)
+  {
+    std::cout << __PRETTY_FUNCTION__ << " is pp mode? " << _pp_mode << std::endl;
+  }
+
   int ret = GetNodes(topNode);
   if (ret != Fun4AllReturnCodes::EVENT_OK)
   {
@@ -83,7 +88,6 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode * /*topNode*/)
   for (const auto &[trackkey, track] : *_track_map)
   {
     auto crossing = track->get_crossing();
-    auto siseed = track->get_silicon_seed();
 
     if (Verbosity() > 0)
       {
@@ -93,10 +97,14 @@ int PHSimpleVertexFinder::process_event(PHCompositeNode * /*topNode*/)
 
     // crossing zero contains unmatched TPC tracks
     // Here we skip those crossing = zero tracks that do not have silicon seeds
-    if( (crossing == 0) & !siseed)
+    if (_pp_mode)
+    {
+      auto siseed = track->get_silicon_seed();
+      if (crossing == 0 && !siseed)
       {
-	continue;
+      continue;
       }
+    }
     
     crossings.insert(crossing);
     _track_vertex_crossing_map->addTrackAssoc(crossing, trackkey);    

--- a/offline/packages/trackreco/PHSimpleVertexFinder.h
+++ b/offline/packages/trackreco/PHSimpleVertexFinder.h
@@ -53,6 +53,7 @@ class PHSimpleVertexFinder : public SubsysReco
   void setVertexMapName(const std::string &name) { _vertex_map_name = name; }
   void zeroField(const bool flag) { _zero_field = flag; }
   void setTrkrClusterContainerName(std::string &name){ m_clusterContainerName = name; }
+  void set_pp_mode(bool mode) { _pp_mode = mode; }
 
  private:
   int GetNodes(PHCompositeNode *topNode);
@@ -105,6 +106,8 @@ class PHSimpleVertexFinder : public SubsysReco
   std::set<unsigned int> _vertex_set;
 
   TrackVertexCrossingAssoc *_track_vertex_crossing_map{nullptr};
+
+  bool _pp_mode = true;  // default to pp mode
 };
 
 #endif  // PHSIMPLEVERTEXFINDER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

1. TrackResiduals module: fix the variable type specifier of the vertex id (which should be unsigned int) of tracks in residualtree 
2. Add a method in PHSimpleVertexFinder to set pp mode

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

