### PR TITLE
update PHSiliconTpcTrackMatching module

### DIFF
--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -632,6 +632,10 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       {
         eta_match = true;
       }
+      else if (fabs(tpc_eta-si_eta) < _deltaeta_min)
+      {
+	eta_match = true;
+      }
       if (!eta_match)
       {
         continue;
@@ -775,12 +779,20 @@ void PHSiliconTpcTrackMatching::checkZMatches(
       {
         z_match = true;
       }
+      else if (fabs(z_mismatch_corrected) < _crossing_deltaz_min)
+      {
+	z_match = true;
+      }
     }
     else
     {
       if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (fabs(z_mismatch) < _crossing_deltaz_max))
       {
         z_match = true;
+      }
+      else if (fabs(z_mismatch) < _crossing_deltaz_min)
+      {
+	z_match = true;
       }
     }
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.cc
@@ -58,7 +58,7 @@ int PHSiliconTpcTrackMatching::InitRun(PHCompositeNode *topNode)
   UpdateParametersWithMacro();
   if(_test_windows)
   {
-  _file = new TFile("track_match.root", "RECREATE");
+  _file = new TFile(_file_name.c_str(), "RECREATE");
   _tree = new TNtuple("track_match", "track_match",
                       "event:sicrossing:siq:siphi:sieta:six:siy:siz:sipx:sipy:sipz:tpcq:tpcphi:tpceta:tpcx:tpcy:tpcz:tpcpx:tpcpy:tpcpz:tpcid:siid");
   }
@@ -235,15 +235,32 @@ int PHSiliconTpcTrackMatching::process_event(PHCompositeNode * /*unused*/)
   }
 
   // Find all matches of tpc and si tracklets in eta and phi, x and y
-  //     If _pp_mode is not set, a match in z is also required - gives same behavior as old code
   std::multimap<unsigned int, unsigned int> tpc_matches;
   std::set<unsigned int> tpc_matched_set;
   std::set<unsigned int> tpc_unmatched_set;
   findEtaPhiMatches(tpc_matched_set, tpc_unmatched_set, tpc_matches);
 
-  // Check that the crossing number is consistent with the tracklet z mismatch, removethe match otherwise
-  // This does nothing if the crossing number is not set
-  checkCrossingMatches(tpc_matches);
+  // check z matching for all matches of tpc and si
+  // for _pp_mode=false, assume zero crossings for all tracks
+  // for _pp_mode=true, correct tpc seed z according to crossing number, do nothing if crossing number is not set
+  // remove matches from tpc_matches if z matching is not satisfied
+  std::multimap<unsigned int, unsigned int> bad_map;
+  checkZMatches(tpc_matches, bad_map);
+
+  // update tpc_matched_set and tpc_unmatched_set
+  tpc_matched_set.clear();
+  for (const auto& [key, _] : tpc_matches)
+  {
+    tpc_matched_set.insert(key);
+  }
+
+  for (const auto& [key, _] : bad_map)
+  {
+    if (!tpc_matched_set.count(key))
+    {
+        tpc_unmatched_set.insert(key);
+    }
+  }
 
   // We have a complete list of all eta/phi matched tracks in the map "tpc_matches"
   // make the combined track seeds from tpc_matches
@@ -568,13 +585,12 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
         continue;
       }
-      bool eta_match = false;
 
-    double si_phi, si_eta, si_pt;
-    float si_px, si_py, si_pz;
-    int si_q;
-    Acts::Vector3 si_pos;
-    if (_zero_field) {
+      double si_phi, si_eta, si_pt;
+      float si_px, si_py, si_pz;
+      int si_q;
+      Acts::Vector3 si_pos;
+      if (_zero_field) {
       auto cluster_list = getTrackletClusterList(_tracklet_si);
 
       Acts::Vector3  mom;
@@ -583,33 +599,35 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       std::tie(ok_track, si_phi, si_eta, si_pt, si_pos, mom) =
         TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list);
       if (!ok_track) { continue; }
-      si_px = mom.x();
-      si_py = mom.y();
-      si_pz = mom.z();
-      si_q = -100;
-    } else {
-      si_eta = _tracklet_si->get_eta();
-      si_phi = _tracklet_si->get_phi();
+        si_px = mom.x();
+        si_py = mom.y();
+        si_pz = mom.z();
+        si_q = -100;
+      } else {
+        si_eta = _tracklet_si->get_eta();
+        si_phi = _tracklet_si->get_phi();
 
-      si_pos = TrackSeedHelper::get_xyz(_tracklet_si);
-      si_px = _tracklet_si->get_px();
-      si_py = _tracklet_si->get_py();
-      si_pz = _tracklet_si->get_pz();
-	    si_q = _tracklet_si->get_charge();
-    }
-	  int si_crossing = _tracklet_si->get_crossing();
-    unsigned int siid = phtrk_iter_si;
+        si_pos = TrackSeedHelper::get_xyz(_tracklet_si);
+        si_px = _tracklet_si->get_px();
+        si_py = _tracklet_si->get_py();
+        si_pz = _tracklet_si->get_pz();
+        si_q = _tracklet_si->get_charge();
+      }
+      int si_crossing = _tracklet_si->get_crossing();
+      unsigned int siid = phtrk_iter_si;
 
