### PR TITLE
prep event plane reco for prod

### DIFF
--- a/offline/packages/eventplaneinfo/EventPlaneReco.cc
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.cc
@@ -16,6 +16,14 @@
 #include <mbd/MbdPmtContainer.h>
 #include <mbd/MbdPmtHit.h>
 
+#include <calotrigger/MinimumBiasInfo.h>
+#include <centrality/CentralityInfo.h>
+
+#include <globalvertex/GlobalVertex.h>
+#include <globalvertex/GlobalVertexMap.h>
+#include <globalvertex/MbdVertex.h>
+#include <globalvertex/MbdVertexMap.h>
+
 #include <cdbobjects/CDBHistos.h>
 #include <cdbobjects/CDBTTree.h>
 #include <ffamodules/CDBInterface.h>
@@ -32,6 +40,10 @@
 #include <phool/phool.h> // for PHWHERE
 #include <phool/recoConsts.h>
 
+#include <TProfile2D.h>
+
+#include <boost/format.hpp>
+
 #include <array> // for array
 #include <cfloat>
 #include <cmath>
@@ -44,6 +56,15 @@
 EventPlaneReco::EventPlaneReco(const std::string &name) : SubsysReco(name) {
   south_q.resize(m_MaxOrder);
   north_q.resize(m_MaxOrder);
+  northsouth_q.resize(m_MaxOrder);
+  south_q_subtract.resize(m_MaxOrder);
+  north_q_subtract.resize(m_MaxOrder);
+  shift_north.resize(m_MaxOrder);
+  shift_south.resize(m_MaxOrder);
+  shift_northsouth.resize(m_MaxOrder);
+  tmp_south_psi.resize(m_MaxOrder);
+  tmp_north_psi.resize(m_MaxOrder);
+  tmp_northsouth_psi.resize(m_MaxOrder);
 
   for (auto &vec : south_q) {
     vec.resize(2);
@@ -52,35 +73,70 @@ EventPlaneReco::EventPlaneReco(const std::string &name) : SubsysReco(name) {
   for (auto &vec : north_q) {
     vec.resize(2);
   }
+   
+  for (auto &vec : northsouth_q) {
+      vec.resize(2);
+  }
+    
+  for (auto &vec : south_q_subtract)
+  {
+    vec.resize(2);
+  }
+
+  for (auto &vec : north_q_subtract)
+  {
+    vec.resize(2);
+  }
+
 }
 
 int EventPlaneReco::InitRun(PHCompositeNode *topNode) {
-  if (!m_overrideSEPDMapName) {
-    m_sEPDMapName = "SEPD_CHANNELMAP";
-  }
-  if (!m_overrideSEPDFieldName) {
-    m_sEPDfieldname = "epd_channel_map";
-  }
-  std::string calibdir = CDBInterface::instance()->getUrl(m_sEPDMapName);
-  if (!calibdir.empty()) {
-    cdbttree = new CDBTTree(calibdir);
-  } else {
-    std::cout << "EventPlaneReco::::InitRun No sEPD mapping file for domain "
-              << m_sEPDMapName << " found" << std::endl;
-    exit(1);
-  }
-  vkey.clear();
-  for (int i = 0; i < 768; i++) {
-
-    int keymap = cdbttree->GetIntValue(i, m_sEPDfieldname);
-    if (keymap == 999) {
-      continue;
+    
+    //default is run 54912
+    //if turned off module will look
+    //for calibration file for this run
+    if(!_default_calib)
+    {
+        recoConsts *rc = recoConsts::instance();
+        m_runNo = rc->get_IntFlag("RUNNUMBER");
     }
 
-    key = TowerInfoDefs::encode_epd(keymap);
-    vkey.push_back(key);
-  }
+    if (Verbosity() > 0)
+    {
+      std::cout << "======================= EventPlaneReco:InitRun() =======================" << std::endl;
+      std::cout << PHWHERE << "RUNNUMBER " << m_runNo << std::endl;
+    }
 
+    FileName = boost::str(boost::format("eventplane_correction_histograms_run_%d.root") % m_runNo).c_str();
+    
+    //-----------------------------------load calibration histograms-----------------------------------------//
+      CDBHistos *cdbhistosIn = new CDBHistos(FileName);
+      cdbhistosIn->LoadCalibrations();
+
+      // Get recentering histograms
+      for (unsigned int order = 0; order < m_MaxOrder; order++)
+      {
+        tprof_mean_cos_south_epd_input[order] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_south_epd_order_%d") % order).c_str(), false));
+        tprof_mean_sin_south_epd_input[order] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_south_epd_order_%d") % order).c_str(), false));
+        tprof_mean_cos_north_epd_input[order] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_cos_north_epd_order_%d") % order).c_str(), false));
+        tprof_mean_sin_north_epd_input[order] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_mean_sin_north_epd_order_%d") % order).c_str(), false));
+      }
+
+    // Get shifting histograms
+    for (unsigned int order = 0; order < m_MaxOrder; order++)
+    {
+      for (int p = 0; p < _imax; p++)
+      {
+        tprof_cos_north_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_north_epd_shift_order_%d_%d") % order % p).c_str(), false));
+        tprof_sin_north_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_north_epd_shift_order_%d_%d") % order % p).c_str(), false));
+        tprof_cos_south_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_south_epd_shift_order_%d_%d") % order % p).c_str(), false));
+        tprof_sin_south_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_south_epd_shift_order_%d_%d") % order % p).c_str(), false));
+          tprof_cos_northsouth_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_cos_northsouth_epd_shift_order_%d_%d") % order % p).c_str(), false));
+          tprof_sin_northsouth_epd_shift_input[order][p] = dynamic_cast<TProfile2D *>(cdbhistosIn->getHisto(boost::str(boost::format("tprof_sin_northsouth_epd_shift_order_%d_%d") % order % p).c_str(), false));
+      }
+    }
+   
+  cdbhistosIn->Print();
   return CreateNodes(topNode);
 }
 
@@ -92,7 +148,39 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode) {
   //---------------------------------
   // Get Objects off of the Node Tree
   //---------------------------------
-
+    
+    MinimumBiasInfo* _minimumbiasinfo = findNode::getClass<MinimumBiasInfo>(topNode, "MinimumBiasInfo");
+    if (!_minimumbiasinfo)
+    {
+        std::cout << PHWHERE << "::ERROR - cannot find MinimumBiasInfo"
+                  << std::endl;
+        exit(-1);
+    }
+    
+    bool is_mb = false;
+    is_mb = (_minimumbiasinfo) ? _minimumbiasinfo->isAuAuMinimumBias() : false;
+    
+    MbdVertexMap* mbdvtxmap = findNode::getClass<MbdVertexMap>(topNode, "MbdVertexMap");
+    if (!mbdvtxmap) {
+        std::cout << PHWHERE << "::ERROR - cannot find MbdVertexMap"
+                  << std::endl;
+        exit(-1);
+      }
+    
+    MbdVertex *mvertex = nullptr;
+    if (mbdvtxmap)
+    {
+      for (MbdVertexMap::ConstIter mbditer = mbdvtxmap->begin();
+           mbditer != mbdvtxmap->end(); ++mbditer)
+      {
+          mvertex = mbditer->second;
+      }
+      if (mvertex)
+      {
+          _mbdvtx = mvertex->get_z();
+      }
+    }
+     
   EventplaneinfoMap *epmap =
       findNode::getClass<EventplaneinfoMap>(topNode, "EventplaneinfoMap");
   if (!epmap) {
@@ -100,84 +188,294 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode) {
               << std::endl;
     exit(-1);
   }
+    
 
-  if (_sepdEpReco) {
-    ResetMe();
-    TowerInfoContainer *epd_towerinfo =
-        findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SEPD");
-    if (!epd_towerinfo) {
-      std::cout << PHWHERE << "::ERROR - cannot find TOWERINFO_CALIB_SEPD"
-                << std::endl;
-      exit(-1);
-    }
-    EpdGeom *_epdgeom = findNode::getClass<EpdGeom>(topNode, "TOWERGEOM_EPD");
-    if (!_epdgeom) {
-      std::cout << PHWHERE << "::ERROR - cannot find TOWERGEOM_EPD"
-                << std::endl;
-      exit(-1);
-    }
-
-    if (epd_towerinfo) {
-      if (Verbosity()) {
-        std::cout << "EventPlaneReco::process_event -  epd_towerinfo"
+  if(_sepdEpReco)
+  {
+      
+      TowerInfoContainer *epd_towerinfo =
+          findNode::getClass<TowerInfoContainer>(topNode, "TOWERINFO_CALIB_SEPD");
+      if (!epd_towerinfo) {
+        std::cout << PHWHERE << "::ERROR - cannot find TOWERINFO_CALIB_SEPD"
                   << std::endl;
+        exit(-1);
       }
-
-      unsigned int ntowers = epd_towerinfo->size();
-      for (unsigned int ch = 0; ch < ntowers; ch++) {
-        TowerInfo *_tower = epd_towerinfo->get_tower_at_channel(ch);
-        float epd_e = _tower->get_energy();
-        float epd_time = _tower->get_time_float();
-        if (epd_time != 20.) // exclude ZS
-        {
-          if (epd_e < 0.2) // expecting Nmips
+      EpdGeom *_epdgeom = findNode::getClass<EpdGeom>(topNode, "TOWERGEOM_EPD");
+      if (!_epdgeom) {
+        std::cout << PHWHERE << "::ERROR - cannot find TOWERGEOM_EPD"
+                  << std::endl;
+        exit(-1);
+      }
+      
+      ResetMe();
+      
+      if ((std::fabs(_mbdvtx) < _mbd_vertex_cut) && is_mb ) {
+    
+          unsigned int ntowers = epd_towerinfo->size();
+          for (unsigned int ch = 0; ch < ntowers; ch++)
           {
-            continue;
-          }
-          float tile_phi = _epdgeom->get_phi(vkey[ch]);
-          int arm = TowerInfoDefs::get_epd_arm(vkey[ch]);
-          float truncated_e =
-              (epd_e < _epd_e) ? epd_e : _epd_e; // set cutoff at _epd_e
-          if (arm == 0) {
-            for (unsigned int order = 0; order < m_MaxOrder; order++) {
-              double Cosine = cos(tile_phi * (double)(order + 1));
-              double Sine = sin(tile_phi * (double)(order + 1));
-              south_q[order][0] += truncated_e * Cosine; // south Qn,x
-              south_q[order][1] += truncated_e * Sine;   // south Qn,y
-            }
-          } else if (arm == 1) {
-            for (unsigned int order = 0; order < m_MaxOrder; order++) {
-              double Cosine = cos(tile_phi * (double)(order + 1));
-              double Sine = sin(tile_phi * (double)(order + 1));
-              north_q[order][0] += truncated_e * Cosine; // north Qn,x
-              north_q[order][1] += truncated_e * Sine;   // north Qn,y
+            TowerInfo *_tower = epd_towerinfo->get_tower_at_channel(ch);
+            float epd_e = _tower->get_energy();
+            float epd_time = _tower->get_time_float();
+            if (epd_time != 20.) // exclude ZS
+            {
+                unsigned int key = TowerInfoDefs::encode_epd(ch);
+                int arm = TowerInfoDefs::get_epd_arm(key);
+                if(arm == 0)
+                {
+                   _ssum += epd_e;
+                }
+                else if (arm == 1)
+                {
+                   _nsum += epd_e;
+                }
             }
           }
-        }
+         
+         if(_ssum > _epd_charge_min && _nsum > _epd_charge_min)
+         {
+             _do_ep = true;
+         }
+        
+         if(_do_ep)
+         {
+             for (unsigned int ch = 0; ch < ntowers; ch++) {
+               TowerInfo *_tower = epd_towerinfo->get_tower_at_channel(ch);
+               float epd_e = _tower->get_energy();
+               float epd_time = _tower->get_time_float();
+               if (epd_time != 20.) // exclude ZS
+               {
+                 if (epd_e < 0.2) // expecting Nmips
+                 {
+                   continue;
+                 }
+                 unsigned int key = TowerInfoDefs::encode_epd(ch);
+                 float tile_phi = _epdgeom->get_phi(key);
+                 int arm = TowerInfoDefs::get_epd_arm(key);
+                 float truncated_e =
+                     (epd_e < _epd_e) ? epd_e : _epd_e; // set cutoff at _epd_e
+                 if (arm == 0) {
+                   for (unsigned int order = 0; order < m_MaxOrder; order++) {
+                     double Cosine = cos(tile_phi * (double)(order + 1));
+                     double Sine = sin(tile_phi * (double)(order + 1));
+                     south_q[order][0] += truncated_e * Cosine; // south Qn,x
+                     south_q[order][1] += truncated_e * Sine;   // south Qn,y
+                   }
+                 } else if (arm == 1) {
+                   for (unsigned int order = 0; order < m_MaxOrder; order++) {
+                     double Cosine = cos(tile_phi * (double)(order + 1));
+                     double Sine = sin(tile_phi * (double)(order + 1));
+                     north_q[order][0] += truncated_e * Cosine; // north Qn,x
+                     north_q[order][1] += truncated_e * Sine;   // north Qn,y
+                   }
+                 }
+               }
+             }
+           
+             
+             // Get recentering histograms and do recentering
+             // Recentering: subtract Qn,x and Qn,y values averaged over all events
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               if (tprof_mean_cos_south_epd_input[order])  // check if recentering histograms exist
+               {
+                   
+                 // south
+                 TAxis *south_xaxis = tprof_mean_cos_south_epd_input[order]->GetXaxis();
+                 TAxis *south_yaxis = tprof_mean_cos_south_epd_input[order]->GetYaxis();
+                 int xbin_south = south_xaxis->FindBin(_ssum);
+                 int ybin_south = south_yaxis->FindBin(_mbdvtx);
+
+                 double event_ave_cos_south = tprof_mean_cos_south_epd_input[order]->GetBinContent(xbin_south, ybin_south);
+                 double event_ave_sin_south = tprof_mean_sin_south_epd_input[order]->GetBinContent(xbin_south, ybin_south);
+                 south_q_subtract[order][0] = _ssum * event_ave_cos_south;
+                 south_q_subtract[order][1] = _ssum * event_ave_sin_south;
+                 south_q[order][0] -= south_q_subtract[order][0];
+                 south_q[order][1] -= south_q_subtract[order][1];
+
+                 // north
+                 TAxis *north_xaxis = tprof_mean_cos_north_epd_input[order]->GetXaxis();
+                 TAxis *north_yaxis = tprof_mean_cos_north_epd_input[order]->GetYaxis();
+                 int xbin_north = north_xaxis->FindBin(_nsum);
+                 int ybin_north = north_yaxis->FindBin(_mbdvtx);
+
+                 double event_ave_cos_north = tprof_mean_cos_north_epd_input[order]->GetBinContent(xbin_north, ybin_north);
+                 double event_ave_sin_north = tprof_mean_sin_north_epd_input[order]->GetBinContent(xbin_north, ybin_north);
+                 north_q_subtract[order][0] = _nsum * event_ave_cos_north;
+                 north_q_subtract[order][1] = _nsum * event_ave_sin_north;
+                 north_q[order][0] -= north_q_subtract[order][0];
+                 north_q[order][1] -= north_q_subtract[order][1];
+               }
+             }
+             
+               
+             //fill combined recentered Q vectors
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               if (tprof_mean_cos_south_epd_input[order])  // check if recentering histograms exist
+               {
+                   
+                 northsouth_q[order][0] = north_q[order][0] + south_q[order][0];
+                 northsouth_q[order][1] = north_q[order][1] + south_q[order][1];
+
+               }
+             }
+        
+             //Get recentered psi_n
+             Eventplaneinfo *epinfo = new Eventplaneinfov1();
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               double n = order + 1.0;
+               if (tprof_mean_cos_south_epd_input[order])  // if present, Qs are recentered
+               {
+                 tmp_south_psi[order] = epinfo->GetPsi(south_q[order][0], south_q[order][1], n);
+                 tmp_north_psi[order] = epinfo->GetPsi(north_q[order][0], north_q[order][1], n);
+                 tmp_northsouth_psi[order] = epinfo->GetPsi(northsouth_q[order][0], northsouth_q[order][1], n);
+               }
+               else
+               {
+                 tmp_south_psi[order] = NAN;
+                 tmp_north_psi[order] = NAN;
+                 tmp_northsouth_psi[order] = NAN;
+               }
+             }
+      
+             
+             // Get shifting histograms and calculate shift
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               for (int p = 0; p < _imax; p++)
+               {
+                 if (tprof_cos_south_epd_shift_input[order][p])  // check if shifting histograms exist
+                 {
+                   double terms = p + 1.0;
+                   double n = order + 1.0;
+                   double tmp = (double) (n * terms);
+                   double prefactor = 2.0 / terms;
+                     
+                   // south
+                   TAxis *south_xaxis = tprof_cos_south_epd_shift_input[order][p]->GetXaxis();
+                   TAxis *south_yaxis = tprof_cos_south_epd_shift_input[order][p]->GetYaxis();
+                   int xbin_south = south_xaxis->FindBin(_ssum);
+                   int ybin_south = south_yaxis->FindBin(_mbdvtx);
+
+                   // north
+                   TAxis *north_xaxis = tprof_cos_north_epd_shift_input[order][p]->GetXaxis();
+                   TAxis *north_yaxis = tprof_cos_north_epd_shift_input[order][p]->GetYaxis();
+                   int xbin_north = north_xaxis->FindBin(_nsum);
+                   int ybin_north = north_yaxis->FindBin(_mbdvtx);
+                     
+                     
+                   // northsouth
+                   TAxis *northsouth_xaxis = tprof_cos_northsouth_epd_shift_input[order][p]->GetXaxis();
+                   TAxis *northsouth_yaxis = tprof_cos_northsouth_epd_shift_input[order][p]->GetYaxis();
+                   int xbin_northsouth = northsouth_xaxis->FindBin(_nsum + _ssum);
+                   int ybin_northsouth = northsouth_yaxis->FindBin(_mbdvtx);
+                     
+
+                   // Equation (6) of arxiv:nucl-ex/9805001
+                   // i = terms; n = order; i*n = tmp
+                   // (2 / i ) * <cos(i*n*psi_n)> * sin(i*n*psi_n) - <sin(i*n*psi_n)> * cos(i*n*psi_n)
+
+                   // north
+                   shift_north[order] += prefactor * (tprof_cos_north_epd_shift_input[order][p]->GetBinContent(xbin_north, ybin_north) * sin(tmp * tmp_north_psi[order]) - tprof_sin_north_epd_shift_input[order][p]->GetBinContent(xbin_north, ybin_north) * cos(tmp * tmp_north_psi[order]));
+
+                   // south
+                   shift_south[order] += prefactor * (tprof_cos_south_epd_shift_input[order][p]->GetBinContent(xbin_south, ybin_south) * sin(tmp * tmp_south_psi[order]) - tprof_sin_south_epd_shift_input[order][p]->GetBinContent(xbin_south, ybin_south) * cos(tmp * tmp_south_psi[order]));
+                     
+                     // northsouth
+                     shift_northsouth[order] += prefactor * (tprof_cos_northsouth_epd_shift_input[order][p]->GetBinContent(xbin_northsouth, ybin_northsouth) * sin(tmp * tmp_northsouth_psi[order]) - tprof_sin_northsouth_epd_shift_input[order][p]->GetBinContent(xbin_northsouth, ybin_northsouth) * cos(tmp * tmp_northsouth_psi[order]));
+                 }
+               }
+             }
+             
+             // n * deltapsi_n = (2 / i ) * <cos(i*n*psi_n)> * sin(i*n*psi_n) - <sin(i*n*psi_n)> * cos(i*n*psi_n)
+               // Divide out n
+               for (unsigned int order = 0; order < m_MaxOrder; order++)
+               {
+                 double n = order + 1.0;
+                 shift_north[order] /= n;
+                 shift_south[order] /= n;
+                 shift_northsouth[order] /= n;
+               }
+             
+             
+             // Now add shift to psi_n to flatten it
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               if (tprof_cos_north_epd_shift_input[0][0])
+               {
+                 tmp_south_psi[order] += shift_south[order];
+                 tmp_north_psi[order] += shift_north[order];
+                 tmp_northsouth_psi[order] += shift_northsouth[order];
+               }
+             }
+             
+             // Now enforce the range
+             for (unsigned int order = 0; order < m_MaxOrder; order++)
+             {
+               if (tprof_cos_north_epd_shift_input[0][0])
+               {
+                 double range = M_PI / (double) (order + 1);
+                 if (tmp_south_psi[order] < -1.0 * range)
+                 {
+                   tmp_south_psi[order] += 2.0 * range;
+                 }
+                 if (tmp_south_psi[order] > range)
+                 {
+                   tmp_south_psi[order] -= 2.0 * range;
+                 }
+                 if (tmp_north_psi[order] < -1.0 * range)
+                 {
+                   tmp_north_psi[order] += 2.0 * range;
+                 }
+                 if (tmp_north_psi[order] > range)
+                 {
+                   tmp_north_psi[order] -= 2.0 * range;
+                 }
+                if (tmp_northsouth_psi[order] < -1.0 * range)
+                {
+                    tmp_northsouth_psi[order] += 2.0 * range;
+                }
+                if (tmp_northsouth_psi[order] > range)
+                {
+                    tmp_northsouth_psi[order] -= 2.0 * range;
+                }
+               }
+             }
+             
+           for (unsigned int order = 0; order < m_MaxOrder; order++) {
+             south_Qvec.emplace_back(south_q[order][0], south_q[order][1]);
+             north_Qvec.emplace_back(north_q[order][0], north_q[order][1]);
+             northsouth_Qvec.emplace_back(northsouth_q[order][0], northsouth_q[order][1]);
+           }
+
+           if (epd_towerinfo) {
+             Eventplaneinfo *sepds = new Eventplaneinfov1();
+             sepds->set_qvector(south_Qvec);
+             sepds->set_shifted_psi(tmp_south_psi);
+             epmap->insert(sepds, EventplaneinfoMap::sEPDS);
+
+             Eventplaneinfo *sepdn = new Eventplaneinfov1();
+             sepdn->set_qvector(north_Qvec);
+             sepdn->set_shifted_psi(tmp_north_psi);
+             epmap->insert(sepdn, EventplaneinfoMap::sEPDN);
+               
+             Eventplaneinfo *sepdns = new Eventplaneinfov1();
+             sepdns->set_qvector(northsouth_Qvec);
+             sepdns->set_shifted_psi(tmp_northsouth_psi);
+             epmap->insert(sepdns, EventplaneinfoMap::sEPDNS);
+
+             if (Verbosity() > 1) {
+               sepds->identify();
+               sepdn->identify();
+               sepdns->identify();
+             }
+           }
+         }
       }
-    }
-    for (unsigned int order = 0; order < m_MaxOrder; order++) {
-      south_Qvec.emplace_back(south_q[order][0], south_q[order][1]);
-      north_Qvec.emplace_back(north_q[order][0], north_q[order][1]);
-    }
-
-    if (epd_towerinfo) {
-      Eventplaneinfo *sepds = new Eventplaneinfov1();
-      sepds->set_qvector(south_Qvec);
-      epmap->insert(sepds, EventplaneinfoMap::sEPDS);
-
-      Eventplaneinfo *sepdn = new Eventplaneinfov1();
-      sepdn->set_qvector(north_Qvec);
-      epmap->insert(sepdn, EventplaneinfoMap::sEPDN);
-
-      if (Verbosity() > 1) {
-        sepds->identify();
-        sepdn->identify();
-      }
-    }
-
-    ResetMe();
   }
+  
 
   if (_mbdEpReco) {
     ResetMe();
@@ -201,11 +499,9 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode) {
         std::cout << "EventPlaneReco::process_event -  mbdpmts" << std::endl;
       }
 
-      mbdQ = 0.;
-
       for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++) {
         float mbd_q = mbdpmts->get_pmt(ipmt)->get_q();
-        mbdQ += mbd_q;
+        _mbdQ += mbd_q;
       }
 
       for (int ipmt = 0; ipmt < mbdpmts->get_npmt(); ipmt++) {
@@ -213,7 +509,7 @@ int EventPlaneReco::process_event(PHCompositeNode *topNode) {
         float phi = mbdgeom->get_phi(ipmt);
         int arm = mbdgeom->get_arm(ipmt);
 
-        if (mbdQ < _mbd_e) {
+        if (_mbdQ < _mbd_e) {
           continue;
         }
 
@@ -302,8 +598,36 @@ void EventPlaneReco::ResetMe() {
     std::fill(vec.begin(), vec.end(), 0.);
   }
 
+  for (auto &vec : northsouth_q) {
+    std::fill(vec.begin(), vec.end(), 0.);
+  }
+    
   south_Qvec.clear();
   north_Qvec.clear();
+  northsouth_Qvec.clear();
+    
+  for (auto &vec : south_q_subtract)
+  {
+    std::fill(vec.begin(), vec.end(), 0.);
+  }
+  
+  for (auto &vec : north_q_subtract)
+  {
+    std::fill(vec.begin(), vec.end(), 0.);
+  }
+    
+  std::fill(shift_north.begin(), shift_north.end(), 0.);
+  std::fill(shift_south.begin(), shift_south.end(), 0.);
+  std::fill(shift_northsouth.begin(), shift_northsouth.end(), 0.);
+
+  std::fill(tmp_south_psi.begin(), tmp_south_psi.end(), NAN);
+  std::fill(tmp_north_psi.begin(), tmp_north_psi.end(), NAN);
+  std::fill(tmp_northsouth_psi.begin(), tmp_northsouth_psi.end(), NAN);
+
+  _nsum = 0.;
+  _ssum = 0.;
+  _do_ep = false;
+  _mbdQ = 0.;
 }
 
 int EventPlaneReco::End(PHCompositeNode * /*topNode*/) {

--- a/offline/packages/eventplaneinfo/EventPlaneReco.h
+++ b/offline/packages/eventplaneinfo/EventPlaneReco.h
@@ -13,6 +13,9 @@
 #include <string> // for string
 #include <vector> // for vector
 
+class CDBHistos;
+class TProfile2D;
+
 class PHCompositeNode;
 
 class EventPlaneReco : public SubsysReco {
@@ -25,35 +28,70 @@ public:
 
   void ResetMe();
   void set_sepd_epreco(bool sepdEpReco) { _sepdEpReco = sepdEpReco; }
+  void set_default_calibfile(bool default_calib) { _default_calib = default_calib; }
   void set_mbd_epreco(bool mbdEpReco) { _mbdEpReco = mbdEpReco; }
   void set_sEPD_Mip_cut(const float e) { _epd_e = e; }
+  void set_sEPD_Charge_cut(const float c) { _epd_charge_min = c; }
   void set_MBD_Min_Qcut(const float f) { _mbd_e = f; }
+  void set_MBD_Vetex_cut(const float v) { _mbd_vertex_cut = v; }
   void set_Ep_orders(const unsigned int n) { m_MaxOrder = n; }
 
 private:
   int CreateNodes(PHCompositeNode *topNode);
 
   unsigned int m_MaxOrder{3};
-
+  int m_runNo{54912};
+  std::string FileName;
   std::vector<std::vector<double>> south_q;
   std::vector<std::vector<double>> north_q;
+  std::vector<std::vector<double>> northsouth_q;
+
   std::vector<std::pair<double, double>> south_Qvec;
   std::vector<std::pair<double, double>> north_Qvec;
+  std::vector<std::pair<double, double>> northsouth_Qvec;
+
+ // recentering utility
+ std::vector<std::vector<double>> south_q_subtract;
+ std::vector<std::vector<double>> north_q_subtract;
+   
+ // shifting utility
+ std::vector<double> shift_north;
+ std::vector<double> shift_south;
+ std::vector<double> shift_northsouth;
+ std::vector<double> tmp_south_psi;
+ std::vector<double> tmp_north_psi;
+ std::vector<double> tmp_northsouth_psi;
+
+// recentering histograms
+ TProfile2D *tprof_mean_cos_north_epd_input[6]{};
+ TProfile2D *tprof_mean_sin_north_epd_input[6]{};
+ TProfile2D *tprof_mean_cos_south_epd_input[6]{};
+ TProfile2D *tprof_mean_sin_south_epd_input[6]{};
+    
+// shifting histograms
+ const int _imax{12};
+ TProfile2D *tprof_cos_north_epd_shift_input[6][12]{};
+ TProfile2D *tprof_sin_north_epd_shift_input[6][12]{};
+ TProfile2D *tprof_cos_south_epd_shift_input[6][12]{};
+ TProfile2D *tprof_sin_south_epd_shift_input[6][12]{};
+ TProfile2D *tprof_cos_northsouth_epd_shift_input[6][12]{};
+ TProfile2D *tprof_sin_northsouth_epd_shift_input[6][12]{};
 
   bool _mbdEpReco{false};
   bool _sepdEpReco{false};
-
+  bool _do_ep{false};
+  bool _default_calib{true};
+    
+  float _nsum{0.0};
+  float _ssum{0.0};
+  float _mbdvtx{999.0};
+  float _epd_charge_min{5.0};
   float _epd_e{10.0};
   float _mbd_e{10.0};
-  float mbdQ{0.};
+  float _mbdQ{0.0};
+  float _mbd_vertex_cut{60.0};
 
-  std::string m_sEPDMapName;
-  std::string m_sEPDfieldname;
-  bool m_overrideSEPDMapName{false};
-  bool m_overrideSEPDFieldName{false};
-  std::vector<unsigned int> vkey;
-  unsigned int key{999};
-  CDBTTree *cdbttree{nullptr};
+ 
 };
 
 #endif // EVENTPLANERECO_H

--- a/offline/packages/eventplaneinfo/Eventplaneinfo.h
+++ b/offline/packages/eventplaneinfo/Eventplaneinfo.h
@@ -21,7 +21,10 @@ class Eventplaneinfo : public PHObject
   PHObject* CloneMe() const override { return nullptr; }
 
   virtual void set_qvector(std::vector<std::pair<double, double>> /*Qvec*/) { return; }
+  virtual void set_shifted_psi(std::vector<double> /*Psi_Shifted*/) { return; }
   virtual std::pair<double, double> get_qvector(int /*order*/) const { return std::make_pair(NAN, NAN); }
+  virtual double get_psi(int /*order*/) const { return NAN; }
+  virtual double get_shifted_psi(int /*order*/) const { return NAN; }
   virtual double GetPsi(const double /*Qx*/, const double /*Qy*/, const unsigned int /*order*/) const { return NAN; }
 
 

--- a/offline/packages/eventplaneinfo/EventplaneinfoMap.h
+++ b/offline/packages/eventplaneinfo/EventplaneinfoMap.h
@@ -18,7 +18,9 @@ class EventplaneinfoMap : public PHObject
     sEPDS = 0,
     sEPDN = 1,
     MBDS = 2,
-    MBDN = 3
+    MBDN = 3,
+    sEPDNS = 4,
+    MBDNS = 5
   };
 
   typedef std::map<unsigned int, Eventplaneinfo*>::const_iterator ConstIter;

--- a/offline/packages/eventplaneinfo/Eventplaneinfov1.h
+++ b/offline/packages/eventplaneinfo/Eventplaneinfov1.h
@@ -24,11 +24,15 @@ class Eventplaneinfov1 : public Eventplaneinfo
   PHObject* CloneMe() const override { return new Eventplaneinfov1(*this); }
 
   void set_qvector(std::vector<std::pair<double, double>> Qvec) override { mQvec = Qvec; }
+  void set_shifted_psi(std::vector<double> Psi_Shifted) override { mPsi_Shifted = Psi_Shifted; }
   std::pair<double, double> get_qvector(int order) const override { return std::make_pair(mQvec[order - 1].first, mQvec[order - 1].second); }
   double GetPsi(const double Qx, const double Qy, const unsigned int order) const override;
-
+  double get_psi(int order) const override { return GetPsi(mQvec[order - 1].first, mQvec[order - 1].second, order);}
+  double get_shifted_psi(int order) const override { return mPsi_Shifted[order - 1]; }
+     
  private:
   std::vector<std::pair<double, double>> mQvec;
+  std::vector<double> mPsi_Shifted;
   ClassDefOverride(Eventplaneinfov1, 1);
 };
 

--- a/offline/packages/eventplaneinfo/Makefile.am
+++ b/offline/packages/eventplaneinfo/Makefile.am
@@ -14,7 +14,8 @@ AM_LDFLAGS = \
   -L$(OFFLINE_MAIN)/lib
 
 libeventplaneinfo_io_la_LIBADD = \
-  -lphool
+  -lphool \
+  -lcentrality_io
 
 libeventplaneinfo_la_LIBADD = \
   libeventplaneinfo_io.la \
@@ -22,6 +23,8 @@ libeventplaneinfo_la_LIBADD = \
   -lmbd_io \
   -lfun4all \
   -lffamodules \
+  -lcalotrigger_io \
+  -lffarawobjects \
   -lcdbobjects \
   -lglobalvertex_io
 


### PR DESCRIPTION
PR  adds sEPD event plane calibration functionality 
Version should be production ready and useable downstream in other modules, e.g. in jet background subtraction.