### PR TITLE
Fixed filling thedistortion matrices.

### DIFF
--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -558,9 +558,9 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     }
 
     // Fill distortion matrices
-    m_matrix_container->add_to_lhs(index, 0, 0, clusR / erp);
+    m_matrix_container->add_to_lhs(index, 0, 0, square(clusR) / erp);
     m_matrix_container->add_to_lhs(index, 0, 1, 0);
-    m_matrix_container->add_to_lhs(index, 0, 2, trackAlpha / erp);
+    m_matrix_container->add_to_lhs(index, 0, 2, clusR*trackAlpha / erp);
 
     m_matrix_container->add_to_lhs(index, 1, 0, 0);
     m_matrix_container->add_to_lhs(index, 1, 1, 1. / ez);
@@ -570,7 +570,7 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     m_matrix_container->add_to_lhs(index, 2, 1, trackBeta / ez);
     m_matrix_container->add_to_lhs(index, 2, 2, square(trackAlpha) / erp + square(trackBeta) / ez);
 
-    m_matrix_container->add_to_rhs(index, 0, drphi / erp);
+    m_matrix_container->add_to_rhs(index, 0, clusR*drphi / erp);
     m_matrix_container->add_to_rhs(index, 1, dz / ez);
     m_matrix_container->add_to_rhs(index, 2, trackAlpha * drphi / erp + trackBeta * dz / ez);
 

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -644,9 +644,9 @@ void TpcSpaceChargeReconstruction::process_track(SvtxTrack* track)
 
     // update matrices
     // see https://indico.bnl.gov/event/7440/contributions/43328/attachments/31334/49446/talk.pdf for details
-    m_matrix_container->add_to_lhs(i, 0, 0, cluster_r / erp);
+    m_matrix_container->add_to_lhs(i, 0, 0, square(cluster_r) / erp);
     m_matrix_container->add_to_lhs(i, 0, 1, 0);
-    m_matrix_container->add_to_lhs(i, 0, 2, talpha / erp);
+    m_matrix_container->add_to_lhs(i, 0, 2, cluster_r*talpha / erp);
 
     m_matrix_container->add_to_lhs(i, 1, 0, 0);
     m_matrix_container->add_to_lhs(i, 1, 1, 1. / ez);
@@ -656,7 +656,7 @@ void TpcSpaceChargeReconstruction::process_track(SvtxTrack* track)
     m_matrix_container->add_to_lhs(i, 2, 1, tbeta / ez);
     m_matrix_container->add_to_lhs(i, 2, 2, square(talpha) / erp + square(tbeta) / ez);
 
-    m_matrix_container->add_to_rhs(i, 0, drp / erp);
+    m_matrix_container->add_to_rhs(i, 0, cluster_r*drp / erp);
     m_matrix_container->add_to_rhs(i, 1, dz / ez);
     m_matrix_container->add_to_rhs(i, 2, talpha * drp / erp + tbeta * dz / ez);
 


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
A bug was introduce in the distortion matrices calculation when switching from using rdelta_phi as a parameter to delta_phi.
This resulted in the matrix not being symetric (though still invertible).
Now fixed.

@xyu3
Unfortunately it means that you would need to regenerate such matrices and the corresponding inversion. 
Hopefully this should stabilize somewhat the calculation of delta_r.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

