### PR TITLE
fix rare duplicate runnode saving at End(), clang-tidy fixes

### DIFF
--- a/offline/framework/fun4all/Fun4AllHistoManager.cc
+++ b/offline/framework/fun4all/Fun4AllHistoManager.cc
@@ -7,19 +7,13 @@
 
 #include <TFile.h>
 #include <TH1.h>
+#include <THnSparse.h>
 #include <TNamed.h>
 #include <TSystem.h>
 #include <TTree.h>
 
-#include <RVersion.h>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5, 20, 0)
-#define HAS_THNSPARSE 1
-#include <THnSparse.h>
-#endif
-
-#include <boost/format.hpp>
-
 #include <filesystem>
+#include <format>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -67,7 +61,7 @@ int Fun4AllHistoManager::RunAfterClosing()
     if (rc->FlagExist("RUNNUMBER") && m_dumpHistoSegments)
     {
       runnumber = rc->get_IntFlag("RUNNUMBER");
-      runseg = (boost::format("-%08d-%05d.root") % runnumber % m_CurrentSegment).str();
+      runseg = std::format("-{:08}-{:05}.root",runnumber,m_CurrentSegment);
     }
     std::string fullcmd = m_RunAfterClosingScript + " " + m_outfilename + runseg + " " + m_ClosingArgs;
     if (Verbosity() > 1)
@@ -116,7 +110,7 @@ int Fun4AllHistoManager::dumpHistos(const std::string &filename, const std::stri
   if (rc->FlagExist("RUNNUMBER") && m_dumpHistoSegments)
   {
     runnumber = rc->get_IntFlag("RUNNUMBER");
-    runseg = (boost::format("-%08d-%05d.root") % runnumber % m_CurrentSegment).str();
+    runseg = std::format("-{:08}-{:05}.root",runnumber,m_CurrentSegment);
   }
 
   std::string theoutfile = m_outfilename + runseg;
@@ -232,13 +226,13 @@ bool Fun4AllHistoManager::registerHisto(const std::string &hname, TNamed *h1d, c
   // reset directory for TTree
   if (h1d->InheritsFrom("TTree"))
   {
-    static_cast<TTree *>(h1d)->SetDirectory(nullptr);
+    static_cast<TTree *>(h1d)->SetDirectory(nullptr); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   }
 
   // For histograms, enforce error calculation and propagation
   if (h1d->InheritsFrom("TH1"))
   {
-    static_cast<TH1 *>(h1d)->Sumw2();
+    static_cast<TH1 *>(h1d)->Sumw2();// NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
   }
 
   return true;

--- a/offline/framework/fun4all/Fun4AllServer.cc
+++ b/offline/framework/fun4all/Fun4AllServer.cc
@@ -979,6 +979,7 @@ int Fun4AllServer::CountOutNodesRecursive(PHCompositeNode *startNode, const int 
   {
     if ((thisNode->getType() == "PHCompositeNode"))
     {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
       icnt = CountOutNodesRecursive(static_cast<PHCompositeNode *>(thisNode), icnt);  // if this is a CompositeNode do this trick again
     }
     else
@@ -1003,6 +1004,7 @@ int Fun4AllServer::MakeNodesTransient(PHCompositeNode *startNode)
   {
     if ((thisNode->getType() == "PHCompositeNode"))
     {
+      //NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
       MakeNodesTransient(static_cast<PHCompositeNode *>(thisNode));  // if this is a CompositeNode do this trick again
     }
     else
@@ -1013,8 +1015,7 @@ int Fun4AllServer::MakeNodesTransient(PHCompositeNode *startNode)
   return 0;
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
-int Fun4AllServer::MakeNodesPersistent(PHCompositeNode *startNode)
+int Fun4AllServer::MakeNodesPersistent(PHCompositeNode *startNode) // NOLINT(misc-no-recursion)
 {
   PHNodeIterator nodeiter(startNode);
   PHPointerListIterator<PHNode> iterat(nodeiter.ls());
@@ -1023,6 +1024,7 @@ int Fun4AllServer::MakeNodesPersistent(PHCompositeNode *startNode)
   {
     if ((thisNode->getType() == "PHCompositeNode"))
     {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
       MakeNodesPersistent(static_cast<PHCompositeNode *>(thisNode));  // if this is a CompositeNode do this trick again
     }
     else

--- a/offline/framework/fun4all/TDirectoryHelper.cc
+++ b/offline/framework/fun4all/TDirectoryHelper.cc
@@ -92,6 +92,7 @@ void TDirectoryHelper::duplicateDir(TDirectory* dest, TDirectory* source)
 
   TDirectory* newdir;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   newdir = static_cast<TDirectory*>(gDirectory->FindObject(source->GetName()));
 
   if (!newdir)
@@ -168,6 +169,7 @@ TDirectoryHelper::mkdir(TDirectory* topDir,
 
   for (size_t i = 0; i < paths.size(); i++)
   {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     TDirectory* subdir = static_cast<TDirectory*>(dir->FindObject(paths[i].c_str()));
     if (subdir == nullptr)
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
When saving DSTs every n Events (like our single stream processing) and the total number of events is a multiple of n, the Fun4AllServer::End() method which saves the Run Node to the last output file created a separate output file (if the files was moved). That's very unlikely to have ever happened.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

