### PR TITLE
Split default 0

### DIFF
--- a/offline/framework/fun4all/Fun4AllDstInputManager.cc
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.cc
@@ -136,6 +136,10 @@ int Fun4AllDstInputManager::fileopen(const std::string &filenam)
     setBranches();                // set branch selections
     AddToFileOpened(FileName());  // add file to the list of files which were opened
                                   // check if our input file has a sync object or not
+    if (ReadCacheDisabled())
+    {
+      m_IManager->DisableReadCache();
+    }
     if (m_IManager->NodeExist(syncdefs::SYNCNODENAME))
     {
       m_HaveSyncObject = 1;

--- a/offline/framework/fun4all/Fun4AllDstInputManager.h
+++ b/offline/framework/fun4all/Fun4AllDstInputManager.h
@@ -28,6 +28,8 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   void Print(const std::string &what = "ALL") const override;
   int PushBackEvents(const int i) override;
   int HasSyncObject() const override;
+  void DisableReadCache() { m_disable_read_cache_flag = true; }
+  bool ReadCacheDisabled() const { return m_disable_read_cache_flag; }
 
  protected:
   int ReadNextEventSyncObject();
@@ -44,20 +46,21 @@ class Fun4AllDstInputManager : public Fun4AllInputManager
   std::string fullfilename;
 
  private:
-  PHCompositeNode *dstNode {nullptr};
-  PHCompositeNode *m_RunNode {nullptr};
-  PHCompositeNode *m_RunNodeCopy {nullptr};
-  PHCompositeNode *m_RunNodeSum {nullptr};
-  PHNodeIOManager *m_IManager {nullptr};
-  SyncObject *syncobject {nullptr};
-  int m_ReadRunTTree {1};
-  int events_total {0};
-  int events_thisfile {0};
-  int events_skipped_during_sync {0};
-  int m_HaveSyncObject {0};
+  PHCompositeNode *dstNode{nullptr};
+  PHCompositeNode *m_RunNode{nullptr};
+  PHCompositeNode *m_RunNodeCopy{nullptr};
+  PHCompositeNode *m_RunNodeSum{nullptr};
+  PHNodeIOManager *m_IManager{nullptr};
+  SyncObject *syncobject{nullptr};
+  int m_ReadRunTTree{1};
+  int events_total{0};
+  int events_thisfile{0};
+  int events_skipped_during_sync{0};
+  int m_HaveSyncObject{0};
+  bool m_disable_read_cache_flag{false};
   std::map<const std::string, int> branchread;
   std::string syncbranchname;
-  std::string RunNode {"RUN"};
+  std::string RunNode{"RUN"};
 };
 
 #endif /* __FUN4ALLDSTINPUTMANAGER_H__ */

--- a/offline/framework/phool/PHIODataNode.h
+++ b/offline/framework/phool/PHIODataNode.h
@@ -32,7 +32,7 @@ class PHIODataNode : public PHDataNode<T>
   bool write(PHIOManager *, const std::string & = "") override;
   PHIODataNode() = delete;
   int buffersize{32000};
-  int splitlevel{99};
+  int splitlevel{0};
 };
 
 template <class T>

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -19,6 +19,7 @@
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TTree.h>
+#include <TTreeCache.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -365,7 +366,6 @@ PHNodeIOManager::reconstructNodeTree(PHCompositeNode* topNode)
               << TreeName << " not found in file " << file->GetName() << std::endl;
     return nullptr;
   }
-
   // ROOT sucks, we need a unique name for the tree so we can open multiple
   // files. So we take the memory location of the file pointer which
   // should be unique within this process to create it
@@ -603,4 +603,13 @@ bool PHNodeIOManager::NodeExist(const std::string& nodename)
     }
   }
   return false;
+}
+
+void PHNodeIOManager::DisableReadCache()
+{
+  if (file)
+  {
+    file->SetCacheRead(nullptr);
+  }
+  return;
 }

--- a/offline/framework/phool/PHNodeIOManager.h
+++ b/offline/framework/phool/PHNodeIOManager.h
@@ -24,7 +24,7 @@ class TTree;
 class PHNodeIOManager : public PHIOManager
 {
  public:
-  PHNodeIOManager() {}
+  PHNodeIOManager() = default;
   PHNodeIOManager(const std::string &, const PHAccessType = PHReadOnly);
   PHNodeIOManager(const std::string &, const std::string &, const PHAccessType = PHReadOnly);
   PHNodeIOManager(const std::string &, const PHAccessType, const PHTreeType);
@@ -54,8 +54,9 @@ class PHNodeIOManager : public PHIOManager
   void BufferSize(const int size) { buffersize = size; }
   int SplitLevel() const { return splitlevel; }
   int BufferSize() const { return buffersize; }
+  void DisableReadCache();
 
- private:
+private:
   int FillBranchMap();
   PHCompositeNode *reconstructNodeTree(PHCompositeNode *);
   bool readEventFromFile(size_t requestedEvent);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This sets the PHIODataNode default to split level 0. It can be overridden when adding the node to the node tree or globally in the output manager

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

