### PR TITLE
Fix deltaz correction

### DIFF
--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -34,6 +34,18 @@ namespace
   /// speed of light, in cm per ns
   static constexpr double speed_of_light = GSL_CONST_MKSA_SPEED_OF_LIGHT * 1e-7;
 
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const Acts::Vector3& v )
+  {
+    out << "(" << v.x() << ", " << v.y() << ", " << v.z() << ")";
+    return out;
+  }
+
+
+  [[maybe_unused]] std::ostream& operator << (std::ostream& out, const Acts::Vector2& v )
+  {
+    out << "(" << v.x() << ", " << v.y() << ")";
+    return out;
+  }
 }  // namespace
 
 //____________________________________________________________________________..
@@ -157,6 +169,16 @@ void PHTpcDeltaZCorrection::process_track(unsigned int key, TrackSeed* track)
               << " center: " << center_x << ", " << center_y
               << " radius: " << radius
               << std::endl;
+  }
+
+  // check track seed fit validity
+  if( std::isnan( center_x ) || std::isnan( center_y ) )
+  {
+    if( Verbosity() )
+    {
+      std::cout << "PHTpcDeltaZCorrection::process_track - invalid seed parameters. Skipping" << std::endl;
+    }
+    return;
   }
 
   // loop over clusters. Assume they are ordered by layer

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.cc
@@ -171,13 +171,13 @@ void PHTpcDeltaZCorrection::process_track(unsigned int key, TrackSeed* track)
               << std::endl;
   }
 
-  // check track seed fit validity
+  /*
+   * check track seed fit validity
+   * skip if invalid, otherwise it will result in clusters with NAN coordinates
+   */
   if( std::isnan( center_x ) || std::isnan( center_y ) )
   {
-    if( Verbosity() )
-    {
-      std::cout << "PHTpcDeltaZCorrection::process_track - invalid seed parameters. Skipping" << std::endl;
-    }
+    std::cout << "PHTpcDeltaZCorrection::process_track - invalid seed parameters. Skipping" << std::endl;
     return;
   }
 

--- a/offline/packages/trackreco/PHTpcDeltaZCorrection.h
+++ b/offline/packages/trackreco/PHTpcDeltaZCorrection.h
@@ -22,7 +22,6 @@ class TrackSeed;
 class PHTpcDeltaZCorrection : public SubsysReco, public PHParameterInterface
 {
  public:
-
   /// constructor
   PHTpcDeltaZCorrection(const std::string &name = "PHTpcDeltaZCorrection");
 
@@ -33,18 +32,17 @@ class PHTpcDeltaZCorrection : public SubsysReco, public PHParameterInterface
   int process_event(PHCompositeNode *topNode) override;
   int End(PHCompositeNode *topNode) override;
   void SetDefaultParameters() override;
-  void setTrkrClusterContainerName(std::string &name){ m_clusterContainerName = name; }
+  void setTrkrClusterContainerName(std::string &name) { m_clusterContainerName = name; }
 
-  private:
-
+ private:
   /// load nodes
-  int load_nodes( PHCompositeNode* );
+  int load_nodes(PHCompositeNode *);
 
   /// process tracks
   void process_tracks();
 
   /// process track
-  void process_track( unsigned int, TrackSeed* );
+  void process_track(unsigned int, TrackSeed *);
 
   /// Acts tracking geometry for surface lookup
   ActsGeometry *m_tGeometry = nullptr;
@@ -55,13 +53,12 @@ class PHTpcDeltaZCorrection : public SubsysReco, public PHParameterInterface
   /// cluster map
   TrkrClusterContainer *m_cluster_map = nullptr;
 
-  //cluster container name
+  // cluster container name
   std::string m_clusterContainerName = "TRKR_CLUSTER";
 
   /// list of corrected cluster keys
   /** needed to prevent clusters to be corrected twice, when same cluster is used for two different tracks */
   std::set<TrkrDefs::cluskey> m_corrected_clusters;
-
 };
 
-#endif // PHTpcDeltaZCorrection_H
+#endif  // PHTpcDeltaZCorrection_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
A lot of messages of type " ckey moved 156511082167402502 and global moved -nan -nan -nan" has appeared in reconstruction log files recently. This originates from track seed parameters being invalid (nan) when applying delta z corrections to clusters in PHTpcDeltaZCorrection.cc. With this PR, cluster delta_z correction is not calculated nor applied if the seed parameters used to calculate the track path length are invalid, thus 'fixing' the error message. The reason for the track seed parameters being invalid is being investigated independently.

Also improved MakeSourceLinks debug messages clarity.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

