### PR TITLE
Cluster reset

### DIFF
--- a/offline/packages/mvtx/MvtxClusterizer.cc
+++ b/offline/packages/mvtx/MvtxClusterizer.cc
@@ -250,6 +250,14 @@ int MvtxClusterizer::process_event(PHCompositeNode *topNode)
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  // reset MVTX clusters and cluster associations
+  const auto hitsetkeys = m_clusterlist->getHitSetKeys(TrkrDefs::mvtxId);
+  for( const auto& hitsetkey:hitsetkeys)
+  {
+    m_clusterlist->removeClusters(hitsetkey);
+    m_clusterhitassoc->removeAssocs(hitsetkey);
+  }
+
   // run clustering
   if (!do_read_raw)
   {

--- a/offline/packages/trackbase/TrkrClusterContainer.h
+++ b/offline/packages/trackbase/TrkrClusterContainer.h
@@ -48,6 +48,10 @@ class TrkrClusterContainer : public PHObject
   //! remove cluster
   virtual void removeCluster(TrkrDefs::cluskey) {}
 
+  //! delete and remove all the clusters matching a given hitsetkey
+  virtual void removeClusters( TrkrDefs::hitsetkey )
+  {}
+
   //! return all clusters
   virtual ConstRange getClusters() const;
 

--- a/offline/packages/trackbase/TrkrClusterContainerv4.cc
+++ b/offline/packages/trackbase/TrkrClusterContainerv4.cc
@@ -91,6 +91,23 @@ void TrkrClusterContainerv4::removeCluster(TrkrDefs::cluskey key)
 }
 
 //_________________________________________________________________
