### PR TITLE
Cluster crossing association

### DIFF
--- a/offline/packages/intt/InttClusterizer.cc
+++ b/offline/packages/intt/InttClusterizer.cc
@@ -439,10 +439,6 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
     for (int clusid : cluster_ids)
     {
       // std::cout << " intt clustering: add cluster number " << clusid << std::endl;
-      // get all hits for this cluster ID only
-      std::pair<std::multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit*>>::iterator,
-                std::multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit*>>::iterator>
-          clusrange = clusters.equal_range(clusid);
 
       // make the cluster directly in the node tree
       TrkrDefs::cluskey ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
@@ -454,6 +450,9 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 
       // get the bunch crossing number from the hitsetkey
       short int crossing = InttDefs::getTimeBucketId(hitset->getHitSetKey());
+
+      // Add clusterkey/bunch crossing to mmap
+      m_clustercrossingassoc->addAssoc(ckey, crossing);
 
       // determine the size of the cluster in phi and z, useful for track fitting the cluster
       std::set<int> phibins;
@@ -467,7 +466,10 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
       unsigned int clus_maxadc = 0.0;
       unsigned nhits = 0;
       // std::cout << PHWHERE << " ckey " << ckey << ":" << std::endl;
-      for (std::multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit*>>::iterator mapiter = clusrange.first; mapiter != clusrange.second; ++mapiter)
+
+      // get all hits for this cluster ID only
+      const auto clusrange = clusters.equal_range(clusid);
+      for (auto mapiter = clusrange.first; mapiter != clusrange.second; ++mapiter)
       {
         // mapiter->second.first  is the hit key
         // std::cout << " adding hitkey " << mapiter->second.first << std::endl;
@@ -478,9 +480,6 @@ void InttClusterizer::ClusterLadderCells(PHCompositeNode* topNode)
 
         // mapiter->second.second is the hit
         unsigned int hit_adc = (mapiter->second).second->getAdc();
-
-        // Add clusterkey/bunch crossing to mmap
-        m_clustercrossingassoc->addAssoc(ckey, crossing);
 
         // now get the positions from the geometry
         double local_hit_location[3] = {0., 0., 0.};
@@ -710,9 +709,6 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
     for (int clusid : cluster_ids)
     {
       // std::cout << " intt clustering: add cluster number " << clusid << std::endl;
-      // get all hits for this cluster ID only
-      auto clusrange = clusters.equal_range(clusid);
-
       // make the cluster directly in the node tree
       TrkrDefs::cluskey ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
 
@@ -723,6 +719,9 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
 
       // get the bunch crossing number from the hitsetkey
       short int crossing = InttDefs::getTimeBucketId(hitset->getHitSetKey());
+
+      // Add clusterkey/bunch crossing to mmap
+      m_clustercrossingassoc->addAssoc(ckey, crossing);
 
       // determine the size of the cluster in phi and z, useful for track fitting the cluster
       std::set<int> phibins;
@@ -736,8 +735,10 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
       unsigned nhits = 0;
 
       // std::cout << PHWHERE << " ckey " << ckey << ":" << std::endl;
-
       std::map<int, unsigned int> m_phi, m_z;  // hold data for
+
+      // get all hits for this cluster ID only
+      const auto clusrange = clusters.equal_range(clusid);
       for (auto mapiter = clusrange.first; mapiter != clusrange.second; ++mapiter)
       {
         // mapiter->second.first  is the hit key
@@ -766,9 +767,6 @@ void InttClusterizer::ClusterLadderCellsRaw(PHCompositeNode* topNode)
 
         // mapiter->second.second is the hit
         unsigned int hit_adc = (mapiter->second)->getAdc();
-
-        // Add clusterkey/bunch crossing to mmap
-        m_clustercrossingassoc->addAssoc(ckey, crossing);
 
         // now get the positions from the geometry
         double local_hit_location[3] = {0., 0., 0.};

--- a/offline/packages/micromegas/MicromegasDefs.cc
+++ b/offline/packages/micromegas/MicromegasDefs.cc
@@ -81,14 +81,14 @@ namespace MicromegasDefs
   //________________________________________________________________
   SegmentationType getSegmentationType(TrkrDefs::cluskey key)
   {
-    TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+    const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
     return getSegmentationType( tmp );
   }
 
   //________________________________________________________________
   uint8_t getTileId(TrkrDefs::cluskey key)
   {
-    TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+    const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
     return getTileId( tmp );
   }
 

--- a/offline/packages/micromegas/MicromegasDefs.cc
+++ b/offline/packages/micromegas/MicromegasDefs.cc
@@ -16,7 +16,21 @@ namespace
     constexpr underlying_type_t<T>
     to_underlying_type(T value) noexcept
   { return static_cast<underlying_type_t<T>>(value);}
- 
+
+  /*!
+   * hitsetkey layout:
+   * Micromegas specific lower 16 bits
+   * 24 - 32  tracker id
+   * 16 - 24  layer
+   * 8 - 16 segmentation type
+   * 0 - 8 tile id
+   */
+  static constexpr unsigned int kBitShiftSegmentation = 8;
+  static constexpr unsigned int kBitShiftTileId = 0;
+
+  //! bit shift for hit key
+  static constexpr unsigned int kBitShiftStrip = 0;
+
 }
 
 namespace MicromegasDefs
@@ -26,13 +40,13 @@ namespace MicromegasDefs
   TrkrDefs::hitsetkey genHitSetKey(uint8_t layer, SegmentationType type, uint8_t tile )
   {
     TrkrDefs::hitsetkey key = TrkrDefs::genHitSetKey(TrkrDefs::TrkrId::micromegasId, layer);
-    
+
     TrkrDefs::hitsetkey tmp = to_underlying_type(type);
     key |= (tmp << kBitShiftSegmentation);
 
     tmp = tile;
     key |= (tmp << kBitShiftTileId);
-        
+
     return key;
   }
 

--- a/offline/packages/micromegas/MicromegasDefs.h
+++ b/offline/packages/micromegas/MicromegasDefs.h
@@ -33,20 +33,6 @@ namespace MicromegasDefs
   };
 
   /*!
-   * hitsetkey layout:
-   * Micromegas specific lower 16 bits
-   * 24 - 32  tracker id
-   * 16 - 24  layer
-   * 8 - 16 segmentation type
-   * 0 - 8 tile id
-   */
-  static constexpr unsigned int kBitShiftSegmentation __attribute__((unused)) = 8;
-  static constexpr unsigned int kBitShiftTileId __attribute__((unused)) = 0;
-
-  //! bit shift for hit key
-  static constexpr unsigned int kBitShiftStrip __attribute__((unused)) = 0;
-
-  /*!
    * @brief Generate a hitsetkey for the micromegas
    * @param[in] layer Layer index
    * @param[in] tile tile index

--- a/offline/packages/trackbase/ActsSurfaceMaps.cc
+++ b/offline/packages/trackbase/ActsSurfaceMaps.cc
@@ -77,13 +77,13 @@ Surface ActsSurfaceMaps::getSiliconSurface(TrkrDefs::hitsetkey hitsetkey) const
   if (trkrid == TrkrDefs::inttId)
   {
     // Set the hitsetkey crossing to zero
-    tmpkey = InttDefs::resetCrossingHitSetKey(hitsetkey);
+    tmpkey = InttDefs::resetCrossing(hitsetkey);
   }
 
   if (trkrid == TrkrDefs::mvtxId)
   {
     // Set the hitsetkey crossing to zero
-    tmpkey = MvtxDefs::resetStrobeHitSetKey(hitsetkey);
+    tmpkey = MvtxDefs::resetStrobe(hitsetkey);
   }
 
   // std::cout << "tmpkey = " << tmpkey << std::endl;

--- a/offline/packages/trackbase/InttDefs.cc
+++ b/offline/packages/trackbase/InttDefs.cc
@@ -43,7 +43,7 @@ InttDefs::getLadderZId(TrkrDefs::hitsetkey key)
 uint8_t
 InttDefs::getLadderZId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getLadderZId(tmp);
 }
 
@@ -61,7 +61,7 @@ InttDefs::getLadderPhiId(TrkrDefs::hitsetkey key)
 uint8_t
 InttDefs::getLadderPhiId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getLadderPhiId(tmp);
 }
 
@@ -80,7 +80,7 @@ int InttDefs::getTimeBucketId(TrkrDefs::hitsetkey key)
 
 int InttDefs::getTimeBucketId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getTimeBucketId(tmp);
 }
 
@@ -142,7 +142,7 @@ InttDefs::genClusKey(const uint8_t lyr, const uint8_t ladder_z_index, const uint
 }
 
 TrkrDefs::hitsetkey
-InttDefs::resetCrossingHitSetKey(const TrkrDefs::hitsetkey hitsetkey)
+InttDefs::resetCrossing(const TrkrDefs::hitsetkey hitsetkey)
 {
   // Note: this method uses the fact that the crossing is in the first 10 bits
   TrkrDefs::hitsetkey tmp = hitsetkey;

--- a/offline/packages/trackbase/InttDefs.cc
+++ b/offline/packages/trackbase/InttDefs.cc
@@ -6,14 +6,37 @@
  */
 #include "InttDefs.h"
 
+namespace
+{
+
+  // hitsetkey layout:
+  //  Intt specific lower 16 bits
+  //   24 - 31  tracker id  // 8 bits
+  //   16 - 23  layer       // 8 bits
+  //   14 - 15  ladder z id   // 2 bits
+  //   10 - 13       ladder phi id  // 4 bits
+  //   0 - 9     time bucket  // 10 bits
+  static constexpr unsigned int kBitShiftTimeBucketIdOffset = 0;
+  static constexpr unsigned int kBitShiftTimeBucketIdWidth = 10;
+  static constexpr unsigned int kBitShiftLadderPhiIdOffset = 10;
+  static constexpr unsigned int kBitShiftLadderPhiIdWidth = 4;
+  static constexpr unsigned int kBitShiftLadderZIdOffset = 14;
+  static constexpr unsigned int kBitShiftLadderZIdWidth = 2;
+  static constexpr int crossingOffset = 512;
+
+  // bit shift for hitkey
+  static const unsigned int kBitShiftCol __attribute__((unused)) = 16;
+  static const unsigned int kBitShiftRow __attribute__((unused)) = 0;
+}
+
 uint8_t
 InttDefs::getLadderZId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> InttDefs::kBitShiftLadderZIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftLadderZIdOffset);
   // clear the bits not associated with the ladderZId
   uint8_t tmp1 = tmp;
-  tmp1 = (tmp1 << (8 - InttDefs::kBitShiftLadderZIdWidth));
-  tmp1 = (tmp1 >> (8 - InttDefs::kBitShiftLadderZIdWidth));
+  tmp1 = (tmp1 << (8 - kBitShiftLadderZIdWidth));
+  tmp1 = (tmp1 >> (8 - kBitShiftLadderZIdWidth));
   return tmp1;
 }
 
