### PR TITLE
fix: seg fault in tpc laser qa 

### DIFF
--- a/offline/QA/Tpc/TpcLaserQA.cc
+++ b/offline/QA/Tpc/TpcLaserQA.cc
@@ -174,7 +174,7 @@ void TpcLaserQA::createHistos()
     hm->registerHisto(h2);
 
     
-    auto h3 = new TH2F(boost::str(boost::format("%saturation_%s") % getHistoPrefix() % (side == 1 ? "North" : "South")).c_str(),boost::str(boost::format("Number of Saturated Hits per event %s") % (side == 1 ? "North" : "South")).c_str(),12,-M_PI/12.,23.*M_PI/12.,4,rBinEdges);
+    auto h3 = new TH2F(boost::str(boost::format("%ssaturation_%s") % getHistoPrefix() % (side == 1 ? "North" : "South")).c_str(),boost::str(boost::format("Number of Saturated Hits per event %s") % (side == 1 ? "North" : "South")).c_str(),12,-M_PI/12.,23.*M_PI/12.,4,rBinEdges);
     hm->registerHisto(h3);
   }
   


### PR DESCRIPTION
The production clustering jobs were dying because of a wrong name in a tpc laser qa histogram, this fixes it

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

