### PR TITLE
Adjust sEPD towerinfo container mapping 

### DIFF
--- a/offline/packages/CaloReco/CaloTowerBuilder.h
+++ b/offline/packages/CaloReco/CaloTowerBuilder.h
@@ -116,6 +116,7 @@ class CaloTowerBuilder : public SubsysReco
   TowerInfoContainer *m_CaloInfoContainer{nullptr};      //! Calo info
   TowerInfoContainer *m_CalowaveformContainer{nullptr};  // waveform from simulation
   CDBTTree *cdbttree = nullptr;
+  CDBTTree *cdbttree_sepd_map = nullptr;
   CDBTTree *cdbttree_tbt_zs = nullptr;
 
   bool m_isdata{true};
@@ -142,7 +143,7 @@ class CaloTowerBuilder : public SubsysReco
   bool m_dobitfliprecovery{false};
 
   int m_saturation{16383};
-
+  std::string calibdir;
   std::string m_fieldname;
   std::string m_calibName;
   std::string m_directURL;


### PR DESCRIPTION
Can be marked as draft until discussion on Tuesday.

PR makes changes to the processed waveform order for the sEPD to map into towerinfocontainer just as installed in the detector and so as use seamlessly with TowerinfoDefs (w/o adjustments)...

TowerinfoDefs can be used directly to get the correct map (no need for CDB lookup)

E.g.
for ( int i = 0; i < 744; ++i )
 {
     unsigned int key = TowerInfoDefs::encode_epd(i);
     int arm = TowerInfoDefs::get_epd_arm(key);
     int phibin = TowerInfoDefs::get_epd_phibin(key);
}
etc...

As a check, produced plots with this setup are attached below (they are in agreement w/ previous setup and online monitoring (north phi bin is flipped)):
<img width="1082" alt="sepd_wheel_adc_map" src="https://github.com/user-attachments/assets/ac8f9f2e-0424-4e5b-aa57-a9f0cdadac58" />


