### PR TITLE
Initialize packet status

### DIFF
--- a/offline/framework/ffarawobjects/CaloPacket.h
+++ b/offline/framework/ffarawobjects/CaloPacket.h
@@ -12,7 +12,8 @@ class CaloPacket : public OfflinePacketv1
   enum enu_femstatus
   {
     FEM_OK = 0,
-    BAD_EVENTNR = 1
+    BAD_EVENTNR = 1,
+    NOTSET =  std::numeric_limits<int>::max()
   };
 
   CaloPacket() = default;

--- a/offline/framework/ffarawobjects/CaloPacket.h
+++ b/offline/framework/ffarawobjects/CaloPacket.h
@@ -13,7 +13,7 @@ class CaloPacket : public OfflinePacketv1
   {
     FEM_OK = 0,
     BAD_EVENTNR = 1,
-    NOTSET =  std::numeric_limits<int>::max()
+    NOTSET = std::numeric_limits<int>::max()
   };
 
   CaloPacket() = default;

--- a/offline/framework/ffarawobjects/CaloPacketv1.cc
+++ b/offline/framework/ffarawobjects/CaloPacketv1.cc
@@ -13,6 +13,7 @@ CaloPacketv1::CaloPacketv1()
   femclock.fill(0);
   femevt.fill(0);
   femslot.fill(0);
+  femstatus.fill(CaloPacket::NOTSET);
   checksumlsb.fill(0);
   checksummsb.fill(0);
   calcchecksumlsb.fill(0);
@@ -44,7 +45,7 @@ void CaloPacketv1::Reset()
   femclock.fill(0);
   femevt.fill(0);
   femslot.fill(0);
-  femstatus.fill(0);
+  femstatus.fill(CaloPacket::NOTSET);
   checksumlsb.fill(0);
   checksummsb.fill(0);
   calcchecksumlsb.fill(0);

--- a/offline/framework/ffarawobjects/Gl1RawHitv1.h
+++ b/offline/framework/ffarawobjects/Gl1RawHitv1.h
@@ -10,7 +10,7 @@ class Gl1RawHitv1 : public Gl1RawHit
  public:
   Gl1RawHitv1() = default;
   Gl1RawHitv1(Gl1RawHit *gl1hit);
