### PR TITLE
Fix sphnx primaries

### DIFF
--- a/simulation/g4simulation/g4main/PHG4Particle.h
+++ b/simulation/g4simulation/g4main/PHG4Particle.h
@@ -5,37 +5,37 @@
 
 #include <phool/PHObject.h>
 
-#include <cmath>
 #include <iostream>
+#include <limits>
 #include <string>
 
 class PHG4Particle : public PHObject
 {
  public:
-  PHG4Particle() {}
-  ~PHG4Particle() override {}
+  PHG4Particle() = default;
+  ~PHG4Particle() override = default;
 
   void identify(std::ostream &os = std::cout) const override;
 
   virtual bool isIon() const { return false; }
   virtual int get_pid() const { return 0; }
   virtual std::string get_name() const { return "NONE"; }
-  virtual double get_px() const { return NAN; }
-  virtual double get_py() const { return NAN; }
-  virtual double get_pz() const { return NAN; }
-  virtual double get_e() const { return NAN; }
+  virtual double get_px() const { return std::numeric_limits<double>::quiet_NaN(); }
+  virtual double get_py() const { return std::numeric_limits<double>::quiet_NaN(); }
+  virtual double get_pz() const { return std::numeric_limits<double>::quiet_NaN(); }
+  virtual double get_e() const { return std::numeric_limits<double>::quiet_NaN(); }
 
   virtual int get_track_id() const { return -9999; }
   virtual int get_vtx_id() const { return -9999; }
   virtual int get_parent_id() const { return -9999; }
-  virtual int get_primary_id() const { return 0xFFFFFFFF; }
+  virtual int get_primary_id() const { return std::numeric_limits<int>::min(); }
 
-  virtual int get_barcode() const { return 0xFFFFFFFF; }
+  virtual int get_barcode() const { return std::numeric_limits<int>::min(); }
 
-  virtual int get_A() const { return 0xFFFFFFFF; }
-  virtual int get_Z() const { return 0xFFFFFFFF; }
-  virtual double get_IonCharge() const { return NAN; }
-  virtual double get_ExcitEnergy() const { return NAN; }
+  virtual int get_A() const { return std::numeric_limits<int>::min(); }
+  virtual int get_Z() const { return std::numeric_limits<int>::min(); }
+  virtual double get_IonCharge() const { return std::numeric_limits<double>::quiet_NaN(); }
+  virtual double get_ExcitEnergy() const { return std::numeric_limits<double>::quiet_NaN(); }
 
   virtual void set_track_id(const int) { return; }
   virtual void set_vtx_id(const int) { return; }

--- a/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGenerator.cc
@@ -54,7 +54,7 @@ int PHG4ParticleGenerator::process_event(PHCompositeNode *topNode)
 
   if (!ReuseExistingVertex(topNode))
   {
-    set_vtx_z((m_ZMax - m_ZMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_ZMin);
+    set_vtx_z(((m_ZMax - m_ZMin) * gsl_rng_uniform_pos(RandomGenerator())) + m_ZMin);
   }
   int vtxindex = ineve->AddVtx(get_vtx_x(), get_vtx_y(), get_vtx_z(), get_t0());
 
@@ -63,9 +63,9 @@ int PHG4ParticleGenerator::process_event(PHCompositeNode *topNode)
   {
     PHG4Particle *particle = new PHG4Particlev2(*iter);
     SetParticleId(particle, ineve);
-    double mom = (m_MomMax - m_MomMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_MomMin;
-    double eta = (m_EtaMax - m_EtaMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_EtaMin;
-    double phi = (m_PhiMax - m_PhiMin) * gsl_rng_uniform_pos(RandomGenerator()) + m_PhiMin;
+    double mom = ((m_MomMax - m_MomMin) * gsl_rng_uniform_pos(RandomGenerator())) + m_MomMin;
+    double eta = ((m_EtaMax - m_EtaMin) * gsl_rng_uniform_pos(RandomGenerator())) + m_EtaMin;
+    double phi = ((m_PhiMax - m_PhiMin) * gsl_rng_uniform_pos(RandomGenerator())) + m_PhiMin;
     double pt = mom / cosh(eta);
 
     particle->set_e(mom);

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -40,8 +40,8 @@
 
 PHG4ParticleGeneratorBase::PHG4ParticleGeneratorBase(const std::string &name)
   : SubsysReco(name)
+  , m_RandomGenerator(gsl_rng_alloc(gsl_rng_mt19937))
 {
-  m_RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   m_Seed = PHRandomSeed();  // fixed seed is handled in this funtcion
   gsl_rng_set(m_RandomGenerator, m_Seed);
   return;
@@ -58,7 +58,7 @@ PHG4ParticleGeneratorBase::~PHG4ParticleGeneratorBase()
   return;
 }
 
-int PHG4ParticleGeneratorBase::get_pdgcode(const std::string &name) const
+int PHG4ParticleGeneratorBase::get_pdgcode(const std::string &name)
 {
   G4ParticleTable *particleTable = G4ParticleTable::GetParticleTable();
   G4ParticleDefinition *particledef = particleTable->FindParticle(name);
@@ -70,7 +70,7 @@ int PHG4ParticleGeneratorBase::get_pdgcode(const std::string &name) const
 }
 
 std::string
-PHG4ParticleGeneratorBase::get_pdgname(const int pdgcode) const
+PHG4ParticleGeneratorBase::get_pdgname(const int pdgcode)
 {
   G4ParticleTable *particleTable = G4ParticleTable::GetParticleTable();
   G4ParticleDefinition *particledef = particleTable->FindParticle(pdgcode);
@@ -83,7 +83,7 @@ PHG4ParticleGeneratorBase::get_pdgname(const int pdgcode) const
 }
 
 double
-PHG4ParticleGeneratorBase::get_mass(const int pdgcode) const
+PHG4ParticleGeneratorBase::get_mass(const int pdgcode)
 {
   G4ParticleTable *particleTable = G4ParticleTable::GetParticleTable();
   G4ParticleDefinition *particledef = particleTable->FindParticle(get_pdgname(pdgcode));
@@ -177,7 +177,7 @@ void PHG4ParticleGeneratorBase::AddParticle(const int pid, const double x, const
 
 void PHG4ParticleGeneratorBase::CheckAndCreateParticleVector()
 {
-  if (!particlelist.size())
+  if (particlelist.empty())
   {
     PHG4Particle *part = new PHG4Particlev1();
     particlelist.push_back(part);
@@ -185,9 +185,9 @@ void PHG4ParticleGeneratorBase::CheckAndCreateParticleVector()
   return;
 }
 
-void PHG4ParticleGeneratorBase::SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve)
+void PHG4ParticleGeneratorBase::SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve) const
 {
-  if ((particle->get_name()).size() == 0)  // no size -> empty name string
+  if (particle->get_name().empty())  // no size -> empty name string
   {
     particle->set_name(get_pdgname(particle->get_pid()));
   }

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorBase.h
@@ -48,11 +48,11 @@ class PHG4ParticleGeneratorBase : public SubsysReco
 
  protected:
   PHG4ParticleGeneratorBase(const std::string &name = "GENERATORBASE");
-  int get_pdgcode(const std::string &name) const;
-  std::string get_pdgname(const int pdgcode) const;
-  double get_mass(const int pdgcode) const;
+  static int get_pdgcode(const std::string &name);
+  static std::string get_pdgname(const int pdgcode);
+  static double get_mass(const int pdgcode);
   void CheckAndCreateParticleVector();
-  void SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve);
+  void SetParticleId(PHG4Particle *particle, PHG4InEvent *ineve) const;
   gsl_rng *RandomGenerator() const { return m_RandomGenerator; }
   int EmbedFlag() const { return m_EmbedFlag; }
   std::vector<PHG4Particle *>::iterator particlelist_begin() { return particlelist.begin(); }

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorD0.cc
@@ -106,7 +106,7 @@ int PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   {
     if (vtx_zmax != vtx_zmin)
     {
-      set_vtx_z((vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator()) + vtx_zmin);
+      set_vtx_z(((vtx_zmax - vtx_zmin) * gsl_rng_uniform_pos(RandomGenerator())) + vtx_zmin);
     }
     else
     {
@@ -143,7 +143,7 @@ int PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
 
   // Get the pseudorapidity, eta, from the rapidity, mass and pt
 
-  double mt = sqrt(mnow * mnow + pt * pt);
+  double mt = sqrt((mnow * mnow) + (pt * pt));
   double eta = asinh(sinh(y) * mt / pt);
 
   // Put it in a TLorentzVector
@@ -162,12 +162,12 @@ int PHG4ParticleGeneratorD0::process_event(PHCompositeNode *topNode)
   }
   set_vtx(vd0.Px() / vd0.P() * lifepath,
           vd0.Py() / vd0.P() * lifepath,
-          get_vtx_z() + vd0.Pz() / vd0.P() * lifepath);
+          get_vtx_z() + (vd0.Pz() / vd0.P() * lifepath));
   set_t0(lifetime);
   int vtxindex = ineve->AddVtx(get_vtx_x(), get_vtx_y(), get_vtx_z(), get_t0());
   if (Verbosity() > 0)
   {
-    std::cout << "  XY vertex: " << sqrt(get_vtx_x() * get_vtx_x() + get_vtx_y() * get_vtx_y()) << " " << sqrt(get_vtx_x() * get_vtx_x() + get_vtx_y() * get_vtx_y()) * 1.0e+04 << std::endl;
+    std::cout << "  XY vertex: " << sqrt((get_vtx_x() * get_vtx_x()) + (get_vtx_y() * get_vtx_y())) << " " << sqrt((get_vtx_x() * get_vtx_x()) + (get_vtx_y() * get_vtx_y())) * 1.0e+04 << std::endl;
   }
 
   // Now decay it

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -44,11 +44,11 @@ PHG4ParticleGeneratorVectorMeson::
 
 void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &name1, const unsigned int decay_id)
 {
-  if (name1.compare("e") == 0)
+  if (name1 == "e")
   {
     add_decay_particles("e+", "e-", decay_id);
   }
-  else if (name1.compare("mu") == 0)
+  else if (name1 == "mu")
   {
     add_decay_particles("mu+", "mu-", decay_id);
   }
@@ -63,10 +63,10 @@ void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &na
 void PHG4ParticleGeneratorVectorMeson::add_decay_particles(const std::string &name1, const std::string &name2, const unsigned int decay_id)
 {
   // check for valid select ion (e+,e- or mu+,mu-)
-  if ((name1.compare("e-") == 0 && name2.compare("e+") == 0) ||
-      (name1.compare("e+") == 0 && name2.compare("e-") == 0) ||
-      (name1.compare("mu+") == 0 && name2.compare("mu-") == 0) ||
-      (name1.compare("mu-") == 0 && name2.compare("mu+") == 0))
+  if ((name1 == "e-" && name2 == "e+") ||
+      (name1 == "e+" && name2 == "e-") ||
+      (name1 == "mu+" && name2 == "mu-") ||
+      (name1 == "mu-" && name2 == "mu+"))
   {
     decay1_names.insert(std::pair<unsigned int, std::string>(decay_id, name1));
     decay2_names.insert(std::pair<unsigned int, std::string>(decay_id, name2));
@@ -168,11 +168,11 @@ void PHG4ParticleGeneratorVectorMeson::set_decay_types(const std::string &name1,
   static const double melectron = 0.5109989461e-3;  //+-0.0000000031e-3
 
   decay1 = name1;
-  if (decay1.compare("e+") == 0 || decay1.compare("e-") == 0)
+  if (decay1 == "e+" || decay1 == "e-")
   {
     m1 = melectron;
   }
-  else if (decay1.compare("mu+") == 0 || decay1.compare("mu-") == 0)
+  else if (decay1 == "mu+" || decay1 == "mu-")
   {
     m1 = mmuon;
   }
@@ -183,11 +183,11 @@ void PHG4ParticleGeneratorVectorMeson::set_decay_types(const std::string &name1,
   }
 
   decay2 = name2;
-  if (decay2.compare("e+") == 0 || decay2.compare("e-") == 0)
+  if (decay2 == "e+" || decay2 == "e-")
   {
     m2 = melectron;
   }
-  else if (decay2.compare("mu+") == 0 || decay2.compare("mu-") == 0)
+  else if (decay2 == "mu+" || decay2 == "mu-")
   {
     m2 = mmuon;
   }
@@ -289,7 +289,7 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
 
   // Get the pseudorapidity, eta, from the rapidity, mass and pt
 
-  double mt = sqrt(mnow * mnow + pt * pt);
+  double mt = sqrt((mnow * mnow) + (pt * pt));
   double eta = asinh(sinh(y) * mt / pt);
 
   // Put it in a TLorentzVector
@@ -337,9 +337,9 @@ int PHG4ParticleGeneratorVectorMeson::process_event(PHCompositeNode *topNode)
     // 3D Randomized vertex
     if ((_vertex_size_width > 0.0) || (_vertex_size_mean != 0.0))
     {
-      _vertex_size_mean = sqrt(get_vtx_x() * get_vtx_x() +
-                               get_vtx_y() * get_vtx_y() +
-                               get_vtx_z() * get_vtx_z());
+      _vertex_size_mean = sqrt((get_vtx_x() * get_vtx_x()) +
+                               (get_vtx_y() * get_vtx_y()) +
+                               (get_vtx_z() * get_vtx_z()));
       double r = smearvtx(_vertex_size_mean, _vertex_size_width, _vertex_size_func_r);
       double x1 = 0.0;
       double y1 = 0.0;

--- a/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
+++ b/simulation/g4simulation/g4main/PHG4ParticleGeneratorVectorMeson.h
@@ -61,7 +61,7 @@ class PHG4ParticleGeneratorVectorMeson : public PHG4ParticleGeneratorBase
 
   void set_mass(const double mass_in) { mass = mass_in; }
   void set_width(const double width_in) { m_Width = width_in; }
-  void set_decay_types(const std::string &decay1, const std::string &decay2);
+  void set_decay_types(const std::string &name1, const std::string &name2);
   void set_histrand_init(const int initflag) { _histrand_init = initflag; }
   void set_upsilon_1s();
   void set_upsilon_2s();

--- a/simulation/g4simulation/g4main/PHG4Particlev1.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.cc
@@ -1,24 +1,11 @@
 #include "PHG4Particlev1.h"
 
-using namespace std;
-
-PHG4Particlev1::PHG4Particlev1()
-  : fname("")
-  , fpid(0)
-  , fpx(0)
-  , fpy(0)
-  , fpz(0)
-  , barcode(-1)
-{
-}
-
-PHG4Particlev1::PHG4Particlev1(const string &name, const int pid, const double px, const double py, const double pz)
+PHG4Particlev1::PHG4Particlev1(const std::string &name, const int pid, const double px, const double py, const double pz)
   : fname(name)
   , fpid(pid)
   , fpx(px)
   , fpy(py)
   , fpz(pz)
-  , barcode(-1)
 {
 }
 
@@ -32,9 +19,9 @@ PHG4Particlev1::PHG4Particlev1(const PHG4Particle *in)
 {
 }
 
-void PHG4Particlev1::identify(ostream &os) const
+void PHG4Particlev1::identify(std::ostream &os) const
 {
-  if (fname.size() > 0)
+  if (!fname.empty())
   {
     os << "PHG4Particlev1 name: " << fname;
   }
@@ -46,6 +33,6 @@ void PHG4Particlev1::identify(ostream &os) const
      << ", px: " << fpx
      << ", py: " << fpy
      << ", pz: " << fpz
-     << ", barcode: " << barcode << endl;
+     << ", barcode: " << barcode << std::endl;
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Particlev1.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev1.h
@@ -6,17 +6,19 @@
 #include "PHG4Particle.h"
 
 #include <iostream>
+#include <limits>
 #include <string>
 
 class PHG4Particlev1 : public PHG4Particle
 {
  public:
-  PHG4Particlev1();
+  PHG4Particlev1() = default;
   PHG4Particlev1(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev1(const PHG4Particle *in);
 
   ~PHG4Particlev1() override {}
 
+  PHObject *CloneMe() const override { return new PHG4Particlev1(*this); }
   void identify(std::ostream &os = std::cout) const override;
 
   int get_pid() const override { return fpid; }
@@ -37,9 +39,11 @@ class PHG4Particlev1 : public PHG4Particle
 
  protected:
   std::string fname;
-  int fpid;
-  double fpx, fpy, fpz;
-  int barcode;
+  int fpid{0};
+  double fpx{std::numeric_limits<double>::quiet_NaN()};
+  double fpy{std::numeric_limits<double>::quiet_NaN()};
+  double fpz{std::numeric_limits<double>::quiet_NaN()};
+  int barcode{std::numeric_limits<int>::min()};
 
   ClassDefOverride(PHG4Particlev1, 1)
 };

--- a/simulation/g4simulation/g4main/PHG4Particlev2.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.cc
@@ -4,16 +4,6 @@
 
 #include <cmath>
 
-PHG4Particlev2::PHG4Particlev2()
-  : PHG4Particlev1()
-  , trkid(0)
-  , vtxid(0)
-  , parentid(0)
-  , primaryid(0xFFFFFFFF)
-  , fe(0.0)
-{
-}
-
 PHG4Particlev2::PHG4Particlev2(const std::string &name, const int pid, const double px, const double py, const double pz)
   : PHG4Particlev1(name, pid, px, py, pz)
 {
@@ -31,7 +21,7 @@ PHG4Particlev2::PHG4Particlev2(const PHG4Particle *in)
 
 void PHG4Particlev2::identify(std::ostream &os) const
 {
-  if (fname.size() > 0)
+  if (!fname.empty())
   {
     os << "PHG4Particlev2 name: " << fname << ", ";
   }
@@ -49,7 +39,7 @@ void PHG4Particlev2::identify(std::ostream &os) const
      << ", py: " << fpy
      << ", pz: " << fpz
      << ", phi: " << atan2(fpy, fpx)
-     << ", eta: " << -1 * log(tan(0.5 * acos(fpz / sqrt(fpx * fpx + fpy * fpy + fpz * fpz))))
+     << ", eta: " << -1 * log(tan(0.5 * acos(fpz / sqrt((fpx * fpx) + (fpy * fpy) + (fpz * fpz)))))
      << ", e: " << fe << std::endl;
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Particlev2.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev2.h
@@ -6,6 +6,7 @@
 #include "PHG4Particlev1.h"
 
 #include <iostream>
+#include <limits>
 #include <string>
 
 class PHG4Particle;
@@ -13,12 +14,13 @@ class PHG4Particle;
 class PHG4Particlev2 : public PHG4Particlev1
 {
  public:
-  PHG4Particlev2();
+  PHG4Particlev2() = default;
   PHG4Particlev2(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev2(const PHG4Particle *in);
 
-  ~PHG4Particlev2() override {}
+  ~PHG4Particlev2() override = default;
 
+  PHObject *CloneMe() const override { return new PHG4Particlev2(*this); }
   void identify(std::ostream &os = std::cout) const override;
 
   int get_track_id() const override { return trkid; }

--- a/simulation/g4simulation/g4main/PHG4Particlev3.cc
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.cc
@@ -3,19 +3,7 @@
 
 #include <Geant4/G4SystemOfUnits.hh>
 
-#include <cmath>
 #include <string>
-
-using namespace std;
-
-PHG4Particlev3::PHG4Particlev3()
-  : PHG4Particlev2()
-  , A(0)
-  , Z(0)
-  , ioncharge(NAN)
-  , excitEnergy(NAN)
-{
-}
 
 PHG4Particlev3::PHG4Particlev3(const PHG4Particle* in)
   : PHG4Particlev2(in)
@@ -33,7 +21,7 @@ void PHG4Particlev3::set_NumCharge(const int c)
 
 void PHG4Particlev3::identify(std::ostream& os) const
 {
-  if (fname.size() > 0)
+  if (!fname.empty())
   {
     os << "PHG4Particlev3 name: " << fname << ", ";
   }
@@ -55,6 +43,6 @@ void PHG4Particlev3::identify(std::ostream& os) const
      << ", Z: " << Z
      << ", Eex: " << excitEnergy
      << ", ioncharge: " << ioncharge
-     << endl;
+     << std::endl;
   return;
 }

--- a/simulation/g4simulation/g4main/PHG4Particlev3.h
+++ b/simulation/g4simulation/g4main/PHG4Particlev3.h
@@ -6,17 +6,20 @@
 #include "PHG4Particlev2.h"
 
 #include <iostream>
+#include <limits>
 
 class PHG4Particle;
 
 class PHG4Particlev3 : public PHG4Particlev2
 {
  public:
-  PHG4Particlev3();
+  PHG4Particlev3() = default;
   //  PHG4Particlev3(const std::string &name, const int pid, const double px, const double py, const double pz);
   PHG4Particlev3(const PHG4Particle* in);
 
-  ~PHG4Particlev3() override {}
+  ~PHG4Particlev3() override = default;
+
+  PHObject* CloneMe() const override { return new PHG4Particlev3(*this); }
 
   void identify(std::ostream& os = std::cout) const override;
 
@@ -32,10 +35,10 @@ class PHG4Particlev3 : public PHG4Particlev2
   double get_ExcitEnergy() const override { return excitEnergy; }
 
  protected:
-  int A;
-  int Z;
-  double ioncharge;
-  double excitEnergy;
+  int A{0};
+  int Z{0};
+  double ioncharge{std::numeric_limits<double>::quiet_NaN()};
+  double excitEnergy{std::numeric_limits<double>::quiet_NaN()};
 
   ClassDefOverride(PHG4Particlev3, 1)
 };

--- a/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
+++ b/simulation/g4simulation/g4main/PHG4TruthTrackingAction.cc
@@ -28,8 +28,6 @@
 #include <iostream>  // for operator<<, endl
 #include <utility>   // for pair
 
-using namespace std;
-
 //________________________________________________________
 PHG4TruthTrackingAction::PHG4TruthTrackingAction(PHG4TruthEventAction* eventAction)
   : m_EventAction(eventAction)
@@ -277,7 +275,8 @@ PHG4Particle* PHG4TruthTrackingAction::AddParticle(PHG4TruthInfoContainer& truth
   // use a new map to hold the new primary particle list
   if(issPHENIXPrimary(truth, ti))
   {
-    truth.AddsPHENIXPrimaryParticle(trackid, ti);
+    PHG4Particle *newparticle = dynamic_cast<PHG4Particle *> (ti->CloneMe());
+    truth.AddsPHENIXPrimaryParticle(trackid, newparticle);
   }
 
   return truth.AddParticle(trackid, ti)->second;


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Writing the new truth info with the sphenix primaries crashes during writing. The reason is the same phg4particle pointer being saved twice. This just doesn't work (our global vertex had the same problem), one has to clone the object and then save the clone

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

