### PR TITLE
add automatic default for payloads

### DIFF
--- a/offline/framework/ffamodules/CDBInterface.h
+++ b/offline/framework/ffamodules/CDBInterface.h
@@ -26,6 +26,10 @@ class CDBInterface : public SubsysReco
   void Print(const std::string &what = "ALL") const override;
 
   void Disable() { disable = true; }
+  void Enable() { disable = false; }
+
+  void Disable_default() { disable_default = true; }
+  void Enable_default() { disable_default = false; }
 
   std::string getUrl(const std::string &domain, const std::string &filename = "");
 
@@ -35,6 +39,7 @@ class CDBInterface : public SubsysReco
   static CDBInterface *__instance;
   SphenixClient *cdbclient{nullptr};
   bool disable{false};
+  bool disable_default{false};
   std::set<std::tuple<std::string, std::string, uint64_t>> m_UrlVector;
 };
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
This PR adds a search for <domain>_default so we can have default calibrations which do not interfere with runwise calibrations (where a missing calibration tells us that run is not calibrated). The cdb instance has a flag
CDBInterface::instance()->Disable_default()
which disables the loading of default calibrations so we can enforce that every processed run has all calibrations

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

