### PR TITLE
fix: INTT/MVTX BCO range needs updating 

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -773,8 +773,6 @@ int Fun4AllStreamingInputManager::FillIntt()
   {
     h_taggedAllFee_intt->Fill(refbcobitshift);
   }
-
-  //  std::cout << "Checking diff " << (m_InttRawHitMap.begin()->first - (select_crossings - m_intt_negative_bco)) << std::endl;
   while (m_InttRawHitMap.begin()->first <= select_crossings - m_intt_negative_bco)
   {
     for (auto intthititer : m_InttRawHitMap.begin()->second.InttRawHitVector)
@@ -908,7 +906,7 @@ int Fun4AllStreamingInputManager::FillMvtx()
       auto [felix, endpoint] = MvtxRawDefs::get_flx_endpoint(link.layer, link.stave);
       int packetid = felix * 2 + endpoint;
       h_bcoLL1Strobediff[packetid]->Fill(diff);
-      if(diff < m_mvtx_bco_range)
+      if(diff <= m_mvtx_bco_range)
       {
         h_tagStBcoFelix_mvtx[packetid]->Fill(refbcobitshift);
         h_tagStBcoFEE_mvtx[packetid]->Fill(feeId);
@@ -1203,39 +1201,7 @@ int Fun4AllStreamingInputManager::FillTpc()
       }
     }
   }