@@ -27,11 +50,11 @@ InttDefs::getLadderZId(TrkrDefs::cluskey key)
 uint8_t
 InttDefs::getLadderPhiId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> InttDefs::kBitShiftLadderPhiIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftLadderPhiIdOffset);
   // clear the bits not associated with the ladderPhiId
   uint8_t tmp1 = tmp;
-  tmp1 = (tmp1 << (8 - InttDefs::kBitShiftLadderPhiIdWidth));
-  tmp1 = (tmp1 >> (8 - InttDefs::kBitShiftLadderPhiIdWidth));
+  tmp1 = (tmp1 << (8 - kBitShiftLadderPhiIdWidth));
+  tmp1 = (tmp1 >> (8 - kBitShiftLadderPhiIdWidth));
   return tmp1;
 }
 
@@ -44,11 +67,11 @@ InttDefs::getLadderPhiId(TrkrDefs::cluskey key)
 
 int InttDefs::getTimeBucketId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> InttDefs::kBitShiftTimeBucketIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftTimeBucketIdOffset);
   // clear the bits not associated with the TimeBucketId
   uint16_t tmp1 = tmp;
-  tmp1 = (tmp1 << (16 - InttDefs::kBitShiftTimeBucketIdWidth));
-  tmp1 = (tmp1 >> (16 - InttDefs::kBitShiftTimeBucketIdWidth));
+  tmp1 = (tmp1 << (16 - kBitShiftTimeBucketIdWidth));
+  tmp1 = (tmp1 >> (16 - kBitShiftTimeBucketIdWidth));
 
   int tmp2 = (int) tmp1 - crossingOffset;  // get back to signed crossing
 
