### PR TITLE
fix: remove some weight from TrackResiduals

### DIFF
--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -281,7 +281,7 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     fillResidualTreeKF(topNode);
   }
 
-  if(m_doVertex)
+  if (m_doVertex)
   {
     fillVertexTree(topNode);
   }
@@ -433,7 +433,7 @@ void TrackResiduals::fillFailedSeedTree(PHCompositeNode* topNode, std::set<unsig
       {
         auto ckey = *it;
         auto cluster = clustermap->findCluster(ckey);
-        const Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, crossing );
+        const Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, crossing);
         const auto local = geometry->getLocalCoords(ckey, cluster);
         m_cluslx.push_back(local.x());
         m_cluslz.push_back(local.y());
@@ -498,7 +498,7 @@ void TrackResiduals::fillVertexTree(PHCompositeNode* topNode)
         {
           TrkrCluster* cluster = clustermap->findCluster(ckey);
 
-          Acts::Vector3 clusglob = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, track->get_crossing() );
+          Acts::Vector3 clusglob = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, track->get_crossing());
 
           m_clusgx.push_back(clusglob.x());
           m_clusgy.push_back(clusglob.y());
@@ -534,18 +534,18 @@ float TrackResiduals::convertTimeToZ(ActsGeometry* geometry, TrkrDefs::cluskey c
   return z;
 }
 void TrackResiduals::circleFitClusters(
-  std::vector<TrkrDefs::cluskey>& keys,
-  TrkrClusterContainer* clusters,
-  const short int& crossing)
+    std::vector<TrkrDefs::cluskey>& keys,
+    TrkrClusterContainer* clusters,
+    const short int& crossing)
 {
   std::vector<Acts::Vector3> clusPos, global_vec;
   for (auto& key : keys)
   {
     auto cluster = clusters->findCluster(key);
-    const Acts::Vector3 pos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, crossing );
+    const Acts::Vector3 pos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, crossing);
     clusPos.push_back(pos);
   }
-  TrackFitUtils::position_vector_t yzpoints,xypoints;
+  TrackFitUtils::position_vector_t yzpoints, xypoints;
 
   for (auto& pos : clusPos)
   {
@@ -594,7 +594,7 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
   for (auto& key : keys)
   {
     auto cluster = clusters->findCluster(key);
-    const Acts::Vector3 pos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, crossing );
+    const Acts::Vector3 pos = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(key, cluster, crossing);
     clusPos.push_back(pos);
   }
   TrackFitUtils::position_vector_t xypoints, rzpoints, yzpoints;
