### PR TITLE
Change JetInput derived classes to treat events without zvtx as 0 zvtx

### DIFF
--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -16,14 +16,14 @@
 //____________________________________________________________________________..
 JetBackgroundCut::JetBackgroundCut(const std::string &jetNodeName, const std::string &name, const int debug, const bool doAbort, GlobalVertex::VTXTYPE vtxtype, int sysvar)
   : SubsysReco(name)
-  , _name(name)
-  , _jetNodeName(jetNodeName)
+  , _doAbort(doAbort), _name(name)
+  , _debug(debug), _jetNodeName(jetNodeName)
   , _vtxtype(vtxtype)
-  , _cutParams(name)
+  , _sysvar(sysvar), _cutParams(name)
 {
-  _debug = debug;
-  _doAbort = doAbort;
-  _sysvar = sysvar;
+  
+  
+  
   SetDefaultParams();
 }
 
@@ -94,9 +94,9 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
       zvtx = 0;
     }
     else
-      {
-	gvtx = gvtxmap->begin()->second;
-      }
+    {
+      gvtx = gvtxmap->begin()->second;
+    }
     if (gvtx)
     {
       auto startIter = gvtx->find_vertexes(_vtxtype);
@@ -129,7 +129,7 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
   }
   else
   {
-    if(_debug > 0)
+    if (_debug > 0)
     {
       std::cout << "gvtxmap is NULL! ABORT EVENT!" << std::endl;
     }

--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -84,15 +84,19 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
 
   if (gvtxmap)
   {
+    GlobalVertex *gvtx;
     if (gvtxmap->empty())
     {
       if (_debug > 0)
       {
-        std::cout << "gvtxmap empty - aborting event." << std::endl;
+        std::cout << "gvtxmap empty - set zvtx to 0 and continue." << std::endl;
       }
-      return Fun4AllReturnCodes::ABORTEVENT;
+      zvtx = 0;
     }
-    GlobalVertex *gvtx = gvtxmap->begin()->second;
+    else
+      {
+	gvtx = gvtxmap->begin()->second;
+      }
     if (gvtx)
     {
       auto startIter = gvtx->find_vertexes(_vtxtype);
@@ -118,19 +122,27 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
     {
       if (_debug > 0)
       {
-        std::cout << "gvtx is NULL! Aborting event." << std::endl;
+        std::cout << "gvtx is NULL! Set zvtx to 0 and continue." << std::endl;
       }
-      return Fun4AllReturnCodes::ABORTEVENT;
+      zvtx = 0;
     }
+  }
+  else
+  {
+    if(_debug > 0)
+    {
+      std::cout << "gvtxmap is NULL! ABORT EVENT!" << std::endl;
+    }
+    return Fun4AllReturnCodes::ABORTEVENT;
   }
 
   if (std::isnan(zvtx))
   {
     if (_debug > 0)
     {
-      std::cout << "zvtx is NAN after attempting to grab it. ABORT EVENT!" << std::endl;
+      std::cout << "zvtx is NAN after attempting to grab it. Set to 0 and continue." << std::endl;
     }
-    return Fun4AllReturnCodes::ABORTEVENT;
+    zvtx = 0;
   }
 
   if (_debug > 1)

--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -84,7 +84,7 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
 
   if (gvtxmap)
   {
-    GlobalVertex *gvtx = NULL;
+    GlobalVertex *gvtx = nullptr;
     if (gvtxmap->empty())
     {
       if (_debug > 0)

--- a/offline/packages/jetbackground/JetBackgroundCut.cc
+++ b/offline/packages/jetbackground/JetBackgroundCut.cc
@@ -84,7 +84,7 @@ int JetBackgroundCut::process_event(PHCompositeNode *topNode)
 
   if (gvtxmap)
   {
-    GlobalVertex *gvtx;
+    GlobalVertex *gvtx = NULL;
     if (gvtxmap->empty())
     {
       if (_debug > 0)

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -52,6 +52,8 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   {
     std::cout << "ClusterJetInput::process_event -- entered" << std::endl;
   }
+
+  CLHEP::Hep3Vector vertex(0, 0, 0);
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
@@ -63,9 +65,40 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
 
   if (vertexmap->empty())
   {
-    std::cout << "ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
-    return std::vector<Jet *>();
+    std::cout << "ClusterJetInput::get_input - Warning - GlobalVertexMap node is empty. Continue as if vtxz = (0,0,0)." << std::endl;
   }
+  else
+    {
+      GlobalVertex *vtx = vertexmap->begin()->second;
+      if (vtx)
+	{
+	  if (m_use_vertextype) 
+	    {
+	      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+	      auto typeEndIter = vtx->end_vertexes();
+	      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+		{
+		  const auto &[type, vertexVec] = *iter;
+		  if (type != m_vertex_type) { continue; }
+		  for (const auto *v : vertexVec)
+		    {
+		      if (!v) { continue; }
+		      vertex.set(v->get_x(), v->get_y(), v->get_z());
+		    }
+		}
+	    } 
+	  else 
+	    {
+	      vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+	    }
+	}
+      
+      if (std::isnan(vertex.z()))
+	{
+	  vertex.set(0,0,0);
+	}
+    }
+
 
   RawClusterContainer *clusters = nullptr;
   if (m_Input == Jet::CEMC_CLUSTER)
@@ -145,40 +178,6 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
     return std::vector<Jet *>();
   }
 
-  // first grab the event vertex or bail
-  GlobalVertex *vtx = vertexmap->begin()->second;
-  CLHEP::Hep3Vector vertex(0, 0, std::nan(""));
-  if (vtx)
-  {
-    if (m_use_vertextype) 
-    {
-      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
-      auto typeEndIter = vtx->end_vertexes();
-      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
-      {
-        const auto &[type, vertexVec] = *iter;
-        if (type != m_vertex_type) { continue; }
-        for (const auto *v : vertexVec)
-        {
-          if (!v) { continue; }
-          vertex.set(v->get_x(), v->get_y(), v->get_z());
-        }
-      }
-    } 
-    else 
-    {
-      vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
-    }
-  }
-  else
-  {
-    return std::vector<Jet *>();
-  }
-
-  if (std::isnan(vertex.z()))
-  {
-    return std::vector<Jet *>();
-  }
 
   std::vector<Jet *> pseudojets;
   RawClusterContainer::ConstRange begin_end = clusters->getClusters();

--- a/offline/packages/jetbase/ClusterJetInput.cc
+++ b/offline/packages/jetbase/ClusterJetInput.cc
@@ -68,37 +68,42 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
     std::cout << "ClusterJetInput::get_input - Warning - GlobalVertexMap node is empty. Continue as if vtxz = (0,0,0)." << std::endl;
   }
   else
+  {
+    GlobalVertex *vtx = vertexmap->begin()->second;
+    if (vtx)
     {
-      GlobalVertex *vtx = vertexmap->begin()->second;
-      if (vtx)
-	{
-	  if (m_use_vertextype) 
-	    {
-	      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
-	      auto typeEndIter = vtx->end_vertexes();
-	      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
-		{
-		  const auto &[type, vertexVec] = *iter;
-		  if (type != m_vertex_type) { continue; }
-		  for (const auto *v : vertexVec)
-		    {
-		      if (!v) { continue; }
-		      vertex.set(v->get_x(), v->get_y(), v->get_z());
-		    }
-		}
-	    } 
-	  else 
-	    {
-	      vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
-	    }
-	}
-      
-      if (std::isnan(vertex.z()))
-	{
-	  vertex.set(0,0,0);
-	}
+      if (m_use_vertextype)
+      {
+        auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+        auto typeEndIter = vtx->end_vertexes();
+        for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+        {
+          const auto &[type, vertexVec] = *iter;
+          if (type != m_vertex_type)
+          {
+            continue;
+          }
+          for (const auto *v : vertexVec)
+          {
+            if (!v)
+            {
+              continue;
+            }
+            vertex.set(v->get_x(), v->get_y(), v->get_z());
+          }
+        }
+      }
+      else
+      {
+        vertex.set(vtx->get_x(), vtx->get_y(), vtx->get_z());
+      }
     }
 
+    if (std::isnan(vertex.z()))
+    {
+      vertex.set(0, 0, 0);
+    }
+  }
 
   RawClusterContainer *clusters = nullptr;
   if (m_Input == Jet::CEMC_CLUSTER)
@@ -177,7 +182,6 @@ std::vector<Jet *> ClusterJetInput::get_input(PHCompositeNode *topNode)
   {
     return std::vector<Jet *>();
   }
-
 
   std::vector<Jet *> pseudojets;
   RawClusterContainer::ConstRange begin_end = clusters->getClusters();

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -77,7 +77,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     if (Verbosity() > 0)
     {
-      std::cout << "TowerJetInput::get_input - empty vertex map, continuing as if zvtx = 0" << endl;
+      std::cout << "TowerJetInput::get_input - empty vertex map, continuing as if zvtx = 0" << std::endl;
     }
   }
   else

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -64,7 +64,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     std::cout << "TowerJetInput::process_event -- entered" << std::endl;
   }
-
+  float vtxz = 0; //default to 0
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
@@ -73,15 +73,62 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
 
     return std::vector<Jet *>();
   }
-
   if (vertexmap->empty())
   {
     if (Verbosity() > 0)
     {
-      std::cout << "TowerJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex." << std::endl;
+      std::cout << "TowerJetInput::get_input - empty vertex map, continuing as if zvtx = 0" << endl;
     }
-    return std::vector<Jet *>();
   }
+  else
+  {
+    GlobalVertex *vtx = vertexmap->begin()->second;
+    if (vtx)
+      {
+	if (m_use_vertextype) 
+	  {
+	    auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+	    auto typeEndIter = vtx->end_vertexes();
+	    for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+	      {
+		const auto &[type, vertexVec] = *iter;
+		if (type != m_vertex_type) { continue; }
+		for (const auto *vertex : vertexVec)
+		  {
+		    if (!vertex) { continue; }
+		    vtxz = vertex->get_z();
+		  }
+	      }
+	  } 
+	else 
+	  {
+	    vtxz = vtx->get_z();
+	  }
+      }
+  }
+  if (std::isnan(vtxz))
+  {
+    static bool once = true;
+    if (once)
+    {
+      once = false;
+      std::cout << "TowerJetInput::get_input - WARNING - vertex is NAN. Continue with zvtx = 0 (further vertex warning will be suppressed)." << std::endl;
+    }
+    vtxz = 0;
+  }
+
+  if (std::abs(vtxz) > 1e3)  // code crashes with very large z vertex, so skip these events
+  {
+    static bool once = true;
+    if (once)
+    {
+      once = false;
+
+      std::cout << "TowerJetInput::get_input - WARNING - vertex is " << vtxz << ". Set vtxz = 0 (further vertex warning will be suppressed)." << std::endl;
+    }
+    vtxz = 0;
+  }
+
   m_use_towerinfo = false;
 
   /* std::string name =(m_input == Jet::CEMC_TOWER ? "CEMC_TOWER" */
@@ -404,61 +451,6 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   }
 
   // first grab the event vertex or bail
