### PR TITLE
Fixed filling cluster multiplicity histograms. 

### DIFF
--- a/offline/QA/Tracking/MicromegasClusterQA.cc
+++ b/offline/QA/Tracking/MicromegasClusterQA.cc
@@ -150,9 +150,6 @@ int MicromegasClusterQA::process_event(PHCompositeNode *topNode)
     const auto cluster_range = m_cluster_map->getClusters(hitsetkey);
     cluster_count[detid] = std::distance( cluster_range.first, cluster_range.second );
 
-    // fill multiplicity histogram
-    m_h_cluster_multiplicity->Fill( detid, cluster_count[detid]);
-
     // loop over clusters
     for( const auto& [ckey,cluster]:range_adaptor(cluster_range))
     {
@@ -204,6 +201,9 @@ int MicromegasClusterQA::process_event(PHCompositeNode *topNode)
     {
       // get detector id
       const int detid = tile+MicromegasDefs::m_ntiles*layer;
+
+      // fill multiplicity histogram
+      m_h_cluster_multiplicity->Fill( detid, cluster_count[detid]);
 
       // get reference detector id. It corresponds to the same tile, but on the other layer
       const int detid_ref = detid >= MicromegasDefs::m_ntiles ?


### PR DESCRIPTION
Previous code would not fill histograms when there is no cluster. Thus leaving the bin at zero empty, and biasing high the mean multiplicity.

This directly impact offline QA.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