-  if(_test_windows)
-  {
-    float data[] = {
-      (float) m_event, (float) si_crossing,
-      (float) si_q, (float) si_phi, (float) si_eta, (float) si_pos.x(), (float) si_pos.y(), (float) si_pos.z(), (float) si_px, (float) si_py, (float) si_pz,
-      (float) tpc_q, (float) tpc_phi, (float) tpc_eta, (float) tpc_pos.x(), (float) tpc_pos.y(), (float) tpc_pos.z(), (float) tpc_px, (float) tpc_py, (float) tpc_pz,
-      (float) tpcid, (float) siid};
-    _tree->Fill(data);
-  }
+      if(_test_windows)
+      {
+        float data[] = {
+          (float) m_event, (float) si_crossing,
+          (float) si_q, (float) si_phi, (float) si_eta, (float) si_pos.x(), (float) si_pos.y(), (float) si_pos.z(), (float) si_px, (float) si_py, (float) si_pz,
+          (float) tpc_q, (float) tpc_phi, (float) tpc_eta, (float) tpc_pos.x(), (float) tpc_pos.y(), (float) tpc_pos.z(), (float) tpc_px, (float) tpc_py, (float) tpc_pz,
+          (float) tpcid, (float) siid
+	};
+        _tree->Fill(data);
+      }
 
+      bool eta_match = false;
       if (window_deta.in_window(is_posQ, tpc_pt, tpc_eta, si_eta))
       {
         eta_match = true;
@@ -620,24 +638,11 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       }
 
       bool position_match = false;
-      if (_pp_mode)
+      if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x())
+       && window_dy.in_window(is_posQ, tpc_pt, tpc_pos.y(), si_pos.y()))
       {
-        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x())
-         && window_dy.in_window(is_posQ, tpc_pt, tpc_pos.y(), si_pos.y()))
-        {
-          position_match = true;
-        }
+        position_match = true;
       }
-      else
-      {
-        if (window_dx.in_window(is_posQ, tpc_pt, tpc_pos.x(), si_pos.x())
-         && window_dy.in_window(is_posQ, tpc_pt, tpc_pos.y(), si_pos.y())
-         && window_dz.in_window(is_posQ, tpc_pt, tpc_pos.z(), si_pos.z()))
-        {
-          position_match = true;
-        }
-      }
-
       if (!position_match)
       {
         continue;
@@ -657,11 +662,11 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
         }
         phi_match = window_dphi.in_window(is_posQ, tpc_pt, tpc_phi_wrap, si_phi);
       }
-
       if (!phi_match)
       {
         continue;
       }
+
       if (Verbosity() > 3)
       {
         cout << " testing for a match for TPC track " << tpcid << " with pT " << _tracklet_tpc->get_pt()
@@ -687,7 +692,7 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
       }
 
       // temporary!
