### PR TITLE
KFP updates

### DIFF
--- a/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_DST.cc
@@ -17,8 +17,8 @@
 
 #include <trackbase_historic/SvtxTrack.h>     // for SvtxTrack
 #include <trackbase_historic/SvtxTrackMap.h>  // for SvtxTrackMap, SvtxTr...
-#include <trackbase_historic/SvtxTrackMap_v1.h>
-#include <trackbase_historic/SvtxTrack_v2.h>
+#include <trackbase_historic/SvtxTrackMap_v2.h>
+#include <trackbase_historic/SvtxTrack_v4.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
 
@@ -88,7 +88,7 @@ int KFParticle_DST::createParticleNode(PHCompositeNode* topNode)
 
   if (m_write_track_container)
   {
-    m_recoTrackMap = new SvtxTrackMap_v1();
+    m_recoTrackMap = new SvtxTrackMap_v2();
     PHIODataNode<PHObject>* trackNode = new PHIODataNode<PHObject>(m_recoTrackMap, trackNodeName.c_str(), "PHObject");
     lowerNode->addNode(trackNode);
     std::cout << trackNodeName << " node added" << std::endl;
@@ -131,6 +131,10 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
                                             std::vector<KFParticle> daughters,
                                             std::vector<KFParticle> intermediates)
 {
+  //Make keys for daughters, mothers and intermediates
+  unsigned int daughterCounter = 0;
+  unsigned int resonanceCounter = UINT_MAX;
+
   std::string baseName;
   std::string trackNodeName;
 
@@ -166,10 +170,16 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
 
   m_recoTrackMap = findNode::getClass<SvtxTrackMap>(topNode, trackNodeName.c_str());
 
-  SvtxTrack* m_recoTrack = new SvtxTrack_v2();
+  SvtxTrack* m_recoTrack = new SvtxTrack_v4();
 
   m_recoTrack = buildSvtxTrack(motherParticle);
-  m_recoTrackMap->insert(m_recoTrack);
+
+  SvtxTrack *dummyMother = nullptr;  
+  while (!dummyMother)
+  {
+    dummyMother = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+    --resonanceCounter;
+  }
   m_recoTrack->Reset();
 
   if (m_has_intermediates_DST)
@@ -179,7 +189,12 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
     for (unsigned int k = 0; k < intermediates.size(); ++k)
     {
       m_recoTrack = buildSvtxTrack(intermediateArray[k]);
-      m_recoTrackMap->insert(m_recoTrack);
+      SvtxTrack *dummyIntermediate = nullptr;  
+      while (!dummyIntermediate)
+      {
+	dummyIntermediate = m_recoTrackMap->insertWithKey(m_recoTrack, resonanceCounter);
+        --resonanceCounter;
+      }
       m_recoTrack->Reset();
     }
   }
@@ -193,13 +208,19 @@ void KFParticle_DST::fillParticleNode_Track(PHCompositeNode* topNode, KFParticle
     {
       std::cout << "There was no original track map found, the tracks will have no cluster information!" << std::endl;
       m_recoTrack = buildSvtxTrack(daughterArray[k]);
+
+      SvtxTrack *dummyDaughter = nullptr;  
+      while (!dummyDaughter)
+      {
+        dummyDaughter = m_recoTrackMap->insertWithKey(m_recoTrack, daughterCounter);
+        ++daughterCounter;
+      }
     }
     else
     {
       m_recoTrack = kfpTruthTools_DST.getTrack(daughterArray[k].Id(), originalTrackMap);
+      m_recoTrackMap->insertWithKey(m_recoTrack, daughterArray[k].Id());
     }
-
-    m_recoTrackMap->insert(m_recoTrack);
   }
 }
 