+void TrkrClusterContainerv4::removeClusters(TrkrDefs::hitsetkey hitsetkey)
+{
+  // find matching vector list
+  auto iter = m_clusmap.find(hitsetkey);
+
+  // do nothing if not found
+  if( iter == m_clusmap.end() ) { return; }
+
+  // delete all clusters
+  for( auto&& cluster:iter->second)
+  { delete cluster; }
+
+  // remove from map
+  m_clusmap.erase(iter);
+}
+
+//_________________________________________________________________
 void TrkrClusterContainerv4::addClusterSpecifyKey(const TrkrDefs::cluskey key, TrkrCluster* newclus)
 {
   // get hitsetkey from cluster

--- a/offline/packages/trackbase/TrkrClusterContainerv4.h
+++ b/offline/packages/trackbase/TrkrClusterContainerv4.h
@@ -22,13 +22,21 @@ class TrkrClusterContainerv4 : public TrkrClusterContainer
  public:
   TrkrClusterContainerv4() = default;
 
+  /**
+   * delete and remove all stored clusters
+   * effectively leaving the container empty
+   */
   void Reset() override;
 
   void identify(std::ostream& os = std::cout) const override;
 
   void addClusterSpecifyKey(const TrkrDefs::cluskey, TrkrCluster*) override;
 
+  //! remove cluster matching a given cluster key
   void removeCluster(TrkrDefs::cluskey) override;
+
+  //! delete and remove all the clusters matching a given key
+  void removeClusters(TrkrDefs::hitsetkey) override;
 
   ConstRange getClusters() const override;  // deprecated
 

--- a/offline/packages/trackbase/TrkrClusterHitAssoc.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssoc.h
@@ -30,6 +30,10 @@ class TrkrClusterHitAssoc : public PHObject
 
   void Reset() override;
 
+  //! remove all associations matching a given hitsetkey
+  virtual void removeAssocs(TrkrDefs::hitsetkey)
+  {}
+
   /**
    * @brief Add association between cluster and hit
    * @param[in] ckey Cluster key

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.cc
@@ -42,6 +42,12 @@ void TrkrClusterHitAssocv3::identify(std::ostream& os) const
 }
 
 //_________________________________________________________________________
+void TrkrClusterHitAssocv3::removeAssocs(TrkrDefs::hitsetkey hitsetkey)
+{
+  m_map.erase(hitsetkey);
+}
+
+//_________________________________________________________________________
 void TrkrClusterHitAssocv3::addAssoc(TrkrDefs::cluskey ckey, unsigned int hidx)
 {
   // get hitset key from cluster

--- a/offline/packages/trackbase/TrkrClusterHitAssocv3.h
+++ b/offline/packages/trackbase/TrkrClusterHitAssocv3.h
@@ -31,10 +31,16 @@ class TrkrClusterHitAssocv3 : public TrkrClusterHitAssoc
 
   void identify(std::ostream& os = std::cout) const override;
 
+  //! remove all associations matching a given hitsetkey
+  void removeAssocs(TrkrDefs::hitsetkey) override;
+
+  //! add cluster to hit association
   void addAssoc(TrkrDefs::cluskey, unsigned int) override;
 
+  //! get all associations matching a given hitsetkey
   Map* getClusterMap(TrkrDefs::hitsetkey) override;
 
+  //! get all hits matching a given cluster key
   ConstRange getHits(TrkrDefs::cluskey) override;
 
   unsigned int size(void) const override;

--- a/offline/packages/trackreco/PHActsSiliconSeeding.cc
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.cc
@@ -134,6 +134,9 @@ int PHActsSiliconSeeding::process_event(PHCompositeNode* topNode)
       std::cerr << PHWHERE << "Cluster Iteration Map missing, aborting." << std::endl;
       return Fun4AllReturnCodes::ABORTEVENT;
     }
+  } else {
+    // reset seed container on first iteration
+    m_seedContainer->Reset();
   }
 
   if (Verbosity() > 0)
@@ -277,17 +280,17 @@ void PHActsSiliconSeeding::runSeeder()
   return;
 }
 
-void PHActsSiliconSeeding::makeSvtxTracks(GridSeeds& seedVector)
+void PHActsSiliconSeeding::makeSvtxTracks(const GridSeeds& seedVector)
 {
   int numSeeds = 0;
   int numGoodSeeds = 0;
   m_seedid = -1;
   int strobe = m_lowStrobeIndex;
   /// Loop over grid volumes. In our case this will be strobe
-  for (auto& seeds : seedVector)
+  for (const auto& seeds : seedVector)
   {
     /// Loop over actual seeds in this grid volume
-    for (auto& seed : seeds)
+    for (const auto& seed : seeds)
     {
       if (Verbosity() > 1)
       {
@@ -668,7 +671,7 @@ std::vector<TrkrDefs::cluskey> PHActsSiliconSeeding::findMatches(
         for (auto clusIter = range.first; clusIter != range.second; ++clusIter)
         {
           const auto cluskey = clusIter->first;
-          if (_iteration_map != nullptr && m_nIteration > 0)
+          if (_iteration_map && m_nIteration > 0)
           {
             if (_iteration_map->getIteration(cluskey) < m_nIteration)
             {
@@ -889,7 +892,7 @@ std::vector<const SpacePoint*> PHActsSiliconSeeding::getSiliconSpacePoints(Acts:
       {
         const auto cluskey = clusIter->first;
         totNumSiliconHits++;
-        if (_iteration_map != nullptr && m_nIteration > 0)
+        if (_iteration_map && m_nIteration > 0)
         {
           if (_iteration_map->getIteration(cluskey) < m_nIteration)
           {

--- a/offline/packages/trackreco/PHActsSiliconSeeding.h
+++ b/offline/packages/trackreco/PHActsSiliconSeeding.h
@@ -177,7 +177,7 @@ class PHActsSiliconSeeding : public SubsysReco
   Acts::SeedFilterConfig configureSeedFilter();
 
   /// Take final seeds and fill the TrackSeedContainer
-  void makeSvtxTracks(GridSeeds &seedVector);
+  void makeSvtxTracks(const GridSeeds &seedVector);
 
   /// Create a seeding space point out of an Acts::SourceLink
   SpacePointPtr makeSpacePoint(


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This Pull Request allows to reset clusters and cluster-to-hit associations for a given subsystem from existing cluster container. (and cluster-hit association container)
Using this, MVTX clusters are first removed from the container before running the MVTX clusterizer. 
Similarily, silicon seeds are removed (deleted) from the silicon seed container, before running the silicon seeder. 

The immediate use case if for @xyu3 (Xu-Dong) to be able to re-run the MVTX clustering, silicon seeding, matching and track fitting, starting from raw hits for the MVTX but using existing clusters and TPC seeds from existing DSTs. 

This is much faster than having to re-run the full reconstruction, and allows to benefit from recent improvements in MVTX clustering, in particular using the MVTX cluster pruner. 

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

