### PR TITLE
Matrix inversion extension

### DIFF
--- a/offline/packages/tpccalib/Makefile.am
+++ b/offline/packages/tpccalib/Makefile.am
@@ -41,6 +41,7 @@ pkginclude_HEADERS = \
   TpcDirectLaserReconstruction.h \
   TpcSpaceChargeMatrixContainer.h \
   TpcSpaceChargeMatrixContainerv1.h \
+  TpcSpaceChargeMatrixContainerv2.h \
   TpcSpaceChargeMatrixInversion.h \
   TpcSpaceChargeReconstruction.h \
   TpcSpaceChargeReconstructionHelper.h \
@@ -51,16 +52,19 @@ pkginclude_HEADERS = \
 
 ROOTDICTS = \
   TpcSpaceChargeMatrixContainer_Dict.cc \
-  TpcSpaceChargeMatrixContainerv1_Dict.cc
+  TpcSpaceChargeMatrixContainerv1_Dict.cc \
+  TpcSpaceChargeMatrixContainerv2_Dict.cc
 
 pcmdir = $(libdir)
 nobase_dist_pcm_DATA = \
   TpcSpaceChargeMatrixContainer_Dict_rdict.pcm \
-  TpcSpaceChargeMatrixContainerv1_Dict_rdict.pcm
+  TpcSpaceChargeMatrixContainerv1_Dict_rdict.pcm \
+  TpcSpaceChargeMatrixContainerv2_Dict_rdict.pcm
 
 libtpccalib_io_la_SOURCES = \
   $(ROOTDICTS) \
-  TpcSpaceChargeMatrixContainerv1.cc
+  TpcSpaceChargeMatrixContainerv1.cc \
+  TpcSpaceChargeMatrixContainerv2.cc
 
 libtpccalib_la_SOURCES = \
   TpcDirectLaserReconstruction.cc \

--- a/offline/packages/tpccalib/PHTpcResiduals.cc
+++ b/offline/packages/tpccalib/PHTpcResiduals.cc
@@ -1,5 +1,5 @@
 #include "PHTpcResiduals.h"
-#include "TpcSpaceChargeMatrixContainerv1.h"
+#include "TpcSpaceChargeMatrixContainerv2.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHCompositeNode.h>
@@ -128,7 +128,7 @@ namespace
 //___________________________________________________________________________________
 PHTpcResiduals::PHTpcResiduals(const std::string& name)
   : SubsysReco(name)
-  , m_matrix_container(new TpcSpaceChargeMatrixContainerv1)
+  , m_matrix_container(new TpcSpaceChargeMatrixContainerv2)
 {
 }
 
@@ -573,6 +573,24 @@ void PHTpcResiduals::processTrack(SvtxTrack* track)
     m_matrix_container->add_to_rhs(index, 0, clusR*drphi / erp);
     m_matrix_container->add_to_rhs(index, 1, dz / ez);
     m_matrix_container->add_to_rhs(index, 2, trackAlpha * drphi / erp + trackBeta * dz / ez);
+
+    // also update rphi reduced matrices
+    m_matrix_container->add_to_lhs_rphi(index, 0, 0, square(clusR) / erp);
+    m_matrix_container->add_to_lhs_rphi(index, 0, 1, clusR*trackAlpha / erp);
+    m_matrix_container->add_to_lhs_rphi(index, 1, 0, clusR * trackAlpha / erp);
+    m_matrix_container->add_to_lhs_rphi(index, 1, 1, square(trackAlpha) / erp);
+
+    m_matrix_container->add_to_rhs_rphi(index, 0, clusR*drphi / erp);
+    m_matrix_container->add_to_rhs_rphi(index, 1, trackAlpha * drphi / erp);
+
+    // also update z reduced matrices
+    m_matrix_container->add_to_lhs_z(index, 0, 0, 1. / ez);
+    m_matrix_container->add_to_lhs_z(index, 0, 1, trackBeta / ez);
+    m_matrix_container->add_to_lhs_z(index, 1, 0, trackBeta / ez);
+    m_matrix_container->add_to_lhs_z(index, 1, 1, square(trackBeta) / ez);
+
+    m_matrix_container->add_to_rhs_z(index, 0, dz / ez);
+    m_matrix_container->add_to_rhs_z(index, 1, trackBeta * dz / ez);
 
     // update entries in cell
     m_matrix_container->add_to_entries(index);

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainer.h
@@ -57,6 +57,22 @@ class TpcSpaceChargeMatrixContainer : public PHObject
   virtual float get_rhs( int /*cell_index*/, int /*i*/ ) const
   { return 0; }
 
