### PR TITLE
Add check in PrelimDistortionCorrection to remove seeds with < 3 clusters

### DIFF
--- a/offline/packages/trackreco/PrelimDistortionCorrection.cc
+++ b/offline/packages/trackreco/PrelimDistortionCorrection.cc
@@ -314,6 +314,11 @@ void PrelimDistortionCorrection::publishSeeds(std::vector<TrackSeed_v2>& seeds, 
   int seed_index = 0;
   for(auto& seed: seeds )
   {
+    if(seed.size_cluster_keys() < 3)
+      {
+	continue;   // ALICEKalmanFilter can drop clusters. Seeds require at least 3 clusters for circle fit
+      }
+    
     /// The ALICEKF gives a better charge determination at high pT
     int q = seed.get_charge();
     TrackSeedHelper::circleFitByTaubin(&seed,positions, 7, 55);


### PR DESCRIPTION


[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
An ALICEKalmanFilter refit of the TPC seeds is called in PrelimDistortionCorrection. This occasionally results in clusters being dropped from the seeds. It happens only for very low pT seeds ( < 100 MeV/c). If the number of clusters drops below 3 the seed cannot be fitted with a circle, and this results in nan values for some seed parameters further down the line.

This PR drops those non-viable seeds.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

