### PR TITLE
Ignore BCO skip in INTT standalone mode

### DIFF
--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1291,14 +1291,13 @@ int Fun4AllStreamingInputManager::FillInttPool()
   }
   for (auto iter : m_InttInputVector)
   {
+	if(!m_gl1_registered_flag)
+	  iter->SetStandaloneMode(true);
 	if (Verbosity() > 0)
 	{
 	  std::cout << "Fun4AllStreamingInputManager::FillInttPool - fill pool for " << iter->Name() << std::endl;
 	}
-	if(!m_gl1_registered_flag)
-	{
-	}
-	iter->FillPool(ref_bco_minus_range,m_gl1_registered_flag);
+	iter->FillPool(ref_bco_minus_range);
 	// iter->FillPool();
 	if (m_RunNumber == 0)
 	{

--- a/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
+++ b/offline/framework/fun4allraw/Fun4AllStreamingInputManager.cc
@@ -1291,30 +1291,33 @@ int Fun4AllStreamingInputManager::FillInttPool()
   }
   for (auto iter : m_InttInputVector)
   {
-    if (Verbosity() > 0)
-    {
-      std::cout << "Fun4AllStreamingInputManager::FillInttPool - fill pool for " << iter->Name() << std::endl;
-    }
-    iter->FillPool(ref_bco_minus_range);
-    // iter->FillPool();
-    if (m_RunNumber == 0)
-    {
-      m_RunNumber = iter->RunNumber();
-      SetRunNumber(m_RunNumber);
-    }
-    else
-    {
-      if (m_RunNumber != iter->RunNumber())
-      {
-        std::cout << PHWHERE << " Run Number mismatch, run is "
-                  << m_RunNumber << ", " << iter->Name() << " reads "
-                  << iter->RunNumber() << std::endl;
-        std::cout << "You are likely reading files from different runs, do not do that" << std::endl;
-        Print("INPUTFILES");
-        gSystem->Exit(1);
-        exit(1);
-      }
-    }
+	if (Verbosity() > 0)
+	{
+	  std::cout << "Fun4AllStreamingInputManager::FillInttPool - fill pool for " << iter->Name() << std::endl;
+	}
+	if(!m_gl1_registered_flag)
+	{
+	}
+	iter->FillPool(ref_bco_minus_range,m_gl1_registered_flag);
+	// iter->FillPool();
+	if (m_RunNumber == 0)
+	{
+	  m_RunNumber = iter->RunNumber();
+	  SetRunNumber(m_RunNumber);
+	}
+	else
+	{
+	  if (m_RunNumber != iter->RunNumber())
+	  {
+		std::cout << PHWHERE << " Run Number mismatch, run is "
+		  << m_RunNumber << ", " << iter->Name() << " reads "
+		  << iter->RunNumber() << std::endl;
+		std::cout << "You are likely reading files from different runs, do not do that" << std::endl;
+		Print("INPUTFILES");
+		gSystem->Exit(1);
+		exit(1);
+	  }
+	}
   }
   if (m_InttRawHitMap.empty())
   {

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -114,7 +114,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
         for (int j = 0; j < numBCOs; j++)
         {
           uint64_t bco = plist[i]->lValue(j, "BCOLIST");
-          if (bco < minBCO)
+		  if (bco < minBCO)
           {
             continue;
           }
@@ -183,7 +183,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
           {
             continue;
           }
-          if(bco > minBCO * 2)
+          if(bco > minBCO * 2 && !m_StandaloneMode)
           {
             continue;
           }
@@ -204,7 +204,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
 			{
 			  continue;
 			}
-			if(bco > minBCO * 2)
+			if(bco > minBCO * 2 && !m_StandaloneMode)
 			{
 			  continue;
 			}
@@ -231,7 +231,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO)
 			  // 	      << std::endl;
 			  continue;
 			}
-			if(gtm_bco > minBCO * 2)
+			if(gtm_bco > minBCO * 2 && !m_StandaloneMode)
 			{
 			  continue;
 			}

--- a/offline/framework/fun4allraw/SingleInttPoolInput.cc
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.cc
@@ -46,153 +46,163 @@ SingleInttPoolInput::~SingleInttPoolInput()
   }
 }
 
