### PR TITLE
Allow to set track map name manually

### DIFF
--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.cc
@@ -139,6 +139,7 @@ int QAG4SimulationDistortions::Init(PHCompositeNode* /*unused*/)
 
   TTree* t(nullptr);
 
+
   t = new TTree(TString(get_histo_prefix()) + "residTree", "tpc residual info");
   t->Branch("tanAlpha", &m_tanAlpha, "tanAlpha/F");
   t->Branch("tanBeta", &m_tanBeta, "tanBeta/F");
@@ -166,7 +167,7 @@ int QAG4SimulationDistortions::Init(PHCompositeNode* /*unused*/)
 int QAG4SimulationDistortions::InitRun(PHCompositeNode* topNode)
 {
   // track map
-  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, "SvtxSiliconMMTrackMap");
+  m_trackMap = findNode::getClass<SvtxTrackMap>(topNode, m_trackmapname);
 
   // cluster map
   m_clusterContainer = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");

--- a/offline/QA/SimulationModules/QAG4SimulationDistortions.h
+++ b/offline/QA/SimulationModules/QAG4SimulationDistortions.h
@@ -28,7 +28,15 @@ class QAG4SimulationDistortions : public SubsysReco
   int InitRun(PHCompositeNode* topNode) override;
   int process_event(PHCompositeNode*) override;
 
+  //! track map name
+  void set_trackmap_name( const std::string& value )
+  { m_trackmapname = value; }
+
  private:
+
+  //! track map name
+  std::string m_trackmapname = "SvtxSiliconMMTrackMap";
+
   std::string get_histo_prefix()
   {
     return std::string("h_") + Name() + std::string("_");


### PR DESCRIPTION
This should allow to run the QA module on top of GenFit.
@xyu3 you will need this change to run Genfit based distortion code and evaluator.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