@@ -64,22 +87,22 @@ int InttDefs::getTimeBucketId(TrkrDefs::cluskey key)
 uint16_t
 InttDefs::getCol(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> InttDefs::kBitShiftCol);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftCol);
   return tmp;
 }
 
 uint16_t
 InttDefs::getRow(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> InttDefs::kBitShiftRow);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftRow);
   return tmp;
 }
 
 TrkrDefs::hitkey
 InttDefs::genHitKey(const uint16_t col, const uint16_t row)
 {
-  TrkrDefs::hitkey key = (col << InttDefs::kBitShiftCol);
-  TrkrDefs::hitkey tmp = (row << InttDefs::kBitShiftRow);
+  TrkrDefs::hitkey key = (col << kBitShiftCol);
+  TrkrDefs::hitkey tmp = (row << kBitShiftRow);
   key |= tmp;
   return key;
 }
@@ -102,11 +125,11 @@ InttDefs::genHitSetKey(const uint8_t lyr, const uint8_t ladder_z_index, uint8_t 
   unsigned int ucrossing = (unsigned int) crossing;
 
   TrkrDefs::hitsetkey tmp = ladder_z_index;
-  key |= (tmp << InttDefs::kBitShiftLadderZIdOffset);
+  key |= (tmp << kBitShiftLadderZIdOffset);
   tmp = ladder_phi_index;
-  key |= (tmp << InttDefs::kBitShiftLadderPhiIdOffset);
+  key |= (tmp << kBitShiftLadderPhiIdOffset);
   tmp = ucrossing;
-  key |= (tmp << InttDefs::kBitShiftTimeBucketIdOffset);
+  key |= (tmp << kBitShiftTimeBucketIdOffset);
 
   return key;
 }
@@ -124,10 +147,10 @@ InttDefs::resetCrossingHitSetKey(const TrkrDefs::hitsetkey hitsetkey)
   // Note: this method uses the fact that the crossing is in the first 10 bits
   TrkrDefs::hitsetkey tmp = hitsetkey;
   // zero the crossing bits by shifting them out of the word, then shift back
-  tmp = (tmp >> InttDefs::kBitShiftTimeBucketIdWidth);
-  tmp = (tmp << InttDefs::kBitShiftTimeBucketIdWidth);
+  tmp = (tmp >> kBitShiftTimeBucketIdWidth);
+  tmp = (tmp << kBitShiftTimeBucketIdWidth);
   unsigned int zero_crossing = crossingOffset;
-  tmp |= (zero_crossing << InttDefs::kBitShiftTimeBucketIdOffset);
+  tmp |= (zero_crossing << kBitShiftTimeBucketIdOffset);
 
   return tmp;
 }

--- a/offline/packages/trackbase/InttDefs.h
+++ b/offline/packages/trackbase/InttDefs.h
@@ -114,7 +114,7 @@ namespace InttDefs
    * @param[in] hitsetkey
    * @param[out] hitsetkey
    */
-  TrkrDefs::hitsetkey resetCrossingHitSetKey(const TrkrDefs::hitsetkey hitsetkey);
+  TrkrDefs::hitsetkey resetCrossing(const TrkrDefs::hitsetkey hitsetkey);
 
 }  // namespace InttDefs
 