-void SingleInttPoolInput::FillPool(const uint64_t minBCO,bool withGl1)
+void SingleInttPoolInput::FillPool(const uint64_t minBCO)
 {
   if (AllDone())  // no more files and all events read
   {
-	return;
+    return;
   }
   while (GetEventiterator() == nullptr)  // at startup this is a null pointer
   {
-	if (!OpenNextFile())
-	{
-	  AllDone(1);
-	  return;
-	}
+    if (!OpenNextFile())
+    {
+      AllDone(1);
+      return;
+    }
   }
+
   //  std::set<uint64_t> saved_beamclocks;
   while (GetSomeMoreEvents(0))
   {
-	Event *evt = GetEventiterator()->getNextEvent();
-	while (!evt)
-	{
-	  fileclose();
-	  if (!OpenNextFile())
-	  {
-		AllDone(1);
-		return;
-	  }
-	  evt = GetEventiterator()->getNextEvent();
-	}
-	if (Verbosity() > 2)
-	{
-	  std::cout << "Fetching next Event" << evt->getEvtSequence() << std::endl;
-	}
-	RunNumber(evt->getRunNumber());
-	if (GetVerbosity() > 1)
-	{
-	  evt->identify();
-	}
-	// not interested in special events, really
-	if (evt->getEvtType() != DATAEVENT)
-	{
-	  m_NumSpecialEvents++;
-	  if (evt->getEvtType() == ENDRUNEVENT)
-	  {
-		std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
-		delete evt;
-		AllDone(1);
-		return;
-	  }
-	  delete evt;
-	  continue;
-	}
+    Event *evt = GetEventiterator()->getNextEvent();
+    while (!evt)
+    {
+      fileclose();
+      if (!OpenNextFile())
+      {
+        AllDone(1);
+        return;
+      }
+      evt = GetEventiterator()->getNextEvent();
+    }
+    if (Verbosity() > 2)
+    {
+      std::cout << "Fetching next Event" << evt->getEvtSequence() << std::endl;
+    }
+    RunNumber(evt->getRunNumber());
+    if (GetVerbosity() > 1)
+    {
+      evt->identify();
+    }
+    // not interested in special events, really
+    if (evt->getEvtType() != DATAEVENT)
+    {
+      m_NumSpecialEvents++;
+      if (evt->getEvtType() == ENDRUNEVENT)
+      {
+        std::cout << "End run flag for INTT found, remaining INTT data is corrupted" << std::endl;
+        delete evt;
+        AllDone(1);
+        return;
+      }
+      delete evt;
+      continue;
+    }
 
-	int EventSequence = evt->getEvtSequence();
-	int npackets = evt->getPacketList(plist, 1);
+    int EventSequence = evt->getEvtSequence();
+    int npackets = evt->getPacketList(plist, 1);
 
-	if (npackets > 1)
-	{
-	  exit(1);
-	}
-	if (m_SkipEarlyEvents)
-	{
-	  for (int i = 0; i < npackets; i++)
-	  {
-		int numBCOs = plist[i]->iValue(0, "NR_BCOS");
-		for (int j = 0; j < numBCOs; j++)
-		{
-		  uint64_t bco = plist[i]->lValue(j, "BCOLIST");
-		  if (bco < minBCO)
-		  {
-			continue;
-		  }
-		  m_SkipEarlyEvents = false;
-		}
-	  }
-	}
-	if (m_SkipEarlyEvents)
-	{
-	  for (int i = 0; i < npackets; i++)
-	  {
-		delete plist[i];
-	  }
-	  delete evt;
-	  continue;
-	}
-	for (int i = 0; i < npackets; i++)
-	{
-	  if (Verbosity() > 2)
-	  {
-		plist[i]->identify();
-	  }
+    if (npackets > 1)
+    {
+      exit(1);
+    }
+    if (m_SkipEarlyEvents)
+    {
+      for (int i = 0; i < npackets; i++)
+      {
+        int numBCOs = plist[i]->iValue(0, "NR_BCOS");
+        for (int j = 0; j < numBCOs; j++)
+        {
+          uint64_t bco = plist[i]->lValue(j, "BCOLIST");
+          if (bco < minBCO)
+          {
+            continue;
+          }
+          m_SkipEarlyEvents = false;
+        }
+      }
+    }
+    if (m_SkipEarlyEvents)
+    {
+      for (int i = 0; i < npackets; i++)
+      {
+        delete plist[i];
+      }
+      delete evt;
+      continue;
+    }
+    for (int i = 0; i < npackets; i++)
+    {
+      if (Verbosity() > 2)
+      {
+        plist[i]->identify();
+      }
 
-	  if (poolmap.find(plist[i]->getIdentifier()) == poolmap.end())  // we haven't seen this one yet
-	  {
-		if (Verbosity() > 1)
-		{
-		  std::cout << "starting new intt pool for packet " << plist[i]->getIdentifier() << std::endl;
-		}
-		poolmap[plist[i]->getIdentifier()] = new intt_pool(1000, 100);
-		poolmap[plist[i]->getIdentifier()]->Verbosity(Verbosity());
-		poolmap[plist[i]->getIdentifier()]->Name(std::to_string(plist[i]->getIdentifier()));
-	  }
-	  poolmap[plist[i]->getIdentifier()]->addPacket(plist[i]);
+      if (poolmap.find(plist[i]->getIdentifier()) == poolmap.end())  // we haven't seen this one yet
+      {
+        if (Verbosity() > 1)
+        {
+          std::cout << "starting new intt pool for packet " << plist[i]->getIdentifier() << std::endl;
+        }
+        poolmap[plist[i]->getIdentifier()] = new intt_pool(1000, 100);
+        poolmap[plist[i]->getIdentifier()]->Verbosity(Verbosity());
+        poolmap[plist[i]->getIdentifier()]->Name(std::to_string(plist[i]->getIdentifier()));
+      }
+      poolmap[plist[i]->getIdentifier()]->addPacket(plist[i]);
 
-	  delete plist[i];
-	}
+      delete plist[i];
+    }
 
-	delete evt;
+    delete evt;
 
-	for (auto iter : poolmap)
-	{
-	  intt_pool *pool = iter.second;  // less typing
-	  auto packet_id = pool->getIdentifier();
-	  if (pool->depth_ok())
-	  {
-		int num_hits = pool->iValue(0, "NR_HITS");
-		if (Verbosity() > 1)
+    for (auto iter : poolmap)
+    {
+      intt_pool *pool = iter.second;  // less typing
+      auto packet_id = pool->getIdentifier();
+      if (pool->depth_ok())
+      {
+        int num_hits = pool->iValue(0, "NR_HITS");
+        if (Verbosity() > 1)
 		{
 		  std::cout << "Number of Hits: " << num_hits << " for packet "
 			<< pool->getIdentifier() << std::endl;
 		}
-
-		int numBCOs = pool->iValue(0, "NR_BCOS");
-		uint64_t largest_bco = 0;
-		bool skipthis{true};
-
-		for (int j = 0; j < numBCOs; j++)
+		if (Verbosity() > 2)
 		{
-		  uint64_t bco = pool->lValue(j, "BCOLIST");
-		  if (largest_bco < bco)
+		  if(IsStandaloneMode())
 		  {
-			largest_bco = bco;
-		  }
-		  if (bco < minBCO)
-		  {
-			continue;
-		  }
-		  if(bco > minBCO * 2 && withGl1)
-		  {
-			continue;
-		  }
-		  skipthis = false;
-		  m_BclkStack.insert(bco);
-		  m_BclkStackPacketMap[packet_id].insert(bco);
-		}
 
-		int nFEEs = pool->iValue(0, "UNIQUE_FEES");
-		for (int j = 0; j < nFEEs; j++)
+			std::cout<<"INTT Pool in Standalone mode "<<std::endl;
+		  }
+		  else
+			std::cout<<"INTT Pool with GL1 BCO "<<std::endl;
+		}
+        int numBCOs = pool->iValue(0, "NR_BCOS");
+        uint64_t largest_bco = 0;
+        bool skipthis{true};
+
+        for (int j = 0; j < numBCOs; j++)
+        {
+          uint64_t bco = pool->lValue(j, "BCOLIST");
+          if (largest_bco < bco)
+          {
+            largest_bco = bco;
+          }
+          if (bco < minBCO)
+          {
+            continue;
+          }
+          if(!IsStandaloneMode() && bco > minBCO * 2)
+          {
+            continue;
+          }
+          skipthis = false;
+          m_BclkStack.insert(bco);
+          m_BclkStackPacketMap[packet_id].insert(bco);
+        }
+
+        int nFEEs = pool->iValue(0, "UNIQUE_FEES");
+        for (int j = 0; j < nFEEs; j++)
 		{
 		  int fee = pool->iValue(j, "FEE_ID");
 		  int nbcos = pool->iValue(fee, "FEE_BCOS");
@@ -203,24 +213,24 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO,bool withGl1)
 			{
 			  continue;
 			}
-			if(bco > minBCO * 2 && withGl1)
+			if(!IsStandaloneMode() && bco > minBCO * 2)
 			{
 			  continue;
 			}
 			m_FeeGTML1BCOMap[fee].insert(bco);
 		  }
 		}
-		if (skipthis)
-		{
-		  if (Verbosity() > 1)
-		  {
-			std::cout << "largest bco: 0x" << std::hex << largest_bco << ", minbco 0x" << minBCO
-			  << std::dec << ", evtno: " << EventSequence << std::endl;
-		  }
-		}
-		else
-		{
-		  for (int j = 0; j < num_hits; j++)
+        if (skipthis)
+        {
+          if (Verbosity() > 1)
+          {
+            std::cout << "largest bco: 0x" << std::hex << largest_bco << ", minbco 0x" << minBCO
+                      << std::dec << ", evtno: " << EventSequence << std::endl;
+          }
+        }
+        else
+        {
+          for (int j = 0; j < num_hits; j++)
 		  {
 			uint64_t gtm_bco = pool->lValue(j, "BCO");
 			if (gtm_bco < minBCO)
@@ -230,7 +240,7 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO,bool withGl1)
 			  // 	      << std::endl;
 			  continue;
 			}
-			if(gtm_bco > minBCO * 2 && withGl1)
+			if(!IsStandaloneMode() && gtm_bco > minBCO * 2)
 			{
 			  continue;
 			}
@@ -275,11 +285,11 @@ void SingleInttPoolInput::FillPool(const uint64_t minBCO,bool withGl1)
 			}
 			m_InttRawHitMap[gtm_bco].push_back(newhit.release());
 		  }
-		}
-		//	    Print("FEEBCLK");
-	  }
-	  pool->next();
-	}
+        }
+        //	    Print("FEEBCLK");
+      }
+      pool->next();
+    }
   }
 }
 

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -20,7 +20,7 @@ class SingleInttPoolInput : public SingleStreamingInput
  public:
   explicit SingleInttPoolInput(const std::string &name);
   ~SingleInttPoolInput() override;
