### PR TITLE
CD: MVTX pooling update for standalone mode

### DIFF
--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.cc
@@ -429,30 +429,34 @@ void SingleMvtxPoolInput::ConfigureStreamingInputManager()
     }
   }
 
-  if (m_strobeWidth > 88.)
+  if (!m_mvtx_is_standalone)
   {
-    m_BcoRange = 1000;
-    m_NegativeBco = 1000;
-  }
-  else if (m_strobeWidth > 9 && m_strobeWidth < 11)
-  {
-    m_BcoRange = 500;
-    m_NegativeBco = 500;
-  }
-  else if (m_strobeWidth < 1)  // triggered mode
-  {
-    m_BcoRange = 3;
-    m_NegativeBco = 0;
-    if (StreamingInputManager())
+    if (m_strobeWidth > 88.)
     {
-      StreamingInputManager()->runMvtxTriggered(true);
+      m_BcoRange = 1000;
+      m_NegativeBco = 1000;
+    }
+    else if (m_strobeWidth > 9 && m_strobeWidth < 11)
+    {
+      m_BcoRange = 500;
+      m_NegativeBco = 500;
+    }
+    else if (m_strobeWidth < 1)  // triggered mode
+    {
+      m_BcoRange = 3;
+      m_NegativeBco = 0;
+      if (StreamingInputManager())
+      {
+        StreamingInputManager()->runMvtxTriggered(true);
+      }
+    }
+    else  // catchall for anyting else to set to a range based on the rhic clock
+    {
+      m_BcoRange = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
+      m_NegativeBco = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
     }
   }
-  else  // catchall for anyting else to set to a range based on the rhic clock
-  {
-    m_BcoRange = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
-    m_NegativeBco = std::ceil(m_strobeWidth * 1000. / sphenix_constants::time_between_crossings);
-  }
+
   if (Verbosity() > 1)
   {
     std::cout << "Mvtx strobe length " << m_strobeWidth << std::endl;

--- a/offline/framework/fun4allraw/SingleMvtxPoolInput.h
+++ b/offline/framework/fun4allraw/SingleMvtxPoolInput.h
@@ -35,6 +35,8 @@ class SingleMvtxPoolInput : public SingleStreamingInput
   void  SetStrobeWidth(const float val) { m_strobeWidth = val; }
   float GetStrobeWidth() { return m_strobeWidth; }
 
+  void runMVTXstandalone() {m_mvtx_is_standalone = true;}
+
  protected:
  private:
   Packet **plist{nullptr};
@@ -52,6 +54,8 @@ class SingleMvtxPoolInput : public SingleStreamingInput
 
   bool m_readStrWidthFromDB = true;
   float m_strobeWidth = 0;
+
+  bool m_mvtx_is_standalone{false};
 };
 
 #endif


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )

There is an overwrite in our pooling that means a user cant set the BCO ranges for filling the MVTX pool. This is intended for collision data but in standalone streaming mode for the MVTX we are filling each Fun4All with several strobes. This causes issues in making a hot pixel map so I added a flag to ignore this overwrite if we run standalone

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