-  ~Gl1RawHitv1() override{};
+  ~Gl1RawHitv1() override {};
 
   void Reset() override;
   /** identify Function from PHObject

--- a/offline/framework/ffarawobjects/Gl1RawHitv2.h
+++ b/offline/framework/ffarawobjects/Gl1RawHitv2.h
@@ -10,7 +10,7 @@ class Gl1RawHitv2 : public Gl1RawHitv1
  public:
   Gl1RawHitv2() = default;
   Gl1RawHitv2(Gl1RawHit *gl1hit);
-  ~Gl1RawHitv2() override{};
+  ~Gl1RawHitv2() override {};
 
   void Reset() override;
   /** identify Function from PHObject

--- a/offline/framework/ffarawobjects/InttRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/InttRawHitContainerv1.cc
@@ -6,8 +6,8 @@
 static const int NINTTHITS = 100;
 
 InttRawHitContainerv1::InttRawHitContainerv1()
+  : InttRawHitsTCArray(new TClonesArray("InttRawHitv1", NINTTHITS))
 {
-  InttRawHitsTCArray = new TClonesArray("InttRawHitv1", NINTTHITS);
 }
 
 InttRawHitContainerv1::~InttRawHitContainerv1()
@@ -25,6 +25,7 @@ void InttRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "InttRawHitContainerv1" << std::endl;
   os << "containing " << InttRawHitsTCArray->GetEntriesFast() << " Intt hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   InttRawHit *intthit = static_cast<InttRawHit *>(InttRawHitsTCArray->At(0));
   if (intthit)
   {

--- a/offline/framework/ffarawobjects/InttRawHitContainerv2.cc
+++ b/offline/framework/ffarawobjects/InttRawHitContainerv2.cc
@@ -6,8 +6,8 @@
 static const int NINTTHITS = 100;
 
 InttRawHitContainerv2::InttRawHitContainerv2()
+  : InttRawHitsTCArray(new TClonesArray("InttRawHitv2", NINTTHITS))
 {
-  InttRawHitsTCArray = new TClonesArray("InttRawHitv2", NINTTHITS);
 }
 
 InttRawHitContainerv2::~InttRawHitContainerv2()
@@ -25,6 +25,7 @@ void InttRawHitContainerv2::identify(std::ostream &os) const
 {
   os << "InttRawHitContainerv2" << std::endl;
   os << "containing " << InttRawHitsTCArray->GetEntriesFast() << " Intt hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   InttRawHit *intthit = static_cast<InttRawHit *>(InttRawHitsTCArray->At(0));
   if (intthit)
   {

--- a/offline/framework/ffarawobjects/Makefile.am
+++ b/offline/framework/ffarawobjects/Makefile.am
@@ -69,58 +69,8 @@ ROOTDICTS = \
   TpcRawHitv3_Dict.cc
 
 pcmdir = $(libdir)
-nobase_dist_pcm_DATA = \
-  CaloPacket_Dict_rdict.pcm \
-  CaloPacketv1_Dict_rdict.pcm \
-  CaloPacketContainer_Dict_rdict.pcm \
-  CaloPacketContainerv1_Dict_rdict.pcm \
-  Gl1Packet_Dict_rdict.pcm \
-  Gl1Packetv1_Dict_rdict.pcm \
-  Gl1Packetv2_Dict_rdict.pcm \
-  Gl1RawHit_Dict_rdict.pcm \
-  Gl1RawHitv1_Dict_rdict.pcm \
-  Gl1RawHitv2_Dict_rdict.pcm \
-  InttRawHit_Dict_rdict.pcm \
-  InttRawHitContainer_Dict_rdict.pcm \
-  InttRawHitContainerv1_Dict_rdict.pcm \
-  InttRawHitContainerv2_Dict_rdict.pcm \
-  InttRawHitv1_Dict_rdict.pcm \
-  InttRawHitv2_Dict_rdict.pcm \
-  LL1Packet_Dict_rdict.pcm \
-  LL1Packetv1_Dict_rdict.pcm \
-  LL1PacketContainer_Dict_rdict.pcm \
-  LL1PacketContainerv1_Dict_rdict.pcm \
-  MicromegasRawHit_Dict_rdict.pcm \
-  MicromegasRawHitContainer_Dict_rdict.pcm \
-  MicromegasRawHitContainerv1_Dict_rdict.pcm \
-  MicromegasRawHitContainerv2_Dict_rdict.pcm \
-  MicromegasRawHitContainerv3_Dict_rdict.pcm \
-  MicromegasRawHitv1_Dict_rdict.pcm \
-  MicromegasRawHitv2_Dict_rdict.pcm \
-  MicromegasRawHitv3_Dict_rdict.pcm \
-  MvtxRawHit_Dict_rdict.pcm \
-  MvtxRawHitv1_Dict_rdict.pcm \
-  MvtxRawHitContainer_Dict_rdict.pcm \
-  MvtxRawHitContainerv1_Dict_rdict.pcm \
-  MvtxFeeIdInfo_Dict_rdict.pcm \
-  MvtxFeeIdInfov1_Dict_rdict.pcm \
-  MvtxRawEvtHeader_Dict_rdict.pcm \
-  MvtxRawEvtHeaderv1_Dict_rdict.pcm \
-  MvtxRawEvtHeaderv2_Dict_rdict.pcm \
-  OfflinePacket_Dict_rdict.pcm \
-  OfflinePacketv1_Dict_rdict.pcm \
-  TpcDiode_Dict_rdict.pcm \
-  TpcDiodeContainer_Dict_rdict.pcm \
-  TpcDiodeContainerv1_Dict_rdict.pcm \
-  TpcDiodev1_Dict_rdict.pcm \
-  TpcRawHit_Dict_rdict.pcm \
-  TpcRawHitContainer_Dict_rdict.pcm \
-  TpcRawHitContainerv1_Dict_rdict.pcm \
-  TpcRawHitContainerv2_Dict_rdict.pcm \
-  TpcRawHitContainerv3_Dict_rdict.pcm \
-  TpcRawHitv1_Dict_rdict.pcm \
-  TpcRawHitv2_Dict_rdict.pcm \
-  TpcRawHitv3_Dict_rdict.pcm
+# more elegant way to create pcm files (without listing them)
+nobase_dist_pcm_DATA = $(ROOTDICTS:.cc=_rdict.pcm)
 
 pkginclude_HEADERS = \
   CaloPacket.h \

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.cc
@@ -6,8 +6,8 @@
 static constexpr int NHITS = 100;
 
 MicromegasRawHitContainerv1::MicromegasRawHitContainerv1()
+  : MicromegasRawHitsTCArray(new TClonesArray("MicromegasRawHitv1", NHITS))
 {
-  MicromegasRawHitsTCArray = new TClonesArray("MicromegasRawHitv1", NHITS);
 }
 
 MicromegasRawHitContainerv1::~MicromegasRawHitContainerv1()
@@ -26,7 +26,8 @@ void MicromegasRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "MicromegasRawHitContainerv1" << std::endl;
   os << "containing " << MicromegasRawHitsTCArray->GetEntriesFast() << " Micromegas hits" << std::endl;
-  auto hit = static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(0));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+  auto *hit = static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(0));
   if (hit)
   {
     os << "for beam clock: " << std::hex << hit->get_bco() << std::dec << std::endl;
@@ -51,11 +52,12 @@ MicromegasRawHit *MicromegasRawHitContainerv1::AddHit()
 
 MicromegasRawHit *MicromegasRawHitContainerv1::AddHit(MicromegasRawHit *source)
 {
-  auto newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv1(source);
+  auto *newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv1(source);
   return newhit;
 }
 
 MicromegasRawHit *MicromegasRawHitContainerv1::get_hit(unsigned int index)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   return static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(index));
 }

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv1.h
@@ -8,7 +8,7 @@ class TClonesArray;
 
 class MicromegasRawHitContainerv1 : public MicromegasRawHitContainer
 {
-  public:
+ public:
   explicit MicromegasRawHitContainerv1();
 
   //! destructor

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv2.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv2.cc
@@ -6,8 +6,8 @@
 static constexpr int NHITS = 100;
 
 MicromegasRawHitContainerv2::MicromegasRawHitContainerv2()
+  : MicromegasRawHitsTCArray(new TClonesArray("MicromegasRawHitv2", NHITS))
 {
-  MicromegasRawHitsTCArray = new TClonesArray("MicromegasRawHitv2", NHITS);
 }
 
 MicromegasRawHitContainerv2::~MicromegasRawHitContainerv2()
@@ -26,7 +26,8 @@ void MicromegasRawHitContainerv2::identify(std::ostream &os) const
 {
   os << "MicromegasRawHitContainerv2" << std::endl;
   os << "containing " << MicromegasRawHitsTCArray->GetEntriesFast() << " Micromegas hits" << std::endl;
-  auto hit = static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(0));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+  auto *hit = static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(0));
   if (hit)
   {
     os << "for beam clock: " << std::hex << hit->get_bco() << std::dec << std::endl;
@@ -51,11 +52,12 @@ MicromegasRawHit *MicromegasRawHitContainerv2::AddHit()
 
 MicromegasRawHit *MicromegasRawHitContainerv2::AddHit(MicromegasRawHit *source)
 {
-  auto newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv2(source);
+  auto *newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv2(source);
   return newhit;
 }
 
 MicromegasRawHit *MicromegasRawHitContainerv2::get_hit(unsigned int index)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   return static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(index));
 }

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv2.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv2.h
@@ -7,8 +7,7 @@ class TClonesArray;
 
 class MicromegasRawHitContainerv2 : public MicromegasRawHitContainer
 {
-  public:
-
+ public:
   /// constructor
   explicit MicromegasRawHitContainerv2();
 

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv3.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv3.cc
@@ -8,8 +8,8 @@
 static constexpr int NHITS = 100;
 
 MicromegasRawHitContainerv3::MicromegasRawHitContainerv3()
+  : MicromegasRawHitsTCArray(new TClonesArray("MicromegasRawHitv3", NHITS))
 {
-  MicromegasRawHitsTCArray = new TClonesArray("MicromegasRawHitv3", NHITS);
 }
 
 MicromegasRawHitContainerv3::~MicromegasRawHitContainerv3()
@@ -28,6 +28,7 @@ void MicromegasRawHitContainerv3::identify(std::ostream &os) const
 {
   os << "MicromegasRawHitContainerv3" << std::endl;
   os << "containing " << MicromegasRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   MicromegasRawHit *tpchit = static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(0));
   if (tpchit)
   {
@@ -47,27 +48,26 @@ unsigned int MicromegasRawHitContainerv3::get_nhits()
 
 MicromegasRawHit *MicromegasRawHitContainerv3::AddHit()
 {
-  auto newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv3();
+  auto *newhit = new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv3();
   return newhit;
 }
 
 MicromegasRawHit *MicromegasRawHitContainerv3::AddHit(MicromegasRawHit *rawhit)
 {
-  if (rawhit->IsA()==MicromegasRawHitv3::Class())
+  if (rawhit->IsA() == MicromegasRawHitv3::Class())
   {
     // fast add with move constructor to avoid ADC data copying
     return new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1])
-        MicromegasRawHitv3(std::move(*static_cast<MicromegasRawHitv3*>(rawhit)));
+        MicromegasRawHitv3(std::move(*dynamic_cast<MicromegasRawHitv3 *>(rawhit)));
   }
-  else
-  {
-    // slow
-    std::cout << __PRETTY_FUNCTION__ << "WARNING: input hit is not of type MicromegasRawHitv3. This is slow, please avoid." << std::endl;
-    return new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv3(rawhit);
-  }
+
+  // slow
+  std::cout << __PRETTY_FUNCTION__ << "WARNING: input hit is not of type MicromegasRawHitv3. This is slow, please avoid." << std::endl;
+  return new ((*MicromegasRawHitsTCArray)[MicromegasRawHitsTCArray->GetLast() + 1]) MicromegasRawHitv3(rawhit);
 }
 
 MicromegasRawHit *MicromegasRawHitContainerv3::get_hit(unsigned int index)
 {
-  return (MicromegasRawHit *) MicromegasRawHitsTCArray->At(index);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+  return static_cast<MicromegasRawHit *>(MicromegasRawHitsTCArray->At(index));
 }

--- a/offline/framework/ffarawobjects/MicromegasRawHitContainerv3.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitContainerv3.h
@@ -10,7 +10,6 @@ class TClonesArray;
 class MicromegasRawHitContainerv3 : public MicromegasRawHitContainer
 {
  public:
-
   /// constructor
   explicit MicromegasRawHitContainerv3();
 
@@ -29,7 +28,7 @@ class MicromegasRawHitContainerv3 : public MicromegasRawHitContainer
   int isValid() const override;
 
   MicromegasRawHit *AddHit() override;
-  MicromegasRawHit *AddHit(MicromegasRawHit*) override;
+  MicromegasRawHit *AddHit(MicromegasRawHit *) override;
   unsigned int get_nhits() override;
   MicromegasRawHit *get_hit(unsigned int) override;
 

--- a/offline/framework/ffarawobjects/MicromegasRawHitv2.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitv2.h
@@ -13,7 +13,7 @@ class MicromegasRawHitv2 : public MicromegasRawHit
 {
  public:
   explicit MicromegasRawHitv2() = default;
-  explicit MicromegasRawHitv2(MicromegasRawHit*);
+  explicit MicromegasRawHitv2(MicromegasRawHit *);
 
   /** identify Function from PHObject
       @param os Output Stream
@@ -52,11 +52,15 @@ class MicromegasRawHitv2 : public MicromegasRawHit
 
   // index of the first sample with data
   uint16_t get_sample_begin() const override
-  { return adcmap.empty() ? 0:adcmap.begin()->first; }
+  {
+    return adcmap.empty() ? 0 : adcmap.begin()->first;
+  }
 
   // index of the next to last sample with data
   uint16_t get_sample_end() const override
-  { return adcmap.empty() ? 0:adcmap.rbegin()->first+1; }
+  {
+    return adcmap.empty() ? 0 : adcmap.rbegin()->first + 1;
+  }
 
   // adc value for a given sample index
   uint16_t get_adc(const uint16_t sample) const override;

--- a/offline/framework/ffarawobjects/MicromegasRawHitv3.cc
+++ b/offline/framework/ffarawobjects/MicromegasRawHitv3.cc
@@ -28,11 +28,12 @@ MicromegasRawHitv3::MicromegasRawHitv3(MicromegasRawHit *source)
   {
     adc_list_t values;
     for (size_t i = source->get_sample_begin(); i < source->get_sample_end(); ++i)
-    { values.push_back( source->get_adc(i)); }
+    {
+      values.push_back(source->get_adc(i));
+    }
 
-    move_adc_waveform( source->get_sample_begin(), std::move(values) );
+    move_adc_waveform(source->get_sample_begin(), std::move(values));
   }
-
 }
 
 // cppcheck-suppress accessMoved
@@ -43,7 +44,8 @@ MicromegasRawHitv3::MicromegasRawHitv3(MicromegasRawHitv3 &&other) noexcept
   , fee(other.fee)
   , channel(other.channel)
   , m_adcData(std::move(other.m_adcData))
-{}
+{
+}
 
 void MicromegasRawHitv3::identify(std::ostream &os) const
 {
@@ -53,9 +55,9 @@ void MicromegasRawHitv3::identify(std::ostream &os) const
 
 uint16_t MicromegasRawHitv3::get_adc(const uint16_t sample) const
 {
-  auto iter = std::find_if( m_adcData.begin(), m_adcData.end(), [sample](const waveform_pair_t& pair)
-    { return sample >= pair.first && sample < pair.first+pair.second.size(); } );
-  return iter == m_adcData.end() ? 0: iter->second[sample-iter->first];
+  auto iter = std::find_if(m_adcData.begin(), m_adcData.end(), [sample](const waveform_pair_t &pair)
+                           { return sample >= pair.first && sample < pair.first + pair.second.size(); });
+  return iter == m_adcData.end() ? 0 : iter->second[sample - iter->first];
 }
 
 void MicromegasRawHitv3::Clear(Option_t * /*unused*/)

