### PR TITLE
fix clang build - replace adjacent check with correct use of abs

### DIFF
--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -75,28 +75,14 @@ bool MvtxClusterizer::are_adjacent(
 {
   if (GetZClustering())
   {
-    // column is first, row is second
-    if (fabs(MvtxDefs::getCol(lhs.first) - MvtxDefs::getCol(rhs.first)) <= 1)
+    if (std::abs(static_cast<int>(MvtxDefs::getCol(lhs.first)) - static_cast<int>(MvtxDefs::getCol(rhs.first))) <= 1)
     {
-      if (fabs(MvtxDefs::getRow(lhs.first) - MvtxDefs::getRow(rhs.first)) <=
-          1)
+      if (std::abs(static_cast<int>(MvtxDefs::getRow(lhs.first)) - static_cast<int>(MvtxDefs::getRow(rhs.first))) <= 1)
       {
-        return true;
+	return true;
       }
     }
   }
-  else
-  {
-    if (fabs(MvtxDefs::getCol(lhs.first) - MvtxDefs::getCol(rhs.first)) == 0)
-    {
-      if (fabs(MvtxDefs::getRow(lhs.first) - MvtxDefs::getRow(rhs.first)) <=
-          1)
-      {
-        return true;
-      }
-    }
-  }
-
   return false;
 }
 
@@ -104,36 +90,19 @@ bool MvtxClusterizer::are_adjacent(RawHit *lhs, RawHit *rhs)
 {
   if (GetZClustering())
   {
-    // column is first, row is second
-    if (fabs(lhs->getPhiBin() - rhs->getPhiBin()) <= 1)  // col
+    if (std::abs(static_cast<int>(lhs->getPhiBin()) - static_cast<int>(rhs->getPhiBin())) <= 1)
     {
-      if (fabs(lhs->getTBin() - rhs->getTBin()) <= 1)  // Row
+      if (std::abs(static_cast<int>(lhs->getTBin()) - static_cast<int>(rhs->getTBin())) <= 1)
       {
-        return true;
+	return true;
       }
     }
   }
-  else
-  {
-    if (fabs(lhs->getPhiBin() - rhs->getPhiBin()) == 0)
-    {
-      if (fabs(lhs->getTBin() - rhs->getTBin()) <= 1)
-      {
-        return true;
-      }
-    }
-  }
-
   return false;
 }
 
 MvtxClusterizer::MvtxClusterizer(const std::string &name)
   : SubsysReco(name)
-  , m_hits(nullptr)
-  , m_rawhits(nullptr)
-  , m_clusterlist(nullptr)
-  , m_clusterhitassoc(nullptr)
-  , m_makeZClustering(true)
 {
 }
 
@@ -170,8 +139,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
   if (!trkrclusters)
   {
     PHNodeIterator dstiter(dstNode);
-    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(
-        dstiter.findFirst("PHCompositeNode", "TRKR"));
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -189,8 +157,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
   if (!clusterhitassoc)
   {
     PHNodeIterator dstiter(dstNode);
-    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(
-        dstiter.findFirst("PHCompositeNode", "TRKR"));
+    PHCompositeNode *DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
     if (!DetNode)
     {
       DetNode = new PHCompositeNode("TRKR");
@@ -198,8 +165,7 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
     }
 
     clusterhitassoc = new TrkrClusterHitAssocv3;
-    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(
-        clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(clusterhitassoc, "TRKR_CLUSTERHITASSOC", "PHObject");
     DetNode->addNode(newNode);
   }
 
@@ -207,21 +173,18 @@ int MvtxClusterizer::InitRun(PHCompositeNode *topNode)
   if (record_ClusHitsVerbose)
   {
     // get the node
-    mClusHitsVerbose = findNode::getClass<ClusHitsVerbose>(
-        topNode, "Trkr_SvtxClusHitsVerbose");
+    mClusHitsVerbose = findNode::getClass<ClusHitsVerbose>(topNode, "Trkr_SvtxClusHitsVerbose");
     if (!mClusHitsVerbose)
     {
       PHNodeIterator dstiter(dstNode);
-      auto DetNode = dynamic_cast<PHCompositeNode *>(
-          dstiter.findFirst("PHCompositeNode", "TRKR"));
+      auto DetNode = dynamic_cast<PHCompositeNode *>(dstiter.findFirst("PHCompositeNode", "TRKR"));
       if (!DetNode)
       {
         DetNode = new PHCompositeNode("TRKR");
         dstNode->addNode(DetNode);
       }
       mClusHitsVerbose = new ClusHitsVerbosev1();
-      auto newNode = new PHIODataNode<PHObject>(
-          mClusHitsVerbose, "Trkr_SvtxClusHitsVerbose", "PHObject");
+      auto newNode = new PHIODataNode<PHObject>(mClusHitsVerbose, "Trkr_SvtxClusHitsVerbose", "PHObject");
       DetNode->addNode(newNode);
     }
   }
@@ -310,8 +273,7 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
   }
 
   PHG4CylinderGeomContainer *geom_container =
-      findNode::getClass<PHG4CylinderGeomContainer>(topNode,
-                                                    "CYLINDERGEOM_MVTX");
+      findNode::getClass<PHG4CylinderGeomContainer>(topNode, "CYLINDERGEOM_MVTX");
   if (!geom_container)
   {
     return;
@@ -420,13 +382,12 @@ void MvtxClusterizer::ClusterMvtx(PHCompositeNode *topNode)
       const unsigned int nhits =
           std::distance(clusrange.first, clusrange.second);
 
-      double locclusx = NAN;
-      double locclusz = NAN;
+      double locclusx = std::numeric_limits<double>::quiet_NaN();
+      double locclusz = std::numeric_limits<double>::quiet_NaN();
 
       // we need the geometry object for this layer to get the global positions
       int layer = TrkrDefs::getLayer(ckey);
-      auto layergeom = dynamic_cast<CylinderGeom_Mvtx *>(
-          geom_container->GetLayerGeom(layer));
+      auto layergeom = dynamic_cast<CylinderGeom_Mvtx *>(geom_container->GetLayerGeom(layer));
       if (!layergeom)
       {
         exit(1);

--- a/offline/packages/mvtx/MvtxClusterizer.h
+++ b/offline/packages/mvtx/MvtxClusterizer.h
@@ -73,16 +73,16 @@ class MvtxClusterizer : public SubsysReco
   void PrintClusters(PHCompositeNode *topNode);
 
   // node tree storage pointers
-  TrkrHitSetContainer *m_hits;
-  RawHitSetContainer *m_rawhits;
-  TrkrClusterContainer *m_clusterlist;
+  TrkrHitSetContainer *m_hits {nullptr};
+  RawHitSetContainer *m_rawhits {nullptr};
+  TrkrClusterContainer *m_clusterlist {nullptr};
 
-  TrkrClusterHitAssoc *m_clusterhitassoc;
+  TrkrClusterHitAssoc *m_clusterhitassoc {nullptr};
 
   // settings
-  bool m_makeZClustering;  // z_clustering_option
-  bool do_hit_assoc = true;
-  bool do_read_raw = false;
+  bool m_makeZClustering {true};  // z_clustering_option
+  bool do_hit_assoc {true};
+  bool do_read_raw {false};
 };
 
 #endif  // MVTX_MVTXCLUSTERIZER_H


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
the clang build crashes since the removal of using namespace std in the MvtxClusterizer which uses a hokey fabs of a diff of unsigned ints to check for them being withing +-1. This PR replaces this with a more decent (and maybe faster) implementation which passes clang

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