-  void FillPool(const uint64_t minBCO,bool flag) override;
+  void FillPool(const uint64_t minBCO) override;
   void CleanupUsedPackets(const uint64_t bclk) override;
   bool CheckPoolDepth(const uint64_t bclk) override;
   void ClearCurrentEvent() override;
@@ -53,7 +53,7 @@ class SingleInttPoolInput : public SingleStreamingInput
  private:
   Packet **plist{nullptr};
   unsigned int m_NumSpecialEvents{0};
-  unsigned int m_BcoRange{0}; 
+  unsigned int m_BcoRange{0};
   unsigned int m_NegativeBco{0};
   bool m_SkipEarlyEvents{true};
   std::array<uint64_t, 14> m_PreviousClock{};

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -28,6 +28,7 @@ class SingleInttPoolInput : public SingleStreamingInput
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
+  void SetStandAloneMode(bool value) {m_StandaloneMode = value; }
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
@@ -53,8 +54,9 @@ class SingleInttPoolInput : public SingleStreamingInput
  private:
   Packet **plist{nullptr};
   unsigned int m_NumSpecialEvents{0};
-  unsigned int m_BcoRange{0};
+  unsigned int m_BcoRange{0}; 
   unsigned int m_NegativeBco{0};
+  bool m_StandaloneMode{false};
   bool m_SkipEarlyEvents{true};
   std::array<uint64_t, 14> m_PreviousClock{};
   std::array<uint64_t, 14> m_Rollover{};