+  /// get reduced rphi left hand side
+  virtual float get_lhs_rphi( int /*cell_index*/, int /*i*/, int /*j*/ ) const
+  { return 0; }
+
+  /// get reduced rphi right hand side
+  virtual float get_rhs_rphi(int /*cell_index*/, int /*i*/ ) const
+  { return 0; }
+
+  /// get reduced z left hand side
+  virtual float get_lhs_z( int /*cell_index*/, int /*i*/, int /*j*/ ) const
+  { return 0; }
+
+  /// get reduced z right hand side
+  virtual float get_rhs_z(int /*cell_index*/, int /*i*/ ) const
+  { return 0; }
+
   //@}
 
   ///@name modifiers
@@ -88,6 +104,22 @@ class TpcSpaceChargeMatrixContainer : public PHObject
 
   /// increment right hand side column
   virtual void add_to_rhs( int /*cell_index*/, int /*i*/, float /*value*/ )
+  {}
+
+  /// increment left hand side reduced rphi matrix
+  virtual void add_to_lhs_rphi( int /*cell_index*/, int /*i*/, int /*j*/, float /*value*/ )
+  {}
+
+  /// increment right hand side reduced rphi column
+  virtual void add_to_rhs_rphi( int /*cell_index*/, int /*i*/, float /*value*/)
+  {}
+
+  /// increment left hand side reduced rphi matrix
+  virtual void add_to_lhs_z( int /*cell_index*/, int /*i*/, int /*j*/, float /*value*/ )
+  {}
+
+  /// increment right hand side reduced rphi column
+  virtual void add_to_rhs_z(int /*cell_index*/, int /*i*/, float /*value*/)
   {}
 
   /// add content from other container, returns true on success

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
@@ -1,0 +1,390 @@
+
+/**
+ * @file tpccalib/TpcSpaceChargeMatrixContainerv2.cc
+ * @author Hugo Pereira Da Costa
+ * @date June 2018
+ * @brief Contains matrices needed for space charge trackbase reconstruction
+ */
+
+#include "TpcSpaceChargeMatrixContainerv2.h"
+
+//___________________________________________________________
+TpcSpaceChargeMatrixContainerv2::TpcSpaceChargeMatrixContainerv2()
+{
+  // reset all matrix arrays
+  TpcSpaceChargeMatrixContainerv2::Reset();
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::identify(std::ostream& out) const
+{
+  out << "TpcSpaceChargeMatrixContainerv2" << std::endl;
+  out << "  phibins: " << m_phibins << std::endl;
+  out << "  rbins: " << m_rbins << std::endl;
+  out << "  zbins: " << m_zbins << std::endl;
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::get_grid_dimensions(int& phibins, int& rbins, int& zbins) const
+{
+  phibins = m_phibins;
+  rbins = m_rbins;
+  zbins = m_zbins;
+}
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_grid_size() const
+{
+  return m_phibins * m_rbins * m_zbins;
+}
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_cell_index(int iphi, int ir, int iz) const
+{
+  if (iphi < 0 || iphi >= m_phibins)
+  {
+    return -1;
+  }
+  if (ir < 0 || ir >= m_rbins)
+  {
+    return -1;
+  }
+  if (iz < 0 || iz >= m_zbins)
+  {
+    return -1;
+  }
+  return iz + m_zbins * (ir + m_rbins * iphi);
+}
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_entries(int cell_index) const
+{
+  // bound check
+  if (!bound_check(cell_index))
+  {
+    return 0;
+  }
+  return m_entries[cell_index];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_lhs(int cell_index, int i, int j) const
+{
+  // bound check
+  if (!bound_check(cell_index, i, j))
+  {
+    return 0;
+  }
+  return m_lhs[cell_index][get_flat_index(i, j)];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_rhs(int cell_index, int i) const
+{
+  // bound check
+  if (!bound_check(cell_index, i))
+  {
+    return 0;
+  }
+  return m_rhs[cell_index][i];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_lhs_rphi(int cell_index, int i, int j) const
+{
+  // bound check
+  if (!bound_check_reduced(cell_index, i, j))
+  {
+    return 0;
+  }
+  return m_lhs_rphi[cell_index][get_flat_index_reduced(i, j)];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_rhs_rphi(int cell_index, int i) const
+{
+  // bound check
+  if (!bound_check_reduced(cell_index, i))
+  {
+    return 0;
+  }
+  return m_rhs_rphi[cell_index][i];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_lhs_z(int cell_index, int i, int j) const
+{
+  // bound check
+  if (!bound_check_reduced(cell_index, i, j))
+  {
+    return 0;
+  }
+  return m_lhs_z[cell_index][get_flat_index_reduced(i, j)];
+}
+
+//___________________________________________________________
+float TpcSpaceChargeMatrixContainerv2::get_rhs_z(int cell_index, int i) const
+{
+  // bound check
+  if (!bound_check_reduced(cell_index, i))
+  {
+    return 0;
+  }
+  return m_rhs_z[cell_index][i];
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::Reset()
+{
+  // reset total number of bins
+  const int totalbins = m_phibins * m_rbins * m_zbins;
+
+  // reset arrays
+  m_entries = std::vector<int>(totalbins, 0);
+  m_lhs = std::vector<matrix_t>(totalbins, {{}});
+  m_rhs = std::vector<column_t>(totalbins, {{}});
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::set_grid_dimensions(int phibins, int rbins, int zbins)
+{
+  m_phibins = phibins;
+  m_rbins = rbins;
+  m_zbins = zbins;
+  Reset();
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_entries(int cell_index, int value)
+{
+  if (bound_check(cell_index))
+  {
+    m_entries[cell_index] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_lhs(int cell_index, int i, int j, float value)
+{
+  if (bound_check(cell_index, i, j))
+  {
+    m_lhs[cell_index][get_flat_index(i, j)] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_rhs(int cell_index, int i, float value)
+{
+  if (bound_check(cell_index, i))
+  {
+    m_rhs[cell_index][i] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_lhs_rphi(int cell_index, int i, int j, float value)
+{
+  if (bound_check_reduced(cell_index, i, j))
+  {
+    m_lhs_rphi[cell_index][get_flat_index_reduced(i, j)] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_rhs_rphi(int cell_index, int i, float value)
+{
+  if (bound_check_reduced(cell_index, i))
+  {
+    m_rhs_rphi[cell_index][i] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_lhs_z(int cell_index, int i, int j, float value)
+{
+  if (bound_check_reduced(cell_index, i, j))
+  {
+    m_lhs_z[cell_index][get_flat_index_reduced(i, j)] += value;
+  }
+}
+
+//___________________________________________________________
+void TpcSpaceChargeMatrixContainerv2::add_to_rhs_z(int cell_index, int i, float value)
+{
+  if (bound_check_reduced(cell_index, i))
+  {
+    m_rhs_z[cell_index][i] += value;
+  }
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::add(const TpcSpaceChargeMatrixContainer& other)
+{
+  // check dimensions
+  int phibins = 0;
+  int rbins = 0;
+  int zbins = 0;
+  other.get_grid_dimensions(phibins, rbins, zbins);
+  if ((m_phibins != phibins) || (m_rbins != rbins) || (m_zbins != zbins))
+  {
+    std::cout << "TpcSpaceChargeMatrixContainerv2::add - inconsistent grid sizes" << std::endl;
+    return false;
+  }
+
+  // increment cell entries
+  for (size_t cell_index = 0; cell_index < m_lhs.size(); ++cell_index)
+  {
+    add_to_entries(cell_index, other.get_entries(cell_index));
+  }
+
+  // increment left hand side matrices
+  for (size_t cell_index = 0; cell_index < m_lhs.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord; ++i)
+    {
+      for (int j = 0; j < m_ncoord; ++j)
+      {
+        add_to_lhs(cell_index, i, j, other.get_lhs(cell_index, i, j));
+      }
+    }
+  }
+
+  // increment right hand side matrices
+  for (size_t cell_index = 0; cell_index < m_rhs.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord; ++i)
+    {
+      add_to_rhs(cell_index, i, other.get_rhs(cell_index, i));
+    }
+  }
+
+  // increment reduced rphi left hand side matrices
+  for (size_t cell_index = 0; cell_index < m_lhs_rphi.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord_reduced; ++i)
+    {
+      for (int j = 0; j < m_ncoord_reduced; ++j)
+      {
+        add_to_lhs_rphi(cell_index, i, j, other.get_lhs_rphi(cell_index, i, j));
+      }
+    }
+  }
+
+  // increment reduced rphi right hand side matrices
+  for (size_t cell_index = 0; cell_index < m_rhs_rphi.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord_reduced; ++i)
+    {
+      add_to_rhs_rphi(cell_index, i, other.get_rhs_rphi(cell_index, i));
+    }
+  }
+
+  // increment reduced z left hand side matrices
+  for (size_t cell_index = 0; cell_index < m_lhs_z.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord_reduced; ++i)
+    {
+      for (int j = 0; j < m_ncoord_reduced; ++j)
+      {
+        add_to_lhs_z(cell_index, i, j, other.get_lhs_z(cell_index, i, j));
+      }
+    }
+  }
+
+  // increment reduced z right hand side matrices
+  for (size_t cell_index = 0; cell_index < m_rhs_z.size(); ++cell_index)
+  {
+    for (int i = 0; i < m_ncoord_reduced; ++i)
+    {
+      add_to_rhs_z(cell_index, i, other.get_rhs_z(cell_index, i));
+    }
+  }
+
+  return true;
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::bound_check(int cell_index) const
+{
+  if (cell_index < 0 || cell_index >= (int) m_rhs.size())
+  {
+    return false;
+  }
+  return true;
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::bound_check(int cell_index, int i) const
+{
+  if (cell_index < 0 || cell_index >= (int) m_rhs.size())
+  {
+    return false;
+  }
+  if (i < 0 || i >= m_ncoord)
+  {
+    return false;
+  }
+  return true;
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::bound_check(int cell_index, int i, int j) const
+{
+  if (cell_index < 0 || cell_index >= (int) m_lhs.size())
+  {
+    return false;
+  }
+  if (i < 0 || i >= m_ncoord)
+  {
+    return false;
+  }
+  if (j < 0 || j >= m_ncoord)
+  {
+    return false;
+  }
+  return true;
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::bound_check_reduced(int cell_index, int i) const
+{
+  if (cell_index < 0 || cell_index >= (int) m_rhs.size())
+  {
+    return false;
+  }
+  if (i < 0 || i >= m_ncoord_reduced)
+  {
+    return false;
+  }
+  return true;
+}
+
+//___________________________________________________________
+bool TpcSpaceChargeMatrixContainerv2::bound_check_reduced(int cell_index, int i, int j) const
+{
+  if (cell_index < 0 || cell_index >= (int) m_lhs.size())
+  {
+    return false;
+  }
+  if (i < 0 || i >= m_ncoord_reduced)
+  {
+    return false;
+  }
+  if (j < 0 || j >= m_ncoord_reduced)
+  {
+    return false;
+  }
+  return true;
+}
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_flat_index(int i, int j) const
+{
+  return j + i * m_ncoord;
+}
+
+//___________________________________________________________
+int TpcSpaceChargeMatrixContainerv2::get_flat_index_reduced(int i, int j) const
+{
+  return j + i * m_ncoord_reduced;
+}

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.cc
@@ -143,6 +143,14 @@ void TpcSpaceChargeMatrixContainerv2::Reset()
   m_entries = std::vector<int>(totalbins, 0);
   m_lhs = std::vector<matrix_t>(totalbins, {{}});
   m_rhs = std::vector<column_t>(totalbins, {{}});
+
+  // rphi reduced arrays
+  m_lhs_rphi = std::vector<reduced_matrix_t>(totalbins, {{}});
+  m_rhs_rphi = std::vector<reduced_column_t>(totalbins, {{}});
+
+  // z reduced arrays
+  m_lhs_z = std::vector<reduced_matrix_t>(totalbins, {{}});
+  m_rhs_z = std::vector<reduced_column_t>(totalbins, {{}});
 }
 
 //___________________________________________________________
@@ -348,7 +356,7 @@ bool TpcSpaceChargeMatrixContainerv2::bound_check(int cell_index, int i, int j) 
 //___________________________________________________________
 bool TpcSpaceChargeMatrixContainerv2::bound_check_reduced(int cell_index, int i) const
 {
-  if (cell_index < 0 || cell_index >= (int) m_rhs.size())
+  if (cell_index < 0 || cell_index >= (int) m_rhs_rphi.size())
   {
     return false;
   }
@@ -362,7 +370,7 @@ bool TpcSpaceChargeMatrixContainerv2::bound_check_reduced(int cell_index, int i)
 //___________________________________________________________
 bool TpcSpaceChargeMatrixContainerv2::bound_check_reduced(int cell_index, int i, int j) const
 {
-  if (cell_index < 0 || cell_index >= (int) m_lhs.size())
+  if (cell_index < 0 || cell_index >= (int) m_lhs_rphi.size())
   {
     return false;
   }

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2.h
@@ -1,0 +1,184 @@
+#ifndef TPCCALIB_TpcSpaceChargeMatrixContainerv2_H
+#define TPCCALIB_TpcSpaceChargeMatrixContainerv2_H
+
+/**
+ * @file tpccalib/TpcSpaceChargeMatrixContainer.h
+ * @author Hugo Pereira Da Costa
+ * @date June 2018
+ * @brief Contains matrices needed for space charge trackbase reconstruction
+ */
+
+#include "TpcSpaceChargeMatrixContainer.h"
+
+#include <array>
+
+/**
+ * @brief Cluster container object
+ */
+class TpcSpaceChargeMatrixContainerv2 : public TpcSpaceChargeMatrixContainer
+{
+ public:
+  /// constructor
+  TpcSpaceChargeMatrixContainerv2();
+
+  /// destructor
+  ~TpcSpaceChargeMatrixContainerv2() override = default;
+
+  ///@name accessors
+  //@{
+
+  /// identify object
+  void identify(std::ostream& os = std::cout) const override;
+
+  /// get grid dimensions
+  void get_grid_dimensions(int& phibins, int& rbins, int& zbins) const override;
+
+  /// get grid size
+  int get_grid_size() const override;
+
+  /// get grid index for given sub-indexes
+  int get_cell_index(int iphibin, int irbin, int izbin) const override;
+
+  /// get entries for a given cell
+  int get_entries(int cell_index) const override;
+
+  /// get left hand side
+  float get_lhs(int cell_index, int i, int j) const override;
+
+  /// get right hand side
+  float get_rhs(int cell_index, int i) const override;
+
+  /// get reduced rphi left hand side
+  float get_lhs_rphi(int cell_index, int i, int j) const override;
+
+  /// get reduced rphi right hand side
+  float get_rhs_rphi(int cell_index, int i) const override;
+
+  /// get reduced z left hand side
+  float get_lhs_z(int cell_index, int i, int j) const override;
+
+  /// get reduced z right hand side
+  float get_rhs_z(int cell_index, int i) const override;
+
+  //@}
+
+  ///@name modifiers
+  //@{
+
+  /// reset method
+  void Reset() override;
+
+  /// set grid dimensions
+  /**
+  \param phibins the number of bins in the azimuth direction
+  \param zbins the number of bins along z
+  */
+  void set_grid_dimensions(int phibins, int rbins, int zbins) override;
+
+  /// increment cell entries
+  void add_to_entries(int cell_index) override
+  {
+    add_to_entries(cell_index, 1);
+  }
+
+  /// increment cell entries
+  void add_to_entries(int cell_index, int value) override;
+
+  /// increment left hand side matrix
+  void add_to_lhs(int cell_index, int i, int j, float value) override;
+
+  /// increment right hand side column
+  void add_to_rhs(int cell_index, int i, float value) override;
+
+  /// increment left hand side reduced rphi matrix
+  void add_to_lhs_rphi(int cell_index, int i, int j, float value) override;
+
+  /// increment right hand side reduced rphi column
+  void add_to_rhs_rphi(int cell_index, int i, float value) override;
+
+  /// increment left hand side reduced rphi matrix
+  void add_to_lhs_z(int cell_index, int i, int j, float value) override;
+
+  /// increment right hand side reduced rphi column
+  void add_to_rhs_z(int cell_index, int i, float value) override;
+
+  /// add content from other container
+  bool add(const TpcSpaceChargeMatrixContainer& other) override;
+
+  //@}
+
+ private:
+  /// boundary check
+  bool bound_check(int cell_index) const;
+
+  /// boundary check
+  bool bound_check(int cell_index, int i) const;
+
+  /// boundary check
+  bool bound_check(int cell_index, int i, int j) const;
+
+  /// map matrix index to flat array
+  int get_flat_index(int i, int j) const;
+
+  /// boundary check
+  bool bound_check_reduced(int cell_index, int i) const;
+
+  /// boundary check
+  bool bound_check_reduced(int cell_index, int i, int j) const;
+
+  /// map matrix index to flat array
+  int get_flat_index_reduced(int i, int j) const;
+
+  ///@name grid size
+  //@{
+  int m_phibins = 36;
+  int m_rbins = 16;
+  int m_zbins = 80;
+  //@}
+
+  //@name full 3D matrices (drphi, dz and dr)
+  //@{
+  //! number of coordinates for full matrix (drphi, dz and dr)
+  static constexpr int m_ncoord = 3;
+
+  /// internal matrix representation
+  using matrix_t = std::array<float, m_ncoord * m_ncoord>;
+  using column_t = std::array<float, m_ncoord>;
+
+  /// left hand side matrices for distortion inversions
+  std::vector<matrix_t> m_lhs;
+
+  /// right hand side matrices for distortion inversions
+  std::vector<column_t> m_rhs;
+  //@}
+
+
+  //@name reduced 2D matrices (drphi, dr) and (dz and dr)
+  //@{
+  //! number of coordinates for reduce matrix (drphi, dr) and (dz and dr)
+  static constexpr int m_ncoord_reduced = 2;
+
+  /// internal matrix representation
+  using reduced_matrix_t = std::array<float, m_ncoord_reduced * m_ncoord_reduced>;
+  using reduced_column_t = std::array<float, m_ncoord_reduced>;
+
+  /// left hand side matrices for reduced rphi distortion inversions
+  std::vector<reduced_matrix_t> m_lhs_rphi;
+
+  /// right hand side matrices for distortion rphi inversions
+  std::vector<reduced_column_t> m_rhs_rphi;
+
+  /// left hand side matrices for reduced z distortion inversions
+  std::vector<reduced_matrix_t> m_lhs_z;
+
+  /// right hand side matrices for reduced z distortion inversions
+  std::vector<reduced_column_t> m_rhs_z;
+  //@}
+
+  /// keep track of how many entries are used per cells
+  std::vector<int> m_entries;
+
+  ClassDefOverride(TpcSpaceChargeMatrixContainerv2, 1)
+};
+
+#endif

--- a/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2LinkDef.h
+++ b/offline/packages/tpccalib/TpcSpaceChargeMatrixContainerv2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class TpcSpaceChargeMatrixContainerv2+;
+
+#endif /* __CINT__ */

--- a/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
+++ b/offline/packages/tpccalib/TpcSpaceChargeReconstruction.cc
@@ -5,7 +5,7 @@
  */
 
 #include "TpcSpaceChargeReconstruction.h"
-#include "TpcSpaceChargeMatrixContainerv1.h"
+#include "TpcSpaceChargeMatrixContainerv2.h"
 #include "TpcSpaceChargeReconstructionHelper.h"
 
 #include <g4detectors/PHG4TpcCylinderGeom.h>
@@ -129,7 +129,7 @@ namespace
 TpcSpaceChargeReconstruction::TpcSpaceChargeReconstruction(const std::string& name)
   : SubsysReco(name)
   , PHParameterInterface(name)
-  , m_matrix_container(new TpcSpaceChargeMatrixContainerv1)
+  , m_matrix_container(new TpcSpaceChargeMatrixContainerv2)
 {
   InitializeParameters();
 }
@@ -659,6 +659,24 @@ void TpcSpaceChargeReconstruction::process_track(SvtxTrack* track)
     m_matrix_container->add_to_rhs(i, 0, cluster_r*drp / erp);
     m_matrix_container->add_to_rhs(i, 1, dz / ez);
     m_matrix_container->add_to_rhs(i, 2, talpha * drp / erp + tbeta * dz / ez);
+
+    // also update rphi reduced matrices
+    m_matrix_container->add_to_lhs_rphi(i, 0, 0, square(cluster_r) / erp);
+    m_matrix_container->add_to_lhs_rphi(i, 0, 1, cluster_r*talpha / erp);
+    m_matrix_container->add_to_lhs_rphi(i, 1, 0, cluster_r * talpha / erp);
+    m_matrix_container->add_to_lhs_rphi(i, 1, 1, square(talpha) / erp);
+
+    m_matrix_container->add_to_rhs_rphi(i, 0, cluster_r*drp / erp);
+    m_matrix_container->add_to_rhs_rphi(i, 1, talpha * drp / erp);
+
+    // also update z reduced matrices
+    m_matrix_container->add_to_lhs_z(i, 0, 0, 1. / ez);
+    m_matrix_container->add_to_lhs_z(i, 0, 1, tbeta / ez);
+    m_matrix_container->add_to_lhs_z(i, 1, 0, tbeta / ez);
+    m_matrix_container->add_to_lhs_z(i, 1, 1, square(tbeta) / ez);
+
+    m_matrix_container->add_to_rhs_z(i, 0, dz / ez);
+    m_matrix_container->add_to_rhs_z(i, 1, tbeta * dz / ez);
 
     // update entries in cell
     m_matrix_container->add_to_entries(i);


### PR DESCRIPTION
[comment]: <> (Please tell us something about this pull request)
This PR extends the Distortion TpcSpaceChargeMatrix container to also include 2x2 matrices that represents (drphi,dr) and (dz,dr) distortions separately, with two, independant, estimate of the delta_r distortion.
This will allow more extended cross-checks of the distortion procedure, similar to what is shown by @xyu3 here: 
https://indico.bnl.gov/event/27808/contributions/108094/attachments/62268/107025/20250603_yuxd_TPC_distortion.pdf

Missing is the relevant code to perform the 2x2 matrix inversions. This will be part of a separate commit.

## Types of changes
[comment]: <> ( What types of changes does your code introduce? Put an `x` in all the boxes that apply: )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work for users)
- [ ] Requiring change in macros repository (Please provide links to the macros pull request in the last section)
- [x] I am a member of [GitHub organization of sPHENIX Collaboration](https://github.com/orgs/sPHENIX-Collaboration/people), EIC, or ECCE (contact Chris Pinkenburg to join)

## What kind of change does this PR introduce? (Bug fix, feature, ...)

[comment]: <> ( What does this PR do? Linking to talk in software meeting encouraged )


## TODOs (if applicable)

[comment]: <> ( In case this is a draft PR, e.g. for running checks using Jenkins, please make the pull request as a draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/  )


## Links to other PRs in macros and calibration repositories (if applicable)