--- a/offline/packages/trackbase/InttDefs.h
+++ b/offline/packages/trackbase/InttDefs.h
@@ -19,26 +19,6 @@
  */
 namespace InttDefs
 {
-  // hitsetkey layout:
-  //  Intt specific lower 16 bits
-  //   24 - 31  tracker id  // 8 bits
-  //   16 - 23  layer       // 8 bits
-  //   14 - 15  ladder z id   // 2 bits
-  //   10 - 13       ladder phi id  // 4 bits
-  //   0 - 9     time bucket  // 10 bits
-
-  static const unsigned int kBitShiftTimeBucketIdOffset __attribute__((unused)) = 0;
-  static const unsigned int kBitShiftTimeBucketIdWidth __attribute__((unused)) = 10;
-  static const unsigned int kBitShiftLadderPhiIdOffset __attribute__((unused)) = 10;
-  static const unsigned int kBitShiftLadderPhiIdWidth __attribute__((unused)) = 4;
-  static const unsigned int kBitShiftLadderZIdOffset __attribute__((unused)) = 14;
-  static const unsigned int kBitShiftLadderZIdWidth __attribute__((unused)) = 2;
-  static const int crossingOffset __attribute__((unused)) = 512;
-
-  // bit shift for hitkey
-  static const unsigned int kBitShiftCol __attribute__((unused)) = 16;
-  static const unsigned int kBitShiftRow __attribute__((unused)) = 0;
-
   /**
    * @brief Get the ladder id from hitsetkey
    * @param[in] hitsetkey

--- a/offline/packages/trackbase/MvtxDefs.cc
+++ b/offline/packages/trackbase/MvtxDefs.cc
@@ -1,13 +1,36 @@
 #include "MvtxDefs.h"
 
+namespace
+{
+  // hitsetkey layout:
+  //  Mvtx specific lower 16 bits
+  //   24 - 31  tracker id  // 8 bits
+  //   16 - 23  layer   // 8 bits
+  //     9 - 15  stave id // 7 bits
+  //     5 - 8     chip  id // 4 bits
+  //     0-4   strobe  id // 5 bits
+
+  static constexpr unsigned int kBitShiftStaveIdOffset = 9;
+  static constexpr unsigned int kBitShiftStaveIdWidth = 7;
+  static constexpr unsigned int kBitShiftChipIdOffset = 5;
+  static constexpr unsigned int kBitShiftChipIdWidth = 4;
+  static constexpr unsigned int kBitShiftStrobeIdOffset = 0;
+  static constexpr unsigned int kBitShiftStrobeIdWidth = 5;
+  static constexpr int strobeOffset = 16;
+
+  // bit shift for hitkey
+  static const unsigned int kBitShiftCol __attribute__((unused)) = 16;
+  static const unsigned int kBitShiftRow __attribute__((unused)) = 0;
+}
+
 uint8_t
 MvtxDefs::getStaveId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> MvtxDefs::kBitShiftStaveIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftStaveIdOffset);
   // zero the bits not in the stave id field
   uint8_t tmp1 = tmp;
-  tmp1 = (tmp1 << (8 - MvtxDefs::kBitShiftStaveIdWidth));
-  tmp1 = (tmp1 >> (8 - MvtxDefs::kBitShiftStaveIdWidth));
+  tmp1 = (tmp1 << (8 - kBitShiftStaveIdWidth));
+  tmp1 = (tmp1 >> (8 - kBitShiftStaveIdWidth));
   return tmp1;
 }
 
@@ -21,10 +44,10 @@ MvtxDefs::getStaveId(TrkrDefs::cluskey key)
 uint8_t
 MvtxDefs::getChipId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> MvtxDefs::kBitShiftChipIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftChipIdOffset);
   uint8_t tmp1 = tmp;
-  tmp1 = (tmp1 << (8 - MvtxDefs::kBitShiftChipIdWidth));
-  tmp1 = (tmp1 >> (8 - MvtxDefs::kBitShiftChipIdWidth));
+  tmp1 = (tmp1 << (8 - kBitShiftChipIdWidth));
+  tmp1 = (tmp1 >> (8 - kBitShiftChipIdWidth));
   return tmp1;
 }
 
@@ -37,10 +60,10 @@ MvtxDefs::getChipId(TrkrDefs::cluskey key)
 
 int MvtxDefs::getStrobeId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> MvtxDefs::kBitShiftStrobeIdOffset);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftStrobeIdOffset);
   uint8_t tmp1 = tmp;
-  tmp1 = (tmp1 << (8 - MvtxDefs::kBitShiftStrobeIdWidth));
-  tmp1 = (tmp1 >> (8 - MvtxDefs::kBitShiftStrobeIdWidth));
+  tmp1 = (tmp1 << (8 - kBitShiftStrobeIdWidth));
+  tmp1 = (tmp1 >> (8 - kBitShiftStrobeIdWidth));
 
   int tmp2 = (int) tmp1 - strobeOffset;  // get back to the signed strobe
 
@@ -56,22 +79,22 @@ int MvtxDefs::getStrobeId(TrkrDefs::cluskey key)
 uint16_t
 MvtxDefs::getCol(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> MvtxDefs::kBitShiftCol);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftCol);
   return tmp;
 }
 
 uint16_t
 MvtxDefs::getRow(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> MvtxDefs::kBitShiftRow);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftRow);
   return tmp;
 }
 
 TrkrDefs::hitkey
 MvtxDefs::genHitKey(const uint16_t col, const uint16_t row)
 {
-  TrkrDefs::hitkey key = (col << MvtxDefs::kBitShiftCol);
-  TrkrDefs::hitkey tmp = (row << MvtxDefs::kBitShiftRow);
+  TrkrDefs::hitkey key = (col << kBitShiftCol);
+  TrkrDefs::hitkey tmp = (row << kBitShiftRow);
   key |= tmp;
   return key;
 }
@@ -94,11 +117,11 @@ MvtxDefs::genHitSetKey(const uint8_t lyr, const uint8_t stave, const uint8_t chi
   unsigned int ustrobe = (unsigned int) strobe;
 
   TrkrDefs::hitsetkey tmp = stave;
-  key |= (tmp << MvtxDefs::kBitShiftStaveIdOffset);
+  key |= (tmp << kBitShiftStaveIdOffset);
   tmp = chip;
-  key |= (tmp << MvtxDefs::kBitShiftChipIdOffset);
+  key |= (tmp << kBitShiftChipIdOffset);
   tmp = ustrobe;
-  key |= (tmp << MvtxDefs::kBitShiftStrobeIdOffset);
+  key |= (tmp << kBitShiftStrobeIdOffset);
   return key;
 }
 
@@ -116,10 +139,10 @@ MvtxDefs::resetStrobeHitSetKey(const TrkrDefs::hitsetkey hitsetkey)
   // Note: this method uses the fact that the crossing is in the first 5 bits
   TrkrDefs::hitsetkey tmp = hitsetkey;
   // zero the crossing bits by shifting them out of the word, then shift back
-  tmp = (tmp >> MvtxDefs::kBitShiftStrobeIdWidth);
-  tmp = (tmp << MvtxDefs::kBitShiftStrobeIdWidth);
+  tmp = (tmp >> kBitShiftStrobeIdWidth);
+  tmp = (tmp << kBitShiftStrobeIdWidth);
   unsigned int zero_strobe = strobeOffset;
-  tmp |= (zero_strobe << MvtxDefs::kBitShiftStrobeIdOffset);
+  tmp |= (zero_strobe << kBitShiftStrobeIdOffset);
 
   return tmp;
 }

--- a/offline/packages/trackbase/MvtxDefs.cc
+++ b/offline/packages/trackbase/MvtxDefs.cc
@@ -37,7 +37,7 @@ MvtxDefs::getStaveId(TrkrDefs::hitsetkey key)
 uint8_t
 MvtxDefs::getStaveId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getStaveId(tmp);
 }
 
@@ -54,7 +54,7 @@ MvtxDefs::getChipId(TrkrDefs::hitsetkey key)
 uint8_t
 MvtxDefs::getChipId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getChipId(tmp);
 }
 
@@ -72,7 +72,7 @@ int MvtxDefs::getStrobeId(TrkrDefs::hitsetkey key)
 
 int MvtxDefs::getStrobeId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getStrobeId(tmp);
 }
 
@@ -129,15 +129,30 @@ TrkrDefs::cluskey
 MvtxDefs::genClusKey(const uint8_t lyr, const uint8_t stave, const uint8_t chip, const int strobe, const uint32_t clusid)
 {
   TrkrDefs::hitsetkey key = genHitSetKey(lyr, stave, chip, strobe);
-  // return TrkrDefs::genClusKey( key, clusid );
   return TrkrDefs::genClusKey(key, clusid);
 }
 
 TrkrDefs::hitsetkey
-MvtxDefs::resetStrobeHitSetKey(const TrkrDefs::hitsetkey hitsetkey)
+MvtxDefs::resetStrobe(const TrkrDefs::hitsetkey hitsetkey)
 {
   // Note: this method uses the fact that the crossing is in the first 5 bits
   TrkrDefs::hitsetkey tmp = hitsetkey;
+  // zero the crossing bits by shifting them out of the word, then shift back
+  tmp = (tmp >> kBitShiftStrobeIdWidth);
+  tmp = (tmp << kBitShiftStrobeIdWidth);
+  unsigned int zero_strobe = strobeOffset;
+  tmp |= (zero_strobe << kBitShiftStrobeIdOffset);
+
+  return tmp;
+}
+
+// this is broken
+TrkrDefs::cluskey
+MvtxDefs::resetStrobe(const TrkrDefs::cluskey ckey)
+{
+  // Note: this method uses the fact that the crossing is in the first 5 bits
+  TrkrDefs::cluskey tmp = ckey;
+
   // zero the crossing bits by shifting them out of the word, then shift back
   tmp = (tmp >> kBitShiftStrobeIdWidth);
   tmp = (tmp << kBitShiftStrobeIdWidth);

--- a/offline/packages/trackbase/MvtxDefs.cc
+++ b/offline/packages/trackbase/MvtxDefs.cc
@@ -146,18 +146,9 @@ MvtxDefs::resetStrobe(const TrkrDefs::hitsetkey hitsetkey)
   return tmp;
 }
 
-// this is broken
 TrkrDefs::cluskey
 MvtxDefs::resetStrobe(const TrkrDefs::cluskey ckey)
 {
-  // Note: this method uses the fact that the crossing is in the first 5 bits
-  TrkrDefs::cluskey tmp = ckey;
-
-  // zero the crossing bits by shifting them out of the word, then shift back
-  tmp = (tmp >> kBitShiftStrobeIdWidth);
-  tmp = (tmp << kBitShiftStrobeIdWidth);
-  unsigned int zero_strobe = strobeOffset;
-  tmp |= (zero_strobe << kBitShiftStrobeIdOffset);
-
-  return tmp;
+  TrkrDefs::hitsetkey tmp =  TrkrDefs::getHitSetKeyFromClusKey(key);
+  return TrkrDefs::genClusKey(resetStrobe(tmp), ckey);
 }

--- a/offline/packages/trackbase/MvtxDefs.cc
+++ b/offline/packages/trackbase/MvtxDefs.cc
@@ -147,8 +147,8 @@ MvtxDefs::resetStrobe(const TrkrDefs::hitsetkey hitsetkey)
 }
 
 TrkrDefs::cluskey
-MvtxDefs::resetStrobe(const TrkrDefs::cluskey ckey)
+MvtxDefs::resetStrobe(const TrkrDefs::cluskey key)
 {
   TrkrDefs::hitsetkey tmp =  TrkrDefs::getHitSetKeyFromClusKey(key);
-  return TrkrDefs::genClusKey(resetStrobe(tmp), ckey);
+  return TrkrDefs::genClusKey(resetStrobe(tmp), key);
 }

--- a/offline/packages/trackbase/MvtxDefs.h
+++ b/offline/packages/trackbase/MvtxDefs.h
@@ -19,29 +19,9 @@
  */
 namespace MvtxDefs
 {
-  // hitsetkey layout:
-  //  Mvtx specific lower 16 bits
-  //   24 - 31  tracker id  // 8 bits
-  //   16 - 23  layer   // 8 bits
-  //     9 - 15  stave id // 7 bits
-  //     5 - 8     chip  id // 4 bits
-  //     0-4   strobe  id // 5 bits
-
-  static const unsigned int kBitShiftStaveIdOffset __attribute__((unused)) = 9;
-  static const unsigned int kBitShiftStaveIdWidth __attribute__((unused)) = 7;
-  static const unsigned int kBitShiftChipIdOffset __attribute__((unused)) = 5;
-  static const unsigned int kBitShiftChipIdWidth __attribute__((unused)) = 4;
-  static const unsigned int kBitShiftStrobeIdOffset __attribute__((unused)) = 0;
-  static const unsigned int kBitShiftStrobeIdWidth __attribute__((unused)) = 5;
-  static const int strobeOffset __attribute__((unused)) = 16;
-
-  // bit shift for hitkey
-  static const unsigned int kBitShiftCol __attribute__((unused)) = 16;
-  static const unsigned int kBitShiftRow __attribute__((unused)) = 0;
-
   // max values for col and row index in chip
-  static const uint16_t MAXCOL __attribute__((unused)) = 1024;
-  static const uint16_t MAXROW __attribute__((unused)) = 512;
+  static constexpr uint16_t MAXCOL __attribute__((unused)) = 1024;
+  static constexpr uint16_t MAXROW __attribute__((unused)) = 512;
 
   /**
    * @brief Get the stave id from hitsetkey

--- a/offline/packages/trackbase/MvtxDefs.h
+++ b/offline/packages/trackbase/MvtxDefs.h
@@ -115,7 +115,7 @@ namespace MvtxDefs
    * @param[in] hskey cluskey
    * @param[out] cluskey with strobe bits set to zero
    */
-  TrkrDefs::cluskey resetStrobe(const TrkrDefs::cluskey /*ckey*/);
+  TrkrDefs::cluskey resetStrobe(const TrkrDefs::cluskey /*key*/);
 
   /**
    * @brief Zero the strobe bits in the hitsetkey

--- a/offline/packages/trackbase/MvtxDefs.h
+++ b/offline/packages/trackbase/MvtxDefs.h
@@ -111,11 +111,18 @@ namespace MvtxDefs
   TrkrDefs::cluskey genClusKey(const uint8_t lyr, const uint8_t stave, const uint8_t chip, const int strobe, const uint32_t clusid);
 
   /**
+   * @brief Zero the strobe bits in the cluster key
+   * @param[in] hskey cluskey
+   * @param[out] cluskey with strobe bits set to zero
+   */
+  TrkrDefs::cluskey resetStrobe(const TrkrDefs::cluskey /*ckey*/);
+
+  /**
    * @brief Zero the strobe bits in the hitsetkey
    * @param[in] hskey hitsetkey
    * @param[out] hitsetkey with strobe bits set to zero
    */
-  TrkrDefs::hitsetkey resetStrobeHitSetKey(const TrkrDefs::hitsetkey hitsetkey);
+  TrkrDefs::hitsetkey resetStrobe(const TrkrDefs::hitsetkey /*hitsetkey*/);
 
 }  // namespace MvtxDefs
 

--- a/offline/packages/trackbase/TpcDefs.cc
+++ b/offline/packages/trackbase/TpcDefs.cc
@@ -37,7 +37,7 @@ TpcDefs::getSectorId(TrkrDefs::hitsetkey key)
 uint8_t
 TpcDefs::getSectorId(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getSectorId(tmp);
 }
 
@@ -51,7 +51,7 @@ TpcDefs::getSide(TrkrDefs::hitsetkey key)
 uint8_t
 TpcDefs::getSide(TrkrDefs::cluskey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = TrkrDefs::getHitSetKeyFromClusKey(key);
   return getSide(tmp);
 }
 

--- a/offline/packages/trackbase/TpcDefs.cc
+++ b/offline/packages/trackbase/TpcDefs.cc
@@ -8,10 +8,29 @@
 
 #include "TrkrDefs.h"  // for hitsetkey, cluskey, hitkey, kBitShif...
 
+namespace
+{
+
+  // hitsetkey layout:
+  //  Tpc specific lower 16 bits
+  //   24 - 32  tracker id
+  //   16 - 24  layer
+  //   8  - 16  sector id
+  //   0  -  8  side
+  static constexpr unsigned int kBitShiftSectorId = 8;
+  static constexpr unsigned int kBitShiftSide = 0;
+
+  // bit shift for hitkey
+  //  16 - 32 pad id
+  //  0  - 16 time bin
+  static constexpr unsigned int kBitShiftPad = 16;
+  static constexpr unsigned int kBitShiftTBin = 0;
+}
+
 uint8_t
 TpcDefs::getSectorId(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TpcDefs::kBitShiftSectorId);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftSectorId);
   return tmp;
 }
 