--- a/offline/framework/ffarawobjects/MicromegasRawHitv3.h
+++ b/offline/framework/ffarawobjects/MicromegasRawHitv3.h
@@ -15,7 +15,7 @@ class MicromegasRawHitv3 : public MicromegasRawHit
 {
  public:
   MicromegasRawHitv3() = default;
-  explicit MicromegasRawHitv3(MicromegasRawHit*);
+  explicit MicromegasRawHitv3(MicromegasRawHit *);
   explicit MicromegasRawHitv3(MicromegasRawHitv3 &&other) noexcept;
 
   /** identify Function from PHObject
@@ -23,7 +23,7 @@ class MicromegasRawHitv3 : public MicromegasRawHit
    */
   void identify(std::ostream &os = std::cout) const override;
 
-  void Clear(Option_t */*unused*/) override;
+  void Clear(Option_t * /*unused*/) override;
 
   uint64_t get_bco() const override { return bco; }
   // cppcheck-suppress virtualCallInConstructor
@@ -42,17 +42,23 @@ class MicromegasRawHitv3 : public MicromegasRawHit
   void set_channel(const uint16_t val) override { channel = val; }
 
   uint16_t get_sampaaddress() const override
-  { return static_cast<uint16_t>(channel >> 5U) & 0xfU; }
+  {
+    return static_cast<uint16_t>(channel >> 5U) & 0xfU;
+  }
 
   uint16_t get_sampachannel() const override { return channel & 0x1fU; }
 
   // index of the first sample with data
   uint16_t get_sample_begin() const override
-  { return m_adcData.empty() ? 0:m_adcData.front().first; }
+  {
+    return m_adcData.empty() ? 0 : m_adcData.front().first;
+  }
 
   // index of the next to last sample with data
   uint16_t get_sample_end() const override
-  { return m_adcData.empty() ? 0:m_adcData.back().first+m_adcData.back().second.size(); }
+  {
+    return m_adcData.empty() ? 0 : m_adcData.back().first + m_adcData.back().second.size();
+  }
 
   // get adc value
   uint16_t get_adc(const uint16_t sample) const override;
@@ -77,7 +83,7 @@ class MicromegasRawHitv3 : public MicromegasRawHit
 
   //! list of waveforms
   /** each pair contains the start sample of the waveform and the constituting adc values */
-  using waveform_pair_t = std::pair<uint16_t,adc_list_t>;
+  using waveform_pair_t = std::pair<uint16_t, adc_list_t>;
   std::vector<waveform_pair_t> m_adcData;
 
   ClassDefOverride(MicromegasRawHitv3, 1)

--- a/offline/framework/ffarawobjects/MvtxRawEvtHeaderv2.cc
+++ b/offline/framework/ffarawobjects/MvtxRawEvtHeaderv2.cc
@@ -7,8 +7,8 @@
 static const uint8_t NMVTXFEEID = 48 * 3;
 
 MvtxRawEvtHeaderv2::MvtxRawEvtHeaderv2()
+  : m_MvtxFeeIdInfoTCArray(new TClonesArray("MvtxFeeIdInfov1", NMVTXFEEID))
 {
-  m_MvtxFeeIdInfoTCArray = new TClonesArray("MvtxFeeIdInfov1", NMVTXFEEID);
 }
 
 MvtxRawEvtHeaderv2::~MvtxRawEvtHeaderv2()

--- a/offline/framework/ffarawobjects/MvtxRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/MvtxRawHitContainerv1.cc
@@ -6,8 +6,8 @@
 static const int NMVTXHITS = 100;
 
 MvtxRawHitContainerv1::MvtxRawHitContainerv1()
+  : MvtxRawHitsTCArray(new TClonesArray("MvtxRawHitv1", NMVTXHITS))
 {
-  MvtxRawHitsTCArray = new TClonesArray("MvtxRawHitv1", NMVTXHITS);
 }
 
 MvtxRawHitContainerv1::~MvtxRawHitContainerv1()
@@ -25,6 +25,7 @@ void MvtxRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "MvtxRawHitContainerv1" << std::endl;
   os << "containing " << MvtxRawHitsTCArray->GetEntriesFast() << " Mvtx hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   MvtxRawHit *mvtxhit = static_cast<MvtxRawHit *>(MvtxRawHitsTCArray->At(0));
   if (mvtxhit)
   {

--- a/offline/framework/ffarawobjects/MvtxRawHitv1.h
+++ b/offline/framework/ffarawobjects/MvtxRawHitv1.h
@@ -10,7 +10,7 @@ class MvtxRawHitv1 : public MvtxRawHit
  public:
   MvtxRawHitv1() {}
   MvtxRawHitv1(MvtxRawHit *mvtxhit);
-  ~MvtxRawHitv1() override{};
+  ~MvtxRawHitv1() override {};
 
   /** identify Function from PHObject
       @param os Output Stream

--- a/offline/framework/ffarawobjects/OfflinePacket.h
+++ b/offline/framework/ffarawobjects/OfflinePacket.h
@@ -9,6 +9,13 @@
 class OfflinePacket : public PHObject
 {
  public:
+  enum enu_packetstatus
+  {
+    PACKET_OK = 0,
+    PACKET_DROPPED = 1,
+    NOTSET = std::numeric_limits<uint64_t>::max()
+  };
+
   OfflinePacket() = default;
   virtual ~OfflinePacket() = default;
   virtual void FillFrom(const OfflinePacket * /*pkt*/) { return; }

--- a/offline/framework/ffarawobjects/OfflinePacketv1.h
+++ b/offline/framework/ffarawobjects/OfflinePacketv1.h
@@ -35,7 +35,7 @@ class OfflinePacketv1 : public OfflinePacket
   int hitformat{std::numeric_limits<int>::min()};
   int packetid{std::numeric_limits<int>::min()};
   uint64_t bco{std::numeric_limits<uint64_t>::max()};
-  uint64_t status{0};
+  uint64_t status{OfflinePacket::NOTSET};
 
  private:
   ClassDefOverride(OfflinePacketv1, 2)

--- a/offline/framework/ffarawobjects/TpcRawHit.h
+++ b/offline/framework/ffarawobjects/TpcRawHit.h
@@ -54,7 +54,7 @@ class TpcRawHit : public PHObject
   virtual bool get_checksumerror() const { return false; }
   virtual void set_checksumerror(const bool /*b*/) { return; }
 
-  //! SAMPA data payload parity check. If true, data from SAMPA is broken, e.g. from SEU 
+  //! SAMPA data payload parity check. If true, data from SAMPA is broken, e.g. from SEU
   virtual bool get_parityerror() const { return false; }
   virtual void set_parityerror(const bool /*b*/) { return; }
 

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv1.cc
@@ -6,8 +6,8 @@
 static const int NTPCHITS = 10000;
 
 TpcRawHitContainerv1::TpcRawHitContainerv1()
+  : TpcRawHitsTCArray(new TClonesArray("TpcRawHitv1", NTPCHITS))
 {
-  TpcRawHitsTCArray = new TClonesArray("TpcRawHitv1", NTPCHITS);
 }
 
 TpcRawHitContainerv1::~TpcRawHitContainerv1()
@@ -26,6 +26,7 @@ void TpcRawHitContainerv1::identify(std::ostream &os) const
 {
   os << "TpcRawHitContainerv1" << std::endl;
   os << "containing " << TpcRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   TpcRawHit *tpchit = static_cast<TpcRawHit *>(TpcRawHitsTCArray->At(0));
   if (tpchit)
   {

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv2.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv2.cc
@@ -6,8 +6,8 @@
 static const int NTPCHITS = 10000;
 
 TpcRawHitContainerv2::TpcRawHitContainerv2()
+  : TpcRawHitsTCArray(new TClonesArray("TpcRawHitv2", NTPCHITS))
 {
-  TpcRawHitsTCArray = new TClonesArray("TpcRawHitv2", NTPCHITS);
 }
 
 TpcRawHitContainerv2::~TpcRawHitContainerv2()
@@ -26,6 +26,7 @@ void TpcRawHitContainerv2::identify(std::ostream &os) const
 {
   os << "TpcRawHitContainerv2" << std::endl;
   os << "containing " << TpcRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   TpcRawHit *tpchit = static_cast<TpcRawHit *>(TpcRawHitsTCArray->At(0));
   if (tpchit)
   {

--- a/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
+++ b/offline/framework/ffarawobjects/TpcRawHitContainerv3.cc
@@ -8,8 +8,8 @@
 static const int NTPCHITS = 10000;
 
 TpcRawHitContainerv3::TpcRawHitContainerv3()
+  : TpcRawHitsTCArray(new TClonesArray("TpcRawHitv3", NTPCHITS))
 {
-  TpcRawHitsTCArray = new TClonesArray("TpcRawHitv3", NTPCHITS);
 }
 
 TpcRawHitContainerv3::~TpcRawHitContainerv3()
@@ -28,6 +28,7 @@ void TpcRawHitContainerv3::identify(std::ostream &os) const
 {
   os << "TpcRawHitContainerv3" << std::endl;
   os << "containing " << TpcRawHitsTCArray->GetEntriesFast() << " Tpc hits" << std::endl;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   TpcRawHit *tpchit = static_cast<TpcRawHit *>(TpcRawHitsTCArray->At(0));
   if (tpchit)
   {
@@ -53,20 +54,18 @@ TpcRawHit *TpcRawHitContainerv3::AddHit()
 
 TpcRawHit *TpcRawHitContainerv3::AddHit(TpcRawHit *tpchit)
 {
-  if (tpchit->IsA()==TpcRawHitv3::Class())
+  if (tpchit->IsA() == TpcRawHitv3::Class())
   {
     // fast add with move constructor to avoid ADC data copying
 
     TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1])
-        TpcRawHitv3(std::move(*(static_cast<TpcRawHitv3 *>(tpchit))));
+        TpcRawHitv3(std::move(*(static_cast<TpcRawHitv3 *>(tpchit))));  // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     return newhit;
   }
-  else
-  {
-    std::cout << __PRETTY_FUNCTION__ << "WARNING: input hit is not of type TpcRawHitv3. This is slow, please avoid." << std::endl;
-    TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3(tpchit);
-    return newhit;
-  }
+
+  std::cout << __PRETTY_FUNCTION__ << "WARNING: input hit is not of type TpcRawHitv3. This is slow, please avoid." << std::endl;
+  TpcRawHit *newhit = new ((*TpcRawHitsTCArray)[TpcRawHitsTCArray->GetLast() + 1]) TpcRawHitv3(tpchit);
+  return newhit;
 }
 
 TpcRawHit *TpcRawHitContainerv3::get_hit(unsigned int index)

--- a/offline/framework/ffarawobjects/TpcRawHitv1.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv1.h
@@ -67,55 +67,54 @@ class TpcRawHitv1 : public TpcRawHit
     adc[sample] = val;
   }
 
-
   class AdcIteratorv1 : public AdcIterator
-    {
-     private:
-      const std::vector<uint16_t> & m_adc;
-      uint16_t m_index = 0;
-
-     public:
-      explicit AdcIteratorv1(const std::vector<uint16_t> & adc)
-        : m_adc(adc)
-      {
-      }
-
-      void First() override { m_index = 0; }
-
-      void Next() override { ++m_index; }
-
-      bool IsDone() const override { return m_index >= m_adc.size(); }
-
-      uint16_t CurrentTimeBin() const override
-      {
-        return m_index;   
-      }
-      uint16_t CurrentAdc() const override
-      {
-        if (!IsDone())
-        {
-          return m_adc[m_index];
-        }
-        return std::numeric_limits<uint16_t>::max();  // Or throw an exception
-      }
-    };
-
-    AdcIterator* CreateAdcIterator() const override { return new AdcIteratorv1(adc); }
-
+  {
    private:
-    uint64_t bco = std::numeric_limits<uint64_t>::max();
-    uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
-    int32_t packetid = std::numeric_limits<int32_t>::max();
-    uint16_t fee = std::numeric_limits<uint16_t>::max();
-    uint16_t channel = std::numeric_limits<uint16_t>::max();
-    uint16_t sampaaddress = std::numeric_limits<uint16_t>::max();
-    uint16_t sampachannel = std::numeric_limits<uint16_t>::max();
-    uint16_t samples = std::numeric_limits<uint16_t>::max();
+    const std::vector<uint16_t>& m_adc;
+    uint16_t m_index = 0;
 
-    //! adc value for each sample
-    std::vector<uint16_t> adc;
+   public:
+    explicit AdcIteratorv1(const std::vector<uint16_t>& adc)
+      : m_adc(adc)
+    {
+    }
 
-    ClassDefOverride(TpcRawHitv1, 1)
+    void First() override { m_index = 0; }
+
+    void Next() override { ++m_index; }
+
+    bool IsDone() const override { return m_index >= m_adc.size(); }
+
+    uint16_t CurrentTimeBin() const override
+    {
+      return m_index;
+    }
+    uint16_t CurrentAdc() const override
+    {
+      if (!IsDone())
+      {
+        return m_adc[m_index];
+      }
+      return std::numeric_limits<uint16_t>::max();  // Or throw an exception
+    }
   };
+
+  AdcIterator* CreateAdcIterator() const override { return new AdcIteratorv1(adc); }
+
+ private:
+  uint64_t bco = std::numeric_limits<uint64_t>::max();
+  uint64_t gtm_bco = std::numeric_limits<uint64_t>::max();
+  int32_t packetid = std::numeric_limits<int32_t>::max();
+  uint16_t fee = std::numeric_limits<uint16_t>::max();
+  uint16_t channel = std::numeric_limits<uint16_t>::max();
+  uint16_t sampaaddress = std::numeric_limits<uint16_t>::max();
+  uint16_t sampachannel = std::numeric_limits<uint16_t>::max();
+  uint16_t samples = std::numeric_limits<uint16_t>::max();
+
+  //! adc value for each sample
+  std::vector<uint16_t> adc;
+
+  ClassDefOverride(TpcRawHitv1, 1)
+};
 
 #endif

--- a/offline/framework/ffarawobjects/TpcRawHitv3.h
+++ b/offline/framework/ffarawobjects/TpcRawHitv3.h
@@ -116,14 +116,14 @@ class TpcRawHitv3 : public TpcRawHit
     void Next() override
     {
       if (IsDone()) return;
-      
+
       // NOLINTNEXTLINE(bugprone-branch-clone)
       if (m_adc_position_in_waveform_index + 1U < m_adc[m_waveform_index].second.size())
       {
         ++m_adc_position_in_waveform_index;
       }
       else
-      { 
+      {
         // advance to the next valid waveform
         m_adc_position_in_waveform_index = 0;
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR initializes the status filed for the offline packets and the fem status for the calo packets. Not yet implemented in the event combiners which now actively have to set this this to OK

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

