### PR TITLE
TpcClusterMover speedup

### DIFF
--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -17,7 +17,7 @@
 
 namespace
 {
-  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const Acts::Vector3 v )
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const Acts::Vector3& v )
   {
     out << "(" << v.x() << ", " << v.y() << ", " << v.z() << ")";
     return out;

--- a/offline/packages/tpc/TpcClusterMover.cc
+++ b/offline/packages/tpc/TpcClusterMover.cc
@@ -15,6 +15,15 @@
 #include <cmath>
 #include <iostream>
 
+namespace
+{
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const Acts::Vector3 v )
+  {
+    out << "(" << v.x() << ", " << v.y() << ", " << v.z() << ")";
+    return out;
+  }
+}
+
 TpcClusterMover::TpcClusterMover()
 {
   // initialize layer radii
@@ -54,8 +63,9 @@ void TpcClusterMover::initialize_geometry(PHG4TpcCylinderGeomContainer *cellgeo)
 }
 
 //____________________________________________________________________________..
-std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::processTrack(std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_in)
+std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::processTrack(const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_in)
 {
+
   // Get the global positions of the TPC clusters for this track, already corrected for distortions, and move them to the surfaces
   // The input object contains all clusters for the track
 
@@ -64,19 +74,18 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
   std::vector<Acts::Vector3> tpc_global_vec;
   std::vector<TrkrDefs::cluskey> tpc_cluskey_vec;
 
-  for (auto &i : global_in)
+  for (const auto& [ckey,global]:global_in)
   {
-    TrkrDefs::cluskey cluskey = i.first;
-    unsigned int trkrid = TrkrDefs::getTrkrId(cluskey);
+    const auto trkrid = TrkrDefs::getTrkrId(ckey);
     if (trkrid == TrkrDefs::tpcId)
     {
-      tpc_global_vec.push_back(i.second);
-      tpc_cluskey_vec.push_back(i.first);
+      tpc_cluskey_vec.push_back(ckey);
+      tpc_global_vec.push_back(global);
     }
     else
     {
       // si clusters stay where they are
-      global_moved.emplace_back(std::make_pair(cluskey, i.second));
+      global_moved.emplace_back(ckey,global);
     }
   }
 
@@ -134,7 +143,7 @@ std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> TpcClusterMover::proces
     Acts::Vector3 global_new(xnew, ynew, znew);
 
     // add the new position and surface to the return object
-    global_moved.emplace_back(std::make_pair(cluskey, global_new));
+    global_moved.emplace_back(cluskey, global_new);
 
     if (_verbosity > 2)
     {

--- a/offline/packages/tpc/TpcClusterMover.h
+++ b/offline/packages/tpc/TpcClusterMover.h
@@ -20,7 +20,7 @@ class TpcClusterMover
 
   void set_verbosity(int verb) { _verbosity = verb; }
 
-  std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> global_in);
+  std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>> processTrack(const std::vector<std::pair<TrkrDefs::cluskey, Acts::Vector3>>& global_in);
 
   //! Updates the assumed default geometry below to that contained in the
   //! cell geo


### PR DESCRIPTION
While tracking the origin of the recent nan messages from MakeSourceLinks, found two small optimizations of TpcClusterMover:
- avoid vector copy in ::processTrack by passing argument by reference rather than value
- proper use of emplace_back

Shoud have no impact on the result (but speed-up)

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