@@ -25,7 +44,7 @@ TpcDefs::getSectorId(TrkrDefs::cluskey key)
 uint8_t
 TpcDefs::getSide(TrkrDefs::hitsetkey key)
 {
-  TrkrDefs::hitsetkey tmp = (key >> TpcDefs::kBitShiftSide);
+  TrkrDefs::hitsetkey tmp = (key >> kBitShiftSide);
   return tmp;
 }
 
@@ -39,22 +58,22 @@ TpcDefs::getSide(TrkrDefs::cluskey key)
 uint16_t
 TpcDefs::getPad(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> TpcDefs::kBitShiftPad);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftPad);
   return tmp;
 }
 
 uint16_t
 TpcDefs::getTBin(TrkrDefs::hitkey key)
 {
-  TrkrDefs::hitkey tmp = (key >> TpcDefs::kBitShiftTBin);
+  TrkrDefs::hitkey tmp = (key >> kBitShiftTBin);
   return tmp;
 }
 
 TrkrDefs::hitkey
 TpcDefs::genHitKey(const uint16_t pad, const uint16_t tbin)
 {
-  TrkrDefs::hitkey key = (pad << TpcDefs::kBitShiftPad);
-  TrkrDefs::hitkey tmp = (tbin << TpcDefs::kBitShiftTBin);
+  TrkrDefs::hitkey key = (pad << kBitShiftPad);
+  TrkrDefs::hitkey tmp = (tbin << kBitShiftTBin);
   key |= tmp;
   return key;
 }
