### PR TITLE
end gracefully without bogus misalignment message

### DIFF
--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -280,8 +280,11 @@ void SingleTriggeredInput::FillPool(const unsigned int keep)
           //   ++iter4;
           // }
         }
-        std::cout << "Event Misalignment, processing remaining good events" << std::endl;
-        EventAlignmentProblem(1);
+	if ( FilesDone() == 0)
+	{
+	  std::cout << "Event Misalignment, processing remaining good events" << std::endl;
+	  EventAlignmentProblem(1);
+	}
         //        FilesDone(1);
       }
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Minor bugfix - the single input manager printed out a bogus misalignment message when the input was exhausted but some strange last event in the gl1 remains. That doesn't happen for all runs - it seems to happen only for earlier runs.

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