-  unsigned int refbcobitshift = m_RefBCO & 0x3FU;
-  h_refbco_tpc->Fill(refbcobitshift);
-  bool allpackets = true;
-  for (auto &p : m_TpcInputVector)
-  {
-    auto bcl_stack = p->BclkStackMap();
-    int packetnum = 0;
-    int histo_to_fill = (bcl_stack.begin()->first - 4000) / 10;
-
-    for (auto &[packetid, bclset] : bcl_stack)
-    {
-      bool thispacket = false;
-      for (auto &bcl : bclset)
-      {
-        auto diff = (m_RefBCO > bcl) ? m_RefBCO - bcl : bcl - m_RefBCO;
-        if (diff < 256)
-        {
-          thispacket = true;
-          h_gl1tagged_tpc[histo_to_fill][packetnum]->Fill(refbcobitshift);
-        }
-      }
-      if (thispacket == false)
-      {
-        allpackets = false;
-      }
-
-      packetnum++;
-    }
-  }
-  if (allpackets)
-  {
-    h_taggedAll_tpc->Fill(refbcobitshift);
-  }
+  
   // again m_TpcRawHitMap.empty() is handled by return of FillTpcPool()
   if (m_TpcRawHitMap.size() > 0)
   {
@@ -1476,12 +1442,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
 {
   auto hm = QAHistManagerDef::getHistoManager();
   assert(hm);
-  {
-    auto h = new TH1I("h_TpcPoolQA_RefGL1BCO", "TPC ref BCO", 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("GL1 BCO");
-    h->SetTitle("GL1 Reference BCO");
-    hm->registerHisto(h);
-  }
+
   {
     auto h = new TH1I("h_InttPoolQA_RefGL1BCO", "INTT ref BCO", 1000, 0, 1000);
     h->GetXaxis()->SetTitle("GL1 BCO");
@@ -1513,13 +1474,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
     hm->registerHisto(h);
     h_taggedAllFelixesAllFees_mvtx = h;
   }
-  {
-    auto h = new TH1I("h_TpcPoolQA_TagBCOAllPackets", "TPC trigger tagged BCO all servers", 1000,
-                      0, 1000);
-    h->GetXaxis()->SetTitle("GL1 BCO");
-    h->SetTitle("GL1 Reference BCO");
-    hm->registerHisto(h);
-  }
+
 
   for (int i = 0; i < 12; i++)
   {
@@ -1566,18 +1521,7 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h_all->SetTitle("GL1 Reference BCO");
     hm->registerHisto(h_all);
   }
-  for (int i = 0; i < 24; i++)
-  {
-    for (int j = 0; j < 2; j++)
-    {
-      {
-        auto h = new TH1I((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str().c_str(), "TPC trigger tagged BCO", 1000, 0, 1000);
-        h->GetXaxis()->SetTitle("GL1 BCO");
-        h->SetTitle((boost::format("Packet %i and packet %i") % i % j).str().c_str());
-        hm->registerHisto(h);
-      }
-    }
-  }
+
 
   for (int i = 0; i < 12; i++)
   {
@@ -1611,14 +1555,5 @@ void Fun4AllStreamingInputManager::createQAHistos()
     h_tagBcoFelixAllFees_mvtx[i] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_MvtxPoolQA_TagBCOAllFees_Felix%i") % i).str().c_str()));
   }
 
-  for (int i = 0; i < 24; i++)
-  {
-    for (int j = 0; j < 2; j++)
-    {
-      h_gl1tagged_tpc[i][j] = dynamic_cast<TH1 *>(hm->getHisto((boost::format("h_TpcPoolQA_TagBCO_ebdc%i_packet%i") % i % j).str()));
-    }
-  }
 
-  h_refbco_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_RefGL1BCO"));
-  h_taggedAll_tpc = dynamic_cast<TH1 *>(hm->getHisto("h_TpcPoolQA_TagBCOAllPackets"));
 }

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.h
@@ -159,9 +159,6 @@ class Fun4AllStreamingInputManager : public Fun4AllInputManager
   TH1 *h_gl1taggedfee_intt[8][14]{{nullptr}};
   TH2 *h_bcodiff_intt[8]{nullptr};
 
-  TH1 *h_gl1tagged_tpc[24][2]{{nullptr}};
-  TH1 *h_refbco_tpc{nullptr};
-  TH1 *h_taggedAll_tpc{nullptr};
 };
 
 #endif /* FUN4ALL_FUN4ALLSTREAMINGINPUTMANAGER_H */

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -11,6 +11,7 @@
 #include <phool/PHIODataNode.h>    // for PHIODataNode
 #include <phool/PHNodeIterator.h>  // for PHNodeIterator
 #include <phool/getClass.h>
+#include <phool/recoConsts.h>
 
 #include <Event/Event.h>
 #include <Event/EventTypes.h>
@@ -461,6 +462,15 @@ void SingleInttPoolInput::ConfigureStreamingInputManager()
 {
   if (StreamingInputManager())
   {
+    auto rc = recoConsts::instance();
+    // if it is triggered after the gtm firmware change
+    if(rc->get_IntFlag("RUNNUMBER") > 58677 && m_BcoRange < 5)
+    {
+      SetBcoRange(3);
+      std::cout << "INTT changed to triggered event combining with range [-"
+                << m_NegativeBco << "," << m_BcoRange << "]" << std::endl;
+    }
+
     StreamingInputManager()->SetInttBcoRange(m_BcoRange);
     StreamingInputManager()->SetInttNegativeBco(m_NegativeBco);
   }

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -45,7 +45,9 @@ class SingleInttPoolInput : public SingleStreamingInput
 
     SetNegativeBco(1);
     SetBcoRange(2);
-    std::cout << "INTT set to triggered event combining" << std::endl;
+
+    std::cout << "INTT set to triggered event combining with range [-" 
+              << m_NegativeBco << "," << m_BcoRange << "]" << std::endl;
   }
 
  private:

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -442,7 +442,7 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   }
   else if (m_strobeWidth < 1) // triggered mode
   {
-    m_BcoRange = 2;
+    m_BcoRange = 3;
     m_NegativeBco = 0;
     if(StreamingInputManager())
     {
@@ -459,6 +459,7 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
     std::cout << "Mvtx strobe length " << m_strobeWidth << std::endl;
     std::cout << "Mvtx BCO range and negative bco range set based on strobe length " << m_BcoRange << ", " << m_NegativeBco << std::endl;
   }
+
   if (StreamingInputManager())
   {
     StreamingInputManager()->SetMvtxBcoRange(m_BcoRange);


### PR DESCRIPTION
Apparently there was a gtm firmware update in late March that resulted in the clock difference between the GL1 and GTM delivered to the INTT being offset by an additional tick. This means that there were no raw hits created because the BCO matching range was too small. This PR fixes this with a hacked update based on the runnumber - we should think about whether or not this should go in the CDB longer term

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

