### PR TITLE
fix: exit if strobe not found

### DIFF
--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -427,8 +427,9 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
   if(std::isnan(m_strobeWidth))
   {
     std::cout << PHWHERE << "WARNING: Strobe length is not defined for run " << runnumber << std::endl;
-    std::cout << "Defaulting to 89 mus strobe length" << std::endl;
-    m_strobeWidth = 89.;
+    std::cout << "Exiting to avoid processing of mvtx" << std::endl;
+    
+    exit(1);
   }
   if(m_strobeWidth > 88.)
   {


### PR DESCRIPTION
@ycorrales this changes the pooler to just exit if the strobe is not found in the db and returned as `nan`

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