@@ -294,7 +315,7 @@ void KFParticle_DST::fillParticleNode_Particle(PHCompositeNode* topNode, KFParti
 
 SvtxTrack* KFParticle_DST::buildSvtxTrack(const KFParticle& particle)
 {
-  SvtxTrack* track = new SvtxTrack_v2();
+  SvtxTrack* track = new SvtxTrack_v4();
 
   track->set_id(std::abs(particle.GetPDG()));
   track->set_charge((int) particle.GetQ());

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_Tools.h
@@ -67,7 +67,7 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   /*const*/ bool isGoodTrack(const KFParticle &particle, const std::vector<KFParticle> &primaryVertices);
 
-  int calcMinIP(const KFParticle &track, const std::vector<KFParticle> &PVs, float &minimumIP, float &minimumIPchi2);
+  int calcMinIP(const KFParticle &track, const std::vector<KFParticle> &PVs, float &minimumIP, float &minimumIPchi2, bool do3D = true);
 
   std::vector<int> findAllGoodTracks(const std::vector<KFParticle> &daughterParticles, const std::vector<KFParticle> &primaryVertices);
 
@@ -134,6 +134,10 @@ class KFParticle_Tools : protected KFParticle_MVA
   std::vector<float> m_intermediate_min_pt;
   std::vector<float> m_intermediate_min_dira;
   std::vector<float> m_intermediate_min_fdchi2;
+  std::vector<float> m_intermediate_min_ip_xy;
+  std::vector<float> m_intermediate_max_ip_xy;
+  std::vector<float> m_intermediate_min_ipchi2_xy;
+  std::vector<float> m_intermediate_max_ipchi2_xy;
   std::vector<float> m_intermediate_min_ip;
   std::vector<float> m_intermediate_max_ip;
   std::vector<float> m_intermediate_min_ipchi2;
@@ -156,17 +160,35 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_max_mass {-1};
 
-  float m_min_decayTime {-1};
+  float m_min_decayTime_xy {-1000};
+
+  float m_max_decayTime_xy {std::numeric_limits<float>::max()};
+
+  float m_min_decayLength_xy {-1000};
+
+  float m_max_decayLength_xy {std::numeric_limits<float>::max()};
+
+  float m_min_decayTime {-1000};
 
   float m_max_decayTime {std::numeric_limits<float>::max()};
 
-  float m_min_decayLength {-1};
+  float m_min_decayLength {-1000};
 
   float m_max_decayLength {std::numeric_limits<float>::max()};
+
+  float m_mother_min_decay_time_significance {-1};
+
+  float m_mother_min_decay_length_significance {-1};
+
+  float m_mother_min_decay_length_xy_significance {-1};
 
   float m_track_pt {-1};
 
   float m_track_ptchi2 {std::numeric_limits<float>::max()};
+
+  float m_track_ip_xy {-1};
+
+  float m_track_ipchi2_xy {-1};
 
   float m_track_ip {-1};
 
@@ -174,9 +196,15 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_track_chi2ndof {std::numeric_limits<float>::max()};
 
-  int m_nMVTXHits {3};
+  int m_nMVTXStates {2};
 
-  int m_nTPCHits {20};
+  int m_nINTTStates {1};
+
+  int m_nTPCStates {20};
+
+  int m_nTPOTStates {0};
+
+  float m_comb_DCA_xy {std::numeric_limits<float>::max()};
 
   float m_comb_DCA {std::numeric_limits<float>::max()};
 
@@ -184,13 +212,23 @@ class KFParticle_Tools : protected KFParticle_MVA
 
   float m_fdchi2 {-1};
 
+  float m_dira_xy_min {-1};
+
+  float m_dira_xy_max {1};
+
   float m_dira_min {-1};
 
   float m_dira_max {1};
 
   float m_mother_pt {-1};
 
+  float m_mother_ip {std::numeric_limits<float>::max()};
+
   float m_mother_ipchi2 {std::numeric_limits<float>::max()};
+
+  float m_mother_ip_xy {std::numeric_limits<float>::max()};
+
+  float m_mother_ipchi2_xy {std::numeric_limits<float>::max()};
 
   float m_mother_vertex_volume {std::numeric_limits<float>::max()};
 

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_eventReconstruction.cc
@@ -452,8 +452,14 @@ void KFParticle_eventReconstruction::getCandidateDecay(std::vector<KFParticle>& 
         {
           float min_ip = 0;
           float min_ipchi2 = 0;
+          float min_ip_xy = 0;
+          float min_ipchi2_xy  = 0;
           calcMinIP(candidate, primaryVerticesCand, min_ip, min_ipchi2);
-          if (!isInRange(m_intermediate_min_ip[intermediateNumber], min_ip, m_intermediate_max_ip[intermediateNumber]) || !isInRange(m_intermediate_min_ipchi2[intermediateNumber], min_ipchi2, m_intermediate_max_ipchi2[intermediateNumber]))
+          calcMinIP(candidate, primaryVerticesCand, min_ip_xy , min_ipchi2_xy, false);
+          if (!isInRange(m_intermediate_min_ip[intermediateNumber], min_ip, m_intermediate_max_ip[intermediateNumber])
+           || !isInRange(m_intermediate_min_ipchi2[intermediateNumber], min_ipchi2, m_intermediate_max_ipchi2[intermediateNumber])
+           || !isInRange(m_intermediate_min_ip_xy[intermediateNumber], min_ip_xy, m_intermediate_max_ip_xy[intermediateNumber])
+           || !isInRange(m_intermediate_min_ipchi2_xy[intermediateNumber], min_ipchi2_xy, m_intermediate_max_ipchi2_xy[intermediateNumber]))
           {
             isGood = false;
           }

--- a/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
+++ b/offline/packages/KFParticle_sPHENIX/KFParticle_sPHENIX.h
@@ -148,6 +148,18 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumMass(float max_mass) { m_max_mass = max_mass; }
 
+  void setDecayTimeRange_XY(float min_decayTime, float max_decayTime)
+  {
+    m_min_decayTime_xy = min_decayTime;
+    m_max_decayTime_xy = max_decayTime;
+  }
+
+  void setDecayLengthRange_XY(float min_decayLength, float max_decayLength)
+  {
+    m_min_decayLength_xy = min_decayLength;
+    m_max_decayLength_xy = max_decayLength;
+  }
+
   void setDecayTimeRange(float min_decayTime, float max_decayTime)
   {
     m_min_decayTime = min_decayTime;
@@ -160,9 +172,19 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     m_max_decayLength = max_decayLength;
   }
 
+  void setMinDecayTimeSignificance(float min = 0) { m_mother_min_decay_time_significance = min; }
+
+  void setMinDecayLengthSignificance(float min = 0) { m_mother_min_decay_length_significance = min; }
+
+  void setMinDecayLengthSignificance_XY(float min = 0) { m_mother_min_decay_length_xy_significance = min; }
+
   void setMinimumTrackPT(float pt) { m_track_pt = pt; }
 
   void setMaximumTrackPTchi2(float ptchi2) { m_track_ptchi2 = ptchi2; }
+
+  void setMinimumTrackIP_XY(float ip) { m_track_ip_xy = ip; }
+
+  void setMinimumTrackIPchi2_XY(float ipchi2) { m_track_ipchi2_xy = ipchi2; }
 
   void setMinimumTrackIP(float ip) { m_track_ip = ip; }
 
@@ -170,9 +192,15 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaximumTrackchi2nDOF(float trackchi2ndof) { m_track_chi2ndof = trackchi2ndof; }
 
-  void setMinMVTXhits(int nHits) { m_nMVTXHits = nHits; }
+  void setMinMVTXhits(int nHits) { m_nMVTXStates = nHits; } //Actually state counting but use this for backwards compatibility!
 
-  void setMinTPChits(int nHits) { m_nTPCHits = nHits; }
+  void setMinINTThits(int nHits) { m_nINTTStates = nHits; } //Actually state counting but use this for backwards compatibility!
+
+  void setMinTPChits(int nHits) { m_nTPCStates = nHits; } //Actually state counting but use this for backwards compatibility!
+
+  void setMinTPOThits(int nHits) { m_nTPCStates = nHits; } //Actually state counting but use this for backwards compatibility!
+
+  void setMaximumDaughterDCA_XY(float dca) { m_comb_DCA_xy = dca; }
 
   void setMaximumDaughterDCA(float dca) { m_comb_DCA = dca; }
  
@@ -186,9 +214,19 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
 
   void setMaxDIRA(float dira_max) { m_dira_max = dira_max; }
 
+  void setMinDIRA_XY(float dira_min) { m_dira_xy_min = dira_min; }
+
+  void setMaxDIRA_XY(float dira_max) { m_dira_xy_max = dira_max; }
+
   void setMotherPT(float mother_pt) { m_mother_pt = mother_pt; }
 
+  void setMotherIP(float mother_ip) { m_mother_ip = mother_ip; }
+
+  void setMotherIP_XY(float mother_ip) { m_mother_ip_xy = mother_ip; }
+
   void setMotherIPchi2(float mother_ipchi2) { m_mother_ipchi2 = mother_ipchi2; }
+
+  void setMotherIPchi2_XY(float mother_ipchi2) { m_mother_ipchi2_xy = mother_ipchi2; }
 
   void setMaximumMotherVertexVolume(float vertexvol) { m_mother_vertex_volume = vertexvol; }
 
@@ -244,6 +282,20 @@ class KFParticle_sPHENIX : public SubsysReco, public KFParticle_nTuple, public K
     {
       m_intermediate_min_ip.push_back(intermediate_IP_range[i].first);
       m_intermediate_max_ip.push_back(intermediate_IP_range[i].second);
+    }
+  }
+
+  void setIntermediateMinIPchi2_XY(const std::vector<float> &intermediate_min_IPchi2)
+  {
+    for (unsigned int i = 0; i < intermediate_min_IPchi2.size(); ++i) m_intermediate_min_ipchi2_xy.push_back(intermediate_min_IPchi2[i]);
+  }
+
+  void setIntermediateIPchi2Range_XY(const std::vector<std::pair<float, float> /*unused*/> &intermediate_IPchi2_range)
+  {
+    for (unsigned int i = 0; i < intermediate_IPchi2_range.size(); ++i)
+    {
+      m_intermediate_min_ipchi2_xy.push_back(intermediate_IPchi2_range[i].first);
+      m_intermediate_max_ipchi2_xy.push_back(intermediate_IPchi2_range[i].second);
     }
   }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Various KFParticle updates:

1. KFParticle SvtxTrack container now retains track IDs for real tracks, while resonances are given IDs counting back from FLT_MAX to avoid accidentally using an ID that could already exist

2. Added electron ID using dE/dx. It's the same as the pion ID as the bands are basically on top of each other

3. Added more selections to match what was used in the offline QM D0 analysis. Testing on K-short reconstruction shows a few percent increase in yield with the same cuts after switching from accepting tracks by clusters on seeds to the number of states for ach subsystem. Run 53877 yield with equivalent cuts went from 99866 candidates to 102337

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