--- a/offline/framework/fun4allraw/SingleInttPoolInput.h
+++ b/offline/framework/fun4allraw/SingleInttPoolInput.h
@@ -20,7 +20,7 @@ class SingleInttPoolInput : public SingleStreamingInput
  public:
   explicit SingleInttPoolInput(const std::string &name);
   ~SingleInttPoolInput() override;
-  void FillPool(const uint64_t minBCO) override;
+  void FillPool(const uint64_t minBCO,bool flag) override;
   void CleanupUsedPackets(const uint64_t bclk) override;
   bool CheckPoolDepth(const uint64_t bclk) override;
   void ClearCurrentEvent() override;
@@ -28,7 +28,6 @@ class SingleInttPoolInput : public SingleStreamingInput
   void Print(const std::string &what = "ALL") const override;
   void CreateDSTNode(PHCompositeNode *topNode) override;
 
-  void SetStandAloneMode(bool value) {m_StandaloneMode = value; }
   void SetBcoRange(const unsigned int value) { m_BcoRange = value; }
   void ConfigureStreamingInputManager() override;
   void SetNegativeBco(const unsigned int value) { m_NegativeBco = value; }
@@ -56,7 +55,6 @@ class SingleInttPoolInput : public SingleStreamingInput
   unsigned int m_NumSpecialEvents{0};
   unsigned int m_BcoRange{0}; 
   unsigned int m_NegativeBco{0};