-  GlobalVertex *vtx = vertexmap->begin()->second;
-  float vtxz = NAN;
-  
-  if (vtx)
-  {
-    if (m_use_vertextype) 
-    {
-      auto typeStartIter = vtx->find_vertexes(m_vertex_type);
-      auto typeEndIter = vtx->end_vertexes();
-      for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
-      {
-        const auto &[type, vertexVec] = *iter;
-        if (type != m_vertex_type) { continue; }
-        for (const auto *vertex : vertexVec)
-        {
-          if (!vertex) { continue; }
-          vtxz = vertex->get_z();
-        }
-      }
-    } 
-    else 
-    {
-      vtxz = vtx->get_z();
-    }
-  }
-  else
-  {
-    return std::vector<Jet *>();
-  }
-
-  if (std::isnan(vtxz))
-  {
-    static bool once = true;
-    if (once)
-    {
-      once = false;
-
-      std::cout << "TowerJetInput::get_input - WARNING - vertex is NAN. Drop all tower inputs (further NAN-vertex warning will be suppressed)." << std::endl;
-    }
-
-    return std::vector<Jet *>();
-  }
-
-  if (std::abs(vtxz) > 1e3)  // code crashes with very large z vertex, so skip these events
-  {
-    static bool once = true;
-    if (once)
-    {
-      once = false;
-
-      std::cout << "TowerJetInput::get_input - WARNING - vertex is " << vtxz << ". Drop all tower inputs (further vertex warning will be suppressed)." << std::endl;
-    }
-
-    return std::vector<Jet *>();
-  }
 
   std::vector<Jet *> pseudojets;
   if (m_use_towerinfo)

