### PR TITLE
Mvtx cluster pruner

### DIFF
--- a/offline/packages/mvtx/Makefile.am
+++ b/offline/packages/mvtx/Makefile.am
@@ -23,6 +23,7 @@ pkginclude_HEADERS = \
   CylinderGeom_MvtxHelper.h \
   MvtxCombinedRawDataDecoder.h \
   MvtxClusterizer.h \
+  MvtxClusterPruner.h \
   MvtxHitPruner.h \
   MvtxNoiseMap.h \
   MvtxPixelDefs.h \
@@ -43,6 +44,7 @@ libmvtx_la_SOURCES = \
   CylinderGeom_MvtxHelper.cc \
   MvtxCombinedRawDataDecoder.cc \
   MvtxClusterizer.cc \
+  MvtxClusterPruner.cc \
   MvtxHitPruner.cc \
   MvtxPixelDefs.cc \
   MvtxPixelMask.cc

--- a/offline/packages/mvtx/MvtxClusterPruner.cc
+++ b/offline/packages/mvtx/MvtxClusterPruner.cc
@@ -1,0 +1,130 @@
+/**
+ * @file mvtx/MvtxClusterPruner.cc
+ * @author Hugo Pereira Da Costa <hugo.pereira-da-costa@lanl.gov>
+ * @date May 2025
+ * @brief Implementation of MvtxClusterPruner
+ */
+
+#include "MvtxClusterPruner.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+#include <trackbase/MvtxDefs.h>
+#include <trackbase/TrkrClusterContainer.h>
+#include <trackbase/TrkrClusterHitAssoc.h>
+
+#include <set>
+#include <algorithm>
+
+namespace
+{
+  //! range adaptor to be able to use range-based for loop
+  template<class T> class range_adaptor
+  {
+    public:
+    range_adaptor( const T& range ):m_range(range){}
+    const typename T::first_type& begin() {return m_range.first;}
+    const typename T::second_type& end() {return m_range.second;}
+    private:
+    T m_range;
+  };
+}
+
+//_____________________________________________________________________________
+MvtxClusterPruner::MvtxClusterPruner(const std::string &name)
+  : SubsysReco(name)
+{
+}
+
+//_____________________________________________________________________________
+int MvtxClusterPruner::InitRun(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//_____________________________________________________________________________
+int MvtxClusterPruner::process_event(PHCompositeNode *topNode)
+{
+  // load relevant nodes
+  auto trkrclusters = findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
+  if( !trkrclusters )
+  {
+    std::cout << "MvtxClusterPruner::process_event - TRKR_CLUSTER not found. Doing nothing" << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  auto clusterhitassoc = findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
+  if( !clusterhitassoc )
+  {
+    std::cout << "MvtxClusterPruner::process_event - TRKR_CLUSTERHITASSOC not found. Doing nothing" << std::endl;
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+
+  // loop over MVTX hitset keys
+  const auto hitsetkeys = trkrclusters->getHitSetKeys(TrkrDefs::mvtxId);
+  for( const auto& hitsetkey:hitsetkeys )
+  {
+    // get layer, stave, chip and current strobe
+    const auto layer = TrkrDefs::getLayer(hitsetkey);
+    const auto stave = MvtxDefs::getStaveId(hitsetkey);
+    const auto chip = MvtxDefs::getChipId(hitsetkey);
+    const auto current_strobe = MvtxDefs::getStrobeId(hitsetkey);
+
+    // get clusters for this hitsetkey
+    const auto cluster_range1= trkrclusters->getClusters(hitsetkey);
+
+    // get clusters for the next strobe
+    int next_strobe = current_strobe+1;
+    const auto hitsetkey_next_strobe = MvtxDefs::genHitSetKey(layer, stave, chip, next_strobe);
+    const auto cluster_range2 = trkrclusters->getClusters(hitsetkey_next_strobe);
+
+    // loop over clusters from first range
+    for( const auto& [ckey1,cluster1]:range_adaptor(cluster_range1) )
+    {
+
+      // get associated hits
+      const auto& hit_range1 = clusterhitassoc->getHits(ckey1);
+      std::set<TrkrDefs::hitkey> hitkeys1;
+      std::transform(hit_range1.first, hit_range1.second, std::inserter(hitkeys1,hitkeys1.end()),
+        [](const TrkrClusterHitAssoc::Map::value_type& pair ){ return pair.second; });
+
+      // loop over clusters from second range
+      for( const auto& [ckey2,cluster2]:range_adaptor(cluster_range2) )
+      {
+        // get associated hits
+        const auto& hit_range2 = clusterhitassoc->getHits(ckey2);
+        std::set<TrkrDefs::hitkey> hitkeys2;
+        std::transform(hit_range2.first, hit_range2.second, std::inserter(hitkeys2,hitkeys2.end()),
+          [](const TrkrClusterHitAssoc::Map::value_type& pair ){ return pair.second; });
+
+        // make sure first set is larger than second
+        const bool swapped = hitkeys2.size() > hitkeys1.size();
+        if( swapped ) { std::swap(hitkeys2,hitkeys1); }
+
+        // see if hitkeys2 is a subset of hitkeys1
+        if( std::includes(hitkeys1.begin(), hitkeys1.end(), hitkeys2.begin(), hitkeys2.end()) )
+        {
+          if( swapped )
+          {
+            // remove first cluster
+            trkrclusters->removeCluster(ckey1);
+            break;
+          } else {
+            // remove second cluster
+            trkrclusters->removeCluster(ckey2);
+          }
+        }
+      } // second cluster loop
+    } // first cluster loop
+  } // hitsetkey loop
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}
+
+//_____________________________________________________________________________
+int MvtxClusterPruner::End(PHCompositeNode * /*topNode*/)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/offline/packages/mvtx/MvtxClusterPruner.h
+++ b/offline/packages/mvtx/MvtxClusterPruner.h
@@ -22,11 +22,10 @@ class PHCompositeNode;
  */
 class MvtxClusterPruner : public SubsysReco
 {
- public:
-  typedef std::pair<unsigned int, unsigned int> pixel;
+  public:
 
+  //! constructor
   MvtxClusterPruner(const std::string &name = "MvtxClusterPruner");
-  ~MvtxClusterPruner() override = default;
 
   //! module initialization
   int Init(PHCompositeNode * /*topNode*/) override { return 0; }
@@ -40,6 +39,20 @@ class MvtxClusterPruner : public SubsysReco
   //! end of process
   int End(PHCompositeNode * /*topNode*/) override;
 
+  //! strict matching
+  void set_use_strict_matching( bool value )
+  { m_use_strict_matching = value; }
+
+  private:
+
+  //! strict matching
+  bool m_use_strict_matching = false;
+
+  //!@name counters
+  //@{
+  uint64_t m_cluster_counter_total = 0;
+  uint64_t m_cluster_counter_deleted = 0;
+  //@}
 };
 
 #endif  // MVTX_MVTXHITPRUNER_H

--- a/offline/packages/mvtx/MvtxClusterPruner.h
+++ b/offline/packages/mvtx/MvtxClusterPruner.h
@@ -1,0 +1,45 @@
+/**
+ * @file mvtx/MvtxClusterPruner.h
+ * @author Hugo Pereira Da Costa <hugo.pereira-da-costa@lanl.gov>
+ * @date May 2025
+ * @brief Pruner to handle multiple copies of clusters for the MVTX
+ */
+#ifndef MVTX_MVTXCLUSTERPRUNER_H
+#define MVTX_MVTXCLUSTERPRUNER_H
+
+#include <fun4all/SubsysReco.h>
+#include <trackbase/TrkrDefs.h>
+
+#include <string>  // for string
+#include <utility>
+
+// forward declarations
+class PHCompositeNode;
+
+
+/**
+ * @brief cluster pruner for the MVTX
+ */
+class MvtxClusterPruner : public SubsysReco
+{
+ public:
+  typedef std::pair<unsigned int, unsigned int> pixel;
+
+  MvtxClusterPruner(const std::string &name = "MvtxClusterPruner");
+  ~MvtxClusterPruner() override = default;
+
+  //! module initialization
+  int Init(PHCompositeNode * /*topNode*/) override { return 0; }
+
+  //! run initialization
+  int InitRun(PHCompositeNode * /*topNode*/) override;
+
+  //! event processing
+  int process_event(PHCompositeNode * /*topNode*/) override;
+
+  //! end of process
+  int End(PHCompositeNode * /*topNode*/) override;
+
+};
+
+#endif  // MVTX_MVTXHITPRUNER_H

--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -58,9 +58,6 @@
 #include <string>
 #include <vector>  // for vector
 
-using namespace boost;
-using namespace std;
-
 namespace
 {
 
@@ -130,7 +127,7 @@ bool MvtxClusterizer::are_adjacent(RawHit *lhs, RawHit *rhs)
   return false;
 }
 
-MvtxClusterizer::MvtxClusterizer(const string &name)
+MvtxClusterizer::MvtxClusterizer(const std::string &name)
   : SubsysReco(name)
   , m_hits(nullptr)
   , m_rawhits(nullptr)
@@ -153,7 +150,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
       dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
   if (!dstNode)
   {
-    cout << PHWHERE << "DST Node missing, doing nothing." << endl;
+    std::cout << PHWHERE << "DST Node missing, doing nothing." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
   PHNodeIterator iter_dst(dstNode);
@@ -235,14 +232,14 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
 
   if (Verbosity() > 0)
   {
-    cout << "====================== MvtxClusterizer::InitRun() "
+    std::cout << "====================== MvtxClusterizer::InitRun() "
             "====================="
-         << endl;
-    cout << " Z-dimension Clustering = " << boolalpha << m_makeZClustering
-         << noboolalpha << endl;
-    cout << "=================================================================="
+         << std::endl;
+    std::cout << " Z-dimension Clustering = " << std::boolalpha << m_makeZClustering
+         << std::noboolalpha << std::endl;
+    std::cout << "=================================================================="
             "========="
-         << endl;
+         << std::endl;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -256,7 +253,7 @@ int MvtxClusterizer::process_event(PHCompositeNode *topNode)
     m_hits = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
     if (!m_hits)
     {
-      cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << endl;
+      std::cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << std::endl;
       return Fun4AllReturnCodes::ABORTRUN;
     }
   }
@@ -277,7 +274,7 @@ int MvtxClusterizer::process_event(PHCompositeNode *topNode)
       findNode::getClass<TrkrClusterContainer>(topNode, "TRKR_CLUSTER");
   if (!m_clusterlist)
   {
-    cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTER." << endl;
+    std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTER." << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -286,7 +283,7 @@ int MvtxClusterizer::process_event(PHCompositeNode *topNode)
       findNode::getClass<TrkrClusterHitAssoc>(topNode, "TRKR_CLUSTERHITASSOC");
   if (!m_clusterhitassoc)
   {
-    cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERHITASSOC" << endl;
+    std::cout << PHWHERE << " ERROR: Can't find TRKR_CLUSTERHITASSOC" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -309,7 +306,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
-    cout << "Entering MvtxClusterizer::ClusterMvtx " << endl;
+    std::cout << "Entering MvtxClusterizer::ClusterMvtx " << std::endl;
   }
 
   PHG4CylinderGeomContainer *geom_container =
@@ -338,9 +335,9 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
       unsigned int stave = MvtxDefs::getStaveId(hitsetitr->first);
       unsigned int chip = MvtxDefs::getChipId(hitsetitr->first);
       unsigned int strobe = MvtxDefs::getStrobeId(hitsetitr->first);
-      cout << "MvtxClusterizer found hitsetkey " << hitsetitr->first
+      std::cout << "MvtxClusterizer found hitsetkey " << hitsetitr->first
            << " layer " << layer << " stave " << stave << " chip " << chip
-           << " strobe " << strobe << endl;
+           << " strobe " << strobe << std::endl;
     }
 
     if (Verbosity() > 2)
@@ -359,7 +356,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
     }
     if (Verbosity() > 2)
     {
-      cout << "hitvec.size(): " << hitvec.size() << endl;
+      std::cout << "hitvec.size(): " << hitvec.size() << std::endl;
     }
 
     if (Verbosity() > 0)
@@ -375,7 +372,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
     }
 
     // do the clustering
-    using Graph = adjacency_list<vecS, vecS, undirectedS>;
+    using Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
     Graph G;
 
     // loop over hits in this chip
@@ -393,41 +390,29 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
     // Find the connections between the vertices of the graph (vertices are the
     // rawhits,
     // connections are made when they are adjacent to one another)
-    vector<int> component(num_vertices(G));
+    std::vector<int> component(num_vertices(G));
 
     // this is the actual clustering, performed by boost
-    connected_components(G, &component[0]);
+    boost::connected_components(G, &component[0]);
 
     // Loop over the components(hits) compiling a list of the
     // unique connected groups (ie. clusters).
-    set<int> cluster_ids;  // unique components
-    // multimap<int, pixel> clusters;
-    multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit *> > clusters;
+    std::set<int> cluster_ids;  // unique components
+    std::multimap<int, std::pair<TrkrDefs::hitkey, TrkrHit *> > clusters;
     for (unsigned int i = 0; i < component.size(); i++)
     {
       cluster_ids.insert(component[i]);
       clusters.insert(make_pair(component[i], hitvec[i]));
     }
-//    int total_clusters = 0;
-    for (set<int>::iterator clusiter = cluster_ids.begin();
-         clusiter != cluster_ids.end(); ++clusiter)
+    for (const auto& clusid:cluster_ids)
     {
-      int clusid = *clusiter;
       auto clusrange = clusters.equal_range(clusid);
-
-      if (Verbosity() > 2)
-      {
-        cout << "Filling cluster id " << clusid << " of "
-             << std::distance(cluster_ids.begin(), clusiter) << endl;
-      }
-//      ++total_clusters;
       auto ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
 
       // determine the size of the cluster in phi and z
-      set<int> phibins;
-      set<int> zbins;
-      std::map<int, unsigned int> m_phi,
-          m_z;  // Note, there are no "cut" bins for Svtx Clusters
+      std::set<int> phibins;
+      std::set<int> zbins;
+      std::map<int, unsigned int> m_phi, m_z;  // Note, there are no "cut" bins for Svtx Clusters
 
       // determine the cluster position...
       double locxsum = 0.;
@@ -588,12 +573,12 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
 
       if (Verbosity() > 0)
       {
-        cout << " MvtxClusterizer: cluskey " << ckey << " layer " << layer
+        std::cout << " MvtxClusterizer: cluskey " << ckey << " layer " << layer
              << " rad " << layergeom->get_radius() << " phibins "
              << phibins.size() << " pitch " << pitch << " phisize " << phisize
              << " zbins " << zbins.size() << " length " << length << " zsize "
              << zsize << " local x " << locclusx << " local y " << locclusz
-             << endl;
+             << std::endl;
       }
 
       auto clus = std::make_unique<TrkrClusterv5>();
@@ -635,7 +620,7 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
 {
   if (Verbosity() > 0)
   {
-    cout << "Entering MvtxClusterizer::ClusterMvtx " << endl;
+    std::cout << "Entering MvtxClusterizer::ClusterMvtx " << std::endl;
   }
 
   PHG4CylinderGeomContainer *geom_container =
@@ -664,9 +649,9 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
       unsigned int stave = MvtxDefs::getStaveId(hitsetitr->first);
       unsigned int chip = MvtxDefs::getChipId(hitsetitr->first);
       unsigned int strobe = MvtxDefs::getStrobeId(hitsetitr->first);
-      cout << "MvtxClusterizer found hitsetkey " << hitsetitr->first
+      std::cout << "MvtxClusterizer found hitsetkey " << hitsetitr->first
            << " layer " << layer << " stave " << stave << " chip " << chip
-           << " strobe " << strobe << endl;
+           << " strobe " << strobe << std::endl;
     }
 
     if (Verbosity() > 2)
@@ -685,11 +670,11 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
     }
     if (Verbosity() > 2)
     {
-      cout << "hitvec.size(): " << hitvec.size() << endl;
+      std::cout << "hitvec.size(): " << hitvec.size() << std::endl;
     }
 
     // do the clustering
-    using Graph = adjacency_list<vecS, vecS, undirectedS>;
+    using Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
     Graph G;
 
     // loop over hits in this chip
@@ -707,42 +692,33 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
     // Find the connections between the vertices of the graph (vertices are the
     // rawhits,
     // connections are made when they are adjacent to one another)
-    vector<int> component(num_vertices(G));
+    std::vector<int> component(num_vertices(G));
 
     // this is the actual clustering, performed by boost
-    connected_components(G, &component[0]);
+    boost::connected_components(G, &component[0]);
 
     // Loop over the components(hits) compiling a list of the
     // unique connected groups (ie. clusters).
-    set<int> cluster_ids;  // unique components
-    // multimap<int, pixel> clusters;
+    std::set<int> cluster_ids;  // unique components
 
-    multimap<int, RawHit *> clusters;
+    std::multimap<int, RawHit *> clusters;
     for (unsigned int i = 0; i < component.size(); i++)
     {
       cluster_ids.insert(component[i]);
-      clusters.insert(make_pair(component[i], hitvec[i]));
+      clusters.emplace(component[i], hitvec[i]);
     }
-    //    cout << "found cluster #: "<< clusters.size()<< endl;
+    //    std::cout << "found cluster #: "<< clusters.size()<< std::endl;
     // loop over the componenets and make clusters
-    for (set<int>::iterator clusiter = cluster_ids.begin();
-         clusiter != cluster_ids.end(); ++clusiter)
+    for( const auto& clusid:cluster_ids)
     {
-      int clusid = *clusiter;
       auto clusrange = clusters.equal_range(clusid);
-
-      if (Verbosity() > 2)
-      {
-        cout << "Filling cluster id " << clusid << " of "
-             << std::distance(cluster_ids.begin(), clusiter) << endl;
-      }
 
       // make the cluster directly in the node tree
       auto ckey = TrkrDefs::genClusKey(hitset->getHitSetKey(), clusid);
 
       // determine the size of the cluster in phi and z
-      set<int> phibins;
-      set<int> zbins;
+      std::set<int> phibins;
+      std::set<int> zbins;
 
       // determine the cluster position...
       double locxsum = 0.;
@@ -868,12 +844,12 @@ void MvtxClusterizer::ClusterMvtxRaw(PHCompositeNode *topNode)
 
       if (Verbosity() > 0)
       {
-        cout << " MvtxClusterizer: cluskey " << ckey << " layer " << layer
+        std::cout << " MvtxClusterizer: cluskey " << ckey << " layer " << layer
              << " rad " << layergeom->get_radius() << " phibins "
              << phibins.size() << " pitch " << pitch << " phisize " << phisize
              << " zbins " << zbins.size() << " length " << length << " zsize "
              << zsize << " local x " << locclusx << " local y " << locclusz
-             << endl;
+             << std::endl;
       }
 
       auto clus = std::make_unique<TrkrClusterv5>();
@@ -921,21 +897,21 @@ void MvtxClusterizer::PrintClusters(PHCompositeNode *topNode)
       return;
     }
 
-    cout << "================= After MvtxClusterizer::process_event() "
+    std::cout << "================= After MvtxClusterizer::process_event() "
             "===================="
-         << endl;
+         << std::endl;
 
-    cout << " There are " << clusterlist->size()
-         << " clusters recorded: " << endl;
+    std::cout << " There are " << clusterlist->size()
+         << " clusters recorded: " << std::endl;
 
     if (Verbosity() > 3)
     {
       clusterlist->identify();
     }
 
-    cout << "=================================================================="
+    std::cout << "=================================================================="
             "========="
-         << endl;
+         << std::endl;
   }
 
   return;

--- a/offline/packages/mvtx/MvtxHitPruner.cc
+++ b/offline/packages/mvtx/MvtxHitPruner.cc
@@ -11,10 +11,6 @@
 #include <g4detectors/PHG4CylinderGeomContainer.h>
 
 #include <trackbase/MvtxDefs.h>
-#include <trackbase/TrkrClusterContainerv4.h>
-#include <trackbase/TrkrClusterHitAssocv3.h>
-#include <trackbase/TrkrClusterv3.h>
-#include <trackbase/TrkrClusterv4.h>
 #include <trackbase/TrkrDefs.h>  // for hitkey, getLayer
 #include <trackbase/TrkrHitSet.h>
 #include <trackbase/TrkrHitSetContainer.h>
@@ -52,12 +48,8 @@
 #include <string>
 #include <vector>  // for vector
 
-using namespace boost;
-using namespace std;
-
-MvtxHitPruner::MvtxHitPruner(const string &name)
+MvtxHitPruner::MvtxHitPruner(const std::string &name)
   : SubsysReco(name)
-  , m_hits(nullptr)
 {
 }
 
@@ -73,9 +65,9 @@ int MvtxHitPruner::InitRun(PHCompositeNode * /*topNode*/)
 
   if (Verbosity() > 0)
   {
-    cout << "====================== MvtxHitPruner::InitRun() "
+    std::cout << "====================== MvtxHitPruner::InitRun() "
             "====================="
-         << endl;
+         << std::endl;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -87,7 +79,7 @@ int MvtxHitPruner::process_event(PHCompositeNode *topNode)
   m_hits = findNode::getClass<TrkrHitSetContainer>(topNode, "TRKR_HITSET");
   if (!m_hits)
   {
-    cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << endl;
+    std::cout << PHWHERE << "ERROR: Can't find node TRKR_HITSET" << std::endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
@@ -119,8 +111,8 @@ int MvtxHitPruner::process_event(PHCompositeNode *topNode)
 
     if (Verbosity() > 0)
     {
-      cout << " found hitsetkey " << hitsetkey << " for bare_hitsetkey "
-           << bare_hitsetkey << endl;
+      std::cout << " found hitsetkey " << hitsetkey << " for bare_hitsetkey "
+           << bare_hitsetkey << std::endl;
     }
   }
 
@@ -148,8 +140,8 @@ int MvtxHitPruner::process_event(PHCompositeNode *topNode)
       {
         if (Verbosity() > 0)
         {
-          cout << "            process hitsetkey " << hitsetkey
-               << " for bare_hitsetkey " << bare_hitsetkey << endl;
+          std::cout << "            process hitsetkey " << hitsetkey
+               << " for bare_hitsetkey " << bare_hitsetkey << std::endl;
         }
 
         // copy all hits to the hitset with strobe 0

--- a/offline/packages/mvtx/MvtxHitPruner.h
+++ b/offline/packages/mvtx/MvtxHitPruner.h
@@ -17,15 +17,17 @@ class TrkrHit;
 class TrkrHitSetContainer;
 
 /**
- * @brief Clusterizer for the MVTX
+ * @brief Hit pruner for the MVTX
  */
 class MvtxHitPruner : public SubsysReco
 {
  public:
-  typedef std::pair<unsigned int, unsigned int> pixel;
 
+  //! constructor
   MvtxHitPruner(const std::string &name = "MvtxHitPruner");
-  ~MvtxHitPruner() override {}
+
+  //! destructor
+  ~MvtxHitPruner() override = default;
 
   //! module initialization
   int Init(PHCompositeNode * /*topNode*/) override { return 0; }
@@ -41,9 +43,7 @@ class MvtxHitPruner : public SubsysReco
 
  private:
   // node tree storage pointers
-  TrkrHitSetContainer *m_hits;
-
-  // settings
+  TrkrHitSetContainer *m_hits = nullptr;
 };
 
 #endif  // MVTX_MVTXHITPRUNER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR
- cleans up MvtxHitPruner and MvtxClusterizer by removing "using namespace ..." directives
- introduces a new module to "prune" MVTX cluster, by remove identical clusters copied accross strobes, due to single hit single waveform overlaping with two strobes. 

Ultimately this should remove a significant number of duplicated seeds upstream, otherwise matched to the TPC and fitted by acts, then removed by the PHTrackCleaner module

The impact of this module on tracking efficiency and speed is still being evaluated. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

