### PR TITLE
Strip composite node

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstOutputManager.h
@@ -22,6 +22,7 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   Fun4AllDstOutputManager &operator=(Fun4AllDstOutputManager const &) = delete;
   int AddNode(const std::string &nodename) override;
   int AddRunNode(const std::string &nodename) override;
+  int StripCompositeNode(const std::string &nodename) override;
   int StripNode(const std::string &nodename) override;
   int StripRunNode(const std::string &nodename) override;
   void SaveRunNode(const int i) override { m_SaveRunNodeFlag = i; }
@@ -45,6 +46,7 @@ class Fun4AllDstOutputManager : public Fun4AllOutputManager
   std::string m_UsedOutFileName;
   std::set<std::string> savenodes;
   std::set<std::string> saverunnodes;
+  std::set<std::string> m_StripCompositeNodes;
   std::set<std::string> stripnodes;
   std::set<std::string> striprunnodes;
 };

--- a/offline/framework/fun4all/Fun4AllOutputManager.h
+++ b/offline/framework/fun4all/Fun4AllOutputManager.h
@@ -44,6 +44,8 @@ class Fun4AllOutputManager : public Fun4AllBase
     return 0;
   }
 
+  virtual int StripCompositeNode(const std::string & /*nodename*/) {return 0;}
+
   virtual void SaveRunNode(const int) { return; }
   virtual void SaveDstNode(const int) { return; }
 

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -142,10 +142,8 @@ int SingleTriggeredInput::FillEventVector()
         delete evt;
         continue;
       }
-      else
-      {
-        m_ProblemEvent--;
-      }
+
+      m_ProblemEvent--;
     }
     //    std::cout << Name() << std::endl;
     //    evt->identify();


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the capability to remove phcompositenodes (and their subnodes) from saving in the dst output manager. Now that each packet is saved in its own node, stripping them by name would result in really longs lists. Now using out->StripCompositeNode("Packets") will strip all of them with a single line

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