-  bool m_StandaloneMode{false};
   bool m_SkipEarlyEvents{true};
   std::array<uint64_t, 14> m_PreviousClock{};
   std::array<uint64_t, 14> m_Rollover{};

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -21,6 +21,7 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   ~SingleStreamingInput() override;
   virtual Eventiterator *GetEventIterator() { return m_EventIterator; }
   virtual void FillPool(const uint64_t) { return; }
+  virtual void FillPool(const uint64_t,bool) { return; }
   virtual void FillPool(const unsigned int = 1) { return; }
   virtual void RunNumber(const int runno) { m_RunNumber = runno; }
   virtual int RunNumber() const { return m_RunNumber; }

--- a/offline/framework/fun4allraw/SingleStreamingInput.h
+++ b/offline/framework/fun4allraw/SingleStreamingInput.h
@@ -21,7 +21,6 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   ~SingleStreamingInput() override;
   virtual Eventiterator *GetEventIterator() { return m_EventIterator; }
   virtual void FillPool(const uint64_t) { return; }
-  virtual void FillPool(const uint64_t,bool) { return; }
   virtual void FillPool(const unsigned int = 1) { return; }
   virtual void RunNumber(const int runno) { m_RunNumber = runno; }
   virtual int RunNumber() const { return m_RunNumber; }
@@ -61,6 +60,8 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   const std::string &getHitContainerName() const { return m_rawHitContainerName; }
   const std::map<int, std::set<uint64_t>> &getFeeGTML1BCOMap() const { return m_FeeGTML1BCOMap; }
 
+  void SetStandaloneMode(bool mode) { m_standalone_mode = mode; }
+  bool IsStandaloneMode() const { return m_standalone_mode; }  
   //! event assembly QA histograms
   virtual void createQAHistos() {}
 
@@ -110,6 +111,7 @@ class SingleStreamingInput : public Fun4AllBase, public InputFileHandler
   std::map<int, std::set<uint64_t>> m_BclkStackPacketMap;
   std::map<int, std::set<uint64_t>> m_FeeGTML1BCOMap;
   std::string m_rawHitContainerName = "";
+  bool m_standalone_mode = false;
 
  private:
   Eventiterator *m_EventIterator{nullptr};


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )
Adding feature to turn ON/OFF big BCO skip based on GL1 BCO value. This is necessary for INTT local run without GL1 combiner. It will not harm any current combiner since standalone flag is false by default ; bool m_StandaloneMode{false}

## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

