### PR TITLE
SvtxEvaluator - add svtxhit x,y info to ntuple 

### DIFF
--- a/simulation/g4simulation/g4eval/SvtxEvaluator.cc
+++ b/simulation/g4simulation/g4eval/SvtxEvaluator.cc
@@ -133,7 +133,7 @@ int SvtxEvaluator::Init(PHCompositeNode* /*topNode*/)
   {
     _ntp_hit = new TNtuple("ntp_hit", "svtxhit => max truth",
                            "event:seed:hitID:e:adc:layer:phielem:zelem:"
-                           "cellID:ecell:phibin:zbin:phi:z:"
+                           "cellID:ecell:phibin:zbin:phi:x:y:z:"
                            "g4hitID:gedep:gx:gy:gz:gt:"
                            "gtrackID:gflavor:"
                            "gpx:gpy:gpz:gvx:gvy:gvz:gvt:"
@@ -1688,6 +1688,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
           float phibin = NAN;
           float zbin = NAN;
           float phi = NAN;
+          float r = NAN;
+          float x = NAN;
+          float y = NAN;
           float z = NAN;
 
           if (local_layer >= _nlayers_maps + _nlayers_intt && local_layer < _nlayers_maps + _nlayers_intt + _nlayers_tpc)
@@ -1697,6 +1700,9 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
             zbin = (float) TpcDefs::getTBin(hit_key);
             phi = local_GeoLayer->get_phicenter(phibin, side);
             z = local_GeoLayer->get_zcenter(zbin);
+            r = local_GeoLayer->get_radius();
+            x = r*cos(phi);
+            y = r*sin(phi);
           }
 
           float g4hitID = NAN;
@@ -1798,6 +1804,8 @@ void SvtxEvaluator::fillOutputNtuples(PHCompositeNode* topNode)
               (float) phibin,
               (float) zbin,
               phi,
+              x,
+              y,
               z,
               g4hitID,
               gedep,


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds the local x,y position of an svtxhit to the SvtxEvaluator ntuple output.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

