### PR TITLE
Fix splitlevel handling

### DIFF
--- a/offline/framework/frog/FROG.cc
+++ b/offline/framework/frog/FROG.cc
@@ -51,7 +51,7 @@ FROG::location(const std::string &logical_name)
     }
     boost::char_separator<char> sep(":");
     boost::tokenizer<boost::char_separator<char> > tok(gsearchpath, sep);
-    for (auto &iter : tok)
+    for (const auto &iter : tok)
     {
       if (iter == "PG")
       {

--- a/offline/framework/frog/FROG.h
+++ b/offline/framework/frog/FROG.h
@@ -18,7 +18,7 @@ class FROG
   virtual ~FROG() = default;
 
   const char *location(const std::string &logical_name);
-  bool localSearch(const std::string &lname);
+  bool localSearch(const std::string &logical_name);
   bool dCacheSearch(const std::string &lname);
   bool XRootDSearch(const std::string &lname);
   bool LustreSearch(const std::string &lname);

--- a/offline/framework/phool/PHNodeIOManager.cc
+++ b/offline/framework/phool/PHNodeIOManager.cc
@@ -161,19 +161,21 @@ bool PHNodeIOManager::write(TObject** data, const std::string& path, int nodebuf
     TBranch* thisBranch = tree->GetBranch(path.c_str());
     if (!thisBranch)
     {
+      int use_splitlevel = splitlevel;
+      int use_buffersize = buffersize;
       // the buffersize and splitlevel are set on the first call
       // when the branch is created, the values come from the caller
       // which is the node which writes itself
       if (splitlevel == std::numeric_limits<int>::min())
       {
-        splitlevel = nodesplitlevel;
+        use_splitlevel = nodesplitlevel;
       }
       if (buffersize == std::numeric_limits<int>::min())
       {
-        buffersize = nodebuffersize;
+        use_buffersize = nodebuffersize;
       }
       tree->Branch(path.c_str(), (*data)->ClassName(),
-                   data, buffersize, splitlevel);
+                   data, use_buffersize, use_splitlevel);
     }
     else
     {


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
The way the split level and buffersize setting was implemented lead to the first node setting the default for all subsequent nodes. It doesn't affect the default setting but if we want to set levels on a node by node basis we need this patch

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

