### PR TITLE
new map in the truth container for sPHENIX primary

### DIFF
--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.cc
@@ -114,6 +114,31 @@ PHG4TruthInfoContainer::AddParticle(const int trackid, PHG4Particle* newparticle
   return particlemap.end();
 }
 
+PHG4TruthInfoContainer::ConstIterator
+PHG4TruthInfoContainer::AddsPHENIXPrimaryParticle(const int trackid, PHG4Particle* newparticle)
+{
+  int key = trackid;
+  ConstIterator it;
+  bool added = false;
+
+  boost::tie(it, added) = sPHENIXprimaryparticlemap.insert(std::make_pair(key, newparticle));
+  if (added)
+  {
+    return it;
+  }
+
+  cerr << "PHG4TruthInfoContainer::AddsPHENIXPrimaryParticle"
+       << " - Attempt to add sPHENIX primary particle with existing trackid "
+       << trackid << ": " << newparticle->get_name() << " id "
+       << newparticle->get_track_id()
+       << ", p = [" << newparticle->get_px()
+       << ", " << newparticle->get_py()
+       << ", " << newparticle->get_pz() << "], "
+       << " parent ID " << newparticle->get_parent_id()
+       << std::endl;
+  return sPHENIXprimaryparticlemap.end();
+}
+
 PHG4Particle* PHG4TruthInfoContainer::GetParticle(const int trackid)
 {
   int key = trackid;
@@ -133,6 +158,16 @@ PHG4Particle* PHG4TruthInfoContainer::GetPrimaryParticle(const int trackid)
   }
   Iterator it = particlemap.find(trackid);
   if (it != particlemap.end())
+  {
+    return it->second;
+  }
+  return nullptr;
+}
+
+PHG4Particle* PHG4TruthInfoContainer::GetsPHENIXPrimaryParticle(const int trackid)
+{
+  Iterator it = sPHENIXprimaryparticlemap.find(trackid);
+  if (it != sPHENIXprimaryparticlemap.end())
   {
     return it->second;
   }
@@ -396,6 +431,13 @@ bool PHG4TruthInfoContainer::is_primary_vtx(const PHG4VtxPoint* v) const
 bool PHG4TruthInfoContainer::is_primary(const PHG4Particle* p) const
 {
   return (p->get_track_id() > 0);
+}
+
+// this is O(log N)...
+bool PHG4TruthInfoContainer::is_sPHENIX_primary(const PHG4Particle* p) const
+{
+  // sPHENIX primary particles are in the sPHENIXprimaryparticlemap
+  return (sPHENIXprimaryparticlemap.find(p->get_track_id()) != sPHENIXprimaryparticlemap.end());
 }
 
 int PHG4TruthInfoContainer::GetPrimaryVertexIndex() const

--- a/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
+++ b/simulation/g4simulation/g4main/PHG4TruthInfoContainer.h
@@ -47,13 +47,18 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Add a particle that the user has created
   ConstIterator AddParticle(const int particleid, PHG4Particle* newparticle);
+  ConstIterator AddsPHENIXPrimaryParticle(const int particleid, PHG4Particle* newparticle);
   void delete_particle(Iterator piter);
   void delete_particle(int trackid);
 
   PHG4Particle* GetParticle(const int trackid);
   PHG4Particle* GetPrimaryParticle(const int trackid);
 
+  PHG4Particle* GetsPHENIXPrimaryParticle(const int trackid);
+
   bool is_primary(const PHG4Particle* p) const;
+
+  bool is_sPHENIX_primary(const PHG4Particle* p) const;
 
   //! Get a range of iterators covering the entire container
   Range GetParticleRange() { return Range(particlemap.begin(), particlemap.end()); }
@@ -61,6 +66,9 @@ class PHG4TruthInfoContainer : public PHObject
 
   Range GetPrimaryParticleRange() { return Range(particlemap.upper_bound(0), particlemap.end()); }
   ConstRange GetPrimaryParticleRange() const { return ConstRange(particlemap.upper_bound(0), particlemap.end()); }
+
+  Range GetSPHENIXPrimaryParticleRange() { return Range(sPHENIXprimaryparticlemap.begin(), sPHENIXprimaryparticlemap.end()); }
+  ConstRange GetSPHENIXPrimaryParticleRange() const { return ConstRange(sPHENIXprimaryparticlemap.begin(), sPHENIXprimaryparticlemap.end());}
 
   Range GetSecondaryParticleRange() { return Range(particlemap.begin(), particlemap.upper_bound(0)); }
   ConstRange GetSecondaryParticleRange() const { return ConstRange(particlemap.begin(), particlemap.upper_bound(0)); }
@@ -74,6 +82,8 @@ class PHG4TruthInfoContainer : public PHObject
 
   //! Get the Particle Map storage
   const Map& GetMap() const { return particlemap; }
+
+  const Map& GetSPHENIXPrimaryParticleMap() const { return sPHENIXprimaryparticlemap; }
 
   int maxtrkindex() const;
   int mintrkindex() const;
@@ -208,6 +218,8 @@ class PHG4TruthInfoContainer : public PHObject
   /// -M   secondary particle id => particle*
   Map particlemap;
 
+  Map sPHENIXprimaryparticlemap;  // for sPHENIX primary particle identification
+
   /// vertex storage map format description:
   /// primary vertexes are appended in the positive direction
   /// secondary vertexes are appended in the negative direction
@@ -230,7 +242,7 @@ class PHG4TruthInfoContainer : public PHObject
   std::map<int, int> particle_embed_flags;  //< trackid => embed flag
   std::map<int, int> vertex_embed_flags;    //< vtxid => embed flag
 
-  ClassDefOverride(PHG4TruthInfoContainer, 1)
+  ClassDefOverride(PHG4TruthInfoContainer, 2)
 };
 
 /**

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -274,7 +274,11 @@ PHG4Particle* PHG4TruthTrackingAction::AddParticle(PHG4TruthInfoContainer& truth
   PHG4VtxPoint* vtx = AddVertex(truth, track);
   ti->set_vtx_id(vtx->get_id());
 
-
+  // use a new map to hold the new primary particle list
+  if(issPHENIXPrimary(truth, ti))
+  {
+    truth.AddsPHENIXPrimaryParticle(trackid, ti);
+  }
 
   return truth.AddParticle(trackid, ti)->second;
 }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

during the truth tracking we figure out if the particle is this new sPHENIX primary, save the sPHENIX primary into a map.


## TODOs (if applicable)

Let Jenkins check if it breaks things and I will do some check on my end at the same time.

For downstream process that would need to use this new def, the working group would need to change `GetPrimaryParticleRange` to `GetSPHENIXPrimaryParticleRange`.


## Links to other PRs in macros and calibration repositories (if applicable)

