### PR TITLE
feat: suppress crossing warning for convert seeds

### DIFF
--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -92,7 +92,10 @@ Acts::Vector3 TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected(con
     // verify crossing validity
     if(crossing == SHRT_MAX)
     {
-      std::cout << "TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected - invalid crossing." << std::endl;
+      if(!m_suppressCrossing)
+      {
+        std::cout << "TpcGlobalPositionWrapper::getGlobalPositionDistortionCorrected - invalid crossing." << std::endl;
+      }
       return global;
     }
 

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -28,6 +28,11 @@ class TpcGlobalPositionWrapper
   {
     m_verbosity = value;
   }
+  
+  void set_suppressCrossing(bool value)
+  {
+    m_suppressCrossing = value;
+  }
 
   //! verbosity
   int verbosity() const
@@ -52,6 +57,8 @@ class TpcGlobalPositionWrapper
 
   //! verbosity
   unsigned int m_verbosity = 0;
+
+  bool m_suppressCrossing = false;
 
   //! distortion correction interface
   TpcDistortionCorrection m_distortionCorrection;


### PR DESCRIPTION
This suppresses the warning for undefined crossing when we convert the seeds to tracks, for which we in general don't need/look at the crossing anyway. It is quite cumbersome in the cosmic analysis.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

