### PR TITLE
Phpythia8 cleanup

### DIFF
--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -38,15 +38,6 @@ class PHHepMCGenEvent;
 
 PHPythia8::PHPythia8(const std::string &name)
   : SubsysReco(name)
-  , m_EventCount(0)
-  , m_TriggersOR(true)
-  , m_TriggersAND(false)
-  , m_Pythia8(nullptr)
-  , m_ConfigFileName("phpythia8.cfg")
-  , m_Pythia8ToHepMC(nullptr)
-  , m_SaveEventWeightFlag(true)
-  , m_SaveIntegratedLuminosityFlag(true)
-  , m_IntegralNode(nullptr)
 {
   char *charPath = getenv("PYTHIA8");
   if (!charPath)
@@ -57,20 +48,14 @@ PHPythia8::PHPythia8(const std::string &name)
 
   std::string thePath(charPath);
   thePath += "/xmldoc/";
-  m_Pythia8 = new Pythia8::Pythia(thePath.c_str());
+  m_Pythia8.reset( new Pythia8::Pythia(thePath.c_str()) );
 
-  m_Pythia8ToHepMC = new HepMC::Pythia8ToHepMC();
+  m_Pythia8ToHepMC.reset( new HepMC::Pythia8ToHepMC() );
   m_Pythia8ToHepMC->set_store_proc(true);
   m_Pythia8ToHepMC->set_store_pdf(true);
   m_Pythia8ToHepMC->set_store_xsec(true);
 
   PHHepMCGenHelper::set_embedding_id(1);  // default embedding ID to 1
-}
-
-PHPythia8::~PHPythia8()
-{
-  delete m_Pythia8;
-  delete m_Pythia8ToHepMC;
 }
 
 int PHPythia8::Init(PHCompositeNode *topNode)
@@ -209,7 +194,7 @@ int PHPythia8::process_event(PHCompositeNode * /*topNode*/)
 
     for (auto &m_RegisteredTrigger : m_RegisteredTriggers)
     {
-      bool trigResult = m_RegisteredTrigger->Apply(m_Pythia8);
+      bool trigResult = m_RegisteredTrigger->Apply(m_Pythia8.get());
 
       if (Verbosity() >= VERBOSITY_EVEN_MORE)
       {

--- a/generators/PHPythia8/PHPythia8.cc
+++ b/generators/PHPythia8/PHPythia8.cc
@@ -34,8 +34,6 @@
 #include <cstdlib>
 #include <iostream>  // for operator<<, endl
 
-class PHHepMCGenEvent;
-
 PHPythia8::PHPythia8(const std::string &name)
   : SubsysReco(name)
 {
@@ -185,7 +183,6 @@ int PHPythia8::process_event(PHCompositeNode * /*topNode*/)
     }
 
     // test trigger logic
-
     bool andScoreKeeper = true;
     if (Verbosity() >= VERBOSITY_EVEN_MORE)
     {
@@ -228,9 +225,13 @@ int PHPythia8::process_event(PHCompositeNode * /*topNode*/)
     passedGen = false;
   }
 
+  // print
+  if( Verbosity() )
+  { m_Pythia8->event.list(); }
+
   // fill HepMC object with event & pass to
 
-  HepMC::GenEvent *genevent = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
+  auto genevent = new HepMC::GenEvent(HepMC::Units::GEV, HepMC::Units::MM);
   m_Pythia8ToHepMC->fill_next_event(*m_Pythia8, genevent, m_EventCount);
   // Enable continuous reweighting by storing additional reweighting factor
   if (m_SaveEventWeightFlag)
@@ -239,7 +240,7 @@ int PHPythia8::process_event(PHCompositeNode * /*topNode*/)
   }
 
   /* pass HepMC to PHNode*/
-  PHHepMCGenEvent *success = PHHepMCGenHelper::insert_event(genevent);
+  auto success = PHHepMCGenHelper::insert_event(genevent);
   if (!success)
   {
     std::cout << "PHPythia8::process_event - Failed to add event to HepMC record!" << std::endl;

--- a/generators/PHPythia8/PHPythia8.h
+++ b/generators/PHPythia8/PHPythia8.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>  // for max
 #include <cmath>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -27,8 +28,12 @@ namespace Pythia8
 class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
 {
  public:
-  PHPythia8(const std::string &name = "PHPythia8");
-  ~PHPythia8() override;
+
+  //! constructor
+  explicit PHPythia8(const std::string &name = "PHPythia8");
+
+  //! destructor
+  ~PHPythia8() override = default;
 
   int Init(PHCompositeNode *topNode) override;
   int process_event(PHCompositeNode *topNode) override;
@@ -74,30 +79,30 @@ class PHPythia8 : public SubsysReco, public PHHepMCGenHelper
   int read_config(const std::string &cfg_file);
   int create_node_tree(PHCompositeNode *topNode) final;
   double percent_diff(const double a, const double b) { return fabs((a - b) / a); }
-  int m_EventCount;
+  int m_EventCount = 0;
 
   // event selection
   std::vector<PHPy8GenTrigger *> m_RegisteredTriggers;
-  bool m_TriggersOR;
-  bool m_TriggersAND;
+  bool m_TriggersOR{true};
+  bool m_TriggersAND{false};
 
   // PYTHIA
-  Pythia8::Pythia *m_Pythia8;
+  std::unique_ptr<Pythia8::Pythia> m_Pythia8;
 
-  std::string m_ConfigFileName;
+  std::string m_ConfigFileName{"phpythia8.cfg"};
   std::vector<std::string> m_Commands;
 
   // HepMC
-  HepMC::Pythia8ToHepMC *m_Pythia8ToHepMC;
+  std::unique_ptr<HepMC::Pythia8ToHepMC> m_Pythia8ToHepMC;
 
   //! whether to store the overall event weight into the HepMC weights
-  bool m_SaveEventWeightFlag;
+  bool m_SaveEventWeightFlag{true};
 
   //! whether to store the integrated luminosity and other event statistics to the TOP/RUN/PHGenIntegral node
-  bool m_SaveIntegratedLuminosityFlag;
+  bool m_SaveIntegratedLuminosityFlag{true};
 
   //! pointer to data node saving the integrated luminosity
-  PHGenIntegral *m_IntegralNode;
+  PHGenIntegral *m_IntegralNode{};
 };
 
 #endif /* PHPYTHIA8_PHPYTHIA8_H */


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Some harmless cleanup to PHPYthia8 class: 
- use std::unique_ptr to Pythia8 and hepMC objects so that they are automatically deleted
- initialize members are declaration rather than in constructor
- destructor is now default. 
Also added full event printout, for debugging, if PHPythia8 verbosity is high enough.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

