### PR TITLE
added Print() to containers, make uniform the CDB calib names

### DIFF
--- a/offline/packages/mbd/MbdEvent.cc
+++ b/offline/packages/mbd/MbdEvent.cc
@@ -320,7 +320,7 @@ int MbdEvent::End()
     std::string fname = _caldir.Data(); fname += "mbd_sampmax.calib";
     _mbdcal->Write_SampMax( fname );
 
-    fname = _caldir.Data(); fname += "mbd_sampmax_";
+    fname = _caldir.Data(); fname += "mbd_sampmax-";
     fname += std::to_string(_runnum); fname += ".root";
 #ifndef ONLINE
     _mbdcal->Write_CDB_SampMax( fname );
@@ -339,7 +339,7 @@ int MbdEvent::End()
     std::string pedfname = _caldir.Data(); pedfname += "mbd_ped.calib";
     _mbdcal->Write_Ped( pedfname );
 
-    pedfname = _caldir.Data(); pedfname += "mbd_ped_"; 
+    pedfname = _caldir.Data(); pedfname += "mbd_ped-";
     pedfname += std::to_string(_runnum); pedfname += ".root";
     //std::cout << "PEDFNAME " << pedfname << std::endl;
 #ifndef ONLINE

--- a/offline/packages/mbd/MbdOut.cc
+++ b/offline/packages/mbd/MbdOut.cc
@@ -2,6 +2,7 @@
 #include "MbdReturnCodes.h"
 
 #include <iostream>
+#include <iomanip>
 #include <limits>
 
 void MbdOut::identify(std::ostream& os) const
@@ -131,4 +132,14 @@ void MbdOut::FillFromClass(const MbdOut& old)
   }
 
   set_t0zvtx(old.get_t0(), old.get_t0err(), old.get_zvtx(), old.get_zvtxerr());
+}
+
+void MbdOut::Print(Option_t * /*option*/) const
+{
+  std::cout << "MbdOut, evt " << get_evt() << std::endl;
+  std::cout << "clk\t" << std::setw(12) << get_clock() << std::setw(12) << get_femclock() << std::endl;
+  std::cout << "zvtx\t" << std::setw(12) << get_zvtx() << std::setw(12) << get_zvtxerr() << std::endl;
+  std::cout << "t0\t" << std::setw(12) << get_t0() << std::setw(12) << get_t0err() << std::endl;
+  std::cout << "npmt\t" << std::setw(12) << get_npmt(0) << std::setw(12) << get_npmt(1) << std::endl;
+  std::cout << "time\t" << std::setw(12) << get_time(0) << std::setw(12) << get_time(1) << std::endl;
 }

--- a/offline/packages/mbd/MbdOut.h
+++ b/offline/packages/mbd/MbdOut.h
@@ -110,6 +110,8 @@ class MbdOut : public PHObject
 
   virtual void FillFromClass(const MbdOut& old);
 
+  virtual void Print(Option_t *option = "") const override;
+
  private:
   static void virtual_warning(const std::string& funcsname) ;
 

--- a/offline/packages/mbd/MbdPmtContainer.cc
+++ b/offline/packages/mbd/MbdPmtContainer.cc
@@ -1,9 +1,12 @@
 #include "MbdPmtContainer.h"
 #include "MbdReturnCodes.h"
+#include "MbdPmtHit.h"
 
 #include <phool/phool.h>
 
 #include <iostream>
+#include <iomanip>
+#include <cmath>
 
 void MbdPmtContainer::identify(std::ostream& os) const
 {
@@ -39,6 +42,23 @@ MbdPmtHit *MbdPmtContainer::get_pmt(const int /*iPmt*/) const
 {
   virtual_warning("get_pmt(const short iPmt)");
   return nullptr;
+}
+
+void MbdPmtContainer::Print(Option_t * /*option*/) const
+{
+  Short_t npmt = get_npmt();
+  std::cout << "MBDPMT values:" << std::endl;
+  for (Short_t ipmt=0; ipmt<npmt; ipmt++)
+  {
+    Float_t q = get_pmt(ipmt)->get_q();
+    Float_t tt = get_pmt(ipmt)->get_tt();
+    Float_t tq = get_pmt(ipmt)->get_tq();
+
+    if ( std::fabs(tt)<100. )
+    {
+      std::cout << std::setw(8) << ipmt << std::setw(12) << q << "\t" << std::setw(12) << tt <<"\t" << std::setw(12) << tq << std::endl;
+    }
+  }
 }
 
 void MbdPmtContainer::virtual_warning(const std::string& funcsname) 

--- a/offline/packages/mbd/MbdPmtContainer.h
+++ b/offline/packages/mbd/MbdPmtContainer.h
@@ -39,6 +39,8 @@ class MbdPmtContainer : public PHObject
   //! get MbdPmtHit Object
   virtual MbdPmtHit *get_pmt(const int ipmt) const;
 
+  virtual void Print(Option_t *option="") const override;
+
  private:
   static void virtual_warning(const std::string& funcsname) ;
 


### PR DESCRIPTION
[comment]: Added Print() method to containers. Also, now saving all CDB calib root files with mbd_<calibname>-<run>.root.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

