### PR TITLE
Add clarity and fix verbosity of dijet warning about vertex node

### DIFF
--- a/offline/QA/Jet/DijetQA.cc
+++ b/offline/QA/Jet/DijetQA.cc
@@ -145,10 +145,16 @@ int DijetQA::process_event(PHCompositeNode* topNode)
   GlobalVertexMap* vtxmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vtxmap || vtxmap->empty())
   {
-	
-    std::cout << "DijetQA::process_event - Error can not find vtxmap node " << "GlobalVertexMap" << std::endl; 
-    if( Verbosity() > 1 ){
-	 std::cout << "No vertex map found, assuming the vertex has z=0" << std::endl;
+    if (!vtxmap)
+    {
+      std::cerr << "DijetQA::process_event - Error can not find vtxmap node " << "GlobalVertexMap" << std::endl;
+    }
+    if(Verbosity() > 1)
+    {
+      if (vtxmap->empty())
+      {
+        std::cerr << "No vertex map found, assuming the vertex has z=0" << std::endl;
+      }
     }
     m_zvtx = 0;
   }

--- a/offline/QA/Jet/DijetQA.cc
+++ b/offline/QA/Jet/DijetQA.cc
@@ -71,7 +71,7 @@ int DijetQA::Init(PHCompositeNode* /*topNode*/)
   m_manager = QAHistManagerDef::getHistoManager();  // get the histogram anager
 
 	if(!m_manager){
-		std::cerr<<PHWHERE <<": PANIC: couldn't grab histogram manager!" <<std::endl;
+		std::cout<<PHWHERE <<": PANIC: couldn't grab histogram manager!" <<std::endl;
 		assert(m_manager);
 	}
 	std::string smallModuleName = m_moduleName; //make sure name is lowercase
@@ -147,13 +147,13 @@ int DijetQA::process_event(PHCompositeNode* topNode)
   {
     if (!vtxmap)
     {
-      std::cerr << "DijetQA::process_event - Error can not find vtxmap node " << "GlobalVertexMap" << std::endl;
+      std::cout << "DijetQA::process_event - Error can not find vtxmap node " << "GlobalVertexMap" << std::endl;
     }
     if(Verbosity() > 1)
     {
       if (vtxmap->empty())
       {
-        std::cerr << "No vertex map found, assuming the vertex has z=0" << std::endl;
+        std::cout << "No vertex map found, assuming the vertex has z=0" << std::endl;
       }
     }
     m_zvtx = 0;
@@ -169,7 +169,7 @@ int DijetQA::process_event(PHCompositeNode* topNode)
     std::cout << "DijetQA::process_event - Error can not find jets node " << m_recoJetName << std::endl;	  
     if (Verbosity() > 1)
     {
-      std::cerr << "No Jet container found" << std::endl;
+      std::cout << "No Jet container found" << std::endl;
     }
     return Fun4AllReturnCodes::EVENT_OK;
   }


### PR DESCRIPTION
Does what it says on the tin.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

Previously, the `DijetQA` module would emit warnings about the `GlobalVertexMap` node being missing if the node actually was missing OR if the node was empty. The severity of these two errors are different, and so the verbosity should reflect this. Also the error message should indicate if it's the node missing or if just empty.

This PR addresses these points.