@@ -632,7 +632,7 @@ void TrackResiduals::lineFitClusters(std::vector<TrkrDefs::cluskey>& keys,
 void TrackResiduals::fillClusterTree(TrkrClusterContainer* clusters,
                                      ActsGeometry* geometry)
 {
-  if (clusters->size()< m_min_cluster_size)
+  if (clusters->size() < m_min_cluster_size)
   {
     return;
   }
@@ -752,11 +752,11 @@ int TrackResiduals::End(PHCompositeNode* /*unused*/)
   {
     m_hittree->Write();
   }
-  if(m_doVertex)
+  if (m_doVertex)
   {
     m_vertextree->Write();
   }
-  if(m_doFailedSeeds)
+  if (m_doFailedSeeds)
   {
     m_failedfits->Write();
   }
@@ -974,13 +974,13 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   auto clustermap = findNode::getClass<TrkrClusterContainer>(topNode, m_clusterContainerName);
   auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
 
-  auto global_moved = global;    // if use transient transforms for distortion correction
-  if(m_use_clustermover)
-    {
-      // move the corrected cluster positions back to the original readout surface
-      global_moved = m_clusterMover.processTrack(global);	 
-    }
-  
+  auto global_moved = global;  // if use transient transforms for distortion correction
+  if (m_use_clustermover)
+  {
+    // move the corrected cluster positions back to the original readout surface
+    global_moved = m_clusterMover.processTrack(global);
+  }
+
   ActsTransformations transformer;
   TrkrCluster* cluster = clustermap->findCluster(ckey);
 
@@ -1083,7 +1083,7 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
 
   // get new local coords from moved cluster
   Surface surf = geometry->maps().getSurface(ckey, cluster);
-  Surface surf_ideal = geometry->maps().getSurface(ckey, cluster); //Unchanged by distortion corrections
+  Surface surf_ideal = geometry->maps().getSurface(ckey, cluster);  // Unchanged by distortion corrections
   // if this is a TPC cluster, the crossing correction may have moved it across the central membrane, check the surface
   auto trkrid = TrkrDefs::getTrkrId(ckey);
   if (trkrid == TrkrDefs::tpcId)
@@ -1104,40 +1104,40 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   // get local coordinates
   Acts::Vector2 loc;
   loc = geometry->getLocalCoords(ckey, cluster, m_crossing);
-  if(m_use_clustermover)
+  if (m_use_clustermover)
+  {
+    // in this case we get local coords from transform of corrected global coords
+    clusglob_moved *= Acts::UnitConstants::cm;  // we want mm for transformations
+    Acts::Vector3 normal = surf->normal(geometry->geometry().getGeoContext(),
+                                        Acts::Vector3(1, 1, 1), Acts::Vector3(1, 1, 1));
+    auto local = surf->globalToLocal(geometry->geometry().getGeoContext(),
+                                     clusglob_moved, normal);
+    if (local.ok())
     {
-      // in this case we get local coords from transform of corrected global coords
-      clusglob_moved *= Acts::UnitConstants::cm;  // we want mm for transformations
-      Acts::Vector3 normal = surf->normal(geometry->geometry().getGeoContext(),
-					  Acts::Vector3(1,1,1), Acts::Vector3(1,1,1));
-      auto local = surf->globalToLocal(geometry->geometry().getGeoContext(),
-				       clusglob_moved, normal);
-      if (local.ok())
-	{
-	  loc = local.value() / Acts::UnitConstants::cm;
-	}
-      else
-	{
-	  // otherwise take the manual calculation for the TPC
-	  // doing it this way just avoids the bounds check that occurs in the surface class method
-	  Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * clusglob_moved;  // global is in mm
-	  loct /= Acts::UnitConstants::cm;
-	  
-	  loc(0) = loct(0);
-	  loc(1) = loct(1);
-	}
-      clusglob_moved /= Acts::UnitConstants::cm;  // we want cm for the tree
+      loc = local.value() / Acts::UnitConstants::cm;
     }
+    else
+    {
+      // otherwise take the manual calculation for the TPC
+      // doing it this way just avoids the bounds check that occurs in the surface class method
+      Acts::Vector3 loct = surf->transform(geometry->geometry().getGeoContext()).inverse() * clusglob_moved;  // global is in mm
+      loct /= Acts::UnitConstants::cm;
+
+      loc(0) = loct(0);
+      loc(1) = loct(1);
+    }
+    clusglob_moved /= Acts::UnitConstants::cm;  // we want cm for the tree
+  }
 
   m_cluslx.push_back(loc.x());
   m_cluslz.push_back(loc.y());
 
-  if(Verbosity() > 2)
-    {
-      std::cout << "Trackresiduals cluster (cm): localX " << loc.x() << " localY " << loc.y() << std::endl
-		<< " global.x " << clusglob_moved(0) << " global.y " << clusglob_moved(1) << " global.z " << clusglob_moved(2) << std::endl;
-    }
-  
+  if (Verbosity() > 2)
+  {
+    std::cout << "Trackresiduals cluster (cm): localX " << loc.x() << " localY " << loc.y() << std::endl
+              << " global.x " << clusglob_moved(0) << " global.y " << clusglob_moved(1) << " global.z " << clusglob_moved(2) << std::endl;
+  }
+
   float clusr = r(clusglob_moved.x(), clusglob_moved.y());
   auto para_errors = m_clusErrPara.get_clusterv5_modified_error(cluster,
                                                                 clusr, ckey);
@@ -1156,7 +1156,6 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   m_clusphisize.push_back(cluster->getPhiSize());
   m_cluszsize.push_back(cluster->getZSize());
 
-	
   auto misaligncenter = surf->center(geometry->geometry().getGeoContext());
   auto misalignnorm = -1 * surf->normal(geometry->geometry().getGeoContext(), Acts::Vector3(1, 1, 1), Acts::Vector3(1, 1, 1));
   auto misrot = surf->transform(geometry->geometry().getGeoContext()).rotation();
@@ -1224,13 +1223,13 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   {
     Acts::Vector3 stateglob(state->get_x(), state->get_y(), state->get_z());
     Acts::Vector2 stateloc(state->get_localX(), state->get_localY());
-    
-    if(Verbosity() > 2)
-      {
-	std::cout << "Trackresiduals state (cm): localX " << stateloc(0) << " localY " << stateloc(1) << std::endl
-		  << " stateglobx " << stateglob(0) << " stategloby " << stateglob(1) << " stateglobz " << stateglob(2) << std::endl;
-      }
-    
+
+    if (Verbosity() > 2)
+    {
+      std::cout << "Trackresiduals state (cm): localX " << stateloc(0) << " localY " << stateloc(1) << std::endl
+                << " stateglobx " << stateglob(0) << " stategloby " << stateglob(1) << " stateglobz " << stateglob(2) << std::endl;
+    }
+
     const auto actscov =
         transformer.rotateSvtxTrackCovToActs(state);
 
@@ -1309,11 +1308,11 @@ void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTr
   auto geometry = findNode::getClass<ActsGeometry>(topNode, "ActsGeometry");
 
   auto global_moved = global;
-  if(m_use_clustermover)
-    {
-      // move the corrected cluster positions back to the original readout surface
-      global_moved = m_clusterMover.processTrack(global);	 
-    }
+  if (m_use_clustermover)
+  {
+    // move the corrected cluster positions back to the original readout surface
+    global_moved = m_clusterMover.processTrack(global);
+  }
 
   TrkrCluster* cluster = clustermap->findCluster(ckey);
 
@@ -1671,7 +1670,7 @@ void TrackResiduals::createBranches()
   m_clustree->Branch("ez", &m_scluselz, "m_scluselz/F");
   m_clustree->Branch("maxadc", &m_clusmaxadc, "m_clusmaxadc/F");
   m_clustree->Branch("hitsetkey", &m_hitsetkey, "m_hitsetkey/i");
-  
+
   m_tree = new TTree("residualtree", "A tree with track, cluster, and state info");
   m_tree->Branch("run", &m_runnumber, "m_runnumber/I");
   m_tree->Branch("segment", &m_segment, "m_segment/I");
@@ -1729,7 +1728,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("vx", &m_vx, "m_vx/F");
   m_tree->Branch("vy", &m_vy, "m_vy/F");
   m_tree->Branch("vz", &m_vz, "m_vz/F");
-  m_tree->Branch("vertex_ntracks",&m_vertex_ntracks, "m_vertex_ntracks/I");
+  m_tree->Branch("vertex_ntracks", &m_vertex_ntracks, "m_vertex_ntracks/I");
   m_tree->Branch("pcax", &m_pcax, "m_pcax/F");
   m_tree->Branch("pcay", &m_pcay, "m_pcay/F");
   m_tree->Branch("pcaz", &m_pcaz, "m_pcaz/F");
@@ -1744,7 +1743,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("Y0", &m_Y0, "m_Y0/F");
   m_tree->Branch("dcaxy", &m_dcaxy, "m_dcaxy/F");
   m_tree->Branch("dcaz", &m_dcaz, "m_dcaz/F");
-  
+
   m_tree->Branch("cluskeys", &m_cluskeys);
   m_tree->Branch("clusedge", &m_clusedge);
   m_tree->Branch("clusoverlap", &m_clusoverlap);
@@ -1756,40 +1755,40 @@ void TrackResiduals::createBranches()
   m_tree->Branch("clusgy", &m_clusgy);
   m_tree->Branch("clusgz", &m_clusgz);
   m_tree->Branch("clusgr", &m_clusgr);
-  if(m_doAlignment)
+  if (m_doAlignment)
   {
-  m_tree->Branch("clusgxunmoved", &m_clusgxunmoved);
-  m_tree->Branch("clusgyunmoved", &m_clusgyunmoved);
-  m_tree->Branch("clusgzunmoved", &m_clusgzunmoved);
+    m_tree->Branch("clusgxunmoved", &m_clusgxunmoved);
+    m_tree->Branch("clusgyunmoved", &m_clusgyunmoved);
+    m_tree->Branch("clusgzunmoved", &m_clusgzunmoved);
   }
   m_tree->Branch("clusAdc", &m_clusAdc);
   m_tree->Branch("clusMaxAdc", &m_clusMaxAdc);
   m_tree->Branch("clusphisize", &m_clusphisize);
   m_tree->Branch("cluszsize", &m_cluszsize);
-  
-  if(m_doAlignment)
+
+  if (m_doAlignment)
   {
-      m_tree->Branch("idealsurfcenterx", &m_idealsurfcenterx);
-  m_tree->Branch("idealsurfcentery", &m_idealsurfcentery);
-  m_tree->Branch("idealsurfcenterz", &m_idealsurfcenterz);
-  m_tree->Branch("idealsurfnormx", &m_idealsurfnormx);
-  m_tree->Branch("idealsurfnormy", &m_idealsurfnormy);
-  m_tree->Branch("idealsurfnormz", &m_idealsurfnormz);
-  m_tree->Branch("missurfcenterx", &m_missurfcenterx);
-  m_tree->Branch("missurfcentery", &m_missurfcentery);
-  m_tree->Branch("missurfcenterz", &m_missurfcenterz);
-  m_tree->Branch("missurfnormx", &m_missurfnormx);
-  m_tree->Branch("missurfnormy", &m_missurfnormy);
-  m_tree->Branch("missurfnormz", &m_missurfnormz);
-  m_tree->Branch("clusgxideal", &m_clusgxideal);
-  m_tree->Branch("clusgyideal", &m_clusgyideal);
-  m_tree->Branch("clusgzideal", &m_clusgzideal);
-  m_tree->Branch("missurfalpha", &m_missurfalpha);
-  m_tree->Branch("missurfbeta", &m_missurfbeta);
-  m_tree->Branch("missurfgamma", &m_missurfgamma);
-  m_tree->Branch("idealsurfalpha", &m_idealsurfalpha);
-  m_tree->Branch("idealsurfbeta", &m_idealsurfbeta);
-  m_tree->Branch("idealsurfgamma", &m_idealsurfgamma);
+    m_tree->Branch("idealsurfcenterx", &m_idealsurfcenterx);
+    m_tree->Branch("idealsurfcentery", &m_idealsurfcentery);
+    m_tree->Branch("idealsurfcenterz", &m_idealsurfcenterz);
+    m_tree->Branch("idealsurfnormx", &m_idealsurfnormx);
+    m_tree->Branch("idealsurfnormy", &m_idealsurfnormy);
+    m_tree->Branch("idealsurfnormz", &m_idealsurfnormz);
+    m_tree->Branch("missurfcenterx", &m_missurfcenterx);
+    m_tree->Branch("missurfcentery", &m_missurfcentery);
+    m_tree->Branch("missurfcenterz", &m_missurfcenterz);
+    m_tree->Branch("missurfnormx", &m_missurfnormx);
+    m_tree->Branch("missurfnormy", &m_missurfnormy);
+    m_tree->Branch("missurfnormz", &m_missurfnormz);
+    m_tree->Branch("clusgxideal", &m_clusgxideal);
+    m_tree->Branch("clusgyideal", &m_clusgyideal);
+    m_tree->Branch("clusgzideal", &m_clusgzideal);
+    m_tree->Branch("missurfalpha", &m_missurfalpha);
+    m_tree->Branch("missurfbeta", &m_missurfbeta);
+    m_tree->Branch("missurfgamma", &m_missurfgamma);
+    m_tree->Branch("idealsurfalpha", &m_idealsurfalpha);
+    m_tree->Branch("idealsurfbeta", &m_idealsurfbeta);
+    m_tree->Branch("idealsurfgamma", &m_idealsurfgamma);
   }
 
   m_tree->Branch("statelx", &m_statelx);
@@ -1803,34 +1802,34 @@ void TrackResiduals::createBranches()
   m_tree->Branch("statepy", &m_statepy);
   m_tree->Branch("statepz", &m_statepz);
   m_tree->Branch("statepl", &m_statepl);
-  
-  if(m_doAlignment)
+
+  if (m_doAlignment)
   {
-  m_tree->Branch("statelxglobderivdx", &m_statelxglobderivdx);
-  m_tree->Branch("statelxglobderivdy", &m_statelxglobderivdy);
-  m_tree->Branch("statelxglobderivdz", &m_statelxglobderivdz);
-  m_tree->Branch("statelxglobderivdalpha", &m_statelxglobderivdalpha);
-  m_tree->Branch("statelxglobderivdbeta", &m_statelxglobderivdbeta);
-  m_tree->Branch("statelxglobderivdgamma", &m_statelxglobderivdgamma);
+    m_tree->Branch("statelxglobderivdx", &m_statelxglobderivdx);
+    m_tree->Branch("statelxglobderivdy", &m_statelxglobderivdy);
+    m_tree->Branch("statelxglobderivdz", &m_statelxglobderivdz);
+    m_tree->Branch("statelxglobderivdalpha", &m_statelxglobderivdalpha);
+    m_tree->Branch("statelxglobderivdbeta", &m_statelxglobderivdbeta);
+    m_tree->Branch("statelxglobderivdgamma", &m_statelxglobderivdgamma);
 
-  m_tree->Branch("statelxlocderivd0", &m_statelxlocderivd0);
-  m_tree->Branch("statelxlocderivz0", &m_statelxlocderivz0);
-  m_tree->Branch("statelxlocderivphi", &m_statelxlocderivphi);
-  m_tree->Branch("statelxlocderivtheta", &m_statelxlocderivtheta);
-  m_tree->Branch("statelxlocderivqop", &m_statelxlocderivqop);
+    m_tree->Branch("statelxlocderivd0", &m_statelxlocderivd0);
+    m_tree->Branch("statelxlocderivz0", &m_statelxlocderivz0);
+    m_tree->Branch("statelxlocderivphi", &m_statelxlocderivphi);
+    m_tree->Branch("statelxlocderivtheta", &m_statelxlocderivtheta);
+    m_tree->Branch("statelxlocderivqop", &m_statelxlocderivqop);
 
-  m_tree->Branch("statelzglobderivdx", &m_statelzglobderivdx);
-  m_tree->Branch("statelzglobderivdy", &m_statelzglobderivdy);
-  m_tree->Branch("statelzglobderivdz", &m_statelzglobderivdz);
-  m_tree->Branch("statelzglobderivdalpha", &m_statelzglobderivdalpha);
-  m_tree->Branch("statelzglobderivdbeta", &m_statelzglobderivdbeta);
-  m_tree->Branch("statelzglobderivdgamma", &m_statelzglobderivdgamma);
+    m_tree->Branch("statelzglobderivdx", &m_statelzglobderivdx);
+    m_tree->Branch("statelzglobderivdy", &m_statelzglobderivdy);
+    m_tree->Branch("statelzglobderivdz", &m_statelzglobderivdz);
+    m_tree->Branch("statelzglobderivdalpha", &m_statelzglobderivdalpha);
+    m_tree->Branch("statelzglobderivdbeta", &m_statelzglobderivdbeta);
+    m_tree->Branch("statelzglobderivdgamma", &m_statelzglobderivdgamma);
 
-  m_tree->Branch("statelzlocderivd0", &m_statelzlocderivd0);
-  m_tree->Branch("statelzlocderivz0", &m_statelzlocderivz0);
-  m_tree->Branch("statelzlocderivphi", &m_statelzlocderivphi);
-  m_tree->Branch("statelzlocderivtheta", &m_statelzlocderivtheta);
-  m_tree->Branch("statelzlocderivqop", &m_statelzlocderivqop);
+    m_tree->Branch("statelzlocderivd0", &m_statelzlocderivd0);
+    m_tree->Branch("statelzlocderivz0", &m_statelzlocderivz0);
+    m_tree->Branch("statelzlocderivphi", &m_statelzlocderivphi);
+    m_tree->Branch("statelzlocderivtheta", &m_statelzlocderivtheta);
+    m_tree->Branch("statelzlocderivqop", &m_statelzlocderivqop);
   }
 }
 
@@ -1992,7 +1991,7 @@ void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)
       auto cluster = clustermap->findCluster(ckey);
 
       // Fully correct the cluster positions for the crossing and all distortions
-      Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, m_crossing );
+      Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, m_crossing);
 
       // add the global positions to a vector to give to the cluster mover
       global_raw.emplace_back(std::make_pair(ckey, global));