--- a/offline/packages/jetbase/TowerJetInput.cc
+++ b/offline/packages/jetbase/TowerJetInput.cc
@@ -64,7 +64,7 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     std::cout << "TowerJetInput::process_event -- entered" << std::endl;
   }
-  float vtxz = 0; //default to 0
+  float vtxz = 0;  // default to 0
   GlobalVertexMap *vertexmap = findNode::getClass<GlobalVertexMap>(topNode, "GlobalVertexMap");
   if (!vertexmap)
   {
@@ -84,27 +84,33 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   {
     GlobalVertex *vtx = vertexmap->begin()->second;
     if (vtx)
+    {
+      if (m_use_vertextype)
       {
-	if (m_use_vertextype) 
-	  {
-	    auto typeStartIter = vtx->find_vertexes(m_vertex_type);
-	    auto typeEndIter = vtx->end_vertexes();
-	    for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
-	      {
-		const auto &[type, vertexVec] = *iter;
-		if (type != m_vertex_type) { continue; }
-		for (const auto *vertex : vertexVec)
-		  {
-		    if (!vertex) { continue; }
-		    vtxz = vertex->get_z();
-		  }
-	      }
-	  } 
-	else 
-	  {
-	    vtxz = vtx->get_z();
-	  }
+        auto typeStartIter = vtx->find_vertexes(m_vertex_type);
+        auto typeEndIter = vtx->end_vertexes();
+        for (auto iter = typeStartIter; iter != typeEndIter; ++iter)
+        {
+          const auto &[type, vertexVec] = *iter;
+          if (type != m_vertex_type)
+          {
+            continue;
+          }
+          for (const auto *vertex : vertexVec)
+          {
+            if (!vertex)
+            {
+              continue;
+            }
+            vtxz = vertex->get_z();
+          }
+        }
       }
+      else
+      {
+        vtxz = vtx->get_z();
+      }
+    }
   }
   if (std::isnan(vtxz))
   {
@@ -158,8 +164,6 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
   TowerInfoContainer *towerinfos = nullptr;
   RawTowerGeomContainer *geom = nullptr;
   RawTowerGeomContainer *EMCal_geom = nullptr;
-
-
 
   if (m_input == Jet::CEMC_TOWER)
   {
@@ -440,8 +444,8 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
     return std::vector<Jet *>();
   }
 
-  //for those cases we need to use the EMCal R and IHCal eta phi to calculate the vertex correction
-  if(m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input == Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
+  // for those cases we need to use the EMCal R and IHCal eta phi to calculate the vertex correction
+  if (m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input == Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
   {
     EMCal_geom = findNode::getClass<RawTowerGeomContainer>(topNode, "TOWERGEOM_CEMC");
     if (!EMCal_geom)
@@ -483,10 +487,10 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
       assert(tower_geom);
 
       double r = tower_geom->get_center_radius();
-      if(m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input ==Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
+      if (m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input == Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
       {
         const RawTowerDefs::keytype EMCal_key = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, 0, 0);
-        RawTowerGeom *EMCal_tower_geom = EMCal_geom->get_tower_geometry(EMCal_key );
+        RawTowerGeom *EMCal_tower_geom = EMCal_geom->get_tower_geometry(EMCal_key);
         assert(EMCal_tower_geom);
         r = EMCal_tower_geom->get_center_radius();
       }
@@ -522,10 +526,10 @@ std::vector<Jet *> TowerJetInput::get_input(PHCompositeNode *topNode)
       assert(tower_geom);
 
       double r = tower_geom->get_center_radius();
-      if(m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input == Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
+      if (m_input == Jet::CEMC_TOWER_RETOWER || m_input == Jet::CEMC_TOWERINFO_RETOWER || m_input == Jet::CEMC_TOWER_SUB1 || m_input == Jet::CEMC_TOWERINFO_SUB1 || m_input == Jet::CEMC_TOWER_SUB1CS)
       {
         const RawTowerDefs::keytype EMCal_key = RawTowerDefs::encode_towerid(RawTowerDefs::CalorimeterId::CEMC, 0, 0);
-        RawTowerGeom *EMCal_tower_geom = EMCal_geom->get_tower_geometry(EMCal_key );
+        RawTowerGeom *EMCal_tower_geom = EMCal_geom->get_tower_geometry(EMCal_key);
         assert(EMCal_tower_geom);
         r = EMCal_tower_geom->get_center_radius();
       }


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)
As discussed in the sim and software meeting on 2025/06/03, this PR modifies JetInput derived classes to treat events with no z vertex as having a z vertex at 0.
[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