@@ -64,9 +83,9 @@ TpcDefs::genHitSetKey(const uint8_t lyr, const uint8_t sector, const uint8_t sid
 {
   TrkrDefs::hitsetkey key = TrkrDefs::genHitSetKey(TrkrDefs::TrkrId::tpcId, lyr);
   TrkrDefs::hitsetkey tmp = sector;
-  key |= (tmp << TpcDefs::kBitShiftSectorId);
+  key |= (tmp << kBitShiftSectorId);
   tmp = side;
-  key |= (tmp << TpcDefs::kBitShiftSide);
+  key |= (tmp << kBitShiftSide);
   return key;
 }
 

--- a/offline/packages/trackbase/TpcDefs.h
+++ b/offline/packages/trackbase/TpcDefs.h
@@ -25,29 +25,14 @@ namespace TpcDefs
 
   //! in memory representation of TPC ADC data: 10bit ADC value as 16bit signed integer.
   // This is signed to allow pedestal subtraction when needed
-  typedef int16_t ADCDataType;
+  using ADCDataType = int16_t;
 
   //! in memory representation of BCO clock using standard 64bit sPHENIX time stamp precision
-  typedef uint64_t BCODataType;
-
-  // hitsetkey layout:
-  //  Tpc specific lower 16 bits
-  //   24 - 32  tracker id
-  //   16 - 24  layer
-  //   8  - 16  sector id
-  //   0  -  8  side
-  static const unsigned int kBitShiftSectorId __attribute__((unused)) = 8;
-  static const unsigned int kBitShiftSide __attribute__((unused)) = 0;
-
-  // bit shift for hitkey
-  //  16 - 32 pad id
-  //  0  - 16 time bin
-  static const unsigned int kBitShiftPad __attribute__((unused)) = 16;
-  static const unsigned int kBitShiftTBin __attribute__((unused)) = 0;
+  using BCODataType = uint64_t;
 
   // max values for pad and time bin
-  static const uint16_t MAXPAD __attribute__((unused)) = 1024;
-  static const uint16_t MAXTBIN __attribute__((unused)) = 512;
+  static constexpr uint16_t MAXPAD __attribute__((unused)) = 1024;
+  static constexpr uint16_t MAXTBIN __attribute__((unused)) = 512;
 
   /**
    * @brief Get the sector id from hitsetkey

--- a/offline/packages/trackbase/TrkrDefs.cc
+++ b/offline/packages/trackbase/TrkrDefs.cc
@@ -2,6 +2,14 @@
 
 #include <bitset>
 
+namespace
+{
+  // cluskey layour
+  //  hitsetkey upper 32 bits
+  //  cluster id lower 32 bits
+  [[maybe_unused]] static constexpr unsigned int kBitShiftClusId = 32;
+}
+
 void TrkrDefs::printBits(const TrkrDefs::hitsetkey key, std::ostream& os)
 {
   os << "key: " << std::bitset<32>(key) << std::endl;

--- a/offline/packages/trackbase/TrkrDefs.cc
+++ b/offline/packages/trackbase/TrkrDefs.cc
@@ -4,10 +4,17 @@
 
 namespace
 {
+  // hitsetkey layout:
+  //  common upper 16 bits
+  //   24 - 32  tracker id
+  //   16 - 24  layer
+  static constexpr unsigned int kBitShiftTrkrId = 24;  // 32 - 8
+  static constexpr unsigned int kBitShiftLayer = 16;   // bitshift_trackerid - 8
+
   // cluskey layour
   //  hitsetkey upper 32 bits
   //  cluster id lower 32 bits
-  [[maybe_unused]] static constexpr unsigned int kBitShiftClusId = 32;
+  static constexpr unsigned int kBitShiftClusId = 32;
 }
 
 void TrkrDefs::printBits(const TrkrDefs::hitsetkey key, std::ostream& os)

--- a/offline/packages/trackbase/TrkrDefs.cc
+++ b/offline/packages/trackbase/TrkrDefs.cc
@@ -126,7 +126,7 @@ TrkrDefs::cluskey
 TrkrDefs::genClusKey(const TrkrDefs::hitsetkey hskey, const uint32_t clusid)
 {
   const TrkrDefs::cluskey tmp = hskey;
-  TrkrDefs::cluskey key = (tmp << TrkrDefs::kBitShiftClusId);
+  TrkrDefs::cluskey key = (tmp << kBitShiftClusId);
   key |= clusid;
   return key;
 }
@@ -145,12 +145,12 @@ uint8_t TrkrDefs::getZElement(TrkrDefs::hitsetkey key)
 
 uint8_t TrkrDefs::getPhiElement(TrkrDefs::cluskey key)
 {
-  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = (key >> kBitShiftClusId);
   return getPhiElement(tmp);
 }
 
 uint8_t TrkrDefs::getZElement(TrkrDefs::cluskey key)  // side
 {
-  const TrkrDefs::hitsetkey tmp = (key >> TrkrDefs::kBitShiftClusId);
+  const TrkrDefs::hitsetkey tmp = (key >> kBitShiftClusId);
   return getZElement(tmp);
 }

--- a/offline/packages/trackbase/TrkrDefs.h
+++ b/offline/packages/trackbase/TrkrDefs.h
@@ -17,35 +17,35 @@
  */
 namespace TrkrDefs
 {
-  static double EdepScaleFactor __attribute__((unused)) = 0.25;
-  static double MvtxEnergyScaleup __attribute__((unused)) = 5.0e8;
-  static double InttEnergyScaleup __attribute__((unused)) = 5.0e7;
+  [[maybe_unused]] static constexpr double EdepScaleFactor = 0.25;
+  [[maybe_unused]] static constexpr double MvtxEnergyScaleup = 5.0e8;
+  [[maybe_unused]] static constexpr double InttEnergyScaleup = 5.0e7;
 
   /// Key types
-  typedef uint32_t hitkey;      // 32 bit TrkrHit key type
-  typedef uint32_t hitsetkey;   // 32 bit TrkrHitSet key type
-  typedef uint64_t cluskey;     // 64 but TrkrCluster id type
-  typedef uint32_t clushitkey;  // 32 bit hit id type in TrkrCluster
-  typedef uint16_t subsurfkey;  // 16 bit sub surface key type
+  using hitkey = uint32_t;      // 32 bit TrkrHit key type
+  using hitsetkey = uint32_t;   // 32 bit TrkrHitSet key type
+  using cluskey = uint64_t;     // 64 but TrkrCluster id type
+  using clushitkey = uint32_t;  // 32 bit hit id type in TrkrCluster
+  using subsurfkey = uint16_t;  // 16 bit sub surface key type
 
   /// Max values for keys (used as defaults or invalid values)
-  static hitkey HITKEYMAX __attribute__((unused)) = UINT32_MAX;
-  static hitsetkey HITSETKEYMAX __attribute__((unused)) = UINT32_MAX;
-  static cluskey CLUSKEYMAX __attribute__((unused)) = UINT64_MAX;
-  static clushitkey CLUSHITKEYMAX __attribute__((unused)) = UINT32_MAX;
-  static subsurfkey SUBSURFKEYMAX __attribute__((unused)) = UINT16_MAX;
+  [[maybe_unused]] static constexpr hitkey HITKEYMAX = UINT32_MAX;
+  [[maybe_unused]] static constexpr hitsetkey HITSETKEYMAX = UINT32_MAX;
+  [[maybe_unused]] static constexpr cluskey CLUSKEYMAX = UINT64_MAX;
+  [[maybe_unused]] static constexpr clushitkey CLUSHITKEYMAX = UINT32_MAX;
+  [[maybe_unused]] static constexpr subsurfkey SUBSURFKEYMAX = UINT16_MAX;
 
   // hitsetkey layout:
   //  common upper 16 bits
   //   24 - 32  tracker id
   //   16 - 24  layer
-  static const unsigned int kBitShiftTrkrId __attribute__((unused)) = 24;  // 32 - 8
-  static const unsigned int kBitShiftLayer __attribute__((unused)) = 16;   // bitshift_trackerid - 8
+  [[maybe_unused]] static constexpr unsigned int kBitShiftTrkrId = 24;  // 32 - 8
+  [[maybe_unused]] static constexpr unsigned int kBitShiftLayer = 16;   // bitshift_trackerid - 8
 
   // cluskey layour
   //  hitsetkey upper 32 bits
   //  cluster id lower 32 bits
-  static const unsigned int kBitShiftClusId __attribute__((unused)) = 32;
+  [[maybe_unused]] static constexpr unsigned int kBitShiftClusId = 32;
 
   /// Enumeration for tracker id to easily maintain consistency
   enum TrkrId
@@ -102,8 +102,8 @@ namespace TrkrDefs
   TrkrDefs::cluskey getClusKeyLo(const TrkrDefs::TrkrId trkrId, const uint8_t lyr);
   TrkrDefs::cluskey getClusKeyHi(const TrkrDefs::TrkrId trkrId, const uint8_t lyr);
 
-  static const unsigned int kBitShiftPhiElement __attribute__((unused)) = 8;  // sector
-  static const unsigned int kBitShiftZElement __attribute__((unused)) = 0;    // side
+  [[maybe_unused]] static constexpr unsigned int kBitShiftPhiElement = 8;  // sector
+  [[maybe_unused]] static constexpr unsigned int kBitShiftZElement = 0;    // side
 
   uint8_t getPhiElement(TrkrDefs::hitsetkey key);  // sector
   uint8_t getZElement(TrkrDefs::hitsetkey key);    // side

--- a/offline/packages/trackbase/TrkrDefs.h
+++ b/offline/packages/trackbase/TrkrDefs.h
@@ -35,13 +35,6 @@ namespace TrkrDefs
   [[maybe_unused]] static constexpr clushitkey CLUSHITKEYMAX = UINT32_MAX;
   [[maybe_unused]] static constexpr subsurfkey SUBSURFKEYMAX = UINT16_MAX;
 
-  // hitsetkey layout:
-  //  common upper 16 bits
-  //   24 - 32  tracker id
-  //   16 - 24  layer
-  [[maybe_unused]] static constexpr unsigned int kBitShiftTrkrId = 24;  // 32 - 8
-  [[maybe_unused]] static constexpr unsigned int kBitShiftLayer = 16;   // bitshift_trackerid - 8
-
   /// Enumeration for tracker id to easily maintain consistency
   enum TrkrId
   {

--- a/offline/packages/trackbase/TrkrDefs.h
+++ b/offline/packages/trackbase/TrkrDefs.h
@@ -42,11 +42,6 @@ namespace TrkrDefs
   [[maybe_unused]] static constexpr unsigned int kBitShiftTrkrId = 24;  // 32 - 8
   [[maybe_unused]] static constexpr unsigned int kBitShiftLayer = 16;   // bitshift_trackerid - 8
 
-  // cluskey layour
-  //  hitsetkey upper 32 bits
-  //  cluster id lower 32 bits
-  [[maybe_unused]] static constexpr unsigned int kBitShiftClusId = 32;
-
   /// Enumeration for tracker id to easily maintain consistency
   enum TrkrId
   {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR
- cleans up cluster to crossing association in InttClusterizer: now that crossing is in the hitset key,  the association can be done once per cluster rather than per-link as before. This is more efficient. In fact the whole table has now become obsolete, for the same reason, and could be removed altogether (to be discussed with other tracking experts)
- it also adds a MvtxDefs::resetStrobe for cluster key, in preparation for additional cleanup in the Silicon seeder. 
- some cleanup in the various XXXDefs classes to better compartimentalize.
I'd like to commit these changes early before testing more significant changes in the Silicon Seeded/Clearner, to make sure that nothing is broken in the process.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

