### PR TITLE
handle cases where last gl1 event is corrupt

### DIFF
--- a/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleGl1TriggeredInput.cc
@@ -156,7 +156,10 @@ uint64_t SingleGl1TriggeredInput::GetClock(Event *evt)
   Packet *packet = evt->getPacket(14001);
   if (!packet)
   {
-    std::cout << "no packet 14001 for event" << std::endl;
+    std::cout << Name()
+	      <<" no packet 14001 for event, possible corrupt data event before EOR"
+	      << std::endl;
+    std::cout << Name() << ": ";
     evt->identify();
     return std::numeric_limits<uint64_t>::max();
   }

--- a/offline/framework/fun4allraw/SingleTriggeredInput.cc
+++ b/offline/framework/fun4allraw/SingleTriggeredInput.cc
@@ -278,10 +278,16 @@ void SingleTriggeredInput::FillPool(const unsigned int keep)
           //        int ifirst = 1;
           while (iter1 != end())
           {
-            std::cout << "position " << position << " test 0x" << std::hex
+            std::cout << Name() << " Debug output: position " << position << " test 0x" << std::hex
                       << *iter1 << " versus 0x" << *iter2 << std::dec << std::endl;
             //           std::cout  << "bclk1: 0x" << *iter3 << ", gl1bclk: 0x" << *iter4 << std::dec << std::endl;
-            m_EventDeque[position]->identify();
+// this catches the condition where there is no gl1 packet (14001)
+	    // the GL1 data sometimes has a corrupt last data event
+	    if (*iter1 != std::numeric_limits<uint64_t>::max())
+	    {
+	      std::cout << Name() << ": ";
+	      m_EventDeque[position]->identify();
+	    }
             if (*iter1 != *iter2)
             {
               if (*iter1 == std::numeric_limits<uint64_t>::max())


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
protect event identify when last GL1 event is corrupt and we have a null pointer (re-enabling previous fix for bad data event before EOR in GL1)

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

