### PR TITLE
Mvtx qa fix

### DIFF
--- a/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationMvtx.cc
@@ -349,13 +349,20 @@ QAG4SimulationMvtx::G4HitSet QAG4SimulationMvtx::find_g4hits(TrkrDefs::cluskey c
 {
   // find hitset associated to cluster
   G4HitSet out;
+
   const auto hitset_key = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
+  // get detector id
+  const auto trkrId = TrkrDefs::getTrkrId(hitset_key);
+
   /*
+   * for MVTX,
    * also get bare (== strobe 0) hitsetkey,
    * since this is the one recorded in the HitTruth association map
    */
-  const auto bare_hitset_key = MvtxDefs::resetStrobe(hitset_key);
+  const auto bare_hitset_key =
+    trkrId ==  TrkrDefs::TrkrId::mvtxId ?
+    MvtxDefs::resetStrobe(hitset_key):hitset_key;
 
   // loop over hits associated to clusters
   const auto range = m_cluster_hit_map->getHits(cluster_key);

--- a/offline/QA/SimulationModules/QAG4SimulationTracking.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTracking.cc
@@ -764,11 +764,17 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
   G4HitSet out;
   const auto hitset_key = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
+  // get detector id
+  const auto trkrId = TrkrDefs::getTrkrId(hitset_key);
+
   /*
+   * for MVTX,
    * also get bare (== strobe 0) hitsetkey,
    * since this is the one recorded in the HitTruth association map
    */
-  const auto bare_hitset_key = MvtxDefs::resetStrobe(hitset_key);
+  const auto bare_hitset_key =
+    trkrId ==  TrkrDefs::TrkrId::mvtxId ?
+    MvtxDefs::resetStrobe(hitset_key):hitset_key;
 
   // loop over hits associated to clusters
   const auto range = m_cluster_hit_map->getHits(cluster_key);

--- a/offline/QA/SimulationModules/QAG4SimulationTracking.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTracking.cc
@@ -10,6 +10,7 @@
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4TruthInfoContainer.h>
 
+#include <trackbase/MvtxDefs.h>
 #include <trackbase/TrkrClusterContainer.h>
 #include <trackbase/TrkrClusterHitAssoc.h>
 #include <trackbase/TrkrDefs.h>  // for cluskey, getLayer
@@ -45,6 +46,7 @@
 #include <set>
 #include <string>
 #include <utility>  // for pair
+
 
 QAG4SimulationTracking::QAG4SimulationTracking(const std::string &name)
   : SubsysReco(name)
@@ -313,7 +315,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
   // clusters per layer and per generated track
   auto h_nClus_layerGen = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "nClus_layerGen"));
-  assert(h_nClus_layer);
+  assert(h_nClus_layerGen);
 
   // n events and n tracks histogram
   TH1 *h_norm = dynamic_cast<TH1 *>(hm->getHisto(get_histo_prefix() + "Normalization"));
@@ -752,6 +754,9 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
   G4HitSet out;
   const auto hitset_key = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
+  // also get bare (== strobe 0) hitsetkey, since this is the one recorded in the HitTruth association map
+  const auto bare_hitset_key = MvtxDefs::resetStrobe(hitset_key);
+
   // loop over hits associated to clusters
   const auto range = m_cluster_hit_map->getHits(cluster_key);
   for (auto iter = range.first; iter != range.second; ++iter)
@@ -761,7 +766,7 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
 
     // store hits to g4hit associations
     TrkrHitTruthAssoc::MMap g4hit_map;
-    m_hit_truth_map->getG4Hits(hitset_key, hit_key, g4hit_map);
+    m_hit_truth_map->getG4Hits(bare_hitset_key, hit_key, g4hit_map);
 
     // find corresponding g4 hist
     for (auto &truth_iter : g4hit_map)

--- a/offline/QA/SimulationModules/QAG4SimulationTracking.cc
+++ b/offline/QA/SimulationModules/QAG4SimulationTracking.cc
@@ -558,7 +558,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
 
     // loop over clusters associated to this G4Particle
     {
-      const auto mapIter = g4particle_map.find(iter->first);
+      const auto mapIter = g4particle_map.find(key);
       if (mapIter != g4particle_map.cend())
       {
         for (const auto &cluster_key : mapIter->second)
@@ -568,7 +568,7 @@ int QAG4SimulationTracking::process_event(PHCompositeNode *topNode)
       }
       else if (Verbosity())
       {
-        std::cout << "QAG4SimulationTracking::process_event - could nof find clusters associated to G4Particle " << iter->first << std::endl;
+        std::cout << "QAG4SimulationTracking::process_event - could nof find clusters associated to G4Particle " << key << std::endl;
       }
     }
     // look for best matching track in reco data & get its information
@@ -764,8 +764,8 @@ QAG4SimulationTracking::G4HitSet QAG4SimulationTracking::find_g4hits(TrkrDefs::c
   G4HitSet out;
   const auto hitset_key = TrkrDefs::getHitSetKeyFromClusKey(cluster_key);
 
-  /* 
-   * also get bare (== strobe 0) hitsetkey, 
+  /*
+   * also get bare (== strobe 0) hitsetkey,
    * since this is the one recorded in the HitTruth association map
    */
   const auto bare_hitset_key = MvtxDefs::resetStrobe(hitset_key);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)

This PR fixes the MVTX QA (and some Tracking QA plots), by reseting the MVTX strobe id from the MVTX hitsetkey, before looking for associated G4Hits, consistently with how TrkrHitTruthAssoc is filled in PHG4MvtxHitReco.

This 'fixes' several QA plots, which got altered after removing the MvtxHitPrunner from the reconstruction chain.
In fact one now has on average 2 MVTX clusters per layer and G4Particle, as a result as the hit (and cluster) duplication across strobes. 
This was previously masked by the MVTXHitPruner, and should now be addressed by the MVTXClusterPrunner.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

