### PR TITLE
Another fix to MVTXClusterizer is_adjacent code.

### DIFF
--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -75,30 +75,61 @@ bool MvtxClusterizer::are_adjacent(
 {
   if (GetZClustering())
   {
-    if (std::abs(static_cast<int>(MvtxDefs::getCol(lhs.first)) - static_cast<int>(MvtxDefs::getCol(rhs.first))) <= 1)
-    {
-      if (std::abs(static_cast<int>(MvtxDefs::getRow(lhs.first)) - static_cast<int>(MvtxDefs::getRow(rhs.first))) <= 1)
-      {
-	return true;
-      }
-    }
+    return
+
+      // column adjacent
+      ( (MvtxDefs::getCol(lhs.first) > MvtxDefs::getCol(rhs.first)) ?
+      MvtxDefs::getCol(lhs.first)<=MvtxDefs::getCol(rhs.first)+1:
+      MvtxDefs::getCol(rhs.first)<=MvtxDefs::getCol(lhs.first)+1) &&
+
+      // row adjacent
+      ( (MvtxDefs::getRow(lhs.first) > MvtxDefs::getRow(rhs.first)) ?
+      MvtxDefs::getRow(lhs.first)<=MvtxDefs::getRow(rhs.first)+1:
+      MvtxDefs::getRow(rhs.first)<=MvtxDefs::getRow(lhs.first)+1);
+
+  } else {
+
+    return
+      // column identical
+      MvtxDefs::getCol(rhs.first)==MvtxDefs::getCol(lhs.first) &&
+
+      // row adjacent
+      ( (MvtxDefs::getRow(lhs.first) > MvtxDefs::getRow(rhs.first)) ?
+      MvtxDefs::getRow(lhs.first)<=MvtxDefs::getRow(rhs.first)+1:
+      MvtxDefs::getRow(rhs.first)<=MvtxDefs::getRow(lhs.first)+1);
+
   }
-  return false;
 }
 
 bool MvtxClusterizer::are_adjacent(RawHit *lhs, RawHit *rhs)
 {
   if (GetZClustering())
   {
-    if (std::abs(static_cast<int>(lhs->getPhiBin()) - static_cast<int>(rhs->getPhiBin())) <= 1)
-    {
-      if (std::abs(static_cast<int>(lhs->getTBin()) - static_cast<int>(rhs->getTBin())) <= 1)
-      {
-	return true;
-      }
-    }
+    return
+
+      // phi adjacent (== column)
+      ((lhs->getPhiBin() > rhs->getPhiBin()) ?
+      lhs->getPhiBin() <= rhs->getPhiBin()+1:
+      rhs->getPhiBin() <= lhs->getPhiBin()+1) &&
+
+      // time adjacent (== row)
+      ((lhs->getTBin() > rhs->getTBin()) ?
+      lhs->getTBin() <= rhs->getTBin()+1:
+      rhs->getTBin() <= lhs->getTBin()+1);
+
+  } else {
+
+    return
+
+      // phi identical (== column)
+      lhs->getPhiBin() == rhs->getPhiBin() &&
+
+      // time adjacent (== row)
+      ((lhs->getTBin() >  rhs->getTBin()) ?
+      lhs->getTBin() <= rhs->getTBin()+1:
+      rhs->getTBin() <= lhs->getTBin()+1);
+
   }
-  return false;
 }
 
 MvtxClusterizer::MvtxClusterizer(const std::string &name)


### PR DESCRIPTION
Fix is_adjacent checks in case ZClustering is not requested (was eron…ously removed during the last edit)

Also rewrote conditions to avoid static_cast and fabs entirely. This should be faster and still clang compliant.

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

