### PR TITLE
bump version numbers for ll1 and gl1 packets bc offline packet depend…

### DIFF
--- a/offline/framework/ffarawobjects/Gl1Packet.h
+++ b/offline/framework/ffarawobjects/Gl1Packet.h
@@ -31,7 +31,7 @@ class Gl1Packet : public OfflinePacketv1
   virtual void FillFrom(const Gl1Packet* /*pkt*/) { return; }
 
  private:
-  ClassDefOverride(Gl1Packet, 1)
+  ClassDefOverride(Gl1Packet, 2)
 };
 
 #endif

--- a/offline/framework/ffarawobjects/Gl1Packetv2.h
+++ b/offline/framework/ffarawobjects/Gl1Packetv2.h
@@ -55,7 +55,7 @@ class Gl1Packetv2 : public Gl1Packet
   std::array<std::array<uint64_t, 3>, 16> gl1pscaler{{{0}}};
 
  private:
-  ClassDefOverride(Gl1Packetv2, 2)
+  ClassDefOverride(Gl1Packetv2, 3)
 };
 
 #endif

--- a/offline/framework/ffarawobjects/LL1Packet.h
+++ b/offline/framework/ffarawobjects/LL1Packet.h
@@ -43,7 +43,7 @@ class LL1Packet : public OfflinePacketv1
   virtual int getFibers() const { return 0; }
 
  private:
-  ClassDefOverride(LL1Packet, 1)
+  ClassDefOverride(LL1Packet, 2)
 };
 
 #endif

--- a/offline/framework/ffarawobjects/LL1Packetv1.h
+++ b/offline/framework/ffarawobjects/LL1Packetv1.h
@@ -66,7 +66,7 @@ class LL1Packetv1 : public LL1Packet
   std::array<std::array<uint32_t, MAX_NUM_CHANNELS>, MAX_NUM_SAMPLES> samples{};
 
  private:
-  ClassDefOverride(LL1Packetv1, 1)
+  ClassDefOverride(LL1Packetv1, 2)
 };
 
 #endif


### PR DESCRIPTION
…ence

[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The versions of the Gl1 and LL1 packets needs to be bumped because of the changes in the OfflinePacketv1

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

