### PR TITLE
yc - fix reading MVTX RO mode. using isnan function for nan comparison

### DIFF
--- a/offline/framework/fun4allraw/MvtxRawDefs.h
+++ b/offline/framework/fun4allraw/MvtxRawDefs.h
@@ -13,78 +13,78 @@ namespace MvtxRawDefs
   static constexpr uint8_t nChipsPerGbt = 3;
   static constexpr uint8_t nStavesPerFelix = 8;
 
-  static const std::array<uint8_t, nMvtxLayers> firstStaveIndex = {{ 0, 12, 28 }};
+  static const std::array<uint8_t, nMvtxLayers> firstStaveIndex = {{0, 12, 28}};
 
-  static const std::array<std::array<uint8_t, nChipsPerGbt>, nGbtPerStave> gbtChipId_to_staveChipId = {{ {{0,1,2}}, {{3,4,5}}, {{6,7,8}} }};
+  static const std::array<std::array<uint8_t, nChipsPerGbt>, nGbtPerStave> gbtChipId_to_staveChipId = {{{{0, 1, 2}}, {{3, 4, 5}}, {{6, 7, 8}}}};
 
   // 07/03/2024
   // {staveIndex[0-47], { FLX[0-5], EndPoint[0-1] } }
   const std::map<uint8_t, std::pair<uint8_t, uint8_t>> stave_felix_map =
-  {
-    { 0, {2,0} },
-    { 1, {2,0} },
-    { 2, {2,1} },
-    { 3, {0,0} },
-    { 4, {0,0} },
-    { 5, {0,1} },
-    { 6, {4,0} },
-    { 7, {4,0} },
-    { 8, {4,1} },
-    { 9, {3,0} },
-    {10, {3,0} },
-    {11, {3,1} },
-    {12, {1,0} },
-    {13, {1,0} },
-    {14, {1,1} },
-    {15, {1,1} },
-    {16, {2,0} },
-    {17, {2,1} },
-    {18, {2,1} },
-    {19, {2,1} },
-    {20, {5,0} },
-    {21, {5,0} },
-    {22, {5,1} },
-    {23, {5,1} },
-    {24, {4,0} },
-    {25, {4,1} },
-    {26, {4,1} },
-    {27, {4,1} },
-    {28, {4,0} },
-    {29, {0,0} },
-    {30, {0,0} },
-    {31, {0,1} },
-    {32, {0,1} },
-    {33, {3,0} },
-    {34, {1,0} },
-    {35, {1,0} },
-    {36, {1,1} },
-    {37, {1,1} },
-    {38, {2,0} },
-    {39, {3,0} },
-    {40, {3,1} },
-    {41, {3,1} },
-    {42, {3,1} },
-    {43, {0,1} },
-    {44, {5,0} },
-    {45, {5,0} },
-    {46, {5,1} },
-    {47, {5,1} },
+      {
+          {0, {2, 0}},
+          {1, {2, 0}},
+          {2, {2, 1}},
+          {3, {0, 0}},
+          {4, {0, 0}},
+          {5, {0, 1}},
+          {6, {4, 0}},
+          {7, {4, 0}},
+          {8, {4, 1}},
+          {9, {3, 0}},
+          {10, {3, 0}},
+          {11, {3, 1}},
+          {12, {1, 0}},
+          {13, {1, 0}},
+          {14, {1, 1}},
+          {15, {1, 1}},
+          {16, {2, 0}},
+          {17, {2, 1}},
+          {18, {2, 1}},
+          {19, {2, 1}},
+          {20, {5, 0}},
+          {21, {5, 0}},
+          {22, {5, 1}},
+          {23, {5, 1}},
+          {24, {4, 0}},
+          {25, {4, 1}},
+          {26, {4, 1}},
+          {27, {4, 1}},
+          {28, {4, 0}},
+          {29, {0, 0}},
+          {30, {0, 0}},
+          {31, {0, 1}},
+          {32, {0, 1}},
+          {33, {3, 0}},
+          {34, {1, 0}},
+          {35, {1, 0}},
+          {36, {1, 1}},
+          {37, {1, 1}},
+          {38, {2, 0}},
+          {39, {3, 0}},
+          {40, {3, 1}},
+          {41, {3, 1}},
+          {42, {3, 1}},
+          {43, {0, 1}},
+          {44, {5, 0}},
+          {45, {5, 0}},
+          {46, {5, 1}},
+          {47, {5, 1}},
   };
 
-  typedef struct linkId
+  using linkId_t = struct linkId
   {
-    uint32_t layer {0xFF};
-    uint32_t stave {0xFF};
-    uint32_t gbtid {0xFF};
-  } linkId_t;
+    uint32_t layer{0xFF};
+    uint32_t stave{0xFF};
+    uint32_t gbtid{0xFF};
+  };
 
-  uint8_t getStaveIndex( const uint8_t& lyrId, const uint8_t& stvId );
-  std::pair<uint8_t, uint8_t> const& get_flx_endpoint( const uint8_t& lyrId, const uint8_t& stvId );
+  uint8_t getStaveIndex(const uint8_t& lyrId, const uint8_t& stvId);
+  std::pair<uint8_t, uint8_t> const& get_flx_endpoint(const uint8_t& lyrId, const uint8_t& stvId);
 
-  linkId_t decode_feeid( const uint16_t feeid );
+  linkId_t decode_feeid(uint16_t feeid);
 
   float getStrobeLength(const int& runNumber);
 
-} // namespace MvtxRawDefs
+}  // namespace MvtxRawDefs
 
-#endif // MVTXRAWDEFS_H
+#endif  // MVTXRAWDEFS_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR will fix the method to read MVTX RO modes.
The current approach is to read the MVTX RO method from OCDB first and in case the
value is not found try with DAQ DB. the latest is never reached becasue the outcome of the
comparison was always true.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
MVTX Offline recosntruction for Run25 must be redone after this PR implementation.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