@@ -2349,7 +2348,7 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
       auto cluster = clustermap->findCluster(ckey);
 
       // Fully correct the cluster positions for the crossing and all distortions
-      Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, m_crossing );
+      Acts::Vector3 global = m_globalPositionWrapper.getGlobalPositionDistortionCorrected(ckey, cluster, m_crossing);
 
       // add the global positions to a vector to give to the cluster mover
       global_raw.emplace_back(std::make_pair(ckey, global));
@@ -2437,11 +2436,15 @@ void TrackResiduals::fillResidualTreeSeeds(PHCompositeNode* topNode)
         }
       }
     }
-    if(!m_doMatchedOnly){
+    if (!m_doMatchedOnly)
+    {
       m_tree->Fill();
-    }else{
-      if(m_nmaps>=3&&m_nintt>=1&&m_ntpc>32&&abs(m_crossing)<5&&m_pt>0.3){
-	m_tree->Fill();
+    }
+    else
+    {
+      if (m_nmaps >= 3 && m_nintt >= 1 && m_ntpc > 32 && abs(m_crossing) < 5 && m_pt > 0.3)
+      {
+        m_tree->Fill();
       }
     }
   }

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -1563,7 +1563,6 @@ void TrackResiduals::createBranches()
     m_eventtree = new TTree("eventtree", "A tree with all hits");
     m_eventtree->Branch("run", &m_runnumber, "m_runnumber/I");
     m_eventtree->Branch("segment", &m_segment, "m_segment/I");
-    m_eventtree->Branch("job", &m_job, "m_job/I");
     m_eventtree->Branch("event", &m_event, "m_event/I");
     m_eventtree->Branch("gl1bco", &m_bco, "m_bco/I");
     m_eventtree->Branch("nmvtx", &m_nmvtx_all, "m_nmvtx_all/I");
@@ -1581,7 +1580,6 @@ void TrackResiduals::createBranches()
   m_failedfits = new TTree("failedfits", "tree with seeds from failed Acts fits");
   m_failedfits->Branch("run", &m_runnumber, "m_runnumber/I");
   m_failedfits->Branch("segment", &m_segment, "m_segment/I");
-  m_failedfits->Branch("job", &m_job, "m_job/I");
   m_failedfits->Branch("trackid", &m_trackid, "m_trackid/I");
   m_failedfits->Branch("event", &m_event, "m_event/I");
   m_failedfits->Branch("silseedx", &m_silseedx, "m_silseedx/F");
@@ -1609,7 +1607,6 @@ void TrackResiduals::createBranches()
   m_vertextree = new TTree("vertextree", "tree with vertices");
   m_vertextree->Branch("run", &m_runnumber, "m_runnumber/I");
   m_vertextree->Branch("segment", &m_segment, "m_segment/I");
-  m_vertextree->Branch("job", &m_job, "m_job/I");
   m_vertextree->Branch("event", &m_event, "m_event/I");
   m_vertextree->Branch("firedTriggers", &m_firedTriggers);
   m_vertextree->Branch("gl1BunchCrossing", &m_gl1BunchCrossing, "m_gl1BunchCrossing/l");
@@ -1630,10 +1627,8 @@ void TrackResiduals::createBranches()
   m_hittree = new TTree("hittree", "A tree with all hits");
   m_hittree->Branch("run", &m_runnumber, "m_runnumber/I");
   m_hittree->Branch("segment", &m_segment, "m_segment/I");
-  m_hittree->Branch("job", &m_job, "m_job/I");
   m_hittree->Branch("event", &m_event, "m_event/I");
   m_hittree->Branch("gl1bco", &m_bco, "m_bco/l");
-  m_hittree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_hittree->Branch("hitsetkey", &m_hitsetkey, "m_hitsetkey/i");
   m_hittree->Branch("gx", &m_hitgx, "m_hitgx/F");
   m_hittree->Branch("gy", &m_hitgy, "m_hitgy/F");
@@ -1660,40 +1655,26 @@ void TrackResiduals::createBranches()
   m_clustree = new TTree("clustertree", "A tree with all clusters");
   m_clustree->Branch("run", &m_runnumber, "m_runnumber/I");
   m_clustree->Branch("segment", &m_segment, "m_segment/I");
-  m_clustree->Branch("job", &m_job, "m_job/I");
   m_clustree->Branch("event", &m_event, "m_event/I");
   m_clustree->Branch("gl1bco", &m_bco, "m_bco/l");
-  m_clustree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_clustree->Branch("lx", &m_scluslx, "m_scluslx/F");
   m_clustree->Branch("lz", &m_scluslz, "m_scluslz/F");
   m_clustree->Branch("gx", &m_sclusgx, "m_sclusgx/F");
   m_clustree->Branch("gy", &m_sclusgy, "m_sclusgy/F");
   m_clustree->Branch("gz", &m_sclusgz, "m_sclusgz/F");
-  m_clustree->Branch("r", &m_sclusgr, "m_sclusgr/F");
   m_clustree->Branch("phi", &m_sclusphi, "m_sclusphi/F");
   m_clustree->Branch("eta", &m_scluseta, "m_scluseta/F");
   m_clustree->Branch("adc", &m_adc, "m_adc/F");
   m_clustree->Branch("phisize", &m_phisize, "m_phisize/I");
   m_clustree->Branch("zsize", &m_zsize, "m_zsize/I");
-  m_clustree->Branch("layer", &m_scluslayer, "m_scluslayer/I");
   m_clustree->Branch("erphi", &m_scluselx, "m_scluselx/F");
   m_clustree->Branch("ez", &m_scluselz, "m_scluselz/F");
   m_clustree->Branch("maxadc", &m_clusmaxadc, "m_clusmaxadc/F");
-  m_clustree->Branch("sector", &m_clussector, "m_clussector/I");
-  m_clustree->Branch("side", &m_side, "m_side/I");
-  m_clustree->Branch("stave", &m_staveid, "m_staveid/I");
-  m_clustree->Branch("chip", &m_chipid, "m_chipid/I");
-  m_clustree->Branch("strobe", &m_strobeid, "m_strobeid/I");
-  m_clustree->Branch("ladderz", &m_ladderzid, "m_ladderzid/I");
-  m_clustree->Branch("ladderphi", &m_ladderphiid, "m_ladderphiid/I");
-  m_clustree->Branch("timebucket", &m_timebucket, "m_timebucket/I");
-  m_clustree->Branch("segtype", &m_segtype, "m_segtype/I");
-  m_clustree->Branch("tile", &m_tileid, "m_tileid/I");
-
+  m_clustree->Branch("hitsetkey", &m_hitsetkey, "m_hitsetkey/i");
+  
   m_tree = new TTree("residualtree", "A tree with track, cluster, and state info");
   m_tree->Branch("run", &m_runnumber, "m_runnumber/I");
   m_tree->Branch("segment", &m_segment, "m_segment/I");
-  m_tree->Branch("job", &m_job, "m_job/I");
   m_tree->Branch("event", &m_event, "m_event/I");
   m_tree->Branch("firedTriggers", &m_firedTriggers);
   m_tree->Branch("gl1BunchCrossing", &m_gl1BunchCrossing, "m_gl1BunchCrossing/l");
@@ -1701,7 +1682,6 @@ void TrackResiduals::createBranches()
   m_tree->Branch("tpcid", &m_tpcid, "m_tpcid/I");
   m_tree->Branch("silid", &m_silid, "m_silid/I");
   m_tree->Branch("gl1bco", &m_bco, "m_bco/l");
-  m_tree->Branch("trbco", &m_bcotr, "m_bcotr/l");
   m_tree->Branch("crossing", &m_crossing, "m_crossing/I");
   m_tree->Branch("crossing_estimate", &m_crossing_estimate, "m_crossing_estimate/I");
   m_tree->Branch("silseedx", &m_silseedx, "m_silseedx/F");

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.cc
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.cc
@@ -186,8 +186,6 @@ void TrackResiduals::clearClusterStateVectors()
   m_clusAdc.clear();
   m_clusMaxAdc.clear();
   m_cluslayer.clear();
-  m_clussize.clear();
-  m_clushitsetkey.clear();
 
   m_statelx.clear();
   m_statelz.clear();
@@ -283,8 +281,10 @@ int TrackResiduals::process_event(PHCompositeNode* topNode)
     fillResidualTreeKF(topNode);
   }
 