-      if (_test_windows)
+      if (_test_windows && Verbosity() > 1)
       {
         cout << " Try_silicon: crossing" << si_crossing <<  "  pt " << tpc_pt << " tpc_phi " << tpc_phi << " si_phi " << si_phi << " dphi " << tpc_phi - si_phi <<  "   si_q" << si_q << "   tpc_q" << tpc_q
              << " tpc_eta " << tpc_eta << " si_eta " << si_eta << " deta " << tpc_eta - si_eta << " tpc_x " << tpc_pos.x() << " tpc_y " << tpc_pos.y() << " tpc_z " << tpc_pos.z()
@@ -709,51 +714,82 @@ void PHSiliconTpcTrackMatching::findEtaPhiMatches(
 
   return;
 }
-
-void PHSiliconTpcTrackMatching::checkCrossingMatches(std::multimap<unsigned int, unsigned int> &tpc_matches)
+void PHSiliconTpcTrackMatching::checkZMatches(
+    std::multimap<unsigned int, unsigned int> &tpc_matches,
+    std::multimap<unsigned int, unsigned int> &bad_map)
 {
-  // if the  crossing was assigned correctly, the (crossing corrected) track position should satisfy the Z matching cut
-  // this is a rough check that this is the case
+  // for _pp_mode=false, assume zero crossings for all track matches
+  // for _pp_mode=true, do crossing correction on track position z according to side and vdrift
+  // z matching criteria follows window_z
+  // there is a dz threshold cut to avoid window_z blow up at low pT
 
   float vdrift = _tGeometry->get_drift_velocity();
-
-  std::multimap<unsigned int, unsigned int> bad_map;
 
   for (auto [tpcid, si_id] : tpc_matches)
   {
     TrackSeed *tpc_track = _track_map->get(tpcid);
     TrackSeed *si_track = _track_map_silicon->get(si_id);
+
     short int crossing = si_track->get_crossing();
+    float tpc_pt, tpc_z, si_z;
+    int tpc_q;
+    if (_zero_field) {
+      auto cluster_list_tpc = getTrackletClusterList(tpc_track);
+      auto cluster_list_si = getTrackletClusterList(si_track);
 
-    if (crossing == SHRT_MAX)
-    {
-      if (Verbosity() > 2)
-      {
-        std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << TrackSeedHelper::get_z(si_track) << " because crossing is undefined " << std::endl;
-      }
-      continue;
+      tpc_pt = std::get<3>(TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list_tpc));
+      tpc_z = std::get<4>(TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list_tpc)).z();
+      tpc_q = -100;
+
+      si_z = std::get<4>(TrackFitUtils::zero_field_track_params(_tGeometry, _cluster_map, cluster_list_si)).z();
+    } else {
+      tpc_pt = fabs(1. / _tracklet_tpc->get_qOverR()) * (0.3 / 100.) * fieldstrength;
+      tpc_z = TrackSeedHelper::get_z(tpc_track);
+      tpc_q = _tracklet_tpc->get_charge();
+      si_z = TrackSeedHelper::get_z(si_track);
     }
-
-    float z_si = TrackSeedHelper::get_z(si_track);
-    float z_tpc = TrackSeedHelper::get_z(tpc_track);
-    float z_mismatch = z_tpc - z_si;
+    bool is_posQ = (tpc_q>0.);
+    float z_mismatch = tpc_z - si_z;
 
     // get TPC side from one of the TPC clusters
     std::vector<TrkrDefs::cluskey> temp_clusters = getTrackletClusterList(tpc_track);
-    if(temp_clusters.size() == 0)
-      {
-	continue;
-      }
-    unsigned int this_side =   TpcDefs::getSide(temp_clusters[0]);
+    if(temp_clusters.size() == 0) { continue; }
+    unsigned int this_side = TpcDefs::getSide(temp_clusters[0]);
 
-    float z_tpc_corrected = _clusterCrossingCorrection.correctZ(z_tpc, this_side, crossing);
-    float z_mismatch_corrected = z_tpc_corrected - z_si;
-    if (fabs(z_mismatch_corrected) < _crossing_deltaz_max)
+    float tpc_z_corrected = _clusterCrossingCorrection.correctZ(tpc_z, this_side, crossing);
+    float z_mismatch_corrected = tpc_z_corrected - si_z;
+
+    bool z_match = false;
+    if (_pp_mode)
+    {
+      if (crossing == SHRT_MAX)
+      {
+        if (Verbosity() > 2)
+        {
+          std::cout << " drop si_track " << si_id << " with eta " << si_track->get_eta() << " and z " << TrackSeedHelper::get_z(si_track) << " because crossing is undefined " << std::endl;
+        }
+        continue;
+      }
+
+      if (window_dz.in_window(is_posQ, tpc_pt, tpc_z_corrected, si_z) && (fabs(z_mismatch_corrected) < _crossing_deltaz_max))
+      {
+        z_match = true;
+      }
+    }
+    else
+    {
+      if (window_dz.in_window(is_posQ, tpc_pt, tpc_z, si_z) && (fabs(z_mismatch) < _crossing_deltaz_max))
+      {
+        z_match = true;
+      }
+    }
+
+    if (z_match)
     {
       if (Verbosity() > 1)
       {
         std::cout << "  Success:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
-                  << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << "z_tpc_corrected " << z_tpc_corrected
+                  << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc z corrected " << tpc_z_corrected
                   << " z_mismatch_corrected " << z_mismatch_corrected << " drift velocity " << vdrift << std::endl;
       }
     }
@@ -762,7 +798,7 @@ void PHSiliconTpcTrackMatching::checkCrossingMatches(std::multimap<unsigned int,
       if (Verbosity() > 1)
       {
         std::cout << "  FAILURE:  crossing " << crossing << " tpcid " << tpcid << " si id " << si_id
-                  << " tpc z " << z_tpc << " si z " << z_si << " z_mismatch " << z_mismatch << "z_tpc_corrected " << z_tpc_corrected
+                  << " tpc z " << tpc_z << " si z " << si_z << " z_mismatch " << z_mismatch << "tpc_z_corrected " << tpc_z_corrected
                   << " z_mismatch_corrected " << z_mismatch_corrected << std::endl;
       }
 

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -43,7 +43,9 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_x_search_window(const double win) { _x_search_win = win; }
   void set_y_search_window(const double win) { _y_search_win = win; }
   void set_z_search_window(const double win) { _z_search_win = win; }
-  void set_crossing_deltaz_max(const double dz) {_crossing_deltaz_max = dz ;}
+  void set_crossing_deltaz_max(const double dz) {_crossing_deltaz_max = dz;}
+  void set_crossing_deltaz_min(const double dz) {_crossing_deltaz_min = dz;}
+  void set_deltaeta_min(const double deta) {_deltaeta_min = deta;}
 
   float get_phi_search_window() const { return _phi_search_win; }
   float get_eta_search_window() const { return _eta_search_win; }
@@ -212,6 +214,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   TpcClusterZCrossingCorrection _clusterCrossingCorrection;
   float _crossing_deltaz_max = 10.0;
+  float _crossing_deltaz_min = 1.5;
+  float _deltaeta_min = 0.03;
 
   //  double _collision_rate = 50e3;  // input rate for phi correction
   //  double _reference_collision_rate = 50e3;  // reference rate for phi correction

--- a/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
+++ b/offline/packages/trackreco/PHSiliconTpcTrackMatching.h
@@ -153,6 +153,7 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
   void set_use_old_matching(const bool flag) { _use_old_matching = flag; }
 
   void set_test_windows_printout(const bool test) { _test_windows = test; }
+  void set_file_name(const std::string &name) { _file_name = name; }
   void set_pp_mode(const bool flag) { _pp_mode = flag; }
   void set_use_intt_crossing(const bool flag) { _use_intt_crossing = flag; }
 
@@ -175,7 +176,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
                          std::set<unsigned int> &tpc_unmatched_set,
                          std::multimap<unsigned int, unsigned int> &tpc_matches);
   std::vector<short int> getInttCrossings(TrackSeed *si_track);
-  void checkCrossingMatches(std::multimap<unsigned int, unsigned int> &tpc_matches);
+  void checkZMatches(std::multimap<unsigned int, unsigned int> &tpc_matches,
+		     std::multimap<unsigned int, unsigned int> &bad_map);
   short int getCrossingIntt(TrackSeed *_tracklet_si);
   // void findCrossingGeometrically(std::multimap<unsigned int, unsigned int> tpc_matches);
   short int findCrossingGeometrically(unsigned int tpc_id, unsigned int si_id);
@@ -183,6 +185,8 @@ class PHSiliconTpcTrackMatching : public SubsysReco, public PHParameterInterface
 
   TFile *_file = nullptr;
   TNtuple *_tree = nullptr;
+
+  std::string _file_name = "track_match.root";
 
   // default values, can be replaced from the macro
   double _phi_search_win = 0.01;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
Update PHSiliconTpcTrackMatching Module as discussed in tracking software meeting on May 13th.
Modification on matching window will be another PR to macro repo

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
1. In ``findEtaPhiMatches`` function, only do Eta/Phi/x/y matching, remove z matching
2. Change ``checkCrossingMatches`` function to ``checkZMatches`` function
If ``_pp_mode=true``, do crossing correction on z position of TPC seed, then match TPC seed corrected z and Silicon seed z using function as well as a threshold cut (|dz|<10 cm by default)
If ``_pp_mode=false``, assume all TPC seed with crossing zero, then directly match TPC seed z with Silicon seed z
3. After all matching, check matched and unmatched TPC seed again to ensure all unmatched TPC seed are stored in SeedContainer

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

