### PR TITLE
add some setters for PHActsTrkFitter and TpcGlobalPositionWrapper

### DIFF
--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -49,22 +49,22 @@ void TpcGlobalPositionWrapper::loadNodes( PHCompositeNode* topNode )
 Acts::Vector3 TpcGlobalPositionWrapper::applyDistortionCorrections(Acts::Vector3 global) const
 {
   // apply distortion corrections
-  if (m_dcc_module_edge)
+  if (!m_disable_module_edge_corr && m_dcc_module_edge)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_module_edge);
   }
 
-  if (m_dcc_static)
+  if (!m_disable_static_corr && m_dcc_static)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_static);
   }
 
-  if (m_dcc_average)
+  if (!m_disable_average_corr && m_dcc_average)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_average);
   }
 
-  if (m_dcc_fluctuation)
+  if (!m_disable_fluctuation_corr && m_dcc_fluctuation)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_fluctuation);
   }

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.cc
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.cc
@@ -49,22 +49,22 @@ void TpcGlobalPositionWrapper::loadNodes( PHCompositeNode* topNode )
 Acts::Vector3 TpcGlobalPositionWrapper::applyDistortionCorrections(Acts::Vector3 global) const
 {
   // apply distortion corrections
-  if (!m_disable_module_edge_corr && m_dcc_module_edge)
+  if (m_enable_module_edge_corr && m_dcc_module_edge)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_module_edge);
   }
 
-  if (!m_disable_static_corr && m_dcc_static)
+  if (m_enable_static_corr && m_dcc_static)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_static);
   }
 
-  if (!m_disable_average_corr && m_dcc_average)
+  if (m_enable_average_corr && m_dcc_average)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_average);
   }
 
-  if (!m_disable_fluctuation_corr && m_dcc_fluctuation)
+  if (m_enable_fluctuation_corr && m_dcc_fluctuation)
   {
     global = m_distortionCorrection.get_corrected_position(global, m_dcc_fluctuation);
   }

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -43,10 +43,10 @@ class TpcGlobalPositionWrapper
   //! load relevant nodes from tree
   void loadNodes(PHCompositeNode* /*topnode*/);
 
-  void disable_module_edge_corr() { m_disable_module_edge_corr = true; }
-  void disable_static_corr() { m_disable_static_corr = true; }
-  void disable_average_corr() { m_disable_average_corr = true; }
-  void disable_fluctuation_corr() { m_disable_fluctuation_corr = true; }
+  void set_enable_module_edge_corr(bool flag) { m_enable_module_edge_corr = flag; }
+  void set_enable_static_corr(bool flag) { m_enable_static_corr = flag; }
+  void set_enable_average_corr(bool flag) { m_enable_average_corr = flag; }
+  void set_enable_fluctuation_corr(bool flag) { m_enable_fluctuation_corr = flag; }
 
   //! apply all loaded distortion corrections to a given position
   Acts::Vector3 applyDistortionCorrections( Acts::Vector3 /*source*/ ) const;
@@ -73,19 +73,19 @@ class TpcGlobalPositionWrapper
 
   //! module edge distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_module_edge{nullptr};
-  bool m_disable_module_edge_corr = false;
+  bool m_enable_module_edge_corr = true;
 
   //! static distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_static{nullptr};
-  bool m_disable_static_corr = false;
+  bool m_enable_static_corr = true;
 
   //! average distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_average{nullptr};
-  bool m_disable_average_corr = false;
+  bool m_enable_average_corr = true;
 
   //! fluctuation distortion container
   TpcDistortionCorrectionContainer* m_dcc_fluctuation{nullptr};
-  bool m_disable_fluctuation_corr = false;
+  bool m_enable_fluctuation_corr = true;
 
 };
 

--- a/offline/packages/tpc/TpcGlobalPositionWrapper.h
+++ b/offline/packages/tpc/TpcGlobalPositionWrapper.h
@@ -43,6 +43,11 @@ class TpcGlobalPositionWrapper
   //! load relevant nodes from tree
   void loadNodes(PHCompositeNode* /*topnode*/);
 
+  void disable_module_edge_corr() { m_disable_module_edge_corr = true; }
+  void disable_static_corr() { m_disable_static_corr = true; }
+  void disable_average_corr() { m_disable_average_corr = true; }
+  void disable_fluctuation_corr() { m_disable_fluctuation_corr = true; }
+
   //! apply all loaded distortion corrections to a given position
   Acts::Vector3 applyDistortionCorrections( Acts::Vector3 /*source*/ ) const;
 
@@ -68,15 +73,19 @@ class TpcGlobalPositionWrapper
 
   //! module edge distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_module_edge{nullptr};
+  bool m_disable_module_edge_corr = false;
 
   //! static distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_static{nullptr};
+  bool m_disable_static_corr = false;
 
   //! average distortion correction container
   TpcDistortionCorrectionContainer* m_dcc_average{nullptr};
+  bool m_disable_average_corr = false;
 
   //! fluctuation distortion container
   TpcDistortionCorrectionContainer* m_dcc_fluctuation{nullptr};
+  bool m_disable_fluctuation_corr = false;
 
 };
 

--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -1261,7 +1261,7 @@ int PHActsTrkFitter::getNodes(PHCompositeNode* topNode)
   }
 
   // track seeds
-  m_seedMap = findNode::getClass<TrackSeedContainer>(topNode, "SvtxTrackSeedContainer");
+  m_seedMap = findNode::getClass<TrackSeedContainer>(topNode, _svtx_seed_map_name);
   if (!m_seedMap)
   {
     std::cout << "No Svtx seed map on node tree. Exiting."

--- a/offline/packages/trackreco/PHActsTrkFitter.h
+++ b/offline/packages/trackreco/PHActsTrkFitter.h
@@ -120,6 +120,7 @@ class PHActsTrkFitter : public SubsysReco
   }
   void SetIteration(int iter) { _n_iteration = iter; }
   void set_track_map_name(const std::string& map_name) { _track_map_name = map_name; }
+  void set_svtx_seed_map_name(const std::string& map_name) { _svtx_seed_map_name = map_name; }
 
   /// Set flag for pp running
   void set_pp_mode(bool ispp) { m_pp_mode = ispp; }
@@ -253,6 +254,7 @@ class PHActsTrkFitter : public SubsysReco
 
   int _n_iteration = 0;
   std::string _track_map_name = "SvtxTrackMap";
+  std::string _svtx_seed_map_name = "SvtxTrackSeedContainer";
 
   /// Default particle assumption to pion
   unsigned int m_pHypothesis = 211;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
1. Add setter of SvtxTrackSeedContainer name in PHActsTrkFitter
2. Add some options to disable distortion correction so that we can decide to disable some of the distortion corrections in downstream evaluation module
Both two changes should be transparent to users and have no impact on normal tracking

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