-  fillVertexTree(topNode);
-
+  if(m_doVertex)
+  {
+    fillVertexTree(topNode);
+  }
   if (m_doEventTree)
   {
     fillEventTree(topNode);
@@ -752,8 +752,14 @@ int TrackResiduals::End(PHCompositeNode* /*unused*/)
   {
     m_hittree->Write();
   }
-  m_vertextree->Write();
-  m_failedfits->Write();
+  if(m_doVertex)
+  {
+    m_vertextree->Write();
+  }
+  if(m_doFailedSeeds)
+  {
+    m_failedfits->Write();
+  }
   if (m_doEventTree)
   {
     m_eventtree->Write();
@@ -1149,8 +1155,6 @@ void TrackResiduals::fillClusterBranchesKF(TrkrDefs::cluskey ckey, SvtxTrack* tr
   m_cluslayer.push_back(TrkrDefs::getLayer(ckey));
   m_clusphisize.push_back(cluster->getPhiSize());
   m_cluszsize.push_back(cluster->getZSize());
-  m_clussize.push_back(cluster->getPhiSize() * cluster->getZSize());
-  m_clushitsetkey.push_back(TrkrDefs::getHitSetKeyFromClusKey(ckey));
 
 	
   auto misaligncenter = surf->center(geometry->geometry().getGeoContext());
@@ -1394,8 +1398,6 @@ void TrackResiduals::fillClusterBranchesSeeds(TrkrDefs::cluskey ckey,  // SvtxTr
   m_cluslayer.push_back(TrkrDefs::getLayer(ckey));
   m_clusphisize.push_back(cluster->getPhiSize());
   m_cluszsize.push_back(cluster->getZSize());
-  m_clussize.push_back(cluster->getPhiSize() * cluster->getZSize());
-  m_clushitsetkey.push_back(TrkrDefs::getHitSetKeyFromClusKey(ckey));
 
   if (Verbosity() > 1)
   {
@@ -1762,7 +1764,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("Y0", &m_Y0, "m_Y0/F");
   m_tree->Branch("dcaxy", &m_dcaxy, "m_dcaxy/F");
   m_tree->Branch("dcaz", &m_dcaz, "m_dcaz/F");
-
+  
   m_tree->Branch("cluskeys", &m_cluskeys);
   m_tree->Branch("clusedge", &m_clusedge);
   m_tree->Branch("clusoverlap", &m_clusoverlap);
@@ -1774,19 +1776,20 @@ void TrackResiduals::createBranches()
   m_tree->Branch("clusgy", &m_clusgy);
   m_tree->Branch("clusgz", &m_clusgz);
   m_tree->Branch("clusgr", &m_clusgr);
+  if(m_doAlignment)
+  {
   m_tree->Branch("clusgxunmoved", &m_clusgxunmoved);
   m_tree->Branch("clusgyunmoved", &m_clusgyunmoved);
   m_tree->Branch("clusgzunmoved", &m_clusgzunmoved);
-  m_tree->Branch("clussector", &m_clsector);
-  m_tree->Branch("clusside", &m_clside);
+  }
   m_tree->Branch("clusAdc", &m_clusAdc);
   m_tree->Branch("clusMaxAdc", &m_clusMaxAdc);
-  m_tree->Branch("cluslayer", &m_cluslayer);
-  m_tree->Branch("clussize", &m_clussize);
   m_tree->Branch("clusphisize", &m_clusphisize);
   m_tree->Branch("cluszsize", &m_cluszsize);
-  m_tree->Branch("clushitsetkey", &m_clushitsetkey);
-  m_tree->Branch("idealsurfcenterx", &m_idealsurfcenterx);
+  
+  if(m_doAlignment)
+  {
+      m_tree->Branch("idealsurfcenterx", &m_idealsurfcenterx);
   m_tree->Branch("idealsurfcentery", &m_idealsurfcentery);
   m_tree->Branch("idealsurfcenterz", &m_idealsurfcenterz);
   m_tree->Branch("idealsurfnormx", &m_idealsurfnormx);
@@ -1807,6 +1810,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("idealsurfalpha", &m_idealsurfalpha);
   m_tree->Branch("idealsurfbeta", &m_idealsurfbeta);
   m_tree->Branch("idealsurfgamma", &m_idealsurfgamma);
+  }
 
   m_tree->Branch("statelx", &m_statelx);
   m_tree->Branch("statelz", &m_statelz);
@@ -1819,7 +1823,9 @@ void TrackResiduals::createBranches()
   m_tree->Branch("statepy", &m_statepy);
   m_tree->Branch("statepz", &m_statepz);
   m_tree->Branch("statepl", &m_statepl);
-
+  
+  if(m_doAlignment)
+  {
   m_tree->Branch("statelxglobderivdx", &m_statelxglobderivdx);
   m_tree->Branch("statelxglobderivdy", &m_statelxglobderivdy);
   m_tree->Branch("statelxglobderivdz", &m_statelxglobderivdz);
@@ -1845,6 +1851,7 @@ void TrackResiduals::createBranches()
   m_tree->Branch("statelzlocderivphi", &m_statelzlocderivphi);
   m_tree->Branch("statelzlocderivtheta", &m_statelzlocderivtheta);
   m_tree->Branch("statelzlocderivqop", &m_statelzlocderivqop);
+  }
 }
 
 void TrackResiduals::fillResidualTreeKF(PHCompositeNode* topNode)

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -48,8 +48,8 @@ class TrackResiduals : public SubsysReco
   void clusterTree() { m_doClusters = true; }
   void vertexTree() { m_doVertex = true; }
   void hitTree() { m_doHits = true; }
-  void eventTree() {m_doEventTree = true;}
-  void MatchedTracksOnly() {m_doMatchedOnly = true;}
+  void eventTree() { m_doEventTree = true; }
+  void MatchedTracksOnly() { m_doMatchedOnly = true; }
   void ppmode() { m_ppmode = true; }
   void convertSeeds(bool flag) { m_convertSeeds = flag; }
   void dropClustersNoState(bool flag) { m_dropClustersNoState = flag; }
@@ -61,11 +61,11 @@ class TrackResiduals : public SubsysReco
   void failedTree() { m_doFailedSeeds = true; }
   void setSegment(const int segment) { m_segment = segment; }
 
-  void set_doMicromegasOnly( bool value ) { m_doMicromegasOnly = value; }
-  void setTrkrClusterContainerName(std::string &name){ m_clusterContainerName = name; }
+  void set_doMicromegasOnly(bool value) { m_doMicromegasOnly = value; }
+  void setTrkrClusterContainerName(std::string &name) { m_clusterContainerName = name; }
 
   void set_use_clustermover(bool flag) { m_use_clustermover = flag; }
-  
+
  private:
   void fillStatesWithLineFit(const TrkrDefs::cluskey &ckey,
                              TrkrCluster *cluster, ActsGeometry *geometry);
@@ -94,7 +94,7 @@ class TrackResiduals : public SubsysReco
   float calc_dedx(TrackSeed *tpcseed, TrkrClusterContainer *clusters, PHG4TpcCylinderGeomContainer *tpcGeom);
 
   bool m_use_clustermover = true;
-  
+
   std::string m_outfileName = "";
   TFile *m_outfile = nullptr;
   TTree *m_tree = nullptr;
@@ -144,9 +144,9 @@ class TrackResiduals : public SubsysReco
   int m_ntpc_hits1 = std::numeric_limits<int>::quiet_NaN();
   int m_ntpc_clus0 = std::numeric_limits<int>::quiet_NaN();
   int m_ntpc_clus1 = std::numeric_limits<int>::quiet_NaN();
-  int m_nmms_all  = std::numeric_limits<int>::quiet_NaN();
-  int m_nsiseed   = std::numeric_limits<int>::quiet_NaN();
-  int m_ntpcseed  = std::numeric_limits<int>::quiet_NaN();
+  int m_nmms_all = std::numeric_limits<int>::quiet_NaN();
+  int m_nsiseed = std::numeric_limits<int>::quiet_NaN();
+  int m_ntpcseed = std::numeric_limits<int>::quiet_NaN();
   int m_ntracks_all = std::numeric_limits<int>::quiet_NaN();
 
   //! Track level quantities

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -56,7 +56,6 @@ class TrackResiduals : public SubsysReco
   void zeroField() { m_zeroField = true; }
   void runnumber(const int run) { m_runnumber = run; }
   void segment(const int seg) { m_segment = seg; }
-  void job(const int job) { m_job = job; }
   void linefitAll() { m_linefitTPCOnly = false; }
   void setClusterMinSize(unsigned int size) { m_min_cluster_size = size; }
   void failedTree() { m_doFailedSeeds = true; }
@@ -133,7 +132,6 @@ class TrackResiduals : public SubsysReco
   int m_event = 0;
   int m_segment = std::numeric_limits<int>::quiet_NaN();
   int m_runnumber = std::numeric_limits<int>::quiet_NaN();
-  int m_job = std::numeric_limits<int>::quiet_NaN();
   int m_ntpcclus = std::numeric_limits<int>::quiet_NaN();
 
   std::vector<int> m_firedTriggers;

--- a/offline/packages/TrackingDiagnostics/TrackResiduals.h
+++ b/offline/packages/TrackingDiagnostics/TrackResiduals.h
@@ -46,8 +46,9 @@ class TrackResiduals : public SubsysReco
   void alignmentmapName(const std::string &name) { m_alignmentMapName = name; }
   void trackmapName(const std::string &name) { m_trackMapName = name; }
   void clusterTree() { m_doClusters = true; }
+  void vertexTree() { m_doVertex = true; }
   void hitTree() { m_doHits = true; }
-  void noEventTree() {m_doEventTree = false;}
+  void eventTree() {m_doEventTree = true;}
   void MatchedTracksOnly() {m_doMatchedOnly = true;}
   void ppmode() { m_ppmode = true; }
   void convertSeeds(bool flag) { m_convertSeeds = flag; }
@@ -104,9 +105,10 @@ class TrackResiduals : public SubsysReco
   TTree *m_vertextree = nullptr;
   TTree *m_failedfits = nullptr;
 
+  bool m_doVertex = false;
   bool m_doClusters = false;
   bool m_doHits = false;
-  bool m_doEventTree = true;
+  bool m_doEventTree = false;
   bool m_zeroField = false;
   bool m_doFailedSeeds = false;
   bool m_doMatchedOnly = false;
@@ -281,12 +283,10 @@ class TrackResiduals : public SubsysReco
   std::vector<int> m_clsector;
   std::vector<int> m_clside;
   std::vector<int> m_cluslayer;
-  std::vector<int> m_clussize;
   std::vector<int> m_clusphisize;
   std::vector<int> m_cluszsize;
   std::vector<int> m_clusedge;
   std::vector<int> m_clusoverlap;
-  std::vector<uint32_t> m_clushitsetkey;
   std::vector<uint64_t> m_cluskeys;
   std::vector<float> m_idealsurfcenterx;
   std::vector<float> m_idealsurfcentery;


### PR DESCRIPTION
This removes some branches from the TrackResiduals trees, and hides some others behind additional flags for expert use. It reduces the size of the residualtree by about 50%. Unfortunately the cluster tree is still large, which I think is just a result of there being so many clusters

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

